### PR TITLE
[Feature] [Refactor] (COW Part2) Introduce Cow Column in StarRocks

### DIFF
--- a/be/src/bench/binary_column_copy_bench.cpp
+++ b/be/src/bench/binary_column_copy_bench.cpp
@@ -52,7 +52,7 @@ public:
 
 private:
     std::string _rand_str();
-    std::shared_ptr<BinaryColumn> _gen_binary_column();
+    BinaryColumn::MutablePtr _gen_binary_column();
 
     int _mode = 1;
     std::random_device _rd;
@@ -107,8 +107,8 @@ std::string BinaryColumnCopyBench::_rand_str() {
     return str;
 }
 
-std::shared_ptr<BinaryColumn> BinaryColumnCopyBench::_gen_binary_column() {
-    std::shared_ptr<BinaryColumn> column = std::make_shared<BinaryColumn>();
+BinaryColumn::MutablePtr BinaryColumnCopyBench::_gen_binary_column() {
+    BinaryColumn::MutablePtr column = BinaryColumn::create();
 
     for (size_t i = 0; i < _chunk_size; i++) {
         std::string str = _rand_str();

--- a/be/src/bench/chunks_sorter_bench.cpp
+++ b/be/src/bench/chunks_sorter_bench.cpp
@@ -60,7 +60,7 @@ public:
         DCHECK_EQ(TYPE_INT, type_desc.type);
         using UniformInt = std::uniform_int_distribution<std::mt19937::result_type>;
 
-        ColumnPtr column = ColumnHelper::create_column(type_desc, nullable);
+        MutableColumnPtr column = ColumnHelper::create_column(type_desc, nullable);
         auto expr = std::make_unique<ColumnRef>(type_desc, slot_index);
 
         std::random_device dev;
@@ -87,7 +87,7 @@ public:
                                                                           bool nullable) {
         using UniformInt = std::uniform_int_distribution<std::mt19937::result_type>;
         using PoissonInt = std::poisson_distribution<std::mt19937::result_type>;
-        ColumnPtr column = ColumnHelper::create_column(type_desc, nullable);
+        MutableColumnPtr column = ColumnHelper::create_column(type_desc, nullable);
         auto expr = std::make_unique<ColumnRef>(type_desc, slot_index);
 
         std::random_device dev;

--- a/be/src/bench/get_dict_codes_bench.cpp
+++ b/be/src/bench/get_dict_codes_bench.cpp
@@ -56,7 +56,7 @@ static void BM_GetDictCodesWithMap(benchmark::State& state) {
     std::mt19937 rng(rd());
     std::uniform_int_distribution<int> dist(0, 999);
 
-    ColumnPtr column = ColumnHelper::create_column(TypeDescriptor{TYPE_VARCHAR}, true);
+    MutableColumnPtr column = ColumnHelper::create_column(TypeDescriptor{TYPE_VARCHAR}, true);
     (void)column->append_strings_overflow(dict_values, kDictLength);
     column->append_default();
     for (int i = 0; i < kDictSize + 1; i++) {

--- a/be/src/bench/hash_functions_bench.cpp
+++ b/be/src/bench/hash_functions_bench.cpp
@@ -38,7 +38,7 @@ private:
     const TypeDescriptor type_desc = TypeDescriptor(TYPE_VARCHAR);
     size_t _num_column = 0;
     size_t _num_rows = 0;
-    std::vector<ColumnPtr> _columns{};
+    Columns _columns{};
 };
 
 void HashFunctionsBench::SetUp() {

--- a/be/src/bench/hyperscan_vec_bench.cpp
+++ b/be/src/bench/hyperscan_vec_bench.cpp
@@ -42,7 +42,7 @@ public:
 private:
     const TypeDescriptor type_desc = TypeDescriptor(TYPE_VARCHAR);
     size_t _ratio = 0;
-    std::vector<ColumnPtr> _columns{};
+    Columns _columns{};
     std::shared_ptr<StringFunctionsState> _state;
     std::string _rpl_value = "";
     size_t _num_rows = 4096;
@@ -62,11 +62,11 @@ void HyperScanBench::SetUp() {
         }
     }
     _columns.push_back(std::move(column));
-    ColumnPtr pattern_data = ColumnHelper::create_column(type_desc, false);
+    MutableColumnPtr pattern_data = ColumnHelper::create_column(type_desc, false);
     pattern_data->append_datum(Datum(Slice("-")));
     auto pattern_column = ConstColumn::create(pattern_data, _num_rows);
     _columns.push_back(std::move(pattern_column));
-    ColumnPtr rpl_data = ColumnHelper::create_column(type_desc, false);
+    MutableColumnPtr rpl_data = ColumnHelper::create_column(type_desc, false);
     rpl_data->append_datum(Datum(Slice("")));
     auto rpl_column = ConstColumn::create(rpl_data, _num_rows);
     _columns.push_back(std::move(rpl_column));

--- a/be/src/bench/orc_column_reader_bench.cpp
+++ b/be/src/bench/orc_column_reader_bench.cpp
@@ -260,7 +260,7 @@ static void BM_primitive(benchmark::State& state) {
         orc::RowReader::ReadPosition pos;
         size_t totalNumRows = 0;
         while (rr->next(*batch, &pos)) {
-            ColumnPtr column = ColumnHelper::create_column(c0Type, isNullable);
+            MutableColumnPtr column = ColumnHelper::create_column(c0Type, isNullable);
             CHECK(orcColumnReader->get_next(c0, column, 0, columnSize).ok());
             DCHECK_EQ(columnSize, column->size());
             totalNumRows += columnSize;

--- a/be/src/bench/parquet_dict_decode_bench.cpp
+++ b/be/src/bench/parquet_dict_decode_bench.cpp
@@ -50,7 +50,7 @@ static void BM_DictDecoder(benchmark::State& state) {
         (void)dict_decoder.set_dict(kTestChunkSize, kDictSize, &decoder);
 
         if (debug) {
-            ColumnPtr column = ColumnHelper::create_column(TypeDescriptor{TYPE_VARCHAR}, true);
+            MutableColumnPtr column = ColumnHelper::create_column(TypeDescriptor{TYPE_VARCHAR}, true);
             (void)dict_decoder.get_dict_values(column.get());
             std::cout << column->debug_string() << "\n";
         }
@@ -84,7 +84,7 @@ static void BM_DictDecoder(benchmark::State& state) {
                   << ".\n";
     }
 
-    ColumnPtr column = ColumnHelper::create_column(TypeDescriptor{TYPE_VARCHAR}, true);
+    MutableColumnPtr column = ColumnHelper::create_column(TypeDescriptor{TYPE_VARCHAR}, true);
     for (auto _ : state) {
         state.PauseTiming();
         column->reset_column();

--- a/be/src/bench/runtime_filter_bench.cpp
+++ b/be/src/bench/runtime_filter_bench.cpp
@@ -41,7 +41,7 @@ namespace starrocks {
 //   Benchmark_RuntimeFilter_Eval/20000000/100/100  968723953 ns    968634431 ns            1 compute_hash_time(ms)=213 evalute_time(ms)=163 items_per_second=20.6476M/s
 
 static void do_benchmark_hash_partitioned(benchmark::State& state, TRuntimeFilterBuildJoinMode::type join_mode,
-                                          std::vector<ColumnPtr> columns, int64_t num_rows, int64_t num_partitions) {
+                                          Columns columns, int64_t num_rows, int64_t num_partitions) {
     std::vector<uint32_t> hash_values;
     std::vector<size_t> num_rows_per_partitions(num_partitions, 0);
 
@@ -129,7 +129,7 @@ static void do_benchmark_hash_partitioned(benchmark::State& state, TRuntimeFilte
     state.PauseTiming();
 }
 
-static std::vector<ColumnPtr> columns;
+static Columns columns;
 class RuntimeFilterBench {
 public:
     static void Setup(int32_t num_rows, int32_t num_column) {

--- a/be/src/bench/shuffle_chunk_bench.cpp
+++ b/be/src/bench/shuffle_chunk_bench.cpp
@@ -73,7 +73,7 @@ void ShuffleChunkPerf::init_types() {
 }
 
 ColumnPtr ShuffleChunkPerf::init_src_column(const TypeDescriptor& type) {
-    ColumnPtr c1 = ColumnHelper::create_column(type, true);
+    MutableColumnPtr c1 = ColumnHelper::create_column(type, true);
     c1->reserve(_src_chunk_size);
     auto* nullable_col = down_cast<NullableColumn*>(c1.get());
     for (int k = 0; k < _src_chunk_size; k++) {
@@ -89,7 +89,7 @@ ColumnPtr ShuffleChunkPerf::init_src_column(const TypeDescriptor& type) {
 }
 
 ColumnPtr ShuffleChunkPerf::init_src_key_column(const TypeDescriptor& type) {
-    ColumnPtr c1 = ColumnHelper::create_column(type, true);
+    MutableColumnPtr c1 = ColumnHelper::create_column(type, true);
     c1->reserve(_src_chunk_size);
     auto* nullable_col = down_cast<NullableColumn*>(c1.get());
     for (int k = 0; k < _src_chunk_size; k++) {

--- a/be/src/column/adaptive_nullable_column.cpp
+++ b/be/src/column/adaptive_nullable_column.cpp
@@ -249,12 +249,12 @@ int AdaptiveNullableColumn::compare_at(size_t left, size_t right, const Column& 
     return NullableColumn::compare_at(left, right, rhs, nan_direction_hint);
 }
 
-uint32_t AdaptiveNullableColumn::serialize(size_t idx, uint8_t* pos) {
+uint32_t AdaptiveNullableColumn::serialize(size_t idx, uint8_t* pos) const {
     materialized_nullable();
     return NullableColumn::serialize(idx, pos);
 }
 
-uint32_t AdaptiveNullableColumn::serialize_default(uint8_t* pos) {
+uint32_t AdaptiveNullableColumn::serialize_default(uint8_t* pos) const {
     materialized_nullable();
     bool null = true;
     strings::memcpy_inlined(pos, &null, sizeof(bool));
@@ -262,13 +262,13 @@ uint32_t AdaptiveNullableColumn::serialize_default(uint8_t* pos) {
 }
 
 size_t AdaptiveNullableColumn::serialize_batch_at_interval(uint8_t* dst, size_t byte_offset, size_t byte_interval,
-                                                           size_t start, size_t count) {
+                                                           size_t start, size_t count) const {
     materialized_nullable();
     return NullableColumn::serialize_batch_at_interval(dst, byte_offset, byte_interval, start, count);
 }
 
 void AdaptiveNullableColumn::serialize_batch(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
-                                             uint32_t max_one_row_size) {
+                                             uint32_t max_one_row_size) const {
     materialized_nullable();
     _data_column->serialize_batch_with_null_masks(dst, slice_sizes, chunk_size, max_one_row_size,
                                                   _null_column->get_data().data(), _has_null);

--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -33,17 +33,19 @@ namespace starrocks {
 ///             - null_column: (0, 0, 0, 0, 1, 0)
 ///             - data_column: (1, 2, 3, 4, <default>, 6)
 ///         - offsets_column: (0, 0, 3, 6)
-class ArrayColumn final : public ColumnFactory<Column, ArrayColumn> {
-    friend class ColumnFactory<Column, ArrayColumn>;
+class ArrayColumn final : public CowFactory<ColumnFactory<Column, ArrayColumn>, ArrayColumn> {
+    friend class CowFactory<ColumnFactory<Column, ArrayColumn>, ArrayColumn>;
+    using Base = CowFactory<ColumnFactory<Column, ArrayColumn>, ArrayColumn>;
 
 public:
     using ValueType = void;
+    using OffsetColumn = UInt32Column;
+    using OffsetColumnPtr = UInt32Column::Ptr;
 
-    ArrayColumn(ColumnPtr elements, UInt32Column::Ptr offsets);
+    ArrayColumn(MutableColumnPtr&& elements, MutableColumnPtr&& offsets);
 
     ArrayColumn(const ArrayColumn& rhs)
-            : _elements(rhs._elements->clone_shared()),
-              _offsets(std::static_pointer_cast<UInt32Column>(rhs._offsets->clone_shared())) {}
+            : _elements(rhs._elements->clone()), _offsets(OffsetColumn::static_pointer_cast(rhs._offsets->clone())) {}
 
     ArrayColumn(ArrayColumn&& rhs) noexcept : _elements(std::move(rhs._elements)), _offsets(std::move(rhs._offsets)) {}
 
@@ -57,6 +59,16 @@ public:
         ArrayColumn tmp(std::move(rhs));
         this->swap_column(tmp);
         return *this;
+    }
+
+    static Ptr create(const ColumnPtr& elements, const ColumnPtr& offsets) {
+        return ArrayColumn::create(elements->as_mutable_ptr(), offsets->as_mutable_ptr());
+    }
+    static Ptr create(const ArrayColumn& rhs) { return Base::create(rhs); }
+
+    template <typename... Args>
+    requires(IsMutableColumns<Args...>::value) static MutablePtr create(Args&&... args) {
+        return Base::create(std::forward<Args>(args)...);
     }
 
     ~ArrayColumn() override = default;
@@ -113,12 +125,12 @@ public:
 
     uint32_t max_one_element_serialize_size() const override;
 
-    uint32_t serialize(size_t idx, uint8_t* pos) override;
+    uint32_t serialize(size_t idx, uint8_t* pos) const override;
 
-    uint32_t serialize_default(uint8_t* pos) override;
+    uint32_t serialize_default(uint8_t* pos) const override;
 
     void serialize_batch(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
-                         uint32_t max_one_row_size) override;
+                         uint32_t max_one_row_size) const override;
 
     const uint8_t* deserialize_and_append(const uint8_t* pos) override;
 
@@ -168,12 +180,14 @@ public:
     void reset_column() override;
 
     const Column& elements() const { return *_elements; }
+    Column& elements() { return *_elements; }
     ColumnPtr& elements_column() { return _elements; }
-    ColumnPtr elements_column() const { return _elements; }
+    const ColumnPtr& elements_column() const { return _elements; }
 
-    const UInt32Column& offsets() const { return *_offsets; }
-    UInt32Column::Ptr& offsets_column() { return _offsets; }
-    UInt32Column::Ptr offsets_column() const { return _offsets; }
+    OffsetColumn& offsets() { return *_offsets; }
+    const OffsetColumn& offsets() const { return *_offsets; }
+    const OffsetColumnPtr& offsets_column() const { return _offsets; }
+    OffsetColumnPtr& offsets_column() { return _offsets; }
 
     bool is_nullable() const override { return false; }
 
@@ -203,6 +217,13 @@ public:
     // v1 and v2 must be one of ArrayColumn or Const(ArrayColumn)
     template <bool IgnoreNull>
     static bool is_all_array_lengths_equal(const ColumnPtr& v1, const ColumnPtr& v2, const NullColumnPtr& null_data);
+
+    void mutate_each_subcolumn() override {
+        // elements
+        _elements = (std::move(*_elements)).mutate();
+        // offsets
+        _offsets = OffsetColumn::static_pointer_cast((std::move(*_offsets)).mutate());
+    }
 
 private:
     template <bool ConstV1, bool ConstV2, bool IgnoreNull>

--- a/be/src/column/chunk_extra_data.cpp
+++ b/be/src/column/chunk_extra_data.cpp
@@ -17,13 +17,13 @@
 #include "column/chunk_extra_data.h"
 
 namespace starrocks {
-void ChunkExtraColumnsData::filter(const Buffer<uint8_t>& selection) const {
+void ChunkExtraColumnsData::filter(const Buffer<uint8_t>& selection) {
     for (auto& col : _columns) {
         col->filter(selection);
     }
 }
 
-void ChunkExtraColumnsData::filter_range(const Buffer<uint8_t>& selection, size_t from, size_t to) const {
+void ChunkExtraColumnsData::filter_range(const Buffer<uint8_t>& selection, size_t from, size_t to) {
     for (auto& col : _columns) {
         col->filter_range(selection, from, to);
     }
@@ -36,11 +36,11 @@ ChunkExtraColumnsDataPtr ChunkExtraColumnsData::clone_empty(size_t size) const {
         columns[i]->reserve(size);
     }
     auto extra_data_metas = _data_metas;
-    return std::make_shared<ChunkExtraColumnsData>(extra_data_metas, columns);
+    return std::make_shared<ChunkExtraColumnsData>(std::move(extra_data_metas), std::move(columns));
 }
 
 void ChunkExtraColumnsData::append(const ChunkExtraColumnsData& src, size_t offset, size_t count) {
-    auto src_columns = src.columns();
+    auto& src_columns = src.columns();
     DCHECK_EQ(src_columns.size(), _columns.size());
     for (size_t i = 0; i < _columns.size(); ++i) {
         _columns[i]->append(*src_columns[i], offset, count);
@@ -49,7 +49,7 @@ void ChunkExtraColumnsData::append(const ChunkExtraColumnsData& src, size_t offs
 
 void ChunkExtraColumnsData::append_selective(const ChunkExtraColumnsData& src, const uint32_t* indexes, uint32_t from,
                                              uint32_t size) {
-    auto src_columns = src.columns();
+    auto& src_columns = src.columns();
     DCHECK_EQ(src_columns.size(), _columns.size());
     for (size_t i = 0; i < _columns.size(); ++i) {
         _columns[i]->append_selective(*src_columns[i], indexes, from, size);

--- a/be/src/column/chunk_extra_data.h
+++ b/be/src/column/chunk_extra_data.h
@@ -40,11 +40,12 @@ public:
 
     std::vector<ChunkExtraColumnsMeta> chunk_data_metas() const { return _data_metas; }
 
-    Columns columns() const { return _columns; }
+    const Columns& columns() const { return _columns; }
+    Columns& columns() { return _columns; }
     size_t num_rows() const { return _columns.empty() ? 0 : _columns[0]->size(); }
 
-    void filter(const Buffer<uint8_t>& selection) const;
-    void filter_range(const Buffer<uint8_t>& selection, size_t from, size_t to) const;
+    void filter(const Buffer<uint8_t>& selection);
+    void filter_range(const Buffer<uint8_t>& selection, size_t from, size_t to);
 
     ChunkExtraColumnsDataPtr clone_empty(size_t size) const;
 

--- a/be/src/column/column.cpp
+++ b/be/src/column/column.cpp
@@ -21,7 +21,8 @@
 namespace starrocks {
 
 void Column::serialize_batch_with_null_masks(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
-                                             uint32_t max_one_row_size, uint8_t* null_masks, bool has_null) {
+                                             uint32_t max_one_row_size, const uint8_t* null_masks,
+                                             bool has_null) const {
     uint32_t* sizes = slice_sizes.data();
 
     if (!has_null) {
@@ -42,7 +43,7 @@ void Column::serialize_batch_with_null_masks(uint8_t* dst, Buffer<uint32_t>& sli
     }
 }
 
-StatusOr<ColumnPtr> Column::downgrade_helper_func(ColumnPtr* col) {
+StatusOr<ColumnPtr> Column::downgrade_helper_func(Ptr* col) {
     auto ret = (*col)->downgrade();
     if (!ret.ok()) {
         return ret;
@@ -54,7 +55,7 @@ StatusOr<ColumnPtr> Column::downgrade_helper_func(ColumnPtr* col) {
     }
 }
 
-StatusOr<ColumnPtr> Column::upgrade_helper_func(ColumnPtr* col) {
+StatusOr<ColumnPtr> Column::upgrade_helper_func(Ptr* col) {
     auto ret = (*col)->upgrade_if_overflow();
     if (!ret.ok()) {
         return ret;

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -22,6 +22,7 @@
 #include "column/column_visitor.h"
 #include "column/column_visitor_mutable.h"
 #include "column/vectorized_fwd.h"
+#include "common/cow.h"
 #include "common/statusor.h"
 #include "gutil/casts.h"
 #include "storage/delete_condition.h" // for DelCondSatisfied
@@ -37,8 +38,10 @@ struct TypeDescriptor;
 // Forward declaration
 class Datum;
 
-class Column {
+class Column : public Cow<Column> {
 public:
+    friend class Cow<Column>;
+
     // we use append fixed size to achieve faster memory copy.
     // We copy 350M rows, which total length is 2GB, max length is 15.
     // When size is 0, it means copy the string's actual size.
@@ -61,11 +64,6 @@ public:
     static const int EQUALS_FALSE = 0;
     static const int EQUALS_NULL = -1;
     static const int EQUALS_TRUE = 1;
-
-    // mutable operations cannot be applied to shared data when concurrent
-    using Ptr = std::shared_ptr<Column>;
-    // mutable means you could modify the data safely
-    using MutablePtr = std::unique_ptr<Column>;
 
     virtual ~Column() = default;
 
@@ -135,14 +133,14 @@ public:
     // Return null, if the column is not overflow.
     // Return the new larger column, if upgrade success
     // Current, only support upgrade BinaryColumn to LargeBinaryColumn
-    virtual StatusOr<ColumnPtr> upgrade_if_overflow() = 0;
+    virtual StatusOr<Ptr> upgrade_if_overflow() = 0;
 
     // Downgrade the column from large column to normal column.
     // Return internal error if downgrade failed.
     // Return null, if the column is already normal column, no need to downgrade.
     // Return the new normal column, if downgrade success
     // Current, only support downgrade LargeBinaryColumn to BinaryColumn
-    virtual StatusOr<ColumnPtr> downgrade() = 0;
+    virtual StatusOr<Ptr> downgrade() = 0;
 
     // Check if the column contains large column.
     // Current, only used to check if it contains LargeBinaryColumn or BinaryColumn
@@ -170,7 +168,7 @@ public:
     // for example: column(1,2)->replicate({0,2,5}) = column(1,1,2,2,2)
     // FixedLengthColumn, BinaryColumn and ConstColumn override this function for better performance.
     // TODO(fzh): optimize replicate() for ArrayColumn, ObjectColumn and others.
-    virtual StatusOr<ColumnPtr> replicate(const Buffer<uint32_t>& offsets) {
+    virtual StatusOr<Ptr> replicate(const Buffer<uint32_t>& offsets) {
         auto dest = this->clone_empty();
         auto dest_size = offsets.size() - 1;
         DCHECK(this->size() >= dest_size) << "The size of the source column is less when duplicating it.";
@@ -293,14 +291,14 @@ public:
     }
 
     // serialize one data,The memory must allocate firstly from mempool
-    virtual uint32_t serialize(size_t idx, uint8_t* pos) = 0;
+    virtual uint32_t serialize(size_t idx, uint8_t* pos) const = 0;
 
     // serialize default value of column
     // The behavior is consistent with append_default
-    virtual uint32_t serialize_default(uint8_t* pos) = 0;
+    virtual uint32_t serialize_default(uint8_t* pos) const = 0;
 
     virtual void serialize_batch(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
-                                 uint32_t max_one_row_size) = 0;
+                                 uint32_t max_one_row_size) const = 0;
 
     // A dedicated serialization method used by HashJoin to combine multiple columns into a wide-key
     // column, and it's only implemented by numeric columns right now.
@@ -309,13 +307,14 @@ public:
     // (which should be fixed size) of this column if this column supports this method, otherwise
     // it returns 0.
     virtual size_t serialize_batch_at_interval(uint8_t* dst, size_t byte_offset, size_t byte_interval, size_t start,
-                                               size_t count) {
+                                               size_t count) const {
         return 0;
     };
 
     // A dedicated serialization method used by NullableColumn to serialize data columns with null_masks.
     virtual void serialize_batch_with_null_masks(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
-                                                 uint32_t max_one_row_size, uint8_t* null_masks, bool has_null);
+                                                 uint32_t max_one_row_size, const uint8_t* null_masks,
+                                                 bool has_null) const;
 
     virtual void deserialize_and_append_batch_nullable(Buffer<Slice>& srcs, size_t chunk_size,
                                                        Buffer<uint8_t>& is_nulls, bool& has_null) = 0;
@@ -332,9 +331,6 @@ public:
     virtual MutablePtr clone_empty() const = 0;
 
     virtual MutablePtr clone() const = 0;
-
-    // clone column
-    virtual Ptr clone_shared() const = 0;
 
     // REQUIRES: size of |filter| equals to the size of this column.
     // Removes elements that don't match the filter.
@@ -453,60 +449,57 @@ public:
     // current only used by adaptive_nullable_column
     virtual void materialized_nullable() const {}
 
+    /// If the column contains subcolumns (such as Array, Nullable, etc), do callback on them.
+    /// Shallow: doesn't do recursive calls; don't do call for itself.
+    virtual void mutate_each_subcolumn() {}
+
+    MutablePtr mutate() const&& {
+        MutablePtr res = try_mutate();
+        res->mutate_each_subcolumn();
+        return res;
+    }
+
+    static MutablePtr mutate(Ptr ptr) {
+        MutablePtr res = ptr->try_mutate(); /// Now use_count is 2.
+        ptr.reset();                        /// Reset use_count to 1.
+        res->mutate_each_subcolumn();
+        return res;
+    }
+
 protected:
-    static StatusOr<ColumnPtr> downgrade_helper_func(ColumnPtr* col);
-    static StatusOr<ColumnPtr> upgrade_helper_func(ColumnPtr* col);
+    static StatusOr<Ptr> downgrade_helper_func(Ptr* col);
+    static StatusOr<Ptr> upgrade_helper_func(Ptr* col);
 
     DelCondSatisfied _delete_state = DEL_NOT_SATISFIED;
 };
 
-// AncestorBase is root class of inheritance hierarchy
-// if Derived class is the direct subclass of the root, then AncestorBase is just the Base class
-// if Derived class is the indirect subclass of the root, Base class is parent class, and
-// AncestorBase must be the root class. because Derived class need some type information from
-// AncestorBase to override the virtual method. e.g. clone and clone_shared method.
-template <typename Base, typename Derived, typename AncestorBase = Base>
+using ColumnPtr = Column::Ptr;
+using Columns = std::vector<ColumnPtr>;
+using MutableColumnPtr = Column::MutablePtr;
+using MutableColumns = std::vector<MutableColumnPtr>;
+
+template <typename... Args>
+struct IsMutableColumns;
+
+template <typename Arg, typename... Args>
+struct IsMutableColumns<Arg, Args...> {
+    static const bool value = std::is_assignable<MutableColumnPtr&&, Arg>::value && IsMutableColumns<Args...>::value;
+};
+
+template <>
+struct IsMutableColumns<> {
+    static const bool value = true;
+};
+
+template <typename Base, typename Derived>
 class ColumnFactory : public Base {
 private:
-    Derived* mutable_derived() { return down_cast<Derived*>(this); }
-    const Derived* derived() const { return down_cast<const Derived*>(this); }
+    Derived* derived() { return static_cast<Derived*>(this); }
+    const Derived* derived() const { return static_cast<const Derived*>(this); }
 
 public:
     template <typename... Args>
     ColumnFactory(Args&&... args) : Base(std::forward<Args>(args)...) {}
-    // mutable operations cannot be applied to shared data when concurrent
-    using Ptr = std::shared_ptr<Derived>;
-    // mutable means you could modify the data safely
-    using MutablePtr = std::unique_ptr<Derived>;
-    using AncestorBaseType = std::enable_if_t<std::is_base_of_v<AncestorBase, Base>, AncestorBase>;
-
-    template <typename... Args>
-    static Ptr create(Args&&... args) {
-        return std::make_shared<Derived>(std::forward<Args>(args)...);
-    }
-
-    template <typename... Args>
-    static MutablePtr create_mutable(Args&&... args) {
-        return std::make_unique<Derived>(std::forward<Args>(args)...);
-    }
-
-    template <typename T>
-    static Ptr create(std::initializer_list<T>&& arg) {
-        return std::make_shared<Derived>(std::move(arg));
-    }
-
-    template <typename T>
-    static MutablePtr create_mutable(std::initializer_list<T>&& arg) {
-        return std::make_unique<Derived>(std::move(arg));
-    }
-
-    typename AncestorBaseType::MutablePtr clone() const override {
-        return typename AncestorBase::MutablePtr(new Derived(*derived()));
-    }
-
-    typename AncestorBaseType::Ptr clone_shared() const override {
-        return typename AncestorBase::Ptr(new Derived(*derived()));
-    }
 
     Status accept(ColumnVisitor* visitor) const override { return visitor->visit(*static_cast<const Derived*>(this)); }
 
@@ -524,10 +517,10 @@ public:
             is_nulls.emplace_back(null);
 
             if (null == 0) {
-                srcs[i].data = (char*)mutable_derived()->deserialize_and_append((uint8_t*)srcs[i].data);
+                srcs[i].data = (char*)derived()->deserialize_and_append((uint8_t*)srcs[i].data);
             } else {
                 has_null = true;
-                mutable_derived()->append_default();
+                derived()->append_default();
             }
         }
     }

--- a/be/src/column/column_access_path.cpp
+++ b/be/src/column/column_access_path.cpp
@@ -56,7 +56,7 @@ Status ColumnAccessPath::init(const std::string& parent_path, const TColumnAcces
         return Status::InternalError("error column access null path.");
     }
 
-    Column* data = ColumnHelper::get_data_column(column.get());
+    const Column* data = ColumnHelper::get_data_column(column.get());
     if (!data->is_binary()) {
         return Status::InternalError("error column access string path.");
     }

--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -53,11 +53,11 @@ Filter& ColumnHelper::merge_nullable_filter(Column* column) {
 
 void ColumnHelper::merge_two_filters(const ColumnPtr& column, Filter* __restrict filter, bool* all_zero) {
     if (column->is_nullable()) {
-        auto* nullable_column = as_raw_column<NullableColumn>(column);
+        const auto* nullable_column = as_raw_const_column<NullableColumn>(column);
 
         // NOTE(zc): Must use uint8_t* to enable auto-vectorized.
-        auto nulls = nullable_column->null_column_data().data();
-        auto datas = (down_cast<UInt8Column*>(nullable_column->mutable_data_column()))->get_data().data();
+        const auto nulls = nullable_column->null_column_data().data();
+        const auto datas = (down_cast<const UInt8Column*>(nullable_column->data_column().get()))->get_data().data();
         auto num_rows = nullable_column->size();
         // we treat null(1) as false(0)
         for (size_t j = 0; j < num_rows; ++j) {
@@ -65,7 +65,7 @@ void ColumnHelper::merge_two_filters(const ColumnPtr& column, Filter* __restrict
         }
     } else {
         size_t num_rows = column->size();
-        auto datas = as_raw_column<UInt8Column>(column)->get_data().data();
+        const auto datas = as_raw_const_column<UInt8Column>(column)->get_data().data();
         for (size_t j = 0; j < num_rows; ++j) {
             (*filter)[j] &= datas[j];
         }
@@ -191,10 +191,10 @@ size_t ColumnHelper::count_false_with_notnull(const starrocks::ColumnPtr& col) {
     }
 }
 
-ColumnPtr ColumnHelper::create_const_null_column(size_t chunk_size) {
+MutableColumnPtr ColumnHelper::create_const_null_column(size_t chunk_size) {
     auto nullable_column = NullableColumn::create(Int8Column::create(), NullColumn::create());
     nullable_column->append_nulls(1);
-    return ConstColumn::create(nullable_column, chunk_size);
+    return ConstColumn::create(std::move(nullable_column), chunk_size);
 }
 
 size_t ColumnHelper::find_nonnull(const Column* col, size_t start, size_t end) {
@@ -232,7 +232,7 @@ size_t ColumnHelper::last_nonnull(const Column* col, size_t start, size_t end) {
     return end;
 }
 
-int64_t ColumnHelper::find_first_not_equal(Column* column, int64_t target, int64_t start, int64_t end) {
+int64_t ColumnHelper::find_first_not_equal(const Column* column, int64_t target, int64_t start, int64_t end) {
     while (start + 1 < end) {
         int64_t mid = start + (end - start) / 2;
         if (column->compare_at(target, mid, *column, 1) == 0) {
@@ -252,7 +252,7 @@ int64_t ColumnHelper::find_first_not_equal(Column* column, int64_t target, int64
 // Nullable(int8), but required return type is nullable(string), so col need align return type to nullable(string).
 ColumnPtr ColumnHelper::align_return_type(const ColumnPtr& old_col, const TypeDescriptor& type_desc, size_t num_rows,
                                           const bool is_nullable) {
-    ColumnPtr new_column = old_col;
+    MutableColumnPtr new_column = old_col->clone();
     if (old_col->only_null()) {
         new_column = ColumnHelper::create_column(type_desc, true);
         new_column->append_nulls(num_rows);
@@ -260,7 +260,7 @@ ColumnPtr ColumnHelper::align_return_type(const ColumnPtr& old_col, const TypeDe
         // Note: we must create a new column every time here,
         // because result_columns[i] is shared_ptr
         new_column = ColumnHelper::create_column(type_desc, false);
-        auto* const_column = down_cast<ConstColumn*>(old_col.get());
+        auto* const_column = down_cast<const ConstColumn*>(old_col.get());
         new_column->append(*const_column->data_column(), 0, 1);
         new_column->assign(num_rows, 0);
     }
@@ -270,13 +270,13 @@ ColumnPtr ColumnHelper::align_return_type(const ColumnPtr& old_col, const TypeDe
     return new_column;
 }
 
-ColumnPtr ColumnHelper::create_column(const TypeDescriptor& type_desc, bool nullable) {
+MutableColumnPtr ColumnHelper::create_column(const TypeDescriptor& type_desc, bool nullable) {
     return create_column(type_desc, nullable, false, 0);
 }
 
 struct ColumnBuilder {
     template <LogicalType ltype>
-    ColumnPtr operator()(const TypeDescriptor& type_desc, size_t size) {
+    MutableColumnPtr operator()(const TypeDescriptor& type_desc, size_t size) {
         switch (ltype) {
         case TYPE_UNKNOWN:
         case TYPE_NULL:
@@ -298,8 +298,8 @@ struct ColumnBuilder {
     }
 };
 
-ColumnPtr ColumnHelper::create_column(const TypeDescriptor& type_desc, bool nullable, bool is_const, size_t size,
-                                      bool use_adaptive_nullable_column) {
+MutableColumnPtr ColumnHelper::create_column(const TypeDescriptor& type_desc, bool nullable, bool is_const, size_t size,
+                                             bool use_adaptive_nullable_column) {
     auto type = type_desc.type;
     if (is_const && (nullable || type == TYPE_NULL)) {
         return ColumnHelper::create_const_null_column(size);
@@ -311,15 +311,15 @@ ColumnPtr ColumnHelper::create_column(const TypeDescriptor& type_desc, bool null
         }
     }
 
-    ColumnPtr p;
+    MutableColumnPtr p;
     if (type_desc.type == LogicalType::TYPE_ARRAY) {
         auto offsets = UInt32Column::create(size);
         auto data = create_column(type_desc.children[0], true, is_const, size);
         p = ArrayColumn::create(std::move(data), std::move(offsets));
     } else if (type_desc.type == LogicalType::TYPE_MAP) {
-        auto offsets = UInt32Column ::create(size);
-        ColumnPtr keys = nullptr;
-        ColumnPtr values = nullptr;
+        MutableColumnPtr offsets = UInt32Column ::create(size);
+        MutableColumnPtr keys = nullptr;
+        MutableColumnPtr values = nullptr;
         if (type_desc.children[0].is_unknown_type()) {
             keys = create_column(TypeDescriptor{TYPE_NULL}, true, is_const, size);
         } else {
@@ -334,24 +334,24 @@ ColumnPtr ColumnHelper::create_column(const TypeDescriptor& type_desc, bool null
     } else if (type_desc.type == LogicalType::TYPE_STRUCT) {
         size_t field_size = type_desc.children.size();
         DCHECK_EQ(field_size, type_desc.field_names.size());
-        Columns columns;
+        MutableColumns columns;
         for (size_t i = 0; i < field_size; i++) {
-            ColumnPtr field_column = create_column(type_desc.children[i], true, is_const, size);
-            columns.emplace_back(field_column);
+            auto field_column = create_column(type_desc.children[i], true, is_const, size);
+            columns.emplace_back(std::move(field_column));
         }
-        p = StructColumn::create(columns, type_desc.field_names);
+        p = StructColumn::create(std::move(columns), type_desc.field_names);
     } else {
         p = type_dispatch_column(type_desc.type, ColumnBuilder(), type_desc, size);
     }
 
     if (is_const) {
-        return ConstColumn::create(p, size);
+        return ConstColumn::create(std::move(p), size);
     }
     if (nullable) {
         if (use_adaptive_nullable_column) {
-            return AdaptiveNullableColumn::create(p, NullColumn::create(size, DATUM_NULL));
+            return AdaptiveNullableColumn::create(std::move(p), NullColumn::create(size, DATUM_NULL));
         } else {
-            return NullableColumn::create(p, NullColumn::create(size, DATUM_NULL));
+            return NullableColumn::create(std::move(p), NullColumn::create(size, DATUM_NULL));
         }
     }
     return p;
@@ -411,7 +411,7 @@ size_t ColumnHelper::compute_bytes_size(ColumnsConstIterator const& begin, Colum
 }
 
 ColumnPtr ColumnHelper::convert_time_column_from_double_to_str(const ColumnPtr& column) {
-    auto get_binary_column = [](DoubleColumn* data_column, size_t size) -> ColumnPtr {
+    auto get_binary_column = [](const DoubleColumn* data_column, size_t size) -> MutableColumnPtr {
         auto new_data_column = BinaryColumn::create();
         new_data_column->reserve(size);
 
@@ -427,17 +427,18 @@ ColumnPtr ColumnHelper::convert_time_column_from_double_to_str(const ColumnPtr& 
     ColumnPtr res;
 
     if (column->only_null()) {
-        res = column;
+        res = std::move(column);
     } else if (column->is_nullable()) {
-        auto* nullable_column = down_cast<NullableColumn*>(column.get());
-        auto* data_column = down_cast<DoubleColumn*>(nullable_column->mutable_data_column());
-        res = NullableColumn::create(get_binary_column(data_column, column->size()), nullable_column->null_column());
+        auto* nullable_column = down_cast<const NullableColumn*>(column.get());
+        auto* data_column = down_cast<const DoubleColumn*>(nullable_column->data_column().get());
+        res = NullableColumn::create(get_binary_column(data_column, column->size()),
+                                     nullable_column->null_column()->as_mutable_ptr());
     } else if (column->is_constant()) {
-        auto* const_column = down_cast<ConstColumn*>(column.get());
+        auto* const_column = down_cast<const ConstColumn*>(column.get());
         std::string time_str = time_str_from_double(const_column->get(0).get_double());
         res = ColumnHelper::create_const_column<TYPE_VARCHAR>(time_str, column->size());
     } else {
-        auto* data_column = down_cast<DoubleColumn*>(column.get());
+        auto* data_column = down_cast<const DoubleColumn*>(column.get());
         res = get_binary_column(data_column, column->size());
     }
 
@@ -448,9 +449,9 @@ std::tuple<UInt32Column::Ptr, ColumnPtr, NullColumnPtr> ColumnHelper::unpack_arr
     DCHECK(!column->is_nullable() && !column->is_constant());
     DCHECK(column->is_array());
 
-    const ArrayColumn* array_column = down_cast<ArrayColumn*>(column.get());
-    auto elements_column = down_cast<NullableColumn*>(array_column->elements_column().get())->data_column();
-    auto null_column = down_cast<NullableColumn*>(array_column->elements_column().get())->null_column();
+    const ArrayColumn* array_column = down_cast<const ArrayColumn*>(column.get());
+    auto elements_column = down_cast<const NullableColumn*>(array_column->elements_column().get())->data_column();
+    auto null_column = down_cast<const NullableColumn*>(array_column->elements_column().get())->null_column();
     auto offsets_column = array_column->offsets_column();
     return {offsets_column, elements_column, null_column};
 }

--- a/be/src/column/column_viewer.cpp
+++ b/be/src/column/column_viewer.cpp
@@ -35,8 +35,9 @@ ColumnViewer<Type>::ColumnViewer(const ColumnPtr& column)
         : _not_const_mask(not_const_mask(column)), _null_mask(null_mask(column)) {
     if (column->only_null()) {
         _null_column = GlobalVariables::GetInstance()->one_size_null_column();
-        _column = RunTimeColumnType<Type>::create();
-        _column->append_default();
+        auto column = RunTimeColumnType<Type>::create();
+        column->append_default();
+        _column = std::move(column);
     } else if (column->is_constant()) {
         auto v = ColumnHelper::as_raw_column<ConstColumn>(column);
         _column = ColumnHelper::cast_to<Type>(v->data_column());

--- a/be/src/column/column_viewer.h
+++ b/be/src/column/column_viewer.h
@@ -40,6 +40,7 @@ template <LogicalType Type>
 class ColumnViewer {
 public:
     static auto constexpr TYPE = Type;
+
     explicit ColumnViewer(const ColumnPtr& column);
 
     const RunTimeCppType<Type> value(const size_t idx) const { return _data[idx & _not_const_mask]; }
@@ -59,9 +60,9 @@ private:
     NullColumnPtr _null_column;
 
     // raw pointer
-    RunTimeCppType<Type>* _data;
+    const RunTimeCppType<Type>* _data;
 
-    NullColumn::ValueType* _null_data;
+    const NullColumn::ValueType* _null_data;
 
     const size_t _not_const_mask;
     const size_t _null_mask;

--- a/be/src/column/const_column.cpp
+++ b/be/src/column/const_column.cpp
@@ -53,7 +53,7 @@ void ConstColumn::append_value_multiple_times(const Column& src, uint32_t index,
 }
 
 StatusOr<ColumnPtr> ConstColumn::replicate(const Buffer<uint32_t>& offsets) {
-    return ConstColumn::create(this->_data->clone_shared(), offsets.back());
+    return ConstColumn::create(this->_data->clone(), offsets.back());
 }
 
 void ConstColumn::fill_default(const Filter& filter) {

--- a/be/src/column/decimalv3_column.cpp
+++ b/be/src/column/decimalv3_column.cpp
@@ -58,11 +58,6 @@ int DecimalV3Column<T>::scale() const {
 }
 
 template <typename T>
-MutableColumnPtr DecimalV3Column<T>::clone_empty() const {
-    return this->create_mutable(_precision, _scale);
-}
-
-template <typename T>
 void DecimalV3Column<T>::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol) const {
     auto& data = this->get_data();
     auto s = DecimalV3Cast::to_string<T>(data[idx], _precision, _scale);

--- a/be/src/column/decimalv3_column.h
+++ b/be/src/column/decimalv3_column.h
@@ -24,7 +24,12 @@
 namespace starrocks {
 
 template <typename T>
-class DecimalV3Column final : public ColumnFactory<FixedLengthColumnBase<T>, DecimalV3Column<DecimalType<T>>, Column> {
+class DecimalV3Column final
+        : public CowFactory<ColumnFactory<FixedLengthColumnBase<T>, DecimalV3Column<DecimalType<T>>>,
+                            DecimalV3Column<DecimalType<T>>, Column> {
+    friend class CowFactory<ColumnFactory<FixedLengthColumnBase<T>, DecimalV3Column<DecimalType<T>>>,
+                            DecimalV3Column<DecimalType<T>>, Column>;
+
 public:
     DecimalV3Column() = default;
     explicit DecimalV3Column(size_t num_rows);
@@ -41,7 +46,7 @@ public:
     int precision() const;
     int scale() const;
 
-    MutableColumnPtr clone_empty() const override;
+    MutableColumnPtr clone_empty() const override { return this->create(_precision, _scale); }
 
     void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false) const override;
     std::string debug_item(size_t idx) const override;

--- a/be/src/column/field.cpp
+++ b/be/src/column/field.cpp
@@ -40,7 +40,7 @@ FieldPtr Field::convert_to(LogicalType to_type) const {
     return new_field;
 }
 
-ColumnPtr Field::create_column() const {
+MutableColumnPtr Field::create_column() const {
     return ChunkHelper::column_from_field(*this);
 }
 

--- a/be/src/column/field.h
+++ b/be/src/column/field.h
@@ -20,6 +20,7 @@
 #include <utility>
 #include <vector>
 
+#include "column/column.h"
 #include "column/vectorized_fwd.h"
 #include "storage/aggregate_type.h"
 #include "storage/olap_common.h"
@@ -188,7 +189,7 @@ public:
 
     bool has_sub_fields() const { return _sub_fields != nullptr; }
 
-    ColumnPtr create_column() const;
+    MutableColumnPtr create_column() const;
 
     void set_uid(ColumnUID uid) { _uid = uid; }
     const ColumnUID& uid() const { return _uid; }

--- a/be/src/column/fixed_length_column.h
+++ b/be/src/column/fixed_length_column.h
@@ -17,11 +17,16 @@
 #include "column/fixed_length_column_base.h"
 namespace starrocks {
 template <typename T>
-class FixedLengthColumn final : public ColumnFactory<FixedLengthColumnBase<T>, FixedLengthColumn<T>, Column> {
+class FixedLengthColumn final : public CowFactory<ColumnFactory<FixedLengthColumnBase<T>, FixedLengthColumn<T>>,
+                                                  FixedLengthColumn<T>, Column> {
+    friend class CowFactory<ColumnFactory<FixedLengthColumnBase<T>, FixedLengthColumn<T>>, FixedLengthColumn<T>,
+                            Column>;
+
 public:
     using ValueType = T;
     using Container = Buffer<ValueType>;
-    using SuperClass = ColumnFactory<FixedLengthColumnBase<T>, FixedLengthColumn<T>, Column>;
+    using SuperClass =
+            CowFactory<ColumnFactory<FixedLengthColumnBase<T>, FixedLengthColumn<T>>, FixedLengthColumn<T>, Column>;
     FixedLengthColumn() = default;
 
     explicit FixedLengthColumn(const size_t n) : SuperClass(n) {}
@@ -29,6 +34,6 @@ public:
     FixedLengthColumn(const size_t n, const ValueType x) : SuperClass(n, x) {}
 
     FixedLengthColumn(const FixedLengthColumn& src) : SuperClass((const FixedLengthColumnBase<T>&)(src)) {}
-    MutableColumnPtr clone_empty() const override { return this->create_mutable(); }
+    MutableColumnPtr clone_empty() const override { return this->create(); }
 };
 } // namespace starrocks

--- a/be/src/column/fixed_length_column_base.cpp
+++ b/be/src/column/fixed_length_column_base.cpp
@@ -128,13 +128,13 @@ int FixedLengthColumnBase<T>::compare_at(size_t left, size_t right, const Column
 }
 
 template <typename T>
-uint32_t FixedLengthColumnBase<T>::serialize(size_t idx, uint8_t* pos) {
+uint32_t FixedLengthColumnBase<T>::serialize(size_t idx, uint8_t* pos) const {
     memcpy(pos, &_data[idx], sizeof(T));
     return sizeof(T);
 }
 
 template <typename T>
-uint32_t FixedLengthColumnBase<T>::serialize_default(uint8_t* pos) {
+uint32_t FixedLengthColumnBase<T>::serialize_default(uint8_t* pos) const {
     ValueType value{};
     memcpy(pos, &value, sizeof(T));
     return sizeof(T);
@@ -142,9 +142,9 @@ uint32_t FixedLengthColumnBase<T>::serialize_default(uint8_t* pos) {
 
 template <typename T>
 void FixedLengthColumnBase<T>::serialize_batch(uint8_t* __restrict__ dst, Buffer<uint32_t>& slice_sizes,
-                                               size_t chunk_size, uint32_t max_one_row_size) {
+                                               size_t chunk_size, uint32_t max_one_row_size) const {
     uint32_t* sizes = slice_sizes.data();
-    T* __restrict__ src = _data.data();
+    const T* __restrict__ src = _data.data();
 
     for (size_t i = 0; i < chunk_size; ++i) {
         memcpy(dst + i * max_one_row_size + sizes[i], src + i, sizeof(T));
@@ -158,9 +158,9 @@ void FixedLengthColumnBase<T>::serialize_batch(uint8_t* __restrict__ dst, Buffer
 template <typename T>
 void FixedLengthColumnBase<T>::serialize_batch_with_null_masks(uint8_t* __restrict__ dst, Buffer<uint32_t>& slice_sizes,
                                                                size_t chunk_size, uint32_t max_one_row_size,
-                                                               uint8_t* null_masks, bool has_null) {
+                                                               const uint8_t* null_masks, bool has_null) const {
     uint32_t* sizes = slice_sizes.data();
-    T* __restrict__ src = _data.data();
+    const T* __restrict__ src = _data.data();
 
     if (!has_null) {
         for (size_t i = 0; i < chunk_size; ++i) {
@@ -187,7 +187,7 @@ void FixedLengthColumnBase<T>::serialize_batch_with_null_masks(uint8_t* __restri
 
 template <typename T>
 size_t FixedLengthColumnBase<T>::serialize_batch_at_interval(uint8_t* dst, size_t byte_offset, size_t byte_interval,
-                                                             size_t start, size_t count) {
+                                                             size_t start, size_t count) const {
     const size_t value_size = sizeof(T);
     const auto& key_data = get_data();
     uint8_t* buf = dst + byte_offset;

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -51,9 +51,7 @@ constexpr bool IsTemporal() {
 }
 
 template <typename T>
-class FixedLengthColumnBase : public ColumnFactory<Column, FixedLengthColumnBase<T>> {
-    friend class ColumnFactory<Column, FixedLengthColumnBase>;
-
+class FixedLengthColumnBase : public Column {
 public:
     using ValueType = T;
     using Container = Buffer<ValueType>;
@@ -172,28 +170,27 @@ public:
 
     bool has_large_column() const override { return false; }
 
-    uint32_t serialize(size_t idx, uint8_t* pos) override;
+    uint32_t serialize(size_t idx, uint8_t* pos) const override;
 
-    uint32_t serialize_default(uint8_t* pos) override;
+    uint32_t serialize_default(uint8_t* pos) const override;
 
     uint32_t max_one_element_serialize_size() const override { return sizeof(ValueType); }
 
     void serialize_batch(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
-                         uint32_t max_one_row_size) override;
+                         uint32_t max_one_row_size) const override;
 
     void serialize_batch_with_null_masks(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
-                                         uint32_t max_one_row_size, uint8_t* null_masks, bool has_null) override;
+                                         uint32_t max_one_row_size, const uint8_t* null_masks,
+                                         bool has_null) const override;
 
     size_t serialize_batch_at_interval(uint8_t* dst, size_t byte_offset, size_t byte_interval, size_t start,
-                                       size_t count) override;
+                                       size_t count) const override;
 
     const uint8_t* deserialize_and_append(const uint8_t* pos) override;
 
     void deserialize_and_append_batch(Buffer<Slice>& srcs, size_t chunk_size) override;
 
     uint32_t serialize_size(size_t idx) const override { return sizeof(ValueType); }
-
-    MutableColumnPtr clone_empty() const override { return this->create_mutable(); }
 
     size_t filter_range(const Filter& filter, size_t from, size_t to) override;
 

--- a/be/src/column/json_column.h
+++ b/be/src/column/json_column.h
@@ -29,10 +29,10 @@ namespace starrocks {
 // JsonColumn column for JSON type
 // format_version 1: store each JSON in binary encoding individually
 // format_version 2: TODO columnar encoding for JSON
-class JsonColumn final : public ColumnFactory<ObjectColumn<JsonValue>, JsonColumn, Column> {
+class JsonColumn final : public CowFactory<ColumnFactory<ObjectColumn<JsonValue>, JsonColumn>, JsonColumn, Column> {
 public:
     using ValueType = JsonValue;
-    using SuperClass = ColumnFactory<ObjectColumn<JsonValue>, JsonColumn, Column>;
+    using SuperClass = CowFactory<ColumnFactory<ObjectColumn<JsonValue>, JsonColumn>, JsonColumn, Column>;
     using BaseClass = JsonColumnBase;
 
     JsonColumn() = default;
@@ -46,8 +46,7 @@ public:
     }
 
     MutableColumnPtr clone() const override;
-    MutableColumnPtr clone_empty() const override;
-    ColumnPtr clone_shared() const override;
+    MutableColumnPtr clone_empty() const override { return this->create(); }
 
     void append_datum(const Datum& datum) override;
     void put_mysql_row_buffer(starrocks::MysqlRowBuffer* buf, size_t idx,
@@ -57,9 +56,9 @@ public:
 
     const uint8_t* deserialize_and_append(const uint8_t* pos) override;
     uint32_t serialize_size(size_t idx) const override;
-    uint32_t serialize(size_t idx, uint8_t* pos) override;
+    uint32_t serialize(size_t idx, uint8_t* pos) const override;
     void serialize_batch(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
-                         uint32_t max_one_row_size) override;
+                         uint32_t max_one_row_size) const override;
 
     // json column & flat column may used
     std::string debug_item(size_t idx) const override;
@@ -117,6 +116,13 @@ public:
 
     const Columns& get_flat_fields() const { return _flat_columns; };
 
+    Columns get_flat_fields_ptrs() const {
+        Columns columns;
+        columns.reserve(_flat_columns.size());
+        columns.assign(_flat_columns.begin(), _flat_columns.end());
+        return columns;
+    };
+
     ColumnPtr& get_flat_field(int index);
 
     const ColumnPtr& get_flat_field(int index) const;
@@ -139,6 +145,12 @@ public:
     bool is_equallity_schema(const Column* other) const;
 
     std::string debug_flat_paths() const;
+
+    void mutate_each_subcolumn() override {
+        for (auto& column : _flat_columns) {
+            column = (std::move(*column)).mutate();
+        }
+    }
 
 private:
     // flat-columns[sub_columns, remain_column]

--- a/be/src/column/map_column.h
+++ b/be/src/column/map_column.h
@@ -23,18 +23,19 @@
 
 namespace starrocks {
 
-class MapColumn final : public ColumnFactory<Column, MapColumn> {
-    friend class ColumnFactory<Column, MapColumn>;
+class MapColumn final : public CowFactory<ColumnFactory<Column, MapColumn>, MapColumn> {
+    friend class CowFactory<ColumnFactory<Column, MapColumn>, MapColumn>;
+    using Base = CowFactory<ColumnFactory<Column, MapColumn>, MapColumn>;
 
 public:
     using ValueType = void;
 
-    MapColumn(ColumnPtr keys, ColumnPtr values, UInt32Column::Ptr offsets);
+    MapColumn(MutableColumnPtr&& keys, MutableColumnPtr&& values, MutableColumnPtr&& offsets);
 
     MapColumn(const MapColumn& rhs)
-            : _keys(rhs._keys->clone_shared()),
-              _values(rhs._values->clone_shared()),
-              _offsets(std::static_pointer_cast<UInt32Column>(rhs._offsets->clone_shared())) {}
+            : _keys(rhs._keys->clone()),
+              _values(rhs._values->clone()),
+              _offsets(UInt32Column::static_pointer_cast(rhs._offsets->clone())) {}
 
     MapColumn(MapColumn&& rhs) noexcept
             : _keys(std::move(rhs._keys)), _values(std::move(rhs._values)), _offsets(std::move(rhs._offsets)) {}
@@ -51,6 +52,18 @@ public:
         return *this;
     }
 
+    static Ptr create(const ColumnPtr& keys, const ColumnPtr& values, const ColumnPtr& offsets) {
+        return MapColumn::create(keys->as_mutable_ptr(), values->as_mutable_ptr(), offsets->as_mutable_ptr());
+    }
+
+    static Ptr create(const MapColumn& rhs) { return Base::create(rhs); }
+
+    static Ptr create(MapColumn&& rhs) { return Base::create(std::move(rhs)); }
+
+    template <typename... Args>
+    requires(IsMutableColumns<Args...>::value) static MutablePtr create(Args&&... args) {
+        return Base::create(std::forward<Args>(args)...);
+    }
     ~MapColumn() override = default;
 
     bool is_map() const override { return true; }
@@ -102,12 +115,12 @@ public:
 
     uint32_t max_one_element_serialize_size() const override;
 
-    uint32_t serialize(size_t idx, uint8_t* pos) override;
+    uint32_t serialize(size_t idx, uint8_t* pos) const override;
 
-    uint32_t serialize_default(uint8_t* pos) override;
+    uint32_t serialize_default(uint8_t* pos) const override;
 
     void serialize_batch(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
-                         uint32_t max_one_row_size) override;
+                         uint32_t max_one_row_size) const override;
 
     const uint8_t* deserialize_and_append(const uint8_t* pos) override;
 
@@ -154,6 +167,7 @@ public:
     void reset_column() override;
 
     const UInt32Column& offsets() const { return *_offsets; }
+    const UInt32Column::Ptr& offsets_column() const { return _offsets; }
     UInt32Column::Ptr& offsets_column() { return _offsets; }
 
     bool is_nullable() const override { return false; }
@@ -177,12 +191,12 @@ public:
     void check_or_die() const override;
 
     const Column& keys() const { return *_keys; }
+    const ColumnPtr& keys_column() const { return _keys; }
     ColumnPtr& keys_column() { return _keys; }
-    ColumnPtr keys_column() const { return _keys; }
 
     const Column& values() const { return *_values; }
+    const ColumnPtr& values_column() const { return _values; }
     ColumnPtr& values_column() { return _values; }
-    ColumnPtr values_column() const { return _values; }
 
     size_t get_map_size(size_t idx) const;
     std::pair<size_t, size_t> get_map_offset_size(size_t idx) const;
@@ -190,6 +204,15 @@ public:
     Status unfold_const_children(const starrocks::TypeDescriptor& type) override;
 
     void remove_duplicated_keys(bool need_recursive = false);
+
+    void mutate_each_subcolumn() override {
+        // keys
+        _keys = (std::move(*_keys)).mutate();
+        // values
+        _values = (std::move(*_values)).mutate();
+        // offsets
+        _offsets = UInt32Column::static_pointer_cast((std::move(*_offsets)).mutate());
+    }
 
 private:
     // Keys must be NullableColumn to facilitate handling nested types.

--- a/be/src/column/object_column.cpp
+++ b/be/src/column/object_column.cpp
@@ -169,19 +169,19 @@ void ObjectColumn<T>::update_rows(const Column& src, const uint32_t* indexes) {
 }
 
 template <typename T>
-uint32_t ObjectColumn<T>::serialize(size_t idx, uint8_t* pos) {
+uint32_t ObjectColumn<T>::serialize(size_t idx, uint8_t* pos) const {
     return static_cast<uint32_t>(get_object(idx)->serialize(pos));
 }
 
 template <typename T>
-uint32_t ObjectColumn<T>::serialize_default(uint8_t* pos) {
+uint32_t ObjectColumn<T>::serialize_default(uint8_t* pos) const {
     DCHECK(false) << "Don't support object column serialize";
     return 0;
 }
 
 template <typename T>
 void ObjectColumn<T>::serialize_batch(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
-                                      uint32_t max_one_row_size) {
+                                      uint32_t max_one_row_size) const {
     for (size_t i = 0; i < chunk_size; ++i) {
         slice_sizes[i] += serialize(i, dst + i * max_one_row_size + slice_sizes[i]);
     }
@@ -300,13 +300,6 @@ void ObjectColumn<T>::_build_slices() const {
 
 template <typename T>
 MutableColumnPtr ObjectColumn<T>::clone() const {
-    auto p = clone_empty();
-    p->append(*this, 0, size());
-    return p;
-}
-
-template <typename T>
-ColumnPtr ObjectColumn<T>::clone_shared() const {
     auto p = clone_empty();
     p->append(*this, 0, size());
     return p;

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -29,8 +29,8 @@
 namespace starrocks {
 
 template <typename T>
-class ObjectColumn : public ColumnFactory<Column, ObjectColumn<T>> {
-    friend class ColumnFactory<Column, ObjectColumn>;
+class ObjectColumn : public CowFactory<ColumnFactory<Column, ObjectColumn<T>>, ObjectColumn<T>> {
+    friend class CowFactory<ColumnFactory<Column, ObjectColumn>, ObjectColumn>;
 
 public:
     using ValueType = T;
@@ -116,11 +116,11 @@ public:
 
     void update_rows(const Column& src, const uint32_t* indexes) override;
 
-    uint32_t serialize(size_t idx, uint8_t* pos) override;
-    uint32_t serialize_default(uint8_t* pos) override;
+    uint32_t serialize(size_t idx, uint8_t* pos) const override;
+    uint32_t serialize_default(uint8_t* pos) const override;
 
     void serialize_batch(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
-                         uint32_t max_one_row_size) override;
+                         uint32_t max_one_row_size) const override;
 
     const uint8_t* deserialize_and_append(const uint8_t* pos) override;
 
@@ -130,11 +130,9 @@ public:
 
     uint32_t serialize_size(size_t idx) const override;
 
-    MutableColumnPtr clone_empty() const override { return this->create_mutable(); }
+    MutableColumnPtr clone_empty() const override { return this->create(); }
 
     MutableColumnPtr clone() const override;
-
-    ColumnPtr clone_shared() const override;
 
     size_t filter_range(const Filter& filter, size_t from, size_t to) override;
 

--- a/be/src/column/stream_chunk.h
+++ b/be/src/column/stream_chunk.h
@@ -108,15 +108,15 @@ struct EpochInfo {
  */
 class StreamChunkConverter {
 public:
-    static StreamChunkPtr make_stream_chunk(ChunkPtr chunk, const Int8ColumnPtr& ops);
+    static StreamChunkPtr make_stream_chunk(ChunkPtr chunk, Int8Column::MutablePtr&& ops);
 
     static bool has_ops_column(const StreamChunk& chunk);
     static bool has_ops_column(const StreamChunkPtr& chunk_ptr);
     static bool has_ops_column(const StreamChunk* chunk_ptr);
 
-    static Int8Column* ops_col(const StreamChunk& stream_chunk);
-    static Int8Column* ops_col(const StreamChunkPtr& stream_chunk_ptr);
-    static Int8Column* ops_col(const StreamChunk* stream_chunk_ptr);
+    static const Int8Column* ops_col(const StreamChunk& stream_chunk);
+    static const Int8Column* ops_col(const StreamChunkPtr& stream_chunk_ptr);
+    static const Int8Column* ops_col(const StreamChunk* stream_chunk_ptr);
 
     static const StreamRowOp* ops(const StreamChunk& stream_chunk);
     static const StreamRowOp* ops(const StreamChunk* stream_chunk);

--- a/be/src/column/vectorized_fwd.h
+++ b/be/src/column/vectorized_fwd.h
@@ -64,11 +64,6 @@ class DecimalV3Column;
 template <typename T>
 class BinaryColumnBase;
 
-using ColumnPtr = std::shared_ptr<Column>;
-using MutableColumnPtr = std::unique_ptr<Column>;
-using Columns = std::vector<ColumnPtr>;
-using MutableColumns = std::vector<MutableColumnPtr>;
-
 using Int8Column = FixedLengthColumn<int8_t>;
 using UInt8Column = FixedLengthColumn<uint8_t>;
 using BooleanColumn = UInt8Column;

--- a/be/src/connector/binlog_connector.cpp
+++ b/be/src/connector/binlog_connector.cpp
@@ -298,7 +298,7 @@ Status BinlogDataSource::_mock_chunk_test(ChunkPtr* chunk) {
             VLOG_ROW << "Append col:" << idx << ", row:" << start;
             column->append(start % ndv_count);
         }
-        chunk_temp->append_column(column, SlotId(idx));
+        chunk_temp->append_column(std::move(column), SlotId(idx));
     }
 
     // ops

--- a/be/src/exec/aggregate/agg_hash_set.h
+++ b/be/src/exec/aggregate/agg_hash_set.h
@@ -157,8 +157,8 @@ struct AggHashSetOfOneNumberKey : public AggHashSet<HashSet, AggHashSetOfOneNumb
     template <bool compute_and_allocate>
     ALWAYS_NOINLINE void build_set_noprefetch(size_t chunk_size, const Columns& key_columns, MemPool* pool,
                                               Filter* not_founds) {
-        auto* column = down_cast<ColumnType*>(key_columns[0].get());
-        auto& keys = column->get_data();
+        const auto* column = down_cast<const ColumnType*>(key_columns[0].get());
+        const auto& keys = column->get_data();
 
         for (size_t i = 0; i < chunk_size; ++i) {
             if constexpr (compute_and_allocate) {
@@ -172,8 +172,8 @@ struct AggHashSetOfOneNumberKey : public AggHashSet<HashSet, AggHashSetOfOneNumb
     template <bool compute_and_allocate>
     ALWAYS_NOINLINE void build_set_prefetch(size_t chunk_size, const Columns& key_columns, MemPool* pool,
                                             Filter* not_founds) {
-        auto* column = down_cast<ColumnType*>(key_columns[0].get());
-        auto& keys = column->get_data();
+        const auto* column = down_cast<const ColumnType*>(key_columns[0].get());
+        const auto& keys = column->get_data();
 
         AGG_HASH_SET_PRECOMPUTE_HASH_VALS();
         for (size_t i = 0; i < chunk_size; ++i) {
@@ -186,7 +186,7 @@ struct AggHashSetOfOneNumberKey : public AggHashSet<HashSet, AggHashSetOfOneNumb
         }
     }
 
-    void insert_keys_to_columns(const ResultVector& keys, const Columns& key_columns, size_t chunk_size) {
+    void insert_keys_to_columns(const ResultVector& keys, Columns& key_columns, size_t chunk_size) {
         auto* column = down_cast<ColumnType*>(key_columns[0].get());
         column->get_data().insert(column->get_data().end(), keys.begin(), keys.begin() + chunk_size);
     }
@@ -242,10 +242,10 @@ struct AggHashSetOfOneNullableNumberKey
     template <bool compute_and_allocate>
     ALWAYS_NOINLINE void build_set_noprefetch(size_t chunk_size, const Columns& key_columns, MemPool* pool,
                                               Filter* not_founds) {
-        auto* nullable_column = down_cast<NullableColumn*>(key_columns[0].get());
-        auto* data_column = down_cast<ColumnType*>(nullable_column->data_column().get());
+        const auto* nullable_column = down_cast<const NullableColumn*>(key_columns[0].get());
+        const auto* data_column = down_cast<const ColumnType*>(nullable_column->data_column().get());
         const auto& null_data = nullable_column->null_column_data();
-        auto& keys = data_column->get_data();
+        const auto& keys = data_column->get_data();
 
         if (nullable_column->has_null()) {
             for (size_t i = 0; i < chunk_size; ++i) {
@@ -273,9 +273,9 @@ struct AggHashSetOfOneNullableNumberKey
     template <bool compute_and_allocate>
     ALWAYS_NOINLINE void build_set_prefetch(size_t chunk_size, const Columns& key_columns, MemPool* pool,
                                             Filter* not_founds) {
-        auto* nullable_column = down_cast<NullableColumn*>(key_columns[0].get());
-        auto* data_column = down_cast<ColumnType*>(nullable_column->data_column().get());
-        auto& keys = data_column->get_data();
+        const auto* nullable_column = down_cast<const NullableColumn*>(key_columns[0].get());
+        const auto* data_column = down_cast<const ColumnType*>(nullable_column->data_column().get());
+        const auto& keys = data_column->get_data();
 
         AGG_HASH_SET_PRECOMPUTE_HASH_VALS();
         for (size_t i = 0; i < chunk_size; ++i) {
@@ -288,7 +288,7 @@ struct AggHashSetOfOneNullableNumberKey
         }
     }
 
-    void insert_keys_to_columns(ResultVector& keys, const Columns& key_columns, size_t chunk_size) {
+    void insert_keys_to_columns(ResultVector& keys, Columns& key_columns, size_t chunk_size) {
         auto* nullable_column = down_cast<NullableColumn*>(key_columns[0].get());
         auto* column = down_cast<ColumnType*>(nullable_column->mutable_data_column());
         column->get_data().insert(column->get_data().end(), keys.begin(), keys.begin() + chunk_size);
@@ -333,7 +333,7 @@ struct AggHashSetOfOneStringKey : public AggHashSet<HashSet, AggHashSetOfOneStri
     template <bool compute_and_allocate>
     ALWAYS_NOINLINE void build_set_noprefetch(size_t chunk_size, const Columns& key_columns, MemPool* pool,
                                               Filter* not_founds) {
-        auto* column = down_cast<BinaryColumn*>(key_columns[0].get());
+        auto* column = down_cast<const BinaryColumn*>(key_columns[0].get());
         for (size_t i = 0; i < chunk_size; ++i) {
             auto tmp = column->get_slice(i);
             if constexpr (compute_and_allocate) {
@@ -353,7 +353,7 @@ struct AggHashSetOfOneStringKey : public AggHashSet<HashSet, AggHashSetOfOneStri
     template <bool compute_and_allocate>
     ALWAYS_NOINLINE void build_set_prefetch(size_t chunk_size, const Columns& key_columns, MemPool* pool,
                                             Filter* not_founds) {
-        auto* column = down_cast<BinaryColumn*>(key_columns[0].get());
+        const auto* column = down_cast<const BinaryColumn*>(key_columns[0].get());
         cache.reserve(chunk_size);
         for (size_t i = 0; i < chunk_size; ++i) {
             cache[i] = KeyType(column->get_slice(i));
@@ -375,7 +375,7 @@ struct AggHashSetOfOneStringKey : public AggHashSet<HashSet, AggHashSetOfOneStri
         }
     }
 
-    void insert_keys_to_columns(ResultVector& keys, const Columns& key_columns, size_t chunk_size) {
+    void insert_keys_to_columns(ResultVector& keys, Columns& key_columns, size_t chunk_size) {
         auto* column = down_cast<BinaryColumn*>(key_columns[0].get());
         keys.resize(chunk_size);
         column->append_strings(keys.data(), keys.size());
@@ -421,8 +421,8 @@ struct AggHashSetOfOneNullableStringKey : public AggHashSet<HashSet, AggHashSetO
     template <bool compute_and_allocate>
     ALWAYS_NOINLINE void build_set_noprefetch(size_t chunk_size, const Columns& key_columns, MemPool* pool,
                                               Filter* not_founds) {
-        auto* nullable_column = down_cast<NullableColumn*>(key_columns[0].get());
-        auto* data_column = down_cast<BinaryColumn*>(nullable_column->data_column().get());
+        const auto* nullable_column = down_cast<const NullableColumn*>(key_columns[0].get());
+        const auto* data_column = down_cast<const BinaryColumn*>(nullable_column->data_column().get());
         const auto& null_data = nullable_column->null_column_data();
 
         if (nullable_column->has_null()) {
@@ -451,8 +451,8 @@ struct AggHashSetOfOneNullableStringKey : public AggHashSet<HashSet, AggHashSetO
     template <bool compute_and_allocate>
     ALWAYS_NOINLINE void build_set_prefetch(size_t chunk_size, const Columns& key_columns, MemPool* pool,
                                             Filter* not_founds) {
-        auto* nullable_column = down_cast<NullableColumn*>(key_columns[0].get());
-        auto* data_column = down_cast<BinaryColumn*>(nullable_column->data_column().get());
+        const auto* nullable_column = down_cast<const NullableColumn*>(key_columns[0].get());
+        const auto* data_column = down_cast<const BinaryColumn*>(nullable_column->data_column().get());
 
         cache.reserve(chunk_size);
         for (size_t i = 0; i < chunk_size; ++i) {
@@ -473,8 +473,8 @@ struct AggHashSetOfOneNullableStringKey : public AggHashSet<HashSet, AggHashSetO
         }
     }
 
-    void _handle_data_key_column(BinaryColumn* data_column, size_t row, MemPool* pool, Filter* not_founds) {
-        auto tmp = data_column->get_slice(row);
+    void _handle_data_key_column(const BinaryColumn* data_column, size_t row, MemPool* pool, Filter* not_founds) {
+        const auto tmp = data_column->get_slice(row);
         KeyType key(tmp);
 
         this->hash_set.lazy_emplace(key, [&](const auto& ctor) {
@@ -484,12 +484,12 @@ struct AggHashSetOfOneNullableStringKey : public AggHashSet<HashSet, AggHashSetO
         });
     }
 
-    void _handle_data_key_column(BinaryColumn* data_column, size_t row, Filter* not_founds) {
-        auto key = data_column->get_slice(row);
+    void _handle_data_key_column(const BinaryColumn* data_column, size_t row, Filter* not_founds) {
+        const auto key = data_column->get_slice(row);
         (*not_founds)[row] = !this->hash_set.contains(key);
     }
 
-    void insert_keys_to_columns(ResultVector& keys, const Columns& key_columns, size_t chunk_size) {
+    void insert_keys_to_columns(ResultVector& keys, Columns& key_columns, size_t chunk_size) {
         DCHECK(key_columns[0]->is_nullable());
         auto* nullable_column = down_cast<NullableColumn*>(key_columns[0].get());
         auto* column = down_cast<BinaryColumn*>(nullable_column->mutable_data_column());
@@ -599,7 +599,7 @@ struct AggHashSetOfSerializedKey : public AggHashSet<HashSet, AggHashSetOfSerial
         return max_size;
     }
 
-    void insert_keys_to_columns(ResultVector& keys, const Columns& key_columns, int32_t chunk_size) {
+    void insert_keys_to_columns(ResultVector& keys, Columns& key_columns, int32_t chunk_size) {
         // When GroupBy has multiple columns, the memory is serialized by row.
         // If the length of a row is relatively long and there are multiple columns,
         // deserialization by column will cause the memory locality to deteriorate,
@@ -607,14 +607,14 @@ struct AggHashSetOfSerializedKey : public AggHashSet<HashSet, AggHashSetOfSerial
         if (keys.size() > 0 && keys[0].size > 64) {
             // deserialize by row
             for (size_t i = 0; i < chunk_size; i++) {
-                for (const auto& key_column : key_columns) {
+                for (auto& key_column : key_columns) {
                     keys[i].data =
                             (char*)(key_column->deserialize_and_append(reinterpret_cast<const uint8_t*>(keys[i].data)));
                 }
             }
         } else {
             // deserialize by column
-            for (const auto& key_column : key_columns) {
+            for (auto& key_column : key_columns) {
                 key_column->deserialize_and_append_batch(keys, chunk_size);
             }
         }
@@ -717,7 +717,7 @@ struct AggHashSetOfSerializedKeyFixedSize : public AggHashSet<HashSet, AggHashSe
         }
     }
 
-    void insert_keys_to_columns(ResultVector& keys, const Columns& key_columns, int32_t chunk_size) {
+    void insert_keys_to_columns(ResultVector& keys, Columns& key_columns, int32_t chunk_size) {
         DCHECK(fixed_byte_size != -1);
         tmp_slices.reserve(chunk_size);
 
@@ -736,7 +736,7 @@ struct AggHashSetOfSerializedKeyFixedSize : public AggHashSet<HashSet, AggHashSe
         }
 
         // deserialize by column
-        for (const auto& key_column : key_columns) {
+        for (auto& key_column : key_columns) {
             key_column->deserialize_and_append_batch(tmp_slices, chunk_size);
         }
     }

--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -879,7 +879,7 @@ Status Aggregator::compute_batch_agg_states_with_selection(Chunk* chunk, size_t 
 
 Status Aggregator::_evaluate_const_columns(int i) {
     // used for const columns.
-    std::vector<ColumnPtr> const_columns;
+    Columns const_columns;
     const_columns.reserve(_agg_expr_ctxs[i].size());
     for (auto& j : _agg_expr_ctxs[i]) {
         ASSIGN_OR_RETURN(auto col, j->root()->evaluate_const(j));
@@ -1145,14 +1145,14 @@ Columns Aggregator::_create_group_by_columns(size_t num_rows) {
     return group_by_columns;
 }
 
-void Aggregator::_serialize_to_chunk(ConstAggDataPtr __restrict state, const Columns& agg_result_columns) {
+void Aggregator::_serialize_to_chunk(ConstAggDataPtr __restrict state, Columns& agg_result_columns) {
     for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
         _agg_functions[i]->serialize_to_column(_agg_fn_ctxs[i], state + _agg_states_offsets[i],
                                                agg_result_columns[i].get());
     }
 }
 
-void Aggregator::_finalize_to_chunk(ConstAggDataPtr __restrict state, const Columns& agg_result_columns) {
+void Aggregator::_finalize_to_chunk(ConstAggDataPtr __restrict state, Columns& agg_result_columns) {
     for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
         _agg_functions[i]->finalize_to_column(_agg_fn_ctxs[i], state + _agg_states_offsets[i],
                                               agg_result_columns[i].get());

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -472,7 +472,7 @@ protected:
     // The expr used to evaluate agg input columns
     // one agg function could have multi input exprs
     std::vector<std::vector<ExprContext*>> _agg_expr_ctxs;
-    std::vector<std::vector<ColumnPtr>> _agg_input_columns;
+    std::vector<Columns> _agg_input_columns;
     //raw pointers in order to get multi-column values
     std::vector<std::vector<const Column*>> _agg_input_raw_columns;
     // The expr used to evaluate agg intermediate columns.
@@ -565,8 +565,8 @@ protected:
     Columns _create_agg_result_columns(size_t num_rows, bool use_intermediate);
     Columns _create_group_by_columns(size_t num_rows);
 
-    void _serialize_to_chunk(ConstAggDataPtr __restrict state, const Columns& agg_result_columns);
-    void _finalize_to_chunk(ConstAggDataPtr __restrict state, const Columns& agg_result_columns);
+    void _serialize_to_chunk(ConstAggDataPtr __restrict state, Columns& agg_result_columns);
+    void _finalize_to_chunk(ConstAggDataPtr __restrict state, Columns& agg_result_columns);
     void _destroy_state(AggDataPtr __restrict state);
 
     ChunkPtr _build_output_chunk(const Columns& group_by_columns, const Columns& agg_result_columns,

--- a/be/src/exec/analytor.cpp
+++ b/be/src/exec/analytor.cpp
@@ -506,7 +506,7 @@ Status Analytor::_evaluate_const_columns(int i) {
         // Only agg fn has this context.
         return Status::OK();
     }
-    std::vector<ColumnPtr> const_columns;
+    Columns const_columns;
     const_columns.reserve(_agg_expr_ctxs[i].size());
     for (auto& j : _agg_expr_ctxs[i]) {
         ASSIGN_OR_RETURN(auto col, j->root()->evaluate_const(j));

--- a/be/src/exec/analytor.h
+++ b/be/src/exec/analytor.h
@@ -289,7 +289,7 @@ private:
     std::vector<const AggregateFunction*> _agg_functions;
     std::vector<ManagedFunctionStatesPtr<Analytor>> _managed_fn_states;
     std::vector<std::vector<ExprContext*>> _agg_expr_ctxs;
-    std::vector<std::vector<ColumnPtr>> _agg_intput_columns;
+    std::vector<Columns> _agg_intput_columns;
     std::vector<FunctionTypes> _agg_fn_types;
 
     std::vector<ExprContext*> _partition_ctxs;

--- a/be/src/exec/assert_num_rows_node.cpp
+++ b/be/src/exec/assert_num_rows_node.cpp
@@ -77,7 +77,7 @@ Status AssertNumRowsNode::open(RuntimeState* state) {
             for (const auto& slot : desc->slots()) {
                 auto column = ColumnHelper::create_column(slot->type(), true);
                 column->append_nulls(_desired_num_rows);
-                chunk->append_column(column, slot->id());
+                chunk->append_column(std::move(column), slot->id());
             }
         }
 

--- a/be/src/exec/avro_scanner.cpp
+++ b/be/src/exec/avro_scanner.cpp
@@ -193,7 +193,7 @@ Status AvroScanner::_create_src_chunk(ChunkPtr* chunk) {
             continue;
         }
         auto column = ColumnHelper::create_column(_avro_types[column_pos], true, false, 0, true);
-        (*chunk)->append_column(column, slot_desc->id());
+        (*chunk)->append_column(std::move(column), slot_desc->id());
     }
 
     return Status::OK();

--- a/be/src/exec/chunks_sorter.h
+++ b/be/src/exec/chunks_sorter.h
@@ -191,7 +191,7 @@ struct SortRuntimeFilterBuilder {
         }
 
         auto data_column = ColumnHelper::get_data_column(column.get());
-        auto runtime_data_column = down_cast<RunTimeColumnType<ltype>*>(data_column);
+        auto runtime_data_column = down_cast<const RunTimeColumnType<ltype>*>(data_column);
         auto data = runtime_data_column->get_data()[rid];
         if (asc) {
             return MinMaxRuntimeFilter<ltype>::template create_with_range<false>(pool, data, is_close_interval,
@@ -226,8 +226,8 @@ struct SortRuntimeFilterUpdater {
             }
         }
 
-        auto data_column = ColumnHelper::get_data_column(column.get());
-        auto runtime_data_column = down_cast<RunTimeColumnType<ltype>*>(data_column);
+        const auto* data_column = ColumnHelper::get_data_column(column.get());
+        const auto* runtime_data_column = down_cast<const RunTimeColumnType<ltype>*>(data_column);
         auto data = GetContainer<ltype>::get_data(runtime_data_column)[rid];
         if (asc) {
             down_cast<MinMaxRuntimeFilter<ltype>*>(filter)->template update_min_max<false>(data);

--- a/be/src/exec/chunks_sorter_full_sort.cpp
+++ b/be/src/exec/chunks_sorter_full_sort.cpp
@@ -185,7 +185,7 @@ void ChunksSorterFullSort::_assign_ordinals_tmpl() {
         for (T offset = 0; offset < num_rows; ++offset) {
             ordinal_data[offset] = static_cast<T>((chunk_idx << _offset_in_chunk_bits) | offset);
         }
-        partial_sort_chunk->append_column(ordinal_column, Chunk::SORT_ORDINAL_COLUMN_SLOT_ID);
+        partial_sort_chunk->append_column(std::move(ordinal_column), Chunk::SORT_ORDINAL_COLUMN_SLOT_ID);
         ++chunk_idx;
     }
 }

--- a/be/src/exec/chunks_sorter_heap_sort.cpp
+++ b/be/src/exec/chunks_sorter_heap_sort.cpp
@@ -217,12 +217,12 @@ void ChunksSorterHeapSort::_do_filter_data_for_type(detail::ChunkHolder* chunk_h
         }
     } else if (top_cursor_column->is_nullable()) {
         bool top_is_null = top_cursor_column->is_null(cursor_rid);
-        const auto& need_filter_data =
-                ColumnHelper::cast_to_raw<TYPE>(down_cast<NullableColumn*>(top_cursor_column.get())->data_column())
-                        ->get_data()[cursor_rid];
+        const auto& need_filter_data = ColumnHelper::cast_to_raw<TYPE>(
+                                               down_cast<const NullableColumn*>(top_cursor_column.get())->data_column())
+                                               ->get_data()[cursor_rid];
 
-        const auto& order_by_null_column = down_cast<NullableColumn*>(input_column.get())->null_column();
-        const auto& order_by_data_column = down_cast<NullableColumn*>(input_column.get())->data_column();
+        const auto& order_by_null_column = down_cast<const NullableColumn*>(input_column.get())->null_column();
+        const auto& order_by_data_column = down_cast<const NullableColumn*>(input_column.get())->data_column();
 
         const auto* null_data = order_by_null_column->get_data().data();
         const auto* order_by_data = ColumnHelper::cast_to_raw<TYPE>(order_by_data_column)->get_data().data();

--- a/be/src/exec/cross_join_node.cpp
+++ b/be/src/exec/cross_join_node.cpp
@@ -557,7 +557,7 @@ void CrossJoinNode::_init_chunk(ChunkPtr* chunk) {
     for (size_t i = 0; i < _build_column_count; ++i) {
         SlotDescriptor* slot = _col_types[_probe_column_count + i];
         ColumnPtr& src_col = _build_chunk->get_column_by_slot_id(slot->id());
-        ColumnPtr new_col = ColumnHelper::create_column(slot->type(), src_col->is_nullable());
+        MutableColumnPtr new_col = ColumnHelper::create_column(slot->type(), src_col->is_nullable());
         new_chunk->append_column(std::move(new_col), slot->id());
     }
 

--- a/be/src/exec/dict_decode_node.cpp
+++ b/be/src/exec/dict_decode_node.cpp
@@ -148,7 +148,7 @@ Status DictDecodeNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos)
 
     Columns decode_columns(_encode_column_cids.size());
     for (size_t i = 0; i < _encode_column_cids.size(); i++) {
-        const ColumnPtr& encode_column = (*chunk)->get_column_by_slot_id(_encode_column_cids[i]);
+        ColumnPtr& encode_column = (*chunk)->get_column_by_slot_id(_encode_column_cids[i]);
         TypeDescriptor desc;
         desc.type = TYPE_VARCHAR;
 

--- a/be/src/exec/es/es_predicate.h
+++ b/be/src/exec/es/es_predicate.h
@@ -39,6 +39,7 @@
 #include <vector>
 
 #include "cctz/time_zone.h"
+#include "column/column.h"
 #include "column/vectorized_fwd.h"
 #include "gen_cpp/Exprs_types.h"
 #include "gen_cpp/Opcodes_types.h"

--- a/be/src/exec/es/es_scroll_parser.cpp
+++ b/be/src/exec/es/es_scroll_parser.cpp
@@ -182,7 +182,7 @@ Status ScrollParser::fill_chunk(RuntimeState* state, ChunkPtr* chunk, bool* line
 
     // init column information
     for (auto& slot_desc : slot_descs) {
-        ColumnPtr column = ColumnHelper::create_column(slot_desc->type(), slot_desc->is_nullable());
+        MutableColumnPtr column = ColumnHelper::create_column(slot_desc->type(), slot_desc->is_nullable());
         column->reserve(fill_sz);
         (*chunk)->append_column(std::move(column), slot_desc->id());
     }

--- a/be/src/exec/except_hash_set.cpp
+++ b/be/src/exec/except_hash_set.cpp
@@ -92,7 +92,7 @@ Status ExceptHashSet<HashSet>::erase_duplicate_row(RuntimeState* state, const Ch
 }
 
 template <typename HashSet>
-void ExceptHashSet<HashSet>::deserialize_to_columns(KeyVector& keys, const Columns& key_columns, size_t chunk_size) {
+void ExceptHashSet<HashSet>::deserialize_to_columns(KeyVector& keys, Columns& key_columns, size_t chunk_size) {
     for (auto& key_column : key_columns) {
         DCHECK(!key_column->is_constant());
         // Because the serialized key is always nullable,

--- a/be/src/exec/except_hash_set.h
+++ b/be/src/exec/except_hash_set.h
@@ -84,7 +84,7 @@ public:
     Status erase_duplicate_row(RuntimeState* state, const ChunkPtr& chunk, const std::vector<ExprContext*>& exprs,
                                BufferState* buffer_state);
 
-    void deserialize_to_columns(KeyVector& keys, const Columns& key_columns, size_t chunk_size);
+    void deserialize_to_columns(KeyVector& keys, Columns& key_columns, size_t chunk_size);
 
     int64_t mem_usage(BufferState* buffer_state);
 

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -298,8 +298,8 @@ Status ExecNode::get_next_big_chunk(RuntimeState* state, ChunkPtr* chunk, bool* 
                     return Status::OK();
                 } else {
                     // TODO: copy the small chunk to big chunk
-                    Columns& dest_columns = pre_output_chunk->columns();
-                    Columns& src_columns = cur_chunk->columns();
+                    auto& dest_columns = pre_output_chunk->columns();
+                    auto& src_columns = cur_chunk->columns();
                     size_t num_rows = cur_size;
                     // copy the new read chunk to the reserved
                     for (size_t i = 0; i < dest_columns.size(); i++) {

--- a/be/src/exec/hash_join_components.cpp
+++ b/be/src/exec/hash_join_components.cpp
@@ -207,7 +207,7 @@ Status PartitionedHashJoinProberImpl::push_probe_chunk(RuntimeState* state, Chun
     size_t num_partitions = probers.size();
     size_t num_partition_cols = partition_keys.size();
 
-    std::vector<ColumnPtr> partition_columns(num_partition_cols);
+    Columns partition_columns(num_partition_cols);
     for (size_t i = 0; i < num_partition_cols; ++i) {
         ASSIGN_OR_RETURN(partition_columns[i], partition_keys[i]->evaluate(chunk.get()));
     }
@@ -642,7 +642,7 @@ Status AdaptivePartitionHashJoinBuilder::_append_chunk_to_partitions(const Chunk
     size_t num_partitions = _builders.size();
     size_t num_partition_cols = build_partition_keys.size();
 
-    std::vector<ColumnPtr> partition_columns(num_partition_cols);
+    Columns partition_columns(num_partition_cols);
     for (size_t i = 0; i < num_partition_cols; ++i) {
         ASSIGN_OR_RETURN(partition_columns[i], build_partition_keys[i]->evaluate(chunk.get()));
     }

--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -575,7 +575,7 @@ Status HashJoiner::_create_runtime_bloom_filters(RuntimeState* state, int64_t li
         int expr_order = rf_desc->build_expr_order();
         bool eq_null = _is_null_safes[expr_order];
         bool is_empty = false;
-        std::vector<ColumnPtr> columns;
+        Columns columns;
 
         for (auto* ht : hash_tables) {
             ColumnPtr column = ht->get_key_columns()[expr_order];

--- a/be/src/exec/hash_joiner.h
+++ b/be/src/exec/hash_joiner.h
@@ -351,9 +351,9 @@ private:
         for (auto& expr_ctx : expr_ctxs) {
             ASSIGN_OR_RETURN(auto column_ptr, expr_ctx->evaluate(chunk.get()));
             if (column_ptr->only_null()) {
-                ColumnPtr column = ColumnHelper::create_column(expr_ctx->root()->type(), true);
+                MutableColumnPtr column = ColumnHelper::create_column(expr_ctx->root()->type(), true);
                 column->append_nulls(chunk->num_rows());
-                key_columns.emplace_back(column);
+                key_columns.emplace_back(std::move(column));
             } else if (column_ptr->is_constant()) {
                 auto* const_column = ColumnHelper::as_raw_column<ConstColumn>(column_ptr);
                 const_column->data_column()->assign(chunk->num_rows(), 0);

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -98,7 +98,7 @@ Status HdfsScanner::init(RuntimeState* runtime_state, const HdfsScannerParams& s
 
 Status HdfsScanner::_build_scanner_context() {
     HdfsScannerContext& ctx = _scanner_ctx;
-    std::vector<ColumnPtr>& partition_values = ctx.partition_values;
+    Columns& partition_values = ctx.partition_values;
 
     // evaluate partition values.
     for (size_t i = 0; i < _scanner_params.partition_slots.size(); i++) {
@@ -110,7 +110,7 @@ Status HdfsScanner::_build_scanner_context() {
     }
 
     // evaluate extended column values
-    std::vector<ColumnPtr>& extended_values = ctx.extended_values;
+    Columns& extended_values = ctx.extended_values;
     for (size_t i = 0; i < _scanner_params.extended_col_slots.size(); i++) {
         int extended_col_idx = _scanner_params.index_in_extended_columns[i];
         ASSIGN_OR_RETURN(auto extended_value_column,
@@ -625,7 +625,7 @@ void HdfsScannerContext::append_or_update_extended_column_to_chunk(ChunkPtr* chu
 
 void HdfsScannerContext::append_or_update_column_to_chunk(ChunkPtr* chunk, size_t row_count,
                                                           const std::vector<ColumnInfo>& columns,
-                                                          const std::vector<ColumnPtr>& values) {
+                                                          const Columns& values) {
     if (columns.size() == 0) return;
 
     ChunkPtr& ck = (*chunk);

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -278,12 +278,12 @@ struct HdfsScannerContext {
     std::vector<ColumnInfo> partition_columns;
 
     // partition column value which read from hdfs file path
-    std::vector<ColumnPtr> partition_values;
+    Columns partition_values;
 
     // extended column
     std::vector<ColumnInfo> extended_columns;
 
-    std::vector<ColumnPtr> extended_values;
+    Columns extended_values;
 
     // scan range
     const THdfsScanRange* scan_range = nullptr;
@@ -350,7 +350,7 @@ struct HdfsScannerContext {
 
     void append_or_update_extended_column_to_chunk(ChunkPtr* chunk, size_t row_count);
     void append_or_update_column_to_chunk(ChunkPtr* chunk, size_t row_count, const std::vector<ColumnInfo>& columns,
-                                          const std::vector<ColumnPtr>& values);
+                                          const Columns& values);
 
     // if we can skip this file by evaluating conjuncts of non-existed columns with default value.
     StatusOr<bool> should_skip_by_evaluating_not_existed_slots();

--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -613,7 +613,7 @@ StatusOr<size_t> HdfsOrcScanner::_do_get_next(ChunkPtr* chunk) {
         orc::RowReader::ReadPosition position;
         size_t read_num_values = 0;
         bool has_used_dict_filter = false;
-        ColumnPtr row_delete_filter = BooleanColumn::create();
+        MutableColumnPtr row_delete_filter = BooleanColumn::create();
         {
             SCOPED_RAW_TIMER(&_app_stats.column_read_ns);
             RETURN_IF_ERROR(_orc_reader->read_next(&position));
@@ -672,7 +672,7 @@ StatusOr<size_t> HdfsOrcScanner::_do_get_next(ChunkPtr* chunk) {
             }
 
             if (rows_read != 0) {
-                ColumnHelper::merge_two_filters(row_delete_filter, &_chunk_filter, nullptr);
+                ColumnHelper::merge_two_filters(std::move(row_delete_filter), &_chunk_filter, nullptr);
                 rows_read = SIMD::count_nonzero(_chunk_filter);
                 if (rows_read == 0) {
                     // If rows_read = 0, we need to set chunk size = 0 and bypass filter chunk directly

--- a/be/src/exec/hdfs_scanner_partition.cpp
+++ b/be/src/exec/hdfs_scanner_partition.cpp
@@ -25,9 +25,9 @@ Status HdfsPartitionScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* 
     _output = true;
     (*chunk) = std::make_shared<Chunk>();
     for (const SlotDescriptor* slot : _scanner_params.materialize_slots) {
-        ColumnPtr column = ColumnHelper::create_column(slot->type(), slot->is_nullable());
+        MutableColumnPtr column = ColumnHelper::create_column(slot->type(), slot->is_nullable());
         column->append_default(1);
-        (*chunk)->append_column(column, slot->id());
+        (*chunk)->append_column(std::move(column), slot->id());
     }
     _scanner_ctx.append_or_update_partition_column_to_chunk(chunk, 1);
     return Status::OK();

--- a/be/src/exec/intersect_hash_set.cpp
+++ b/be/src/exec/intersect_hash_set.cpp
@@ -83,8 +83,8 @@ Status IntersectHashSet<HashSet>::refine_intersect_row(RuntimeState* state, cons
 }
 
 template <typename HashSet>
-void IntersectHashSet<HashSet>::deserialize_to_columns(KeyVector& keys, const Columns& key_columns, size_t chunk_size) {
-    for (const auto& key_column : key_columns) {
+void IntersectHashSet<HashSet>::deserialize_to_columns(KeyVector& keys, Columns& key_columns, size_t chunk_size) {
+    for (auto& key_column : key_columns) {
         // Because the serialized key is always nullable,
         // drop the null byte of the key if the dest column is non-nullable.
         if (!key_column->is_nullable()) {

--- a/be/src/exec/intersect_hash_set.h
+++ b/be/src/exec/intersect_hash_set.h
@@ -70,7 +70,7 @@ public:
     Status refine_intersect_row(RuntimeState* state, const ChunkPtr& chunkPtr, const std::vector<ExprContext*>& exprs,
                                 int hit_times);
 
-    void deserialize_to_columns(KeyVector& keys, const Columns& key_columns, size_t chunk_size);
+    void deserialize_to_columns(KeyVector& keys, Columns& key_columns, size_t chunk_size);
 
     int64_t mem_usage() const;
 

--- a/be/src/exec/json_scanner.cpp
+++ b/be/src/exec/json_scanner.cpp
@@ -262,7 +262,7 @@ Status JsonScanner::_create_src_chunk(ChunkPtr* chunk) {
 
         // The columns in source chunk are all in AdaptiveNullableColumn type;
         auto col = ColumnHelper::create_column(_json_types[column_pos], true, false, 0, true);
-        (*chunk)->append_column(col, slot_desc->id());
+        (*chunk)->append_column(std::move(col), slot_desc->id());
     }
 
     return Status::OK();
@@ -315,7 +315,7 @@ StatusOr<ChunkPtr> JsonScanner::_cast_chunk(const starrocks::ChunkPtr& src_chunk
         }
 
         ASSIGN_OR_RETURN(ColumnPtr col, _cast_exprs[column_pos]->evaluate_checked(nullptr, src_chunk.get()));
-        col = ColumnHelper::unfold_const_column(slot->type(), src_chunk->num_rows(), col);
+        col = ColumnHelper::unfold_const_column(slot->type(), src_chunk->num_rows(), std::move(col));
         cast_chunk->append_column(std::move(col), slot->id());
     }
 

--- a/be/src/exec/parquet_scanner.cpp
+++ b/be/src/exec/parquet_scanner.cpp
@@ -317,8 +317,8 @@ Status ParquetScanner::new_column(const arrow::DataType* arrow_type, const SlotD
 }
 
 Status ParquetScanner::convert_array_to_column(ConvertFuncTree* conv_func, size_t num_elements,
-                                               const arrow::Array* array, const ColumnPtr& column,
-                                               size_t batch_start_idx, size_t chunk_start_idx, Filter* chunk_filter,
+                                               const arrow::Array* array, ColumnPtr& column, size_t batch_start_idx,
+                                               size_t chunk_start_idx, Filter* chunk_filter,
                                                ArrowConvertContext* conv_ctx) {
     // for timestamp type, state->timezone which is specified by user. convert function
     // obtains timezone from array. thus timezone in array should be rectified to

--- a/be/src/exec/parquet_scanner.h
+++ b/be/src/exec/parquet_scanner.h
@@ -51,7 +51,7 @@ public:
     void close() override;
 
     static Status convert_array_to_column(ConvertFuncTree* func, size_t num_elements, const arrow::Array* array,
-                                          const ColumnPtr& column, size_t batch_start_idx, size_t column_start_idx,
+                                          ColumnPtr& column, size_t batch_start_idx, size_t column_start_idx,
                                           Filter* chunk_filter, ArrowConvertContext* conv_ctx);
 
     static Status new_column(const arrow::DataType* arrow_type, const SlotDescriptor* slot_desc, ColumnPtr* column,

--- a/be/src/exec/pipeline/assert_num_rows_operator.cpp
+++ b/be/src/exec/pipeline/assert_num_rows_operator.cpp
@@ -28,9 +28,9 @@ Status AssertNumRowsOperator::prepare(RuntimeState* state) {
 
     for (const auto& desc : _factory->row_desc()->tuple_descriptors()) {
         for (const auto& slot : desc->slots()) {
-            ColumnPtr column = ColumnHelper::create_column(slot->type(), true);
+            MutableColumnPtr column = ColumnHelper::create_column(slot->type(), true);
             column->append_nulls(1);
-            chunk->append_column(column, slot->id());
+            chunk->append_column(std::move(column), slot->id());
         }
     }
 

--- a/be/src/exec/pipeline/exchange/local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange.cpp
@@ -291,7 +291,7 @@ Status KeyPartitionExchanger::accept(const ChunkPtr& chunk, const int32_t sink_d
         return Status::OK();
     }
 
-    std::vector<ColumnPtr> partition_columns;
+    Columns partition_columns;
     for (size_t i = 0; i < _partition_expr_ctxs.size(); i++) {
         ASSIGN_OR_RETURN(auto partition_column, _partition_expr_ctxs[i]->evaluate(chunk.get()));
         partition_columns.push_back(std::move(partition_column));

--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
@@ -261,8 +261,8 @@ ChunkPtr NLJoinProbeOperator::_init_output_chunk(size_t chunk_size) const {
         if (_probe_chunk) {
             nullable |= _probe_chunk->is_column_nullable(slot->id());
         }
-        ColumnPtr new_col = ColumnHelper::create_column(slot->type(), nullable);
-        chunk->append_column(new_col, slot->id());
+        MutableColumnPtr new_col = ColumnHelper::create_column(slot->type(), nullable);
+        chunk->append_column(std::move(new_col), slot->id());
     }
     for (size_t i = _probe_column_count; i < _col_types.size(); i++) {
         SlotDescriptor* slot = _col_types[i];
@@ -270,8 +270,8 @@ ChunkPtr NLJoinProbeOperator::_init_output_chunk(size_t chunk_size) const {
         if (_curr_build_chunk) {
             nullable |= _curr_build_chunk->is_column_nullable(slot->id());
         }
-        ColumnPtr new_col = ColumnHelper::create_column(slot->type(), nullable);
-        chunk->append_column(new_col, slot->id());
+        MutableColumnPtr new_col = ColumnHelper::create_column(slot->type(), nullable);
+        chunk->append_column(std::move(new_col), slot->id());
     }
 
     chunk->reserve(chunk_size);

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.cpp
@@ -76,8 +76,8 @@ ChunkPtr NLJoinProber::_init_output_chunk(RuntimeState* state, const ChunkPtr& b
         if (!is_probe && build_chunk) {
             nullable |= build_chunk->get_column_by_slot_id(slot->id())->is_nullable();
         }
-        ColumnPtr new_col = ColumnHelper::create_column(slot->type(), nullable);
-        chunk->append_column(new_col, slot->id());
+        MutableColumnPtr new_col = ColumnHelper::create_column(slot->type(), nullable);
+        chunk->append_column(std::move(new_col), slot->id());
     }
 
     chunk->reserve(state->chunk_size());

--- a/be/src/exec/pipeline/project_operator.cpp
+++ b/be/src/exec/pipeline/project_operator.cpp
@@ -65,7 +65,7 @@ Status ProjectOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
             } else if (result_columns[i]->is_constant()) {
                 // Note: we must create a new column every time here,
                 // because result_columns[i] is shared_ptr
-                ColumnPtr new_column = ColumnHelper::create_column(_expr_ctxs[i]->root()->type(), false);
+                MutableColumnPtr new_column = ColumnHelper::create_column(_expr_ctxs[i]->root()->type(), false);
                 auto* const_column = down_cast<ConstColumn*>(result_columns[i].get());
                 new_column->append(*const_column->data_column(), 0, 1);
                 new_column->assign(chunk->num_rows(), 0);

--- a/be/src/exec/pipeline/runtime_filter_types.h
+++ b/be/src/exec/pipeline/runtime_filter_types.h
@@ -50,7 +50,7 @@ struct RuntimeBloomFilterBuildParam;
 using OptRuntimeBloomFilterBuildParams = std::vector<std::optional<RuntimeBloomFilterBuildParam>>;
 // Parameters used to build runtime bloom-filters.
 struct RuntimeBloomFilterBuildParam {
-    RuntimeBloomFilterBuildParam(bool multi_partitioned, bool eq_null, bool is_empty, std::vector<ColumnPtr> columns,
+    RuntimeBloomFilterBuildParam(bool multi_partitioned, bool eq_null, bool is_empty, Columns columns,
                                  MutableRuntimeFilterPtr runtime_filter)
             : multi_partitioned(multi_partitioned),
               eq_null(eq_null),
@@ -60,7 +60,7 @@ struct RuntimeBloomFilterBuildParam {
     bool multi_partitioned;
     bool eq_null;
     bool is_empty;
-    std::vector<ColumnPtr> columns;
+    Columns columns;
     MutableRuntimeFilterPtr runtime_filter;
 };
 

--- a/be/src/exec/pipeline/scan/schema_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/schema_chunk_source.cpp
@@ -116,7 +116,7 @@ Status SchemaChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
         DCHECK(dest_slot_descs[i]->is_materialized());
         int j = _index_map[i];
         SlotDescriptor* src_slot = src_slot_descs[j];
-        ColumnPtr column = ColumnHelper::create_column(src_slot->type(), src_slot->is_nullable());
+        MutableColumnPtr column = ColumnHelper::create_column(src_slot->type(), src_slot->is_nullable());
         column->reserve(state->chunk_size());
         chunk_src->append_column(std::move(column), src_slot->id());
     }
@@ -127,7 +127,7 @@ Status SchemaChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
     }
 
     for (auto dest_slot_desc : dest_slot_descs) {
-        ColumnPtr column = ColumnHelper::create_column(dest_slot_desc->type(), dest_slot_desc->is_nullable());
+        MutableColumnPtr column = ColumnHelper::create_column(dest_slot_desc->type(), dest_slot_desc->is_nullable());
         chunk_dst->append_column(std::move(column), dest_slot_desc->id());
     }
 

--- a/be/src/exec/pipeline/select_operator.cpp
+++ b/be/src/exec/pipeline/select_operator.cpp
@@ -64,8 +64,8 @@ StatusOr<ChunkPtr> SelectOperator::pull_chunk(RuntimeState* state) {
                 _pre_output_chunk = std::move(_curr_chunk);
                 return output_chunk;
             } else {
-                Columns& dest_columns = _pre_output_chunk->columns();
-                Columns& src_columns = _curr_chunk->columns();
+                auto& dest_columns = _pre_output_chunk->columns();
+                auto& src_columns = _curr_chunk->columns();
                 size_t num_rows = cur_size;
                 // copy the new read chunk to the reserved
                 for (size_t i = 0; i < dest_columns.size(); i++) {

--- a/be/src/exec/pipeline/set/union_const_source_operator.cpp
+++ b/be/src/exec/pipeline/set/union_const_source_operator.cpp
@@ -29,7 +29,7 @@ StatusOr<ChunkPtr> UnionConstSourceOperator::pull_chunk(starrocks::RuntimeState*
     for (size_t col_i = 0; col_i < columns_count; col_i++) {
         const auto* dst_slot = _dst_slots[col_i];
 
-        ColumnPtr dst_column = ColumnHelper::create_column(dst_slot->type(), dst_slot->is_nullable());
+        MutableColumnPtr dst_column = ColumnHelper::create_column(dst_slot->type(), dst_slot->is_nullable());
         dst_column->reserve(rows_count);
 
         for (size_t row_i = 0; row_i < rows_count; row_i++) {

--- a/be/src/exec/pipeline/sort/local_partition_topn_context.h
+++ b/be/src/exec/pipeline/sort/local_partition_topn_context.h
@@ -54,7 +54,7 @@ struct PreAggState {
     std::vector<FunctionContext*> _agg_fn_ctxs;
     std::vector<const AggregateFunction*> _agg_functions;
     std::vector<std::vector<ExprContext*>> _agg_expr_ctxs;
-    std::vector<std::vector<ColumnPtr>> _agg_input_columns;
+    std::vector<Columns> _agg_input_columns;
     //raw pointers in order to get multi-column values
     std::vector<std::vector<const Column*>> _agg_input_raw_columns;
     std::vector<FunctionTypes> _agg_fn_types;
@@ -154,7 +154,7 @@ private:
     // std::vector<FunctionContext*> _agg_fn_ctxs;
     // std::vector<const AggregateFunction*> _agg_functions;
     // std::vector<std::vector<ExprContext*>> _agg_expr_ctxs;
-    // std::vector<std::vector<ColumnPtr>> _agg_input_columns;
+    // std::vector<Columns> _agg_input_columns;
     // //raw pointers in order to get multi-column values
     // std::vector<std::vector<const Column*>> _agg_input_raw_columns;
     // std::vector<FunctionTypes> _agg_fn_types;

--- a/be/src/exec/pipeline/table_function_operator.cpp
+++ b/be/src/exec/pipeline/table_function_operator.cpp
@@ -111,7 +111,7 @@ Status TableFunctionOperator::prepare(RuntimeState* state) {
 StatusOr<ChunkPtr> TableFunctionOperator::pull_chunk(RuntimeState* state) {
     DCHECK(_input_chunk != nullptr);
     size_t max_chunk_size = state->chunk_size();
-    std::vector<ColumnPtr> output_columns;
+    Columns output_columns;
 
     if (_table_function_result.second == nullptr) {
         RETURN_IF_ERROR(_process_table_function(state));
@@ -158,7 +158,7 @@ Status TableFunctionOperator::push_chunk(RuntimeState* state, const ChunkPtr& ch
     return Status::OK();
 }
 
-ChunkPtr TableFunctionOperator::_build_chunk(const std::vector<ColumnPtr>& columns) {
+ChunkPtr TableFunctionOperator::_build_chunk(const Columns& columns) {
     ChunkPtr chunk = std::make_shared<Chunk>();
 
     for (size_t i = 0; i < _outer_slots.size(); ++i) {
@@ -199,7 +199,7 @@ Status TableFunctionOperator::reset_state(RuntimeState* state, const std::vector
     return Status::OK();
 }
 
-void TableFunctionOperator::_copy_result(const std::vector<ColumnPtr>& columns, uint32_t max_output_size) {
+void TableFunctionOperator::_copy_result(Columns& columns, uint32_t max_output_size) {
     DCHECK_LE(_next_output_row, _table_function_result.first[0]->size());
     DCHECK_LT(_next_output_row_offset, _table_function_result.second->size());
     uint32_t curr_output_size = columns[0]->size();

--- a/be/src/exec/pipeline/table_function_operator.h
+++ b/be/src/exec/pipeline/table_function_operator.h
@@ -49,9 +49,9 @@ public:
     Status reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) override;
 
 private:
-    ChunkPtr _build_chunk(const std::vector<ColumnPtr>& output_columns);
+    ChunkPtr _build_chunk(const Columns& output_columns);
     Status _process_table_function(RuntimeState* state);
-    void _copy_result(const std::vector<ColumnPtr>& columns, uint32_t max_column_size);
+    void _copy_result(Columns& columns, uint32_t max_column_size);
 
     const TPlanNode& _tnode;
     const TableFunction* _table_function = nullptr;

--- a/be/src/exec/repeat_node.cpp
+++ b/be/src/exec/repeat_node.cpp
@@ -49,7 +49,7 @@ RepeatNode::RepeatNode(ObjectPool* pool, const TPlanNode& tnode, const Descripto
 
     // initial for _grouping_columns;
     for (auto& group : _grouping_list) {
-        std::vector<ColumnPtr> columns;
+        Columns columns;
         columns.reserve(group.size());
         for (auto slot_id : group) {
             columns.push_back(generate_repeat_column(slot_id, config::vector_chunk_size));

--- a/be/src/exec/repeat_node.h
+++ b/be/src/exec/repeat_node.h
@@ -39,13 +39,13 @@ private:
     static ColumnPtr generate_null_column(int64_t num_rows) {
         auto nullable_column = NullableColumn::create(Int8Column::create(), NullColumn::create());
         nullable_column->append_nulls(1);
-        return ConstColumn::create(nullable_column, num_rows);
+        return ConstColumn::create(std::move(nullable_column), num_rows);
     }
 
     static ColumnPtr generate_repeat_column(int64_t value, int64_t num_rows) {
         auto ptr = RunTimeColumnType<TYPE_BIGINT>::create();
         ptr->append_datum(Datum(value));
-        return ConstColumn::create(ptr, num_rows);
+        return ConstColumn::create(std::move(ptr), num_rows);
     }
 
     void extend_and_update_columns(ChunkPtr* curr_chunk, ChunkPtr* chunk);
@@ -72,7 +72,7 @@ private:
 
     // column for grouping_id and virtual columns for grouping()/grouping_id() for reusing.
     // It has chunk_size rows.
-    std::vector<std::vector<ColumnPtr>> _grouping_columns;
+    std::vector<Columns> _grouping_columns;
 
     // _grouping_list for gourping_id'value and grouping()/grouping_id()'s value.
     // It's a two dimensional array.

--- a/be/src/exec/schema_scan_node.cpp
+++ b/be/src/exec/schema_scan_node.cpp
@@ -211,7 +211,7 @@ Status SchemaScanNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos)
         DCHECK(dest_slot_descs[i]->is_materialized());
         int j = _index_map[i];
         SlotDescriptor* src_slot = src_slot_descs[j];
-        ColumnPtr column = ColumnHelper::create_column(src_slot->type(), src_slot->is_nullable());
+        MutableColumnPtr column = ColumnHelper::create_column(src_slot->type(), src_slot->is_nullable());
         column->reserve(state->chunk_size());
         chunk_src->append_column(std::move(column), src_slot->id());
     }
@@ -223,7 +223,7 @@ Status SchemaScanNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos)
     }
 
     for (auto dest_slot_desc : dest_slot_descs) {
-        ColumnPtr column = ColumnHelper::create_column(dest_slot_desc->type(), dest_slot_desc->is_nullable());
+        MutableColumnPtr column = ColumnHelper::create_column(dest_slot_desc->type(), dest_slot_desc->is_nullable());
         chunk_dst->append_column(std::move(column), dest_slot_desc->id());
     }
 

--- a/be/src/exec/schema_scanner/schema_be_datacache_metrics_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_datacache_metrics_scanner.cpp
@@ -117,7 +117,7 @@ Status SchemaBeDataCacheMetricsScanner::get_next(ChunkPtr* chunk, bool* eos) {
     }
 
     for (const auto& [slot_id, index] : (*chunk)->get_slot_id_to_index_map()) {
-        const ColumnPtr& column = (*chunk)->get_column_by_slot_id(slot_id);
+        ColumnPtr& column = (*chunk)->get_column_by_slot_id(slot_id);
         column->append_datum(row[slot_id - 1]);
     }
 

--- a/be/src/exec/sorted_streaming_aggregator.cpp
+++ b/be/src/exec/sorted_streaming_aggregator.cpp
@@ -47,7 +47,7 @@ public:
               _null_masks(null_masks) {}
 
     Status do_visit(const NullableColumn& column) {
-        ColumnPtr ptr = down_cast<NullableColumn*>(_first_column.get())->data_column();
+        const ColumnPtr ptr = down_cast<const NullableColumn*>(_first_column.get())->data_column();
         ColumnSelfComparator comparator(ptr, _cmp_vector, column.immutable_null_column_data());
         RETURN_IF_ERROR(column.data_column()->accept(&comparator));
 

--- a/be/src/exec/sorting/compare_column.cpp
+++ b/be/src/exec/sorting/compare_column.cpp
@@ -278,7 +278,7 @@ public:
     template <typename T>
     Status do_visit(const BinaryColumnBase<T>& column) {
         auto& data = column.get_proxy_data();
-        NullData* null_data = nullptr;
+        const NullData* null_data = nullptr;
         if (_nullable_column != nullptr) {
             null_data = &_nullable_column->get_data();
         }
@@ -293,7 +293,7 @@ public:
     template <typename T>
     Status do_visit(const FixedLengthColumnBase<T>& column) {
         auto& data = column.get_data();
-        NullData* null_data = nullptr;
+        const NullData* null_data = nullptr;
         if (_nullable_column != nullptr) {
             null_data = &_nullable_column->get_data();
         }

--- a/be/src/exec/sorting/merge_path.cpp
+++ b/be/src/exec/sorting/merge_path.cpp
@@ -625,7 +625,7 @@ void detail::LeafNode::process_input(const int32_t parallel_idx) {
 ChunkPtr detail::LeafNode::_generate_ordinal(const size_t chunk_id, const size_t num_rows) {
     static TypeDescriptor s_type_desc = TypeDescriptor(TYPE_BIGINT);
     static Chunk::SlotHashMap s_slot_map = {{0, 0}};
-    ColumnPtr ordinal_column = ColumnHelper::create_column(s_type_desc, false);
+    MutableColumnPtr ordinal_column = ColumnHelper::create_column(s_type_desc, false);
     ordinal_column->resize(num_rows);
     auto* raw_array = down_cast<Int64Column*>(ordinal_column.get())->get_data().data();
 

--- a/be/src/exec/sorting/sort_helper.h
+++ b/be/src/exec/sorting/sort_helper.h
@@ -96,8 +96,7 @@ struct SorterComparator<T> {
 
 // TODO: reduce duplicate code
 template <class NullPred>
-static inline Status sort_and_tie_helper_nullable_vertical(const std::atomic<bool>& cancel,
-                                                           const std::vector<ColumnPtr>& data_columns,
+static inline Status sort_and_tie_helper_nullable_vertical(const std::atomic<bool>& cancel, const Columns& data_columns,
                                                            NullPred null_pred, const SortDesc& sort_desc,
                                                            Permutation& permutation, Tie& tie,
                                                            std::pair<int, int> range, bool build_tie, size_t limit,

--- a/be/src/exec/sorting/sorting.h
+++ b/be/src/exec/sorting/sorting.h
@@ -53,7 +53,7 @@ Status sort_and_tie_columns(const std::atomic<bool>& cancel, const Columns& colu
 ///     key_column0 = ([1,1], [2,2], [3, 3], [4,4]),
 ///     key_column1 = ([1,2], [3,4], null, [5,6])
 ///     so, src_offsets = (0, 0, 2, 4, 6), offsets_per_key = ((0, 0, 2, 4, 6, 8), (0, 2, 4, 4, 6))
-Status sort_and_tie_columns(const std::atomic<bool>& cancel, const std::vector<Column*>& columns,
+Status sort_and_tie_columns(const std::atomic<bool>& cancel, const std::vector<const Column*>& columns,
                             const SortDescs& sort_desc, SmallPermutation& perm,
                             const std::span<const uint32_t> src_offsets,
                             const std::vector<std::span<const uint32_t>>& offsets_per_key);
@@ -63,9 +63,9 @@ Status stable_sort_and_tie_columns(const std::atomic<bool>& cancel, const Column
                                    SmallPermutation* permutation);
 
 // Sort multiple columns in vertical
-Status sort_vertical_columns(const std::atomic<bool>& cancel, const std::vector<ColumnPtr>& columns,
-                             const SortDesc& sort_desc, Permutation& permutation, Tie& tie, std::pair<int, int> range,
-                             const bool build_tie, const size_t limit = 0, size_t* limited = nullptr);
+Status sort_vertical_columns(const std::atomic<bool>& cancel, const Columns& columns, const SortDesc& sort_desc,
+                             Permutation& permutation, Tie& tie, std::pair<int, int> range, const bool build_tie,
+                             const size_t limit = 0, size_t* limited = nullptr);
 
 // Sort multiple chunks in column-wise style
 Status sort_vertical_chunks(const std::atomic<bool>& cancel, const std::vector<Columns>& vertical_chunks,

--- a/be/src/exec/stream/aggregate/agg_group_state.h
+++ b/be/src/exec/stream/aggregate/agg_group_state.h
@@ -36,7 +36,7 @@ public:
     Status open(RuntimeState* state);
 
     Status process_chunk(size_t chunk_size, const Columns& group_by_columns, const Buffer<uint8_t>& keys_not_in_map,
-                         const StreamRowOp* ops, const std::vector<std::vector<ColumnPtr>>& agg_columns,
+                         const StreamRowOp* ops, const std::vector<Columns>& agg_columns,
                          std::vector<std::vector<const Column*>>& raw_columns,
                          const Buffer<AggDataPtr>& agg_group_state) const;
 

--- a/be/src/exec/stream/aggregate/agg_state_data.cpp
+++ b/be/src/exec/stream/aggregate/agg_state_data.cpp
@@ -96,7 +96,7 @@ Status AggStateData::output_result(size_t chunk_size, const Columns& group_by_co
                                    Column* to) const {
     if (detail_state_table && is_detail_agg_state()) {
         DCHECK(detail_state_table);
-        UInt8Column::Ptr is_sync_col = UInt8Column::create();
+        UInt8Column::MutablePtr is_sync_col = UInt8Column::create();
         for (size_t i = 0; i < chunk_size; i++) {
             _agg_function->output_is_sync(_agg_fn_ctx, chunk_size, is_sync_col.get(),
                                           agg_group_data[i] + _agg_state_offset);
@@ -137,7 +137,7 @@ Status AggStateData::output_result(size_t chunk_size, const Columns& group_by_co
     return Status::OK();
 }
 
-Status AggStateData::output_detail(size_t chunk_size, const Buffer<AggDataPtr>& agg_group_data, const Columns& to,
+Status AggStateData::output_detail(size_t chunk_size, const Buffer<AggDataPtr>& agg_group_data, Columns& to,
                                    Column* count) const {
     for (size_t i = 0; i < chunk_size; i++) {
         _agg_function->output_detail(_agg_fn_ctx, agg_group_data[i] + _agg_state_offset, to, count);

--- a/be/src/exec/stream/aggregate/agg_state_data.h
+++ b/be/src/exec/stream/aggregate/agg_state_data.h
@@ -69,7 +69,7 @@ public:
     Status output_result(size_t chunk_size, const Columns& group_by_columns, const Buffer<AggDataPtr>& agg_group_data,
                          const StateTable* detail_state_table, Column* to) const;
 
-    Status output_detail(size_t chunk_size, const Buffer<AggDataPtr>& agg_group_state, const Columns& to,
+    Status output_detail(size_t chunk_size, const Buffer<AggDataPtr>& agg_group_state, Columns& to,
                          Column* count) const;
 
     const AggregateFunction* agg_function() const { return _agg_function; }

--- a/be/src/exec/stream/aggregate/stream_aggregator.cpp
+++ b/be/src/exec/stream/aggregate/stream_aggregator.cpp
@@ -245,7 +245,7 @@ Status StreamAggregator::_output_result_changes_with_retract(size_t chunk_size, 
     DCHECK_LE(_agg_functions.size(), prev_result->num_columns());
 
     // 3. generate result chunks
-    Int8ColumnPtr ops = Int8Column::create();
+    Int8Column::MutablePtr ops = Int8Column::create();
     ChunkPtr result_chunk = final_result_chunk->clone_empty();
     size_t j = 0;
     for (size_t i = 0; i < chunk_size; i++) {
@@ -271,7 +271,7 @@ Status StreamAggregator::_output_result_changes_with_retract(size_t chunk_size, 
         }
     }
     DCHECK_EQ(prev_result->num_rows(), j);
-    *result_chunk_with_ops = StreamChunkConverter::make_stream_chunk(result_chunk, ops);
+    *result_chunk_with_ops = StreamChunkConverter::make_stream_chunk(result_chunk, std::move(ops));
     return Status::OK();
 }
 
@@ -283,7 +283,7 @@ Status StreamAggregator::_output_result_changes_without_retract(size_t chunk_siz
             _agg_group_state->output_results(chunk_size, group_by_columns, _tmp_agg_states, agg_result_columns));
 
     // op col
-    Int8ColumnPtr ops = Int8Column::create();
+    Int8Column::MutablePtr ops = Int8Column::create();
     ops->append_value_multiple_times(&INSERT_OP, chunk_size);
 
     auto final_result_chunk = _build_output_chunk(group_by_columns, agg_result_columns, false);

--- a/be/src/exec/table_function_node.cpp
+++ b/be/src/exec/table_function_node.cpp
@@ -108,7 +108,7 @@ Status TableFunctionNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* e
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     int chunk_size = runtime_state()->chunk_size();
     int reserve_chunk_size = chunk_size;
-    std::vector<ColumnPtr> output_columns;
+    Columns output_columns;
 
     if (reached_limit()) {
         *eos = true;
@@ -230,7 +230,7 @@ void TableFunctionNode::close(RuntimeState* state) {
     ExecNode::close(state);
 }
 
-Status TableFunctionNode::build_chunk(ChunkPtr* chunk, const std::vector<ColumnPtr>& output_columns) {
+Status TableFunctionNode::build_chunk(ChunkPtr* chunk, const Columns& output_columns) {
     *chunk = std::make_shared<Chunk>();
 
     for (int outer_idx = 0; outer_idx < _outer_slots.size(); ++outer_idx) {

--- a/be/src/exec/table_function_node.h
+++ b/be/src/exec/table_function_node.h
@@ -36,7 +36,7 @@ public:
     Status reset(RuntimeState* state) override;
     void close(RuntimeState* state) override;
 
-    Status build_chunk(ChunkPtr* chunk, const std::vector<ColumnPtr>& output_columns);
+    Status build_chunk(ChunkPtr* chunk, const Columns& output_columns);
 
     Status get_next_input_chunk(RuntimeState* state, bool* eos);
 

--- a/be/src/exec/tablet_info.h
+++ b/be/src/exec/tablet_info.h
@@ -222,8 +222,8 @@ private:
         bool is_l_null = lc->is_null(l_idx);
         bool is_r_null = rc->is_null(r_idx);
         if (!is_l_null && !is_r_null) {
-            Column* ldc = ColumnHelper::get_data_column(lc.get());
-            Column* rdc = ColumnHelper::get_data_column(rc.get());
+            const Column* ldc = ColumnHelper::get_data_column(lc.get());
+            const Column* rdc = ColumnHelper::get_data_column(rc.get());
             return ldc->compare_at(l_idx, r_idx, *rdc, -1);
         } else {
             if (is_l_null && is_r_null) {

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -788,8 +788,8 @@ Status OlapTableSink::_fill_auto_increment_id_internal(Chunk* chunk, SlotDescrip
         return Status::OK();
     }
 
-    ColumnPtr& data_col = std::dynamic_pointer_cast<NullableColumn>(col)->data_column();
-    Filter filter(std::dynamic_pointer_cast<NullableColumn>(col)->immutable_null_column_data());
+    ColumnPtr& data_col = NullableColumn::dynamic_pointer_cast(col)->data_column();
+    Filter filter(NullableColumn::dynamic_pointer_cast(col)->immutable_null_column_data());
 
     Filter init_filter(chunk->num_rows(), 0);
 
@@ -817,7 +817,7 @@ Status OlapTableSink::_fill_auto_increment_id_internal(Chunk* chunk, SlotDescrip
     // Here we just set 0 value in this case.
     uint32 del_rows = SIMD::count_nonzero(init_filter);
     if (del_rows != 0) {
-        RETURN_IF_ERROR((std::dynamic_pointer_cast<Int64Column>(data_col))
+        RETURN_IF_ERROR((Int64Column::dynamic_pointer_cast(data_col))
                                 ->fill_range(std::vector<int64_t>(del_rows, 0), init_filter));
     }
 
@@ -837,7 +837,7 @@ Status OlapTableSink::_fill_auto_increment_id_internal(Chunk* chunk, SlotDescrip
             // it will be allocate in DeltaWriter.
             ids.assign(null_rows, 0);
         }
-        RETURN_IF_ERROR((std::dynamic_pointer_cast<Int64Column>(data_col))->fill_range(ids, filter));
+        RETURN_IF_ERROR((Int64Column::dynamic_pointer_cast(data_col))->fill_range(ids, filter));
         break;
     }
     default:
@@ -974,7 +974,7 @@ void OlapTableSink::_validate_data(RuntimeState* state, Chunk* chunk) {
     size_t num_rows = chunk->num_rows();
     for (int i = 0; i < _output_tuple_desc->slots().size(); ++i) {
         SlotDescriptor* desc = _output_tuple_desc->slots()[i];
-        const ColumnPtr& column_ptr = chunk->get_column_by_slot_id(desc->id());
+        ColumnPtr& column_ptr = chunk->get_column_by_slot_id(desc->id());
 
         // change validation selection value back to OK/FAILED
         // because in previous run, some validation selection value could
@@ -1015,7 +1015,8 @@ void OlapTableSink::_validate_data(RuntimeState* state, Chunk* chunk) {
         // Validate column nullable info
         // Column nullable info need to respect slot nullable info
         if (desc->is_nullable() && !column_ptr->is_nullable()) {
-            ColumnPtr new_column = NullableColumn::create(column_ptr, NullColumn::create(num_rows, 0));
+            MutableColumnPtr new_column =
+                    NullableColumn::create(std::move(column_ptr)->as_mutable_ptr(), NullColumn::create(num_rows, 0));
             chunk->update_column(std::move(new_column), desc->id());
             // Auto increment column is not nullable but use NullableColumn to implement. We should skip the check for it.
         } else if (!desc->is_nullable() && column_ptr->is_nullable() &&
@@ -1163,10 +1164,11 @@ void OlapTableSink::_padding_char_column(Chunk* chunk) {
 
             if (desc->is_nullable()) {
                 auto* nullable_column = down_cast<NullableColumn*>(column);
-                ColumnPtr new_column = NullableColumn::create(new_binary, nullable_column->null_column());
-                chunk->update_column(new_column, desc->id());
+                MutableColumnPtr new_column =
+                        NullableColumn::create(std::move(new_binary), nullable_column->null_column()->as_mutable_ptr());
+                chunk->update_column(std::move(new_column), desc->id());
             } else {
-                chunk->update_column(new_binary, desc->id());
+                chunk->update_column(std::move(new_binary), desc->id());
             }
         }
     }

--- a/be/src/exprs/agg/aggregate.h
+++ b/be/src/exprs/agg/aggregate.h
@@ -331,7 +331,7 @@ public:
     //  columns[0] is the aggregate function column(`k`);
     //  columns[1] is the count column(`v`);
     // Column `count` is output to indicate how many detail rows each key has.
-    virtual void output_detail(FunctionContext* ctx, ConstAggDataPtr __restrict state, const Columns& tos,
+    virtual void output_detail(FunctionContext* ctx, ConstAggDataPtr __restrict state, Columns& tos,
                                Column* count) const {
         throw std::runtime_error("output_detail function in aggregate is not supported for now.");
     }

--- a/be/src/exprs/agg/approx_top_k.h
+++ b/be/src/exprs/agg/approx_top_k.h
@@ -344,8 +344,8 @@ public:
         auto* dst_column = down_cast<BinaryColumn*>((*dst).get());
 
         if (src[0]->is_nullable()) {
-            auto* src_nullable_column = down_cast<NullableColumn*>(src[0].get());
-            auto* src_column = down_cast<InputColumnType*>(src_nullable_column->data_column().get());
+            auto* src_nullable_column = down_cast<const NullableColumn*>(src[0].get());
+            auto* src_column = down_cast<const InputColumnType*>(src_nullable_column->data_column().get());
 
             ApproxTopKState<LT> state;
             for (size_t i = 0; i < src_nullable_column->size(); ++i) {
@@ -358,7 +358,7 @@ public:
                 serialize_state(state, dst_column);
             }
         } else {
-            auto* src_column = down_cast<InputColumnType*>(src[0].get());
+            auto* src_column = down_cast<const InputColumnType*>(src[0].get());
 
             ApproxTopKState<LT> state;
             for (auto& value : src_column->get_data()) {

--- a/be/src/exprs/agg/bitmap_agg.h
+++ b/be/src/exprs/agg/bitmap_agg.h
@@ -82,7 +82,7 @@ public:
 
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
                                      ColumnPtr* dst) const override {
-        auto& src_column = down_cast<InputColumnType&>(*src[0].get());
+        auto& src_column = down_cast<const InputColumnType&>(*src[0].get());
         auto* dest_column = down_cast<BitmapColumn*>(dst->get());
         for (size_t i = 0; i < chunk_size; i++) {
             BitmapValue bitmap;

--- a/be/src/exprs/agg/group_concat.h
+++ b/be/src/exprs/agg/group_concat.h
@@ -207,9 +207,9 @@ public:
         if (src.size() > 1) {
             auto* dst_column = down_cast<BinaryColumn*>((*dst).get());
             Bytes& bytes = dst_column->get_bytes();
-            const auto* column_value = down_cast<BinaryColumn*>(src[0].get());
+            const auto* column_value = down_cast<const BinaryColumn*>(src[0].get());
             if (!src[1]->is_constant()) {
-                const auto* column_sep = down_cast<BinaryColumn*>(src[1].get());
+                const auto* column_sep = down_cast<const BinaryColumn*>(src[1].get());
                 if (chunk_size > 0) {
                     size_t old_size = bytes.size();
                     CHECK_EQ(old_size, 0);
@@ -255,7 +255,7 @@ public:
         } else { //", "
             auto* dst_column = down_cast<BinaryColumn*>((*dst).get());
             Bytes& bytes = dst_column->get_bytes();
-            const auto* column_value = down_cast<BinaryColumn*>(src[0].get());
+            const auto* column_value = down_cast<const BinaryColumn*>(src[0].get());
 
             if (chunk_size > 0) {
                 const char* sep = ", ";
@@ -515,7 +515,7 @@ public:
         }
         // get null info from output columns
         auto output_col_num = ctx->get_num_args() - ctx->get_nulls_first().size() - 1;
-        NullColumnPtr nulls = NullColumn::create(chunk_size, false);
+        NullColumn::MutablePtr nulls = NullColumn::create(chunk_size, false);
         auto& null_data = nulls->get_data();
         for (int j = 0; j < output_col_num; ++j) {
             if (src[j]->only_null()) {
@@ -528,7 +528,7 @@ public:
                 continue;
             }
             if (src[j]->is_nullable()) {
-                auto null_col = down_cast<NullableColumn*>(src[j].get())->null_column_data();
+                auto null_col = down_cast<const NullableColumn*>(src[j].get())->null_column_data();
                 for (int i = 0; i < chunk_size; ++i) {
                     null_data[i] |= null_col[i];
                 }

--- a/be/src/exprs/agg/histogram.h
+++ b/be/src/exprs/agg/histogram.h
@@ -63,7 +63,7 @@ template <LogicalType LT>
 struct HistogramState {
     HistogramState() {
         auto data = RunTimeColumnType<LT>::create();
-        column = NullableColumn::create(data, NullColumn::create());
+        column = NullableColumn::create(std::move(data), NullColumn::create());
     }
 
     ColumnPtr column;

--- a/be/src/exprs/agg/java_udaf_function.h
+++ b/be/src/exprs/agg/java_udaf_function.h
@@ -448,8 +448,8 @@ public:
         LogicalType type = udf_ctxs->finalize->method_desc[0].type;
         // For nullable inputs, our UDAF does not produce nullable results
         if (!to->is_nullable()) {
-            ColumnPtr wrapper(const_cast<Column*>(to), [](auto p) {});
-            auto output = NullableColumn::create(wrapper, NullColumn::create());
+            MutableColumnPtr wrapper = const_cast<Column*>(to)->as_mutable_ptr();
+            MutableColumnPtr output = NullableColumn::create(std::move(wrapper), NullColumn::create());
             helper.get_result_from_boxed_array(ctx, type, output.get(), res, batch_size);
         } else {
             helper.get_result_from_boxed_array(ctx, type, to, res, batch_size);

--- a/be/src/exprs/agg/map_agg.h
+++ b/be/src/exprs/agg/map_agg.h
@@ -94,7 +94,7 @@ public:
         if (offsets[row_num + 1] > offsets[row_num]) {
             this->data(state).update(
                     ctx->mem_pool(),
-                    *down_cast<KeyColumnType*>(ColumnHelper::get_data_column(map_column->keys_column().get())),
+                    *down_cast<const KeyColumnType*>(ColumnHelper::get_data_column(map_column->keys_column().get())),
                     map_column->values(), offsets[row_num], offsets[row_num + 1] - offsets[row_num]);
         }
     }

--- a/be/src/exprs/agg/retention.h
+++ b/be/src/exprs/agg/retention.h
@@ -43,7 +43,7 @@ struct RetentionState {
         size_t array_size = 0;
         if (ele_col.is_nullable()) {
             const auto& null_column = down_cast<const NullableColumn&>(ele_col);
-            auto data_column = down_cast<BooleanColumn*>(null_column.data_column().get());
+            auto data_column = down_cast<const BooleanColumn*>(null_column.data_column().get());
             size_t offset = offsets[row_num];
             array_size = offsets[row_num + 1] - offset;
 

--- a/be/src/exprs/agg/stream/retract_maxmin.h
+++ b/be/src/exprs/agg/stream/retract_maxmin.h
@@ -254,7 +254,7 @@ public:
         sync_col->append(is_sync);
     }
 
-    void output_detail(FunctionContext* ctx, ConstAggDataPtr __restrict state, const Columns& to,
+    void output_detail(FunctionContext* ctx, ConstAggDataPtr __restrict state, Columns& to,
                        Column* count) const override {
         if constexpr (lt_is_string<LT>) {
             DCHECK((*to[0]).is_binary());

--- a/be/src/exprs/agg/window_funnel.h
+++ b/be/src/exprs/agg/window_funnel.h
@@ -477,7 +477,7 @@ public:
         const Column& elements = event_column->elements();
         if (elements.is_nullable()) {
             const auto& null_column = down_cast<const NullableColumn&>(elements);
-            auto data_column = down_cast<BooleanColumn*>(null_column.data_column().get());
+            auto data_column = down_cast<const BooleanColumn*>(null_column.data_column().get());
             const auto& null_vector = null_column.null_column()->get_data();
             for (int i = 0; i < array_size; ++i) {
                 auto ele_offset = offset + i;

--- a/be/src/exprs/agg_state_function.h
+++ b/be/src/exprs/agg_state_function.h
@@ -78,7 +78,8 @@ public:
                 new_columns.push_back(column);
             }
         }
-        auto result = ColumnHelper::create_column(_immediate_type, _agg_state_desc.is_result_nullable());
+        // TODO: use mutable ptr as result
+        ColumnPtr result = ColumnHelper::create_column(_immediate_type, _agg_state_desc.is_result_nullable());
         auto chunk_size = columns[0]->size();
         _function->convert_to_serialize_format(context, new_columns, chunk_size, &result);
         return result;

--- a/be/src/exprs/array_element_expr.cpp
+++ b/be/src/exprs/array_element_expr.cpp
@@ -125,7 +125,7 @@ public:
 
         // Construct the final result column;
         ColumnPtr result_data = array_elements_data->clone_empty();
-        NullColumnPtr result_null = NullColumn::create();
+        NullColumn::MutablePtr result_null = NullColumn::create();
         result_null->get_data().swap(null_flags);
 
         if (!array_elements_data->empty()) {

--- a/be/src/exprs/array_expr.cpp
+++ b/be/src/exprs/array_expr.cpp
@@ -41,7 +41,7 @@ public:
         }
 
         bool all_const = true;
-        std::vector<ColumnPtr> element_columns(num_elements);
+        Columns element_columns(num_elements);
         for (size_t i = 0; i < num_elements; i++) {
             ASSIGN_OR_RETURN(auto col, _children[i]->evaluate_checked(context, chunk));
             output_rows = std::max(output_rows, col->size());

--- a/be/src/exprs/array_functions.cpp
+++ b/be/src/exprs/array_functions.cpp
@@ -37,14 +37,14 @@ StatusOr<ColumnPtr> ArrayFunctions::array_length([[maybe_unused]] FunctionContex
     DCHECK_EQ(1, columns.size());
     RETURN_IF_COLUMNS_ONLY_NULL(columns);
     const size_t num_rows = columns[0]->size();
-    auto* col_array = down_cast<ArrayColumn*>(ColumnHelper::get_data_column(columns[0].get()));
+    const auto* col_array = down_cast<const ArrayColumn*>(ColumnHelper::get_data_column(columns[0].get()));
     if (columns[0]->is_constant()) {
         auto col_result = Int32Column::create();
         col_result->append(col_array->offsets().get_data().data()[1]);
         auto const_column = ConstColumn::create(std::move(col_result), num_rows);
         return const_column;
     } else {
-        Column* arg0 = columns[0].get();
+        const auto* arg0 = columns[0].get();
         auto col_result = Int32Column::create();
         raw::make_room(&col_result->get_data(), num_rows);
         DCHECK_EQ(col_array->size(), col_result->size());
@@ -57,7 +57,8 @@ StatusOr<ColumnPtr> ArrayFunctions::array_length([[maybe_unused]] FunctionContex
 
         if (arg0->has_null()) {
             // Copy null flags.
-            return NullableColumn::create(std::move(col_result), down_cast<NullableColumn*>(arg0)->null_column());
+            return NullableColumn::create(std::move(col_result),
+                                          down_cast<const NullableColumn*>(arg0)->null_column()->as_mutable_ptr());
         } else {
             return col_result;
         }
@@ -368,7 +369,7 @@ private:
             return NullableColumn::create(std::move(result), nullable->null_column());
         }
 
-        return _array_remove_non_nullable(down_cast<ArrayColumn&>(*array), *target);
+        return _array_remove_non_nullable(down_cast<const ArrayColumn&>(*array), *target);
     }
 };
 
@@ -377,7 +378,7 @@ struct ArrayCumSumImpl {
 public:
     static StatusOr<ColumnPtr> evaluate(const ColumnPtr& col) {
         if (col->is_constant()) {
-            auto* input = down_cast<ConstColumn*>(col.get());
+            const auto* input = down_cast<const ConstColumn*>(col.get());
             auto arr_col_h = input->data_column()->clone();
             auto* arr_col = down_cast<ArrayColumn*>(arr_col_h.get());
             call_cum_sum(arr_col, nullptr);
@@ -1110,9 +1111,9 @@ StatusOr<ColumnPtr> ArrayFunctions::concat(FunctionContext* ctx, const Columns& 
     NullColumnPtr nulls;
     for (auto& column : columns) {
         if (column->has_null()) {
-            auto nullable_column = down_cast<NullableColumn*>(column.get());
+            auto nullable_column = down_cast<const NullableColumn*>(column.get());
             if (nulls == nullptr) {
-                nulls = std::static_pointer_cast<NullColumn>(nullable_column->null_column()->clone_shared());
+                nulls = NullColumn::static_pointer_cast(nullable_column->null_column()->clone());
             } else {
                 ColumnHelper::or_two_filters(num_rows, nulls->get_data().data(),
                                              nullable_column->null_column()->get_data().data());
@@ -1124,14 +1125,14 @@ StatusOr<ColumnPtr> ArrayFunctions::concat(FunctionContext* ctx, const Columns& 
     std::vector<ArrayColumn::Ptr> array_columns;
     for (auto& column : columns) {
         if (column->is_nullable()) {
-            auto nullable_column = down_cast<NullableColumn*>(column.get());
-            array_columns.emplace_back(std::static_pointer_cast<ArrayColumn>(nullable_column->data_column()));
+            const auto nullable_column = down_cast<const NullableColumn*>(column.get());
+            array_columns.emplace_back(ArrayColumn::static_pointer_cast(nullable_column->data_column()));
         } else if (column->is_constant()) {
             // NOTE: I'm not sure if there will be const array, just to be safe
-            array_columns.emplace_back(std::static_pointer_cast<ArrayColumn>(
+            array_columns.emplace_back(ArrayColumn::static_pointer_cast(
                     ColumnHelper::unpack_and_duplicate_const_column(num_rows, column)));
         } else {
-            array_columns.emplace_back(std::static_pointer_cast<ArrayColumn>(column));
+            array_columns.emplace_back(ArrayColumn::static_pointer_cast(column));
         }
     }
     auto dst = array_columns[0]->clone_empty();
@@ -1167,7 +1168,8 @@ StatusOr<ColumnPtr> ArrayFunctions::concat(FunctionContext* ctx, const Columns& 
 }
 
 template <bool with_length>
-void _array_slice_item(ArrayColumn* column, size_t index, ArrayColumn* dest_column, int64_t offset, int64_t length) {
+void _array_slice_item(const ArrayColumn* column, size_t index, ArrayColumn* dest_column, int64_t offset,
+                       int64_t length) {
     auto& dest_offsets = dest_column->offsets_column()->get_data();
     if (!offset) {
         dest_offsets.emplace_back(dest_offsets.back());
@@ -1216,36 +1218,36 @@ StatusOr<ColumnPtr> ArrayFunctions::array_slice(FunctionContext* ctx, const Colu
     bool has_null = false;
     NullColumnPtr null_result = nullptr;
 
-    ArrayColumn* array_column = nullptr;
+    const ArrayColumn* array_column = nullptr;
     if (columns[0]->is_nullable()) {
         is_nullable = true;
         has_null = (columns[0]->has_null() || has_null);
 
         const auto* src_nullable_column = down_cast<const NullableColumn*>(columns[0].get());
-        array_column = down_cast<ArrayColumn*>(src_nullable_column->data_column().get());
+        array_column = down_cast<const ArrayColumn*>(src_nullable_column->data_column().get());
         null_result = NullColumn::create(*src_nullable_column->null_column());
     } else {
-        array_column = down_cast<ArrayColumn*>(src_column.get());
+        array_column = down_cast<const ArrayColumn*>(src_column.get());
     }
 
-    Int64Column* offset_column = nullptr;
+    const Int64Column* offset_column = nullptr;
     if (columns[1]->is_nullable()) {
         is_nullable = true;
         has_null = (columns[1]->has_null() || has_null);
 
         const auto* src_nullable_column = down_cast<const NullableColumn*>(columns[1].get());
-        offset_column = down_cast<Int64Column*>(src_nullable_column->data_column().get());
+        offset_column = down_cast<const Int64Column*>(src_nullable_column->data_column().get());
         if (null_result) {
             null_result = FunctionHelper::union_null_column(null_result, src_nullable_column->null_column());
         } else {
             null_result = NullColumn::create(*src_nullable_column->null_column());
         }
     } else {
-        offset_column =
-                down_cast<Int64Column*>(ColumnHelper::unpack_and_duplicate_const_column(chunk_size, columns[1]).get());
+        offset_column = down_cast<const Int64Column*>(
+                ColumnHelper::unpack_and_duplicate_const_column(chunk_size, columns[1]).get());
     }
 
-    Int64Column* length_column = nullptr;
+    const Int64Column* length_column = nullptr;
     // length_column is provided.
     if (columns.size() > 2) {
         if (columns[2]->is_nullable()) {
@@ -1253,14 +1255,14 @@ StatusOr<ColumnPtr> ArrayFunctions::array_slice(FunctionContext* ctx, const Colu
             has_null = (columns[2]->has_null() || has_null);
 
             const auto* src_nullable_column = down_cast<const NullableColumn*>(columns[2].get());
-            length_column = down_cast<Int64Column*>(src_nullable_column->data_column().get());
+            length_column = down_cast<const Int64Column*>(src_nullable_column->data_column().get());
             if (null_result) {
                 null_result = FunctionHelper::union_null_column(null_result, src_nullable_column->null_column());
             } else {
                 null_result = NullColumn::create(*src_nullable_column->null_column());
             }
         } else {
-            length_column = down_cast<Int64Column*>(
+            length_column = down_cast<const Int64Column*>(
                     ColumnHelper::unpack_and_duplicate_const_column(chunk_size, columns[2]).get());
         }
     }
@@ -1292,7 +1294,7 @@ StatusOr<ColumnPtr> ArrayFunctions::array_slice(FunctionContext* ctx, const Colu
         if (columns[0]->is_nullable()) {
             return dest_column;
         } else {
-            return NullableColumn::create(dest_column, null_result);
+            return NullableColumn::create(std::move(dest_column), std::move(null_result));
         }
     } else {
         return dest_column;
@@ -1384,7 +1386,8 @@ StatusOr<ColumnPtr> ArrayFunctions::array_distinct_any_type(FunctionContext* ctx
         result_offsets->append(result_elements->size());
     }
 
-    return NullableColumn::create(ArrayColumn::create(std::move(result_elements), result_offsets), array_null);
+    return NullableColumn::create(ArrayColumn::create(std::move(result_elements), std::move(result_offsets)),
+                                  std::move(array_null));
 }
 
 StatusOr<ColumnPtr> ArrayFunctions::array_reverse_any_types(FunctionContext* ctx, const Columns& columns) {
@@ -1415,7 +1418,7 @@ StatusOr<ColumnPtr> ArrayFunctions::array_reverse_any_types(FunctionContext* ctx
     }
 
     return NullableColumn::create(ArrayColumn::create(std::move(result_elements), std::move(result_offsets)),
-                                  array_null);
+                                  std::move(array_null));
 }
 
 inline static void nestloop_intersect(uint8_t* hits, const Column* base, size_t base_start, size_t base_end,
@@ -1447,7 +1450,7 @@ StatusOr<ColumnPtr> ArrayFunctions::array_intersect_any_type(FunctionContext* ct
     ColumnPtr base_col = columns[0];
     int base_idx = 0;
 
-    auto nulls = NullColumn::create(rows, 0);
+    NullColumnPtr nulls = NullColumn::create(rows, 0);
     // find minimum column
     for (size_t i = 0; i < columns.size(); i++) {
         if (columns[i]->memory_usage() < usage) {
@@ -1513,7 +1516,7 @@ StatusOr<ColumnPtr> ArrayFunctions::array_intersect_any_type(FunctionContext* ct
         result_offsets->append(pre_offset);
     }
 
-    return NullableColumn::create(ArrayColumn::create(base_elements, result_offsets), nulls);
+    return NullableColumn::create(ArrayColumn::create(base_elements, std::move(result_offsets)), std::move(nulls));
 }
 
 static Status sort_multi_array_column(FunctionContext* ctx, const Column* src_column, const NullColumn* src_null_column,
@@ -1531,7 +1534,7 @@ static Status sort_multi_array_column(FunctionContext* ctx, const Column* src_co
     dest_offsets_column->get_data() = src_offsets_column->get_data();
 
     // Unpack each key array column.
-    std::vector<Column*> elements_per_key_col(num_key_columns);
+    std::vector<const Column*> elements_per_key_col(num_key_columns);
     std::vector<std::span<const uint32_t>> offsets_per_key_col(num_key_columns);
     std::vector<const uint8_t*> nulls_per_key_col(num_key_columns, nullptr);
     for (size_t i = 0; i < num_key_columns; ++i) {
@@ -1543,6 +1546,7 @@ static Status sort_multi_array_column(FunctionContext* ctx, const Column* src_co
         }
 
         const auto* key_array_column = down_cast<const ArrayColumn*>(key_column);
+        // elements_per_key_col[i] = const_cast<Column*>(key_array_column->elements_column().get());
         elements_per_key_col[i] = key_array_column->elements_column().get();
         offsets_per_key_col[i] = key_array_column->offsets().get_data();
     }
@@ -1643,7 +1647,7 @@ StatusOr<ColumnPtr> ArrayFunctions::repeat(FunctionContext* ctx, const Columns& 
     // Because the _elements of ArrayColumn must be nullable, but a non-null ConstColumn cannot be converted to nullable;
     // therefore, the _data of ConstColumn is extracted as dest_column_elements.
     if (src_column->is_constant() && !src_column->is_nullable()) {
-        ConstColumn* const_src_column = down_cast<ConstColumn*>(src_column.get());
+        const ConstColumn* const_src_column = down_cast<const ConstColumn*>(src_column.get());
         dest_column_elements = const_src_column->data_column()->clone_empty();
     } else {
         dest_column_elements = src_column->clone_empty();
@@ -1684,7 +1688,7 @@ StatusOr<ColumnPtr> ArrayFunctions::repeat(FunctionContext* ctx, const Columns& 
     }
 
     if (null_result) {
-        return NullableColumn::create(dest_column, null_result);
+        return NullableColumn::create(std::move(dest_column), std::move(null_result));
     } else {
         return dest_column;
     }
@@ -1697,14 +1701,15 @@ StatusOr<ColumnPtr> ArrayFunctions::array_flatten(FunctionContext* ctx, const Co
     size_t chunk_size = columns[0]->size();
 
     // Helper function to init result array elements and offsets
-    auto build_result_array_elements_and_offsets = [](const ColumnPtr& elements_column, size_t offsets_size) {
+    auto build_result_array_elements_and_offsets = [](const ColumnPtr& elements_column,
+                                                      size_t offsets_size) -> std::pair<ColumnPtr, UInt32Column::Ptr> {
         DCHECK(elements_column->is_array());
         auto [array_null, elements, offsets] = unpack_array_column(elements_column);
-        ColumnPtr result_elements = elements->clone_empty();
+        auto result_elements = elements->clone_empty();
         auto result_offsets = UInt32Column::create();
         result_offsets->reserve(offsets_size);
         result_offsets->append(0);
-        return std::make_pair(result_elements, result_offsets);
+        return std::make_pair(std::move(result_elements), std::move(result_offsets));
     };
 
     // Helper function to flatten a single array item
@@ -1725,8 +1730,8 @@ StatusOr<ColumnPtr> ArrayFunctions::array_flatten(FunctionContext* ctx, const Co
 
     // Special handle const column
     if (columns[0]->is_constant()) {
-        auto* const_column = down_cast<ConstColumn*>(columns[0].get());
-        ArrayColumn* const_array = down_cast<ArrayColumn*>(const_column->mutable_data_column()->get());
+        const auto* const_column = down_cast<const ConstColumn*>(columns[0].get());
+        const ArrayColumn* const_array = down_cast<const ArrayColumn*>(const_column->data_column().get());
 
         auto [result_elements, result_offsets] =
                 build_result_array_elements_and_offsets(const_array->elements_column(), 1);
@@ -1736,12 +1741,12 @@ StatusOr<ColumnPtr> ArrayFunctions::array_flatten(FunctionContext* ctx, const Co
     }
 
     const NullableColumn* src_nullable_column = nullptr;
-    ArrayColumn* array_column = nullptr;
+    const ArrayColumn* array_column = nullptr;
     if (columns[0]->is_nullable()) {
         src_nullable_column = down_cast<const NullableColumn*>(columns[0].get());
-        array_column = down_cast<ArrayColumn*>(src_nullable_column->data_column().get());
+        array_column = down_cast<const ArrayColumn*>(src_nullable_column->data_column().get());
     } else {
-        array_column = down_cast<ArrayColumn*>(columns[0].get());
+        array_column = down_cast<const ArrayColumn*>(columns[0].get());
     }
 
     auto [result_elements, result_offsets] =

--- a/be/src/exprs/array_map_expr.h
+++ b/be/src/exprs/array_map_expr.h
@@ -47,8 +47,8 @@ public:
 
 private:
     template <bool all_const_input, bool independent_lambda_expr>
-    StatusOr<ColumnPtr> evaluate_lambda_expr(ExprContext* context, Chunk* chunk,
-                                             const std::vector<ColumnPtr>& arguments, const NullColumnPtr& null_column);
+    StatusOr<ColumnPtr> evaluate_lambda_expr(ExprContext* context, Chunk* chunk, const Columns& arguments,
+                                             const NullColumnPtr& null_column);
 
     // use map to make sure the order of execution
     std::map<SlotId, Expr*> _outer_common_exprs;

--- a/be/src/exprs/binary_function.h
+++ b/be/src/exprs/binary_function.h
@@ -262,7 +262,7 @@ public:
                 null_flags->resize(data->size());
             }
             const auto& real_data =
-                    ColumnHelper::cast_to_raw<ResultType>(FunctionHelper::get_data_column_of_nullable(data));
+                    ColumnHelper::cast_to_raw<ResultType>(FunctionHelper::get_data_column_of_nullable(data).get());
 
             // Avoid calling virtual fuctions `size` in for loop
             const auto size = data->size();
@@ -314,7 +314,7 @@ public:
         if (v1->is_constant() && v2->is_constant()) {
             const ColumnPtr& data2 = ColumnHelper::as_column<ConstColumn>(v2)->data_column();
 
-            auto null_result = std::static_pointer_cast<NullColumn>(
+            auto null_result = NullColumn::static_pointer_cast(
                     PRODUCE_NULL_FN::template evaluate<LType, RType, TYPE_NULL>(v1, data2));
 
             // is null, return only null
@@ -327,7 +327,7 @@ public:
         }
 
         if (!v1->is_nullable() && !v2->is_nullable()) {
-            NullColumnPtr null_result = std::static_pointer_cast<NullColumn>(
+            NullColumnPtr null_result = NullColumn::static_pointer_cast(
                     PRODUCE_NULL_FN::template evaluate<LType, RType, TYPE_NULL>(v1, v2));
 
             ColumnPtr data_result = FN::template evaluate<LType, RType, ResultType>(v1, v2);

--- a/be/src/exprs/binary_predicate.cpp
+++ b/be/src/exprs/binary_predicate.cpp
@@ -347,7 +347,7 @@ public:
             return ColumnHelper::create_const_column<TYPE_BOOLEAN>(true, l->size());
         }
 
-        auto is_null_predicate = [&](const ColumnPtr& column) {
+        auto is_null_predicate = [&](const ColumnPtr& column) -> ColumnPtr {
             if (!column->is_nullable() || !column->has_null()) {
                 return ColumnHelper::create_const_column<TYPE_BOOLEAN>(false, column->size());
             }

--- a/be/src/exprs/bitmap_functions.cpp
+++ b/be/src/exprs/bitmap_functions.cpp
@@ -336,10 +336,10 @@ StatusOr<ColumnPtr> BitmapFunctions::bitmap_to_array(FunctionContext* context, c
     ColumnViewer<TYPE_OBJECT> lhs(columns[0]);
 
     size_t size = columns[0]->size();
-    UInt32Column::Ptr array_offsets = UInt32Column::create();
+    UInt32Column::MutablePtr array_offsets = UInt32Column::create();
     array_offsets->reserve(size + 1);
 
-    Int64Column::Ptr array_bigint_column = Int64Column::create();
+    Int64Column::MutablePtr array_bigint_column = Int64Column::create();
     size_t data_size = 0;
 
     if (columns[0]->has_null()) {
@@ -383,14 +383,16 @@ StatusOr<ColumnPtr> BitmapFunctions::bitmap_to_array(FunctionContext* context, c
 
     //Array Column
     if (!columns[0]->has_null()) {
-        return ArrayColumn::create(NullableColumn::create(array_bigint_column, NullColumn::create(offset, 0)),
-                                   array_offsets);
+        return ArrayColumn::create(
+                NullableColumn::create(std::move(array_bigint_column), NullColumn::create(offset, 0)),
+                std::move(array_offsets));
     } else if (columns[0]->only_null()) {
         return ColumnHelper::create_const_null_column(size);
     } else {
         return NullableColumn::create(
-                ArrayColumn::create(NullableColumn::create(array_bigint_column, NullColumn::create(offset, 0)),
-                                    array_offsets),
+                ArrayColumn::create(
+                        NullableColumn::create(std::move(array_bigint_column), NullColumn::create(offset, 0)),
+                        std::move(array_offsets)),
                 NullColumn::create(*ColumnHelper::as_raw_column<NullableColumn>(columns[0])->null_column()));
     }
 }
@@ -401,23 +403,25 @@ StatusOr<ColumnPtr> BitmapFunctions::array_to_bitmap(FunctionContext* context, c
     size_t size = columns[0]->is_constant() ? 1 : columns[0]->size();
     ColumnBuilder<TYPE_OBJECT> builder(size);
 
-    Column* data_column = ColumnHelper::get_data_column(columns[0].get());
-    NullData::pointer null_data = columns[0]->is_nullable()
-                                          ? down_cast<NullableColumn*>(columns[0].get())->null_column_data().data()
-                                          : nullptr;
-    auto* array_column = down_cast<ArrayColumn*>(data_column);
+    const Column* data_column = ColumnHelper::get_data_column(columns[0].get());
+    const auto null_data = columns[0]->is_nullable()
+                                   ? down_cast<const NullableColumn*>(columns[0].get())->null_column_data().data()
+                                   : nullptr;
+    const auto* array_column = down_cast<const ArrayColumn*>(data_column);
 
-    RunTimeColumnType<TYPE>::Container& element_container =
+    auto element_container =
             array_column->elements_column()->is_nullable()
-                    ? down_cast<RunTimeColumnType<TYPE>*>(
-                              down_cast<NullableColumn*>(array_column->elements_column().get())->data_column().get())
+                    ? down_cast<const RunTimeColumnType<TYPE>*>(
+                              down_cast<const NullableColumn*>(array_column->elements_column().get())
+                                      ->data_column()
+                                      .get())
                               ->get_data()
-                    : down_cast<RunTimeColumnType<TYPE>*>(array_column->elements_column().get())->get_data();
+                    : down_cast<const RunTimeColumnType<TYPE>*>(array_column->elements_column().get())->get_data();
     const auto& offsets = array_column->offsets_column()->get_data();
 
-    NullColumn::Container::pointer element_null_data =
+    auto element_null_data =
             array_column->elements_column()->is_nullable()
-                    ? down_cast<NullableColumn*>(array_column->elements_column().get())->null_column_data().data()
+                    ? down_cast<const NullableColumn*>(array_column->elements_column().get())->null_column_data().data()
                     : nullptr;
 
     for (int row = 0; row < size; ++row) {
@@ -440,8 +444,8 @@ StatusOr<ColumnPtr> BitmapFunctions::array_to_bitmap(FunctionContext* context, c
         // append bitmap
         builder.append(std::move(bitmap));
     }
-    auto result = builder.build(false);
-    return columns[0]->is_constant() ? ConstColumn::create(std::move(result), columns[0]->size()) : result;
+    ColumnPtr result = builder.build(false);
+    return columns[0]->is_constant() ? ConstColumn::create(std::move(result), columns[0]->size()) : std::move(result);
 }
 
 StatusOr<ColumnPtr> BitmapFunctions::bitmap_max(FunctionContext* context, const starrocks::Columns& columns) {

--- a/be/src/exprs/case_expr.cpp
+++ b/be/src/exprs/case_expr.cpp
@@ -350,7 +350,7 @@ private:
                     res_nullable = true;
                 }
             }
-            ColumnPtr res = ColumnHelper::create_column(this->type(), res_nullable);
+            MutableColumnPtr res = ColumnHelper::create_column(this->type(), res_nullable);
 
             for (auto& then_column : then_columns) {
                 then_column = ColumnHelper::unpack_and_duplicate_const_column(size, then_column);
@@ -517,7 +517,7 @@ private:
                     res_nullable = true;
                 }
             }
-            ColumnPtr res = ColumnHelper::create_column(this->type(), res_nullable);
+            MutableColumnPtr res = ColumnHelper::create_column(this->type(), res_nullable);
 
             for (auto& then_column : then_columns) {
                 then_column = ColumnHelper::unpack_and_duplicate_const_column(size, then_column);

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -436,7 +436,7 @@ ColumnPtr cast_int_from_string_fn(ColumnPtr& column) {
         }
         return NullableColumn::create(std::move(res_data_column), std::move(null_column));
     } else {
-        NullColumnPtr null_column = NullColumn::create(sz);
+        NullColumn::MutablePtr null_column = NullColumn::create(sz);
         auto& null_data = null_column->get_data();
         auto* data_column = down_cast<BinaryColumn*>(column.get());
 
@@ -883,8 +883,8 @@ static ColumnPtr cast_from_string_to_datetime_fn(ColumnPtr& column) {
     auto& res_data = res_data_column->get_data();
 
     if (column->is_nullable()) {
-        const auto* input_column = down_cast<NullableColumn*>(column.get());
-        const auto* data_column = down_cast<BinaryColumn*>(input_column->data_column().get());
+        auto* input_column = down_cast<NullableColumn*>(column.get());
+        auto* data_column = down_cast<BinaryColumn*>(input_column->data_column().get());
 
         NullColumnPtr null_column = ColumnHelper::as_column<NullColumn>(input_column->null_column()->clone());
         auto& null_data = down_cast<NullColumn*>(null_column.get())->get_data();
@@ -905,7 +905,7 @@ static ColumnPtr cast_from_string_to_datetime_fn(ColumnPtr& column) {
         return NullableColumn::create(std::move(res_data_column), std::move(null_column));
     } else {
         auto* data_column = down_cast<BinaryColumn*>(column.get());
-        NullColumnPtr null_column = NullColumn::create(num_rows);
+        NullColumn::MutablePtr null_column = NullColumn::create(num_rows);
         auto& null_data = null_column->get_data();
 
         bool has_null = false;
@@ -1429,7 +1429,7 @@ private:
     //    length of char.
     // In SR, behaviors of both cast(string as varchar(n)) and cast(string as char(n)) keep the same: neglect
     // of the length of char/varchar and return input column directly.
-    ColumnPtr _evaluate_string(ExprContext* context, const ColumnPtr& column) { return column->clone(); }
+    ColumnPtr _evaluate_string(ExprContext* context, ColumnPtr& column) { return column->clone(); }
 
     ColumnPtr _evaluate_time(ExprContext* context, const ColumnPtr& column) {
         ColumnViewer<TYPE_TIME> viewer(column);
@@ -1547,7 +1547,7 @@ StatusOr<ColumnPtr> MustNullExpr::evaluate_checked(ExprContext* context, Chunk* 
     // only null
     auto column = ColumnHelper::create_column(_type, true);
     column->append_nulls(1);
-    auto only_null = ConstColumn::create(column, 1);
+    auto only_null = ConstColumn::create(std::move(column), 1);
     if (ptr != nullptr) {
         only_null->resize(ptr->num_rows());
     }

--- a/be/src/exprs/cast_expr_json.cpp
+++ b/be/src/exprs/cast_expr_json.cpp
@@ -130,9 +130,9 @@ public:
             _builder->add(_field_name, vpack::Value(vpack::ValueType::Object));
         }
         auto [map_start, map_size] = col.get_map_offset_size(_row);
-        auto key_col = col.keys_column();
-        auto val_col = col.values_column();
+        auto& val_col = col.values_column();
 
+        auto key_col = col.keys_column();
         if (key_col->has_null()) {
             return Status::NotSupported("key of Map should not be null");
         }
@@ -175,7 +175,7 @@ public:
         }
 
         auto [offset, size] = col.get_element_offset_size(_row);
-        auto elements = col.elements_column();
+        auto& elements = col.elements_column();
         for (int i = offset; i < offset + size; i++) {
             RETURN_IF_ERROR(cast_datum_to_json(elements, i, "", _builder));
         }

--- a/be/src/exprs/clone_expr.h
+++ b/be/src/exprs/clone_expr.h
@@ -29,7 +29,7 @@ public:
 
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override {
         ASSIGN_OR_RETURN(ColumnPtr column, get_child(0)->evaluate_checked(context, ptr));
-        return column->clone_shared();
+        return column->clone();
     }
 
     static Expr* from_child(Expr* child, ObjectPool* pool) {

--- a/be/src/exprs/dict_query_expr.cpp
+++ b/be/src/exprs/dict_query_expr.cpp
@@ -38,7 +38,7 @@ StatusOr<ColumnPtr> DictQueryExpr::evaluate_checked(ExprContext* context, Chunk*
         columns[i] = _children[i]->evaluate(context, ptr);
     }
 
-    ColumnPtr res;
+    MutableColumnPtr res;
     for (auto& column : columns) {
         if (column->is_constant()) {
             column = ColumnHelper::unpack_and_duplicate_const_column(size, column);
@@ -78,7 +78,7 @@ StatusOr<ColumnPtr> DictQueryExpr::evaluate_checked(ExprContext* context, Chunk*
     res = value_chunk->get_column_by_index(0)->clone_empty();
     if (!res->is_nullable()) {
         auto null_column = UInt8Column::create(0, 0);
-        res = NullableColumn::create(res, null_column);
+        res = NullableColumn::create(std::move(res), std::move(null_column));
     }
 
     int res_idx = 0;

--- a/be/src/exprs/expr_context.h
+++ b/be/src/exprs/expr_context.h
@@ -166,13 +166,14 @@ private:
         }                                          \
     } while (false)
 
-#define EVALUATE_NULL_IF_ERROR(ctx, expr, chunk)                                             \
-    [](ExprContext* c, Expr* e, Chunk* ptr) {                                                \
-        auto st = c->evaluate(e, ptr);                                                       \
-        if (st.ok()) {                                                                       \
-            return st.value();                                                               \
-        }                                                                                    \
-        return ColumnHelper::create_const_null_column(ptr == nullptr ? 1 : ptr->num_rows()); \
+#define EVALUATE_NULL_IF_ERROR(ctx, expr, chunk)                                                      \
+    [](ExprContext* c, Expr* e, Chunk* ptr) {                                                         \
+        auto st = c->evaluate(e, ptr);                                                                \
+        if (st.ok()) {                                                                                \
+            return st.value();                                                                        \
+        }                                                                                             \
+        ColumnPtr res = ColumnHelper::create_const_null_column(ptr == nullptr ? 1 : ptr->num_rows()); \
+        return res;                                                                                   \
     }(ctx, expr, chunk)
 
 } // namespace starrocks

--- a/be/src/exprs/function_call_expr.cpp
+++ b/be/src/exprs/function_call_expr.cpp
@@ -125,7 +125,7 @@ Status VectorizedFunctionCallExpr::open(starrocks::RuntimeState* state, starrock
     FunctionContext* fn_ctx = context->fn_context(_fn_context_index);
 
     if (scope == FunctionContext::FRAGMENT_LOCAL) {
-        std::vector<ColumnPtr> const_columns;
+        Columns const_columns;
         const_columns.reserve(_children.size());
         for (const auto& child : _children) {
             ASSIGN_OR_RETURN(auto&& child_col, child->evaluate_const(context))
@@ -149,9 +149,8 @@ Status VectorizedFunctionCallExpr::open(starrocks::RuntimeState* state, starrock
     if (_fn.name.function_name == "round" && _type.type == TYPE_DOUBLE) {
         if (_children[1]->is_constant()) {
             ASSIGN_OR_RETURN(ColumnPtr ptr, _children[1]->evaluate_checked(context, nullptr));
-            _output_scale =
-                    std::static_pointer_cast<Int32Column>(std::static_pointer_cast<ConstColumn>(ptr)->data_column())
-                            ->get_data()[0];
+            _output_scale = Int32Column::static_pointer_cast(ConstColumn::static_pointer_cast(ptr)->data_column())
+                                    ->get_data()[0];
         }
     }
 

--- a/be/src/exprs/function_context.h
+++ b/be/src/exprs/function_context.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <vector>
 
+#include "column/column.h"
 #include "common/status.h"
 #include "runtime/types.h"
 #include "types/logical_type.h"
@@ -35,7 +36,6 @@ class Column;
 class Slice;
 struct JavaUDAFContext;
 struct NgramBloomFilterState;
-using ColumnPtr = std::shared_ptr<Column>;
 
 class FunctionContext {
 public:
@@ -128,7 +128,7 @@ public:
     // Return true if it's constant and not null
     bool is_notnull_constant_column(int i) const;
 
-    std::shared_ptr<starrocks::Column> get_constant_column(int arg_idx) const;
+    ColumnPtr get_constant_column(int arg_idx) const;
 
     bool is_udf() { return _is_udf; }
     void set_is_udf(bool is_udf) { this->_is_udf = is_udf; }
@@ -145,7 +145,7 @@ public:
     /// it.
     FunctionContext* clone(MemPool* pool);
 
-    void set_constant_columns(std::vector<ColumnPtr> columns) { _constant_columns = std::move(columns); }
+    void set_constant_columns(Columns columns) { _constant_columns = std::move(columns); }
 
     MemPool* mem_pool() { return _mem_pool; }
 
@@ -205,7 +205,7 @@ private:
     // TODO: support complex type
     std::vector<FunctionContext::TypeDesc> _arg_types;
 
-    std::vector<ColumnPtr> _constant_columns;
+    Columns _constant_columns;
 
     // Indicates whether this context has been closed. Used for verification/debugging.
     bool _is_udf = false;

--- a/be/src/exprs/function_helper.h
+++ b/be/src/exprs/function_helper.h
@@ -33,7 +33,7 @@ public:
      */
     static inline const ColumnPtr& get_data_column_of_nullable(const ColumnPtr& ptr) {
         if (ptr->is_nullable()) {
-            return down_cast<NullableColumn*>(ptr.get())->data_column();
+            return down_cast<const NullableColumn*>(ptr.get())->data_column();
         }
         return ptr;
     }
@@ -60,7 +60,7 @@ public:
      */
     static inline const ColumnPtr& get_data_column_of_const(const ColumnPtr& ptr) {
         if (ptr->is_constant()) {
-            return down_cast<ConstColumn*>(ptr.get())->data_column();
+            return down_cast<const ConstColumn*>(ptr.get())->data_column();
         }
         return ptr;
     }
@@ -74,14 +74,14 @@ public:
      * @param v1 
      * @param v2 
      */
-    static NullColumnPtr union_nullable_column(const ColumnPtr& v1, const ColumnPtr& v2);
+    static NullColumn::MutablePtr union_nullable_column(const ColumnPtr& v1, const ColumnPtr& v2);
 
     static void union_produce_nullable_column(const ColumnPtr& v1, const ColumnPtr& v2,
                                               NullColumnPtr* produce_null_column);
 
     static void union_produce_nullable_column(const ColumnPtr& v1, NullColumnPtr* produce_null_column);
 
-    static NullColumnPtr union_null_column(const NullColumnPtr& v1, const NullColumnPtr& v2);
+    static NullColumn::MutablePtr union_null_column(const NullColumnPtr& v1, const NullColumnPtr& v2);
 
     // merge a column and null_column and generate a column with null values.
     static ColumnPtr merge_column_and_null_column(ColumnPtr&& column, NullColumnPtr&& null_column);

--- a/be/src/exprs/hyperloglog_functions.cpp
+++ b/be/src/exprs/hyperloglog_functions.cpp
@@ -63,7 +63,7 @@ StatusOr<ColumnPtr> HyperloglogFunctions::hll_hash(FunctionContext* context, con
     }
 
     if (ColumnHelper::is_all_const(columns)) {
-        return ConstColumn::create(hll_column, columns[0]->size());
+        return ConstColumn::create(std::move(hll_column), columns[0]->size());
     } else {
         return hll_column;
     }
@@ -74,7 +74,7 @@ StatusOr<ColumnPtr> HyperloglogFunctions::hll_empty(FunctionContext* context, co
     auto p = HyperLogLogColumn::create();
 
     p->append_default();
-    return ConstColumn::create(p, 1);
+    return ConstColumn::create(std::move(p), 1);
 }
 
 // hll_serialize
@@ -105,7 +105,7 @@ StatusOr<ColumnPtr> HyperloglogFunctions::hll_deserialize(FunctionContext* conte
     }
 
     if (ColumnHelper::is_all_const(columns)) {
-        return ConstColumn::create(hll_column, columns[0]->size());
+        return ConstColumn::create(std::move(hll_column), columns[0]->size());
     } else {
         return hll_column;
     }

--- a/be/src/exprs/jit/jit_expr.cpp
+++ b/be/src/exprs/jit/jit_expr.cpp
@@ -110,7 +110,7 @@ StatusOr<ColumnPtr> JITExpr::evaluate_checked(starrocks::ExprContext* context, C
     jit_columns.reserve(_children.size() + 1);
     Columns args;
     args.reserve(_children.size() + 1);
-    auto unfold_ptr = [&](const ColumnPtr& column) {
+    auto unfold_ptr = [&jit_columns](const ColumnPtr& column) {
         DCHECK(!column->is_constant());
         auto [un_col, un_col_null] = ColumnHelper::unpack_nullable_column(column);
         auto data_col_ptr = reinterpret_cast<const int8_t*>(un_col->raw_data());
@@ -164,7 +164,7 @@ StatusOr<ColumnPtr> JITExpr::evaluate_checked(starrocks::ExprContext* context, C
         backup_args.emplace_back(column);
     }
 
-    unfold_ptr(result_column);
+    unfold_ptr(result_column->as_mutable_ptr());
     // inputs are not empty.
     _jit_function(num_rows, jit_columns.data());
     //TODO: _jit_function return has_null

--- a/be/src/exprs/like_predicate.cpp
+++ b/be/src/exprs/like_predicate.cpp
@@ -331,7 +331,7 @@ StatusOr<ColumnPtr> LikePredicate::constant_substring_fn(FunctionContext* contex
         } else {
             res->append(true);
         }
-        return ConstColumn::create(res, columns[0]->size());
+        return ConstColumn::create(std::move(res), columns[0]->size());
     }
 
     BinaryColumn* haystack = nullptr;
@@ -386,7 +386,7 @@ StatusOr<ColumnPtr> LikePredicate::constant_substring_fn(FunctionContext* contex
     }
 
     if (columns[0]->has_null()) {
-        return NullableColumn::create(res, res_null);
+        return NullableColumn::create(std::move(res), std::move(res_null));
     }
     return res;
 }

--- a/be/src/exprs/locate.cpp
+++ b/be/src/exprs/locate.cpp
@@ -102,7 +102,7 @@ ColumnPtr haystack_vector_and_needle_const(const ColumnPtr& haystack_ptr, const 
             }
         }
         if (res_null != nullptr) {
-            return NullableColumn::create(res, res_null);
+            return NullableColumn::create(std::move(res), std::move(res_null));
         } else {
             return res;
         }
@@ -147,7 +147,7 @@ ColumnPtr haystack_vector_and_needle_const(const ColumnPtr& haystack_ptr, const 
     }
 
     if (res_null != nullptr) {
-        return NullableColumn::create(res, res_null);
+        return NullableColumn::create(std::move(res), std::move(res_null));
     } else {
         return res;
     }

--- a/be/src/exprs/map_element_expr.cpp
+++ b/be/src/exprs/map_element_expr.cpp
@@ -66,9 +66,9 @@ public:
         auto [map_column, map_nulls] = ColumnHelper::unpack_nullable_column(map_col);
         auto [key_column, key_nulls] = ColumnHelper::unpack_nullable_column(key_col);
 
-        auto& map_keys = down_cast<MapColumn*>(map_column)->keys_column();
-        auto& map_values = down_cast<MapColumn*>(map_column)->values_column();
-        const auto& offsets = down_cast<MapColumn*>(map_column)->offsets().get_data();
+        const auto& map_keys = down_cast<const MapColumn*>(map_column)->keys_column();
+        const auto& map_values = down_cast<const MapColumn*>(map_column)->values_column();
+        const auto& offsets = down_cast<const MapColumn*>(map_column)->offsets().get_data();
 
         size_t actual_rows = map_is_const && key_is_const ? 1 : num_rows;
         auto res = map_values->clone_empty(); // must be nullable

--- a/be/src/exprs/math_functions.cpp
+++ b/be/src/exprs/math_functions.cpp
@@ -547,7 +547,7 @@ StatusOr<ColumnPtr> MathFunctions::decimal_round(FunctionContext* context, const
             res = ColumnHelper::create_const_null_column(size);
         } else {
             res->resize(1);
-            res = ConstColumn::create(res, size);
+            res = ConstColumn::create(std::move(res), size);
         }
     } else if (c0_is_const) {
         for (auto i = 0; i < size; i++) {
@@ -779,13 +779,13 @@ StatusOr<ColumnPtr> MathFunctions::cosine_similarity(FunctionContext* context, c
                             base->has_null() ? "base" : "target"));
     }
     if (base->is_constant()) {
-        auto* const_column = down_cast<const ConstColumn*>(base);
-        const_column->data_column()->assign(base->size(), 0);
+        const auto* const_column = down_cast<const ConstColumn*>(base);
+        const_column->data_column()->as_mutable_ptr()->assign(base->size(), 0);
         base = const_column->data_column().get();
     }
     if (target->is_constant()) {
-        auto* const_column = down_cast<const ConstColumn*>(target);
-        const_column->data_column()->assign(target->size(), 0);
+        const auto* const_column = down_cast<const ConstColumn*>(target);
+        const_column->data_column()->as_mutable_ptr()->assign(target->size(), 0);
         target = const_column->data_column().get();
     }
 
@@ -826,7 +826,7 @@ StatusOr<ColumnPtr> MathFunctions::cosine_similarity(FunctionContext* context, c
     const CppType* target_data_head = down_cast<const ColumnType*>(target_flat)->get_data().data();
 
     // prepare result with nullable value.
-    ColumnPtr result = ColumnHelper::create_column(TypeDescriptor{TYPE}, false, false, target_size);
+    MutableColumnPtr result = ColumnHelper::create_column(TypeDescriptor{TYPE}, false, false, target_size);
     ColumnType* data_result = down_cast<ColumnType*>(result.get());
     CppType* result_data = data_result->get_data().data();
 
@@ -922,12 +922,12 @@ StatusOr<ColumnPtr> MathFunctions::l2_distance(FunctionContext* context, const C
     }
     if (base->is_constant()) {
         auto* const_column = down_cast<const ConstColumn*>(base);
-        const_column->data_column()->assign(base->size(), 0);
+        const_column->data_column()->as_mutable_ptr()->assign(base->size(), 0);
         base = const_column->data_column().get();
     }
     if (target->is_constant()) {
         auto* const_column = down_cast<const ConstColumn*>(target);
-        const_column->data_column()->assign(target->size(), 0);
+        const_column->data_column()->as_mutable_ptr()->assign(target->size(), 0);
         target = const_column->data_column().get();
     }
     if (base->is_nullable()) {
@@ -967,7 +967,7 @@ StatusOr<ColumnPtr> MathFunctions::l2_distance(FunctionContext* context, const C
     const CppType* target_data_head = down_cast<const ColumnType*>(target_flat)->get_data().data();
 
     // prepare result with nullable value.
-    ColumnPtr result = ColumnHelper::create_column(TypeDescriptor{TYPE}, false, false, target_size);
+    MutableColumnPtr result = ColumnHelper::create_column(TypeDescriptor{TYPE}, false, false, target_size);
     ColumnType* data_result = down_cast<ColumnType*>(result.get());
     CppType* result_data = data_result->get_data().data();
 

--- a/be/src/exprs/min_max_predicate.h
+++ b/be/src/exprs/min_max_predicate.h
@@ -50,7 +50,7 @@ public:
         const ColumnPtr col = ptr->get_column_by_slot_id(_slot_id);
         size_t size = col->size();
 
-        std::shared_ptr<BooleanColumn> result(new BooleanColumn(size, 1));
+        BooleanColumn::MutablePtr result = BooleanColumn::create(size, 1);
         uint8_t* res = result->get_data().data();
 
         if (col->only_null()) {

--- a/be/src/exprs/ngram.cpp
+++ b/be/src/exprs/ngram.cpp
@@ -218,7 +218,7 @@ private:
         }
 
         if (haystack_column->is_nullable()) {
-            return NullableColumn::create(res, res_null);
+            return NullableColumn::create(std::move(res), std::move(res_null));
         } else {
             return res;
         }

--- a/be/src/exprs/percentile_functions.cpp
+++ b/be/src/exprs/percentile_functions.cpp
@@ -40,7 +40,7 @@ StatusOr<ColumnPtr> PercentileFunctions::percentile_hash(FunctionContext* contex
     }
 
     if (ColumnHelper::is_all_const(columns)) {
-        return ConstColumn::create(percentile_column, columns[0]->size());
+        return ConstColumn::create(std::move(percentile_column), columns[0]->size());
     } else {
         return percentile_column;
     }

--- a/be/src/exprs/runtime_filter_bank.cpp
+++ b/be/src/exprs/runtime_filter_bank.cpp
@@ -146,8 +146,8 @@ Status RuntimeFilterHelper::fill_runtime_bloom_filter(const ColumnPtr& column, L
     return Status::OK();
 }
 
-Status RuntimeFilterHelper::fill_runtime_bloom_filter(const std::vector<ColumnPtr>& columns, LogicalType type,
-                                                      RuntimeFilter* filter, size_t column_offset, bool eq_null) {
+Status RuntimeFilterHelper::fill_runtime_bloom_filter(const Columns& columns, LogicalType type, RuntimeFilter* filter,
+                                                      size_t column_offset, bool eq_null) {
     for (const auto& column : columns) {
         RETURN_IF_ERROR(fill_runtime_bloom_filter(column, type, filter, column_offset, eq_null));
     }
@@ -175,10 +175,10 @@ StatusOr<ExprContext*> RuntimeFilterHelper::rewrite_runtime_filter_in_cross_join
             col = ColumnHelper::create_const_null_column(1);
         } else {
             auto data_col = down_cast<NullableColumn*>(res.get())->data_column();
-            col = std::make_shared<ConstColumn>(data_col, 1);
+            col = ConstColumn::create(std::move(data_col), 1);
         }
     } else {
-        col = std::make_shared<ConstColumn>(res, 1);
+        col = ConstColumn::create(std::move(res), 1);
     }
 
     auto literal = pool->add(new VectorizedLiteral(std::move(col), right_child->type()));

--- a/be/src/exprs/runtime_filter_bank.h
+++ b/be/src/exprs/runtime_filter_bank.h
@@ -61,8 +61,8 @@ public:
     // ====================================
     static Status fill_runtime_bloom_filter(const ColumnPtr& column, LogicalType type, RuntimeFilter* filter,
                                             size_t column_offset, bool eq_null);
-    static Status fill_runtime_bloom_filter(const std::vector<ColumnPtr>& column, LogicalType type,
-                                            RuntimeFilter* filter, size_t column_offset, bool eq_null);
+    static Status fill_runtime_bloom_filter(const Columns& column, LogicalType type, RuntimeFilter* filter,
+                                            size_t column_offset, bool eq_null);
     static Status fill_runtime_bloom_filter(const starrocks::pipeline::RuntimeBloomFilterBuildParam& param,
                                             LogicalType type, RuntimeFilter* filter, size_t column_offset);
     static StatusOr<ExprContext*> rewrite_runtime_filter_in_cross_join_node(ObjectPool* pool, ExprContext* conjunct,

--- a/be/src/exprs/split.cpp
+++ b/be/src/exprs/split.cpp
@@ -104,12 +104,12 @@ StatusOr<ColumnPtr> StringFunctions::split(FunctionContext* context, const starr
 
     //Array Offset
     int offset = 0;
-    UInt32Column::Ptr array_offsets = UInt32Column::create();
+    UInt32Column::MutablePtr array_offsets = UInt32Column::create();
     array_offsets->reserve(row_nums + 1);
 
     //Array Binary
-    auto* haystack_columns = down_cast<BinaryColumn*>(ColumnHelper::get_data_column(columns[0].get()));
-    BinaryColumn::Ptr array_binary_column = BinaryColumn::create();
+    const auto* haystack_columns = down_cast<const BinaryColumn*>(ColumnHelper::get_data_column(columns[0].get()));
+    BinaryColumn::MutablePtr array_binary_column = BinaryColumn::create();
 
     auto state = reinterpret_cast<SplitState*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
     if (context->is_notnull_constant_column(0) && context->is_notnull_constant_column(1)) {
@@ -125,8 +125,9 @@ StatusOr<ColumnPtr> StringFunctions::split(FunctionContext* context, const starr
         }
         array_offsets->append(offset);
 
-        return ArrayColumn::create(NullableColumn::create(array_binary_column, NullColumn::create(offset, 0)),
-                                   array_offsets);
+        return ArrayColumn::create(
+                NullableColumn::create(std::move(array_binary_column), NullColumn::create(std::move(offset), 0)),
+                std::move(array_offsets));
     } else if (columns[1]->is_constant()) {
         Slice delimiter = state->delimiter;
 
@@ -178,12 +179,14 @@ StatusOr<ColumnPtr> StringFunctions::split(FunctionContext* context, const starr
             array_offsets->append(offset);
         }
         if (!columns[0]->has_null()) {
-            return ArrayColumn::create(NullableColumn::create(array_binary_column, NullColumn::create(offset, 0)),
-                                       array_offsets);
+            return ArrayColumn::create(
+                    NullableColumn::create(std::move(array_binary_column), NullColumn::create(std::move(offset), 0)),
+                    std::move(array_offsets));
         } else {
             return NullableColumn::create(
-                    ArrayColumn::create(NullableColumn::create(array_binary_column, NullColumn::create(offset, 0)),
-                                        array_offsets),
+                    ArrayColumn::create(NullableColumn::create(std::move(array_binary_column),
+                                                               NullColumn::create(std::move(offset), 0)),
+                                        std::move(array_offsets)),
                     NullColumn::create(*ColumnHelper::as_raw_column<NullableColumn>(columns[0])->null_column()));
         }
     } else {
@@ -191,7 +194,7 @@ StatusOr<ColumnPtr> StringFunctions::split(FunctionContext* context, const starr
 
         auto result_array = ArrayColumn::create(NullableColumn::create(BinaryColumn::create(), NullColumn::create()),
                                                 UInt32Column::create());
-        NullColumnPtr null_array = NullColumn::create();
+        NullColumn::MutablePtr null_array = NullColumn::create();
         for (int row = 0; row < row_nums; ++row) {
             array_offsets->append(offset);
 
@@ -221,9 +224,10 @@ StatusOr<ColumnPtr> StringFunctions::split(FunctionContext* context, const starr
             }
         }
         array_offsets->append(offset);
-        result_array = ArrayColumn::create(NullableColumn::create(array_binary_column, NullColumn::create(offset, 0)),
-                                           array_offsets);
-        return NullableColumn::create(result_array, null_array);
+        result_array = ArrayColumn::create(
+                NullableColumn::create(std::move(array_binary_column), NullColumn::create(std::move(offset), 0)),
+                std::move(array_offsets));
+        return NullableColumn::create(std::move(result_array), std::move(null_array));
     }
 }
 

--- a/be/src/exprs/str_to_map.cpp
+++ b/be/src/exprs/str_to_map.cpp
@@ -180,8 +180,8 @@ StatusOr<ColumnPtr> StringFunctions::str_to_map_v1(FunctionContext* context, con
     }
 
     auto map = MapColumn::create(keys_builder.build_nullable_column(), values_builder.build_nullable_column(),
-                                 res_offsets);
-    return NullableColumn::create(std::move(map), res_null);
+                                 std::move(res_offsets));
+    return NullableColumn::create(std::move(map), std::move(res_null));
 }
 
 } // namespace starrocks

--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -236,7 +236,7 @@ static inline void binary_column_non_empty_op(uint8_t* begin, uint8_t* end, Byte
 }
 
 template <bool off_is_negative, bool allow_out_of_left_bound>
-static inline void ascii_substr(BinaryColumn* src, Bytes* bytes, Offsets* offsets, int off, int len) {
+static inline void ascii_substr(const BinaryColumn* src, Bytes* bytes, Offsets* offsets, int off, int len) {
     const auto size = src->size();
     size_t i = 0;
     for (; i < size; ++i) {
@@ -246,7 +246,7 @@ static inline void ascii_substr(BinaryColumn* src, Bytes* bytes, Offsets* offset
     }
 }
 
-static inline void utf8_substr_from_left(BinaryColumn* src, Bytes* bytes, Offsets* offsets, int off, int len) {
+static inline void utf8_substr_from_left(const BinaryColumn* src, Bytes* bytes, Offsets* offsets, int off, int len) {
     const auto size = src->size();
     size_t i = 0;
     for (; i < size; ++i) {
@@ -257,7 +257,7 @@ static inline void utf8_substr_from_left(BinaryColumn* src, Bytes* bytes, Offset
 }
 
 template <bool allow_out_of_left_bound>
-static inline void utf8_substr_from_right(BinaryColumn* src, Bytes* bytes, Offsets* offsets, int off, int len) {
+static inline void utf8_substr_from_right(const BinaryColumn* src, Bytes* bytes, Offsets* offsets, int off, int len) {
     const auto size = src->size();
     size_t i = 0;
     for (; i < size; ++i) {
@@ -406,8 +406,8 @@ static inline void column_builder_non_empty_op(uint8_t* begin, uint8_t* end, Nul
     builder->append(begin, end, i);
 }
 
-ColumnPtr substr_const_not_null(const Columns& columns, BinaryColumn* src, SubstrState* state) {
-    ColumnPtr result = BinaryColumn::create();
+ColumnPtr substr_const_not_null(const Columns& columns, const BinaryColumn* src, SubstrState* state) {
+    MutableColumnPtr result = BinaryColumn::create();
     auto* binary = down_cast<BinaryColumn*>(result.get());
     Bytes& bytes = binary->get_bytes();
     Offsets& offsets = binary->get_offset();
@@ -463,8 +463,8 @@ ColumnPtr substr_const_not_null(const Columns& columns, BinaryColumn* src, Subst
     return result;
 }
 
-ColumnPtr right_const_not_null(const Columns& columns, BinaryColumn* src, SubstrState* state) {
-    ColumnPtr result = BinaryColumn::create();
+ColumnPtr right_const_not_null(const Columns& columns, const BinaryColumn* src, SubstrState* state) {
+    MutableColumnPtr result = BinaryColumn::create();
     auto* binary = down_cast<BinaryColumn*>(result.get());
     Bytes& bytes = binary->get_bytes();
     Offsets& offsets = binary->get_offset();
@@ -502,11 +502,11 @@ ColumnPtr right_const_not_null(const Columns& columns, BinaryColumn* src, Substr
 template <typename StringConstFuncType, typename... Args>
 ColumnPtr string_func_const(StringConstFuncType func, const Columns& columns, Args&&... args) {
     if (columns[0]->is_nullable()) {
-        auto* src_nullable = down_cast<NullableColumn*>(columns[0].get());
+        auto* src_nullable = down_cast<const NullableColumn*>(columns[0].get());
         if (src_nullable->has_null()) {
-            auto* src_binary = down_cast<BinaryColumn*>(src_nullable->data_column().get());
+            auto* src_binary = down_cast<const BinaryColumn*>(src_nullable->data_column().get());
             ColumnPtr binary = func(columns, src_binary, std::forward<Args>(args)...);
-            NullColumnPtr src_null = NullColumn::create(*(src_nullable->null_column()));
+            NullColumn::MutablePtr src_null = NullColumn::create(*(src_nullable->null_column()));
 
             // - if binary is null ConstColumn, just return it.
             // - if binary is non-null ConstColumn, unfold it and wrap with src_null.
@@ -518,7 +518,7 @@ ColumnPtr string_func_const(StringConstFuncType func, const Columns& columns, Ar
             if (binary->is_constant()) {
                 auto* dst_const = down_cast<ConstColumn*>(binary.get());
                 dst_const->data_column()->assign(dst_const->size(), 0);
-                return NullableColumn::create(dst_const->data_column(), src_null);
+                return NullableColumn::create(dst_const->data_column(), std::move(src_null));
             }
             if (binary->is_nullable()) {
                 auto* binary_nullable = down_cast<NullableColumn*>(binary.get());
@@ -526,31 +526,31 @@ ColumnPtr string_func_const(StringConstFuncType func, const Columns& columns, Ar
                     // case 2: some rows are nulls and some rows are non-nulls, merge the column
                     // inside original result and the null column inside the columns[0].
                     NullColumnPtr binary_null = binary_nullable->null_column();
-                    auto union_null = FunctionHelper::union_null_column(src_null, binary_null);
-                    return NullableColumn::create(binary_nullable->data_column(), union_null);
+                    auto union_null = FunctionHelper::union_null_column(std::move(src_null), binary_null);
+                    return NullableColumn::create(binary_nullable->data_column(), std::move(union_null));
                 } else {
                     // case 3: any of the result rows is not null, so return the original result.
                     // no merge is needed.
-                    return NullableColumn::create(binary_nullable->data_column(), src_null);
+                    return NullableColumn::create(binary_nullable->data_column(), std::move(src_null));
                 }
             } else {
-                return NullableColumn::create(binary, src_null);
+                return NullableColumn::create(std::move(binary), std::move(src_null));
             }
         } else {
-            auto* src = down_cast<BinaryColumn*>(src_nullable->data_column().get());
+            auto* src = down_cast<const BinaryColumn*>(src_nullable->data_column().get());
             return func(columns, src, std::forward<Args>(args)...);
         }
     } else if (columns[0]->is_constant()) {
-        auto* src_constant = down_cast<ConstColumn*>(columns[0].get());
-        auto* src_binary = down_cast<BinaryColumn*>(src_constant->data_column().get());
+        auto* src_constant = down_cast<const ConstColumn*>(columns[0].get());
+        auto* src_binary = down_cast<const BinaryColumn*>(src_constant->data_column().get());
         ColumnPtr binary = func(columns, src_binary, std::forward<Args>(args)...);
         if (binary->is_constant()) {
             return binary;
         } else {
-            return ConstColumn::create(binary, src_constant->size());
+            return ConstColumn::create(std::move(binary), src_constant->size());
         }
     } else {
-        auto* src = down_cast<BinaryColumn*>(columns[0].get());
+        auto* src = down_cast<const BinaryColumn*>(columns[0].get());
         return func(columns, src, std::forward<Args>(args)...);
     }
 }
@@ -670,14 +670,14 @@ static inline ColumnPtr substr_not_const(FunctionContext* context, const starroc
 
     ColumnViewer<TYPE_INT> len_viewer(len_column);
 
-    auto data_column = ColumnHelper::get_data_column(columns[0].get());
-    auto* src = down_cast<BinaryColumn*>(data_column);
+    const auto data_column = ColumnHelper::get_data_column(columns[0].get());
+    const auto* src = down_cast<const BinaryColumn*>(data_column);
 
     const auto rows_num = columns[0]->size();
     NullableBinaryColumnBuilder result;
     result.resize(rows_num, src->byte_size());
 
-    Bytes& src_bytes = src->get_bytes();
+    const Bytes& src_bytes = src->get_bytes();
     auto is_ascii = validate_ascii_fast((const char*)src_bytes.data(), src_bytes.size());
     if (is_ascii) {
         ascii_substr_not_const(rows_num, &str_viewer, &off_viewer, &len_viewer, &result);
@@ -691,13 +691,13 @@ static inline ColumnPtr right_not_const(FunctionContext* context, const starrock
     ColumnViewer<TYPE_VARCHAR> str_viewer(columns[0]);
     ColumnViewer<TYPE_INT> len_viewer(columns[1]);
 
-    auto data_column = ColumnHelper::get_data_column(columns[0].get());
-    auto* src = down_cast<BinaryColumn*>(data_column);
+    const auto data_column = ColumnHelper::get_data_column(columns[0].get());
+    auto* src = down_cast<const BinaryColumn*>(data_column);
     const auto rows_num = columns[0]->size();
 
     NullableBinaryColumnBuilder result;
 
-    Bytes& src_bytes = src->get_bytes();
+    const Bytes& src_bytes = src->get_bytes();
     auto is_ascii = validate_ascii_fast((const char*)src_bytes.data(), src_bytes.size());
     result.resize(rows_num, src->byte_size());
 
@@ -776,7 +776,7 @@ struct SpaceFunction {
 public:
     template <LogicalType Type, LogicalType ResultType>
     static ColumnPtr evaluate(const ColumnPtr& v1) {
-        auto len_column = down_cast<Int32Column*>(v1.get());
+        const auto* len_column = down_cast<const Int32Column*>(v1.get());
         auto& len_array = len_column->get_data();
         const auto num_rows = len_column->size();
         NullableBinaryColumnBuilder builder;
@@ -1177,7 +1177,7 @@ Status StringFunctions::translate_close(FunctionContext* context, FunctionContex
  * @param state stores the ASCII map.
  * @return The translated column, which is a non-nullable BinaryColumn.
  */
-static inline ColumnPtr translate_with_ascii_const_nonnull_from_and_to(const Columns& columns, BinaryColumn* src,
+static inline ColumnPtr translate_with_ascii_const_nonnull_from_and_to(const Columns& columns, const BinaryColumn* src,
                                                                        const TranslateState* state) {
     DCHECK(state->is_from_and_to_const);
     DCHECK(state->is_ascii_map);
@@ -1226,7 +1226,7 @@ static inline ColumnPtr translate_with_ascii_const_nonnull_from_and_to(const Col
  * @return the translated column, which may be a nullable BinaryColumn.
  *  The row will be null, if it exceeds get_olap_string_max_length() after translated.
  */
-static inline ColumnPtr translate_with_utf8_const_nonnull_from_and_to(const Columns& columns, BinaryColumn* src,
+static inline ColumnPtr translate_with_utf8_const_nonnull_from_and_to(const Columns& columns, const BinaryColumn* src,
                                                                       const TranslateState* state) {
     DCHECK(state->is_from_and_to_const);
     DCHECK(!state->is_ascii_map);
@@ -1430,7 +1430,7 @@ Status StringFunctions::pad_close(FunctionContext* context, FunctionContext::Fun
 
 enum PadType { PAD_TYPE_LEFT, PAD_TYPE_RIGHT };
 template <PadType pad_type>
-static inline ColumnPtr ascii_pad_ascii_const(Columns const& columns, BinaryColumn* src, const uint8_t* fill,
+static inline ColumnPtr ascii_pad_ascii_const(Columns const& columns, const BinaryColumn* src, const uint8_t* fill,
                                               const size_t fill_size, const size_t len) {
     DCHECK(0 < len && len <= get_olap_string_max_length());
     DCHECK(fill_size > 0);
@@ -1483,7 +1483,7 @@ static inline ColumnPtr ascii_pad_ascii_const(Columns const& columns, BinaryColu
 }
 
 template <bool src_is_utf8, bool fill_is_utf8, PadType pad_type>
-static inline ColumnPtr pad_utf8_const(Columns const& columns, BinaryColumn* src, const uint8_t* fill,
+static inline ColumnPtr pad_utf8_const(Columns const& columns, const BinaryColumn* src, const uint8_t* fill,
                                        const size_t fill_size, const size_t len,
                                        std::vector<size_t> const& fill_utf8_index) {
     static_assert(src_is_utf8 || fill_is_utf8);
@@ -1575,7 +1575,7 @@ static inline ColumnPtr pad_utf8_const(Columns const& columns, BinaryColumn* src
 }
 
 template <PadType pad_type>
-static inline ColumnPtr pad_const_not_null(const Columns& columns, BinaryColumn* src, const PadState* pad_state) {
+static inline ColumnPtr pad_const_not_null(const Columns& columns, const BinaryColumn* src, const PadState* pad_state) {
     auto len = ColumnHelper::get_const_value<TYPE_INT>(columns[1]);
     auto fill = ColumnHelper::get_const_value<TYPE_VARCHAR>(columns[2]);
 
@@ -1964,9 +1964,9 @@ struct StringCaseToggleFunction {
 public:
     template <LogicalType Type, LogicalType ResultType>
     static ColumnPtr evaluate(const ColumnPtr& v1) {
-        auto* src = down_cast<BinaryColumn*>(v1.get());
-        Bytes& src_bytes = src->get_bytes();
-        Offsets& src_offsets = src->get_offset();
+        const auto* src = down_cast<const BinaryColumn*>(v1.get());
+        const Bytes& src_bytes = src->get_bytes();
+        const Offsets& src_offsets = src->get_offset();
         auto dst = RunTimeColumnType<TYPE_VARCHAR>::create();
         auto& dst_offsets = dst->get_offset();
         auto& dst_bytes = dst->get_bytes();
@@ -2034,7 +2034,7 @@ static inline void utf8_reverse_per_slice(const char* src_begin, const char* src
 }
 
 template <bool is_ascii>
-static inline void reverse(BinaryColumn* src, Bytes* dst_bytes) {
+static inline void reverse(const BinaryColumn* src, Bytes* dst_bytes) {
     const auto num_rows = src->size();
     char* dst_curr = (char*)dst_bytes->data();
     for (auto i = 0; i < num_rows; ++i) {
@@ -2053,9 +2053,9 @@ static inline void reverse(BinaryColumn* src, Bytes* dst_bytes) {
 struct ReverseFunction {
     template <LogicalType Type, LogicalType ResultType>
     static inline ColumnPtr evaluate(const ColumnPtr& column) {
-        auto* src = down_cast<BinaryColumn*>(column.get());
-        auto& src_bytes = src->get_bytes();
-        auto& src_offsets = src->get_offset();
+        const auto* src = down_cast<const BinaryColumn*>(column.get());
+        const auto& src_bytes = src->get_bytes();
+        const auto& src_offsets = src->get_offset();
 
         auto result = BinaryColumn::create();
         auto& dst_bytes = result->get_bytes();
@@ -2219,7 +2219,7 @@ template <TrimType trim_type, size_t simd_threshold, bool trim_single, bool trim
 struct AdaptiveTrimFunction {
     template <LogicalType Type, LogicalType ResultType, class RemoveArg, class Utf8Index>
     static ColumnPtr evaluate(const ColumnPtr& column, RemoveArg&& remove, Utf8Index&& utf8_index) {
-        auto* src = down_cast<BinaryColumn*>(column.get());
+        const auto* src = down_cast<const BinaryColumn*>(column.get());
 
         auto dst = RunTimeColumnType<TYPE_VARCHAR>::create();
         auto& dst_offsets = dst->get_offset();
@@ -2650,7 +2650,8 @@ StatusOr<ColumnPtr> StringFunctions::strcmp(FunctionContext* context, const Colu
     return VectorizedStrictBinaryFunction<strcmpImpl>::evaluate<TYPE_VARCHAR, TYPE_INT>(columns[0], columns[1]);
 }
 
-static inline ColumnPtr concat_const_not_null(Columns const& columns, BinaryColumn* src, const ConcatState* state) {
+static inline ColumnPtr concat_const_not_null(Columns const& columns, const BinaryColumn* src,
+                                              const ConcatState* state) {
     NullableBinaryColumnBuilder builder;
     auto* binary = down_cast<BinaryColumn*>(builder.data_column().get());
     auto& nulls = builder.get_null_data();
@@ -3298,9 +3299,9 @@ static ColumnPtr regexp_extract_all_general(FunctionContext* context, re2::RE2::
         offset_col->append(index);
     }
 
-    auto array =
-            ArrayColumn::create(NullableColumn::create(str_col, NullColumn::create(str_col->size(), 0)), offset_col);
-    return NullableColumn::create(array, nl_col);
+    auto array = ArrayColumn::create(NullableColumn::create(std::move(str_col), NullColumn::create(str_col->size(), 0)),
+                                     std::move(offset_col));
+    return NullableColumn::create(std::move(array), std::move(nl_col));
 }
 
 static ColumnPtr regexp_extract_all_const_pattern(re2::RE2* const_re, const Columns& columns) {
@@ -3353,12 +3354,12 @@ static ColumnPtr regexp_extract_all_const_pattern(re2::RE2* const_re, const Colu
         offset_col->append(index);
     }
 
-    auto array =
-            ArrayColumn::create(NullableColumn::create(str_col, NullColumn::create(str_col->size(), 0)), offset_col);
+    auto array = ArrayColumn::create(NullableColumn::create(std::move(str_col), NullColumn::create(str_col->size(), 0)),
+                                     std::move(offset_col));
     if (ColumnHelper::is_all_const(columns)) {
-        return ConstColumn::create(array, columns[0]->size());
+        return ConstColumn::create(std::move(array), columns[0]->size());
     }
-    return NullableColumn::create(array, nl_col);
+    return NullableColumn::create(std::move(array), std::move(nl_col));
 }
 
 static ColumnPtr regexp_extract_all_const(re2::RE2* const_re, const Columns& columns) {
@@ -3371,10 +3372,10 @@ static ColumnPtr regexp_extract_all_const(re2::RE2* const_re, const Columns& col
     auto offset_col = UInt32Column::create();
     offset_col->append(0);
 
-    NullColumnPtr nl_col;
+    NullColumn::MutablePtr nl_col;
     if (columns[0]->is_nullable()) {
-        auto x = down_cast<NullableColumn*>(columns[0].get())->null_column();
-        nl_col = ColumnHelper::as_column<NullColumn>(x->clone_shared());
+        auto x = down_cast<const NullableColumn*>(columns[0].get())->null_column();
+        nl_col = NullColumn::static_pointer_cast(x->clone());
     } else {
         nl_col = NullColumn::create(size, 0);
     }
@@ -3383,12 +3384,13 @@ static ColumnPtr regexp_extract_all_const(re2::RE2* const_re, const Columns& col
     int max_matches = 1 + const_re->NumberOfCapturingGroups();
     if (group <= 0 || group >= max_matches) {
         offset_col->append_value_multiple_times(&index, size);
-        auto array = ArrayColumn::create(NullableColumn::create(str_col, NullColumn::create(0, 0)), offset_col);
+        auto array = ArrayColumn::create(NullableColumn::create(std::move(str_col), NullColumn::create(0, 0)),
+                                         std::move(offset_col));
 
         if (ColumnHelper::is_all_const(columns)) {
-            return ConstColumn::create(array, columns[0]->size());
+            return ConstColumn::create(std::move(array), columns[0]->size());
         }
-        return NullableColumn::create(array, nl_col);
+        return NullableColumn::create(std::move(array), std::move(nl_col));
     }
 
     re2::StringPiece find[group];
@@ -3415,13 +3417,13 @@ static ColumnPtr regexp_extract_all_const(re2::RE2* const_re, const Columns& col
         offset_col->append(index);
     }
 
-    auto array =
-            ArrayColumn::create(NullableColumn::create(str_col, NullColumn::create(str_col->size(), 0)), offset_col);
+    auto array = ArrayColumn::create(NullableColumn::create(std::move(str_col), NullColumn::create(str_col->size(), 0)),
+                                     std::move(offset_col));
 
     if (ColumnHelper::is_all_const(columns)) {
-        return ConstColumn::create(array, columns[0]->size());
+        return ConstColumn::create(std::move(array), columns[0]->size());
     }
-    return NullableColumn::create(array, nl_col);
+    return NullableColumn::create(std::move(array), std::move(nl_col));
 }
 
 StatusOr<ColumnPtr> StringFunctions::regexp_extract_all(FunctionContext* context, const Columns& columns) {
@@ -3556,7 +3558,7 @@ static StatusOr<ColumnPtr> hyperscan_vec_evaluate(const BinaryColumn* src, Strin
 
     // no match in row
     if (match_info_chain_in_one_row.info_chain.empty()) {
-        return src->clone_shared();
+        return src->clone();
     }
 
     auto data_count = [&]() {
@@ -3629,8 +3631,8 @@ StatusOr<ColumnPtr> StringFunctions::regexp_replace_use_hyperscan_vec(StringFunc
     ASSIGN_OR_RETURN(auto res, hyperscan_vec_evaluate(binary, state, rpl_value));
     if (columns[0]->is_nullable()) {
         return NullableColumn::create(
-                std::move(res), std::static_pointer_cast<NullColumn>(
-                                        down_cast<NullableColumn*>(columns[0].get())->null_column()->clone_shared()));
+                std::move(res), NullColumn::static_pointer_cast(
+                                        down_cast<const NullableColumn*>(columns[0].get())->null_column()->clone()));
     } else if (columns[0]->is_constant()) {
         return ConstColumn::create(std::move(res), columns[0]->size());
     }
@@ -3739,10 +3741,10 @@ static StatusOr<ColumnPtr> regexp_split_const(re2::RE2* const_re, const Columns&
     auto offset_col = UInt32Column::create();
     offset_col->append(0);
 
-    NullColumnPtr nl_col;
+    NullColumn::MutablePtr nl_col;
     if (columns[0]->is_nullable()) {
-        auto x = down_cast<NullableColumn*>(columns[0].get())->null_column();
-        nl_col = ColumnHelper::as_column<NullColumn>(x->clone_shared());
+        auto x = down_cast<const NullableColumn*>(columns[0].get())->null_column();
+        nl_col = NullColumn::static_pointer_cast(x->clone());
     } else {
         nl_col = NullColumn::create(size, 0);
     }
@@ -3772,13 +3774,13 @@ static StatusOr<ColumnPtr> regexp_split_const(re2::RE2* const_re, const Columns&
         offset_col->append(index);
     }
 
-    auto array =
-            ArrayColumn::create(NullableColumn::create(str_col, NullColumn::create(str_col->size(), 0)), offset_col);
+    auto array = ArrayColumn::create(NullableColumn::create(std::move(str_col), NullColumn::create(str_col->size(), 0)),
+                                     std::move(offset_col));
 
     if (ColumnHelper::is_all_const(columns)) {
-        return ConstColumn::create(array, columns[0]->size());
+        return ConstColumn::create(std::move(array), columns[0]->size());
     }
-    return NullableColumn::create(array, nl_col);
+    return NullableColumn::create(std::move(array), std::move(nl_col));
 }
 
 static StatusOr<ColumnPtr> regexp_split_const_pattern(re2::RE2* const_re, const Columns& columns) {
@@ -3797,10 +3799,10 @@ static StatusOr<ColumnPtr> regexp_split_const_pattern(re2::RE2* const_re, const 
     auto offset_col = UInt32Column::create();
     offset_col->append(0);
 
-    NullColumnPtr nl_col;
+    NullColumn::MutablePtr nl_col;
     if (columns[0]->is_nullable()) {
-        auto x = down_cast<NullableColumn*>(columns[0].get())->null_column();
-        nl_col = ColumnHelper::as_column<NullColumn>(x->clone_shared());
+        auto x = down_cast<const NullableColumn*>(columns[0].get())->null_column();
+        nl_col = NullColumn::static_pointer_cast(x->clone());
     } else {
         nl_col = NullColumn::create(size, 0);
     }
@@ -3832,13 +3834,13 @@ static StatusOr<ColumnPtr> regexp_split_const_pattern(re2::RE2* const_re, const 
         offset_col->append(index);
     }
 
-    auto array =
-            ArrayColumn::create(NullableColumn::create(str_col, NullColumn::create(str_col->size(), 0)), offset_col);
+    auto array = ArrayColumn::create(NullableColumn::create(std::move(str_col), NullColumn::create(str_col->size(), 0)),
+                                     std::move(offset_col));
 
     if (ColumnHelper::is_all_const(columns)) {
-        return ConstColumn::create(array, columns[0]->size());
+        return ConstColumn::create(std::move(array), columns[0]->size());
     }
-    return NullableColumn::create(array, nl_col);
+    return NullableColumn::create(std::move(array), std::move(nl_col));
 }
 
 static StatusOr<ColumnPtr> regexp_split_general(FunctionContext* context, re2::RE2::Options* options,
@@ -3900,9 +3902,9 @@ static StatusOr<ColumnPtr> regexp_split_general(FunctionContext* context, re2::R
         offset_col->append(index);
     }
 
-    auto array =
-            ArrayColumn::create(NullableColumn::create(str_col, NullColumn::create(str_col->size(), 0)), offset_col);
-    return NullableColumn::create(array, nl_col);
+    auto array = ArrayColumn::create(NullableColumn::create(std::move(str_col), NullColumn::create(str_col->size(), 0)),
+                                     std::move(offset_col));
+    return NullableColumn::create(std::move(array), std::move(nl_col));
 }
 
 StatusOr<ColumnPtr> StringFunctions::regexp_split(FunctionContext* context, const Columns& columns) {

--- a/be/src/exprs/struct_functions.cpp
+++ b/be/src/exprs/struct_functions.cpp
@@ -23,7 +23,7 @@ StatusOr<ColumnPtr> StructFunctions::new_struct(FunctionContext* context, const 
     ColumnPtr res = context->create_column(context->get_return_type(), false);
 
     StructColumn* st = down_cast<StructColumn*>(res.get());
-    auto fields = st->fields_column();
+    auto& fields = st->fields_column();
 
     DCHECK_EQ(fields.size(), columns.size());
 

--- a/be/src/exprs/subfield_expr.cpp
+++ b/be/src/exprs/subfield_expr.cpp
@@ -54,7 +54,8 @@ public:
             // merge null flags for each level
             if (col->is_nullable()) {
                 auto* nullable = down_cast<NullableColumn*>(col.get());
-                union_null_column = FunctionHelper::union_null_column(union_null_column, nullable->null_column());
+                union_null_column =
+                        FunctionHelper::union_null_column(std::move(union_null_column), nullable->null_column());
             }
 
             Column* tmp_col = ColumnHelper::get_data_column(col.get());
@@ -68,7 +69,8 @@ public:
 
         if (col->is_nullable()) {
             auto* nullable = down_cast<NullableColumn*>(col.get());
-            union_null_column = FunctionHelper::union_null_column(union_null_column, nullable->null_column());
+            union_null_column =
+                    FunctionHelper::union_null_column(std::move(union_null_column), nullable->null_column());
             col = nullable->data_column();
         }
 
@@ -76,9 +78,9 @@ public:
 
         // We need to clone a new subfield column
         if (_copy_flag) {
-            return NullableColumn::create(col->clone_shared(), union_null_column);
+            return NullableColumn::create(col->clone(), std::move(union_null_column));
         } else {
-            return NullableColumn::create(col, union_null_column);
+            return NullableColumn::create(std::move(col), std::move(union_null_column));
         }
     }
 

--- a/be/src/exprs/table_function/generate_series.h
+++ b/be/src/exprs/table_function/generate_series.h
@@ -126,7 +126,7 @@ public:
             }
         } // while
         offsets->append(res->size());
-        return std::make_pair(Columns{res}, offsets);
+        return std::make_pair(Columns{std::move(res)}, std::move(offsets));
     }
 
 private:

--- a/be/src/exprs/table_function/java_udtf_function.cpp
+++ b/be/src/exprs/table_function/java_udtf_function.cpp
@@ -178,7 +178,7 @@ std::pair<Columns, UInt32Column::Ptr> JavaUDTFFunction::process(RuntimeState* ru
     }
 
     // Build Return Type
-    auto offsets_col = UInt32Column::create_mutable();
+    auto offsets_col = UInt32Column::create();
     auto& offsets = offsets_col->get_data();
     offsets.resize(num_rows + 1);
 

--- a/be/src/exprs/table_function/json_each.cpp
+++ b/be/src/exprs/table_function/json_each.cpp
@@ -32,8 +32,8 @@ std::pair<Columns, UInt32Column::Ptr> JsonEach::process(RuntimeState* runtime_st
     state->set_processed_rows(num_input_rows);
 
     Columns result;
-    auto key_column_ptr = BinaryColumn::create();
-    auto value_column_ptr = JsonColumn::create();
+    BinaryColumn::Ptr key_column_ptr = BinaryColumn::create();
+    JsonColumn::Ptr value_column_ptr = JsonColumn::create();
     result.emplace_back(key_column_ptr);
     result.emplace_back(value_column_ptr);
     auto offset_column = UInt32Column::create();
@@ -65,7 +65,7 @@ std::pair<Columns, UInt32Column::Ptr> JsonEach::process(RuntimeState* runtime_st
         offset_column->append(offset);
     }
 
-    return std::make_pair(result, offset_column);
+    return std::make_pair(std::move(result), std::move(offset_column));
 }
 
 } // namespace starrocks

--- a/be/src/exprs/table_function/multi_unnest.h
+++ b/be/src/exprs/table_function/multi_unnest.h
@@ -38,7 +38,7 @@ public:
         long row_count = state->get_columns()[0]->size();
         state->set_processed_rows(row_count);
 
-        std::vector<ColumnPtr> unnested_array_list;
+        Columns unnested_array_list;
         for (auto& col_idx : state->get_columns()) {
             Column* column = col_idx.get();
 
@@ -106,7 +106,7 @@ public:
             result.emplace_back(col_idx);
         }
 
-        return std::make_pair(result, copy_count_column);
+        return std::make_pair(std::move(result), std::move(copy_count_column));
     }
 
     class UnnestState : public TableFunctionState {

--- a/be/src/exprs/table_function/subdivide_bitmap.h
+++ b/be/src/exprs/table_function/subdivide_bitmap.h
@@ -118,7 +118,7 @@ public:
             return {};
         }
         dst_columns.emplace_back(std::move(dst_bitmap_col));
-        return std::make_pair(dst_columns, dst_offset_col);
+        return std::make_pair(std::move(dst_columns), std::move(dst_offset_col));
     }
 };
 } // namespace starrocks

--- a/be/src/exprs/table_function/unnest.h
+++ b/be/src/exprs/table_function/unnest.h
@@ -76,10 +76,10 @@ public:
             }
 
             result.emplace_back(unnested_array_elements);
-            return std::make_pair(result, copy_count_column);
+            return std::make_pair(std::move(result), std::move(copy_count_column));
         } else {
             result.emplace_back(col_array->elements_column());
-            return std::make_pair(result, col_array->offsets_column());
+            return std::make_pair(std::move(result), col_array->offsets_column());
         }
     }
 

--- a/be/src/exprs/table_function/unnest_bitmap.h
+++ b/be/src/exprs/table_function/unnest_bitmap.h
@@ -96,7 +96,7 @@ public:
 
         res_data_col->resize(cur_size);
         res_offset_col->append(cur_size);
-        return std::make_pair(Columns{std::move(res_data_col)}, res_offset_col);
+        return std::make_pair(Columns{std::move(res_data_col)}, std::move(res_offset_col));
     }
 };
 } // namespace starrocks

--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -91,7 +91,7 @@ ColumnPtr date_valid(const ColumnPtr& v1) {
             null_result[i] = nulls[i] | (!values[i].is_valid_non_strict());
         }
 
-        return NullableColumn::create(v->data_column(), null_column);
+        return NullableColumn::create(v->data_column(), std::move(null_column));
     } else {
         auto null_column = NullColumn::create();
         null_column->resize(v1->size());
@@ -103,7 +103,7 @@ ColumnPtr date_valid(const ColumnPtr& v1) {
             nulls[i] = (!values[i].is_valid_non_strict());
         }
 
-        return NullableColumn::create(v1, null_column);
+        return NullableColumn::create(v1, std::move(null_column));
     }
 }
 
@@ -1467,7 +1467,7 @@ StatusOr<ColumnPtr> TimeFunctions::to_unix_for_now_64(FunctionContext* context, 
     int64_t value = context->state()->timestamp_ms() / 1000;
     auto result = Int64Column::create();
     result->append(value);
-    return ConstColumn::create(result, 1);
+    return ConstColumn::create(std::move(result), 1);
 }
 
 StatusOr<ColumnPtr> TimeFunctions::to_unix_for_now_32(FunctionContext* context, const Columns& columns) {
@@ -1475,7 +1475,7 @@ StatusOr<ColumnPtr> TimeFunctions::to_unix_for_now_32(FunctionContext* context, 
     int64_t value = context->state()->timestamp_ms() / 1000;
     auto result = Int32Column::create();
     result->append(value);
-    return ConstColumn::create(result, 1);
+    return ConstColumn::create(std::move(result), 1);
 }
 
 /*

--- a/be/src/exprs/unary_function.h
+++ b/be/src/exprs/unary_function.h
@@ -70,7 +70,7 @@ public:
         }
 
         if (SIMD::count_nonzero(nulls->get_data())) {
-            return NullableColumn::create(result, nulls);
+            return NullableColumn::create(std::move(result), std::move(nulls));
         }
         return result;
     }
@@ -158,7 +158,7 @@ public:
             auto eva1 = ColumnHelper::as_raw_column<ConstColumn>(v1)->data_column();
             ColumnPtr data_column = FN::template evaluate<Type, ResultType, Args...>(eva1, std::forward<Args>(args)...);
 
-            return ConstColumn::create(data_column, v1->size());
+            return ConstColumn::create(std::move(data_column), v1->size());
         } else {
             return FN::template evaluate<Type, ResultType, Args...>(v1, std::forward<Args>(args)...);
         }
@@ -187,7 +187,7 @@ public:
                 data->resize(v1->size());
                 auto nul = NullColumn::create();
                 nul->append(*col->null_column(), 0, col->null_column()->size());
-                return NullableColumn::create(data, std::move(nul));
+                return NullableColumn::create(std::move(data), std::move(nul));
             }
 
             ColumnPtr result =
@@ -207,7 +207,7 @@ public:
                     // both inside the input column and inside the results.
                     auto finally_null_column =
                             FunctionHelper::union_null_column(col->null_column(), nullable_data->null_column());
-                    return NullableColumn::create(nullable_data->data_column(), finally_null_column);
+                    return NullableColumn::create(nullable_data->data_column(), std::move(finally_null_column));
 
                 } else {
                     // case 3: the result rows are all non-nulls, the data of null column should

--- a/be/src/formats/csv/csv_file_writer.cpp
+++ b/be/src/formats/csv/csv_file_writer.cpp
@@ -70,7 +70,7 @@ int64_t CSVFileWriter::get_allocated_bytes() {
 Status CSVFileWriter::write(Chunk* chunk) {
     _num_rows += chunk->num_rows();
 
-    auto columns = std::vector<ColumnPtr>();
+    auto columns = Columns();
     for (auto& e : _column_evaluators) {
         ASSIGN_OR_RETURN(auto column, e->evaluate(chunk));
         columns.push_back(std::move(column));

--- a/be/src/formats/orc/column_reader.cpp
+++ b/be/src/formats/orc/column_reader.cpp
@@ -942,7 +942,7 @@ Status StructColumnReader::_fill_struct_column(orc::ColumnVectorBatch* cvb, Colu
     auto* orc_struct = down_cast<orc::StructVectorBatch*>(cvb);
     auto* col_struct = down_cast<StructColumn*>(col.get());
 
-    Columns& field_columns = col_struct->fields_column();
+    auto& field_columns = col_struct->fields_column();
 
     for (size_t i = 0; i < _type.children.size(); i++) {
         size_t column_id = _child_readers[i]->get_orc_type()->getColumnId();

--- a/be/src/formats/orc/orc_chunk_reader.h
+++ b/be/src/formats/orc/orc_chunk_reader.h
@@ -126,7 +126,7 @@ public:
     Status lazy_seek_to(uint64_t rowInStripe);
     void lazy_filter_on_cvb(Filter* filter);
     StatusOr<ChunkPtr> get_lazy_chunk();
-    StatusOr<ColumnPtr> get_row_delete_filter(const SkipRowsContextPtr& skip_rows_ctx);
+    StatusOr<MutableColumnPtr> get_row_delete_filter(const SkipRowsContextPtr& skip_rows_ctx);
     size_t get_row_delete_number(const SkipRowsContextPtr& skip_rows_ctx);
 
     bool is_implicit_castable(TypeDescriptor& starrocks_type, const TypeDescriptor& orc_type);

--- a/be/src/formats/orc/orc_file_writer.cpp
+++ b/be/src/formats/orc/orc_file_writer.cpp
@@ -244,19 +244,19 @@ Status ORCFileWriter::_write_column(orc::ColumnVectorBatch& orc_column, ColumnPt
     }
 }
 
-inline uint8_t* get_raw_null_column(const ColumnPtr& col) {
+inline const uint8_t* get_raw_null_column(const ColumnPtr& col) {
     if (!col->has_null()) {
         return nullptr;
     }
-    auto& null_column = down_cast<NullableColumn*>(col.get())->null_column();
+    auto& null_column = down_cast<const NullableColumn*>(col.get())->null_column();
     auto* raw_column = null_column->get_data().data();
     return raw_column;
 }
 
 template <LogicalType lt>
-inline RunTimeCppType<lt>* get_raw_data_column(const ColumnPtr& col) {
+inline const RunTimeCppType<lt>* get_raw_data_column(const ColumnPtr& col) {
     auto* data_column = ColumnHelper::get_data_column(col.get());
-    auto* raw_column = down_cast<RunTimeColumnType<lt>*>(data_column)->get_data().data();
+    auto* raw_column = down_cast<const RunTimeColumnType<lt>*>(data_column)->get_data().data();
     return raw_column;
 }
 
@@ -267,8 +267,8 @@ Status ORCFileWriter::_write_number(orc::ColumnVectorBatch& orc_column, ColumnPt
     orc_column.resize(column_size);
     orc_column.numElements = column_size;
 
-    auto* null_col = get_raw_null_column(column);
-    auto* data_col = get_raw_data_column<Type>(column);
+    const auto* null_col = get_raw_null_column(column);
+    const auto* data_col = get_raw_data_column<Type>(column);
 
     _populate_orc_notnull(orc_column, null_col, column_size);
 
@@ -311,8 +311,8 @@ Status ORCFileWriter::_write_decimal32or64or128(orc::ColumnVectorBatch& orc_colu
     decimal_orc_column.precision = precision;
     decimal_orc_column.scale = scale;
 
-    auto* null_col = get_raw_null_column(column);
-    auto* data_col = get_raw_data_column<DecimalType>(column);
+    const auto* null_col = get_raw_null_column(column);
+    const auto* data_col = get_raw_data_column<DecimalType>(column);
 
     _populate_orc_notnull(orc_column, null_col, column_size);
 
@@ -338,8 +338,8 @@ Status ORCFileWriter::_write_date(orc::ColumnVectorBatch& orc_column, ColumnPtr&
     orc_column.resize(column_size);
     orc_column.numElements = column_size;
 
-    auto* null_col = get_raw_null_column(column);
-    auto* data_col = get_raw_data_column<TYPE_DATE>(column);
+    const auto* null_col = get_raw_null_column(column);
+    const auto* data_col = get_raw_data_column<TYPE_DATE>(column);
 
     _populate_orc_notnull(orc_column, null_col, column_size);
 
@@ -357,8 +357,8 @@ Status ORCFileWriter::_write_datetime(orc::ColumnVectorBatch& orc_column, Column
     orc_column.resize(column_size);
     orc_column.numElements = column_size;
 
-    auto* null_col = get_raw_null_column(column);
-    auto* data_col = get_raw_data_column<TYPE_DATETIME>(column);
+    const auto* null_col = get_raw_null_column(column);
+    const auto* data_col = get_raw_data_column<TYPE_DATETIME>(column);
 
     _populate_orc_notnull(orc_column, null_col, column_size);
 
@@ -462,7 +462,7 @@ StatusOr<std::unique_ptr<orc::Type>> ORCFileWriter::_make_schema_node(const Type
     }
 }
 
-void ORCFileWriter::_populate_orc_notnull(orc::ColumnVectorBatch& orc_column, uint8_t* null_column,
+void ORCFileWriter::_populate_orc_notnull(orc::ColumnVectorBatch& orc_column, const uint8_t* null_column,
                                           size_t column_size) {
     orc_column.notNull.resize(column_size);
     if (null_column != nullptr) {

--- a/be/src/formats/orc/orc_file_writer.h
+++ b/be/src/formats/orc/orc_file_writer.h
@@ -95,7 +95,8 @@ private:
 
     static StatusOr<std::unique_ptr<orc::Type>> _make_schema_node(const TypeDescriptor& type_desc);
 
-    static void _populate_orc_notnull(orc::ColumnVectorBatch& orc_column, uint8_t* null_column, size_t column_size);
+    static void _populate_orc_notnull(orc::ColumnVectorBatch& orc_column, const uint8_t* null_column,
+                                      size_t column_size);
 
     StatusOr<std::unique_ptr<orc::ColumnVectorBatch>> _convert(Chunk* chunk);
 

--- a/be/src/formats/parquet/column_reader.h
+++ b/be/src/formats/parquet/column_reader.h
@@ -126,8 +126,8 @@ public:
 
     virtual void set_can_lazy_decode(bool can_lazy_decode) {}
 
-    virtual Status filter_dict_column(const ColumnPtr& column, Filter* filter,
-                                      const std::vector<std::string>& sub_field_path, const size_t& layer) {
+    virtual Status filter_dict_column(ColumnPtr& column, Filter* filter, const std::vector<std::string>& sub_field_path,
+                                      const size_t& layer) {
         return Status::OK();
     }
 

--- a/be/src/formats/parquet/complex_column_reader.cpp
+++ b/be/src/formats/parquet/complex_column_reader.cpp
@@ -273,7 +273,7 @@ bool StructColumnReader::try_to_use_dict_filter(ExprContext* ctx, bool is_decode
     return _child_readers[sub_field]->try_to_use_dict_filter(ctx, is_decode_needed, slotId, sub_field_path, layer + 1);
 }
 
-Status StructColumnReader::filter_dict_column(const ColumnPtr& column, Filter* filter,
+Status StructColumnReader::filter_dict_column(ColumnPtr& column, Filter* filter,
                                               const std::vector<std::string>& sub_field_path, const size_t& layer) {
     const std::string& sub_field = sub_field_path[layer];
     StructColumn* struct_column = nullptr;

--- a/be/src/formats/parquet/complex_column_reader.h
+++ b/be/src/formats/parquet/complex_column_reader.h
@@ -192,7 +192,7 @@ public:
                                                                              layer + 1);
     }
 
-    Status filter_dict_column(const ColumnPtr& column, Filter* filter, const std::vector<std::string>& sub_field_path,
+    Status filter_dict_column(ColumnPtr& column, Filter* filter, const std::vector<std::string>& sub_field_path,
                               const size_t& layer) override;
 
     Status fill_dst_column(ColumnPtr& dst, ColumnPtr& src) override;

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -99,7 +99,7 @@ struct GroupReaderParam {
     // partition column
     const std::vector<HdfsScannerContext::ColumnInfo>* partition_columns = nullptr;
     // partition column value which read from hdfs file path
-    const std::vector<ColumnPtr>* partition_values = nullptr;
+    const Columns* partition_values = nullptr;
     // not existed column
     const std::vector<SlotDescriptor*>* not_existed_slots = nullptr;
     // used for global low cardinality optimization

--- a/be/src/formats/parquet/scalar_column_reader.cpp
+++ b/be/src/formats/parquet/scalar_column_reader.cpp
@@ -220,8 +220,8 @@ StatusOr<bool> RawColumnReader::_row_group_zone_map_filter(const std::vector<con
     std::optional<ZoneMapDetail> zone_map_detail = std::nullopt;
 
     // used to hold min/max slice values
-    const ColumnPtr min_column = ColumnHelper::create_column(col_type, true);
-    const ColumnPtr max_column = ColumnHelper::create_column(col_type, true);
+    const MutableColumnPtr min_column = ColumnHelper::create_column(col_type, true);
+    const MutableColumnPtr max_column = ColumnHelper::create_column(col_type, true);
     if (is_all_null) {
         // if the entire column's value is null, the min/max value not existed
         zone_map_detail = ZoneMapDetail{Datum{}, Datum{}, true};
@@ -282,8 +282,8 @@ StatusOr<bool> RawColumnReader::_page_index_zone_map_filter(const std::vector<co
     const size_t page_num = column_index.min_values.size();
     const std::vector<bool> null_pages = column_index.null_pages;
 
-    ColumnPtr min_column = ColumnHelper::create_column(col_type, true);
-    ColumnPtr max_column = ColumnHelper::create_column(col_type, true);
+    MutableColumnPtr min_column = ColumnHelper::create_column(col_type, true);
+    MutableColumnPtr max_column = ColumnHelper::create_column(col_type, true);
     // deal with min_values
     auto st = StatisticsHelper::decode_value_into_column(min_column, column_index.min_values, null_pages, col_type,
                                                          get_column_parquet_field(), _opts.timezone);

--- a/be/src/formats/parquet/scalar_column_reader.h
+++ b/be/src/formats/parquet/scalar_column_reader.h
@@ -150,7 +150,7 @@ public:
         _can_lazy_dict_decode = can_lazy_decode && _col_type->is_string_type() && column_all_pages_dict_encoded();
     }
 
-    Status filter_dict_column(const ColumnPtr& column, Filter* filter, const std::vector<std::string>& sub_field_path,
+    Status filter_dict_column(ColumnPtr& column, Filter* filter, const std::vector<std::string>& sub_field_path,
                               const size_t& layer) override {
         DCHECK_EQ(sub_field_path.size(), layer);
         return _dict_filter_ctx->predicate->evaluate_and(column.get(), filter->data());
@@ -214,7 +214,7 @@ public:
         return _dict_filter_ctx->rewrite_conjunct_ctxs_to_predicate(_reader.get(), is_group_filtered);
     }
 
-    Status filter_dict_column(const ColumnPtr& column, Filter* filter, const std::vector<std::string>& sub_field_path,
+    Status filter_dict_column(ColumnPtr& column, Filter* filter, const std::vector<std::string>& sub_field_path,
                               const size_t& layer) override {
         DCHECK_EQ(sub_field_path.size(), layer);
         return _dict_filter_ctx->predicate->evaluate_and(column.get(), filter->data());

--- a/be/src/formats/parquet/statistics_helper.cpp
+++ b/be/src/formats/parquet/statistics_helper.cpp
@@ -38,7 +38,8 @@
 
 namespace starrocks::parquet {
 
-Status StatisticsHelper::decode_value_into_column(const ColumnPtr& column, const std::vector<std::string>& values,
+Status StatisticsHelper::decode_value_into_column(const MutableColumnPtr& column,
+                                                  const std::vector<std::string>& values,
                                                   const std::vector<bool>& null_pages, const TypeDescriptor& type,
                                                   const ParquetField* field, const std::string& timezone) {
     std::unique_ptr<ColumnConverter> converter;

--- a/be/src/formats/parquet/statistics_helper.h
+++ b/be/src/formats/parquet/statistics_helper.h
@@ -27,7 +27,7 @@ class StatisticsHelper {
 public:
     enum StatSupportedFilter { FILTER_IN, IS_NULL, IS_NOT_NULL, RF_MIN_MAX };
 
-    static Status decode_value_into_column(const ColumnPtr& column, const std::vector<std::string>& values,
+    static Status decode_value_into_column(const MutableColumnPtr& column, const std::vector<std::string>& values,
                                            const std::vector<bool>& null_pages, const TypeDescriptor& type,
                                            const ParquetField* field, const std::string& timezone);
 

--- a/be/src/runtime/global_dict/decoder.h
+++ b/be/src/runtime/global_dict/decoder.h
@@ -23,9 +23,9 @@ class GlobalDictDecoder {
 public:
     virtual ~GlobalDictDecoder() = default;
 
-    virtual Status decode_string(Column* in, Column* out) = 0;
+    virtual Status decode_string(const Column* in, Column* out) = 0;
 
-    virtual Status decode_array(Column* in, Column* out) = 0;
+    virtual Status decode_array(const Column* in, Column* out) = 0;
 };
 
 using GlobalDictDecoderPtr = std::unique_ptr<GlobalDictDecoder>;

--- a/be/src/runtime/global_dict/miscs.cpp
+++ b/be/src/runtime/global_dict/miscs.cpp
@@ -22,9 +22,8 @@
 
 namespace starrocks {
 
-std::pair<std::shared_ptr<NullableColumn>, std::vector<int32_t>> extract_column_with_codes(
-        const GlobalDictMap& dict_map) {
-    auto res = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+std::pair<NullableColumn::Ptr, std::vector<int32_t>> extract_column_with_codes(const GlobalDictMap& dict_map) {
+    NullableColumn::Ptr res = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
     res->reserve(dict_map.size() + 1);
 
     std::vector<Slice> slices;
@@ -40,8 +39,8 @@ std::pair<std::shared_ptr<NullableColumn>, std::vector<int32_t>> extract_column_
         slices.emplace_back(slice);
         codes.emplace_back(code);
     }
-    res->append_strings(slices.data(), slices.size());
-    res->set_null(0);
+    (void)res->append_strings(slices.data(), slices.size());
+    (void)res->set_null(0);
     return std::make_pair(std::move(res), std::move(codes));
 }
 

--- a/be/src/runtime/global_dict/miscs.h
+++ b/be/src/runtime/global_dict/miscs.h
@@ -23,7 +23,6 @@
 
 namespace starrocks {
 
-std::pair<std::shared_ptr<NullableColumn>, std::vector<int32_t>> extract_column_with_codes(
-        const GlobalDictMap& dict_map);
+std::pair<NullableColumn::Ptr, std::vector<int32_t>> extract_column_with_codes(const GlobalDictMap& dict_map);
 
 } // namespace starrocks

--- a/be/src/runtime/global_dict/parser.cpp
+++ b/be/src/runtime/global_dict/parser.cpp
@@ -178,7 +178,7 @@ private:
 
             ColumnPtr string_col = _translate_string(element, element->size());
             string_col = ColumnHelper::unfold_const_column(stringType, element->size(), string_col);
-            return ConstColumn::create(ArrayColumn::create(string_col, offsets), num_rows);
+            return ConstColumn::create(ArrayColumn::create(string_col, std::move(offsets)), num_rows);
         } else if (array->is_nullable()) {
             auto nullable = down_cast<NullableColumn*>(array.get());
             array_col = down_cast<ArrayColumn*>(nullable->data_column().get());
@@ -189,7 +189,7 @@ private:
 
             ColumnPtr string_col = _translate_string(element, element->size());
             string_col = ColumnHelper::unfold_const_column(stringType, element->size(), string_col);
-            return NullableColumn::create(ArrayColumn::create(string_col, offsets), array_null);
+            return NullableColumn::create(ArrayColumn::create(string_col, std::move(offsets)), array_null);
         } else {
             array_col = down_cast<ArrayColumn*>(array.get());
             auto element = array_col->elements_column();
@@ -197,7 +197,7 @@ private:
 
             ColumnPtr string_col = _translate_string(element, element->size());
             string_col = ColumnHelper::unfold_const_column(stringType, element->size(), string_col);
-            return ArrayColumn::create(string_col, offsets);
+            return ArrayColumn::create(string_col, std::move(offsets));
         }
     }
 

--- a/be/src/runtime/metadata_result_writer.cpp
+++ b/be/src/runtime/metadata_result_writer.cpp
@@ -123,21 +123,21 @@ Status MetadataResultWriter::_fill_iceberg_metadata(const Columns& columns, cons
                                                     TFetchDataResult* result) const {
     SCOPED_TIMER(_convert_tuple_timer);
 
-    auto content = down_cast<Int32Column*>(ColumnHelper::get_data_column(columns[0].get()));
-    auto file_path = down_cast<BinaryColumn*>(ColumnHelper::get_data_column(columns[1].get()));
-    auto file_format = down_cast<BinaryColumn*>(ColumnHelper::get_data_column(columns[2].get()));
-    auto spec_id = down_cast<Int32Column*>(ColumnHelper::get_data_column(columns[3].get()));
-    auto partition_data = down_cast<BinaryColumn*>(ColumnHelper::get_data_column(columns[4].get()));
-    auto record_count = down_cast<Int64Column*>(ColumnHelper::get_data_column(columns[5].get()));
-    auto file_size_in_bytes = down_cast<Int64Column*>(ColumnHelper::get_data_column(columns[6].get()));
-    auto split_offsets = down_cast<ArrayColumn*>(ColumnHelper::get_data_column(columns[7].get()));
+    const auto* content = down_cast<const Int32Column*>(ColumnHelper::get_data_column(columns[0].get()));
+    const auto* file_path = down_cast<const BinaryColumn*>(ColumnHelper::get_data_column(columns[1].get()));
+    const auto* file_format = down_cast<const BinaryColumn*>(ColumnHelper::get_data_column(columns[2].get()));
+    const auto* spec_id = down_cast<const Int32Column*>(ColumnHelper::get_data_column(columns[3].get()));
+    const auto* partition_data = down_cast<const BinaryColumn*>(ColumnHelper::get_data_column(columns[4].get()));
+    const auto* record_count = down_cast<const Int64Column*>(ColumnHelper::get_data_column(columns[5].get()));
+    const auto* file_size_in_bytes = down_cast<const Int64Column*>(ColumnHelper::get_data_column(columns[6].get()));
+    const auto* split_offsets = down_cast<const ArrayColumn*>(ColumnHelper::get_data_column(columns[7].get()));
 
-    auto sort_id = down_cast<Int32Column*>(ColumnHelper::get_data_column(columns[8].get()));
-    auto equality_ids = down_cast<ArrayColumn*>(ColumnHelper::get_data_column(columns[9].get()));
-    auto file_sequence_number = down_cast<Int64Column*>(ColumnHelper::get_data_column(columns[10].get()));
-    auto data_sequence_number = down_cast<Int64Column*>(ColumnHelper::get_data_column(columns[11].get()));
-    auto iceberg_metrics = down_cast<BinaryColumn*>(ColumnHelper::get_data_column(columns[12].get()));
-    auto key_metadata = down_cast<BinaryColumn*>(ColumnHelper::get_data_column(columns[13].get()));
+    const auto* sort_id = down_cast<const Int32Column*>(ColumnHelper::get_data_column(columns[8].get()));
+    const auto* equality_ids = down_cast<const ArrayColumn*>(ColumnHelper::get_data_column(columns[9].get()));
+    const auto* file_sequence_number = down_cast<const Int64Column*>(ColumnHelper::get_data_column(columns[10].get()));
+    const auto* data_sequence_number = down_cast<const Int64Column*>(ColumnHelper::get_data_column(columns[11].get()));
+    const auto* iceberg_metrics = down_cast<const BinaryColumn*>(ColumnHelper::get_data_column(columns[12].get()));
+    const auto* key_metadata = down_cast<const BinaryColumn*>(ColumnHelper::get_data_column(columns[13].get()));
 
     std::vector<TMetadataEntry> meta_entries;
     int num_rows = chunk->num_rows();

--- a/be/src/runtime/result_writer.h
+++ b/be/src/runtime/result_writer.h
@@ -36,6 +36,7 @@
 
 #include <stdexcept>
 
+#include "column/column.h"
 #include "column/vectorized_fwd.h"
 #include "common/status.h"
 #include "common/statusor.h"

--- a/be/src/runtime/statistic_result_writer.cpp
+++ b/be/src/runtime/statistic_result_writer.cpp
@@ -201,12 +201,12 @@ Status StatisticResultWriter::_fill_statistic_data_v1(int version, const Columns
     auto& dbIds = ColumnHelper::cast_to_raw<TYPE_BIGINT>(columns[2])->get_data();
     auto& tableIds = ColumnHelper::cast_to_raw<TYPE_BIGINT>(columns[3])->get_data();
     BinaryColumn* nameColumn = ColumnHelper::cast_to_raw<TYPE_VARCHAR>(columns[4]);
-    auto* rowCounts = down_cast<Int64Column*>(ColumnHelper::get_data_column(columns[5].get()));
-    auto* dataSizes = down_cast<Int64Column*>(ColumnHelper::get_data_column(columns[6].get()));
-    auto* countDistincts = down_cast<Int64Column*>(ColumnHelper::get_data_column(columns[7].get()));
-    auto* nullCounts = down_cast<Int64Column*>(ColumnHelper::get_data_column(columns[8].get()));
-    auto* maxColumn = down_cast<BinaryColumn*>(ColumnHelper::get_data_column(columns[9].get()));
-    auto* minColumn = down_cast<BinaryColumn*>(ColumnHelper::get_data_column(columns[10].get()));
+    const auto* rowCounts = down_cast<const Int64Column*>(ColumnHelper::get_data_column(columns[5].get()));
+    const auto* dataSizes = down_cast<const Int64Column*>(ColumnHelper::get_data_column(columns[6].get()));
+    const auto* countDistincts = down_cast<const Int64Column*>(ColumnHelper::get_data_column(columns[7].get()));
+    const auto* nullCounts = down_cast<const Int64Column*>(ColumnHelper::get_data_column(columns[8].get()));
+    const auto* maxColumn = down_cast<const BinaryColumn*>(ColumnHelper::get_data_column(columns[9].get()));
+    const auto* minColumn = down_cast<const BinaryColumn*>(ColumnHelper::get_data_column(columns[10].get()));
 
     std::vector<TStatisticData> data_list;
     int num_rows = chunk->num_rows();
@@ -248,13 +248,13 @@ Status StatisticResultWriter::_fill_statistic_data_v2(int version, const Columns
     auto& dbIds = ColumnHelper::cast_to_raw<TYPE_BIGINT>(columns[2])->get_data();
     auto& tableIds = ColumnHelper::cast_to_raw<TYPE_BIGINT>(columns[3])->get_data();
     BinaryColumn* nameColumn = ColumnHelper::cast_to_raw<TYPE_VARCHAR>(columns[4]);
-    auto* rowCounts = down_cast<Int64Column*>(ColumnHelper::get_data_column(columns[5].get()));
-    auto* dataSizes = down_cast<Int64Column*>(ColumnHelper::get_data_column(columns[6].get()));
-    auto* countDistincts = down_cast<Int64Column*>(ColumnHelper::get_data_column(columns[7].get()));
-    auto* nullCounts = down_cast<Int64Column*>(ColumnHelper::get_data_column(columns[8].get()));
-    auto* maxColumn = down_cast<BinaryColumn*>(ColumnHelper::get_data_column(columns[9].get()));
-    auto* minColumn = down_cast<BinaryColumn*>(ColumnHelper::get_data_column(columns[10].get()));
-    auto* collectionSize = down_cast<Int64Column*>(ColumnHelper::get_data_column(columns[11].get()));
+    auto* rowCounts = down_cast<const Int64Column*>(ColumnHelper::get_data_column(columns[5].get()));
+    auto* dataSizes = down_cast<const Int64Column*>(ColumnHelper::get_data_column(columns[6].get()));
+    auto* countDistincts = down_cast<const Int64Column*>(ColumnHelper::get_data_column(columns[7].get()));
+    auto* nullCounts = down_cast<const Int64Column*>(ColumnHelper::get_data_column(columns[8].get()));
+    auto* maxColumn = down_cast<const BinaryColumn*>(ColumnHelper::get_data_column(columns[9].get()));
+    auto* minColumn = down_cast<const BinaryColumn*>(ColumnHelper::get_data_column(columns[10].get()));
+    auto* collectionSize = down_cast<const Int64Column*>(ColumnHelper::get_data_column(columns[11].get()));
 
     std::vector<TStatisticData> data_list;
     int num_rows = chunk->num_rows();
@@ -289,10 +289,10 @@ Status StatisticResultWriter::_fill_statistic_histogram(int version, const Colum
     SCOPED_TIMER(_serialize_timer);
     DCHECK(columns.size() == 5);
 
-    auto* dbIds = down_cast<Int64Column*>(ColumnHelper::get_data_column(columns[1].get()));
-    auto* tableIds = down_cast<Int64Column*>(ColumnHelper::get_data_column(columns[2].get()));
-    auto* nameColumn = down_cast<BinaryColumn*>(ColumnHelper::get_data_column(columns[3].get()));
-    auto* histogramColumn = down_cast<BinaryColumn*>(ColumnHelper::get_data_column(columns[4].get()));
+    auto* dbIds = down_cast<const Int64Column*>(ColumnHelper::get_data_column(columns[1].get()));
+    auto* tableIds = down_cast<const Int64Column*>(ColumnHelper::get_data_column(columns[2].get()));
+    auto* nameColumn = down_cast<const BinaryColumn*>(ColumnHelper::get_data_column(columns[3].get()));
+    auto* histogramColumn = down_cast<const BinaryColumn*>(ColumnHelper::get_data_column(columns[4].get()));
 
     std::vector<TStatisticData> data_list;
     int num_rows = chunk->num_rows();
@@ -320,8 +320,8 @@ Status StatisticResultWriter::_fill_statistic_histogram_external(int version, co
     SCOPED_TIMER(_serialize_timer);
     DCHECK(columns.size() == 3);
 
-    auto* columnName = down_cast<BinaryColumn*>(ColumnHelper::get_data_column(columns[1].get()));
-    auto* histogramColumn = down_cast<BinaryColumn*>(ColumnHelper::get_data_column(columns[2].get()));
+    auto* columnName = down_cast<const BinaryColumn*>(ColumnHelper::get_data_column(columns[1].get()));
+    auto* histogramColumn = down_cast<const BinaryColumn*>(ColumnHelper::get_data_column(columns[2].get()));
 
     std::vector<TStatisticData> data_list;
     int num_rows = chunk->num_rows();
@@ -347,8 +347,8 @@ Status StatisticResultWriter::_fill_table_statistic_data(int version, const Colu
     SCOPED_TIMER(_serialize_timer);
     DCHECK(columns.size() == 3);
 
-    auto* partitionId = down_cast<Int64Column*>(ColumnHelper::get_data_column(columns[1].get()));
-    auto* rowCounts = down_cast<Int64Column*>(ColumnHelper::get_data_column(columns[2].get()));
+    auto* partitionId = down_cast<const Int64Column*>(ColumnHelper::get_data_column(columns[1].get()));
+    auto* rowCounts = down_cast<const Int64Column*>(ColumnHelper::get_data_column(columns[2].get()));
 
     std::vector<TStatisticData> data_list;
     int num_rows = chunk->num_rows();

--- a/be/src/runtime/variable_result_writer.cpp
+++ b/be/src/runtime/variable_result_writer.cpp
@@ -90,7 +90,7 @@ StatusOr<TFetchDataResultPtr> VariableResultWriter::_process_chunk(Chunk* chunk)
         return Status::MemoryAllocFailed("memory allocate failed");
     }
 
-    auto* variable = down_cast<BinaryColumn*>(ColumnHelper::get_data_column(result_columns[0].get()));
+    auto* variable = down_cast<const BinaryColumn*>(ColumnHelper::get_data_column(result_columns[0].get()));
     std::vector<TVariableData> var_list;
 
     int num_rows = chunk->num_rows();

--- a/be/src/serde/column_array_serde.cpp
+++ b/be/src/serde/column_array_serde.cpp
@@ -460,7 +460,7 @@ public:
     }
 
     static const uint8_t* deserialize(const uint8_t* buff, StructColumn* column, const int encode_level) {
-        for (const auto& field : column->fields_column()) {
+        for (auto& field : column->fields_column()) {
             buff = serde::ColumnArraySerde::deserialize(buff, field.get(), false, encode_level);
         }
         return buff;

--- a/be/src/serde/protobuf_serde.cpp
+++ b/be/src/serde/protobuf_serde.cpp
@@ -219,7 +219,7 @@ StatusOr<Chunk> ProtobufChunkDeserializer::deserialize(std::string_view buff, in
     uint32_t rows = decode_fixed32_le(cur);
     cur += 4;
 
-    std::vector<ColumnPtr> columns;
+    Columns columns;
     columns.resize(_meta.slot_id_to_index.size());
     for (size_t i = 0, sz = _meta.is_nulls.size(); i < sz; ++i) {
         columns[i] = ColumnHelper::create_column(_meta.types[i], _meta.is_nulls[i], _meta.is_consts[i], rows);
@@ -250,7 +250,7 @@ StatusOr<Chunk> ProtobufChunkDeserializer::deserialize(std::string_view buff, in
     // deserialize extra data
     ChunkExtraDataPtr chunk_extra_data;
     if (!_meta.extra_data_metas.empty()) {
-        std::vector<ColumnPtr> extra_columns;
+        Columns extra_columns;
         extra_columns.resize(_meta.extra_data_metas.size());
         for (size_t i = 0, sz = _meta.extra_data_metas.size(); i < sz; ++i) {
             auto extra_meta = _meta.extra_data_metas[i];

--- a/be/src/storage/chunk_helper.h
+++ b/be/src/storage/chunk_helper.h
@@ -78,10 +78,10 @@ public:
 
     // Create a vectorized column from field .
     // REQUIRE: |type| must be scalar type.
-    static std::shared_ptr<Column> column_from_field_type(LogicalType type, bool nullable);
+    static MutableColumnPtr column_from_field_type(LogicalType type, bool nullable);
 
     // Create a vectorized column from field.
-    static std::shared_ptr<Column> column_from_field(const Field& field);
+    static MutableColumnPtr column_from_field(const Field& field);
 
     // Get char column indexes
     static std::vector<size_t> get_char_field_indexes(const Schema& schema);
@@ -160,7 +160,7 @@ private:
 class SegmentedColumn final : public std::enable_shared_from_this<SegmentedColumn> {
 public:
     SegmentedColumn(const SegmentedChunkPtr& chunk, size_t column_index);
-    SegmentedColumn(std::vector<ColumnPtr> columns, size_t segment_size);
+    SegmentedColumn(Columns columns, size_t segment_size);
     ~SegmentedColumn() = default;
 
     ColumnPtr clone_selective(const uint32_t* indexes, uint32_t from, uint32_t size);
@@ -172,14 +172,14 @@ public:
     void upgrade_to_nullable();
     size_t segment_size() const;
     size_t num_segments() const;
-    std::vector<ColumnPtr> columns() const;
+    Columns columns() const;
 
 private:
     SegmentedChunkWeakPtr _chunk; // The chunk it belongs to
     size_t _column_index;         // The index in original chunk
     const size_t _segment_size;
 
-    std::vector<ColumnPtr> _cached_columns; // Only used for SelectiveCopy
+    Columns _cached_columns; // Only used for SelectiveCopy
 };
 
 // A big-chunk would be segmented into multi small ones, to avoid allocating large-continuous memory

--- a/be/src/storage/column_aggregate_func.cpp
+++ b/be/src/storage/column_aggregate_func.cpp
@@ -53,7 +53,7 @@ template <typename ColumnType, typename StateType>
 class ReplaceAggregator final : public ValueColumnAggregator<ColumnType, StateType> {
 public:
     void aggregate_impl(int row, const ColumnPtr& src) override {
-        auto* data = down_cast<ColumnType*>(src.get())->get_data().data();
+        const auto* data = down_cast<const ColumnType*>(src.get())->get_data().data();
         this->data() = data[row];
     }
 
@@ -68,7 +68,7 @@ template <>
 class ReplaceAggregator<BitmapColumn, BitmapValue> final : public ValueColumnAggregator<BitmapColumn, BitmapValue> {
 public:
     void aggregate_impl(int row, const ColumnPtr& src) override {
-        auto* data = down_cast<BitmapColumn*>(src.get());
+        const auto* data = down_cast<const BitmapColumn*>(src.get());
         this->data() = *(data->get_object(row));
     }
 
@@ -88,7 +88,7 @@ class ReplaceAggregator<HyperLogLogColumn, HyperLogLog> final
         : public ValueColumnAggregator<HyperLogLogColumn, HyperLogLog> {
 public:
     void aggregate_impl(int row, const ColumnPtr& src) override {
-        auto* data = down_cast<HyperLogLogColumn*>(src.get());
+        auto* data = down_cast<const HyperLogLogColumn*>(src.get());
         this->data() = *(data->get_object(row));
     }
 
@@ -108,7 +108,7 @@ class ReplaceAggregator<PercentileColumn, PercentileValue> final
         : public ValueColumnAggregator<PercentileColumn, PercentileValue> {
 public:
     void aggregate_impl(int row, const ColumnPtr& src) override {
-        auto* data = down_cast<PercentileColumn*>(src.get());
+        const auto* data = down_cast<const PercentileColumn*>(src.get());
         this->data() = *(data->get_object(row));
     }
 
@@ -129,13 +129,13 @@ public:
     void reset() override { this->data().reset(); }
 
     void aggregate_impl(int row, const ColumnPtr& src) override {
-        auto* col = down_cast<BinaryColumn*>(src.get());
+        const auto* col = down_cast<const BinaryColumn*>(src.get());
         Slice data = col->get_slice(row);
         this->data().update(data);
     }
 
     void aggregate_batch_impl(int start, int end, const ColumnPtr& src) override {
-        auto* col = down_cast<BinaryColumn*>(src.get());
+        auto* col = down_cast<const BinaryColumn*>(src.get());
         Slice data = col->get_slice(end - 1);
         this->data().update(data);
     }
@@ -193,7 +193,7 @@ public:
     void update_source(const ColumnPtr& src) override {
         _source_column = src;
 
-        auto* nullable = down_cast<NullableColumn*>(src.get());
+        const auto* nullable = down_cast<const NullableColumn*>(src.get());
         _child->update_source(nullable->data_column());
         _null_child->update_source(nullable->null_column());
     }

--- a/be/src/storage/column_aggregator.h
+++ b/be/src/storage/column_aggregator.h
@@ -137,7 +137,7 @@ public:
     void update_source(const ColumnPtr& src) override {
         _source_column = src;
 
-        auto* nullable = down_cast<NullableColumn*>(src.get());
+        const auto* nullable = down_cast<const NullableColumn*>(src.get());
         _child->update_source(nullable->data_column());
 
         _source_nulls_data = nullable->null_column_data().data();
@@ -280,7 +280,7 @@ private:
 
     NullColumn* _aggregate_nulls{nullptr};
 
-    uint8_t* _source_nulls_data{nullptr};
+    const uint8_t* _source_nulls_data{nullptr};
 
     uint8_t _row_is_null{0};
 };

--- a/be/src/storage/column_expr_predicate.cpp
+++ b/be/src/storage/column_expr_predicate.cpp
@@ -80,7 +80,7 @@ Status ColumnExprPredicate::evaluate(const Column* column, uint8_t* selection, u
     Chunk chunk;
     // `column` is owned by storage layer
     // we don't have ownership
-    ColumnPtr bits(const_cast<Column*>(column), [](auto p) {});
+    ColumnPtr bits = const_cast<Column*>(column)->as_mutable_ptr();
     chunk.append_column(bits, _slot_desc->id());
 
     // theoretically there will be a chain of expr contexts.
@@ -157,7 +157,7 @@ bool ColumnExprPredicate::zone_map_filter(const ZoneMapDetail& detail) const {
     if (!_monotonic) return true;
     // construct column and chunk by zone map
     TypeDescriptor type_desc = TypeDescriptor::from_storage_type_info(_type_info.get());
-    ColumnPtr col = ColumnHelper::create_column(type_desc, detail.has_null());
+    MutableColumnPtr col = ColumnHelper::create_column(type_desc, detail.has_null());
     // null, min, max
     uint16_t size = 0;
     uint8_t selection[3];

--- a/be/src/storage/column_predicate_rewriter.cpp
+++ b/be/src/storage/column_predicate_rewriter.cpp
@@ -384,14 +384,14 @@ Status ColumnPredicateRewriter::_load_segment_dict_vec(ColumnIterator* iter, Col
 
     if (field_nullable) {
         // create nullable column with NULL at last.
-        NullColumnPtr null_col = NullColumn::create();
+        NullColumn::MutablePtr null_col = NullColumn::create();
         null_col->resize(dict_size);
-        auto null_column = NullableColumn::create(dict_col, null_col);
+        auto null_column = NullableColumn::create(std::move(dict_col), std::move(null_col));
         null_column->append_default();
-        *dict_column = null_column;
+        *dict_column = std::move(null_column);
     } else {
         // otherwise we just give binary column.
-        *dict_column = dict_col;
+        *dict_column = std::move(dict_col);
     }
 
     auto code_col = Int32Column::create();
@@ -400,7 +400,7 @@ Status ColumnPredicateRewriter::_load_segment_dict_vec(ColumnIterator* iter, Col
     for (int i = 0; i < dict_size; i++) {
         code_buf[i] = dict_codes[i];
     }
-    *code_column = code_col;
+    *code_column = std::move(code_col);
     return Status::OK();
 }
 
@@ -480,7 +480,7 @@ StatusOr<ColumnPredicateRewriter::RewriteStatus> ColumnPredicateRewriter::_rewri
     builder.set_is_not_in(is_not_in);
     builder.use_array_set(code_size);
     DCHECK_IF_ERROR(builder.create());
-    (void)builder.add_values(used_values, 0);
+    (void)builder.add_values(std::move(used_values), 0);
     ExprContext* filter = builder.get_in_const_predicate();
 
     DCHECK_IF_ERROR(filter->prepare(state));

--- a/be/src/storage/convert_helper.cpp
+++ b/be/src/storage/convert_helper.cpp
@@ -1282,7 +1282,7 @@ public:
 
     void convert(Datum* dst, const Datum& src) const override { *dst = src; }
 
-    ColumnPtr copy_convert(const Column& src) const override { return src.clone_shared(); }
+    ColumnPtr copy_convert(const Column& src) const override { return src.clone(); }
 
     ColumnPtr move_convert(Column* src) const override {
         auto ret = src->clone_empty();
@@ -1583,7 +1583,7 @@ public:
             } else if (src.is_nullable() && !dst->only_null()) {
                 dst = NullableColumn::create(dst, NullColumn::create());
                 auto* nullable_dst_column = down_cast<NullableColumn*>(dst.get());
-                auto* nullable_src_column = down_cast<const NullableColumn*>(&src);
+                auto* nullable_src_column = down_cast<NullableColumn*>(const_cast<Column*>(&src));
                 auto* dst_column = down_cast<DstColumnType*>(nullable_dst_column->data_column().get());
                 auto* src_column = down_cast<SrcColumnType*>(nullable_src_column->data_column().get());
                 auto& null_dst_column = nullable_dst_column->null_column();

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -872,14 +872,14 @@ Status DeltaWriter::_fill_auto_increment_id(const Chunk& chunk) {
         pk_columns.push_back((uint32_t)i);
     }
     Schema pkey_schema = ChunkHelper::convert_schema(_tablet_schema, pk_columns);
-    std::unique_ptr<Column> pk_column;
+    MutableColumnPtr pk_column;
     if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column).ok()) {
         CHECK(false) << "create column for primary key encoder failed";
     }
     auto col = pk_column->clone();
 
     PrimaryKeyEncoder::encode(pkey_schema, chunk, 0, chunk.num_rows(), col.get());
-    std::unique_ptr<Column> upserts = std::move(col);
+    MutableColumnPtr upserts = std::move(col);
 
     std::vector<uint64_t> rss_rowids;
     rss_rowids.resize(upserts->size());
@@ -908,7 +908,7 @@ Status DeltaWriter::_fill_auto_increment_id(const Chunk& chunk) {
         const TabletColumn& tablet_column = _tablet_schema->column(i);
         if (tablet_column.is_auto_increment()) {
             auto& column = chunk.get_column_by_index(i);
-            RETURN_IF_ERROR((std::dynamic_pointer_cast<Int64Column>(column))->fill_range(ids, filter));
+            RETURN_IF_ERROR((Int64Column::dynamic_pointer_cast(column))->fill_range(ids, filter));
             break;
         }
     }

--- a/be/src/storage/dictionary_cache_manager.h
+++ b/be/src/storage/dictionary_cache_manager.h
@@ -362,11 +362,11 @@ public:
     ~DictionaryCacheUtil();
 
     // using primary key encoding function
-    static std::unique_ptr<Column> encode_columns(const Schema& schema, const Chunk* chunk,
-                                                  const DictionaryCacheEncoderType& encoder_type = PK_ENCODE) {
+    static MutableColumnPtr encode_columns(const Schema& schema, const Chunk* chunk,
+                                           const DictionaryCacheEncoderType& encoder_type = PK_ENCODE) {
         switch (encoder_type) {
         case PK_ENCODE: {
-            std::unique_ptr<Column> encoded_columns;
+            MutableColumnPtr encoded_columns;
             if (!PrimaryKeyEncoder::create_column(schema, &encoded_columns).ok()) {
                 std::stringstream ss;
                 ss << "create column for primary key encoder failed";

--- a/be/src/storage/index/vector/vector_index_writer.cpp
+++ b/be/src/storage/index/vector/vector_index_writer.cpp
@@ -50,7 +50,7 @@ Status VectorIndexWriter::append(const Column& src) {
                 RETURN_IF_ERROR(_prepare_index_builder());
             } else {
                 if (_buffer_column == nullptr) {
-                    _buffer_column = src.clone_shared();
+                    _buffer_column = src.clone();
                 } else {
                     _buffer_column->append(src, 0, src.size());
                 }

--- a/be/src/storage/lake/column_mode_partial_update_handler.cpp
+++ b/be/src/storage/lake/column_mode_partial_update_handler.cpp
@@ -100,7 +100,7 @@ Status ColumnModePartialUpdateHandler::_load_upserts(const RowsetUpdateStatePara
     }
 
     // 2. build schema.
-    std::unique_ptr<Column> pk_column;
+    MutableColumnPtr pk_column;
     if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column).ok()) {
         std::string err_msg =
                 fmt::format("create column for primary key encoder failed, tablet_id: {}", params.tablet->id());

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -651,14 +651,14 @@ Status DeltaWriterImpl::fill_auto_increment_id(const Chunk& chunk) {
         pk_columns.push_back((uint32_t)i);
     }
     Schema pkey_schema = ChunkHelper::convert_schema(_write_schema, pk_columns);
-    std::unique_ptr<Column> pk_column;
+    MutableColumnPtr pk_column;
     if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column).ok()) {
         CHECK(false) << "create column for primary key encoder failed";
     }
     auto col = pk_column->clone();
 
     PrimaryKeyEncoder::encode(pkey_schema, chunk, 0, chunk.num_rows(), col.get());
-    std::vector<std::unique_ptr<Column>> upserts;
+    MutableColumns upserts;
     upserts.resize(1);
     upserts[0] = std::move(col);
 
@@ -702,7 +702,7 @@ Status DeltaWriterImpl::fill_auto_increment_id(const Chunk& chunk) {
         const TabletColumn& tablet_column = _write_schema->column(i);
         if (tablet_column.is_auto_increment()) {
             auto& column = chunk.get_column_by_index(i);
-            RETURN_IF_ERROR((std::dynamic_pointer_cast<Int64Column>(column))->fill_range(ids, filter));
+            RETURN_IF_ERROR((Int64Column::dynamic_pointer_cast(column))->fill_range(ids, filter));
             break;
         }
     }

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -559,7 +559,7 @@ Status LakePersistentIndex::commit(MetaFileBuilder* builder) {
 Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pkey_schema, int64_t rowset_version) {
     TRACE_COUNTER_SCOPE_LATENCY_US("rebuild_index_del_cost_us");
     // Build pk column struct from schema
-    std::unique_ptr<Column> pk_column;
+    MutableColumnPtr pk_column;
     RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));
     // Iterate all del files and insert into index.
     for (int del_idx = 0; del_idx < rowset->metadata().del_files_size(); ++del_idx) {
@@ -689,7 +689,7 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
     const uint64_t rebuild_rss_rowid_point = sstables.empty() ? 0 : sstables.rbegin()->max_rss_rowid();
     const uint32_t rebuild_rss_id = rebuild_rss_rowid_point >> 32;
     OlapReaderStatistics stats;
-    std::unique_ptr<Column> pk_column;
+    MutableColumnPtr pk_column;
     if (pk_columns.size() > 1) {
         // more than one key column
         if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column).ok()) {

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -121,7 +121,7 @@ Status LakePrimaryIndex::_do_lake_load(TabletManager* tablet_mgr, const TabletMe
     }
 
     OlapReaderStatistics stats;
-    std::unique_ptr<Column> pk_column;
+    MutableColumnPtr pk_column;
     if (pk_columns.size() > 1) {
         // more than one key column
         RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));

--- a/be/src/storage/lake/lake_primary_key_recover.h
+++ b/be/src/storage/lake/lake_primary_key_recover.h
@@ -63,7 +63,7 @@ private:
     MetaFileBuilder* _builder;
     Tablet* _tablet;
     MutableTabletMetadataPtr _metadata;
-    std::unique_ptr<Column> _pk_column;
+    MutableColumnPtr _pk_column;
 };
 
 } // namespace lake

--- a/be/src/storage/lake/types_fwd.h
+++ b/be/src/storage/lake/types_fwd.h
@@ -43,7 +43,6 @@ using RowsetPtr = std::shared_ptr<starrocks::lake::Rowset>;
 using SegmentPtr = std::shared_ptr<starrocks::Segment>;
 using TabletSchemaPtr = std::shared_ptr<const starrocks::TabletSchema>;
 using CompactionTaskPtr = std::shared_ptr<CompactionTask>;
-using ColumnUniquePtr = std::unique_ptr<Column>;
 using segment_rowid_t = uint32_t;
 using DeletesMap = std::unordered_map<uint32_t, std::vector<segment_rowid_t>>;
 using DelVectorPtr = std::shared_ptr<DelVector>;

--- a/be/src/storage/lake/update_compaction_state.cpp
+++ b/be/src/storage/lake/update_compaction_state.cpp
@@ -62,7 +62,7 @@ Status CompactionState::_load_segments(Rowset* rowset, const TabletSchemaCSPtr& 
 
     Schema pkey_schema = ChunkHelper::convert_schema(tablet_schema, pk_columns);
 
-    std::unique_ptr<Column> pk_column;
+    MutableColumnPtr pk_column;
     RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, true));
 
     if (_segment_iters.empty()) {

--- a/be/src/storage/lake/update_compaction_state.h
+++ b/be/src/storage/lake/update_compaction_state.h
@@ -44,7 +44,7 @@ public:
 
     std::string to_string() const;
 
-    std::vector<ColumnUniquePtr> pk_cols;
+    std::vector<MutableColumnPtr> pk_cols;
 
 private:
     Status _load_segments(Rowset* rowset, const TabletSchemaCSPtr& tablet_schema, uint32_t segment_id);

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -95,15 +95,16 @@ public:
                                               MetaFileBuilder* builder, int64_t base_version);
 
     // get rowids from primary index by each upserts
-    Status get_rowids_from_pkindex(int64_t tablet_id, int64_t base_version, const std::vector<ColumnUniquePtr>& upserts,
+    Status get_rowids_from_pkindex(int64_t tablet_id, int64_t base_version,
+                                   const std::vector<MutableColumnPtr>& upserts,
                                    std::vector<std::vector<uint64_t>*>* rss_rowids, bool need_lock);
-    Status get_rowids_from_pkindex(int64_t tablet_id, int64_t base_version, const ColumnUniquePtr& upsert,
+    Status get_rowids_from_pkindex(int64_t tablet_id, int64_t base_version, const MutableColumnPtr& upsert,
                                    std::vector<uint64_t>* rss_rowids, bool need_lock);
 
     // get column data by rssid and rowids
     Status get_column_values(const RowsetUpdateStateParams& params, std::vector<uint32_t>& column_ids,
                              bool with_default, std::map<uint32_t, std::vector<uint32_t>>& rowids_by_rssid,
-                             vector<std::unique_ptr<Column>>* columns,
+                             vector<MutableColumnPtr>* columns,
                              const std::map<string, string>* column_to_expr_value = nullptr,
                              AutoIncrementPartialUpdateState* auto_increment_state = nullptr);
     // get delvec by version
@@ -212,7 +213,7 @@ private:
                       PrimaryIndex& index, DeletesMap* new_deletes);
 
     Status _do_update_with_condition(const RowsetUpdateStateParams& params, uint32_t rowset_id, int32_t upsert_idx,
-                                     int32_t condition_column, const ColumnUniquePtr& upsert, PrimaryIndex& index,
+                                     int32_t condition_column, const MutableColumnPtr& upsert, PrimaryIndex& index,
                                      DeletesMap* new_deletes);
 
     int32_t _get_condition_column(const TxnLogPB_OpWrite& op_write, const TabletSchema& tablet_schema);

--- a/be/src/storage/local_tablet_reader.cpp
+++ b/be/src/storage/local_tablet_reader.cpp
@@ -114,7 +114,7 @@ Status LocalTabletReader::multi_get(const Chunk& keys, const std::vector<uint32_
     for (size_t i = 0; i < tablet_schema->num_key_columns(); i++) {
         pk_columns.push_back((uint32_t)i);
     }
-    std::unique_ptr<Column> pk_column;
+    MutableColumnPtr pk_column;
     RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(*tablet_schema->schema(), &pk_column));
     PrimaryKeyEncoder::encode(*tablet_schema->schema(), keys, 0, keys.num_rows(), pk_column.get());
 
@@ -147,7 +147,7 @@ Status LocalTabletReader::multi_get(const Chunk& keys, const std::vector<uint32_
     for (const auto& p : value_column_ids_by_order_with_orig_idx) {
         value_column_ids_by_order.push_back(p.first);
     }
-    std::vector<std::unique_ptr<Column>> read_columns(value_column_ids_by_order.size());
+    MutableColumns read_columns(value_column_ids_by_order.size());
     for (uint32_t i = 0; i < read_columns.size(); ++i) {
         read_columns[i] = ChunkHelper::column_from_field(*read_column_schema.field(i).get())->clone_empty();
     }

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -172,7 +172,7 @@ StatusOr<bool> MemTable::insert(const Chunk& chunk, const uint32_t* indexes, uin
     }
 
     bool is_column_with_row = false;
-    auto full_row_col = std::make_unique<BinaryColumn>();
+    auto full_row_col = BinaryColumn::create();
     if (_keys_type == PRIMARY_KEYS) {
         std::unique_ptr<Schema> schema_without_full_row_column;
         if (_vectorized_schema->field_names().back() == Schema::FULL_ROW_COLUMN) {
@@ -451,7 +451,7 @@ void MemTable::_append_to_sorted_chunk(Chunk* src, Chunk* dest, bool is_final) {
     }
 }
 
-Status MemTable::_split_upserts_deletes(ChunkPtr& src, ChunkPtr* upserts, std::unique_ptr<Column>* deletes) {
+Status MemTable::_split_upserts_deletes(ChunkPtr& src, ChunkPtr* upserts, MutableColumnPtr* deletes) {
     size_t op_column_id = src->num_columns() - 1;
     auto op_column = src->get_column_by_index(op_column_id);
     src->remove_column_by_index(op_column_id);

--- a/be/src/storage/memtable.h
+++ b/be/src/storage/memtable.h
@@ -124,7 +124,7 @@ private:
     void _init_aggregator_if_needed();
     void _aggregate(bool is_final);
 
-    Status _split_upserts_deletes(ChunkPtr& src, ChunkPtr* upserts, std::unique_ptr<Column>* deletes);
+    Status _split_upserts_deletes(ChunkPtr& src, ChunkPtr* upserts, MutableColumnPtr* deletes);
 
     ChunkPtr _chunk;
     ChunkPtr _result_chunk;
@@ -148,7 +148,7 @@ private:
     uint64_t _merge_count = 0;
 
     bool _has_op_slot = false;
-    std::unique_ptr<Column> _deletes;
+    MutableColumnPtr _deletes;
 
     std::string _merge_condition;
 

--- a/be/src/storage/meta_reader.cpp
+++ b/be/src/storage/meta_reader.cpp
@@ -72,7 +72,7 @@ Status MetaReader::_read(Chunk* chunk, size_t n) {
 
     std::vector<Column*> columns;
     for (size_t i = 0; i < _collect_context.seg_collecter_params.fields.size(); ++i) {
-        const ColumnPtr& col = chunk->get_column_by_index(i);
+        ColumnPtr& col = chunk->get_column_by_index(i);
         columns.emplace_back(col.get());
     }
 
@@ -122,7 +122,7 @@ Status MetaReader::_fill_result_chunk(Chunk* chunk) {
             TypeDescriptor desc;
             desc.type = TYPE_ARRAY;
             desc.children.emplace_back(item_desc);
-            ColumnPtr column = ColumnHelper::create_column(desc, _has_count_agg);
+            MutableColumnPtr column = ColumnHelper::create_column(desc, _has_count_agg);
             chunk->append_column(std::move(column), slot->id());
         } else if (field == META_COUNT_COL || field == META_COUNT_ROWS) {
             TypeDescriptor item_desc;
@@ -130,7 +130,7 @@ Status MetaReader::_fill_result_chunk(Chunk* chunk) {
             TypeDescriptor desc;
             desc.type = TYPE_BIGINT;
             desc.children.emplace_back(item_desc);
-            ColumnPtr column = ColumnHelper::create_column(desc, true);
+            MutableColumnPtr column = ColumnHelper::create_column(desc, true);
             chunk->append_column(std::move(column), slot->id());
         } else if (field == META_FLAT_JSON_META) {
             TypeDescriptor item_desc;
@@ -138,10 +138,10 @@ Status MetaReader::_fill_result_chunk(Chunk* chunk) {
             TypeDescriptor desc;
             desc.type = TYPE_ARRAY;
             desc.children.emplace_back(item_desc);
-            ColumnPtr column = ColumnHelper::create_column(desc, false);
+            MutableColumnPtr column = ColumnHelper::create_column(desc, false);
             chunk->append_column(std::move(column), slot->id());
         } else {
-            ColumnPtr column = ColumnHelper::create_column(slot->type(), true);
+            MutableColumnPtr column = ColumnHelper::create_column(slot->type(), true);
             chunk->append_column(std::move(column), slot->id());
         }
     }

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -3365,8 +3365,7 @@ Status PersistentIndex::_build_commit(TabletLoader* loader, PersistentIndexMetaP
     return status;
 }
 
-Status PersistentIndex::_insert_rowsets(TabletLoader* loader, const Schema& pkey_schema,
-                                        std::unique_ptr<Column> pk_column) {
+Status PersistentIndex::_insert_rowsets(TabletLoader* loader, const Schema& pkey_schema, MutableColumnPtr pk_column) {
     CHECK_MEM_LIMIT("PersistentIndex::_insert_rowsets");
     std::vector<uint32_t> rowids;
     TRY_CATCH_BAD_ALLOC(rowids.reserve(4096));
@@ -5272,7 +5271,7 @@ Status PersistentIndex::_load_by_loader(TabletLoader* loader) {
     data->set_offset(0);
     data->set_size(0);
 
-    std::unique_ptr<Column> pk_column;
+    MutableColumnPtr pk_column;
     if (pkey_schema.num_fields() > 1) {
         RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));
     }

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -857,7 +857,7 @@ private:
     Status _build_commit(TabletLoader* loader, PersistentIndexMetaPB& index_meta);
 
     // insert rowset data into persistent index
-    Status _insert_rowsets(TabletLoader* loader, const Schema& pkey_schema, std::unique_ptr<Column> pk_column);
+    Status _insert_rowsets(TabletLoader* loader, const Schema& pkey_schema, MutableColumnPtr pk_column);
 
     Status _get_from_immutable_index(size_t n, const Slice* keys, IndexValue* values,
                                      std::map<size_t, KeysInfo>& keys_info_by_key_size, IOStat* stat);

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1208,7 +1208,7 @@ Status PrimaryIndex::_do_load(Tablet* tablet) {
     }
 
     OlapReaderStatistics stats;
-    std::unique_ptr<Column> pk_column;
+    MutableColumnPtr pk_column;
     if (pk_columns.size() > 1) {
         RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));
     }

--- a/be/src/storage/primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.cpp
@@ -27,7 +27,7 @@ namespace starrocks {
 Status PrimaryKeyCompactionConflictResolver::execute() {
     Schema pkey_schema = generate_pkey_schema();
 
-    std::unique_ptr<Column> pk_column;
+    MutableColumnPtr pk_column;
     RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, true));
 
     // init rows mapper iter

--- a/be/src/storage/primary_key_encoder.h
+++ b/be/src/storage/primary_key_encoder.h
@@ -49,15 +49,15 @@ public:
     //   schema: schema of the table
     //   pcolumn: output column
     //   large_column: some usage may fill the column with more than uint32_max elements, set true to support this
-    static Status create_column(const Schema& schema, std::unique_ptr<Column>* pcolumn, bool large_column = false);
+    static Status create_column(const Schema& schema, MutableColumnPtr* pcolumn, bool large_column = false);
 
     // create suitable column to hold encoded key
     //   schema: schema of the table
     //   pcolumn: output column
     //   key_idxes: indexes of columns for encoding
     //   large_column: some usage may fill the column with more than uint32_max elements, set true to support this
-    static Status create_column(const Schema& schema, std::unique_ptr<Column>* pcolumn,
-                                const std::vector<ColumnId>& key_idxes, bool large_column = false);
+    static Status create_column(const Schema& schema, MutableColumnPtr* pcolumn, const std::vector<ColumnId>& key_idxes,
+                                bool large_column = false);
 
     static void encode(const Schema& schema, const Chunk& chunk, size_t offset, size_t len, Column* dest);
 

--- a/be/src/storage/primary_key_recover.cpp
+++ b/be/src/storage/primary_key_recover.cpp
@@ -26,7 +26,7 @@ Status PrimaryKeyRecover::recover() {
     LOG(INFO) << "PrimaryKeyRecover pre clean up finish. tablet_id: " << tablet_id();
 
     // 2. generate primary key schema
-    std::unique_ptr<Column> pk_column;
+    MutableColumnPtr pk_column;
     auto pkey_schema = generate_pkey_schema();
     if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column).ok()) {
         CHECK(false) << "create column for primary key encoder failed";

--- a/be/src/storage/row_source_mask.cpp
+++ b/be/src/storage/row_source_mask.cpp
@@ -25,7 +25,7 @@
 namespace starrocks {
 
 RowSourceMaskBuffer::RowSourceMaskBuffer(int64_t tablet_id, std::string storage_root_path)
-        : _mask_column(UInt16Column::create_mutable()),
+        : _mask_column(UInt16Column::create()),
           _tablet_id(tablet_id),
           _storage_root_path(std::move(storage_root_path)) {}
 

--- a/be/src/storage/row_store_encoder.h
+++ b/be/src/storage/row_store_encoder.h
@@ -42,7 +42,7 @@ public:
                                                      BinaryColumn& dest) = 0;
     virtual Status decode_columns_from_full_row_column(const Schema& schema, const BinaryColumn& full_row_column,
                                                        const std::vector<uint32_t>& read_column_ids,
-                                                       std::vector<std::unique_ptr<Column>>* dest) = 0;
+                                                       MutableColumns* dest) = 0;
     Status is_supported(const Schema& schema);
 
 protected:

--- a/be/src/storage/row_store_encoder_simple.cpp
+++ b/be/src/storage/row_store_encoder_simple.cpp
@@ -106,7 +106,7 @@ Status RowStoreEncoderSimple::encode_chunk_to_full_row_column(const Schema& sche
 Status RowStoreEncoderSimple::decode_columns_from_full_row_column(const Schema& schema,
                                                                   const BinaryColumn& full_row_column,
                                                                   const std::vector<uint32_t>& read_column_ids,
-                                                                  std::vector<std::unique_ptr<Column>>* pdest) {
+                                                                  MutableColumns* pdest) {
     auto& dest = *pdest;
     int num_rows = full_row_column.size();
     for (size_t i = 0; i < num_rows; i++) {

--- a/be/src/storage/row_store_encoder_simple.h
+++ b/be/src/storage/row_store_encoder_simple.h
@@ -32,7 +32,7 @@ public:
     Status encode_columns_to_full_row_column(const Schema& schema, const Columns& columns, BinaryColumn& dest) override;
     Status decode_columns_from_full_row_column(const Schema& schema, const BinaryColumn& full_row_column,
                                                const std::vector<uint32_t>& read_column_ids,
-                                               std::vector<std::unique_ptr<Column>>* dest) override;
+                                               MutableColumns* dest) override;
 
 private: // -- for simple and length
     void encode_null_bitmap(BitmapValue& null_bitmap, std::string* dest);

--- a/be/src/storage/rowset/array_column_writer.cpp
+++ b/be/src/storage/rowset/array_column_writer.cpp
@@ -153,11 +153,11 @@ Status ArrayColumnWriter::init() {
 
 Status ArrayColumnWriter::append(const Column& column) {
     const ArrayColumn* array_column = nullptr;
-    NullColumn* null_column = nullptr;
+    const NullColumn* null_column = nullptr;
     if (is_nullable()) {
         const auto& nullable_column = down_cast<const NullableColumn&>(column);
-        array_column = down_cast<ArrayColumn*>(nullable_column.data_column().get());
-        null_column = down_cast<NullColumn*>(nullable_column.null_column().get());
+        array_column = down_cast<const ArrayColumn*>(nullable_column.data_column().get());
+        null_column = down_cast<const NullColumn*>(nullable_column.null_column().get());
     } else {
         array_column = down_cast<const ArrayColumn*>(&column);
     }

--- a/be/src/storage/rowset/binary_dict_page.h
+++ b/be/src/storage/rowset/binary_dict_page.h
@@ -151,7 +151,7 @@ private:
     const BinaryPlainPageDecoder<Type>* _dict_decoder = nullptr;
     bool _parsed;
     EncodingTypePB _encoding_type;
-    std::shared_ptr<Column> _vec_code_buf;
+    ColumnPtr _vec_code_buf;
 
     uint32_t _max_value_legth = 0;
 };

--- a/be/src/storage/rowset/bitmap_index_reader.cpp
+++ b/be/src/storage/rowset/bitmap_index_reader.cpp
@@ -113,7 +113,7 @@ Status BitmapIndexIterator::read_bitmap(rowid_t ordinal, Roaring* result) {
     RETURN_IF_ERROR(_bitmap_column_iter->next_batch(&num_read, column.get()));
     DCHECK(num_to_read == num_read);
 
-    ColumnViewer<TYPE_VARCHAR> viewer(column);
+    ColumnViewer<TYPE_VARCHAR> viewer(std::move(column));
     auto value = viewer.value(0);
 
     *result = Roaring::read(value.data, false);

--- a/be/src/storage/rowset/bloom_filter_index_reader.cpp
+++ b/be/src/storage/rowset/bloom_filter_index_reader.cpp
@@ -101,7 +101,7 @@ Status BloomFilterIndexIterator::read_bloom_filter(rowid_t ordinal, std::unique_
     RETURN_IF_ERROR(_bloom_filter_iter->next_batch(&num_read, column.get()));
     DCHECK(num_to_read == num_read);
 
-    ColumnViewer<TYPE_VARCHAR> viewer(column);
+    ColumnViewer<TYPE_VARCHAR> viewer(std::move(column));
     auto value = viewer.value(0);
     // construct bloom filter
     RETURN_IF_ERROR(BloomFilter::create(_reader->_algorithm, bf));

--- a/be/src/storage/rowset/cast_column_iterator.cpp
+++ b/be/src/storage/rowset/cast_column_iterator.cpp
@@ -32,7 +32,7 @@ CastColumnIterator::CastColumnIterator(std::unique_ptr<ColumnIterator> source_it
     auto slot_desc = SlotDescriptor(slot_id, "", source_type);
     auto column_ref = _obj_pool->add(new ColumnRef(&slot_desc));
     CHECK(column != nullptr) << "source type=" << source_type;
-    _source_chunk.append_column(column, slot_id);
+    _source_chunk.append_column(std::move(column), slot_id);
     _cast_expr = VectorizedCastExprFactory::from_type(source_type, target_type, column_ref, _obj_pool.get(), false);
     CHECK(_cast_expr != nullptr) << "Fail to create cast expr for source type=" << source_type
                                  << " target type=" << target_type;

--- a/be/src/storage/rowset/column_iterator.cpp
+++ b/be/src/storage/rowset/column_iterator.cpp
@@ -42,7 +42,7 @@ namespace starrocks {
 Status ColumnIterator::decode_dict_codes(const Column& codes, Column* words) {
     if (codes.is_nullable()) {
         const ColumnPtr& data_column = down_cast<const NullableColumn&>(codes).data_column();
-        const Buffer<int32_t>& v = std::static_pointer_cast<Int32Column>(data_column)->get_data();
+        const Buffer<int32_t>& v = Int32Column::static_pointer_cast(data_column)->get_data();
         return this->decode_dict_codes(v.data(), v.size(), words);
     } else {
         const Buffer<int32_t>& v = down_cast<const Int32Column&>(codes).get_data();

--- a/be/src/storage/rowset/column_writer.cpp
+++ b/be/src/storage/rowset/column_writer.cpp
@@ -854,7 +854,7 @@ inline void StringColumnWriter::speculate_column_and_set_encoding(const Column& 
     Status st;
     if (column.is_nullable()) {
         const auto& data_col = down_cast<const NullableColumn&>(column).data_column();
-        const auto& bin_col = down_cast<BinaryColumn&>(*data_col);
+        const auto& bin_col = down_cast<const BinaryColumn&>(*data_col);
         const auto detect_encoding = speculate_string_encoding(bin_col);
         st = _scalar_column_writer->set_encoding(detect_encoding);
     } else if (column.is_binary()) {
@@ -1019,7 +1019,7 @@ inline EncodingTypePB DictColumnWriter::speculate_encoding(const Column& column)
     const ColumnType* numerical_col;
     if (column.is_nullable()) {
         const auto& data_col = down_cast<const NullableColumn&>(column).data_column();
-        numerical_col = &down_cast<ColumnType&>(*data_col);
+        numerical_col = &down_cast<const ColumnType&>(*data_col);
     } else {
         numerical_col = &down_cast<const ColumnType&>(column);
     }

--- a/be/src/storage/rowset/dict_page.h
+++ b/be/src/storage/rowset/dict_page.h
@@ -156,7 +156,7 @@ private:
     const BitShufflePageDecoder<Type>* _dict_decoder = nullptr;
     bool _parsed;
     EncodingTypePB _encoding_type;
-    std::shared_ptr<Column> _vec_code_buf;
+    ColumnPtr _vec_code_buf;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/dictcode_column_iterator.cpp
+++ b/be/src/storage/rowset/dictcode_column_iterator.cpp
@@ -127,11 +127,11 @@ Status GlobalDictCodeColumnIterator::build_code_convert_map(ColumnIterator* file
     return Status::OK();
 }
 
-ColumnPtr GlobalDictCodeColumnIterator::_new_local_dict_col(Column* src) {
-    ColumnPtr res = std::make_unique<Int32Column>();
+MutableColumnPtr GlobalDictCodeColumnIterator::_new_local_dict_col(Column* src) {
+    MutableColumnPtr res = Int32Column::create();
     auto code_data = ColumnHelper::get_data_column(src);
     if (code_data->is_array()) {
-        res = ArrayColumn::create(NullableColumn::create(res, NullColumn::create()), UInt32Column::create());
+        res = ArrayColumn::create(NullableColumn::create(std::move(res), NullColumn::create()), UInt32Column::create());
     }
 
     if (src->is_nullable()) {

--- a/be/src/storage/rowset/dictcode_column_iterator.h
+++ b/be/src/storage/rowset/dictcode_column_iterator.h
@@ -97,7 +97,7 @@ private:
 
 private:
     // create a new empty local dict column
-    ColumnPtr _new_local_dict_col(Column* src);
+    MutableColumnPtr _new_local_dict_col(Column* src);
     // swap null column between src and dst column
     void _swap_null_columns(Column* src, Column* dst);
 

--- a/be/src/storage/rowset/json_column_compactor.h
+++ b/be/src/storage/rowset/json_column_compactor.h
@@ -29,11 +29,11 @@ public:
     Status finish() override;
 
 private:
-    Status _compact_columns(std::vector<ColumnPtr>& json_datas);
+    Status _compact_columns(Columns& json_datas);
 
-    Status _merge_columns(std::vector<ColumnPtr>& json_datas);
+    Status _merge_columns(Columns& json_datas);
 
-    Status _flatten_columns(std::vector<ColumnPtr>& json_datas);
+    Status _flatten_columns(Columns& json_datas);
 };
 
 class JsonColumnCompactor final : public ColumnWriter {
@@ -65,7 +65,7 @@ public:
     uint64_t total_mem_footprint() const override { return _json_writer->total_mem_footprint(); }
 
 private:
-    void _flat_column(std::vector<ColumnPtr>& json_datas);
+    void _flat_column(Columns& json_datas);
 
 private:
     ColumnMetaPB* _json_meta;

--- a/be/src/storage/rowset/json_column_iterator.cpp
+++ b/be/src/storage/rowset/json_column_iterator.cpp
@@ -96,7 +96,7 @@ private:
     std::vector<LogicalType> _source_types;
     bool _need_remain = false;
 
-    std::vector<ColumnPtr> _source_column_modules;
+    Columns _source_column_modules;
     // to avoid create column with find type
 
     bool _is_direct = false;
@@ -120,7 +120,7 @@ Status JsonFlatColumnIterator::init(const ColumnIteratorOptions& opts) {
 
     for (int i = 0; i < _source_paths.size(); i++) {
         auto column = ColumnHelper::create_column(TypeDescriptor(_source_types[i]), true);
-        _source_column_modules.emplace_back(column);
+        _source_column_modules.emplace_back(std::move(column));
     }
 
     DCHECK_EQ(_source_column_modules.size(), _source_paths.size());
@@ -175,7 +175,7 @@ Status JsonFlatColumnIterator::init(const ColumnIteratorOptions& opts) {
 
 template <typename FUNC>
 Status JsonFlatColumnIterator::_read(JsonColumn* json_column, FUNC read_fn) {
-    std::vector<ColumnPtr> columns;
+    Columns columns;
     for (int i = 0; i < _source_column_modules.size(); i++) {
         columns.emplace_back(_source_column_modules[i]->clone_empty());
     }
@@ -185,11 +185,11 @@ Status JsonFlatColumnIterator::_read(JsonColumn* json_column, FUNC read_fn) {
     }
 
     if (_is_direct) {
-        json_column->set_flat_columns(_source_paths, _source_types, columns);
+        json_column->set_flat_columns(_source_paths, _source_types, std::move(columns));
     } else {
-        RETURN_IF_ERROR(transformer->trans(columns));
+        RETURN_IF_ERROR(transformer->trans(std::move(columns)));
         auto result = transformer->mutable_result();
-        json_column->set_flat_columns(_target_paths, _target_types, result);
+        json_column->set_flat_columns(_target_paths, _target_types, std::move(result));
     }
     return Status::OK();
 }
@@ -387,7 +387,7 @@ Status JsonDynamicFlatIterator::_dynamic_flat(Column* output, FUNC read_fn) {
     // 2. flat
     _flattener->flatten(proxy.get());
     auto result = _flattener->mutable_result();
-    json_data->set_flat_columns(_target_paths, _target_types, result);
+    json_data->set_flat_columns(_target_paths, _target_types, std::move(result));
     return Status::OK();
 }
 
@@ -465,7 +465,7 @@ private:
     std::vector<std::unique_ptr<ColumnIterator>> _all_iter;
     std::vector<std::string> _src_paths;
     std::vector<LogicalType> _src_types;
-    std::vector<ColumnPtr> _src_column_modules;
+    Columns _src_column_modules;
 
     std::unique_ptr<JsonMerger> _merger;
 };
@@ -485,7 +485,7 @@ Status JsonMergeIterator::init(const ColumnIteratorOptions& opts) {
     DCHECK(_all_iter.size() == _src_paths.size() || _all_iter.size() == _src_paths.size() + 1);
     for (int i = 0; i < _src_paths.size(); i++) {
         auto column = ColumnHelper::create_column(TypeDescriptor(_src_types[i]), true);
-        _src_column_modules.emplace_back(column);
+        _src_column_modules.emplace_back(std::move(column));
     }
 
     if (_all_iter.size() != _src_paths.size()) {
@@ -502,7 +502,7 @@ Status JsonMergeIterator::init(const ColumnIteratorOptions& opts) {
 
 template <typename FUNC>
 Status JsonMergeIterator::_merge(JsonColumn* dst, FUNC func) {
-    std::vector<ColumnPtr> all_columns;
+    Columns all_columns;
     for (size_t i = 0; i < _all_iter.size(); i++) {
         auto iter = _all_iter[i].get();
         auto c = _src_column_modules[i]->clone_empty();

--- a/be/src/storage/rowset/json_column_writer.cpp
+++ b/be/src/storage/rowset/json_column_writer.cpp
@@ -79,7 +79,7 @@ Status FlatJsonColumnWriter::append(const Column& column) {
     return Status::OK();
 }
 
-Status FlatJsonColumnWriter::_flat_column(std::vector<ColumnPtr>& json_datas) {
+Status FlatJsonColumnWriter::_flat_column(Columns& json_datas) {
     // all json datas must full json
     JsonPathDeriver deriver;
     std::vector<const Column*> vc;
@@ -115,13 +115,13 @@ Status FlatJsonColumnWriter::_flat_column(std::vector<ColumnPtr>& json_datas) {
                 nulls->append_value_multiple_times(&IS_NULL, json_data->size());
             } else if (json_data->is_nullable()) {
                 auto* nullable_column = down_cast<const NullableColumn*>(json_data);
-                auto* nl = down_cast<NullColumn*>(nullable_column->null_column().get());
+                auto* nl = down_cast<const NullColumn*>(nullable_column->null_column().get());
                 nulls->append(*nl, 0, nl->size());
             } else {
                 nulls->append_value_multiple_times(&NOT_NULL, json_data->size());
             }
 
-            _flat_columns.insert(_flat_columns.begin(), nulls);
+            _flat_columns.insert(_flat_columns.begin(), std::move(nulls));
         }
         RETURN_IF_ERROR(_write_flat_column());
         _flat_columns.clear();

--- a/be/src/storage/rowset/json_column_writer.h
+++ b/be/src/storage/rowset/json_column_writer.h
@@ -54,7 +54,7 @@ protected:
     Status _write_flat_column();
 
 private:
-    Status _flat_column(std::vector<ColumnPtr>& json_datas);
+    Status _flat_column(Columns& json_datas);
 
 protected:
     ColumnMetaPB* _json_meta;
@@ -64,9 +64,9 @@ protected:
     std::vector<std::unique_ptr<ColumnWriter>> _flat_writers;
     std::vector<std::string> _flat_paths;
     std::vector<LogicalType> _flat_types;
-    std::vector<ColumnPtr> _flat_columns;
+    Columns _flat_columns;
 
-    std::vector<ColumnPtr> _json_datas;
+    Columns _json_datas;
     size_t _estimate_size = 0;
 
     bool _has_remain;

--- a/be/src/storage/rowset/map_column_writer.cpp
+++ b/be/src/storage/rowset/map_column_writer.cpp
@@ -169,11 +169,11 @@ Status MapColumnWriter::init() {
 
 Status MapColumnWriter::append(const Column& column) {
     const MapColumn* map_column = nullptr;
-    NullColumn* null_column = nullptr;
+    const NullColumn* null_column = nullptr;
     if (is_nullable()) {
         const auto& nullable_column = down_cast<const NullableColumn&>(column);
-        map_column = down_cast<MapColumn*>(nullable_column.data_column().get());
-        null_column = down_cast<NullColumn*>(nullable_column.null_column().get());
+        map_column = down_cast<const MapColumn*>(nullable_column.data_column().get());
+        null_column = down_cast<const NullColumn*>(nullable_column.null_column().get());
     } else {
         map_column = down_cast<const MapColumn*>(&column);
     }

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -146,7 +146,7 @@ private:
         Status read_columns(Chunk* chunk, const SparseRange<>& range) {
             bool may_has_del_row = chunk->delete_state() != DEL_NOT_SATISFIED;
             for (size_t i = 0; i < _column_iterators.size(); i++) {
-                const ColumnPtr& col = chunk->get_column_by_index(i);
+                ColumnPtr& col = chunk->get_column_by_index(i);
                 if (_prune_column_after_index_filter && _prune_cols.count(i)) {
                     // make sure each pruned column has the same size as the unpruneable one.
                     col->resize(range.span_size());
@@ -1543,7 +1543,7 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
 
     if (_use_vector_index && !_use_ivfpq) {
         DCHECK(rowid != nullptr);
-        std::shared_ptr<FloatColumn> distance_column = FloatColumn::create();
+        FloatColumn::MutablePtr distance_column = FloatColumn::create();
         vector<rowid_t> rowids;
         for (const auto& rid : *rowid) {
             auto it = _id2distance_map.find(rid);
@@ -1559,7 +1559,7 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
         }
 
         // TODO: plan vector column in FE Planner
-        chunk->append_vector_column(distance_column, _make_field(_vector_column_id), _vector_slot_id);
+        chunk->append_vector_column(std::move(distance_column), _make_field(_vector_column_id), _vector_slot_id);
     }
 
     result->swap_chunk(*chunk);

--- a/be/src/storage/rowset/segment_rewriter.cpp
+++ b/be/src/storage/rowset/segment_rewriter.cpp
@@ -24,9 +24,8 @@ SegmentRewriter::SegmentRewriter() = default;
 
 Status SegmentRewriter::rewrite_partial_update(const FileInfo& src, FileInfo* dest,
                                                const std::shared_ptr<const TabletSchema>& tschema,
-                                               std::vector<uint32_t>& column_ids,
-                                               std::vector<std::unique_ptr<Column>>& columns, uint32_t segment_id,
-                                               const FooterPointerPB& partial_rowset_footer) {
+                                               std::vector<uint32_t>& column_ids, MutableColumns& columns,
+                                               uint32_t segment_id, const FooterPointerPB& partial_rowset_footer) {
     constexpr size_t kBufferSize = 1024 * 1024; // 1 MB
     if (UNLIKELY(column_ids.empty())) {
         // In shared-nothing mode, this size can be null, and we don't need it so it's ok to return zero;
@@ -73,7 +72,7 @@ Status SegmentRewriter::rewrite_partial_update(const FileInfo& src, FileInfo* de
     auto schema = ChunkHelper::convert_schema(tschema, column_ids);
     auto chunk = ChunkHelper::new_chunk(schema, columns[0]->size());
     for (int i = 0; i < columns.size(); ++i) {
-        chunk->get_column_by_index(i).reset(columns[i].release());
+        chunk->get_column_by_index(i).reset(std::move(columns[i]));
     }
     uint64_t index_size = 0;
     uint64_t segment_file_size;
@@ -92,8 +91,7 @@ Status SegmentRewriter::rewrite_partial_update(const FileInfo& src, FileInfo* de
 Status SegmentRewriter::rewrite_auto_increment(const std::string& src_path, const std::string& dest_path,
                                                const TabletSchemaCSPtr& tschema,
                                                AutoIncrementPartialUpdateState& auto_increment_partial_update_state,
-                                               std::vector<uint32_t>& column_ids,
-                                               std::vector<std::unique_ptr<Column>>* columns) {
+                                               std::vector<uint32_t>& column_ids, MutableColumns* columns) {
     if (column_ids.size() == 0) {
         DCHECK_EQ(columns, nullptr);
     }
@@ -154,9 +152,9 @@ Status SegmentRewriter::rewrite_auto_increment(const std::string& src_path, cons
     size_t read_columns_index = 0;
     for (int i = 0; i < tschema->num_columns(); ++i) {
         if (i == auto_increment_column_id) {
-            chunk->get_column_by_index(i).reset(auto_increment_partial_update_state.write_column.release());
+            chunk->get_column_by_index(i).reset(std::move(auto_increment_partial_update_state.write_column));
         } else if (update_columns_set.find(i) != update_columns_set.end()) {
-            chunk->get_column_by_index(i).reset((*columns)[update_columns_index].release());
+            chunk->get_column_by_index(i).reset(std::move((*columns)[update_columns_index]));
             ++update_columns_index;
         } else {
             chunk->get_column_by_index(i).swap(read_chunk->get_column_by_index(read_columns_index));
@@ -184,8 +182,8 @@ Status SegmentRewriter::rewrite_auto_increment(const std::string& src_path, cons
 Status SegmentRewriter::rewrite_auto_increment_lake(
         const FileInfo& src, FileInfo* dest, const TabletSchemaCSPtr& tschema,
         starrocks::lake::AutoIncrementPartialUpdateState& auto_increment_partial_update_state,
-        const std::vector<uint32_t>& unmodified_column_ids,
-        std::vector<std::unique_ptr<Column>>* unmodified_column_data, const starrocks::lake::Tablet* tablet) {
+        const std::vector<uint32_t>& unmodified_column_ids, MutableColumns* unmodified_column_data,
+        const starrocks::lake::Tablet* tablet) {
     if (unmodified_column_ids.size() == 0) {
         DCHECK_EQ(unmodified_column_data, nullptr);
     }
@@ -254,9 +252,9 @@ Status SegmentRewriter::rewrite_auto_increment_lake(
     size_t modified_column_index = 0;
     for (ColumnId i = 0, sz = tschema->num_columns(); i < sz; ++i) {
         if (i == auto_increment_column_id) {
-            chunk->get_column_by_index(i).reset(auto_increment_partial_update_state.write_column.release());
+            chunk->get_column_by_index(i).reset(std::move(auto_increment_partial_update_state.write_column));
         } else if (unmodified_column_id_set.count(i) > 0) {
-            chunk->get_column_by_index(i).reset(unmodified_column_data->at(unmodified_column_index).release());
+            chunk->get_column_by_index(i).reset(std::move(unmodified_column_data->at(unmodified_column_index)));
             ++unmodified_column_index;
         } else {
             chunk->get_column_by_index(i).swap(read_chunk->get_column_by_index(modified_column_index));

--- a/be/src/storage/rowset/segment_rewriter.h
+++ b/be/src/storage/rowset/segment_rewriter.h
@@ -28,19 +28,17 @@ public:
     // then append write_column to dest file
     static Status rewrite_partial_update(const FileInfo& src, FileInfo* dest,
                                          const std::shared_ptr<const TabletSchema>& tschema,
-                                         std::vector<uint32_t>& column_ids,
-                                         std::vector<std::unique_ptr<Column>>& columns, uint32_t segment_id,
-                                         const FooterPointerPB& partial_rowset_footer);
+                                         std::vector<uint32_t>& column_ids, MutableColumns& columns,
+                                         uint32_t segment_id, const FooterPointerPB& partial_rowset_footer);
     static Status rewrite_auto_increment(const std::string& src_path, const std::string& dest_path,
                                          const TabletSchemaCSPtr& tschema,
                                          AutoIncrementPartialUpdateState& auto_increment_partial_update_state,
-                                         std::vector<uint32_t>& column_ids,
-                                         std::vector<std::unique_ptr<Column>>* columns);
+                                         std::vector<uint32_t>& column_ids, MutableColumns* columns);
     static Status rewrite_auto_increment_lake(
             const FileInfo& src, FileInfo* dest, const TabletSchemaCSPtr& tschema,
             starrocks::lake::AutoIncrementPartialUpdateState& auto_increment_partial_update_state,
-            const std::vector<uint32_t>& unmodified_column_ids,
-            std::vector<std::unique_ptr<Column>>* unmodified_column_data, const starrocks::lake::Tablet* tablet);
+            const std::vector<uint32_t>& unmodified_column_ids, MutableColumns* unmodified_column_data,
+            const starrocks::lake::Tablet* tablet);
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -398,7 +398,7 @@ Status SegmentWriter::append_chunk(const Chunk& chunk) {
         _tablet_schema->columns().back().name() == Schema::FULL_ROW_COLUMN &&
         chunk_num_columns + 1 == _column_writers.size()) {
         // just missing full row column, generate it and write to file
-        auto full_row_col = std::make_unique<BinaryColumn>();
+        auto full_row_col = BinaryColumn::create();
         auto row_encoder = RowStoreEncoderFactory::instance()->get_or_create_encoder(SIMPLE);
         RETURN_IF_ERROR(row_encoder->encode_chunk_to_full_row_column(*_schema_without_full_row_column, chunk,
                                                                      full_row_col.get()));

--- a/be/src/storage/rowset/struct_column_writer.cpp
+++ b/be/src/storage/rowset/struct_column_writer.cpp
@@ -116,11 +116,11 @@ Status StructColumnWriter::init() {
 
 Status StructColumnWriter::append(const Column& column) {
     const StructColumn* struct_column = nullptr;
-    NullColumn* null_column = nullptr;
+    const NullColumn* null_column = nullptr;
     if (is_nullable()) {
         const auto& nullable_column = down_cast<const NullableColumn&>(column);
-        struct_column = down_cast<StructColumn*>(nullable_column.data_column().get());
-        null_column = down_cast<NullColumn*>(nullable_column.null_column().get());
+        struct_column = down_cast<const StructColumn*>(nullable_column.data_column().get());
+        null_column = down_cast<const NullColumn*>(nullable_column.null_column().get());
     } else {
         struct_column = down_cast<const StructColumn*>(&column);
     }

--- a/be/src/storage/rowset/zone_map_index.cpp
+++ b/be/src/storage/rowset/zone_map_index.cpp
@@ -311,7 +311,7 @@ Status ZoneMapIndexReader::_do_load(const IndexReadOptions& opts, const ZoneMapI
 
     _page_zone_maps.resize(reader.num_values());
 
-    auto column = ChunkHelper::column_from_field_type(TYPE_VARCHAR, false);
+    ColumnPtr column = ChunkHelper::column_from_field_type(TYPE_VARCHAR, false);
     // read and cache all page zone maps
     for (int i = 0; i < reader.num_values(); ++i) {
         RETURN_IF_ERROR(iter->seek_to_ordinal(i));

--- a/be/src/storage/rowset_column_update_state.h
+++ b/be/src/storage/rowset_column_update_state.h
@@ -98,11 +98,9 @@ struct ColumnPartialUpdateState {
     }
 };
 
-using ColumnUniquePtr = std::unique_ptr<Column>;
-
 // It contains multi segment's pk list, segment's id is between [start_idx, end_idx)
 struct BatchPKs {
-    ColumnUniquePtr upserts;
+    MutableColumnPtr upserts;
     uint32_t start_idx;
     uint32_t end_idx;
     std::vector<uint64_t> src_rss_rowids;
@@ -213,7 +211,7 @@ private:
                                                                      int segment_id);
 
     Status _fill_default_columns(const TabletSchemaCSPtr& tablet_schema, const std::vector<uint32_t>& column_ids,
-                                 const int64_t row_cnt, vector<std::shared_ptr<Column>>* columns);
+                                 const int64_t row_cnt, vector<ColumnPtr>* columns);
     Status _update_primary_index(const TabletSchemaCSPtr& tablet_schema, Tablet* tablet,
                                  const EditVersion& edit_version, uint32_t rowset_id,
                                  std::map<int, ChunkUniquePtr>& segid_to_chunk, int64_t insert_row_cnt,

--- a/be/src/storage/schema_change_utils.cpp
+++ b/be/src/storage/schema_change_utils.cpp
@@ -403,8 +403,8 @@ Status ChunkChanger::fill_generated_columns(ChunkPtr& new_chunk) {
         if (tmp->only_null()) {
             // Only null column maybe lost type info, we append null
             // for the chunk instead of swapping the tmp column.
-            std::dynamic_pointer_cast<NullableColumn>(new_chunk->get_column_by_index(it.first))->reset_column();
-            std::dynamic_pointer_cast<NullableColumn>(new_chunk->get_column_by_index(it.first))
+            NullableColumn::dynamic_pointer_cast(new_chunk->get_column_by_index(it.first))->reset_column();
+            NullableColumn::dynamic_pointer_cast(new_chunk->get_column_by_index(it.first))
                     ->append_nulls(new_chunk->num_rows());
         } else if (tmp->is_nullable()) {
             new_chunk->get_column_by_index(it.first).swap(tmp);
@@ -413,7 +413,7 @@ Status ChunkChanger::fill_generated_columns(ChunkPtr& new_chunk) {
             // it maybe a constant column or some other column type.
             // Unpack normal const column
             ColumnPtr output_column = ColumnHelper::unpack_and_duplicate_const_column(new_chunk->num_rows(), tmp);
-            std::dynamic_pointer_cast<NullableColumn>(new_chunk->get_column_by_index(it.first))
+            NullableColumn::dynamic_pointer_cast(new_chunk->get_column_by_index(it.first))
                     ->swap_by_data_column(output_column);
         }
     }
@@ -501,8 +501,8 @@ Status ChunkChanger::append_generated_columns(ChunkPtr& read_chunk, ChunkPtr& ne
         if (tmp->only_null()) {
             // Only null column maybe lost type info, we append null
             // for the chunk instead of swapping the tmp column.
-            std::dynamic_pointer_cast<NullableColumn>(tmp_new_chunk->get_column_by_index(cid))->reset_column();
-            std::dynamic_pointer_cast<NullableColumn>(tmp_new_chunk->get_column_by_index(cid))
+            NullableColumn::dynamic_pointer_cast(tmp_new_chunk->get_column_by_index(cid))->reset_column();
+            NullableColumn::dynamic_pointer_cast(tmp_new_chunk->get_column_by_index(cid))
                     ->append_nulls(read_chunk->num_rows());
         } else if (tmp->is_nullable()) {
             tmp_new_chunk->get_column_by_index(cid).swap(tmp);
@@ -511,7 +511,7 @@ Status ChunkChanger::append_generated_columns(ChunkPtr& read_chunk, ChunkPtr& ne
             // it maybe a constant column or some other column type
             // Unpack normal const column
             ColumnPtr output_column = ColumnHelper::unpack_and_duplicate_const_column(read_chunk->num_rows(), tmp);
-            std::dynamic_pointer_cast<NullableColumn>(tmp_new_chunk->get_column_by_index(cid))
+            NullableColumn::dynamic_pointer_cast(tmp_new_chunk->get_column_by_index(cid))
                     ->swap_by_data_column(output_column);
         }
     }

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -242,7 +242,7 @@ Status TabletReader::_init_collector_for_pk_index_read() {
         return Status::NotSupported(strings::Substitute("should have eq predicates on all pk columns current: $0 < $1",
                                                         num_pk_eq_predicates, tablet_schema->num_key_columns()));
     }
-    std::unique_ptr<Column> pk_column;
+    MutableColumnPtr pk_column;
     RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(*tablet_schema->schema(), &pk_column));
     PrimaryKeyEncoder::encode(*tablet_schema->schema(), *keys, 0, keys->num_rows(), pk_column.get());
 

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -107,7 +107,6 @@ struct EditVersionInfo {
 class TabletUpdates {
 public:
     friend class LocalPrimaryKeyRecover;
-    using ColumnUniquePtr = std::unique_ptr<Column>;
     using segment_rowid_t = uint32_t;
     using DeletesMap = std::unordered_map<uint32_t, vector<segment_rowid_t>>;
 
@@ -305,8 +304,7 @@ public:
     // ]
     Status get_column_values(const std::vector<uint32_t>& column_ids, int64_t read_version, bool with_default,
                              std::map<uint32_t, std::vector<uint32_t>>& rowids_by_rssid,
-                             vector<std::unique_ptr<Column>>* columns, void* state,
-                             const TabletSchemaCSPtr& tablet_schema,
+                             vector<MutableColumnPtr>* columns, void* state, const TabletSchemaCSPtr& tablet_schema,
                              const std::map<string, string>* column_to_expr_value = nullptr);
 
     Status get_rss_rowids_by_pk(Tablet* tablet, const Column& keys, EditVersion* read_version,
@@ -451,7 +449,7 @@ private:
     void _calc_compaction_score(RowsetStats* stats);
 
     Status _do_update(uint32_t rowset_id, int32_t upsert_idx, int32_t condition_column, int64_t read_version,
-                      const std::vector<ColumnUniquePtr>& upserts, PrimaryIndex& index, int64_t tablet_id,
+                      const std::vector<MutableColumnPtr>& upserts, PrimaryIndex& index, int64_t tablet_id,
                       DeletesMap* new_deletes, const TabletSchemaCSPtr& tablet_schema);
 
     // This method will acquire |_lock|.

--- a/be/src/storage/update_compaction_state.cpp
+++ b/be/src/storage/update_compaction_state.cpp
@@ -75,7 +75,7 @@ Status CompactionState::_load_segments(Rowset* rowset, uint32_t segment_id) {
 
     Schema pkey_schema = ChunkHelper::convert_schema(schema, pk_columns);
 
-    std::unique_ptr<Column> pk_column;
+    MutableColumnPtr pk_column;
     RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, true));
 
     RowsetReleaseGuard guard(rowset->shared_from_this());

--- a/be/src/storage/update_compaction_state.h
+++ b/be/src/storage/update_compaction_state.h
@@ -17,6 +17,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "column/column.h"
 #include "column/vectorized_fwd.h"
 #include "common/status.h"
 #include "storage/olap_common.h"
@@ -40,7 +41,7 @@ public:
 
     size_t memory_usage() const { return _memory_usage; }
 
-    std::vector<ColumnPtr> pk_cols;
+    Columns pk_cols;
 
 private:
     Status _load_segments(Rowset* rowset, uint32_t segment_id);

--- a/be/src/testutil/column_test_helper.h
+++ b/be/src/testutil/column_test_helper.h
@@ -22,7 +22,7 @@ namespace starrocks {
 class ColumnTestHelper {
 public:
     template <class T>
-    static ColumnPtr build_column(const std::vector<T>& values) {
+    static MutableColumnPtr build_column(const std::vector<T>& values) {
         if constexpr (std::is_same_v<T, uint8_t>) {
             auto data = UInt8Column::create();
             data->append_numbers(values.data(), values.size() * sizeof(T));
@@ -49,14 +49,14 @@ public:
     }
 
     template <class T>
-    static ColumnPtr build_nullable_column(const std::vector<T>& values) {
+    static MutableColumnPtr build_nullable_column(const std::vector<T>& values) {
         auto null_column = NullColumn::create(values.size(), 0);
         auto data_column = build_column<T>(values);
         return NullableColumn::create(std::move(data_column), std::move(null_column));
     }
 
     template <class T>
-    static ColumnPtr build_nullable_column(const std::vector<T>& values, const std::vector<uint8_t>& nullflags) {
+    static MutableColumnPtr build_nullable_column(const std::vector<T>& values, const std::vector<uint8_t>& nullflags) {
         DCHECK_EQ(values.size(), nullflags.size());
         auto null = NullColumn::create();
         null->append_numbers(nullflags.data(), nullflags.size());
@@ -65,7 +65,7 @@ public:
     }
 
     template <LogicalType TYPE>
-    static ColumnPtr create_nullable_column() {
+    static MutableColumnPtr create_nullable_column() {
         return NullableColumn::create(RunTimeColumnType<TYPE>::create(), RunTimeColumnType<TYPE_NULL>::create());
     }
 };

--- a/be/src/udf/java/java_data_converter.cpp
+++ b/be/src/udf/java/java_data_converter.cpp
@@ -332,7 +332,7 @@ Status JavaDataTypeConverter::convert_to_boxed_array(FunctionContext* ctx, std::
             arg = helper.create_array(num_rows);
         } else if (columns[i]->is_constant()) {
             auto& data_column = down_cast<const ConstColumn*>(columns[i])->data_column();
-            data_column->resize(1);
+            data_column->as_mutable_ptr()->resize(1);
             jobject jval = cast_to_jvalue<false>(types[i], true, data_column.get(), 0).l;
             arg = helper.create_object_array(jval, num_rows);
             env->DeleteLocalRef(jval);

--- a/be/src/util/arrow/starrocks_column_to_arrow.cpp
+++ b/be/src/util/arrow/starrocks_column_to_arrow.cpp
@@ -95,8 +95,8 @@ struct ColumnToArrowConverter<LT, AT, is_nullable, ConvFloatAndIntegerGuard<LT, 
         ARROW_RETURN_NOT_OK(check_const(column));
         ArrowBuilderType* builder = down_cast<ArrowBuilderType*>(array_builder);
         if constexpr (is_nullable) {
-            const auto* nullable_column = down_cast<NullableColumn*>(column.get());
-            const auto* data_column = down_cast<StarRocksColumnType*>(nullable_column->data_column().get());
+            const auto* nullable_column = down_cast<const NullableColumn*>(column.get());
+            const auto* data_column = down_cast<const StarRocksColumnType*>(nullable_column->data_column().get());
             const auto& data = data_column->get_data();
             for (auto i = start_idx; i < end_idx; ++i) {
                 if (nullable_column->is_null(i)) {
@@ -106,7 +106,7 @@ struct ColumnToArrowConverter<LT, AT, is_nullable, ConvFloatAndIntegerGuard<LT, 
                 }
             }
         } else {
-            const auto* data_column = down_cast<StarRocksColumnType*>(column.get());
+            const auto* data_column = down_cast<const StarRocksColumnType*>(column.get());
             const auto* values = data_column->get_data().data() + start_idx;
             ARROW_RETURN_NOT_OK(builder->AppendValues(values, end_idx - start_idx));
         }
@@ -147,8 +147,8 @@ struct ColumnToArrowConverter<LT, AT, is_nullable, ConvDecimalGuard<LT, AT>> {
         ARROW_RETURN_NOT_OK(check_const(column));
         ArrowBuilderType* builder = down_cast<ArrowBuilderType*>(array_builder);
         if constexpr (is_nullable) {
-            const auto* nullable_column = down_cast<NullableColumn*>(column.get());
-            const auto* data_column = down_cast<StarRocksColumnType*>(nullable_column->data_column().get());
+            const auto* nullable_column = down_cast<const NullableColumn*>(column.get());
+            const auto* data_column = down_cast<const StarRocksColumnType*>(nullable_column->data_column().get());
             const auto& data = data_column->get_data();
             for (auto i = start_idx; i < end_idx; ++i) {
                 if (nullable_column->is_null(i)) {
@@ -158,7 +158,7 @@ struct ColumnToArrowConverter<LT, AT, is_nullable, ConvDecimalGuard<LT, AT>> {
                 }
             }
         } else {
-            const auto* data_column = down_cast<StarRocksColumnType*>(column.get());
+            const auto* data_column = down_cast<const StarRocksColumnType*>(column.get());
             const auto& data = data_column->get_data();
             for (auto i = start_idx; i < end_idx; ++i) {
                 ARROW_RETURN_NOT_OK(builder->Append(convert_datum(data[i])));
@@ -211,8 +211,8 @@ struct ColumnToArrowConverter<LT, AT, is_nullable, ConvBinaryGuard<LT, AT>> {
         ARROW_RETURN_NOT_OK(check_const(column));
         ArrowBuilderType* builder = down_cast<ArrowBuilderType*>(array_builder);
         if constexpr (is_nullable) {
-            const auto* nullable_column = down_cast<NullableColumn*>(column.get());
-            const auto* data_column = down_cast<StarRocksColumnType*>(nullable_column->data_column().get());
+            const auto* nullable_column = down_cast<const NullableColumn*>(column.get());
+            const auto* data_column = down_cast<const StarRocksColumnType*>(nullable_column->data_column().get());
             if constexpr (lt_is_string<LT>) {
                 const auto& data = data_column->get_proxy_data();
                 for (auto i = start_idx; i < end_idx; ++i) {
@@ -239,7 +239,7 @@ struct ColumnToArrowConverter<LT, AT, is_nullable, ConvBinaryGuard<LT, AT>> {
                 }
             }
         } else {
-            const auto* data_column = down_cast<StarRocksColumnType*>(column.get());
+            const auto* data_column = down_cast<const StarRocksColumnType*>(column.get());
             if constexpr (lt_is_string<LT>) {
                 const auto& data = data_column->get_proxy_data();
                 for (auto i = start_idx; i < end_idx; ++i) {
@@ -279,11 +279,11 @@ struct ColumnToArrowConverter<LT, AT, is_nullable, ConvArrayGuard<LT, AT>> {
 
         bool element_is_nullable;
         if constexpr (is_nullable) {
-            const auto* nullable_column = down_cast<NullableColumn*>(column.get());
-            const auto* data_column = down_cast<ArrayColumn*>(nullable_column->data_column().get());
+            const auto* nullable_column = down_cast<const NullableColumn*>(column.get());
+            const auto* data_column = down_cast<const ArrayColumn*>(nullable_column->data_column().get());
             element_is_nullable = data_column->elements_column()->is_nullable();
         } else {
-            const auto* data_column = down_cast<ArrayColumn*>(column.get());
+            const auto* data_column = down_cast<const ArrayColumn*>(column.get());
             element_is_nullable = data_column->elements_column()->is_nullable();
         }
 
@@ -307,8 +307,8 @@ struct ColumnToArrowConverter<LT, AT, is_nullable, ConvArrayGuard<LT, AT>> {
         arrow::ListBuilder* builder = down_cast<arrow::ListBuilder*>(array_builder);
         auto element_builder = builder->value_builder();
         if constexpr (is_nullable) {
-            const auto* nullable_column = down_cast<NullableColumn*>(column.get());
-            const auto* data_column = down_cast<ArrayColumn*>(nullable_column->data_column().get());
+            const auto* nullable_column = down_cast<const NullableColumn*>(column.get());
+            const auto* data_column = down_cast<const ArrayColumn*>(nullable_column->data_column().get());
             auto& offsets = data_column->offsets().get_data();
             const auto& element_column = data_column->elements_column();
             ARROW_RETURN_NOT_OK(element_builder->Reserve(end_idx - start_idx));
@@ -322,7 +322,7 @@ struct ColumnToArrowConverter<LT, AT, is_nullable, ConvArrayGuard<LT, AT>> {
                 }
             }
         } else {
-            const auto* data_column = down_cast<ArrayColumn*>(column.get());
+            const auto* data_column = down_cast<const ArrayColumn*>(column.get());
             auto& offsets = data_column->offsets().get_data();
             const auto& child_column = data_column->elements_column();
             ARROW_RETURN_NOT_OK(element_builder->Reserve(end_idx - start_idx));
@@ -353,10 +353,10 @@ struct ColumnToArrowConverter<LT, AT, is_nullable, ConvStructGuard<LT, AT>> {
 
         const StructColumn* data_column;
         if constexpr (is_nullable) {
-            const auto* nullable_column = down_cast<NullableColumn*>(column.get());
-            data_column = down_cast<StructColumn*>(nullable_column->data_column().get());
+            const auto* nullable_column = down_cast<const NullableColumn*>(column.get());
+            data_column = down_cast<const StructColumn*>(nullable_column->data_column().get());
         } else {
-            data_column = down_cast<StructColumn*>(column.get());
+            data_column = down_cast<const StructColumn*>(column.get());
         }
 
         const auto& type_desc = column_context->type_desc;
@@ -385,14 +385,14 @@ struct ColumnToArrowConverter<LT, AT, is_nullable, ConvStructGuard<LT, AT>> {
         const StructColumn* data_column;
         // 1. set null bitmap of builder
         if constexpr (is_nullable) {
-            const auto* nullable_column = down_cast<NullableColumn*>(column.get());
-            data_column = down_cast<StructColumn*>(nullable_column->data_column().get());
+            const auto* nullable_column = down_cast<const NullableColumn*>(column.get());
+            data_column = down_cast<const StructColumn*>(nullable_column->data_column().get());
             ARROW_RETURN_NOT_OK(builder->Reserve(end_idx - start_idx));
             for (auto i = start_idx; i < end_idx; ++i) {
                 ARROW_RETURN_NOT_OK(builder->Append(!nullable_column->is_null(i)));
             }
         } else {
-            data_column = down_cast<StructColumn*>(column.get());
+            data_column = down_cast<const StructColumn*>(column.get());
             // Set null bitmap in batch. *nullptr* indicates all values are not null
             ARROW_RETURN_NOT_OK(builder->AppendValues(end_idx - start_idx, nullptr));
         }
@@ -424,10 +424,10 @@ struct ColumnToArrowConverter<LT, AT, is_nullable, ConvMapGuard<LT, AT>> {
 
         const MapColumn* data_column;
         if constexpr (is_nullable) {
-            const auto* nullable_column = down_cast<NullableColumn*>(column.get());
-            data_column = down_cast<MapColumn*>(nullable_column->data_column().get());
+            const auto* nullable_column = down_cast<const NullableColumn*>(column.get());
+            data_column = down_cast<const MapColumn*>(nullable_column->data_column().get());
         } else {
-            data_column = down_cast<MapColumn*>(column.get());
+            data_column = down_cast<const MapColumn*>(column.get());
         }
 
         const auto& type_desc = column_context->type_desc;
@@ -476,8 +476,8 @@ struct ColumnToArrowConverter<LT, AT, is_nullable, ConvMapGuard<LT, AT>> {
         auto& value_context = column_context->child_column_contexts[1];
         auto value_builder = builder->item_builder();
         if constexpr (is_nullable) {
-            const auto* nullable_column = down_cast<NullableColumn*>(column.get());
-            const MapColumn* data_column = down_cast<MapColumn*>(nullable_column->data_column().get());
+            const auto* nullable_column = down_cast<const NullableColumn*>(column.get());
+            const MapColumn* data_column = down_cast<const MapColumn*>(nullable_column->data_column().get());
             auto& offsets = data_column->offsets().get_data();
             const auto& key_column = data_column->keys_column();
             const auto& value_column = data_column->values_column();
@@ -494,7 +494,7 @@ struct ColumnToArrowConverter<LT, AT, is_nullable, ConvMapGuard<LT, AT>> {
                 }
             }
         } else {
-            const MapColumn* data_column = down_cast<MapColumn*>(column.get());
+            const MapColumn* data_column = down_cast<const MapColumn*>(column.get());
             auto& offsets = data_column->offsets().get_data();
             const auto& key_column = data_column->keys_column();
             const auto& value_column = data_column->values_column();

--- a/be/src/util/json_flattener.h
+++ b/be/src/util/json_flattener.h
@@ -180,7 +180,7 @@ public:
     // flatten without flat json, input must not flat json
     void flatten(const Column* json_column);
 
-    std::vector<ColumnPtr> mutable_result();
+    Columns mutable_result();
 
 private:
     template <bool HAS_REMAIN>
@@ -196,7 +196,7 @@ private:
     std::vector<std::string> _dst_paths;
     std::shared_ptr<JsonFlatPath> _dst_root;
 
-    std::vector<ColumnPtr> _flat_columns;
+    Columns _flat_columns;
     JsonColumn* _remain;
 };
 
@@ -221,7 +221,7 @@ public:
     bool has_exclude_paths() const { return !_exclude_paths.empty(); }
 
     // input nullable-json, output none null json
-    ColumnPtr merge(const std::vector<ColumnPtr>& columns);
+    ColumnPtr merge(const Columns& columns);
 
 private:
     template <bool IN_TREE>
@@ -277,11 +277,11 @@ public:
     void init_compaction_task(const std::vector<std::string>& paths, const std::vector<LogicalType>& types,
                               bool has_remain);
 
-    Status trans(std::vector<ColumnPtr>& columns);
+    Status trans(const Columns& columns);
 
-    std::vector<ColumnPtr>& result() { return _dst_columns; }
+    Columns& result() { return _dst_columns; }
 
-    std::vector<ColumnPtr> mutable_result();
+    Columns mutable_result();
 
     std::vector<std::string> cast_paths() const;
 
@@ -315,16 +315,16 @@ private:
         std::unique_ptr<JsonFlattener> flattener;
     };
 
-    Status _equals(const MergeTask& task, std::vector<ColumnPtr>& columns);
-    Status _cast(const MergeTask& task, ColumnPtr& columns);
-    Status _merge(const MergeTask& task, std::vector<ColumnPtr>& columns);
-    void _flat(const FlatTask& task, std::vector<ColumnPtr>& columns);
+    Status _equals(const MergeTask& task, const Columns& columns);
+    Status _cast(const MergeTask& task, const ColumnPtr& columns);
+    Status _merge(const MergeTask& task, const Columns& columns);
+    void _flat(const FlatTask& task, const Columns& columns);
 
 private:
     bool _dst_remain = false;
     std::vector<std::string> _dst_paths;
     std::vector<LogicalType> _dst_types;
-    std::vector<ColumnPtr> _dst_columns;
+    Columns _dst_columns;
 
     std::vector<std::string> _src_paths;
     std::vector<LogicalType> _src_types;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -20,11 +20,13 @@ set(EXEC_FILES
         ./column/timestamp_value_test.cpp
         ./common/cow_test.cpp
         ./column/schema_test.cpp
+        ./column/column_cow_test.cpp
         ./common/config_test.cpp
         ./common/process_exit_test.cpp
         ./common/status_test.cpp
         ./common/tracer_test.cpp
         ./common/uri_test.cpp
+        ./common/cow_test.cpp
         ./connector/deletion_vector/deletion_vector_test.cpp
         ./connector_sink/hive_chunk_sink_test.cpp
         ./connector_sink/iceberg_chunk_sink_test.cpp

--- a/be/test/column/array_column_test.cpp
+++ b/be/test/column/array_column_test.cpp
@@ -29,9 +29,9 @@ namespace starrocks {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(ArrayColumnTest, test_create) {
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto column = ArrayColumn::create(elements, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    NullableColumn::Ptr elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    ArrayColumn::Ptr column = ArrayColumn::create(elements, offsets);
     ASSERT_TRUE(column->is_array());
     ASSERT_FALSE(column->is_nullable());
     ASSERT_EQ(0, column->size());
@@ -40,9 +40,9 @@ PARALLEL_TEST(ArrayColumnTest, test_create) {
 // NOLINTNEXTLINE
 PARALLEL_TEST(ArrayColumnTest, test_array_column_update_if_overflow) {
     // normal
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
-    auto column = ArrayColumn::create(elements, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    NullableColumn::Ptr elements = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+    ArrayColumn::Ptr column = ArrayColumn::create(elements, offsets);
 
     elements->append_datum("1");
     elements->append_datum("2");
@@ -58,19 +58,19 @@ PARALLEL_TEST(ArrayColumnTest, test_array_column_update_if_overflow) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(ArrayColumnTest, test_array_column_downgrade) {
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    NullableColumn::Ptr elements = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
     elements->append_datum("1");
     elements->append_datum("2");
     offsets->append(2);
-    auto column = ArrayColumn::create(elements, offsets);
+    ArrayColumn::Ptr column = ArrayColumn::create(elements, offsets);
     ASSERT_FALSE(column->has_large_column());
     auto ret = column->downgrade();
     ASSERT_TRUE(ret.ok());
     ASSERT_TRUE(ret.value() == nullptr);
 
     offsets = UInt32Column::create();
-    auto large_elements = NullableColumn::create(LargeBinaryColumn::create(), NullColumn::create());
+    NullableColumn::Ptr large_elements = NullableColumn::create(LargeBinaryColumn::create(), NullColumn::create());
     column = ArrayColumn::create(large_elements, offsets);
     for (size_t i = 0; i < 10; i++) {
         large_elements->append_datum(Slice(std::to_string(i)));
@@ -89,9 +89,9 @@ PARALLEL_TEST(ArrayColumnTest, test_array_column_downgrade) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(ArrayColumnTest, test_get_elements) {
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto column = ArrayColumn::create(elements, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    NullableColumn::Ptr elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    ArrayColumn::Ptr column = ArrayColumn::create(elements, offsets);
 
     // insert [1, 2, 3], [4, 5, 6]
     elements->append_datum(1);
@@ -110,9 +110,9 @@ PARALLEL_TEST(ArrayColumnTest, test_get_elements) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(ArrayColumnTest, test_byte_size) {
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto column = ArrayColumn::create(elements, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    NullableColumn::Ptr elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    ArrayColumn::Ptr column = ArrayColumn::create(elements, offsets);
 
     // insert [1, 2, 3], [4, 5, 6]
     elements->append_datum(1);
@@ -144,8 +144,8 @@ PARALLEL_TEST(ArrayColumnTest, test_byte_size) {
 PARALLEL_TEST(ArrayColumnTest, test_filter) {
     // ARRAY<INT>
     {
-        auto column = ArrayColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                          UInt32Column::create());
+        ArrayColumn::Ptr column = ArrayColumn::create(
+                NullableColumn::create(Int32Column::create(), NullColumn::create()), UInt32Column::create());
         // The width of AVX2 register is 256 bits, aka 32 bytes, make the column size equals
         // to 2 * 32 + 31 in order to cover both the SIMD instructions and non-SIMD instructions.
         const int N = 2 * 32 + 31;
@@ -228,8 +228,8 @@ PARALLEL_TEST(ArrayColumnTest, test_filter) {
     }
     // ARRAY<INT>
     {
-        auto column = ArrayColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                          UInt32Column::create());
+        ArrayColumn::Ptr column = ArrayColumn::create(
+                NullableColumn::create(Int32Column::create(), NullColumn::create()), UInt32Column::create());
         // The width of AVX2 register is 256 bits, aka 32 bytes, make the column size equals
         // to 2 * 32 + 31 in order to cover both the SIMD instructions and non-SIMD instructions.
         const int N = 3 * 32 + 31;
@@ -267,8 +267,8 @@ PARALLEL_TEST(ArrayColumnTest, test_filter) {
     }
     // ARRAY<INT> with the number of elements > 2^16
     {
-        auto column = ArrayColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                          UInt32Column::create());
+        ArrayColumn::Ptr column = ArrayColumn::create(
+                NullableColumn::create(Int32Column::create(), NullColumn::create()), UInt32Column::create());
         column->reserve(4096);
         for (int i = 0; i < 4096; i++) {
             DatumArray array;
@@ -304,11 +304,11 @@ PARALLEL_TEST(ArrayColumnTest, test_filter) {
     // ARRAY<ARRAY<INT>>
     {
         const int N = 100;
-        auto elements = ArrayColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                            UInt32Column::create());
-        auto nullable_elements = NullableColumn::create(std::move(elements), NullColumn::create());
+        ArrayColumn::Ptr elements = ArrayColumn::create(
+                NullableColumn::create(Int32Column::create(), NullColumn::create()), UInt32Column::create());
+        NullableColumn::Ptr nullable_elements = NullableColumn::create(std::move(elements), NullColumn::create());
         auto offsets = UInt32Column ::create();
-        auto column = ArrayColumn::create(std::move(nullable_elements), std::move(offsets));
+        ArrayColumn::Ptr column = ArrayColumn::create(std::move(nullable_elements), std::move(offsets));
 
         for (int i = 0; i < N; i++) {
             column->append_datum(DatumArray{DatumArray{i * 3, i * 3 + 1}, DatumArray{i * 2, i * 2 + 1}});
@@ -391,9 +391,9 @@ PARALLEL_TEST(ArrayColumnTest, test_filter) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(ArrayColumnTest, test_append_array) {
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto column = ArrayColumn::create(elements, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    NullableColumn::Ptr elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    ArrayColumn::Ptr column = ArrayColumn::create(elements, offsets);
 
     // insert [1, 2, 3], [4, 5, 6]
     elements->append_datum(1);
@@ -417,11 +417,11 @@ PARALLEL_TEST(ArrayColumnTest, test_append_array) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(ArrayColumnTest, test_append_nulls) {
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto column = ArrayColumn::create(elements, offsets);
-    auto null_column = NullColumn::create();
-    auto nullable_column = NullableColumn::create(column, null_column);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    NullableColumn::Ptr elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    ArrayColumn::Ptr column = ArrayColumn::create(elements, offsets);
+    NullColumn::Ptr null_column = NullColumn::create();
+    NullableColumn::Ptr nullable_column = NullableColumn::create(column, null_column);
 
     ASSERT_TRUE(nullable_column->append_nulls(1));
 
@@ -445,9 +445,9 @@ PARALLEL_TEST(ArrayColumnTest, test_append_nulls) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(ArrayColumnTest, test_append_defaults) {
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto column = ArrayColumn::create(elements, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    NullableColumn::Ptr elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    ArrayColumn::Ptr column = ArrayColumn::create(elements, offsets);
 
     // insert [1, 2, 3], [4, 5, 6]
     elements->append_datum(1);
@@ -470,9 +470,9 @@ PARALLEL_TEST(ArrayColumnTest, test_append_defaults) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(ArrayColumnTest, test_compare_at) {
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto column = ArrayColumn::create(elements, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    NullableColumn::Ptr elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    ArrayColumn::Ptr column = ArrayColumn::create(elements, offsets);
 
     // insert [1, 2, 3], [4, 5, 6]
     elements->append_datum(1);
@@ -485,9 +485,9 @@ PARALLEL_TEST(ArrayColumnTest, test_compare_at) {
     elements->append_datum(6);
     offsets->append(6);
 
-    auto offsets_2 = UInt32Column::create();
-    auto elements_2 = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto column_2 = ArrayColumn::create(elements_2, offsets_2);
+    UInt32Column::Ptr offsets_2 = UInt32Column::create();
+    NullableColumn::Ptr elements_2 = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    ArrayColumn::Ptr column_2 = ArrayColumn::create(elements_2, offsets_2);
 
     // insert [4, 5, 6], [7, 8, 9]
     elements_2->append_datum(4);
@@ -564,13 +564,14 @@ PARALLEL_TEST(ArrayColumnTest, equals) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(ArrayColumnTest, test_multi_dimension_array) {
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    NullableColumn::Ptr elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
 
-    auto offsets_1 = UInt32Column::create();
-    auto elements_1 = NullableColumn::create(ArrayColumn::create(elements, offsets), NullColumn::create());
+    UInt32Column::Ptr offsets_1 = UInt32Column::create();
+    NullableColumn::Ptr elements_1 =
+            NullableColumn::create(ArrayColumn::create(elements, offsets), NullColumn::create());
 
-    auto column = ArrayColumn::create(elements_1, offsets_1);
+    ArrayColumn::Ptr column = ArrayColumn::create(elements_1, offsets_1);
 
     // insert [[1, 2, 3], [4, 5, 6]], [[7], [8], [9]]
     elements->append_datum(1);
@@ -605,9 +606,9 @@ PARALLEL_TEST(ArrayColumnTest, test_multi_dimension_array) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(ArrayColumnTest, test_resize) {
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto column = ArrayColumn::create(elements, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    NullableColumn::Ptr elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    ArrayColumn::Ptr column = ArrayColumn::create(elements, offsets);
 
     // insert [1, 2, 3], [4, 5, 6], [7, 8, 9]
     elements->append_datum(1);
@@ -632,9 +633,9 @@ PARALLEL_TEST(ArrayColumnTest, test_resize) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(ArrayColumnTest, test_reset_column) {
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto column = ArrayColumn::create(elements, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    NullableColumn::Ptr elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    ArrayColumn::Ptr column = ArrayColumn::create(elements, offsets);
 
     // insert [1, 2, 3], [4, 5, 6], [7, 8, 9]
     elements->append_datum(1);
@@ -658,9 +659,9 @@ PARALLEL_TEST(ArrayColumnTest, test_reset_column) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(ArrayColumnTest, test_swap_column) {
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto column = ArrayColumn::create(elements, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    NullableColumn::Ptr elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    ArrayColumn::Ptr column = ArrayColumn::create(elements, offsets);
 
     // insert [1, 2, 3], [4, 5, 6]
     elements->append_datum(1);
@@ -673,9 +674,9 @@ PARALLEL_TEST(ArrayColumnTest, test_swap_column) {
     elements->append_datum(6);
     offsets->append(6);
 
-    auto offsets_2 = UInt32Column::create();
-    auto elements_2 = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto column_2 = ArrayColumn::create(elements_2, offsets_2);
+    UInt32Column::Ptr offsets_2 = UInt32Column::create();
+    NullableColumn::Ptr elements_2 = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    ArrayColumn::Ptr column_2 = ArrayColumn::create(elements_2, offsets_2);
 
     // insert [4, 5, 6], [7, 8, 9]
     elements_2->append_datum(4);
@@ -695,9 +696,9 @@ PARALLEL_TEST(ArrayColumnTest, test_swap_column) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(ArrayColumnTest, test_copy_constructor) {
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto c0 = ArrayColumn::create(elements, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    NullableColumn::Ptr elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    ArrayColumn::Ptr c0 = ArrayColumn::create(elements, offsets);
 
     // insert [1, 2, 3], [4, 5, 6]
     elements->append_datum(1);
@@ -714,15 +715,15 @@ PARALLEL_TEST(ArrayColumnTest, test_copy_constructor) {
     c0->reset_column();
     ASSERT_EQ("[1,2,3]", c1.debug_item(0));
     ASSERT_EQ("[4,5,6]", c1.debug_item(1));
-    ASSERT_TRUE(c1.elements_column().unique());
-    ASSERT_TRUE(c1.offsets_column().unique());
+    ASSERT_TRUE(c1.elements_column()->use_count() == 1);
+    ASSERT_TRUE(c1.offsets_column()->use_count() == 1);
 }
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(ArrayColumnTest, test_move_constructor) {
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto c0 = ArrayColumn::create(elements, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    NullableColumn::Ptr elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    ArrayColumn::Ptr c0 = ArrayColumn::create(elements, offsets);
 
     // insert [1, 2, 3], [4, 5, 6]
     elements->append_datum(1);
@@ -742,9 +743,9 @@ PARALLEL_TEST(ArrayColumnTest, test_move_constructor) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(ArrayColumnTest, test_copy_assignment) {
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto c0 = ArrayColumn::create(elements, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    NullableColumn::Ptr elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    ArrayColumn::Ptr c0 = ArrayColumn::create(elements, offsets);
 
     // insert [1, 2, 3], [4, 5, 6]
     elements->append_datum(1);
@@ -762,15 +763,15 @@ PARALLEL_TEST(ArrayColumnTest, test_copy_assignment) {
     c0->reset_column();
     ASSERT_EQ("[1,2,3]", c1.debug_item(0));
     ASSERT_EQ("[4,5,6]", c1.debug_item(1));
-    ASSERT_TRUE(c1.elements_column().unique());
-    ASSERT_TRUE(c1.offsets_column().unique());
+    ASSERT_TRUE(c1.elements_column()->use_count() == 1);
+    ASSERT_TRUE(c1.offsets_column()->use_count() == 1);
 }
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(ArrayColumnTest, test_move_assignment) {
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto c0 = ArrayColumn::create(elements, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    NullableColumn::Ptr elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    ArrayColumn::Ptr c0 = ArrayColumn::create(elements, offsets);
 
     // insert [1, 2, 3], [4, 5, 6]
     elements->append_datum(1);
@@ -787,15 +788,15 @@ PARALLEL_TEST(ArrayColumnTest, test_move_assignment) {
     c1 = std::move(*c0);
     ASSERT_EQ("[1,2,3]", c1.debug_item(0));
     ASSERT_EQ("[4,5,6]", c1.debug_item(1));
-    ASSERT_TRUE(c1.elements_column().unique());
-    ASSERT_TRUE(c1.offsets_column().unique());
+    ASSERT_TRUE(c1.elements_column()->use_count() == 1);
+    ASSERT_TRUE(c1.offsets_column()->use_count() == 1);
 }
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(ArrayColumnTest, test_clone) {
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto c0 = ArrayColumn::create(elements, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    NullableColumn::Ptr elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    ArrayColumn::Ptr c0 = ArrayColumn::create(elements, offsets);
 
     // insert [1, 2, 3], [4, 5, 6]
     elements->append_datum(1);
@@ -812,15 +813,15 @@ PARALLEL_TEST(ArrayColumnTest, test_clone) {
     c0->reset_column();
     ASSERT_EQ("[1,2,3]", c1->debug_item(0));
     ASSERT_EQ("[4,5,6]", c1->debug_item(1));
-    ASSERT_TRUE(down_cast<ArrayColumn*>(c1.get())->elements_column().unique());
-    ASSERT_TRUE(down_cast<ArrayColumn*>(c1.get())->offsets_column().unique());
+    ASSERT_TRUE(down_cast<ArrayColumn*>(c1.get())->elements_column()->use_count() == 1);
+    ASSERT_TRUE(down_cast<ArrayColumn*>(c1.get())->offsets_column()->use_count() == 1);
 }
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(ArrayColumnTest, test_clone_shared) {
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto c0 = ArrayColumn::create(elements, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    NullableColumn::Ptr elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    ArrayColumn::Ptr c0 = ArrayColumn::create(elements, offsets);
 
     // insert [1, 2, 3], [4, 5, 6]
     elements->append_datum(1);
@@ -833,20 +834,20 @@ PARALLEL_TEST(ArrayColumnTest, test_clone_shared) {
     elements->append_datum(6);
     offsets->append(6);
 
-    auto c1 = c0->clone_shared();
+    auto c1 = c0->clone();
     c0->reset_column();
     ASSERT_EQ("[1,2,3]", c1->debug_item(0));
     ASSERT_EQ("[4,5,6]", c1->debug_item(1));
-    ASSERT_TRUE(c1.unique());
-    ASSERT_TRUE(down_cast<ArrayColumn*>(c1.get())->elements_column().unique());
-    ASSERT_TRUE(down_cast<ArrayColumn*>(c1.get())->offsets_column().unique());
+    ASSERT_TRUE(c1->use_count() == 1);
+    ASSERT_TRUE(down_cast<ArrayColumn*>(c1.get())->elements_column()->use_count() == 1);
+    ASSERT_TRUE(down_cast<ArrayColumn*>(c1.get())->offsets_column()->use_count() == 1);
 }
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(ArrayColumnTest, test_clone_column) {
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto c0 = ArrayColumn::create(elements, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    NullableColumn::Ptr elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    ArrayColumn::Ptr c0 = ArrayColumn::create(elements, offsets);
 
     // insert [1, 2, 3], [4, 5, 6]
     elements->append_datum(1);
@@ -867,9 +868,9 @@ PARALLEL_TEST(ArrayColumnTest, test_clone_column) {
 }
 
 PARALLEL_TEST(ArrayColumnTest, test_array_hash) {
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto c0 = ArrayColumn::create(elements, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    NullableColumn::Ptr elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    ArrayColumn::Ptr c0 = ArrayColumn::create(elements, offsets);
 
     // insert [1, 2, 3], [4, 5, 6]
     size_t array_size_1 = 3;
@@ -933,9 +934,9 @@ PARALLEL_TEST(ArrayColumnTest, test_array_hash) {
 }
 
 PARALLEL_TEST(ArrayColumnTest, test_xor_checksum) {
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto c0 = ArrayColumn::create(elements, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    NullableColumn::Ptr elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    ArrayColumn::Ptr c0 = ArrayColumn::create(elements, offsets);
 
     // insert [1, 2, 3], [4, 5, 6, 7]
     elements->append_datum(1);
@@ -957,9 +958,9 @@ PARALLEL_TEST(ArrayColumnTest, test_xor_checksum) {
 }
 
 PARALLEL_TEST(ArrayColumnTest, test_update_rows) {
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto column = ArrayColumn::create(elements, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    NullableColumn::Ptr elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    ArrayColumn::Ptr column = ArrayColumn::create(elements, offsets);
 
     // insert [1, 2, 3], [4, 5, 6]
     elements->append_datum(1);
@@ -984,9 +985,9 @@ PARALLEL_TEST(ArrayColumnTest, test_update_rows) {
     elements->append_datum(12);
     offsets->append(12);
 
-    auto offset_col1 = UInt32Column::create();
-    auto element_col1 = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto replace_col1 = ArrayColumn::create(element_col1, offset_col1);
+    UInt32Column::Ptr offset_col1 = UInt32Column::create();
+    NullableColumn::Ptr element_col1 = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    ArrayColumn::Ptr replace_col1 = ArrayColumn::create(element_col1, offset_col1);
 
     // insert [101, 102], [103, 104]
     element_col1->append_datum(101);
@@ -1006,9 +1007,9 @@ PARALLEL_TEST(ArrayColumnTest, test_update_rows) {
     ASSERT_EQ("[7,8,9]", column->debug_item(2));
     ASSERT_EQ("[103,104]", column->debug_item(3));
 
-    auto offset_col2 = UInt32Column::create();
-    auto element_col2 = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto replace_col2 = ArrayColumn::create(element_col2, offset_col2);
+    UInt32Column::Ptr offset_col2 = UInt32Column::create();
+    NullableColumn::Ptr element_col2 = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    ArrayColumn::Ptr replace_col2 = ArrayColumn::create(element_col2, offset_col2);
 
     // insert [201, 202], [203, 204]
     element_col2->append_datum(201);
@@ -1030,9 +1031,9 @@ PARALLEL_TEST(ArrayColumnTest, test_update_rows) {
 
 PARALLEL_TEST(ArrayColumnTest, test_assign) {
     /// test assign comment arrays
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto column = ArrayColumn::create(elements, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    NullableColumn::Ptr elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    ArrayColumn::Ptr column = ArrayColumn::create(elements, offsets);
 
     // insert [1, 2, 3], [4, 5, 6]
     elements->append_datum(1);
@@ -1084,9 +1085,9 @@ PARALLEL_TEST(ArrayColumnTest, test_assign) {
 }
 
 PARALLEL_TEST(ArrayColumnTest, test_empty_null_array) {
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto column = ArrayColumn::create(elements, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    NullableColumn::Ptr elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    ArrayColumn::Ptr column = ArrayColumn::create(elements, offsets);
 
     // insert [1, 2, 3], [4, 5, 6]
     elements->append_datum(1);
@@ -1099,7 +1100,7 @@ PARALLEL_TEST(ArrayColumnTest, test_empty_null_array) {
     elements->append_datum(6);
     offsets->append(6);
 
-    auto null_map = NullColumn::create(2, 0);
+    NullColumn::Ptr null_map = NullColumn::create(2, 0);
     auto res = column->empty_null_in_complex_column(null_map->get_data(), column->offsets_column()->get_data());
     ASSERT_FALSE(res);
     ASSERT_EQ(2, column->size());
@@ -1122,9 +1123,9 @@ PARALLEL_TEST(ArrayColumnTest, test_empty_null_array) {
 }
 
 PARALLEL_TEST(ArrayColumnTest, test_replicate) {
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto column = ArrayColumn::create(elements, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    NullableColumn::Ptr elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    ArrayColumn::Ptr column = ArrayColumn::create(elements, offsets);
 
     // insert [1, 2, 3], [4, 5, 6],[]
     elements->append_datum(1);
@@ -1157,9 +1158,9 @@ PARALLEL_TEST(ArrayColumnTest, test_replicate) {
 
 PARALLEL_TEST(ArrayColumnTest, test_reference_memory_usage) {
     {
-        auto offsets = UInt32Column::create();
-        auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
-        auto column = ArrayColumn::create(elements, offsets);
+        UInt32Column::Ptr offsets = UInt32Column::create();
+        NullableColumn::Ptr elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+        ArrayColumn::Ptr column = ArrayColumn::create(elements, offsets);
 
         // insert [],[1],[2, 3],[4, 5, 6]
         offsets->append(0);
@@ -1186,9 +1187,9 @@ PARALLEL_TEST(ArrayColumnTest, test_reference_memory_usage) {
     }
 
     {
-        auto offsets = UInt32Column::create();
-        auto elements = NullableColumn::create(JsonColumn::create(), NullColumn::create());
-        auto column = ArrayColumn::create(elements, offsets);
+        UInt32Column::Ptr offsets = UInt32Column::create();
+        NullableColumn::Ptr elements = NullableColumn::create(JsonColumn::create(), NullColumn::create());
+        ArrayColumn::Ptr column = ArrayColumn::create(elements, offsets);
 
         auto append_json_value = [&](const std::string& json_str) {
             auto json_value = JsonValue::parse(json_str).value();

--- a/be/test/column/array_view_column_test.cpp
+++ b/be/test/column/array_view_column_test.cpp
@@ -23,8 +23,8 @@
 namespace starrocks {
 
 ColumnPtr create_int32_array_column(const std::vector<std::vector<int32_t>>& values) {
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    NullableColumn::Ptr elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
     offsets->append(0);
     for (const auto& value : values) {
         for (auto v : value) {
@@ -54,8 +54,7 @@ PARALLEL_TEST(ArrayViewColumnTest, test_to_array) {
 
 PARALLEL_TEST(ArrayViewColumnTest, test_get_elements) {
     auto array_column = create_int32_array_column({{1}, {2, 3}});
-    auto array_view_column =
-            std::dynamic_pointer_cast<ArrayViewColumn>(ArrayViewColumn::from_array_column(array_column));
+    auto array_view_column = ArrayViewColumn::dynamic_pointer_cast(ArrayViewColumn::from_array_column(array_column));
 
     ASSERT_EQ(array_view_column->get_element_size(0), 1);
     ASSERT_EQ(array_view_column->debug_item(0), "[1]");
@@ -69,13 +68,13 @@ PARALLEL_TEST(ArrayViewColumnTest, test_get_elements) {
 PARALLEL_TEST(ArrayViewColumnTest, test_append) {
     auto array_column_1 = create_int32_array_column({{}, {1}, {2, 3}});
     auto array_view_column_1 =
-            std::dynamic_pointer_cast<ArrayViewColumn>(ArrayViewColumn::from_array_column(array_column_1));
+            ArrayViewColumn::dynamic_pointer_cast(ArrayViewColumn::from_array_column(array_column_1));
     auto array_view_column_3 =
-            std::dynamic_pointer_cast<ArrayViewColumn>(ArrayViewColumn::from_array_column(array_column_1));
+            ArrayViewColumn::dynamic_pointer_cast(ArrayViewColumn::from_array_column(array_column_1));
 
     auto array_column_2 = create_int32_array_column({{}, {1}, {2, 3}});
     auto array_view_column_2 =
-            std::dynamic_pointer_cast<ArrayViewColumn>(ArrayViewColumn::from_array_column(array_column_2));
+            ArrayViewColumn::dynamic_pointer_cast(ArrayViewColumn::from_array_column(array_column_2));
 
     std::vector<uint32_t> indexes{2, 1};
     // not support to append data from another array
@@ -96,11 +95,11 @@ PARALLEL_TEST(ArrayViewColumnTest, test_append) {
 PARALLEL_TEST(ArrayViewColumnTest, test_compare) {
     auto array_column_1 = create_int32_array_column({{}, {1}, {2, 3}});
     auto array_view_column_1 =
-            std::dynamic_pointer_cast<ArrayViewColumn>(ArrayViewColumn::from_array_column(array_column_1));
+            ArrayViewColumn::dynamic_pointer_cast(ArrayViewColumn::from_array_column(array_column_1));
 
     auto array_column_2 = create_int32_array_column({{1}, {2, 3}, {4}});
     auto array_view_column_2 =
-            std::dynamic_pointer_cast<ArrayViewColumn>(ArrayViewColumn::from_array_column(array_column_2));
+            ArrayViewColumn::dynamic_pointer_cast(ArrayViewColumn::from_array_column(array_column_2));
 
     std::vector<int> expected_compare_results = {-1, -1, -1, 0, -1, -1, 1, 0, -1};
     std::vector<int> expected_equal_results = {0, 0, 0, 1, 0, 0, 0, 1, 0};
@@ -128,8 +127,7 @@ PARALLEL_TEST(ArrayViewColumnTest, test_filter_range) {
     for (int32_t i = 0; i < total_rows; i++) {
         array_column->append_datum(DatumArray{i, i * 2});
     }
-    auto array_view_column =
-            std::dynamic_pointer_cast<ArrayViewColumn>(ArrayViewColumn::from_array_column(array_column));
+    auto array_view_column = ArrayViewColumn::dynamic_pointer_cast(ArrayViewColumn::from_array_column(array_column));
     Filter filter(total_rows, 1);
     // filter nothing
     array_view_column->filter_range(filter, 0, total_rows);
@@ -174,11 +172,11 @@ PARALLEL_TEST(ArrayViewColumnTest, test_other_manipulations) {
     {
         // replicate
         auto array_view_column =
-                std::dynamic_pointer_cast<ArrayViewColumn>(ArrayViewColumn::from_array_column(array_column));
+                ArrayViewColumn::dynamic_pointer_cast(ArrayViewColumn::from_array_column(array_column));
         Buffer<uint32_t> offsets{0, 2, 3, 6};
         auto column = array_view_column->replicate(offsets).value();
         ASSERT_TRUE(column->is_array_view());
-        auto result = std::dynamic_pointer_cast<ArrayViewColumn>(column);
+        auto result = ArrayViewColumn::dynamic_pointer_cast(column);
         ASSERT_EQ(result->size(), 6);
         // element column won't be changed
         ASSERT_EQ(result->elements().size(), 5);
@@ -194,7 +192,7 @@ PARALLEL_TEST(ArrayViewColumnTest, test_other_manipulations) {
     }
     {
         auto array_view_column =
-                std::dynamic_pointer_cast<ArrayViewColumn>(ArrayViewColumn::from_array_column(array_column));
+                ArrayViewColumn::dynamic_pointer_cast(ArrayViewColumn::from_array_column(array_column));
         array_view_column->remove_first_n_values(1);
         ASSERT_EQ(array_view_column->size(), 2);
         // elements column won't be changed
@@ -216,7 +214,7 @@ PARALLEL_TEST(ArrayViewColumnTest, test_other_manipulations) {
     {
         // assign
         auto array_view_column =
-                std::dynamic_pointer_cast<ArrayViewColumn>(ArrayViewColumn::from_array_column(array_column));
+                ArrayViewColumn::dynamic_pointer_cast(ArrayViewColumn::from_array_column(array_column));
 
         array_view_column->assign(5, 0);
         ASSERT_EQ(array_view_column->size(), 5);

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -27,7 +27,7 @@ namespace starrocks {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_create) {
-    auto column = BinaryColumn::create();
+    BinaryColumn::Ptr column = BinaryColumn::create();
     ASSERT_TRUE(column->is_binary());
     ASSERT_FALSE(column->is_nullable());
     ASSERT_EQ(0u, column->size());
@@ -36,7 +36,7 @@ PARALLEL_TEST(BinaryColumnTest, test_create) {
 // NOLINTNEXTLINE
 GROUP_SLOW_PARALLEL_TEST(BinaryColumnTest, test_binary_column_upgrade_if_overflow) {
     // small column
-    auto column = BinaryColumn::create();
+    BinaryColumn::Ptr column = BinaryColumn::create();
     for (size_t i = 0; i < 10; i++) {
         column->append(std::to_string(i));
     }
@@ -73,14 +73,14 @@ GROUP_SLOW_PARALLEL_TEST(BinaryColumnTest, test_binary_column_upgrade_if_overflo
 
 // NOLINTNEXTLINE
 GROUP_SLOW_PARALLEL_TEST(BinaryColumnTest, test_binary_column_downgrade) {
-    auto column = BinaryColumn::create();
+    BinaryColumn::Ptr column = BinaryColumn::create();
     column->append_string("test");
     ASSERT_FALSE(column->has_large_column());
     auto ret = column->downgrade();
     ASSERT_TRUE(ret.ok());
     ASSERT_TRUE(ret.value() == nullptr);
 
-    auto large_column = LargeBinaryColumn::create();
+    LargeBinaryColumn::Ptr large_column = LargeBinaryColumn::create();
     ASSERT_TRUE(large_column->has_large_column());
     for (size_t i = 0; i < 10; i++) {
         large_column->append_string(std::to_string(i));
@@ -104,7 +104,7 @@ GROUP_SLOW_PARALLEL_TEST(BinaryColumnTest, test_binary_column_downgrade) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_get_data) {
-    auto column = BinaryColumn::create();
+    BinaryColumn::Ptr column = BinaryColumn::create();
     for (int i = 0; i < 100; i++) {
         column->append(std::string("str:").append(std::to_string(i)));
     }
@@ -116,7 +116,7 @@ PARALLEL_TEST(BinaryColumnTest, test_get_data) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_byte_size) {
-    auto column = BinaryColumn::create();
+    BinaryColumn::Ptr column = BinaryColumn::create();
     ASSERT_EQ(sizeof(BinaryColumn::Offset), column->byte_size());
     std::string s("test_string");
     for (int i = 0; i < 10; i++) {
@@ -129,7 +129,7 @@ PARALLEL_TEST(BinaryColumnTest, test_byte_size) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_filter) {
-    auto column = BinaryColumn::create();
+    BinaryColumn::Ptr column = BinaryColumn::create();
     for (int i = 0; i < 100; ++i) {
         column->append(std::to_string(i));
     }
@@ -152,7 +152,7 @@ PARALLEL_TEST(BinaryColumnTest, test_filter) {
 // NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_append_strings) {
     std::vector<Slice> values{{"hello"}, {"starrocks"}};
-    auto c1 = BinaryColumn::create();
+    BinaryColumn::Ptr c1 = BinaryColumn::create();
     ASSERT_TRUE(c1->append_strings(values.data(), values.size()));
     ASSERT_EQ(values.size(), c1->size());
     for (size_t i = 0; i < values.size(); i++) {
@@ -160,7 +160,7 @@ PARALLEL_TEST(BinaryColumnTest, test_append_strings) {
     }
 
     // Nullable BinaryColumn
-    auto c2 = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+    NullableColumn::Ptr c2 = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
     ASSERT_TRUE(c2->append_strings(values.data(), values.size()));
     ASSERT_EQ(values.size(), c2->size());
     auto* c = reinterpret_cast<BinaryColumn*>(c2->mutable_data_column());
@@ -175,18 +175,18 @@ PARALLEL_TEST(BinaryColumnTest, test_append_numbers) {
     void* buff = values.data();
     size_t length = values.size() * sizeof(values[0]);
 
-    auto c4 = BinaryColumn::create();
+    BinaryColumn::Ptr c4 = BinaryColumn::create();
     ASSERT_EQ(-1, c4->append_numbers(buff, length));
 }
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_append_nulls) {
     // BinaryColumn
-    auto c1 = BinaryColumn::create();
+    BinaryColumn::Ptr c1 = BinaryColumn::create();
     ASSERT_FALSE(c1->append_nulls(10));
 
     // NullableColumn
-    auto c2 = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+    NullableColumn::Ptr c2 = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
     ASSERT_TRUE(c2->append_nulls(10));
     ASSERT_EQ(10U, c2->size());
     for (int i = 0; i < 10; i++) {
@@ -197,7 +197,7 @@ PARALLEL_TEST(BinaryColumnTest, test_append_nulls) {
 // NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_append_defaults) {
     // BinaryColumn
-    auto c1 = BinaryColumn::create();
+    BinaryColumn::Ptr c1 = BinaryColumn::create();
     c1->append_default(10);
     ASSERT_EQ(10U, c1->size());
     for (int i = 0; i < 10; i++) {
@@ -205,7 +205,7 @@ PARALLEL_TEST(BinaryColumnTest, test_append_defaults) {
     }
 
     // NullableColumn
-    auto c2 = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+    NullableColumn::Ptr c2 = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
     c2->append_default(10);
     ASSERT_EQ(10U, c2->size());
     for (int i = 0; i < 10; i++) {
@@ -217,8 +217,8 @@ PARALLEL_TEST(BinaryColumnTest, test_append_defaults) {
 PARALLEL_TEST(BinaryColumnTest, test_compare_at) {
     // Binary columns
     std::vector<Slice> strings{{"bbb"}, {"bbc"}, {"ccc"}};
-    auto c1 = BinaryColumn::create();
-    auto c2 = BinaryColumn::create();
+    BinaryColumn::Ptr c1 = BinaryColumn::create();
+    BinaryColumn::Ptr c2 = BinaryColumn::create();
     c1->append_strings(strings.data(), strings.size());
     c2->append_strings(strings.data(), strings.size());
     for (size_t i = 0; i < strings.size(); i++) {
@@ -235,8 +235,8 @@ PARALLEL_TEST(BinaryColumnTest, test_compare_at) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_append_binary) {
-    auto c1 = BinaryColumn::create();
-    auto c2 = BinaryColumn::create();
+    BinaryColumn::Ptr c1 = BinaryColumn::create();
+    BinaryColumn::Ptr c2 = BinaryColumn::create();
     c1->append(Slice("first"));
 
     c2->append(Slice("second"));
@@ -262,7 +262,7 @@ PARALLEL_TEST(BinaryColumnTest, test_append_binary) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_filter_range) {
-    auto column = BinaryColumn::create();
+    BinaryColumn::Ptr column = BinaryColumn::create();
 
     column->append(Slice("m"));
 
@@ -282,7 +282,7 @@ PARALLEL_TEST(BinaryColumnTest, test_filter_range) {
 
     column->filter_range(filter, 0, 66);
 
-    auto* binary_column = ColumnHelper::as_raw_column<BinaryColumn>(column);
+    auto* binary_column = ColumnHelper::as_raw_column<BinaryColumn>(column.get());
     auto& data = binary_column->get_data();
     for (size_t i = 0; i < 63; i++) {
         ASSERT_EQ(data[i], "a");
@@ -293,7 +293,7 @@ PARALLEL_TEST(BinaryColumnTest, test_filter_range) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_resize) {
-    auto c = BinaryColumn::create();
+    BinaryColumn::Ptr c = BinaryColumn::create();
     c->append(Slice("abc"));
     c->append(Slice("def"));
     c->append(Slice("xyz"));
@@ -315,8 +315,8 @@ PARALLEL_TEST(BinaryColumnTest, test_resize) {
 // NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_assign) {
     std::vector<Slice> strings{{"bbb"}, {"bbc"}, {"ccc"}};
-    auto c1 = BinaryColumn::create();
-    auto c2 = BinaryColumn::create();
+    BinaryColumn::Ptr c1 = BinaryColumn::create();
+    BinaryColumn::Ptr c2 = BinaryColumn::create();
     c1->append_strings(strings.data(), strings.size());
     c2->append_strings(strings.data(), strings.size());
 
@@ -334,7 +334,7 @@ PARALLEL_TEST(BinaryColumnTest, test_assign) {
 // NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_reset_column) {
     std::vector<Slice> strings{{"bbb"}, {"bbc"}, {"ccc"}};
-    auto c1 = BinaryColumn::create();
+    BinaryColumn::Ptr c1 = BinaryColumn::create();
     c1->append_strings(strings.data(), strings.size());
     c1->set_delete_state(DEL_PARTIAL_SATISFIED);
 
@@ -347,11 +347,11 @@ PARALLEL_TEST(BinaryColumnTest, test_reset_column) {
 // NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_swap_column) {
     std::vector<Slice> strings{{"bbb"}, {"bbc"}, {"ccc"}};
-    auto c1 = BinaryColumn::create();
+    BinaryColumn::Ptr c1 = BinaryColumn::create();
     c1->append_strings(strings.data(), strings.size());
     c1->set_delete_state(DEL_PARTIAL_SATISFIED);
 
-    auto c2 = BinaryColumn::create();
+    BinaryColumn::Ptr c2 = BinaryColumn::create();
 
     c1->swap_column(*c2);
 
@@ -369,19 +369,19 @@ PARALLEL_TEST(BinaryColumnTest, test_swap_column) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_slice_cache) {
-    auto c1 = BinaryColumn::create();
+    BinaryColumn::Ptr c1 = BinaryColumn::create();
     c1->get_data().reserve(10);
     c1->append_default();
     ASSERT_FALSE(c1->_slices_cache);
     ASSERT_EQ(c1->get_offset().size(), 2);
 
-    auto c2 = BinaryColumn::create();
+    BinaryColumn::Ptr c2 = BinaryColumn::create();
     c2->get_data().reserve(10);
     c2->append_default(5);
     ASSERT_FALSE(c2->_slices_cache);
     ASSERT_EQ(c2->get_offset().size(), 6);
 
-    auto c3 = BinaryColumn::create();
+    BinaryColumn::Ptr c3 = BinaryColumn::create();
     c3->get_data().reserve(10);
     c3->append(Slice("1"));
     ASSERT_FALSE(c3->_slices_cache);
@@ -390,7 +390,7 @@ PARALLEL_TEST(BinaryColumnTest, test_slice_cache) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_reserve) {
-    auto c1 = BinaryColumn::create();
+    BinaryColumn::Ptr c1 = BinaryColumn::create();
     c1->reserve(10, 40);
 
     ASSERT_FALSE(c1->_slices_cache);
@@ -400,7 +400,7 @@ PARALLEL_TEST(BinaryColumnTest, test_reserve) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_copy_constructor) {
-    auto c1 = BinaryColumn::create();
+    BinaryColumn::Ptr c1 = BinaryColumn::create();
     c1->append_datum("abc");
     c1->append_datum("def");
 
@@ -420,7 +420,7 @@ PARALLEL_TEST(BinaryColumnTest, test_copy_constructor) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_move_constructor) {
-    auto c1 = BinaryColumn::create();
+    BinaryColumn::Ptr c1 = BinaryColumn::create();
     c1->append_datum("abc");
     c1->append_datum("def");
 
@@ -440,7 +440,7 @@ PARALLEL_TEST(BinaryColumnTest, test_move_constructor) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_copy_assignment) {
-    auto c1 = BinaryColumn::create();
+    BinaryColumn::Ptr c1 = BinaryColumn::create();
     c1->append_datum("abc");
     c1->append_datum("def");
 
@@ -461,7 +461,7 @@ PARALLEL_TEST(BinaryColumnTest, test_copy_assignment) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_move_assignment) {
-    auto c1 = BinaryColumn::create();
+    BinaryColumn::Ptr c1 = BinaryColumn::create();
     c1->append_datum("abc");
     c1->append_datum("def");
 
@@ -482,7 +482,7 @@ PARALLEL_TEST(BinaryColumnTest, test_move_assignment) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_clone) {
-    auto c1 = BinaryColumn::create();
+    BinaryColumn::Ptr c1 = BinaryColumn::create();
     c1->append_datum("abc");
     c1->append_datum("def");
 
@@ -503,7 +503,7 @@ PARALLEL_TEST(BinaryColumnTest, test_clone) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_clone_shared) {
-    auto c1 = BinaryColumn::create();
+    BinaryColumn::Ptr c1 = BinaryColumn::create();
     c1->append_datum("abc");
     c1->append_datum("def");
 
@@ -512,8 +512,8 @@ PARALLEL_TEST(BinaryColumnTest, test_clone_shared) {
     ASSERT_EQ("abc", slices[0]);
     ASSERT_EQ("def", slices[1]);
 
-    auto c2 = c1->clone_shared();
-    ASSERT_TRUE(c2.unique());
+    auto c2 = c1->clone();
+    ASSERT_TRUE(c2->use_count() == 1);
 
     c1.reset();
 
@@ -525,7 +525,7 @@ PARALLEL_TEST(BinaryColumnTest, test_clone_shared) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_clone_empty) {
-    auto c1 = BinaryColumn::create();
+    BinaryColumn::Ptr c1 = BinaryColumn::create();
     c1->append_datum("abc");
     c1->append_datum("def");
 
@@ -543,7 +543,7 @@ PARALLEL_TEST(BinaryColumnTest, test_clone_empty) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_update_rows) {
-    auto c1 = BinaryColumn::create();
+    BinaryColumn::Ptr c1 = BinaryColumn::create();
     c1->append_datum("abc");
     c1->append_datum("def");
     c1->append_datum("ghi");
@@ -551,7 +551,7 @@ PARALLEL_TEST(BinaryColumnTest, test_update_rows) {
     c1->append_datum("mno");
 
     std::vector<uint32_t> replace_idxes = {1, 3};
-    auto c2 = BinaryColumn::create();
+    BinaryColumn::Ptr c2 = BinaryColumn::create();
     c2->append_datum("pq");
     c2->append_datum("rstu");
     c1->update_rows(*c2.get(), replace_idxes.data());
@@ -564,7 +564,7 @@ PARALLEL_TEST(BinaryColumnTest, test_update_rows) {
     ASSERT_EQ("rstu", slices[3]);
     ASSERT_EQ("mno", slices[4]);
 
-    auto c3 = BinaryColumn::create();
+    BinaryColumn::Ptr c3 = BinaryColumn::create();
     c3->append_datum("ab");
     c3->append_datum("cdef");
     c1->update_rows(*c3.get(), replace_idxes.data());
@@ -577,7 +577,7 @@ PARALLEL_TEST(BinaryColumnTest, test_update_rows) {
     ASSERT_EQ("cdef", slices[3]);
     ASSERT_EQ("mno", slices[4]);
 
-    auto c4 = BinaryColumn::create();
+    BinaryColumn::Ptr c4 = BinaryColumn::create();
     std::vector<uint32_t> new_replace_idxes = {0, 1};
     c4->append_datum("ab");
     c4->append_datum("cdef");
@@ -596,14 +596,14 @@ PARALLEL_TEST(BinaryColumnTest, test_update_rows) {
     // So i temp comment it and will open if i find one better solution
     /*
     size_t count = (1ul << 31ul) + 5;
-    auto c5 = BinaryColumn::create();
+    BinaryColumn::Ptr c5 = BinaryColumn::create();
     c5->get_bytes().resize(count);
     c5->get_offset().resize(count + 1);
     for (size_t i = 0; i < c5->get_offset().size(); i++) {
         c5->get_offset()[i] = i;
     }
 
-    auto c6 = BinaryColumn::create();
+    BinaryColumn::Ptr c6 = BinaryColumn::create();
     c6->append("22");
 
     std::vector<uint32_t> c6_replace_idxes = {0};
@@ -615,7 +615,7 @@ PARALLEL_TEST(BinaryColumnTest, test_update_rows) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_xor_checksum) {
-    auto column = BinaryColumn::create();
+    BinaryColumn::Ptr column = BinaryColumn::create();
     std::string str;
     str.reserve(3000);
     for (int i = 0; i <= 1000; i++) {
@@ -629,7 +629,7 @@ PARALLEL_TEST(BinaryColumnTest, test_xor_checksum) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_replicate) {
-    auto c1 = BinaryColumn::create();
+    BinaryColumn::Ptr c1 = BinaryColumn::create();
     c1->append_datum("abc");
     c1->append_datum("def");
 
@@ -650,7 +650,7 @@ PARALLEL_TEST(BinaryColumnTest, test_replicate) {
 }
 
 PARALLEL_TEST(BinaryColumnTest, test_reference_memory_usage) {
-    auto column = BinaryColumn::create();
+    BinaryColumn::Ptr column = BinaryColumn::create();
     column->append("");
     column->append("1");
     column->append("23");

--- a/be/test/column/chunk_test.cpp
+++ b/be/test/column/chunk_test.cpp
@@ -84,7 +84,7 @@ public:
             extra_data_metas.push_back(
                     ChunkExtraColumnsMeta{.type = TypeDescriptor(TYPE_INT), .is_null = false, .is_const = false});
         }
-        auto extra_data_cols = std::vector<ColumnPtr>{make_columns(num_cols, size)};
+        auto extra_data_cols = make_columns(num_cols, size);
         return std::make_shared<ChunkExtraColumnsData>(std::move(extra_data_metas), std::move(extra_data_cols));
     }
 };
@@ -92,9 +92,9 @@ public:
 // NOLINTNEXTLINE
 GROUP_SLOW_TEST_F(ChunkTest, test_chunk_upgrade_if_overflow) {
     size_t row_count = 1 << 30;
-    auto c1 = BinaryColumn::create();
+    BinaryColumn::Ptr c1 = BinaryColumn::create();
     c1->resize(row_count);
-    auto c2 = BinaryColumn::create();
+    BinaryColumn::Ptr c2 = BinaryColumn::create();
     for (size_t i = 0; i < row_count; i++) {
         c2->append(std::to_string(i));
     }
@@ -110,10 +110,10 @@ GROUP_SLOW_TEST_F(ChunkTest, test_chunk_upgrade_if_overflow) {
 
 // NOLINTNEXTLINE
 TEST_F(ChunkTest, test_remove_column_by_slot_id) {
-    auto c1 = ColumnTestHelper::build_column<int32_t>({1});
-    auto c2 = ColumnTestHelper::build_column<int32_t>({2});
-    auto c3 = ColumnTestHelper::build_column<int32_t>({3});
-    auto c4 = ColumnTestHelper::build_column<int32_t>({4});
+    ColumnPtr c1 = ColumnTestHelper::build_column<int32_t>({1});
+    ColumnPtr c2 = ColumnTestHelper::build_column<int32_t>({2});
+    ColumnPtr c3 = ColumnTestHelper::build_column<int32_t>({3});
+    ColumnPtr c4 = ColumnTestHelper::build_column<int32_t>({4});
 
     auto chunk = std::make_shared<Chunk>();
     chunk->append_column(c1, 1);
@@ -130,9 +130,9 @@ TEST_F(ChunkTest, test_remove_column_by_slot_id) {
 
 // NOLINTNEXTLINE
 TEST_F(ChunkTest, test_chunk_downgrade) {
-    auto c1 = BinaryColumn::create();
+    BinaryColumn::Ptr c1 = BinaryColumn::create();
     c1->append_string("1");
-    auto c2 = BinaryColumn::create();
+    BinaryColumn::Ptr c2 = BinaryColumn::create();
     c2->append_string("11");
     auto chunk = std::make_shared<Chunk>();
     chunk->append_column(c1, 1);
@@ -143,9 +143,9 @@ TEST_F(ChunkTest, test_chunk_downgrade) {
     ASSERT_TRUE(ret.ok());
     ASSERT_FALSE(chunk->has_large_column());
 
-    auto c3 = LargeBinaryColumn::create();
+    LargeBinaryColumn::Ptr c3 = LargeBinaryColumn::create();
     c3->append_string("1");
-    auto c4 = LargeBinaryColumn::create();
+    LargeBinaryColumn::Ptr c4 = LargeBinaryColumn::create();
     c4->append_string("2");
     chunk = std::make_shared<Chunk>();
     chunk->append_column(c3, 1);
@@ -161,8 +161,8 @@ TEST_F(ChunkTest, test_chunk_downgrade) {
 // NOLINTNEXTLINE
 TEST_F(ChunkTest, test_is_column_nullable) {
     Chunk chunk;
-    auto c1 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_INT), false);
-    auto c2 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_INT), true);
+    ColumnPtr c1 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_INT), false);
+    ColumnPtr c2 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_INT), true);
     chunk.append_column(c1, 1);
     chunk.append_column(c2, 2);
 

--- a/be/test/column/column_cow_test.cpp
+++ b/be/test/column/column_cow_test.cpp
@@ -1,0 +1,229 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+#include "column/array_column.h"
+#include "column/binary_column.h"
+#include "column/column_helper.h"
+#include "column/const_column.h"
+#include "column/fixed_length_column.h"
+#include "column/map_column.h"
+#include "column/nullable_column.h"
+#include "column/vectorized_fwd.h"
+#include "runtime/types.h"
+#include "testutil/parallel_test.h"
+
+namespace starrocks {
+
+class ColumnCOWTest : public testing::Test {
+public:
+    template <typename Type>
+    static void test_column_cow(ColumnPtr&& col) {
+        // COW: mut1 is as shadow copy of col, because col's use count is 1
+        ColumnPtr mut1 = Type::static_pointer_cast(Column::mutate(std::move(col)));
+        EXPECT_EQ(nullptr, col);
+        EXPECT_EQ(1, mut1->use_count());
+
+        // mut2 is shadow copy of mut1 which is not mutable
+        auto mut2 = mut1;
+        EXPECT_EQ(mut1.get(), mut2.get());
+        EXPECT_EQ(2, mut1->use_count());
+        EXPECT_EQ(2, mut2->use_count());
+
+        // COW: mut3 is a deep copy of mut1
+        auto mut3 = Type::static_pointer_cast(Column::mutate(std::move(mut1)));
+        EXPECT_EQ(nullptr, mut1);
+        EXPECT_NE(mut2.get(), mut3.get());
+        EXPECT_EQ(1, mut3->use_count());
+    }
+};
+
+TEST_F(ColumnCOWTest, test_int_column) {
+    UInt32Column::Ptr col = UInt32Column::create();
+    col->append(1);
+    EXPECT_EQ(1, col->size());
+    EXPECT_EQ(1, col->use_count());
+
+    {
+        UInt32Column::Ptr col1 = UInt32Column::static_pointer_cast(col);
+        // col1 is deep copy of col
+        EXPECT_EQ(1, col1->size());
+        EXPECT_EQ(2, col1->use_count());
+        EXPECT_EQ(1, col1->get(0).get_int32());
+        EXPECT_EQ(col.get(), col1.get());
+    }
+
+    // mut is as shadow copy of col, because col's use count is 1
+    UInt32Column::MutablePtr mut1 = UInt32Column::static_pointer_cast(Column::mutate(std::move(col)));
+    EXPECT_EQ(nullptr, col);
+    EXPECT_EQ(1, mut1->size());
+    EXPECT_EQ(1, mut1->use_count());
+    mut1->append(2);
+    EXPECT_EQ(2, mut1->size());
+    EXPECT_EQ(1, mut1->get(0).get_int32());
+    EXPECT_EQ(2, mut1->get(1).get_int32());
+
+    UInt32Column::MutablePtr mut2 = UInt32Column::static_pointer_cast(Column::mutate(std::move(mut1)));
+    EXPECT_EQ(nullptr, mut1);
+    EXPECT_EQ(2, mut2->size());
+    EXPECT_EQ(1, mut2->use_count());
+    mut2->append(3);
+    EXPECT_EQ(3, mut2->size());
+    EXPECT_EQ(1, mut2->get(0).get_int32());
+    EXPECT_EQ(2, mut2->get(1).get_int32());
+    EXPECT_EQ(3, mut2->get(2).get_int32());
+}
+
+TEST_F(ColumnCOWTest, test_nullable_column) {
+    auto col = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    col->append_datum(1);
+    col->append_datum(2);
+
+    // COW: mut1 is as shadow copy of col, because col's use count is 1
+    NullableColumn::Ptr mut1 = NullableColumn::static_pointer_cast(Column::mutate(std::move(col)));
+    EXPECT_EQ(nullptr, col);
+    EXPECT_EQ(2, mut1->size());
+    EXPECT_EQ(1, mut1->use_count());
+    auto& mut1_data = mut1->data_column();
+    auto& mut1_null = mut1->null_column();
+    EXPECT_EQ(1, mut1_data->use_count());
+    EXPECT_EQ(1, mut1_null->use_count());
+
+    // mut2 is shadow copy of mut1 which is not mutable
+    NullableColumn::Ptr mut2 = mut1;
+    EXPECT_EQ(mut1.get(), mut2.get());
+    EXPECT_EQ(2, mut2->size());
+    EXPECT_EQ(2, mut1->use_count());
+    EXPECT_EQ(2, mut2->use_count());
+
+    // COW: mut3 is a deep copy of mut1
+    NullableColumn::Ptr mut3 = NullableColumn::static_pointer_cast(Column::mutate(std::move(mut1)));
+    EXPECT_EQ(nullptr, mut1);
+    EXPECT_NE(mut2.get(), mut3.get());
+    EXPECT_EQ(2, mut3->size());
+    EXPECT_EQ(1, mut3->use_count());
+    auto& mut3_data = mut3->data_column();
+    auto& mut3_null = mut3->null_column();
+    EXPECT_EQ(1, mut3_data->use_count());
+    EXPECT_EQ(1, mut3_null->use_count());
+}
+
+TEST_F(ColumnCOWTest, test_array_column) {
+    auto offsets = UInt32Column::create();
+    offsets->append(0);
+
+    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    elements->append_datum(1);
+    elements->append_datum(2);
+    offsets->append(2);
+
+    elements->append_datum(3);
+    elements->append_datum(4);
+    elements->append_datum(5);
+    offsets->append(5);
+    auto col = ArrayColumn::create(std::move(elements), std::move(offsets));
+
+    ASSERT_TRUE(col->is_array());
+    ASSERT_FALSE(col->is_nullable());
+    ASSERT_EQ(2, col->size());
+
+    // mut is as shadow copy of col, because col's use count is 1
+    ArrayColumn::Ptr mut1 = ArrayColumn::static_pointer_cast(Column::mutate(std::move(col)));
+    EXPECT_EQ(nullptr, col);
+    EXPECT_EQ(2, mut1->size());
+    EXPECT_EQ(1, mut1->use_count());
+    auto& mut_elements = mut1->elements_column();
+    auto& mut_offsets = mut1->offsets_column();
+    EXPECT_EQ(1, mut_elements->use_count());
+    EXPECT_EQ(1, mut_offsets->use_count());
+
+    // ref count +1
+    ArrayColumn::Ptr mut2 = mut1;
+    EXPECT_EQ(mut1.get(), mut2.get());
+    EXPECT_EQ(2, mut2->size());
+    EXPECT_EQ(2, mut1->use_count());
+    EXPECT_EQ(2, mut2->use_count());
+
+    // mut3 is a deep copy of mut1
+    ArrayColumn::Ptr mut3 = ArrayColumn::static_pointer_cast(Column::mutate(std::move(mut1)));
+    EXPECT_EQ(nullptr, mut1);
+    EXPECT_NE(mut2.get(), mut3.get());
+    EXPECT_EQ(2, mut3->size());
+    EXPECT_EQ(1, mut3->use_count());
+    auto& mut3_elements = mut3->elements_column();
+    auto& mut3_offsets = mut3->offsets_column();
+    EXPECT_EQ(1, mut3_elements->use_count());
+    EXPECT_EQ(1, mut3_offsets->use_count());
+}
+
+TEST_F(ColumnCOWTest, test_binary_column) {
+    BinaryColumn::Ptr col = BinaryColumn::create();
+    for (size_t i = 0; i < 10; i++) {
+        col->append(std::to_string(i));
+    }
+    test_column_cow<BinaryColumn>(std::move(col));
+}
+
+TEST_F(ColumnCOWTest, test_json_column) {
+    JsonColumn::Ptr col = JsonColumn::create();
+    col->append(JsonValue::parse("1").value());
+    test_column_cow<JsonColumn>(std::move(col));
+}
+
+TEST_F(ColumnCOWTest, test_struct_column) {
+    std::vector<std::string> field_name{"id", "name"};
+    auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
+    auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+    Columns fields{std::move(id), std::move(name)};
+    auto col = StructColumn::create(std::move(fields), std::move(field_name));
+    DatumStruct struct1{uint64_t(1), Slice("smith")};
+    DatumStruct struct2{uint64_t(2), Slice("cruise")};
+    col->append_datum(struct1);
+    col->append_datum(struct2);
+
+    test_column_cow<StructColumn>(std::move(col));
+}
+
+TEST_F(ColumnCOWTest, test_map_column) {
+    MapColumn::Ptr column = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                              NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                              UInt32Column::create());
+    for (int32_t i = 0; i < 10; i++) {
+        column->append_datum(DatumMap{{i, i + 1}});
+    }
+    test_column_cow<MapColumn>(std::move(column));
+}
+
+TEST_F(ColumnCOWTest, test_object_column) {
+    BitmapColumn::Ptr src_col = BitmapColumn::create();
+    BitmapValue bitmap;
+    for (size_t i = 0; i < 64; i++) {
+        bitmap.add(i);
+    }
+    src_col->append(&bitmap);
+    test_column_cow<BitmapColumn>(std::move(src_col));
+}
+
+TEST_F(ColumnCOWTest, test_const_column) {
+    Int32Column::Ptr data_column = Int32Column::create();
+    data_column->append(1);
+
+    ConstColumn::Ptr column = ConstColumn::create(std::move(data_column), 1024);
+    test_column_cow<ConstColumn>(std::move(column));
+}
+
+} // namespace starrocks

--- a/be/test/column/const_column_test.cpp
+++ b/be/test/column/const_column_test.cpp
@@ -25,10 +25,10 @@ namespace starrocks {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(ConstColumnTest, test_const_column_upgrade_if_overflow) {
-    auto data_column = Int32Column::create();
+    Int32Column::Ptr data_column = Int32Column::create();
     data_column->append(1);
 
-    auto column = ConstColumn::create(std::move(data_column), 1024);
+    ConstColumn::Ptr column = ConstColumn::create(std::move(data_column), 1024);
     auto ret = column->upgrade_if_overflow();
     ASSERT_TRUE(ret.ok());
     ASSERT_TRUE(ret.value() == nullptr);
@@ -42,15 +42,15 @@ PARALLEL_TEST(ConstColumnTest, test_const_column_upgrade_if_overflow) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(ConstColumnTest, test_const_column_downgrade) {
-    auto data_column = BinaryColumn::create();
+    BinaryColumn::Ptr data_column = BinaryColumn::create();
     ASSERT_FALSE(data_column->has_large_column());
     data_column->append_string("1");
-    auto const_column = ConstColumn::create(data_column, 1024);
+    ConstColumn::Ptr const_column = ConstColumn::create(data_column, 1024);
     auto ret = const_column->downgrade();
     ASSERT_TRUE(ret.ok());
     ASSERT_TRUE(ret.value() == nullptr);
 
-    auto large_data_column = LargeBinaryColumn::create();
+    LargeBinaryColumn::Ptr large_data_column = LargeBinaryColumn::create();
     large_data_column->append_string("1");
     const_column = ConstColumn::create(large_data_column, 1024);
     ASSERT_TRUE(const_column->has_large_column());
@@ -66,7 +66,7 @@ PARALLEL_TEST(ConstColumnTest, test_basic) {
     auto data_column = FixedLengthColumn<int32_t>::create();
     data_column->append(2020);
 
-    auto column = ConstColumn::create(std::move(data_column), 1024);
+    ConstColumn::Ptr column = ConstColumn::create(std::move(data_column), 1024);
 
     ASSERT_EQ(true, column->is_constant());
     ASSERT_EQ(1024, column->size());
@@ -90,7 +90,7 @@ PARALLEL_TEST(ConstColumnTest, test_basic) {
 // NOLINTNEXTLINE
 PARALLEL_TEST(ConstColumnTest, test_compare_at) {
     auto create_const_column = [](int32_t value, size_t size) {
-        auto c = Int32Column::create();
+        Int32Column::Ptr c = Int32Column::create();
         c->append_numbers(&value, sizeof(value));
         return ConstColumn::create(c, size);
     };
@@ -105,7 +105,7 @@ PARALLEL_TEST(ConstColumnTest, test_compare_at) {
 // NOLINTNEXTLINE
 PARALLEL_TEST(ConstColumnTest, test_assign) {
     auto create_const_column = [](int32_t value, size_t size) {
-        auto c = Int32Column::create();
+        Int32Column::Ptr c = Int32Column::create();
         c->append_numbers(&value, sizeof(value));
         return ConstColumn::create(c, size);
     };
@@ -127,7 +127,7 @@ PARALLEL_TEST(ConstColumnTest, test_assign) {
 // NOLINTNEXTLINE
 PARALLEL_TEST(ConstColumnTest, test_reset_column) {
     auto create_const_column = [](int32_t value, size_t size) {
-        auto c = Int32Column::create();
+        Int32Column::Ptr c = Int32Column::create();
         c->append_numbers(&value, sizeof(value));
         return ConstColumn::create(c, size);
     };
@@ -141,7 +141,7 @@ PARALLEL_TEST(ConstColumnTest, test_reset_column) {
 // NOLINTNEXTLINE
 PARALLEL_TEST(ConstColumnTest, test_swap_column) {
     auto create_const_column = [](int32_t value, size_t size) {
-        auto c = Int32Column::create();
+        Int32Column::Ptr c = Int32Column::create();
         c->append_numbers(&value, sizeof(value));
         return ConstColumn::create(c, size);
     };
@@ -161,7 +161,7 @@ PARALLEL_TEST(ConstColumnTest, test_swap_column) {
 // NOLINTNEXTLINE
 PARALLEL_TEST(ConstColumnTest, test_copy_constructor) {
     auto create_const_column = [](int32_t value, size_t size) {
-        auto c = Int32Column::create();
+        Int32Column::Ptr c = Int32Column::create();
         c->append_numbers(&value, sizeof(value));
         return ConstColumn::create(c, size);
     };
@@ -172,14 +172,14 @@ PARALLEL_TEST(ConstColumnTest, test_copy_constructor) {
 
     auto c2(*c1);
     ASSERT_EQ(100, c2.size());
-    ASSERT_TRUE(c2.data_column().unique());
+    ASSERT_TRUE(c2.data_column()->use_count() == 1);
     for (int i = 0; i < 100; i++) {
         ASSERT_EQ(1, c2.get(i).get_int32());
     }
 
     c1->reset_column();
     ASSERT_EQ(100, c2.size());
-    ASSERT_TRUE(c2.data_column().unique());
+    ASSERT_TRUE(c2.data_column()->use_count() == 1);
     for (int i = 0; i < 100; i++) {
         ASSERT_EQ(1, c2.get(i).get_int32());
     }
@@ -188,7 +188,7 @@ PARALLEL_TEST(ConstColumnTest, test_copy_constructor) {
 // NOLINTNEXTLINE
 PARALLEL_TEST(ConstColumnTest, test_move_constructor) {
     auto create_const_column = [](int32_t value, size_t size) {
-        auto c = Int32Column::create();
+        Int32Column::Ptr c = Int32Column::create();
         c->append_numbers(&value, sizeof(value));
         return ConstColumn::create(c, size);
     };
@@ -199,7 +199,7 @@ PARALLEL_TEST(ConstColumnTest, test_move_constructor) {
 
     auto c2(std::move(*c1));
     ASSERT_EQ(100, c2.size());
-    ASSERT_TRUE(c2.data_column().unique());
+    ASSERT_TRUE(c2.data_column()->use_count() == 1);
     for (int i = 0; i < 100; i++) {
         ASSERT_EQ(1, c2.get(i).get_int32());
     }
@@ -208,7 +208,7 @@ PARALLEL_TEST(ConstColumnTest, test_move_constructor) {
 // NOLINTNEXTLINE
 PARALLEL_TEST(ConstColumnTest, test_copy_assignment) {
     auto create_const_column = [](int32_t value, size_t size) {
-        auto c = Int32Column::create();
+        Int32Column::Ptr c = Int32Column::create();
         c->append_numbers(&value, sizeof(value));
         return ConstColumn::create(c, size);
     };
@@ -221,14 +221,14 @@ PARALLEL_TEST(ConstColumnTest, test_copy_assignment) {
     *c2 = *c1;
 
     ASSERT_EQ(100, c2->size());
-    ASSERT_TRUE(c2->data_column().unique());
+    ASSERT_TRUE(c2->data_column()->use_count() == 1);
     for (int i = 0; i < 100; i++) {
         ASSERT_EQ(1, c2->get(i).get_int32());
     }
 
     c1->reset_column();
     ASSERT_EQ(100, c2->size());
-    ASSERT_TRUE(c2->data_column().unique());
+    ASSERT_TRUE(c2->data_column()->use_count() == 1);
     for (int i = 0; i < 100; i++) {
         ASSERT_EQ(1, c2->get(i).get_int32());
     }
@@ -237,7 +237,7 @@ PARALLEL_TEST(ConstColumnTest, test_copy_assignment) {
 // NOLINTNEXTLINE
 PARALLEL_TEST(ConstColumnTest, test_move_assignment) {
     auto create_const_column = [](int32_t value, size_t size) {
-        auto c = Int32Column::create();
+        Int32Column::Ptr c = Int32Column::create();
         c->append_numbers(&value, sizeof(value));
         return ConstColumn::create(c, size);
     };
@@ -250,7 +250,7 @@ PARALLEL_TEST(ConstColumnTest, test_move_assignment) {
     *c2 = std::move(*c1);
 
     ASSERT_EQ(100, c2->size());
-    ASSERT_TRUE(c2->data_column().unique());
+    ASSERT_TRUE(c2->data_column()->use_count() == 1);
     for (int i = 0; i < 100; i++) {
         ASSERT_EQ(1, c2->get(i).get_int32());
     }
@@ -259,7 +259,7 @@ PARALLEL_TEST(ConstColumnTest, test_move_assignment) {
 // NOLINTNEXTLINE
 PARALLEL_TEST(ConstColumnTest, test_clone) {
     auto create_const_column = [](int32_t value, size_t size) {
-        auto c = Int32Column::create();
+        Int32Column::Ptr c = Int32Column::create();
         c->append_numbers(&value, sizeof(value));
         return ConstColumn::create(c, size);
     };
@@ -271,14 +271,14 @@ PARALLEL_TEST(ConstColumnTest, test_clone) {
     auto cloned_col = c1->clone();
     auto c2 = down_cast<ConstColumn*>(cloned_col.get());
     ASSERT_EQ(100, c2->size());
-    ASSERT_TRUE(c2->data_column().unique());
+    ASSERT_TRUE(c2->data_column()->use_count() == 1);
     for (int i = 0; i < 100; i++) {
         ASSERT_EQ(1, c2->get(i).get_int32());
     }
 
     c1->reset_column();
     ASSERT_EQ(100, c2->size());
-    ASSERT_TRUE(c2->data_column().unique());
+    ASSERT_TRUE(c2->data_column()->use_count() == 1);
     for (int i = 0; i < 100; i++) {
         ASSERT_EQ(1, c2->get(i).get_int32());
     }
@@ -287,7 +287,7 @@ PARALLEL_TEST(ConstColumnTest, test_clone) {
 // NOLINTNEXTLINE
 PARALLEL_TEST(ConstColumnTest, test_clone_shared) {
     auto create_const_column = [](int32_t value, size_t size) {
-        auto c = Int32Column::create();
+        Int32Column::Ptr c = Int32Column::create();
         c->append_numbers(&value, sizeof(value));
         return ConstColumn::create(c, size);
     };
@@ -296,18 +296,18 @@ PARALLEL_TEST(ConstColumnTest, test_clone_shared) {
 
     ASSERT_EQ(100, c1->size());
 
-    auto cloned_col = c1->clone_shared();
-    ASSERT_TRUE(cloned_col.unique());
+    auto cloned_col = c1->clone();
+    ASSERT_TRUE(cloned_col->use_count() == 1);
     auto c2 = down_cast<ConstColumn*>(cloned_col.get());
     ASSERT_EQ(100, c2->size());
-    ASSERT_TRUE(c2->data_column().unique());
+    ASSERT_TRUE(c2->data_column()->use_count() == 1);
     for (int i = 0; i < 100; i++) {
         ASSERT_EQ(1, c2->get(i).get_int32());
     }
 
     c1->reset_column();
     ASSERT_EQ(100, c2->size());
-    ASSERT_TRUE(c2->data_column().unique());
+    ASSERT_TRUE(c2->data_column()->use_count() == 1);
     for (int i = 0; i < 100; i++) {
         ASSERT_EQ(1, c2->get(i).get_int32());
     }
@@ -316,7 +316,7 @@ PARALLEL_TEST(ConstColumnTest, test_clone_shared) {
 // NOLINTNEXTLINE
 PARALLEL_TEST(ConstColumnTest, test_clone_empty) {
     auto create_const_column = [](int32_t value, size_t size) {
-        auto c = Int32Column::create();
+        Int32Column::Ptr c = Int32Column::create();
         c->append_numbers(&value, sizeof(value));
         return ConstColumn::create(c, size);
     };
@@ -328,13 +328,13 @@ PARALLEL_TEST(ConstColumnTest, test_clone_empty) {
     auto cloned_col = c1->clone_empty();
     auto c2 = down_cast<ConstColumn*>(cloned_col.get());
     ASSERT_EQ(0, c2->size());
-    ASSERT_TRUE(c2->data_column().unique());
+    ASSERT_TRUE(c2->data_column()->use_count() == 1);
 }
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(ConstColumnTest, test_replicate) {
     auto create_const_column = [](int32_t value, size_t size) {
-        auto c = Int32Column::create();
+        Int32Column::Ptr c = Int32Column::create();
         c->append_numbers(&value, sizeof(value));
         return ConstColumn::create(c, size);
     };
@@ -358,7 +358,7 @@ PARALLEL_TEST(ConstColumnTest, test_replicate) {
 PARALLEL_TEST(ConstColumnTest, test_reference_memory_usage) {
     {
         auto create_int_const_column = [](int32_t value, size_t size) {
-            auto c = Int32Column::create();
+            Int32Column::Ptr c = Int32Column::create();
             c->append_numbers(&value, sizeof(value));
             return ConstColumn::create(c, size);
         };
@@ -368,7 +368,7 @@ PARALLEL_TEST(ConstColumnTest, test_reference_memory_usage) {
     }
     {
         auto create_json_const_column = [](const std::string& json_str, size_t size) {
-            auto c = JsonColumn::create();
+            JsonColumn::Ptr c = JsonColumn::create();
             auto json_value = JsonValue::parse(json_str).value();
             c->append_datum(&json_value);
             return ConstColumn::create(c, size);

--- a/be/test/column/decimalv3_column_test.cpp
+++ b/be/test/column/decimalv3_column_test.cpp
@@ -44,9 +44,9 @@ TEST(DecimalV3ColumnTest, test_crc32_hash_decimal128p27s9) {
     std::vector<uint32_t> hash0(num_rows, 0);
     col0->crc32_hash(&hash0.front(), 0, num_rows);
 
-    auto col1 = DecimalColumn::create();
-    auto& data0 = ColumnHelper::cast_to_raw<TYPE_DECIMAL128>(col0)->get_data();
-    auto& data1 = ColumnHelper::cast_to_raw<TYPE_DECIMALV2>(col1)->get_data();
+    DecimalColumn::Ptr col1 = DecimalColumn::create();
+    auto& data0 = ColumnHelper::cast_to_raw<TYPE_DECIMAL128>(col0.get())->get_data();
+    auto& data1 = ColumnHelper::cast_to_raw<TYPE_DECIMALV2>(col1.get())->get_data();
     std::swap((DecimalColumn::Container&)data0, data1);
     std::vector<uint32_t> hash1(num_rows, 0);
     col1->crc32_hash(&hash1.front(), 0, num_rows);
@@ -62,9 +62,9 @@ TEST(DecimalV3ColumnTest, test_crc32_hash_decimal128p27s10) {
     std::vector<uint32_t> hash0(num_rows, 0);
     col0->crc32_hash(&hash0.front(), 0, num_rows);
 
-    auto col1 = Int128Column::create();
-    auto& data0 = ColumnHelper::cast_to_raw<TYPE_DECIMAL128>(col0)->get_data();
-    auto& data1 = ColumnHelper::cast_to_raw<TYPE_LARGEINT>(col1)->get_data();
+    Int128Column::Ptr col1 = Int128Column::create();
+    auto& data0 = ColumnHelper::cast_to_raw<TYPE_DECIMAL128>(col0.get())->get_data();
+    auto& data1 = ColumnHelper::cast_to_raw<TYPE_LARGEINT>(col1.get())->get_data();
     std::swap(data0, data1);
     std::vector<uint32_t> hash1(num_rows, 0);
     col1->crc32_hash(&hash1.front(), 0, num_rows);
@@ -80,9 +80,9 @@ TEST(DecimalV3ColumnTest, test_crc32_hash_decimal64p15s6) {
     std::vector<uint32_t> hash0(17, 0);
     col0->crc32_hash(&hash0.front(), 0, num_rows);
 
-    auto col1 = Int64Column::create();
-    auto& data0 = ColumnHelper::cast_to_raw<TYPE_DECIMAL64>(col0)->get_data();
-    auto& data1 = ColumnHelper::cast_to_raw<TYPE_BIGINT>(col1)->get_data();
+    Int64Column::Ptr col1 = Int64Column::create();
+    auto& data0 = ColumnHelper::cast_to_raw<TYPE_DECIMAL64>(col0.get())->get_data();
+    auto& data1 = ColumnHelper::cast_to_raw<TYPE_BIGINT>(col1.get())->get_data();
     std::swap(data0, data1);
     std::vector<uint32_t> hash1(17, 0);
     col1->crc32_hash(&hash1.front(), 0, num_rows);

--- a/be/test/column/fixed_length_column_test.cpp
+++ b/be/test/column/fixed_length_column_test.cpp
@@ -26,7 +26,7 @@ namespace starrocks {
 
 // NOLINTNEXTLINE
 TEST(FixedLengthColumnTest, test_basic) {
-    auto column = FixedLengthColumn<int32_t>::create();
+    FixedLengthColumn<int32_t>::Ptr column = FixedLengthColumn<int32_t>::create();
     for (int i = 0; i < 100; i++) {
         column->append(i);
     }
@@ -85,7 +85,7 @@ TEST(FixedLengthColumnTest, test_nullable) {
         null_column->append(i % 2 ? 1 : 0);
     }
 
-    auto column = NullableColumn::create(std::move(data_column), std::move(null_column));
+    NullableColumn::Ptr column = NullableColumn::create(std::move(data_column), std::move(null_column));
 
     ASSERT_EQ(false, column->is_numeric());
     ASSERT_EQ(100, column->size());
@@ -148,7 +148,7 @@ TEST(FixedLengthColumnTest, test_nullable) {
 
         column->filter(filter);
         auto result = column;
-        auto data_result = std::static_pointer_cast<Int32Column>(result->data_column());
+        auto data_result = Int32Column::static_pointer_cast(result->data_column());
 
         ASSERT_EQ(50, result->size());
         for (int j = 0; j < 50; ++j) {
@@ -165,8 +165,8 @@ TEST(FixedLengthColumnTest, test_nullable) {
 // NOLINTNEXTLINE
 TEST(FixedLengthColumnTest, test_append_strings) {
     std::vector<Slice> values{{"hello"}, {"starrocks"}};
-    auto c1 = Int32Column::create();
-    auto nullable_c1 = NullableColumn::create(c1, NullColumn::create());
+    Int32Column::Ptr c1 = Int32Column::create();
+    NullableColumn::Ptr nullable_c1 = NullableColumn::create(c1, NullColumn::create());
     ASSERT_FALSE(c1->append_strings(values));
     ASSERT_FALSE(nullable_c1->append_strings(values.data(), values.size()));
 }
@@ -178,7 +178,7 @@ TEST(FixedLengthColumnTest, test_append_numbers) {
     size_t length = values.size() * sizeof(values[0]);
 
     // FixedLengthColumn
-    auto c1 = Int32Column::create();
+    Int32Column::Ptr c1 = Int32Column::create();
     ASSERT_EQ(values.size(), c1->append_numbers(buff, length));
     ASSERT_EQ(values.size(), c1->size());
     for (size_t i = 0; i < values.size(); i++) {
@@ -187,7 +187,7 @@ TEST(FixedLengthColumnTest, test_append_numbers) {
     }
 
     // Nullable FixedLengthColumn
-    auto c2 = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    NullableColumn::Ptr c2 = NullableColumn::create(Int32Column::create(), NullColumn::create());
     ASSERT_EQ(values.size(), c2->append_numbers(buff, length));
     ASSERT_EQ(values.size(), c2->size());
     for (size_t i = 0; i < values.size(); i++) {
@@ -199,11 +199,11 @@ TEST(FixedLengthColumnTest, test_append_numbers) {
 // NOLINTNEXTLINE
 TEST(FixedLengthColumnTest, test_append_nulls) {
     // FixedLengthColumn
-    auto c1 = Int32Column::create();
+    Int32Column::Ptr c1 = Int32Column::create();
     ASSERT_FALSE(c1->append_nulls(10));
 
     // NullableColumn
-    auto c2 = NullableColumn::create(Int64Column::create(), NullColumn::create());
+    NullableColumn::Ptr c2 = NullableColumn::create(Int64Column::create(), NullColumn::create());
     ASSERT_TRUE(c2->append_nulls(10));
     ASSERT_EQ(10U, c2->size());
     for (int i = 0; i < 10; i++) {
@@ -214,7 +214,7 @@ TEST(FixedLengthColumnTest, test_append_nulls) {
 // NOLINTNEXTLINE
 TEST(FixedLengthColumnTest, test_append_defaults) {
     // FixedLengthColumn
-    auto c1 = Int32Column::create();
+    Int32Column::Ptr c1 = Int32Column::create();
     c1->append_default(10);
     ASSERT_EQ(10U, c1->size());
     for (int i = 0; i < 10; i++) {
@@ -222,7 +222,7 @@ TEST(FixedLengthColumnTest, test_append_defaults) {
     }
 
     // NullableColumn
-    auto c2 = NullableColumn::create(Int16Column::create(), NullColumn::create());
+    NullableColumn::Ptr c2 = NullableColumn::create(Int16Column::create(), NullColumn::create());
     c2->append_default(10);
     ASSERT_EQ(10U, c2->size());
     for (int i = 0; i < 10; i++) {
@@ -235,8 +235,8 @@ TEST(FixedLengthColumnTest, test_compare_at) {
     // int32 basic
     {
         std::vector<int32_t> numbers{1, 2, 3, 4, 5, 6, 7};
-        auto c1 = Int32Column::create();
-        auto c2 = Int32Column::create();
+        Int32Column::Ptr c1 = Int32Column::create();
+        Int32Column::Ptr c2 = Int32Column::create();
         c1->append_numbers(numbers.data(), numbers.size() * sizeof(int32_t));
         c2->append_numbers(numbers.data(), numbers.size() * sizeof(int32_t));
         for (size_t i = 0; i < numbers.size(); i++) {
@@ -253,8 +253,8 @@ TEST(FixedLengthColumnTest, test_compare_at) {
     // int32 boundary test
     {
         std::vector<int32_t> numbers{-2147483648, 1514736000, 1577808000, 2147483647};
-        auto c1 = Int32Column::create();
-        auto c2 = Int32Column::create();
+        Int32Column::Ptr c1 = Int32Column::create();
+        Int32Column::Ptr c2 = Int32Column::create();
         c1->append_numbers(numbers.data(), numbers.size() * sizeof(int32_t));
         c2->append_numbers(numbers.data(), numbers.size() * sizeof(int32_t));
         for (size_t i = 0; i < numbers.size(); i++) {
@@ -271,8 +271,8 @@ TEST(FixedLengthColumnTest, test_compare_at) {
     // double
     {
         std::vector<double> numbers{1, 2, 3, 4, 5, 6, 7};
-        auto c1 = DoubleColumn::create();
-        auto c2 = DoubleColumn::create();
+        DoubleColumn::Ptr c1 = DoubleColumn::create();
+        DoubleColumn::Ptr c2 = DoubleColumn::create();
         c1->append_numbers(numbers.data(), numbers.size() * sizeof(double));
         c1->append(34315.800000033356);
         c2->append_numbers(numbers.data(), numbers.size() * sizeof(double));
@@ -294,8 +294,8 @@ TEST(FixedLengthColumnTest, test_compare_at) {
     // nullable int32
     {
         std::vector<int32_t> numbers{1, 2, 3, 4, 5, 6, 7};
-        auto c1 = NullableColumn::create(Int32Column::create(), NullColumn::create());
-        auto c2 = NullableColumn::create(Int32Column::create(), NullColumn::create());
+        NullableColumn::Ptr c1 = NullableColumn::create(Int32Column::create(), NullColumn::create());
+        NullableColumn::Ptr c2 = NullableColumn::create(Int32Column::create(), NullColumn::create());
         c1->append_numbers(numbers.data(), numbers.size() * sizeof(int32_t));
         c2->append_numbers(numbers.data(), numbers.size() * sizeof(int32_t));
         for (size_t i = 0; i < numbers.size(); i++) {
@@ -323,8 +323,8 @@ TEST(FixedLengthColumnTest, test_compare_at) {
     }
     // big int
     {
-        auto c1 = NullableColumn::create(Int64Column::create(), NullColumn::create());
-        auto c2 = NullableColumn::create(Int64Column::create(), NullColumn::create());
+        NullableColumn::Ptr c1 = NullableColumn::create(Int64Column::create(), NullColumn::create());
+        NullableColumn::Ptr c2 = NullableColumn::create(Int64Column::create(), NullColumn::create());
         c1->append_datum(Datum(int64_t(53988727729812)));
         c2->append_datum(Datum(int64_t(10872854479952)));
         ASSERT_EQ(1, c1->compare_at(0, 0, *c2, -1));
@@ -333,8 +333,8 @@ TEST(FixedLengthColumnTest, test_compare_at) {
     }
     // large int
     {
-        auto c1 = NullableColumn::create(Int128Column::create(), NullColumn::create());
-        auto c2 = NullableColumn::create(Int128Column::create(), NullColumn::create());
+        NullableColumn::Ptr c1 = NullableColumn::create(Int128Column::create(), NullColumn::create());
+        NullableColumn::Ptr c2 = NullableColumn::create(Int128Column::create(), NullColumn::create());
         c1->append_datum(Datum(int128_t(5398872772981245727)));
         c2->append_datum(Datum(int128_t(1087285447995287452)));
         ASSERT_EQ(1, c1->compare_at(0, 0, *c2, -1));
@@ -345,7 +345,7 @@ TEST(FixedLengthColumnTest, test_compare_at) {
 
 // NOLINTNEXTLINE
 TEST(FixedLengthColumnTest, test_decimal) {
-    auto dc = DecimalColumn::create();
+    DecimalColumn::Ptr dc = DecimalColumn::create();
 
     dc->append(DecimalV2Value(1));
     dc->append(DecimalV2Value(2));
@@ -393,8 +393,8 @@ TEST(FixedLengthColumnTest, test_append_numeric) {
 
 // NOLINTNEXTLINE
 TEST(FixedLengthColumnTest, test_append_nullable_numeric) {
-    auto c1 = NullableColumn::create(FixedLengthColumn<int64_t>::create(), NullColumn::create());
-    auto c2 = NullableColumn::create(FixedLengthColumn<int64_t>::create(), NullColumn::create());
+    NullableColumn::Ptr c1 = NullableColumn::create(FixedLengthColumn<int64_t>::create(), NullColumn::create());
+    NullableColumn::Ptr c2 = NullableColumn::create(FixedLengthColumn<int64_t>::create(), NullColumn::create());
     c1->append_datum(Datum((int64_t)0));
 
     c2->append_nulls(1);
@@ -429,8 +429,8 @@ TEST(FixedLengthColumnTest, test_assign) {
     // int32
     {
         std::vector<int32_t> numbers{1, 2, 3, 4, 5, 6, 7};
-        auto c1 = Int32Column::create();
-        auto c2 = Int32Column::create();
+        Int32Column::Ptr c1 = Int32Column::create();
+        Int32Column::Ptr c2 = Int32Column::create();
         c1->append_numbers(numbers.data(), numbers.size() * sizeof(int32_t));
         c2->append_numbers(numbers.data(), numbers.size() * sizeof(int32_t));
 
@@ -447,8 +447,8 @@ TEST(FixedLengthColumnTest, test_assign) {
     // nullable int32
     {
         std::vector<int32_t> numbers{1, 2, 3, 4, 5, 6, 7};
-        auto c1 = NullableColumn::create(Int32Column::create(), NullColumn::create());
-        auto c2 = NullableColumn::create(Int32Column::create(), NullColumn::create());
+        NullableColumn::Ptr c1 = NullableColumn::create(Int32Column::create(), NullColumn::create());
+        NullableColumn::Ptr c2 = NullableColumn::create(Int32Column::create(), NullColumn::create());
         c1->append_numbers(numbers.data(), numbers.size() * sizeof(int32_t));
         c1->append_nulls(1);
         c2->append_numbers(numbers.data(), numbers.size() * sizeof(int32_t));
@@ -547,14 +547,15 @@ TEST(FixedLengthColumnTest, test_xor_checksum) {
 }
 
 TEST(FixedLengthColumnTest, test_compare_row) {
-    auto column = FixedLengthColumn<int32_t>::create();
+    auto mutable_column = FixedLengthColumn<int32_t>::create();
     for (int i = 0; i <= 100; i++) {
-        column->append(i);
+        mutable_column->append(i);
     }
 
-    CompareVector cmp_vector(column->size());
+    CompareVector cmp_vector(mutable_column->size());
 
     // ascending
+    ColumnPtr column = std::move(mutable_column);
     EXPECT_EQ(1, compare_column(column, cmp_vector, {30}, SortDesc(1, 1)));
     EXPECT_EQ(30, std::count(cmp_vector.begin(), cmp_vector.end(), -1));
     EXPECT_EQ(70, std::count(cmp_vector.begin(), cmp_vector.end(), 1));
@@ -628,7 +629,7 @@ TEST(FixedLengthColumnTest, test_fill_range) {
     void* buff = values.data();
     size_t length = values.size() * sizeof(values[0]);
 
-    auto c1 = Int64Column::create();
+    Int64Column::Ptr c1 = Int64Column::create();
     ASSERT_EQ(values.size(), c1->append_numbers(buff, length));
     ASSERT_EQ(values.size(), c1->size());
 

--- a/be/test/column/json_column_test.cpp
+++ b/be/test/column/json_column_test.cpp
@@ -266,7 +266,7 @@ PARALLEL_TEST(JsonColumnTest, test_hash) {
 PARALLEL_TEST(JsonColumnTest, test_filter) {
     // TODO(mofei)
     const int N = 100;
-    auto json_column = JsonColumn::create();
+    JsonColumn::Ptr json_column = JsonColumn::create();
     for (int i = 0; i < N; i++) {
         std::string json_str = strings::Substitute("{\"a\": $0}", i);
         json_column->append(JsonValue::parse(json_str).value());
@@ -279,7 +279,7 @@ PARALLEL_TEST(JsonColumnTest, test_filter) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(JsonColumnTest, put_mysql_buffer) {
-    auto json_column = JsonColumn::create();
+    JsonColumn::Ptr json_column = JsonColumn::create();
     json_column->append(JsonValue::parse("{\"a\": 0}").value());
 
     MysqlRowBuffer rowBuffer;
@@ -315,14 +315,14 @@ PARALLEL_TEST(JsonColumnTest, test_column_builder) {
         builder.append(&json);
         auto result = builder.build(false);
 
-        JsonColumn::Ptr json_column_ptr = ColumnHelper::cast_to<TYPE_JSON>(result);
+        JsonColumn::Ptr json_column_ptr = ColumnHelper::cast_to<TYPE_JSON>(std::move(result));
         JsonColumn* json_column = json_column_ptr.get();
         ASSERT_EQ(1, json_column->size());
         ASSERT_EQ(0, json_column->get_object(0)->compare(json));
     }
     // clone
     {
-        auto column = JsonColumn::create();
+        JsonColumn::Ptr column = JsonColumn::create();
         column->append(JsonValue::parse("1").value());
 
         {
@@ -350,7 +350,7 @@ PARALLEL_TEST(JsonColumnTest, test_column_builder) {
         // clone json_column by helper
         {
             TypeDescriptor desc = TypeDescriptor::create_json_type();
-            auto copy = ColumnHelper::clone_column(desc, false, column, column->size());
+            ColumnPtr copy = ColumnHelper::clone_column(desc, false, column, column->size());
             ASSERT_EQ(1, copy->size());
             ASSERT_EQ(0, copy->compare_at(0, 0, *column, 0));
             ASSERT_FALSE(copy->is_nullable());
@@ -359,7 +359,7 @@ PARALLEL_TEST(JsonColumnTest, test_column_builder) {
             ASSERT_EQ(1, json_column_ptr->size());
             ASSERT_EQ(0, json_column_ptr->compare_at(0, 0, *column, 0));
 
-            JsonColumn* json_column = ColumnHelper::cast_to_raw<TYPE_JSON>(copy);
+            JsonColumn* json_column = ColumnHelper::cast_to_raw<TYPE_JSON>(copy.get());
             ASSERT_EQ(1, json_column->size());
             ASSERT_EQ(0, json_column->compare_at(0, 0, *column, 0));
         }

--- a/be/test/column/map_column_test.cpp
+++ b/be/test/column/map_column_test.cpp
@@ -30,14 +30,14 @@ namespace starrocks {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(MapColumnTest, test_create) {
-    auto offsets = UInt32Column::create();
-    auto keys_data = Int32Column::create();
-    auto keys_null = NullColumn::create();
-    auto keys = NullableColumn::create(keys_data, keys_null);
-    auto values_data = Int32Column::create();
-    auto values_null = NullColumn::create();
-    auto values = NullableColumn::create(values_data, values_null);
-    auto column = MapColumn::create(keys, values, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    Int32Column::Ptr keys_data = Int32Column::create();
+    NullColumn::Ptr keys_null = NullColumn::create();
+    NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+    Int32Column::Ptr values_data = Int32Column::create();
+    NullColumn::Ptr values_null = NullColumn::create();
+    NullableColumn::Ptr values = NullableColumn::create(values_data, values_null);
+    MapColumn::Ptr column = MapColumn::create(keys, values, offsets);
     ASSERT_TRUE(column->is_map());
     ASSERT_FALSE(column->is_nullable());
     ASSERT_EQ(0, column->size());
@@ -46,14 +46,14 @@ PARALLEL_TEST(MapColumnTest, test_create) {
 // NOLINTNEXTLINE
 PARALLEL_TEST(MapColumnTest, test_map_column_update_if_overflow) {
     // normal
-    auto offsets = UInt32Column::create();
-    auto keys_data = BinaryColumn::create();
-    auto keys_null = NullColumn::create();
-    auto keys = NullableColumn::create(keys_data, keys_null);
-    auto values_data = BinaryColumn::create();
-    auto null_column = NullColumn::create();
-    auto values = NullableColumn::create(values_data, null_column);
-    auto column = MapColumn::create(keys, values, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    BinaryColumn::Ptr keys_data = BinaryColumn::create();
+    NullColumn::Ptr keys_null = NullColumn::create();
+    NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+    BinaryColumn::Ptr values_data = BinaryColumn::create();
+    NullColumn::Ptr null_column = NullColumn::create();
+    NullableColumn::Ptr values = NullableColumn::create(values_data, null_column);
+    MapColumn::Ptr column = MapColumn::create(keys, values, offsets);
 
     DatumMap map;
     map[(Slice) "a"] = (Slice) "hello";
@@ -78,12 +78,12 @@ PARALLEL_TEST(MapColumnTest, test_map_column_update_if_overflow) {
     /*
     // the test case case will use a lot of memory, so temp comment it
     // upgrade
-    auto offsets_large = UInt32Column::create();
-    auto keys_large = BinaryColumn::create();
-    auto values_data_large = Int32Column::create();
-    auto values_null_large = NullColumn::create();
-    auto values_large = NullableColumn::create(values_data_large, values_null_large);
-    auto column_large = MapColumn::create(keys_large, values_large, offsets_large);
+    UInt32Column::Ptr offsets_large = UInt32Column::create();
+    BinaryColumn::Ptr keys_large = BinaryColumn::create();
+    Int32Column::Ptr values_data_large = Int32Column::create();
+    NullColumn::Ptr values_null_large = NullColumn::create();
+    NullableColumn::Ptr values_large = NullableColumn::create(values_data_large, values_null_large);
+    MapColumn::Ptr column_large = MapColumn::create(keys_large, values_large, offsets_large);
 
     size_t item_count = 1<<30;
     for (size_t i = 0; i < item_count; i++) {
@@ -100,14 +100,14 @@ PARALLEL_TEST(MapColumnTest, test_map_column_update_if_overflow) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(MapColumnTest, test_map_column_downgrade) {
-    auto offsets = UInt32Column::create();
-    auto keys_data = BinaryColumn::create();
-    auto keys_null = NullColumn::create();
-    auto keys = NullableColumn::create(keys_data, keys_null);
-    auto values_data = BinaryColumn::create();
-    auto null_column = NullColumn::create();
-    auto values = NullableColumn::create(values_data, null_column);
-    auto column = MapColumn::create(keys, values, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    BinaryColumn::Ptr keys_data = BinaryColumn::create();
+    NullColumn::Ptr keys_null = NullColumn::create();
+    NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+    BinaryColumn::Ptr values_data = BinaryColumn::create();
+    NullColumn::Ptr null_column = NullColumn::create();
+    NullableColumn::Ptr values = NullableColumn::create(values_data, null_column);
+    MapColumn::Ptr column = MapColumn::create(keys, values, offsets);
 
     DatumMap map;
     map[(Slice) "a"] = (Slice) "hello";
@@ -125,14 +125,14 @@ PARALLEL_TEST(MapColumnTest, test_map_column_downgrade) {
     ASSERT_TRUE(ret.ok());
     ASSERT_TRUE(ret.value() == nullptr);
 
-    auto offsets_large = UInt32Column::create();
-    auto keys_data_large = LargeBinaryColumn::create();
-    auto keys_null_large = NullColumn::create();
-    auto keys_large = NullableColumn::create(keys_data_large, keys_null_large);
-    auto values_data_large = LargeBinaryColumn::create();
-    auto null_column_large = NullColumn::create();
-    auto values_large = NullableColumn::create(values_data_large, null_column_large);
-    auto column_large = MapColumn::create(keys_large, values_large, offsets_large);
+    UInt32Column::Ptr offsets_large = UInt32Column::create();
+    LargeBinaryColumn::Ptr keys_data_large = LargeBinaryColumn::create();
+    NullColumn::Ptr keys_null_large = NullColumn::create();
+    NullableColumn::Ptr keys_large = NullableColumn::create(keys_data_large, keys_null_large);
+    LargeBinaryColumn::Ptr values_data_large = LargeBinaryColumn::create();
+    NullColumn::Ptr null_column_large = NullColumn::create();
+    NullableColumn::Ptr values_large = NullableColumn::create(values_data_large, null_column_large);
+    MapColumn::Ptr column_large = MapColumn::create(keys_large, values_large, offsets_large);
 
     for (size_t i = 0; i < 10; i++) {
         column_large->append_datum(DatumMap{{Slice(std::to_string(i)), Slice(std::to_string(i))}});
@@ -152,14 +152,14 @@ PARALLEL_TEST(MapColumnTest, test_map_column_downgrade) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(MapColumnTest, test_get_kvs) {
-    auto offsets = UInt32Column::create();
-    auto keys_data = Int32Column::create();
-    auto keys_null = NullColumn::create();
-    auto keys = NullableColumn::create(keys_data, keys_null);
-    auto values_data = Int32Column::create();
-    auto values_null = NullColumn::create();
-    auto values = NullableColumn::create(values_data, values_null);
-    auto column = MapColumn::create(keys, values, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    Int32Column::Ptr keys_data = Int32Column::create();
+    NullColumn::Ptr keys_null = NullColumn::create();
+    NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+    Int32Column::Ptr values_data = Int32Column::create();
+    NullColumn::Ptr values_null = NullColumn::create();
+    NullableColumn::Ptr values = NullableColumn::create(values_data, values_null);
+    MapColumn::Ptr column = MapColumn::create(keys, values, offsets);
 
     // insert [1, 2, 3], [4, 5, 6]
     DatumMap map;
@@ -180,14 +180,14 @@ PARALLEL_TEST(MapColumnTest, test_get_kvs) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(MapColumnTest, test_byte_size) {
-    auto offsets = UInt32Column::create();
-    auto keys_data = Int32Column::create();
-    auto keys_null = NullColumn::create();
-    auto keys = NullableColumn::create(keys_data, keys_null);
-    auto values_data = Int32Column::create();
-    auto values_null = NullColumn::create();
-    auto values = NullableColumn::create(values_data, values_null);
-    auto column = MapColumn::create(keys, values, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    Int32Column::Ptr keys_data = Int32Column::create();
+    NullColumn::Ptr keys_null = NullColumn::create();
+    NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+    Int32Column::Ptr values_data = Int32Column::create();
+    NullColumn::Ptr values_null = NullColumn::create();
+    NullableColumn::Ptr values = NullableColumn::create(values_data, values_null);
+    MapColumn::Ptr column = MapColumn::create(keys, values, offsets);
 
     // insert [1, 2, 3], [4, 5, 6]
     DatumMap map;
@@ -229,9 +229,9 @@ PARALLEL_TEST(MapColumnTest, test_byte_size) {
 PARALLEL_TEST(MapColumnTest, test_filter) {
     // MAP<INT->INT>
     {
-        auto column = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                        NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                        UInt32Column::create());
+        MapColumn::Ptr column = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                                  NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                                  UInt32Column::create());
         // The width of AVX2 register is 256 bits, aka 32 bytes, make the column size equals
         // to 2 * 32 + 31 in order to cover both the SIMD instructions and non-SIMD instructions.
         const int N = 2 * 32 + 31;
@@ -309,9 +309,9 @@ PARALLEL_TEST(MapColumnTest, test_filter) {
     }
     // MAP<INT->INT>
     {
-        auto column = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                        NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                        UInt32Column::create());
+        MapColumn::Ptr column = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                                  NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                                  UInt32Column::create());
         // The width of AVX2 register is 256 bits, aka 32 bytes, make the column size equals
         // to 2 * 32 + 31 in order to cover both the SIMD instructions and non-SIMD instructions.
         const int N = 3 * 32 + 31;
@@ -347,9 +347,9 @@ PARALLEL_TEST(MapColumnTest, test_filter) {
     }
     // MAP<INT->INT> with the number of elements > 2^16
     {
-        auto column = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                        NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                        UInt32Column::create());
+        MapColumn::Ptr column = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                                  NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                                  UInt32Column::create());
         column->reserve(4096);
         for (int i = 0; i < 4096; i++) {
             DatumMap map;
@@ -385,11 +385,11 @@ PARALLEL_TEST(MapColumnTest, test_filter) {
     // MAP<INT->ARRAY<INT>>
     {
         const int N = 100;
-        auto array_nullable = NullableColumn::create(Int32Column::create(), NullColumn::create());
-        auto value_column = NullableColumn::create(ArrayColumn::create(array_nullable, UInt32Column::create()),
-                                                   NullColumn::create());
-        auto column = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                        value_column, UInt32Column::create());
+        NullableColumn::Ptr array_nullable = NullableColumn::create(Int32Column::create(), NullColumn::create());
+        NullableColumn::Ptr value_column = NullableColumn::create(
+                ArrayColumn::create(array_nullable, UInt32Column::create()), NullColumn::create());
+        MapColumn::Ptr column = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                                  value_column, UInt32Column::create());
 
         for (int i = 0; i < N; i++) {
             column->append_datum(DatumMap{{i, DatumArray{i + 1, i + 2}}, {i + 1, DatumArray{i + 1, i + 2}}});
@@ -473,14 +473,14 @@ PARALLEL_TEST(MapColumnTest, test_filter) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(MapColumnTest, test_append_datumMap_with_null_value) {
-    auto offsets = UInt32Column::create();
-    auto keys_data = Int32Column::create();
-    auto keys_null = NullColumn::create();
-    auto keys = NullableColumn::create(keys_data, keys_null);
-    auto values_data = Int32Column::create();
-    auto values_null = NullColumn::create();
-    auto values = NullableColumn::create(values_data, values_null);
-    auto column = MapColumn::create(keys, values, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    Int32Column::Ptr keys_data = Int32Column::create();
+    NullColumn::Ptr keys_null = NullColumn::create();
+    NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+    Int32Column::Ptr values_data = Int32Column::create();
+    NullColumn::Ptr values_null = NullColumn::create();
+    NullableColumn::Ptr values = NullableColumn::create(values_data, values_null);
+    MapColumn::Ptr column = MapColumn::create(keys, values, offsets);
 
     // insert [1, 2, 3], [4, 5, 6]
     DatumMap map;
@@ -505,14 +505,14 @@ PARALLEL_TEST(MapColumnTest, test_append_datumMap_with_null_value) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(MapColumnTest, test_append_nulls) {
-    auto offsets = UInt32Column::create();
-    auto keys_data = Int32Column::create();
-    auto keys_null = NullColumn::create();
-    auto keys = NullableColumn::create(keys_data, keys_null);
-    auto values_data = Int32Column::create();
-    auto values_null = NullColumn::create();
-    auto values = NullableColumn::create(values_data, values_null);
-    auto column = MapColumn::create(keys, values, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    Int32Column::Ptr keys_data = Int32Column::create();
+    NullColumn::Ptr keys_null = NullColumn::create();
+    NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+    Int32Column::Ptr values_data = Int32Column::create();
+    NullColumn::Ptr values_null = NullColumn::create();
+    NullableColumn::Ptr values = NullableColumn::create(values_data, values_null);
+    MapColumn::Ptr column = MapColumn::create(keys, values, offsets);
 
     ASSERT_TRUE(column->append_nulls(1));
 
@@ -536,14 +536,14 @@ PARALLEL_TEST(MapColumnTest, test_append_nulls) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(MapColumnTest, test_append_defaults) {
-    auto offsets = UInt32Column::create();
-    auto keys_data = Int32Column::create();
-    auto keys_null = NullColumn::create();
-    auto keys = NullableColumn::create(keys_data, keys_null);
-    auto values_data = Int32Column::create();
-    auto null_column = NullColumn::create();
-    auto values = NullableColumn::create(values_data, null_column);
-    auto column = MapColumn::create(keys, values, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    Int32Column::Ptr keys_data = Int32Column::create();
+    NullColumn::Ptr keys_null = NullColumn::create();
+    NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+    Int32Column::Ptr values_data = Int32Column::create();
+    NullColumn::Ptr null_column = NullColumn::create();
+    NullableColumn::Ptr values = NullableColumn::create(values_data, null_column);
+    MapColumn::Ptr column = MapColumn::create(keys, values, offsets);
 
     // insert [1, 2, 3], [4, 5, 6]
     DatumMap map;
@@ -568,14 +568,14 @@ PARALLEL_TEST(MapColumnTest, test_append_defaults) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(MapColumnTest, test_string_key) {
-    auto offsets = UInt32Column::create();
-    auto keys_data = BinaryColumn::create();
-    auto keys_null = NullColumn::create();
-    auto keys = NullableColumn::create(keys_data, keys_null);
-    auto values_data = Int32Column::create();
-    auto null_column = NullColumn::create();
-    auto values = NullableColumn::create(values_data, null_column);
-    auto column = MapColumn::create(keys, values, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    BinaryColumn::Ptr keys_data = BinaryColumn::create();
+    NullColumn::Ptr keys_null = NullColumn::create();
+    NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+    Int32Column::Ptr values_data = Int32Column::create();
+    NullColumn::Ptr null_column = NullColumn::create();
+    NullableColumn::Ptr values = NullableColumn::create(values_data, null_column);
+    MapColumn::Ptr column = MapColumn::create(keys, values, offsets);
 
     // insert ["a"->1, "b"->2, "c"->3], ["d"->4, "e"->5]
     DatumMap map;
@@ -595,14 +595,14 @@ PARALLEL_TEST(MapColumnTest, test_string_key) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(MapColumnTest, test_string_value) {
-    auto offsets = UInt32Column::create();
-    auto keys_data = BinaryColumn::create();
-    auto keys_null = NullColumn::create();
-    auto keys = NullableColumn::create(keys_data, keys_null);
-    auto values_data = BinaryColumn::create();
-    auto null_column = NullColumn::create();
-    auto values = NullableColumn::create(values_data, null_column);
-    auto column = MapColumn::create(keys, values, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    BinaryColumn::Ptr keys_data = BinaryColumn::create();
+    NullColumn::Ptr keys_null = NullColumn::create();
+    NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+    BinaryColumn::Ptr values_data = BinaryColumn::create();
+    NullColumn::Ptr null_column = NullColumn::create();
+    NullableColumn::Ptr values = NullableColumn::create(values_data, null_column);
+    MapColumn::Ptr column = MapColumn::create(keys, values, offsets);
 
     // insert ["a"->1, "b"->2, "c"->3], ["d"->4, "e"->5]
     DatumMap map;
@@ -622,18 +622,18 @@ PARALLEL_TEST(MapColumnTest, test_string_value) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(MapColumnTest, test_array_value) {
-    auto offsets = UInt32Column::create();
-    auto keys_data = BinaryColumn::create();
-    auto keys_null = NullColumn::create();
-    auto keys = NullableColumn::create(keys_data, keys_null);
-    auto array_offsets = UInt32Column::create();
-    auto array_elements_data = Int32Column::create();
-    auto array_elements_null = NullColumn::create();
-    auto array_elements = NullableColumn::create(array_elements_data, array_elements_null);
-    auto values_data = ArrayColumn::create(array_elements, array_offsets);
-    auto null_column = NullColumn::create();
-    auto values = NullableColumn::create(values_data, null_column);
-    auto column = MapColumn::create(keys, values, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    BinaryColumn::Ptr keys_data = BinaryColumn::create();
+    NullColumn::Ptr keys_null = NullColumn::create();
+    NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+    UInt32Column::Ptr array_offsets = UInt32Column::create();
+    Int32Column::Ptr array_elements_data = Int32Column::create();
+    NullColumn::Ptr array_elements_null = NullColumn::create();
+    NullableColumn::Ptr array_elements = NullableColumn::create(array_elements_data, array_elements_null);
+    ArrayColumn::Ptr values_data = ArrayColumn::create(array_elements, array_offsets);
+    NullColumn::Ptr null_column = NullColumn::create();
+    NullableColumn::Ptr values = NullableColumn::create(values_data, null_column);
+    MapColumn::Ptr column = MapColumn::create(keys, values, offsets);
 
     // insert ["a"->[1, 2, 3], "b"->[2, 3, 4], "c"->[3]], ["def"->[4, 5, 6, 7], "g h"->[5]]
     DatumMap map;
@@ -670,14 +670,14 @@ PARALLEL_TEST(MapColumnTest, test_array_value) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(MapColumnTest, test_resize) {
-    auto offsets = UInt32Column::create();
-    auto keys_data = Int32Column::create();
-    auto keys_null = NullColumn::create();
-    auto keys = NullableColumn::create(keys_data, keys_null);
-    auto values_data = Int32Column::create();
-    auto null_column = NullColumn::create();
-    auto values = NullableColumn::create(values_data, null_column);
-    auto column = MapColumn::create(keys, values, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    Int32Column::Ptr keys_data = Int32Column::create();
+    NullColumn::Ptr keys_null = NullColumn::create();
+    NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+    Int32Column::Ptr values_data = Int32Column::create();
+    NullColumn::Ptr null_column = NullColumn::create();
+    NullableColumn::Ptr values = NullableColumn::create(values_data, null_column);
+    MapColumn::Ptr column = MapColumn::create(keys, values, offsets);
 
     // insert [1, 2, 3], [4, 5, 6], [7, 8, 9]
     DatumMap map;
@@ -707,14 +707,14 @@ PARALLEL_TEST(MapColumnTest, test_resize) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(MapColumnTest, test_reset_column) {
-    auto offsets = UInt32Column::create();
-    auto keys_data = Int32Column::create();
-    auto keys_null = NullColumn::create();
-    auto keys = NullableColumn::create(keys_data, keys_null);
-    auto values_data = Int32Column::create();
-    auto null_column = NullColumn::create();
-    auto values = NullableColumn::create(values_data, null_column);
-    auto column = MapColumn::create(keys, values, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    Int32Column::Ptr keys_data = Int32Column::create();
+    NullColumn::Ptr keys_null = NullColumn::create();
+    NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+    Int32Column::Ptr values_data = Int32Column::create();
+    NullColumn::Ptr null_column = NullColumn::create();
+    NullableColumn::Ptr values = NullableColumn::create(values_data, null_column);
+    MapColumn::Ptr column = MapColumn::create(keys, values, offsets);
 
     // insert [1, 2, 3], [4, 5, 6], [7, 8, 9]
     // insert [1, 2, 3], [4, 5, 6], [7, 8, 9]
@@ -744,14 +744,14 @@ PARALLEL_TEST(MapColumnTest, test_reset_column) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(MapColumnTest, test_swap_column) {
-    auto offsets = UInt32Column::create();
-    auto keys_data = Int32Column::create();
-    auto keys_null = NullColumn::create();
-    auto keys = NullableColumn::create(keys_data, keys_null);
-    auto values_data = Int32Column::create();
-    auto null_column = NullColumn::create();
-    auto values = NullableColumn::create(values_data, null_column);
-    auto column = MapColumn::create(keys, values, offsets);
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    Int32Column::Ptr keys_data = Int32Column::create();
+    NullColumn::Ptr keys_null = NullColumn::create();
+    NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+    Int32Column::Ptr values_data = Int32Column::create();
+    NullColumn::Ptr null_column = NullColumn::create();
+    NullableColumn::Ptr values = NullableColumn::create(values_data, null_column);
+    MapColumn::Ptr column = MapColumn::create(keys, values, offsets);
 
     // insert [1, 2, 3], [4, 5, 6]
     DatumMap map;
@@ -766,14 +766,14 @@ PARALLEL_TEST(MapColumnTest, test_swap_column) {
     map1[(int32_t)6] = (int32_t)66;
     column->append_datum(map1);
 
-    auto offsets2 = UInt32Column::create();
-    auto keys2_data = Int32Column::create();
-    auto keys2_null = NullColumn::create();
-    auto keys2 = NullableColumn::create(keys2_data, keys2_null);
-    auto values_data2 = Int32Column::create();
-    auto null_column2 = NullColumn::create();
-    auto values2 = NullableColumn::create(values_data2, null_column2);
-    auto column2 = MapColumn::create(keys2, values2, offsets2);
+    UInt32Column::Ptr offsets2 = UInt32Column::create();
+    Int32Column::Ptr keys2_data = Int32Column::create();
+    NullColumn::Ptr keys2_null = NullColumn::create();
+    NullableColumn::Ptr keys2 = NullableColumn::create(keys2_data, keys2_null);
+    Int32Column::Ptr values_data2 = Int32Column::create();
+    NullColumn::Ptr null_column2 = NullColumn::create();
+    NullableColumn::Ptr values2 = NullableColumn::create(values_data2, null_column2);
+    MapColumn::Ptr column2 = MapColumn::create(keys2, values2, offsets2);
 
     // insert [7, 8, 9]
     DatumMap map3;
@@ -792,9 +792,9 @@ PARALLEL_TEST(MapColumnTest, test_swap_column) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(MapColumnTest, test_copy_constructor) {
-    auto c0 = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                UInt32Column::create());
+    MapColumn::Ptr c0 = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                          NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                          UInt32Column::create());
 
     // insert [1, 2, 3], [4, 5, 6]
     DatumMap map;
@@ -813,16 +813,16 @@ PARALLEL_TEST(MapColumnTest, test_copy_constructor) {
     c0->reset_column();
     ASSERT_EQ("{1:11,2:22,3:33}", c1.debug_item(0));
     ASSERT_EQ("{4:44,5:55,6:66}", c1.debug_item(1));
-    ASSERT_TRUE(c1.keys_column().unique());
-    ASSERT_TRUE(c1.values_column().unique());
-    ASSERT_TRUE(c1.offsets_column().unique());
+    ASSERT_TRUE(c1.keys_column()->use_count() == 1);
+    ASSERT_TRUE(c1.values_column()->use_count() == 1);
+    ASSERT_TRUE(c1.offsets_column()->use_count() == 1);
 }
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(MapColumnTest, test_move_constructor) {
-    auto c0 = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                UInt32Column::create());
+    MapColumn::Ptr c0 = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                          NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                          UInt32Column::create());
 
     // insert [1, 2, 3], [4, 5, 6]
     DatumMap map;
@@ -840,16 +840,16 @@ PARALLEL_TEST(MapColumnTest, test_move_constructor) {
     MapColumn c1(std::move(*c0));
     ASSERT_EQ("{1:11,2:22,3:33}", c1.debug_item(0));
     ASSERT_EQ("{4:44,5:55,6:66}", c1.debug_item(1));
-    ASSERT_TRUE(c1.keys_column().unique());
-    ASSERT_TRUE(c1.values_column().unique());
-    ASSERT_TRUE(c1.offsets_column().unique());
+    ASSERT_TRUE(c1.keys_column()->use_count() == 1);
+    ASSERT_TRUE(c1.values_column()->use_count() == 1);
+    ASSERT_TRUE(c1.offsets_column()->use_count() == 1);
 }
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(MapColumnTest, test_copy_assignment) {
-    auto c0 = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                UInt32Column::create());
+    MapColumn::Ptr c0 = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                          NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                          UInt32Column::create());
 
     // insert [1, 2, 3], [4, 5, 6]
     DatumMap map;
@@ -870,16 +870,16 @@ PARALLEL_TEST(MapColumnTest, test_copy_assignment) {
     c0->reset_column();
     ASSERT_EQ("{1:11,2:22,3:33}", c1.debug_item(0));
     ASSERT_EQ("{4:44,5:55,6:66}", c1.debug_item(1));
-    ASSERT_TRUE(c1.keys_column().unique());
-    ASSERT_TRUE(c1.values_column().unique());
-    ASSERT_TRUE(c1.offsets_column().unique());
+    ASSERT_TRUE(c1.keys_column()->use_count() == 1);
+    ASSERT_TRUE(c1.values_column()->use_count() == 1);
+    ASSERT_TRUE(c1.offsets_column()->use_count() == 1);
 }
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(MapColumnTest, test_move_assignment) {
-    auto c0 = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                UInt32Column::create());
+    MapColumn::Ptr c0 = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                          NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                          UInt32Column::create());
 
     // insert [1, 2, 3], [4, 5, 6]
     DatumMap map;
@@ -899,16 +899,16 @@ PARALLEL_TEST(MapColumnTest, test_move_assignment) {
     c1 = std::move(*c0);
     ASSERT_EQ("{1:11,2:22,3:33}", c1.debug_item(0));
     ASSERT_EQ("{4:44,5:55,6:66}", c1.debug_item(1));
-    ASSERT_TRUE(c1.keys_column().unique());
-    ASSERT_TRUE(c1.values_column().unique());
-    ASSERT_TRUE(c1.offsets_column().unique());
+    ASSERT_TRUE(c1.keys_column()->use_count() == 1);
+    ASSERT_TRUE(c1.values_column()->use_count() == 1);
+    ASSERT_TRUE(c1.offsets_column()->use_count() == 1);
 }
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(MapColumnTest, test_clone) {
-    auto c0 = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                UInt32Column::create());
+    MapColumn::Ptr c0 = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                          NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                          UInt32Column::create());
 
     // insert [1, 2, 3], [4, 5, 6]
     DatumMap map;
@@ -927,16 +927,16 @@ PARALLEL_TEST(MapColumnTest, test_clone) {
     c0->reset_column();
     ASSERT_EQ("{1:11,2:22,3:33}", down_cast<MapColumn*>(c1.get())->debug_item(0));
     ASSERT_EQ("{4:44,5:55,6:66}", down_cast<MapColumn*>(c1.get())->debug_item(1));
-    ASSERT_TRUE(down_cast<MapColumn*>(c1.get())->keys_column().unique());
-    ASSERT_TRUE(down_cast<MapColumn*>(c1.get())->values_column().unique());
-    ASSERT_TRUE(down_cast<MapColumn*>(c1.get())->offsets_column().unique());
+    ASSERT_TRUE(down_cast<MapColumn*>(c1.get())->keys_column()->use_count() == 1);
+    ASSERT_TRUE(down_cast<MapColumn*>(c1.get())->values_column()->use_count() == 1);
+    ASSERT_TRUE(down_cast<MapColumn*>(c1.get())->offsets_column()->use_count() == 1);
 }
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(MapColumnTest, test_clone_shared) {
-    auto c0 = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                UInt32Column::create());
+    MapColumn::Ptr c0 = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                          NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                          UInt32Column::create());
 
     // insert [1, 2, 3], [4, 5, 6]
     DatumMap map;
@@ -951,21 +951,21 @@ PARALLEL_TEST(MapColumnTest, test_clone_shared) {
     map1[(int32_t)6] = (int32_t)66;
     c0->append_datum(map1);
 
-    auto c1 = c0->clone_shared();
+    auto c1 = c0->clone();
     c0->reset_column();
     ASSERT_EQ("{1:11,2:22,3:33}", down_cast<MapColumn*>(c1.get())->debug_item(0));
     ASSERT_EQ("{4:44,5:55,6:66}", down_cast<MapColumn*>(c1.get())->debug_item(1));
-    ASSERT_TRUE(c1.unique());
-    ASSERT_TRUE(down_cast<MapColumn*>(c1.get())->keys_column().unique());
-    ASSERT_TRUE(down_cast<MapColumn*>(c1.get())->values_column().unique());
-    ASSERT_TRUE(down_cast<MapColumn*>(c1.get())->offsets_column().unique());
+    ASSERT_TRUE(c1->use_count() == 1);
+    ASSERT_TRUE(down_cast<MapColumn*>(c1.get())->keys_column()->use_count() == 1);
+    ASSERT_TRUE(down_cast<MapColumn*>(c1.get())->values_column()->use_count() == 1);
+    ASSERT_TRUE(down_cast<MapColumn*>(c1.get())->offsets_column()->use_count() == 1);
 }
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(MapColumnTest, test_clone_column) {
-    auto c0 = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                UInt32Column::create());
+    MapColumn::Ptr c0 = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                          NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                          UInt32Column::create());
 
     // insert [1, 2, 3], [4, 5, 6]
     DatumMap map;
@@ -989,9 +989,9 @@ PARALLEL_TEST(MapColumnTest, test_clone_column) {
 }
 
 PARALLEL_TEST(MapColumnTest, test_update_rows) {
-    auto c0 = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                UInt32Column::create());
+    MapColumn::Ptr c0 = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                          NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                          UInt32Column::create());
 
     // insert [1, 2, 3], [4, 5, 6]
     DatumMap map;
@@ -1015,9 +1015,9 @@ PARALLEL_TEST(MapColumnTest, test_update_rows) {
     map2[9] = 99;
     c0->append_datum(map2);
 
-    auto c1 = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                UInt32Column::create());
+    MapColumn::Ptr c1 = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                          NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                          UInt32Column::create());
 
     // insert [101, 102], [103, 104]
     DatumMap map3;
@@ -1039,9 +1039,9 @@ PARALLEL_TEST(MapColumnTest, test_update_rows) {
     ASSERT_EQ("{}", c0->debug_item(2));
     ASSERT_EQ("{103:113,104:114}", c0->debug_item(3));
 
-    auto c2 = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                UInt32Column::create());
+    MapColumn::Ptr c2 = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                          NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                          UInt32Column::create());
 
     // insert [201, 202], [203, 204]
     DatumMap map5;
@@ -1065,9 +1065,9 @@ PARALLEL_TEST(MapColumnTest, test_update_rows) {
 }
 
 PARALLEL_TEST(MapColumnTest, test_assign) {
-    auto c0 = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                UInt32Column::create());
+    MapColumn::Ptr c0 = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                          NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                          UInt32Column::create());
 
     // insert [1, 2, 3], [4, 5, 6]
     DatumMap map;
@@ -1121,13 +1121,13 @@ PARALLEL_TEST(MapColumnTest, test_euqals) {
     // rhs: {2:2,1:1}, {4:4}, {null, 1}, {1, 1}
     MapColumn::Ptr lhs;
     {
-        auto offsets = UInt32Column::create();
-        auto keys_data = Int32Column::create();
-        auto keys_null = NullColumn::create();
-        auto keys = NullableColumn::create(keys_data, keys_null);
-        auto values_data = Int32Column::create();
-        auto values_null = NullColumn::create();
-        auto values = NullableColumn::create(values_data, values_null);
+        UInt32Column::Ptr offsets = UInt32Column::create();
+        Int32Column::Ptr keys_data = Int32Column::create();
+        NullColumn::Ptr keys_null = NullColumn::create();
+        NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+        Int32Column::Ptr values_data = Int32Column::create();
+        NullColumn::Ptr values_null = NullColumn::create();
+        NullableColumn::Ptr values = NullableColumn::create(values_data, values_null);
         lhs = MapColumn::create(keys, values, offsets);
     }
     {
@@ -1155,13 +1155,13 @@ PARALLEL_TEST(MapColumnTest, test_euqals) {
 
     MapColumn::Ptr rhs;
     {
-        auto offsets = UInt32Column::create();
-        auto keys_data = Int32Column::create();
-        auto keys_null = NullColumn::create();
-        auto keys = NullableColumn::create(keys_data, keys_null);
-        auto values_data = Int32Column::create();
-        auto values_null = NullColumn::create();
-        auto values = NullableColumn::create(values_data, values_null);
+        UInt32Column::Ptr offsets = UInt32Column::create();
+        Int32Column::Ptr keys_data = Int32Column::create();
+        NullColumn::Ptr keys_null = NullColumn::create();
+        NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+        Int32Column::Ptr values_data = Int32Column::create();
+        NullColumn::Ptr values_null = NullColumn::create();
+        NullableColumn::Ptr values = NullableColumn::create(values_data, values_null);
         rhs = MapColumn::create(keys, values, offsets);
     }
     {
@@ -1193,9 +1193,9 @@ PARALLEL_TEST(MapColumnTest, test_euqals) {
 }
 
 PARALLEL_TEST(MapColumnTest, test_reference_memory_usage) {
-    auto column = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                    NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                                    UInt32Column::create());
+    MapColumn::Ptr column = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                              NullableColumn::create(Int32Column::create(), NullColumn::create()),
+                                              UInt32Column::create());
 
     // {}, {1:2},{3:4,5:6}
     column->append_datum(DatumMap{});
@@ -1208,14 +1208,14 @@ PARALLEL_TEST(MapColumnTest, test_reference_memory_usage) {
 // NOLINTNEXTLINE
 PARALLEL_TEST(MapColumnTest, test_remove_duplicated_keys) {
     {
-        auto offsets = UInt32Column::create();
-        auto keys_data = Int32Column::create();
-        auto keys_null = NullColumn::create();
-        auto keys = NullableColumn::create(keys_data, keys_null);
-        auto values_data = Int32Column::create();
-        auto values_null = NullColumn::create();
-        auto values = NullableColumn::create(values_data, values_null);
-        auto column = MapColumn::create(keys, values, offsets);
+        UInt32Column::Ptr offsets = UInt32Column::create();
+        Int32Column::Ptr keys_data = Int32Column::create();
+        NullColumn::Ptr keys_null = NullColumn::create();
+        NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+        Int32Column::Ptr values_data = Int32Column::create();
+        NullColumn::Ptr values_null = NullColumn::create();
+        NullableColumn::Ptr values = NullableColumn::create(values_data, values_null);
+        MapColumn::Ptr column = MapColumn::create(keys, values, offsets);
 
         DatumMap map;
         map[(int32_t)1] = (int32_t)11;
@@ -1244,14 +1244,14 @@ PARALLEL_TEST(MapColumnTest, test_remove_duplicated_keys) {
         ASSERT_EQ("{}", column->debug_item(3));
     }
     {
-        auto offsets = UInt32Column::create();
-        auto keys_data = BinaryColumn::create();
-        auto keys_null = NullColumn::create();
-        auto keys = NullableColumn::create(keys_data, keys_null);
-        auto values_data = BinaryColumn::create();
-        auto null_column = NullColumn::create();
-        auto values = NullableColumn::create(values_data, null_column);
-        auto column = MapColumn::create(keys, values, offsets);
+        UInt32Column::Ptr offsets = UInt32Column::create();
+        BinaryColumn::Ptr keys_data = BinaryColumn::create();
+        NullColumn::Ptr keys_null = NullColumn::create();
+        NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+        BinaryColumn::Ptr values_data = BinaryColumn::create();
+        NullColumn::Ptr null_column = NullColumn::create();
+        NullableColumn::Ptr values = NullableColumn::create(values_data, null_column);
+        MapColumn::Ptr column = MapColumn::create(keys, values, offsets);
 
         DatumMap map;
         map[(Slice) "a"] = (Slice) "hello";
@@ -1270,14 +1270,14 @@ PARALLEL_TEST(MapColumnTest, test_remove_duplicated_keys) {
         ASSERT_EQ("{'def':'haha','g h':'let's dance'}", column->debug_item(1));
     }
     { // nested map
-        auto offsets = UInt32Column::create();
-        auto keys_data = Int32Column::create();
-        auto keys_null = NullColumn::create();
-        auto keys = NullableColumn::create(keys_data, keys_null);
-        auto values_data = Int32Column::create();
-        auto values_null = NullColumn::create();
-        auto values = NullableColumn::create(values_data, values_null);
-        auto column = MapColumn::create(keys, values, offsets);
+        UInt32Column::Ptr offsets = UInt32Column::create();
+        Int32Column::Ptr keys_data = Int32Column::create();
+        NullColumn::Ptr keys_null = NullColumn::create();
+        NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+        Int32Column::Ptr values_data = Int32Column::create();
+        NullColumn::Ptr values_null = NullColumn::create();
+        NullableColumn::Ptr values = NullableColumn::create(values_data, values_null);
+        MapColumn::Ptr column = MapColumn::create(keys, values, offsets);
 
         DatumMap map;
         map[(int32_t)1] = (int32_t)11;
@@ -1298,7 +1298,7 @@ PARALLEL_TEST(MapColumnTest, test_remove_duplicated_keys) {
         // {} empty
         column->append_datum(DatumMap());
 
-        auto nest_offsets = UInt32Column::create();
+        UInt32Column::Ptr nest_offsets = UInt32Column::create();
         auto nest_keys = keys->clone_empty();
         nest_keys->append_datum(1);
         nest_keys->append_datum(1);
@@ -1316,14 +1316,14 @@ PARALLEL_TEST(MapColumnTest, test_remove_duplicated_keys) {
         ASSERT_EQ("{1:{}}", nest_map->debug_item(1));
     }
     {
-        auto offsets = UInt32Column::create();
-        auto keys_data = Int32Column::create();
-        auto keys_null = NullColumn::create();
-        auto keys = NullableColumn::create(keys_data, keys_null);
-        auto values_data = Int32Column::create();
-        auto values_null = NullColumn::create();
-        auto values = NullableColumn::create(values_data, values_null);
-        auto column = MapColumn::create(keys, values, offsets);
+        UInt32Column::Ptr offsets = UInt32Column::create();
+        Int32Column::Ptr keys_data = Int32Column::create();
+        NullColumn::Ptr keys_null = NullColumn::create();
+        NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+        Int32Column::Ptr values_data = Int32Column::create();
+        NullColumn::Ptr values_null = NullColumn::create();
+        NullableColumn::Ptr values = NullableColumn::create(values_data, values_null);
+        MapColumn::Ptr column = MapColumn::create(keys, values, offsets);
 
         DatumMap map;
         map[(int32_t)1] = (int32_t)11;
@@ -1358,14 +1358,14 @@ PARALLEL_TEST(MapColumnTest, test_remove_duplicated_keys) {
         ASSERT_EQ("{}", column->debug_item(3));
     }
     {
-        auto offsets = UInt32Column::create();
-        auto keys_data = BinaryColumn::create();
-        auto keys_null = NullColumn::create();
-        auto keys = NullableColumn::create(keys_data, keys_null);
-        auto values_data = BinaryColumn::create();
-        auto null_column = NullColumn::create();
-        auto values = NullableColumn::create(values_data, null_column);
-        auto column = MapColumn::create(keys, values, offsets);
+        UInt32Column::Ptr offsets = UInt32Column::create();
+        BinaryColumn::Ptr keys_data = BinaryColumn::create();
+        NullColumn::Ptr keys_null = NullColumn::create();
+        NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+        BinaryColumn::Ptr values_data = BinaryColumn::create();
+        NullColumn::Ptr null_column = NullColumn::create();
+        NullableColumn::Ptr values = NullableColumn::create(values_data, null_column);
+        MapColumn::Ptr column = MapColumn::create(keys, values, offsets);
 
         DatumMap map;
         map[(Slice) "a"] = (Slice) "aaa";
@@ -1388,13 +1388,13 @@ TEST(MapColumnTest, test_hash) {
     ColumnPtr column1 = nullptr;
 
     {
-        auto offsets = UInt32Column::create();
-        auto keys_data = Int32Column::create();
-        auto keys_null = NullColumn::create();
-        auto keys = NullableColumn::create(keys_data, keys_null);
-        auto values_data = Int32Column::create();
-        auto values_null = NullColumn::create();
-        auto values = NullableColumn::create(values_data, values_null);
+        UInt32Column::Ptr offsets = UInt32Column::create();
+        Int32Column::Ptr keys_data = Int32Column::create();
+        NullColumn::Ptr keys_null = NullColumn::create();
+        NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+        Int32Column::Ptr values_data = Int32Column::create();
+        NullColumn::Ptr values_null = NullColumn::create();
+        NullableColumn::Ptr values = NullableColumn::create(values_data, values_null);
 
         offsets->append(0);
         offsets->append(3);
@@ -1419,13 +1419,13 @@ TEST(MapColumnTest, test_hash) {
     }
 
     {
-        auto offsets = UInt32Column::create();
-        auto keys_data = Int32Column::create();
-        auto keys_null = NullColumn::create();
-        auto keys = NullableColumn::create(keys_data, keys_null);
-        auto values_data = Int32Column::create();
-        auto values_null = NullColumn::create();
-        auto values = NullableColumn::create(values_data, values_null);
+        UInt32Column::Ptr offsets = UInt32Column::create();
+        Int32Column::Ptr keys_data = Int32Column::create();
+        NullColumn::Ptr keys_null = NullColumn::create();
+        NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+        Int32Column::Ptr values_data = Int32Column::create();
+        NullColumn::Ptr values_null = NullColumn::create();
+        NullableColumn::Ptr values = NullableColumn::create(values_data, values_null);
 
         offsets->append(0);
         offsets->append(3);

--- a/be/test/column/nullable_column_test.cpp
+++ b/be/test/column/nullable_column_test.cpp
@@ -28,7 +28,7 @@ namespace starrocks {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(NullableColumnTest, test_nullable_column_upgrade_if_overflow) {
-    auto c0 = NullableColumn::create(UInt32Column::create(), NullColumn::create());
+    NullableColumn::Ptr c0 = NullableColumn::create(UInt32Column::create(), NullColumn::create());
     c0->append_datum((uint32_t)1);
 
     auto ret = c0->upgrade_if_overflow();
@@ -38,7 +38,7 @@ PARALLEL_TEST(NullableColumnTest, test_nullable_column_upgrade_if_overflow) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(NullableColumnTest, test_nullable_column_downgrade) {
-    auto c0 = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+    NullableColumn::Ptr c0 = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
     c0->append_datum(Slice("1"));
 
     ASSERT_FALSE(c0->has_large_column());
@@ -58,7 +58,7 @@ PARALLEL_TEST(NullableColumnTest, test_nullable_column_downgrade) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(NullableColumnTest, test_copy_constructor) {
-    auto c0 = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    NullableColumn::Ptr c0 = NullableColumn::create(Int32Column::create(), NullColumn::create());
 
     c0->append_datum({}); // NULL
     c0->append_datum((int32_t)1);
@@ -69,8 +69,8 @@ PARALLEL_TEST(NullableColumnTest, test_copy_constructor) {
     c0->reset_column();
 
     ASSERT_EQ(4, c1.size());
-    ASSERT_TRUE(c1.data_column().unique());
-    ASSERT_TRUE(c1.null_column().unique());
+    ASSERT_TRUE(c1.data_column()->use_count() == 1);
+    ASSERT_TRUE(c1.null_column()->use_count() == 1);
     ASSERT_EQ(4, c1.data_column()->size());
     ASSERT_EQ(4, c1.null_column()->size());
     ASSERT_TRUE(c1.get(0).is_null());
@@ -81,7 +81,7 @@ PARALLEL_TEST(NullableColumnTest, test_copy_constructor) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(NullableColumnTest, test_move_constructor) {
-    auto c0 = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    NullableColumn::Ptr c0 = NullableColumn::create(Int32Column::create(), NullColumn::create());
 
     c0->append_datum({}); // NULL
     c0->append_datum((int32_t)1);
@@ -91,8 +91,8 @@ PARALLEL_TEST(NullableColumnTest, test_move_constructor) {
     NullableColumn c1(std::move(*c0));
 
     ASSERT_EQ(4, c1.size());
-    ASSERT_TRUE(c1.data_column().unique());
-    ASSERT_TRUE(c1.null_column().unique());
+    ASSERT_TRUE(c1.data_column()->use_count() == 1);
+    ASSERT_TRUE(c1.null_column()->use_count() == 1);
     ASSERT_EQ(4, c1.data_column()->size());
     ASSERT_EQ(4, c1.null_column()->size());
     ASSERT_TRUE(c1.get(0).is_null());
@@ -103,7 +103,7 @@ PARALLEL_TEST(NullableColumnTest, test_move_constructor) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(NullableColumnTest, test_copy_assignment) {
-    auto c0 = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    NullableColumn::Ptr c0 = NullableColumn::create(Int32Column::create(), NullColumn::create());
 
     c0->append_datum({}); // NULL
     c0->append_datum((int32_t)1);
@@ -115,8 +115,8 @@ PARALLEL_TEST(NullableColumnTest, test_copy_assignment) {
     c0->reset_column();
 
     ASSERT_EQ(4, c1.size());
-    ASSERT_TRUE(c1.data_column().unique());
-    ASSERT_TRUE(c1.null_column().unique());
+    ASSERT_TRUE(c1.data_column()->use_count() == 1);
+    ASSERT_TRUE(c1.null_column()->use_count() == 1);
     ASSERT_EQ(4, c1.data_column()->size());
     ASSERT_EQ(4, c1.null_column()->size());
     ASSERT_TRUE(c1.get(0).is_null());
@@ -127,7 +127,7 @@ PARALLEL_TEST(NullableColumnTest, test_copy_assignment) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(NullableColumnTest, test_move_assignment) {
-    auto c0 = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    NullableColumn::Ptr c0 = NullableColumn::create(Int32Column::create(), NullColumn::create());
 
     c0->append_datum({}); // NULL
     c0->append_datum((int32_t)1);
@@ -138,8 +138,8 @@ PARALLEL_TEST(NullableColumnTest, test_move_assignment) {
     c1 = *c0;
 
     ASSERT_EQ(4, c1.size());
-    ASSERT_TRUE(c1.data_column().unique());
-    ASSERT_TRUE(c1.null_column().unique());
+    ASSERT_TRUE(c1.data_column()->use_count() == 1);
+    ASSERT_TRUE(c1.null_column()->use_count() == 1);
     ASSERT_EQ(4, c1.data_column()->size());
     ASSERT_EQ(4, c1.null_column()->size());
     ASSERT_TRUE(c1.get(0).is_null());
@@ -150,14 +150,14 @@ PARALLEL_TEST(NullableColumnTest, test_move_assignment) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(NullableColumnTest, test_clone) {
-    auto c0 = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    NullableColumn::Ptr c0 = NullableColumn::create(Int32Column::create(), NullColumn::create());
 
     auto c1 = c0->clone();
     ASSERT_TRUE(c1->is_nullable());
     ASSERT_EQ(0, c1->size());
     ASSERT_TRUE(down_cast<NullableColumn*>(c1.get()) != nullptr);
-    ASSERT_TRUE(down_cast<NullableColumn*>(c1.get())->data_column().unique());
-    ASSERT_TRUE(down_cast<NullableColumn*>(c1.get())->null_column().unique());
+    ASSERT_TRUE(down_cast<NullableColumn*>(c1.get())->data_column()->use_count() == 1);
+    ASSERT_TRUE(down_cast<NullableColumn*>(c1.get())->null_column()->use_count() == 1);
     ASSERT_EQ(0, down_cast<NullableColumn*>(c1.get())->data_column()->size());
     ASSERT_EQ(0, down_cast<NullableColumn*>(c1.get())->null_column()->size());
 
@@ -181,34 +181,34 @@ PARALLEL_TEST(NullableColumnTest, test_clone) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(NullableColumnTest, test_clone_shared) {
-    auto c0 = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    NullableColumn::Ptr c0 = NullableColumn::create(Int32Column::create(), NullColumn::create());
 
-    auto c1 = c0->clone_shared();
-    ASSERT_TRUE(c1.unique());
+    ColumnPtr c1 = c0->clone();
+    ASSERT_TRUE(c1->use_count() == 1);
     ASSERT_TRUE(c1->is_nullable());
     ASSERT_EQ(0, c1->size());
-    ASSERT_TRUE(std::dynamic_pointer_cast<NullableColumn>(c1) != nullptr);
-    ASSERT_TRUE(std::dynamic_pointer_cast<NullableColumn>(c1)->data_column().unique());
-    ASSERT_TRUE(std::dynamic_pointer_cast<NullableColumn>(c1)->null_column().unique());
-    ASSERT_EQ(0, std::dynamic_pointer_cast<NullableColumn>(c1)->data_column()->size());
-    ASSERT_EQ(0, std::dynamic_pointer_cast<NullableColumn>(c1)->null_column()->size());
+    ASSERT_TRUE(NullableColumn::dynamic_pointer_cast(c1) != nullptr);
+    ASSERT_TRUE(NullableColumn::dynamic_pointer_cast(c1)->data_column()->use_count() == 1);
+    ASSERT_TRUE(NullableColumn::dynamic_pointer_cast(c1)->null_column()->use_count() == 1);
+    ASSERT_EQ(0, NullableColumn::dynamic_pointer_cast(c1)->data_column()->size());
+    ASSERT_EQ(0, NullableColumn::dynamic_pointer_cast(c1)->null_column()->size());
 
     c1->append_datum({}); // NULL
     c1->append_datum({(int32_t)1});
     c1->append_datum({(int32_t)2});
     c1->append_datum({(int32_t)3});
 
-    auto c2 = c1->clone_shared();
+    ColumnPtr c2 = c1->clone();
     c1->reset_column();
 
-    ASSERT_TRUE(c2.unique());
+    ASSERT_TRUE(c2->use_count() == 1);
     ASSERT_TRUE(c2->is_nullable());
     ASSERT_EQ(4, c2->size());
-    ASSERT_TRUE(std::dynamic_pointer_cast<NullableColumn>(c2) != nullptr);
-    ASSERT_TRUE(std::dynamic_pointer_cast<NullableColumn>(c2)->data_column().unique());
-    ASSERT_TRUE(std::dynamic_pointer_cast<NullableColumn>(c2)->null_column().unique());
-    ASSERT_EQ(4, std::dynamic_pointer_cast<NullableColumn>(c2)->data_column()->size());
-    ASSERT_EQ(4, std::dynamic_pointer_cast<NullableColumn>(c2)->null_column()->size());
+    ASSERT_TRUE(NullableColumn::dynamic_pointer_cast(c2) != nullptr);
+    ASSERT_TRUE(NullableColumn::dynamic_pointer_cast(c2)->data_column()->use_count() == 1);
+    ASSERT_TRUE(NullableColumn::dynamic_pointer_cast(c2)->null_column()->use_count() == 1);
+    ASSERT_EQ(4, NullableColumn::dynamic_pointer_cast(c2)->data_column()->size());
+    ASSERT_EQ(4, NullableColumn::dynamic_pointer_cast(c2)->null_column()->size());
     ASSERT_TRUE(c2->get(0).is_null());
     ASSERT_EQ(1, c2->get(1).get_int32());
     ASSERT_EQ(2, c2->get(2).get_int32());
@@ -217,14 +217,14 @@ PARALLEL_TEST(NullableColumnTest, test_clone_shared) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(NullableColumnTest, test_clone_empty) {
-    auto c0 = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    NullableColumn::Ptr c0 = NullableColumn::create(Int32Column::create(), NullColumn::create());
 
     auto c1 = c0->clone_empty();
     ASSERT_TRUE(c1->is_nullable());
     ASSERT_EQ(0, c1->size());
     ASSERT_TRUE(down_cast<NullableColumn*>(c1.get()) != nullptr);
-    ASSERT_TRUE(down_cast<NullableColumn*>(c1.get())->data_column().unique());
-    ASSERT_TRUE(down_cast<NullableColumn*>(c1.get())->null_column().unique());
+    ASSERT_TRUE(down_cast<NullableColumn*>(c1.get())->data_column()->use_count() == 1);
+    ASSERT_TRUE(down_cast<NullableColumn*>(c1.get())->null_column()->use_count() == 1);
     ASSERT_EQ(0, down_cast<NullableColumn*>(c1.get())->data_column()->size());
     ASSERT_EQ(0, down_cast<NullableColumn*>(c1.get())->null_column()->size());
 
@@ -238,29 +238,29 @@ PARALLEL_TEST(NullableColumnTest, test_clone_empty) {
     ASSERT_TRUE(c2->is_nullable());
     ASSERT_EQ(0, c2->size());
     ASSERT_TRUE(down_cast<NullableColumn*>(c2.get()) != nullptr);
-    ASSERT_TRUE(down_cast<NullableColumn*>(c2.get())->data_column().unique());
-    ASSERT_TRUE(down_cast<NullableColumn*>(c2.get())->null_column().unique());
+    ASSERT_TRUE(down_cast<NullableColumn*>(c2.get())->data_column()->use_count() == 1);
+    ASSERT_TRUE(down_cast<NullableColumn*>(c2.get())->null_column()->use_count() == 1);
     ASSERT_EQ(0, down_cast<NullableColumn*>(c2.get())->data_column()->size());
     ASSERT_EQ(0, down_cast<NullableColumn*>(c2.get())->null_column()->size());
 }
 
 PARALLEL_TEST(NullableColumnTest, test_update_rows) {
-    auto column = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    NullableColumn::Ptr column = NullableColumn::create(Int32Column::create(), NullColumn::create());
     column->append_datum((int32_t)1);
     column->append_datum((int32_t)2);
     column->append_datum({});
     column->append_datum((int32_t)4);
     column->append_datum({});
 
-    auto replace_col1 = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    NullableColumn::Ptr replace_col1 = NullableColumn::create(Int32Column::create(), NullColumn::create());
     replace_col1->append_datum({});
     replace_col1->append_datum((int32_t)5);
 
     std::vector<uint32_t> replace_idxes = {1, 4};
     column->update_rows(*replace_col1.get(), replace_idxes.data());
     ASSERT_EQ(5, column->size());
-    ASSERT_TRUE(column->data_column().unique());
-    ASSERT_TRUE(column->null_column().unique());
+    ASSERT_TRUE(column->data_column()->use_count() == 1);
+    ASSERT_TRUE(column->null_column()->use_count() == 1);
     ASSERT_EQ(5, column->data_column()->size());
     ASSERT_EQ(5, column->null_column()->size());
 
@@ -270,21 +270,21 @@ PARALLEL_TEST(NullableColumnTest, test_update_rows) {
     ASSERT_EQ(4, column->get(3).get_int32());
     ASSERT_EQ(5, column->get(4).get_int32());
 
-    auto column1 = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+    NullableColumn::Ptr column1 = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
     column1->append_datum("abc");
     column1->append_datum("def");
     column1->append_datum({});
     column1->append_datum("ghi");
     column1->append_datum({});
 
-    auto replace_col2 = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+    NullableColumn::Ptr replace_col2 = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
     replace_col2->append_datum({});
     replace_col2->append_datum("jk");
 
     column1->update_rows(*replace_col2.get(), replace_idxes.data());
     ASSERT_EQ(5, column1->size());
-    ASSERT_TRUE(column1->data_column().unique());
-    ASSERT_TRUE(column1->null_column().unique());
+    ASSERT_TRUE(column1->data_column()->use_count() == 1);
+    ASSERT_TRUE(column1->null_column()->use_count() == 1);
     ASSERT_EQ(5, column1->data_column()->size());
     ASSERT_EQ(5, column1->null_column()->size());
 
@@ -296,7 +296,7 @@ PARALLEL_TEST(NullableColumnTest, test_update_rows) {
 }
 
 PARALLEL_TEST(NullableColumnTest, test_xor_checksum) {
-    auto c0 = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    NullableColumn::Ptr c0 = NullableColumn::create(Int32Column::create(), NullColumn::create());
 
     c0->append_datum({}); // NULL
     for (int i = 0; i <= 1000; i++) {
@@ -314,7 +314,7 @@ PARALLEL_TEST(NullableColumnTest, test_xor_checksum) {
 }
 
 PARALLEL_TEST(NullableColumnTest, test_compare_row) {
-    auto c0 = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    NullableColumn::Ptr c0 = NullableColumn::create(Int32Column::create(), NullColumn::create());
     c0->append_datum({});
     c0->append_datum(1);
     c0->append_datum(2);
@@ -326,7 +326,7 @@ PARALLEL_TEST(NullableColumnTest, test_compare_row) {
     c0->append_datum({});
     auto correct = [&](const Datum& rhs_value, int sort_order, int null_first) {
         CompareVector res;
-        auto rhs_column = NullableColumn::create(Int32Column::create(), NullColumn::create());
+        NullableColumn::Ptr rhs_column = NullableColumn::create(Int32Column::create(), NullColumn::create());
         rhs_column->append_datum(rhs_value);
 
         auto desc = SortDesc(sort_order, null_first);
@@ -363,7 +363,7 @@ PARALLEL_TEST(NullableColumnTest, test_compare_row) {
 }
 
 PARALLEL_TEST(NullableColumnTest, test_replicate) {
-    auto column = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    NullableColumn::Ptr column = NullableColumn::create(Int32Column::create(), NullColumn::create());
     column->append_datum((int32_t)1);
     column->append_datum({});
     column->append_datum((int32_t)4);
@@ -385,7 +385,7 @@ PARALLEL_TEST(NullableColumnTest, test_replicate) {
 }
 
 PARALLEL_TEST(NullableColumnTest, test_remove_first_n_values) {
-    auto column = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    NullableColumn::Ptr column = NullableColumn::create(Int32Column::create(), NullColumn::create());
     column->append_datum((int32_t)1);
     column->append_datum({});
     column->append_datum((int32_t)4);

--- a/be/test/column/object_column_test.cpp
+++ b/be/test/column/object_column_test.cpp
@@ -30,7 +30,7 @@ namespace starrocks {
 TEST(ObjectColumnTest, HLL_test_filter) {
     // keep all.
     {
-        auto c = ColumnHelper::create_column(TypeDescriptor::create_hll_type(), false);
+        ColumnPtr c = ColumnHelper::create_column(TypeDescriptor::create_hll_type(), false);
         c->resize(100);
         ASSERT_EQ(100, c->size());
 
@@ -40,7 +40,7 @@ TEST(ObjectColumnTest, HLL_test_filter) {
     }
     // filter all.
     {
-        auto c = HyperLogLogColumn::create();
+        HyperLogLogColumn::Ptr c = HyperLogLogColumn::create();
         c->resize(100);
 
         Filter filter(100, 0);
@@ -49,7 +49,7 @@ TEST(ObjectColumnTest, HLL_test_filter) {
     }
     // filter out the last 10 elements.
     {
-        auto c = HyperLogLogColumn::create();
+        HyperLogLogColumn::Ptr c = HyperLogLogColumn::create();
         c->resize(100);
         ASSERT_EQ(100, c->size());
 
@@ -62,7 +62,7 @@ TEST(ObjectColumnTest, HLL_test_filter) {
     }
     // filter out the first 10 elements.
     {
-        auto c = HyperLogLogColumn::create();
+        HyperLogLogColumn::Ptr c = HyperLogLogColumn::create();
         c->resize(100);
         ASSERT_EQ(100, c->size());
 
@@ -75,7 +75,7 @@ TEST(ObjectColumnTest, HLL_test_filter) {
     }
     // filter out half elements.
     {
-        auto c = HyperLogLogColumn::create();
+        HyperLogLogColumn::Ptr c = HyperLogLogColumn::create();
         c->resize(100);
         ASSERT_EQ(100, c->size());
 
@@ -92,7 +92,7 @@ TEST(ObjectColumnTest, HLL_test_filter) {
 TEST(ObjectColumnTest, HLL_test_filter_range) {
     // keep all.
     {
-        auto c = HyperLogLogColumn::create();
+        HyperLogLogColumn::Ptr c = HyperLogLogColumn::create();
         c->resize(100);
         ASSERT_EQ(100, c->size());
 
@@ -102,7 +102,7 @@ TEST(ObjectColumnTest, HLL_test_filter_range) {
     }
     // filter all.
     {
-        auto c = HyperLogLogColumn::create();
+        HyperLogLogColumn::Ptr c = HyperLogLogColumn::create();
         c->resize(100);
 
         Filter filter(100, 0);
@@ -111,7 +111,7 @@ TEST(ObjectColumnTest, HLL_test_filter_range) {
     }
     // filter out the last 10 elements.
     {
-        auto c = HyperLogLogColumn::create();
+        HyperLogLogColumn::Ptr c = HyperLogLogColumn::create();
         c->resize(100);
         ASSERT_EQ(100, c->size());
 
@@ -121,7 +121,7 @@ TEST(ObjectColumnTest, HLL_test_filter_range) {
     }
     // filter out the first 10 elements.
     {
-        auto c = HyperLogLogColumn::create();
+        HyperLogLogColumn::Ptr c = HyperLogLogColumn::create();
         c->resize(100);
         ASSERT_EQ(100, c->size());
 
@@ -131,7 +131,7 @@ TEST(ObjectColumnTest, HLL_test_filter_range) {
     }
     // filter 12 elements in the middle
     {
-        auto c = HyperLogLogColumn::create();
+        HyperLogLogColumn::Ptr c = HyperLogLogColumn::create();
         c->resize(100);
         ASSERT_EQ(100, c->size());
 
@@ -143,7 +143,7 @@ TEST(ObjectColumnTest, HLL_test_filter_range) {
 
 // NOLINTNEXTLINE
 TEST(ObjectColumnTest, test_object_column_upgrade_if_overflow) {
-    auto c = HyperLogLogColumn::create();
+    HyperLogLogColumn::Ptr c = HyperLogLogColumn::create();
     c->append(HyperLogLog());
 
     auto ret = c->upgrade_if_overflow();
@@ -153,8 +153,8 @@ TEST(ObjectColumnTest, test_object_column_upgrade_if_overflow) {
 
 // NOLINTNEXTLINE
 TEST(ObjectColumnTest, test_append_value_multiple_times) {
-    auto src_col = BitmapColumn::create();
-    auto copy_col = BitmapColumn::create();
+    BitmapColumn::Ptr src_col = BitmapColumn::create();
+    BitmapColumn::Ptr copy_col = BitmapColumn::create();
 
     BitmapValue bitmap;
     for (size_t i = 0; i < 64; i++) {
@@ -173,7 +173,7 @@ TEST(ObjectColumnTest, test_append_value_multiple_times) {
 
 // NOLINTNEXTLINE
 TEST(ObjectColumnTest, test_object_column_downgrade) {
-    auto c = HyperLogLogColumn::create();
+    HyperLogLogColumn::Ptr c = HyperLogLogColumn::create();
     c->append(HyperLogLog());
 
     auto ret = c->downgrade();
@@ -184,7 +184,7 @@ TEST(ObjectColumnTest, test_object_column_downgrade) {
 
 // NOLINTNEXTLINE
 TEST(ObjectColumnTest, HLL_test_reset_column) {
-    auto c = HyperLogLogColumn::create();
+    HyperLogLogColumn::Ptr c = HyperLogLogColumn::create();
 
     c->append(HyperLogLog());
     c->append(HyperLogLog());
@@ -203,8 +203,8 @@ TEST(ObjectColumnTest, HLL_test_reset_column) {
 
 // NOLINTNEXTLINE
 TEST(ObjectColumnTest, HLL_test_swap_column) {
-    auto c1 = HyperLogLogColumn::create();
-    auto c2 = HyperLogLogColumn::create();
+    HyperLogLogColumn::Ptr c1 = HyperLogLogColumn::create();
+    HyperLogLogColumn::Ptr c2 = HyperLogLogColumn::create();
 
     c1->append(HyperLogLog());
     c1->append(HyperLogLog());
@@ -229,7 +229,7 @@ TEST(ObjectColumnTest, HLL_test_swap_column) {
 TEST(ObjectColumnTest, Percentile_test_swap_column) {
     Columns columns;
     FunctionContext* ctx = FunctionContext::create_test_context();
-    auto s = DoubleColumn::create();
+    DoubleColumn::Ptr s = DoubleColumn::create();
     s->append(1);
     s->append(2);
     s->append(3);
@@ -243,7 +243,7 @@ TEST(ObjectColumnTest, Percentile_test_swap_column) {
     ASSERT_EQ(2, percentile->get_object(1)->quantile(1));
     ASSERT_EQ(3, percentile->get_object(2)->quantile(1));
 
-    auto s1 = DoubleColumn::create();
+    DoubleColumn::Ptr s1 = DoubleColumn::create();
     s1->append(4);
     columns.clear();
     columns.push_back(s1);

--- a/be/test/column/struct_column_test.cpp
+++ b/be/test/column/struct_column_test.cpp
@@ -23,12 +23,12 @@
 
 namespace starrocks {
 
-std::shared_ptr<StructColumn> create_test_column() {
+StructColumn::Ptr create_test_column() {
     std::vector<std::string> field_name{"id", "name"};
     auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
     auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
-    Columns fields{id, name};
-    auto column = StructColumn::create(fields, field_name);
+    Columns fields{std::move(id), std::move(name)};
+    auto column = StructColumn::create(std::move(fields), std::move(field_name));
 
     DatumStruct struct1{uint64_t(1), Slice("smith")};
     DatumStruct struct2{uint64_t(2), Slice("cruise")};
@@ -69,10 +69,10 @@ TEST(StructColumnTest, test_column_downgrade) {
 
     {
         std::vector<std::string> field_name{"id", "name"};
-        auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
-        auto name = NullableColumn::create(LargeBinaryColumn::create(), NullColumn::create());
+        NullableColumn::Ptr id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
+        NullableColumn::Ptr name = NullableColumn::create(LargeBinaryColumn::create(), NullColumn::create());
         Columns fields{id, name};
-        auto column = StructColumn::create(fields, field_name);
+        StructColumn::Ptr column = StructColumn::create(fields, field_name);
 
         for (size_t i = 0; i < 10; i++) {
             column->append_datum(DatumStruct{i, Slice(std::to_string(i))});
@@ -95,10 +95,10 @@ TEST(StructColumnTest, test_column_downgrade) {
 TEST(StructColumnTest, test_append_null) {
     {
         std::vector<std::string> field_name{"id", "name"};
-        auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
-        auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+        NullableColumn::Ptr id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
+        NullableColumn::Ptr name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
         Columns fields{id, name};
-        auto column = StructColumn::create(fields, field_name);
+        StructColumn::Ptr column = StructColumn::create(fields, field_name);
 
         DatumStruct struct1{uint64_t(1), Slice("smith")};
         DatumStruct struct3{uint64_t(3), Slice("cruise")};
@@ -114,11 +114,11 @@ TEST(StructColumnTest, test_append_null) {
 
     {
         std::vector<std::string> field_name{"id", "name"};
-        auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
+        NullableColumn::Ptr id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
         // one subfield is not nullable
-        auto name = BinaryColumn::create();
+        BinaryColumn::Ptr name = BinaryColumn::create();
         Columns fields{id, name};
-        auto column = StructColumn::create(fields, field_name);
+        StructColumn::Ptr column = StructColumn::create(fields, field_name);
 
         DatumStruct struct1{uint64_t(1), Slice("smith")};
         DatumStruct struct3{uint64_t(3), Slice("cruise")};
@@ -134,10 +134,10 @@ TEST(StructColumnTest, test_append_null) {
 
 TEST(StructColumnTest, test_append_defaults) {
     std::vector<std::string> field_name{"id", "name"};
-    auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
-    auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+    NullableColumn::Ptr id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
+    NullableColumn::Ptr name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
     Columns fields{id, name};
-    auto column = StructColumn::create(fields, field_name);
+    StructColumn::Ptr column = StructColumn::create(fields, field_name);
 
     column->append_default();
     ASSERT_EQ(1, column->size());
@@ -154,8 +154,8 @@ TEST(StructColumnTest, equals) {
     // rhs: {1, 2}, {1, 2}, {6, 7}, {2, 1}
     StructColumn::Ptr lhs;
     {
-        auto field1 = NullableColumn::create(Int32Column::create(), NullColumn::create());
-        auto field2 = NullableColumn::create(Int32Column::create(), NullColumn::create());
+        NullableColumn::Ptr field1 = NullableColumn::create(Int32Column::create(), NullColumn::create());
+        NullableColumn::Ptr field2 = NullableColumn::create(Int32Column::create(), NullColumn::create());
         Columns fields{field1, field2};
         lhs = StructColumn::create(fields);
     }
@@ -171,8 +171,8 @@ TEST(StructColumnTest, equals) {
 
     StructColumn::Ptr rhs;
     {
-        auto field1 = Int32Column::create();
-        auto field2 = Int32Column::create();
+        Int32Column::Ptr field1 = Int32Column::create();
+        Int32Column::Ptr field2 = Int32Column::create();
         Columns fields{field1, field2};
         rhs = StructColumn::create(fields);
     }
@@ -228,8 +228,8 @@ TEST(StructColumnTest, test_swap_column) {
     ColumnPtr column2;
     {
         std::vector<std::string> field_name{"id", "name"};
-        auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
-        auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+        NullableColumn::Ptr id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
+        NullableColumn::Ptr name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
         Columns fields{id, name};
         column1 = StructColumn::create(fields, field_name);
 
@@ -238,8 +238,8 @@ TEST(StructColumnTest, test_swap_column) {
     }
     {
         std::vector<std::string> field_name{"id", "name"};
-        auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
-        auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+        NullableColumn::Ptr id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
+        NullableColumn::Ptr name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
         Columns fields{id, name};
         column2 = StructColumn::create(fields, field_name);
 
@@ -276,8 +276,8 @@ TEST(StructColumnTest, test_copy_construtor) {
     ASSERT_EQ("{id:1,name:'smith'}", copy.debug_item(0));
     ASSERT_EQ("{id:2,name:'cruise'}", copy.debug_item(1));
 
-    ASSERT_TRUE(copy.fields().at(0).unique());
-    ASSERT_TRUE(copy.fields().at(1).unique());
+    ASSERT_TRUE(copy.fields().at(0)->use_count() == 1);
+    ASSERT_TRUE(copy.fields().at(1)->use_count() == 1);
 }
 
 TEST(StructColumnTest, test_move_construtor) {
@@ -292,8 +292,8 @@ TEST(StructColumnTest, test_move_construtor) {
     ASSERT_EQ("{id:1,name:'smith'}", copy.debug_item(0));
     ASSERT_EQ("{id:2,name:'cruise'}", copy.debug_item(1));
 
-    ASSERT_TRUE(copy.fields().at(0).unique());
-    ASSERT_TRUE(copy.fields().at(1).unique());
+    ASSERT_TRUE(copy.fields().at(0)->use_count() == 1);
+    ASSERT_TRUE(copy.fields().at(1)->use_count() == 1);
 }
 
 TEST(StructColumnTest, test_clone) {
@@ -309,8 +309,8 @@ TEST(StructColumnTest, test_clone) {
     ASSERT_EQ("{id:1,name:'smith'}", copy->debug_item(0));
     ASSERT_EQ("{id:2,name:'cruise'}", copy->debug_item(1));
 
-    ASSERT_TRUE(down_cast<StructColumn*>(copy.get())->fields().at(0).unique());
-    ASSERT_TRUE(down_cast<StructColumn*>(copy.get())->fields().at(1).unique());
+    ASSERT_TRUE(down_cast<StructColumn*>(copy.get())->fields().at(0)->use_count() == 1);
+    ASSERT_TRUE(down_cast<StructColumn*>(copy.get())->fields().at(1)->use_count() == 1);
 }
 
 TEST(StructColumnTest, test_clone_shared) {
@@ -320,14 +320,14 @@ TEST(StructColumnTest, test_clone_shared) {
     ASSERT_EQ("{id:1,name:'smith'}", col->debug_item(0));
     ASSERT_EQ("{id:2,name:'cruise'}", col->debug_item(1));
 
-    auto copy = col->clone_shared();
+    auto copy = col->clone();
     col->reset_column();
     ASSERT_EQ(2, copy->size());
     ASSERT_EQ("{id:1,name:'smith'}", copy->debug_item(0));
     ASSERT_EQ("{id:2,name:'cruise'}", copy->debug_item(1));
 
-    ASSERT_TRUE(down_cast<StructColumn*>(copy.get())->fields().at(0).unique());
-    ASSERT_TRUE(down_cast<StructColumn*>(copy.get())->fields().at(1).unique());
+    ASSERT_TRUE(down_cast<StructColumn*>(copy.get())->fields().at(0)->use_count() == 1);
+    ASSERT_TRUE(down_cast<StructColumn*>(copy.get())->fields().at(1)->use_count() == 1);
 }
 
 TEST(StructColumnTest, test_clone_empty) {
@@ -341,15 +341,15 @@ TEST(StructColumnTest, test_clone_empty) {
     col->reset_column();
     ASSERT_EQ(0, copy->size());
 
-    ASSERT_TRUE(down_cast<StructColumn*>(copy.get())->fields().at(0).unique());
-    ASSERT_TRUE(down_cast<StructColumn*>(copy.get())->fields().at(1).unique());
+    ASSERT_TRUE(down_cast<StructColumn*>(copy.get())->fields().at(0)->use_count() == 1);
+    ASSERT_TRUE(down_cast<StructColumn*>(copy.get())->fields().at(1)->use_count() == 1);
 }
 
 TEST(StructColumnTest, test_update_rows) {
     std::vector<std::string> field_name{"id", "name"};
-    auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
-    auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
-    auto column = StructColumn::create(Columns{id, name}, field_name);
+    NullableColumn::Ptr id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
+    NullableColumn::Ptr name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+    StructColumn::Ptr column = StructColumn::create(Columns{id, name}, field_name);
 
     ASSERT_TRUE(column->is_struct());
     ASSERT_FALSE(column->is_nullable());
@@ -376,9 +376,9 @@ TEST(StructColumnTest, test_update_rows) {
 
 TEST(StructColumnTest, test_assign) {
     std::vector<std::string> field_name{"id", "name"};
-    auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
-    auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
-    auto column = StructColumn::create(Columns{id, name}, field_name);
+    NullableColumn::Ptr id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
+    NullableColumn::Ptr name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+    StructColumn::Ptr column = StructColumn::create(Columns{id, name}, field_name);
 
     ASSERT_TRUE(column->is_struct());
     ASSERT_FALSE(column->is_nullable());
@@ -396,10 +396,10 @@ TEST(StructColumnTest, test_assign) {
 }
 
 TEST(StructColumnTest, test_reference_memory_usage) {
-    auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
-    auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+    NullableColumn::Ptr id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
+    NullableColumn::Ptr name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
     Columns fields{id, name};
-    auto column = StructColumn::create(fields);
+    StructColumn::Ptr column = StructColumn::create(fields);
 
     column->append_datum(DatumStruct{uint64_t(1), Slice("2")});
     column->append_datum(DatumStruct{uint64_t(1), Slice("4")});

--- a/be/test/exec/analytor_test.cpp
+++ b/be/test/exec/analytor_test.cpp
@@ -38,7 +38,7 @@ TEST_F(AnalytorTest, find_peer_group_end) {
     c1->append_value_multiple_times(&v, 10);
 
     analytor._input_rows += 20;
-    analytor._order_columns.emplace_back(c1);
+    analytor._order_columns.emplace_back(std::move(c1));
     analytor._partition.is_real = true;
     analytor._partition.end = 20;
 
@@ -83,8 +83,8 @@ TEST_F(AnalytorTest, find_partition_end) {
 
     analytor1._input_rows += 20;
     analytor1._input_eos = true;
-    analytor1._partition_columns.emplace_back(c1);
-    analytor1._partition_columns.emplace_back(c2);
+    analytor1._partition_columns.emplace_back(std::move(c1));
+    analytor1._partition_columns.emplace_back(std::move(c2));
 
     analytor1._current_row_position = analytor1._partition.end;
     analytor1._find_partition_end();

--- a/be/test/exec/arrow_converter_test.cpp
+++ b/be/test/exec/arrow_converter_test.cpp
@@ -175,7 +175,7 @@ PARALLEL_TEST(ArrowConverterTest, test_assignable_converter_float) {
 PARALLEL_TEST(ArrowConverterTest, test_nullable_copyable_converter_int32) {
     auto data_column = Int32Column::create();
     auto null_column = NullColumn::create();
-    auto col = NullableColumn::create(data_column, null_column);
+    auto col = NullableColumn::create(std::move(data_column), std::move(null_column));
     col->reserve(4096);
     size_t counter = 0;
     add_arrow_to_nullable_column<ArrowTypeId::INT32, TYPE_INT, arrow::Int32Type>(col.get(), 11, 0, counter);
@@ -191,7 +191,7 @@ PARALLEL_TEST(ArrowConverterTest, test_nullable_copyable_converter_int32) {
 PARALLEL_TEST(ArrowConverterTest, test_nullable_assignable_converter_uint16) {
     auto data_column = Int128Column::create();
     auto null_column = NullColumn::create();
-    auto col = NullableColumn::create(data_column, null_column);
+    auto col = NullableColumn::create(std::move(data_column), std::move(null_column));
     col->reserve(4096);
     size_t counter = 0;
     add_arrow_to_nullable_column<ArrowTypeId::UINT16, TYPE_LARGEINT, arrow::UInt16Type>(col.get(), 11, uint16_t(0),
@@ -335,7 +335,7 @@ void test_nullable_binary(const TestCaseArray<ArrowCppType>& test_cases, bool st
     using ColumnType = RunTimeColumnType<LT>;
     auto binary_column = ColumnType::create();
     auto null_column = NullColumn::create();
-    auto col = NullableColumn::create(binary_column, null_column);
+    auto col = NullableColumn::create(std::move(binary_column), std::move(null_column));
     col->reserve(4096);
     size_t counter = 0;
     auto expect_num_rows = 0;
@@ -347,7 +347,7 @@ void test_nullable_binary(const TestCaseArray<ArrowCppType>& test_cases, bool st
         add_arrow_to_nullable_binary_column<AT, LT, ArrowType, ArrowCppType>(col.get(), num_elements, value, counter,
                                                                              strict_mode, fail);
     }
-    ASSERT_EQ(binary_column->size(), expect_num_rows);
+    ASSERT_EQ(col->size(), expect_num_rows);
 }
 
 void test_nullable_binary_with_strict_mode(const TestCaseArray<std::string>& test_cases, bool strict_mode) {
@@ -594,7 +594,7 @@ void test_nullable_fixed_size_binary(const TestCaseArray<std::string>& test_case
     using ColumnType = RunTimeColumnType<LT>;
     auto binary_column = ColumnType::create();
     auto null_column = NullColumn::create();
-    auto col = NullableColumn::create(binary_column, null_column);
+    auto col = NullableColumn::create(std::move(binary_column), std::move(null_column));
     col->reserve(4096);
     size_t counter = 0;
     for (auto& tc : test_cases) {
@@ -844,7 +844,7 @@ void test_nullable_datetime(std::shared_ptr<ArrowType> type, const TestCaseArray
     using ArrowCppType = typename arrow::TypeTraits<ArrowType>::CType;
     auto datetime_column = ColumnType::create();
     auto null_column = NullColumn::create();
-    auto col = NullableColumn::create(datetime_column, null_column);
+    auto col = NullableColumn::create(std::move(datetime_column), std::move(null_column));
     col->reserve(4096);
     size_t counter = 0;
     for (auto& tc : test_cases) {
@@ -1096,7 +1096,7 @@ void test_nullable_decimal(std::shared_ptr<arrow::Decimal128Type> type, const Te
         decimal_column = ColumnType::create(precision, scale);
     }
     auto null_column = NullColumn::create();
-    auto col = NullableColumn::create(decimal_column, null_column);
+    auto col = NullableColumn::create(std::move(decimal_column), std::move(null_column));
     col->reserve(4096);
     size_t counter = 0;
     for (auto& tc : test_cases) {
@@ -1471,7 +1471,7 @@ PARALLEL_TEST(ArrowConverterTest, test_convert_nullable_list_array) {
     ASSERT_STATUS_OK(st);
     ASSERT_FALSE(need_cast);
 
-    auto column = ColumnHelper::create_column(array_type, true);
+    ColumnPtr column = ColumnHelper::create_column(array_type, true);
     column->reserve(4096);
     ssize_t counter = 0;
     int num = 100;
@@ -1522,7 +1522,7 @@ PARALLEL_TEST(ArrowConverterTest, test_convert_nullable_map) {
     map_type.children.emplace_back(TYPE_VARCHAR);
     map_type.children.emplace_back(TYPE_INT);
 
-    auto map_column = ColumnHelper::create_column(map_type, true);
+    ColumnPtr map_column = ColumnHelper::create_column(map_type, true);
     map_column->reserve(4096);
     size_t counter = 0;
     std::map<std::string, int> map_value = {
@@ -1555,7 +1555,7 @@ PARALLEL_TEST(ArrowConverterTest, test_convert_struct) {
     struct_type.field_names.emplace_back("col2");
     struct_type.field_names.emplace_back("col3");
 
-    auto st_col = ColumnHelper::create_column(struct_type, true);
+    ColumnPtr st_col = ColumnHelper::create_column(struct_type, true);
 
     auto array = create_struct_array(10, false);
 
@@ -1585,7 +1585,7 @@ PARALLEL_TEST(ArrowConverterTest, test_convert_struct_null) {
     struct_type.field_names.emplace_back("col2");
     struct_type.field_names.emplace_back("col3");
 
-    auto st_col = ColumnHelper::create_column(struct_type, true);
+    ColumnPtr st_col = ColumnHelper::create_column(struct_type, true);
 
     auto array = create_struct_array(10, true);
     ConvertFuncTree cf;
@@ -1632,7 +1632,7 @@ PARALLEL_TEST(ArrowConverterTest, test_convert_struct_less_column) {
     ASSERT_STATUS_OK(st);
     ASSERT_FALSE(need_cast);
 
-    auto st_col = ColumnHelper::create_column(struct_type, true);
+    ColumnPtr st_col = ColumnHelper::create_column(struct_type, true);
 
     Filter filter;
     filter.resize(array->length(), 1);
@@ -1652,7 +1652,7 @@ PARALLEL_TEST(ArrowConverterTest, test_convert_struct_more_column) {
     struct_type.field_names.emplace_back("col1");
     struct_type.field_names.emplace_back("col2");
 
-    auto st_col = ColumnHelper::create_column(struct_type, true);
+    ColumnPtr st_col = ColumnHelper::create_column(struct_type, true);
 
     auto array = create_struct_array(10, false);
     ConvertFuncTree cf;

--- a/be/test/exec/es/es_scroll_parser_test.cpp
+++ b/be/test/exec/es/es_scroll_parser_test.cpp
@@ -87,7 +87,7 @@ TEST_F(ScrollParserTest, ArrayTest) {
 
     auto get_parsed_column = [&scroll_parser](const rapidjson::Document& document, const TypeDescriptor& t,
                                               bool pure_doc_value) {
-        ColumnPtr column = ColumnHelper::create_column(t, true);
+        MutableColumnPtr column = ColumnHelper::create_column(t, true);
         if (pure_doc_value) {
             const rapidjson::Value& val = document["fields"]["array"];
             EXPECT_TRUE(scroll_parser->_append_value_from_json_val(column.get(), t, val, pure_doc_value).ok());
@@ -108,7 +108,7 @@ TEST_F(ScrollParserTest, ArrayTest) {
         //     }
         // }
 
-        auto validator = [](const ColumnPtr& col) {
+        auto validator = [](const MutableColumnPtr& col) {
             auto arr = col->get(0).get_array();
             EXPECT_EQ(1, arr.size());
             EXPECT_EQ(1, arr[0].get_int8());
@@ -134,7 +134,7 @@ TEST_F(ScrollParserTest, ArrayTest) {
         //     }
         // }
 
-        auto validator = [](const ColumnPtr& col) {
+        auto validator = [](const MutableColumnPtr& col) {
             auto arr = col->get(0).get_array();
             EXPECT_EQ(3, arr.size());
             EXPECT_EQ(1, arr[0].get_int8());
@@ -162,7 +162,7 @@ TEST_F(ScrollParserTest, ArrayTest) {
         //     }
         // }
 
-        auto validator = [](const ColumnPtr& col) {
+        auto validator = [](const MutableColumnPtr& col) {
             auto arr = col->get(0).get_array();
             EXPECT_EQ(3, arr.size());
             EXPECT_EQ(1, arr[0].get_int8());
@@ -190,7 +190,7 @@ TEST_F(ScrollParserTest, ArrayTest) {
         //     }
         // }
 
-        auto validator = [](const ColumnPtr& col) {
+        auto validator = [](const MutableColumnPtr& col) {
             auto arr = col->get(0).get_array();
             EXPECT_EQ(2, arr.size());
             EXPECT_EQ(1, arr[0].get_int8());
@@ -217,7 +217,7 @@ TEST_F(ScrollParserTest, ArrayTest) {
         //     }
         // }
 
-        auto validator = [](const ColumnPtr& col) {
+        auto validator = [](const MutableColumnPtr& col) {
             auto arr = col->get(0).get_array();
             EXPECT_EQ(0, arr.size());
         };

--- a/be/test/exec/hdfs_scan_node_test.cpp
+++ b/be/test/exec/hdfs_scan_node_test.cpp
@@ -73,10 +73,10 @@ ChunkPtr HdfsScanNodeTest::_create_chunk() {
     auto col2 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), true);
     auto col3 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR), true);
     auto col4 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_DATETIME), true);
-    chunk->append_column(col1, 0);
-    chunk->append_column(col2, 1);
-    chunk->append_column(col3, 2);
-    chunk->append_column(col4, 3);
+    chunk->append_column(std::move(col1), 0);
+    chunk->append_column(std::move(col2), 1);
+    chunk->append_column(std::move(col3), 2);
+    chunk->append_column(std::move(col4), 3);
 
     return chunk;
 }

--- a/be/test/exec/query_cache/query_cache_test.cpp
+++ b/be/test/exec/query_cache/query_cache_test.cpp
@@ -107,7 +107,7 @@ TEST_F(QueryCacheTest, testCacheManager) {
         auto col = Int8Column::create();
         auto payload = byte_size - sizeof(query_cache::CacheValue);
         col->resize(payload);
-        chk->append_column(col, 0);
+        chk->append_column(std::move(col), 0);
         query_cache::CacheValue value(0, 0, {chk});
         return value;
     };
@@ -177,7 +177,7 @@ ChunkPtr create_test_chunk(query_cache::LaneOwnerType owner, long from, long to,
     for (auto i = from; i < to; ++i) {
         data[i - from] = double(i);
     }
-    chunk->append_column(column, SlotId(1));
+    chunk->append_column(std::move(column), SlotId(1));
     return chunk;
 }
 struct Task {

--- a/be/test/exec/query_cache/transform_operator.cpp
+++ b/be/test/exec/query_cache/transform_operator.cpp
@@ -70,7 +70,7 @@ Status MapOperator::push_chunk(starrocks::RuntimeState* state, const ChunkPtr& c
         new_data[i] = _map_func(data[i]);
     }
     auto new_chunk = std::make_shared<Chunk>();
-    new_chunk->append_column(new_column, SlotId(1));
+    new_chunk->append_column(std::move(new_column), SlotId(1));
     _cur_chunk = std::move(new_chunk);
     return Status::OK();
 }
@@ -193,7 +193,7 @@ StatusOr<ChunkPtr> ReduceSourceOperator::pull_chunk(starrocks::RuntimeState* sta
     auto& data = dynamic_cast<DoubleColumn*>(column.get())->get_data();
     data.assign(num_rows, _reducer->result());
     auto chunk = std::make_shared<Chunk>();
-    chunk->append_column(column, SlotId(1));
+    chunk->append_column(std::move(column), SlotId(1));
     if (_current_output_num_rows == _reducer->output_num_rows()) {
         _reducer->set_source_finished();
     }

--- a/be/test/exec/repeat_node_test.cpp
+++ b/be/test/exec/repeat_node_test.cpp
@@ -53,8 +53,8 @@ public:
             second_column->append(22);
 
             auto result_chunk = std::make_shared<Chunk>();
-            result_chunk->append_column(first_column, 0);
-            result_chunk->append_column(second_column, 1);
+            result_chunk->append_column(std::move(first_column), 0);
+            result_chunk->append_column(std::move(second_column), 1);
 
             *chunk = std::move(result_chunk);
         } else {

--- a/be/test/exec/sink/sink_io_buffer_test.cpp
+++ b/be/test/exec/sink/sink_io_buffer_test.cpp
@@ -87,7 +87,7 @@ ChunkPtr SinkIOBufferTest::gen_test_chunk(int value) {
     auto col = Int32Column::create();
     col->resize(value);
     auto chunk = std::make_shared<Chunk>();
-    chunk->append_column(col, 1);
+    chunk->append_column(std::move(col), 1);
     return chunk;
 }
 

--- a/be/test/exec/stream/stream_operators_test.cpp
+++ b/be/test/exec/stream/stream_operators_test.cpp
@@ -55,7 +55,7 @@ StatusOr<ChunkPtr> GeneratorStreamSourceOperator::pull_chunk(starrocks::RuntimeS
             VLOG_ROW << "Append col:" << idx << ", row:" << _param.start;
             column->append(_param.start % _param.ndv_count);
         }
-        chunk->append_column(column, SlotId(idx));
+        chunk->append_column(std::move(column), SlotId(idx));
     }
 
     // ops

--- a/be/test/exec/stream/stream_test.h
+++ b/be/test/exec/stream/stream_test.h
@@ -108,7 +108,7 @@ protected:
             auto col = ColumnTestHelper::build_column<T>(cols[i]);
             chunk_ptr->append_column(std::move(col), i);
         }
-        Int8ColumnPtr ops_col = Int8Column::create();
+        Int8Column::MutablePtr ops_col = Int8Column::create();
         ops_col->append_numbers(ops.data(), ops.size() * sizeof(int8_t));
         return StreamChunkConverter::make_stream_chunk(std::move(chunk_ptr), std::move(ops_col));
     }

--- a/be/test/exprs/agg/aggregate_test.cpp
+++ b/be/test/exprs/agg/aggregate_test.cpp
@@ -226,7 +226,8 @@ void test_agg_function(FunctionContext* ctx, const AggregateFunction* func, TRes
     int64_t mem_usage = 0;
     ctx->set_mem_usage_counter(&mem_usage);
     using ResultColumn = typename ColumnTraits<TResult>::ColumnType;
-    auto result_column = ResultColumn::create();
+    using ResultColumnPtr = typename ColumnTraits<TResult>::ColumnType::Ptr;
+    ResultColumnPtr result_column = ResultColumn::create();
 
     // update input column 1
     auto aggr_state = ManagedAggrState::create(ctx, func);
@@ -263,8 +264,9 @@ template <LogicalType LT, typename TResult = RunTimeCppType<TYPE_DECIMAL128>, ty
 void test_decimal_agg_function(FunctionContext* ctx, const AggregateFunction* func, TResult update_result1,
                                TResult update_result2, TResult merge_result) {
     using ResultColumn = RunTimeColumnType<TYPE_DECIMAL128>;
+    using ResultColumnPtr = typename RunTimeColumnType<TYPE_DECIMAL128>::Ptr;
     const auto& result_type = ctx->get_return_type();
-    auto result_column = ResultColumn::create(result_type.precision, result_type.scale);
+    ResultColumnPtr result_column = ResultColumn::create(result_type.precision, result_type.scale);
 
     // update input column 1
     auto aggr_state = ManagedAggrState::create(ctx, func);
@@ -299,7 +301,8 @@ template <typename T, typename TResult>
 void test_agg_variance_function(FunctionContext* ctx, const AggregateFunction* func, TResult update_result1,
                                 TResult update_result2, TResult merge_result) {
     using ResultColumn = typename ColumnTraits<TResult>::ColumnType;
-    auto result_column = ResultColumn::create();
+    using ResultColumnPtr = typename ColumnTraits<TResult>::ColumnType::Ptr;
+    ResultColumnPtr result_column = ResultColumn::create();
 
     auto state = ManagedAggrState::create(ctx, func);
     // update input column 1
@@ -679,13 +682,13 @@ TEST_F(AggregateTest, test_stddev_samp) {
 
 void test_max_by_helper(FunctionContext* ctx, const char* max_by_name) {
     const AggregateFunction* func = get_aggregate_function(max_by_name, TYPE_VARCHAR, TYPE_INT, false);
-    auto result_column = Int32Column::create();
+    Int32Column::Ptr result_column = Int32Column::create();
     auto aggr_state = ManagedAggrState::create(ctx, func);
-    auto int_column = Int32Column::create();
+    Int32Column::Ptr int_column = Int32Column::create();
     for (int i = 0; i < 10; i++) {
         int_column->append(i);
     }
-    auto varchar_column = BinaryColumn::create();
+    BinaryColumn::Ptr varchar_column = BinaryColumn::create();
     std::vector<Slice> strings{{"aaa"}, {"ddd"}, {"zzzz"}, {"ff"}, {"ff"}, {"ddd"}, {"ddd"}, {"ddd"}, {"ddd"}, {""}};
     varchar_column->append_strings(strings.data(), strings.size());
     Columns columns;
@@ -703,23 +706,24 @@ void test_max_by_helper(FunctionContext* ctx, const char* max_by_name) {
     //test nullable column
     func = get_aggregate_function(max_by_name, TYPE_DECIMALV2, TYPE_DOUBLE, false);
     aggr_state = ManagedAggrState::create(ctx, func);
-    auto data_column1 = DoubleColumn::create();
-    auto null_column1 = NullColumn::create();
+    DoubleColumn::Ptr data_column1 = DoubleColumn::create();
+    NullColumn::Ptr null_column1 = NullColumn::create();
     for (int i = 0; i < 100; i++) {
         data_column1->append(i + 0.11);
         null_column1->append(i % 13 ? false : true);
     }
-    auto doubleColumn = NullableColumn::create(std::move(data_column1), std::move(null_column1));
-    auto data_column2 = DecimalColumn::create();
-    auto null_column2 = NullColumn::create();
+    NullableColumn::Ptr doubleColumn = NullableColumn::create(std::move(data_column1), std::move(null_column1));
+    DecimalColumn::Ptr data_column2 = DecimalColumn::create();
+    NullColumn::Ptr null_column2 = NullColumn::create();
     for (int i = 0; i < 100; i++) {
         data_column2->append(DecimalV2Value(i));
         null_column2->append(i % 11 ? false : true);
     }
-    auto decimalColumn = NullableColumn::create(std::move(data_column2), std::move(null_column2));
-    auto data_column3 = DoubleColumn::create();
-    auto null_column3 = NullColumn::create();
-    auto nullable_result_column = NullableColumn::create(std::move(data_column3), std::move(null_column3));
+    NullableColumn::Ptr decimalColumn = NullableColumn::create(std::move(data_column2), std::move(null_column2));
+    DoubleColumn::Ptr data_column3 = DoubleColumn::create();
+    NullColumn::Ptr null_column3 = NullColumn::create();
+    NullableColumn::Ptr nullable_result_column =
+            NullableColumn::create(std::move(data_column3), std::move(null_column3));
     Columns nullColumns;
     nullColumns.emplace_back(doubleColumn);
     nullColumns.emplace_back(decimalColumn);
@@ -743,13 +747,13 @@ TEST_F(AggregateTest, test_max_by_v2) {
 
 void test_min_by_helper(FunctionContext* ctx, const char* min_by_name) {
     const AggregateFunction* func = get_aggregate_function(min_by_name, TYPE_VARCHAR, TYPE_INT, false);
-    auto result_column = Int32Column::create();
+    Int32Column::Ptr result_column = Int32Column::create();
     auto aggr_state = ManagedAggrState::create(ctx, func);
-    auto int_column = Int32Column::create();
+    Int32Column::Ptr int_column = Int32Column::create();
     for (int i = 0; i < 10; i++) {
         int_column->append(i);
     }
-    auto varchar_column = BinaryColumn::create();
+    BinaryColumn::Ptr varchar_column = BinaryColumn::create();
     std::vector<Slice> strings{{"ccc"}, {"aaa"}, {"ddd"}, {"zzzz"}, {"ff"}, {"ff"}, {"ddd"}, {"ddd"}, {"ddd"}, {"ddd"}};
     varchar_column->append_strings(strings.data(), strings.size());
     Columns columns;
@@ -767,23 +771,24 @@ void test_min_by_helper(FunctionContext* ctx, const char* min_by_name) {
     //test nullable column
     func = get_aggregate_function(min_by_name, TYPE_DECIMALV2, TYPE_DOUBLE, false);
     aggr_state = ManagedAggrState::create(ctx, func);
-    auto data_column1 = DoubleColumn::create();
-    auto null_column1 = NullColumn::create();
+    DoubleColumn::Ptr data_column1 = DoubleColumn::create();
+    NullColumn::Ptr null_column1 = NullColumn::create();
     for (int i = 0; i < 100; i++) {
         data_column1->append(i + 0.11);
         null_column1->append(i % 13 ? false : true);
     }
-    auto doubleColumn = NullableColumn::create(std::move(data_column1), std::move(null_column1));
-    auto data_column2 = DecimalColumn::create();
-    auto null_column2 = NullColumn::create();
+    NullableColumn::Ptr doubleColumn = NullableColumn::create(std::move(data_column1), std::move(null_column1));
+    DecimalColumn::Ptr data_column2 = DecimalColumn::create();
+    NullColumn::Ptr null_column2 = NullColumn::create();
     for (int i = 0; i < 100; i++) {
         data_column2->append(DecimalV2Value(i));
         null_column2->append(i % 11 ? false : true);
     }
-    auto decimalColumn = NullableColumn::create(std::move(data_column2), std::move(null_column2));
-    auto data_column3 = DoubleColumn::create();
-    auto null_column3 = NullColumn::create();
-    auto nullable_result_column = NullableColumn::create(std::move(data_column3), std::move(null_column3));
+    NullableColumn::Ptr decimalColumn = NullableColumn::create(std::move(data_column2), std::move(null_column2));
+    DoubleColumn::Ptr data_column3 = DoubleColumn::create();
+    NullColumn::Ptr null_column3 = NullColumn::create();
+    NullableColumn::Ptr nullable_result_column =
+            NullableColumn::create(std::move(data_column3), std::move(null_column3));
     Columns nullColumns;
     nullColumns.emplace_back(doubleColumn);
     nullColumns.emplace_back(decimalColumn);
@@ -811,13 +816,13 @@ void test_max_by_with_nullable_aggregator_helper(FunctionContext* ctx, const cha
             {UTRawType{.type = TYPE_INT}, UTRawType{.type = TYPE_VARCHAR}}, UTRawType{.type = TYPE_INT});
     std::unique_ptr<FunctionContext> gc_ctx0(ctx_with_args0);
 
-    auto result_column = Int32Column::create();
+    Int32Column::Ptr result_column = Int32Column::create();
     auto aggr_state = ManagedAggrState::create(ctx_with_args0, func);
-    auto int_column = Int32Column::create();
+    Int32Column::Ptr int_column = Int32Column::create();
     for (int i = 0; i < 10; i++) {
         int_column->append(i);
     }
-    auto varchar_column = BinaryColumn::create();
+    BinaryColumn::Ptr varchar_column = BinaryColumn::create();
     std::vector<Slice> strings{{"aaa"}, {"ddd"}, {"zzzz"}, {"ff"}, {"ff"}, {"ddd"}, {"ddd"}, {"ddd"}, {"ddd"}, {""}};
     varchar_column->append_strings(strings.data(), strings.size());
     Columns columns;
@@ -840,23 +845,24 @@ void test_max_by_with_nullable_aggregator_helper(FunctionContext* ctx, const cha
     std::unique_ptr<FunctionContext> gc_ctx1(ctx_with_args1);
 
     aggr_state = ManagedAggrState::create(ctx_with_args1, func);
-    auto data_column1 = DoubleColumn::create();
-    auto null_column1 = NullColumn::create();
+    DoubleColumn::Ptr data_column1 = DoubleColumn::create();
+    NullColumn::Ptr null_column1 = NullColumn::create();
     for (int i = 0; i < 100; i++) {
         data_column1->append(i + 0.11);
         null_column1->append(i % 13 ? false : true);
     }
-    auto doubleColumn = NullableColumn::create(std::move(data_column1), std::move(null_column1));
-    auto data_column2 = DecimalColumn::create();
-    auto null_column2 = NullColumn::create();
+    NullableColumn::Ptr doubleColumn = NullableColumn::create(std::move(data_column1), std::move(null_column1));
+    DecimalColumn::Ptr data_column2 = DecimalColumn::create();
+    NullColumn::Ptr null_column2 = NullColumn::create();
     for (int i = 0; i < 100; i++) {
         data_column2->append(DecimalV2Value(i));
         null_column2->append(i % 11 ? false : true);
     }
-    auto decimalColumn = NullableColumn::create(std::move(data_column2), std::move(null_column2));
-    auto data_column3 = DoubleColumn::create();
-    auto null_column3 = NullColumn::create();
-    auto nullable_result_column = NullableColumn::create(std::move(data_column3), std::move(null_column3));
+    NullableColumn::Ptr decimalColumn = NullableColumn::create(std::move(data_column2), std::move(null_column2));
+    DoubleColumn::Ptr data_column3 = DoubleColumn::create();
+    NullColumn::Ptr null_column3 = NullColumn::create();
+    NullableColumn::Ptr nullable_result_column =
+            NullableColumn::create(std::move(data_column3), std::move(null_column3));
     Columns nullColumns;
     nullColumns.emplace_back(doubleColumn);
     nullColumns.emplace_back(decimalColumn);
@@ -882,13 +888,13 @@ void test_min_by_with_nullable_aggregator_helper(FunctionContext* ctx, const cha
             {UTRawType{.type = TYPE_INT}, UTRawType{.type = TYPE_VARCHAR}}, UTRawType{.type = TYPE_INT});
     std::unique_ptr<FunctionContext> gc_ctx0(ctx_with_args0);
 
-    auto result_column = Int32Column::create();
+    Int32Column::Ptr result_column = Int32Column::create();
     auto aggr_state = ManagedAggrState::create(ctx_with_args0, func);
-    auto int_column = Int32Column::create();
+    Int32Column::Ptr int_column = Int32Column::create();
     for (int i = 0; i < 10; i++) {
         int_column->append(i);
     }
-    auto varchar_column = BinaryColumn::create();
+    BinaryColumn::Ptr varchar_column = BinaryColumn::create();
     std::vector<Slice> strings{{"xxx"}, {"aaa"}, {"ddd"}, {"zzzz"}, {"ff"}, {"ff"}, {"ddd"}, {"ddd"}, {"ddd"}, {"ddd"}};
     varchar_column->append_strings(strings.data(), strings.size());
     Columns columns;
@@ -911,23 +917,24 @@ void test_min_by_with_nullable_aggregator_helper(FunctionContext* ctx, const cha
     std::unique_ptr<FunctionContext> gc_ctx1(ctx_with_args1);
 
     aggr_state = ManagedAggrState::create(ctx_with_args1, func);
-    auto data_column1 = DoubleColumn::create();
-    auto null_column1 = NullColumn::create();
+    DoubleColumn::Ptr data_column1 = DoubleColumn::create();
+    NullColumn::Ptr null_column1 = NullColumn::create();
     for (int i = 0; i < 100; i++) {
         data_column1->append(i + 0.11);
         null_column1->append(i % 13 ? false : true);
     }
-    auto doubleColumn = NullableColumn::create(std::move(data_column1), std::move(null_column1));
-    auto data_column2 = DecimalColumn::create();
-    auto null_column2 = NullColumn::create();
+    NullableColumn::Ptr doubleColumn = NullableColumn::create(std::move(data_column1), std::move(null_column1));
+    DecimalColumn::Ptr data_column2 = DecimalColumn::create();
+    NullColumn::Ptr null_column2 = NullColumn::create();
     for (int i = 0; i < 100; i++) {
         data_column2->append(DecimalV2Value(i));
         null_column2->append(i % 11 ? false : true);
     }
-    auto decimalColumn = NullableColumn::create(std::move(data_column2), std::move(null_column2));
-    auto data_column3 = DoubleColumn::create();
-    auto null_column3 = NullColumn::create();
-    auto nullable_result_column = NullableColumn::create(std::move(data_column3), std::move(null_column3));
+    NullableColumn::Ptr decimalColumn = NullableColumn::create(std::move(data_column2), std::move(null_column2));
+    DoubleColumn::Ptr data_column3 = DoubleColumn::create();
+    NullColumn::Ptr null_column3 = NullColumn::create();
+    NullableColumn::Ptr nullable_result_column =
+            NullableColumn::create(std::move(data_column3), std::move(null_column3));
     Columns nullColumns;
     nullColumns.emplace_back(doubleColumn);
     nullColumns.emplace_back(decimalColumn);
@@ -1140,19 +1147,19 @@ TEST_F(AggregateTest, test_window_funnel) {
     builder.append(true);
     builder.append(true);
     builder.append(true);
-    auto data_col = NullableColumn::create(builder.build(false), NullColumn::create(6, 0));
+    NullableColumn::Ptr data_col = NullableColumn::create(builder.build(false), NullColumn::create(6, 0));
 
-    auto offsets = UInt32Column::create();
-    offsets->append(2);                                    // [true, true]
-    offsets->append(4);                                    // [true, true]
-    offsets->append(6);                                    // [true, true]
-    auto column4 = ArrayColumn::create(data_col, offsets); // array_column, 4th column
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    offsets->append(2);                                                // [true, true]
+    offsets->append(4);                                                // [true, true]
+    offsets->append(6);                                                // [true, true]
+    ArrayColumn::Ptr column4 = ArrayColumn::create(data_col, offsets); // array_column, 4th column
 
-    auto column1 = Int64Column::create(); // first column, but there use const.
+    Int64Column::Ptr column1 = Int64Column::create(); // first column, but there use const.
     column1->append(1800);
     // column1->append(1800);
 
-    auto column2 = TimestampColumn::create();
+    TimestampColumn::Ptr column2 = TimestampColumn::create();
     column2->append(TimestampValue::create(2022, 6, 10, 12, 30, 30)); // 2nd column.
 
     auto const_column1 = ColumnHelper::create_const_column<TYPE_BIGINT>(1800, 1);
@@ -1171,7 +1178,8 @@ TEST_F(AggregateTest, test_window_funnel) {
     raw_column[3] = column4.get();
 
     using ResultColumn = typename ColumnTraits<int32_t>::ColumnType;
-    auto result_column = ResultColumn::create();
+    using ResultColumnPtr = typename ResultColumn::Ptr;
+    ResultColumnPtr result_column = ResultColumn::create();
     auto state = ManagedAggrState::create(ctx, func);
     func->update(local_ctx.get(), raw_column.data(), state->state(), 0);
     func->finalize_to_column(local_ctx.get(), state->state(), result_column.get());
@@ -1188,9 +1196,9 @@ TEST_F(AggregateTest, test_dict_merge) {
     builder.append(Slice("starrocks-1"));
     builder.append(Slice("starrocks-starrocks"));
     builder.append(Slice("starrocks-starrocks"));
-    auto data_col = NullableColumn::create(builder.build(false), NullColumn::create(5, 0));
+    NullableColumn::Ptr data_col = NullableColumn::create(builder.build(false), NullColumn::create(5, 0));
 
-    auto offsets = UInt32Column::create();
+    UInt32Column::Ptr offsets = UInt32Column::create();
     offsets->append(0);
     offsets->append(0);
     offsets->append(2);
@@ -1198,12 +1206,12 @@ TEST_F(AggregateTest, test_dict_merge) {
     // []
     // [key1, key2]
     // [sr-1, sr-2, sr-3]
-    auto col = ArrayColumn::create(data_col, offsets);
+    ArrayColumn::Ptr col = ArrayColumn::create(data_col, offsets);
     const Column* column = col.get();
     auto state = ManagedAggrState::create(ctx, func);
     func->update_batch_single_state(ctx, col->size(), &column, state->state());
 
-    auto res = BinaryColumn::create();
+    BinaryColumn::Ptr res = BinaryColumn::create();
     func->finalize_to_column(ctx, state->state(), res.get());
 
     ASSERT_EQ(res->size(), 1);
@@ -1244,14 +1252,14 @@ TEST_F(AggregateTest, test_sum_nullable) {
     const AggregateFunction* sum_null = get_aggregate_function("sum", TYPE_INT, TYPE_BIGINT, true);
     auto state = ManagedAggrState::create(ctx, sum_null);
 
-    auto data_column = Int32Column::create();
-    auto null_column = NullColumn::create();
+    Int32Column::Ptr data_column = Int32Column::create();
+    NullColumn::Ptr null_column = NullColumn::create();
     for (int i = 0; i < 100; i++) {
         data_column->append(i);
         null_column->append(i % 2 ? 1 : 0);
     }
 
-    auto column = NullableColumn::create(std::move(data_column), std::move(null_column));
+    NullableColumn::Ptr column = NullableColumn::create(std::move(data_column), std::move(null_column));
     const Column* row_column = column.get();
 
     // test update
@@ -1261,26 +1269,26 @@ TEST_F(AggregateTest, test_sum_nullable) {
     ASSERT_EQ(2450, result);
 
     // test serialize
-    auto serde_column2 = NullableColumn::create(Int64Column::create(), NullColumn::create());
+    NullableColumn::Ptr serde_column2 = NullableColumn::create(Int64Column::create(), NullColumn::create());
     sum_null->serialize_to_column(ctx, state->state(), serde_column2.get());
 
     // test merge
     auto state2 = ManagedAggrState::create(ctx, sum_null);
 
-    auto data_column2 = Int32Column::create();
-    auto null_column2 = NullColumn::create();
+    Int32Column::Ptr data_column2 = Int32Column::create();
+    NullColumn::Ptr null_column2 = NullColumn::create();
     for (int i = 0; i < 100; i++) {
         data_column2->append(i);
         null_column2->append(i % 2 ? 0 : 1);
     }
-    auto column2 = NullableColumn::create(std::move(data_column2), std::move(null_column2));
+    NullableColumn::Ptr column2 = NullableColumn::create(std::move(data_column2), std::move(null_column2));
     const Column* row_column2 = column2.get();
 
     sum_null->update_batch_single_state(ctx, column2->size(), &row_column2, state2->state());
 
     sum_null->merge(ctx, serde_column2.get(), state2->state(), 0);
 
-    auto result_column = NullableColumn::create(Int64Column::create(), NullColumn::create());
+    NullableColumn::Ptr result_column = NullableColumn::create(Int64Column::create(), NullColumn::create());
     sum_null->finalize_to_column(ctx, state2->state(), result_column.get());
 
     const Column& result_data_column = result_column->data_column_ref();
@@ -1292,15 +1300,15 @@ TEST_F(AggregateTest, test_count_nullable) {
     const AggregateFunction* func = get_aggregate_function("count", TYPE_BIGINT, TYPE_BIGINT, true);
     auto state = ManagedAggrState::create(ctx, func);
 
-    auto data_column = Int32Column::create();
-    auto null_column = NullColumn::create();
+    Int32Column::Ptr data_column = Int32Column::create();
+    NullColumn::Ptr null_column = NullColumn::create();
 
     for (int i = 0; i < 1024; i++) {
         data_column->append(i);
         null_column->append(i % 2 ? 1 : 0);
     }
 
-    auto column = NullableColumn::create(std::move(data_column), std::move(null_column));
+    NullableColumn::Ptr column = NullableColumn::create(std::move(data_column), std::move(null_column));
 
     const Column* row_column = column.get();
     func->update_batch_single_state(ctx, column->size(), &row_column, state->state());
@@ -1313,21 +1321,21 @@ TEST_F(AggregateTest, test_bitmap_nullable) {
     const AggregateFunction* bitmap_null = get_aggregate_function("bitmap_union_int", TYPE_INT, TYPE_BIGINT, true);
     auto state = ManagedAggrState::create(ctx, bitmap_null);
 
-    auto data_column = Int32Column::create();
-    auto null_column = NullColumn::create();
+    Int32Column::Ptr data_column = Int32Column::create();
+    NullColumn::Ptr null_column = NullColumn::create();
 
     for (int i = 0; i < 100; i++) {
         data_column->append(i);
         null_column->append(i % 2 ? 1 : 0);
     }
 
-    auto column = NullableColumn::create(std::move(data_column), std::move(null_column));
+    NullableColumn::Ptr column = NullableColumn::create(std::move(data_column), std::move(null_column));
     const Column* row_column = column.get();
 
     // test update
     bitmap_null->update_batch_single_state(ctx, column->size(), &row_column, state->state());
 
-    auto result_column = NullableColumn::create(Int64Column::create(), NullColumn::create());
+    NullableColumn::Ptr result_column = NullableColumn::create(Int64Column::create(), NullColumn::create());
     bitmap_null->finalize_to_column(ctx, state->state(), result_column.get());
 
     const Column& result_data_column = result_column->data_column_ref();
@@ -1341,7 +1349,7 @@ TEST_F(AggregateTest, test_group_concat) {
             get_aggregate_function("group_concat", TYPE_VARCHAR, TYPE_VARCHAR, false);
     auto state = ManagedAggrState::create(ctx, group_concat_function);
 
-    auto data_column = BinaryColumn::create();
+    BinaryColumn::Ptr data_column = BinaryColumn::create();
 
     for (int i = 0; i < 6; i++) {
         std::string val("starrocks");
@@ -1354,7 +1362,7 @@ TEST_F(AggregateTest, test_group_concat) {
     // test update
     group_concat_function->update_batch_single_state(ctx, data_column->size(), &row_column, state->state());
 
-    auto result_column = BinaryColumn::create();
+    BinaryColumn::Ptr result_column = BinaryColumn::create();
     group_concat_function->finalize_to_column(ctx, state->state(), result_column.get());
 
     ASSERT_EQ("starrocks0, starrocks1, starrocks2, starrocks3, starrocks4, starrocks5", result_column->get_data()[0]);
@@ -1371,7 +1379,7 @@ TEST_F(AggregateTest, test_group_concat_const_seperator) {
             get_aggregate_function("group_concat", TYPE_VARCHAR, TYPE_VARCHAR, false);
     auto state = ManagedAggrState::create(ctx, group_concat_function);
 
-    auto data_column = BinaryColumn::create();
+    BinaryColumn::Ptr data_column = BinaryColumn::create();
 
     data_column->append("abc");
     data_column->append("bcd");
@@ -1399,7 +1407,7 @@ TEST_F(AggregateTest, test_group_concat_const_seperator) {
     group_concat_function->update_batch_single_state(local_ctx.get(), data_column->size(), raw_columns.data(),
                                                      state->state());
 
-    auto result_column = BinaryColumn::create();
+    BinaryColumn::Ptr result_column = BinaryColumn::create();
     group_concat_function->finalize_to_column(local_ctx.get(), state->state(), result_column.get());
 
     ASSERT_EQ("abcbcdcdedefefgfghghihijijk", result_column->get_data()[0]);
@@ -1413,12 +1421,12 @@ TEST_F(AggregateTest, test_percentile_cont) {
 
     const AggregateFunction* func = get_aggregate_function("percentile_cont", TYPE_DOUBLE, TYPE_DOUBLE, false);
 
-    auto data_column1 = DoubleColumn::create();
+    DoubleColumn::Ptr data_column1 = DoubleColumn::create();
     data_column1->append(2.0);
     data_column1->append(3.0);
     data_column1->append(4.0);
 
-    auto data_column2 = DoubleColumn::create();
+    DoubleColumn::Ptr data_column2 = DoubleColumn::create();
     data_column2->append(5.0);
     data_column2->append(6.0);
 
@@ -1444,7 +1452,7 @@ TEST_F(AggregateTest, test_percentile_cont) {
     auto state3 = ManagedAggrState::create(ctx, func);
 
     // merge column 1 and column 2
-    auto result_column = DoubleColumn::create();
+    DoubleColumn::Ptr result_column = DoubleColumn::create();
     ColumnPtr serde_column1 = BinaryColumn::create();
     func->serialize_to_column(local_ctx.get(), state1->state(), serde_column1.get());
     ColumnPtr serde_column2 = BinaryColumn::create();
@@ -1467,12 +1475,12 @@ TEST_F(AggregateTest, test_percentile_cont_1) {
 
     const AggregateFunction* func = get_aggregate_function("percentile_cont", TYPE_DOUBLE, TYPE_DOUBLE, false);
 
-    auto data_column1 = DoubleColumn::create();
+    DoubleColumn::Ptr data_column1 = DoubleColumn::create();
     data_column1->append(2.0);
     data_column1->append(3.0);
     data_column1->append(4.0);
 
-    auto data_column2 = DoubleColumn::create();
+    DoubleColumn::Ptr data_column2 = DoubleColumn::create();
     data_column2->append(5.0);
     data_column2->append(6.0);
 
@@ -1498,7 +1506,7 @@ TEST_F(AggregateTest, test_percentile_cont_1) {
     auto state3 = ManagedAggrState::create(ctx, func);
 
     // merge column 1 and column 2
-    auto result_column = DoubleColumn::create();
+    DoubleColumn::Ptr result_column = DoubleColumn::create();
     ColumnPtr serde_column1 = BinaryColumn::create();
     func->serialize_to_column(local_ctx.get(), state1->state(), serde_column1.get());
     ColumnPtr serde_column2 = BinaryColumn::create();
@@ -1521,7 +1529,7 @@ TEST_F(AggregateTest, test_percentile_cont_2) {
 
     const AggregateFunction* func = get_aggregate_function("percentile_cont", TYPE_DOUBLE, TYPE_DOUBLE, false);
 
-    auto data_column1 = DoubleColumn::create();
+    DoubleColumn::Ptr data_column1 = DoubleColumn::create();
     data_column1->append(2.0);
     data_column1->append(3.0);
     data_column1->append(4.0);
@@ -1538,7 +1546,7 @@ TEST_F(AggregateTest, test_percentile_cont_2) {
     func->update_batch_single_state(local_ctx.get(), data_column1->size(), raw_columns1.data(), state1->state());
 
     // merge column 1 and column 2
-    auto result_column = DoubleColumn::create();
+    DoubleColumn::Ptr result_column = DoubleColumn::create();
     func->finalize_to_column(local_ctx.get(), state1->state(), result_column.get());
 
     // [2,3,4,5,6], rate = 0.25 -> 3
@@ -1556,7 +1564,7 @@ TEST_F(AggregateTest, test_percentile_disc) {
     // update input column 1
     auto state1 = ManagedAggrState::create(ctx, func);
 
-    auto data_column1 = DoubleColumn::create();
+    DoubleColumn::Ptr data_column1 = DoubleColumn::create();
     auto const_colunm1 = ColumnHelper::create_const_column<TYPE_DOUBLE>(0.1, 1);
     data_column1->append(3.0);
     data_column1->append(4.0);
@@ -1571,7 +1579,7 @@ TEST_F(AggregateTest, test_percentile_disc) {
     // update input column 2
     auto state2 = ManagedAggrState::create(ctx, func);
 
-    auto data_column2 = DoubleColumn::create();
+    DoubleColumn::Ptr data_column2 = DoubleColumn::create();
     auto const_colunm2 = ColumnHelper::create_const_column<TYPE_DOUBLE>(0.1, 1);
     data_column2->append(6.0);
 
@@ -1584,7 +1592,7 @@ TEST_F(AggregateTest, test_percentile_disc) {
 
     // merge column 1 and column 2
     ColumnPtr serde_column = BinaryColumn::create();
-    auto result_column = DoubleColumn::create();
+    DoubleColumn::Ptr result_column = DoubleColumn::create();
     func->serialize_to_column(local_ctx.get(), state1->state(), serde_column.get());
     func->merge(local_ctx.get(), serde_column.get(), state2->state(), 0);
     func->finalize_to_column(local_ctx.get(), state2->state(), result_column.get());
@@ -1598,8 +1606,8 @@ TEST_F(AggregateTest, test_intersect_count) {
             get_aggregate_function("intersect_count", TYPE_INT, TYPE_BIGINT, false);
     auto state = ManagedAggrState::create(ctx, group_concat_function);
 
-    auto data_column = BitmapColumn::create();
-    auto int_column = Int32Column::create();
+    BitmapColumn::Ptr data_column = BitmapColumn::create();
+    Int32Column::Ptr int_column = Int32Column::create();
     auto int_const1 = ColumnHelper::create_const_column<TYPE_INT>(1, 1);
     auto int_const2 = ColumnHelper::create_const_column<TYPE_INT>(2, 1);
 
@@ -1642,7 +1650,7 @@ TEST_F(AggregateTest, test_intersect_count) {
     // test update
     group_concat_function->update_batch_single_state(ctx, data_column->size(), raw_columns.data(), state->state());
 
-    auto result_column = Int64Column::create();
+    Int64Column::Ptr result_column = Int64Column::create();
     group_concat_function->finalize_to_column(ctx, state->state(), result_column.get());
 
     ASSERT_EQ(1, result_column->get_data()[0]);
@@ -1653,7 +1661,7 @@ TEST_F(AggregateTest, test_bitmap_intersect) {
             get_aggregate_function("bitmap_intersect", TYPE_OBJECT, TYPE_OBJECT, false);
     auto state = ManagedAggrState::create(ctx, group_concat_function);
 
-    auto data_column = BitmapColumn::create();
+    BitmapColumn::Ptr data_column = BitmapColumn::create();
 
     BitmapValue b1;
     b1.add(1);
@@ -1674,7 +1682,7 @@ TEST_F(AggregateTest, test_bitmap_intersect) {
     // test update
     group_concat_function->update_batch_single_state(ctx, data_column->size(), &row_column, state->state());
 
-    auto result_column = BitmapColumn::create();
+    BitmapColumn::Ptr result_column = BitmapColumn::create();
     group_concat_function->finalize_to_column(ctx, state->state(), result_column.get());
 
     ASSERT_EQ("1", result_column->get_pool()[0].to_string());
@@ -1730,7 +1738,7 @@ TEST_F(AggregateTest, test_histogram) {
     //     histogram_function->update(local_ctx.get(), raw_columns.data(), state->state(), i);
     // }
 
-    auto result_column = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+    NullableColumn::Ptr result_column = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
     histogram_function->finalize_to_column(local_ctx.get(), state->state(), result_column.get());
     ASSERT_EQ(
             "['[[\"0\",\"100\",\"102\",\"2\"],[\"101\",\"201\",\"204\",\"1\"],[\"202\",\"303\",\"306\",\"1\"],[\"304\","
@@ -1745,8 +1753,8 @@ TEST_F(AggregateTest, test_bitmap_intersect_nullable) {
             get_aggregate_function("bitmap_intersect", TYPE_OBJECT, TYPE_OBJECT, true);
     auto state = ManagedAggrState::create(ctx, group_concat_function);
 
-    auto data_column = BitmapColumn::create();
-    auto null_column = NullColumn::create();
+    BitmapColumn::Ptr data_column = BitmapColumn::create();
+    NullColumn::Ptr null_column = NullColumn::create();
 
     BitmapValue b1;
     b1.add(1);
@@ -1765,13 +1773,13 @@ TEST_F(AggregateTest, test_bitmap_intersect_nullable) {
     data_column->append(&b3);
     null_column->append(false);
 
-    auto column = NullableColumn::create(std::move(data_column), std::move(null_column));
+    NullableColumn::Ptr column = NullableColumn::create(std::move(data_column), std::move(null_column));
     const Column* row_column = column.get();
 
     // test update
     group_concat_function->update_batch_single_state(ctx, column->size(), &row_column, state->state());
 
-    auto result_column = NullableColumn::create(BitmapColumn::create(), NullColumn::create());
+    NullableColumn::Ptr result_column = NullableColumn::create(BitmapColumn::create(), NullColumn::create());
     group_concat_function->finalize_to_column(ctx, state->state(), result_column.get());
 
     const Column& result_data_column = result_column->data_column_ref();
@@ -1783,10 +1791,11 @@ TEST_F(AggregateTest, test_bitmap_intersect_nullable) {
 template <typename T, typename TResult>
 void test_non_deterministic_agg_function(FunctionContext* ctx, const AggregateFunction* func) {
     using ResultColumn = typename ColumnTraits<TResult>::ColumnType;
+    using ResultColumnPtr = typename ResultColumn::Ptr;
     using ExpeactedResultColumnType = typename ColumnTraits<T>::ColumnType;
     auto state = ManagedAggrState::create(ctx, func);
     // update input column 1
-    auto result_column1 = ResultColumn::create();
+    ResultColumnPtr result_column1 = ResultColumn::create();
     ColumnPtr column = gen_input_column1<T>();
     const Column* row_column = column.get();
     func->update_batch_single_state(ctx, row_column->size(), &row_column, state->state());
@@ -1796,7 +1805,7 @@ void test_non_deterministic_agg_function(FunctionContext* ctx, const AggregateFu
     ASSERT_EQ(expected_column1.get_data()[0], result_column1->get_data()[0]);
 
     // update input column 2
-    auto result_column2 = ResultColumn::create();
+    ResultColumnPtr result_column2 = ResultColumn::create();
     auto state2 = ManagedAggrState::create(ctx, func);
     ColumnPtr column2 = gen_input_column2<T>();
     row_column = column2.get();
@@ -1807,7 +1816,7 @@ void test_non_deterministic_agg_function(FunctionContext* ctx, const AggregateFu
     ASSERT_EQ(expected_column2.get_data()[0], result_column2->get_data()[0]);
 
     // merge column 1 and column 2
-    auto final_result_column = ResultColumn::create();
+    ResultColumnPtr final_result_column = ResultColumn::create();
     func->serialize_to_column(ctx, state->state(), final_result_column.get());
     func->merge(ctx, final_result_column.get(), state2->state(), 0);
     func->finalize_to_column(ctx, state2->state(), final_result_column.get());
@@ -1858,13 +1867,13 @@ TEST_F(AggregateTest, test_exchange_bytes) {
             get_aggregate_function("exchange_bytes", TYPE_BIGINT, TYPE_BIGINT, false);
     auto state = ManagedAggrState::create(ctx, exchange_bytes_function);
 
-    auto data_column = BinaryColumn::create();
+    BinaryColumn::Ptr data_column = BinaryColumn::create();
 
     data_column->append("abc");
     data_column->append("bcd");
     data_column->append("cde");
 
-    auto data_column_bigint = Int64Column::create();
+    Int64Column::Ptr data_column_bigint = Int64Column::create();
     data_column_bigint->append(21023);
     data_column_bigint->append(410223);
     data_column_bigint->append(710233);
@@ -1878,7 +1887,7 @@ TEST_F(AggregateTest, test_exchange_bytes) {
     exchange_bytes_function->update_batch_single_state(local_ctx.get(), data_column->size(), raw_columns.data(),
                                                        state->state());
 
-    auto result_column = Int64Column::create();
+    Int64Column::Ptr result_column = Int64Column::create();
     exchange_bytes_function->finalize_to_column(local_ctx.get(), state->state(), result_column.get());
 
     ASSERT_EQ(data_column_bigint->byte_size() + data_column->byte_size(), result_column->get_data()[0]);
@@ -1902,7 +1911,7 @@ TEST_F(AggregateTest, test_array_aggV2) {
     // nullable columns input
     {
         auto char_type = TypeDescriptor::create_varchar_type(30);
-        auto char_column = ColumnHelper::create_column(char_type, true);
+        ColumnPtr char_column = ColumnHelper::create_column(char_type, true);
         char_column->append_datum(Datum());
         char_column->append_datum("bcd");
         char_column->append_datum("cdrdfe");
@@ -1910,7 +1919,7 @@ TEST_F(AggregateTest, test_array_aggV2) {
         char_column->append_datum("esfg");
 
         auto int_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_INT);
-        auto int_column = ColumnHelper::create_column(int_type, true);
+        ColumnPtr int_column = ColumnHelper::create_column(int_type, true);
         int_column->append_datum(Datum());
         int_column->append_datum(9);
         int_column->append_datum(Datum());
@@ -1948,7 +1957,7 @@ TEST_F(AggregateTest, test_array_aggV2) {
         type_struct_char_int.children.emplace_back(type_array_int);
         type_struct_char_int.field_names.emplace_back("vchar");
         type_struct_char_int.field_names.emplace_back("int");
-        auto res_struct_col = ColumnHelper::create_column(type_struct_char_int, true);
+        ColumnPtr res_struct_col = ColumnHelper::create_column(type_struct_char_int, true);
         array_agg_func->serialize_to_column(local_ctx.get(), state->state(), res_struct_col.get());
         ASSERT_EQ(strcmp(res_struct_col->debug_string().c_str(),
                          "[{vchar:[NULL,'bcd','cdrdfe',NULL,'esfg'],int:[NULL,9,NULL,7,6]}]"),
@@ -1965,7 +1974,7 @@ TEST_F(AggregateTest, test_array_aggV2) {
                          "{vchar:[NULL],int:[7]}, {vchar:['esfg'],int:[6]}]"),
                   0);
 
-        auto res_array_col = ColumnHelper::create_column(type_array_char, false);
+        ColumnPtr res_array_col = ColumnHelper::create_column(type_array_char, false);
         array_agg_func->finalize_to_column(local_ctx.get(), state->state(), res_array_col.get());
         ASSERT_EQ(strcmp(res_array_col->debug_string().c_str(), "[[NULL,'cdrdfe','bcd',NULL,'esfg']]"), 0);
     }
@@ -1973,7 +1982,7 @@ TEST_F(AggregateTest, test_array_aggV2) {
     state = ManagedAggrState::create(local_ctx.get(), array_agg_func);
     {
         auto char_type = TypeDescriptor::create_varchar_type(30);
-        auto char_column = ColumnHelper::create_column(char_type, false);
+        ColumnPtr char_column = ColumnHelper::create_column(char_type, false);
         char_column->append_datum("");
         char_column->append_datum("bcd");
         char_column->append_datum("cdrdfe");
@@ -1981,7 +1990,7 @@ TEST_F(AggregateTest, test_array_aggV2) {
         char_column->append_datum("esfg");
 
         auto int_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_INT);
-        auto int_column = ColumnHelper::create_column(int_type, false);
+        ColumnPtr int_column = ColumnHelper::create_column(int_type, false);
         int_column->append_datum(2);
         int_column->append_datum(9);
         int_column->append_datum(5);
@@ -2019,7 +2028,7 @@ TEST_F(AggregateTest, test_array_aggV2) {
         type_struct_char_int.children.emplace_back(type_array_int);
         type_struct_char_int.field_names.emplace_back("vchar");
         type_struct_char_int.field_names.emplace_back("int");
-        auto res_struct_col = ColumnHelper::create_column(type_struct_char_int, true);
+        ColumnPtr res_struct_col = ColumnHelper::create_column(type_struct_char_int, true);
         array_agg_func->serialize_to_column(local_ctx.get(), state->state(), res_struct_col.get());
         ASSERT_EQ(strcmp(res_struct_col->debug_string().c_str(),
                          "[{vchar:['','bcd','cdrdfe','Datum()','esfg'],int:[2,9,5,7,6]}]"),
@@ -2040,7 +2049,7 @@ TEST_F(AggregateTest, test_array_aggV2) {
 
     // append only column + const column
     {
-        auto char_column = ColumnHelper::create_const_null_column(2);
+        ColumnPtr char_column = ColumnHelper::create_const_null_column(2);
         auto int_column = ColumnHelper::create_const_column<TYPE_INT>(3, 2);
 
         std::vector<const Column*> raw_columns;
@@ -2076,7 +2085,7 @@ TEST_F(AggregateTest, test_array_aggV2) {
         type_struct_char_int.children.emplace_back(type_array_int);
         type_struct_char_int.field_names.emplace_back("vchar");
         type_struct_char_int.field_names.emplace_back("int");
-        auto res_struct_col = ColumnHelper::create_column(type_struct_char_int, true);
+        ColumnPtr res_struct_col = ColumnHelper::create_column(type_struct_char_int, true);
         array_agg_func->serialize_to_column(local_ctx.get(), state->state(), res_struct_col.get());
         ASSERT_EQ(strcmp(res_struct_col->debug_string().c_str(),
                          "[{vchar:['','bcd','cdrdfe','Datum()','esfg',NULL,NULL],int:[2,9,5,7,6,3,3]}]"),
@@ -2091,7 +2100,7 @@ TEST_F(AggregateTest, test_array_aggV2) {
         ASSERT_EQ(strcmp(res_struct_col->debug_string().c_str(), "[{vchar:[NULL],int:[3]}, {vchar:[NULL],int:[3]}]"),
                   0);
 
-        auto res_array_col = ColumnHelper::create_column(type_array_char, false);
+        ColumnPtr res_array_col = ColumnHelper::create_column(type_array_char, false);
         array_agg_func->finalize_to_column(local_ctx.get(), state->state(), res_array_col.get());
         ASSERT_EQ(strcmp(res_array_col->debug_string().c_str(), "[['bcd','Datum()','esfg','cdrdfe',NULL,NULL,'']]"), 0);
     }
@@ -2099,7 +2108,7 @@ TEST_F(AggregateTest, test_array_aggV2) {
     // only column + const column
     state = ManagedAggrState::create(local_ctx.get(), array_agg_func);
     {
-        auto char_column = ColumnHelper::create_const_null_column(2);
+        ColumnPtr char_column = ColumnHelper::create_const_null_column(2);
         auto int_column = ColumnHelper::create_const_column<TYPE_INT>(3, 2);
 
         std::vector<const Column*> raw_columns;
@@ -2133,7 +2142,7 @@ TEST_F(AggregateTest, test_array_aggV2) {
         type_struct_char_int.children.emplace_back(type_array_int);
         type_struct_char_int.field_names.emplace_back("vchar");
         type_struct_char_int.field_names.emplace_back("int");
-        auto res_struct_col = ColumnHelper::create_column(type_struct_char_int, true);
+        ColumnPtr res_struct_col = ColumnHelper::create_column(type_struct_char_int, true);
         array_agg_func->serialize_to_column(local_ctx.get(), state->state(), res_struct_col.get());
         ASSERT_EQ(strcmp(res_struct_col->debug_string().c_str(), "[{vchar:[NULL,NULL],int:[3,3]}]"), 0);
 
@@ -2150,7 +2159,7 @@ TEST_F(AggregateTest, test_array_aggV2) {
     // append nullable columns input
     {
         auto char_type = TypeDescriptor::create_varchar_type(30);
-        auto char_column = ColumnHelper::create_column(char_type, true);
+        ColumnPtr char_column = ColumnHelper::create_column(char_type, true);
         char_column->append_datum(Datum());
         char_column->append_datum("bcd");
         char_column->append_datum("cdrdfe");
@@ -2158,7 +2167,7 @@ TEST_F(AggregateTest, test_array_aggV2) {
         char_column->append_datum("esfg");
 
         auto int_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_INT);
-        auto int_column = ColumnHelper::create_column(int_type, true);
+        ColumnPtr int_column = ColumnHelper::create_column(int_type, true);
         int_column->append_datum(Datum());
         int_column->append_datum(9);
         int_column->append_datum(Datum());
@@ -2198,7 +2207,7 @@ TEST_F(AggregateTest, test_array_aggV2) {
         type_struct_char_int.children.emplace_back(type_array_int);
         type_struct_char_int.field_names.emplace_back("vchar");
         type_struct_char_int.field_names.emplace_back("int");
-        auto res_struct_col = ColumnHelper::create_column(type_struct_char_int, true);
+        ColumnPtr res_struct_col = ColumnHelper::create_column(type_struct_char_int, true);
         array_agg_func->serialize_to_column(local_ctx.get(), state->state(), res_struct_col.get());
         ASSERT_EQ(strcmp(res_struct_col->debug_string().c_str(),
                          "[{vchar:[NULL,NULL,NULL,'bcd','cdrdfe',NULL,'esfg'],int:[3,3,NULL,9,NULL,7,6]}]"),
@@ -2215,7 +2224,7 @@ TEST_F(AggregateTest, test_array_aggV2) {
                          "{vchar:[NULL],int:[7]}, {vchar:['esfg'],int:[6]}]"),
                   0);
 
-        auto res_array_col = ColumnHelper::create_column(type_array_char, false);
+        ColumnPtr res_array_col = ColumnHelper::create_column(type_array_char, false);
         array_agg_func->finalize_to_column(local_ctx.get(), state->state(), res_array_col.get());
         ASSERT_EQ(strcmp(res_array_col->debug_string().c_str(), "[['cdrdfe',NULL,'bcd',NULL,'esfg',NULL,NULL]]"), 0);
     }
@@ -2223,7 +2232,7 @@ TEST_F(AggregateTest, test_array_aggV2) {
     {
         auto state = ManagedAggrState::create(local_ctx.get(), array_agg_func);
         auto char_type = TypeDescriptor::create_varchar_type(30);
-        auto char_column = ColumnHelper::create_column(char_type, true);
+        ColumnPtr char_column = ColumnHelper::create_column(char_type, true);
         char_column->append_datum(Datum());
         char_column->append_datum("bcd");
         char_column->append_datum("cdrdfe");
@@ -2231,7 +2240,7 @@ TEST_F(AggregateTest, test_array_aggV2) {
         char_column->append_datum("esfg");
 
         auto int_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_INT);
-        auto int_column = ColumnHelper::create_column(int_type, true);
+        ColumnPtr int_column = ColumnHelper::create_column(int_type, true);
         int_column->append_datum(Datum());
         int_column->append_datum(9);
         int_column->append_datum(Datum());
@@ -2269,7 +2278,7 @@ TEST_F(AggregateTest, test_array_aggV2) {
         type_struct_char_int.children.emplace_back(type_array_int);
         type_struct_char_int.field_names.emplace_back("vchar");
         type_struct_char_int.field_names.emplace_back("int");
-        auto res_struct_col = ColumnHelper::create_column(type_struct_char_int, true);
+        ColumnPtr res_struct_col = ColumnHelper::create_column(type_struct_char_int, true);
         array_agg_func->serialize_to_column(local_ctx.get(), state->state(), res_struct_col.get());
         ASSERT_EQ(strcmp(res_struct_col->debug_string().c_str(),
                          "[{vchar:[NULL,'bcd','cdrdfe',NULL,'esfg'],int:[NULL,9,NULL,7,6]}]"),
@@ -2285,7 +2294,7 @@ TEST_F(AggregateTest, test_array_aggV2) {
                          "{vchar:[NULL],int:[7]}, {vchar:['esfg'],int:[6]}]"),
                   0);
 
-        auto res_array_col = ColumnHelper::create_column(type_array_char, false);
+        ColumnPtr res_array_col = ColumnHelper::create_column(type_array_char, false);
         local_ctx->state()->set_is_cancelled(true);
         array_agg_func->finalize_to_column(local_ctx.get(), state->state(), res_array_col.get());
         ASSERT_TRUE(local_ctx->has_error());
@@ -2312,7 +2321,7 @@ TEST_F(AggregateTest, test_group_concatV2) {
     // nullable columns input
     {
         auto char_type = TypeDescriptor::create_varchar_type(30);
-        auto char_column = ColumnHelper::create_column(char_type, true);
+        ColumnPtr char_column = ColumnHelper::create_column(char_type, true);
         char_column->append_datum(Datum());
         char_column->append_datum("bcd");
         char_column->append_datum("cdrdfe");
@@ -2322,7 +2331,7 @@ TEST_F(AggregateTest, test_group_concatV2) {
         auto sep_column = ColumnHelper::create_const_column<TYPE_VARCHAR>(",", 5);
 
         auto int_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_INT);
-        auto int_column = ColumnHelper::create_column(int_type, true);
+        ColumnPtr int_column = ColumnHelper::create_column(int_type, true);
         int_column->append_datum(Datum());
         int_column->append_datum(9);
         int_column->append_datum(Datum());
@@ -2364,7 +2373,7 @@ TEST_F(AggregateTest, test_group_concatV2) {
         type_struct_char_int.field_names.emplace_back("vchar");
         type_struct_char_int.field_names.emplace_back("sep");
         type_struct_char_int.field_names.emplace_back("int");
-        auto res_struct_col = ColumnHelper::create_column(type_struct_char_int, true);
+        ColumnPtr res_struct_col = ColumnHelper::create_column(type_struct_char_int, true);
         gc_func->serialize_to_column(local_ctx.get(), state->state(), res_struct_col.get());
         ASSERT_EQ(res_struct_col->debug_string(), "[{vchar:['bcd','cdrdfe','esfg'],sep:[',',',',','],int:[9,NULL,6]}]");
 
@@ -2378,7 +2387,7 @@ TEST_F(AggregateTest, test_group_concatV2) {
                   "[NULL, {vchar:['bcd'],sep:[','],int:[9]}, {vchar:['cdrdfe'],sep:[','],int:[NULL]}, "
                   "NULL, {vchar:['esfg'],sep:[','],int:[6]}]");
 
-        auto res_col = ColumnHelper::create_column(char_type, false);
+        ColumnPtr res_col = ColumnHelper::create_column(char_type, false);
         gc_func->finalize_to_column(local_ctx.get(), state->state(), res_col.get());
         ASSERT_EQ(res_col->debug_string(), "['cdrdfe,bcd,esfg']");
     }
@@ -2387,7 +2396,7 @@ TEST_F(AggregateTest, test_group_concatV2) {
     state = ManagedAggrState::create(local_ctx.get(), gc_func);
     {
         auto char_type = TypeDescriptor::create_varchar_type(30);
-        auto char_column = ColumnHelper::create_column(char_type, false);
+        ColumnPtr char_column = ColumnHelper::create_column(char_type, false);
         char_column->append_datum("");
         char_column->append_datum("bcd");
         char_column->append_datum("cdrdfe");
@@ -2397,7 +2406,7 @@ TEST_F(AggregateTest, test_group_concatV2) {
         auto sep_column = ColumnHelper::create_const_column<TYPE_VARCHAR>(",", 5);
 
         auto int_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_INT);
-        auto int_column = ColumnHelper::create_column(int_type, false);
+        ColumnPtr int_column = ColumnHelper::create_column(int_type, false);
         int_column->append_datum(2);
         int_column->append_datum(9);
         int_column->append_datum(5);
@@ -2438,7 +2447,7 @@ TEST_F(AggregateTest, test_group_concatV2) {
         type_struct_char_int.field_names.emplace_back("vchar");
         type_struct_char_int.field_names.emplace_back("sep");
         type_struct_char_int.field_names.emplace_back("int");
-        auto res_struct_col = ColumnHelper::create_column(type_struct_char_int, true);
+        ColumnPtr res_struct_col = ColumnHelper::create_column(type_struct_char_int, true);
         gc_func->serialize_to_column(local_ctx.get(), state->state(), res_struct_col.get());
         ASSERT_EQ(res_struct_col->debug_string(),
                   "[{vchar:['','bcd','cdrdfe','Datum()','esfg'],sep:[',',',',',',',',','],int:[2,9,5,7,6]}]");
@@ -2453,7 +2462,7 @@ TEST_F(AggregateTest, test_group_concatV2) {
                   "[{vchar:[''],sep:[','],int:[2]}, {vchar:['bcd'],sep:[','],int:[9]}, "
                   "{vchar:['cdrdfe'],sep:[','],int:[5]}, {vchar:['Datum()'],sep:[','],int:[7]}, "
                   "{vchar:['esfg'],sep:[','],int:[6]}]");
-        auto res_col = ColumnHelper::create_column(char_type, false);
+        ColumnPtr res_col = ColumnHelper::create_column(char_type, false);
         gc_func->finalize_to_column(local_ctx.get(), state->state(), res_col.get());
         ASSERT_EQ(res_col->debug_string(), "['bcd,Datum(),esfg,cdrdfe,']");
     }
@@ -2462,7 +2471,7 @@ TEST_F(AggregateTest, test_group_concatV2) {
     state = ManagedAggrState::create(local_ctx.get(), gc_func);
     // append only column + const column
     {
-        auto char_column = ColumnHelper::create_const_null_column(2);
+        ColumnPtr char_column = ColumnHelper::create_const_null_column(2);
         auto int_column = ColumnHelper::create_const_column<TYPE_INT>(3, 2);
         auto sep_column = ColumnHelper::create_const_column<TYPE_VARCHAR>(",", 2);
 
@@ -2498,7 +2507,7 @@ TEST_F(AggregateTest, test_group_concatV2) {
         type_struct_char_int.field_names.emplace_back("vchar");
         type_struct_char_int.field_names.emplace_back("sep");
         type_struct_char_int.field_names.emplace_back("int");
-        auto res_struct_col = ColumnHelper::create_column(type_struct_char_int, true);
+        ColumnPtr res_struct_col = ColumnHelper::create_column(type_struct_char_int, true);
         gc_func->serialize_to_column(local_ctx.get(), state->state(), res_struct_col.get());
         ASSERT_EQ(res_struct_col->size(), 1); // empty also need output
 
@@ -2510,7 +2519,7 @@ TEST_F(AggregateTest, test_group_concatV2) {
         gc_func->convert_to_serialize_format(local_ctx.get(), columns, int_column->size(), &res_struct_col);
         ASSERT_EQ(res_struct_col->debug_string(), "[NULL, NULL]");
 
-        auto res_col = ColumnHelper::create_column(TypeDescriptor(LogicalType::TYPE_VARCHAR), true);
+        ColumnPtr res_col = ColumnHelper::create_column(TypeDescriptor(LogicalType::TYPE_VARCHAR), true);
         gc_func->finalize_to_column(local_ctx.get(), state->state(), res_col.get());
         ASSERT_EQ(res_col->debug_string(), "[NULL]");
     }
@@ -2521,7 +2530,7 @@ TEST_F(AggregateTest, test_group_concatV2) {
     // nullable columns input with cancelled
     {
         auto char_type = TypeDescriptor::create_varchar_type(30);
-        auto char_column = ColumnHelper::create_column(char_type, true);
+        ColumnPtr char_column = ColumnHelper::create_column(char_type, true);
         char_column->append_datum(Datum());
         char_column->append_datum("bcd");
         char_column->append_datum("cdrdfe");
@@ -2531,7 +2540,7 @@ TEST_F(AggregateTest, test_group_concatV2) {
         auto sep_column = ColumnHelper::create_const_column<TYPE_VARCHAR>(",", 5);
 
         auto int_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_INT);
-        auto int_column = ColumnHelper::create_column(int_type, true);
+        ColumnPtr int_column = ColumnHelper::create_column(int_type, true);
         int_column->append_datum(Datum());
         int_column->append_datum(9);
         int_column->append_datum(Datum());
@@ -2573,7 +2582,7 @@ TEST_F(AggregateTest, test_group_concatV2) {
         type_struct_char_int.field_names.emplace_back("vchar");
         type_struct_char_int.field_names.emplace_back("sep");
         type_struct_char_int.field_names.emplace_back("int");
-        auto res_struct_col = ColumnHelper::create_column(type_struct_char_int, true);
+        ColumnPtr res_struct_col = ColumnHelper::create_column(type_struct_char_int, true);
         gc_func->serialize_to_column(local_ctx.get(), state->state(), res_struct_col.get());
         ASSERT_EQ(res_struct_col->debug_string(), "[{vchar:['bcd','cdrdfe','esfg'],sep:[',',',',','],int:[9,NULL,6]}]");
 
@@ -2587,7 +2596,7 @@ TEST_F(AggregateTest, test_group_concatV2) {
                   "[NULL, {vchar:['bcd'],sep:[','],int:[9]}, {vchar:['cdrdfe'],sep:[','],int:[NULL]}, "
                   "NULL, {vchar:['esfg'],sep:[','],int:[6]}]");
 
-        auto res_col = ColumnHelper::create_column(char_type, false);
+        ColumnPtr res_col = ColumnHelper::create_column(char_type, false);
         local_ctx->state()->set_is_cancelled(true);
         gc_func->finalize_to_column(local_ctx.get(), state->state(), res_col.get());
         ASSERT_TRUE(local_ctx->has_error());
@@ -2598,7 +2607,7 @@ TEST_F(AggregateTest, test_array_agg) {
     const AggregateFunction* agg_function = get_aggregate_function("array_agg", TYPE_VARCHAR, TYPE_ARRAY, false);
     auto state = ManagedAggrState::create(ctx, agg_function);
 
-    auto data_column = BinaryColumn::create();
+    BinaryColumn::Ptr data_column = BinaryColumn::create();
 
     for (int i = 0; i < 6; i++) {
         std::string val("starrocks");
@@ -2610,9 +2619,9 @@ TEST_F(AggregateTest, test_array_agg) {
     // test update
     agg_function->update_batch_single_state(ctx, data_column->size(), &row_column, state->state());
 
-    auto elem = BinaryColumn::create();
-    auto offsets = UInt32Column::create(0);
-    auto result_column = ArrayColumn::create(ColumnHelper::cast_to_nullable_column(elem), offsets);
+    BinaryColumn::Ptr elem = BinaryColumn::create();
+    UInt32Column::Ptr offsets = UInt32Column::create(0);
+    ArrayColumn::Ptr result_column = ArrayColumn::create(ColumnHelper::cast_to_nullable_column(elem), offsets);
     agg_function->finalize_to_column(ctx, state->state(), result_column.get());
 
     for (int i = 0; i < 6; i++) {
@@ -2627,7 +2636,7 @@ TEST_F(AggregateTest, test_array_agg_distinct) {
             get_aggregate_function("array_agg_distinct", TYPE_VARCHAR, TYPE_ARRAY, false);
     auto state = ManagedAggrState::create(ctx, agg_function);
 
-    auto data_column = BinaryColumn::create();
+    BinaryColumn::Ptr data_column = BinaryColumn::create();
 
     for (int i = 0; i < 6; i++) {
         std::string val("starrocks");
@@ -2641,9 +2650,9 @@ TEST_F(AggregateTest, test_array_agg_distinct) {
     // test update
     agg_function->update_batch_single_state(ctx, data_column->size(), &row_column, state->state());
 
-    auto elem = BinaryColumn::create();
-    auto offsets = UInt32Column::create(0);
-    auto result_column = ArrayColumn::create(ColumnHelper::cast_to_nullable_column(elem), offsets);
+    BinaryColumn::Ptr elem = BinaryColumn::create();
+    UInt32Column::Ptr offsets = UInt32Column::create(0);
+    ArrayColumn::Ptr result_column = ArrayColumn::create(ColumnHelper::cast_to_nullable_column(elem), offsets);
     agg_function->finalize_to_column(ctx, state->state(), result_column.get());
 
     ASSERT_EQ(6, elem->size());
@@ -2653,21 +2662,21 @@ TEST_F(AggregateTest, test_array_agg_nullable) {
     const AggregateFunction* func = get_aggregate_function("array_agg", TYPE_INT, TYPE_ARRAY, true);
     auto state = ManagedAggrState::create(ctx, func);
 
-    auto data_column = Int32Column::create();
-    auto null_column = NullColumn::create();
+    Int32Column::Ptr data_column = Int32Column::create();
+    NullColumn::Ptr null_column = NullColumn::create();
 
     for (int i = 0; i < 1024; i++) {
         data_column->append(i % 2 ? 0 : i);
         null_column->append(i % 2 ? 1 : 0);
     }
 
-    auto column = NullableColumn::create(std::move(data_column), std::move(null_column));
+    NullableColumn::Ptr column = NullableColumn::create(std::move(data_column), std::move(null_column));
 
     const Column* row_column = column.get();
     func->update_batch_single_state(ctx, column->size(), &row_column, state->state());
-    auto elem = Int32Column::create();
-    auto offsets = UInt32Column::create(0);
-    auto result_column = ArrayColumn::create(ColumnHelper::cast_to_nullable_column(elem), offsets);
+    Int32Column::Ptr elem = Int32Column::create();
+    UInt32Column::Ptr offsets = UInt32Column::create(0);
+    ArrayColumn::Ptr result_column = ArrayColumn::create(ColumnHelper::cast_to_nullable_column(elem), offsets);
     func->finalize_to_column(ctx, state->state(), result_column.get());
 
     ASSERT_EQ(1024, offsets->get_data().back());
@@ -2677,21 +2686,21 @@ TEST_F(AggregateTest, test_array_agg_nullable_distinct) {
     const AggregateFunction* func = get_aggregate_function("array_agg_distinct", TYPE_INT, TYPE_ARRAY, true);
     auto state = ManagedAggrState::create(ctx, func);
 
-    auto data_column = Int32Column::create();
-    auto null_column = NullColumn::create();
+    Int32Column::Ptr data_column = Int32Column::create();
+    NullColumn::Ptr null_column = NullColumn::create();
 
     for (int i = 0; i < 1024; i++) {
         data_column->append(i % 100);
         null_column->append(i % 4 ? 1 : 0);
     }
 
-    auto column = NullableColumn::create(std::move(data_column), std::move(null_column));
+    NullableColumn::Ptr column = NullableColumn::create(std::move(data_column), std::move(null_column));
     const Column* row_column = column.get();
     func->update_batch_single_state(ctx, column->size(), &row_column, state->state());
 
-    auto elem = Int32Column::create();
-    auto offsets = UInt32Column::create(0);
-    auto result_column = ArrayColumn::create(ColumnHelper::cast_to_nullable_column(elem), offsets);
+    Int32Column::Ptr elem = Int32Column::create();
+    UInt32Column::Ptr offsets = UInt32Column::create(0);
+    ArrayColumn::Ptr result_column = ArrayColumn::create(ColumnHelper::cast_to_nullable_column(elem), offsets);
 
     func->finalize_to_column(ctx, state->state(), result_column.get());
 

--- a/be/test/exprs/agg/json_each_test.cpp
+++ b/be/test/exprs/agg/json_each_test.cpp
@@ -44,7 +44,7 @@ public:
         }
         Columns input_columns;
         if (!inputs.empty()) {
-            input_columns.push_back(json_column);
+            input_columns.push_back(json_column->clone());
         }
         TableFunctionState* func_state;
 

--- a/be/test/exprs/arithmetic_expr_test.cpp
+++ b/be/test/exprs/arithmetic_expr_test.cpp
@@ -63,7 +63,7 @@ TEST_F(VectorizedArithmeticExprTest, addExpr) {
             ASSERT_FALSE(ptr->is_nullable());
             ASSERT_TRUE(ptr->is_numeric());
 
-            auto v = std::static_pointer_cast<Int8Column>(ptr);
+            auto v = Int8Column::static_pointer_cast(ptr);
             ASSERT_EQ(10, v->size());
 
             for (int j = 0; j < v->size(); ++j) {
@@ -91,7 +91,7 @@ TEST_F(VectorizedArithmeticExprTest, addExpr) {
             ASSERT_FALSE(ptr->is_nullable());
             ASSERT_TRUE(ptr->is_numeric());
 
-            auto v = std::static_pointer_cast<Int32Column>(ptr);
+            auto v = Int32Column::static_pointer_cast(ptr);
             ASSERT_EQ(10, v->size());
 
             for (int j = 0; j < v->size(); ++j) {
@@ -119,7 +119,7 @@ TEST_F(VectorizedArithmeticExprTest, addExpr) {
             ASSERT_FALSE(ptr->is_nullable());
             ASSERT_TRUE(ptr->is_numeric());
 
-            auto v = std::static_pointer_cast<Int128Column>(ptr);
+            auto v = Int128Column::static_pointer_cast(ptr);
             ASSERT_EQ(10, v->size());
 
             for (int j = 0; j < v->size(); ++j) {
@@ -147,7 +147,7 @@ TEST_F(VectorizedArithmeticExprTest, addExpr) {
             ASSERT_FALSE(ptr->is_nullable());
             ASSERT_TRUE(ptr->is_numeric());
 
-            auto v = std::static_pointer_cast<FloatColumn>(ptr);
+            auto v = FloatColumn::static_pointer_cast(ptr);
             ASSERT_EQ(10, v->size());
 
             for (int j = 0; j < v->size(); ++j) {
@@ -171,7 +171,7 @@ TEST_F(VectorizedArithmeticExprTest, mulExpr) {
         ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
 
         ExprsTestHelper::verify_with_jit(ptr, expr.get(), &runtime_state, [](ColumnPtr const& ptr) {
-            auto v = std::static_pointer_cast<Int32Column>(ptr);
+            auto v = Int32Column::static_pointer_cast(ptr);
             ASSERT_EQ(10, v->size());
 
             for (int j = 0; j < v->size(); ++j) {
@@ -207,9 +207,9 @@ TEST_F(VectorizedArithmeticExprTest, nullMulExpr) {
             }
         }
 
-        auto ptr = std::static_pointer_cast<NullableColumn>(v)->data_column();
+        auto ptr = NullableColumn::static_pointer_cast(v)->data_column();
         for (int j = 0; j < v->size(); ++j) {
-            ASSERT_EQ(10, std::static_pointer_cast<Int32Column>(ptr)->get_data()[j]);
+            ASSERT_EQ(10, Int32Column::static_pointer_cast(ptr)->get_data()[j]);
         }
     }
 
@@ -233,7 +233,7 @@ TEST_F(VectorizedArithmeticExprTest, nullMulExpr) {
             ASSERT_TRUE(ptr->is_nullable());
             ASSERT_FALSE(ptr->is_numeric());
 
-            auto v = std::static_pointer_cast<NullableColumn>(ptr);
+            auto v = NullableColumn::static_pointer_cast(ptr);
             ASSERT_EQ(10, v->size());
 
             for (int j = 0; j < v->size(); ++j) {
@@ -259,11 +259,11 @@ TEST_F(VectorizedArithmeticExprTest, divExpr) {
         ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
 
         ExprsTestHelper::verify_with_jit(ptr, expr.get(), &runtime_state, [](ColumnPtr const& ptr) {
-            auto v = std::static_pointer_cast<NullableColumn>(ptr);
+            auto v = NullableColumn::static_pointer_cast(ptr);
             ASSERT_TRUE(v->is_nullable());
             ASSERT_EQ(10, v->size());
 
-            auto nums = std::static_pointer_cast<Int32Column>(v->data_column());
+            auto nums = Int32Column::static_pointer_cast(v->data_column());
 
             for (int j = 0; j < nums->size(); ++j) {
                 ASSERT_EQ(5, nums->get_data()[j]);
@@ -285,11 +285,11 @@ TEST_F(VectorizedArithmeticExprTest, divExpr) {
         ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
 
         ExprsTestHelper::verify_with_jit(ptr, expr.get(), &runtime_state, [](ColumnPtr const& ptr) {
-            auto v = std::static_pointer_cast<NullableColumn>(ptr);
+            auto v = NullableColumn::static_pointer_cast(ptr);
             ASSERT_TRUE(v->is_nullable());
             ASSERT_EQ(1, v->size());
 
-            auto nums = std::static_pointer_cast<Int32Column>(v->data_column());
+            auto nums = Int32Column::static_pointer_cast(v->data_column());
 
             ASSERT_EQ(nums->size(), 1);
             int32_t zero = 0;
@@ -327,11 +327,11 @@ TEST_F(VectorizedArithmeticExprTest, produceNullModExpr) {
             ASSERT_TRUE(ptr->is_nullable());
             ASSERT_FALSE(ptr->is_numeric());
 
-            auto v = std::static_pointer_cast<NullableColumn>(ptr);
+            auto v = NullableColumn::static_pointer_cast(ptr);
             ASSERT_EQ(10, v->size());
 
             for (int j = 0; j < v->size(); ++j) {
-                ASSERT_EQ(0, std::static_pointer_cast<Int32Column>(v->data_column())->get_data()[j]);
+                ASSERT_EQ(0, Int32Column::static_pointer_cast(v->data_column())->get_data()[j]);
             }
 
             for (int j = 0; j < v->size(); ++j) {
@@ -391,11 +391,11 @@ TEST_F(VectorizedArithmeticExprTest, mergeNullDivExpr) {
             ASSERT_TRUE(ptr->is_nullable());
             ASSERT_FALSE(ptr->is_numeric());
 
-            auto v = std::static_pointer_cast<NullableColumn>(ptr);
+            auto v = NullableColumn::static_pointer_cast(ptr);
             ASSERT_EQ(10, v->size());
 
             for (int j = 0; j < v->size(); ++j) {
-                ASSERT_EQ(5, std::static_pointer_cast<Int32Column>(v->data_column())->get_data()[j]);
+                ASSERT_EQ(5, Int32Column::static_pointer_cast(v->data_column())->get_data()[j]);
             }
 
             for (int j = 0; j < v->size(); ++j) {
@@ -419,7 +419,7 @@ TEST_F(VectorizedArithmeticExprTest, constVectorMulExpr) {
         ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
 
         ExprsTestHelper::verify_with_jit(ptr, expr.get(), &runtime_state, [](ColumnPtr const& ptr) {
-            auto v = std::static_pointer_cast<Int32Column>(ptr);
+            auto v = Int32Column::static_pointer_cast(ptr);
             ASSERT_EQ(10, v->size());
 
             for (int j = 0; j < v->size(); ++j) {
@@ -443,11 +443,11 @@ TEST_F(VectorizedArithmeticExprTest, constConstAddExpr) {
         ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
 
         ASSERT_TRUE(ptr->is_constant());
-        auto v = std::static_pointer_cast<ConstColumn>(ptr)->data_column();
+        auto v = ConstColumn::static_pointer_cast(ptr)->data_column();
         ASSERT_EQ(1, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
-            ASSERT_EQ(13, std::static_pointer_cast<Int32Column>(v)->get_data()[j]);
+            ASSERT_EQ(13, Int32Column::static_pointer_cast(v)->get_data()[j]);
         }
     }
 }
@@ -485,11 +485,11 @@ TEST_F(VectorizedArithmeticExprTest, produceNullVecotConstModExpr) {
             ASSERT_TRUE(ptr->is_nullable());
             ASSERT_FALSE(ptr->is_numeric());
 
-            auto v = std::static_pointer_cast<NullableColumn>(ptr);
+            auto v = NullableColumn::static_pointer_cast(ptr);
             ASSERT_EQ(10, v->size());
 
             for (int j = 0; j < v->size(); ++j) {
-                ASSERT_EQ(0, std::static_pointer_cast<Int32Column>(v->data_column())->get_data()[j]);
+                ASSERT_EQ(0, Int32Column::static_pointer_cast(v->data_column())->get_data()[j]);
             }
 
             for (int j = 0; j < v->size(); ++j) {
@@ -510,7 +510,7 @@ TEST_F(VectorizedArithmeticExprTest, bitNotExpr) {
         ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
 
         ExprsTestHelper::verify_with_jit(ptr, expr.get(), &runtime_state, [](ColumnPtr const& ptr) {
-            auto v = std::static_pointer_cast<Int32Column>(ptr);
+            auto v = Int32Column::static_pointer_cast(ptr);
 
             for (int j = 0; j < ptr->size(); ++j) {
                 ASSERT_EQ(~1, v->get_data()[j]);
@@ -535,8 +535,8 @@ TEST_F(VectorizedArithmeticExprTest, constBitNotExpr) {
 
         ASSERT_TRUE(ptr->is_constant());
 
-        auto re = std::static_pointer_cast<ConstColumn>(ptr);
-        auto v = std::static_pointer_cast<Int32Column>(re->data_column());
+        auto re = ConstColumn::static_pointer_cast(ptr);
+        auto v = Int32Column::static_pointer_cast(re->data_column());
 
         for (int j = 0; j < ptr->size(); ++j) {
             ASSERT_EQ(~2, v->get_data()[j]);
@@ -584,7 +584,7 @@ TEST_F(VectorizedArithmeticExprTest, constModExpr) {
         ASSERT_TRUE(ptr->is_constant());
         ASSERT_FALSE(ptr->is_numeric());
 
-        auto v = std::static_pointer_cast<ConstColumn>(ptr);
+        auto v = ConstColumn::static_pointer_cast(ptr);
         ASSERT_EQ(1, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -636,7 +636,7 @@ TEST_F(VectorizedArithmeticExprTest, constMod128Expr) {
                     ASSERT_TRUE(ptr->is_constant());
                     ASSERT_FALSE(ptr->is_numeric());
 
-                    auto v = std::static_pointer_cast<ConstColumn>(ptr);
+                    auto v = ConstColumn::static_pointer_cast(ptr);
                     ASSERT_EQ(1, v->size());
 
                     for (int j = 0; j < v->size(); ++j) {
@@ -690,7 +690,7 @@ TEST_F(VectorizedArithmeticExprTest, constModN128Expr) {
                     ASSERT_TRUE(ptr->is_constant());
                     ASSERT_FALSE(ptr->is_numeric());
 
-                    auto v = std::static_pointer_cast<ConstColumn>(ptr);
+                    auto v = ConstColumn::static_pointer_cast(ptr);
                     ASSERT_EQ(1, v->size());
 
                     for (int j = 0; j < v->size(); ++j) {

--- a/be/test/exprs/array_element_expr_test.cpp
+++ b/be/test/exprs/array_element_expr_test.cpp
@@ -25,7 +25,7 @@ namespace starrocks {
 
 namespace {
 
-ColumnPtr const_int_column(int32_t value, size_t size = 1) {
+MutableColumnPtr const_int_column(int32_t value, size_t size = 1) {
     auto data = Int32Column::create();
     data->append(value);
     return ConstColumn::create(std::move(data), size);
@@ -53,7 +53,7 @@ protected:
     void SetUp() override {}
     void TearDown() override { _objpool.clear(); }
 
-    FakeConstExpr* new_fake_const_expr(ColumnPtr value, const TypeDescriptor& type) {
+    FakeConstExpr* new_fake_const_expr(MutableColumnPtr&& value, const TypeDescriptor& type) {
         TExprNode node;
         node.__set_node_type(TExprNodeType::INT_LITERAL);
         node.__set_num_children(0);
@@ -103,7 +103,7 @@ TEST_F(ArrayElementExprTest, test_one_dim_array) {
     {
         std::unique_ptr<Expr> expr = create_array_element_expr(type_int);
 
-        expr->add_child(new_fake_const_expr(array, type_array_int));
+        expr->add_child(new_fake_const_expr(array->clone(), type_array_int));
         expr->add_child(new_fake_const_expr(const_int_column(1), type_int));
 
         auto result = expr->evaluate(nullptr, nullptr);
@@ -143,7 +143,7 @@ TEST_F(ArrayElementExprTest, test_one_dim_array) {
     {
         std::unique_ptr<Expr> expr = create_array_element_expr(type_int);
 
-        expr->add_child(new_fake_const_expr(array, type_array_int));
+        expr->add_child(new_fake_const_expr(array->clone(), type_array_int));
         expr->add_child(new_fake_const_expr(const_int_column(0), type_int));
 
         auto result = expr->evaluate(nullptr, nullptr);
@@ -177,7 +177,7 @@ TEST_F(ArrayElementExprTest, test_one_dim_array) {
     {
         std::unique_ptr<Expr> expr = create_array_element_expr(type_int);
 
-        expr->add_child(new_fake_const_expr(array, type_array_int));
+        expr->add_child(new_fake_const_expr(array->clone(), type_array_int));
         expr->add_child(new_fake_const_expr(const_int_column(-1), type_int));
 
         auto result = expr->evaluate(nullptr, nullptr);
@@ -214,8 +214,8 @@ TEST_F(ArrayElementExprTest, test_one_dim_array) {
         auto subscript = NullableColumn::create(Int32Column::create(), NullColumn::create());
         (void)subscript->append_nulls(5);
 
-        expr->add_child(new_fake_const_expr(array, type_array_int));
-        expr->add_child(new_fake_const_expr(subscript, type_int));
+        expr->add_child(new_fake_const_expr(array->clone(), type_array_int));
+        expr->add_child(new_fake_const_expr(std::move(subscript), type_int));
 
         auto result = expr->evaluate(nullptr, nullptr);
         EXPECT_TRUE(result->is_nullable());
@@ -244,7 +244,7 @@ TEST_F(ArrayElementExprTest, test_one_dim_array) {
                                           UInt32Column::create());
         array1->append_datum(Datum(DatumArray()));
 
-        expr->add_child(new_fake_const_expr(array1, type_array_int));
+        expr->add_child(new_fake_const_expr(std::move(array1), type_array_int));
         expr->add_child(new_fake_const_expr(const_int_column(1), type_int));
 
         auto result = expr->evaluate(nullptr, nullptr);
@@ -270,7 +270,7 @@ TEST_F(ArrayElementExprTest, test_one_dim_array) {
                                           UInt32Column::create());
         array1->append_datum(Datum(DatumArray()));
 
-        expr->add_child(new_fake_const_expr(array1, type_array_int));
+        expr->add_child(new_fake_const_expr(std::move(array1), type_array_int));
         expr->add_child(new_fake_const_expr(const_int_column(100), type_int));
 
         auto result = expr->evaluate(nullptr, nullptr);
@@ -296,7 +296,7 @@ TEST_F(ArrayElementExprTest, test_one_dim_array) {
                                           UInt32Column::create());
         array1->append_datum(Datum(DatumArray()));
 
-        expr->add_child(new_fake_const_expr(array1, type_array_int));
+        expr->add_child(new_fake_const_expr(std::move(array1), type_array_int));
         expr->add_child(new_fake_const_expr(const_int_column(0), type_int));
 
         auto result = expr->evaluate(nullptr, nullptr);
@@ -343,8 +343,8 @@ TEST_F(ArrayElementExprTest, test_two_dim_array) {
         auto subscript = NullableColumn::create(Int32Column::create(), NullColumn::create());
         (void)subscript->append_nulls(4);
 
-        expr->add_child(new_fake_const_expr(array, type_desc));
-        expr->add_child(new_fake_const_expr(subscript, type_int));
+        expr->add_child(new_fake_const_expr(array->clone(), type_desc));
+        expr->add_child(new_fake_const_expr(std::move(subscript), type_int));
 
         auto result = expr->evaluate(nullptr, nullptr);
         EXPECT_TRUE(result->is_nullable());
@@ -365,7 +365,7 @@ TEST_F(ArrayElementExprTest, test_two_dim_array) {
     {
         std::unique_ptr<Expr> expr = create_array_element_expr(type_desc.children[0]);
 
-        expr->add_child(new_fake_const_expr(array, type_desc));
+        expr->add_child(new_fake_const_expr(array->clone(), type_desc));
         expr->add_child(new_fake_const_expr(const_int_column(-1), type_int));
 
         auto result = expr->evaluate(nullptr, nullptr);
@@ -387,7 +387,7 @@ TEST_F(ArrayElementExprTest, test_two_dim_array) {
     {
         std::unique_ptr<Expr> expr = create_array_element_expr(type_desc.children[0]);
 
-        expr->add_child(new_fake_const_expr(array, type_desc));
+        expr->add_child(new_fake_const_expr(array->clone(), type_desc));
         expr->add_child(new_fake_const_expr(const_int_column(0), type_int));
 
         auto result = expr->evaluate(nullptr, nullptr);
@@ -409,7 +409,7 @@ TEST_F(ArrayElementExprTest, test_two_dim_array) {
     {
         std::unique_ptr<Expr> expr = create_array_element_expr(type_desc.children[0]);
 
-        expr->add_child(new_fake_const_expr(array, type_desc));
+        expr->add_child(new_fake_const_expr(array->clone(), type_desc));
         expr->add_child(new_fake_const_expr(const_int_column(1), type_int));
 
         auto result = expr->evaluate(nullptr, nullptr);
@@ -436,7 +436,7 @@ TEST_F(ArrayElementExprTest, test_two_dim_array) {
     {
         std::unique_ptr<Expr> expr = create_array_element_expr(type_desc.children[0]);
 
-        expr->add_child(new_fake_const_expr(array, type_desc));
+        expr->add_child(new_fake_const_expr(array->clone(), type_desc));
         expr->add_child(new_fake_const_expr(const_int_column(2), type_int));
 
         auto result = expr->evaluate(nullptr, nullptr);
@@ -468,7 +468,7 @@ TEST_F(ArrayElementExprTest, test_two_dim_array) {
     {
         std::unique_ptr<Expr> expr = create_array_element_expr(type_desc.children[0]);
 
-        expr->add_child(new_fake_const_expr(array, type_desc));
+        expr->add_child(new_fake_const_expr(array->clone(), type_desc));
         expr->add_child(new_fake_const_expr(const_int_column(3), type_int));
 
         auto result = expr->evaluate(nullptr, nullptr);
@@ -490,7 +490,7 @@ TEST_F(ArrayElementExprTest, test_two_dim_array) {
     {
         std::unique_ptr<Expr> expr = create_array_element_expr(type_desc.children[0]);
 
-        expr->add_child(new_fake_const_expr(array, type_desc));
+        expr->add_child(new_fake_const_expr(array->clone(), type_desc));
         expr->add_child(new_fake_const_expr(const_int_column(100000), type_int));
 
         auto result = expr->evaluate(nullptr, nullptr);
@@ -511,7 +511,7 @@ TEST_F(ArrayElementExprTest, test_two_dim_array) {
     {
         std::unique_ptr<Expr> expr = create_array_element_expr(type_desc.children[0]);
 
-        expr->add_child(new_fake_const_expr(array, type_desc));
+        expr->add_child(new_fake_const_expr(array->clone(), type_desc));
         expr->add_child(new_fake_const_expr(const_int_column(-100000), type_int));
 
         auto result = expr->evaluate(nullptr, nullptr);

--- a/be/test/exprs/array_functions_test.cpp
+++ b/be/test/exprs/array_functions_test.cpp
@@ -152,7 +152,7 @@ TEST_F(ArrayFunctionsTest, array_length) {
     // [1]
     // [1, 2]
     {
-        auto c = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+        ColumnPtr c = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
         c->append_datum(Datum(DatumArray{}));
         c->append_datum(Datum());
         c->append_datum(Datum(DatumArray{Datum()}));
@@ -175,7 +175,7 @@ TEST_F(ArrayFunctionsTest, array_length) {
     // ["a"]
     // ["a", "b"]
     {
-        auto c = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+        ColumnPtr c = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
         c->append_datum(Datum(DatumArray{}));
         c->append_datum(Datum());
         c->append_datum(Datum(DatumArray{Datum()}));
@@ -205,7 +205,7 @@ TEST_F(ArrayFunctionsTest, array_length) {
     // [[],[]]
     // [[1], [2], [3]]
     {
-        auto c = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, true);
+        ColumnPtr c = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, true);
         c->append_datum(Datum(DatumArray{}));
         c->append_datum(Datum());
         c->append_datum(Datum(DatumArray{Datum()}));
@@ -242,7 +242,7 @@ TEST_F(ArrayFunctionsTest, array_length) {
 
     // [] only null
     {
-        auto c = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, true, true, 10);
+        ColumnPtr c = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, true, true, 10);
 
         auto result = ArrayFunctions::array_length(nullptr, {c}).value();
         EXPECT_EQ(10, result->size());
@@ -251,9 +251,9 @@ TEST_F(ArrayFunctionsTest, array_length) {
 
     // [] only const
     {
-        auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+        ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         src_column->append_datum(DatumArray{"5", "5", "33", "666"});
-        src_column = std::make_shared<ConstColumn>(src_column, 3);
+        src_column = ConstColumn::create(src_column, 3);
 
         auto result = ArrayFunctions::array_length(nullptr, {src_column}).value();
         EXPECT_EQ(3, result->size());
@@ -270,7 +270,7 @@ TEST_F(ArrayFunctionsTest, array_cum_sum) {
     // [1,2,3,4,5]
     // [null,null,1, null]
     {
-        auto c = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, true);
+        ColumnPtr c = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, true);
         c->append_datum(Datum(DatumArray{}));
         c->append_datum(Datum());
         c->append_datum(Datum(DatumArray{Datum()}));
@@ -298,7 +298,7 @@ TEST_F(ArrayFunctionsTest, array_cum_sum) {
 
     // [] only null
     {
-        auto c = ColumnHelper::create_const_null_column(3);
+        ColumnPtr c = ColumnHelper::create_const_null_column(3);
 
         auto result = ArrayFunctions::array_cum_sum_bigint(nullptr, {c}).value();
         EXPECT_EQ(3, result->size());
@@ -309,11 +309,11 @@ TEST_F(ArrayFunctionsTest, array_cum_sum) {
 
     // [] only const
     {
-        auto src_column = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, true);
+        ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, true);
         src_column->append_datum(Datum(DatumArray{Datum((int64_t)1), Datum((int64_t)2), Datum((int64_t)3),
                                                   Datum((int64_t)4), Datum((int64_t)5)}));
-        auto c = std::make_shared<ConstColumn>(src_column, 3);
-        auto result = ArrayFunctions::array_cum_sum_bigint(nullptr, {c}).value();
+        auto c = ConstColumn::create(src_column, 3);
+        auto result = ArrayFunctions::array_cum_sum_bigint(nullptr, {std::move(c)}).value();
         EXPECT_EQ(3, result->size());
     }
 }
@@ -322,10 +322,10 @@ TEST_F(ArrayFunctionsTest, array_cum_sum) {
 TEST_F(ArrayFunctionsTest, array_contains_empty_array) {
     // array_contains([], 1)
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 0);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 0);
         target->append_datum(Datum{(int32_t)1});
 
         auto result = ArrayFunctions::array_contains_specific<TYPE_INT>(nullptr, {array, target}).value();
@@ -334,10 +334,10 @@ TEST_F(ArrayFunctionsTest, array_contains_empty_array) {
     }
     // array_contains([], "abc")
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
         target->append_datum(Datum{"abc"});
 
         auto result = ArrayFunctions::array_contains_specific<TYPE_VARCHAR>(nullptr, {array, target}).value();
@@ -346,10 +346,10 @@ TEST_F(ArrayFunctionsTest, array_contains_empty_array) {
     }
     // array_contains(ARRAY<ARRAY<int>>[], [1])
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_INT), false);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_INT), false);
         target->append_datum(Datum(DatumArray{Datum{(int32_t)1}}));
 
         auto result = ArrayFunctions::array_contains_generic(nullptr, {array, target}).value();
@@ -358,10 +358,10 @@ TEST_F(ArrayFunctionsTest, array_contains_empty_array) {
     }
     // array_contains(ARRAY<ARRAY<int>>[], ARRAY<int>[])
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_INT), false);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_INT), false);
         target->append_datum(Datum(DatumArray{}));
 
         auto result = ArrayFunctions::array_contains_generic(nullptr, {array, target}).value();
@@ -374,13 +374,13 @@ TEST_F(ArrayFunctionsTest, array_contains_empty_array) {
     //  array_contains([], 1);
     //  array_contains([], 1);
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 0);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 0);
         DCHECK(target->is_constant());
         target->append_datum(Datum((int32_t)1));
         target->resize(4);
@@ -398,13 +398,13 @@ TEST_F(ArrayFunctionsTest, array_contains_empty_array) {
     //  array_contains([], NULL);
     //  array_contains([], 3);
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), true);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), true);
         target->append_datum(Datum((int32_t)1));
         target->append_datum(Datum((int32_t)2));
         target->append_datum(Datum{});
@@ -423,13 +423,13 @@ TEST_F(ArrayFunctionsTest, array_contains_empty_array) {
     //  array_contains([], NULL);
     //  array_contains([], NULL);
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_const_null_column(1);
+        ColumnPtr target = ColumnHelper::create_const_null_column(1);
         target->resize(4);
 
         auto result = ArrayFunctions::array_contains_specific<TYPE_INT>(nullptr, {array, target}).value();
@@ -479,7 +479,7 @@ TEST_F(ArrayFunctionsTest, array_contains_no_null) {
     // array_contains(array<boolean>[1,0], 0) : 1
     // array_contains(array<boolean>[1,0], 1) : 1
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{(int8_t) false});
@@ -489,7 +489,7 @@ TEST_F(ArrayFunctionsTest, array_contains_no_null) {
         array->append_datum(DatumArray{(int8_t) true, (int8_t) false});
         array->append_datum(DatumArray{(int8_t) true, (int8_t) false});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_BOOLEAN), false);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_BOOLEAN), false);
         target->append_datum(Datum{(int8_t)0});
         target->append_datum(Datum{(int8_t)1});
         target->append_datum(Datum{(int8_t)0});
@@ -516,14 +516,14 @@ TEST_F(ArrayFunctionsTest, array_contains_no_null) {
     // array_contains([3, 2, 1], 3) : 1
     // array_contains([2, 1, 3], 3) : 1
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{2});
         array->append_datum(DatumArray{1, 2, 3});
         array->append_datum(DatumArray{3, 2, 1});
         array->append_datum(DatumArray{2, 1, 3});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 0);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 0);
         target->append_datum(Datum{3});
         target->resize(5);
 
@@ -546,7 +546,7 @@ TEST_F(ArrayFunctionsTest, array_contains_no_null) {
     // array_contains([["d", "o"], ["r"], ["i", "s"]], ["r", "i"]) : 0
     // array_contains([["d", "o"], ["r"], ["i", "s"]], ["i", "s"]) : 1
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{Datum(DatumArray{})});
         array->append_datum(DatumArray{DatumArray{"d", "o"}, DatumArray{"r"}, DatumArray{"i", "s"}});
@@ -558,7 +558,7 @@ TEST_F(ArrayFunctionsTest, array_contains_no_null) {
         array->append_datum(DatumArray{DatumArray{"d", "o"}, DatumArray{"r"}, DatumArray{"i", "s"}});
         array->append_datum(DatumArray{DatumArray{"d", "o"}, DatumArray{"r"}, DatumArray{"i", "s"}});
 
-        auto target = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+        ColumnPtr target = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         target->append_datum(Datum(DatumArray{}));
         target->append_datum(Datum(DatumArray{}));
         target->append_datum(Datum(DatumArray{}));
@@ -591,12 +591,12 @@ TEST_F(ArrayFunctionsTest, array_contains_has_null_element) {
     // array_contains(["abc", NULL], "abc")
     // array_contains([NULL, "abc"], "abc")
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         array->append_datum(DatumArray{Datum{}});
         array->append_datum(DatumArray{"abc", Datum{}});
         array->append_datum(DatumArray{Datum{}, "abc"});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
         target->append_datum(Datum{"abc"});
         target->append_datum(Datum{"abc"});
         target->append_datum(Datum{"abc"});
@@ -613,11 +613,11 @@ TEST_F(ArrayFunctionsTest, array_contains_has_null_element) {
 TEST_F(ArrayFunctionsTest, array_contains_has_null_target) {
     // array_contains(["abc", "def"], NULL)
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         array->append_datum(DatumArray{"abc", "def"});
 
         // const-null column.
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 0);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 0);
 
         auto result = ArrayFunctions::array_contains_specific<TYPE_VARCHAR>(nullptr, {array, target}).value();
         EXPECT_EQ(1, result->size());
@@ -627,12 +627,12 @@ TEST_F(ArrayFunctionsTest, array_contains_has_null_target) {
     // array_contains(ARRAY<TINYINT>[1, 2, 3], 4)
     // array_contains(ARRAY<TINYINT>[1, 2, 3], NULL)
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
         array->append_datum(DatumArray{(int8_t)1, (int8_t)2, (int8_t)3});
         array->append_datum(DatumArray{(int8_t)1, (int8_t)2, (int8_t)3});
         array->append_datum(DatumArray{(int8_t)1, (int8_t)2, (int8_t)3});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_TINYINT), true);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_TINYINT), true);
         target->append_datum(Datum((int8_t)2));
         target->append_datum(Datum((int8_t)4));
         target->append_datum(Datum());
@@ -650,12 +650,12 @@ TEST_F(ArrayFunctionsTest, array_contains_has_null_element_and_target) {
     // array_contains([NULL], NULL)
     // array_contains([NULL, "abc"], NULL)
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         array->append_datum(DatumArray{Datum()});
         array->append_datum(DatumArray{Datum(), "abc"});
 
         // const-null column.
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 0);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 0);
 
         auto result = ArrayFunctions::array_contains_specific<TYPE_VARCHAR>(nullptr, {array, target}).value();
         EXPECT_EQ(2, result->size());
@@ -668,14 +668,14 @@ TEST_F(ArrayFunctionsTest, array_contains_has_null_element_and_target) {
     // array_contains([[1,2], NULL], [1,2])
     // array_contains([[1,2], NULL], NULL)
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, false);
         array->append_datum(DatumArray{Datum()});
         array->append_datum(DatumArray{Datum(), DatumArray{1, 2}});
         array->append_datum(DatumArray{Datum(), DatumArray{1, 2}});
         array->append_datum(DatumArray{DatumArray{1, 2}, Datum()});
         array->append_datum(DatumArray{DatumArray{1, 2}, Datum()});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_INT), true);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_INT), true);
         target->append_datum(Datum());
         target->append_datum(Datum());
         target->append_datum(DatumArray{1, 2});
@@ -698,12 +698,12 @@ TEST_F(ArrayFunctionsTest, array_contains_nullable_array) {
     // array_contains(NULL, "c")
     // array_contains(["a", "b", "c"], "c")
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
         array->append_datum(DatumArray{"a", "b"});
         array->append_datum(Datum());
         array->append_datum(DatumArray{"a", "b", "c"});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
         target->append_datum(Datum("c"));
         target->append_datum(Datum("c"));
         target->append_datum(Datum("c"));
@@ -718,12 +718,12 @@ TEST_F(ArrayFunctionsTest, array_contains_nullable_array) {
     // array_contains(NULL, ["c"])
     // array_contains([["a", "b"], ["c"]], ["c"])
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, true);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, true);
         array->append_datum(DatumArray{DatumArray{"a"}, DatumArray{"b"}});
         array->append_datum(Datum());
         array->append_datum(DatumArray{DatumArray{"a", "b"}, DatumArray{"c"}});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_VARCHAR), false);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_VARCHAR), false);
         target->append_datum(DatumArray{"c"});
         target->append_datum(DatumArray{"c"});
         target->append_datum(DatumArray{"c"});
@@ -738,12 +738,12 @@ TEST_F(ArrayFunctionsTest, array_contains_nullable_array) {
     // array_contains(NULL, ["a"])
     // array_contains(NULL, [NULL])
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, true);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, true);
         array->append_datum(Datum());
         array->append_datum(Datum());
         array->append_datum(Datum());
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_VARCHAR), true);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_VARCHAR), true);
         target->append_datum(Datum());
         target->append_datum(DatumArray{"a"});
         target->append_datum(DatumArray{Datum()});
@@ -769,7 +769,7 @@ TEST_F(ArrayFunctionsTest, array_contains_all) {
     // array_contains_all(["a", "b", "c"], ["a", "d"])    -> 0
     // array_contains_all(["a", "b", "c"], ["a", "c"])    -> 1
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
         array->append_datum(DatumArray{"a", "b", "c"});
         array->append_datum(Datum());
         array->append_datum(DatumArray{"a", "b", "c"});
@@ -781,7 +781,7 @@ TEST_F(ArrayFunctionsTest, array_contains_all) {
         array->append_datum(DatumArray{"a", "b", "c"});
         array->append_datum(DatumArray{"a", "b", "c"});
 
-        auto target = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+        ColumnPtr target = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
         target->append_datum(DatumArray{"c"});
         target->append_datum(DatumArray{"c"});
         target->append_datum(Datum());
@@ -810,12 +810,12 @@ TEST_F(ArrayFunctionsTest, array_contains_all) {
     // array_contains_all(NULL, [["c"]])
     // array_contains_all([["a", "b"], ["c"], NULL], [["a", "b"], NULL])
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, true);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, true);
         array->append_datum(DatumArray{Datum(DatumArray{"a"}), Datum(DatumArray{"b"})});
         array->append_datum(Datum());
         array->append_datum(DatumArray{Datum(DatumArray{"a", "b"}), Datum(DatumArray{"c"}), Datum()});
 
-        auto target = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, false);
+        ColumnPtr target = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, false);
         target->append_datum(DatumArray{Datum(DatumArray{"c"})});
         target->append_datum(DatumArray{Datum(DatumArray{"c"})});
         target->append_datum(DatumArray{Datum(DatumArray{"a", "b"}), Datum()});
@@ -832,10 +832,10 @@ TEST_F(ArrayFunctionsTest, array_contains_all) {
 TEST_F(ArrayFunctionsTest, array_position_empty_array) {
     // array_position([], 1) : 0
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 0);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 0);
         target->append_datum(Datum{(int32_t)1});
 
         auto result = ArrayFunctions::array_position_specific<TYPE_INT>(nullptr, {array, target}).value();
@@ -844,10 +844,10 @@ TEST_F(ArrayFunctionsTest, array_position_empty_array) {
     }
     // array_position([], "abc"): 0
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
         target->append_datum(Datum{"abc"});
 
         auto result = ArrayFunctions::array_position_specific<TYPE_VARCHAR>(nullptr, {array, target}).value();
@@ -856,10 +856,10 @@ TEST_F(ArrayFunctionsTest, array_position_empty_array) {
     }
     // array_position(ARRAY<ARRAY<int>>[], [1]): 0
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_INT), false);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_INT), false);
         target->append_datum(Datum(DatumArray{Datum{(int32_t)1}}));
 
         auto result = ArrayFunctions::array_position_generic(nullptr, {array, target}).value();
@@ -868,10 +868,10 @@ TEST_F(ArrayFunctionsTest, array_position_empty_array) {
     }
     // array_position(ARRAY<ARRAY<int>>[], ARRAY<int>[]): 0
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_INT), false);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_INT), false);
         target->append_datum(Datum(DatumArray{}));
 
         auto result = ArrayFunctions::array_position_generic(nullptr, {array, target}).value();
@@ -884,13 +884,13 @@ TEST_F(ArrayFunctionsTest, array_position_empty_array) {
     //  array_position([], 1): 0;
     //  array_position([], 1): 0;
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 0);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 0);
         DCHECK(target->is_constant());
         target->append_datum(Datum((int32_t)1));
         target->resize(4);
@@ -908,13 +908,13 @@ TEST_F(ArrayFunctionsTest, array_position_empty_array) {
     //  array_position([], NULL): 0;
     //  array_position([], 3): 0;
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), true);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), true);
         target->append_datum(Datum((int32_t)1));
         target->append_datum(Datum((int32_t)2));
         target->append_datum(Datum{});
@@ -933,13 +933,13 @@ TEST_F(ArrayFunctionsTest, array_position_empty_array) {
     //  array_position([], NULL): 0;
     //  array_position([], NULL): 0;
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_const_null_column(1);
+        ColumnPtr target = ColumnHelper::create_const_null_column(1);
         target->resize(4);
 
         auto result = ArrayFunctions::array_position_specific<TYPE_INT>(nullptr, {array, target}).value();
@@ -989,7 +989,7 @@ TEST_F(ArrayFunctionsTest, array_position_no_null) {
     // array_position(array<boolean>[1,0], 0) : 2
     // array_position(array<boolean>[1,0], 1) : 1
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{(int8_t) false});
@@ -999,7 +999,7 @@ TEST_F(ArrayFunctionsTest, array_position_no_null) {
         array->append_datum(DatumArray{(int8_t) true, (int8_t) false});
         array->append_datum(DatumArray{(int8_t) true, (int8_t) false});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_BOOLEAN), false);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_BOOLEAN), false);
         target->append_datum(Datum{(int8_t)0});
         target->append_datum(Datum{(int8_t)1});
         target->append_datum(Datum{(int8_t)0});
@@ -1026,14 +1026,14 @@ TEST_F(ArrayFunctionsTest, array_position_no_null) {
     // array_position([3, 2, 1], 3) : 1
     // array_position([2, 1, 3], 3) : 3
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{2});
         array->append_datum(DatumArray{1, 2, 3});
         array->append_datum(DatumArray{3, 2, 1});
         array->append_datum(DatumArray{2, 1, 3});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 0);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 0);
         target->append_datum(Datum{3});
         target->resize(5);
 
@@ -1056,7 +1056,7 @@ TEST_F(ArrayFunctionsTest, array_position_no_null) {
     // array_position([["d", "o"], ["r"], ["i", "s"]], ["r", "i"]) : 0
     // array_position([["d", "o"], ["r"], ["i", "s"]], ["i", "s"]) : 3
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{Datum(DatumArray{})});
         array->append_datum(DatumArray{DatumArray{"d", "o"}, DatumArray{"r"}, DatumArray{"i", "s"}});
@@ -1068,7 +1068,7 @@ TEST_F(ArrayFunctionsTest, array_position_no_null) {
         array->append_datum(DatumArray{DatumArray{"d", "o"}, DatumArray{"r"}, DatumArray{"i", "s"}});
         array->append_datum(DatumArray{DatumArray{"d", "o"}, DatumArray{"r"}, DatumArray{"i", "s"}});
 
-        auto target = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+        ColumnPtr target = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         target->append_datum(Datum(DatumArray{}));
         target->append_datum(Datum(DatumArray{}));
         target->append_datum(Datum(DatumArray{}));
@@ -1101,12 +1101,12 @@ TEST_F(ArrayFunctionsTest, array_position_has_null_element) {
     // array_position(["abc", NULL], "abc"): 1
     // array_position([NULL, "abc"], "abc"): 2
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         array->append_datum(DatumArray{Datum{}});
         array->append_datum(DatumArray{"abc", Datum{}});
         array->append_datum(DatumArray{Datum{}, "abc"});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
         target->append_datum(Datum{"abc"});
         target->append_datum(Datum{"abc"});
         target->append_datum(Datum{"abc"});
@@ -1123,11 +1123,11 @@ TEST_F(ArrayFunctionsTest, array_position_has_null_element) {
 TEST_F(ArrayFunctionsTest, array_position_has_null_target) {
     // array_position(["abc", "def"], NULL): 0
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         array->append_datum(DatumArray{"abc", "def"});
 
         // const-null column.
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 0);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 0);
 
         auto result = ArrayFunctions::array_position_specific<TYPE_VARCHAR>(nullptr, {array, target}).value();
         EXPECT_EQ(1, result->size());
@@ -1137,12 +1137,12 @@ TEST_F(ArrayFunctionsTest, array_position_has_null_target) {
     // array_position(ARRAY<TINYINT>[1, 2, 3], 4): 0
     // array_position(ARRAY<TINYINT>[1, 2, 3], NULL): 0
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
         array->append_datum(DatumArray{(int8_t)1, (int8_t)2, (int8_t)3});
         array->append_datum(DatumArray{(int8_t)1, (int8_t)2, (int8_t)3});
         array->append_datum(DatumArray{(int8_t)1, (int8_t)2, (int8_t)3});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_TINYINT), true);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_TINYINT), true);
         target->append_datum(Datum((int8_t)2));
         target->append_datum(Datum((int8_t)4));
         target->append_datum(Datum());
@@ -1160,12 +1160,12 @@ TEST_F(ArrayFunctionsTest, array_position_has_null_element_and_target) {
     // array_position([NULL], NULL): 1
     // array_position([NULL, "abc"], NULL): 1
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         array->append_datum(DatumArray{Datum()});
         array->append_datum(DatumArray{Datum(), "abc"});
 
         // const-null column.
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 1);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 1);
 
         auto result = ArrayFunctions::array_position_specific<TYPE_VARCHAR>(nullptr, {array, target}).value();
         EXPECT_EQ(2, result->size());
@@ -1178,14 +1178,14 @@ TEST_F(ArrayFunctionsTest, array_position_has_null_element_and_target) {
     // array_position([[1,2], NULL], [1,2]): 1
     // array_position([[1,2], NULL], NULL): 2
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, false);
         array->append_datum(DatumArray{Datum()});
         array->append_datum(DatumArray{Datum(), DatumArray{1, 2}});
         array->append_datum(DatumArray{Datum(), DatumArray{1, 2}});
         array->append_datum(DatumArray{DatumArray{1, 2}, Datum()});
         array->append_datum(DatumArray{DatumArray{1, 2}, Datum()});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_INT), true);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_INT), true);
         target->append_datum(Datum());
         target->append_datum(Datum());
         target->append_datum(DatumArray{1, 2});
@@ -1206,12 +1206,12 @@ TEST_F(ArrayFunctionsTest, array_position_has_null_element_and_target_and_check_
     // array_position([NULL], NULL): 1
     // array_position([NULL, "abc"], NULL): 1
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         array->append_datum(DatumArray{Datum()});
         array->append_datum(DatumArray{Datum(), "abc"});
 
         // const-null column.
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 0);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 0);
 
         auto result = ArrayFunctions::array_position_specific<TYPE_VARCHAR>(nullptr, {array, target}).value();
         EXPECT_EQ(2, result->size());
@@ -1224,14 +1224,14 @@ TEST_F(ArrayFunctionsTest, array_position_has_null_element_and_target_and_check_
     // array_position([[1,2], NULL], [1,2]): 1
     // array_position([[1,2], NULL], NULL): 2
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, false);
         array->append_datum(DatumArray{Datum()});
         array->append_datum(DatumArray{Datum(), DatumArray{1, 2}});
         array->append_datum(DatumArray{Datum(), DatumArray{1, 2}});
         array->append_datum(DatumArray{DatumArray{1, 2}, Datum()});
         array->append_datum(DatumArray{DatumArray{1, 2}, Datum()});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_INT), true);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_INT), true);
         target->append_datum(Datum());
         target->append_datum(Datum());
         target->append_datum(DatumArray{1, 2});
@@ -1255,12 +1255,12 @@ TEST_F(ArrayFunctionsTest, array_position_nullable_array) {
     // array_position(NULL, "c"): null
     // array_position(["a", "b", "c"], "c"): 3
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
         array->append_datum(DatumArray{"a", "b"});
         array->append_datum(Datum());
         array->append_datum(DatumArray{"a", "b", "c"});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
         target->append_datum(Datum("c"));
         target->append_datum(Datum("c"));
         target->append_datum(Datum("c"));
@@ -1275,12 +1275,12 @@ TEST_F(ArrayFunctionsTest, array_position_nullable_array) {
     // array_position(NULL, ["c"]): null
     // array_position([["a", "b"], ["c"]], ["c"]): 2
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, true);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, true);
         array->append_datum(DatumArray{DatumArray{"a"}, DatumArray{"b"}});
         array->append_datum(Datum());
         array->append_datum(DatumArray{DatumArray{"a", "b"}, DatumArray{"c"}});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_VARCHAR), false);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_VARCHAR), false);
         target->append_datum(DatumArray{"c"});
         target->append_datum(DatumArray{"c"});
         target->append_datum(DatumArray{"c"});
@@ -1295,12 +1295,12 @@ TEST_F(ArrayFunctionsTest, array_position_nullable_array) {
     // array_position(NULL, ["a"]): null
     // array_position(NULL, [NULL]): null
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, true);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, true);
         array->append_datum(Datum());
         array->append_datum(Datum());
         array->append_datum(Datum());
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_VARCHAR), true);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_VARCHAR), true);
         target->append_datum(Datum());
         target->append_datum(DatumArray{"a"});
         target->append_datum(DatumArray{Datum()});
@@ -1317,10 +1317,10 @@ TEST_F(ArrayFunctionsTest, array_position_nullable_array) {
 TEST_F(ArrayFunctionsTest, array_remove_empty_array) {
     // array_remove([], 1) -> []
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 0);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 0);
         target->append_datum(Datum{(int32_t)1});
 
         auto result = ArrayFunctions::array_remove(nullptr, {array, target}).value();
@@ -1330,10 +1330,10 @@ TEST_F(ArrayFunctionsTest, array_remove_empty_array) {
 
     // array_remove([], "abc") -> []
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
         target->append_datum(Datum{"abc"});
 
         auto result = ArrayFunctions::array_remove(nullptr, {array, target}).value();
@@ -1343,10 +1343,10 @@ TEST_F(ArrayFunctionsTest, array_remove_empty_array) {
 
     // array_remove([[]], [1]) -> [[]]
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_INT), false);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_INT), false);
         target->append_datum(Datum(DatumArray{Datum{(int32_t)1}}));
 
         auto result = ArrayFunctions::array_remove(nullptr, {array, target}).value();
@@ -1358,10 +1358,10 @@ TEST_F(ArrayFunctionsTest, array_remove_empty_array) {
 
     // array_remove([[]], []) -> []
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_INT), false);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_INT), false);
         target->append_datum(Datum(DatumArray{}));
 
         auto result = ArrayFunctions::array_remove(nullptr, {array, target}).value();
@@ -1376,13 +1376,13 @@ TEST_F(ArrayFunctionsTest, array_remove_empty_array) {
     // array_remove([], 1) -> []
     // array_remove([], 1) -> []
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 0);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 0);
         DCHECK(target->is_constant());
         target->append_datum(Datum((int32_t)1));
         target->resize(4);
@@ -1412,13 +1412,13 @@ TEST_F(ArrayFunctionsTest, array_remove_empty_array) {
     // array_remove([], NULL) -> []
     // array_remove([], 3) -> []
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), true);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), true);
         target->append_datum(Datum((int32_t)1));
         target->append_datum(Datum((int32_t)2));
         target->append_datum(Datum{});
@@ -1449,13 +1449,13 @@ TEST_F(ArrayFunctionsTest, array_remove_empty_array) {
     // array_remove([], NULL) -> []
     // array_remove([], NULL) -> []
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_const_null_column(1);
+        ColumnPtr target = ColumnHelper::create_const_null_column(1);
         target->resize(4);
 
         auto result = ArrayFunctions::array_remove(nullptr, {array, target}).value();
@@ -1502,7 +1502,7 @@ TEST_F(ArrayFunctionsTest, array_remove_no_null) {
     // array_remove([true, false], false) -> [true]
     // array_remove([true, false], true)  -> [false]
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{(int8_t) false});
@@ -1512,7 +1512,7 @@ TEST_F(ArrayFunctionsTest, array_remove_no_null) {
         array->append_datum(DatumArray{(int8_t) true, (int8_t) false});
         array->append_datum(DatumArray{(int8_t) true, (int8_t) false});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_BOOLEAN), false);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_BOOLEAN), false);
         target->append_datum(Datum{(int8_t)0});
         target->append_datum(Datum{(int8_t)1});
         target->append_datum(Datum{(int8_t)0});
@@ -1568,14 +1568,14 @@ TEST_F(ArrayFunctionsTest, array_remove_no_null) {
     // array_remove([3, 2, 1], 3) -> [2, 1]
     // array_remove([2, 1, 3], 3) -> [2, 1]
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{2});
         array->append_datum(DatumArray{1, 2, 3});
         array->append_datum(DatumArray{3, 2, 1});
         array->append_datum(DatumArray{2, 1, 3});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 0);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 0);
         target->append_datum(Datum{3});
         target->resize(5);
 
@@ -1621,7 +1621,7 @@ TEST_F(ArrayFunctionsTest, array_remove_no_null) {
     // array_remove([["d", "o"], ["r"], ["i", "s"]], ["r", "i"]) -> [["d", "o"], ["r"], ["i", "s"]]
     // array_remove([["d", "o"], ["r"], ["i", "s"]], ["i", "s"]) -> [["d", "o"], ["r"]]
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{Datum(DatumArray{})});
         array->append_datum(DatumArray{DatumArray{"d", "o"}, DatumArray{"r"}, DatumArray{"i", "s"}});
@@ -1633,7 +1633,7 @@ TEST_F(ArrayFunctionsTest, array_remove_no_null) {
         array->append_datum(DatumArray{DatumArray{"d", "o"}, DatumArray{"r"}, DatumArray{"i", "s"}});
         array->append_datum(DatumArray{DatumArray{"d", "o"}, DatumArray{"r"}, DatumArray{"i", "s"}});
 
-        auto target = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+        ColumnPtr target = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         target->append_datum(Datum(DatumArray{}));
         target->append_datum(Datum(DatumArray{}));
         target->append_datum(Datum(DatumArray{}));
@@ -1752,12 +1752,12 @@ TEST_F(ArrayFunctionsTest, array_remove_has_null_element) {
     // array_remove(["abc", NULL], "abc") -> [NULL]
     // array_remove([NULL, "abc"], "abc") -> [NULL]
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         array->append_datum(DatumArray{Datum{}});
         array->append_datum(DatumArray{"abc", Datum{}});
         array->append_datum(DatumArray{Datum{}, "abc"});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
         target->append_datum(Datum{"abc"});
         target->append_datum(Datum{"abc"});
         target->append_datum(Datum{"abc"});
@@ -1785,11 +1785,11 @@ TEST_F(ArrayFunctionsTest, array_remove_has_null_element) {
 TEST_F(ArrayFunctionsTest, array_remove_has_null_target) {
     {
         // array_remove(["abc", "def"], NULL) -> ["abc", "def"]
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         array->append_datum(DatumArray{"abc", "def"});
 
         // const-null column.
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 0);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 0);
         auto result = ArrayFunctions::array_remove(nullptr, {array, target}).value();
         EXPECT_EQ(1, result->size());
 
@@ -1803,12 +1803,12 @@ TEST_F(ArrayFunctionsTest, array_remove_has_null_target) {
     // array_remove([1, 2, 3], 4) -> [1, 2, 3]
     // array_remove([1, 2, 3], NULL) -> [1, 2, 3]
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
         array->append_datum(DatumArray{(int8_t)1, (int8_t)2, (int8_t)3});
         array->append_datum(DatumArray{(int8_t)1, (int8_t)2, (int8_t)3});
         array->append_datum(DatumArray{(int8_t)1, (int8_t)2, (int8_t)3});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_TINYINT), true);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_TINYINT), true);
         target->append_datum(Datum((int8_t)2));
         target->append_datum(Datum((int8_t)4));
         target->append_datum(Datum());
@@ -1843,12 +1843,12 @@ TEST_F(ArrayFunctionsTest, array_remove_has_null_element_and_target) {
     // array_remove([NULL], NULL)  -> []
     // array_remove([NULL, "abc"], NULL) -> ["abc"]
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         array->append_datum(DatumArray{Datum()});
         array->append_datum(DatumArray{Datum(), "abc"});
 
         // const-null column.
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 0);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 0);
 
         auto result = ArrayFunctions::array_remove(nullptr, {array, target}).value();
         EXPECT_EQ(2, result->size());
@@ -1869,14 +1869,14 @@ TEST_F(ArrayFunctionsTest, array_remove_has_null_element_and_target) {
     // array_remove([[1, 2], NULL], [1, 2]) -> [NULL]
     // array_remove([NULL, [1, 2]], NULL)   -> [[1, 2]]
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, false);
         array->append_datum(DatumArray{Datum()});
         array->append_datum(DatumArray{Datum(), DatumArray{1, 2}});
         array->append_datum(DatumArray{Datum(), DatumArray{1, 2}});
         array->append_datum(DatumArray{DatumArray{1, 2}, Datum()});
         array->append_datum(DatumArray{DatumArray{1, 2}, Datum()});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_INT), true);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_INT), true);
         target->append_datum(Datum());
         target->append_datum(Datum());
         target->append_datum(DatumArray{1, 2});
@@ -1922,12 +1922,12 @@ TEST_F(ArrayFunctionsTest, array_remove_nullable_array) {
         // array_remove(["a", "b"], "c")      -> ["a", "b"]
         // array_remove(NULL, "c")            -> NULL
         // array_remove(["a", "b", "c"], "c") -> ["a", "b"]
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
         array->append_datum(DatumArray{"a", "b"});
         array->append_datum(Datum());
         array->append_datum(DatumArray{"a", "b", "c"});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
         target->append_datum(Datum("c"));
         target->append_datum(Datum("c"));
         target->append_datum(Datum("c"));
@@ -1955,12 +1955,12 @@ TEST_F(ArrayFunctionsTest, array_remove_nullable_array) {
     // array_remove(NULL, ["c"])           -> NULL
     // array_remove([["a", "b"], ["c"]])   -> [["a", "b"]]
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, true);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, true);
         array->append_datum(DatumArray{DatumArray{"a"}, DatumArray{"b"}});
         array->append_datum(Datum());
         array->append_datum(DatumArray{DatumArray{"a", "b"}, DatumArray{"c"}});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_VARCHAR), false);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_VARCHAR), false);
         target->append_datum(DatumArray{"c"});
         target->append_datum(DatumArray{"c"});
         target->append_datum(DatumArray{"c"});
@@ -1988,12 +1988,12 @@ TEST_F(ArrayFunctionsTest, array_remove_nullable_array) {
     // array_remove(NULL, ["a"]) -> NULL
     // array_remove(NULL, [])    -> NULL
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, true);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, true);
         array->append_datum(Datum());
         array->append_datum(Datum());
         array->append_datum(Datum());
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_VARCHAR), true);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_ARRAY_VARCHAR), true);
         target->append_datum(Datum());
         target->append_datum(DatumArray{"a"});
         target->append_datum(DatumArray{Datum()});
@@ -2007,8 +2007,8 @@ TEST_F(ArrayFunctionsTest, array_remove_nullable_array) {
     }
     // array_remove(NULL,1)
     {
-        auto array = ColumnHelper::create_const_null_column(3);
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_TINYINT), true);
+        ColumnPtr array = ColumnHelper::create_const_null_column(3);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_TINYINT), true);
         target->append_datum(Datum((int8_t)2));
         target->append_datum(Datum((int8_t)4));
         target->append_datum(Datum());
@@ -2025,10 +2025,10 @@ TEST_F(ArrayFunctionsTest, array_remove_nullable_array) {
 // NOLINTNEXTLINE
 TEST_F(ArrayFunctionsTest, array_append) {
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         array->append_datum(Datum(DatumArray{}));
 
-        auto null = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 0);
+        ColumnPtr null = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 0);
 
         auto result = ArrayFunctions::array_append(nullptr, {array, null}).value();
         EXPECT_EQ(1, result->size());
@@ -2040,13 +2040,13 @@ TEST_F(ArrayFunctionsTest, array_append) {
     // array_append([], 'def')
     // array_append(NULL, 'def')
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
         array->append_datum(DatumArray{"abc"});
         array->append_datum(DatumArray{"xyz", "xxx"});
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum());
 
-        auto data = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
+        ColumnPtr data = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
         data->append_datum("def");
 
         auto result = ArrayFunctions::array_append(nullptr, {array, data}).value();
@@ -2072,14 +2072,14 @@ TEST_F(ArrayFunctionsTest, array_append) {
     // array_append(NULL, NULL)                   -> NULL
     // array_append([[10, 11],[12,13]], [14,15])  -> [[10,11],[12,13],[14,15]]
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, true);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, true);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{Datum(DatumArray{0, 1})});
         array->append_datum(DatumArray{Datum()});
         array->append_datum(Datum());
         array->append_datum(DatumArray{Datum(DatumArray{10, 11}), Datum(DatumArray{12, 13})});
 
-        auto data = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+        ColumnPtr data = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
         data->append_datum(Datum(DatumArray{}));
         data->append_datum(DatumArray{2});
         data->append_datum(DatumArray{3, 4});
@@ -2129,8 +2129,8 @@ TEST_F(ArrayFunctionsTest, array_append) {
 
     // array_append(NULL,1)
     {
-        auto array = ColumnHelper::create_const_null_column(3);
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_TINYINT), true);
+        ColumnPtr array = ColumnHelper::create_const_null_column(3);
+        ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_TINYINT), true);
         target->append_datum(Datum((int8_t)2));
         target->append_datum(Datum((int8_t)4));
         target->append_datum(Datum());
@@ -2146,7 +2146,7 @@ TEST_F(ArrayFunctionsTest, array_append) {
 
 TEST_F(ArrayFunctionsTest, array_sum_empty_array) {
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
 
         auto result = ArrayFunctions::array_sum<TYPE_INT>(nullptr, {array}).value();
@@ -2154,7 +2154,7 @@ TEST_F(ArrayFunctionsTest, array_sum_empty_array) {
         EXPECT_TRUE(result->is_null(0));
     }
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
         array->append_datum(Datum(DatumArray{}));
 
         auto result = ArrayFunctions::array_sum<TYPE_BOOLEAN>(nullptr, {array}).value();
@@ -2163,7 +2163,7 @@ TEST_F(ArrayFunctionsTest, array_sum_empty_array) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
@@ -2178,7 +2178,7 @@ TEST_F(ArrayFunctionsTest, array_sum_empty_array) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
@@ -2193,7 +2193,7 @@ TEST_F(ArrayFunctionsTest, array_sum_empty_array) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
@@ -2223,7 +2223,7 @@ TEST_F(ArrayFunctionsTest, array_sum_empty_array) {
 
 TEST_F(ArrayFunctionsTest, array_avg_empty_array) {
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
 
         auto result = ArrayFunctions::array_avg<TYPE_INT>(nullptr, {array}).value();
@@ -2231,7 +2231,7 @@ TEST_F(ArrayFunctionsTest, array_avg_empty_array) {
         EXPECT_TRUE(result->is_null(0));
     }
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
         array->append_datum(Datum(DatumArray{}));
 
         auto result = ArrayFunctions::array_avg<TYPE_BOOLEAN>(nullptr, {array}).value();
@@ -2240,7 +2240,7 @@ TEST_F(ArrayFunctionsTest, array_avg_empty_array) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
@@ -2255,7 +2255,7 @@ TEST_F(ArrayFunctionsTest, array_avg_empty_array) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
@@ -2270,7 +2270,7 @@ TEST_F(ArrayFunctionsTest, array_avg_empty_array) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
@@ -2300,7 +2300,7 @@ TEST_F(ArrayFunctionsTest, array_avg_empty_array) {
 
 TEST_F(ArrayFunctionsTest, array_min_empty_array) {
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
 
         auto result = ArrayFunctions::array_min<TYPE_INT>(nullptr, {array}).value();
@@ -2308,7 +2308,7 @@ TEST_F(ArrayFunctionsTest, array_min_empty_array) {
         EXPECT_TRUE(result->is_null(0));
     }
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
         array->append_datum(Datum(DatumArray{}));
 
         auto result = ArrayFunctions::array_min<TYPE_BOOLEAN>(nullptr, {array}).value();
@@ -2317,7 +2317,7 @@ TEST_F(ArrayFunctionsTest, array_min_empty_array) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
@@ -2332,7 +2332,7 @@ TEST_F(ArrayFunctionsTest, array_min_empty_array) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
@@ -2347,7 +2347,7 @@ TEST_F(ArrayFunctionsTest, array_min_empty_array) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
@@ -2377,7 +2377,7 @@ TEST_F(ArrayFunctionsTest, array_min_empty_array) {
 
 TEST_F(ArrayFunctionsTest, array_max_empty_array) {
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
 
         auto result = ArrayFunctions::array_max<TYPE_INT>(nullptr, {array}).value();
@@ -2385,7 +2385,7 @@ TEST_F(ArrayFunctionsTest, array_max_empty_array) {
         EXPECT_TRUE(result->is_null(0));
     }
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
         array->append_datum(Datum(DatumArray{}));
 
         auto result = ArrayFunctions::array_max<TYPE_BOOLEAN>(nullptr, {array}).value();
@@ -2394,7 +2394,7 @@ TEST_F(ArrayFunctionsTest, array_max_empty_array) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
@@ -2409,7 +2409,7 @@ TEST_F(ArrayFunctionsTest, array_max_empty_array) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
@@ -2424,7 +2424,7 @@ TEST_F(ArrayFunctionsTest, array_max_empty_array) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
@@ -2454,7 +2454,7 @@ TEST_F(ArrayFunctionsTest, array_max_empty_array) {
 
 TEST_F(ArrayFunctionsTest, array_sum_no_null) {
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{(int8_t) false});
@@ -2477,7 +2477,7 @@ TEST_F(ArrayFunctionsTest, array_sum_no_null) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{2});
         array->append_datum(DatumArray{1, 2, 3});
@@ -2496,7 +2496,7 @@ TEST_F(ArrayFunctionsTest, array_sum_no_null) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{(int8_t)127, (int8_t)100, (int8_t)-1});
         array->append_datum(DatumArray{(int8_t)-128, (int8_t)-1, (int8_t)10});
@@ -2511,7 +2511,7 @@ TEST_F(ArrayFunctionsTest, array_sum_no_null) {
 
 TEST_F(ArrayFunctionsTest, array_avg_no_null) {
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{(int8_t) false});
@@ -2534,7 +2534,7 @@ TEST_F(ArrayFunctionsTest, array_avg_no_null) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{2});
         array->append_datum(DatumArray{1, 2, 3});
@@ -2553,7 +2553,7 @@ TEST_F(ArrayFunctionsTest, array_avg_no_null) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{(int8_t) true, Datum(), Datum(), (int8_t) false});
         array->append_datum(DatumArray{(int8_t) false, Datum()});
@@ -2568,7 +2568,7 @@ TEST_F(ArrayFunctionsTest, array_avg_no_null) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{(int8_t)-128, (int8_t)127, (int8_t)0, Datum()});
         array->append_datum(DatumArray{(int8_t)127, (int8_t)10, (int8_t)100});
@@ -2581,7 +2581,7 @@ TEST_F(ArrayFunctionsTest, array_avg_no_null) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_SMALLINT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_SMALLINT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{(int16_t)30000, (int16_t)30000, Datum()});
         array->append_datum(DatumArray{(int16_t)-32768, (int16_t)32767, Datum(), (int16_t)0, (int16_t)1});
@@ -2597,7 +2597,7 @@ TEST_F(ArrayFunctionsTest, array_avg_no_null) {
 
 TEST_F(ArrayFunctionsTest, array_min_no_null) {
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{(int8_t) false});
@@ -2620,7 +2620,7 @@ TEST_F(ArrayFunctionsTest, array_min_no_null) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{2});
         array->append_datum(DatumArray{1, 2, 3});
@@ -2639,7 +2639,7 @@ TEST_F(ArrayFunctionsTest, array_min_no_null) {
 
 TEST_F(ArrayFunctionsTest, array_max_no_null) {
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{(int8_t) false});
@@ -2662,7 +2662,7 @@ TEST_F(ArrayFunctionsTest, array_max_no_null) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{2});
         array->append_datum(DatumArray{1, 2, 3});
@@ -2681,7 +2681,7 @@ TEST_F(ArrayFunctionsTest, array_max_no_null) {
 
 TEST_F(ArrayFunctionsTest, array_sum_has_null_element) {
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{(int64_t)2000});
         array->append_datum(DatumArray{(int64_t)1000, (int64_t)2, (int64_t)3});
@@ -2700,7 +2700,7 @@ TEST_F(ArrayFunctionsTest, array_sum_has_null_element) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_LARGEINT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_LARGEINT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{(int128_t)2000});
         array->append_datum(DatumArray{(int128_t)1000, (int128_t)2, (int128_t)3});
@@ -2721,7 +2721,7 @@ TEST_F(ArrayFunctionsTest, array_sum_has_null_element) {
 
 TEST_F(ArrayFunctionsTest, array_avg_has_null_element) {
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{(int64_t)2000});
         array->append_datum(DatumArray{(int64_t)1000, (int64_t)2, (int64_t)3});
@@ -2740,7 +2740,7 @@ TEST_F(ArrayFunctionsTest, array_avg_has_null_element) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_LARGEINT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_LARGEINT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{(int128_t)2000});
         array->append_datum(DatumArray{(int128_t)1000, (int128_t)2, (int128_t)3});
@@ -2761,7 +2761,7 @@ TEST_F(ArrayFunctionsTest, array_avg_has_null_element) {
 
 TEST_F(ArrayFunctionsTest, array_min_has_null_element) {
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{(int64_t)2000});
         array->append_datum(DatumArray{(int64_t)1000, (int64_t)2, (int64_t)3});
@@ -2780,7 +2780,7 @@ TEST_F(ArrayFunctionsTest, array_min_has_null_element) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_LARGEINT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_LARGEINT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{(int128_t)2000});
         array->append_datum(DatumArray{(int128_t)1000, (int128_t)2, (int128_t)3});
@@ -2799,7 +2799,7 @@ TEST_F(ArrayFunctionsTest, array_min_has_null_element) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_DATE, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_DATE, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{DateValue::create(1990, 3, 22)});
         array->append_datum(DatumArray{DateValue::create(1990, 3, 22), DateValue::create(1990, 3, 24)});
@@ -2818,7 +2818,7 @@ TEST_F(ArrayFunctionsTest, array_min_has_null_element) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_DATETIME, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_DATETIME, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{TimestampValue::create(1990, 3, 22, 5, 32, 32)});
         array->append_datum(DatumArray{TimestampValue::create(1990, 3, 22, 5, 32, 32),
@@ -2840,7 +2840,7 @@ TEST_F(ArrayFunctionsTest, array_min_has_null_element) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{"varchar"});
         array->append_datum(DatumArray{"varchar1", "varchar2"});
@@ -2861,7 +2861,7 @@ TEST_F(ArrayFunctionsTest, array_min_has_null_element) {
 
 TEST_F(ArrayFunctionsTest, array_max_has_null_element) {
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{(int64_t)2000});
         array->append_datum(DatumArray{(int64_t)1000, (int64_t)2, (int64_t)3});
@@ -2878,7 +2878,7 @@ TEST_F(ArrayFunctionsTest, array_max_has_null_element) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_LARGEINT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_LARGEINT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{(int128_t)2000});
         array->append_datum(DatumArray{(int128_t)1000, (int128_t)2, (int128_t)3});
@@ -2897,7 +2897,7 @@ TEST_F(ArrayFunctionsTest, array_max_has_null_element) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_DATE, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_DATE, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{DateValue::create(1990, 3, 22)});
         array->append_datum(DatumArray{DateValue::create(1990, 3, 22), DateValue::create(1990, 3, 24)});
@@ -2916,7 +2916,7 @@ TEST_F(ArrayFunctionsTest, array_max_has_null_element) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_DATETIME, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_DATETIME, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{TimestampValue::create(1990, 3, 22, 5, 32, 32)});
         array->append_datum(DatumArray{TimestampValue::create(1990, 3, 22, 5, 32, 32),
@@ -2938,7 +2938,7 @@ TEST_F(ArrayFunctionsTest, array_max_has_null_element) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{"varchar"});
         array->append_datum(DatumArray{"varchar1", "varchar2"});
@@ -2959,7 +2959,7 @@ TEST_F(ArrayFunctionsTest, array_max_has_null_element) {
 
 TEST_F(ArrayFunctionsTest, array_sum_nullable_array) {
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
         array->append_datum(DatumArray{3, 5});
         array->append_datum(DatumArray{Datum(), 54});
         array->append_datum(DatumArray{5352, 121, 30});
@@ -2974,7 +2974,7 @@ TEST_F(ArrayFunctionsTest, array_sum_nullable_array) {
 
 TEST_F(ArrayFunctionsTest, array_avg_nullable_array) {
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
         array->append_datum(DatumArray{3, 5});
         array->append_datum(DatumArray{Datum(), 54});
         array->append_datum(DatumArray{5352, 121, 32});
@@ -2989,7 +2989,7 @@ TEST_F(ArrayFunctionsTest, array_avg_nullable_array) {
 
 TEST_F(ArrayFunctionsTest, array_min_nullable_array) {
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
         array->append_datum(DatumArray{3, 5});
         array->append_datum(DatumArray{Datum(), 54});
         array->append_datum(DatumArray{5352, 121, 32});
@@ -3004,7 +3004,7 @@ TEST_F(ArrayFunctionsTest, array_min_nullable_array) {
 
 TEST_F(ArrayFunctionsTest, array_max_nullable_array) {
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
         array->append_datum(DatumArray{3, 5});
         array->append_datum(DatumArray{Datum(), 54});
         array->append_datum(DatumArray{5352, 121, 32});
@@ -3019,7 +3019,7 @@ TEST_F(ArrayFunctionsTest, array_max_nullable_array) {
 
 TEST_F(ArrayFunctionsTest, array_all_null) {
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{Datum()});
         array->append_datum(DatumArray{Datum(), Datum(), Datum()});
@@ -3034,7 +3034,7 @@ TEST_F(ArrayFunctionsTest, array_all_null) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{Datum()});
         array->append_datum(DatumArray{Datum(), Datum(), Datum()});
@@ -3049,7 +3049,7 @@ TEST_F(ArrayFunctionsTest, array_all_null) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{Datum()});
         array->append_datum(DatumArray{Datum(), Datum(), Datum()});
@@ -3064,7 +3064,7 @@ TEST_F(ArrayFunctionsTest, array_all_null) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{Datum()});
         array->append_datum(DatumArray{Datum(), Datum(), Datum()});
@@ -3079,7 +3079,7 @@ TEST_F(ArrayFunctionsTest, array_all_null) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{Datum()});
         array->append_datum(DatumArray{Datum(), Datum(), Datum()});
@@ -3094,7 +3094,7 @@ TEST_F(ArrayFunctionsTest, array_all_null) {
     }
 
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(DatumArray{Datum()});
         array->append_datum(DatumArray{Datum(), Datum(), Datum()});
@@ -3110,7 +3110,7 @@ TEST_F(ArrayFunctionsTest, array_all_null) {
 }
 
 TEST_F(ArrayFunctionsTest, array_reverse_int) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
     src_column->append_datum(DatumArray{5, 3, 6});
     src_column->append_datum(DatumArray{2, 3, 7, 8});
     src_column->append_datum(DatumArray{4, 3, 2, 1});
@@ -3125,7 +3125,7 @@ TEST_F(ArrayFunctionsTest, array_reverse_int) {
 }
 
 TEST_F(ArrayFunctionsTest, array_reverse_string) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
     src_column->append_datum(DatumArray{"352", "66", "4325"});
     src_column->append_datum(DatumArray{"235", "99", "8", "43251"});
     src_column->append_datum(DatumArray{"44", "33", "22", "112"});
@@ -3140,7 +3140,7 @@ TEST_F(ArrayFunctionsTest, array_reverse_string) {
 }
 
 TEST_F(ArrayFunctionsTest, array_reverse_nullable_elements) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
     src_column->append_datum(DatumArray{5, Datum(), 3, 6});
     src_column->append_datum(DatumArray{2, 3, Datum(), Datum()});
     src_column->append_datum(DatumArray{Datum(), Datum(), Datum(), Datum()});
@@ -3155,7 +3155,7 @@ TEST_F(ArrayFunctionsTest, array_reverse_nullable_elements) {
 }
 
 TEST_F(ArrayFunctionsTest, array_reverse_nullable_array) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
     src_column->append_datum(DatumArray{5, Datum(), 3, 6});
     src_column->append_datum(Datum());
     src_column->append_datum(DatumArray{Datum(), Datum(), Datum(), Datum()});
@@ -3170,7 +3170,7 @@ TEST_F(ArrayFunctionsTest, array_reverse_nullable_array) {
 }
 
 TEST_F(ArrayFunctionsTest, array_reverse_only_null) {
-    auto src_column = ColumnHelper::create_const_null_column(3);
+    ColumnPtr src_column = ColumnHelper::create_const_null_column(3);
 
     ArrayReverse<LogicalType::TYPE_INT> reverse;
     auto dest_column = reverse.process(nullptr, {src_column});
@@ -3182,7 +3182,7 @@ TEST_F(ArrayFunctionsTest, array_reverse_only_null) {
 }
 
 TEST_F(ArrayFunctionsTest, array_difference_boolean) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, true);
     src_column->append_datum(DatumArray{(uint8_t)5, (uint8_t)3, (uint8_t)6});
     src_column->append_datum(DatumArray{(uint8_t)2, (uint8_t)3, (uint8_t)7, (uint8_t)8});
     src_column->append_datum(DatumArray{(uint8_t)4, (uint8_t)3, (uint8_t)2, (uint8_t)1});
@@ -3197,7 +3197,7 @@ TEST_F(ArrayFunctionsTest, array_difference_boolean) {
 }
 
 TEST_F(ArrayFunctionsTest, array_difference_boolean_with_entry_null) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, true);
     src_column->append_datum(DatumArray{(uint8_t)5, Datum(), (uint8_t)6});
     src_column->append_datum(DatumArray{Datum(), (uint8_t)3, (uint8_t)7, (uint8_t)8});
     src_column->append_datum(DatumArray{(uint8_t)4, (uint8_t)3, (uint8_t)2, Datum()});
@@ -3225,7 +3225,7 @@ TEST_F(ArrayFunctionsTest, array_difference_boolean_with_entry_null) {
 }
 
 TEST_F(ArrayFunctionsTest, array_difference_int) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
     src_column->append_datum(DatumArray{5, 3, 6});
     src_column->append_datum(DatumArray{2, 3, 7, 8});
     src_column->append_datum(DatumArray{4, 3, 2, 1});
@@ -3240,7 +3240,7 @@ TEST_F(ArrayFunctionsTest, array_difference_int) {
 }
 
 TEST_F(ArrayFunctionsTest, array_difference_int_with_entry_null) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
     src_column->append_datum(DatumArray{5, Datum(), 6});
     src_column->append_datum(DatumArray{Datum(), 3, 7, 8});
     src_column->append_datum(DatumArray{4, 3, 2, Datum()});
@@ -3268,7 +3268,7 @@ TEST_F(ArrayFunctionsTest, array_difference_int_with_entry_null) {
 }
 
 TEST_F(ArrayFunctionsTest, array_difference_bigint) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, true);
     src_column->append_datum(DatumArray{(int64_t)5, (int64_t)3, (int64_t)6});
     src_column->append_datum(DatumArray{(int64_t)2, (int64_t)3, (int64_t)7, (int64_t)8});
     src_column->append_datum(DatumArray{(int64_t)4, (int64_t)3, (int64_t)2, (int64_t)1});
@@ -3283,7 +3283,7 @@ TEST_F(ArrayFunctionsTest, array_difference_bigint) {
 }
 
 TEST_F(ArrayFunctionsTest, array_difference_bigint_with_entry_null) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, true);
     src_column->append_datum(DatumArray{(int64_t)5, Datum(), (int64_t)6});
     src_column->append_datum(DatumArray{Datum(), (int64_t)3, (int64_t)7, (int64_t)8});
     src_column->append_datum(DatumArray{(int64_t)4, (int64_t)3, (int64_t)2, Datum()});
@@ -3311,7 +3311,7 @@ TEST_F(ArrayFunctionsTest, array_difference_bigint_with_entry_null) {
 }
 
 TEST_F(ArrayFunctionsTest, array_difference_double) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, true);
     src_column->append_datum(DatumArray{(double)5, (double)3, (double)6});
     src_column->append_datum(DatumArray{(double)2, (double)3, (double)7, (double)8});
     src_column->append_datum(DatumArray{(double)4, (double)3, (double)2, (double)1});
@@ -3326,7 +3326,7 @@ TEST_F(ArrayFunctionsTest, array_difference_double) {
 }
 
 TEST_F(ArrayFunctionsTest, array_slice_int) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
     src_column->append_datum(DatumArray{(int32_t)5, (int32_t)3, (int32_t)6});
     src_column->append_datum(DatumArray{(int32_t)2, (int32_t)3, (int32_t)7, (int32_t)8});
     src_column->append_datum(DatumArray{(int32_t)4, (int32_t)3, (int32_t)2, (int32_t)1});
@@ -3336,7 +3336,7 @@ TEST_F(ArrayFunctionsTest, array_slice_int) {
     src_column->append_datum(DatumArray{(int32_t)1, (int32_t)2, Datum(), (int32_t)4, (int32_t)5});
     src_column->append_datum(DatumArray{(int32_t)1, (int32_t)2, Datum(), (int32_t)4, (int32_t)5});
 
-    auto offset_column = Int64Column::create();
+    Int64Column::Ptr offset_column = Int64Column::create();
     offset_column->append(1);
     offset_column->append(2);
     offset_column->append(3);
@@ -3346,7 +3346,7 @@ TEST_F(ArrayFunctionsTest, array_slice_int) {
     offset_column->append(-7);
     offset_column->append(-8);
 
-    auto length_column = Int64Column::create();
+    Int64Column::Ptr length_column = Int64Column::create();
     length_column->append(1);
     length_column->append(3);
     length_column->append(2);
@@ -3371,21 +3371,21 @@ TEST_F(ArrayFunctionsTest, array_slice_int) {
 }
 
 TEST_F(ArrayFunctionsTest, array_slice_bigint) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, true);
     src_column->append_datum(DatumArray{(int64_t)5, (int64_t)3, (int64_t)6});
     src_column->append_datum(DatumArray{(int64_t)2, (int64_t)3, (int64_t)7, (int64_t)8});
     src_column->append_datum(DatumArray{(int64_t)4, (int64_t)3, (int64_t)2, (int64_t)1});
     src_column->append_datum(Datum());
     src_column->append_datum(DatumArray{(int64_t)4, Datum(), (int64_t)2, (int64_t)1});
 
-    auto offset_column = Int64Column::create();
+    Int64Column::Ptr offset_column = Int64Column::create();
     offset_column->append(1);
     offset_column->append(2);
     offset_column->append(3);
     offset_column->append(1);
     offset_column->append(2);
 
-    auto length_column = Int64Column::create();
+    Int64Column::Ptr length_column = Int64Column::create();
     length_column->append(1);
     length_column->append(3);
     length_column->append(2);
@@ -3404,21 +3404,21 @@ TEST_F(ArrayFunctionsTest, array_slice_bigint) {
 }
 
 TEST_F(ArrayFunctionsTest, array_slice_float) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_FLOAT, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_FLOAT, true);
     src_column->append_datum(DatumArray{(float)5, (float)3, (float)6});
     src_column->append_datum(DatumArray{(float)2, (float)3, (float)7, (float)8});
     src_column->append_datum(DatumArray{(float)4, (float)3, (float)2, (float)1});
     src_column->append_datum(Datum());
     src_column->append_datum(DatumArray{(float)4, Datum(), (float)2, (float)1});
 
-    auto offset_column = Int64Column::create();
+    Int64Column::Ptr offset_column = Int64Column::create();
     offset_column->append(1);
     offset_column->append(2);
     offset_column->append(3);
     offset_column->append(1);
     offset_column->append(2);
 
-    auto length_column = Int64Column::create();
+    Int64Column::Ptr length_column = Int64Column::create();
     length_column->append(1);
     length_column->append(3);
     length_column->append(2);
@@ -3437,21 +3437,21 @@ TEST_F(ArrayFunctionsTest, array_slice_float) {
 }
 
 TEST_F(ArrayFunctionsTest, array_slice_double) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, true);
     src_column->append_datum(DatumArray{(double)5, (double)3, (double)6});
     src_column->append_datum(DatumArray{(double)2, (double)3, (double)7, (double)8});
     src_column->append_datum(DatumArray{(double)4, (double)3, (double)2, (double)1});
     src_column->append_datum(Datum());
     src_column->append_datum(DatumArray{(double)4, Datum(), (double)2, (double)1});
 
-    auto offset_column = Int64Column::create();
+    Int64Column::Ptr offset_column = Int64Column::create();
     offset_column->append(1);
     offset_column->append(2);
     offset_column->append(3);
     offset_column->append(1);
     offset_column->append(2);
 
-    auto length_column = Int64Column::create();
+    Int64Column::Ptr length_column = Int64Column::create();
     length_column->append(1);
     length_column->append(3);
     length_column->append(2);
@@ -3470,21 +3470,21 @@ TEST_F(ArrayFunctionsTest, array_slice_double) {
 }
 
 TEST_F(ArrayFunctionsTest, array_slice_varchar) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
     src_column->append_datum(DatumArray{Slice("5"), Slice("3"), Slice("6")});
     src_column->append_datum(DatumArray{Slice("2"), Slice("3"), Slice("7"), Slice("8")});
     src_column->append_datum(DatumArray{Slice("4"), Slice("3"), Slice("2"), Slice("1")});
     src_column->append_datum(Datum());
     src_column->append_datum(DatumArray{Slice("4"), Datum(), Slice("2"), Slice("1")});
 
-    auto offset_column = Int64Column::create();
+    Int64Column::Ptr offset_column = Int64Column::create();
     offset_column->append(1);
     offset_column->append(2);
     offset_column->append(3);
     offset_column->append(1);
     offset_column->append(2);
 
-    auto length_column = Int64Column::create();
+    Int64Column::Ptr length_column = Int64Column::create();
     length_column->append(1);
     length_column->append(3);
     length_column->append(2);
@@ -3503,14 +3503,14 @@ TEST_F(ArrayFunctionsTest, array_slice_varchar) {
 }
 
 TEST_F(ArrayFunctionsTest, array_slice_bigint_only_offset) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, true);
     src_column->append_datum(DatumArray{(int64_t)5, (int64_t)3, (int64_t)6});
     src_column->append_datum(DatumArray{(int64_t)2, (int64_t)3, (int64_t)7, (int64_t)8});
     src_column->append_datum(DatumArray{(int64_t)4, (int64_t)3, (int64_t)2, (int64_t)1});
     src_column->append_datum(Datum());
     src_column->append_datum(DatumArray{(int64_t)4, Datum(), (int64_t)2, (int64_t)1});
 
-    auto offset_column = Int64Column::create();
+    Int64Column::Ptr offset_column = Int64Column::create();
     offset_column->append(1);
     offset_column->append(2);
     offset_column->append(3);
@@ -3530,14 +3530,14 @@ TEST_F(ArrayFunctionsTest, array_slice_bigint_only_offset) {
 }
 
 TEST_F(ArrayFunctionsTest, array_slice_double_only_offset) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, true);
     src_column->append_datum(DatumArray{(double)5, (double)3, (double)6});
     src_column->append_datum(DatumArray{(double)2, (double)3, (double)7, (double)8});
     src_column->append_datum(DatumArray{(double)4, (double)3, (double)2, (double)1});
     src_column->append_datum(Datum());
     src_column->append_datum(DatumArray{(double)4, Datum(), (double)2, (double)1});
 
-    auto offset_column = Int64Column::create();
+    Int64Column::Ptr offset_column = Int64Column::create();
     offset_column->append(1);
     offset_column->append(2);
     offset_column->append(3);
@@ -3557,14 +3557,14 @@ TEST_F(ArrayFunctionsTest, array_slice_double_only_offset) {
 }
 
 TEST_F(ArrayFunctionsTest, array_slice_varchar_only_offset) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
     src_column->append_datum(DatumArray{Slice("5"), Slice("3"), Slice("6")});
     src_column->append_datum(DatumArray{Slice("2"), Slice("3"), Slice("7"), Slice("8")});
     src_column->append_datum(DatumArray{Slice("4"), Slice("3"), Slice("2"), Slice("1")});
     src_column->append_datum(Datum());
     src_column->append_datum(DatumArray{Slice("4"), Datum(), Slice("2"), Slice("1")});
 
-    auto offset_column = Int64Column::create();
+    Int64Column::Ptr offset_column = Int64Column::create();
     offset_column->append(1);
     offset_column->append(2);
     offset_column->append(3);
@@ -3584,21 +3584,21 @@ TEST_F(ArrayFunctionsTest, array_slice_varchar_only_offset) {
 }
 
 TEST_F(ArrayFunctionsTest, array_concat_tinyint) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, true);
     src_column->append_datum(DatumArray{(int8_t)5, (int8_t)3, (int8_t)6});
     src_column->append_datum(DatumArray{(int8_t)8});
     src_column->append_datum(DatumArray{(int8_t)4});
     src_column->append_datum(Datum());
     src_column->append_datum(DatumArray{(int8_t)4, (int8_t)1});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, true);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, true);
     src_column2->append_datum(DatumArray{(int8_t)5, (int8_t)6});
     src_column2->append_datum(DatumArray{(int8_t)2});
     src_column2->append_datum(DatumArray{(int8_t)4, (int8_t)3, (int8_t)2, (int8_t)1});
     src_column2->append_datum(DatumArray{(int8_t)4, (int8_t)9});
     src_column2->append_datum(DatumArray{(int8_t)4, Datum()});
 
-    auto src_column3 = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, true);
+    ColumnPtr src_column3 = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, true);
     src_column3->append_datum(DatumArray{(int8_t)5});
     src_column3->append_datum(DatumArray{(int8_t)2, (int8_t)8});
     src_column3->append_datum(DatumArray{(int8_t)2, (int8_t)1});
@@ -3627,19 +3627,19 @@ TEST_F(ArrayFunctionsTest, array_concat_tinyint) {
 }
 
 TEST_F(ArrayFunctionsTest, array_concat_tinyint_not_nullable) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
     src_column->append_datum(DatumArray{(int8_t)5, (int8_t)3, (int8_t)6});
     src_column->append_datum(DatumArray{(int8_t)8});
     src_column->append_datum(DatumArray{(int8_t)4});
     src_column->append_datum(DatumArray{(int8_t)4, (int8_t)1});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
     src_column2->append_datum(DatumArray{(int8_t)5, (int8_t)6});
     src_column2->append_datum(DatumArray{(int8_t)2});
     src_column2->append_datum(DatumArray{(int8_t)4, (int8_t)3, (int8_t)2, (int8_t)1});
     src_column2->append_datum(DatumArray{(int8_t)4, Datum()});
 
-    auto src_column3 = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
+    ColumnPtr src_column3 = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
     src_column3->append_datum(DatumArray{(int8_t)5});
     src_column3->append_datum(DatumArray{(int8_t)2, (int8_t)8});
     src_column3->append_datum(DatumArray{(int8_t)2, (int8_t)1});
@@ -3665,21 +3665,21 @@ TEST_F(ArrayFunctionsTest, array_concat_tinyint_not_nullable) {
 }
 
 TEST_F(ArrayFunctionsTest, array_concat_bigint) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, true);
     src_column->append_datum(DatumArray{(int64_t)5, (int64_t)3, (int64_t)6});
     src_column->append_datum(DatumArray{(int64_t)8});
     src_column->append_datum(DatumArray{(int64_t)4});
     src_column->append_datum(Datum());
     src_column->append_datum(DatumArray{(int64_t)4, (int64_t)1});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, true);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, true);
     src_column2->append_datum(DatumArray{(int64_t)5, (int64_t)6});
     src_column2->append_datum(DatumArray{(int64_t)2});
     src_column2->append_datum(DatumArray{(int64_t)4, (int64_t)3, (int64_t)2, (int64_t)1});
     src_column2->append_datum(DatumArray{(int64_t)4, (int64_t)9});
     src_column2->append_datum(DatumArray{(int64_t)4, Datum()});
 
-    auto src_column3 = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, true);
+    ColumnPtr src_column3 = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, true);
     src_column3->append_datum(DatumArray{(int64_t)5});
     src_column3->append_datum(DatumArray{(int64_t)2, (int64_t)8});
     src_column3->append_datum(DatumArray{(int64_t)2, (int64_t)1});
@@ -3708,19 +3708,19 @@ TEST_F(ArrayFunctionsTest, array_concat_bigint) {
 }
 
 TEST_F(ArrayFunctionsTest, array_concat_bigint_not_nullable) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
     src_column->append_datum(DatumArray{(int64_t)5, (int64_t)3, (int64_t)6});
     src_column->append_datum(DatumArray{(int64_t)8});
     src_column->append_datum(DatumArray{(int64_t)4});
     src_column->append_datum(DatumArray{(int64_t)4, (int64_t)1});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
     src_column2->append_datum(DatumArray{(int64_t)5, (int64_t)6});
     src_column2->append_datum(DatumArray{(int64_t)2});
     src_column2->append_datum(DatumArray{(int64_t)4, (int64_t)3, (int64_t)2, (int64_t)1});
     src_column2->append_datum(DatumArray{(int64_t)4, Datum()});
 
-    auto src_column3 = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
+    ColumnPtr src_column3 = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
     src_column3->append_datum(DatumArray{(int64_t)5});
     src_column3->append_datum(DatumArray{(int64_t)2, (int64_t)8});
     src_column3->append_datum(DatumArray{(int64_t)2, (int64_t)1});
@@ -3746,21 +3746,21 @@ TEST_F(ArrayFunctionsTest, array_concat_bigint_not_nullable) {
 }
 
 TEST_F(ArrayFunctionsTest, array_concat_double) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, true);
     src_column->append_datum(DatumArray{(double)5, (double)3, (double)6});
     src_column->append_datum(DatumArray{(double)8});
     src_column->append_datum(DatumArray{(double)4});
     src_column->append_datum(Datum());
     src_column->append_datum(DatumArray{(double)4, (double)1});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, true);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, true);
     src_column2->append_datum(DatumArray{(double)5, (double)6});
     src_column2->append_datum(DatumArray{(double)2});
     src_column2->append_datum(DatumArray{(double)4, (double)3, (double)2, (double)1});
     src_column2->append_datum(DatumArray{(double)4, (double)9});
     src_column2->append_datum(DatumArray{(double)4, Datum()});
 
-    auto src_column3 = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, true);
+    ColumnPtr src_column3 = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, true);
     src_column3->append_datum(DatumArray{(double)5});
     src_column3->append_datum(DatumArray{(double)2, (double)8});
     src_column3->append_datum(DatumArray{(double)2, (double)1});
@@ -3789,19 +3789,19 @@ TEST_F(ArrayFunctionsTest, array_concat_double) {
 }
 
 TEST_F(ArrayFunctionsTest, array_concat_double_not_nullable) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, false);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, false);
     src_column->append_datum(DatumArray{(double)5, (double)3, (double)6});
     src_column->append_datum(DatumArray{(double)8});
     src_column->append_datum(DatumArray{(double)4});
     src_column->append_datum(DatumArray{(double)4, (double)1});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, false);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, false);
     src_column2->append_datum(DatumArray{(double)5, (double)6});
     src_column2->append_datum(DatumArray{(double)2});
     src_column2->append_datum(DatumArray{(double)4, (double)3, (double)2, (double)1});
     src_column2->append_datum(DatumArray{(double)4, Datum()});
 
-    auto src_column3 = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, false);
+    ColumnPtr src_column3 = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, false);
     src_column3->append_datum(DatumArray{(double)5});
     src_column3->append_datum(DatumArray{(double)2, (double)8});
     src_column3->append_datum(DatumArray{(double)2, (double)1});
@@ -3827,21 +3827,21 @@ TEST_F(ArrayFunctionsTest, array_concat_double_not_nullable) {
 }
 
 TEST_F(ArrayFunctionsTest, array_concat_varchar) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
     src_column->append_datum(DatumArray{Slice("5"), Slice("3"), Slice("6")});
     src_column->append_datum(DatumArray{Slice("8")});
     src_column->append_datum(DatumArray{Slice("4")});
     src_column->append_datum(Datum());
     src_column->append_datum(DatumArray{Slice("4"), Slice("1")});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
     src_column2->append_datum(DatumArray{Slice("5"), Slice("6")});
     src_column2->append_datum(DatumArray{Slice("2")});
     src_column2->append_datum(DatumArray{Slice("4"), Slice("3"), Slice("2"), Slice("1")});
     src_column2->append_datum(DatumArray{Slice("4"), Slice("9")});
     src_column2->append_datum(DatumArray{Slice("4"), Datum()});
 
-    auto src_column3 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    ColumnPtr src_column3 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
     src_column3->append_datum(DatumArray{Slice("5")});
     src_column3->append_datum(DatumArray{Slice("2"), Slice("8")});
     src_column3->append_datum(DatumArray{Slice("2"), Slice("1")});
@@ -3870,19 +3870,19 @@ TEST_F(ArrayFunctionsTest, array_concat_varchar) {
 }
 
 TEST_F(ArrayFunctionsTest, array_concat_varchar_not_nullable) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
     src_column->append_datum(DatumArray{Slice("5"), Slice("3"), Slice("6")});
     src_column->append_datum(DatumArray{Slice("8")});
     src_column->append_datum(DatumArray{Slice("4")});
     src_column->append_datum(DatumArray{Slice("4"), Slice("1")});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
     src_column2->append_datum(DatumArray{Slice("5"), Slice("6")});
     src_column2->append_datum(DatumArray{Slice("2")});
     src_column2->append_datum(DatumArray{Slice("4"), Slice("3"), Slice("2"), Slice("1")});
     src_column2->append_datum(DatumArray{Slice("4"), Datum()});
 
-    auto src_column3 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+    ColumnPtr src_column3 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
     src_column3->append_datum(DatumArray{Slice("5")});
     src_column3->append_datum(DatumArray{Slice("2"), Slice("8")});
     src_column3->append_datum(DatumArray{Slice("2"), Slice("1")});
@@ -3908,14 +3908,14 @@ TEST_F(ArrayFunctionsTest, array_concat_varchar_not_nullable) {
 }
 
 TEST_F(ArrayFunctionsTest, array_overlap_tinyint_with_nullable) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, true);
     src_column->append_datum(DatumArray{(int8_t)5, (int8_t)3, (int8_t)6});
     src_column->append_datum(DatumArray{(int8_t)8});
     src_column->append_datum(DatumArray{(int8_t)4});
     src_column->append_datum(Datum());
     src_column->append_datum(DatumArray{(int8_t)4, (int8_t)1});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
     src_column2->append_datum(DatumArray{(int8_t)5, (int8_t)6});
     src_column2->append_datum(DatumArray{(int8_t)2});
     src_column2->append_datum(DatumArray{(int8_t)4, (int8_t)3, (int8_t)2, (int8_t)1});
@@ -3942,14 +3942,14 @@ TEST_F(ArrayFunctionsTest, array_overlap_tinyint_with_nullable) {
 }
 
 TEST_F(ArrayFunctionsTest, array_overlap_tinyint) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
     src_column->append_datum(DatumArray{(int8_t)5, (int8_t)3, (int8_t)6});
     src_column->append_datum(DatumArray{(int8_t)8});
     src_column->append_datum(DatumArray{(int8_t)4});
     src_column->append_datum(DatumArray{(int8_t)99});
     src_column->append_datum(DatumArray{(int8_t)4, (int8_t)1});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
     src_column2->append_datum(DatumArray{(int8_t)5, (int8_t)6});
     src_column2->append_datum(DatumArray{(int8_t)2});
     src_column2->append_datum(DatumArray{(int8_t)4, (int8_t)3, (int8_t)2, (int8_t)1});
@@ -3974,14 +3974,14 @@ TEST_F(ArrayFunctionsTest, array_overlap_tinyint) {
 }
 
 TEST_F(ArrayFunctionsTest, array_overlap_bigint_with_nullable) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, true);
     src_column->append_datum(DatumArray{(int64_t)5, (int64_t)3, (int64_t)6});
     src_column->append_datum(DatumArray{(int64_t)8});
     src_column->append_datum(DatumArray{(int64_t)4});
     src_column->append_datum(Datum());
     src_column->append_datum(DatumArray{(int64_t)4, (int64_t)1});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
     src_column2->append_datum(DatumArray{(int64_t)5, (int64_t)6});
     src_column2->append_datum(DatumArray{(int64_t)2});
     src_column2->append_datum(DatumArray{(int64_t)4, (int64_t)3, (int64_t)2, (int64_t)1});
@@ -4008,14 +4008,14 @@ TEST_F(ArrayFunctionsTest, array_overlap_bigint_with_nullable) {
 }
 
 TEST_F(ArrayFunctionsTest, array_overlap_bigint) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
     src_column->append_datum(DatumArray{(int64_t)5, (int64_t)3, (int64_t)6});
     src_column->append_datum(DatumArray{(int64_t)8});
     src_column->append_datum(DatumArray{(int64_t)4});
     src_column->append_datum(DatumArray{(int64_t)99});
     src_column->append_datum(DatumArray{(int64_t)4, (int64_t)1});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
     src_column2->append_datum(DatumArray{(int64_t)5, (int64_t)6});
     src_column2->append_datum(DatumArray{(int64_t)2});
     src_column2->append_datum(DatumArray{(int64_t)4, (int64_t)3, (int64_t)2, (int64_t)1});
@@ -4040,14 +4040,14 @@ TEST_F(ArrayFunctionsTest, array_overlap_bigint) {
 }
 
 TEST_F(ArrayFunctionsTest, array_overlap_double_with_nullable) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, true);
     src_column->append_datum(DatumArray{(double)5, (double)3, (double)6});
     src_column->append_datum(DatumArray{(double)8});
     src_column->append_datum(DatumArray{(double)4});
     src_column->append_datum(Datum());
     src_column->append_datum(DatumArray{(double)4, (double)1});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, false);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, false);
     src_column2->append_datum(DatumArray{(double)5, (double)6});
     src_column2->append_datum(DatumArray{(double)2});
     src_column2->append_datum(DatumArray{(double)4, (double)3, (double)2, (double)1});
@@ -4074,14 +4074,14 @@ TEST_F(ArrayFunctionsTest, array_overlap_double_with_nullable) {
 }
 
 TEST_F(ArrayFunctionsTest, array_overlap_double) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, false);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, false);
     src_column->append_datum(DatumArray{(double)5, (double)3, (double)6});
     src_column->append_datum(DatumArray{(double)8});
     src_column->append_datum(DatumArray{(double)4});
     src_column->append_datum(DatumArray{(double)99});
     src_column->append_datum(DatumArray{(double)4, (double)1});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, false);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, false);
     src_column2->append_datum(DatumArray{(double)5, (double)6});
     src_column2->append_datum(DatumArray{(double)2});
     src_column2->append_datum(DatumArray{(double)4, (double)3, (double)2, (double)1});
@@ -4106,14 +4106,14 @@ TEST_F(ArrayFunctionsTest, array_overlap_double) {
 }
 
 TEST_F(ArrayFunctionsTest, array_overlap_varchar_with_nullable) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
     src_column->append_datum(DatumArray{Slice("5"), Slice("3"), Slice("6")});
     src_column->append_datum(DatumArray{Slice("8")});
     src_column->append_datum(DatumArray{Slice("4")});
     src_column->append_datum(Datum());
     src_column->append_datum(DatumArray{Slice("4"), Slice("1")});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
     src_column2->append_datum(DatumArray{Slice("5"), Slice("6")});
     src_column2->append_datum(DatumArray{Slice("2")});
     src_column2->append_datum(DatumArray{Slice("4"), Slice("3"), Slice("2"), Slice("1")});
@@ -4140,14 +4140,14 @@ TEST_F(ArrayFunctionsTest, array_overlap_varchar_with_nullable) {
 }
 
 TEST_F(ArrayFunctionsTest, array_overlap_varchar) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
     src_column->append_datum(DatumArray{Slice("5"), Slice("3"), Slice("6")});
     src_column->append_datum(DatumArray{Slice("8")});
     src_column->append_datum(DatumArray{Slice("4")});
     src_column->append_datum(DatumArray{Slice("99")});
     src_column->append_datum(DatumArray{Slice("4"), Slice("1")});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
     src_column2->append_datum(DatumArray{Slice("5"), Slice("6")});
     src_column2->append_datum(DatumArray{Slice("2")});
     src_column2->append_datum(DatumArray{Slice("4"), Slice("3"), Slice("2"), Slice("1")});
@@ -4172,10 +4172,10 @@ TEST_F(ArrayFunctionsTest, array_overlap_varchar) {
 }
 
 TEST_F(ArrayFunctionsTest, array_overlap_with_onlynull) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
     src_column->append_datum(DatumArray{(int8_t)5, (int8_t)3, (int8_t)6});
 
-    auto src_column2 = ColumnHelper::create_const_null_column(1);
+    ColumnPtr src_column2 = ColumnHelper::create_const_null_column(1);
 
     ArrayOverlap<LogicalType::TYPE_TINYINT> overlap;
     ASSERT_TRUE(overlap.prepare(&_ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
@@ -4186,19 +4186,19 @@ TEST_F(ArrayFunctionsTest, array_overlap_with_onlynull) {
 }
 
 TEST_F(ArrayFunctionsTest, array_intersect_int) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
     src_column->append_datum(DatumArray{(int32_t)5, (int32_t)3, (int32_t)6});
     src_column->append_datum(DatumArray{(int32_t)8});
     src_column->append_datum(DatumArray{(int32_t)4, (int32_t)1});
     src_column->append_datum(Datum());
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
     src_column2->append_datum(DatumArray{(int32_t)(5), (int32_t)(6)});
     src_column2->append_datum(DatumArray{(int32_t)(2)});
     src_column2->append_datum(DatumArray{(int32_t)(4), (int32_t)(3), (int32_t)(2), (int32_t)(1)});
     src_column2->append_datum(DatumArray{(int32_t)(4), (int32_t)(9)});
 
-    auto src_column3 = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+    ColumnPtr src_column3 = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
     src_column3->append_datum(DatumArray{(int32_t)(5)});
     src_column3->append_datum(DatumArray{(int32_t)(2), (int32_t)(8)});
     src_column3->append_datum(DatumArray{(int32_t)(4), (int32_t)(1)});
@@ -4215,19 +4215,19 @@ TEST_F(ArrayFunctionsTest, array_intersect_int) {
 }
 
 TEST_F(ArrayFunctionsTest, array_intersect_int_with_not_null) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
     src_column->append_datum(DatumArray{(int32_t)(5), (int32_t)(3), (int32_t)(6)});
     src_column->append_datum(DatumArray{(int32_t)(8)});
     src_column->append_datum(DatumArray{(int32_t)(4), (int32_t)(1)});
     src_column->append_datum(DatumArray{(int32_t)(4), (int32_t)(22), Datum()});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
     src_column2->append_datum(DatumArray{(int32_t)(5), (int32_t)(6)});
     src_column2->append_datum(DatumArray{(int32_t)(2)});
     src_column2->append_datum(DatumArray{(int32_t)(4), (int32_t)(3), (int32_t)(2), (int32_t)(1)});
     src_column2->append_datum(DatumArray{(int32_t)(4), Datum(), (int32_t)(22), (int32_t)(66)});
 
-    auto src_column3 = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+    ColumnPtr src_column3 = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
     src_column3->append_datum(DatumArray{(int32_t)(5)});
     src_column3->append_datum(DatumArray{(int32_t)(2), (int32_t)(8)});
     src_column3->append_datum(DatumArray{(int32_t)(4), (int32_t)(1)});
@@ -4268,19 +4268,19 @@ TEST_F(ArrayFunctionsTest, array_intersect_int_with_not_null) {
 }
 
 TEST_F(ArrayFunctionsTest, array_intersect_varchar) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
     src_column->append_datum(DatumArray{Slice("5"), Slice("3"), Slice("6")});
     src_column->append_datum(DatumArray{Slice("8")});
     src_column->append_datum(DatumArray{Slice("4"), Slice("1")});
     src_column->append_datum(Datum());
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
     src_column2->append_datum(DatumArray{Slice("5"), Slice("6")});
     src_column2->append_datum(DatumArray{Slice("2")});
     src_column2->append_datum(DatumArray{Slice("4"), Slice("3"), Slice("2"), Slice("1")});
     src_column2->append_datum(DatumArray{Slice("4"), Slice("9")});
 
-    auto src_column3 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    ColumnPtr src_column3 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
     src_column3->append_datum(DatumArray{Slice("5")});
     src_column3->append_datum(DatumArray{Slice("2"), Slice("8")});
     src_column3->append_datum(DatumArray{Slice("4"), Slice("1")});
@@ -4297,19 +4297,19 @@ TEST_F(ArrayFunctionsTest, array_intersect_varchar) {
 }
 
 TEST_F(ArrayFunctionsTest, array_intersect_varchar_with_not_null) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
     src_column->append_datum(DatumArray{Slice("5"), Slice("3"), Slice("6")});
     src_column->append_datum(DatumArray{Slice("8")});
     src_column->append_datum(DatumArray{Slice("4"), Slice("1")});
     src_column->append_datum(DatumArray{Slice("4"), Slice("22"), Datum()});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
     src_column2->append_datum(DatumArray{Slice("5"), Slice("6")});
     src_column2->append_datum(DatumArray{Slice("2")});
     src_column2->append_datum(DatumArray{Slice("4"), Slice("3"), Slice("2"), Slice("1")});
     src_column2->append_datum(DatumArray{Slice("4"), Datum(), Slice("22"), Slice("66")});
 
-    auto src_column3 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+    ColumnPtr src_column3 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
     src_column3->append_datum(DatumArray{Slice("5")});
     src_column3->append_datum(DatumArray{Slice("2"), Slice("8")});
     src_column3->append_datum(DatumArray{Slice("4"), Slice("1")});
@@ -4351,7 +4351,7 @@ TEST_F(ArrayFunctionsTest, array_intersect_varchar_with_not_null) {
 
 // NOLINTNEXTLINE
 TEST_F(ArrayFunctionsTest, array_join_string) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
     src_column->append_datum(DatumArray{"352", "66", "4325"});
     src_column->append_datum(DatumArray{"235", "99", "8", "43251"});
     src_column->append_datum(DatumArray{"44", "33", "22", "112"});
@@ -4376,7 +4376,7 @@ TEST_F(ArrayFunctionsTest, array_join_string) {
 }
 
 TEST_F(ArrayFunctionsTest, array_concat_ws) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
     src_column->append_datum(DatumArray{"352", "66", "4325"});
     src_column->append_datum(DatumArray{"235", "99", "8", "43251"});
     src_column->append_datum(DatumArray{"44", "33", "22", "112"});
@@ -4393,7 +4393,7 @@ TEST_F(ArrayFunctionsTest, array_concat_ws) {
 
 // NOLINTNEXTLINE
 TEST_F(ArrayFunctionsTest, array_join_nullable_elements) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
     src_column->append_datum(DatumArray{"55", Datum(), "333", "6666"});
     src_column->append_datum(DatumArray{"22", "333", Datum(), Datum()});
     src_column->append_datum(DatumArray{Datum(), Datum(), Datum(), Datum()});
@@ -4418,7 +4418,7 @@ TEST_F(ArrayFunctionsTest, array_join_nullable_elements) {
 }
 
 TEST_F(ArrayFunctionsTest, array_concat_ws_nullable_elements) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
     src_column->append_datum(DatumArray{"55", Datum(), "333", "6666"});
     src_column->append_datum(DatumArray{"22", "333", Datum(), Datum()});
     src_column->append_datum(DatumArray{Datum(), Datum(), Datum(), Datum()});
@@ -4435,7 +4435,7 @@ TEST_F(ArrayFunctionsTest, array_concat_ws_nullable_elements) {
 
 // NOLINTNEXTLINE
 TEST_F(ArrayFunctionsTest, array_join_nullable_array) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
     src_column->append_datum(DatumArray{"5", Datum(), "33", "666"});
     src_column->append_datum(Datum());
     src_column->append_datum(DatumArray{Datum(), Datum(), Datum(), Datum()});
@@ -4460,7 +4460,7 @@ TEST_F(ArrayFunctionsTest, array_join_nullable_array) {
 }
 
 TEST_F(ArrayFunctionsTest, array_concat_ws_nullable_array) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
     src_column->append_datum(DatumArray{"5", Datum(), "33", "666"});
     src_column->append_datum(Datum());
     src_column->append_datum(DatumArray{Datum(), Datum(), Datum(), Datum()});
@@ -4477,7 +4477,7 @@ TEST_F(ArrayFunctionsTest, array_concat_ws_nullable_array) {
 
 // NOLINTNEXTLINE
 TEST_F(ArrayFunctionsTest, array_join_only_null) {
-    auto src_column = ColumnHelper::create_const_null_column(3);
+    ColumnPtr src_column = ColumnHelper::create_const_null_column(3);
 
     Slice sep_str("__");
     auto sep_column = ColumnHelper::create_const_column<LogicalType::TYPE_VARCHAR>(sep_str, 3);
@@ -4499,7 +4499,7 @@ TEST_F(ArrayFunctionsTest, array_join_only_null) {
 }
 
 TEST_F(ArrayFunctionsTest, array_concat_ws_only_null) {
-    auto src_column = ColumnHelper::create_const_null_column(3);
+    ColumnPtr src_column = ColumnHelper::create_const_null_column(3);
 
     Slice sep_str("__");
     auto sep_column = ColumnHelper::create_const_column<LogicalType::TYPE_VARCHAR>(sep_str, 3);
@@ -4512,14 +4512,14 @@ TEST_F(ArrayFunctionsTest, array_concat_ws_only_null) {
 }
 
 TEST_F(ArrayFunctionsTest, array_filter_tinyint_with_nullable) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, true);
     src_column->append_datum(DatumArray{(int8_t)5, (int8_t)3, (int8_t)6});
     src_column->append_datum(DatumArray{(int8_t)8});
     src_column->append_datum(DatumArray{(int8_t)4});
     src_column->append_datum(Datum());
     src_column->append_datum(DatumArray{(int8_t)4, (int8_t)1});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, true);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, true);
     src_column2->append_datum(DatumArray{true, false, true});
     src_column2->append_datum(Datum());
     src_column2->append_datum(DatumArray{});
@@ -4539,14 +4539,14 @@ TEST_F(ArrayFunctionsTest, array_filter_tinyint_with_nullable) {
 }
 
 TEST_F(ArrayFunctionsTest, array_filter_tinyint) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
     src_column->append_datum(DatumArray{(int8_t)5, (int8_t)3, (int8_t)6});
     src_column->append_datum(DatumArray{(int8_t)8});
     src_column->append_datum(DatumArray{(int8_t)4});
     src_column->append_datum(DatumArray{(int8_t)99});
     src_column->append_datum(DatumArray{(int8_t)4, (int8_t)1});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
     src_column2->append_datum(DatumArray{Datum(), true, false});
     src_column2->append_datum(DatumArray{true});
     src_column2->append_datum(DatumArray{false});
@@ -4567,14 +4567,14 @@ TEST_F(ArrayFunctionsTest, array_filter_tinyint) {
 }
 
 TEST_F(ArrayFunctionsTest, array_filter_tinyint_with_nullable_notnull) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, true);
     src_column->append_datum(DatumArray{(int8_t)5, (int8_t)3, (int8_t)6});
     src_column->append_datum(DatumArray{(int8_t)8});
     src_column->append_datum(DatumArray{(int8_t)4});
     src_column->append_datum(Datum());
     src_column->append_datum(DatumArray{(int8_t)4, (int8_t)1});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
     src_column2->append_datum(DatumArray{Datum(), true, false});
     src_column2->append_datum(DatumArray{true});
     src_column2->append_datum(DatumArray{false});
@@ -4594,14 +4594,14 @@ TEST_F(ArrayFunctionsTest, array_filter_tinyint_with_nullable_notnull) {
 }
 
 TEST_F(ArrayFunctionsTest, array_filter_tinyint_notnull_nullable) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
     src_column->append_datum(DatumArray{(int8_t)5, (int8_t)3, (int8_t)6});
     src_column->append_datum(DatumArray{(int8_t)8});
     src_column->append_datum(DatumArray{(int8_t)4});
     src_column->append_datum(DatumArray{(int8_t)99});
     src_column->append_datum(DatumArray{(int8_t)4, (int8_t)1});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, true);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, true);
     src_column2->append_datum(DatumArray{true, false, true});
     src_column2->append_datum(Datum());
     src_column2->append_datum(DatumArray{});
@@ -4622,14 +4622,14 @@ TEST_F(ArrayFunctionsTest, array_filter_tinyint_notnull_nullable) {
 }
 
 TEST_F(ArrayFunctionsTest, array_filter_bigint_with_nullable) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, true);
     src_column->append_datum(DatumArray{(int64_t)5, (int64_t)3, (int64_t)6});
     src_column->append_datum(DatumArray{(int64_t)8});
     src_column->append_datum(DatumArray{(int64_t)4});
     src_column->append_datum(Datum());
     src_column->append_datum(DatumArray{(int64_t)4, (int64_t)1});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, true);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, true);
     src_column2->append_datum(DatumArray{true, false, true});
     src_column2->append_datum(Datum());
     src_column2->append_datum(DatumArray{});
@@ -4649,14 +4649,14 @@ TEST_F(ArrayFunctionsTest, array_filter_bigint_with_nullable) {
 }
 
 TEST_F(ArrayFunctionsTest, array_filter_bigint) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_BIGINT, false);
     src_column->append_datum(DatumArray{(int64_t)5, (int64_t)3, (int64_t)6});
     src_column->append_datum(DatumArray{(int64_t)8});
     src_column->append_datum(DatumArray{(int64_t)4});
     src_column->append_datum(DatumArray{(int64_t)99});
     src_column->append_datum(DatumArray{(int64_t)4, (int64_t)1});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
     src_column2->append_datum(DatumArray{Datum(), true});
     src_column2->append_datum(DatumArray{true});
     src_column2->append_datum(DatumArray{false});
@@ -4677,14 +4677,14 @@ TEST_F(ArrayFunctionsTest, array_filter_bigint) {
 }
 
 TEST_F(ArrayFunctionsTest, array_filter_double_with_nullable) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, true);
     src_column->append_datum(DatumArray{(double)5, (double)3, (double)6});
     src_column->append_datum(DatumArray{(double)8});
     src_column->append_datum(DatumArray{(double)4});
     src_column->append_datum(Datum());
     src_column->append_datum(DatumArray{(double)4, (double)1});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, true);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, true);
     src_column2->append_datum(DatumArray{true, false, true});
     src_column2->append_datum(Datum());
     src_column2->append_datum(DatumArray{});
@@ -4704,14 +4704,14 @@ TEST_F(ArrayFunctionsTest, array_filter_double_with_nullable) {
 }
 
 TEST_F(ArrayFunctionsTest, array_filter_double) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, false);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_DOUBLE, false);
     src_column->append_datum(DatumArray{(double)5, (double)3, (double)6});
     src_column->append_datum(DatumArray{(double)8});
     src_column->append_datum(DatumArray{(double)4});
     src_column->append_datum(DatumArray{(double)99});
     src_column->append_datum(DatumArray{(double)4, (double)1});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
     src_column2->append_datum(DatumArray{Datum(), true, false, true}); //more one
     src_column2->append_datum(DatumArray{true});
     src_column2->append_datum(DatumArray{false});
@@ -4732,14 +4732,14 @@ TEST_F(ArrayFunctionsTest, array_filter_double) {
 }
 
 TEST_F(ArrayFunctionsTest, array_filter_varchar_with_nullable) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
     src_column->append_datum(DatumArray{Slice("5"), Slice("3"), Slice("6")});
     src_column->append_datum(DatumArray{Slice("8")});
     src_column->append_datum(DatumArray{Slice("4")});
     src_column->append_datum(Datum());
     src_column->append_datum(DatumArray{Slice("4"), Slice("1")});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, true);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, true);
     src_column2->append_datum(DatumArray{true, false, true});
     src_column2->append_datum(Datum());
     src_column2->append_datum(DatumArray{});
@@ -4759,14 +4759,14 @@ TEST_F(ArrayFunctionsTest, array_filter_varchar_with_nullable) {
 }
 
 TEST_F(ArrayFunctionsTest, array_filter_varchar) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
     src_column->append_datum(DatumArray{Slice("5"), Slice("3"), Slice("6")});
     src_column->append_datum(DatumArray{Slice("8")});
     src_column->append_datum(DatumArray{Slice("4")});
     src_column->append_datum(DatumArray{Slice("99")});
     src_column->append_datum(DatumArray{Slice("4"), Slice("1")});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
     src_column2->append_datum(DatumArray{Datum(), true, false, true}); //more one
     src_column2->append_datum(DatumArray{true});
     src_column2->append_datum(DatumArray{false});
@@ -4787,10 +4787,10 @@ TEST_F(ArrayFunctionsTest, array_filter_varchar) {
 }
 
 TEST_F(ArrayFunctionsTest, array_filter_with_onlynull) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
     src_column->append_datum(DatumArray{(int8_t)5, (int8_t)3, (int8_t)6});
 
-    auto src_column2 = ColumnHelper::create_const_null_column(1);
+    ColumnPtr src_column2 = ColumnHelper::create_const_null_column(1);
 
     // bool_array is null
     ArrayFilter filter;
@@ -4806,7 +4806,7 @@ TEST_F(ArrayFunctionsTest, array_filter_with_onlynull) {
     ASSERT_TRUE(dest_column->only_null());
 
     // src is nullable & bool_array is null
-    auto src_column_nullable = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, true);
+    ColumnPtr src_column_nullable = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, true);
     src_column_nullable->append_datum(DatumArray{(int8_t)5, (int8_t)3, (int8_t)6});
     src_column_nullable->append_datum(Datum());
     dest_column = filter.process(nullptr, {src_column_nullable, src_column2});
@@ -4819,23 +4819,23 @@ TEST_F(ArrayFunctionsTest, array_filter_with_onlynull) {
 TEST_F(ArrayFunctionsTest, array_distinct_only_null) {
     // test only null
     {
-        auto src_column = ColumnHelper::create_const_null_column(3);
+        ColumnPtr src_column = ColumnHelper::create_const_null_column(3);
         auto dest_column = ArrayDistinct<TYPE_VARCHAR>::process(nullptr, {src_column});
         ASSERT_EQ(dest_column->size(), 3);
         ASSERT_TRUE(dest_column->only_null());
     }
     // test const
     {
-        auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+        ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         src_column->append_datum(DatumArray{"5", "5", "33", "666"});
-        src_column = std::make_shared<ConstColumn>(src_column, 3);
+        src_column = ConstColumn::create(src_column, 3);
         auto dest_column = ArrayDistinct<TYPE_VARCHAR>::process(nullptr, {src_column});
         ASSERT_EQ(dest_column->size(), 3);
         ASSERT_STREQ(dest_column->debug_string().c_str(), "[['5','33','666'], ['5','33','666'], ['5','33','666']]");
     }
     // test normal
     {
-        auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+        ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
         src_column->append_datum(DatumArray{"5", "5", "33", "666"});
         auto dest_column = ArrayDistinct<TYPE_VARCHAR>::process(nullptr, {src_column});
         ASSERT_EQ(dest_column->size(), 1);
@@ -4844,7 +4844,7 @@ TEST_F(ArrayFunctionsTest, array_distinct_only_null) {
 }
 
 TEST_F(ArrayFunctionsTest, array_sortby_tinyint_with_nullable) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, true);
     src_column->append_datum(DatumArray{(int8_t)3, (int8_t)4, (int8_t)5});
     src_column->append_datum(Datum());
     src_column->append_datum(DatumArray{(int8_t)2, (int8_t)4});
@@ -4856,7 +4856,7 @@ TEST_F(ArrayFunctionsTest, array_sortby_tinyint_with_nullable) {
     src_column->append_datum(DatumArray{(int8_t)43, (int8_t)23});
     src_column->append_datum(DatumArray{(int8_t)43, (int8_t)23, Datum()});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, true);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, true);
     src_column2->append_datum(DatumArray{(int8_t)82, (int8_t)1, (int8_t)4});
     src_column2->append_datum(DatumArray{(int8_t)23});
     src_column2->append_datum(Datum());
@@ -4911,7 +4911,7 @@ TEST_F(ArrayFunctionsTest, array_sortby_tinyint_with_nullable) {
 }
 
 TEST_F(ArrayFunctionsTest, array_sortby_tinyint) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
     src_column->append_datum(DatumArray{(int8_t)5, (int8_t)3, (int8_t)6});
     src_column->append_datum(DatumArray{(int8_t)5, (int8_t)3, (int8_t)6});
     src_column->append_datum(DatumArray{});
@@ -4919,7 +4919,7 @@ TEST_F(ArrayFunctionsTest, array_sortby_tinyint) {
     src_column->append_datum(DatumArray{Datum()});
     src_column->append_datum(DatumArray{(int8_t)4, Datum()});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
     src_column2->append_datum(DatumArray{(int8_t)3, (int8_t)73, (int8_t)30});
     src_column2->append_datum(DatumArray{(int8_t)3, (int8_t)2, (int8_t)1});
     src_column2->append_datum(DatumArray{});
@@ -4961,7 +4961,7 @@ TEST_F(ArrayFunctionsTest, array_sortby_tinyint) {
 }
 
 TEST_F(ArrayFunctionsTest, array_sortby_tinyint_with_nullable_notnull) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, true);
     src_column->append_datum(DatumArray{(int8_t)3, (int8_t)4, (int8_t)5});
     src_column->append_datum(Datum());
     src_column->append_datum(DatumArray{(int8_t)2, (int8_t)4});
@@ -4973,7 +4973,7 @@ TEST_F(ArrayFunctionsTest, array_sortby_tinyint_with_nullable_notnull) {
     src_column->append_datum(DatumArray{(int8_t)43, (int8_t)23});
     src_column->append_datum(DatumArray{(int8_t)43, (int8_t)23, Datum()});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
     src_column2->append_datum(DatumArray{(int8_t)82, (int8_t)1, (int8_t)4});
     src_column2->append_datum(DatumArray{(int8_t)23});
     src_column2->append_datum(DatumArray{(int8_t)3, Datum()});
@@ -5028,7 +5028,7 @@ TEST_F(ArrayFunctionsTest, array_sortby_tinyint_with_nullable_notnull) {
 }
 
 TEST_F(ArrayFunctionsTest, array_sortby_varchar_with_nullable) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
     src_column->append_datum(DatumArray{Slice("5"), Slice("3"), Slice("6")});
     src_column->append_datum(DatumArray{Slice("8")});
     src_column->append_datum(DatumArray{Slice("4")});
@@ -5036,7 +5036,7 @@ TEST_F(ArrayFunctionsTest, array_sortby_varchar_with_nullable) {
     src_column->append_datum(DatumArray{Slice("4"), Slice("1")});
     src_column->append_datum(DatumArray{Slice("4"), Slice("1")});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, true);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, true);
     src_column2->append_datum(DatumArray{(int8_t)3, (int8_t)5, (int8_t)6});
     src_column2->append_datum(DatumArray{(int8_t)3});
     src_column2->append_datum(Datum());
@@ -5075,10 +5075,10 @@ TEST_F(ArrayFunctionsTest, array_sortby_varchar_with_nullable) {
 }
 
 TEST_F(ArrayFunctionsTest, array_sortby_with_only_null) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
     src_column->append_datum(DatumArray{(int8_t)5, (int8_t)3, (int8_t)6});
 
-    auto src_column2 = ColumnHelper::create_const_null_column(1);
+    ColumnPtr src_column2 = ColumnHelper::create_const_null_column(1);
 
     {
         ArraySortBy<LogicalType::TYPE_TINYINT> sort;
@@ -5099,9 +5099,9 @@ TEST_F(ArrayFunctionsTest, array_sortby_with_only_null) {
 }
 
 TEST_F(ArrayFunctionsTest, array_generate_with_integer_columns) {
-    auto start_column = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), true);
-    auto stop_column = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), true);
-    auto step_column = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), true);
+    ColumnPtr start_column = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), true);
+    ColumnPtr stop_column = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), true);
+    ColumnPtr step_column = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), true);
 
     start_column->append_datum(Datum((int32_t)3));
     stop_column->append_datum(Datum((int32_t)9));
@@ -5142,9 +5142,9 @@ TEST_F(ArrayFunctionsTest, array_generate_with_integer_columns) {
 }
 
 TEST_F(ArrayFunctionsTest, array_generate_when_overflow) {
-    auto start_column = ColumnHelper::create_column(TypeDescriptor(TYPE_TINYINT), true);
-    auto stop_column = ColumnHelper::create_column(TypeDescriptor(TYPE_TINYINT), true);
-    auto step_column = ColumnHelper::create_column(TypeDescriptor(TYPE_TINYINT), true);
+    ColumnPtr start_column = ColumnHelper::create_column(TypeDescriptor(TYPE_TINYINT), true);
+    ColumnPtr stop_column = ColumnHelper::create_column(TypeDescriptor(TYPE_TINYINT), true);
+    ColumnPtr step_column = ColumnHelper::create_column(TypeDescriptor(TYPE_TINYINT), true);
 
     start_column->append_datum(Datum((int8_t)9));
     stop_column->append_datum(Datum((int8_t)100));
@@ -5166,32 +5166,32 @@ TEST_F(ArrayFunctionsTest, array_generate_when_overflow) {
 TEST_F(ArrayFunctionsTest, array_distinct_any_type_only_null) {
     // test only null
     {
-        auto src_column = ColumnHelper::create_const_null_column(3);
+        ColumnPtr src_column = ColumnHelper::create_const_null_column(3);
         auto dest_column = ArrayFunctions::array_distinct_any_type(nullptr, {src_column}).value();
         ASSERT_EQ(dest_column->size(), 3);
         ASSERT_TRUE(dest_column->only_null());
     }
     // test const
     {
-        auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+        ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         src_column->append_datum(DatumArray{"5", "5", "33", "666"});
-        src_column = std::make_shared<ConstColumn>(src_column, 3);
+        src_column = ConstColumn::create(src_column, 3);
         auto dest_column = ArrayFunctions::array_distinct_any_type(nullptr, {src_column}).value();
         ASSERT_EQ(dest_column->size(), 3);
         ASSERT_STREQ(dest_column->debug_string().c_str(), "[['5','33','666'], ['5','33','666'], ['5','33','666']]");
     }
     // test array[null]
     {
-        auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+        ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         src_column->append_datum(DatumArray{"5", Datum(), Datum(), "5", "33", "666", Datum()});
-        src_column = std::make_shared<ConstColumn>(src_column, 1);
+        src_column = ConstColumn::create(src_column, 1);
         auto dest_column = ArrayFunctions::array_distinct_any_type(nullptr, {src_column}).value();
         ASSERT_EQ(dest_column->size(), 1);
         ASSERT_STREQ(dest_column->debug_string().c_str(), "[['5',NULL,'33','666']]");
     }
     // test null array
     {
-        auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+        ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
         src_column->append_datum(DatumArray{"5", "5", "33", "666"});
         src_column->append_nulls(2);
         auto dest_column = ArrayFunctions::array_distinct_any_type(nullptr, {src_column}).value();
@@ -5200,7 +5200,7 @@ TEST_F(ArrayFunctionsTest, array_distinct_any_type_only_null) {
     }
     // test normal
     {
-        auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+        ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
         src_column->append_datum(DatumArray{"5", "5", "33", "666"});
         auto dest_column = ArrayFunctions::array_distinct_any_type(nullptr, {src_column}).value();
         ASSERT_EQ(dest_column->size(), 1);
@@ -5209,19 +5209,19 @@ TEST_F(ArrayFunctionsTest, array_distinct_any_type_only_null) {
 }
 
 TEST_F(ArrayFunctionsTest, array_intersect_any_type_int) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
     src_column->append_datum(DatumArray{(int32_t)5, (int32_t)3, (int32_t)6});
     src_column->append_datum(DatumArray{(int32_t)8});
     src_column->append_datum(DatumArray{(int32_t)4, (int32_t)1});
     src_column->append_datum(Datum());
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
     src_column2->append_datum(DatumArray{(int32_t)(5), (int32_t)(6)});
     src_column2->append_datum(DatumArray{(int32_t)(2)});
     src_column2->append_datum(DatumArray{(int32_t)(4), (int32_t)(3), (int32_t)(2), (int32_t)(1)});
     src_column2->append_datum(DatumArray{(int32_t)(4), (int32_t)(9)});
 
-    auto src_column3 = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+    ColumnPtr src_column3 = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
     src_column3->append_datum(DatumArray{(int32_t)(5)});
     src_column3->append_datum(DatumArray{(int32_t)(2), (int32_t)(8)});
     src_column3->append_datum(DatumArray{(int32_t)(4), (int32_t)(1)});
@@ -5238,19 +5238,19 @@ TEST_F(ArrayFunctionsTest, array_intersect_any_type_int) {
 }
 
 TEST_F(ArrayFunctionsTest, array_intersect_any_type_int_with_not_null) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
     src_column->append_datum(DatumArray{(int32_t)(5), (int32_t)(3), (int32_t)(6)});
     src_column->append_datum(DatumArray{(int32_t)(8)});
     src_column->append_datum(DatumArray{(int32_t)(4), (int32_t)(1)});
     src_column->append_datum(DatumArray{(int32_t)(4), (int32_t)(22), Datum()});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
     src_column2->append_datum(DatumArray{(int32_t)(5), (int32_t)(6)});
     src_column2->append_datum(DatumArray{(int32_t)(2)});
     src_column2->append_datum(DatumArray{(int32_t)(4), (int32_t)(3), (int32_t)(2), (int32_t)(1)});
     src_column2->append_datum(DatumArray{(int32_t)(4), Datum(), (int32_t)(22), (int32_t)(66)});
 
-    auto src_column3 = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
+    ColumnPtr src_column3 = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
     src_column3->append_datum(DatumArray{(int32_t)(5)});
     src_column3->append_datum(DatumArray{(int32_t)(2), (int32_t)(8)});
     src_column3->append_datum(DatumArray{(int32_t)(4), (int32_t)(1)});
@@ -5291,19 +5291,19 @@ TEST_F(ArrayFunctionsTest, array_intersect_any_type_int_with_not_null) {
 }
 
 TEST_F(ArrayFunctionsTest, array_intersect_any_type_varchar) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
     src_column->append_datum(DatumArray{Slice("5"), Slice("3"), Slice("6")});
     src_column->append_datum(DatumArray{Slice("8")});
     src_column->append_datum(DatumArray{Slice("4"), Slice("1")});
     src_column->append_datum(Datum());
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
     src_column2->append_datum(DatumArray{Slice("5"), Slice("6")});
     src_column2->append_datum(DatumArray{Slice("2")});
     src_column2->append_datum(DatumArray{Slice("4"), Slice("3"), Slice("2"), Slice("1")});
     src_column2->append_datum(DatumArray{Slice("4"), Slice("9")});
 
-    auto src_column3 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    ColumnPtr src_column3 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
     src_column3->append_datum(DatumArray{Slice("5")});
     src_column3->append_datum(DatumArray{Slice("2"), Slice("8")});
     src_column3->append_datum(DatumArray{Slice("4"), Slice("1")});
@@ -5320,19 +5320,19 @@ TEST_F(ArrayFunctionsTest, array_intersect_any_type_varchar) {
 }
 
 TEST_F(ArrayFunctionsTest, array_intersect_any_type_varchar_with_not_null) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
     src_column->append_datum(DatumArray{Slice("5"), Slice("3"), Slice("6")});
     src_column->append_datum(DatumArray{Slice("8")});
     src_column->append_datum(DatumArray{Slice("4"), Slice("1")});
     src_column->append_datum(DatumArray{Slice("4"), Slice("22"), Datum()});
 
-    auto src_column2 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+    ColumnPtr src_column2 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
     src_column2->append_datum(DatumArray{Slice("5"), Slice("6")});
     src_column2->append_datum(DatumArray{Slice("2")});
     src_column2->append_datum(DatumArray{Slice("4"), Slice("3"), Slice("2"), Slice("1")});
     src_column2->append_datum(DatumArray{Slice("4"), Datum(), Slice("22"), Slice("66")});
 
-    auto src_column3 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+    ColumnPtr src_column3 = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
     src_column3->append_datum(DatumArray{Slice("5")});
     src_column3->append_datum(DatumArray{Slice("2"), Slice("8")});
     src_column3->append_datum(DatumArray{Slice("4"), Slice("1")});
@@ -5373,7 +5373,7 @@ TEST_F(ArrayFunctionsTest, array_intersect_any_type_varchar_with_not_null) {
 }
 
 TEST_F(ArrayFunctionsTest, array_reverse_any_types_int) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
     src_column->append_datum(DatumArray{5, 3, 6});
     src_column->append_datum(DatumArray{2, 3, 7, 8});
     src_column->append_datum(DatumArray{4, 3, 2, 1});
@@ -5388,7 +5388,7 @@ TEST_F(ArrayFunctionsTest, array_reverse_any_types_int) {
 }
 
 TEST_F(ArrayFunctionsTest, array_reverse_any_types_string) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
     src_column->append_datum(DatumArray{"352", "66", "4325"});
     src_column->append_datum(DatumArray{"235", "99", "8", "43251"});
     src_column->append_datum(DatumArray{"44", "33", "22", "112"});
@@ -5402,7 +5402,7 @@ TEST_F(ArrayFunctionsTest, array_reverse_any_types_string) {
 }
 
 TEST_F(ArrayFunctionsTest, array_reverse_any_types_nullable_elements) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
     src_column->append_datum(DatumArray{5, Datum(), 3, 6});
     src_column->append_datum(DatumArray{2, 3, Datum(), Datum()});
     src_column->append_datum(DatumArray{Datum(), Datum(), Datum(), Datum()});
@@ -5416,7 +5416,7 @@ TEST_F(ArrayFunctionsTest, array_reverse_any_types_nullable_elements) {
 }
 
 TEST_F(ArrayFunctionsTest, array_reverse_any_types_nullable_array) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
     src_column->append_datum(DatumArray{5, Datum(), 3, 6});
     src_column->append_datum(Datum());
     src_column->append_datum(DatumArray{Datum(), Datum(), Datum(), Datum()});
@@ -5430,7 +5430,7 @@ TEST_F(ArrayFunctionsTest, array_reverse_any_types_nullable_array) {
 }
 
 TEST_F(ArrayFunctionsTest, array_reverse_any_types_only_null) {
-    auto src_column = ColumnHelper::create_const_null_column(3);
+    ColumnPtr src_column = ColumnHelper::create_const_null_column(3);
 
     auto dest_column = ArrayFunctions::array_reverse_any_types(nullptr, {src_column}).value();
 
@@ -5441,7 +5441,7 @@ TEST_F(ArrayFunctionsTest, array_reverse_any_types_only_null) {
 }
 
 TEST_F(ArrayFunctionsTest, array_match_nullable) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, true);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, true);
     src_column->append_datum(DatumArray{(int8_t)1, (int8_t)1, (int8_t)0});
     src_column->append_datum(DatumArray{(int8_t)0});
     src_column->append_datum(DatumArray{(int8_t)1});
@@ -5474,7 +5474,7 @@ TEST_F(ArrayFunctionsTest, array_match_nullable) {
 }
 
 TEST_F(ArrayFunctionsTest, array_match_not_null) {
-    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
+    ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
     src_column->append_datum(DatumArray{(int8_t)1, (int8_t)1, (int8_t)0});
     src_column->append_datum(DatumArray{(int8_t)0});
     src_column->append_datum(DatumArray{(int8_t)1});
@@ -5509,7 +5509,7 @@ TEST_F(ArrayFunctionsTest, array_match_not_null) {
 TEST_F(ArrayFunctionsTest, array_match_only_null) {
     // test only null
     {
-        auto src_column = ColumnHelper::create_const_null_column(3);
+        ColumnPtr src_column = ColumnHelper::create_const_null_column(3);
         auto dest_column = ArrayMatch<false>::process(nullptr, {src_column});
         ASSERT_EQ(dest_column->size(), 3);
         ASSERT_TRUE(dest_column->only_null());
@@ -5520,9 +5520,9 @@ TEST_F(ArrayFunctionsTest, array_match_only_null) {
     }
     // test const
     {
-        auto src_column = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
+        ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
         src_column->append_datum(DatumArray{(uint8) false, (uint8) true});
-        src_column = std::make_shared<ConstColumn>(src_column, 3);
+        src_column = ConstColumn::create(src_column, 3);
         auto dest_column = ArrayMatch<false>::process(nullptr, {src_column});
         ASSERT_EQ(dest_column->size(), 3);
         ASSERT_FALSE(dest_column->get(0).get_int8());
@@ -5533,9 +5533,9 @@ TEST_F(ArrayFunctionsTest, array_match_only_null) {
     }
     // test const
     {
-        auto src_column = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
+        ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
         src_column->append_datum(DatumArray{});
-        src_column = std::make_shared<ConstColumn>(src_column, 3);
+        src_column = ConstColumn::create(src_column, 3);
         auto dest_column = ArrayMatch<true>::process(nullptr, {src_column});
         ASSERT_EQ(dest_column->size(), 3);
         ASSERT_FALSE(dest_column->get(0).get_int8());
@@ -5558,7 +5558,7 @@ TEST_F(ArrayFunctionsTest, array_contains_seq) {
     // array_contains_seq(["a", "b", "c"], ["a", "d"])    -> 0
     // array_contains_all(["a", "b", "c"], ["a", "c"])    -> 0
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
         array->append_datum(DatumArray{"a", "b", "c"});
         array->append_datum(Datum());
         array->append_datum(DatumArray{"a", "b", "c"});
@@ -5570,7 +5570,7 @@ TEST_F(ArrayFunctionsTest, array_contains_seq) {
         array->append_datum(DatumArray{"a", "b", "c"});
         array->append_datum(DatumArray{"a", "b", "c"});
 
-        auto target = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+        ColumnPtr target = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
         target->append_datum(DatumArray{"c"});
         target->append_datum(DatumArray{"c"});
         target->append_datum(Datum());
@@ -5600,12 +5600,12 @@ TEST_F(ArrayFunctionsTest, array_contains_seq) {
     // array_contains_seq(["a","c"], [["c"]])
     // array_contains_seq([["a", "b"], ["c"]], [["a", "b"]])
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, false);
         array->append_datum(DatumArray{Datum(DatumArray{"a"}), Datum(DatumArray{"b"})});
         array->append_datum(DatumArray{Datum(DatumArray{"a", "c"})});
         array->append_datum(DatumArray{Datum(DatumArray{"a", "b"}), Datum(DatumArray{"c"})});
 
-        auto target = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, false);
+        ColumnPtr target = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, false);
         target->append_datum(DatumArray{Datum(DatumArray{"c"})});
         target->append_datum(DatumArray{Datum(DatumArray{"c"})});
         target->append_datum(DatumArray{Datum(DatumArray{"a", "b"})});
@@ -5620,12 +5620,12 @@ TEST_F(ArrayFunctionsTest, array_contains_seq) {
     // array_contains_seq([["a","d","c"]], [["e"]])
     // array_contains_seq([["a", "b"], ["c"]], [["a", "b"]])
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, true);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, true);
         array->append_datum(DatumArray{Datum(DatumArray{"a"}), Datum(DatumArray{"b"}), Datum()});
         array->append_datum(DatumArray{Datum(DatumArray{"a", "d", "c"})});
         array->append_datum(DatumArray{Datum(DatumArray{"a", "b"}), Datum(DatumArray{"c"})});
 
-        auto target = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, false);
+        ColumnPtr target = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, false);
         target->append_datum(DatumArray{Datum(DatumArray{"c"})});
         target->append_datum(DatumArray{Datum(DatumArray{"e"})});
         target->append_datum(DatumArray{Datum(DatumArray{"a", "b"})});
@@ -5640,12 +5640,12 @@ TEST_F(ArrayFunctionsTest, array_contains_seq) {
     // array_contains_seq([["a","d","c"]], [["e", NULL]])
     // array_contains_seq([["a", "b"], ["c"]], [["a", "b"]])
     {
-        auto array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, false);
+        ColumnPtr array = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, false);
         array->append_datum(DatumArray{Datum(DatumArray{"a"}), Datum(DatumArray{"b"})});
         array->append_datum(DatumArray{Datum(DatumArray{"a", "d", "c"})});
         array->append_datum(DatumArray{Datum(DatumArray{"a", "b"}), Datum(DatumArray{"c"})});
 
-        auto target = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, true);
+        ColumnPtr target = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_VARCHAR, true);
         target->append_datum(DatumArray{Datum(DatumArray{"c"}), Datum()});
         target->append_datum(DatumArray{Datum(DatumArray{"e"}), Datum()});
         target->append_datum(DatumArray{Datum(DatumArray{"a", "b"})});
@@ -5675,7 +5675,7 @@ void array_repeat_test(Datum element_0, Datum element_1, Datum element_2, Datum 
             src_column->append_datum(element_1);
             src_column->append_datum(element_2);
 
-            auto repeat_count_column = Int32Column::create();
+            Int32Column::Ptr repeat_count_column = Int32Column::create();
             repeat_count_column->append(repeat_count_0);
             repeat_count_column->append(repeat_count_1);
             repeat_count_column->append(repeat_count_2);
@@ -5711,7 +5711,8 @@ void array_repeat_test(Datum element_0, Datum element_1, Datum element_2, Datum 
             src_column->append_datum(element_1);
             src_column->append_datum(element_null);
 
-            auto repeat_count_column = NullableColumn::create(Int32Column::create(), NullColumn::create(0, DATUM_NULL));
+            NullableColumn::Ptr repeat_count_column =
+                    NullableColumn::create(Int32Column::create(), NullColumn::create(0, DATUM_NULL));
             repeat_count_column->append_datum(repeat_count_null);
             repeat_count_column->append_datum(Datum(repeat_count_1));
             repeat_count_column->append_datum(Datum(repeat_count_2));
@@ -5735,9 +5736,10 @@ void array_repeat_test(Datum element_0, Datum element_1, Datum element_2, Datum 
                 src_column->append_datum(element_0);
             }
 
-            auto repeat_count_data_column = Int32Column::create();
+            Int32Column::Ptr repeat_count_data_column = Int32Column::create();
             repeat_count_data_column->append(repeat_count_0);
-            auto repeat_count_column = ConstColumn::create(std::move(repeat_count_data_column), const_column_row_count);
+            ConstColumn::Ptr repeat_count_column =
+                    ConstColumn::create(std::move(repeat_count_data_column), const_column_row_count);
 
             auto dest_column = ArrayFunctions::repeat(nullptr, {src_column, repeat_count_column}).value();
             ASSERT_EQ(dest_column->size(), const_column_row_count);
@@ -5790,12 +5792,12 @@ TEST_F(ArrayFunctionsTest, array_repeat_array) {
 
         // The normal case
         {
-            auto src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+            ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
             src_column->append_datum(element_0);
             src_column->append_datum(element_1);
             src_column->append_datum(element_2);
 
-            auto repeat_count_column = Int32Column::create();
+            Int32Column::Ptr repeat_count_column = Int32Column::create();
             repeat_count_column->append(repeat_count_0);
             repeat_count_column->append(repeat_count_1);
             repeat_count_column->append(repeat_count_2);
@@ -5817,12 +5819,13 @@ TEST_F(ArrayFunctionsTest, array_repeat_array) {
 
         // The case for testing NullableColumn
         {
-            auto src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+            ColumnPtr src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
             src_column->append_datum(element_0);
             src_column->append_datum(element_1);
             src_column->append_datum(element_null);
 
-            auto repeat_count_column = NullableColumn::create(Int32Column::create(), NullColumn::create(0, DATUM_NULL));
+            NullableColumn::Ptr repeat_count_column =
+                    NullableColumn::create(Int32Column::create(), NullColumn::create(0, DATUM_NULL));
             repeat_count_column->append_datum(repeat_count_null);
             repeat_count_column->append_datum(Datum(repeat_count_1));
             repeat_count_column->append_datum(Datum(repeat_count_2));
@@ -5842,13 +5845,14 @@ TEST_F(ArrayFunctionsTest, array_repeat_array) {
         {
             size_t const_column_row_count = 2;
 
-            auto src_data_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+            ColumnPtr src_data_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
             src_data_column->append_datum(element_0);
-            auto src_column = ConstColumn::create(std::move(src_data_column), const_column_row_count);
+            ConstColumn::Ptr src_column = ConstColumn::create(std::move(src_data_column), const_column_row_count);
 
-            auto repeat_count_data_column = Int32Column::create();
+            Int32Column::Ptr repeat_count_data_column = Int32Column::create();
             repeat_count_data_column->append(repeat_count_0);
-            auto repeat_count_column = ConstColumn::create(std::move(repeat_count_data_column), const_column_row_count);
+            ConstColumn::Ptr repeat_count_column =
+                    ConstColumn::create(std::move(repeat_count_data_column), const_column_row_count);
 
             auto dest_column = ArrayFunctions::repeat(nullptr, {src_column, repeat_count_column}).value();
             ASSERT_EQ(dest_column->size(), const_column_row_count);
@@ -5879,19 +5883,19 @@ TEST_F(ArrayFunctionsTest, array_repeat_map) {
 
         // The normal case
         {
-            auto offsets = UInt32Column::create();
-            auto keys_data = Int32Column::create();
-            auto keys_null = NullColumn::create();
-            auto keys = NullableColumn::create(keys_data, keys_null);
-            auto values_data = Int32Column::create();
-            auto values_null = NullColumn::create();
-            auto values = NullableColumn::create(values_data, values_null);
-            auto src_column = MapColumn::create(keys, values, offsets);
+            UInt32Column::Ptr offsets = UInt32Column::create();
+            Int32Column::Ptr keys_data = Int32Column::create();
+            NullColumn::Ptr keys_null = NullColumn::create();
+            NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+            Int32Column::Ptr values_data = Int32Column::create();
+            NullColumn::Ptr values_null = NullColumn::create();
+            NullableColumn::Ptr values = NullableColumn::create(values_data, values_null);
+            MapColumn::Ptr src_column = MapColumn::create(keys, values, offsets);
             src_column->append_datum(element_0);
             src_column->append_datum(element_1);
             src_column->append_datum(element_2);
 
-            auto repeat_count_column = Int32Column::create();
+            Int32Column::Ptr repeat_count_column = Int32Column::create();
             repeat_count_column->append(repeat_count_0);
             repeat_count_column->append(repeat_count_1);
             repeat_count_column->append(repeat_count_2);
@@ -5910,20 +5914,22 @@ TEST_F(ArrayFunctionsTest, array_repeat_map) {
 
         // The case for testing NullableColumn
         {
-            auto offsets = UInt32Column::create();
-            auto keys_data = Int32Column::create();
-            auto keys_null = NullColumn::create();
-            auto keys = NullableColumn::create(keys_data, keys_null);
-            auto values_data = Int32Column::create();
-            auto values_null = NullColumn::create();
-            auto values = NullableColumn::create(values_data, values_null);
-            auto map_column = MapColumn::create(keys, values, offsets);
-            auto src_column = NullableColumn::create(std::move(map_column), NullColumn::create(0, DATUM_NULL));
+            UInt32Column::Ptr offsets = UInt32Column::create();
+            Int32Column::Ptr keys_data = Int32Column::create();
+            NullColumn::Ptr keys_null = NullColumn::create();
+            NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+            Int32Column::Ptr values_data = Int32Column::create();
+            NullColumn::Ptr values_null = NullColumn::create();
+            NullableColumn::Ptr values = NullableColumn::create(values_data, values_null);
+            MapColumn::Ptr map_column = MapColumn::create(keys, values, offsets);
+            NullableColumn::Ptr src_column =
+                    NullableColumn::create(std::move(map_column), NullColumn::create(0, DATUM_NULL));
             src_column->append_datum(element_0);
             src_column->append_datum(element_1);
             src_column->append_datum(element_null);
 
-            auto count_column = NullableColumn::create(Int32Column::create(), NullColumn::create(0, DATUM_NULL));
+            NullableColumn::Ptr count_column =
+                    NullableColumn::create(Int32Column::create(), NullColumn::create(0, DATUM_NULL));
             count_column->append_datum(repeat_count_null);
             count_column->append_datum(Datum(repeat_count_1));
             count_column->append_datum(Datum(repeat_count_2));
@@ -5942,20 +5948,21 @@ TEST_F(ArrayFunctionsTest, array_repeat_map) {
         // The case for testing ConstColumn
         {
             size_t const_column_row_count = 2;
-            auto offsets = UInt32Column::create();
-            auto keys_data = Int32Column::create();
-            auto keys_null = NullColumn::create();
-            auto keys = NullableColumn::create(keys_data, keys_null);
-            auto values_data = Int32Column::create();
-            auto values_null = NullColumn::create();
-            auto values = NullableColumn::create(values_data, values_null);
-            auto map_column = MapColumn::create(keys, values, offsets);
+            UInt32Column::Ptr offsets = UInt32Column::create();
+            Int32Column::Ptr keys_data = Int32Column::create();
+            NullColumn::Ptr keys_null = NullColumn::create();
+            NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+            Int32Column::Ptr values_data = Int32Column::create();
+            NullColumn::Ptr values_null = NullColumn::create();
+            NullableColumn::Ptr values = NullableColumn::create(values_data, values_null);
+            MapColumn::Ptr map_column = MapColumn::create(keys, values, offsets);
             map_column->append_datum(element_0);
-            auto src_column = ConstColumn::create(std::move(map_column), const_column_row_count);
+            ConstColumn::Ptr src_column = ConstColumn::create(std::move(map_column), const_column_row_count);
 
-            auto repeat_count_data_column = Int32Column::create();
+            Int32Column::Ptr repeat_count_data_column = Int32Column::create();
             repeat_count_data_column->append(repeat_count_0);
-            auto repeat_count_column = ConstColumn::create(std::move(repeat_count_data_column), const_column_row_count);
+            ConstColumn::Ptr repeat_count_column =
+                    ConstColumn::create(std::move(repeat_count_data_column), const_column_row_count);
 
             auto dest_column = ArrayFunctions::repeat(nullptr, {src_column, repeat_count_column}).value();
             ASSERT_EQ(dest_column->size(), const_column_row_count);
@@ -5977,7 +5984,7 @@ TEST_F(ArrayFunctionsTest, array_flatten_int) {
         array->append_datum(DatumArray{DatumArray{1, 2}, DatumArray{1, 4}});
         array->append_datum(DatumArray{DatumArray{1, 2}, DatumArray{3}});
 
-        auto result = ArrayFunctions::array_flatten(nullptr, {array}).value();
+        auto result = ArrayFunctions::array_flatten(nullptr, {std::move(array)}).value();
         EXPECT_EQ(3, result->size());
         EXPECT_TRUE(result->get(0).is_null());
         EXPECT_EQ("[1,2,1,4]", result->debug_item(1));

--- a/be/test/exprs/binary_functions_test.cpp
+++ b/be/test/exprs/binary_functions_test.cpp
@@ -111,7 +111,7 @@ TEST_F(BinaryFunctionsTest, TestToBinaryNormal) {
 TEST_F(BinaryFunctionsTest, TestToBinaryNull) {
     auto arg = ColumnHelper::create_const_null_column(2);
     state->to_binary_type = BinaryFormatType::HEX;
-    auto result = BinaryFunctions::to_binary(ctx.get(), {arg});
+    auto result = BinaryFunctions::to_binary(ctx.get(), {std::move(arg)});
     ASSERT_TRUE(result.ok());
     const auto v = ColumnHelper::as_column<ConstColumn>(result.value());
     ASSERT_EQ(v->size(), 2);

--- a/be/test/exprs/binary_predicate_test.cpp
+++ b/be/test/exprs/binary_predicate_test.cpp
@@ -60,7 +60,7 @@ TEST_F(VectorizedBinaryPredicateTest, eqExpr) {
                     ASSERT_FALSE(ptr->is_nullable());
                     ASSERT_TRUE(ptr->is_numeric());
 
-                    auto v = std::static_pointer_cast<BooleanColumn>(ptr);
+                    auto v = BooleanColumn::static_pointer_cast(ptr);
                     ASSERT_EQ(10, v->size());
 
                     for (int j = 0; j < v->size(); ++j) {
@@ -92,7 +92,7 @@ TEST_F(VectorizedBinaryPredicateTest, neExpr) {
                     ASSERT_FALSE(ptr->is_nullable());
                     ASSERT_TRUE(ptr->is_numeric());
 
-                    auto v = std::static_pointer_cast<BooleanColumn>(ptr);
+                    auto v = BooleanColumn::static_pointer_cast(ptr);
                     ASSERT_EQ(10, v->size());
 
                     for (int j = 0; j < v->size(); ++j) {
@@ -123,7 +123,7 @@ TEST_F(VectorizedBinaryPredicateTest, geExpr) {
                     ASSERT_FALSE(ptr->is_nullable());
                     ASSERT_TRUE(ptr->is_numeric());
 
-                    auto v = std::static_pointer_cast<BooleanColumn>(ptr);
+                    auto v = BooleanColumn::static_pointer_cast(ptr);
                     ASSERT_EQ(10, v->size());
 
                     for (int j = 0; j < v->size(); ++j) {
@@ -159,9 +159,9 @@ TEST_F(VectorizedBinaryPredicateTest, nullLtExpr) {
             }
         }
 
-        auto ptr = std::static_pointer_cast<NullableColumn>(v)->data_column();
+        auto ptr = NullableColumn::static_pointer_cast(v)->data_column();
         for (int j = 0; j < v->size(); ++j) {
-            ASSERT_EQ(1, (int)std::static_pointer_cast<BooleanColumn>(ptr)->get_data()[j]);
+            ASSERT_EQ(1, (int)BooleanColumn::static_pointer_cast(ptr)->get_data()[j]);
         }
     }
 
@@ -183,13 +183,13 @@ TEST_F(VectorizedBinaryPredicateTest, nullLtExpr) {
         ExprsTestHelper::verify_with_jit(
                 v, expr.get(), &runtime_state,
                 [](ColumnPtr const& v) {
-                    ColumnPtr ptr = std::static_pointer_cast<NullableColumn>(v)->data_column();
+                    ColumnPtr ptr = NullableColumn::static_pointer_cast(v)->data_column();
 
                     ASSERT_TRUE(v->is_nullable());
                     ASSERT_FALSE(v->is_numeric());
 
                     for (int j = 0; j < ptr->size(); ++j) {
-                        ASSERT_EQ(0, (int)std::static_pointer_cast<BooleanColumn>(ptr)->get_data()[j]);
+                        ASSERT_EQ(0, (int)BooleanColumn::static_pointer_cast(ptr)->get_data()[j]);
                     }
 
                     for (int j = 0; j < ptr->size(); ++j) {
@@ -246,13 +246,13 @@ TEST_F(VectorizedBinaryPredicateTest, mergeNullLtExpr) {
         ExprsTestHelper::verify_with_jit(
                 v, expr.get(), &runtime_state,
                 [](ColumnPtr const& v) {
-                    ColumnPtr ptr = std::static_pointer_cast<NullableColumn>(v)->data_column();
+                    ColumnPtr ptr = NullableColumn::static_pointer_cast(v)->data_column();
 
                     ASSERT_TRUE(v->is_nullable());
                     ASSERT_FALSE(v->is_numeric());
 
                     for (int j = 0; j < ptr->size(); ++j) {
-                        ASSERT_EQ(1, (int)std::static_pointer_cast<BooleanColumn>(ptr)->get_data()[j]);
+                        ASSERT_EQ(1, (int)BooleanColumn::static_pointer_cast(ptr)->get_data()[j]);
                     }
 
                     for (int j = 0; j < ptr->size(); ++j) {
@@ -289,7 +289,7 @@ TEST_F(VectorizedBinaryPredicateTest, eqForNullExpr) {
                     ASSERT_FALSE(ptr->is_nullable());
                     ASSERT_TRUE(ptr->is_numeric());
 
-                    auto v = std::static_pointer_cast<BooleanColumn>(ptr);
+                    auto v = BooleanColumn::static_pointer_cast(ptr);
                     ASSERT_EQ(10, v->size());
 
                     for (int j = 0; j < v->size(); ++j) {
@@ -330,9 +330,9 @@ TEST_F(VectorizedBinaryPredicateTest, nullEqForNullExpr) {
             }
         }
 
-        auto ptr = std::static_pointer_cast<NullableColumn>(v)->data_column();
+        auto ptr = NullableColumn::static_pointer_cast(v)->data_column();
         for (int j = 0; j < v->size(); ++j) {
-            ASSERT_EQ(0, (int)std::static_pointer_cast<BooleanColumn>(ptr)->get_data()[j]);
+            ASSERT_EQ(0, (int)BooleanColumn::static_pointer_cast(ptr)->get_data()[j]);
         }
     }
 
@@ -354,7 +354,7 @@ TEST_F(VectorizedBinaryPredicateTest, nullEqForNullExpr) {
         ExprsTestHelper::verify_with_jit(
                 v, expr.get(), &runtime_state,
                 [](ColumnPtr const& v) {
-                    auto ptr = std::static_pointer_cast<BooleanColumn>(v);
+                    auto ptr = BooleanColumn::static_pointer_cast(v);
 
                     ASSERT_FALSE(v->is_nullable());
                     ASSERT_TRUE(v->is_numeric());
@@ -400,9 +400,9 @@ TEST_F(VectorizedBinaryPredicateTest, nullAndNotNullEqForNullExpr) {
             }
         }
 
-        auto ptr = std::static_pointer_cast<NullableColumn>(v)->data_column();
+        auto ptr = NullableColumn::static_pointer_cast(v)->data_column();
         for (int j = 0; j < v->size(); ++j) {
-            ASSERT_EQ(1, (int)std::static_pointer_cast<BooleanColumn>(ptr)->get_data()[j]);
+            ASSERT_EQ(1, (int)BooleanColumn::static_pointer_cast(ptr)->get_data()[j]);
         }
     }
 
@@ -411,7 +411,7 @@ TEST_F(VectorizedBinaryPredicateTest, nullAndNotNullEqForNullExpr) {
         ExprsTestHelper::verify_with_jit(
                 v, expr.get(), &runtime_state,
                 [](ColumnPtr const& v) {
-                    auto ptr = std::static_pointer_cast<BooleanColumn>(v);
+                    auto ptr = BooleanColumn::static_pointer_cast(v);
 
                     ASSERT_FALSE(v->is_nullable());
                     ASSERT_TRUE(v->is_numeric());
@@ -473,7 +473,7 @@ TEST_F(VectorizedBinaryPredicateTest, diffNullEqForNullExpr) {
         ExprsTestHelper::verify_with_jit(
                 v, expr.get(), &runtime_state,
                 [](ColumnPtr const& v) {
-                    auto ptr = std::static_pointer_cast<BooleanColumn>(v);
+                    auto ptr = BooleanColumn::static_pointer_cast(v);
 
                     ASSERT_FALSE(v->is_nullable());
                     ASSERT_TRUE(v->is_numeric());
@@ -517,7 +517,7 @@ TEST_F(VectorizedBinaryPredicateStringTest, eqExpr) {
     ASSERT_FALSE(ptr->is_nullable());
     ASSERT_TRUE(ptr->is_numeric());
 
-    auto v = std::static_pointer_cast<BooleanColumn>(ptr);
+    auto v = BooleanColumn::static_pointer_cast(ptr);
     ASSERT_EQ(size, v->size());
     for (int j = 0; j < v->size(); ++j) {
         ASSERT_TRUE(v->get_data()[j]);
@@ -537,7 +537,7 @@ TEST_F(VectorizedBinaryPredicateStringTest, neExpr) {
     ASSERT_FALSE(ptr->is_nullable());
     ASSERT_TRUE(ptr->is_numeric());
 
-    auto v = std::static_pointer_cast<BooleanColumn>(ptr);
+    auto v = BooleanColumn::static_pointer_cast(ptr);
     ASSERT_EQ(size, v->size());
     for (int j = 0; j < v->size(); ++j) {
         ASSERT_TRUE(v->get_data()[j]);
@@ -557,7 +557,7 @@ TEST_F(VectorizedBinaryPredicateStringTest, gtExpr) {
     ASSERT_FALSE(ptr->is_nullable());
     ASSERT_TRUE(ptr->is_numeric());
 
-    auto v = std::static_pointer_cast<BooleanColumn>(ptr);
+    auto v = BooleanColumn::static_pointer_cast(ptr);
     ASSERT_EQ(size, v->size());
     for (int j = 0; j < v->size(); ++j) {
         ASSERT_TRUE(v->get_data()[j]);
@@ -577,7 +577,7 @@ TEST_F(VectorizedBinaryPredicateStringTest, ltExpr) {
     ASSERT_FALSE(ptr->is_nullable());
     ASSERT_TRUE(ptr->is_numeric());
 
-    auto v = std::static_pointer_cast<BooleanColumn>(ptr);
+    auto v = BooleanColumn::static_pointer_cast(ptr);
     ASSERT_EQ(size, v->size());
     for (int j = 0; j < v->size(); ++j) {
         ASSERT_TRUE(v->get_data()[j]);
@@ -637,7 +637,7 @@ public:
         expr_node.__set_child_type_desc(type_desc);
     }
 
-    FakeConstExpr* new_fake_const_expr(ColumnPtr value, const TypeDescriptor& type) {
+    FakeConstExpr* new_fake_const_expr(MutableColumnPtr&& value, const TypeDescriptor& type) {
         TExprNode node;
         node.__set_node_type(TExprNodeType::INT_LITERAL);
         node.__set_num_children(0);
@@ -661,20 +661,20 @@ TEST_F(VectorizedBinaryPredicateArrayTest, arrayGT) {
     array0->append_datum(DatumArray{Datum((int32_t)11), Datum((int32_t)4)}); // [11,4]
     array0->append_datum(DatumArray{Datum(), Datum()});                      // [NULL, NULL]
     array0->append_datum(DatumArray{Datum(), Datum((int32_t)1)});            // [NULL, 1]
-    auto array_expr0 = MockExpr(type_arr_int, array0);
+    auto array_expr0 = MockExpr(type_arr_int, std::move(array0));
 
     auto array1 = ColumnHelper::create_column(type_arr_int, false);
     array1->append_datum(DatumArray{Datum((int32_t)1), Datum((int32_t)4)}); // [1,4]
     array1->append_datum(DatumArray{Datum(), Datum()});                     // [NULL, NULL]
     array1->append_datum(DatumArray{Datum(), Datum((int32_t)1)});           // [NULL, 1]
-    auto array_expr1 = MockExpr(type_arr_int, array1);
+    auto array_expr1 = MockExpr(type_arr_int, std::move(array1));
     expr->add_child(&array_expr0);
     expr->add_child(&array_expr1);
 
     ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
     ASSERT_FALSE(ptr->is_nullable());
 
-    auto v = std::static_pointer_cast<BooleanColumn>(ptr);
+    auto v = BooleanColumn::static_pointer_cast(ptr);
     ASSERT_TRUE(v->get_data()[0]);
     ASSERT_FALSE(v->get_data()[1]); // TODO: should be null
     ASSERT_FALSE(v->get_data()[2]); // TODO: should be null
@@ -689,19 +689,19 @@ TEST_F(VectorizedBinaryPredicateArrayTest, arrayConstGT) {
     array0->append_datum(DatumArray{Datum((int32_t)11), Datum((int32_t)4)}); // [11,4]
     array0->append_datum(DatumArray{Datum(), Datum()});                      // [NULL, NULL]
     array0->append_datum(DatumArray{Datum(), Datum((int32_t)1)});            // [NULL, 1]
-    auto array_expr0 = MockExpr(type_arr_int, array0);
+    auto array_expr0 = MockExpr(type_arr_int, std::move(array0));
 
     auto array = ColumnHelper::create_column(type_arr_int, false);
     array->append_datum(DatumArray{Datum((int32_t)1), Datum((int32_t)4)}); // [1,4]
-    auto const_col = ConstColumn::create(array, 3);
-    auto* const_array = new_fake_const_expr(const_col, type_arr_int);
+    auto const_col = ConstColumn::create(std::move(array), 3);
+    auto* const_array = new_fake_const_expr(std::move(const_col), type_arr_int);
     expr->add_child(&array_expr0);
     expr->add_child(const_array);
 
     ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
     ASSERT_FALSE(ptr->is_nullable());
 
-    auto v = std::static_pointer_cast<BooleanColumn>(ptr);
+    auto v = BooleanColumn::static_pointer_cast(ptr);
     ASSERT_TRUE(v->get_data()[0]);
     ASSERT_TRUE(v->get_data()[1]); // TODO: should be null
     ASSERT_TRUE(v->get_data()[2]); // TODO: should be null
@@ -751,7 +751,7 @@ TEST_F(VectorizedBinaryPredicateMapTest, mapEqExpr1) {
     map1[(int32_t)2] = (int32_t)2;
     col1->append_datum(map1);
 
-    MockColumnExpr expr1(expr_node, col1);
+    MockColumnExpr expr1(expr_node, std::move(col1));
     expr->add_child(&expr1);
 
     auto col2 = ColumnHelper::create_column(map_type(LogicalType::TYPE_INT, LogicalType::TYPE_INT), true);
@@ -760,14 +760,14 @@ TEST_F(VectorizedBinaryPredicateMapTest, mapEqExpr1) {
     map2[(int32_t)2] = (int32_t)2;
     col2->append_datum(map2);
 
-    MockColumnExpr expr2(expr_node, col2);
+    MockColumnExpr expr2(expr_node, std::move(col2));
     expr->add_child(&expr2);
 
     ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
     ASSERT_FALSE(ptr->is_nullable());
     ASSERT_TRUE(ptr->is_numeric());
 
-    auto v = std::static_pointer_cast<BooleanColumn>(ptr);
+    auto v = BooleanColumn::static_pointer_cast(ptr);
     for (int j = 0; j < v->size(); ++j) {
         ASSERT_TRUE(v->get_data()[j]);
     }
@@ -783,7 +783,7 @@ TEST_F(VectorizedBinaryPredicateMapTest, mapEqExpr2) {
     map1[(int32_t)2] = (int32_t)2;
     col1->append_datum(map1);
 
-    MockColumnExpr expr1(expr_node, col1);
+    MockColumnExpr expr1(expr_node, std::move(col1));
     expr->add_child(&expr1);
 
     auto col2 = ColumnHelper::create_column(map_type(LogicalType::TYPE_INT, LogicalType::TYPE_INT), true);
@@ -792,14 +792,14 @@ TEST_F(VectorizedBinaryPredicateMapTest, mapEqExpr2) {
     map2[(int32_t)4] = (int32_t)2;
     col2->append_datum(map2);
 
-    MockColumnExpr expr2(expr_node, col2);
+    MockColumnExpr expr2(expr_node, std::move(col2));
     expr->add_child(&expr2);
 
     ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
     ASSERT_FALSE(ptr->is_nullable());
     ASSERT_TRUE(ptr->is_numeric());
 
-    auto v = std::static_pointer_cast<BooleanColumn>(ptr);
+    auto v = BooleanColumn::static_pointer_cast(ptr);
     for (int j = 0; j < v->size(); ++j) {
         ASSERT_FALSE(v->get_data()[j]);
     }

--- a/be/test/exprs/bitmap_functions_test.cpp
+++ b/be/test/exprs/bitmap_functions_test.cpp
@@ -56,7 +56,7 @@ TEST_F(VecBitmapFunctionsTest, toBitmapTest) {
     {
         Columns columns;
 
-        auto s = BinaryColumn::create();
+        BinaryColumn::Ptr s = BinaryColumn::create();
 
         s->append(Slice("12312313"));
         s->append(Slice("1"));
@@ -78,7 +78,7 @@ TEST_F(VecBitmapFunctionsTest, toBitmapTest) {
     {
         Columns columns;
 
-        auto s = BinaryColumn::create();
+        BinaryColumn::Ptr s = BinaryColumn::create();
 
         s->append(Slice("-1"));
         s->append(Slice("1"));
@@ -103,7 +103,7 @@ TEST_F(VecBitmapFunctionsTest, toBitmapTest_Int) {
     {
         Columns columns;
 
-        auto s = Int32Column::create();
+        Int32Column::Ptr s = Int32Column::create();
 
         s->append(-1);
         s->append(1);
@@ -126,7 +126,7 @@ TEST_F(VecBitmapFunctionsTest, toBitmapTest_Int) {
     {
         Columns columns;
 
-        auto s = Int64Column::create();
+        Int64Column::Ptr s = Int64Column::create();
 
         s->append(12312313);
         s->append(1);
@@ -149,7 +149,7 @@ TEST_F(VecBitmapFunctionsTest, toBitmapTest_Int) {
     {
         Columns columns;
 
-        auto s = Int128Column::create();
+        Int128Column::Ptr s = Int128Column::create();
 
         int128_t inputs[] = {-1, 1, 0, int128_t(std::numeric_limits<uint64_t>::max()),
                              int128_t(std::numeric_limits<uint64_t>::max()) + 1};
@@ -180,7 +180,7 @@ TEST_F(VecBitmapFunctionsTest, bitmapHashTest) {
     {
         Columns columns;
 
-        auto s = BinaryColumn::create();
+        BinaryColumn::Ptr s = BinaryColumn::create();
 
         s->append(Slice("12312313"));
         s->append(Slice("1"));
@@ -202,8 +202,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapHashTest) {
     {
         Columns columns;
 
-        auto s = BinaryColumn::create();
-        auto n = NullColumn::create();
+        BinaryColumn::Ptr s = BinaryColumn::create();
+        NullColumn::Ptr n = NullColumn::create();
 
         s->append(Slice("-1"));
         s->append(Slice("1"));
@@ -257,7 +257,7 @@ TEST_F(VecBitmapFunctionsTest, bitmapCountTest) {
     {
         Columns columns;
 
-        auto s = BitmapColumn::create();
+        BitmapColumn::Ptr s = BitmapColumn::create();
 
         s->append(&b1);
         s->append(&b2);
@@ -280,14 +280,14 @@ TEST_F(VecBitmapFunctionsTest, bitmapCountTest) {
 
     {
         Columns columns;
-        auto s = BitmapColumn::create();
+        BitmapColumn::Ptr s = BitmapColumn::create();
 
         s->append(&b1);
         s->append(&b2);
         s->append(&b3);
         s->append(&b4);
 
-        auto n = NullColumn::create();
+        NullColumn::Ptr n = NullColumn::create();
 
         n->append(0);
         n->append(0);
@@ -339,8 +339,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapOrTest) {
     {
         Columns columns;
 
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1);
         s1->append(&b2);
@@ -362,15 +362,15 @@ TEST_F(VecBitmapFunctionsTest, bitmapOrTest) {
 
     {
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1);
         s1->append(&b2);
         s2->append(&b3);
         s2->append(&b4);
 
-        auto n = NullColumn::create();
+        NullColumn::Ptr n = NullColumn::create();
 
         n->append(0);
         n->append(1);
@@ -419,8 +419,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapAndTest) {
     {
         Columns columns;
 
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1);
         s1->append(&b2);
@@ -458,7 +458,7 @@ TEST_F(VecBitmapFunctionsTest, bitmapToStringTest) {
     {
         Columns columns;
 
-        auto s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
 
         s1->append(&b1);
         s1->append(&b2);
@@ -493,7 +493,7 @@ TEST_F(VecBitmapFunctionsTest, bitmapToStringTest) {
     {
         Columns columns;
 
-        auto s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
 
         s1->append(&b3);
         s1->append(&b4);
@@ -515,7 +515,7 @@ TEST_F(VecBitmapFunctionsTest, bitmapToStringTest) {
 TEST_F(VecBitmapFunctionsTest, bitmapFromStringTest) {
     {
         Columns columns;
-        auto s1 = BinaryColumn::create();
+        BinaryColumn::Ptr s1 = BinaryColumn::create();
 
         s1->append(Slice("1,2,3,4"));
         s1->append(Slice("4,5,6,7"));
@@ -534,7 +534,7 @@ TEST_F(VecBitmapFunctionsTest, bitmapFromStringTest) {
 
     {
         Columns columns;
-        auto s1 = BinaryColumn::create();
+        BinaryColumn::Ptr s1 = BinaryColumn::create();
 
         s1->append(Slice("1,2,3,4"));
         s1->append(Slice("asdf,7"));
@@ -567,12 +567,12 @@ TEST_F(VecBitmapFunctionsTest, bitmapContainsTest) {
     b2.add(7);
     {
         Columns columns;
-        auto s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
 
         s1->append(&b1);
         s1->append(&b2);
 
-        auto b1 = Int64Column::create();
+        Int64Column::Ptr b1 = Int64Column::create();
 
         b1->append(4);
         b1->append(1);
@@ -618,8 +618,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapHasAnyTest) {
     b4.add(17);
     {
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1);
         s1->append(&b2);
@@ -656,8 +656,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapNotTest) {
         b1_column1.add(4);
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -687,8 +687,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapNotTest) {
         b1_column1.add(634);
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -716,8 +716,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapNotTest) {
         b1_column1.add(6);
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -744,8 +744,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapNotTest) {
         BitmapValue b1_column1;
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -775,8 +775,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapNotTest) {
         b1_column1.add(4);
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -805,8 +805,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapNotTest) {
         b1_column1.add(634);
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -833,8 +833,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapNotTest) {
         b1_column1.add(6);
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -860,8 +860,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapNotTest) {
         BitmapValue b1_column1;
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -889,8 +889,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapNotTest) {
         b1_column1.add(4);
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -917,8 +917,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapNotTest) {
         b1_column1.add(634);
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -943,8 +943,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapNotTest) {
         b1_column1.add(6);
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -968,8 +968,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapNotTest) {
         BitmapValue b1_column1;
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -996,8 +996,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapNotTest) {
         b1_column1.add(4);
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -1023,8 +1023,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapNotTest) {
         b1_column1.add(634);
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -1048,8 +1048,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapNotTest) {
         b1_column1.add(6);
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -1072,8 +1072,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapNotTest) {
         BitmapValue b1_column1;
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -1106,8 +1106,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapXorTest) {
         b1_column1.add(4);
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -1137,8 +1137,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapXorTest) {
         b1_column1.add(634);
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -1166,8 +1166,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapXorTest) {
         b1_column1.add(6);
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -1194,8 +1194,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapXorTest) {
         BitmapValue b1_column1;
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -1225,8 +1225,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapXorTest) {
         b1_column1.add(4);
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -1255,8 +1255,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapXorTest) {
         b1_column1.add(634);
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -1283,8 +1283,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapXorTest) {
         b1_column1.add(6);
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -1310,8 +1310,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapXorTest) {
         BitmapValue b1_column1;
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -1339,8 +1339,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapXorTest) {
         b1_column1.add(4);
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -1367,8 +1367,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapXorTest) {
         b1_column1.add(634);
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -1393,8 +1393,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapXorTest) {
         b1_column1.add(6);
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -1418,8 +1418,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapXorTest) {
         BitmapValue b1_column1;
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -1446,8 +1446,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapXorTest) {
         b1_column1.add(4);
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -1473,8 +1473,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapXorTest) {
         b1_column1.add(634);
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -1498,8 +1498,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapXorTest) {
         b1_column1.add(6);
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -1522,8 +1522,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapXorTest) {
         BitmapValue b1_column1;
 
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s2 = BitmapColumn::create();
 
         s1->append(&b1_column0);
         s2->append(&b1_column1);
@@ -1560,8 +1560,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapRemoveTest) {
 
     {
         Columns columns;
-        auto s1 = BitmapColumn::create();
-        auto s2 = Int64Column::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
+        Int64Column::Ptr s2 = Int64Column::create();
 
         s1->append(&b1);
         s1->append(&b2);
@@ -1608,7 +1608,7 @@ TEST_F(VecBitmapFunctionsTest, bitmapToArrayTest) {
 
     {
         Columns columns;
-        auto s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
 
         s1->append(&b1);
         s1->append(&b2);
@@ -1661,14 +1661,14 @@ TEST_F(VecBitmapFunctionsTest, bitmapToArrayNullTest) {
 
     {
         Columns columns;
-        auto s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
 
         s1->append(&b1);
         s1->append(&b2);
         s1->append(&b3);
         s1->append(&b4);
 
-        auto n = NullColumn::create();
+        NullColumn::Ptr n = NullColumn::create();
 
         n->append(0);
         n->append(0);
@@ -1709,7 +1709,7 @@ TEST_F(VecBitmapFunctionsTest, bitmapToArrayConstTest) {
 
     {
         Columns columns;
-        auto s1 = BitmapColumn::create();
+        BitmapColumn::Ptr s1 = BitmapColumn::create();
 
         s1->append(&b1);
 
@@ -1733,7 +1733,7 @@ TEST_F(VecBitmapFunctionsTest, bitmapToArrayOnlyNullTest) {
     {
         Columns columns;
         size_t size = 8;
-        auto s1 = ColumnHelper::create_const_null_column(size);
+        ColumnPtr s1 = ColumnHelper::create_const_null_column(size);
         columns.push_back(s1);
 
         auto column = BitmapFunctions::bitmap_to_array(ctx, columns).value();
@@ -1817,7 +1817,7 @@ TEST_F(VecBitmapFunctionsTest, bitmapMaxTest) {
     {
         Columns columns;
 
-        auto s = BitmapColumn::create();
+        BitmapColumn::Ptr s = BitmapColumn::create();
 
         s->append(&b1);
         s->append(&b2);
@@ -1849,14 +1849,14 @@ TEST_F(VecBitmapFunctionsTest, bitmapMaxTest) {
 
     {
         Columns columns;
-        auto s = BitmapColumn::create();
+        BitmapColumn::Ptr s = BitmapColumn::create();
 
         s->append(&b1);
         s->append(&b2);
         s->append(&b3);
         s->append(&b4);
 
-        auto n = NullColumn::create();
+        NullColumn::Ptr n = NullColumn::create();
 
         n->append(0);
         n->append(1);
@@ -1908,7 +1908,7 @@ TEST_F(VecBitmapFunctionsTest, bitmapMinTest) {
     {
         Columns columns;
 
-        auto s = BitmapColumn::create();
+        BitmapColumn::Ptr s = BitmapColumn::create();
 
         s->append(&b1);
         s->append(&b2);
@@ -1940,14 +1940,14 @@ TEST_F(VecBitmapFunctionsTest, bitmapMinTest) {
 
     {
         Columns columns;
-        auto s = BitmapColumn::create();
+        BitmapColumn::Ptr s = BitmapColumn::create();
 
         s->append(&b1);
         s->append(&b2);
         s->append(&b3);
         s->append(&b4);
 
-        auto n = NullColumn::create();
+        NullColumn::Ptr n = NullColumn::create();
 
         n->append(0);
         n->append(1);
@@ -1999,25 +1999,25 @@ TEST_F(VecBitmapFunctionsTest, base64ToBitmapTest) {
 
 TEST_F(VecBitmapFunctionsTest, array_to_bitmap_test) {
     auto builder = [](const Buffer<int64_t>& val) {
-        auto ele_column = NullableColumn::create(Int64Column::create(), NullColumn::create());
+        NullableColumn::Ptr ele_column = NullableColumn::create(Int64Column::create(), NullColumn::create());
         for (auto& v : val) {
             ele_column->append_datum(v);
         }
-        auto offset_column = UInt32Column::create();
+        UInt32Column::Ptr offset_column = UInt32Column::create();
         offset_column->append(0);
         offset_column->append(val.size());
         return ArrayColumn::create(ele_column, offset_column);
     };
 
     auto nullable_builder = [](const Buffer<int64_t>& val, const Buffer<int32_t>& null_idx) {
-        auto ele_column = Int64Column::create();
+        Int64Column::Ptr ele_column = Int64Column::create();
         ele_column->append(val);
 
-        auto nullable_column = NullableColumn::create(ele_column, NullColumn::create(val.size()));
+        NullableColumn::Ptr nullable_column = NullableColumn::create(ele_column, NullColumn::create(val.size()));
         for (auto idx : null_idx) {
             nullable_column->set_null(idx);
         }
-        auto offset_column = UInt32Column::create();
+        UInt32Column::Ptr offset_column = UInt32Column::create();
         offset_column->append(0);
         offset_column->append(val.size());
         return ArrayColumn::create(nullable_column, offset_column);
@@ -2039,7 +2039,7 @@ TEST_F(VecBitmapFunctionsTest, array_to_bitmap_test) {
 TEST_F(VecBitmapFunctionsTest, bitmapToBase64Test) {
     { // Empty Bitmap
         Columns columns;
-        auto s = BitmapColumn::create();
+        BitmapColumn::Ptr s = BitmapColumn::create();
         BitmapValue empty;
         s->append(&empty);
         columns.push_back(s);
@@ -2059,7 +2059,7 @@ TEST_F(VecBitmapFunctionsTest, bitmapToBase64Test) {
 
     { // Single Bitmap
         Columns columns;
-        auto s = BitmapColumn::create();
+        BitmapColumn::Ptr s = BitmapColumn::create();
         BitmapValue single({1});
         s->append(&single);
 
@@ -2082,7 +2082,7 @@ TEST_F(VecBitmapFunctionsTest, bitmapToBase64Test) {
 
     { // Set Bitmap
         Columns columns;
-        auto s = BitmapColumn::create();
+        BitmapColumn::Ptr s = BitmapColumn::create();
         // Adding values one by one, no more than 32, which makes the bitmap stores value with set
         BitmapValue set;
         set.add(1);
@@ -2112,7 +2112,7 @@ TEST_F(VecBitmapFunctionsTest, bitmapToBase64Test) {
 
     { // 32bit Bitmap
         Columns columns;
-        auto s = BitmapColumn::create();
+        BitmapColumn::Ptr s = BitmapColumn::create();
         // Constructing bitmap with vector which contains 32bit values makes it a 32bit bitmap
         BitmapValue bmp32bit({1, 2, 3, 4});
         s->append(&bmp32bit);
@@ -2138,7 +2138,7 @@ TEST_F(VecBitmapFunctionsTest, bitmapToBase64Test) {
 
     { // 64bit Bitmap
         Columns columns;
-        auto s = BitmapColumn::create();
+        BitmapColumn::Ptr s = BitmapColumn::create();
         // Constructing bitmap with vector which contains 64bit values makes it a 64bit bitmap
         BitmapValue bmp64bit({600123456781, 600123456782, 600123456783, 600123456784});
         s->append(&bmp64bit);
@@ -2165,13 +2165,13 @@ TEST_F(VecBitmapFunctionsTest, bitmapToBase64Test) {
 
 TEST_F(VecBitmapFunctionsTest, sub_bitmap) {
     BitmapValue bitmap({1, 2, 3, 4, 5, 64, 128, 256, 512, 1024});
-    auto bitmap_column = BitmapColumn::create();
+    BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
     bitmap_column->append(&bitmap);
 
     {
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(2);
         len->append(3);
 
@@ -2186,8 +2186,8 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap) {
 
     {
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(5);
         len->append(100);
 
@@ -2202,8 +2202,8 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap) {
 
     {
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(5);
         len->append(INT64_MAX);
 
@@ -2218,8 +2218,8 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap) {
 
     {
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(0);
         len->append(2);
 
@@ -2234,8 +2234,8 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap) {
 
     {
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(-1);
         len->append(1);
 
@@ -2250,8 +2250,8 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap) {
 
     {
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(-1);
         len->append(100);
 
@@ -2266,8 +2266,8 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap) {
 
     {
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(-6);
         len->append(100);
 
@@ -2282,8 +2282,8 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap) {
 
     {
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(-6);
         len->append(5);
 
@@ -2298,8 +2298,8 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap) {
 
     {
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(0);
         len->append(0);
 
@@ -2313,8 +2313,8 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap) {
 
     {
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(100);
         len->append(5);
 
@@ -2328,8 +2328,8 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap) {
 
     {
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(-100);
         len->append(5);
 
@@ -2343,8 +2343,8 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap) {
 
     {
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(5);
         len->append(INT64_MIN);
 
@@ -2359,9 +2359,9 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap) {
     {
         Columns columns;
         BitmapValue bitmap1;
-        auto bitmap_column1 = BitmapColumn::create();
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        BitmapColumn::Ptr bitmap_column1 = BitmapColumn::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         bitmap_column1->append(&bitmap1);
         offset->append(5);
         len->append(5);
@@ -2378,13 +2378,13 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap) {
 TEST_F(VecBitmapFunctionsTest, sub_bitmap_special_cases) {
     // empty bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         BitmapValue empty;
         bitmap_column->append(&empty);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(2);
         len->append(3);
 
@@ -2397,13 +2397,13 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_special_cases) {
     }
     // single bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         BitmapValue single({1});
         bitmap_column->append(&single);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(0);
         len->append(1);
 
@@ -2417,13 +2417,13 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_special_cases) {
     }
     // single bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         BitmapValue single({1});
         bitmap_column->append(&single);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(0);
         len->append(0);
 
@@ -2436,13 +2436,13 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_special_cases) {
     }
     // single bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         BitmapValue single({1});
         bitmap_column->append(&single);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(-1);
         len->append(1);
 
@@ -2456,7 +2456,7 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_special_cases) {
     }
     // set bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         // Adding values one by one, no more than 32, which makes the bitmap stores value with set
         BitmapValue set;
         set.add(1);
@@ -2466,8 +2466,8 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_special_cases) {
         bitmap_column->append(&set);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(2);
         len->append(3);
 
@@ -2481,7 +2481,7 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_special_cases) {
     }
     // set bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         // Adding values one by one, no more than 32, which makes the bitmap stores value with set
         BitmapValue set;
         set.add(1);
@@ -2491,8 +2491,8 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_special_cases) {
         bitmap_column->append(&set);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(-3);
         len->append(3);
 
@@ -2506,14 +2506,14 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_special_cases) {
     }
     // 32bit Bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         // Constructing bitmap with vector which contains 32bit values makes it a 32bit bitmap
         BitmapValue bmp32bit({1});
         bitmap_column->append(&bmp32bit);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(0);
         len->append(1);
 
@@ -2527,14 +2527,14 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_special_cases) {
     }
     // 32bit Bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         // Constructing bitmap with vector which contains 32bit values makes it a 32bit bitmap
         BitmapValue bmp32bit({1});
         bitmap_column->append(&bmp32bit);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(-1);
         len->append(1);
 
@@ -2548,14 +2548,14 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_special_cases) {
     }
     // 32bit Bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         // Constructing bitmap with vector which contains 32bit values makes it a 32bit bitmap
         BitmapValue bmp32bit({1, 2, 3, 4});
         bitmap_column->append(&bmp32bit);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(-3);
         len->append(3);
 
@@ -2569,14 +2569,14 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_special_cases) {
     }
     // 32bit Bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         // Constructing bitmap with vector which contains 32bit values makes it a 32bit bitmap
         BitmapValue bmp32bit({1, 2, 3, 4});
         bitmap_column->append(&bmp32bit);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(2);
         len->append(3);
 
@@ -2590,14 +2590,14 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_special_cases) {
     }
     // 64bit bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         // Constructing bitmap with vector which contains 64bit values makes it a 64bit bitmap
         BitmapValue bmp64bit({600123456781, 600123456782, 600123456783, 600123456784});
         bitmap_column->append(&bmp64bit);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(2);
         len->append(3);
 
@@ -2613,13 +2613,13 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_special_cases) {
 
 TEST_F(VecBitmapFunctionsTest, bitmap_subset_limit) {
     BitmapValue bitmap({1, 2, 3, 4, 5, 64, 128, 256, 512, 1024});
-    auto bitmap_column = BitmapColumn::create();
+    BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
     bitmap_column->append(&bitmap);
 
     {
         Columns columns;
-        auto start = Int64Column::create();
-        auto limit = Int64Column::create();
+        Int64Column::Ptr start = Int64Column::create();
+        Int64Column::Ptr limit = Int64Column::create();
         start->append(2);
         limit->append(3);
 
@@ -2634,8 +2634,8 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_limit) {
 
     {
         Columns columns;
-        auto start = Int64Column::create();
-        auto limit = Int64Column::create();
+        Int64Column::Ptr start = Int64Column::create();
+        Int64Column::Ptr limit = Int64Column::create();
         start->append(5);
         limit->append(100);
 
@@ -2650,8 +2650,8 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_limit) {
 
     {
         Columns columns;
-        auto start = Int64Column::create();
-        auto limit = Int64Column::create();
+        Int64Column::Ptr start = Int64Column::create();
+        Int64Column::Ptr limit = Int64Column::create();
         start->append(5);
         limit->append(INT64_MAX);
 
@@ -2666,8 +2666,8 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_limit) {
 
     {
         Columns columns;
-        auto start = Int64Column::create();
-        auto limit = Int64Column::create();
+        Int64Column::Ptr start = Int64Column::create();
+        Int64Column::Ptr limit = Int64Column::create();
         start->append(0);
         limit->append(2);
 
@@ -2682,8 +2682,8 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_limit) {
 
     {
         Columns columns;
-        auto start = Int64Column::create();
-        auto limit = Int64Column::create();
+        Int64Column::Ptr start = Int64Column::create();
+        Int64Column::Ptr limit = Int64Column::create();
         start->append(-1);
         limit->append(1);
 
@@ -2698,8 +2698,8 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_limit) {
 
     {
         Columns columns;
-        auto start = Int64Column::create();
-        auto limit = Int64Column::create();
+        Int64Column::Ptr start = Int64Column::create();
+        Int64Column::Ptr limit = Int64Column::create();
         start->append(5);
         limit->append(-2);
 
@@ -2714,8 +2714,8 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_limit) {
 
     {
         Columns columns;
-        auto start = Int64Column::create();
-        auto limit = Int64Column::create();
+        Int64Column::Ptr start = Int64Column::create();
+        Int64Column::Ptr limit = Int64Column::create();
         start->append(1025);
         limit->append(-100);
 
@@ -2730,8 +2730,8 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_limit) {
 
     {
         Columns columns;
-        auto start = Int64Column::create();
-        auto limit = Int64Column::create();
+        Int64Column::Ptr start = Int64Column::create();
+        Int64Column::Ptr limit = Int64Column::create();
         start->append(1025);
         limit->append(-2);
 
@@ -2746,8 +2746,8 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_limit) {
 
     {
         Columns columns;
-        auto start = Int64Column::create();
-        auto limit = Int64Column::create();
+        Int64Column::Ptr start = Int64Column::create();
+        Int64Column::Ptr limit = Int64Column::create();
         start->append(0);
         limit->append(0);
 
@@ -2761,8 +2761,8 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_limit) {
 
     {
         Columns columns;
-        auto start = Int64Column::create();
-        auto limit = Int64Column::create();
+        Int64Column::Ptr start = Int64Column::create();
+        Int64Column::Ptr limit = Int64Column::create();
         start->append(1025);
         limit->append(5);
 
@@ -2776,8 +2776,8 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_limit) {
 
     {
         Columns columns;
-        auto start = Int64Column::create();
-        auto limit = Int64Column::create();
+        Int64Column::Ptr start = Int64Column::create();
+        Int64Column::Ptr limit = Int64Column::create();
         start->append(0);
         limit->append(-5);
 
@@ -2791,8 +2791,8 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_limit) {
 
     {
         Columns columns;
-        auto start = Int64Column::create();
-        auto limit = Int64Column::create();
+        Int64Column::Ptr start = Int64Column::create();
+        Int64Column::Ptr limit = Int64Column::create();
         start->append(1025);
         limit->append(INT64_MAX);
 
@@ -2807,9 +2807,9 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_limit) {
     {
         Columns columns;
         BitmapValue bitmap1;
-        auto bitmap_column1 = BitmapColumn::create();
-        auto start = Int64Column::create();
-        auto limit = Int64Column::create();
+        BitmapColumn::Ptr bitmap_column1 = BitmapColumn::create();
+        Int64Column::Ptr start = Int64Column::create();
+        Int64Column::Ptr limit = Int64Column::create();
         bitmap_column1->append(&bitmap1);
         start->append(5);
         limit->append(5);
@@ -2826,13 +2826,13 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_limit) {
 TEST_F(VecBitmapFunctionsTest, sub_bitmap_limit_special_cases) {
     // empty bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         BitmapValue empty;
         bitmap_column->append(&empty);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(2);
         len->append(3);
 
@@ -2845,13 +2845,13 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_limit_special_cases) {
     }
     // single bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         BitmapValue single({1});
         bitmap_column->append(&single);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(0);
         len->append(1);
 
@@ -2865,13 +2865,13 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_limit_special_cases) {
     }
     // single bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         BitmapValue single({1});
         bitmap_column->append(&single);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(2);
         len->append(-1);
 
@@ -2885,13 +2885,13 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_limit_special_cases) {
     }
     // single bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         BitmapValue single({1});
         bitmap_column->append(&single);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(0);
         len->append(-1);
 
@@ -2904,7 +2904,7 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_limit_special_cases) {
     }
     // set bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         // Adding values one by one, no more than 32, which makes the bitmap stores value with set
         BitmapValue set;
         set.add(1);
@@ -2914,8 +2914,8 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_limit_special_cases) {
         bitmap_column->append(&set);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(2);
         len->append(3);
 
@@ -2929,7 +2929,7 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_limit_special_cases) {
     }
     // set bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         // Adding values one by one, no more than 32, which makes the bitmap stores value with set
         BitmapValue set;
         set.add(1);
@@ -2939,8 +2939,8 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_limit_special_cases) {
         bitmap_column->append(&set);
 
         Columns columns;
-        auto range_start = Int64Column::create();
-        auto limit = Int64Column::create();
+        Int64Column::Ptr range_start = Int64Column::create();
+        Int64Column::Ptr limit = Int64Column::create();
         range_start->append(3);
         limit->append(-3);
 
@@ -2954,14 +2954,14 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_limit_special_cases) {
     }
     // 32bit Bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         // Constructing bitmap with vector which contains 32bit values makes it a 32bit bitmap
         BitmapValue bmp32bit({1});
         bitmap_column->append(&bmp32bit);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(0);
         len->append(1);
 
@@ -2975,14 +2975,14 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_limit_special_cases) {
     }
     // 32bit Bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         // Constructing bitmap with vector which contains 32bit values makes it a 32bit bitmap
         BitmapValue bmp32bit({1});
         bitmap_column->append(&bmp32bit);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(0);
         len->append(-1);
 
@@ -2995,14 +2995,14 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_limit_special_cases) {
     }
     // 32bit Bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         // Constructing bitmap with vector which contains 32bit values makes it a 32bit bitmap
         BitmapValue bmp32bit({1});
         bitmap_column->append(&bmp32bit);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(2);
         len->append(-1);
 
@@ -3016,14 +3016,14 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_limit_special_cases) {
     }
     // 32bit Bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         // Constructing bitmap with vector which contains 32bit values makes it a 32bit bitmap
         BitmapValue bmp32bit({1, 2, 3, 4});
         bitmap_column->append(&bmp32bit);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(2);
         len->append(3);
 
@@ -3037,14 +3037,14 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_limit_special_cases) {
     }
     // 32bit Bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         // Constructing bitmap with vector which contains 32bit values makes it a 32bit bitmap
         BitmapValue bmp32bit({1, 2, 3, 4});
         bitmap_column->append(&bmp32bit);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(3);
         len->append(-3);
 
@@ -3058,14 +3058,14 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_limit_special_cases) {
     }
     // 64bit bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         // Constructing bitmap with vector which contains 64bit values makes it a 64bit bitmap
         BitmapValue bmp64bit({600123456781, 600123456782, 600123456783, 600123456784});
         bitmap_column->append(&bmp64bit);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(2);
         len->append(3);
 
@@ -3081,13 +3081,13 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_limit_special_cases) {
 
 TEST_F(VecBitmapFunctionsTest, bitmap_subset_in_range) {
     BitmapValue bitmap({1, 2, 3, 4, 5, 64, 128, 256, 512, 1024});
-    auto bitmap_column = BitmapColumn::create();
+    BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
     bitmap_column->append(&bitmap);
 
     {
         Columns columns;
-        auto start = Int64Column::create();
-        auto end = Int64Column::create();
+        Int64Column::Ptr start = Int64Column::create();
+        Int64Column::Ptr end = Int64Column::create();
         start->append(2);
         end->append(3);
 
@@ -3102,8 +3102,8 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_in_range) {
 
     {
         Columns columns;
-        auto start = Int64Column::create();
-        auto end = Int64Column::create();
+        Int64Column::Ptr start = Int64Column::create();
+        Int64Column::Ptr end = Int64Column::create();
         start->append(5);
         end->append(100);
 
@@ -3118,8 +3118,8 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_in_range) {
 
     {
         Columns columns;
-        auto start = Int64Column::create();
-        auto end = Int64Column::create();
+        Int64Column::Ptr start = Int64Column::create();
+        Int64Column::Ptr end = Int64Column::create();
         start->append(5);
         end->append(INT64_MAX);
 
@@ -3134,8 +3134,8 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_in_range) {
 
     {
         Columns columns;
-        auto start = Int64Column::create();
-        auto end = Int64Column::create();
+        Int64Column::Ptr start = Int64Column::create();
+        Int64Column::Ptr end = Int64Column::create();
         start->append(0);
         end->append(3);
 
@@ -3150,8 +3150,8 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_in_range) {
 
     {
         Columns columns;
-        auto start = Int64Column::create();
-        auto end = Int64Column::create();
+        Int64Column::Ptr start = Int64Column::create();
+        Int64Column::Ptr end = Int64Column::create();
         start->append(1);
         end->append(2);
 
@@ -3166,8 +3166,8 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_in_range) {
 
     {
         Columns columns;
-        auto start = Int64Column::create();
-        auto end = Int64Column::create();
+        Int64Column::Ptr start = Int64Column::create();
+        Int64Column::Ptr end = Int64Column::create();
         start->append(4);
         end->append(6);
 
@@ -3182,8 +3182,8 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_in_range) {
 
     {
         Columns columns;
-        auto start = Int64Column::create();
-        auto end = Int64Column::create();
+        Int64Column::Ptr start = Int64Column::create();
+        Int64Column::Ptr end = Int64Column::create();
         start->append(0);
         end->append(1025);
 
@@ -3198,8 +3198,8 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_in_range) {
 
     {
         Columns columns;
-        auto start = Int64Column::create();
-        auto end = Int64Column::create();
+        Int64Column::Ptr start = Int64Column::create();
+        Int64Column::Ptr end = Int64Column::create();
         start->append(510);
         end->append(1025);
 
@@ -3214,8 +3214,8 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_in_range) {
 
     {
         Columns columns;
-        auto start = Int64Column::create();
-        auto end = Int64Column::create();
+        Int64Column::Ptr start = Int64Column::create();
+        Int64Column::Ptr end = Int64Column::create();
         start->append(0);
         end->append(0);
 
@@ -3229,8 +3229,8 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_in_range) {
 
     {
         Columns columns;
-        auto start = Int64Column::create();
-        auto end = Int64Column::create();
+        Int64Column::Ptr start = Int64Column::create();
+        Int64Column::Ptr end = Int64Column::create();
         start->append(1025);
         end->append(5);
 
@@ -3244,8 +3244,8 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_in_range) {
 
     {
         Columns columns;
-        auto start = Int64Column::create();
-        auto end = Int64Column::create();
+        Int64Column::Ptr start = Int64Column::create();
+        Int64Column::Ptr end = Int64Column::create();
         start->append(0);
         end->append(-5);
 
@@ -3259,8 +3259,8 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_in_range) {
 
     {
         Columns columns;
-        auto start = Int64Column::create();
-        auto end = Int64Column::create();
+        Int64Column::Ptr start = Int64Column::create();
+        Int64Column::Ptr end = Int64Column::create();
         start->append(1025);
         end->append(INT64_MAX);
 
@@ -3275,9 +3275,9 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_in_range) {
     {
         Columns columns;
         BitmapValue bitmap1;
-        auto bitmap_column1 = BitmapColumn::create();
-        auto start = Int64Column::create();
-        auto end = Int64Column::create();
+        BitmapColumn::Ptr bitmap_column1 = BitmapColumn::create();
+        Int64Column::Ptr start = Int64Column::create();
+        Int64Column::Ptr end = Int64Column::create();
         bitmap_column1->append(&bitmap1);
         start->append(5);
         end->append(5);
@@ -3294,13 +3294,13 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_in_range) {
 TEST_F(VecBitmapFunctionsTest, bitmap_subset_in_range_special_cases) {
     // empty bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         BitmapValue empty;
         bitmap_column->append(&empty);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(2);
         len->append(3);
 
@@ -3313,13 +3313,13 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_in_range_special_cases) {
     }
     // single bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         BitmapValue single({1});
         bitmap_column->append(&single);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(0);
         len->append(2);
 
@@ -3333,13 +3333,13 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_in_range_special_cases) {
     }
     // single bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         BitmapValue single({1});
         bitmap_column->append(&single);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(2);
         len->append(3);
 
@@ -3352,7 +3352,7 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_in_range_special_cases) {
     }
     // set bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         // Adding values one by one, no more than 32, which makes the bitmap stores value with set
         BitmapValue set;
         set.add(1);
@@ -3362,8 +3362,8 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_in_range_special_cases) {
         bitmap_column->append(&set);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(2);
         len->append(4);
 
@@ -3377,14 +3377,14 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_in_range_special_cases) {
     }
     // 32bit Bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         // Constructing bitmap with vector which contains 32bit values makes it a 32bit bitmap
         BitmapValue bmp32bit({1, 2, 3, 4});
         bitmap_column->append(&bmp32bit);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(2);
         len->append(4);
 
@@ -3398,14 +3398,14 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_in_range_special_cases) {
     }
     // 64bit bitmap
     {
-        auto bitmap_column = BitmapColumn::create();
+        BitmapColumn::Ptr bitmap_column = BitmapColumn::create();
         // Constructing bitmap with vector which contains 64bit values makes it a 64bit bitmap
         BitmapValue bmp64bit({600123456781, 600123456782, 600123456783, 600123456784});
         bitmap_column->append(&bmp64bit);
 
         Columns columns;
-        auto offset = Int64Column::create();
-        auto len = Int64Column::create();
+        Int64Column::Ptr offset = Int64Column::create();
+        Int64Column::Ptr len = Int64Column::create();
         offset->append(600123456781);
         len->append(600123456782);
 

--- a/be/test/exprs/case_expr_test.cpp
+++ b/be/test/exprs/case_expr_test.cpp
@@ -129,13 +129,13 @@ TEST_F(VectorizedCaseExprTest, whenArrayMapCase) {
     array0->append_datum(DatumArray{Datum((int32_t)1), Datum((int32_t)4)}); // [1,4]
     array0->append_datum(DatumArray{Datum(), Datum()});                     // [NULL, NULL]
     array0->append_datum(DatumArray{Datum(), Datum((int32_t)12)});          // [NULL, 12]
-    auto array_expr0 = MockExpr(type_arr_int, array0);
+    auto array_expr0 = MockExpr(type_arr_int, std::move(array0));
 
     auto array1 = ColumnHelper::create_column(type_arr_int, false);
     array1->append_datum(DatumArray{Datum((int32_t)11), Datum((int32_t)41)}); // [11,41]
     array1->append_datum(DatumArray{Datum(), Datum()});                       // [NULL, NULL]
     array1->append_datum(DatumArray{Datum(), Datum((int32_t)1)});             // [NULL, 1]
-    auto array_expr1 = MockExpr(type_arr_int, array1);
+    auto array_expr1 = MockExpr(type_arr_int, std::move(array1));
 
     TypeDescriptor type_map_int_int = map_type(TYPE_INT, TYPE_INT);
     expr->set_type(type_map_int_int);
@@ -156,7 +156,7 @@ TEST_F(VectorizedCaseExprTest, whenArrayMapCase) {
         // {} empty
         map_column_not_nullable->append_datum(DatumMap());
     }
-    auto map_expr = MockExpr(type_map_int_int, map_column_not_nullable);
+    auto map_expr = MockExpr(type_map_int_int, map_column_not_nullable->clone());
 
     expr->_children.push_back(&array_expr0); // case
     expr->_children.push_back(&array_expr1); // when1

--- a/be/test/exprs/cast_expr_test.cpp
+++ b/be/test/exprs/cast_expr_test.cpp
@@ -82,7 +82,7 @@ TEST_F(VectorizedCastExprTest, IntCastToDate) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -102,7 +102,7 @@ TEST_F(VectorizedCastExprTest, BigIntCastToTimestamp) {
 
         ASSERT_TRUE(ptr->is_timestamp());
 
-        auto v = std::static_pointer_cast<TimestampColumn>(ptr);
+        auto v = TimestampColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -110,7 +110,7 @@ TEST_F(VectorizedCastExprTest, BigIntCastToTimestamp) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -138,7 +138,7 @@ TEST_F(VectorizedCastExprTest, BigIntCastToTimestampError) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<TimestampColumn>(ptr));
+        ASSERT_EQ(nullptr, TimestampColumn::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -159,7 +159,7 @@ TEST_F(VectorizedCastExprTest, dateCastToBoolean) {
         ASSERT_TRUE(ptr->is_numeric());
 
         // right cast
-        auto v = std::static_pointer_cast<BooleanColumn>(ptr);
+        auto v = BooleanColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -167,7 +167,7 @@ TEST_F(VectorizedCastExprTest, dateCastToBoolean) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -188,7 +188,7 @@ TEST_F(VectorizedCastExprTest, timestampCastToBoolean) {
         ASSERT_TRUE(ptr->is_numeric());
 
         // right cast
-        auto v = std::static_pointer_cast<BooleanColumn>(ptr);
+        auto v = BooleanColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -196,7 +196,7 @@ TEST_F(VectorizedCastExprTest, timestampCastToBoolean) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -217,7 +217,7 @@ TEST_F(VectorizedCastExprTest, stringLiteralTrueCastToBoolean) {
         ASSERT_TRUE(ptr->is_numeric());
 
         // right cast
-        auto v = std::static_pointer_cast<BooleanColumn>(ptr);
+        auto v = BooleanColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -225,7 +225,7 @@ TEST_F(VectorizedCastExprTest, stringLiteralTrueCastToBoolean) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -246,7 +246,7 @@ TEST_F(VectorizedCastExprTest, stringLiteralFalseCastToBoolean) {
         ASSERT_TRUE(ptr->is_numeric());
 
         // right cast
-        auto v = std::static_pointer_cast<BooleanColumn>(ptr);
+        auto v = BooleanColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -254,7 +254,7 @@ TEST_F(VectorizedCastExprTest, stringLiteralFalseCastToBoolean) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -275,7 +275,7 @@ TEST_F(VectorizedCastExprTest, stringLiteralIntCastToBoolean) {
         ASSERT_TRUE(ptr->is_numeric());
 
         // right cast
-        auto v = std::static_pointer_cast<BooleanColumn>(ptr);
+        auto v = BooleanColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -283,7 +283,7 @@ TEST_F(VectorizedCastExprTest, stringLiteralIntCastToBoolean) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -387,7 +387,7 @@ TEST_F(VectorizedCastExprTest, intCastSelfExpr) {
             ASSERT_TRUE(ptr->is_numeric());
 
             // right cast
-            auto v = std::static_pointer_cast<Int32Column>(ptr);
+            auto v = Int32Column::static_pointer_cast(ptr);
             ASSERT_EQ(10, v->size());
 
             for (int j = 0; j < v->size(); ++j) {
@@ -395,7 +395,7 @@ TEST_F(VectorizedCastExprTest, intCastSelfExpr) {
             }
 
             // error cast
-            ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+            ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
         });
     }
 }
@@ -418,7 +418,7 @@ TEST_F(VectorizedCastExprTest, intToFloatCastExpr) {
             ASSERT_TRUE(ptr->is_numeric());
 
             // right cast
-            auto v = std::static_pointer_cast<FloatColumn>(ptr);
+            auto v = FloatColumn::static_pointer_cast(ptr);
             ASSERT_EQ(10, v->size());
 
             for (int j = 0; j < v->size(); ++j) {
@@ -426,7 +426,7 @@ TEST_F(VectorizedCastExprTest, intToFloatCastExpr) {
             }
 
             // error cast
-            ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+            ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
         });
     }
 }
@@ -448,7 +448,7 @@ TEST_F(VectorizedCastExprTest, intToInt8CastExpr) {
             ASSERT_TRUE(ptr->is_numeric());
 
             // right cast
-            auto v = std::static_pointer_cast<Int8Column>(ptr);
+            auto v = Int8Column::static_pointer_cast(ptr);
             ASSERT_EQ(10, v->size());
 
             for (int j = 0; j < v->size(); ++j) {
@@ -456,7 +456,7 @@ TEST_F(VectorizedCastExprTest, intToInt8CastExpr) {
             }
 
             // error cast
-            ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+            ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
         });
     }
 }
@@ -479,7 +479,7 @@ TEST_F(VectorizedCastExprTest, intToBigIntCastExpr) {
             ASSERT_TRUE(ptr->is_numeric());
 
             // right cast
-            auto v = std::static_pointer_cast<Int64Column>(ptr);
+            auto v = Int64Column::static_pointer_cast(ptr);
             ASSERT_EQ(10, v->size());
 
             for (int j = 0; j < v->size(); ++j) {
@@ -487,7 +487,7 @@ TEST_F(VectorizedCastExprTest, intToBigIntCastExpr) {
             }
 
             // error cast
-            ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int8Column>(ptr));
+            ASSERT_EQ(nullptr, Int8Column::dynamic_pointer_cast(ptr));
         });
     }
 }
@@ -512,8 +512,7 @@ TEST_F(VectorizedCastExprTest, NullableBooleanCastExpr) {
             ASSERT_TRUE(ptr->is_nullable());
 
             // right cast
-            auto v = std::static_pointer_cast<BooleanColumn>(
-                    std::static_pointer_cast<NullableColumn>(ptr)->data_column());
+            auto v = BooleanColumn::static_pointer_cast(NullableColumn::static_pointer_cast(ptr)->data_column());
             ASSERT_EQ(10, v->size());
 
             for (int j = 0; j < v->size(); ++j) {
@@ -521,7 +520,7 @@ TEST_F(VectorizedCastExprTest, NullableBooleanCastExpr) {
             }
 
             // error cast
-            ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+            ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
         });
     }
 }
@@ -545,7 +544,7 @@ TEST_F(VectorizedCastExprTest, dateCastToDecimalV2) {
         ASSERT_TRUE(ptr->is_decimal());
 
         // right cast
-        auto v = std::static_pointer_cast<DecimalColumn>(ptr);
+        auto v = DecimalColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -553,7 +552,7 @@ TEST_F(VectorizedCastExprTest, dateCastToDecimalV2) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -574,7 +573,7 @@ TEST_F(VectorizedCastExprTest, decimalV2CastToTimestamp) {
         ASSERT_TRUE(ptr->is_timestamp());
 
         // right cast
-        auto v = std::static_pointer_cast<TimestampColumn>(ptr);
+        auto v = TimestampColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -582,7 +581,7 @@ TEST_F(VectorizedCastExprTest, decimalV2CastToTimestamp) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -603,7 +602,7 @@ TEST_F(VectorizedCastExprTest, dateCastToTimestamp) {
         ASSERT_TRUE(ptr->is_timestamp());
 
         // right cast
-        auto v = std::static_pointer_cast<TimestampColumn>(ptr);
+        auto v = TimestampColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -611,7 +610,7 @@ TEST_F(VectorizedCastExprTest, dateCastToTimestamp) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -633,7 +632,7 @@ TEST_F(VectorizedCastExprTest, decimalCastString) {
         ASSERT_TRUE(ptr->is_binary());
 
         // right cast
-        auto v = std::static_pointer_cast<BinaryColumn>(ptr);
+        auto v = BinaryColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -641,7 +640,7 @@ TEST_F(VectorizedCastExprTest, decimalCastString) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -663,7 +662,7 @@ TEST_F(VectorizedCastExprTest, intCastString) {
         ASSERT_TRUE(ptr->is_binary());
 
         // right cast
-        auto v = std::static_pointer_cast<BinaryColumn>(ptr);
+        auto v = BinaryColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -671,7 +670,7 @@ TEST_F(VectorizedCastExprTest, intCastString) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -693,7 +692,7 @@ TEST_F(VectorizedCastExprTest, booleanCastString) {
         ASSERT_TRUE(ptr->is_binary());
 
         // right cast
-        auto v = std::static_pointer_cast<BinaryColumn>(ptr);
+        auto v = BinaryColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -701,7 +700,7 @@ TEST_F(VectorizedCastExprTest, booleanCastString) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -723,7 +722,7 @@ TEST_F(VectorizedCastExprTest, timestmapCastString) {
         ASSERT_TRUE(ptr->is_binary());
 
         // right cast
-        auto v = std::static_pointer_cast<BinaryColumn>(ptr);
+        auto v = BinaryColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -731,7 +730,7 @@ TEST_F(VectorizedCastExprTest, timestmapCastString) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -762,7 +761,7 @@ TEST_F(VectorizedCastExprTest, stringCastInt) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -793,7 +792,7 @@ TEST_F(VectorizedCastExprTest, stringCastIntError) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -824,7 +823,7 @@ TEST_F(VectorizedCastExprTest, stringCastDouble) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -856,7 +855,7 @@ TEST_F(VectorizedCastExprTest, stringCastDoubleError) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -890,7 +889,7 @@ TEST_F(VectorizedCastExprTest, stringCastDecimal) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -924,7 +923,7 @@ TEST_F(VectorizedCastExprTest, stringCastDecimalError) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -955,7 +954,7 @@ TEST_F(VectorizedCastExprTest, stringCastDate) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -986,7 +985,7 @@ TEST_F(VectorizedCastExprTest, stringCastDate2) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -1017,7 +1016,7 @@ TEST_F(VectorizedCastExprTest, stringCastDateError) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -1040,7 +1039,7 @@ TEST_F(VectorizedCastExprTest, stringCastTimestmap) {
         ASSERT_TRUE(ptr->is_timestamp());
 
         // right cast
-        auto v = std::static_pointer_cast<TimestampColumn>(ptr);
+        auto v = TimestampColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -1048,7 +1047,7 @@ TEST_F(VectorizedCastExprTest, stringCastTimestmap) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -1070,7 +1069,7 @@ TEST_F(VectorizedCastExprTest, stringCastBitmapFailed0) {
         ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
 
         // right cast
-        auto v = std::static_pointer_cast<BitmapColumn>(ptr);
+        auto v = BitmapColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -1106,7 +1105,7 @@ TEST_F(VectorizedCastExprTest, stringCastBitmapFailed1) {
         ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
 
         // right cast
-        auto v = std::static_pointer_cast<BitmapColumn>(ptr);
+        auto v = BitmapColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -1137,7 +1136,7 @@ TEST_F(VectorizedCastExprTest, stringCastBitmapSingle) {
         ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
 
         // right cast
-        auto v = std::static_pointer_cast<BitmapColumn>(ptr);
+        auto v = BitmapColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         Buffer<int64_t> expect_array;
@@ -1178,7 +1177,7 @@ TEST_F(VectorizedCastExprTest, stringCastBitmapSingleFailed) {
         ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
 
         // right cast
-        auto v = std::static_pointer_cast<BitmapColumn>(ptr);
+        auto v = BitmapColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -1210,7 +1209,7 @@ TEST_F(VectorizedCastExprTest, stringCastBitmapSet) {
         ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
 
         // right cast
-        auto v = std::static_pointer_cast<BitmapColumn>(ptr);
+        auto v = BitmapColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         Buffer<int64_t> expect_array;
@@ -1253,7 +1252,7 @@ TEST_F(VectorizedCastExprTest, stringCastBitmapSetFailed) {
         ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
 
         // right cast
-        auto v = std::static_pointer_cast<BitmapColumn>(ptr);
+        auto v = BitmapColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -1287,7 +1286,7 @@ TEST_F(VectorizedCastExprTest, stringCastBitmapMap) {
         ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
 
         // right cast
-        auto v = std::static_pointer_cast<BitmapColumn>(ptr);
+        auto v = BitmapColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         Buffer<int64_t> expect_array;
@@ -1332,7 +1331,7 @@ TEST_F(VectorizedCastExprTest, stringCastBitmapMapFailed) {
         ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
 
         // right cast
-        auto v = std::static_pointer_cast<BitmapColumn>(ptr);
+        auto v = BitmapColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -1360,7 +1359,7 @@ TEST_F(VectorizedCastExprTest, stringCastTimestmap2) {
         ASSERT_TRUE(ptr->is_timestamp());
 
         // right cast
-        auto v = std::static_pointer_cast<TimestampColumn>(ptr);
+        auto v = TimestampColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -1368,7 +1367,7 @@ TEST_F(VectorizedCastExprTest, stringCastTimestmap2) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -1391,7 +1390,7 @@ TEST_F(VectorizedCastExprTest, stringCastTimestmap3) {
         ASSERT_TRUE(ptr->is_timestamp());
 
         // right cast
-        auto v = std::static_pointer_cast<TimestampColumn>(ptr);
+        auto v = TimestampColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -1399,7 +1398,7 @@ TEST_F(VectorizedCastExprTest, stringCastTimestmap3) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -1422,7 +1421,7 @@ TEST_F(VectorizedCastExprTest, stringCastTimestmap4) {
         ASSERT_TRUE(ptr->is_timestamp());
 
         // right cast
-        auto v = std::static_pointer_cast<TimestampColumn>(ptr);
+        auto v = TimestampColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -1430,7 +1429,7 @@ TEST_F(VectorizedCastExprTest, stringCastTimestmap4) {
         }
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -1457,7 +1456,7 @@ TEST_F(VectorizedCastExprTest, stringCastTimestmapError) {
         ASSERT_EQ(10, v->size());
 
         // error cast
-        ASSERT_EQ(nullptr, std::dynamic_pointer_cast<Int64Column>(ptr));
+        ASSERT_EQ(nullptr, Int64Column::dynamic_pointer_cast(ptr));
     }
 }
 
@@ -1505,7 +1504,7 @@ TEST_F(VectorizedCastExprTest, BigIntCastToInt2) {
             ASSERT_TRUE(ptr->is_numeric());
 
             // right cast
-            auto v = std::static_pointer_cast<Int32Column>(ptr);
+            auto v = Int32Column::static_pointer_cast(ptr);
             ASSERT_EQ(10, v->size());
 
             for (int j = 0; j < v->size(); ++j) {
@@ -1557,7 +1556,7 @@ TEST_F(VectorizedCastExprTest, stringCastToTime) {
         ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
 
         // right cast
-        auto v = std::static_pointer_cast<DoubleColumn>(ptr);
+        auto v = DoubleColumn::static_pointer_cast(ptr);
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
@@ -2181,7 +2180,7 @@ TEST_F(VectorizedCastExprTest, string_to_array_with_const_input) {
     cast_expr.__isset.child_type = true;
 
     // const null
-    auto src = ColumnHelper::create_const_null_column(2);
+    ColumnPtr src = ColumnHelper::create_const_null_column(2);
     auto result = cast_string_to_array_ptr(cast_expr, TYPE_VARCHAR, src);
     DCHECK_EQ(result->size(), 2);
     DCHECK(result->is_constant());
@@ -2328,28 +2327,28 @@ TEST_F(VectorizedCastExprTest, json_to_array_with_const_input) {
     cast_expr.__isset.child_type = true;
 
     // const null
-    auto src = ColumnHelper::create_const_null_column(2);
-    auto result = cast_json_to_array_ptr(cast_expr, TYPE_JSON, src);
+    ColumnPtr src = ColumnHelper::create_const_null_column(2);
+    auto result = cast_json_to_array_ptr(cast_expr, TYPE_JSON, std::move(src));
     DCHECK_EQ(result->size(), 2);
     DCHECK(result->is_constant());
     DCHECK(result->only_null());
 
     // const json
     src = create_json_const_column(R"(["a","b"])", 2);
-    result = cast_json_to_array_ptr(cast_expr, TYPE_JSON, src);
+    result = cast_json_to_array_ptr(cast_expr, TYPE_JSON, std::move(src));
     DCHECK(result->is_constant());
     DCHECK_EQ(result->size(), 2);
     EXPECT_EQ("CONST: [\"a\",\"b\"]", result->debug_item(0));
 
     // const json: multi-dims
     src = create_json_const_column(R"([{"a": 1}, {"a": 2}])", 2);
-    result = cast_json_to_array_ptr(cast_expr, TYPE_JSON, src);
+    result = cast_json_to_array_ptr(cast_expr, TYPE_JSON, std::move(src));
     DCHECK(result->is_constant());
     DCHECK_EQ(result->size(), 2);
     EXPECT_EQ("CONST: [{\"a\": 1},{\"a\": 2}]", result->debug_item(0));
 
     src = create_json_const_column(R"( [null, {"a": 2}] )", 2);
-    result = cast_json_to_array_ptr(cast_expr, TYPE_JSON, src);
+    result = cast_json_to_array_ptr(cast_expr, TYPE_JSON, std::move(src));
     DCHECK(result->is_constant());
     DCHECK_EQ(result->size(), 2);
     EXPECT_EQ("CONST: [null,{\"a\": 2}]", result->debug_item(0));

--- a/be/test/exprs/coalesce_expr_test.cpp
+++ b/be/test/exprs/coalesce_expr_test.cpp
@@ -56,13 +56,13 @@ TEST_F(VectorizedCoalesceExprTest, coalesceArray) {
     expr_node.type = tttype_desc[1];
     auto expr = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_coalesce_expr(expr_node));
     TypeDescriptor type_arr_int = array_type(TYPE_INT);
-    auto array0 = ColumnHelper::create_column(type_arr_int, true);
+    ColumnPtr array0 = ColumnHelper::create_column(type_arr_int, true);
     array0->append_datum(DatumArray{Datum((int32_t)1), Datum((int32_t)4)}); // [1,4]
     array0->append_datum(DatumArray{Datum(), Datum()});                     // [NULL, NULL]
     array0->append_datum(Datum{});                                          // NULL
     auto array_expr0 = MockExpr(type_arr_int, array0);
 
-    auto array1 = ColumnHelper::create_column(type_arr_int, false);
+    ColumnPtr array1 = ColumnHelper::create_column(type_arr_int, false);
     array1->append_datum(DatumArray{Datum((int32_t)11), Datum((int32_t)41)}); // [11,41]
     array1->append_datum(DatumArray{Datum(), Datum()});                       // [NULL, NULL]
     array1->append_datum(DatumArray{Datum(), Datum((int32_t)1)});             // [NULL, 1]

--- a/be/test/exprs/compound_predicate_test.cpp
+++ b/be/test/exprs/compound_predicate_test.cpp
@@ -58,7 +58,7 @@ TEST_F(VectorizedCompoundPredicateTest, andExpr) {
             ASSERT_FALSE(ptr->is_nullable());
             ASSERT_TRUE(ptr->is_numeric());
 
-            auto v = std::static_pointer_cast<BooleanColumn>(ptr);
+            auto v = BooleanColumn::static_pointer_cast(ptr);
             ASSERT_EQ(10, v->size());
 
             for (int j = 0; j < v->size(); ++j) {
@@ -85,7 +85,7 @@ TEST_F(VectorizedCompoundPredicateTest, orExpr) {
             ASSERT_FALSE(ptr->is_nullable());
             ASSERT_TRUE(ptr->is_numeric());
 
-            auto v = std::static_pointer_cast<BooleanColumn>(ptr);
+            auto v = BooleanColumn::static_pointer_cast(ptr);
             ASSERT_EQ(10, v->size());
 
             for (int j = 0; j < v->size(); ++j) {
@@ -120,9 +120,9 @@ TEST_F(VectorizedCompoundPredicateTest, nullAndExpr) {
             }
         }
 
-        auto ptr = std::static_pointer_cast<NullableColumn>(v)->data_column();
+        auto ptr = NullableColumn::static_pointer_cast(v)->data_column();
         for (int j = 0; j < v->size(); ++j) {
-            ASSERT_EQ(1, (int)std::static_pointer_cast<BooleanColumn>(ptr)->get_data()[j]);
+            ASSERT_EQ(1, (int)BooleanColumn::static_pointer_cast(ptr)->get_data()[j]);
         }
     }
 
@@ -142,7 +142,7 @@ TEST_F(VectorizedCompoundPredicateTest, nullAndExpr) {
     {
         ColumnPtr v = expr->evaluate(nullptr, nullptr);
         ExprsTestHelper::verify_with_jit(v, expr.get(), &runtime_state, [](ColumnPtr const& v) {
-            auto ptr = ColumnHelper::cast_to<TYPE_BOOLEAN>(std::static_pointer_cast<NullableColumn>(v)->data_column());
+            auto ptr = ColumnHelper::cast_to<TYPE_BOOLEAN>(NullableColumn::static_pointer_cast(v)->data_column());
 
             ASSERT_TRUE(v->is_nullable());
             ASSERT_FALSE(v->is_numeric());
@@ -175,13 +175,13 @@ TEST_F(VectorizedCompoundPredicateTest, nullAndTrueExpr) {
         ColumnPtr colv1 = col1.evaluate(nullptr, nullptr);
 
         ExprsTestHelper::verify_with_jit(v, expr.get(), &runtime_state, [&colv1](ColumnPtr const& v) {
-            ColumnPtr ptr = std::static_pointer_cast<NullableColumn>(v)->data_column();
+            ColumnPtr ptr = NullableColumn::static_pointer_cast(v)->data_column();
 
             ASSERT_TRUE(v->is_nullable());
             ASSERT_FALSE(v->is_numeric());
 
             for (int j = 0; j < ptr->size(); ++j) {
-                ASSERT_EQ(1, (int)std::static_pointer_cast<BooleanColumn>(ptr)->get_data()[j]);
+                ASSERT_EQ(1, (int)BooleanColumn::static_pointer_cast(ptr)->get_data()[j]);
             }
 
             for (int j = 0; j < ptr->size(); ++j) {
@@ -206,13 +206,13 @@ TEST_F(VectorizedCompoundPredicateTest, constAndExpr) {
     {
         ColumnPtr v = expr->evaluate(nullptr, nullptr);
         ExprsTestHelper::verify_with_jit(v, expr.get(), &runtime_state, [](ColumnPtr const& v) {
-            ColumnPtr ptr = std::static_pointer_cast<NullableColumn>(v)->data_column();
+            ColumnPtr ptr = NullableColumn::static_pointer_cast(v)->data_column();
 
             ASSERT_TRUE(v->is_nullable());
             ASSERT_FALSE(v->is_numeric());
 
             for (int j = 0; j < ptr->size(); ++j) {
-                ASSERT_EQ(0, (int)std::static_pointer_cast<BooleanColumn>(ptr)->get_data()[j]);
+                ASSERT_EQ(0, (int)BooleanColumn::static_pointer_cast(ptr)->get_data()[j]);
             }
 
             for (int j = 0; j < ptr->size(); ++j) {
@@ -237,13 +237,13 @@ TEST_F(VectorizedCompoundPredicateTest, nullAndFalseExpr) {
     {
         ColumnPtr v = expr->evaluate(nullptr, nullptr);
         ExprsTestHelper::verify_with_jit(v, expr.get(), &runtime_state, [](ColumnPtr const& v) {
-            ColumnPtr ptr = std::static_pointer_cast<NullableColumn>(v)->data_column();
+            ColumnPtr ptr = NullableColumn::static_pointer_cast(v)->data_column();
 
             ASSERT_TRUE(v->is_nullable());
             ASSERT_FALSE(v->is_numeric());
 
             for (int j = 0; j < ptr->size(); ++j) {
-                ASSERT_EQ(0, (int)std::static_pointer_cast<BooleanColumn>(ptr)->get_data()[j]);
+                ASSERT_EQ(0, (int)BooleanColumn::static_pointer_cast(ptr)->get_data()[j]);
             }
 
             for (int j = 0; j < ptr->size(); ++j) {
@@ -299,7 +299,7 @@ TEST_F(VectorizedCompoundPredicateTest, mergeNullOrExpr) {
             ASSERT_EQ(10, v->size());
 
             for (int j = 0; j < v->size(); ++j) {
-                ASSERT_EQ(1, (int)std::static_pointer_cast<BooleanColumn>(v)->get_data()[j]);
+                ASSERT_EQ(1, (int)BooleanColumn::static_pointer_cast(v)->get_data()[j]);
             }
 
             for (int j = 0; j < v->size(); ++j) {
@@ -329,8 +329,7 @@ TEST_F(VectorizedCompoundPredicateTest, FalseNullOrExpr) {
             ASSERT_FALSE(v->is_numeric());
             ASSERT_EQ(10, v->size());
 
-            auto p = std::static_pointer_cast<BooleanColumn>(
-                    ColumnHelper::as_raw_column<NullableColumn>(v)->data_column());
+            auto p = BooleanColumn::static_pointer_cast(ColumnHelper::as_raw_column<NullableColumn>(v)->data_column());
 
             for (int j = 0; j < v->size(); ++j) {
                 if (j % 2) {
@@ -360,10 +359,10 @@ TEST_F(VectorizedCompoundPredicateTest, OnlyNullOrExpr) {
         ASSERT_TRUE(v->only_null());
         ASSERT_EQ(1, v->size());
 
-        ASSERT_TRUE(nullptr != std::dynamic_pointer_cast<ConstColumn>(v));
-        ASSERT_TRUE(nullptr == std::dynamic_pointer_cast<NullableColumn>(v));
-        ASSERT_TRUE(nullptr != std::dynamic_pointer_cast<NullableColumn>(
-                                       std::dynamic_pointer_cast<ConstColumn>(v)->data_column()));
+        ASSERT_TRUE(nullptr != ConstColumn::dynamic_pointer_cast(v));
+        ASSERT_TRUE(nullptr == NullableColumn::dynamic_pointer_cast(v));
+        ASSERT_TRUE(nullptr !=
+                    NullableColumn::dynamic_pointer_cast(ConstColumn::dynamic_pointer_cast(v)->data_column()));
     }
 }
 
@@ -381,7 +380,7 @@ TEST_F(VectorizedCompoundPredicateTest, notExpr) {
             ASSERT_FALSE(ptr->is_nullable());
             ASSERT_TRUE(ptr->is_numeric());
 
-            auto v = std::static_pointer_cast<BooleanColumn>(ptr);
+            auto v = BooleanColumn::static_pointer_cast(ptr);
             ASSERT_EQ(10, v->size());
 
             for (int j = 0; j < v->size(); ++j) {
@@ -401,7 +400,7 @@ TEST_F(VectorizedCompoundPredicateTest, notExpr) {
             ASSERT_FALSE(ptr->is_nullable());
             ASSERT_TRUE(ptr->is_numeric());
 
-            auto v = std::static_pointer_cast<BooleanColumn>(ptr);
+            auto v = BooleanColumn::static_pointer_cast(ptr);
             ASSERT_EQ(10, v->size());
 
             for (int j = 0; j < v->size(); ++j) {

--- a/be/test/exprs/condition_expr_test.cpp
+++ b/be/test/exprs/condition_expr_test.cpp
@@ -69,13 +69,13 @@ TEST_F(VectorizedConditionExprTest, ifNullLArray) {
     auto expr = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_if_null_expr(expr_node));
     TypeDescriptor type_arr_int = array_type(TYPE_INT);
 
-    auto array0 = ColumnHelper::create_column(type_arr_int, true);
+    ColumnPtr array0 = ColumnHelper::create_column(type_arr_int, true);
     array0->append_datum(DatumArray{Datum((int32_t)1), Datum((int32_t)4)}); // [1,4]
     array0->append_datum(DatumArray{Datum(), Datum()});                     // [NULL, NULL]
     array0->append_datum(Datum{});                                          // NULL
     auto array_expr0 = MockExpr(type_arr_int, array0);
 
-    auto array1 = ColumnHelper::create_column(type_arr_int, false);
+    ColumnPtr array1 = ColumnHelper::create_column(type_arr_int, false);
     array1->append_datum(DatumArray{Datum((int32_t)11), Datum((int32_t)41)}); // [11,41]
     array1->append_datum(DatumArray{Datum(), Datum()});                       // [NULL, NULL]
     array1->append_datum(DatumArray{Datum(), Datum((int32_t)1)});             // [NULL, 1]
@@ -261,7 +261,7 @@ private:
             }
         }
     }
-    std::shared_ptr<RunTimeColumnType<Type>> col;
+    RunTimeColumnType<Type>::Ptr col;
     std::default_random_engine& _re;
 };
 

--- a/be/test/exprs/decimal_cast_expr_test_helper.h
+++ b/be/test/exprs/decimal_cast_expr_test_helper.h
@@ -75,11 +75,11 @@ ColumnPtr create_column(RunTimeCppType<Type> value, size_t front_fill_size, size
         auto data_column = RunTimeColumnType<Type>::create(std::forward<Args>(args)...);
         data_column->reserve(1);
         data_column->append_datum(Datum(value));
-        column = ConstColumn::create(data_column, rows_num);
+        column = ConstColumn::create(std::move(data_column), rows_num);
     } else if constexpr (ColumnPackedType::NULLABLE == PackedType) {
         auto data_column = RunTimeColumnType<Type>::create(std::forward<Args>(args)...);
         auto nulls = NullColumn::create();
-        column = NullableColumn::create(data_column, nulls);
+        column = NullableColumn::create(std::move(data_column), std::move(nulls));
         column->reserve(rows_num);
         column->append_nulls(front_fill_size);
         column->append_datum(Datum(value));

--- a/be/test/exprs/encryption_functions_test.cpp
+++ b/be/test/exprs/encryption_functions_test.cpp
@@ -44,13 +44,13 @@ TEST_F(EncryptionFunctionsTest, aes_encryptGeneralTest) {
         text->append(texts[j]);
     }
 
-    columns.emplace_back(plain);
-    columns.emplace_back(text);
+    columns.emplace_back(std::move(plain));
+    columns.emplace_back(std::move(text));
 
     ColumnPtr result = EncryptionFunctions::aes_encrypt(ctx.get(), columns).value();
 
     columns.clear();
-    columns.emplace_back(result);
+    columns.emplace_back(std::move(result));
     result = StringFunctions::hex_string(ctx.get(), columns).value();
 
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
@@ -84,14 +84,14 @@ TEST_F(EncryptionFunctionsTest, aes_encryptSingularCasesTest) {
         }
     }
 
-    auto nullable_text = NullableColumn::create(text, null_column);
-    columns.emplace_back(plain);
-    columns.emplace_back(nullable_text);
+    auto nullable_text = NullableColumn::create(std::move(text), std::move(null_column));
+    columns.emplace_back(std::move(plain));
+    columns.emplace_back(std::move(nullable_text));
 
     ColumnPtr result = EncryptionFunctions::aes_encrypt(ctx.get(), columns).value();
 
     columns.clear();
-    columns.emplace_back(result);
+    columns.emplace_back(std::move(result));
     result = StringFunctions::hex_string(ctx.get(), columns).value();
     ASSERT_TRUE(result->is_nullable());
     for (int j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
@@ -122,13 +122,13 @@ TEST_F(EncryptionFunctionsTest, aes_encryptBigDataTest) {
         text->append(texts[j]);
     }
 
-    columns.emplace_back(plain);
-    columns.emplace_back(text);
+    columns.emplace_back(std::move(plain));
+    columns.emplace_back(std::move(text));
 
     ColumnPtr result = EncryptionFunctions::aes_encrypt(ctx.get(), columns).value();
 
     columns.clear();
-    columns.emplace_back(result);
+    columns.emplace_back(std::move(result));
     result = StringFunctions::hex_string(ctx.get(), columns).value();
 
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
@@ -160,13 +160,13 @@ TEST_F(EncryptionFunctionsTest, aes_encryptNullPlainTest) {
 
     text->append_default();
 
-    columns.emplace_back(NullableColumn::create(plain, plain_null));
-    columns.emplace_back(text);
+    columns.emplace_back(NullableColumn::create(std::move(plain), std::move(plain_null)));
+    columns.emplace_back(std::move(text));
 
     auto result = EncryptionFunctions::aes_encrypt(ctx.get(), columns).value();
 
     columns.clear();
-    columns.emplace_back(result);
+    columns.emplace_back(std::move(result));
     result = StringFunctions::hex_string(ctx.get(), columns).value();
 
     auto result2 = ColumnHelper::as_column<NullableColumn>(result);
@@ -200,13 +200,13 @@ TEST_F(EncryptionFunctionsTest, aes_encryptNullTextTest) {
     text->append_default();
     text_null->append(1);
 
-    columns.emplace_back(plain);
-    columns.emplace_back(NullableColumn::create(text, text_null));
+    columns.emplace_back(std::move(plain));
+    columns.emplace_back(NullableColumn::create(std::move(text), std::move(text_null)));
 
     auto result = EncryptionFunctions::aes_encrypt(ctx.get(), columns).value();
 
     columns.clear();
-    columns.emplace_back(result);
+    columns.emplace_back(std::move(result));
     result = StringFunctions::hex_string(ctx.get(), columns).value();
 
     auto result2 = ColumnHelper::as_column<NullableColumn>(result);
@@ -233,13 +233,13 @@ TEST_F(EncryptionFunctionsTest, aes_encryptConstTextTest) {
         plain->append(j);
     }
 
-    columns.emplace_back(plain);
-    columns.emplace_back(text);
+    columns.emplace_back(std::move(plain));
+    columns.emplace_back(std::move(text));
 
     ColumnPtr result = EncryptionFunctions::aes_encrypt(ctx.get(), columns).value();
 
     columns.clear();
-    columns.emplace_back(result);
+    columns.emplace_back(std::move(result));
 
     result = StringFunctions::hex_string(ctx.get(), columns).value();
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
@@ -257,13 +257,13 @@ TEST_F(EncryptionFunctionsTest, aes_encryptConstAllTest) {
 
     std::string results[] = {"71AB242103F038D433D392A7DE0909AB"};
 
-    columns.emplace_back(plain);
-    columns.emplace_back(text);
+    columns.emplace_back(std::move(plain));
+    columns.emplace_back(std::move(text));
 
     ColumnPtr result = EncryptionFunctions::aes_encrypt(ctx.get(), columns).value();
 
     columns.clear();
-    columns.emplace_back(result);
+    columns.emplace_back(std::move(result));
     result = StringFunctions::hex_string(ctx.get(), columns).value();
 
     auto v = ColumnHelper::as_column<ConstColumn>(result);
@@ -290,13 +290,13 @@ TEST_F(EncryptionFunctionsTest, aes_decryptGeneralTest) {
         text->append(texts[j]);
     }
 
-    columns.emplace_back(plain);
+    columns.emplace_back(std::move(plain));
 
     ColumnPtr result = StringFunctions::unhex(ctx.get(), columns).value();
 
     columns.clear();
-    columns.emplace_back(result);
-    columns.emplace_back(text);
+    columns.emplace_back(std::move(result));
+    columns.emplace_back(std::move(text));
     result = EncryptionFunctions::aes_decrypt(ctx.get(), columns).value();
 
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
@@ -323,13 +323,13 @@ TEST_F(EncryptionFunctionsTest, aes_decryptBigDataTest) {
         text->append(texts[j]);
     }
 
-    columns.emplace_back(plain);
+    columns.emplace_back(std::move(plain));
 
     ColumnPtr result = StringFunctions::unhex(ctx.get(), columns).value();
 
     columns.clear();
-    columns.emplace_back(result);
-    columns.emplace_back(text);
+    columns.emplace_back(std::move(result));
+    columns.emplace_back(std::move(text));
     result = EncryptionFunctions::aes_decrypt(ctx.get(), columns).value();
 
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
@@ -360,13 +360,13 @@ TEST_F(EncryptionFunctionsTest, aes_decryptNullPlainTest) {
     plain_null->append(1);
     text->append_default();
 
-    columns.emplace_back(NullableColumn::create(plain, plain_null));
+    columns.emplace_back(NullableColumn::create(std::move(plain), std::move(plain_null)));
 
     ColumnPtr result = StringFunctions::unhex(ctx.get(), columns).value();
 
     columns.clear();
-    columns.emplace_back(result);
-    columns.emplace_back(text);
+    columns.emplace_back(std::move(result));
+    columns.emplace_back(std::move(text));
     result = EncryptionFunctions::aes_decrypt(ctx.get(), columns).value();
 
     auto result2 = ColumnHelper::as_column<NullableColumn>(result);
@@ -400,13 +400,13 @@ TEST_F(EncryptionFunctionsTest, aes_decryptNullTextTest) {
     text->append_default();
     text_null->append(1);
 
-    columns.emplace_back(NullableColumn::create(plain, text_null));
+    columns.emplace_back(NullableColumn::create(std::move(plain), std::move(text_null)));
 
     ColumnPtr result = StringFunctions::unhex(ctx.get(), columns).value();
 
     columns.clear();
-    columns.emplace_back(result);
-    columns.emplace_back(text);
+    columns.emplace_back(std::move(result));
+    columns.emplace_back(std::move(text));
     result = EncryptionFunctions::aes_decrypt(ctx.get(), columns).value();
 
     auto result2 = ColumnHelper::as_column<NullableColumn>(result);
@@ -433,13 +433,13 @@ TEST_F(EncryptionFunctionsTest, aes_decryptConstTextTest) {
         plain->append(result);
     }
 
-    columns.emplace_back(plain);
+    columns.emplace_back(std::move(plain));
 
     ColumnPtr result = StringFunctions::unhex(ctx.get(), columns).value();
 
     columns.clear();
-    columns.emplace_back(result);
-    columns.emplace_back(text);
+    columns.emplace_back(std::move(result));
+    columns.emplace_back(std::move(text));
 
     result = EncryptionFunctions::aes_decrypt(ctx.get(), columns).value();
 
@@ -458,13 +458,13 @@ TEST_F(EncryptionFunctionsTest, aes_decryptConstAllTest) {
 
     std::string results[] = {"sdkfljljl"};
 
-    columns.emplace_back(plain);
+    columns.emplace_back(std::move(plain));
 
     ColumnPtr result = StringFunctions::unhex(ctx.get(), columns).value();
 
     columns.clear();
-    columns.emplace_back(result);
-    columns.emplace_back(text);
+    columns.emplace_back(std::move(result));
+    columns.emplace_back(std::move(text));
 
     result = EncryptionFunctions::aes_decrypt(ctx.get(), columns).value();
 
@@ -489,7 +489,7 @@ TEST_F(EncryptionFunctionsTest, from_base64GeneralTest) {
         plain->append(j);
     }
 
-    columns.emplace_back(plain);
+    columns.emplace_back(std::move(plain));
 
     ColumnPtr result = EncryptionFunctions::from_base64(ctx.get(), columns).value();
 
@@ -516,7 +516,7 @@ TEST_F(EncryptionFunctionsTest, from_base64NullTest) {
     plain->append_default();
     plain_null->append(1);
 
-    columns.emplace_back(NullableColumn::create(plain, plain_null));
+    columns.emplace_back(NullableColumn::create(std::move(plain), std::move(plain_null)));
 
     ColumnPtr result = EncryptionFunctions::from_base64(ctx.get(), columns).value();
 
@@ -537,7 +537,7 @@ TEST_F(EncryptionFunctionsTest, from_base64ConstTest) {
 
     std::string results[] = {"349uionfklwnefk"};
 
-    columns.emplace_back(plain);
+    columns.emplace_back(std::move(plain));
 
     ColumnPtr result = EncryptionFunctions::from_base64(ctx.get(), columns).value();
 
@@ -561,7 +561,7 @@ TEST_F(EncryptionFunctionsTest, to_base64Test) {
         plain->append(j);
     }
 
-    columns.emplace_back(plain);
+    columns.emplace_back(std::move(plain));
 
     ColumnPtr result = EncryptionFunctions::to_base64(ctx.get(), columns).value();
 
@@ -588,7 +588,7 @@ TEST_F(EncryptionFunctionsTest, to_base64NullTest) {
     plain->append_default();
     plain_null->append(1);
 
-    columns.emplace_back(NullableColumn::create(plain, plain_null));
+    columns.emplace_back(NullableColumn::create(std::move(plain), std::move(plain_null)));
 
     ColumnPtr result = EncryptionFunctions::to_base64(ctx.get(), columns).value();
 
@@ -609,7 +609,7 @@ TEST_F(EncryptionFunctionsTest, to_base64ConstTest) {
 
     std::string results[] = {"MzQ5dWlvbmZrbHduZWZr"};
 
-    columns.emplace_back(plain);
+    columns.emplace_back(std::move(plain));
 
     ColumnPtr result = EncryptionFunctions::to_base64(ctx.get(), columns).value();
 
@@ -633,7 +633,7 @@ TEST_F(EncryptionFunctionsTest, md5GeneralTest) {
         plain->append(j);
     }
 
-    columns.emplace_back(plain);
+    columns.emplace_back(std::move(plain));
 
     ColumnPtr result = EncryptionFunctions::md5(ctx.get(), columns).value();
 
@@ -660,7 +660,7 @@ TEST_F(EncryptionFunctionsTest, md5NullTest) {
     plain->append_default();
     plain_null->append(1);
 
-    columns.emplace_back(NullableColumn::create(plain, plain_null));
+    columns.emplace_back(NullableColumn::create(std::move(plain), std::move(plain_null)));
 
     ColumnPtr result = EncryptionFunctions::md5(ctx.get(), columns).value();
 
@@ -681,15 +681,15 @@ TEST_F(EncryptionFunctionsTest, md5ConstTest) {
 
     std::string results[] = {"4402f1c78924499be8a48506c00dc070"};
 
-    columns.emplace_back(plain);
+    columns.emplace_back(std::move(plain));
 
     ColumnPtr result = EncryptionFunctions::md5(ctx.get(), columns).value();
 
-    auto result2 = ColumnHelper::as_column<ConstColumn>(result);
+    ConstColumn::Ptr result2 = ColumnHelper::as_column<ConstColumn>(result);
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result2->data_column());
 
     for (auto& result : results) {
-        ASSERT_EQ(result, ColumnHelper::get_const_value<TYPE_VARCHAR>(result2));
+        ASSERT_EQ(result, ColumnHelper::get_const_value<TYPE_VARCHAR>((ColumnPtr)result2));
     }
 }
 
@@ -703,7 +703,7 @@ TEST_F(EncryptionFunctionsTest, md5sumTest) {
     for (auto& j : plains) {
         auto plain = BinaryColumn::create();
         plain->append(j);
-        columns.emplace_back(plain);
+        columns.emplace_back(std::move(plain));
     }
 
     ColumnPtr result = EncryptionFunctions::md5sum(ctx.get(), columns).value();
@@ -725,7 +725,7 @@ TEST_F(EncryptionFunctionsTest, md5sumNullTest) {
     for (auto& j : plains) {
         auto plain = BinaryColumn::create();
         plain->append(j);
-        columns.emplace_back(plain);
+        columns.emplace_back(std::move(plain));
     }
 
     for (auto& j : plains) {
@@ -733,7 +733,7 @@ TEST_F(EncryptionFunctionsTest, md5sumNullTest) {
         plain->append(j);
         auto plain_null = NullColumn::create();
         plain_null->append(1);
-        columns.emplace_back(NullableColumn::create(plain, plain_null));
+        columns.emplace_back(NullableColumn::create(std::move(plain), std::move(plain_null)));
     }
 
     ColumnPtr result = EncryptionFunctions::md5sum(ctx.get(), columns).value();
@@ -761,7 +761,7 @@ TEST_F(EncryptionFunctionsTest, md5sum_numericTest) {
     for (auto& j : plains) {
         auto plain = BinaryColumn::create();
         plain->append(j);
-        columns.emplace_back(plain);
+        columns.emplace_back(std::move(plain));
     }
 
     ColumnPtr result = EncryptionFunctions::md5sum_numeric(ctx.get(), columns).value();
@@ -783,7 +783,7 @@ TEST_F(EncryptionFunctionsTest, md5sum_numericNullTest) {
     for (auto& j : plains) {
         auto plain = BinaryColumn::create();
         plain->append(j);
-        columns.emplace_back(plain);
+        columns.emplace_back(std::move(plain));
     }
 
     for (auto& j : plains) {
@@ -791,7 +791,7 @@ TEST_F(EncryptionFunctionsTest, md5sum_numericNullTest) {
         plain->append(j);
         auto plain_null = NullColumn::create();
         plain_null->append(1);
-        columns.emplace_back(NullableColumn::create(plain, plain_null));
+        columns.emplace_back(NullableColumn::create(std::move(plain), std::move(plain_null)));
     }
 
     ColumnPtr result = EncryptionFunctions::md5sum_numeric(ctx.get(), columns).value();
@@ -820,9 +820,9 @@ TEST_P(ShaTestFixture, test_sha2) {
     if (str == "NULL") {
         columns.emplace_back(ColumnHelper::create_const_null_column(1));
     } else {
-        columns.emplace_back(plain);
+        columns.emplace_back(std::move(plain));
     }
-    columns.emplace_back(hash_length);
+    columns.emplace_back(std::move(hash_length));
 
     ctx->set_constant_columns(columns);
     ASSERT_TRUE(EncryptionFunctions::sha2_prepare(ctx.get(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());

--- a/be/test/exprs/es_functions_test.cpp
+++ b/be/test/exprs/es_functions_test.cpp
@@ -41,8 +41,8 @@ TEST_F(EsFunctionsTest, matchTest) {
         auto var2_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("STRING2"), 1);
 
         Columns columns;
-        columns.emplace_back(var1_col);
-        columns.emplace_back(var2_col);
+        columns.emplace_back(std::move(var1_col));
+        columns.emplace_back(std::move(var2_col));
 
         ColumnPtr result = ESFunctions::match(ctx, columns).value();
 

--- a/be/test/exprs/exprs_test_helper.h
+++ b/be/test/exprs/exprs_test_helper.h
@@ -162,7 +162,7 @@ public:
                                           size_t min_length = 0) {
         using UniformInt = std::uniform_int_distribution<std::mt19937::result_type>;
         using PoissonInt = std::poisson_distribution<std::mt19937::result_type>;
-        ColumnPtr column = ColumnHelper::create_column(type_desc, nullable);
+        MutableColumnPtr column = ColumnHelper::create_column(type_desc, nullable);
 
         std::random_device dev;
         std::mt19937 rng(dev());

--- a/be/test/exprs/flat_json_functions_test.cpp
+++ b/be/test/exprs/flat_json_functions_test.cpp
@@ -73,7 +73,7 @@ TEST_P(FlatJsonQueryTestFixture2, flat_json_query) {
     jf.flatten(json_col.get());
     flat_json_ptr->set_flat_columns(param_flat_path, param_flat_type, jf.mutable_result());
 
-    Columns columns{flat_json, builder.build(true)};
+    Columns columns{std::move(flat_json), builder.build(true)};
 
     ctx.get()->set_constant_columns(columns);
     std::ignore =
@@ -177,7 +177,7 @@ TEST_P(FlatJsonQueryErrorTestFixture, json_query) {
     jf.flatten(json_col.get());
     flat_json_ptr->set_flat_columns(param_flat_path, param_flat_type, jf.mutable_result());
 
-    Columns columns{flat_json, builder.build(true)};
+    Columns columns{std::move(flat_json), builder.build(true)};
 
     ctx.get()->set_constant_columns(columns);
     std::ignore =
@@ -229,11 +229,11 @@ TEST_P(FlatJsonExistsTestFixture2, flat_json_exists_test) {
     flat_json_ptr->set_flat_columns(param_flat_path, param_flat_type, jf.mutable_result());
 
     Columns columns;
-    columns.push_back(flat_json);
+    columns.emplace_back(std::move(flat_json));
     if (!param_path.empty()) {
         auto path_column = BinaryColumn::create();
         path_column->append(param_path);
-        columns.push_back(path_column);
+        columns.emplace_back(std::move(path_column));
     }
 
     ctx.get()->set_constant_columns(columns);
@@ -309,11 +309,11 @@ TEST_P(FlatJsonLengthTestFixture2, flat_json_length_test) {
     flat_json_ptr->set_flat_columns(param_flat_path, param_flat_type, jf.mutable_result());
 
     Columns columns;
-    columns.push_back(flat_json);
+    columns.emplace_back(std::move(flat_json));
     if (!param_path.empty()) {
         auto path_column = BinaryColumn::create();
         path_column->append(param_path);
-        columns.push_back(path_column);
+        columns.emplace_back(std::move(path_column));
     }
 
     // ctx.get()->set_constant_columns(columns);
@@ -367,7 +367,7 @@ TEST_P(FlatJsonKeysTestFixture2, json_keys) {
     auto flat_json = JsonColumn::create();
     auto flat_json_ptr = flat_json.get();
 
-    Columns columns{flat_json, builder.build(true)};
+    Columns columns{std::move(flat_json), builder.build(true)};
 
     JsonFlattener jf(param_flat_path, param_flat_type, false);
     jf.flatten(json_column.get());
@@ -444,7 +444,7 @@ public:
         jf.flatten(ints.get());
         flat_json_ptr->set_flat_columns(flat_path, flat_type, jf.mutable_result());
 
-        Columns columns{flat_json, builder.build(true)};
+        Columns columns{std::move(flat_json), builder.build(true)};
 
         _ctx->set_constant_columns(columns);
         std::ignore = JsonFunctions::native_json_path_prepare(_ctx.get(),

--- a/be/test/exprs/function_helper_test.cpp
+++ b/be/test/exprs/function_helper_test.cpp
@@ -38,7 +38,7 @@ TEST_F(FunctionHelperTest, testMergeOnlyNullColumnMergeWithNullColumn) {
 TEST_F(FunctionHelperTest, testMergeConstColumnMergeWithNullColumn) {
     auto data_column = Decimal128Column::create(38, 10);
     data_column->append((int128_t)111);
-    auto const_column = ConstColumn::create(data_column, 10);
+    auto const_column = ConstColumn::create(std::move(data_column), 10);
     auto null_column = NullColumn::create();
     null_column->reserve(10);
     for (int i = 0; i < 10; ++i) {

--- a/be/test/exprs/geography_functions_test.cpp
+++ b/be/test/exprs/geography_functions_test.cpp
@@ -37,12 +37,12 @@ TEST_F(geographyFunctionsTest, st_pointTest) {
 
         str_1->append(24.7);
         str_2->append(56.7);
-        columns.emplace_back(str_1);
-        columns.emplace_back(str_2);
+        columns.emplace_back(std::move(str_1));
+        columns.emplace_back(std::move(str_2));
         ColumnPtr result = GeoFunctions::st_point(ctx.get(), columns).value();
 
         columns.clear();
-        columns.emplace_back(result);
+        columns.emplace_back(std::move(result));
         result = GeoFunctions::st_as_wkt(ctx.get(), columns).value();
 
         auto v = ColumnHelper::as_column<BinaryColumn>(result);
@@ -58,8 +58,8 @@ TEST_F(geographyFunctionsTest, st_pointTest) {
 
         str_1->append(24.7);
         str_2->append(56.7);
-        columns.emplace_back(str_1);
-        columns.emplace_back(str_2);
+        columns.emplace_back(std::move(str_1));
+        columns.emplace_back(std::move(str_2));
         ColumnPtr result = GeoFunctions::st_point(ctx.get(), columns).value();
         auto v = ColumnHelper::as_column<BinaryColumn>(result);
         auto str_value = v->get_data()[0];
@@ -83,7 +83,7 @@ TEST_F(geographyFunctionsTest, st_xDoubleTest) {
     std::string buf;
     point.encode_to(&buf);
     str_column->append(Slice(buf));
-    columns.emplace_back(str_column);
+    columns.emplace_back(std::move(str_column));
 
     auto result = GeoFunctions::st_x(ctx.get(), columns).value();
     auto v = ColumnHelper::as_column<DoubleColumn>(result);
@@ -103,7 +103,7 @@ TEST_F(geographyFunctionsTest, st_yDoubleTest) {
     std::string buf;
     point.encode_to(&buf);
     str_column->append(Slice(buf));
-    columns.emplace_back(str_column);
+    columns.emplace_back(std::move(str_column));
 
     auto result = GeoFunctions::st_y(ctx.get(), columns).value();
     auto v = ColumnHelper::as_column<DoubleColumn>(result);
@@ -124,10 +124,10 @@ TEST_F(geographyFunctionsTest, st_distance_sphereTest) {
     ylng->append(0.0);
     ylat->append(0.0);
 
-    columns.emplace_back(xlng);
-    columns.emplace_back(xlat);
-    columns.emplace_back(ylng);
-    columns.emplace_back(ylat);
+    columns.emplace_back(std::move(xlng));
+    columns.emplace_back(std::move(xlat));
+    columns.emplace_back(std::move(ylng));
+    columns.emplace_back(std::move(ylat));
 
     ColumnPtr result = GeoFunctions::st_distance_sphere(ctx.get(), columns).value();
     auto v = ColumnHelper::as_column<DoubleColumn>(result);
@@ -145,8 +145,8 @@ TEST_F(geographyFunctionsTest, as_wktTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
     auto str_point = BinaryColumn::create();
-    columns.emplace_back(str_point);
     str_point->append(buf);
+    columns.emplace_back(std::move(str_point));
 
     auto result = GeoFunctions::st_as_wkt(ctx.get(), columns).value();
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
@@ -161,7 +161,7 @@ TEST_F(geographyFunctionsTest, st_from_wktGeneralTest) {
     auto wkt_column = BinaryColumn::create();
     wkt_column->append(wkt);
 
-    columns.emplace_back(wkt_column);
+    columns.emplace_back(std::move(wkt_column));
 
     ctx->set_constant_columns(columns);
 
@@ -187,7 +187,7 @@ TEST_F(geographyFunctionsTest, st_from_wktConstTest) {
 
     auto wkt_column = ColumnHelper::create_const_column<TYPE_VARCHAR>("POINT (10.1 20.2)", 1);
 
-    columns.emplace_back(wkt_column);
+    columns.emplace_back(std::move(wkt_column));
 
     ctx->set_constant_columns(columns);
 
@@ -214,7 +214,7 @@ TEST_F(geographyFunctionsTest, st_lineGeneralTest) {
     auto line_string = BinaryColumn::create();
     line_string->append(line);
 
-    columns.emplace_back(line_string);
+    columns.emplace_back(std::move(line_string));
     ctx->set_constant_columns(columns);
 
     GeoFunctions::st_line_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL);
@@ -231,11 +231,11 @@ TEST_F(geographyFunctionsTest, st_lineConstTest) {
     Columns columns;
     auto line_string = ColumnHelper::create_const_column<TYPE_VARCHAR>("LINESTRING (10.1 20.2, 21.1 30.1)", 1);
 
-    columns.emplace_back(line_string);
+    columns.emplace_back(std::move(line_string));
     ctx->set_constant_columns(columns);
 
     GeoFunctions::st_line_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL);
-    auto result = GeoFunctions::st_line(ctx.get(), columns).value();
+    ColumnPtr result = GeoFunctions::st_line(ctx.get(), columns).value();
     auto v = ColumnHelper::get_const_value<TYPE_VARCHAR>(result);
 
     GeoLine line;
@@ -250,7 +250,7 @@ TEST_F(geographyFunctionsTest, st_polygonGeneralTest) {
     std::string wkt = "POLYGON ((10 10, 50 10, 50 50, 10 50, 10 10))";
     auto polygon_str = BinaryColumn::create();
     polygon_str->append(wkt);
-    columns.emplace_back(polygon_str);
+    columns.emplace_back(std::move(polygon_str));
 
     ctx->set_constant_columns(columns);
     GeoFunctions::st_polygon_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL);
@@ -272,14 +272,14 @@ TEST_F(geographyFunctionsTest, st_polygonConstTest) {
     Columns columns;
     auto const_polygon =
             ColumnHelper::create_const_column<TYPE_VARCHAR>("POLYGON ((10 10, 50 10, 50 50, 10 50, 10 10))", 1);
-    columns.emplace_back(const_polygon);
+    columns.emplace_back(std::move(const_polygon));
 
     ctx->set_constant_columns(columns);
     GeoFunctions::st_polygon_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL);
     ASSERT_NE(nullptr, ctx->get_function_state(FunctionContext::FRAGMENT_LOCAL));
 
     auto str2 = GeoFunctions::st_polygon(ctx.get(), columns).value();
-    auto result = ColumnHelper::as_column<ConstColumn>(str2);
+    ColumnPtr result = ColumnHelper::as_column<ConstColumn>(str2);
     auto v = ColumnHelper::get_const_value<TYPE_VARCHAR>(result);
 
     GeoPolygon polygon;
@@ -298,9 +298,9 @@ TEST_F(geographyFunctionsTest, st_circleGeneralTest) {
     lat_column->append(64);
     auto radius_column = DoubleColumn::create();
     radius_column->append(10 * 100);
-    columns.emplace_back(lng_column);
-    columns.emplace_back(lat_column);
-    columns.emplace_back(radius_column);
+    columns.emplace_back(std::move(lng_column));
+    columns.emplace_back(std::move(lat_column));
+    columns.emplace_back(std::move(radius_column));
 
     ctx->set_constant_columns(columns);
     GeoFunctions::st_circle_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL);
@@ -325,9 +325,9 @@ TEST_F(geographyFunctionsTest, st_circleConstTest) {
     auto lng_column = ColumnHelper::create_const_column<TYPE_DOUBLE>(111, 1);
     auto lat_column = ColumnHelper::create_const_column<TYPE_DOUBLE>(64, 1);
     auto radius_column = ColumnHelper::create_const_column<TYPE_DOUBLE>(10 * 100, 1);
-    columns.emplace_back(lng_column);
-    columns.emplace_back(lat_column);
-    columns.emplace_back(radius_column);
+    columns.emplace_back(std::move(lng_column));
+    columns.emplace_back(std::move(lat_column));
+    columns.emplace_back(std::move(radius_column));
 
     ctx->set_constant_columns(columns);
     GeoFunctions::st_circle_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL);
@@ -336,7 +336,7 @@ TEST_F(geographyFunctionsTest, st_circleConstTest) {
     auto result = GeoFunctions::st_circle(ctx.get(), columns).value();
     ASSERT_FALSE(result->is_null(0));
 
-    auto v = ColumnHelper::as_column<ConstColumn>(result);
+    ColumnPtr v = ColumnHelper::as_column<ConstColumn>(result);
     auto cir_str = ColumnHelper::get_const_value<TYPE_VARCHAR>(v);
 
     GeoCircle circle;
@@ -354,7 +354,7 @@ TEST_F(geographyFunctionsTest, st_containsGeneralTest) {
     std::string polygon_wkt = "POLYGON ((10 10, 50 10, 50 50, 10 50, 10 10))";
     auto polygon_column = BinaryColumn::create();
     polygon_column->append(polygon_wkt);
-    columns.emplace_back(polygon_column);
+    columns.emplace_back(std::move(polygon_column));
     ctx->set_constant_columns(columns);
     GeoFunctions::st_from_wkt_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL);
     auto result1 = GeoFunctions::st_from_wkt(ctx.get(), columns).value();
@@ -363,14 +363,14 @@ TEST_F(geographyFunctionsTest, st_containsGeneralTest) {
     std::string point_wkt = "POINT (25 25)";
     auto point_column = BinaryColumn::create();
     point_column->append(point_wkt);
-    columns.emplace_back(point_column);
+    columns.emplace_back(std::move(point_column));
     ctx->set_constant_columns(columns);
     GeoFunctions::st_from_wkt_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL);
     auto result2 = GeoFunctions::st_from_wkt(ctx.get(), columns).value();
 
     columns.clear();
-    columns.emplace_back(result1);
-    columns.emplace_back(result2);
+    columns.emplace_back(std::move(result1));
+    columns.emplace_back(std::move(result2));
     ctx->set_constant_columns(columns);
     GeoFunctions::st_contains_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL);
 
@@ -392,7 +392,7 @@ TEST_F(geographyFunctionsTest, st_containsWithUnexpectedInputTest) {
     std::string polygon_wkt = "POLYGON ((10 10, 50 10, 50 50, 10 50, 10 10))";
     auto polygon_column = BinaryColumn::create();
     polygon_column->append(polygon_wkt);
-    columns.emplace_back(polygon_column);
+    columns.emplace_back(std::move(polygon_column));
     ctx->set_constant_columns(columns);
     GeoFunctions::st_from_wkt_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL);
     auto result1 = GeoFunctions::st_from_wkt(ctx.get(), columns).value();
@@ -401,7 +401,7 @@ TEST_F(geographyFunctionsTest, st_containsWithUnexpectedInputTest) {
     std::string point_wkt = "POINT (25 25)";
     auto point_column = BinaryColumn::create();
     point_column->append(point_wkt);
-    columns.emplace_back(point_column);
+    columns.emplace_back(std::move(point_column));
     ctx->set_constant_columns(columns);
     GeoFunctions::st_from_wkt_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL);
     auto result2 = GeoFunctions::st_from_wkt(ctx.get(), columns).value();
@@ -415,8 +415,8 @@ TEST_F(geographyFunctionsTest, st_containsWithUnexpectedInputTest) {
     string_value.append("A");
     auto input_column = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice(string_value), varchar_column->size());
 
-    columns.emplace_back(input_column);
-    columns.emplace_back(result2);
+    columns.emplace_back(std::move(input_column));
+    columns.emplace_back(std::move(result2));
     ctx->set_constant_columns(columns);
     GeoFunctions::st_contains_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL);
     auto res = GeoFunctions::st_contains(ctx.get(), columns).value();
@@ -433,7 +433,7 @@ TEST_F(geographyFunctionsTest, st_containsConstTest) {
     std::string polygon_wkt = "POLYGON ((10 10, 50 10, 50 50, 10 50, 10 10))";
     auto polygon_column = BinaryColumn::create();
     polygon_column->append(polygon_wkt);
-    columns.emplace_back(polygon_column);
+    columns.emplace_back(std::move(polygon_column));
     ctx->set_constant_columns(columns);
     GeoFunctions::st_from_wkt_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL);
     auto result1 = ConstColumn::create(GeoFunctions::st_from_wkt(ctx.get(), columns).value(), 1);
@@ -442,14 +442,14 @@ TEST_F(geographyFunctionsTest, st_containsConstTest) {
     std::string point_wkt = "POINT (25 25)";
     auto point_column = BinaryColumn::create();
     point_column->append(point_wkt);
-    columns.emplace_back(point_column);
+    columns.emplace_back(std::move(point_column));
     ctx->set_constant_columns(columns);
     GeoFunctions::st_from_wkt_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL);
     auto result2 = ConstColumn::create(GeoFunctions::st_from_wkt(ctx.get(), columns).value(), 1);
 
     columns.clear();
-    columns.emplace_back(result1);
-    columns.emplace_back(result2);
+    columns.emplace_back(std::move(result1));
+    columns.emplace_back(std::move(result2));
     ctx->set_constant_columns(columns);
     GeoFunctions::st_contains_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL);
 

--- a/be/test/exprs/hash_functions_test.cpp
+++ b/be/test/exprs/hash_functions_test.cpp
@@ -31,7 +31,7 @@ TEST_F(HashFunctionsTest, hashTest) {
         auto tc1 = BinaryColumn::create();
         tc1->append("test1234567");
 
-        columns.emplace_back(tc1);
+        columns.emplace_back(std::move(tc1));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result = HashFunctions::murmur_hash3_32(ctx.get(), columns).value();
@@ -49,8 +49,8 @@ TEST_F(HashFunctionsTest, hashTest) {
         auto tc2 = BinaryColumn::create();
         tc2->append("asdf213");
 
-        columns.emplace_back(tc1);
-        columns.emplace_back(tc2);
+        columns.emplace_back(std::move(tc1));
+        columns.emplace_back(std::move(tc2));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result = HashFunctions::murmur_hash3_32(ctx.get(), columns).value();
@@ -70,9 +70,9 @@ TEST_F(HashFunctionsTest, hashTest) {
 
         auto tc3 = ColumnHelper::create_const_null_column(1);
 
-        columns.emplace_back(tc1);
-        columns.emplace_back(tc2);
-        columns.emplace_back(tc3);
+        columns.emplace_back(std::move(tc1));
+        columns.emplace_back(std::move(tc2));
+        columns.emplace_back(std::move(tc3));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result = HashFunctions::murmur_hash3_32(ctx.get(), columns).value();
@@ -87,7 +87,7 @@ TEST_F(HashFunctionsTest, test_xx_hash3_64) {
         auto tc1 = BinaryColumn::create();
         tc1->append("hello");
         tc1->append("starrocks");
-        columns.emplace_back(tc1);
+        columns.emplace_back(std::move(tc1));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result = HashFunctions::xx_hash3_64(ctx.get(), columns).value();
@@ -107,8 +107,8 @@ TEST_F(HashFunctionsTest, test_xx_hash3_64) {
         tc2->append("world");
         tc2->append("starrocks");
 
-        columns.emplace_back(tc1);
-        columns.emplace_back(tc2);
+        columns.emplace_back(std::move(tc1));
+        columns.emplace_back(std::move(tc2));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result = HashFunctions::xx_hash3_64(ctx.get(), columns).value();
@@ -128,9 +128,9 @@ TEST_F(HashFunctionsTest, test_xx_hash3_64) {
         auto tc3 = BinaryColumn::create();
         tc3->append("world");
 
-        columns.emplace_back(tc1);
-        columns.emplace_back(tc2);
-        columns.emplace_back(tc3);
+        columns.emplace_back(std::move(tc1));
+        columns.emplace_back(std::move(tc2));
+        columns.emplace_back(std::move(tc3));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result = HashFunctions::xx_hash3_64(ctx.get(), columns).value();
@@ -147,7 +147,7 @@ TEST_F(HashFunctionsTest, test_xx_hash3_128) {
         auto tc1 = BinaryColumn::create();
         tc1->append("hello");
         tc1->append("starrocks");
-        columns.emplace_back(tc1);
+        columns.emplace_back(std::move(tc1));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result = HashFunctions::xx_hash3_128(ctx.get(), columns).value();
@@ -167,8 +167,8 @@ TEST_F(HashFunctionsTest, test_xx_hash3_128) {
         tc2->append("world");
         tc2->append("starrocks");
 
-        columns.emplace_back(tc1);
-        columns.emplace_back(tc2);
+        columns.emplace_back(std::move(tc1));
+        columns.emplace_back(std::move(tc2));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result = HashFunctions::xx_hash3_128(ctx.get(), columns).value();
@@ -188,9 +188,9 @@ TEST_F(HashFunctionsTest, test_xx_hash3_128) {
         auto tc3 = BinaryColumn::create();
         tc3->append("world");
 
-        columns.emplace_back(tc1);
-        columns.emplace_back(tc2);
-        columns.emplace_back(tc3);
+        columns.emplace_back(std::move(tc1));
+        columns.emplace_back(std::move(tc2));
+        columns.emplace_back(std::move(tc3));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result = HashFunctions::xx_hash3_128(ctx.get(), columns).value();

--- a/be/test/exprs/hyperloglog_functions_test.cpp
+++ b/be/test/exprs/hyperloglog_functions_test.cpp
@@ -56,7 +56,7 @@ TEST_F(HyperLogLogFunctionsTest, hllHashTest) {
         col1->append(Slice("test3"));
         col1->append(Slice("test1"));
 
-        columns.push_back(col1);
+        columns.emplace_back(std::move(col1));
 
         auto v = HyperloglogFunctions::hll_hash(ctx, columns).value();
 
@@ -102,7 +102,7 @@ TEST_F(HyperLogLogFunctionsTest, hllCardinalityTest) {
         col1->append(std::move(h3));
         col1->append(std::move(h4));
 
-        columns.push_back(col1);
+        columns.emplace_back(std::move(col1));
 
         auto v = HyperloglogFunctions::hll_cardinality(ctx, columns).value();
 
@@ -156,7 +156,7 @@ TEST_F(HyperLogLogFunctionsTest, hllCardinalityFromStringTest) {
 
         HyperLogLog t1;
 
-        columns.push_back(col1);
+        columns.emplace_back(std::move(col1));
 
         auto v = HyperloglogFunctions::hll_cardinality_from_string(ctx, columns).value();
 
@@ -209,11 +209,11 @@ TEST_F(HyperLogLogFunctionsTest, hllSerializeTest) {
         col1->append(std::move(h6));
 
         ColumnPtr v = nullptr;
-        v = HyperloglogFunctions::hll_cardinality(ctx, {col1}).value();
+        v = HyperloglogFunctions::hll_cardinality(ctx, {col1->clone()}).value();
         ASSERT_TRUE(v->is_numeric());
         auto expect = ColumnHelper::cast_to<TYPE_BIGINT>(v);
 
-        v = HyperloglogFunctions::hll_serialize(ctx, {col1}).value();
+        v = HyperloglogFunctions::hll_serialize(ctx, {std::move(col1)}).value();
         ASSERT_TRUE(v->is_binary());
         v = HyperloglogFunctions::hll_deserialize(ctx, {v}).value();
         ASSERT_TRUE(v->is_object());

--- a/be/test/exprs/if_expr_test.cpp
+++ b/be/test/exprs/if_expr_test.cpp
@@ -56,7 +56,7 @@ TEST_F(VectorizedIfExprTest, ifArray) {
     auto expr = VectorizedConditionExprFactory::create_if_expr(expr_node);
     std::unique_ptr<Expr> expr_ptr(expr);
 
-    auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_BOOLEAN), false);
+    ColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_BOOLEAN), false);
     target->append_datum(Datum{(int8_t)0});
     target->append_datum(Datum{(int8_t)1});
     target->append_datum(Datum{(int8_t)0});
@@ -64,13 +64,13 @@ TEST_F(VectorizedIfExprTest, ifArray) {
 
     TypeDescriptor type_arr_int = array_type(TYPE_INT);
 
-    auto array0 = ColumnHelper::create_column(type_arr_int, true);
+    ColumnPtr array0 = ColumnHelper::create_column(type_arr_int, true);
     array0->append_datum(DatumArray{Datum((int32_t)1), Datum((int32_t)4)}); // [1,4]
     array0->append_datum(DatumArray{Datum(), Datum()});                     // [NULL, NULL]
     array0->append_datum(DatumArray{Datum(), Datum((int32_t)12)});          // [NULL, 12]
     auto array_expr0 = MockExpr(type_arr_int, array0);
 
-    auto array1 = ColumnHelper::create_column(type_arr_int, false);
+    ColumnPtr array1 = ColumnHelper::create_column(type_arr_int, false);
     array1->append_datum(DatumArray{Datum((int32_t)11), Datum((int32_t)41)}); // [11,41]
     array1->append_datum(DatumArray{Datum(), Datum()});                       // [NULL, NULL]
     array1->append_datum(DatumArray{Datum(), Datum((int32_t)1)});             // [NULL, 1]

--- a/be/test/exprs/in_predicate_test.cpp
+++ b/be/test/exprs/in_predicate_test.cpp
@@ -48,7 +48,7 @@ public:
         is_not_in.push_back(true);
         is_not_in.push_back(false);
     }
-    FakeConstExpr* new_fake_const_expr(ColumnPtr value, const TypeDescriptor& type) {
+    FakeConstExpr* new_fake_const_expr(MutableColumnPtr&& value, const TypeDescriptor& type) {
         TExprNode node;
         node.__set_node_type(TExprNodeType::INT_LITERAL);
         node.__set_num_children(0);
@@ -329,7 +329,7 @@ TEST_F(VectorizedInPredicateTest, inConstPred) {
         Slice s2(v2);
 
         auto mock_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(s2, 5);
-        MockExpr col1(expr_node, mock_col);
+        MockExpr col1(expr_node, std::move(mock_col));
 
         MockNullVectorizedExpr<TYPE_VARCHAR> col2(expr_node, 1, s2);
         col2.all_null = true;
@@ -362,18 +362,18 @@ TEST_F(VectorizedInPredicateTest, inArray) {
         array0->append_datum(DatumArray{Datum((int32_t)11), Datum((int32_t)4)}); // [11,4]
         array0->append_datum(Datum{});                                           // NULL
         array0->append_datum(DatumArray{Datum(), Datum((int32_t)1)});            // [NULL, 1]
-        auto array_expr0 = MockExpr(type_arr_int, array0);
+        auto array_expr0 = MockExpr(type_arr_int, std::move(array0));
 
         auto array1 = ColumnHelper::create_column(type_arr_int, false);
         array1->append_datum(DatumArray{Datum((int32_t)1), Datum((int32_t)4)}); // [1,4]
         array1->append_datum(DatumArray{Datum(), Datum()});                     // [NULL, NULL]
         array1->append_datum(DatumArray{Datum(), Datum((int32_t)2)});           // [NULL, 2]
-        auto array_expr1 = MockExpr(type_arr_int, array1);
+        auto array_expr1 = MockExpr(type_arr_int, std::move(array1));
 
         auto array = ColumnHelper::create_column(type_arr_int, false);
         array->append_datum(DatumArray{Datum((int32_t)11), Datum((int32_t)4)}); // [11,4]
-        auto const_col = ConstColumn::create(array, 3);
-        auto* const_array = new_fake_const_expr(const_col, type_arr_int);
+        auto const_col = ConstColumn::create(std::move(array), 3);
+        auto* const_array = new_fake_const_expr(std::move(const_col), type_arr_int);
 
         expr->add_child(&array_expr0);
         expr->add_child(&array_expr1);
@@ -409,18 +409,18 @@ TEST_F(VectorizedInPredicateTest, inArrayConstAll) {
         TypeDescriptor type_arr_int = array_type(TYPE_INT);
         auto array = ColumnHelper::create_column(type_arr_int, false);
         array->append_datum(DatumArray{Datum((int32_t)11), Datum((int32_t)4)}); // [11,4]
-        auto const_col = ConstColumn::create(array, 3);
-        auto* const_array = new_fake_const_expr(const_col, type_arr_int);
+        auto const_col = ConstColumn::create(std::move(array), 3);
+        auto* const_array = new_fake_const_expr(std::move(const_col), type_arr_int);
 
         auto array0 = ColumnHelper::create_column(type_arr_int, false);
         array0->append_datum(DatumArray{Datum(), Datum((int32_t)4)}); // [NULL,4]
-        auto const_col0 = ConstColumn::create(array0, 3);
-        auto* const_array0 = new_fake_const_expr(const_col0, type_arr_int);
+        auto const_col0 = ConstColumn::create(std::move(array0), 3);
+        auto* const_array0 = new_fake_const_expr(std::move(const_col0), type_arr_int);
 
         auto array1 = ColumnHelper::create_column(type_arr_int, false);
         array1->append_datum(DatumArray{Datum((int32_t)11), Datum((int32_t)4)}); // [11,4]
-        auto const_col1 = ConstColumn::create(array1, 3);
-        auto* const_array1 = new_fake_const_expr(const_col1, type_arr_int);
+        auto const_col1 = ConstColumn::create(std::move(array1), 3);
+        auto* const_array1 = new_fake_const_expr(std::move(const_col1), type_arr_int);
 
         expr->add_child(const_array);
         expr->add_child(const_array0);
@@ -451,18 +451,18 @@ TEST_F(VectorizedInPredicateTest, inArrayConstAllNULL) {
         TypeDescriptor type_arr_int = array_type(TYPE_INT);
         auto array = ColumnHelper::create_column(type_arr_int, true);
         array->append_datum(Datum{}); // NULL
-        auto const_col = ConstColumn::create(array, 3);
-        auto* const_array = new_fake_const_expr(const_col, type_arr_int);
+        auto const_col = ConstColumn::create(std::move(array), 3);
+        auto* const_array = new_fake_const_expr(std::move(const_col), type_arr_int);
 
         auto array0 = ColumnHelper::create_column(type_arr_int, false);
         array0->append_datum(DatumArray{Datum(), Datum((int32_t)4)}); // [NULL,4]
-        auto const_col0 = ConstColumn::create(array0, 3);
-        auto* const_array0 = new_fake_const_expr(const_col0, type_arr_int);
+        auto const_col0 = ConstColumn::create(std::move(array0), 3);
+        auto* const_array0 = new_fake_const_expr(std::move(const_col0), type_arr_int);
 
         auto array1 = ColumnHelper::create_column(type_arr_int, false);
         array1->append_datum(DatumArray{Datum((int32_t)11), Datum((int32_t)4)}); // [11,4]
-        auto const_col1 = ConstColumn::create(array1, 3);
-        auto* const_array1 = new_fake_const_expr(const_col1, type_arr_int);
+        auto const_col1 = ConstColumn::create(std::move(array1), 3);
+        auto* const_array1 = new_fake_const_expr(std::move(const_col1), type_arr_int);
 
         expr->add_child(const_array);
         expr->add_child(const_array0);

--- a/be/test/exprs/jit_func_cache_test.cpp
+++ b/be/test/exprs/jit_func_cache_test.cpp
@@ -79,7 +79,7 @@ TEST_F(JITFunctionCacheTest, cache) {
                 ASSERT_FALSE(ptr->is_nullable());
                 ASSERT_TRUE(ptr->is_numeric());
 
-                auto v = std::static_pointer_cast<Int8Column>(ptr);
+                auto v = Int8Column::static_pointer_cast(ptr);
                 ASSERT_EQ(10, v->size());
 
                 for (int j = 0; j < v->size(); ++j) {
@@ -93,7 +93,7 @@ TEST_F(JITFunctionCacheTest, cache) {
                 ASSERT_FALSE(ptr->is_nullable());
                 ASSERT_TRUE(ptr->is_numeric());
 
-                auto v = std::static_pointer_cast<Int8Column>(ptr);
+                auto v = Int8Column::static_pointer_cast(ptr);
                 ASSERT_EQ(10, v->size());
 
                 for (int j = 0; j < v->size(); ++j) {
@@ -125,7 +125,7 @@ TEST_F(JITFunctionCacheTest, cache) {
                 ASSERT_FALSE(ptr->is_nullable());
                 ASSERT_TRUE(ptr->is_numeric());
 
-                auto v = std::static_pointer_cast<Int32Column>(ptr);
+                auto v = Int32Column::static_pointer_cast(ptr);
                 ASSERT_EQ(10, v->size());
 
                 for (int j = 0; j < v->size(); ++j) {
@@ -139,7 +139,7 @@ TEST_F(JITFunctionCacheTest, cache) {
                 ASSERT_FALSE(ptr->is_nullable());
                 ASSERT_TRUE(ptr->is_numeric());
 
-                auto v = std::static_pointer_cast<Int32Column>(ptr);
+                auto v = Int32Column::static_pointer_cast(ptr);
                 ASSERT_EQ(10, v->size());
 
                 for (int j = 0; j < v->size(); ++j) {
@@ -171,7 +171,7 @@ TEST_F(JITFunctionCacheTest, cache) {
                 ASSERT_FALSE(ptr->is_nullable());
                 ASSERT_TRUE(ptr->is_numeric());
 
-                auto v = std::static_pointer_cast<Int128Column>(ptr);
+                auto v = Int128Column::static_pointer_cast(ptr);
                 ASSERT_EQ(10, v->size());
 
                 for (int j = 0; j < v->size(); ++j) {
@@ -185,7 +185,7 @@ TEST_F(JITFunctionCacheTest, cache) {
                 ASSERT_FALSE(ptr->is_nullable());
                 ASSERT_TRUE(ptr->is_numeric());
 
-                auto v = std::static_pointer_cast<Int128Column>(ptr);
+                auto v = Int128Column::static_pointer_cast(ptr);
                 ASSERT_EQ(10, v->size());
 
                 for (int j = 0; j < v->size(); ++j) {

--- a/be/test/exprs/json_functions_test.cpp
+++ b/be/test/exprs/json_functions_test.cpp
@@ -85,8 +85,8 @@ public:
 TEST_F(JsonFunctionsTest, get_json_string_casting) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto strings = BinaryColumn::create();
-    auto strings2 = BinaryColumn::create();
+    BinaryColumn::Ptr strings = BinaryColumn::create();
+    BinaryColumn::Ptr strings2 = BinaryColumn::create();
 
     std::string values[] = {
             R"({"k1":    1})",          //int, 1 key
@@ -148,8 +148,8 @@ TEST_F(JsonFunctionsTest, get_json_string_casting) {
 TEST_F(JsonFunctionsTest, get_json_string_array) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto strings = BinaryColumn::create();
-    auto strings2 = BinaryColumn::create();
+    BinaryColumn::Ptr strings = BinaryColumn::create();
+    BinaryColumn::Ptr strings2 = BinaryColumn::create();
 
     std::string values[] = {R"([{"key":    1}, {"key": 2 }])", R"([{"key":    1}, {"key": 2 }])"};
 
@@ -185,8 +185,8 @@ TEST_F(JsonFunctionsTest, get_json_emptyTest) {
     {
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         Columns columns;
-        auto doubles = BinaryColumn::create();
-        auto doubles2 = BinaryColumn::create();
+        BinaryColumn::Ptr doubles = BinaryColumn::create();
+        BinaryColumn::Ptr doubles2 = BinaryColumn::create();
 
         std::string values[] = {R"({"k1":1.3, "k2":"2"})", R"({"k1":"v1", "my.key":[1.1, 2.2, 3.3]})"};
         std::string strs[] = {"", ""};
@@ -220,8 +220,8 @@ TEST_F(JsonFunctionsTest, get_json_emptyTest) {
     {
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         Columns columns;
-        auto str_values = BinaryColumn::create();
-        auto str_values2 = BinaryColumn::create();
+        BinaryColumn::Ptr str_values = BinaryColumn::create();
+        BinaryColumn::Ptr str_values2 = BinaryColumn::create();
 
         std::string values[] = {R"({"k1":1.3, "k2":"2"})", R"({"k1":"v1", "my.key":[1.1, 2.2, 3.3]})"};
         std::string strs[] = {"", ""};
@@ -255,8 +255,8 @@ TEST_F(JsonFunctionsTest, get_json_emptyTest) {
     {
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         Columns columns;
-        auto ints = BinaryColumn::create();
-        auto ints2 = BinaryColumn::create();
+        BinaryColumn::Ptr ints = BinaryColumn::create();
+        BinaryColumn::Ptr ints2 = BinaryColumn::create();
 
         std::string values[] = {R"({"k1":1.3, "k2":"2"})", R"({"k1":"v1", "my.key":[1.1, 2.2, 3.3]})"};
         std::string strs[] = {"", ""};
@@ -290,8 +290,8 @@ TEST_F(JsonFunctionsTest, get_json_emptyTest) {
     {
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         Columns columns;
-        auto ints = BinaryColumn::create();
-        auto ints2 = BinaryColumn::create();
+        BinaryColumn::Ptr ints = BinaryColumn::create();
+        BinaryColumn::Ptr ints2 = BinaryColumn::create();
 
         std::string values[] = {R"({"k1":1.3, "k2":"2"})", R"({"k1":"v1", "my.key":[1.1, 2.2, 3.3]})"};
         std::string strs[] = {"$.k3", "$.k4"};
@@ -341,7 +341,7 @@ class JsonQueryTestFixture : public ::testing::TestWithParam<std::tuple<std::str
 
 TEST_P(JsonQueryTestFixture, json_query) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
-    auto ints = JsonColumn::create();
+    JsonColumn::Ptr ints = JsonColumn::create();
     ColumnBuilder<TYPE_VARCHAR> builder(1);
 
     std::string param_json = std::get<0>(GetParam());
@@ -472,7 +472,7 @@ class FlatJsonQueryTestFixture
 
 TEST_P(FlatJsonQueryTestFixture, json_query) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
-    auto json_col = JsonColumn::create();
+    JsonColumn::Ptr json_col = JsonColumn::create();
     ColumnBuilder<TYPE_VARCHAR> builder(1);
 
     std::string param_json = std::get<0>(GetParam());
@@ -490,7 +490,7 @@ TEST_P(FlatJsonQueryTestFixture, json_query) {
         builder.append(param_path);
     }
 
-    auto flat_json = JsonColumn::create();
+    JsonColumn::Ptr flat_json = JsonColumn::create();
     auto flat_json_ptr = flat_json.get();
     std::vector<LogicalType> param_flat_type;
     for (auto _ : param_flat_path) {
@@ -592,7 +592,7 @@ class JsonExistTestFixture : public ::testing::TestWithParam<std::tuple<std::str
 
 TEST_P(JsonExistTestFixture, json_exists) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
-    auto ints = JsonColumn::create();
+    JsonColumn::Ptr ints = JsonColumn::create();
     ColumnBuilder<TYPE_VARCHAR> builder(1);
 
     std::string param_json = std::get<0>(GetParam());
@@ -667,7 +667,7 @@ class FlatJsonExistsTestFixture
 
 TEST_P(FlatJsonExistsTestFixture, flat_json_exists_test) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
-    auto json_col = JsonColumn::create();
+    JsonColumn::Ptr json_col = JsonColumn::create();
 
     std::string param_json = std::get<0>(GetParam());
     std::vector<std::string> param_flat_path = std::get<1>(GetParam());
@@ -680,7 +680,7 @@ TEST_P(FlatJsonExistsTestFixture, flat_json_exists_test) {
 
     Columns flat_columns;
 
-    auto flat_json = JsonColumn::create();
+    JsonColumn::Ptr flat_json = JsonColumn::create();
     auto* flat_json_ptr = down_cast<JsonColumn*>(flat_json.get());
 
     std::vector<LogicalType> param_flat_type;
@@ -694,7 +694,7 @@ TEST_P(FlatJsonExistsTestFixture, flat_json_exists_test) {
     Columns columns;
     columns.push_back(flat_json);
     if (!param_path.empty()) {
-        auto path_column = BinaryColumn::create();
+        BinaryColumn::Ptr path_column = BinaryColumn::create();
         path_column->append(param_path);
         columns.push_back(path_column);
     }
@@ -743,7 +743,7 @@ INSTANTIATE_TEST_SUITE_P(FlatJsonExistsTest, FlatJsonExistsTestFixture,
 
 TEST_F(JsonFunctionsTest, flat_json_invalid_path_test) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
-    auto json_col = JsonColumn::create();
+    JsonColumn::Ptr json_col = JsonColumn::create();
 
     std::string param_json = R"({"k1":1, "k2":"2"})";
     std::vector<std::string> param_flat_path = std::vector<std::string>{"k1", "k2"};
@@ -755,7 +755,7 @@ TEST_F(JsonFunctionsTest, flat_json_invalid_path_test) {
 
     Columns flat_columns;
 
-    auto flat_json = JsonColumn::create();
+    JsonColumn::Ptr flat_json = JsonColumn::create();
     auto* flat_json_ptr = down_cast<JsonColumn*>(flat_json.get());
 
     std::vector<LogicalType> param_flat_type;
@@ -769,7 +769,7 @@ TEST_F(JsonFunctionsTest, flat_json_invalid_path_test) {
     Columns columns;
     columns.push_back(flat_json);
     if (!param_path.empty()) {
-        auto path_column = BinaryColumn::create();
+        BinaryColumn::Ptr path_column = BinaryColumn::create();
         path_column->append(param_path);
         columns.push_back(ConstColumn::create(path_column));
     }
@@ -792,7 +792,7 @@ TEST_F(JsonFunctionsTest, flat_json_invalid_path_test) {
 
 TEST_F(JsonFunctionsTest, flat_json_invalid_constant_json_test) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
-    auto json_col = JsonColumn::create();
+    JsonColumn::Ptr json_col = JsonColumn::create();
 
     std::string param_json = R"({"k1":1, "k2":"2"})";
     std::vector<std::string> param_flat_path = std::vector<std::string>{"k1", "k2"};
@@ -804,7 +804,7 @@ TEST_F(JsonFunctionsTest, flat_json_invalid_constant_json_test) {
 
     Columns flat_columns;
 
-    auto flat_json = JsonColumn::create();
+    JsonColumn::Ptr flat_json = JsonColumn::create();
     auto* flat_json_ptr = down_cast<JsonColumn*>(flat_json.get());
 
     std::vector<LogicalType> param_flat_type;
@@ -818,7 +818,7 @@ TEST_F(JsonFunctionsTest, flat_json_invalid_constant_json_test) {
     Columns columns;
     columns.push_back(ConstColumn::create(flat_json, 2));
     if (!param_path.empty()) {
-        auto path_column = BinaryColumn::create();
+        BinaryColumn::Ptr path_column = BinaryColumn::create();
         path_column->append(param_path);
         columns.push_back(ConstColumn::create(path_column, 2));
     }
@@ -837,7 +837,7 @@ TEST_F(JsonFunctionsTest, flat_json_invalid_constant_json_test) {
 
 TEST_F(JsonFunctionsTest, flat_json_variable_path_test) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
-    auto json_col = JsonColumn::create();
+    JsonColumn::Ptr json_col = JsonColumn::create();
 
     std::string param_json = R"({"k1":1, "k2":"2"})";
     std::vector<std::string> param_flat_path = std::vector<std::string>{"k1", "k2"};
@@ -849,7 +849,7 @@ TEST_F(JsonFunctionsTest, flat_json_variable_path_test) {
 
     Columns flat_columns;
 
-    auto flat_json = JsonColumn::create();
+    JsonColumn::Ptr flat_json = JsonColumn::create();
     auto* flat_json_ptr = down_cast<JsonColumn*>(flat_json.get());
 
     std::vector<LogicalType> param_flat_type;
@@ -865,7 +865,7 @@ TEST_F(JsonFunctionsTest, flat_json_variable_path_test) {
     flat_json->assign(10, 0);
 
     if (!param_path.empty()) {
-        auto path_column = BinaryColumn::create();
+        BinaryColumn::Ptr path_column = BinaryColumn::create();
         path_column->append(param_path);
         path_column->assign(10, 0);
         columns.push_back(path_column);
@@ -883,7 +883,7 @@ TEST_F(JsonFunctionsTest, flat_json_variable_path_test) {
 
 TEST_F(JsonFunctionsTest, flat_json_invalid_variable_path_test) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
-    auto json_col = JsonColumn::create();
+    JsonColumn::Ptr json_col = JsonColumn::create();
 
     std::string param_json = R"({"k1":1, "k2":"2"})";
     std::vector<std::string> param_flat_path = std::vector<std::string>{"k1", "k2"};
@@ -895,7 +895,7 @@ TEST_F(JsonFunctionsTest, flat_json_invalid_variable_path_test) {
 
     Columns flat_columns;
 
-    auto flat_json = JsonColumn::create();
+    JsonColumn::Ptr flat_json = JsonColumn::create();
     auto* flat_json_ptr = down_cast<JsonColumn*>(flat_json.get());
 
     std::vector<LogicalType> param_flat_type;
@@ -911,7 +911,7 @@ TEST_F(JsonFunctionsTest, flat_json_invalid_variable_path_test) {
     flat_json->assign(2, 0);
 
     if (!param_path.empty()) {
-        auto path_column = BinaryColumn::create();
+        BinaryColumn::Ptr path_column = BinaryColumn::create();
         path_column->append(param_path);
         path_column->append("$.k3");
         columns.push_back(path_column);
@@ -931,7 +931,7 @@ TEST_F(JsonFunctionsTest, flat_json_invalid_variable_path_test) {
 
 TEST_F(JsonFunctionsTest, flat_json_invalid_null_path_test) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
-    auto json_col = JsonColumn::create();
+    JsonColumn::Ptr json_col = JsonColumn::create();
 
     std::string param_json = R"({"k1":1, "k2":"2"})";
     std::vector<std::string> param_flat_path = std::vector<std::string>{"k1", "k2"};
@@ -943,7 +943,7 @@ TEST_F(JsonFunctionsTest, flat_json_invalid_null_path_test) {
 
     Columns flat_columns;
 
-    auto flat_json = JsonColumn::create();
+    JsonColumn::Ptr flat_json = JsonColumn::create();
     auto* flat_json_ptr = down_cast<JsonColumn*>(flat_json.get());
 
     std::vector<LogicalType> param_flat_type;
@@ -959,7 +959,7 @@ TEST_F(JsonFunctionsTest, flat_json_invalid_null_path_test) {
     flat_json->assign(2, 0);
 
     if (!param_path.empty()) {
-        auto path_column = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+        NullableColumn::Ptr path_column = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
         path_column->append_nulls(2);
         columns.push_back(path_column);
     }
@@ -978,7 +978,7 @@ TEST_F(JsonFunctionsTest, flat_json_invalid_null_path_test) {
 
 TEST_F(JsonFunctionsTest, flat_json_constant_path_test) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
-    auto json_col = JsonColumn::create();
+    JsonColumn::Ptr json_col = JsonColumn::create();
 
     std::string param_json = R"({"k1":1, "k2":"2"})";
     std::vector<std::string> param_flat_path = std::vector<std::string>{"k1", "k2"};
@@ -990,7 +990,7 @@ TEST_F(JsonFunctionsTest, flat_json_constant_path_test) {
 
     Columns flat_columns;
 
-    auto flat_json = JsonColumn::create();
+    JsonColumn::Ptr flat_json = JsonColumn::create();
     auto* flat_json_ptr = down_cast<JsonColumn*>(flat_json.get());
 
     std::vector<LogicalType> param_flat_type;
@@ -1005,7 +1005,7 @@ TEST_F(JsonFunctionsTest, flat_json_constant_path_test) {
     columns.push_back(flat_json);
 
     if (!param_path.empty()) {
-        auto path_column = BinaryColumn::create();
+        BinaryColumn::Ptr path_column = BinaryColumn::create();
         path_column->append(param_path);
         columns.push_back(ConstColumn::create(path_column, 1));
     }
@@ -1027,7 +1027,7 @@ TEST_P(JsonParseTestFixture, json_parse) {
     auto [param_json, param_ok, expected] = GetParam();
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
 
-    auto ints = BinaryColumn::create();
+    BinaryColumn::Ptr ints = BinaryColumn::create();
     ints->append(param_json);
     Columns columns{ints};
     ctx.get()->set_constant_columns(columns);
@@ -1092,7 +1092,7 @@ TEST_P(JsonArrayTestFixture, json_array) {
     std::vector<std::string> param_json = std::get<0>(GetParam());
     std::string param_result = std::get<1>(GetParam());
     for (const auto& json_str : param_json) {
-        auto column = JsonColumn::create();
+        JsonColumn::Ptr column = JsonColumn::create();
         auto json = JsonValue::parse(json_str);
         ASSERT_TRUE(json.ok());
         column->append(&json.value());
@@ -1139,7 +1139,7 @@ TEST_P(JsonObjectTestFixture, json_object) {
     std::vector<std::string> param_json = std::get<0>(GetParam());
     std::string param_result = std::get<1>(GetParam());
     for (const auto& json_str : param_json) {
-        auto column = JsonColumn::create();
+        JsonColumn::Ptr column = JsonColumn::create();
         auto json = JsonValue::parse(json_str);
         ASSERT_TRUE(json.ok()) << "parse json failed: " << json_str;
         column->append(&json.value());
@@ -1235,7 +1235,7 @@ class JsonLengthTestFixture : public ::testing::TestWithParam<std::tuple<std::st
 
 TEST_P(JsonLengthTestFixture, json_length_test) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
-    auto json_column = JsonColumn::create();
+    JsonColumn::Ptr json_column = JsonColumn::create();
 
     std::string param_json = std::get<0>(GetParam());
     std::string param_path = std::get<1>(GetParam());
@@ -1248,7 +1248,7 @@ TEST_P(JsonLengthTestFixture, json_length_test) {
     Columns columns;
     columns.push_back(json_column);
     if (!param_path.empty()) {
-        auto path_column = BinaryColumn::create();
+        BinaryColumn::Ptr path_column = BinaryColumn::create();
         path_column->append(param_path);
         columns.push_back(path_column);
     }
@@ -1286,7 +1286,7 @@ class FlatJsonLengthTestFixture
 
 TEST_P(FlatJsonLengthTestFixture, flat_json_length_test) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
-    auto json_col = JsonColumn::create();
+    JsonColumn::Ptr json_col = JsonColumn::create();
 
     std::string param_json = std::get<0>(GetParam());
     std::vector<std::string> param_flat_path = std::get<1>(GetParam());
@@ -1299,7 +1299,7 @@ TEST_P(FlatJsonLengthTestFixture, flat_json_length_test) {
 
     Columns flat_columns;
 
-    auto flat_json = JsonColumn::create();
+    JsonColumn::Ptr flat_json = JsonColumn::create();
     auto* flat_json_ptr = down_cast<JsonColumn*>(flat_json.get());
 
     std::vector<LogicalType> param_flat_type;
@@ -1313,7 +1313,7 @@ TEST_P(FlatJsonLengthTestFixture, flat_json_length_test) {
     Columns columns;
     columns.push_back(flat_json);
     if (!param_path.empty()) {
-        auto path_column = BinaryColumn::create();
+        BinaryColumn::Ptr path_column = BinaryColumn::create();
         path_column->append(param_path);
         columns.push_back(path_column);
     }
@@ -1345,7 +1345,7 @@ class JsonKeysTestFixture : public ::testing::TestWithParam<std::tuple<std::stri
 
 TEST_P(JsonKeysTestFixture, json_keys) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
-    auto json_column = JsonColumn::create();
+    JsonColumn::Ptr json_column = JsonColumn::create();
 
     std::string param_json = std::get<0>(GetParam());
     std::string param_path = std::get<1>(GetParam());
@@ -1358,7 +1358,7 @@ TEST_P(JsonKeysTestFixture, json_keys) {
     Columns columns;
     columns.push_back(json_column);
     if (!param_path.empty()) {
-        auto path_column = BinaryColumn::create();
+        BinaryColumn::Ptr path_column = BinaryColumn::create();
         path_column->append(param_path);
         columns.push_back(path_column);
     }
@@ -1409,7 +1409,7 @@ class GetJsonXXXTestFixture : public ::testing::TestWithParam<GetJsonXXXParam> {
 public:
     StatusOr<Columns> setup() {
         _ctx = std::unique_ptr<FunctionContext>(FunctionContext::create_test_context());
-        auto ints = JsonColumn::create();
+        JsonColumn::Ptr ints = JsonColumn::create();
         ColumnBuilder<TYPE_VARCHAR> builder(1);
 
         std::string param_json = std::get<0>(GetParam());
@@ -1544,7 +1544,7 @@ TEST_F(JsonFunctionsTest, struct_to_json) {
     // Build struct column
     Columns fields{NullableColumn::create(Int64Column::create(), NullColumn::create()),
                    NullableColumn::create(BinaryColumn::create(), NullColumn::create())};
-    auto struct_column = StructColumn::create(fields, names);
+    StructColumn::Ptr struct_column = StructColumn::create(fields, names);
     struct_column->append_datum(DatumStruct{int64_t(1), Slice("park")});
     struct_column->append_datum(DatumStruct{int64_t(2), Slice("menlo")});
 
@@ -1569,9 +1569,9 @@ TEST_F(JsonFunctionsTest, map_to_json) {
 
     // Build MAP<int, string> column
     {
-        auto key_column = NullableColumn::create(Int64Column::create(), NullColumn::create());
-        auto val_column = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
-        auto struct_column = MapColumn::create(key_column, val_column, UInt32Column::create());
+        NullableColumn::Ptr key_column = NullableColumn::create(Int64Column::create(), NullColumn::create());
+        NullableColumn::Ptr val_column = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+        MapColumn::Ptr struct_column = MapColumn::create(key_column, val_column, UInt32Column::create());
 
         DatumMap map1;
         map1[int64_t(1)] = Slice("menlo");
@@ -1600,9 +1600,9 @@ TEST_F(JsonFunctionsTest, map_to_json) {
 
     // Build MAP<string, int> column
     {
-        auto key_column = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
-        auto val_column = NullableColumn::create(Int64Column::create(), NullColumn::create());
-        auto struct_column = MapColumn::create(key_column, val_column, UInt32Column::create());
+        NullableColumn::Ptr key_column = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+        NullableColumn::Ptr val_column = NullableColumn::create(Int64Column::create(), NullColumn::create());
+        MapColumn::Ptr struct_column = MapColumn::create(key_column, val_column, UInt32Column::create());
 
         DatumMap map1;
         map1[Slice("menlo")] = int64_t(1);

--- a/be/test/exprs/lambda_array_expr_test.cpp
+++ b/be/test/exprs/lambda_array_expr_test.cpp
@@ -63,25 +63,25 @@ public:
         array->append_datum(DatumArray{Datum((int32_t)1), Datum((int32_t)4)}); // [1,4]
         array->append_datum(DatumArray{Datum(), Datum()});                     // [NULL, NULL]
         array->append_datum(DatumArray{Datum(), Datum((int32_t)12)});          // [NULL, 12]
-        auto* array_values = new_fake_const_expr(array, type_arr_int);
+        auto* array_values = new_fake_const_expr(std::move(array), type_arr_int);
         _array_expr.push_back(array_values);
 
         // null
         array = ColumnHelper::create_column(type_arr_int, true);
         array->append_datum(Datum{}); // null
-        auto* const_null = new_fake_const_expr(array, type_arr_int);
+        auto* const_null = new_fake_const_expr(std::move(array), type_arr_int);
         _array_expr.push_back(const_null);
 
         // [null]
         array = ColumnHelper::create_column(type_arr_int, true);
         array->append_datum(DatumArray{Datum()});
-        auto* null_array = new_fake_const_expr(array, type_arr_int);
+        auto* null_array = new_fake_const_expr(std::move(array), type_arr_int);
         _array_expr.push_back(null_array);
 
         // []
         array = ColumnHelper::create_column(type_arr_int, true);
         array->append_datum(DatumArray{}); // []
-        auto empty_array = new_fake_const_expr(array, type_arr_int);
+        auto empty_array = new_fake_const_expr(std::move(array), type_arr_int);
         _array_expr.push_back(empty_array);
 
         // [null]
@@ -91,39 +91,39 @@ public:
         array->append_datum(DatumArray{Datum()}); // [null]
         array->append_datum(DatumArray{});        // []
         array->append_datum(Datum{});             // NULL
-        auto* array_special = new_fake_const_expr(array, type_arr_int);
+        auto* array_special = new_fake_const_expr(std::move(array), type_arr_int);
         _array_expr.push_back(array_special);
 
         // const([1,4]...)
         array = ColumnHelper::create_column(type_arr_int, false);
         array->append_datum(DatumArray{Datum((int32_t)1), Datum((int32_t)4)}); // [1,4]
-        auto const_col = ConstColumn::create(array, 3);
-        auto* const_array = new_fake_const_expr(const_col, type_arr_int);
+        auto const_col = ConstColumn::create(std::move(array), 3);
+        auto* const_array = new_fake_const_expr(std::move(const_col), type_arr_int);
         _array_expr.push_back(const_array);
 
         // const(null...)
         array = ColumnHelper::create_column(type_arr_int, true);
         array->append_datum(Datum{}); // null...
-        const_col = ConstColumn::create(array, 3);
-        const_array = new_fake_const_expr(const_col, type_arr_int);
+        const_col = ConstColumn::create(std::move(array), 3);
+        const_array = new_fake_const_expr(std::move(const_col), type_arr_int);
         _array_expr.push_back(const_array);
 
         // const([null]...)
         array = ColumnHelper::create_column(type_arr_int, false);
         array->append_datum(DatumArray{Datum()}); // [null]...
-        const_col = ConstColumn::create(array, 3);
-        const_array = new_fake_const_expr(const_col, type_arr_int);
+        const_col = ConstColumn::create(std::move(array), 3);
+        const_array = new_fake_const_expr(std::move(const_col), type_arr_int);
         _array_expr.push_back(const_array);
 
         // const([]...)
         array = ColumnHelper::create_column(type_arr_int, false);
         array->append_datum(DatumArray{}); // []...
-        const_col = ConstColumn::create(array, 3);
-        const_array = new_fake_const_expr(const_col, type_arr_int);
+        const_col = ConstColumn::create(std::move(array), 3);
+        const_array = new_fake_const_expr(std::move(const_col), type_arr_int);
         _array_expr.push_back(const_array);
     }
 
-    FakeConstExpr* new_fake_const_expr(ColumnPtr value, const TypeDescriptor& type) {
+    FakeConstExpr* new_fake_const_expr(MutableColumnPtr&& value, const TypeDescriptor& type) {
         TExprNode node;
         node.__set_node_type(TExprNodeType::INT_LITERAL);
         node.__set_num_children(0);
@@ -480,7 +480,7 @@ TEST_F(VectorizedLambdaFunctionExprTest, array_map_lambda_test_const_array) {
                 if (data_column->is_nullable()) {
                     data_column = down_cast<NullableColumn*>(data_column.get())->data_column();
                 }
-                auto array_col = std::dynamic_pointer_cast<ArrayColumn>(data_column);
+                auto array_col = ArrayColumn::dynamic_pointer_cast(data_column);
                 ASSERT_EQ(2, array_col->elements_column()->type_size());
             }
             Expr::close(expr_ctxs, &_runtime_state);

--- a/be/test/exprs/lambda_map_expr_test.cpp
+++ b/be/test/exprs/lambda_map_expr_test.cpp
@@ -170,7 +170,7 @@ TEST_F(MapApplyExprTest, test_map_int_int) {
     type_map_int_int.children.emplace_back(TypeDescriptor(LogicalType::TYPE_INT));
 
     create_lambda_expr(type_map_int_int);
-    auto column = ColumnHelper::create_column(type_map_int_int, true);
+    ColumnPtr column = ColumnHelper::create_column(type_map_int_int, true);
 
     DatumMap map1;
     map1[(int32_t)1] = (int32_t)44;
@@ -270,7 +270,7 @@ TEST_F(MapApplyExprTest, test_map_varchar_int) {
     type_varchar.len = 10;
     create_lambda_expr(type_map_varchar_int);
 
-    auto column = ColumnHelper::create_column(type_map_varchar_int, false);
+    ColumnPtr column = ColumnHelper::create_column(type_map_varchar_int, false);
 
     DatumMap map;
     map[(Slice) "a"] = (int32_t)11;

--- a/be/test/exprs/like_test.cpp
+++ b/be/test/exprs/like_test.cpp
@@ -51,8 +51,8 @@ TEST_F(LikeTest, startConstPatternLike) {
         str->append("test" + std::to_string(j));
     }
 
-    columns.push_back(str);
-    columns.push_back(pattern);
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(pattern));
 
     context->set_constant_columns(columns);
 
@@ -90,8 +90,8 @@ TEST_F(LikeTest, endConstPatternLike) {
         null->append(j % 2 == 0);
     }
 
-    columns.push_back(NullableColumn::create(str, null));
-    columns.push_back(pattern);
+    columns.push_back(NullableColumn::create(std::move(str), std::move(null)));
+    columns.emplace_back(std::move(pattern));
 
     context->set_constant_columns(columns);
 
@@ -134,8 +134,8 @@ TEST_F(LikeTest, substringConstPatternLike) {
         str->append(std::to_string(j) + "test" + std::to_string(j));
     }
 
-    columns.push_back(str);
-    columns.push_back(pattern);
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(pattern));
 
     context->set_constant_columns(columns);
 
@@ -167,8 +167,8 @@ TEST_F(LikeTest, haystackConstantLike) {
     auto haystack = ColumnHelper::create_const_column<TYPE_VARCHAR>("CHINA", 1);
     auto pattern = ColumnHelper::create_const_column<TYPE_VARCHAR>("%IN%", 1);
 
-    columns.push_back(haystack);
-    columns.push_back(pattern);
+    columns.emplace_back(std::move(haystack));
+    columns.emplace_back(std::move(pattern));
 
     context->set_constant_columns(columns);
 
@@ -202,8 +202,8 @@ TEST_F(LikeTest, haystackConstantLikeLargerThanHyperscan) {
 
     auto pattern = ColumnHelper::create_const_column<TYPE_VARCHAR>(large_pattern, 1);
 
-    columns.push_back(haystack);
-    columns.push_back(pattern);
+    columns.emplace_back(std::move(haystack));
+    columns.emplace_back(std::move(pattern));
 
     context->set_constant_columns(columns);
 
@@ -238,8 +238,8 @@ TEST_F(LikeTest, haystackNullableLike) {
         }
     }
 
-    columns.push_back(NullableColumn::create(haystack, null));
-    columns.push_back(pattern);
+    columns.push_back(NullableColumn::create(std::move(haystack), std::move(null)));
+    columns.emplace_back(std::move(pattern));
     context->set_constant_columns(columns);
 
     ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
@@ -276,8 +276,8 @@ TEST_F(LikeTest, patternEmptyLike) {
         str->append("test");
     }
 
-    columns.push_back(str);
-    columns.push_back(pattern);
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(pattern));
 
     context->set_constant_columns(columns);
 
@@ -309,8 +309,8 @@ TEST_F(LikeTest, patternStrAndPatternBothEmptyLike) {
         str->append("");
     }
 
-    columns.push_back(str);
-    columns.push_back(pattern);
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(pattern));
 
     context->set_constant_columns(columns);
 
@@ -343,8 +343,8 @@ TEST_F(LikeTest, patternStrAndPatternBothEmptyExplicitNullPtrLike) {
         str->append(Slice(null_ptr, 0));
     }
 
-    columns.push_back(str);
-    columns.push_back(pattern);
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(pattern));
 
     context->set_constant_columns(columns);
 
@@ -372,8 +372,8 @@ TEST_F(LikeTest, patternOnlyNullLike) {
     auto str = ColumnHelper::create_const_null_column(1);
     auto pattern = ColumnHelper::create_const_column<TYPE_VARCHAR>("%Test%", 1);
 
-    columns.push_back(str);
-    columns.push_back(pattern);
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(pattern));
 
     context->set_constant_columns(columns);
 
@@ -406,8 +406,8 @@ TEST_F(LikeTest, rowsPatternLike) {
         }
     }
 
-    columns.push_back(str);
-    columns.push_back(pattern);
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(pattern));
 
     context->set_constant_columns(columns);
 
@@ -453,8 +453,8 @@ TEST_F(LikeTest, rowsNullablePatternLike) {
         }
     }
 
-    columns.push_back(str);
-    columns.push_back(NullableColumn::create(pattern, null));
+    columns.emplace_back(std::move(str));
+    columns.push_back(NullableColumn::create(std::move(pattern), std::move(null)));
 
     context->set_constant_columns(columns);
 
@@ -494,8 +494,8 @@ TEST_F(LikeTest, rowsPatternRegex) {
         pattern->append(".+\\d\\d");
     }
 
-    columns.push_back(str);
-    columns.push_back(pattern);
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(pattern));
 
     context->set_constant_columns(columns);
 
@@ -611,8 +611,8 @@ TEST_F(LikeTest, constValueRegexpLargerThanHyperscan) {
 
     auto pattern = ColumnHelper::create_const_column<TYPE_VARCHAR>(large_pattern, 1);
 
-    columns.push_back(haystack);
-    columns.push_back(pattern);
+    columns.emplace_back(std::move(haystack));
+    columns.emplace_back(std::move(pattern));
 
     context->set_constant_columns(columns);
 
@@ -644,8 +644,8 @@ TEST_F(LikeTest, constValueLikeComplicateForHyperscan) {
             "增|毛|胖|牙|奶|肉|毒|暑|总).{0,5}(永)";
     auto pattern = ColumnHelper::create_const_column<TYPE_VARCHAR>(large_pattern, 1);
 
-    columns.push_back(haystack);
-    columns.push_back(pattern);
+    columns.emplace_back(std::move(haystack));
+    columns.emplace_back(std::move(pattern));
 
     context->set_constant_columns(columns);
 

--- a/be/test/exprs/map_element_expr_test.cpp
+++ b/be/test/exprs/map_element_expr_test.cpp
@@ -29,13 +29,13 @@
 namespace starrocks {
 namespace {
 
-ColumnPtr const_int_column(int32_t value, size_t size = 1) {
+MutableColumnPtr const_int_column(int32_t value, size_t size = 1) {
     auto data = Int32Column::create();
     data->append(value);
     return ConstColumn::create(std::move(data), size);
 }
 
-ColumnPtr const_varchar_column(const std::string& value, size_t size = 1) {
+MutableColumnPtr const_varchar_column(const std::string& value, size_t size = 1) {
     auto data = BinaryColumn::create();
     data->append_string(value);
     return ConstColumn::create(std::move(data), size);
@@ -95,7 +95,7 @@ TEST_F(MapElementExprTest, test_map_int_int) {
 
     TypeDescriptor type_int(LogicalType::TYPE_INT);
 
-    auto column = ColumnHelper::create_column(type_map_int_int, false);
+    ColumnPtr column = ColumnHelper::create_column(type_map_int_int, false);
 
     DatumMap map;
     map[(int32_t)1] = (int32_t)11;
@@ -253,7 +253,7 @@ TEST_F(MapElementExprTest, test_map_varchar_int) {
 
     TypeDescriptor type_int(LogicalType::TYPE_INT);
 
-    auto column = ColumnHelper::create_column(type_map_varchar_int, true);
+    ColumnPtr column = ColumnHelper::create_column(type_map_varchar_int, true);
 
     DatumMap map;
     map[(Slice) "a"] = (int32_t)11;
@@ -372,7 +372,7 @@ TEST_F(MapElementExprTest, test_map_const) {
 
     TypeDescriptor type_int(LogicalType::TYPE_INT);
 
-    auto column = ColumnHelper::create_column(type_map_int_int, false);
+    ColumnPtr column = ColumnHelper::create_column(type_map_int_int, false);
 
     DatumMap map;
     map[(int32_t)1] = (int32_t)11;
@@ -453,7 +453,7 @@ TEST_F(MapElementExprTest, test_map_const) {
     //   33
 
     {
-        auto const_map = ConstColumn::create(column->clone(), column->size());
+        ColumnPtr const_map = ConstColumn::create(column->clone(), column->size());
         std::unique_ptr<Expr> expr = create_map_element_expr(type_int);
 
         expr->add_child(new_fake_col_expr(const_map, type_map_int_int));
@@ -477,14 +477,14 @@ TEST_F(MapElementExprTest, test_const_map_int_variable_int) {
 
     TypeDescriptor type_int(LogicalType::TYPE_INT);
 
-    auto column = ColumnHelper::create_column(type_map_int_int, false);
+    ColumnPtr column = ColumnHelper::create_column(type_map_int_int, false);
 
     DatumMap map;
     map[(int32_t)1] = (int32_t)11;
     map[(int32_t)2] = (int32_t)22;
     map[(int32_t)3] = (int32_t)33;
     column->append_datum(map);
-    auto const_column = ConstColumn::create(column->clone(), 1);
+    ColumnPtr const_column = ConstColumn::create(column->clone(), 1);
 
     // Inputs:
     //   c0
@@ -502,7 +502,7 @@ TEST_F(MapElementExprTest, test_const_map_int_variable_int) {
     //   11
     //   22
     //   33
-    auto key = RunTimeColumnType<TYPE_INT>::create();
+    RunTimeColumnType<TYPE_INT>::Ptr key = RunTimeColumnType<TYPE_INT>::create();
     key->append(1);
     key->append(2);
     key->append(3);
@@ -540,7 +540,7 @@ TEST_F(MapElementExprTest, test_map_null_key) {
 
     TypeDescriptor type_int(LogicalType::TYPE_INT);
 
-    auto column = ColumnHelper::create_column(type_map_varchar_int, false);
+    ColumnPtr column = ColumnHelper::create_column(type_map_varchar_int, false);
 
     DatumMap map;
     map[(Slice) "a"] = (int32_t)11;

--- a/be/test/exprs/map_functions_test.cpp
+++ b/be/test/exprs/map_functions_test.cpp
@@ -40,7 +40,7 @@ PARALLEL_TEST(MapFunctionsTest, test_map) {
     input_values_type.type = LogicalType::TYPE_ARRAY;
     input_values_type.children.emplace_back(LogicalType::TYPE_VARCHAR);
 
-    auto input_keys = ColumnHelper::create_column(input_keys_type, true);
+    ColumnPtr input_keys = ColumnHelper::create_column(input_keys_type, true);
     // keys:   [[1,2,3], NULL, [4,5], [6,7], NULL, [9]]
     // values: [[a,b,c], [d],   NULL, [f,g], NULL, [h]]
     {
@@ -69,7 +69,7 @@ PARALLEL_TEST(MapFunctionsTest, test_map) {
             input_keys->append_datum(datum);
         }
     }
-    auto input_values = ColumnHelper::create_column(input_values_type, true);
+    ColumnPtr input_values = ColumnHelper::create_column(input_values_type, true);
     {
         // [a,b,c]
         {
@@ -118,7 +118,7 @@ PARALLEL_TEST(MapFunctionsTest, test_map_mismatch1) {
     input_values_type.type = LogicalType::TYPE_ARRAY;
     input_values_type.children.emplace_back(LogicalType::TYPE_VARCHAR);
 
-    auto input_keys = ColumnHelper::create_column(input_keys_type, true);
+    ColumnPtr input_keys = ColumnHelper::create_column(input_keys_type, true);
     // keys:   [[1,2,3], NULL, [4,5]]
     // values: [[a,b,c], [d],  [h]]
     {
@@ -135,7 +135,7 @@ PARALLEL_TEST(MapFunctionsTest, test_map_mismatch1) {
             input_keys->append_datum(datum);
         }
     }
-    auto input_values = ColumnHelper::create_column(input_values_type, true);
+    ColumnPtr input_values = ColumnHelper::create_column(input_values_type, true);
     {
         // [a,b,c]
         {
@@ -166,7 +166,7 @@ PARALLEL_TEST(MapFunctionsTest, test_map_mismatch2) {
     input_values_type.type = LogicalType::TYPE_ARRAY;
     input_values_type.children.emplace_back(LogicalType::TYPE_VARCHAR);
 
-    auto input_keys = ColumnHelper::create_column(input_keys_type, true);
+    ColumnPtr input_keys = ColumnHelper::create_column(input_keys_type, true);
     // keys:   [[1,2,3]]
     // values: [[a]]
     {
@@ -176,7 +176,7 @@ PARALLEL_TEST(MapFunctionsTest, test_map_mismatch2) {
             input_keys->append_datum(datum);
         }
     }
-    auto input_values = ColumnHelper::create_column(input_values_type, true);
+    ColumnPtr input_values = ColumnHelper::create_column(input_values_type, true);
     {
         // [a]
         {
@@ -191,7 +191,7 @@ PARALLEL_TEST(MapFunctionsTest, test_map_mismatch2) {
 PARALLEL_TEST(MapFunctionsTest, test_map_function) {
     TypeDescriptor type_map_int_int = map_type(TYPE_INT, TYPE_INT);
 
-    auto column = ColumnHelper::create_column(type_map_int_int, true);
+    ColumnPtr column = ColumnHelper::create_column(type_map_int_int, true);
 
     DatumMap map;
     map[(int32_t)1] = (int32_t)11;
@@ -328,7 +328,7 @@ PARALLEL_TEST(MapFunctionsTest, test_map_function) {
 PARALLEL_TEST(MapFunctionsTest, test_map_filter_int_nullable) {
     TypeDescriptor type_map_int_int = map_type(TYPE_INT, TYPE_INT);
 
-    auto map_column_nullable = ColumnHelper::create_column(type_map_int_int, true);
+    ColumnPtr map_column_nullable = ColumnHelper::create_column(type_map_int_int, true);
     {
         //   [1->44, 2->55, 4->66]
         //   [2->77, 3->88]
@@ -356,7 +356,7 @@ PARALLEL_TEST(MapFunctionsTest, test_map_filter_int_nullable) {
         map_column_nullable->append_datum(Datum{});
     }
 
-    auto map_column_not_nullable = ColumnHelper::create_column(type_map_int_int, false);
+    ColumnPtr map_column_not_nullable = ColumnHelper::create_column(type_map_int_int, false);
     {
         //   [1->44, 2->55, 4->66]
         //   [2->77, 3->88]
@@ -390,7 +390,7 @@ PARALLEL_TEST(MapFunctionsTest, test_map_filter_int_nullable) {
     // [false]
     // [NULL]
     // [true]
-    auto bool_array_not_nullable = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
+    ColumnPtr bool_array_not_nullable = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
     bool_array_not_nullable->append_datum(DatumArray{Datum(), true, false});
     bool_array_not_nullable->append_datum(DatumArray{});
     bool_array_not_nullable->append_datum(DatumArray{false});
@@ -402,7 +402,7 @@ PARALLEL_TEST(MapFunctionsTest, test_map_filter_int_nullable) {
     // [false]
     // [null]
     // [false, null]
-    auto bool_array_nullable = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, true);
+    ColumnPtr bool_array_nullable = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, true);
     bool_array_nullable->append_datum(DatumArray{Datum(), true, false});
     bool_array_nullable->append_datum(Datum{});
     bool_array_nullable->append_datum(DatumArray{false});
@@ -429,7 +429,7 @@ PARALLEL_TEST(MapFunctionsTest, test_map_filter_int_nullable) {
         EXPECT_FALSE(result->is_nullable());
         EXPECT_STREQ(result->debug_string().c_str(), "{2:55}, {}, {}, {}, {}");
     }
-    auto only_null_column = ColumnHelper::create_const_null_column(1);
+    ColumnPtr only_null_column = ColumnHelper::create_const_null_column(1);
     {
         auto result = MapFunctions::map_filter(nullptr, {map_column_nullable, only_null_column}).value();
         EXPECT_TRUE(result->is_nullable());
@@ -450,14 +450,14 @@ PARALLEL_TEST(MapFunctionsTest, test_map_filter_int_nullable) {
 // NOLINTNEXTLINE
 PARALLEL_TEST(MapFunctionsTest, test_distinct_map_keys) {
     {
-        auto offsets = UInt32Column::create();
-        auto keys_data = Int32Column::create();
-        auto keys_null = NullColumn::create();
-        auto keys = NullableColumn::create(keys_data, keys_null);
-        auto values_data = Int32Column::create();
-        auto values_null = NullColumn::create();
-        auto values = NullableColumn::create(values_data, values_null);
-        auto column = MapColumn::create(keys, values, offsets);
+        UInt32Column::Ptr offsets = UInt32Column::create();
+        Int32Column::Ptr keys_data = Int32Column::create();
+        NullColumn::Ptr keys_null = NullColumn::create();
+        NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+        Int32Column::Ptr values_data = Int32Column::create();
+        NullColumn::Ptr values_null = NullColumn::create();
+        NullableColumn::Ptr values = NullableColumn::create(values_data, values_null);
+        MapColumn::Ptr column = MapColumn::create(keys, values, offsets);
 
         DatumMap map;
         map[(int32_t)1] = (int32_t)11;
@@ -486,14 +486,14 @@ PARALLEL_TEST(MapFunctionsTest, test_distinct_map_keys) {
         ASSERT_EQ("{}", res->debug_item(3));
     }
     {
-        auto offsets = UInt32Column::create();
-        auto keys_data = BinaryColumn::create();
-        auto keys_null = NullColumn::create();
-        auto keys = NullableColumn::create(keys_data, keys_null);
-        auto values_data = BinaryColumn::create();
-        auto null_column = NullColumn::create();
-        auto values = NullableColumn::create(values_data, null_column);
-        auto column = MapColumn::create(keys, values, offsets);
+        UInt32Column::Ptr offsets = UInt32Column::create();
+        BinaryColumn::Ptr keys_data = BinaryColumn::create();
+        NullColumn::Ptr keys_null = NullColumn::create();
+        NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+        BinaryColumn::Ptr values_data = BinaryColumn::create();
+        NullColumn::Ptr null_column = NullColumn::create();
+        NullableColumn::Ptr values = NullableColumn::create(values_data, null_column);
+        MapColumn::Ptr column = MapColumn::create(keys, values, offsets);
 
         DatumMap map;
         map[(Slice) "a"] = (Slice) "hello";
@@ -512,14 +512,14 @@ PARALLEL_TEST(MapFunctionsTest, test_distinct_map_keys) {
         ASSERT_EQ("{'def':'haha','g h':'let's dance'}", res->debug_item(1));
     }
     { // nested map
-        auto offsets = UInt32Column::create();
-        auto keys_data = Int32Column::create();
-        auto keys_null = NullColumn::create();
-        auto keys = NullableColumn::create(keys_data, keys_null);
-        auto values_data = Int32Column::create();
-        auto values_null = NullColumn::create();
-        auto values = NullableColumn::create(values_data, values_null);
-        auto column = MapColumn::create(keys, values, offsets);
+        UInt32Column::Ptr offsets = UInt32Column::create();
+        Int32Column::Ptr keys_data = Int32Column::create();
+        NullColumn::Ptr keys_null = NullColumn::create();
+        NullableColumn::Ptr keys = NullableColumn::create(keys_data, keys_null);
+        Int32Column::Ptr values_data = Int32Column::create();
+        NullColumn::Ptr values_null = NullColumn::create();
+        NullableColumn::Ptr values = NullableColumn::create(values_data, values_null);
+        MapColumn::Ptr column = MapColumn::create(keys, values, offsets);
 
         DatumMap map;
         map[(int32_t)1] = (int32_t)11;
@@ -540,7 +540,7 @@ PARALLEL_TEST(MapFunctionsTest, test_distinct_map_keys) {
         // {} empty
         column->append_datum(DatumMap());
 
-        auto nest_offsets = UInt32Column::create();
+        UInt32Column::Ptr nest_offsets = UInt32Column::create();
         auto nest_keys = keys->clone_empty();
         nest_keys->append_datum(1);
         nest_keys->append_datum(1);
@@ -562,7 +562,7 @@ PARALLEL_TEST(MapFunctionsTest, test_distinct_map_keys) {
 PARALLEL_TEST(MapFunctionsTest, test_map_concat) {
     TypeDescriptor type_map_int_int = map_type(TYPE_INT, TYPE_INT);
 
-    auto map_column_nullable = ColumnHelper::create_column(type_map_int_int, true);
+    ColumnPtr map_column_nullable = ColumnHelper::create_column(type_map_int_int, true);
     {
         //   [11->44, 2->55, 4->66]
         //   [2->77, 3->88]
@@ -590,7 +590,7 @@ PARALLEL_TEST(MapFunctionsTest, test_map_concat) {
         map_column_nullable->append_datum(Datum{});
     }
 
-    auto map_column_not_nullable = ColumnHelper::create_column(type_map_int_int, false);
+    ColumnPtr map_column_not_nullable = ColumnHelper::create_column(type_map_int_int, false);
     {
         //   [1->44, 2->55, 4->66]
         //   [2->77, 3->88]
@@ -617,11 +617,11 @@ PARALLEL_TEST(MapFunctionsTest, test_map_concat) {
         map_column_not_nullable->append_datum(DatumMap());
     }
 
-    auto only_null_column = ColumnHelper::create_const_null_column(5);
+    ColumnPtr only_null_column = ColumnHelper::create_const_null_column(5);
 
-    auto mapn = down_cast<NullableColumn*>(map_column_nullable->clone_shared().get())->data_column();
+    auto mapn = down_cast<NullableColumn*>(map_column_nullable->clone().get())->data_column();
 
-    auto const_column = ConstColumn::create(mapn, 5);
+    ConstColumn::Ptr const_column = ConstColumn::create(mapn, 5);
 
     {
         auto result = MapFunctions::map_concat(nullptr, {map_column_nullable, map_column_not_nullable}).value();

--- a/be/test/exprs/math_functions_test.cpp
+++ b/be/test/exprs/math_functions_test.cpp
@@ -46,8 +46,8 @@ TEST_F(VecMathFunctionsTest, truncateTest) {
             c1->append(ints[i]);
         }
 
-        columns.emplace_back(c0);
-        columns.emplace_back(c1);
+        columns.emplace_back(std::move(c0));
+        columns.emplace_back(std::move(c1));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr res = MathFunctions::truncate(ctx.get(), columns).value();
@@ -70,8 +70,8 @@ TEST_F(VecMathFunctionsTest, truncateNanTest) {
         c0->append(0);
         c1->append(1591994755);
 
-        columns.emplace_back(c0);
-        columns.emplace_back(c1);
+        columns.emplace_back(std::move(c0));
+        columns.emplace_back(std::move(c1));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr res = MathFunctions::truncate(ctx.get(), columns).value();
@@ -144,11 +144,11 @@ static void testRoundDecimal(const std::vector<std::string>& arg0_values, const 
         // ConstColumn
         c0_const = true;
         arg0_data_column->resize(1);
-        c0 = ConstColumn::create(arg0_data_column, arg0_values.size());
+        c0 = ConstColumn::create(std::move(arg0_data_column), arg0_values.size());
     } else {
         if (arg0_null_flags.empty()) {
             // normal Column
-            c0 = arg0_data_column;
+            c0 = std::move(arg0_data_column);
         } else {
             // NullableColumn
             c0_nullable = true;
@@ -156,7 +156,7 @@ static void testRoundDecimal(const std::vector<std::string>& arg0_values, const 
             for (int i = 0; i < arg0_values.size(); i++) {
                 null_flags->append(arg0_null_flags[i]);
             }
-            c0 = NullableColumn::create(arg0_data_column, null_flags);
+            c0 = NullableColumn::create(std::move(arg0_data_column), std::move(null_flags));
         }
     }
 
@@ -172,11 +172,11 @@ static void testRoundDecimal(const std::vector<std::string>& arg0_values, const 
         // ConstColumn
         c1_const = true;
         arg1_data_column->resize(1);
-        c1 = ConstColumn::create(arg1_data_column, arg1_values.size());
+        c1 = ConstColumn::create(std::move(arg1_data_column), arg1_values.size());
     } else {
         if (arg1_null_flags.empty()) {
             // normal Column
-            c1 = arg1_data_column;
+            c1 = std::move(arg1_data_column);
         } else {
             // NullableColumn
             c1_nullable = true;
@@ -184,16 +184,16 @@ static void testRoundDecimal(const std::vector<std::string>& arg0_values, const 
             for (int i = 0; i < arg1_values.size(); i++) {
                 null_flags->append(arg1_null_flags[i]);
             }
-            c1 = NullableColumn::create(arg1_data_column, null_flags);
+            c1 = NullableColumn::create(std::move(arg1_data_column), std::move(null_flags));
         }
     }
 
-    columns.emplace_back(c0);
+    columns.emplace_back(std::move(c0));
     if (type == TYPE_ROUND) {
         c1_const = true;
         c1_nullable = false;
     } else {
-        columns.emplace_back(c1);
+        columns.emplace_back(std::move(c1));
     }
 
     FunctionContext::TypeDesc return_type;
@@ -415,8 +415,8 @@ TEST_F(VecMathFunctionsTest, RoundUpToTest) {
             tc2->append(ints[i]);
         }
 
-        columns.emplace_back(tc1);
-        columns.emplace_back(tc2);
+        columns.emplace_back(std::move(tc1));
+        columns.emplace_back(std::move(tc2));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result = MathFunctions::round_up_to(ctx.get(), columns).value();
@@ -446,8 +446,8 @@ TEST_F(VecMathFunctionsTest, RoundUpToHalfwayCasesWithPositiveTest) {
             tc2->append(ints[i]);
         }
 
-        columns.emplace_back(tc1);
-        columns.emplace_back(tc2);
+        columns.emplace_back(std::move(tc1));
+        columns.emplace_back(std::move(tc2));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result = MathFunctions::round_up_to(ctx.get(), columns).value();
@@ -477,8 +477,8 @@ TEST_F(VecMathFunctionsTest, RoundUpToHalfwayCasesWithNegativeTest) {
             tc2->append(ints[i]);
         }
 
-        columns.emplace_back(tc1);
-        columns.emplace_back(tc2);
+        columns.emplace_back(std::move(tc1));
+        columns.emplace_back(std::move(tc2));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result = MathFunctions::round_up_to(ctx.get(), columns).value();
@@ -505,7 +505,7 @@ TEST_F(VecMathFunctionsTest, BinTest) {
             tc1->append(i);
         }
 
-        columns.emplace_back(tc1);
+        columns.emplace_back(std::move(tc1));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result = MathFunctions::bin(ctx.get(), columns).value();
@@ -545,8 +545,8 @@ TEST_F(VecMathFunctionsTest, LeastDecimalTest) {
         }
     }
 
-    columns.emplace_back(tc1);
-    columns.emplace_back(tc2);
+    columns.emplace_back(std::move(tc1));
+    columns.emplace_back(std::move(tc2));
 
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     ColumnPtr result = MathFunctions::template least<TYPE_DECIMALV2>(ctx.get(), columns).value();
@@ -591,8 +591,8 @@ TEST_F(VecMathFunctionsTest, GreatestDecimalTest) {
         }
     }
 
-    columns.emplace_back(tc1);
-    columns.emplace_back(tc2);
+    columns.emplace_back(std::move(tc1));
+    columns.emplace_back(std::move(tc2));
 
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     ColumnPtr result = MathFunctions::template greatest<TYPE_DECIMALV2>(ctx.get(), columns).value();
@@ -625,7 +625,7 @@ TEST_F(VecMathFunctionsTest, PositiveDecimalTest) {
         }
     }
 
-    columns.emplace_back(tc1);
+    columns.emplace_back(std::move(tc1));
 
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     ColumnPtr result = MathFunctions::template positive<TYPE_DECIMALV2>(ctx.get(), columns).value();
@@ -658,7 +658,7 @@ TEST_F(VecMathFunctionsTest, NegativeDecimalTest) {
         }
     }
 
-    columns.emplace_back(tc1);
+    columns.emplace_back(std::move(tc1));
 
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     ColumnPtr result = MathFunctions::template negative<TYPE_DECIMALV2>(ctx.get(), columns).value();
@@ -703,8 +703,8 @@ TEST_F(VecMathFunctionsTest, ModDecimalGeneralTest) {
         }
     }
 
-    columns.emplace_back(tc1);
-    columns.emplace_back(tc2);
+    columns.emplace_back(std::move(tc1));
+    columns.emplace_back(std::move(tc2));
 
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     ColumnPtr result = MathFunctions::template mod<TYPE_DECIMALV2>(ctx.get(), columns).value();
@@ -752,8 +752,8 @@ TEST_F(VecMathFunctionsTest, ModDecimalBigTest) {
         }
     }
 
-    columns.emplace_back(tc1);
-    columns.emplace_back(tc2);
+    columns.emplace_back(std::move(tc1));
+    columns.emplace_back(std::move(tc2));
 
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     ColumnPtr result = MathFunctions::template mod<TYPE_DECIMALV2>(ctx.get(), columns).value();
@@ -821,9 +821,9 @@ TEST_F(VecMathFunctionsTest, Conv_intTest) {
             tc3->append(destints[i]);
         }
 
-        columns.emplace_back(tc1);
-        columns.emplace_back(tc2);
-        columns.emplace_back(tc3);
+        columns.emplace_back(std::move(tc1));
+        columns.emplace_back(std::move(tc2));
+        columns.emplace_back(std::move(tc3));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result = MathFunctions::conv_int(ctx.get(), columns).value();
@@ -924,9 +924,9 @@ TEST_F(VecMathFunctionsTest, Conv_stringTest) {
             tc3->append(destints[i]);
         }
 
-        columns.emplace_back(tc1);
-        columns.emplace_back(tc2);
-        columns.emplace_back(tc3);
+        columns.emplace_back(std::move(tc1));
+        columns.emplace_back(std::move(tc2));
+        columns.emplace_back(std::move(tc3));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result = MathFunctions::conv_string(ctx.get(), columns).value();
@@ -947,7 +947,7 @@ TEST_F(VecMathFunctionsTest, LnTest) {
         tc1->append(0);
         tc1->append(2.0);
         tc1->append(-1);
-        columns.emplace_back(tc1);
+        columns.emplace_back(std::move(tc1));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result_log10 = MathFunctions::log10(ctx.get(), columns).value();
@@ -972,7 +972,7 @@ TEST_F(VecMathFunctionsTest, ExpTest) {
         tc1->append(2.0);
         tc1->append(709.0);
 
-        columns.emplace_back(tc1);
+        columns.emplace_back(std::move(tc1));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result_exp = MathFunctions::exp(ctx.get(), columns).value();
@@ -992,7 +992,7 @@ TEST_F(VecMathFunctionsTest, InfNanTest) {
         tc1->append(710.0);
         tc1->append(2.47498282E8);
         tc1->append(2.47498282E3);
-        columns.emplace_back(tc1);
+        columns.emplace_back(std::move(tc1));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result_exp = MathFunctions::exp(ctx.get(), columns).value();
@@ -1009,14 +1009,14 @@ TEST_F(VecMathFunctionsTest, InfNanTest) {
         tc1->append(0.2);
         tc1->append(0.3);
         tc1->append(4.0);
-        binary_columns.emplace_back(tc1);
+        binary_columns.emplace_back(std::move(tc1));
 
         auto tc2 = DoubleColumn::create();
         tc2->append(0.8);
         tc2->append(0.2);
         tc2->append(0.3);
         tc2->append(1024.0);
-        binary_columns.emplace_back(tc2);
+        binary_columns.emplace_back(std::move(tc2));
 
         std::vector<bool> null_expect = {true, false, false, true};
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
@@ -1038,7 +1038,7 @@ TEST_F(VecMathFunctionsTest, CbrtTest) {
     tc1->append(8);
     tc1->append(3.1415);
     tc1->append(-3.1415);
-    columns.emplace_back(tc1);
+    columns.emplace_back(std::move(tc1));
 
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     ColumnPtr results = MathFunctions::cbrt(ctx.get(), columns).value();
@@ -1059,7 +1059,7 @@ TEST_F(VecMathFunctionsTest, squareTest) {
         tc1->append(2.0);
         tc1->append(-1);
         tc1->append(std::nan("not a double number"));
-        columns.emplace_back(tc1);
+        columns.emplace_back(std::move(tc1));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result_square = MathFunctions::square(ctx.get(), columns).value();
@@ -1083,7 +1083,7 @@ TEST_F(VecMathFunctionsTest, AbsTest) {
             tc1->append(input);
         }
 
-        columns.emplace_back(tc1);
+        columns.emplace_back(std::move(tc1));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result = MathFunctions::abs_tinyint(ctx.get(), columns).value();
@@ -1106,7 +1106,7 @@ TEST_F(VecMathFunctionsTest, AbsTest) {
             tc1->append(input);
         }
 
-        columns.emplace_back(tc1);
+        columns.emplace_back(std::move(tc1));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result = MathFunctions::abs_smallint(ctx.get(), columns).value();
@@ -1129,7 +1129,7 @@ TEST_F(VecMathFunctionsTest, AbsTest) {
             tc1->append(input);
         }
 
-        columns.emplace_back(tc1);
+        columns.emplace_back(std::move(tc1));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result = MathFunctions::abs_int(ctx.get(), columns).value();
@@ -1154,7 +1154,7 @@ TEST_F(VecMathFunctionsTest, AbsTest) {
             tc1->append(input);
         }
 
-        columns.emplace_back(tc1);
+        columns.emplace_back(std::move(tc1));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result = MathFunctions::abs_bigint(ctx.get(), columns).value();
@@ -1179,7 +1179,7 @@ TEST_F(VecMathFunctionsTest, AbsTest) {
             tc1->append(input);
         }
 
-        columns.emplace_back(tc1);
+        columns.emplace_back(std::move(tc1));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result = MathFunctions::abs_largeint(ctx.get(), columns).value();
@@ -1202,7 +1202,7 @@ TEST_F(VecMathFunctionsTest, AbsTest) {
             tc1->append(input);
         }
 
-        columns.emplace_back(tc1);
+        columns.emplace_back(std::move(tc1));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result = MathFunctions::abs_double(ctx.get(), columns).value();
@@ -1225,7 +1225,7 @@ TEST_F(VecMathFunctionsTest, AbsTest) {
             tc1->append(input);
         }
 
-        columns.emplace_back(tc1);
+        columns.emplace_back(std::move(tc1));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result = MathFunctions::abs_float(ctx.get(), columns).value();
@@ -1252,7 +1252,7 @@ TEST_F(VecMathFunctionsTest, AbsTest) {
             }
         }
 
-        columns.emplace_back(tc1);
+        columns.emplace_back(std::move(tc1));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result = MathFunctions::abs_decimalv2val(ctx.get(), columns).value();
@@ -1279,7 +1279,7 @@ TEST_F(VecMathFunctionsTest, CotTest) {
         tc1->append(0.1);
         tc1->append(0.2);
         tc1->append(0.3);
-        columns.emplace_back(tc1);
+        columns.emplace_back(std::move(tc1));
 
         Columns columns2;
         auto tc2 = DoubleColumn::create();
@@ -1287,7 +1287,7 @@ TEST_F(VecMathFunctionsTest, CotTest) {
         tc2->append(0.1);
         tc2->append(0.2);
         tc2->append(0.3);
-        columns2.emplace_back(tc2);
+        columns2.emplace_back(std::move((tc2)));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result = MathFunctions::cot(ctx.get(), columns).value();
@@ -1312,13 +1312,13 @@ TEST_F(VecMathFunctionsTest, Atan2Test) {
         tc1->append(0.1);
         tc1->append(0.2);
         tc1->append(0.3);
-        columns.emplace_back(tc1);
+        columns.emplace_back(std::move(tc1));
 
         auto tc2 = DoubleColumn::create();
         tc2->append(0.1);
         tc2->append(0.2);
         tc2->append(0.3);
-        columns.emplace_back(tc2);
+        columns.emplace_back(std::move(tc2));
 
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         ColumnPtr result = MathFunctions::atan2(ctx.get(), columns).value();
@@ -1339,7 +1339,7 @@ TEST_F(VecMathFunctionsTest, TrigonometricFunctionTest) {
     tc1->append(1);
     tc1->append(3.1415926);
     tc1->append(30);
-    columns.emplace_back(tc1);
+    columns.emplace_back(std::move(tc1));
 
     {
         std::vector<double> result_expect = {std::sinh(-1), std::sinh(0), std::sinh(1), std::sinh(3.1415926),
@@ -1384,7 +1384,7 @@ TEST_F(VecMathFunctionsTest, OutputNanTest) {
     tc1->append(-10);
     tc1->append(1.0);
     tc1->append(std::nan("not a double number"));
-    columns.emplace_back(tc1);
+    columns.emplace_back(std::move(tc1));
 
     {
         std::vector<bool> null_expect = {true, false, true};
@@ -1480,13 +1480,13 @@ TEST_F(VecMathFunctionsTest, OutputNanTest) {
         tc1->append(std::nan("not a double number"));
         tc1->append(0.2);
         tc1->append(0.3);
-        binary_columns.emplace_back(tc1);
+        binary_columns.emplace_back(std::move(tc1));
 
         auto tc2 = DoubleColumn::create();
         tc2->append(0.8);
         tc2->append(0.2);
         tc2->append(0.3);
-        binary_columns.emplace_back(tc2);
+        binary_columns.emplace_back(std::move(tc2));
 
         std::vector<bool> null_expect = {true, false, false};
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());

--- a/be/test/exprs/mock_vectorized_expr.h
+++ b/be/test/exprs/mock_vectorized_expr.h
@@ -93,13 +93,13 @@ public:
 
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override {
         start();
-        ColumnPtr col;
+        MutableColumnPtr col;
         if constexpr (lt_is_decimal<Type>) {
             col = RunTimeColumnType<Type>::create(this->type().precision, this->type().scale);
         } else {
             col = RunTimeColumnType<Type>::create();
         }
-        auto* concrete_col = ColumnHelper::cast_to_raw<Type>(col);
+        auto* concrete_col = ColumnHelper::cast_to_raw<Type>(col.get());
         concrete_col->reserve(size);
         for (int j = 0; j < size; ++j) {
             concrete_col->append(value);
@@ -156,13 +156,13 @@ public:
         if (only_null) {
             return ColumnHelper::create_const_null_column(size);
         }
-        ColumnPtr col = nullptr;
+        MutableColumnPtr col = nullptr;
         if constexpr (lt_is_decimal<Type>) {
             col = RunTimeColumnType<Type>::create(this->type().precision, this->type().scale);
         } else {
             col = RunTimeColumnType<Type>::create();
         }
-        auto* concrete_col = ColumnHelper::cast_to_raw<Type>(col);
+        auto* concrete_col = ColumnHelper::cast_to_raw<Type>(col.get());
         for (int j = 0; j < size; ++j) {
             concrete_col->append(value);
         }
@@ -176,7 +176,7 @@ public:
                 nul->append((flag + i) % 2);
             }
         }
-        auto re = NullableColumn::create(col, nul);
+        auto re = NullableColumn::create(std::move(col), std::move(nul));
         re->update_has_null();
         stop();
         return re;

--- a/be/test/exprs/null_if_expr_test.cpp
+++ b/be/test/exprs/null_if_expr_test.cpp
@@ -63,13 +63,13 @@ TEST_F(VectorizedNullIfExprTest, nullIfArray) {
     array0->append_datum(DatumArray{Datum((int32_t)1), Datum((int32_t)4)}); // [1,4]
     array0->append_datum(DatumArray{Datum(), Datum()});                     // [NULL, NULL]
     array0->append_datum(DatumArray{Datum(), Datum((int32_t)12)});          // [NULL, 12]
-    auto array_expr0 = MockExpr(type_arr_int, array0);
+    auto array_expr0 = MockExpr(type_arr_int, std::move(array0));
 
     auto array1 = ColumnHelper::create_column(type_arr_int, false);
     array1->append_datum(DatumArray{Datum((int32_t)1), Datum((int32_t)4)}); // [1,4]
     array1->append_datum(DatumArray{Datum(), Datum()});                     // [NULL, NULL]
     array1->append_datum(DatumArray{Datum(), Datum((int32_t)1)});           // [NULL, 1]
-    auto array_expr1 = MockExpr(type_arr_int, array1);
+    auto array_expr1 = MockExpr(type_arr_int, std::move(array1));
 
     expr->_children.push_back(&array_expr0);
     expr->_children.push_back(&array_expr1);

--- a/be/test/exprs/percentile_functions_test.cpp
+++ b/be/test/exprs/percentile_functions_test.cpp
@@ -49,7 +49,7 @@ TEST_F(PercentileFunctionsTest, percentileHashTest) {
     s->append(1);
     s->append(2);
     s->append(3);
-    columns.push_back(s);
+    columns.push_back(std::move(s));
 
     auto column = PercentileFunctions::percentile_hash(ctx, columns).value();
     ASSERT_TRUE(column->is_object());
@@ -63,14 +63,14 @@ TEST_F(PercentileFunctionsTest, percentileHashTest) {
 TEST_F(PercentileFunctionsTest, percentileNullTest) {
     Columns columns;
     auto c1 = PercentileColumn::create();
-    auto c1_null = NullableColumn::create(c1, NullColumn::create());
+    auto c1_null = NullableColumn::create(std::move(c1), NullColumn::create());
     c1_null->append_nulls(1);
-    columns.push_back(c1_null);
+    columns.emplace_back(std::move(c1_null));
 
     auto c2 = DoubleColumn::create();
-    auto c2_null = NullableColumn::create(c2, NullColumn::create());
+    auto c2_null = NullableColumn::create(std::move(c2), NullColumn::create());
     c2_null->append_nulls(1);
-    columns.push_back(c2_null);
+    columns.emplace_back(std::move(c2_null));
 
     ColumnPtr column = PercentileFunctions::percentile_approx_raw(ctx, columns).value();
     ASSERT_TRUE(column->is_nullable());

--- a/be/test/exprs/runtime_filter_test.cpp
+++ b/be/test/exprs/runtime_filter_test.cpp
@@ -275,8 +275,8 @@ static std::string alphabet0 =
 
 static std::string alphabet1 = "~!@#$%^&*()_+{}|:\"<>?[]\\;',./";
 
-static std::shared_ptr<BinaryColumn> gen_random_binary_column(const std::string& alphabet, size_t avg_length,
-                                                              size_t num_rows) {
+static BinaryColumn::MutablePtr gen_random_binary_column(const std::string& alphabet, size_t avg_length,
+                                                         size_t num_rows) {
     auto col = BinaryColumn::create();
     col->reserve(num_rows);
     std::random_device rd;
@@ -1183,7 +1183,7 @@ void TestMultiColumnsOnRuntimeFilter(TRuntimeFilterBuildJoinMode::type join_mode
 
 ColumnPtr CreateSeriesColumnInt32(int32_t num_rows, bool nullable) {
     auto type_desc = TypeDescriptor(TYPE_INT);
-    ColumnPtr column = ColumnHelper::create_column(type_desc, nullable);
+    MutableColumnPtr column = ColumnHelper::create_column(type_desc, nullable);
     std::vector<int32_t> elements(num_rows);
     std::iota(elements.begin(), elements.end(), 0);
     for (auto& x : elements) {

--- a/be/test/exprs/string_fn_field.cpp
+++ b/be/test/exprs/string_fn_field.cpp
@@ -40,8 +40,8 @@ PARALLEL_TEST(VecFieldFunctionsTest, fieldStringTest) {
         str2->append("test" + std::to_string(j % 10));
     }
 
-    columns.emplace_back(str1);
-    columns.emplace_back(str2);
+    columns.emplace_back(std::move(str1));
+    columns.emplace_back(std::move(str2));
 
     ColumnPtr result = StringFunctions::field<TYPE_VARCHAR>(ctx.get(), columns).value();
 
@@ -85,9 +85,9 @@ PARALLEL_TEST(VecFieldFunctionsTest, fieldIntTest) {
     auto param2 = paramBuilder2.build_nullable_column();
     auto param3 = paramBuilder3.build_nullable_column();
 
-    columns.emplace_back(param1);
-    columns.emplace_back(param2);
-    columns.emplace_back(param3);
+    columns.emplace_back(std::move(param1));
+    columns.emplace_back(std::move(param2));
+    columns.emplace_back(std::move(param3));
     int res[] = {0, 1, 2, 0, 0};
     ctx->set_function_state(FunctionContext::FRAGMENT_LOCAL, nullptr);
     ColumnPtr result = StringFunctions::field<TYPE_INT>(ctx.get(), columns).value();
@@ -141,9 +141,9 @@ PARALLEL_TEST(VecFieldFunctionsTest, fieldDecTest) {
     DecimalV3Cast::from_string<int64_t>(&data3[i], precision, scale, s.c_str(), s.size());
     int res[] = {0, 2, 1};
 
-    columns.emplace_back(param1);
-    columns.emplace_back(param2);
-    columns.emplace_back(param3);
+    columns.emplace_back(std::move(param1));
+    columns.emplace_back(std::move(param2));
+    columns.emplace_back(std::move(param3));
     ColumnPtr result = StringFunctions::field<TYPE_DECIMAL64>(ctx.get(), columns).value();
 
     ASSERT_TRUE(result->is_numeric());
@@ -186,9 +186,9 @@ PARALLEL_TEST(VecFieldFunctionsTest, fieldIntTest2) {
     auto param2 = paramBuilder2.build(true);
     auto param3 = paramBuilder3.build(true);
 
-    columns.emplace_back(param1);
-    columns.emplace_back(param2);
-    columns.emplace_back(param3);
+    columns.emplace_back(std::move(param1));
+    columns.emplace_back(std::move(param2));
+    columns.emplace_back(std::move(param3));
     int res[] = {0, 0, 0, 0, 0};
     ctx->set_constant_columns(columns);
     ASSERT_TRUE(StringFunctions::field_prepare<TYPE_INT>(ctx.get(), FunctionContext::FRAGMENT_LOCAL).ok());
@@ -221,9 +221,9 @@ PARALLEL_TEST(VecFieldFunctionsTest, fieldIntTest3) {
     auto param2 = paramBuilder2.build(true);
     auto param3 = paramBuilder3.build(true);
 
-    columns.emplace_back(param1);
-    columns.emplace_back(param2);
-    columns.emplace_back(param3);
+    columns.emplace_back(std::move(param1));
+    columns.emplace_back(std::move(param2));
+    columns.emplace_back(std::move(param3));
     int res[] = {0, 0, 0, 0, 0};
     ctx->set_constant_columns(columns);
     ASSERT_TRUE(StringFunctions::field_prepare<TYPE_INT>(ctx.get(), FunctionContext::FRAGMENT_LOCAL).ok());
@@ -268,9 +268,9 @@ PARALLEL_TEST(VecFieldFunctionsTest, fieldIntTest4) {
     auto param2 = paramBuilder2.build(true);
     auto param3 = paramBuilder3.build(true);
 
-    columns.emplace_back(param1);
-    columns.emplace_back(param2);
-    columns.emplace_back(param3);
+    columns.emplace_back(std::move(param1));
+    columns.emplace_back(std::move(param2));
+    columns.emplace_back(std::move(param3));
     int res[] = {2, 0, 0, 0, 0};
     ctx->set_constant_columns(columns);
     ASSERT_TRUE(StringFunctions::field_prepare<TYPE_INT>(ctx.get(), FunctionContext::THREAD_LOCAL).ok());

--- a/be/test/exprs/string_fn_locate_test.cpp
+++ b/be/test/exprs/string_fn_locate_test.cpp
@@ -46,8 +46,8 @@ TEST_F(StringFunctionLocateTest, instrTest) {
         sub->append(std::to_string(j));
     }
 
-    columns.emplace_back(str);
-    columns.emplace_back(sub);
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(sub));
 
     ColumnPtr result = StringFunctions::instr(ctx.get(), columns).value();
     ASSERT_EQ(20, result->size());
@@ -70,8 +70,8 @@ TEST_F(StringFunctionLocateTest, instrChineseTest) {
         sub->append(std::to_string(j));
     }
 
-    columns.emplace_back(str);
-    columns.emplace_back(sub);
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(sub));
 
     ColumnPtr result = StringFunctions::instr(ctx.get(), columns).value();
     ASSERT_EQ(20, result->size());
@@ -96,8 +96,8 @@ TEST_F(StringFunctionLocateTest, locateNullTest) {
         null->append(j % 2);
     }
 
-    columns.emplace_back(NullableColumn::create(sub, null));
-    columns.emplace_back(str);
+    columns.emplace_back(NullableColumn::create(std::move(sub), std::move(null)));
+    columns.emplace_back(std::move(str));
 
     ColumnPtr result = StringFunctions::locate(ctx.get(), columns).value();
     ASSERT_EQ(20, result->size());
@@ -127,9 +127,9 @@ TEST_F(StringFunctionLocateTest, locatePosTest) {
         pos->append(4);
     }
 
-    columns.emplace_back(sub);
-    columns.emplace_back(str);
-    columns.emplace_back(pos);
+    columns.emplace_back(std::move(sub));
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(pos));
 
     ColumnPtr result = StringFunctions::locate_pos(ctx.get(), columns).value();
     ASSERT_EQ(20, result->size());
@@ -158,9 +158,9 @@ TEST_F(StringFunctionLocateTest, locateHayStackEqualNeedleTest) {
         pos->append(1);
     }
 
-    columns.emplace_back(sub);
-    columns.emplace_back(str);
-    columns.emplace_back(pos);
+    columns.emplace_back(std::move(sub));
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(pos));
 
     ColumnPtr result = StringFunctions::locate_pos(ctx.get(), columns).value();
     ASSERT_EQ(20, result->size());
@@ -185,9 +185,9 @@ TEST_F(StringFunctionLocateTest, locateNegativePosTest) {
         pos->append(-4);
     }
 
-    columns.emplace_back(sub);
-    columns.emplace_back(str);
-    columns.emplace_back(pos);
+    columns.emplace_back(std::move(sub));
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(pos));
 
     ColumnPtr result = StringFunctions::locate_pos(ctx.get(), columns).value();
     ASSERT_EQ(20, result->size());
@@ -212,9 +212,9 @@ TEST_F(StringFunctionLocateTest, locatePosLargerThanHaystackSizeTest) {
         pos->append(10);
     }
 
-    columns.emplace_back(sub);
-    columns.emplace_back(str);
-    columns.emplace_back(pos);
+    columns.emplace_back(std::move(sub));
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(pos));
 
     ColumnPtr result = StringFunctions::locate_pos(ctx.get(), columns).value();
     ASSERT_EQ(20, result->size());
@@ -238,8 +238,8 @@ TEST_F(StringFunctionLocateTest, locateNeedleAllNullTest) {
         start_pos->append(3);
     }
     columns.emplace_back(ColumnHelper::create_const_null_column(1));
-    columns.emplace_back(haystack);
-    columns.emplace_back(start_pos);
+    columns.emplace_back(std::move(haystack));
+    columns.emplace_back(std::move(start_pos));
 
     ColumnPtr result = StringFunctions::locate_pos(ctx.get(), columns).value();
     ASSERT_EQ(1, result->size());
@@ -272,9 +272,9 @@ TEST_F(StringFunctionLocateTest, locateNeedleEmptyTest) {
         }
     }
 
-    columns.emplace_back(needle);
-    columns.emplace_back(haystack);
-    columns.emplace_back(start_pos);
+    columns.emplace_back(std::move(needle));
+    columns.emplace_back(std::move(haystack));
+    columns.emplace_back(std::move(start_pos));
 
     ColumnPtr result = StringFunctions::locate_pos(ctx.get(), columns).value();
     ASSERT_EQ(100, result->size());
@@ -304,9 +304,9 @@ TEST_F(StringFunctionLocateTest, locateInVolnitskyTest) {
         start_pos->append(3);
     }
     needle->append(needle_const);
-    columns.emplace_back(ConstColumn::create(needle, 1));
-    columns.emplace_back(haystack);
-    columns.emplace_back(start_pos);
+    columns.emplace_back(ConstColumn::create(std::move(needle), 1));
+    columns.emplace_back(std::move(haystack));
+    columns.emplace_back(std::move(start_pos));
 
     ColumnPtr result = StringFunctions::locate_pos(ctx.get(), columns).value();
     ASSERT_EQ(100, result->size());
@@ -335,9 +335,9 @@ TEST_F(StringFunctionLocateTest, locateInVolnitskyTest2) {
         start_pos->append(3);
     }
     needle->append(needle_const);
-    columns.emplace_back(ConstColumn::create(needle, 1));
-    columns.emplace_back(haystack);
-    columns.emplace_back(start_pos);
+    columns.emplace_back(ConstColumn::create(std::move(needle), 1));
+    columns.emplace_back(std::move(haystack));
+    columns.emplace_back(std::move(start_pos));
 
     ColumnPtr result = StringFunctions::locate_pos(ctx.get(), columns).value();
     ASSERT_EQ(100, result->size());
@@ -367,9 +367,9 @@ TEST_F(StringFunctionLocateTest, locateInVolnitskyTest3) {
         start_pos->append(3);
     }
     needle->append(needle_const);
-    columns.emplace_back(ConstColumn::create(needle, 1));
-    columns.emplace_back(haystack);
-    columns.emplace_back(start_pos);
+    columns.emplace_back(ConstColumn::create(std::move(needle), 1));
+    columns.emplace_back(std::move(haystack));
+    columns.emplace_back(std::move(start_pos));
 
     ColumnPtr result = StringFunctions::locate_pos(ctx.get(), columns).value();
     ASSERT_EQ(100, result->size());
@@ -396,9 +396,9 @@ TEST_F(StringFunctionLocateTest, locateInVolnitskyTest4) {
         start_pos->append(3);
     }
     needle->append(needle_const);
-    columns.emplace_back(ConstColumn::create(needle, 1));
-    columns.emplace_back(haystack);
-    columns.emplace_back(start_pos);
+    columns.emplace_back(ConstColumn::create(std::move(needle), 1));
+    columns.emplace_back(std::move(haystack));
+    columns.emplace_back(std::move(start_pos));
 
     ColumnPtr result = StringFunctions::locate_pos(ctx.get(), columns).value();
     ASSERT_EQ(100, result->size());
@@ -428,9 +428,9 @@ TEST_F(StringFunctionLocateTest, locateVolnitskyTest5) {
     }
 
     needle->append(needle_const);
-    columns.emplace_back(ConstColumn::create(needle, 1));
-    columns.emplace_back(NullableColumn::create(haystack, null));
-    columns.emplace_back(start_pos);
+    columns.emplace_back(ConstColumn::create(std::move(needle), 1));
+    columns.emplace_back(NullableColumn::create(std::move(haystack), std::move(null)));
+    columns.emplace_back(std::move(start_pos));
 
     ColumnPtr result = StringFunctions::locate_pos(ctx.get(), columns).value();
     ASSERT_EQ(100, result->size());
@@ -477,9 +477,9 @@ TEST_F(StringFunctionLocateTest, locateVolnitskyTest6) {
     }
 
     needle->append(needle_const);
-    columns.emplace_back(ConstColumn::create(needle, 1));
-    columns.emplace_back(haystack);
-    columns.emplace_back(start_pos);
+    columns.emplace_back(ConstColumn::create(std::move(needle), 1));
+    columns.emplace_back(std::move(haystack));
+    columns.emplace_back(std::move(start_pos));
 
     ColumnPtr result = StringFunctions::locate_pos(ctx.get(), columns).value();
     ASSERT_EQ(100, result->size());
@@ -513,8 +513,8 @@ TEST_F(StringFunctionLocateTest, locateInFallbackVolnitskyTest) {
         haystack->append(haystack_data);
     }
     needle->append(needle_const);
-    columns.emplace_back(ConstColumn::create(needle, 1));
-    columns.emplace_back(haystack);
+    columns.emplace_back(ConstColumn::create(std::move(needle), 1));
+    columns.emplace_back(std::move(haystack));
 
     ColumnPtr result = StringFunctions::locate(ctx.get(), columns).value();
     ASSERT_EQ(100, result->size());
@@ -539,9 +539,9 @@ TEST_F(StringFunctionLocateTest, locatePosChineseTest) {
         pos->append(4);
     }
 
-    columns.emplace_back(sub);
-    columns.emplace_back(str);
-    columns.emplace_back(pos);
+    columns.emplace_back(std::move(sub));
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(pos));
 
     ColumnPtr result = StringFunctions::locate_pos(ctx.get(), columns).value();
     ASSERT_EQ(20, result->size());

--- a/be/test/exprs/string_fn_money_format_decimal_test.cpp
+++ b/be/test/exprs/string_fn_money_format_decimal_test.cpp
@@ -43,7 +43,7 @@ void test_money_format_decimal(TestArray const& test_cases, int precision, int s
         money_column->append(value);
     }
 
-    columns.emplace_back(money_column);
+    columns.emplace_back(std::move(money_column));
     ColumnPtr result = StringFunctions::money_format_decimal<Type>(ctx.get(), columns).value();
     auto v = ColumnHelper::as_raw_column<BinaryColumn>(result);
 

--- a/be/test/exprs/string_fn_regexp_replace_test.cpp
+++ b/be/test/exprs/string_fn_regexp_replace_test.cpp
@@ -46,13 +46,13 @@ public:
             }
         }
         _columns.push_back(std::move(column));
-        ColumnPtr pattern_data = ColumnHelper::create_column(type_desc, false);
+        MutableColumnPtr pattern_data = ColumnHelper::create_column(type_desc, false);
         pattern_data->append_datum(Datum(Slice("-")));
-        auto pattern_column = ConstColumn::create(pattern_data, _num_rows);
+        auto pattern_column = ConstColumn::create(std::move(pattern_data), _num_rows);
         _columns.push_back(std::move(pattern_column));
-        ColumnPtr rpl_data = ColumnHelper::create_column(type_desc, false);
+        MutableColumnPtr rpl_data = ColumnHelper::create_column(type_desc, false);
         rpl_data->append_datum(Datum(Slice("")));
-        auto rpl_column = ConstColumn::create(rpl_data, _num_rows);
+        auto rpl_column = ConstColumn::create(std::move(rpl_data), _num_rows);
         _columns.push_back(std::move(rpl_column));
         _state = std::make_shared<StringFunctionsState>();
         _state->options = std::make_unique<re2::RE2::Options>();

--- a/be/test/exprs/string_fn_repeat_test.cpp
+++ b/be/test/exprs/string_fn_repeat_test.cpp
@@ -29,8 +29,8 @@ TEST_F(StringFunctionRepeatTest, repeatTest) {
         times->append(j);
     }
 
-    columns.emplace_back(str);
-    columns.emplace_back(times);
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(times));
 
     ColumnPtr result = StringFunctions::repeat(ctx.get(), columns).value();
     ASSERT_EQ(20, result->size());
@@ -55,8 +55,8 @@ TEST_F(StringFunctionRepeatTest, repeatLargeTest) {
     str->append(std::to_string(1));
     times->append(get_olap_string_max_length() + 100);
 
-    columns.emplace_back(str);
-    columns.emplace_back(times);
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(times));
 
     ColumnPtr result = StringFunctions::repeat(ctx.get(), columns).value();
     ASSERT_EQ(1, result->size());
@@ -76,8 +76,8 @@ TEST_F(StringFunctionRepeatTest, repeatConstTest) {
     int32_t repeat_times = get_olap_string_max_length() / 100 + 10;
     times->append(repeat_times);
 
-    columns.emplace_back(str);
-    columns.emplace_back(ConstColumn::create(times, 1));
+    columns.emplace_back(str->clone());
+    columns.emplace_back(ConstColumn::create(std::move(times), 1));
 
     ColumnPtr result = StringFunctions::repeat(ctx.get(), columns).value();
     const auto num_rows = str->size();

--- a/be/test/exprs/string_fn_reverse_test.cpp
+++ b/be/test/exprs/string_fn_reverse_test.cpp
@@ -47,7 +47,7 @@ TEST_F(StringFunctionReverseTest, reverseASCIITest) {
         str->append(s.substr(0, j));
     }
 
-    columns.emplace_back(str);
+    columns.emplace_back(str->clone());
 
     ColumnPtr result = StringFunctions::reverse(ctx.get(), columns).value();
     ASSERT_EQ(100, result->size());
@@ -76,7 +76,7 @@ TEST_F(StringFunctionReverseTest, reverseUtf8Test) {
         str->append(std::get<0>(c));
     }
 
-    columns.emplace_back(str);
+    columns.emplace_back(str->clone());
 
     ColumnPtr result = StringFunctions::reverse(ctx.get(), columns).value();
     ASSERT_EQ(str->size(), result->size());

--- a/be/test/exprs/string_fn_sm3_test.cpp
+++ b/be/test/exprs/string_fn_sm3_test.cpp
@@ -24,8 +24,8 @@ TEST_F(StringFunctionSm3Test, abcA1Test) {
 
     Columns columns;
     auto str = BinaryColumn::create();
-    columns.emplace_back(str);
     str->append("abc");
+    columns.emplace_back(std::move(str));
 
     ColumnPtr result = StringFunctions::sm3(ctx.get(), columns).value();
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
@@ -39,8 +39,8 @@ TEST_F(StringFunctionSm3Test, abcA2Test) {
 
     Columns columns;
     auto str = BinaryColumn::create();
-    columns.emplace_back(str);
     str->append("abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+    columns.emplace_back(std::move(str));
 
     ColumnPtr result = StringFunctions::sm3(ctx.get(), columns).value();
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
@@ -55,7 +55,7 @@ TEST_F(StringFunctionSm3Test, abcConstTest) {
     Columns columns;
     auto str = BinaryColumn::create();
     str->append("abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
-    columns.emplace_back(ConstColumn::create(str, 1));
+    columns.emplace_back(ConstColumn::create(std::move(str), 1));
     ColumnPtr result = StringFunctions::sm3(ctx.get(), columns).value();
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(ColumnHelper::as_raw_column<ConstColumn>(result)->data_column());
 
@@ -73,7 +73,7 @@ TEST_F(StringFunctionSm3Test, abcNull1Test) {
         str1->append("abc");
         null->append(j % 2 == 0);
     }
-    columns.emplace_back(NullableColumn::create(str1, null));
+    columns.emplace_back(NullableColumn::create(std::move(str1), std::move(null)));
     ColumnPtr result = StringFunctions::sm3(ctx.get(), columns).value();
     auto nullable_column = ColumnHelper::as_raw_column<NullableColumn>(result);
     auto data_column = ColumnHelper::cast_to<TYPE_VARCHAR>(nullable_column->data_column());
@@ -98,7 +98,7 @@ TEST_F(StringFunctionSm3Test, abcNull2Test) {
         str1->append("abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
         null->append(j % 2 == 0);
     }
-    columns.emplace_back(NullableColumn::create(str1, null));
+    columns.emplace_back(NullableColumn::create(std::move(str1), std::move(null)));
     ColumnPtr result = StringFunctions::sm3(ctx.get(), columns).value();
     auto nullable_column = ColumnHelper::as_raw_column<NullableColumn>(result);
     auto data_column = ColumnHelper::cast_to<TYPE_VARCHAR>(nullable_column->data_column());
@@ -123,7 +123,7 @@ TEST_F(StringFunctionSm3Test, abcNullLiteralTest) {
         str1->append("");
         null->append(j % 2 == 0);
     }
-    columns.emplace_back(NullableColumn::create(str1, null));
+    columns.emplace_back(NullableColumn::create(std::move(str1), std::move(null)));
     ColumnPtr result = StringFunctions::sm3(ctx.get(), columns).value();
     auto nullable_column = ColumnHelper::as_raw_column<NullableColumn>(result);
     auto data_column = ColumnHelper::cast_to<TYPE_VARCHAR>(nullable_column->data_column());

--- a/be/test/exprs/string_fn_space_test.cpp
+++ b/be/test/exprs/string_fn_space_test.cpp
@@ -28,7 +28,7 @@ TEST_F(StringFunctionSpaceTest, spaceTest) {
         times->append(j);
     }
 
-    columns.emplace_back(times);
+    columns.emplace_back(std::move(times));
 
     ColumnPtr result = StringFunctions::space(ctx.get(), columns).value();
     ASSERT_EQ(20, result->size());
@@ -116,9 +116,9 @@ TEST_F(StringFunctionSpaceTest, spaceNullableColumnTest) {
         times_col->append(times);
         null_col->append(is_null);
     }
-    Columns columns{NullableColumn::create(times_col, null_col)};
-    auto result = StringFunctions::space(ctx.get(), columns).value();
     const auto num_rows = times_col->size();
+    Columns columns{NullableColumn::create(std::move(times_col), std::move(null_col))};
+    auto result = StringFunctions::space(ctx.get(), columns).value();
     ASSERT_EQ(result->size(), num_rows);
     ASSERT_TRUE(num_rows - start_row > 0);
     for (int i = start_row; i < num_rows; ++i) {

--- a/be/test/exprs/string_fn_substr_test.cpp
+++ b/be/test/exprs/string_fn_substr_test.cpp
@@ -52,9 +52,9 @@ TEST_F(StringFunctionSubstrTest, substringNormalTest) {
         len->append(2);
     }
 
-    columns.emplace_back(str);
-    columns.emplace_back(pos);
-    columns.emplace_back(len);
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(pos));
+    columns.emplace_back(std::move(len));
 
     ColumnPtr result = StringFunctions::substring(ctx.get(), columns).value();
 
@@ -80,9 +80,9 @@ TEST_F(StringFunctionSubstrTest, substringChineseTest) {
         len->append(2);
     }
 
-    columns.emplace_back(str);
-    columns.emplace_back(pos);
-    columns.emplace_back(len);
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(pos));
+    columns.emplace_back(std::move(len));
 
     ColumnPtr result = StringFunctions::substring(ctx.get(), columns).value();
 
@@ -108,9 +108,9 @@ TEST_F(StringFunctionSubstrTest, substringleftTest) {
         len->append(2);
     }
 
-    columns.emplace_back(str);
-    columns.emplace_back(pos);
-    columns.emplace_back(len);
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(pos));
+    columns.emplace_back(std::move(len));
 
     ColumnPtr result = StringFunctions::substring(ctx.get(), columns).value();
 
@@ -139,7 +139,7 @@ TEST_F(StringFunctionSubstrTest, substrConstASCIITest) {
     auto state = std::make_unique<SubstrState>();
     ctx->set_function_state(FunctionContext::FRAGMENT_LOCAL, state.get());
     starrocks::Columns columns;
-    columns.emplace_back(str);
+    columns.emplace_back(std::move(str));
     for (auto& e : cases) {
         auto [offset, len, expect] = e;
         state->is_const = true;
@@ -187,7 +187,7 @@ TEST_F(StringFunctionSubstrTest, substrConstZhTest) {
     auto state = std::make_unique<SubstrState>();
     ctx->set_function_state(FunctionContext::FRAGMENT_LOCAL, state.get());
     starrocks::Columns columns;
-    columns.emplace_back(str);
+    columns.emplace_back(std::move(str));
     for (auto& e : cases) {
         auto [offset, len, expect] = e;
         state->is_const = true;
@@ -270,7 +270,7 @@ TEST_F(StringFunctionSubstrTest, substrConstUtf8Test) {
     auto state = std::make_unique<SubstrState>();
     ctx->set_function_state(FunctionContext::FRAGMENT_LOCAL, state.get());
     starrocks::Columns columns;
-    columns.emplace_back(str);
+    columns.emplace_back(std::move(str));
     for (auto& e : cases) {
         auto [offset, len, expect] = e;
         state->is_const = true;
@@ -296,9 +296,9 @@ TEST_F(StringFunctionSubstrTest, substringOverleftTest) {
         len->append(2);
     }
 
-    columns.emplace_back(str);
-    columns.emplace_back(pos);
-    columns.emplace_back(len);
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(pos));
+    columns.emplace_back(std::move(len));
 
     ColumnPtr result = StringFunctions::substring(ctx.get(), columns).value();
 
@@ -325,9 +325,9 @@ TEST_F(StringFunctionSubstrTest, substringConstTest) {
         str->append("test" + std::to_string(j));
     }
 
-    columns.emplace_back(str);
-    columns.emplace_back(ConstColumn::create(pos, 1));
-    columns.emplace_back(ConstColumn::create(len, 1));
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(ConstColumn::create(std::move(pos), 1));
+    columns.emplace_back(ConstColumn::create(std::move(len), 1));
 
     ColumnPtr result = StringFunctions::substring(ctx.get(), columns).value();
 
@@ -356,8 +356,8 @@ TEST_F(StringFunctionSubstrTest, substringNullTest) {
     }
 
     columns.emplace_back(b.build(false));
-    columns.emplace_back(ConstColumn::create(pos, 1));
-    columns.emplace_back(ConstColumn::create(len, 1));
+    columns.emplace_back(ConstColumn::create(std::move(pos), 1));
+    columns.emplace_back(ConstColumn::create(std::move(len), 1));
 
     ColumnPtr result = StringFunctions::substring(ctx.get(), columns).value();
 
@@ -387,8 +387,8 @@ TEST_F(StringFunctionSubstrTest, leftTest) {
         inx->append(j);
     }
 
-    columns.emplace_back(str);
-    columns.emplace_back(inx);
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(inx));
 
     ColumnPtr result = StringFunctions::left(ctx.get(), columns).value();
     ASSERT_EQ(20, result->size());
@@ -416,8 +416,8 @@ TEST_F(StringFunctionSubstrTest, rightTest) {
         inx->append(j);
     }
 
-    columns.emplace_back(str);
-    columns.emplace_back(inx);
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(inx));
 
     ColumnPtr result = StringFunctions::right(ctx.get(), columns).value();
     ASSERT_EQ(20, result->size());
@@ -439,8 +439,8 @@ static void test_left_and_right_not_const(
     // left_not_const and right_not_const
     std::unique_ptr<FunctionContext> context(FunctionContext::create_test_context());
     Columns columns;
-    auto str_col = BinaryColumn::create();
-    auto len_col = Int32Column::create();
+    BinaryColumn::Ptr str_col = BinaryColumn::create();
+    Int32Column::Ptr len_col = Int32Column::create();
     for (auto& c : cases) {
         auto s = std::get<0>(c);
         auto len = std::get<1>(c);
@@ -568,8 +568,8 @@ static void test_left_and_right_const(
         Columns columns;
         auto len_col = Int32Column::create();
         len_col->append(len);
-        columns.push_back(str_col);
-        columns.push_back(ConstColumn::create(len_col, 1));
+        columns.emplace_back(std::move(str_col));
+        columns.push_back(ConstColumn::create(std::move(len_col), 1));
         auto substr_state = std::make_unique<SubstrState>();
         std::unique_ptr<FunctionContext> context(FunctionContext::create_test_context());
         context->set_function_state(FunctionContext::FRAGMENT_LOCAL, substr_state.get());
@@ -610,7 +610,7 @@ TEST_F(StringFunctionSubstrTest, leftAndRightConstASCIITest) {
             {-111, {"", "", ""}, {"", "", ""}},
             {INT_MIN, {"", "", ""}, {"", "", ""}},
     };
-    test_left_and_right_const(str_col, cases);
+    test_left_and_right_const(std::move(str_col), cases);
 }
 
 TEST_F(StringFunctionSubstrTest, leftAndRightConstUtf8Test) {
@@ -644,7 +644,7 @@ TEST_F(StringFunctionSubstrTest, leftAndRightConstUtf8Test) {
             {-111, {"", "", "", ""}, {"", "", "", ""}},
             {INT_MIN, {"", "", "", ""}, {"", "", "", ""}},
     };
-    test_left_and_right_const(str_col, cases);
+    test_left_and_right_const(std::move(str_col), cases);
 }
 
 static void test_substr_not_const(std::vector<std::tuple<std::string, int, int, std::string>>& cases) {
@@ -660,7 +660,7 @@ static void test_substr_not_const(std::vector<std::tuple<std::string, int, int, 
         off_col->append(std::get<1>(c));
         len_col->append(std::get<2>(c));
     }
-    Columns columns{str_col, off_col, len_col};
+    Columns columns{std::move(str_col), std::move(off_col), std::move(len_col)};
     auto result = StringFunctions::substring(context.get(), columns).value();
     auto* binary_result = down_cast<BinaryColumn*>(result.get());
     const auto size = cases.size();
@@ -674,7 +674,7 @@ static void test_substr_not_const(std::vector<std::tuple<std::string, int, int, 
 }
 
 TEST_F(StringFunctionSubstrTest, substrNotConstASCIITest) {
-    ColumnPtr str_col = BinaryColumn::create();
+    MutableColumnPtr str_col = BinaryColumn::create();
     std::string ascii_1_9 = "123456789";
     std::vector<std::tuple<std::string, int, int, std::string>> cases = {
             {"", 0, 1, ""},
@@ -750,7 +750,7 @@ TEST_F(StringFunctionSubstrTest, substrNotConstASCIITest) {
 }
 
 TEST_F(StringFunctionSubstrTest, substrNotConstUtf8Test) {
-    ColumnPtr str_col = BinaryColumn::create();
+    MutableColumnPtr str_col = BinaryColumn::create();
     std::string zh_1_9 = "壹贰叁肆伍陆柒捌玖";
     std::vector<std::tuple<std::string, int, int, std::string>> cases = {
             {"", 0, 1, ""},

--- a/be/test/exprs/string_fn_test.cpp
+++ b/be/test/exprs/string_fn_test.cpp
@@ -46,9 +46,9 @@ PARALLEL_TEST(VecStringFunctionsTest, substringNormalTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
 
-    auto str = BinaryColumn::create();
-    auto pos = Int32Column::create();
-    auto len = Int32Column::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    Int32Column::Ptr pos = Int32Column::create();
+    Int32Column::Ptr len = Int32Column::create();
     for (int j = 0; j < 20; ++j) {
         str->append("test" + std::to_string(j));
         pos->append(5);
@@ -74,9 +74,9 @@ PARALLEL_TEST(VecStringFunctionsTest, substringChineseTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
 
-    auto str = BinaryColumn::create();
-    auto pos = Int32Column::create();
-    auto len = Int32Column::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    Int32Column::Ptr pos = Int32Column::create();
+    Int32Column::Ptr len = Int32Column::create();
     for (int j = 0; j < 20; ++j) {
         str->append("我是中文字符串！！！" + std::to_string(j));
         pos->append(3);
@@ -102,9 +102,9 @@ PARALLEL_TEST(VecStringFunctionsTest, substringleftTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
 
-    auto str = BinaryColumn::create();
-    auto pos = Int32Column::create();
-    auto len = Int32Column::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    Int32Column::Ptr pos = Int32Column::create();
+    Int32Column::Ptr len = Int32Column::create();
     for (int j = 0; j < 10; ++j) {
         str->append("我是中文字符串" + std::to_string(j));
         pos->append(-2);
@@ -127,7 +127,7 @@ PARALLEL_TEST(VecStringFunctionsTest, substringleftTest) {
 }
 
 PARALLEL_TEST(VecStringFunctionsTest, substrConstASCIITest) {
-    auto str = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
     str->append("123456789");
     str->append("");
     std::vector<std::tuple<int, int, std::string>> cases = {
@@ -157,7 +157,7 @@ PARALLEL_TEST(VecStringFunctionsTest, substrConstASCIITest) {
 }
 
 PARALLEL_TEST(VecStringFunctionsTest, substrConstZhTest) {
-    auto str = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
     str->append("壹贰叁肆伍陆柒捌玖");
     str->append("");
 
@@ -204,7 +204,7 @@ PARALLEL_TEST(VecStringFunctionsTest, substrConstZhTest) {
 }
 
 PARALLEL_TEST(VecStringFunctionsTest, substrConstUtf8Test) {
-    auto str = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
     std::string s;
     s.append("\x7f");
     s.append("\xdf\xbf");
@@ -290,9 +290,9 @@ PARALLEL_TEST(VecStringFunctionsTest, substringOverleftTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
 
-    auto str = BinaryColumn::create();
-    auto pos = Int32Column::create();
-    auto len = Int32Column::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    Int32Column::Ptr pos = Int32Column::create();
+    Int32Column::Ptr len = Int32Column::create();
     for (int j = 0; j < 20; ++j) {
         str->append("我是中文字符串" + std::to_string(j));
         pos->append(-100);
@@ -318,9 +318,9 @@ PARALLEL_TEST(VecStringFunctionsTest, substringConstTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
 
-    auto str = BinaryColumn::create();
-    auto pos = Int32Column::create();
-    auto len = Int32Column::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    Int32Column::Ptr pos = Int32Column::create();
+    Int32Column::Ptr len = Int32Column::create();
     pos->append(5);
     len->append(2);
 
@@ -347,8 +347,8 @@ PARALLEL_TEST(VecStringFunctionsTest, substringNullTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
 
-    auto pos = Int32Column::create();
-    auto len = Int32Column::create();
+    Int32Column::Ptr pos = Int32Column::create();
+    Int32Column::Ptr len = Int32Column::create();
     pos->append(5);
     len->append(2);
 
@@ -382,10 +382,10 @@ PARALLEL_TEST(VecStringFunctionsTest, substringNullTest) {
 PARALLEL_TEST(VecStringFunctionsTest, concatNormalTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto str1 = BinaryColumn::create();
-    auto str2 = BinaryColumn::create();
-    auto str3 = BinaryColumn::create();
-    auto str4 = BinaryColumn::create();
+    BinaryColumn::Ptr str1 = BinaryColumn::create();
+    BinaryColumn::Ptr str2 = BinaryColumn::create();
+    BinaryColumn::Ptr str3 = BinaryColumn::create();
+    BinaryColumn::Ptr str4 = BinaryColumn::create();
     for (int j = 0; j < 20; ++j) {
         str1->append("test");
         str2->append(std::to_string(j));
@@ -412,10 +412,10 @@ PARALLEL_TEST(VecStringFunctionsTest, concatNormalTest) {
 PARALLEL_TEST(VecStringFunctionsTest, concatConstTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto str1 = BinaryColumn::create();
-    auto str2 = BinaryColumn::create();
-    auto str3 = BinaryColumn::create();
-    auto str4 = BinaryColumn::create();
+    BinaryColumn::Ptr str1 = BinaryColumn::create();
+    BinaryColumn::Ptr str2 = BinaryColumn::create();
+    BinaryColumn::Ptr str3 = BinaryColumn::create();
+    BinaryColumn::Ptr str4 = BinaryColumn::create();
     for (int j = 0; j < 20; ++j) {
         str1->append("test" + std::to_string(j));
     }
@@ -442,11 +442,11 @@ PARALLEL_TEST(VecStringFunctionsTest, concatConstTest) {
 PARALLEL_TEST(VecStringFunctionsTest, concatNullTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto str1 = BinaryColumn::create();
-    auto str2 = BinaryColumn::create();
-    auto str3 = BinaryColumn::create();
-    auto str4 = BinaryColumn::create();
-    auto null = NullColumn::create();
+    BinaryColumn::Ptr str1 = BinaryColumn::create();
+    BinaryColumn::Ptr str2 = BinaryColumn::create();
+    BinaryColumn::Ptr str3 = BinaryColumn::create();
+    BinaryColumn::Ptr str4 = BinaryColumn::create();
+    NullColumn::Ptr null = NullColumn::create();
     for (int j = 0; j < 20; ++j) {
         str1->append("test");
         str2->append(std::to_string(j));
@@ -481,7 +481,7 @@ PARALLEL_TEST(VecStringFunctionsTest, lowerNormalTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
 
-    auto str = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
     for (int j = 0; j < 20; ++j) {
         str->append("TEST" + std::to_string(j));
     }
@@ -503,7 +503,7 @@ PARALLEL_TEST(VecStringFunctionsTest, nullOrEmpty) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
 
-    auto str = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
     str->append("");
     str->append(" ");
     str->append("hello");
@@ -530,9 +530,9 @@ PARALLEL_TEST(VecStringFunctionsTest, split) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
 
-    auto str = BinaryColumn::create();
-    auto delim = BinaryColumn::create();
-    auto null = NullColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    BinaryColumn::Ptr delim = BinaryColumn::create();
+    NullColumn::Ptr null = NullColumn::create();
 
     str->append("1,2,3");
     delim->append(",");
@@ -561,15 +561,15 @@ PARALLEL_TEST(VecStringFunctionsTest, split) {
     delim->append(",");
     null->append(1);
 
-    auto null_column = NullableColumn::create(str, null);
+    NullableColumn::Ptr null_column = NullableColumn::create(str, null);
     columns.emplace_back(null_column);
     columns.emplace_back(delim);
     result = StringFunctions::split(ctx.get(), columns).value();
     ASSERT_EQ("[['1','2','3'], ['aa','bb','cc'], ['a','b','c'], ['',''], NULL]", result->debug_string());
 
     //two const param
-    auto str_const = ConstColumn::create(BinaryColumn::create());
-    auto delim_const = ConstColumn::create(BinaryColumn::create());
+    ConstColumn::Ptr str_const = ConstColumn::create(BinaryColumn::create());
+    ConstColumn::Ptr delim_const = ConstColumn::create(BinaryColumn::create());
     str_const->append_datum("a,bc,d,eeee,f");
     delim_const->append_datum(",");
     columns.clear();
@@ -586,8 +586,8 @@ PARALLEL_TEST(VecStringFunctionsTest, splitConst1) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
 
-    auto str_const = ConstColumn::create(BinaryColumn::create());
-    auto delim_const = ConstColumn::create(BinaryColumn::create());
+    ConstColumn::Ptr str_const = ConstColumn::create(BinaryColumn::create());
+    ConstColumn::Ptr delim_const = ConstColumn::create(BinaryColumn::create());
     str_const->append_datum("a,bc,d,eeee,f");
     delim_const->append_datum(",d,");
     columns.clear();
@@ -604,8 +604,8 @@ PARALLEL_TEST(VecStringFunctionsTest, splitConst2) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
 
-    auto delim_const = ConstColumn::create(BinaryColumn::create());
-    auto str_binary_column = BinaryColumn::create();
+    ConstColumn::Ptr delim_const = ConstColumn::create(BinaryColumn::create());
+    BinaryColumn::Ptr str_binary_column = BinaryColumn::create();
 
     str_binary_column->append("a,b,c");
     str_binary_column->append("aa,bb,cc");
@@ -629,9 +629,9 @@ PARALLEL_TEST(VecStringFunctionsTest, splitChinese) {
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         Columns columns;
 
-        auto str = BinaryColumn::create();
-        auto delim = BinaryColumn::create();
-        auto null = NullColumn::create();
+        BinaryColumn::Ptr str = BinaryColumn::create();
+        BinaryColumn::Ptr delim = BinaryColumn::create();
+        NullColumn::Ptr null = NullColumn::create();
 
         str->append("1上海,北,京");
         delim->append(",");
@@ -663,8 +663,8 @@ PARALLEL_TEST(VecStringFunctionsTest, splitChinese) {
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         Columns columns;
 
-        auto delim_const = ConstColumn::create(BinaryColumn::create());
-        auto str_binary_column = BinaryColumn::create();
+        ConstColumn::Ptr delim_const = ConstColumn::create(BinaryColumn::create());
+        BinaryColumn::Ptr str_binary_column = BinaryColumn::create();
 
         str_binary_column->append("a地 区b");
         str_binary_column->append("");
@@ -703,8 +703,8 @@ PARALLEL_TEST(VecStringFunctionsTest, splitChinese) {
             std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
             Columns columns;
 
-            auto src_const = ConstColumn::create(BinaryColumn::create());
-            auto delim_const = ConstColumn::create(BinaryColumn::create());
+            ConstColumn::Ptr src_const = ConstColumn::create(BinaryColumn::create());
+            ConstColumn::Ptr delim_const = ConstColumn::create(BinaryColumn::create());
 
             src_const->append_datum(Slice(src));
             delim_const->append_datum(Slice(delimiter));
@@ -731,7 +731,7 @@ PARALLEL_TEST(VecStringFunctionsTest, str_to_map_v1) {
     // input array<string>
     int chunk_size = 7;
     TypeDescriptor TYPE_ARRAY_VARCHAR = array_type(TYPE_VARCHAR);
-    auto array_str_null = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    ColumnPtr array_str_null = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
     // []
     // NULL
     // ['NULL']
@@ -745,11 +745,11 @@ PARALLEL_TEST(VecStringFunctionsTest, str_to_map_v1) {
 
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     TypeDescriptor string_type_desc = TypeDescriptor::create_varchar_type(10);
-    auto string_column = ColumnHelper::create_column(string_type_desc, true);
+    ColumnPtr string_column = ColumnHelper::create_column(string_type_desc, true);
     string_column->append_datum("a:b,c:d");
     string_column->append_datum("a:1,b:2");
 
-    auto array_str_notnull = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
+    ColumnPtr array_str_notnull = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
     array_str_notnull->append_datum(Datum(DatumArray{}));
     array_str_notnull->append_datum(Datum(DatumArray{Datum("中国:shang海")}));
     array_str_notnull->append_datum(Datum(DatumArray{Datum()}));
@@ -759,7 +759,7 @@ PARALLEL_TEST(VecStringFunctionsTest, str_to_map_v1) {
     array_str_notnull->append_datum(Datum(DatumArray{Datum("a:c:b:d"), Datum(""), Datum("")}));
     array_str_notnull->append_datum(Datum(DatumArray{Datum("ab:b"), Datum("ab:b"), Datum("")}));
 
-    auto only_null = ColumnHelper::create_const_null_column(chunk_size);
+    ColumnPtr only_null = ColumnHelper::create_const_null_column(chunk_size);
 
     // delimiters
 
@@ -771,8 +771,8 @@ PARALLEL_TEST(VecStringFunctionsTest, str_to_map_v1) {
     map_delimiter_builder_nullable.append(":b");
     map_delimiter_builder_nullable.append("");
     map_delimiter_builder_nullable.append_null();
-    auto map_delimiter_nullable = map_delimiter_builder_nullable.build_nullable_column();
-    auto delimiter_column = ColumnHelper::create_column(string_type_desc, true);
+    ColumnPtr map_delimiter_nullable = map_delimiter_builder_nullable.build_nullable_column();
+    ColumnPtr delimiter_column = ColumnHelper::create_column(string_type_desc, true);
     delimiter_column->append_datum(",");
     delimiter_column->append_datum(",");
 
@@ -784,19 +784,19 @@ PARALLEL_TEST(VecStringFunctionsTest, str_to_map_v1) {
     map_delimiter_builder_notnull.append(":b");
     map_delimiter_builder_notnull.append("");
     map_delimiter_builder_notnull.append("");
-    auto map_delimiter_notnull = map_delimiter_builder_notnull.build(false);
+    ColumnPtr map_delimiter_notnull = map_delimiter_builder_notnull.build(false);
 
-    auto empty_col = BinaryColumn::create();
+    BinaryColumn::Ptr empty_col = BinaryColumn::create();
     empty_col->append_datum("");
-    auto delim_const_empty = ConstColumn::create(empty_col, chunk_size);
+    ConstColumn::Ptr delim_const_empty = ConstColumn::create(empty_col, chunk_size);
 
-    auto ch_col = BinaryColumn::create();
+    BinaryColumn::Ptr ch_col = BinaryColumn::create();
     ch_col->append_datum("中");
-    auto delim_const_ch = ConstColumn::create(ch_col, chunk_size);
+    ConstColumn::Ptr delim_const_ch = ConstColumn::create(ch_col, chunk_size);
 
-    auto const_col = BinaryColumn::create();
+    BinaryColumn::Ptr const_col = BinaryColumn::create();
     const_col->append_datum(":");
-    auto delim_const = ConstColumn::create(const_col, chunk_size);
+    ConstColumn::Ptr delim_const = ConstColumn::create(const_col, chunk_size);
 
     {
         Columns columns{string_column, delimiter_column, map_delimiter_nullable};
@@ -884,9 +884,9 @@ PARALLEL_TEST(VecStringFunctionsTest, splitPart) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
 
-    auto str = BinaryColumn::create();
-    auto delim = BinaryColumn::create();
-    auto field = Int32Column::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    BinaryColumn::Ptr delim = BinaryColumn::create();
+    Int32Column::Ptr field = Int32Column::create();
 
     // 0
     str->append("hello word");
@@ -1075,8 +1075,8 @@ PARALLEL_TEST(VecStringFunctionsTest, leftTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
 
-    auto str = BinaryColumn::create();
-    auto inx = Int32Column::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    Int32Column::Ptr inx = Int32Column::create();
     for (int j = 0; j < 20; ++j) {
         str->append(std::to_string(j) + "TEST");
         inx->append(j);
@@ -1104,8 +1104,8 @@ PARALLEL_TEST(VecStringFunctionsTest, rightTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
 
-    auto str = BinaryColumn::create();
-    auto inx = Int32Column::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    Int32Column::Ptr inx = Int32Column::create();
     for (int j = 0; j < 20; ++j) {
         str->append(std::to_string(j) + "TEST");
         inx->append(j);
@@ -1132,8 +1132,8 @@ PARALLEL_TEST(VecStringFunctionsTest, rightTest) {
 PARALLEL_TEST(VecStringFunctionsTest, startsWithTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto str = BinaryColumn::create();
-    auto prefix = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    BinaryColumn::Ptr prefix = BinaryColumn::create();
     for (int j = 0; j < 20; ++j) {
         str->append(std::to_string(j) + "TEST");
         prefix->append(std::to_string(j % 10) + "T");
@@ -1159,9 +1159,9 @@ PARALLEL_TEST(VecStringFunctionsTest, startsWithTest) {
 PARALLEL_TEST(VecStringFunctionsTest, startsWithNullTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto str = BinaryColumn::create();
-    auto prefix = BinaryColumn::create();
-    auto null = NullColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    BinaryColumn::Ptr prefix = BinaryColumn::create();
+    NullColumn::Ptr null = NullColumn::create();
 
     for (int j = 0; j < 20; ++j) {
         str->append(std::to_string(j) + "TEST");
@@ -1195,9 +1195,9 @@ PARALLEL_TEST(VecStringFunctionsTest, startsWithNullTest) {
 PARALLEL_TEST(VecStringFunctionsTest, endsWithNullTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto str = BinaryColumn::create();
-    auto suffix = BinaryColumn::create();
-    auto null = NullColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    BinaryColumn::Ptr suffix = BinaryColumn::create();
+    NullColumn::Ptr null = NullColumn::create();
 
     for (int j = 0; j < 20; ++j) {
         str->append("TEST" + std::to_string(j));
@@ -1231,8 +1231,8 @@ PARALLEL_TEST(VecStringFunctionsTest, endsWithNullTest) {
 PARALLEL_TEST(VecStringFunctionsTest, appendTrailingCharIfAbsentTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto str = BinaryColumn::create();
-    auto pad = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    BinaryColumn::Ptr pad = BinaryColumn::create();
 
     str->append("qwer");
     pad->append("r");
@@ -1259,8 +1259,8 @@ PARALLEL_TEST(VecStringFunctionsTest, appendTrailingCharIfAbsentTest) {
 PARALLEL_TEST(VecStringFunctionsTest, appendTrailingCharIfAbsentNullTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto str = BinaryColumn::create();
-    auto pad = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    BinaryColumn::Ptr pad = BinaryColumn::create();
 
     str->append("qwer");
     pad->append("rw");
@@ -1282,8 +1282,8 @@ PARALLEL_TEST(VecStringFunctionsTest, appendTrailingCharIfAbsentNullTest) {
 PARALLEL_TEST(VecStringFunctionsTest, appendTrailingCharIfAbsentUTF8Test) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto str = BinaryColumn::create();
-    auto pad = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    BinaryColumn::Ptr pad = BinaryColumn::create();
 
     str->append("中国");
     pad->append("a");
@@ -1306,8 +1306,8 @@ PARALLEL_TEST(VecStringFunctionsTest, appendTrailingCharIfAbsentUTF8Test) {
 PARALLEL_TEST(VecStringFunctionsTest, appendTrailingCharIfAbsentUTF8NullTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto str = BinaryColumn::create();
-    auto pad = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    BinaryColumn::Ptr pad = BinaryColumn::create();
 
     str->append("中国");
     pad->append("国");
@@ -1329,7 +1329,7 @@ PARALLEL_TEST(VecStringFunctionsTest, appendTrailingCharIfAbsentUTF8NullTest) {
 PARALLEL_TEST(VecStringFunctionsTest, lengthTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto str = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
     for (int j = 0; j < 20; ++j) {
         str->append(std::to_string(j));
     }
@@ -1353,7 +1353,7 @@ PARALLEL_TEST(VecStringFunctionsTest, lengthTest) {
 PARALLEL_TEST(VecStringFunctionsTest, lengthChineseTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto str = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
     for (int j = 0; j < 20; ++j) {
         str->append("中文" + std::to_string(j));
     }
@@ -1377,7 +1377,7 @@ PARALLEL_TEST(VecStringFunctionsTest, lengthChineseTest) {
 PARALLEL_TEST(VecStringFunctionsTest, utf8LengthTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto str = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
     for (int j = 0; j < 20; ++j) {
         str->append(std::to_string(j));
     }
@@ -1401,7 +1401,7 @@ PARALLEL_TEST(VecStringFunctionsTest, utf8LengthTest) {
 PARALLEL_TEST(VecStringFunctionsTest, utf8LengthChineseTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto str = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
     for (int j = 0; j < 20; ++j) {
         str->append("中文" + std::to_string(j));
     }
@@ -1425,7 +1425,7 @@ PARALLEL_TEST(VecStringFunctionsTest, utf8LengthChineseTest) {
 PARALLEL_TEST(VecStringFunctionsTest, upperTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto str = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
     for (int j = 0; j < 20; ++j) {
         str->append("abcd" + std::to_string(j));
     }
@@ -1445,7 +1445,7 @@ PARALLEL_TEST(VecStringFunctionsTest, upperTest) {
 PARALLEL_TEST(VecStringFunctionsTest, caseToggleTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto src = BinaryColumn::create();
+    BinaryColumn::Ptr src = BinaryColumn::create();
     src->append("");
     src->append("a");
     src->append("1");
@@ -1488,7 +1488,7 @@ PARALLEL_TEST(VecStringFunctionsTest, caseToggleTest) {
 PARALLEL_TEST(VecStringFunctionsTest, asciiTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto str = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
 
     str->append("qwer");
     str->append("qwe");
@@ -1509,7 +1509,7 @@ PARALLEL_TEST(VecStringFunctionsTest, asciiTest) {
 PARALLEL_TEST(VecStringFunctionsTest, charTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto str = Int32Column::create();
+    Int32Column::Ptr str = Int32Column::create();
 
     str->append(65);
     str->append(66);
@@ -1537,7 +1537,7 @@ PARALLEL_TEST(VecStringFunctionsTest, inetAtonInvalidIPv4Test) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
 
     Columns columns;
-    auto input_column = BinaryColumn::create();
+    BinaryColumn::Ptr input_column = BinaryColumn::create();
     input_column->append("999.999.999.999");
     input_column->append("abc.def.ghi.jkl");
     input_column->append("192.168.1.1.1");
@@ -1558,7 +1558,7 @@ PARALLEL_TEST(VecStringFunctionsTest, inetAtonValidIPv4Test) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
 
     Columns columns;
-    auto input_column = BinaryColumn::create();
+    BinaryColumn::Ptr input_column = BinaryColumn::create();
     input_column->append("192.168.1.1");
     input_column->append("0.0.0.0");
     input_column->append("255.255.255.255");
@@ -1575,8 +1575,8 @@ PARALLEL_TEST(VecStringFunctionsTest, inetAtonValidIPv4Test) {
 PARALLEL_TEST(VecStringFunctionsTest, instrTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto str = BinaryColumn::create();
-    auto sub = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    BinaryColumn::Ptr sub = BinaryColumn::create();
 
     for (int j = 0; j < 20; ++j) {
         str->append("abcd" + std::to_string(j));
@@ -1599,8 +1599,8 @@ PARALLEL_TEST(VecStringFunctionsTest, instrTest) {
 PARALLEL_TEST(VecStringFunctionsTest, instrChineseTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto str = BinaryColumn::create();
-    auto sub = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    BinaryColumn::Ptr sub = BinaryColumn::create();
 
     for (int j = 0; j < 20; ++j) {
         str->append("中文字符" + std::to_string(j));
@@ -1623,9 +1623,9 @@ PARALLEL_TEST(VecStringFunctionsTest, instrChineseTest) {
 PARALLEL_TEST(VecStringFunctionsTest, locateNullTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto str = BinaryColumn::create();
-    auto sub = BinaryColumn::create();
-    auto null = NullColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    BinaryColumn::Ptr sub = BinaryColumn::create();
+    NullColumn::Ptr null = NullColumn::create();
 
     for (int j = 0; j < 20; ++j) {
         str->append("abcd" + std::to_string(j));
@@ -1654,9 +1654,9 @@ PARALLEL_TEST(VecStringFunctionsTest, locateNullTest) {
 PARALLEL_TEST(VecStringFunctionsTest, locatePosTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto str = BinaryColumn::create();
-    auto sub = BinaryColumn::create();
-    auto pos = Int32Column::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    BinaryColumn::Ptr sub = BinaryColumn::create();
+    Int32Column::Ptr pos = Int32Column::create();
 
     for (int j = 0; j < 20; ++j) {
         str->append(std::to_string(j) + "abcd" + std::to_string(j));
@@ -1685,9 +1685,9 @@ PARALLEL_TEST(VecStringFunctionsTest, locatePosTest) {
 PARALLEL_TEST(VecStringFunctionsTest, locatePosChineseTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto str = BinaryColumn::create();
-    auto sub = BinaryColumn::create();
-    auto pos = Int32Column::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    BinaryColumn::Ptr sub = BinaryColumn::create();
+    Int32Column::Ptr pos = Int32Column::create();
 
     for (int j = 0; j < 20; ++j) {
         str->append(std::to_string(j) + "中文字符" + std::to_string(j));
@@ -1717,12 +1717,12 @@ PARALLEL_TEST(VecStringFunctionsTest, concatWsTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
 
-    auto step = BinaryColumn::create();
-    auto str1 = BinaryColumn::create();
-    auto str2 = BinaryColumn::create();
-    auto str3 = BinaryColumn::create();
+    BinaryColumn::Ptr step = BinaryColumn::create();
+    BinaryColumn::Ptr str1 = BinaryColumn::create();
+    BinaryColumn::Ptr str2 = BinaryColumn::create();
+    BinaryColumn::Ptr str3 = BinaryColumn::create();
 
-    auto null = NullColumn::create();
+    NullColumn::Ptr null = NullColumn::create();
 
     for (int j = 0; j < 20; ++j) {
         step->append("|");
@@ -1756,12 +1756,12 @@ PARALLEL_TEST(VecStringFunctionsTest, concatWs1Test) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
 
-    auto step = BinaryColumn::create();
-    auto str1 = BinaryColumn::create();
-    auto str2 = BinaryColumn::create();
-    auto str3 = BinaryColumn::create();
+    BinaryColumn::Ptr step = BinaryColumn::create();
+    BinaryColumn::Ptr str1 = BinaryColumn::create();
+    BinaryColumn::Ptr str2 = BinaryColumn::create();
+    BinaryColumn::Ptr str3 = BinaryColumn::create();
 
-    auto null = NullColumn::create();
+    NullColumn::Ptr null = NullColumn::create();
 
     for (int j = 0; j < 20; ++j) {
         step->append("-----");
@@ -1794,8 +1794,8 @@ PARALLEL_TEST(VecStringFunctionsTest, concatWs1Test) {
 PARALLEL_TEST(VecStringFunctionsTest, findInSetTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto str = BinaryColumn::create();
-    auto strlist = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    BinaryColumn::Ptr strlist = BinaryColumn::create();
 
     str->append("b");
     strlist->append("a,b,c");
@@ -1849,10 +1849,10 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractNullablePattern) {
 
     Columns columns;
 
-    auto str = BinaryColumn::create();
-    auto pattern = BinaryColumn::create();
-    auto null = NullColumn::create();
-    auto index = Int64Column::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    BinaryColumn::Ptr pattern = BinaryColumn::create();
+    NullColumn::Ptr null = NullColumn::create();
+    Int64Column::Ptr index = Int64Column::create();
 
     std::string strs[] = {"AbCdE", "AbCdrrryE", "hitdeciCsiondlist", "hitdecCisiondlist"};
     int indexs[] = {1, 2, 1, 2};
@@ -1900,9 +1900,9 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractOnlyNullPattern) {
 
     Columns columns;
 
-    auto str = BinaryColumn::create();
-    auto pattern = ColumnHelper::create_const_null_column(1);
-    auto index = Int64Column::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    ColumnPtr pattern = ColumnHelper::create_const_null_column(1);
+    Int64Column::Ptr index = Int64Column::create();
 
     int length = 4;
 
@@ -1936,9 +1936,9 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractConstPattern) {
 
     Columns columns;
 
-    auto str = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
     auto pattern = ColumnHelper::create_const_column<TYPE_VARCHAR>("([[:lower:]]+)C([[:lower:]]+)", 1);
-    auto index = Int64Column::create();
+    Int64Column::Ptr index = Int64Column::create();
 
     std::string strs[] = {"AbCdE", "AbCdrrryE", "hitdeciCsiondlist", "hitdecCisiondlist"};
     int indexs[] = {1, 2, 1, 2};
@@ -1977,9 +1977,9 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtract) {
 
     Columns columns;
 
-    auto str = BinaryColumn::create();
-    auto pattern = BinaryColumn::create();
-    auto index = Int64Column::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    BinaryColumn::Ptr pattern = BinaryColumn::create();
+    Int64Column::Ptr index = Int64Column::create();
 
     std::string strs[] = {"AbCdE", "AbCDdrrryE", "hitdecisiondlist", "hitdecisiondlist"};
     std::string ptns[] = {"([[:lower:]]+)C([[:lower:]]+)", "([[:lower:]]+)CD([[:lower:]]+)", "(i)(.*?)(e)",
@@ -2021,10 +2021,10 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplaceNullablePattern) {
 
     Columns columns;
 
-    auto str = BinaryColumn::create();
-    auto pattern = BinaryColumn::create();
-    auto null = NullColumn::create();
-    auto replace = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    BinaryColumn::Ptr pattern = BinaryColumn::create();
+    NullColumn::Ptr null = NullColumn::create();
+    BinaryColumn::Ptr replace = BinaryColumn::create();
 
     std::string strs[] = {"a b c", "a sdfwe b c"};
     std::string replaces[] = {"-", "<\\1>"};
@@ -2067,9 +2067,9 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplaceOnlyNullPattern) {
 
     Columns columns;
 
-    auto str = BinaryColumn::create();
-    auto pattern = ColumnHelper::create_const_null_column(1);
-    auto replace = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    ColumnPtr pattern = ColumnHelper::create_const_null_column(1);
+    BinaryColumn::Ptr replace = BinaryColumn::create();
 
     std::string strs[] = {"a b c", "a sdfwe b c"};
     std::string replaces[] = {"-", "<\\1>"};
@@ -2106,9 +2106,9 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplaceConstPattern) {
 
     Columns columns;
 
-    auto str = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
     auto ptn = ColumnHelper::create_const_column<TYPE_VARCHAR>("( )", 1);
-    auto replace = BinaryColumn::create();
+    BinaryColumn::Ptr replace = BinaryColumn::create();
 
     std::string strs[] = {"a b c", "a sdfwe b c"};
     std::string replaces[] = {"-", "<\\1>"};
@@ -2148,7 +2148,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplaceConstPattern) {
         std::unique_ptr<char[]> binary_datas = std::make_unique<char[]>(binary_size);
         memset(binary_datas.get(), 0xff, binary_size);
 
-        auto par0 = BinaryColumn::create();
+        BinaryColumn::Ptr par0 = BinaryColumn::create();
         auto par1 = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice(binary_datas.get(), binary_size), 1);
 
         ctx0->set_constant_columns({par0, par1});
@@ -2164,9 +2164,9 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplace) {
 
     Columns columns;
 
-    auto str = BinaryColumn::create();
-    auto ptn = BinaryColumn::create();
-    auto replace = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    BinaryColumn::Ptr ptn = BinaryColumn::create();
+    BinaryColumn::Ptr replace = BinaryColumn::create();
 
     std::string strs[] = {"a b c", "a b c"};
     std::string ptns[] = {" ", "(b)"};
@@ -2207,9 +2207,9 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplaceWithEmptyPattern) {
 
     Columns columns;
 
-    auto str = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
     auto ptn = ColumnHelper::create_const_column<TYPE_VARCHAR>("", 1);
-    auto replace = BinaryColumn::create();
+    BinaryColumn::Ptr replace = BinaryColumn::create();
 
     std::string strs[] = {"yyyy-mm-dd", "yyyy-mm-dd"};
     std::string replaces[] = {"CHINA", "CHINA"};
@@ -2249,10 +2249,10 @@ PARALLEL_TEST(VecStringFunctionsTest, replaceNullablePattern) {
 
     Columns columns;
 
-    auto str = BinaryColumn::create();
-    auto pattern = BinaryColumn::create();
-    auto null = NullColumn::create();
-    auto replace = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    BinaryColumn::Ptr pattern = BinaryColumn::create();
+    NullColumn::Ptr null = NullColumn::create();
+    BinaryColumn::Ptr replace = BinaryColumn::create();
 
     const std::string strs[] = {"a u z", "a sdfwe b c", "a equals c"};
     const std::string replaces[] = {"Ü", " ", ""};
@@ -2298,9 +2298,9 @@ PARALLEL_TEST(VecStringFunctionsTest, replaceOnlyNullPattern1) {
 
     Columns columns;
 
-    auto str = BinaryColumn::create();
-    auto pattern = ColumnHelper::create_const_null_column(1);
-    auto replace = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    ColumnPtr pattern = ColumnHelper::create_const_null_column(1);
+    BinaryColumn::Ptr replace = BinaryColumn::create();
 
     const std::string strs[] = {"a b c", "a sdfwe b c"};
 
@@ -2335,9 +2335,9 @@ PARALLEL_TEST(VecStringFunctionsTest, replaceOnlyNullPattern2) {
 
     Columns columns;
 
-    auto str = ColumnHelper::create_const_null_column(2);
-    auto pattern = ColumnHelper::create_const_null_column(1);
-    auto replace = ColumnHelper::create_const_null_column(1);
+    ColumnPtr str = ColumnHelper::create_const_null_column(2);
+    ColumnPtr pattern = ColumnHelper::create_const_null_column(1);
+    ColumnPtr replace = ColumnHelper::create_const_null_column(1);
 
     columns.emplace_back(str);
     columns.emplace_back(pattern);
@@ -2366,8 +2366,8 @@ PARALLEL_TEST(VecStringFunctionsTest, replaceOnlyNullPattern2) {
     Columns columns;
 
     auto str = ColumnHelper::create_const_column<TYPE_VARCHAR>("a b c", 2);
-    auto pattern = ColumnHelper::create_const_null_column(1);
-    auto replace = ColumnHelper::create_const_null_column(1);
+    ColumnPtr pattern = ColumnHelper::create_const_null_column(1);
+    ColumnPtr replace = ColumnHelper::create_const_null_column(1);
 
     columns.emplace_back(str);
     columns.emplace_back(pattern);
@@ -2394,9 +2394,9 @@ PARALLEL_TEST(VecStringFunctionsTest, replaceConstPattern) {
 
     Columns columns;
 
-    auto str = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
     auto ptn = ColumnHelper::create_const_column<TYPE_VARCHAR>(" ", 1);
-    auto replace = BinaryColumn::create();
+    BinaryColumn::Ptr replace = BinaryColumn::create();
 
     const std::string strs[] = {"a b c", "a sdfwe b c"};
     const std::string replaces[] = {"-", "< > "};
@@ -2437,7 +2437,7 @@ PARALLEL_TEST(VecStringFunctionsTest, replaceConstColumn1) {
 
     auto str = ColumnHelper::create_const_column<TYPE_VARCHAR>("a b c", 2);
     auto pattern = ColumnHelper::create_const_column<TYPE_VARCHAR>(" ", 1);
-    auto replace = BinaryColumn::create();
+    BinaryColumn::Ptr replace = BinaryColumn::create();
     const std::string replaces[] = {"-", "+"};
     for (int i = 0; i < sizeof(replaces) / sizeof(replaces[0]); ++i) {
         replace->append(replaces[i]);
@@ -2503,9 +2503,9 @@ PARALLEL_TEST(VecStringFunctionsTest, replace) {
 
     Columns columns;
 
-    auto str = BinaryColumn::create();
-    auto ptn = BinaryColumn::create();
-    auto replace = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    BinaryColumn::Ptr ptn = BinaryColumn::create();
+    BinaryColumn::Ptr replace = BinaryColumn::create();
 
     const std::string strs[] = {"a b c", "a . c", "a b c", "abc?", "xyz"};
     const std::string ptns[] = {" ", ".", "^a", "abc?", "z$"};
@@ -2545,9 +2545,9 @@ PARALLEL_TEST(VecStringFunctionsTest, replaceWithEmptyPattern) {
 
     Columns columns;
 
-    auto str = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
     auto ptn = ColumnHelper::create_const_column<TYPE_VARCHAR>("", 1);
-    auto replace = BinaryColumn::create();
+    BinaryColumn::Ptr replace = BinaryColumn::create();
 
     const std::string strs[] = {"yyyy-mm-dd", "*starrocks."};
     const std::string replaces[] = {"CHINA", "CHINA"};
@@ -2584,7 +2584,7 @@ PARALLEL_TEST(VecStringFunctionsTest, moneyFormatDouble) {
     std::string results[] = {"1,234.46", "1,234.45", "1,234.40", "1,234.45"};
 
     Columns columns;
-    auto money = DoubleColumn::create();
+    DoubleColumn::Ptr money = DoubleColumn::create();
 
     for (double i : moneys) money->append(i);
 
@@ -2602,7 +2602,7 @@ PARALLEL_TEST(VecStringFunctionsTest, moneyFormatBigInt) {
     std::string results[] = {"123,456.00", "-123,456.00", "9,223,372,036,854,775,807.00"};
 
     Columns columns;
-    auto money = Int64Column::create();
+    Int64Column::Ptr money = Int64Column::create();
 
     for (long i : moneys) money->append(i);
 
@@ -2629,7 +2629,7 @@ PARALLEL_TEST(VecStringFunctionsTest, moneyFormatLargeInt) {
                              "170,141,183,460,469,231,731,687,303,715,884,105,723.00"};
 
     Columns columns;
-    auto money = Int128Column::create();
+    Int128Column::Ptr money = Int128Column::create();
 
     for (__int128 i : moneys) {
         money->append(i);
@@ -2653,7 +2653,7 @@ PARALLEL_TEST(VecStringFunctionsTest, moneyFormatDecimalV2Value) {
     std::string results[] = {"3,333,333,333.22", "-740,740,740.72"};
 
     Columns columns;
-    auto money = DecimalColumn::create();
+    DecimalColumn::Ptr money = DecimalColumn::create();
 
     for (auto i : moneys) {
         money->append(i);
@@ -2672,9 +2672,9 @@ PARALLEL_TEST(VecStringFunctionsTest, parseUrlNullable) {
 
     Columns columns;
 
-    auto str = BinaryColumn::create();
-    auto data = BinaryColumn::create();
-    auto null = NullColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    BinaryColumn::Ptr data = BinaryColumn::create();
+    NullColumn::Ptr null = NullColumn::create();
 
     std::string strs[] = {"http://cccccc:password@hostname/dsfsf?vdv=value#xcvxv",
                           "http://werwrw:sdf@sdfsceesvdsdvs/ccvwfewf?cvx=value#sdfs",
@@ -2716,8 +2716,8 @@ PARALLEL_TEST(VecStringFunctionsTest, parseUrlOnlyNull) {
 
     Columns columns;
 
-    auto str = BinaryColumn::create();
-    auto part = ColumnHelper::create_const_null_column(1);
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    ColumnPtr part = ColumnHelper::create_const_null_column(1);
 
     std::string strs[] = {"http://cccccc:password@hostname/dsfsf?vdv=value#xcvxv",
                           "http://werwrw:sdf@hostname/path?cvx=value#sdfs",
@@ -2752,7 +2752,7 @@ PARALLEL_TEST(VecStringFunctionsTest, parseUrlForConst) {
 
         Columns columns;
 
-        auto str = BinaryColumn::create();
+        BinaryColumn::Ptr str = BinaryColumn::create();
         auto part = ColumnHelper::create_const_column<TYPE_VARCHAR>("AUTHORITY", 1);
 
         std::string strs[] = {"http://username:password@hostname/path?arg=value#anchor",
@@ -2791,7 +2791,7 @@ PARALLEL_TEST(VecStringFunctionsTest, parseUrlForConst) {
 
         Columns columns;
 
-        auto str = BinaryColumn::create();
+        BinaryColumn::Ptr str = BinaryColumn::create();
         auto part = ColumnHelper::create_const_column<TYPE_VARCHAR>("PATH", 1);
 
         std::string strs[] = {"http://useraadfname:password@hostname/path?arg=value#anchor",
@@ -2831,8 +2831,8 @@ PARALLEL_TEST(VecStringFunctionsTest, parseUrl) {
 
     Columns columns;
 
-    auto str = BinaryColumn::create();
-    auto part = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    BinaryColumn::Ptr part = BinaryColumn::create();
 
     std::string strs[] = {"http://username:password@hostname/path?arg=value#anchor"};
 
@@ -2874,7 +2874,7 @@ PARALLEL_TEST(VecStringFunctionsTest, parseUrl) {
 PARALLEL_TEST(VecStringFunctionsTest, hex_intTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto ints = Int64Column::create();
+    Int64Column::Ptr ints = Int64Column::create();
 
     int64_t values[] = {21, 16, 256, 514};
     std::string strs[] = {"15", "10", "100", "202"};
@@ -2896,7 +2896,7 @@ PARALLEL_TEST(VecStringFunctionsTest, hex_intTest) {
 PARALLEL_TEST(VecStringFunctionsTest, hex_stringTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto ints = BinaryColumn::create();
+    BinaryColumn::Ptr ints = BinaryColumn::create();
 
     std::string values[] = {"21", "16", "256", "514"};
     std::string strs[] = {"3231", "3136", "323536", "353134"};
@@ -2919,7 +2919,7 @@ PARALLEL_TEST(VecStringFunctionsTest, unhexTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
 
     Columns columns;
-    auto ints = BinaryColumn::create();
+    BinaryColumn::Ptr ints = BinaryColumn::create();
 
     std::string strs[] = {"21", "16", "256", "514"};
     std::string values[] = {"3231", "3136", "323536", "353134"};
@@ -2943,8 +2943,8 @@ static void test_left_and_right_not_const(
     // left_not_const and right_not_const
     std::unique_ptr<FunctionContext> context(FunctionContext::create_test_context());
     Columns columns;
-    auto str_col = BinaryColumn::create();
-    auto len_col = Int32Column::create();
+    BinaryColumn::Ptr str_col = BinaryColumn::create();
+    Int32Column::Ptr len_col = Int32Column::create();
     for (auto& c : cases) {
         auto s = std::get<0>(c);
         auto len = std::get<1>(c);
@@ -3070,7 +3070,7 @@ static void test_left_and_right_const(
     for (auto& c : cases) {
         auto [len, left_expect, right_expect] = c;
         Columns columns;
-        auto len_col = Int32Column::create();
+        Int32Column::Ptr len_col = Int32Column::create();
         len_col->append(len);
         columns.push_back(str_col);
         columns.push_back(ConstColumn::create(len_col, 1));
@@ -3097,7 +3097,7 @@ static void test_left_and_right_const(
 }
 
 PARALLEL_TEST(VecStringFunctionsTest, leftAndRightConstASCIITest) {
-    auto str_col = BinaryColumn::create();
+    BinaryColumn::Ptr str_col = BinaryColumn::create();
     str_col->append("");
     str_col->append("a");
     str_col->append("ABCDEFG_HIJKLMN");
@@ -3118,7 +3118,7 @@ PARALLEL_TEST(VecStringFunctionsTest, leftAndRightConstASCIITest) {
 }
 
 PARALLEL_TEST(VecStringFunctionsTest, leftAndRightConstUtf8Test) {
-    auto str_col = BinaryColumn::create();
+    BinaryColumn::Ptr str_col = BinaryColumn::create();
     str_col->append("");
     str_col->append("a");
     str_col->append("三十年众生牛马，六十年诸佛龙象");
@@ -3156,9 +3156,9 @@ static void test_substr_not_const(std::vector<std::tuple<std::string, int, int, 
     std::mt19937 gen(rd());
     std::shuffle(cases.begin(), cases.end(), gen);
     std::unique_ptr<FunctionContext> context(FunctionContext::create_test_context());
-    auto str_col = BinaryColumn::create();
-    auto off_col = Int32Column::create();
-    auto len_col = Int32Column::create();
+    BinaryColumn::Ptr str_col = BinaryColumn::create();
+    Int32Column::Ptr off_col = Int32Column::create();
+    Int32Column::Ptr len_col = Int32Column::create();
     for (auto& c : cases) {
         str_col->append(Slice(std::get<0>(c)));
         off_col->append(std::get<1>(c));
@@ -3330,8 +3330,8 @@ PARALLEL_TEST(VecStringFunctionsTest, substrNotConstUtf8Test) {
 PARALLEL_TEST(VecStringFunctionsTest, strcmpTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto lhs = BinaryColumn::create();
-    auto rhs = BinaryColumn::create();
+    BinaryColumn::Ptr lhs = BinaryColumn::create();
+    BinaryColumn::Ptr rhs = BinaryColumn::create();
 
     lhs->append("");
     rhs->append("");
@@ -3372,9 +3372,9 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractAllPattern) {
 
     Columns columns;
 
-    auto str = BinaryColumn::create();
-    auto pattern = BinaryColumn::create();
-    auto index = Int64Column::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    BinaryColumn::Ptr pattern = BinaryColumn::create();
+    Int64Column::Ptr index = Int64Column::create();
 
     std::string strs[] = {"AbCdE", "AbCdrrCryE", "hitCdeciCsionCdlist", "hitCdecCisiCondlCist", "12342356"};
     std::string res[] = {"['b']", "['b']", "['hit','sion']", "['hit','isi']", "[]"};
@@ -3412,9 +3412,9 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractAllNullablePattern1) {
 
     Columns columns;
 
-    auto str = BinaryColumn::create();
-    auto pattern = BinaryColumn::create();
-    auto index = Int64Column::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    BinaryColumn::Ptr pattern = BinaryColumn::create();
+    Int64Column::Ptr index = Int64Column::create();
 
     std::string strs[] = {"AbCdE", "AbCdrrryE", "hitdeciCsiondlist", "hitdecCisiondlist"};
     int indexs[] = {1, 2, 1, 2};
@@ -3451,10 +3451,10 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractAllNullablePattern2) {
 
     Columns columns;
 
-    auto str = BinaryColumn::create();
-    auto pattern = BinaryColumn::create();
-    auto null = NullColumn::create();
-    auto index = Int64Column::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    BinaryColumn::Ptr pattern = BinaryColumn::create();
+    NullColumn::Ptr null = NullColumn::create();
+    Int64Column::Ptr index = Int64Column::create();
 
     std::string strs[] = {"AbCdE", "AbCdrrryE", "hitdeciCsiondlist", "hitdecCisioedlise"};
     int indexs[] = {1, 2, 1, 2};
@@ -3494,9 +3494,9 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractAllOnlyNullPattern) {
 
     Columns columns;
 
-    auto str = BinaryColumn::create();
-    auto pattern = ColumnHelper::create_const_null_column(1);
-    auto index = Int64Column::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    ColumnPtr pattern = ColumnHelper::create_const_null_column(1);
+    Int64Column::Ptr index = Int64Column::create();
 
     int length = 4;
 
@@ -3530,9 +3530,9 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractAllConstPattern) {
 
     Columns columns;
 
-    auto str = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
     auto pattern = ColumnHelper::create_const_column<TYPE_VARCHAR>("([[:lower:]]+)C([[:lower:]]+)", 1);
-    auto index = Int64Column::create();
+    Int64Column::Ptr index = Int64Column::create();
 
     std::string strs[] = {"AbCdE", "AbCdrrryE", "hitdeciCsiondlist", "hitdecCisiondlist"};
     int indexs[] = {1, 2, 1, 2};
@@ -3570,7 +3570,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractAllConst) {
 
     Columns columns;
 
-    auto str = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
     auto pattern = ColumnHelper::create_const_column<TYPE_VARCHAR>("([[:lower:]]+)C([[:lower:]]+)", 5);
     auto index = ColumnHelper::create_const_column<TYPE_BIGINT>(2, 5);
 
@@ -3604,7 +3604,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractAllConst) {
 PARALLEL_TEST(VecStringFunctionsTest, crc32Test) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
-    auto str = BinaryColumn::create();
+    BinaryColumn::Ptr str = BinaryColumn::create();
     str->append("starrocks");
     str->append("STARROCKS");
     columns.push_back(str);
@@ -3624,7 +3624,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpSplitTest) {
 
         Columns columns;
 
-        auto str = BinaryColumn::create();
+        BinaryColumn::Ptr str = BinaryColumn::create();
         auto pattern = ColumnHelper::create_const_column<TYPE_VARCHAR>("[ABC]", 1);
 
         std::string strs[] = {"oneAtwoBthreeC", "1A2B3C", "AABBCC"};
@@ -3659,8 +3659,8 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpSplitTest) {
 
         Columns columns;
 
-        auto str = BinaryColumn::create();
-        auto null = NullColumn::create();
+        BinaryColumn::Ptr str = BinaryColumn::create();
+        NullColumn::Ptr null = NullColumn::create();
         auto pattern = ColumnHelper::create_const_column<TYPE_VARCHAR>("[ABC]", 1);
         auto max_split = ColumnHelper::create_const_column<TYPE_INT>(2, 1);
 
@@ -3698,7 +3698,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpSplitTest) {
 
         Columns columns;
 
-        auto str = BinaryColumn::create();
+        BinaryColumn::Ptr str = BinaryColumn::create();
         auto pattern = ColumnHelper::create_const_column<TYPE_VARCHAR>("[ABC]", 1);
 
         std::string strs[] = {"oneAtwoBthreeC", "oneAtwoBthreeC", "oneAtwoBthreeC",
@@ -3736,10 +3736,10 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpSplitTest) {
 
         Columns columns;
 
-        auto str = BinaryColumn::create();
-        auto null = NullColumn::create();
+        BinaryColumn::Ptr str = BinaryColumn::create();
+        NullColumn::Ptr null = NullColumn::create();
         auto pattern = ColumnHelper::create_const_column<TYPE_VARCHAR>("[ABC]", 1);
-        auto max_split = Int32Column::create();
+        Int32Column::Ptr max_split = Int32Column::create();
 
         std::string strs[] = {"oneAtwoBthreeC", "oneAtwoBthreeC", "oneAtwoBthreeC", "oneAtwoBthreeC",
                               "oneAtwoBthreeC", "oneAtwoBthreeC", "oneAtwoBthreeC"};
@@ -3785,8 +3785,8 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpSplitTest) {
 
         Columns columns;
 
-        auto str = BinaryColumn::create();
-        auto pattern = BinaryColumn::create();
+        BinaryColumn::Ptr str = BinaryColumn::create();
+        BinaryColumn::Ptr pattern = BinaryColumn::create();
 
         std::string strs[] = {"oneAtwoBthreeC", "oneAtwoBthreeC", "oneAtwoBthreeC"};
         std::string patterns[] = {"[nwe]", "[ne]", "[123]"};
@@ -3822,9 +3822,9 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpSplitTest) {
 
         Columns columns;
 
-        auto str = BinaryColumn::create();
-        auto pattern = BinaryColumn::create();
-        auto null = NullColumn::create();
+        BinaryColumn::Ptr str = BinaryColumn::create();
+        BinaryColumn::Ptr pattern = BinaryColumn::create();
+        NullColumn::Ptr null = NullColumn::create();
         auto max_split = ColumnHelper::create_const_column<TYPE_INT>(4, 1);
 
         std::string strs[] = {"oneAtwoBthreeC", "oneAtwoBthreeC", "oneAtwoBthreeC", "oneAtwoBthreeC"};
@@ -3863,8 +3863,8 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpSplitTest) {
 
         Columns columns;
 
-        auto str = BinaryColumn::create();
-        auto pattern = BinaryColumn::create();
+        BinaryColumn::Ptr str = BinaryColumn::create();
+        BinaryColumn::Ptr pattern = BinaryColumn::create();
 
         std::string strs[] = {"oneAtwoBthreeC", "oneAtwoBthreeC", "oneAtwoBthreeC"};
         std::string patterns[] = {"[nwe]", "[ne]", "[123]"};
@@ -3901,10 +3901,10 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpSplitTest) {
 
         Columns columns;
 
-        auto str = BinaryColumn::create();
-        auto pattern = BinaryColumn::create();
-        auto null = NullColumn::create();
-        auto max_split = Int32Column::create();
+        BinaryColumn::Ptr str = BinaryColumn::create();
+        BinaryColumn::Ptr pattern = BinaryColumn::create();
+        NullColumn::Ptr null = NullColumn::create();
+        Int32Column::Ptr max_split = Int32Column::create();
 
         std::string strs[] = {"oneAtwoBthreeC", "oneAtwoBthreeC", "oneAtwoBthreeC", "oneAtwoBthreeC"};
         std::string patterns[] = {"[nwe]", "[ne]", "[123]", "[123]"};

--- a/be/test/exprs/subfield_expr_test.cpp
+++ b/be/test/exprs/subfield_expr_test.cpp
@@ -44,7 +44,7 @@ protected:
     void SetUp() override {}
     void TearDown() override { _objpool.clear(); }
 
-    FakeConstExpr* new_fake_const_expr(ColumnPtr value, const TypeDescriptor& type) {
+    FakeConstExpr* new_fake_const_expr(MutableColumnPtr&& value, const TypeDescriptor& type) {
         TExprNode node;
         node.__set_node_type(TExprNodeType::INT_LITERAL);
         node.__set_num_children(0);
@@ -80,7 +80,7 @@ TEST_F(SubfieldExprTest, subfield_test) {
 
     {
         std::unique_ptr<Expr> expr = create_subfield_expr(TypeDescriptor(LogicalType::TYPE_INT), {"id"});
-        expr->add_child(new_fake_const_expr(column, struct_type));
+        expr->add_child(new_fake_const_expr(column->clone(), struct_type));
         auto result = expr->evaluate(nullptr, nullptr);
         EXPECT_TRUE(result->is_nullable());
         auto subfield_column = ColumnHelper::get_data_column(result.get());
@@ -92,7 +92,7 @@ TEST_F(SubfieldExprTest, subfield_test) {
 
     {
         std::unique_ptr<Expr> expr = create_subfield_expr(TypeDescriptor(LogicalType::TYPE_INT), {"name"});
-        expr->add_child(new_fake_const_expr(column, struct_type));
+        expr->add_child(new_fake_const_expr(column->clone(), struct_type));
         auto result = expr->evaluate(nullptr, nullptr);
         EXPECT_TRUE(result->is_nullable());
         auto subfield_column = ColumnHelper::get_data_column(result.get());
@@ -126,7 +126,7 @@ TEST_F(SubfieldExprTest, subfield_null_test) {
         column->append_datum(datum_struct_3);
 
         std::unique_ptr<Expr> expr = create_subfield_expr(TypeDescriptor(LogicalType::TYPE_INT), {"id"});
-        expr->add_child(new_fake_const_expr(column, struct_type));
+        expr->add_child(new_fake_const_expr(std::move(column), struct_type));
         auto result = expr->evaluate(nullptr, nullptr);
         EXPECT_TRUE(result->is_nullable());
         auto subfield_column = ColumnHelper::get_data_column(result.get());
@@ -153,7 +153,7 @@ TEST_F(SubfieldExprTest, subfield_null_test) {
         column->append_datum(datum_struct_3);
 
         std::unique_ptr<Expr> expr = create_subfield_expr(TypeDescriptor(LogicalType::TYPE_INT), {"id"});
-        expr->add_child(new_fake_const_expr(column, struct_type));
+        expr->add_child(new_fake_const_expr(std::move(column), struct_type));
         auto result = expr->evaluate(nullptr, nullptr);
         EXPECT_TRUE(result->is_nullable());
         auto subfield_column = ColumnHelper::get_data_column(result.get());
@@ -187,7 +187,7 @@ TEST_F(SubfieldExprTest, subfield_clone_test) {
     column->append_datum(datum_struct_3);
 
     std::unique_ptr<Expr> expr = create_subfield_expr(TypeDescriptor(LogicalType::TYPE_INT), {"id"});
-    expr->add_child(new_fake_const_expr(column, struct_type));
+    expr->add_child(new_fake_const_expr(column->clone(), struct_type));
     auto result = expr->evaluate(nullptr, nullptr);
     EXPECT_TRUE(result->is_nullable());
     auto subfield_column = ColumnHelper::get_data_column(result.get());
@@ -230,7 +230,7 @@ TEST_F(SubfieldExprTest, subfield_multi_level_test) {
     column->append_datum(datum_struct_3_level1);
 
     std::unique_ptr<Expr> expr = create_subfield_expr(TypeDescriptor(LogicalType::TYPE_INT), {"level1", "level2"});
-    expr->add_child(new_fake_const_expr(column, struct_type));
+    expr->add_child(new_fake_const_expr(std::move(column), struct_type));
     auto result = expr->evaluate(nullptr, nullptr);
     EXPECT_TRUE(result->is_nullable());
     EXPECT_EQ(3, result->size());

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -71,7 +71,7 @@ private:
 TEST_F(TimeFunctionsTest, yearTest) {
     Columns columns;
 
-    auto tc = TimestampColumn::create();
+    TimestampColumn::Ptr tc = TimestampColumn::create();
     for (int j = 0; j < 20; ++j) {
         tc->append(TimestampValue::create(2000 + j, 1, 1, 0, 30, 30));
     }
@@ -92,8 +92,8 @@ TEST_F(TimeFunctionsTest, yearTest) {
 TEST_F(TimeFunctionsTest, quarterNullTest) {
     Columns columns;
 
-    auto null = NullColumn::create();
-    auto tc = TimestampColumn::create();
+    NullColumn::Ptr null = NullColumn::create();
+    TimestampColumn::Ptr tc = TimestampColumn::create();
     for (int j = 0; j < 10; ++j) {
         tc->append(TimestampValue::create(2000, j + 1, 1, 0, 30, 30));
         null->append(j % 2 == 0);
@@ -120,8 +120,8 @@ TEST_F(TimeFunctionsTest, quarterNullTest) {
 TEST_F(TimeFunctionsTest, yearAddTest) {
     Columns columns;
 
-    auto tc = TimestampColumn::create();
-    auto year = Int32Column::create();
+    TimestampColumn::Ptr tc = TimestampColumn::create();
+    Int32Column::Ptr year = Int32Column::create();
     for (int j = 0; j < 20; ++j) {
         tc->append(TimestampValue::create(2000, 1, 1, 0, 30, 30));
         year->append(j);
@@ -145,8 +145,8 @@ TEST_F(TimeFunctionsTest, yearAddTest) {
 TEST_F(TimeFunctionsTest, quarterAddTest) {
     Columns columns;
 
-    auto tc = TimestampColumn::create();
-    auto quarter = Int32Column::create();
+    TimestampColumn::Ptr tc = TimestampColumn::create();
+    Int32Column::Ptr quarter = Int32Column::create();
 
     tc->append(TimestampValue::create(2000, 1, 1, 0, 30, 30));
     quarter->append(2);
@@ -165,8 +165,8 @@ TEST_F(TimeFunctionsTest, quarterAddTest) {
 TEST_F(TimeFunctionsTest, millisAddTest) {
     Columns columns;
 
-    auto tc = TimestampColumn::create();
-    auto millis = Int32Column::create();
+    TimestampColumn::Ptr tc = TimestampColumn::create();
+    Int32Column::Ptr millis = Int32Column::create();
 
     tc->append(TimestampValue::create(2000, 1, 1, 0, 30, 30));
     millis->append(200);
@@ -188,8 +188,8 @@ TEST_F(TimeFunctionsTest, millisAddTest) {
 TEST_F(TimeFunctionsTest, yearOverflowTest) {
     Columns columns;
 
-    auto tc = TimestampColumn::create();
-    auto year = Int32Column::create();
+    TimestampColumn::Ptr tc = TimestampColumn::create();
+    Int32Column::Ptr year = Int32Column::create();
     tc->append(TimestampValue::create(2000, 1, 1, 0, 30, 30));
     year->append(8000);
 
@@ -214,7 +214,7 @@ TEST_F(TimeFunctionsTest, yearOverflowTest) {
 
 TEST_F(TimeFunctionsTest, monthTest) {
     Columns columns;
-    auto tc = TimestampColumn::create();
+    TimestampColumn::Ptr tc = TimestampColumn::create();
     for (int j = 0; j < 20; ++j) {
         tc->append(TimestampValue::create(2000, j + 1, 1, 0, 1, 1));
     }
@@ -236,7 +236,7 @@ TEST_F(TimeFunctionsTest, monthTest) {
 }
 
 TEST_F(TimeFunctionsTest, dayOfWeekTest) {
-    auto tc = TimestampColumn::create();
+    TimestampColumn::Ptr tc = TimestampColumn::create();
     tc->append(TimestampValue::create(2020, 7, 5, 0, 1, 1));  // Sunday
     tc->append(TimestampValue::create(2020, 7, 6, 0, 1, 1));  // Monday
     tc->append(TimestampValue::create(2020, 7, 7, 0, 1, 1));  // Tuesday
@@ -259,7 +259,7 @@ TEST_F(TimeFunctionsTest, dayOfWeekTest) {
 }
 
 TEST_F(TimeFunctionsTest, dayOfYearTest) {
-    auto tc = TimestampColumn::create();
+    TimestampColumn::Ptr tc = TimestampColumn::create();
     tc->append(TimestampValue::create(2020, 1, 1, 0, 1, 1));
     tc->append(TimestampValue::create(2020, 2, 2, 0, 0, 1));
     tc->append(TimestampValue::create(2020, 3, 6, 0, 1, 1));
@@ -284,7 +284,7 @@ TEST_F(TimeFunctionsTest, dayOfYearTest) {
 }
 
 TEST_F(TimeFunctionsTest, weekOfYearTest) {
-    auto tc = TimestampColumn::create();
+    TimestampColumn::Ptr tc = TimestampColumn::create();
     tc->append(TimestampValue::create(2020, 1, 1, 0, 1, 1));
     tc->append(TimestampValue::create(2020, 7, 5, 3, 0, 1));
     tc->append(TimestampValue::create(2020, 3, 28, 7, 12, 1));
@@ -309,7 +309,7 @@ TEST_F(TimeFunctionsTest, weekOfYearTest) {
 }
 
 TEST_F(TimeFunctionsTest, weekOfYearIsoTest) {
-    auto tc = TimestampColumn::create();
+    TimestampColumn::Ptr tc = TimestampColumn::create();
     tc->append(TimestampValue::create(2023, 1, 5, 0, 5, 0));
     tc->append(TimestampValue::create(2023, 1, 9, 0, 9, 0));
     tc->append(TimestampValue::create(2023, 1, 2, 0, 2, 0));
@@ -335,7 +335,7 @@ TEST_F(TimeFunctionsTest, weekOfYearIsoTest) {
 }
 
 TEST_F(TimeFunctionsTest, weekWithDefaultModeTest) {
-    auto tc = TimestampColumn::create();
+    TimestampColumn::Ptr tc = TimestampColumn::create();
     tc->append(TimestampValue::create(2007, 1, 1, 0, 0, 0));
     tc->append(TimestampValue::create(2017, 5, 1, 0, 0, 0));
     tc->append(TimestampValue::create(2020, 9, 23, 0, 0, 0));
@@ -355,7 +355,7 @@ TEST_F(TimeFunctionsTest, weekWithDefaultModeTest) {
 }
 
 TEST_F(TimeFunctionsTest, dayofweekisoTest) {
-    auto tc = TimestampColumn::create();
+    TimestampColumn::Ptr tc = TimestampColumn::create();
     tc->append(TimestampValue::create(2023, 1, 1, 0, 5, 0));
     tc->append(TimestampValue::create(2023, 1, 2, 0, 9, 0));
     tc->append(TimestampValue::create(2023, 1, 3, 0, 2, 0));
@@ -374,7 +374,7 @@ TEST_F(TimeFunctionsTest, dayofweekisoTest) {
 }
 
 TEST_F(TimeFunctionsTest, weekWithModeTest) {
-    auto tc = TimestampColumn::create();
+    TimestampColumn::Ptr tc = TimestampColumn::create();
     tc->append(TimestampValue::create(2007, 1, 1, 0, 0, 0));
     tc->append(TimestampValue::create(2017, 5, 1, 0, 0, 0));
     tc->append(TimestampValue::create(2020, 9, 23, 0, 0, 0));
@@ -384,7 +384,7 @@ TEST_F(TimeFunctionsTest, weekWithModeTest) {
     tc->append(TimestampValue::create(2005, 2, 3, 0, 0, 0));
     tc->append(TimestampValue::create(2003, 9, 3, 0, 0, 0));
 
-    auto mode_column = Int32Column::create();
+    Int32Column::Ptr mode_column = Int32Column::create();
     mode_column->append(3);
     mode_column->append(2);
     mode_column->append(1);
@@ -410,7 +410,7 @@ TEST_F(TimeFunctionsTest, weekWithModeTest) {
 
 TEST_F(TimeFunctionsTest, toDateTest) {
     const int year = 2020, month = 6, day = 18;
-    auto tc = TimestampColumn::create();
+    TimestampColumn::Ptr tc = TimestampColumn::create();
     tc->append(TimestampValue::create(year, month, day, 19, 21, 21));
     Columns columns;
     columns.emplace_back(tc);
@@ -439,11 +439,11 @@ TEST_P(ToTeraDateTestFixture, to_tera_date) {
     auto utils = std::make_shared<FunctionUtils>(state.get());
 
     Columns columns;
-    auto data = BinaryColumn::create();
+    BinaryColumn::Ptr data = BinaryColumn::create();
     data->append(datetime_str);
-    auto format_data = BinaryColumn::create();
+    BinaryColumn::Ptr format_data = BinaryColumn::create();
     format_data->append(format_str);
-    auto format = ConstColumn::create(format_data, 1);
+    ConstColumn::Ptr format = ConstColumn::create(format_data, 1);
 
     columns.emplace_back(data);
     columns.emplace_back(format);
@@ -498,11 +498,11 @@ TEST_P(ToTimestampTestFixture, to_tera_timestamp) {
     auto utils = std::make_shared<FunctionUtils>(state.get());
 
     Columns columns;
-    auto data = BinaryColumn::create();
+    BinaryColumn::Ptr data = BinaryColumn::create();
     data->append(datetime_str);
-    auto format_data = BinaryColumn::create();
+    BinaryColumn::Ptr format_data = BinaryColumn::create();
     format_data->append(format_str);
-    auto format = ConstColumn::create(format_data, 1);
+    ConstColumn::Ptr format = ConstColumn::create(format_data, 1);
 
     columns.emplace_back(data);
     columns.emplace_back(format);
@@ -552,8 +552,8 @@ INSTANTIATE_TEST_SUITE_P(
                 ));
 
 TEST_F(TimeFunctionsTest, dateAndDaysDiffTest) {
-    auto tc1 = TimestampColumn::create();
-    auto tc2 = TimestampColumn::create();
+    TimestampColumn::Ptr tc1 = TimestampColumn::create();
+    TimestampColumn::Ptr tc2 = TimestampColumn::create();
     // group 1
     tc1->append(TimestampValue::create(2012, 8, 30, 0, 0, 0));
     tc2->append(TimestampValue::create(2012, 8, 24, 0, 0, 1));
@@ -633,9 +633,9 @@ TEST_F(TimeFunctionsTest, dateDiffTest) {
             std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
             Columns columns;
 
-            auto type_col = ConstColumn::create(BinaryColumn::create());
-            auto lhs_col = TimestampColumn::create();
-            auto rhs_col = TimestampColumn::create();
+            ConstColumn::Ptr type_col = ConstColumn::create(BinaryColumn::create());
+            TimestampColumn::Ptr lhs_col = TimestampColumn::create();
+            TimestampColumn::Ptr rhs_col = TimestampColumn::create();
 
             type_col->append_datum(Slice(type_value));
             for (const auto& v : lhs_values) {
@@ -679,9 +679,9 @@ TEST_F(TimeFunctionsTest, dateDiffTest) {
             std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
             Columns columns;
 
-            auto type_col = BinaryColumn::create();
-            auto lhs_col = TimestampColumn::create();
-            auto rhs_col = TimestampColumn::create();
+            BinaryColumn::Ptr type_col = BinaryColumn::create();
+            TimestampColumn::Ptr lhs_col = TimestampColumn::create();
+            TimestampColumn::Ptr rhs_col = TimestampColumn::create();
 
             for (const auto& v : type_values) {
                 type_col->append_datum(Slice(v));
@@ -711,8 +711,8 @@ TEST_F(TimeFunctionsTest, dateDiffTest) {
 }
 
 TEST_F(TimeFunctionsTest, timeDiffTest) {
-    auto tc1 = TimestampColumn::create();
-    auto tc2 = TimestampColumn::create();
+    TimestampColumn::Ptr tc1 = TimestampColumn::create();
+    TimestampColumn::Ptr tc2 = TimestampColumn::create();
     // group 1: from TimestampFunctionsTest.time_diff_test
     tc1->append(TimestampValue::create(2019, 7, 18, 12, 0, 0));
     tc2->append(TimestampValue::create(2019, 7, 18, 13, 1, 2));
@@ -742,8 +742,8 @@ TEST_F(TimeFunctionsTest, yearsDiffTest) {
     {
         Columns columns;
 
-        auto tc1 = TimestampColumn::create();
-        auto tc2 = TimestampColumn::create();
+        TimestampColumn::Ptr tc1 = TimestampColumn::create();
+        TimestampColumn::Ptr tc2 = TimestampColumn::create();
         for (int j = 0; j < 20; ++j) {
             tc1->append(TimestampValue::create(2001, 11, 1, 0, 30, 30));
             tc2->append(TimestampValue::create(2000, 12, 1, 0, 30, 30));
@@ -765,8 +765,8 @@ TEST_F(TimeFunctionsTest, yearsDiffTest) {
     {
         Columns columns;
 
-        auto tc1 = TimestampColumn::create();
-        auto tc2 = TimestampColumn::create();
+        TimestampColumn::Ptr tc1 = TimestampColumn::create();
+        TimestampColumn::Ptr tc2 = TimestampColumn::create();
         for (int j = 0; j < 20; ++j) {
             tc1->append(TimestampValue::create(2002, 12, 1, 0, 30, 30));
             tc2->append(TimestampValue::create(2000, 11, 1, 0, 30, 30));
@@ -788,8 +788,8 @@ TEST_F(TimeFunctionsTest, yearsDiffTest) {
     {
         Columns columns;
 
-        auto tc1 = TimestampColumn::create();
-        auto tc2 = TimestampColumn::create();
+        TimestampColumn::Ptr tc1 = TimestampColumn::create();
+        TimestampColumn::Ptr tc2 = TimestampColumn::create();
         for (int j = 0; j < 20; ++j) {
             tc1->append(TimestampValue::create(2000, 11, 1, 0, 30, 30));
             tc2->append(TimestampValue::create(2001, 12, 1, 0, 30, 30));
@@ -813,8 +813,8 @@ TEST_F(TimeFunctionsTest, monthsDiffTest) {
     {
         Columns columns;
 
-        auto tc1 = TimestampColumn::create();
-        auto tc2 = TimestampColumn::create();
+        TimestampColumn::Ptr tc1 = TimestampColumn::create();
+        TimestampColumn::Ptr tc2 = TimestampColumn::create();
         for (int j = 0; j < 20; ++j) {
             tc1->append(TimestampValue::create(2000, 1, 1, 0, 30, 30));
             tc2->append(TimestampValue::create(2000, 12, 1, 0, 30, 30));
@@ -836,8 +836,8 @@ TEST_F(TimeFunctionsTest, monthsDiffTest) {
     {
         Columns columns;
 
-        auto tc1 = TimestampColumn::create();
-        auto tc2 = TimestampColumn::create();
+        TimestampColumn::Ptr tc1 = TimestampColumn::create();
+        TimestampColumn::Ptr tc2 = TimestampColumn::create();
         for (int j = 0; j < 20; ++j) {
             tc1->append(TimestampValue::create(2002, 1, 1, 0, 30, 30));
             tc2->append(TimestampValue::create(2000, 12, 1, 0, 30, 30));
@@ -913,7 +913,7 @@ TEST_F(TimeFunctionsTest, now) {
         starrocks::FunctionUtils futils(&state);
         FunctionContext* ctx = futils.get_fn_ctx();
         Columns args;
-        auto precisions = Int32Column::create();
+        Int32Column::Ptr precisions = Int32Column::create();
         for (int i = 0; i <= 6; i++) {
             precisions->append(i);
         }
@@ -989,8 +989,8 @@ TEST_F(TimeFunctionsTest, curdate) {
 }
 
 TEST_F(TimeFunctionsTest, weeks_diff) {
-    auto tc1 = TimestampColumn::create();
-    auto tc2 = TimestampColumn::create();
+    TimestampColumn::Ptr tc1 = TimestampColumn::create();
+    TimestampColumn::Ptr tc2 = TimestampColumn::create();
     // case 1: 0 week, from TimestampFunctionsTest.time_diff_test
     tc1->append(TimestampValue::create(2012, 8, 24, 0, 0, 1));
     tc2->append(TimestampValue::create(2012, 8, 30, 0, 0, 0));
@@ -1036,8 +1036,8 @@ TEST_F(TimeFunctionsTest, weeks_diff) {
 }
 
 TEST_F(TimeFunctionsTest, quarters_diff) {
-    auto tc1 = TimestampColumn::create();
-    auto tc2 = TimestampColumn::create();
+    TimestampColumn::Ptr tc1 = TimestampColumn::create();
+    TimestampColumn::Ptr tc2 = TimestampColumn::create();
     // case 1: 0 quarter
     tc1->append(TimestampValue::create(2020, 1, 2, 3, 4, 5));
     tc2->append(TimestampValue::create(2020, 4, 2, 3, 4, 4));
@@ -1075,8 +1075,8 @@ TEST_F(TimeFunctionsTest, quarters_diff) {
 }
 
 TEST_F(TimeFunctionsTest, hours_minutes_seconds_diff) {
-    auto tc1 = TimestampColumn::create();
-    auto tc2 = TimestampColumn::create();
+    TimestampColumn::Ptr tc1 = TimestampColumn::create();
+    TimestampColumn::Ptr tc2 = TimestampColumn::create();
     // case 1: from TimestampFunctionsTest.timestampdiff_test
     tc1->append(TimestampValue::create(2012, 8, 30, 0, 0, 0));
     tc2->append(TimestampValue::create(2012, 8, 24, 0, 0, 1));
@@ -1143,9 +1143,9 @@ TEST_F(TimeFunctionsTest, toUnixForNow) {
 
         ASSERT_TRUE(result->is_constant());
 
-        auto v = std::static_pointer_cast<ConstColumn>(result)->data_column();
+        auto v = ConstColumn::static_pointer_cast(result)->data_column();
         //auto v = ColumnHelper::cast_to<TYPE_BIGINT>(result);
-        ASSERT_EQ(1565080737, std::static_pointer_cast<Int32Column>(v)->get_data()[0]);
+        ASSERT_EQ(1565080737, Int32Column::static_pointer_cast(v)->get_data()[0]);
     }
 }
 
@@ -1153,7 +1153,7 @@ TEST_F(TimeFunctionsTest, toUnixFromDatetime) {
     {
         Columns columns;
 
-        auto tc1 = TimestampColumn::create();
+        TimestampColumn::Ptr tc1 = TimestampColumn::create();
         tc1->append(TimestampValue::create(1970, 1, 1, 16, 0, 0));
         tc1->append(TimestampValue::create(2019, 8, 6, 1, 38, 57));
 
@@ -1173,7 +1173,7 @@ TEST_F(TimeFunctionsTest, toUnixFromDate) {
     {
         Columns columns;
 
-        auto tc1 = DateColumn::create();
+        DateColumn::Ptr tc1 = DateColumn::create();
         tc1->append(DateValue::create(1970, 1, 1));
         tc1->append(DateValue::create(1970, 1, 2));
 
@@ -1193,10 +1193,10 @@ TEST_F(TimeFunctionsTest, toUnixFromDatetimeWithFormat) {
     {
         Columns columns;
         //     ASSERT_EQ(1565080737, TimestampFunctions::to_unix(ctx, StringVal("2019-08-06 01:38:57"), "%Y-%m-%d %H:%i:%S").val);
-        auto tc1 = BinaryColumn::create();
+        BinaryColumn::Ptr tc1 = BinaryColumn::create();
         tc1->append("2019-08-06 01:38:57");
         tc1->append("2019-08-06 01:38:58");
-        auto tc2 = BinaryColumn::create();
+        BinaryColumn::Ptr tc2 = BinaryColumn::create();
         tc2->append("%Y-%m-%d %H:%i:%S");
         tc2->append("%Y-%m-%d %H:%i:%S");
 
@@ -1217,7 +1217,7 @@ TEST_F(TimeFunctionsTest, fromUnixToDatetime) {
     {
         Columns columns;
         //     ASSERT_EQ(1565080737, TimestampFunctions::to_unix(ctx, StringVal("2019-08-06 01:38:57"), "%Y-%m-%d %H:%i:%S").val);
-        auto tc1 = Int32Column::create();
+        Int32Column::Ptr tc1 = Int32Column::create();
         tc1->append(1565080737);
         tc1->append(1565080797);
         tc1->append(1565084337);
@@ -1239,11 +1239,11 @@ TEST_F(TimeFunctionsTest, fromUnixToDatetimeWithFormat) {
     {
         Columns columns;
         //     ASSERT_EQ(1565080737, TimestampFunctions::to_unix(ctx, StringVal("2019-08-06 01:38:57"), "%Y-%m-%d %H:%i:%S").val);
-        auto tc1 = Int32Column::create();
+        Int32Column::Ptr tc1 = Int32Column::create();
         tc1->append(24 * 60 * 60);
         tc1->append(61 + 24 * 60 * 60);
         tc1->append(3789 + 24 * 60 * 60);
-        auto tc2 = BinaryColumn::create();
+        BinaryColumn::Ptr tc2 = BinaryColumn::create();
         tc2->append("%Y-%m-%d %H:%i:%S");
         tc2->append("%Y-%m-%d %H:%i:%S");
         tc2->append("%Y-%m-%d %H:%i:%S");
@@ -1276,7 +1276,7 @@ TEST_F(TimeFunctionsTest, fromUnixToDatetimeWithConstFormat) {
     {
         Columns columns;
         //     ASSERT_EQ(1565080737, TimestampFunctions::to_unix(ctx, StringVal("2019-08-06 01:38:57"), "%Y-%m-%d %H:%i:%S").val);
-        auto tc1 = Int32Column::create();
+        Int32Column::Ptr tc1 = Int32Column::create();
         tc1->append(24 * 60 * 60);
         tc1->append(61 + 24 * 60 * 60);
         tc1->append(3789 + 24 * 60 * 60);
@@ -1333,7 +1333,7 @@ TEST_F(TimeFunctionsTest, from_days) {
     DateValue date = DateValue::create(Year, Month, Day);
     // nullable
     {
-        auto tc = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), true);
+        ColumnPtr tc = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), true);
         tc->append_datum((RunTimeTypeTraits<TYPE_INT>::CppType)dtv.daynr());
         (void)tc->append_nulls(1);
 
@@ -1362,7 +1362,7 @@ TEST_F(TimeFunctionsTest, from_days) {
     }
     // null
     {
-        auto tc = ColumnHelper::create_const_null_column(1);
+        ColumnPtr tc = ColumnHelper::create_const_null_column(1);
         Columns columns;
         columns.emplace_back(tc);
         ColumnPtr result = TimeFunctions::from_days(ctx, columns).value();
@@ -1370,7 +1370,7 @@ TEST_F(TimeFunctionsTest, from_days) {
     }
     // normal
     {
-        auto col = Int32Column::create();
+        Int32Column::Ptr col = Int32Column::create();
         col->append(730850);
 
         Columns columns;
@@ -1385,7 +1385,7 @@ TEST_F(TimeFunctionsTest, from_days) {
     }
     // overflow
     {
-        auto tc = Int32Column::create();
+        Int32Column::Ptr tc = Int32Column::create();
         tc->append(3652425);
 
         Columns columns;
@@ -1399,7 +1399,7 @@ TEST_F(TimeFunctionsTest, from_days) {
     }
     // from_days(negative) return "0000-00-00"
     {
-        auto tc = Int32Column::create();
+        Int32Column::Ptr tc = Int32Column::create();
         tc->append(-1);
         tc->append(-2);
         tc->append(-2147483648);
@@ -1424,7 +1424,7 @@ TEST_F(TimeFunctionsTest, to_days) {
     tc->append(DateValue::create(Year, Month, Day));
 
     Columns columns;
-    columns.emplace_back(tc);
+    columns.emplace_back(std::move(tc));
 
     ColumnPtr result = TimeFunctions::to_days(_utils->get_fn_ctx(), columns).value();
     ASSERT_TRUE(result->is_numeric());
@@ -1448,8 +1448,8 @@ TEST_F(TimeFunctionsTest, str_to_date) {
     const auto& varchar_type_desc = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
     // nullable
     {
-        auto str_col = ColumnHelper::create_column(varchar_type_desc, true);
-        auto fmt_col = ColumnHelper::create_column(varchar_type_desc, true);
+        ColumnPtr str_col = ColumnHelper::create_column(varchar_type_desc, true);
+        ColumnPtr fmt_col = ColumnHelper::create_column(varchar_type_desc, true);
         str_col->append_datum(Slice(str1)); // str1 <=> fmt1
         fmt_col->append_datum(Slice(fmt1));
         str_col->append_datum(Slice(str2)); // str2 <=> fmt2
@@ -1492,7 +1492,7 @@ TEST_F(TimeFunctionsTest, str_to_date) {
     }
     // const <=> non-const
     {
-        auto str_col = ColumnHelper::create_column(varchar_type_desc, true);
+        ColumnPtr str_col = ColumnHelper::create_column(varchar_type_desc, true);
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(fmt1, 1);
         str_col->append_datum(Slice(str1));
         (void)str_col->append_nulls(1);
@@ -1523,7 +1523,7 @@ TEST_F(TimeFunctionsTest, str_to_date_of_dateformat) {
     const auto& varchar_type_desc = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
     // const <=> non-const
     {
-        auto str_col = ColumnHelper::create_column(varchar_type_desc, true);
+        ColumnPtr str_col = ColumnHelper::create_column(varchar_type_desc, true);
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(fmt1, 1);
         str_col->append_datum(Slice(str1));
         (void)str_col->append_nulls(1);
@@ -1561,7 +1561,7 @@ TEST_F(TimeFunctionsTest, str_to_date_of_datetimeformat) {
     const auto& varchar_type_desc = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
     // const <=> non-const
     {
-        auto str_col = ColumnHelper::create_column(varchar_type_desc, true);
+        ColumnPtr str_col = ColumnHelper::create_column(varchar_type_desc, true);
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(fmt1, 1);
         str_col->append_datum(Slice(str1));
         (void)str_col->append_nulls(1);
@@ -1592,9 +1592,9 @@ TEST_F(TimeFunctionsTest, date_format) {
     FunctionContext* ctx = FunctionContext::create_test_context();
     auto ptr = std::unique_ptr<FunctionContext>(ctx);
 
-    auto date_col = DateColumn::create();
+    DateColumn::Ptr date_col = DateColumn::create();
     date_col->append(DateValue::create(2013, 5, 1));
-    auto dt_col = TimestampColumn::create();
+    TimestampColumn::Ptr dt_col = TimestampColumn::create();
     dt_col->append(TimestampValue::create(2020, 6, 25, 15, 58, 21));
     // date_format
     {
@@ -1725,8 +1725,8 @@ TEST_F(TimeFunctionsTest, date_format) {
         auto dts_col = TimestampColumn::create();
         dts_col->append(TimestampValue::create(2020, 6, 25, 15, 58, 21, 111000));
         Columns columns;
-        columns.emplace_back(dts_col);
-        columns.emplace_back(fmt_col);
+        columns.emplace_back(std::move(dts_col));
+        columns.emplace_back(std::move(fmt_col));
         ctx->set_constant_columns(columns);
         TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
         ColumnPtr result = TimeFunctions::datetime_format(ctx, columns).value();
@@ -1741,7 +1741,7 @@ TEST_F(TimeFunctionsTest, date_format) {
 
         Columns columns;
         columns.emplace_back(dt_col);
-        columns.emplace_back(fmt_col);
+        columns.emplace_back(std::move(fmt_col));
         ctx->set_constant_columns(columns);
         TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
         ColumnPtr result = TimeFunctions::datetime_format(ctx, columns).value();
@@ -1756,7 +1756,7 @@ TEST_F(TimeFunctionsTest, date_format) {
 
         Columns columns;
         columns.emplace_back(dt_col);
-        columns.emplace_back(fmt_col);
+        columns.emplace_back(std::move(fmt_col));
         ctx->set_constant_columns(columns);
         TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
         ColumnPtr result = TimeFunctions::datetime_format(ctx, columns).value();
@@ -1771,7 +1771,7 @@ TEST_F(TimeFunctionsTest, date_format) {
 
         Columns columns;
         columns.emplace_back(dt_col);
-        columns.emplace_back(fmt_col);
+        columns.emplace_back(std::move(fmt_col));
         ctx->set_constant_columns(columns);
         TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
         ColumnPtr result = TimeFunctions::datetime_format(ctx, columns).value();
@@ -1786,7 +1786,7 @@ TEST_F(TimeFunctionsTest, date_format) {
 
         Columns columns;
         columns.emplace_back(dt_col);
-        columns.emplace_back(fmt_col);
+        columns.emplace_back(std::move(fmt_col));
         ctx->set_constant_columns(columns);
         TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
         ColumnPtr result = TimeFunctions::datetime_format(ctx, columns).value();
@@ -1801,7 +1801,7 @@ TEST_F(TimeFunctionsTest, date_format) {
 
         Columns columns;
         columns.emplace_back(dt_col);
-        columns.emplace_back(fmt_col);
+        columns.emplace_back(std::move(fmt_col));
         ctx->set_constant_columns(columns);
         TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
         ColumnPtr result = TimeFunctions::datetime_format(ctx, columns).value();
@@ -1816,7 +1816,7 @@ TEST_F(TimeFunctionsTest, date_format) {
 
         Columns columns;
         columns.emplace_back(dt_col);
-        columns.emplace_back(fmt_col);
+        columns.emplace_back(std::move(fmt_col));
         ctx->set_constant_columns(columns);
         TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
         ColumnPtr result = TimeFunctions::datetime_format(ctx, columns).value();
@@ -1836,7 +1836,7 @@ TEST_F(TimeFunctionsTest, date_format) {
                 ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice(test_string.c_str(), test_string.size()), 1);
         Columns columns;
         columns.emplace_back(dt_col);
-        columns.emplace_back(fmt_col);
+        columns.emplace_back(std::move(fmt_col));
 
         ctx->set_constant_columns(columns);
         TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
@@ -1848,7 +1848,7 @@ TEST_F(TimeFunctionsTest, date_format) {
         // Test(const,var)
         auto datetime_col =
                 ColumnHelper::create_const_column<TYPE_DATETIME>(TimestampValue::create(2020, 12, 18, 10, 9, 8), 2);
-        auto string_col = BinaryColumn::create();
+        BinaryColumn::Ptr string_col = BinaryColumn::create();
         string_col->append_string(std::string("a"));
         string_col->append_string(std::string("b"));
 
@@ -1877,7 +1877,7 @@ TEST_F(TimeFunctionsTest, date_format) {
         ASSERT_TRUE(result->only_null());
     }
     {
-        auto fmt_col = BinaryColumn::create();
+        BinaryColumn::Ptr fmt_col = BinaryColumn::create();
         fmt_col->append_string(std::string(""));
 
         Columns columns;
@@ -1901,7 +1901,7 @@ TEST_F(TimeFunctionsTest, date_format) {
         ASSERT_TRUE(result->only_null());
     }
     {
-        auto string_col = BinaryColumn::create();
+        BinaryColumn::Ptr string_col = BinaryColumn::create();
         string_col->append_string(std::string(""));
 
         Columns columns;
@@ -1920,9 +1920,9 @@ TEST_F(TimeFunctionsTest, jodatime_format) {
     FunctionContext* ctx = FunctionContext::create_test_context();
     auto ptr = std::unique_ptr<FunctionContext>(ctx);
 
-    auto date_col = DateColumn::create();
+    DateColumn::Ptr date_col = DateColumn::create();
     date_col->append(DateValue::create(2013, 5, 1));
-    auto dt_col = TimestampColumn::create();
+    TimestampColumn::Ptr dt_col = TimestampColumn::create();
     dt_col->append(TimestampValue::create(2020, 6, 25, 15, 58, 21));
     // jodadate_format
     {
@@ -2340,7 +2340,7 @@ TEST_F(TimeFunctionsTest, trino_str_to_jodatime) {
 }
 
 TEST_F(TimeFunctionsTest, daynameTest) {
-    auto tc = TimestampColumn::create();
+    TimestampColumn::Ptr tc = TimestampColumn::create();
     tc->append(TimestampValue::create(2020, 1, 1, 21, 22, 1));
     tc->append(TimestampValue::create(2020, 2, 2, 14, 17, 1));
     tc->append(TimestampValue::create(2020, 3, 6, 11, 54, 1));
@@ -2362,7 +2362,7 @@ TEST_F(TimeFunctionsTest, daynameTest) {
 }
 
 TEST_F(TimeFunctionsTest, monthnameTest) {
-    auto tc = TimestampColumn::create();
+    TimestampColumn::Ptr tc = TimestampColumn::create();
     tc->append(TimestampValue::create(2020, 1, 1, 21, 22, 1));
     tc->append(TimestampValue::create(2020, 2, 2, 14, 17, 1));
     tc->append(TimestampValue::create(2020, 3, 6, 11, 54, 1));
@@ -2384,21 +2384,21 @@ TEST_F(TimeFunctionsTest, monthnameTest) {
 }
 
 TEST_F(TimeFunctionsTest, convertTzGeneralTest) {
-    auto tc = TimestampColumn::create();
+    TimestampColumn::Ptr tc = TimestampColumn::create();
     tc->append(TimestampValue::create(2019, 8, 1, 13, 21, 3));
     tc->append(TimestampValue::create(2019, 8, 1, 13, 21, 3));
     tc->append(TimestampValue::create(2019, 8, 1, 13, 21, 3));
     tc->append(TimestampValue::create(2019, 8, 1, 8, 21, 3));
     tc->append(TimestampValue::create(2019, 8, 1, 8, 21, 3));
 
-    auto tc_from = BinaryColumn::create();
+    BinaryColumn::Ptr tc_from = BinaryColumn::create();
     tc_from->append(Slice("Asia/Shanghai"));
     tc_from->append(Slice("Asia/Urumqi"));
     tc_from->append(Slice("America/Los_Angeles"));
     tc_from->append(Slice("Asia/Shanghai"));
     tc_from->append(Slice("Asia/Shanghai"));
 
-    auto tc_to = BinaryColumn::create();
+    BinaryColumn::Ptr tc_to = BinaryColumn::create();
     tc_to->append(Slice("America/Los_Angeles"));
     tc_to->append(Slice("America/Los_Angeles"));
     tc_to->append(Slice("Asia/Urumqi"));
@@ -2430,7 +2430,7 @@ TEST_F(TimeFunctionsTest, convertTzGeneralTest) {
 }
 
 TEST_F(TimeFunctionsTest, convertTzConstTest) {
-    auto tc = TimestampColumn::create();
+    TimestampColumn::Ptr tc = TimestampColumn::create();
     tc->append(TimestampValue::create(2019, 4, 7, 21, 21, 3));
     tc->append(TimestampValue::create(2019, 8, 1, 13, 8, 7));
     tc->append(TimestampValue::create(2019, 6, 18, 9, 13, 27));
@@ -2438,11 +2438,11 @@ TEST_F(TimeFunctionsTest, convertTzConstTest) {
     auto tc_from = ColumnHelper::create_const_column<TYPE_VARCHAR>("Asia/Urumqi", 1);
 
     const char* literal = "America/Los_Angeles";
-    auto to_col = BinaryColumn::create();
+    BinaryColumn::Ptr to_col = BinaryColumn::create();
     to_col->append(Slice(literal));
     to_col->get_bytes().emplace_back('X');
     to_col->get_bytes().resize(to_col->get_offset().back());
-    auto tc_to = ConstColumn::create(std::move(to_col));
+    ConstColumn::Ptr tc_to = ConstColumn::create(std::move(to_col));
 
     TimestampValue res[] = {TimestampValue::create(2019, 4, 7, 8, 21, 3), TimestampValue::create(2019, 8, 1, 0, 8, 7),
                             TimestampValue::create(2019, 6, 17, 20, 13, 27)};
@@ -2527,7 +2527,7 @@ TEST_F(TimeFunctionsTest, utctimeTest) {
 }
 
 TEST_F(TimeFunctionsTest, hourTest) {
-    auto tc = TimestampColumn::create();
+    TimestampColumn::Ptr tc = TimestampColumn::create();
     tc->append(TimestampValue::create(2020, 1, 1, 21, 1, 1));
     tc->append(TimestampValue::create(2020, 2, 2, 14, 0, 1));
     tc->append(TimestampValue::create(2020, 3, 6, 11, 1, 1));
@@ -2551,7 +2551,7 @@ TEST_F(TimeFunctionsTest, hourTest) {
 }
 
 TEST_F(TimeFunctionsTest, minuteTest) {
-    auto tc = TimestampColumn::create();
+    TimestampColumn::Ptr tc = TimestampColumn::create();
     tc->append(TimestampValue::create(2020, 1, 1, 21, 22, 1));
     tc->append(TimestampValue::create(2020, 2, 2, 14, 17, 1));
     tc->append(TimestampValue::create(2020, 3, 6, 11, 54, 1));
@@ -2576,7 +2576,7 @@ TEST_F(TimeFunctionsTest, minuteTest) {
 }
 
 TEST_F(TimeFunctionsTest, secondTest) {
-    auto tc = TimestampColumn::create();
+    TimestampColumn::Ptr tc = TimestampColumn::create();
     tc->append(TimestampValue::create(2020, 1, 1, 21, 22, 51));
     tc->append(TimestampValue::create(2020, 2, 2, 14, 17, 28));
     tc->append(TimestampValue::create(2020, 3, 6, 11, 54, 23));
@@ -2601,7 +2601,7 @@ TEST_F(TimeFunctionsTest, secondTest) {
 }
 
 TEST_F(TimeFunctionsTest, timestampTest) {
-    auto tc = TimestampColumn::create();
+    TimestampColumn::Ptr tc = TimestampColumn::create();
     tc->append(TimestampValue::create(2020, 1, 1, 21, 22, 51));
 
     //second
@@ -2622,7 +2622,7 @@ TEST_F(TimeFunctionsTest, timestampTest) {
 }
 
 TEST_F(TimeFunctionsTest, datetimeTruncTest) {
-    auto tc = TimestampColumn::create();
+    TimestampColumn::Ptr tc = TimestampColumn::create();
     tc->append(TimestampValue::create(2020, 1, 1, 21, 22, 51));
     tc->append(TimestampValue::create(2020, 2, 2, 14, 17, 28));
     tc->append(TimestampValue::create(2020, 3, 6, 11, 54, 23));
@@ -2632,9 +2632,9 @@ TEST_F(TimeFunctionsTest, datetimeTruncTest) {
 
     //second
     {
-        auto text = BinaryColumn::create();
+        BinaryColumn::Ptr text = BinaryColumn::create();
         text->append("second");
-        auto format = ConstColumn::create(text, 1);
+        ConstColumn::Ptr format = ConstColumn::create(text, 1);
 
         Columns columns;
         columns.emplace_back(format);
@@ -2665,9 +2665,9 @@ TEST_F(TimeFunctionsTest, datetimeTruncTest) {
 
     //minute
     {
-        auto text = BinaryColumn::create();
+        BinaryColumn::Ptr text = BinaryColumn::create();
         text->append("minute");
-        auto format = ConstColumn::create(text, 1);
+        ConstColumn::Ptr format = ConstColumn::create(text, 1);
 
         Columns columns;
         columns.emplace_back(format);
@@ -2698,9 +2698,9 @@ TEST_F(TimeFunctionsTest, datetimeTruncTest) {
 
     //hour
     {
-        auto text = BinaryColumn::create();
+        BinaryColumn::Ptr text = BinaryColumn::create();
         text->append("hour");
-        auto format = ConstColumn::create(text, 1);
+        ConstColumn::Ptr format = ConstColumn::create(text, 1);
 
         Columns columns;
         columns.emplace_back(format);
@@ -2731,9 +2731,9 @@ TEST_F(TimeFunctionsTest, datetimeTruncTest) {
 
     //day
     {
-        auto text = BinaryColumn::create();
+        BinaryColumn::Ptr text = BinaryColumn::create();
         text->append("day");
-        auto format = ConstColumn::create(text, 1);
+        ConstColumn::Ptr format = ConstColumn::create(text, 1);
 
         Columns columns;
         columns.emplace_back(format);
@@ -2764,9 +2764,9 @@ TEST_F(TimeFunctionsTest, datetimeTruncTest) {
 
     //month
     {
-        auto text = BinaryColumn::create();
+        BinaryColumn::Ptr text = BinaryColumn::create();
         text->append("month");
-        auto format = ConstColumn::create(text, 1);
+        ConstColumn::Ptr format = ConstColumn::create(text, 1);
 
         Columns columns;
         columns.emplace_back(format);
@@ -2797,9 +2797,9 @@ TEST_F(TimeFunctionsTest, datetimeTruncTest) {
 
     //year
     {
-        auto text = BinaryColumn::create();
+        BinaryColumn::Ptr text = BinaryColumn::create();
         text->append("year");
-        auto format = ConstColumn::create(text, 1);
+        ConstColumn::Ptr format = ConstColumn::create(text, 1);
 
         Columns columns;
         columns.emplace_back(format);
@@ -2830,9 +2830,9 @@ TEST_F(TimeFunctionsTest, datetimeTruncTest) {
 
     //week
     {
-        auto text = BinaryColumn::create();
+        BinaryColumn::Ptr text = BinaryColumn::create();
         text->append("week");
-        auto format = ConstColumn::create(text, 1);
+        ConstColumn::Ptr format = ConstColumn::create(text, 1);
 
         Columns columns;
         columns.emplace_back(format);
@@ -2863,9 +2863,9 @@ TEST_F(TimeFunctionsTest, datetimeTruncTest) {
 
     //quarter
     {
-        auto text = BinaryColumn::create();
+        BinaryColumn::Ptr text = BinaryColumn::create();
         text->append("quarter");
-        auto format = ConstColumn::create(text, 1);
+        ConstColumn::Ptr format = ConstColumn::create(text, 1);
 
         Columns columns;
         columns.emplace_back(format);
@@ -2896,7 +2896,7 @@ TEST_F(TimeFunctionsTest, datetimeTruncTest) {
 }
 
 TEST_F(TimeFunctionsTest, dateTruncTest) {
-    auto tc = DateColumn::create();
+    DateColumn::Ptr tc = DateColumn::create();
     tc->append(DateValue::create(2020, 1, 1));
     tc->append(DateValue::create(2020, 2, 2));
     tc->append(DateValue::create(2020, 3, 6));
@@ -2932,9 +2932,9 @@ TEST_F(TimeFunctionsTest, dateTruncTest) {
               DateValue::create(2020, 4, 6), DateValue::create(2020, 5, 4), DateValue::create(2020, 11, 2)}}};
 
     for (const auto& test_case : test_cases) {
-        auto text = BinaryColumn::create();
+        BinaryColumn::Ptr text = BinaryColumn::create();
         text->append(test_case.first);
-        auto format = ConstColumn::create(text, 1);
+        ConstColumn::Ptr format = ConstColumn::create(text, 1);
 
         Columns columns;
         columns.emplace_back(format);
@@ -2975,8 +2975,8 @@ TEST_F(TimeFunctionsTest, str2date) {
     const auto& varchar_type_desc = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
     // nullable
     {
-        auto str_col = ColumnHelper::create_column(varchar_type_desc, true);
-        auto fmt_col = ColumnHelper::create_column(varchar_type_desc, true);
+        ColumnPtr str_col = ColumnHelper::create_column(varchar_type_desc, true);
+        ColumnPtr fmt_col = ColumnHelper::create_column(varchar_type_desc, true);
         str_col->append_datum(Slice(str1)); // str1 <=> fmt1
         fmt_col->append_datum(Slice(fmt1));
         str_col->append_datum(Slice(str2)); // str2 <=> fmt2
@@ -3019,7 +3019,7 @@ TEST_F(TimeFunctionsTest, str2date) {
     }
     // const <=> non-const
     {
-        auto str_col = ColumnHelper::create_column(varchar_type_desc, true);
+        ColumnPtr str_col = ColumnHelper::create_column(varchar_type_desc, true);
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(fmt1, 1);
         str_col->append_datum(Slice(str1));
         (void)str_col->append_nulls(1);
@@ -3050,7 +3050,7 @@ TEST_F(TimeFunctionsTest, str2date_of_dateformat) {
     const auto& varchar_type_desc = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
     // const <=> non-const
     {
-        auto str_col = ColumnHelper::create_column(varchar_type_desc, true);
+        ColumnPtr str_col = ColumnHelper::create_column(varchar_type_desc, true);
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(fmt1, 1);
         str_col->append_datum(Slice(str1));
         (void)str_col->append_nulls(1);
@@ -3088,7 +3088,7 @@ TEST_F(TimeFunctionsTest, str2date_of_datetimeformat) {
     const auto& varchar_type_desc = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
     // const <=> non-const
     {
-        auto str_col = ColumnHelper::create_column(varchar_type_desc, true);
+        ColumnPtr str_col = ColumnHelper::create_column(varchar_type_desc, true);
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(fmt1, 1);
         str_col->append_datum(Slice(str1));
         (void)str_col->append_nulls(1);
@@ -3116,7 +3116,7 @@ TEST_F(TimeFunctionsTest, str2date_of_datetimeformat) {
 }
 
 TEST_F(TimeFunctionsTest, timeSliceFloorTest) {
-    auto tc = TimestampColumn::create();
+    TimestampColumn::Ptr tc = TimestampColumn::create();
     tc->append(TimestampValue::create(0001, 1, 1, 21, 22, 51));
     tc->append(TimestampValue::create(0001, 3, 2, 14, 17, 28));
     tc->append(TimestampValue::create(0001, 5, 6, 11, 54, 23));
@@ -3131,13 +3131,13 @@ TEST_F(TimeFunctionsTest, timeSliceFloorTest) {
 
     //second
     {
-        auto period_value = Int32Column::create();
+        Int32Column::Ptr period_value = Int32Column::create();
         period_value->append(5);
-        auto period_column = ConstColumn::create(period_value, 1);
+        ConstColumn::Ptr period_column = ConstColumn::create(period_value, 1);
 
-        auto unit_text = BinaryColumn::create();
+        BinaryColumn::Ptr unit_text = BinaryColumn::create();
         unit_text->append("second");
-        auto unit_column = ConstColumn::create(unit_text, 1);
+        ConstColumn::Ptr unit_column = ConstColumn::create(unit_text, 1);
 
         Columns columns;
         columns.emplace_back(tc);
@@ -3171,17 +3171,17 @@ TEST_F(TimeFunctionsTest, timeSliceFloorTest) {
 
     //minute
     {
-        auto period_value = Int32Column::create();
+        Int32Column::Ptr period_value = Int32Column::create();
         period_value->append(5);
-        auto period_column = ConstColumn::create(period_value, 1);
+        ConstColumn::Ptr period_column = ConstColumn::create(period_value, 1);
 
-        auto unit_text = BinaryColumn::create();
+        BinaryColumn::Ptr unit_text = BinaryColumn::create();
         unit_text->append("minute");
-        auto unit_column = ConstColumn::create(unit_text, 1);
+        ConstColumn::Ptr unit_column = ConstColumn::create(unit_text, 1);
 
-        auto boundary_text = BinaryColumn::create();
+        BinaryColumn::Ptr boundary_text = BinaryColumn::create();
         boundary_text->append("floor");
-        auto boundary_column = ConstColumn::create(boundary_text, 1);
+        ConstColumn::Ptr boundary_column = ConstColumn::create(boundary_text, 1);
 
         Columns columns;
         columns.emplace_back(tc);
@@ -3216,17 +3216,17 @@ TEST_F(TimeFunctionsTest, timeSliceFloorTest) {
 
     //hour
     {
-        auto period_value = Int32Column::create();
+        Int32Column::Ptr period_value = Int32Column::create();
         period_value->append(5);
-        auto period_column = ConstColumn::create(period_value, 1);
+        ConstColumn::Ptr period_column = ConstColumn::create(period_value, 1);
 
-        auto unit_text = BinaryColumn::create();
+        BinaryColumn::Ptr unit_text = BinaryColumn::create();
         unit_text->append("hour");
-        auto unit_column = ConstColumn::create(unit_text, 1);
+        ConstColumn::Ptr unit_column = ConstColumn::create(unit_text, 1);
 
-        auto boundary_text = BinaryColumn::create();
+        BinaryColumn::Ptr boundary_text = BinaryColumn::create();
         boundary_text->append("floor");
-        auto boundary_column = ConstColumn::create(boundary_text, 1);
+        ConstColumn::Ptr boundary_column = ConstColumn::create(boundary_text, 1);
 
         Columns columns;
         columns.emplace_back(tc);
@@ -3261,17 +3261,17 @@ TEST_F(TimeFunctionsTest, timeSliceFloorTest) {
 
     //day
     {
-        auto period_value = Int32Column::create();
+        Int32Column::Ptr period_value = Int32Column::create();
         period_value->append(5);
-        auto period_column = ConstColumn::create(period_value, 1);
+        ConstColumn::Ptr period_column = ConstColumn::create(period_value, 1);
 
-        auto unit_text = BinaryColumn::create();
+        BinaryColumn::Ptr unit_text = BinaryColumn::create();
         unit_text->append("day");
-        auto unit_column = ConstColumn::create(unit_text, 1);
+        ConstColumn::Ptr unit_column = ConstColumn::create(unit_text, 1);
 
-        auto boundary_text = BinaryColumn::create();
+        BinaryColumn::Ptr boundary_text = BinaryColumn::create();
         boundary_text->append("floor");
-        auto boundary_column = ConstColumn::create(boundary_text, 1);
+        ConstColumn::Ptr boundary_column = ConstColumn::create(boundary_text, 1);
 
         Columns columns;
         columns.emplace_back(tc);
@@ -3306,17 +3306,17 @@ TEST_F(TimeFunctionsTest, timeSliceFloorTest) {
 
     //month
     {
-        auto period_value = Int32Column::create();
+        Int32Column::Ptr period_value = Int32Column::create();
         period_value->append(5);
-        auto period_column = ConstColumn::create(period_value, 1);
+        ConstColumn::Ptr period_column = ConstColumn::create(period_value, 1);
 
-        auto unit_text = BinaryColumn::create();
+        BinaryColumn::Ptr unit_text = BinaryColumn::create();
         unit_text->append("month");
-        auto unit_column = ConstColumn::create(unit_text, 1);
+        ConstColumn::Ptr unit_column = ConstColumn::create(unit_text, 1);
 
-        auto boundary_text = BinaryColumn::create();
+        BinaryColumn::Ptr boundary_text = BinaryColumn::create();
         boundary_text->append("floor");
-        auto boundary_column = ConstColumn::create(boundary_text, 1);
+        ConstColumn::Ptr boundary_column = ConstColumn::create(boundary_text, 1);
 
         Columns columns;
         columns.emplace_back(tc);
@@ -3351,17 +3351,17 @@ TEST_F(TimeFunctionsTest, timeSliceFloorTest) {
 
     //year
     {
-        auto period_value = Int32Column::create();
+        Int32Column::Ptr period_value = Int32Column::create();
         period_value->append(5);
-        auto period_column = ConstColumn::create(period_value, 1);
+        ConstColumn::Ptr period_column = ConstColumn::create(period_value, 1);
 
-        auto unit_text = BinaryColumn::create();
+        BinaryColumn::Ptr unit_text = BinaryColumn::create();
         unit_text->append("year");
-        auto unit_column = ConstColumn::create(unit_text, 1);
+        ConstColumn::Ptr unit_column = ConstColumn::create(unit_text, 1);
 
-        auto boundary_text = BinaryColumn::create();
+        BinaryColumn::Ptr boundary_text = BinaryColumn::create();
         boundary_text->append("floor");
-        auto boundary_column = ConstColumn::create(boundary_text, 1);
+        ConstColumn::Ptr boundary_column = ConstColumn::create(boundary_text, 1);
 
         Columns columns;
         columns.emplace_back(tc);
@@ -3396,17 +3396,17 @@ TEST_F(TimeFunctionsTest, timeSliceFloorTest) {
 
     //week
     {
-        auto period_value = Int32Column::create();
+        Int32Column::Ptr period_value = Int32Column::create();
         period_value->append(5);
-        auto period_column = ConstColumn::create(period_value, 1);
+        ConstColumn::Ptr period_column = ConstColumn::create(period_value, 1);
 
-        auto unit_text = BinaryColumn::create();
+        BinaryColumn::Ptr unit_text = BinaryColumn::create();
         unit_text->append("week");
-        auto unit_column = ConstColumn::create(unit_text, 1);
+        ConstColumn::Ptr unit_column = ConstColumn::create(unit_text, 1);
 
-        auto boundary_text = BinaryColumn::create();
+        BinaryColumn::Ptr boundary_text = BinaryColumn::create();
         boundary_text->append("floor");
-        auto boundary_column = ConstColumn::create(boundary_text, 1);
+        ConstColumn::Ptr boundary_column = ConstColumn::create(boundary_text, 1);
 
         Columns columns;
         columns.emplace_back(tc);
@@ -3441,17 +3441,17 @@ TEST_F(TimeFunctionsTest, timeSliceFloorTest) {
 
     //quarter
     {
-        auto period_value = Int32Column::create();
+        Int32Column::Ptr period_value = Int32Column::create();
         period_value->append(5);
-        auto period_column = ConstColumn::create(period_value, 1);
+        ConstColumn::Ptr period_column = ConstColumn::create(period_value, 1);
 
-        auto unit_text = BinaryColumn::create();
+        BinaryColumn::Ptr unit_text = BinaryColumn::create();
         unit_text->append("quarter");
-        auto unit_column = ConstColumn::create(unit_text, 1);
+        ConstColumn::Ptr unit_column = ConstColumn::create(unit_text, 1);
 
-        auto boundary_text = BinaryColumn::create();
+        BinaryColumn::Ptr boundary_text = BinaryColumn::create();
         boundary_text->append("floor");
-        auto boundary_column = ConstColumn::create(boundary_text, 1);
+        ConstColumn::Ptr boundary_column = ConstColumn::create(boundary_text, 1);
 
         Columns columns;
         columns.emplace_back(tc);
@@ -3486,7 +3486,7 @@ TEST_F(TimeFunctionsTest, timeSliceFloorTest) {
 }
 
 TEST_F(TimeFunctionsTest, timeSliceCeilTest) {
-    auto tc = TimestampColumn::create();
+    TimestampColumn::Ptr tc = TimestampColumn::create();
     tc->append(TimestampValue::create(0001, 1, 1, 21, 22, 51));
     tc->append(TimestampValue::create(0001, 3, 2, 14, 17, 28));
     tc->append(TimestampValue::create(0001, 5, 6, 11, 54, 23));
@@ -3501,17 +3501,17 @@ TEST_F(TimeFunctionsTest, timeSliceCeilTest) {
 
     //second
     {
-        auto period_value = Int32Column::create();
+        Int32Column::Ptr period_value = Int32Column::create();
         period_value->append(5);
-        auto period_column = ConstColumn::create(period_value, 1);
+        ConstColumn::Ptr period_column = ConstColumn::create(period_value, 1);
 
-        auto unit_text = BinaryColumn::create();
+        BinaryColumn::Ptr unit_text = BinaryColumn::create();
         unit_text->append("second");
-        auto unit_column = ConstColumn::create(unit_text, 1);
+        ConstColumn::Ptr unit_column = ConstColumn::create(unit_text, 1);
 
-        auto boundary_text = BinaryColumn::create();
+        BinaryColumn::Ptr boundary_text = BinaryColumn::create();
         boundary_text->append("ceil");
-        auto boundary_column = ConstColumn::create(boundary_text, 1);
+        ConstColumn::Ptr boundary_column = ConstColumn::create(boundary_text, 1);
 
         Columns columns;
         columns.emplace_back(tc);
@@ -3546,7 +3546,7 @@ TEST_F(TimeFunctionsTest, timeSliceCeilTest) {
 }
 
 TEST_F(TimeFunctionsTest, timeSliceTestWithThrowExceptions) {
-    auto tc = TimestampColumn::create();
+    TimestampColumn::Ptr tc = TimestampColumn::create();
     tc->append(TimestampValue::create(0000, 1, 1, 0, 0, 0));
 
     std::vector<FunctionContext::TypeDesc> arg_types = {TypeDescriptor::from_logical_type(TYPE_DATETIME)};
@@ -3556,17 +3556,17 @@ TEST_F(TimeFunctionsTest, timeSliceTestWithThrowExceptions) {
 
     //second
     {
-        auto period_value = Int32Column::create();
+        Int32Column::Ptr period_value = Int32Column::create();
         period_value->append(5);
-        auto period_column = ConstColumn::create(period_value, 1);
+        ConstColumn::Ptr period_column = ConstColumn::create(period_value, 1);
 
-        auto unit_text = BinaryColumn::create();
+        BinaryColumn::Ptr unit_text = BinaryColumn::create();
         unit_text->append("second");
-        auto unit_column = ConstColumn::create(unit_text, 1);
+        ConstColumn::Ptr unit_column = ConstColumn::create(unit_text, 1);
 
-        auto boundary_text = BinaryColumn::create();
+        BinaryColumn::Ptr boundary_text = BinaryColumn::create();
         boundary_text->append("floor");
-        auto boundary_column = ConstColumn::create(boundary_text, 1);
+        ConstColumn::Ptr boundary_column = ConstColumn::create(boundary_text, 1);
 
         Columns columns;
         columns.emplace_back(tc);
@@ -3592,7 +3592,7 @@ TEST_F(TimeFunctionsTest, timeSliceTestWithThrowExceptions) {
 }
 
 TEST_F(TimeFunctionsTest, DateSliceFloorTest) {
-    auto tc = DateColumn::create();
+    DateColumn::Ptr tc = DateColumn::create();
     tc->append(DateValue::create(0001, 1, 1));
     tc->append(DateValue::create(0001, 3, 2));
     tc->append(DateValue::create(0001, 5, 6));
@@ -3607,17 +3607,17 @@ TEST_F(TimeFunctionsTest, DateSliceFloorTest) {
 
     //day
     {
-        auto period_value = Int32Column::create();
+        Int32Column::Ptr period_value = Int32Column::create();
         period_value->append(5);
-        auto period_column = ConstColumn::create(period_value, 1);
+        ConstColumn::Ptr period_column = ConstColumn::create(period_value, 1);
 
-        auto unit_text = BinaryColumn::create();
+        BinaryColumn::Ptr unit_text = BinaryColumn::create();
         unit_text->append("day");
-        auto unit_column = ConstColumn::create(unit_text, 1);
+        ConstColumn::Ptr unit_column = ConstColumn::create(unit_text, 1);
 
-        auto boundary_text = BinaryColumn::create();
+        BinaryColumn::Ptr boundary_text = BinaryColumn::create();
         boundary_text->append("floor");
-        auto boundary_column = ConstColumn::create(boundary_text, 1);
+        ConstColumn::Ptr boundary_column = ConstColumn::create(boundary_text, 1);
 
         Columns columns;
         columns.emplace_back(tc);
@@ -3651,17 +3651,17 @@ TEST_F(TimeFunctionsTest, DateSliceFloorTest) {
 
     //month
     {
-        auto period_value = Int32Column::create();
+        Int32Column::Ptr period_value = Int32Column::create();
         period_value->append(5);
-        auto period_column = ConstColumn::create(period_value, 1);
+        ConstColumn::Ptr period_column = ConstColumn::create(period_value, 1);
 
-        auto unit_text = BinaryColumn::create();
+        BinaryColumn::Ptr unit_text = BinaryColumn::create();
         unit_text->append("month");
-        auto unit_column = ConstColumn::create(unit_text, 1);
+        ConstColumn::Ptr unit_column = ConstColumn::create(unit_text, 1);
 
-        auto boundary_text = BinaryColumn::create();
+        BinaryColumn::Ptr boundary_text = BinaryColumn::create();
         boundary_text->append("floor");
-        auto boundary_column = ConstColumn::create(boundary_text, 1);
+        ConstColumn::Ptr boundary_column = ConstColumn::create(boundary_text, 1);
 
         Columns columns;
         columns.emplace_back(tc);
@@ -3695,17 +3695,17 @@ TEST_F(TimeFunctionsTest, DateSliceFloorTest) {
 
     //year
     {
-        auto period_value = Int32Column::create();
+        Int32Column::Ptr period_value = Int32Column::create();
         period_value->append(5);
-        auto period_column = ConstColumn::create(period_value, 1);
+        ConstColumn::Ptr period_column = ConstColumn::create(period_value, 1);
 
-        auto unit_text = BinaryColumn::create();
+        BinaryColumn::Ptr unit_text = BinaryColumn::create();
         unit_text->append("year");
-        auto unit_column = ConstColumn::create(unit_text, 1);
+        ConstColumn::Ptr unit_column = ConstColumn::create(unit_text, 1);
 
-        auto boundary_text = BinaryColumn::create();
+        BinaryColumn::Ptr boundary_text = BinaryColumn::create();
         boundary_text->append("floor");
-        auto boundary_column = ConstColumn::create(boundary_text, 1);
+        ConstColumn::Ptr boundary_column = ConstColumn::create(boundary_text, 1);
 
         Columns columns;
         columns.emplace_back(tc);
@@ -3739,17 +3739,17 @@ TEST_F(TimeFunctionsTest, DateSliceFloorTest) {
 
     //week
     {
-        auto period_value = Int32Column::create();
+        Int32Column::Ptr period_value = Int32Column::create();
         period_value->append(5);
-        auto period_column = ConstColumn::create(period_value, 1);
+        ConstColumn::Ptr period_column = ConstColumn::create(period_value, 1);
 
-        auto unit_text = BinaryColumn::create();
+        BinaryColumn::Ptr unit_text = BinaryColumn::create();
         unit_text->append("week");
-        auto unit_column = ConstColumn::create(unit_text, 1);
+        ConstColumn::Ptr unit_column = ConstColumn::create(unit_text, 1);
 
-        auto boundary_text = BinaryColumn::create();
+        BinaryColumn::Ptr boundary_text = BinaryColumn::create();
         boundary_text->append("floor");
-        auto boundary_column = ConstColumn::create(boundary_text, 1);
+        ConstColumn::Ptr boundary_column = ConstColumn::create(boundary_text, 1);
 
         Columns columns;
         columns.emplace_back(tc);
@@ -3783,17 +3783,17 @@ TEST_F(TimeFunctionsTest, DateSliceFloorTest) {
 
     //quarter
     {
-        auto period_value = Int32Column::create();
+        Int32Column::Ptr period_value = Int32Column::create();
         period_value->append(5);
-        auto period_column = ConstColumn::create(period_value, 1);
+        ConstColumn::Ptr period_column = ConstColumn::create(period_value, 1);
 
-        auto unit_text = BinaryColumn::create();
+        BinaryColumn::Ptr unit_text = BinaryColumn::create();
         unit_text->append("quarter");
-        auto unit_column = ConstColumn::create(unit_text, 1);
+        ConstColumn::Ptr unit_column = ConstColumn::create(unit_text, 1);
 
-        auto boundary_text = BinaryColumn::create();
+        BinaryColumn::Ptr boundary_text = BinaryColumn::create();
         boundary_text->append("floor");
-        auto boundary_column = ConstColumn::create(boundary_text, 1);
+        ConstColumn::Ptr boundary_column = ConstColumn::create(boundary_text, 1);
 
         Columns columns;
         columns.emplace_back(tc);
@@ -3827,7 +3827,7 @@ TEST_F(TimeFunctionsTest, DateSliceFloorTest) {
 }
 
 TEST_F(TimeFunctionsTest, DateSliceCeilTest) {
-    auto tc = DateColumn::create();
+    DateColumn::Ptr tc = DateColumn::create();
     tc->append(DateValue::create(0001, 1, 1));
     tc->append(DateValue::create(0001, 3, 2));
     tc->append(DateValue::create(0001, 5, 6));
@@ -3842,17 +3842,17 @@ TEST_F(TimeFunctionsTest, DateSliceCeilTest) {
 
     //day
     {
-        auto period_value = Int32Column::create();
+        Int32Column::Ptr period_value = Int32Column::create();
         period_value->append(5);
-        auto period_column = ConstColumn::create(period_value, 1);
+        ConstColumn::Ptr period_column = ConstColumn::create(period_value, 1);
 
-        auto unit_text = BinaryColumn::create();
+        BinaryColumn::Ptr unit_text = BinaryColumn::create();
         unit_text->append("day");
-        auto unit_column = ConstColumn::create(unit_text, 1);
+        ConstColumn::Ptr unit_column = ConstColumn::create(unit_text, 1);
 
-        auto boundary_text = BinaryColumn::create();
+        BinaryColumn::Ptr boundary_text = BinaryColumn::create();
         boundary_text->append("ceil");
-        auto boundary_column = ConstColumn::create(boundary_text, 1);
+        ConstColumn::Ptr boundary_column = ConstColumn::create(boundary_text, 1);
 
         Columns columns;
         columns.emplace_back(tc);
@@ -3886,8 +3886,8 @@ TEST_F(TimeFunctionsTest, DateSliceCeilTest) {
 }
 
 TEST_F(TimeFunctionsTest, MakeDateTest) {
-    auto year_value = Int32Column::create();
-    auto day_of_year_value = Int32Column::create();
+    Int32Column::Ptr year_value = Int32Column::create();
+    Int32Column::Ptr day_of_year_value = Int32Column::create();
 
     year_value->append(0);
     day_of_year_value->append(1);
@@ -3957,8 +3957,8 @@ TEST_F(TimeFunctionsTest, formatTimeTest) {
 
         // Set up columns and function context
         Columns columns;
-        columns.emplace_back(time_column);
-        columns.emplace_back(format_column);
+        columns.emplace_back(std::move(time_column));
+        columns.emplace_back(std::move(format_column));
 
         // Execute format_time function
         TimeFunctions::format_prepare(_utils->get_fn_ctx(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
@@ -3991,8 +3991,8 @@ TEST_F(TimeFunctionsTest, formatTimeTest) {
 
         // Set up columns and function context
         Columns columns;
-        columns.emplace_back(time_column);
-        columns.emplace_back(format_column);
+        columns.emplace_back(std::move(time_column));
+        columns.emplace_back(std::move(format_column));
 
         // Execute format_time function
         TimeFunctions::format_prepare(_utils->get_fn_ctx(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);

--- a/be/test/exprs/utility_functions_test.cpp
+++ b/be/test/exprs/utility_functions_test.cpp
@@ -42,7 +42,7 @@ TEST_F(UtilityFunctionsTest, versionTest) {
         auto var1_col = ColumnHelper::create_const_column<TYPE_INT>(2, 1);
 
         Columns columns;
-        columns.emplace_back(var1_col);
+        columns.emplace_back(std::move(var1_col));
 
         ColumnPtr result = UtilityFunctions::version(ctx, columns).value();
 
@@ -65,7 +65,7 @@ TEST_F(UtilityFunctionsTest, sleepTest) {
         auto var1_col = ColumnHelper::create_const_column<TYPE_INT>(1, 1);
 
         Columns columns;
-        columns.emplace_back(var1_col);
+        columns.emplace_back(std::move(var1_col));
 
         ColumnPtr result = UtilityFunctions::sleep(ctx, columns).value();
 
@@ -86,7 +86,7 @@ TEST_F(UtilityFunctionsTest, uuidTest) {
         auto var1_col = ColumnHelper::create_const_column<TYPE_INT>(column_size, column_size);
 
         Columns columns;
-        columns.emplace_back(var1_col);
+        columns.emplace_back(std::move(var1_col));
 
         ColumnPtr result = UtilityFunctions::uuid(ctx, columns).value();
 
@@ -111,7 +111,7 @@ TEST_F(UtilityFunctionsTest, uuidTest) {
         int32_t chunk_size = 4096;
         auto var1_col = ColumnHelper::create_const_column<TYPE_INT>(chunk_size, 1);
         Columns columns;
-        columns.emplace_back(var1_col);
+        columns.emplace_back(std::move(var1_col));
         ColumnPtr result = UtilityFunctions::uuid_numeric(ctx, columns).value();
         Int128Column* col = ColumnHelper::cast_to_raw<TYPE_LARGEINT>(result);
         std::set<int128_t> vals;

--- a/be/test/formats/csv/csv_file_writer_test.cpp
+++ b/be/test/formats/csv/csv_file_writer_test.cpp
@@ -83,25 +83,25 @@ TEST_F(CSVFileWriterTest, TestWriteIntergers) {
         std::vector<int8_t> int8_nums{INT8_MIN, INT8_MAX, 0, 1};
         auto count = col0->append_numbers(int8_nums.data(), size(int8_nums) * sizeof(int8_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col0, chunk->num_columns());
+        chunk->append_column(std::move(col0), chunk->num_columns());
 
         auto col1 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_SMALLINT), true);
         std::vector<int16_t> int16_nums{INT16_MIN, INT16_MAX, 0, 1};
         count = col1->append_numbers(int16_nums.data(), size(int16_nums) * sizeof(int16_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col1, chunk->num_columns());
+        chunk->append_column(std::move(col1), chunk->num_columns());
 
         auto col2 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_INT), true);
         std::vector<int32_t> int32_nums{INT32_MIN, INT32_MAX, 0, 1};
         count = col2->append_numbers(int32_nums.data(), size(int32_nums) * sizeof(int32_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col2, chunk->num_columns());
+        chunk->append_column(std::move(col2), chunk->num_columns());
 
         auto col3 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_BIGINT), true);
         std::vector<int64_t> int64_nums{INT64_MIN, INT64_MAX, 0, 1};
         count = col3->append_numbers(int64_nums.data(), size(int64_nums) * sizeof(int64_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col3, chunk->num_columns());
+        chunk->append_column(std::move(col3), chunk->num_columns());
     }
 
     // write chunk
@@ -141,8 +141,8 @@ TEST_F(CSVFileWriterTest, TestWriteBoolean) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {1, 0, 1, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk
@@ -182,8 +182,8 @@ TEST_F(CSVFileWriterTest, TestWriteFloat) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {0, 0, 1, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk
@@ -223,8 +223,8 @@ TEST_F(CSVFileWriterTest, TestWriteDouble) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {0, 0, 1, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk
@@ -273,8 +273,8 @@ TEST_F(CSVFileWriterTest, TestWriteDate) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {0, 0, 0, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk
@@ -323,8 +323,8 @@ TEST_F(CSVFileWriterTest, TestWriteDatetime) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {0, 0, 0, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk
@@ -366,8 +366,8 @@ TEST_F(CSVFileWriterTest, TestWriteVarchar) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {0, 0, 0, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk

--- a/be/test/formats/orc/orc_chunk_reader_test.cpp
+++ b/be/test/formats/orc/orc_chunk_reader_test.cpp
@@ -572,9 +572,9 @@ Buffer<DecimalV2Value> convert_orc_to_starrocks_decimalv2(RuntimeState* state, O
     CHECK(!st.ok());
     std::filesystem::remove(filename);
 
-    auto nullable = std::static_pointer_cast<NullableColumn>(chunk->get_column_by_index(0));
+    auto nullable = NullableColumn::static_pointer_cast(chunk->get_column_by_index(0));
     CHECK(!nullable->has_null());
-    auto decimal_col = std::static_pointer_cast<DecimalColumn>(nullable->data_column());
+    auto decimal_col = DecimalColumn::static_pointer_cast(nullable->data_column());
     return decimal_col->get_data();
 }
 
@@ -907,9 +907,9 @@ Buffer<TimestampValue> convert_orc_to_starrocks_timestamp(RuntimeState* state, O
     CHECK(!st.ok());
     std::filesystem::remove(filename);
 
-    auto nullable = std::static_pointer_cast<NullableColumn>(chunk->get_column_by_index(0));
+    auto nullable = NullableColumn::static_pointer_cast(chunk->get_column_by_index(0));
     CHECK(!nullable->has_null());
-    auto ts_col = std::static_pointer_cast<TimestampColumn>(nullable->data_column());
+    auto ts_col = TimestampColumn::static_pointer_cast(nullable->data_column());
     return ts_col->get_data();
 }
 
@@ -2135,9 +2135,9 @@ TEST_F(OrcChunkReaderTest, TestOrcIcebergPositionDelete) {
     roaring64_bitmap_add(bitmap, 4);
     skip_rows_ctx->deletion_bitmap = std::make_shared<DeletionBitmap>(bitmap);
 
-    StatusOr<ColumnPtr> status = reader.get_row_delete_filter(skip_rows_ctx);
+    StatusOr<MutableColumnPtr> status = reader.get_row_delete_filter(skip_rows_ctx);
     EXPECT_TRUE(status.ok());
-    ColumnPtr row_delete_filter = status.value();
+    MutableColumnPtr row_delete_filter = std::move(status.value());
 
     EXPECT_EQ(4, row_delete_filter->size());
     BooleanColumn* binary_column = down_cast<BooleanColumn*>(row_delete_filter.get());

--- a/be/test/formats/orc/orc_file_writer_test.cpp
+++ b/be/test/formats/orc/orc_file_writer_test.cpp
@@ -159,25 +159,25 @@ TEST_F(OrcFileWriterTest, TestWriteIntergersNullable) {
         std::vector<int8_t> int8_nums{INT8_MIN, INT8_MAX, 0, 1};
         auto count = col0->append_numbers(int8_nums.data(), size(int8_nums) * sizeof(int8_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col0, chunk->num_columns());
+        chunk->append_column(std::move(col0), chunk->num_columns());
 
         auto col1 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_SMALLINT), true);
         std::vector<int16_t> int16_nums{INT16_MIN, INT16_MAX, 0, 1};
         count = col1->append_numbers(int16_nums.data(), size(int16_nums) * sizeof(int16_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col1, chunk->num_columns());
+        chunk->append_column(std::move(col1), chunk->num_columns());
 
         auto col2 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_INT), true);
         std::vector<int32_t> int32_nums{INT32_MIN, INT32_MAX, 0, 1};
         count = col2->append_numbers(int32_nums.data(), size(int32_nums) * sizeof(int32_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col2, chunk->num_columns());
+        chunk->append_column(std::move(col2), chunk->num_columns());
 
         auto col3 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_BIGINT), true);
         std::vector<int64_t> int64_nums{INT64_MIN, INT64_MAX, 0, 1};
         count = col3->append_numbers(int64_nums.data(), size(int64_nums) * sizeof(int64_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col3, chunk->num_columns());
+        chunk->append_column(std::move(col3), chunk->num_columns());
     }
 
     // write chunk
@@ -218,25 +218,25 @@ TEST_F(OrcFileWriterTest, TestWriteIntergersNotNull) {
         std::vector<int8_t> int8_nums{INT8_MIN, INT8_MAX, 0, 1};
         auto count = col0->append_numbers(int8_nums.data(), size(int8_nums) * sizeof(int8_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col0, chunk->num_columns());
+        chunk->append_column(std::move(col0), chunk->num_columns());
 
         auto col1 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_SMALLINT), false);
         std::vector<int16_t> int16_nums{INT16_MIN, INT16_MAX, 0, 1};
         count = col1->append_numbers(int16_nums.data(), size(int16_nums) * sizeof(int16_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col1, chunk->num_columns());
+        chunk->append_column(std::move(col1), chunk->num_columns());
 
         auto col2 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_INT), false);
         std::vector<int32_t> int32_nums{INT32_MIN, INT32_MAX, 0, 1};
         count = col2->append_numbers(int32_nums.data(), size(int32_nums) * sizeof(int32_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col2, chunk->num_columns());
+        chunk->append_column(std::move(col2), chunk->num_columns());
 
         auto col3 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_BIGINT), false);
         std::vector<int64_t> int64_nums{INT64_MIN, INT64_MAX, 0, 1};
         count = col3->append_numbers(int64_nums.data(), size(int64_nums) * sizeof(int64_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col3, chunk->num_columns());
+        chunk->append_column(std::move(col3), chunk->num_columns());
     }
 
     // write chunk
@@ -275,8 +275,8 @@ TEST_F(OrcFileWriterTest, TestWriteFloat) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {1, 0, 1, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk
@@ -315,8 +315,8 @@ TEST_F(OrcFileWriterTest, TestWriteDouble) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {1, 0, 1, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk
@@ -354,8 +354,8 @@ TEST_F(OrcFileWriterTest, TestWriteBooleanNullable) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {1, 0, 1, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk
@@ -391,7 +391,7 @@ TEST_F(OrcFileWriterTest, TestWriteBooleanNotNull) {
         auto data_column = BooleanColumn::create();
         std::vector<uint8_t> values = {0, 1, 1, 0};
         data_column->append_numbers(values.data(), values.size() * sizeof(uint8_t));
-        chunk->append_column(data_column, chunk->num_columns());
+        chunk->append_column(std::move(data_column), chunk->num_columns());
     }
 
     // write chunk
@@ -435,8 +435,8 @@ TEST_F(OrcFileWriterTest, TestWriteStringsNullable) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {1, 0, 1, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
 
         auto data_column2 = BinaryColumn::create();
         data_column2->append("hello");
@@ -447,8 +447,8 @@ TEST_F(OrcFileWriterTest, TestWriteStringsNullable) {
         auto null_column2 = UInt8Column::create();
         std::vector<uint8_t> nulls2 = {0, 0, 1, 1};
         null_column2->append_numbers(nulls2.data(), nulls2.size());
-        auto nullable_column2 = NullableColumn::create(data_column2, null_column2);
-        chunk->append_column(nullable_column2, chunk->num_columns());
+        auto nullable_column2 = NullableColumn::create(std::move(data_column2), std::move(null_column2));
+        chunk->append_column(std::move(nullable_column2), chunk->num_columns());
     }
 
     // write chunk
@@ -489,7 +489,7 @@ TEST_F(OrcFileWriterTest, TestWriteStringsNotNull) {
         data_column->append("starrocks");
         data_column->append("lakehouse");
 
-        chunk->append_column(data_column, chunk->num_columns());
+        chunk->append_column(std::move(data_column), chunk->num_columns());
 
         auto data_column2 = BinaryColumn::create();
         data_column2->append("hello");
@@ -497,7 +497,7 @@ TEST_F(OrcFileWriterTest, TestWriteStringsNotNull) {
         data_column2->append("abc");
         data_column2->append("def");
 
-        chunk->append_column(data_column2, chunk->num_columns());
+        chunk->append_column(std::move(data_column2), chunk->num_columns());
     }
 
     // write chunk
@@ -538,19 +538,19 @@ TEST_F(OrcFileWriterTest, TestWriteDecimal) {
         std::vector<int32_t> int32_nums{INT32_MIN, INT32_MAX, 0, 1};
         auto count = col0->append_numbers(int32_nums.data(), size(int32_nums) * sizeof(int32_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col0, chunk->num_columns());
+        chunk->append_column(std::move(col0), chunk->num_columns());
 
         auto col1 = ColumnHelper::create_column(type_descs[1], true);
         std::vector<int64_t> int64_nums{INT64_MIN, INT64_MAX, 0, 1};
         count = col1->append_numbers(int64_nums.data(), size(int64_nums) * sizeof(int64_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col1, chunk->num_columns());
+        chunk->append_column(std::move(col1), chunk->num_columns());
 
         auto col2 = ColumnHelper::create_column(type_descs[2], true);
         std::vector<int128_t> int128_nums{INT64_MIN, INT64_MAX, 0, 1};
         count = col2->append_numbers(int128_nums.data(), size(int128_nums) * sizeof(int128_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col2, chunk->num_columns());
+        chunk->append_column(std::move(col2), chunk->num_columns());
     }
 
     // write chunk
@@ -591,19 +591,19 @@ TEST_F(OrcFileWriterTest, TestWriteDecimalNotNull) {
         std::vector<int32_t> int32_nums{INT32_MIN, INT32_MAX, 0, 1};
         auto count = col1->append_numbers(int32_nums.data(), size(int32_nums) * sizeof(int32_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col1, chunk->num_columns());
+        chunk->append_column(std::move(col1), chunk->num_columns());
 
         auto col2 = ColumnHelper::create_column(type_descs[1], false);
         std::vector<int64_t> int64_nums{INT64_MIN, INT64_MAX, 0, 1};
         count = col2->append_numbers(int64_nums.data(), size(int64_nums) * sizeof(int64_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col2, chunk->num_columns());
+        chunk->append_column(std::move(col2), chunk->num_columns());
 
         auto col3 = ColumnHelper::create_column(type_descs[2], false);
         std::vector<int128_t> int128_nums{INT64_MIN, INT64_MAX, 0, 1};
         count = col3->append_numbers(int128_nums.data(), size(int128_nums) * sizeof(int128_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col3, chunk->num_columns());
+        chunk->append_column(std::move(col3), chunk->num_columns());
     }
 
     // write chunk
@@ -652,8 +652,8 @@ TEST_F(OrcFileWriterTest, TestWriteDate) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {1, 0, 1, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk
@@ -699,7 +699,7 @@ TEST_F(OrcFileWriterTest, TestWriteDateNotNull) {
             data_column->append_default();
         }
 
-        chunk->append_column(data_column, chunk->num_columns());
+        chunk->append_column(std::move(data_column), chunk->num_columns());
     }
 
     // write chunk
@@ -749,8 +749,8 @@ TEST_F(OrcFileWriterTest, TestAllocatedBytes) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {1, 0, 1, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk
@@ -802,8 +802,8 @@ TEST_F(OrcFileWriterTest, TestWriteTimestamp) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {1, 0, 1, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk
@@ -850,7 +850,7 @@ TEST_F(OrcFileWriterTest, TestWriteTimestampNotNull) {
             data_column->append_default();
         }
 
-        chunk->append_column(data_column, chunk->num_columns());
+        chunk->append_column(std::move(data_column), chunk->num_columns());
     }
 
     // write chunk
@@ -1064,7 +1064,7 @@ TEST_F(OrcFileWriterTest, TestOrcPatchedBaseWrongBaseWidth) {
         std::vector<int64_t> intValues = {12, -5400, -5400, 12,    -5400, 12, 12,    -5400, -5400, 24363720,  -2654,
                                           12, -5400, 12,    -5400, -5400, 12, -5400, 12,    12,    -14000000, 4};
         intColumn->append_numbers(intValues.data(), intValues.size() * sizeof(int64_t));
-        chunk->append_column(intColumn, chunk->num_columns());
+        chunk->append_column(std::move(intColumn), chunk->num_columns());
     }
 
     ASSERT_OK(writer->write(chunk.get()));

--- a/be/test/formats/parquet/encoding_test.cpp
+++ b/be/test/formats/parquet/encoding_test.cpp
@@ -110,7 +110,7 @@ struct DecoderChecker {
     // read
     {
         auto data_column = starrocks::FixedLengthColumn<T>::create();
-        auto column = NullableColumn::create(data_column, NullColumn::create());
+        auto column = NullableColumn::create(std::move(data_column), NullColumn::create());
 
         decoder->set_data(encoded_data);
         auto st = decoder->next_batch(values.size(), ColumnContentType::VALUE, column.get());
@@ -134,7 +134,7 @@ struct DecoderChecker {
         size_t remain_values = values.size() - values_to_skip;
 
         auto data_column = starrocks::FixedLengthColumn<T>::create();
-        auto column = NullableColumn::create(data_column, NullColumn::create());
+        auto column = NullableColumn::create(std::move(data_column), NullColumn::create());
 
         decoder->set_data(encoded_data);
         auto st = decoder->skip(values_to_skip);
@@ -240,7 +240,7 @@ struct DecoderChecker<Slice, is_dictionary> {
     // read
     {
         auto data_column = starrocks::BinaryColumn::create();
-        auto column = NullableColumn::create(data_column, NullColumn::create());
+        auto column = NullableColumn::create(std::move(data_column), NullColumn::create());
 
         decoder->set_data(encoded_data);
         auto st = decoder->next_batch(values.size(), ColumnContentType::VALUE, column.get());
@@ -264,7 +264,7 @@ struct DecoderChecker<Slice, is_dictionary> {
         size_t remain_values = values.size() - values_to_skip;
 
         auto data_column = starrocks::BinaryColumn::create();
-        auto column = NullableColumn::create(data_column, NullColumn::create());
+        auto column = NullableColumn::create(std::move(data_column), NullColumn::create());
 
         decoder->set_data(encoded_data);
         auto st = decoder->skip(values_to_skip);

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -1064,7 +1064,7 @@ THdfsScanRange* FileReaderTest::_create_scan_range(const std::string& file_path,
 
 void FileReaderTest::_append_column_for_chunk(LogicalType column_type, ChunkPtr* chunk) {
     auto c = ColumnHelper::create_column(TypeDescriptor::from_logical_type(column_type), true);
-    (*chunk)->append_column(c, (*chunk)->num_columns());
+    (*chunk)->append_column(std::move(c), (*chunk)->num_columns());
 }
 
 ChunkPtr FileReaderTest::_create_chunk() {
@@ -1106,7 +1106,7 @@ ChunkPtr FileReaderTest::_create_required_array_chunk() {
     _append_column_for_chunk(LogicalType::TYPE_INT, &chunk);
 
     auto c = ColumnHelper::create_column(TYPE_INT_ARRAY_DESC, true);
-    chunk->append_column(c, chunk->num_columns());
+    chunk->append_column(std::move(c), chunk->num_columns());
     return chunk;
 }
 
@@ -1449,7 +1449,7 @@ TEST_F(FileReaderTest, TestReadArray2dColumn) {
     ChunkPtr chunk = std::make_shared<Chunk>();
     _append_column_for_chunk(LogicalType::TYPE_INT, &chunk);
     auto c = ColumnHelper::create_column(TYPE_INT_ARRAY_ARRAY_DESC, true);
-    chunk->append_column(c, chunk->num_columns());
+    chunk->append_column(std::move(c), chunk->num_columns());
     status = file_reader->get_next(&chunk);
     ASSERT_TRUE(status.ok());
     EXPECT_EQ(chunk->num_rows(), 5);
@@ -1501,9 +1501,9 @@ TEST_F(FileReaderTest, TestReadMapCharKeyColumn) {
     ChunkPtr chunk = std::make_shared<Chunk>();
     _append_column_for_chunk(LogicalType::TYPE_INT, &chunk);
     auto c = ColumnHelper::create_column(TYPE_CHAR_INT_MAP_DESC, true);
-    chunk->append_column(c, chunk->num_columns());
+    chunk->append_column(std::move(c), chunk->num_columns());
     auto c_map1 = ColumnHelper::create_column(TYPE_VARCHAR_INT_MAP_DESC, true);
-    chunk->append_column(c_map1, chunk->num_columns());
+    chunk->append_column(std::move(c_map1), chunk->num_columns());
 
     status = file_reader->get_next(&chunk);
     ASSERT_TRUE(status.ok()) << status.message();
@@ -1534,11 +1534,11 @@ TEST_F(FileReaderTest, TestReadMapColumn) {
     ChunkPtr chunk = std::make_shared<Chunk>();
     _append_column_for_chunk(LogicalType::TYPE_INT, &chunk);
     auto c = ColumnHelper::create_column(TYPE_VARCHAR_INT_MAP_DESC, true);
-    chunk->append_column(c, chunk->num_columns());
+    chunk->append_column(std::move(c), chunk->num_columns());
     auto c_map_map = ColumnHelper::create_column(type_map_map, true);
-    chunk->append_column(c_map_map, chunk->num_columns());
+    chunk->append_column(std::move(c_map_map), chunk->num_columns());
     auto c_map_array = ColumnHelper::create_column(TYPE_VARCHAR_INTARRAY_MAP_DESC, true);
-    chunk->append_column(c_map_array, chunk->num_columns());
+    chunk->append_column(std::move(c_map_array), chunk->num_columns());
 
     status = file_reader->get_next(&chunk);
     ASSERT_TRUE(status.ok());
@@ -1822,11 +1822,11 @@ TEST_F(FileReaderTest, TestReadMapColumnWithPartialMaterialize) {
     ChunkPtr chunk = std::make_shared<Chunk>();
     _append_column_for_chunk(LogicalType::TYPE_INT, &chunk);
     auto c = ColumnHelper::create_column(TYPE_VARCHAR_UNKNOWN_MAP_DESC, true);
-    chunk->append_column(c, chunk->num_columns());
+    chunk->append_column(std::move(c), chunk->num_columns());
     auto c_map_map = ColumnHelper::create_column(type_map_map, true);
-    chunk->append_column(c_map_map, chunk->num_columns());
+    chunk->append_column(std::move(c_map_map), chunk->num_columns());
     auto c_map_array = ColumnHelper::create_column(type_map_array, true);
-    chunk->append_column(c_map_array, chunk->num_columns());
+    chunk->append_column(std::move(c_map_array), chunk->num_columns());
 
     status = file_reader->get_next(&chunk);
     ASSERT_TRUE(status.ok());

--- a/be/test/formats/parquet/file_writer_test.cpp
+++ b/be/test/formats/parquet/file_writer_test.cpp
@@ -127,7 +127,7 @@ protected:
         auto read_chunk = std::make_shared<Chunk>();
         for (auto type_desc : type_descs) {
             auto col = ColumnHelper::create_column(type_desc, true);
-            read_chunk->append_column(col, read_chunk->num_columns());
+            read_chunk->append_column(std::move(col), read_chunk->num_columns());
         }
 
         file_reader->get_next(&read_chunk);
@@ -154,25 +154,25 @@ TEST_F(FileWriterTest, TestWriteIntegralTypes) {
         std::vector<int8_t> int8_nums{INT8_MIN, INT8_MAX, 0, 1};
         auto count = col0->append_numbers(int8_nums.data(), size(int8_nums) * sizeof(int8_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col0, chunk->num_columns());
+        chunk->append_column(std::move(col0), chunk->num_columns());
 
         auto col1 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_SMALLINT), true);
         std::vector<int16_t> int16_nums{INT16_MIN, INT16_MAX, 0, 1};
         count = col1->append_numbers(int16_nums.data(), size(int16_nums) * sizeof(int16_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col1, chunk->num_columns());
+        chunk->append_column(std::move(col1), chunk->num_columns());
 
         auto col2 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_INT), true);
         std::vector<int32_t> int32_nums{INT32_MIN, INT32_MAX, 0, 1};
         count = col2->append_numbers(int32_nums.data(), size(int32_nums) * sizeof(int32_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col2, chunk->num_columns());
+        chunk->append_column(std::move(col2), chunk->num_columns());
 
         auto col3 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_BIGINT), true);
         std::vector<int64_t> int64_nums{INT64_MIN, INT64_MAX, 0, 1};
         count = col3->append_numbers(int64_nums.data(), size(int64_nums) * sizeof(int64_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col3, chunk->num_columns());
+        chunk->append_column(std::move(col3), chunk->num_columns());
     }
 
     // write chunk
@@ -200,19 +200,19 @@ TEST_F(FileWriterTest, TestWriteDecimal) {
         std::vector<int32_t> int32_nums{-999999, 999999, 0, 1};
         auto count = col0->append_numbers(int32_nums.data(), size(int32_nums) * sizeof(int32_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col0, chunk->num_columns());
+        chunk->append_column(std::move(col0), chunk->num_columns());
 
         auto col1 = ColumnHelper::create_column(type_descs[1], true);
         std::vector<int64_t> int64_nums{-999999999999, 999999999999, 0, 1};
         count = col1->append_numbers(int64_nums.data(), size(int64_nums) * sizeof(int64_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col1, chunk->num_columns());
+        chunk->append_column(std::move(col1), chunk->num_columns());
 
         auto col2 = ColumnHelper::create_column(type_descs[2], true);
         std::vector<int128_t> int128_nums{-999999999999, 999999999999, 0, 1};
         count = col2->append_numbers(int128_nums.data(), size(int128_nums) * sizeof(int128_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col2, chunk->num_columns());
+        chunk->append_column(std::move(col2), chunk->num_columns());
     }
 
     // write chunk
@@ -239,8 +239,8 @@ TEST_F(FileWriterTest, TestWriteBoolean) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {1, 0, 1, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk
@@ -268,8 +268,8 @@ TEST_F(FileWriterTest, TestWriteFloat) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {1, 0, 1, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk
@@ -297,8 +297,8 @@ TEST_F(FileWriterTest, TestWriteDouble) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {1, 0, 1, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk
@@ -335,8 +335,8 @@ TEST_F(FileWriterTest, TestWriteDate) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {1, 0, 1, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk
@@ -374,8 +374,8 @@ TEST_F(FileWriterTest, TestWriteDatetime) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {0, 0, 0, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk
@@ -406,8 +406,8 @@ TEST_F(FileWriterTest, TestWriteVarchar) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {1, 0, 1, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk
@@ -439,19 +439,19 @@ TEST_F(FileWriterTest, TestWriteArray) {
         auto elements_null_col = UInt8Column::create();
         std::vector<uint8_t> nulls{0, 0, 1, 0};
         elements_null_col->append_numbers(nulls.data(), sizeof(uint8_t) * nulls.size());
-        auto elements_col = NullableColumn::create(elements_data_col, elements_null_col);
+        auto elements_col = NullableColumn::create(std::move(elements_data_col), std::move(elements_null_col));
 
         auto offsets_col = UInt32Column::create();
         std::vector<uint32_t> offsets{0, 1, 1, 1, 4};
         offsets_col->append_numbers(offsets.data(), sizeof(uint32_t) * offsets.size());
-        auto array_col = ArrayColumn::create(elements_col, offsets_col);
+        auto array_col = ArrayColumn::create(std::move(elements_col), std::move(offsets_col));
 
         std::vector<uint8_t> _nulls{0, 1, 0, 0};
         auto null_col = UInt8Column::create();
         null_col->append_numbers(_nulls.data(), sizeof(uint8_t) * _nulls.size());
-        auto nullable_col = NullableColumn::create(array_col, null_col);
+        auto nullable_col = NullableColumn::create(std::move(array_col), std::move(null_col));
 
-        chunk->append_column(nullable_col, chunk->num_columns());
+        chunk->append_column(std::move(nullable_col), chunk->num_columns());
     }
 
     // write chunk
@@ -486,29 +486,29 @@ TEST_F(FileWriterTest, TestWriteStruct) {
         data_col_a->append_numbers(nums_a.data(), sizeof(int16_t) * nums_a.size());
         auto null_col_a = UInt8Column::create();
         null_col_a->append_numbers(nulls.data(), sizeof(uint8_t) * nulls.size());
-        auto nullable_col_a = NullableColumn::create(data_col_a, null_col_a);
+        auto nullable_col_a = NullableColumn::create(std::move(data_col_a), std::move(null_col_a));
 
         auto data_col_b = Int32Column::create();
         std::vector<int32_t> nums_b{1, 2, -99, 3};
         data_col_b->append_numbers(nums_b.data(), sizeof(int32_t) * nums_b.size());
         auto null_col_b = UInt8Column::create();
         null_col_b->append_numbers(nulls.data(), sizeof(uint8_t) * nulls.size());
-        auto nullable_col_b = NullableColumn::create(data_col_b, null_col_b);
+        auto nullable_col_b = NullableColumn::create(std::move(data_col_b), std::move(null_col_b));
 
         auto data_col_c = Int64Column::create();
         std::vector<int64_t> nums_c{1, 2, -99, 3};
         data_col_c->append_numbers(nums_c.data(), sizeof(int64_t) * nums_c.size());
         auto null_col_c = UInt8Column::create();
         null_col_c->append_numbers(nulls.data(), sizeof(uint8_t) * nulls.size());
-        auto nullable_col_c = NullableColumn::create(data_col_c, null_col_c);
+        auto nullable_col_c = NullableColumn::create(std::move(data_col_c), std::move(null_col_c));
 
-        Columns fields{nullable_col_a, nullable_col_b, nullable_col_c};
-        auto struct_column = StructColumn::create(fields, type_int_struct.field_names);
+        Columns fields{std::move(nullable_col_a), std::move(nullable_col_b), std::move(nullable_col_c)};
+        auto struct_column = StructColumn::create(std::move(fields), std::move(type_int_struct.field_names));
         auto null_column = UInt8Column::create();
         null_column->append_numbers(nulls.data(), sizeof(uint8_t) * nulls.size());
-        auto nullable_col = NullableColumn::create(struct_column, null_column);
+        auto nullable_col = NullableColumn::create(std::move(struct_column), std::move(null_column));
 
-        chunk->append_column(nullable_col, chunk->num_columns());
+        chunk->append_column(std::move(nullable_col), chunk->num_columns());
     }
 
     // write chunk
@@ -542,7 +542,7 @@ TEST_F(FileWriterTest, TestWriteMap) {
         auto key_null_col = UInt8Column::create();
         std::vector<uint8_t> key_nulls{0, 0, 0, 0};
         key_null_col->append_numbers(key_nulls.data(), sizeof(uint8_t) * key_nulls.size());
-        auto key_col = NullableColumn::create(key_data_col, key_null_col);
+        auto key_col = NullableColumn::create(std::move(key_data_col), std::move(key_null_col));
 
         auto value_data_col = Int32Column::create();
         std::vector<int32_t> value_nums{1, 2, -99, 4};
@@ -550,19 +550,19 @@ TEST_F(FileWriterTest, TestWriteMap) {
         auto value_null_col = UInt8Column::create();
         std::vector<uint8_t> value_nulls{0, 0, 1, 0};
         value_null_col->append_numbers(value_nulls.data(), sizeof(uint8_t) * value_nulls.size());
-        auto value_col = NullableColumn::create(value_data_col, value_null_col);
+        auto value_col = NullableColumn::create(std::move(value_data_col), std::move(value_null_col));
 
         auto offsets_col = UInt32Column::create();
         std::vector<uint32_t> offsets{0, 1, 1, 1, 4};
         offsets_col->append_numbers(offsets.data(), sizeof(uint32_t) * offsets.size());
-        auto map_col = MapColumn::create(key_col, value_col, offsets_col);
+        auto map_col = MapColumn::create(std::move(key_col), std::move(value_col), std::move(offsets_col));
 
         std::vector<uint8_t> _nulls{0, 1, 0, 0};
         auto null_col = UInt8Column::create();
         null_col->append_numbers(_nulls.data(), sizeof(uint8_t) * _nulls.size());
-        auto nullable_col = NullableColumn::create(map_col, null_col);
+        auto nullable_col = NullableColumn::create(std::move(map_col), std::move(null_col));
 
-        chunk->append_column(nullable_col, chunk->num_columns());
+        chunk->append_column(std::move(nullable_col), chunk->num_columns());
     }
 
     // write chunk
@@ -596,30 +596,30 @@ TEST_F(FileWriterTest, TestWriteNestedArray) {
         auto int_null_col = UInt8Column::create();
         std::vector<uint8_t> nulls{0, 0, 1, 0, 0, 0, 0};
         int_null_col->append_numbers(nulls.data(), sizeof(uint8_t) * nulls.size());
-        auto int_col = NullableColumn::create(int_data_col, int_null_col);
+        auto int_col = NullableColumn::create(std::move(int_data_col), std::move(int_null_col));
 
         auto offsets_col = UInt32Column::create();
         std::vector<uint32_t> offsets{0, 1, 1, 1, 4, 6, 7};
         offsets_col->append_numbers(offsets.data(), sizeof(uint32_t) * offsets.size());
-        auto array_data_col = ArrayColumn::create(int_col, offsets_col);
+        auto array_data_col = ArrayColumn::create(std::move(int_col), std::move(offsets_col));
 
         std::vector<uint8_t> _nulls{0, 1, 0, 0, 0, 0};
         auto array_null_col = UInt8Column::create();
         array_null_col->append_numbers(_nulls.data(), sizeof(uint8_t) * _nulls.size());
-        auto array_col = NullableColumn::create(array_data_col, array_null_col);
+        auto array_col = NullableColumn::create(std::move(array_data_col), std::move(array_null_col));
 
         auto array_array_offsets_col = UInt32Column::create();
         std::vector<uint32_t> array_array_offsets{0, 4, 6, 6};
         array_array_offsets_col->append_numbers(array_array_offsets.data(),
                                                 sizeof(uint32_t) * array_array_offsets.size());
-        auto array_array_data_col = ArrayColumn::create(array_col, array_array_offsets_col);
+        auto array_array_data_col = ArrayColumn::create(std::move(array_col), std::move(array_array_offsets_col));
 
         std::vector<uint8_t> outer_nulls{0, 0, 1};
         auto array_array_null_col = UInt8Column::create();
         array_array_null_col->append_numbers(outer_nulls.data(), sizeof(uint8_t) * outer_nulls.size());
-        auto array_array_col = NullableColumn::create(array_array_data_col, array_array_null_col);
+        auto array_array_col = NullableColumn::create(std::move(array_array_data_col), std::move(array_array_null_col));
 
-        chunk->append_column(array_array_col, chunk->num_columns());
+        chunk->append_column(std::move(array_array_col), chunk->num_columns());
     }
 
     // write chunk
@@ -650,8 +650,8 @@ TEST_F(FileWriterTest, TestWriteVarbinary) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {1, 0, 1, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -160,7 +160,7 @@ ChunkPtr GroupReaderTest::_create_chunk(GroupReaderParam* param) {
     ChunkPtr chunk = std::make_shared<Chunk>();
     for (auto& column : param->read_cols) {
         auto c = ColumnHelper::create_column(column.slot_type(), true);
-        chunk->append_column(c, column.slot_id());
+        chunk->append_column(std::move(c), column.slot_id());
     }
     return chunk;
 }

--- a/be/test/formats/parquet/parquet_file_writer_test.cpp
+++ b/be/test/formats/parquet/parquet_file_writer_test.cpp
@@ -101,7 +101,7 @@ protected:
         auto read_chunk = std::make_shared<Chunk>();
         for (auto type_desc : type_descs) {
             auto col = ColumnHelper::create_column(type_desc, true);
-            read_chunk->append_column(col, read_chunk->num_columns());
+            read_chunk->append_column(std::move(col), read_chunk->num_columns());
         }
 
         EXPECT_OK(file_reader->get_next(&read_chunk));
@@ -181,25 +181,25 @@ TEST_F(ParquetFileWriterTest, TestWriteIntegralTypes) {
         std::vector<int8_t> int8_nums{INT8_MIN, INT8_MAX, 0, 1};
         auto count = col0->append_numbers(int8_nums.data(), size(int8_nums) * sizeof(int8_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col0, chunk->num_columns());
+        chunk->append_column(std::move(col0), chunk->num_columns());
 
         auto col1 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_SMALLINT), true);
         std::vector<int16_t> int16_nums{INT16_MIN, INT16_MAX, 0, 1};
         count = col1->append_numbers(int16_nums.data(), size(int16_nums) * sizeof(int16_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col1, chunk->num_columns());
+        chunk->append_column(std::move(col1), chunk->num_columns());
 
         auto col2 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_INT), true);
         std::vector<int32_t> int32_nums{INT32_MIN, INT32_MAX, 0, 1};
         count = col2->append_numbers(int32_nums.data(), size(int32_nums) * sizeof(int32_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col2, chunk->num_columns());
+        chunk->append_column(std::move(col2), chunk->num_columns());
 
         auto col3 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_BIGINT), true);
         std::vector<int64_t> int64_nums{INT64_MIN, INT64_MAX, 0, 1};
         count = col3->append_numbers(int64_nums.data(), size(int64_nums) * sizeof(int64_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col3, chunk->num_columns());
+        chunk->append_column(std::move(col3), chunk->num_columns());
     }
 
     // write chunk
@@ -238,19 +238,19 @@ TEST_F(ParquetFileWriterTest, TestWriteDecimal) {
         std::vector<int32_t> int32_nums{-999999, 999999, 0, 1};
         auto count = col0->append_numbers(int32_nums.data(), size(int32_nums) * sizeof(int32_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col0, chunk->num_columns());
+        chunk->append_column(std::move(col0), chunk->num_columns());
 
         auto col1 = ColumnHelper::create_column(type_descs[1], true);
         std::vector<int64_t> int64_nums{-999999999999, 999999999999, 0, 1};
         count = col1->append_numbers(int64_nums.data(), size(int64_nums) * sizeof(int64_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col1, chunk->num_columns());
+        chunk->append_column(std::move(col1), chunk->num_columns());
 
         auto col2 = ColumnHelper::create_column(type_descs[2], true);
         std::vector<int128_t> int128_nums{-999999999999, 999999999999, 0, 1};
         count = col2->append_numbers(int128_nums.data(), size(int128_nums) * sizeof(int128_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col2, chunk->num_columns());
+        chunk->append_column(std::move(col2), chunk->num_columns());
     }
 
     // write chunk
@@ -290,19 +290,19 @@ TEST_F(ParquetFileWriterTest, TestWriteDecimalCompatibleWithHiveReader) {
         std::vector<int32_t> int32_nums{-999999, 999999, 0, 1};
         auto count = col0->append_numbers(int32_nums.data(), size(int32_nums) * sizeof(int32_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col0, chunk->num_columns());
+        chunk->append_column(std::move(col0), chunk->num_columns());
 
         auto col1 = ColumnHelper::create_column(type_descs[1], true);
         std::vector<int64_t> int64_nums{-999999999999, 999999999999, 0, 1};
         count = col1->append_numbers(int64_nums.data(), size(int64_nums) * sizeof(int64_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col1, chunk->num_columns());
+        chunk->append_column(std::move(col1), chunk->num_columns());
 
         auto col2 = ColumnHelper::create_column(type_descs[2], true);
         std::vector<int128_t> int128_nums{-999999999999, 999999999999, 0, 1};
         count = col2->append_numbers(int128_nums.data(), size(int128_nums) * sizeof(int128_t));
         ASSERT_EQ(4, count);
-        chunk->append_column(col2, chunk->num_columns());
+        chunk->append_column(std::move(col2), chunk->num_columns());
     }
 
     // write chunk
@@ -340,8 +340,8 @@ TEST_F(ParquetFileWriterTest, TestWriteBoolean) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {1, 0, 1, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk
@@ -380,8 +380,8 @@ TEST_F(ParquetFileWriterTest, TestWriteFloat) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {1, 0, 1, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk
@@ -420,8 +420,8 @@ TEST_F(ParquetFileWriterTest, TestWriteDouble) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {1, 0, 1, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk
@@ -469,8 +469,8 @@ TEST_F(ParquetFileWriterTest, TestWriteDate) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {1, 0, 1, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk
@@ -519,8 +519,8 @@ TEST_F(ParquetFileWriterTest, TestWriteDatetime) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {0, 0, 0, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk
@@ -573,8 +573,8 @@ TEST_F(ParquetFileWriterTest, TestWriteDatetimeCompatibleWithHiveReader) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {1, 0, 1, 0, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk
@@ -615,8 +615,8 @@ TEST_F(ParquetFileWriterTest, TestWriteVarchar) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {1, 0, 1, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk
@@ -659,19 +659,19 @@ TEST_F(ParquetFileWriterTest, TestWriteArray) {
         auto elements_null_col = UInt8Column::create();
         std::vector<uint8_t> nulls{0, 0, 1, 0};
         elements_null_col->append_numbers(nulls.data(), sizeof(uint8_t) * nulls.size());
-        auto elements_col = NullableColumn::create(elements_data_col, elements_null_col);
+        auto elements_col = NullableColumn::create(std::move(elements_data_col), std::move(elements_null_col));
 
         auto offsets_col = UInt32Column::create();
         std::vector<uint32_t> offsets{0, 1, 1, 1, 4};
         offsets_col->append_numbers(offsets.data(), sizeof(uint32_t) * offsets.size());
-        auto array_col = ArrayColumn::create(elements_col, offsets_col);
+        auto array_col = ArrayColumn::create(std::move(elements_col), std::move(offsets_col));
 
         std::vector<uint8_t> _nulls{0, 1, 0, 0};
         auto null_col = UInt8Column::create();
         null_col->append_numbers(_nulls.data(), sizeof(uint8_t) * _nulls.size());
-        auto nullable_col = NullableColumn::create(array_col, null_col);
+        auto nullable_col = NullableColumn::create(std::move(array_col), std::move(null_col));
 
-        chunk->append_column(nullable_col, chunk->num_columns());
+        chunk->append_column(std::move(nullable_col), chunk->num_columns());
     }
 
     // write chunk
@@ -717,29 +717,29 @@ TEST_F(ParquetFileWriterTest, TestWriteStruct) {
         data_col_a->append_numbers(nums_a.data(), sizeof(int16_t) * nums_a.size());
         auto null_col_a = UInt8Column::create();
         null_col_a->append_numbers(nulls.data(), sizeof(uint8_t) * nulls.size());
-        auto nullable_col_a = NullableColumn::create(data_col_a, null_col_a);
+        auto nullable_col_a = NullableColumn::create(std::move(data_col_a), std::move(null_col_a));
 
         auto data_col_b = Int32Column::create();
         std::vector<int32_t> nums_b{1, 2, -99, 3};
         data_col_b->append_numbers(nums_b.data(), sizeof(int32_t) * nums_b.size());
         auto null_col_b = UInt8Column::create();
         null_col_b->append_numbers(nulls.data(), sizeof(uint8_t) * nulls.size());
-        auto nullable_col_b = NullableColumn::create(data_col_b, null_col_b);
+        auto nullable_col_b = NullableColumn::create(std::move(data_col_b), std::move(null_col_b));
 
         auto data_col_c = Int64Column::create();
         std::vector<int64_t> nums_c{1, 2, -99, 3};
         data_col_c->append_numbers(nums_c.data(), sizeof(int64_t) * nums_c.size());
         auto null_col_c = UInt8Column::create();
         null_col_c->append_numbers(nulls.data(), sizeof(uint8_t) * nulls.size());
-        auto nullable_col_c = NullableColumn::create(data_col_c, null_col_c);
+        auto nullable_col_c = NullableColumn::create(std::move(data_col_c), std::move(null_col_c));
 
-        Columns fields{nullable_col_a, nullable_col_b, nullable_col_c};
-        auto struct_column = StructColumn::create(fields, type_int_struct.field_names);
+        Columns fields{std::move(nullable_col_a), std::move(nullable_col_b), std::move(nullable_col_c)};
+        auto struct_column = StructColumn::create(std::move(fields), std::move(type_int_struct.field_names));
         auto null_column = UInt8Column::create();
         null_column->append_numbers(nulls.data(), sizeof(uint8_t) * nulls.size());
-        auto nullable_col = NullableColumn::create(struct_column, null_column);
+        auto nullable_col = NullableColumn::create(std::move(struct_column), std::move(null_column));
 
-        chunk->append_column(nullable_col, chunk->num_columns());
+        chunk->append_column(std::move(nullable_col), chunk->num_columns());
     }
 
     // write chunk
@@ -784,7 +784,7 @@ TEST_F(ParquetFileWriterTest, TestWriteMap) {
         auto key_null_col = UInt8Column::create();
         std::vector<uint8_t> key_nulls{0, 0, 0, 0};
         key_null_col->append_numbers(key_nulls.data(), sizeof(uint8_t) * key_nulls.size());
-        auto key_col = NullableColumn::create(key_data_col, key_null_col);
+        auto key_col = NullableColumn::create(std::move(key_data_col), std::move(key_null_col));
 
         auto value_data_col = Int32Column::create();
         std::vector<int32_t> value_nums{1, 2, -99, 4};
@@ -792,19 +792,19 @@ TEST_F(ParquetFileWriterTest, TestWriteMap) {
         auto value_null_col = UInt8Column::create();
         std::vector<uint8_t> value_nulls{0, 0, 1, 0};
         value_null_col->append_numbers(value_nulls.data(), sizeof(uint8_t) * value_nulls.size());
-        auto value_col = NullableColumn::create(value_data_col, value_null_col);
+        auto value_col = NullableColumn::create(std::move(value_data_col), std::move(value_null_col));
 
         auto offsets_col = UInt32Column::create();
         std::vector<uint32_t> offsets{0, 1, 1, 1, 4};
         offsets_col->append_numbers(offsets.data(), sizeof(uint32_t) * offsets.size());
-        auto map_col = MapColumn::create(key_col, value_col, offsets_col);
+        auto map_col = MapColumn::create(std::move(key_col), std::move(value_col), std::move(offsets_col));
 
         std::vector<uint8_t> _nulls{0, 1, 0, 0};
         auto null_col = UInt8Column::create();
         null_col->append_numbers(_nulls.data(), sizeof(uint8_t) * _nulls.size());
-        auto nullable_col = NullableColumn::create(map_col, null_col);
+        auto nullable_col = NullableColumn::create(std::move(map_col), std::move(null_col));
 
-        chunk->append_column(nullable_col, chunk->num_columns());
+        chunk->append_column(std::move(nullable_col), chunk->num_columns());
     }
 
     // write chunk
@@ -849,7 +849,7 @@ TEST_F(ParquetFileWriterTest, TestWriteMapOfNullKey) {
         auto key_null_col = UInt8Column::create();
         std::vector<uint8_t> key_nulls{1, 0, 0, 0};
         key_null_col->append_numbers(key_nulls.data(), sizeof(uint8_t) * key_nulls.size());
-        auto key_col = NullableColumn::create(key_data_col, key_null_col);
+        auto key_col = NullableColumn::create(std::move(key_data_col), std::move(key_null_col));
 
         auto value_data_col = Int32Column::create();
         std::vector<int32_t> value_nums{1, 2, -99, 4};
@@ -857,19 +857,19 @@ TEST_F(ParquetFileWriterTest, TestWriteMapOfNullKey) {
         auto value_null_col = UInt8Column::create();
         std::vector<uint8_t> value_nulls{0, 0, 1, 0};
         value_null_col->append_numbers(value_nulls.data(), sizeof(uint8_t) * value_nulls.size());
-        auto value_col = NullableColumn::create(value_data_col, value_null_col);
+        auto value_col = NullableColumn::create(std::move(value_data_col), std::move(value_null_col));
 
         auto offsets_col = UInt32Column::create();
         std::vector<uint32_t> offsets{0, 1, 1, 1, 4};
         offsets_col->append_numbers(offsets.data(), sizeof(uint32_t) * offsets.size());
-        auto map_col = MapColumn::create(key_col, value_col, offsets_col);
+        auto map_col = MapColumn::create(std::move(key_col), std::move(value_col), std::move(offsets_col));
 
         std::vector<uint8_t> _nulls{0, 1, 0, 0};
         auto null_col = UInt8Column::create();
         null_col->append_numbers(_nulls.data(), sizeof(uint8_t) * _nulls.size());
-        auto nullable_col = NullableColumn::create(map_col, null_col);
+        auto nullable_col = NullableColumn::create(std::move(map_col), std::move(null_col));
 
-        chunk->append_column(nullable_col, chunk->num_columns());
+        chunk->append_column(std::move(nullable_col), chunk->num_columns());
     }
 
     // write chunk
@@ -905,30 +905,30 @@ TEST_F(ParquetFileWriterTest, TestWriteNestedArray) {
         auto int_null_col = UInt8Column::create();
         std::vector<uint8_t> nulls{0, 0, 1, 0, 0, 0, 0};
         int_null_col->append_numbers(nulls.data(), sizeof(uint8_t) * nulls.size());
-        auto int_col = NullableColumn::create(int_data_col, int_null_col);
+        auto int_col = NullableColumn::create(std::move(int_data_col), std::move(int_null_col));
 
         auto offsets_col = UInt32Column::create();
         std::vector<uint32_t> offsets{0, 1, 1, 1, 4, 6, 7};
         offsets_col->append_numbers(offsets.data(), sizeof(uint32_t) * offsets.size());
-        auto array_data_col = ArrayColumn::create(int_col, offsets_col);
+        auto array_data_col = ArrayColumn::create(std::move(int_col), std::move(offsets_col));
 
         std::vector<uint8_t> _nulls{0, 1, 0, 0, 0, 0};
         auto array_null_col = UInt8Column::create();
         array_null_col->append_numbers(_nulls.data(), sizeof(uint8_t) * _nulls.size());
-        auto array_col = NullableColumn::create(array_data_col, array_null_col);
+        auto array_col = NullableColumn::create(std::move(array_data_col), std::move(array_null_col));
 
         auto array_array_offsets_col = UInt32Column::create();
         std::vector<uint32_t> array_array_offsets{0, 4, 6, 6};
         array_array_offsets_col->append_numbers(array_array_offsets.data(),
                                                 sizeof(uint32_t) * array_array_offsets.size());
-        auto array_array_data_col = ArrayColumn::create(array_col, array_array_offsets_col);
+        auto array_array_data_col = ArrayColumn::create(std::move(array_col), std::move(array_array_offsets_col));
 
         std::vector<uint8_t> outer_nulls{0, 0, 1};
         auto array_array_null_col = UInt8Column::create();
         array_array_null_col->append_numbers(outer_nulls.data(), sizeof(uint8_t) * outer_nulls.size());
-        auto array_array_col = NullableColumn::create(array_array_data_col, array_array_null_col);
+        auto array_array_col = NullableColumn::create(std::move(array_array_data_col), std::move(array_array_null_col));
 
-        chunk->append_column(array_array_col, chunk->num_columns());
+        chunk->append_column(std::move(array_array_col), chunk->num_columns());
     }
 
     // write chunk
@@ -969,8 +969,8 @@ TEST_F(ParquetFileWriterTest, TestWriteVarbinary) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {1, 0, 1, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk
@@ -1012,8 +1012,8 @@ TEST_F(ParquetFileWriterTest, TestAllocatedBytes) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {1, 0, 1, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk
@@ -1054,8 +1054,8 @@ TEST_F(ParquetFileWriterTest, TestFlushRowgroup) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {1, 0, 1, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk twice
@@ -1090,8 +1090,8 @@ TEST_F(ParquetFileWriterTest, TestWriteWithFieldID) {
         auto null_column = UInt8Column::create();
         std::vector<uint8_t> nulls = {1, 0, 1, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
-        auto nullable_column = NullableColumn::create(data_column, null_column);
-        chunk->append_column(nullable_column, chunk->num_columns());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
     }
 
     // write chunk twice

--- a/be/test/io/spill_test.cpp
+++ b/be/test/io/spill_test.cpp
@@ -294,23 +294,6 @@ struct SpillerCaller {
     spill::Spiller* _spiller;
 };
 
-bool chunk_equals(const ChunkPtr& l, const ChunkPtr& r) {
-    if (l->columns() != r->columns() || l->num_columns() != r->num_columns() ||
-        l->get_slot_id_to_index_map() != r->get_slot_id_to_index_map()) {
-        return false;
-    }
-    size_t num_rows = l->num_rows();
-    auto& lcolumns = l->columns();
-    auto& rcolumns = r->columns();
-    for (size_t i = 0; i < lcolumns.size(); ++i) {
-        if (!lcolumns[i]->equals(num_rows, *rcolumns[i], num_rows)) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
 TEST_F(SpillTest, unsorted_process) {
     ObjectPool pool;
 

--- a/be/test/runtime/http_result_writer_test.cpp
+++ b/be/test/runtime/http_result_writer_test.cpp
@@ -34,7 +34,7 @@ static ChunkPtr create_chunk(SchemaPtr schema, int col0value, int col1value) {
     auto c1 = Int32Column::create();
     c0->append_numbers(c0v.data(), c0v.size() * sizeof(int));
     c1->append_numbers(c1v.data(), c1v.size() * sizeof(int));
-    auto chunk = std::shared_ptr<Chunk>(new Chunk({c0, c1}, schema));
+    auto chunk = std::shared_ptr<Chunk>(new Chunk({std::move(c0), std::move(c1)}, schema));
     chunk->set_slot_id_to_index(0, 0);
     chunk->set_slot_id_to_index(1, 1);
     return chunk;
@@ -94,7 +94,7 @@ TEST(HttpResultWriterTest, BasicJsonFormat) {
         std::vector<int> c0v{10};
         auto c0 = Int32Column::create();
         c0->append_numbers(c0v.data(), c0v.size() * sizeof(int));
-        auto chunk = std::shared_ptr<Chunk>(new Chunk({c0, c0}, schema));
+        auto chunk = std::shared_ptr<Chunk>(new Chunk({c0->clone(), c0->clone()}, schema));
         chunk->set_slot_id_to_index(0, 0);
         chunk->set_slot_id_to_index(1, 1);
         auto result = writer.process_chunk(chunk.get());

--- a/be/test/runtime/lake_tablets_channel_test.cpp
+++ b/be/test/runtime/lake_tablets_channel_test.cpp
@@ -165,7 +165,7 @@ public:
         auto c1 = Int32Column::create();
         c0->append_numbers(v0.data(), v0.size() * sizeof(int));
         c1->append_numbers(v1.data(), v1.size() * sizeof(int));
-        Chunk chunk({c0, c1}, _schema);
+        Chunk chunk({std::move(c0), std::move(c1)}, _schema);
         chunk.set_slot_id_to_index(0, 0);
         chunk.set_slot_id_to_index(1, 1);
         return chunk;

--- a/be/test/runtime/load_channel_test.cpp
+++ b/be/test/runtime/load_channel_test.cpp
@@ -162,7 +162,7 @@ public:
         auto c1 = Int32Column::create();
         c0->append_numbers(v0.data(), v0.size() * sizeof(int));
         c1->append_numbers(v1.data(), v1.size() * sizeof(int));
-        Chunk chunk({c0, c1}, _schema);
+        Chunk chunk({std::move(c0), std::move(c1)}, _schema);
         chunk.set_slot_id_to_index(0, 0);
         chunk.set_slot_id_to_index(1, 1);
         return chunk;

--- a/be/test/runtime/local_tablets_channel_test.cpp
+++ b/be/test/runtime/local_tablets_channel_test.cpp
@@ -170,7 +170,7 @@ protected:
         auto c1 = Int32Column::create();
         c0->append_numbers(v0.data(), v0.size() * sizeof(int));
         c1->append_numbers(v1.data(), v1.size() * sizeof(int));
-        Chunk chunk({c0, c1}, _schema);
+        Chunk chunk({std::move(c0), std::move(c1)}, _schema);
         chunk.set_slot_id_to_index(0, 0);
         chunk.set_slot_id_to_index(1, 1);
         return chunk;

--- a/be/test/serde/column_array_serde_test.cpp
+++ b/be/test/serde/column_array_serde_test.cpp
@@ -274,7 +274,7 @@ PARALLEL_TEST(ColumnArraySerdeTest, const_column) {
     auto create_const_column = [](int32_t value, size_t size) {
         auto c = Int32Column::create();
         c->append_numbers(&value, sizeof(value));
-        return ConstColumn::create(c, size);
+        return ConstColumn::create(std::move(c), size);
     };
 
     auto c1 = create_const_column(100, 10);
@@ -304,9 +304,9 @@ PARALLEL_TEST(ColumnArraySerdeTest, const_column) {
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(ColumnArraySerdeTest, array_column) {
-    auto off1 = UInt32Column::create();
-    auto elem1 = NullableColumn::create(Int32Column::create(), NullColumn ::create());
-    auto c1 = ArrayColumn::create(elem1, off1);
+    UInt32Column::Ptr off1 = UInt32Column::create();
+    NullableColumn::Ptr elem1 = NullableColumn::create(Int32Column::create(), NullColumn ::create());
+    ArrayColumn::Ptr c1 = ArrayColumn::create(elem1, off1);
 
     // insert [1, 2, 3], [4, 5, 6]
     elem1->append_datum(1);
@@ -327,9 +327,9 @@ PARALLEL_TEST(ColumnArraySerdeTest, array_column) {
     buffer.resize(ColumnArraySerde::max_serialized_size(*c1));
     ASSERT_EQ(buffer.data() + buffer.size(), ColumnArraySerde::serialize(*c1, buffer.data()));
 
-    auto off2 = UInt32Column::create();
-    auto elem2 = NullableColumn::create(Int32Column::create(), NullColumn ::create());
-    auto c2 = ArrayColumn::create(elem1, off2);
+    UInt32Column::Ptr off2 = UInt32Column::create();
+    NullableColumn::Ptr elem2 = NullableColumn::create(Int32Column::create(), NullColumn ::create());
+    ArrayColumn::Ptr c2 = ArrayColumn::create(elem1, off2);
 
     ASSERT_EQ(buffer.data() + buffer.size(), ColumnArraySerde::deserialize(buffer.data(), c2.get()));
     ASSERT_EQ("[1,2,3]", c2->debug_item(0));

--- a/be/test/serde/protobuf_serde_test.cpp
+++ b/be/test/serde/protobuf_serde_test.cpp
@@ -101,7 +101,7 @@ PARALLEL_TEST(ProtobufChunkSerde, TestChunkWithExtraData) {
     auto chunk = std::make_unique<Chunk>(make_columns(2), make_schema(2));
     auto extra_data_meta = std::vector<ChunkExtraColumnsMeta>{
             ChunkExtraColumnsMeta{.type = TypeDescriptor(TYPE_INT), .is_null = false, .is_const = false}};
-    auto extra_data_cols = std::vector<ColumnPtr>{make_columns(2)};
+    auto extra_data_cols = make_columns(2);
     auto extra_data = std::make_shared<ChunkExtraColumnsData>(std::move(extra_data_meta), std::move(extra_data_cols));
     chunk->set_extra_data(extra_data);
 

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -1905,7 +1905,7 @@ TEST_F(LakeServiceTest, test_abort_txn2) {
         auto c1 = Int32Column::create();
         c0->append_numbers(v0.data(), v0.size() * sizeof(int));
         c1->append_numbers(v1.data(), v1.size() * sizeof(int));
-        Chunk chunk({c0, c1}, schema);
+        Chunk chunk({std::move(c0), std::move(c1)}, schema);
         chunk.set_slot_id_to_index(0, 0);
         chunk.set_slot_id_to_index(1, 1);
         return chunk;

--- a/be/test/storage/aggregate_iterator_test.cpp
+++ b/be/test/storage/aggregate_iterator_test.cpp
@@ -464,7 +464,7 @@ TEST_F(AggregateIteratorTest, agg_max_small_chunk) {
         }
         auto& c = chunk->get_column_by_index(1);
         // std::vector<int16_t>
-        auto& v = std::dynamic_pointer_cast<FixedLengthColumn<int16_t>>(c)->get_data();
+        auto& v = FixedLengthColumn<int16_t>::dynamic_pointer_cast(c)->get_data();
         values.insert(values.end(), v.begin(), v.end());
     }
     ASSERT_TRUE(st.is_end_of_file());
@@ -509,7 +509,7 @@ TEST_F(AggregateIteratorTest, agg_max_all_duplicate) {
         }
         auto& c = chunk->get_column_by_index(1);
         // std::vector<int16_t>
-        auto& v = std::dynamic_pointer_cast<FixedLengthColumn<int16_t>>(c)->get_data();
+        auto& v = FixedLengthColumn<int16_t>::dynamic_pointer_cast(c)->get_data();
         values.insert(values.end(), v.begin(), v.end());
     }
     ASSERT_TRUE(st.is_end_of_file());
@@ -552,7 +552,7 @@ TEST_F(AggregateIteratorTest, agg_boolean_key) {
         }
         auto& c = chunk->get_column_by_index(1);
         // std::vector<int16_t>
-        auto& v = std::dynamic_pointer_cast<FixedLengthColumn<int16_t>>(c)->get_data();
+        auto& v = FixedLengthColumn<int16_t>::dynamic_pointer_cast(c)->get_data();
         values.insert(values.end(), v.begin(), v.end());
     }
     ASSERT_TRUE(st.is_end_of_file());
@@ -592,7 +592,7 @@ TEST_F(AggregateIteratorTest, agg_varchar_key) {
             }
             auto& c = chunk->get_column_by_index(1);
             // std::vector<int16_t>
-            auto& v = std::dynamic_pointer_cast<FixedLengthColumn<int16_t>>(c)->get_data();
+            auto& v = FixedLengthColumn<int16_t>::dynamic_pointer_cast(c)->get_data();
             values.insert(values.end(), v.begin(), v.end());
         }
         ASSERT_TRUE(st.is_end_of_file());
@@ -622,7 +622,7 @@ TEST_F(AggregateIteratorTest, agg_varchar_key) {
             }
             auto& c = chunk->get_column_by_index(1);
             // std::vector<int16_t>
-            auto& v = std::dynamic_pointer_cast<FixedLengthColumn<int16_t>>(c)->get_data();
+            auto& v = FixedLengthColumn<int16_t>::dynamic_pointer_cast(c)->get_data();
             values.insert(values.end(), v.begin(), v.end());
         }
         ASSERT_TRUE(st.is_end_of_file());
@@ -647,7 +647,7 @@ TEST_F(AggregateIteratorTest, agg_varchar_key) {
             }
             auto& c = chunk->get_column_by_index(1);
             // std::vector<int16_t>
-            auto& v = std::dynamic_pointer_cast<FixedLengthColumn<int16_t>>(c)->get_data();
+            auto& v = FixedLengthColumn<int16_t>::dynamic_pointer_cast(c)->get_data();
             values.insert(values.end(), v.begin(), v.end());
         }
         ASSERT_TRUE(st.is_end_of_file());
@@ -690,7 +690,7 @@ TEST_F(AggregateIteratorTest, agg_date_key) {
             }
             auto& c = chunk->get_column_by_index(1);
             // std::vector<int16_t>
-            auto& v = std::dynamic_pointer_cast<FixedLengthColumn<int16_t>>(c)->get_data();
+            auto& v = FixedLengthColumn<int16_t>::dynamic_pointer_cast(c)->get_data();
             values.insert(values.end(), v.begin(), v.end());
         }
         ASSERT_TRUE(st.is_end_of_file());
@@ -718,7 +718,7 @@ TEST_F(AggregateIteratorTest, agg_date_key) {
             }
             auto& c = chunk->get_column_by_index(1);
             // std::vector<int16_t>
-            auto& v = std::dynamic_pointer_cast<FixedLengthColumn<int16_t>>(c)->get_data();
+            auto& v = FixedLengthColumn<int16_t>::dynamic_pointer_cast(c)->get_data();
             values.insert(values.end(), v.begin(), v.end());
         }
         ASSERT_TRUE(st.is_end_of_file());
@@ -743,7 +743,7 @@ TEST_F(AggregateIteratorTest, agg_date_key) {
             }
             auto& c = chunk->get_column_by_index(1);
             // std::vector<int16_t>
-            auto& v = std::dynamic_pointer_cast<FixedLengthColumn<int16_t>>(c)->get_data();
+            auto& v = FixedLengthColumn<int16_t>::dynamic_pointer_cast(c)->get_data();
             values.insert(values.end(), v.begin(), v.end());
         }
         ASSERT_TRUE(st.is_end_of_file());
@@ -785,7 +785,7 @@ TEST_F(AggregateIteratorTest, agg_decimal_key) {
             }
             auto& c = chunk->get_column_by_index(1);
             // std::vector<int16_t>
-            auto& v = std::dynamic_pointer_cast<FixedLengthColumn<int16_t>>(c)->get_data();
+            auto& v = FixedLengthColumn<int16_t>::dynamic_pointer_cast(c)->get_data();
             values.insert(values.end(), v.begin(), v.end());
         }
         ASSERT_TRUE(st.is_end_of_file());
@@ -813,7 +813,7 @@ TEST_F(AggregateIteratorTest, agg_decimal_key) {
             }
             auto& c = chunk->get_column_by_index(1);
             // std::vector<int16_t>
-            auto& v = std::dynamic_pointer_cast<FixedLengthColumn<int16_t>>(c)->get_data();
+            auto& v = FixedLengthColumn<int16_t>::dynamic_pointer_cast(c)->get_data();
             values.insert(values.end(), v.begin(), v.end());
         }
         ASSERT_TRUE(st.is_end_of_file());
@@ -838,7 +838,7 @@ TEST_F(AggregateIteratorTest, agg_decimal_key) {
             }
             auto& c = chunk->get_column_by_index(1);
             // std::vector<int16_t>
-            auto& v = std::dynamic_pointer_cast<FixedLengthColumn<int16_t>>(c)->get_data();
+            auto& v = FixedLengthColumn<int16_t>::dynamic_pointer_cast(c)->get_data();
             values.insert(values.end(), v.begin(), v.end());
         }
         ASSERT_TRUE(st.is_end_of_file());
@@ -885,7 +885,7 @@ TEST_F(AggregateIteratorTest, agg_varchar_date_key) {
             }
             auto& c = chunk->get_column_by_index(2);
             // std::vector<int16_t>
-            auto& v = std::dynamic_pointer_cast<FixedLengthColumn<int16_t>>(c)->get_data();
+            auto& v = FixedLengthColumn<int16_t>::dynamic_pointer_cast(c)->get_data();
             values.insert(values.end(), v.begin(), v.end());
         }
         ASSERT_TRUE(st.is_end_of_file());
@@ -915,7 +915,7 @@ TEST_F(AggregateIteratorTest, agg_varchar_date_key) {
             }
             auto& c = chunk->get_column_by_index(2);
             // std::vector<int16_t>
-            auto& v = std::dynamic_pointer_cast<FixedLengthColumn<int16_t>>(c)->get_data();
+            auto& v = FixedLengthColumn<int16_t>::dynamic_pointer_cast(c)->get_data();
             values.insert(values.end(), v.begin(), v.end());
         }
         ASSERT_TRUE(st.is_end_of_file());
@@ -945,7 +945,7 @@ TEST_F(AggregateIteratorTest, agg_varchar_date_key) {
             }
             auto& c = chunk->get_column_by_index(2);
             // std::vector<int16_t>
-            auto& v = std::dynamic_pointer_cast<FixedLengthColumn<int16_t>>(c)->get_data();
+            auto& v = FixedLengthColumn<int16_t>::dynamic_pointer_cast(c)->get_data();
             values.insert(values.end(), v.begin(), v.end());
         }
         ASSERT_TRUE(st.is_end_of_file());
@@ -972,7 +972,7 @@ TEST_F(AggregateIteratorTest, agg_varchar_date_key) {
             }
             auto& c = chunk->get_column_by_index(2);
             // std::vector<int16_t>
-            auto& v = std::dynamic_pointer_cast<FixedLengthColumn<int16_t>>(c)->get_data();
+            auto& v = FixedLengthColumn<int16_t>::dynamic_pointer_cast(c)->get_data();
             values.insert(values.end(), v.begin(), v.end());
         }
         ASSERT_TRUE(st.is_end_of_file());
@@ -1027,7 +1027,7 @@ TEST_F(AggregateIteratorTest, agg_varchar_date_key_with_null) {
             }
             auto& c = chunk->get_column_by_index(2);
             // std::vector<int16_t>
-            auto& v = std::dynamic_pointer_cast<FixedLengthColumn<int16_t>>(c)->get_data();
+            auto& v = FixedLengthColumn<int16_t>::dynamic_pointer_cast(c)->get_data();
             values.insert(values.end(), v.begin(), v.end());
         }
         ASSERT_TRUE(st.is_end_of_file());
@@ -1106,7 +1106,7 @@ TEST_F(AggregateIteratorTest, sum_from_source_masks) {
         }
         auto& c = chunk->get_column_by_index(0);
         // std::vector<int16_t>
-        auto& v = std::dynamic_pointer_cast<FixedLengthColumn<int16_t>>(c)->get_data();
+        auto& v = FixedLengthColumn<int16_t>::dynamic_pointer_cast(c)->get_data();
         values.insert(values.end(), v.begin(), v.end());
     }
     ASSERT_TRUE(st.is_end_of_file());
@@ -1150,7 +1150,7 @@ TEST_F(AggregateIteratorTest, max_from_source_masks) {
         }
         auto& c = chunk->get_column_by_index(0);
         // std::vector<int16_t>
-        auto& v = std::dynamic_pointer_cast<FixedLengthColumn<int16_t>>(c)->get_data();
+        auto& v = FixedLengthColumn<int16_t>::dynamic_pointer_cast(c)->get_data();
         values.insert(values.end(), v.begin(), v.end());
     }
     ASSERT_TRUE(st.is_end_of_file());

--- a/be/test/storage/chunk_aggregator_test.cpp
+++ b/be/test/storage/chunk_aggregator_test.cpp
@@ -51,7 +51,7 @@ TEST(ChunkAggregatorTest, testNoneAggregator) {
         v_col->append(1);
     }
 
-    Columns cols{k_col, v_col};
+    Columns cols({std::move(k_col), std::move(v_col)});
 
     ChunkPtr chunk = std::make_shared<Chunk>(cols, schema);
 
@@ -102,7 +102,7 @@ TEST(ChunkAggregatorTest, testNonKeyColumnsByMask) {
             source_masks.emplace_back(RowSourceMask{0, true});
         }
     }
-    Columns cols{v_col};
+    Columns cols{std::move(v_col)};
     ChunkPtr chunk = std::make_shared<Chunk>(cols, schema);
 
     aggregator.update_source(chunk, &source_masks);

--- a/be/test/storage/chunk_helper_test.cpp
+++ b/be/test/storage/chunk_helper_test.cpp
@@ -300,7 +300,7 @@ ChunkPtr ChunkPipelineAccumulatorTest::_generate_chunk(size_t rows, size_t cols,
     auto chunk = std::make_shared<Chunk>();
     for (size_t i = 0; i < cols; i++) {
         auto col = Int8Column::create(rows, reserve_size);
-        chunk->append_column(col, i);
+        chunk->append_column(std::move(col), i);
     }
     return chunk;
 }

--- a/be/test/storage/column_aggregator_test.cpp
+++ b/be/test/storage/column_aggregator_test.cpp
@@ -31,9 +31,9 @@ TEST(ColumnAggregator, testIntSum) {
 
     auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field);
 
-    auto src1 = Int32Column::create();
-    auto src2 = Int32Column::create();
-    auto src3 = Int32Column::create();
+    Int32Column::Ptr src1 = Int32Column::create();
+    Int32Column::Ptr src2 = Int32Column::create();
+    Int32Column::Ptr src3 = Int32Column::create();
 
     for (int i = 0; i < 1024; i++) {
         src1->append(1);
@@ -41,7 +41,7 @@ TEST(ColumnAggregator, testIntSum) {
         src3->append(1);
     }
 
-    auto agg1 = Int32Column::create();
+    Int32Column::Ptr agg1 = Int32Column::create();
 
     aggregator->update_aggregate(agg1.get());
     aggregator->update_source(src1);
@@ -94,14 +94,14 @@ TEST(ColumnAggregator, testNullIntSum) {
 
     auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field);
 
-    auto src1 = Int32Column::create();
+    Int32Column::Ptr src1 = Int32Column::create();
     auto null1 = NullColumn ::create();
 
-    auto src2 = Int32Column::create();
-    auto null2 = NullColumn::create();
+    Int32Column::Ptr src2 = Int32Column::create();
+    NullColumn::Ptr null2 = NullColumn::create();
 
-    auto src3 = Int32Column::create();
-    auto null3 = NullColumn::create();
+    Int32Column::Ptr src3 = Int32Column::create();
+    NullColumn::Ptr null3 = NullColumn::create();
 
     for (int i = 0; i < 1024; i++) {
         src1->append(1);
@@ -118,11 +118,11 @@ TEST(ColumnAggregator, testNullIntSum) {
         null3->append(i % 2 == 0);
     }
 
-    auto nsrc1 = NullableColumn::create(src1, null1);
-    auto nsrc2 = NullableColumn::create(src2, null2);
-    auto nsrc3 = NullableColumn::create(src3, null3);
+    NullableColumn::Ptr nsrc1 = NullableColumn::create(std::move(src1), std::move(null1));
+    NullableColumn::Ptr nsrc2 = NullableColumn::create(std::move(src2), std::move(null2));
+    NullableColumn::Ptr nsrc3 = NullableColumn::create(std::move(src3), std::move(null3));
 
-    auto agg1 = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    NullableColumn::Ptr agg1 = NullableColumn::create(Int32Column::create(), NullColumn::create());
 
     auto dst = down_cast<Int32Column*>(agg1->data_column().get());
     auto ndst = down_cast<NullColumn*>(agg1->null_column().get());
@@ -200,9 +200,9 @@ TEST(ColumnAggregator, testIntMax) {
 
     auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field);
 
-    auto src1 = Int32Column::create();
-    auto src2 = Int32Column::create();
-    auto src3 = Int32Column::create();
+    Int32Column::Ptr src1 = Int32Column::create();
+    Int32Column::Ptr src2 = Int32Column::create();
+    Int32Column::Ptr src3 = Int32Column::create();
 
     for (int i = 0; i < 1024; i++) {
         src1->append(i);
@@ -210,7 +210,7 @@ TEST(ColumnAggregator, testIntMax) {
         src3->append(i * 2);
     }
 
-    auto agg1 = Int32Column::create();
+    Int32Column::Ptr agg1 = Int32Column::create();
 
     aggregator->update_aggregate(agg1.get());
     aggregator->update_source(src1);
@@ -263,9 +263,9 @@ TEST(ColumnAggregator, testStringMin) {
 
     auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field);
 
-    auto src1 = BinaryColumn::create();
-    auto src2 = BinaryColumn::create();
-    auto src3 = BinaryColumn::create();
+    BinaryColumn::Ptr src1 = BinaryColumn::create();
+    BinaryColumn::Ptr src2 = BinaryColumn::create();
+    BinaryColumn::Ptr src3 = BinaryColumn::create();
 
     for (int i = 0; i < 1024; i++) {
         src1->append(Slice(std::to_string(i + 1000)));
@@ -273,7 +273,7 @@ TEST(ColumnAggregator, testStringMin) {
         src3->append(Slice(std::to_string(i + 2000)));
     }
 
-    auto agg1 = BinaryColumn::create();
+    BinaryColumn::Ptr agg1 = BinaryColumn::create();
 
     aggregator->update_aggregate(agg1.get());
     aggregator->update_source(src1);
@@ -324,13 +324,13 @@ TEST(ColumnAggregator, testNullBooleanMin) {
     FieldPtr field = std::make_shared<Field>(1, "test_boolean", LogicalType::TYPE_BOOLEAN, true);
     field->set_aggregate_method(StorageAggregateType::STORAGE_AGGREGATE_MIN);
 
-    auto agg = NullableColumn::create(BooleanColumn::create(), NullColumn::create());
+    NullableColumn::Ptr agg = NullableColumn::create(BooleanColumn::create(), NullColumn::create());
     auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field);
     aggregator->update_aggregate(agg.get());
     std::vector<uint32_t> loops;
 
     // first chunk column
-    auto src = NullableColumn::create(BooleanColumn::create(), NullColumn::create());
+    NullableColumn::Ptr src = NullableColumn::create(BooleanColumn::create(), NullColumn::create());
     src->append_nulls(1);
 
     aggregator->update_source(src);
@@ -389,14 +389,14 @@ TEST(ColumnAggregator, testNullIntReplaceIfNotNull) {
 
     auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field);
 
-    auto src1 = Int32Column::create();
+    Int32Column::Ptr src1 = Int32Column::create();
     auto null1 = NullColumn ::create();
 
-    auto src2 = Int32Column::create();
-    auto null2 = NullColumn::create();
+    Int32Column::Ptr src2 = Int32Column::create();
+    NullColumn::Ptr null2 = NullColumn::create();
 
-    auto src3 = Int32Column::create();
-    auto null3 = NullColumn::create();
+    Int32Column::Ptr src3 = Int32Column::create();
+    NullColumn::Ptr null3 = NullColumn::create();
 
     for (int i = 0; i < 1024; i++) {
         src1->append(i);
@@ -413,11 +413,11 @@ TEST(ColumnAggregator, testNullIntReplaceIfNotNull) {
         null3->append(i > 512);
     }
 
-    auto nsrc1 = NullableColumn::create(src1, null1);
-    auto nsrc2 = NullableColumn::create(src2, null2);
-    auto nsrc3 = NullableColumn::create(src3, null3);
+    NullableColumn::Ptr nsrc1 = NullableColumn::create(std::move(src1), std::move(null1));
+    NullableColumn::Ptr nsrc2 = NullableColumn::create(std::move(src2), std::move(null2));
+    NullableColumn::Ptr nsrc3 = NullableColumn::create(std::move(src3), std::move(null3));
 
-    auto agg1 = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    NullableColumn::Ptr agg1 = NullableColumn::create(Int32Column::create(), NullColumn::create());
 
     auto dst = down_cast<Int32Column*>(agg1->data_column().get());
     auto ndst = down_cast<NullColumn*>(agg1->null_column().get());
@@ -496,14 +496,14 @@ TEST(ColumnAggregator, testNullIntReplace) {
 
     auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field);
 
-    auto src1 = Int32Column::create();
+    Int32Column::Ptr src1 = Int32Column::create();
     auto null1 = NullColumn ::create();
 
-    auto src2 = Int32Column::create();
-    auto null2 = NullColumn::create();
+    Int32Column::Ptr src2 = Int32Column::create();
+    NullColumn::Ptr null2 = NullColumn::create();
 
-    auto src3 = Int32Column::create();
-    auto null3 = NullColumn::create();
+    Int32Column::Ptr src3 = Int32Column::create();
+    NullColumn::Ptr null3 = NullColumn::create();
 
     for (int i = 0; i < 1024; i++) {
         src1->append(i);
@@ -520,11 +520,11 @@ TEST(ColumnAggregator, testNullIntReplace) {
         null3->append(i > 512);
     }
 
-    auto nsrc1 = NullableColumn::create(src1, null1);
-    auto nsrc2 = NullableColumn::create(src2, null2);
-    auto nsrc3 = NullableColumn::create(src3, null3);
+    NullableColumn::Ptr nsrc1 = NullableColumn::create(std::move(src1), std::move(null1));
+    NullableColumn::Ptr nsrc2 = NullableColumn::create(std::move(src2), std::move(null2));
+    NullableColumn::Ptr nsrc3 = NullableColumn::create(std::move(src3), std::move(null3));
 
-    auto agg1 = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    NullableColumn::Ptr agg1 = NullableColumn::create(Int32Column::create(), NullColumn::create());
 
     auto dst = down_cast<Int32Column*>(agg1->data_column().get());
     auto ndst = down_cast<NullColumn*>(agg1->null_column().get());
@@ -605,18 +605,18 @@ TEST(ColumnAggregator, testArrayReplace) {
     FieldPtr field = std::make_shared<Field>(1, "test_array", array_type_info,
                                              StorageAggregateType::STORAGE_AGGREGATE_REPLACE, 1, false, false);
 
-    auto agg_elements = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
-    auto agg_offsets = UInt32Column::create();
-    auto agg = ArrayColumn::create(agg_elements, agg_offsets);
+    NullableColumn::Ptr agg_elements = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+    UInt32Column::Ptr agg_offsets = UInt32Column::create();
+    ArrayColumn::Ptr agg = ArrayColumn::create(std::move(agg_elements), std::move(agg_offsets));
 
     auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field);
     aggregator->update_aggregate(agg.get());
     std::vector<uint32_t> loops;
 
     // first chunk column
-    auto elements = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
-    auto offsets = UInt32Column::create();
-    auto src = ArrayColumn::create(elements, offsets);
+    NullableColumn::Ptr elements = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+    UInt32Column::Ptr offsets = UInt32Column::create();
+    ArrayColumn::Ptr src = ArrayColumn::create(elements, offsets);
     for (int i = 0; i < 10; ++i) {
         elements->append_datum(Slice(std::to_string(i)));
     }
@@ -685,7 +685,7 @@ TEST(ColumnAggregator, testNullArrayReplaceIfNotNull2) {
     FieldPtr field =
             std::make_shared<Field>(1, "test_array", array_type_info,
                                     StorageAggregateType::STORAGE_AGGREGATE_REPLACE_IF_NOT_NULL, 1, false, true);
-    auto agg = NullableColumn::create(
+    NullableColumn::Ptr agg = NullableColumn::create(
             ArrayColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
                                 UInt32Column::create()),
             NullColumn::create());
@@ -693,7 +693,7 @@ TEST(ColumnAggregator, testNullArrayReplaceIfNotNull2) {
     aggregator->update_aggregate(agg.get());
 
     // first chunk column
-    auto src = NullableColumn::create(
+    NullableColumn::Ptr src = NullableColumn::create(
             ArrayColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
                                 UInt32Column::create()),
             NullColumn::create());
@@ -763,7 +763,7 @@ TEST(ColumnAggregator, testNullArrayReplaceIfNotNull) {
             std::make_shared<Field>(1, "test_array", array_type_info,
                                     StorageAggregateType::STORAGE_AGGREGATE_REPLACE_IF_NOT_NULL, 1, false, true);
 
-    auto agg = NullableColumn::create(
+    NullableColumn::Ptr agg = NullableColumn::create(
             ArrayColumn::create(NullableColumn::create(BinaryColumn::create(), NullColumn::create()),
                                 UInt32Column::create()),
             NullColumn::create());
@@ -772,7 +772,7 @@ TEST(ColumnAggregator, testNullArrayReplaceIfNotNull) {
     std::vector<uint32_t> loops;
 
     // first chunk column
-    auto src = NullableColumn::create(
+    NullableColumn::Ptr src = NullableColumn::create(
             ArrayColumn::create(NullableColumn::create(BinaryColumn::create(), NullColumn::create()),
                                 UInt32Column::create()),
             NullColumn::create());

--- a/be/test/storage/conjunctive_predicates_test.cpp
+++ b/be/test/storage/conjunctive_predicates_test.cpp
@@ -124,7 +124,8 @@ TEST(ConjunctivePredicatesTest, test_evaluate) {
     c4->append_datum(Datum(DecimalV2Value("0.000002")));
     c4->append_datum(Datum(DecimalV2Value("0.000003")));
 
-    ChunkPtr chunk = std::make_shared<Chunk>(Columns{c0, c1, c2, c3, c4}, schema);
+    ChunkPtr chunk = std::make_shared<Chunk>(
+            Columns{std::move(c0), std::move(c1), std::move(c2), std::move(c3), std::move(c4)}, schema);
 
     std::vector<uint8_t> selection(chunk->num_rows(), 0);
 
@@ -190,7 +191,7 @@ TEST(ConjunctivePredicatesTest, test_evaluate_and) {
     c0->append_datum(Datum(2));
     c0->append_datum(Datum(3));
 
-    ChunkPtr chunk = std::make_shared<Chunk>(Columns{c0}, schema);
+    ChunkPtr chunk = std::make_shared<Chunk>(Columns{std::move(c0)}, schema);
 
     {
         std::vector<uint8_t> selection(chunk->num_rows(), 0);
@@ -229,7 +230,7 @@ TEST(ConjunctivePredicatesTest, test_evaluate_or) {
     c0->append_datum(Datum(2));
     c0->append_datum(Datum(3));
 
-    ChunkPtr chunk = std::make_shared<Chunk>(Columns{c0}, schema);
+    ChunkPtr chunk = std::make_shared<Chunk>(Columns{std::move(c0)}, schema);
 
     {
         std::vector<uint8_t> selection(chunk->num_rows(), 0);

--- a/be/test/storage/disjunctive_predicates_test.cpp
+++ b/be/test/storage/disjunctive_predicates_test.cpp
@@ -49,7 +49,7 @@ TEST(DisjunctivePredicatesTest, TwoPredicateTest) {
     ContainerIniter<SegDataGenerator, RunTimeColumnType<TYPE0>::Container, chunk_size>::init(column0->get_data());
     ContainerIniter<SegDataGeneratorWithRange<4>, RunTimeColumnType<TYPE1>::Container, chunk_size>::init(
             column1->get_data());
-    Columns columns = {column0, column1};
+    Columns columns = {std::move(column0), std::move(column1)};
     Chunk::SlotHashMap hash_map;
     hash_map[0] = 0;
     hash_map[1] = 1;

--- a/be/test/storage/index/vector_index_test.cpp
+++ b/be/test/storage/index/vector_index_test.cpp
@@ -68,17 +68,17 @@ protected:
         CHECK_OK(vector_index_writer->init());
 
         // construct columns
-        std::shared_ptr<FixedLengthColumn<float>> element = std::make_shared<FixedLengthColumn<float>>();
+        auto element = FixedLengthColumn<float>::create();
         element->append(1);
         element->append(2);
         element->append(3);
-        NullColumnPtr null_column = std::make_shared<NullColumn>(element->size(), 0);
-        std::shared_ptr<NullableColumn> nullable_column = std::make_shared<NullableColumn>(element, null_column);
-        std::shared_ptr<UInt32Column> offsets = std::make_shared<UInt32Column>();
+        NullColumnPtr null_column = NullColumn::create(element->size(), 0);
+        auto nullable_column = NullableColumn::create(std::move(element), std::move(null_column));
+        auto offsets = UInt32Column::create();
         offsets->append(0);
         offsets->append(3);
         for (int i = 0; i < 10; i++) {
-            std::shared_ptr<FixedLengthColumn<float>> e = std::make_shared<FixedLengthColumn<float>>();
+            auto e = FixedLengthColumn<float>::create();
             e->append(i + 1.1);
             e->append(i + 2.2);
             e->append(i + 3.3);
@@ -86,9 +86,9 @@ protected:
             offsets->append((i + 2) * 3);
         }
 
-        ArrayColumn array_column(nullable_column, offsets);
+        ArrayColumn::Ptr array_column = ArrayColumn::create(std::move(nullable_column), std::move(offsets));
 
-        CHECK_OK(vector_index_writer->append(array_column));
+        CHECK_OK(vector_index_writer->append(*array_column));
 
         ASSERT_EQ(vector_index_writer->size(), 11);
 

--- a/be/test/storage/index/vector_search_test.cpp
+++ b/be/test/storage/index/vector_search_test.cpp
@@ -69,17 +69,17 @@ protected:
         CHECK_OK(vector_index_writer->init());
 
         // construct columns
-        std::shared_ptr<FixedLengthColumn<float>> element = std::make_shared<FixedLengthColumn<float>>();
+        auto element = FixedLengthColumn<float>::create();
         element->append(1);
         element->append(2);
         element->append(3);
-        NullColumnPtr null_column = std::make_shared<NullColumn>(element->size(), 0);
-        std::shared_ptr<NullableColumn> nullable_column = std::make_shared<NullableColumn>(element, null_column);
-        std::shared_ptr<UInt32Column> offsets = std::make_shared<UInt32Column>();
+        NullColumnPtr null_column = NullColumn::create(element->size(), 0);
+        auto nullable_column = NullableColumn::create(std::move(element), std::move(null_column));
+        auto offsets = UInt32Column::create();
         offsets->append(0);
         offsets->append(3);
         for (int i = 0; i < 10; i++) {
-            std::shared_ptr<FixedLengthColumn<float>> e = std::make_shared<FixedLengthColumn<float>>();
+            auto e = FixedLengthColumn<float>::create();
             e->append(i + 1.1);
             e->append(i + 2.2);
             e->append(i + 3.3);
@@ -87,9 +87,9 @@ protected:
             offsets->append((i + 2) * 3);
         }
 
-        ArrayColumn array_column(nullable_column, offsets);
+        ArrayColumn::Ptr array_column = ArrayColumn::create(std::move(nullable_column), std::move(offsets));
 
-        CHECK_OK(vector_index_writer->append(array_column));
+        CHECK_OK(vector_index_writer->append(*array_column));
 
         ASSERT_EQ(vector_index_writer->size(), 11);
 

--- a/be/test/storage/lake/alter_tablet_meta_test.cpp
+++ b/be/test/storage/lake/alter_tablet_meta_test.cpp
@@ -98,7 +98,7 @@ TEST_F(AlterTabletMetaTest, test_alter_enable_persistent_index) {
     auto c1 = Int32Column::create();
     c0->append_numbers(k0.data(), k0.size() * sizeof(int));
     c1->append_numbers(v0.data(), v0.size() * sizeof(int));
-    Chunk chunk0({c0, c1}, _schema);
+    Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
     auto rowset_txn_meta = std::make_unique<RowsetTxnMetaPB>();
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
     std::shared_ptr<const TabletSchema> const_schema = _tablet_schema;
@@ -506,7 +506,7 @@ TEST_F(AlterTabletMetaTest, test_alter_persistent_index_type) {
         auto c1 = Int32Column::create();
         c0->append_numbers(k0.data(), k0.size() * sizeof(int));
         c1->append_numbers(v0.data(), v0.size() * sizeof(int));
-        Chunk chunk0({c0, c1}, _schema);
+        Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
         auto rowset_txn_meta = std::make_unique<RowsetTxnMetaPB>();
         ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
         std::shared_ptr<const TabletSchema> const_schema = _tablet_schema;

--- a/be/test/storage/lake/async_delta_writer_test.cpp
+++ b/be/test/storage/lake/async_delta_writer_test.cpp
@@ -76,7 +76,7 @@ protected:
         auto c1 = Int32Column::create();
         c0->append_numbers(v0.data(), v0.size() * sizeof(int));
         c1->append_numbers(v1.data(), v1.size() * sizeof(int));
-        return Chunk({c0, c1}, _schema);
+        return Chunk({std::move(c0), std::move(c1)}, _schema);
     }
 
     constexpr static const char* const kTestDirectory = "test_lake_async_delta_writer";

--- a/be/test/storage/lake/auto_increment_partial_update_test.cpp
+++ b/be/test/storage/lake/auto_increment_partial_update_test.cpp
@@ -142,9 +142,9 @@ public:
             }
             auto c2 = Int64Column::create();
             c2->append_numbers(v2.data(), v2.size() * sizeof(int64_t));
-            return Chunk({c0, c1, c2}, _slot_cid_map);
+            return Chunk({std::move(c0), std::move(c1), std::move(c2)}, _slot_cid_map);
         } else {
-            return Chunk({c0, c1}, _slot_cid_map);
+            return Chunk({std::move(c0), std::move(c1)}, _slot_cid_map);
         }
     }
 

--- a/be/test/storage/lake/compaction_task_test.cpp
+++ b/be/test/storage/lake/compaction_task_test.cpp
@@ -109,7 +109,7 @@ protected:
         auto c1 = Int32Column::create();
         c0->append_numbers(v0.data(), v0.size() * sizeof(int));
         c1->append_numbers(v1.data(), v1.size() * sizeof(int));
-        return Chunk({c0, c1}, _schema);
+        return Chunk({std::move(c0), std::move(c1)}, _schema);
     }
 
     int64_t read(int64_t version) {
@@ -248,7 +248,7 @@ protected:
         auto c1 = Int32Column::create();
         c0->append_numbers(v0.data(), v0.size() * sizeof(int));
         c1->append_numbers(v1.data(), v1.size() * sizeof(int));
-        return Chunk({c0, c1}, _schema);
+        return Chunk({std::move(c0), std::move(c1)}, _schema);
     }
 
     int64_t read(int64_t version) {
@@ -408,7 +408,7 @@ protected:
         auto c1 = Int32Column::create();
         c0->append_numbers(v0.data(), v0.size() * sizeof(int));
         c1->append_numbers(v1.data(), v1.size() * sizeof(int));
-        return Chunk({c0, c1}, _schema);
+        return Chunk({std::move(c0), std::move(c1)}, _schema);
     }
 
     int64_t read(int64_t version) {
@@ -532,7 +532,7 @@ protected:
         auto c1 = Int32Column::create();
         c0->append_numbers(v0.data(), v0.size() * sizeof(int));
         c1->append_numbers(v1.data(), v1.size() * sizeof(int));
-        return Chunk({c0, c1}, _schema);
+        return Chunk({std::move(c0), std::move(c1)}, _schema);
     }
 
     int64_t read(int64_t version) {

--- a/be/test/storage/lake/condition_update_test.cpp
+++ b/be/test/storage/lake/condition_update_test.cpp
@@ -97,7 +97,7 @@ public:
         c1->append_numbers(v1.data(), v1.size() * sizeof(int));
         c2->append_numbers(v2.data(), v2.size() * sizeof(int));
 
-        return Chunk({c0, c1, c2}, _schema);
+        return Chunk({std::move(c0), std::move(c1), std::move(c2)}, _schema);
     }
 
     int64_t check(int64_t version, std::function<bool(int c0, int c1, int c2)> check_fn) {

--- a/be/test/storage/lake/delta_writer_test.cpp
+++ b/be/test/storage/lake/delta_writer_test.cpp
@@ -74,7 +74,7 @@ protected:
         auto c1 = Int32Column::create();
         c0->append_numbers(v0.data(), v0.size() * sizeof(int));
         c1->append_numbers(v1.data(), v1.size() * sizeof(int));
-        return Chunk({c0, c1}, _schema);
+        return Chunk({std::move(c0), std::move(c1)}, _schema);
     }
 
     constexpr static const char* const kTestDirectory = "test_lake_delta_writer";

--- a/be/test/storage/lake/lake_data_source_test.cpp
+++ b/be/test/storage/lake/lake_data_source_test.cpp
@@ -94,8 +94,8 @@ public:
         c2->append_numbers(k1.data(), k1.size() * sizeof(int));
         c3->append_numbers(v1.data(), v1.size() * sizeof(int));
 
-        Chunk chunk0({c0, c1}, _schema);
-        Chunk chunk1({c2, c3}, _schema);
+        Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
+        Chunk chunk1({std::move(c2), std::move(c3)}, _schema);
 
         ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(tablet_metadata->id()));
 

--- a/be/test/storage/lake/lake_primary_key_consistency_test.cpp
+++ b/be/test/storage/lake/lake_primary_key_consistency_test.cpp
@@ -342,7 +342,9 @@ public:
         for (uint32_t i = 0; i < chunk_size; i++) {
             indexes[i] = i;
         }
-        return {std::make_shared<Chunk>(Columns{c0, c1, c2, c3}, _slot_cid_map), std::move(indexes)};
+        return {std::make_shared<Chunk>(Columns{std::move(c0), std::move(c1), std::move(c2), std::move(c3)},
+                                        _slot_cid_map),
+                std::move(indexes)};
     }
 
     std::pair<ChunkPtr, std::vector<uint32_t>> gen_partial_update_data() {
@@ -359,7 +361,7 @@ public:
         for (uint32_t i = 0; i < chunk_size; i++) {
             indexes[i] = i;
         }
-        return {std::make_shared<Chunk>(Columns{c0, c1}, _slot_cid_map), std::move(indexes)};
+        return {std::make_shared<Chunk>(Columns{std::move(c0), std::move(c1)}, _slot_cid_map), std::move(indexes)};
     }
 
     ChunkPtr read(int64_t tablet_id, int64_t version) {

--- a/be/test/storage/lake/lake_scan_node_test.cpp
+++ b/be/test/storage/lake/lake_scan_node_test.cpp
@@ -94,8 +94,8 @@ public:
         c2->append_numbers(k1.data(), k1.size() * sizeof(int));
         c3->append_numbers(v1.data(), v1.size() * sizeof(int));
 
-        Chunk chunk0({c0, c1}, _schema);
-        Chunk chunk1({c2, c3}, _schema);
+        Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
+        Chunk chunk1({std::move(c2), std::move(c3)}, _schema);
 
         ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(tablet_metadata->id()));
 

--- a/be/test/storage/lake/local_pk_index_manager_test.cpp
+++ b/be/test/storage/lake/local_pk_index_manager_test.cpp
@@ -103,7 +103,7 @@ TEST_F(LocalPkIndexManagerTest, test_gc) {
     c0->append_numbers(k0.data(), k0.size() * sizeof(int));
     c1->append_numbers(v0.data(), v0.size() * sizeof(int));
 
-    Chunk chunk0({c0, c1}, _schema);
+    Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
     auto rowset_txn_meta = std::make_unique<RowsetTxnMetaPB>();
 
     int64_t txn_id = next_id();
@@ -187,7 +187,7 @@ TEST_F(LocalPkIndexManagerTest, test_gc_while_index_dir_changed) {
     c0->append_numbers(k0.data(), k0.size() * sizeof(int));
     c1->append_numbers(v0.data(), v0.size() * sizeof(int));
 
-    Chunk chunk0({c0, c1}, _schema);
+    Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
     auto rowset_txn_meta = std::make_unique<RowsetTxnMetaPB>();
 
     int64_t txn_id = next_id();
@@ -290,7 +290,7 @@ TEST_F(LocalPkIndexManagerTest, test_evict) {
     c0->append_numbers(k0.data(), k0.size() * sizeof(int));
     c1->append_numbers(v0.data(), v0.size() * sizeof(int));
 
-    Chunk chunk0({c0, c1}, _schema);
+    Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
     auto rowset_txn_meta = std::make_unique<RowsetTxnMetaPB>();
 
     int64_t txn_id = next_id();
@@ -374,7 +374,7 @@ TEST_F(LocalPkIndexManagerTest, test_major_compaction) {
     c0->append_numbers(k0.data(), k0.size() * sizeof(int));
     c1->append_numbers(v0.data(), v0.size() * sizeof(int));
 
-    Chunk chunk0({c0, c1}, _schema);
+    Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
     auto rowset_txn_meta = std::make_unique<RowsetTxnMetaPB>();
 
     int64_t txn_id = next_id();
@@ -465,7 +465,7 @@ TEST_F(LocalPkIndexManagerTest, test_major_compaction_with_unload) {
     c0->append_numbers(k0.data(), k0.size() * sizeof(int));
     c1->append_numbers(v0.data(), v0.size() * sizeof(int));
 
-    Chunk chunk0({c0, c1}, _schema);
+    Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
     auto rowset_txn_meta = std::make_unique<RowsetTxnMetaPB>();
 
     int64_t txn_id = next_id();

--- a/be/test/storage/lake/metacache_test.cpp
+++ b/be/test/storage/lake/metacache_test.cpp
@@ -146,8 +146,8 @@ TEST_F(LakeMetacacheTest, test_segment_cache) {
     c2->append_numbers(k1.data(), k1.size() * sizeof(int));
     c3->append_numbers(v1.data(), v1.size() * sizeof(int));
 
-    Chunk chunk0({c0, c1}, _schema);
-    Chunk chunk1({c2, c3}, _schema);
+    Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
+    Chunk chunk1({std::move(c2), std::move(c3)}, _schema);
 
     const int segment_rows = chunk0.num_rows() + chunk1.num_rows();
 

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -139,9 +139,9 @@ public:
             }
             auto c2 = Int32Column::create();
             c2->append_numbers(v2.data(), v2.size() * sizeof(int));
-            return Chunk({c0, c1, c2}, _slot_cid_map);
+            return Chunk({std::move(c0), std::move(c1), std::move(c2)}, _slot_cid_map);
         } else {
-            return Chunk({c0, c1}, _slot_cid_map);
+            return Chunk({std::move(c0), std::move(c1)}, _slot_cid_map);
         }
     }
 
@@ -1182,7 +1182,7 @@ public:
         c0->append_numbers(v0.data(), v0.size() * sizeof(int));
         c1->append_numbers(v1.data(), v1.size() * sizeof(int));
 
-        return Chunk({c0, c1}, _slot_cid_map);
+        return Chunk({std::move(c0), std::move(c1)}, _slot_cid_map);
     }
 
 protected:

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -96,7 +96,7 @@ protected:
         auto c1 = Int32Column::create();
         c0->append_numbers(v0.data(), v0.size() * sizeof(int));
         c1->append_numbers(v1.data(), v1.size() * sizeof(int));
-        return Chunk({c0, c1}, _schema);
+        return Chunk({std::move(c0), std::move(c1)}, _schema);
     }
 
     Chunk generate_data2(int64_t chunk_size, int interval, int shift) {
@@ -115,7 +115,7 @@ protected:
         auto c1 = Int32Column::create();
         c0->append_numbers(v0.data(), v0.size() * sizeof(int));
         c1->append_numbers(v1.data(), v1.size() * sizeof(int));
-        return Chunk({c0, c1}, _schema);
+        return Chunk({std::move(c0), std::move(c1)}, _schema);
     }
 
     int64_t read(int64_t version) {

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -121,7 +121,7 @@ public:
         c0->append_numbers(v0.data(), v0.size() * sizeof(int));
         c1->append_numbers(v1.data(), v1.size() * sizeof(int));
         c2->append_numbers(v2.data(), v2.size() * sizeof(uint8_t));
-        return std::make_shared<Chunk>(Columns{c0, c1, c2}, _slot_cid_map);
+        return std::make_shared<Chunk>(Columns{std::move(c0), std::move(c1), std::move(c2)}, _slot_cid_map);
     }
 
     std::pair<ChunkPtr, std::vector<uint32_t>> gen_data_and_index(int64_t chunk_size, int shift, bool random_shuffle,
@@ -183,7 +183,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_read_success) {
     c0->append_numbers(k0.data(), k0.size() * sizeof(int));
     c1->append_numbers(v0.data(), v0.size() * sizeof(int));
 
-    Chunk chunk0({c0, c1}, _schema);
+    Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
     auto rowset_txn_meta = std::make_unique<RowsetTxnMetaPB>();
 
     int64_t txn_id = next_id();

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -63,8 +63,8 @@ public:
         c2->append_numbers(k1.data(), k1.size() * sizeof(int));
         c3->append_numbers(v1.data(), v1.size() * sizeof(int));
 
-        Chunk chunk0({c0, c1}, _schema);
-        Chunk chunk1({c2, c3}, _schema);
+        Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
+        Chunk chunk1({std::move(c2), std::move(c3)}, _schema);
 
         ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
 
@@ -226,7 +226,7 @@ TEST_F(LakeRowsetTest, test_add_partial_compaction_segments_info) {
         auto c1 = Int32Column::create();
         c0->append_numbers(k1.data(), k1.size() * sizeof(int));
         c1->append_numbers(v1.data(), v1.size() * sizeof(int));
-        Chunk chunk0({c0, c1}, _schema);
+        Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
 
         ASSERT_OK(writer->open());
         ASSERT_OK(writer->write(chunk0));

--- a/be/test/storage/lake/schema_change_test.cpp
+++ b/be/test/storage/lake/schema_change_test.cpp
@@ -307,7 +307,7 @@ TEST_P(SchemaChangeAddColumnTest, test_add_column) {
         c0->append_datum(Datum(i * 1));
         c1->append_datum(Datum(i * 2));
 
-        VChunk chunk0({c0, c1}, _base_schema);
+        VChunk chunk0({std::move(c0), std::move(c1)}, _base_schema);
         uint32_t indexes[1] = {0};
 
         ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
@@ -352,7 +352,7 @@ TEST_P(SchemaChangeAddColumnTest, test_add_column) {
         c1->append_datum(Datum(i * 4));
         c2->append_datum(Datum(i * 8));
 
-        VChunk chunk1({c0, c1, c2}, _new_schema);
+        VChunk chunk1({std::move(c0), std::move(c1), std::move(c2)}, _new_schema);
         uint32_t indexes[1] = {0};
 
         ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
@@ -437,7 +437,7 @@ TEST_P(SchemaChangeAddColumnTest, test_add_generated_column) {
         c0->append_datum(Datum(i * 1));
         c1->append_datum(Datum(i * 2));
 
-        VChunk chunk0({c0, c1}, _base_schema);
+        VChunk chunk0({std::move(c0), std::move(c1)}, _base_schema);
         uint32_t indexes[1] = {0};
 
         ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
@@ -508,7 +508,7 @@ TEST_P(SchemaChangeAddColumnTest, test_add_generated_column) {
         c1->append_datum(Datum(i * 4));
         c2->append_datum(Datum(i * 5 /* c0 + c1 */));
 
-        VChunk chunk1({c0, c1, c2}, _new_schema_with_generated_column);
+        VChunk chunk1({std::move(c0), std::move(c1), std::move(c2)}, _new_schema_with_generated_column);
         uint32_t indexes[1] = {0};
 
         ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
@@ -718,7 +718,7 @@ TEST_P(SchemaChangeModifyColumnTypeTest, test_alter_column_type) {
         c0->append_datum(Datum(i * 1));
         c1->append_datum(Datum(i * 2));
 
-        VChunk chunk0({c0, c1}, _base_schema);
+        VChunk chunk0({std::move(c0), std::move(c1)}, _base_schema);
         uint32_t indexes[1] = {0};
 
         ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
@@ -762,7 +762,7 @@ TEST_P(SchemaChangeModifyColumnTypeTest, test_alter_column_type) {
         c0->append_datum(Datum((int32_t)(i * 1)));
         c1->append_datum(Datum((int64_t)(i * 4)));
 
-        VChunk chunk1({c0, c1}, _new_schema);
+        VChunk chunk1({std::move(c0), std::move(c1)}, _new_schema);
         uint32_t indexes[1] = {0};
 
         ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
@@ -981,9 +981,9 @@ TEST_P(SchemaChangeModifyColumnOrderTest, test_alter_key_order) {
     std::vector<int> k1{1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3};
     std::vector<int> v0{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24};
 
-    auto ck0 = Int32Column::create();
-    auto ck1 = Int32Column::create();
-    auto cv0 = Int32Column::create();
+    Int32Column::Ptr ck0 = Int32Column::create();
+    Int32Column::Ptr ck1 = Int32Column::create();
+    Int32Column::Ptr cv0 = Int32Column::create();
     ck0->append_numbers(k0.data(), k0.size() * sizeof(int));
     ck1->append_numbers(k1.data(), k1.size() * sizeof(int));
     cv0->append_numbers(v0.data(), v0.size() * sizeof(int));
@@ -1271,8 +1271,8 @@ TEST_P(SchemaChangeModifyColumnMultiSegmentOrderTest, test_alter_table) {
         // mutli segments in on rowset
         const int64_t old_size = config::write_buffer_size;
         config::write_buffer_size = 1;
-        VChunk chunk0({ck0, ck1, cv0}, _base_schema);
-        VChunk chunk1({ck0_2, ck1_2, cv0_2}, _base_schema);
+        VChunk chunk0({std::move(ck0), std::move(ck1), std::move(cv0)}, _base_schema);
+        VChunk chunk1({std::move(ck0_2), std::move(ck1_2), std::move(cv0_2)}, _base_schema);
 
         ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
                                                    .set_tablet_manager(_tablet_manager.get())
@@ -1470,9 +1470,9 @@ TEST_P(SchemaChangeSortKeyReorderTest1, test_alter_sortkey_reorder_1) {
     std::vector<int> k1{1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3};
     std::vector<int> v0{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24};
 
-    auto ck0 = Int32Column::create();
-    auto ck1 = Int32Column::create();
-    auto cv0 = Int32Column::create();
+    Int32Column::Ptr ck0 = Int32Column::create();
+    Int32Column::Ptr ck1 = Int32Column::create();
+    Int32Column::Ptr cv0 = Int32Column::create();
     ck0->append_numbers(k0.data(), k0.size() * sizeof(int));
     ck1->append_numbers(k1.data(), k1.size() * sizeof(int));
     cv0->append_numbers(v0.data(), v0.size() * sizeof(int));
@@ -1708,9 +1708,9 @@ TEST_P(SchemaChangeSortKeyReorderTest2, test_alter_sortkey_reorder2) {
     std::vector<int> k1{1, 2, 3, 3, 2, 1, 1, 2, 3, 1, 2, 3};
     std::vector<int> v0{2, 4, 6, 12, 10, 8, 14, 16, 18, 20, 22, 24};
 
-    auto ck0 = Int32Column::create();
-    auto ck1 = Int32Column::create();
-    auto cv0 = Int32Column::create();
+    Int32Column::Ptr ck0 = Int32Column::create();
+    Int32Column::Ptr ck1 = Int32Column::create();
+    Int32Column::Ptr cv0 = Int32Column::create();
     ck0->append_numbers(k0.data(), k0.size() * sizeof(int));
     ck1->append_numbers(k1.data(), k1.size() * sizeof(int));
     cv0->append_numbers(v0.data(), v0.size() * sizeof(int));
@@ -1944,9 +1944,9 @@ TEST_P(SchemaChangeSortKeyReorderTest3, test_alter_sortkey_reorder3) {
     std::vector<int> k1{1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3};
     std::vector<int> v0{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24};
 
-    auto ck0 = Int32Column::create();
-    auto ck1 = Int32Column::create();
-    auto cv0 = Int32Column::create();
+    Int32Column::Ptr ck0 = Int32Column::create();
+    Int32Column::Ptr ck1 = Int32Column::create();
+    Int32Column::Ptr cv0 = Int32Column::create();
     ck0->append_numbers(k0.data(), k0.size() * sizeof(int));
     ck1->append_numbers(k1.data(), k1.size() * sizeof(int));
     cv0->append_numbers(v0.data(), v0.size() * sizeof(int));

--- a/be/test/storage/lake/spill_mem_table_sink_test.cpp
+++ b/be/test/storage/lake/spill_mem_table_sink_test.cpp
@@ -70,7 +70,7 @@ public:
         auto c1 = Int32Column::create();
         c0->append_numbers(v0.data(), v0.size() * sizeof(int));
         c1->append_numbers(v1.data(), v1.size() * sizeof(int));
-        return std::make_shared<Chunk>(Columns{c0, c1}, _schema);
+        return std::make_shared<Chunk>(Columns{std::move(c0), std::move(c1)}, _schema);
     }
 
 protected:

--- a/be/test/storage/lake/tablet_reader_test.cpp
+++ b/be/test/storage/lake/tablet_reader_test.cpp
@@ -76,8 +76,8 @@ TEST_F(LakeDuplicateTabletReaderTest, test_read_success) {
     c2->append_numbers(k1.data(), k1.size() * sizeof(int));
     c3->append_numbers(v1.data(), v1.size() * sizeof(int));
 
-    Chunk chunk0({c0, c1}, _schema);
-    Chunk chunk1({c2, c3}, _schema);
+    Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
+    Chunk chunk1({std::move(c2), std::move(c3)}, _schema);
 
     const int segment_rows = chunk0.num_rows() + chunk1.num_rows();
 
@@ -187,8 +187,8 @@ TEST_F(LakeAggregateTabletReaderTest, test_read_success) {
     c2->append_numbers(k1.data(), k1.size() * sizeof(int));
     c3->append_numbers(v1.data(), v1.size() * sizeof(int));
 
-    Chunk chunk0({c0, c1}, _schema);
-    Chunk chunk1({c2, c3}, _schema);
+    Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
+    Chunk chunk1({std::move(c2), std::move(c3)}, _schema);
 
     const int segment_rows = chunk0.num_rows() + chunk1.num_rows();
 
@@ -324,8 +324,8 @@ TEST_F(LakeDuplicateTabletReaderWithDeleteTest, test_read_success) {
     c2->append_numbers(k1.data(), k1.size() * sizeof(int));
     c3->append_numbers(v1.data(), v1.size() * sizeof(int));
 
-    Chunk chunk0({c0, c1}, _schema);
-    Chunk chunk1({c2, c3}, _schema);
+    Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
+    Chunk chunk1({std::move(c2), std::move(c3)}, _schema);
 
     const int segment_rows = chunk0.num_rows() + chunk1.num_rows();
 
@@ -455,7 +455,7 @@ TEST_F(LakeDuplicateTabletReaderWithDeleteNotInOneValueTest, test_read_success) 
     c0->append_numbers(k0.data(), k0.size() * sizeof(int));
     c1->append_numbers(v0.data(), v0.size() * sizeof(int));
 
-    Chunk chunk0({c0, c1}, _schema);
+    Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
 
     VersionedTablet tablet(_tablet_mgr.get(), _tablet_metadata);
     {
@@ -573,8 +573,8 @@ TEST_F(LakeTabletReaderSpit, test_reader_split) {
     c2->append_numbers(k1.data(), k1.size() * sizeof(int));
     c3->append_numbers(v1.data(), v1.size() * sizeof(int));
 
-    Chunk chunk0({c0, c1}, _schema);
-    Chunk chunk1({c2, c3}, _schema);
+    Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
+    Chunk chunk1({std::move(c2), std::move(c3)}, _schema);
 
     VersionedTablet tablet(_tablet_mgr.get(), _tablet_metadata);
 
@@ -771,8 +771,8 @@ TEST_F(DISABLED_LakeLoadSegmentParallelTest, test_normal) {
     c2->append_numbers(k1.data(), k1.size() * sizeof(int));
     c3->append_numbers(v1.data(), v1.size() * sizeof(int));
 
-    Chunk chunk0({c0, c1}, _schema);
-    Chunk chunk1({c2, c3}, _schema);
+    Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
+    Chunk chunk1({std::move(c2), std::move(c3)}, _schema);
 
     const int segment_rows = chunk0.num_rows() + chunk1.num_rows();
 

--- a/be/test/storage/lake/tablet_test.cpp
+++ b/be/test/storage/lake/tablet_test.cpp
@@ -92,8 +92,8 @@ public:
         c2->append_numbers(k1.data(), k1.size() * sizeof(int));
         c3->append_numbers(v1.data(), v1.size() * sizeof(int));
 
-        Chunk chunk0({c0, c1}, _schema);
-        Chunk chunk1({c2, c3}, _schema);
+        Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
+        Chunk chunk1({std::move(c2), std::move(c3)}, _schema);
 
         ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
 

--- a/be/test/storage/lake/tablet_writer_test.cpp
+++ b/be/test/storage/lake/tablet_writer_test.cpp
@@ -76,8 +76,8 @@ TEST_P(LakeTabletWriterTest, test_write_success) {
     c2->append_numbers(k1.data(), k1.size() * sizeof(int));
     c3->append_numbers(v1.data(), v1.size() * sizeof(int));
 
-    Chunk chunk0({c0, c1}, _schema);
-    Chunk chunk1({c2, c3}, _schema);
+    Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
+    Chunk chunk1({std::move(c2), std::move(c3)}, _schema);
 
     const int segment_rows = chunk0.num_rows() + chunk1.num_rows();
 
@@ -162,10 +162,10 @@ TEST_P(LakeTabletWriterTest, test_vertical_write_success) {
     auto schema0 = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema, {0}));
     auto schema1 = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema, {1}));
 
-    Chunk c0_chunk({c0}, schema0);
-    Chunk c1_chunk({c1}, schema1);
-    Chunk c2_chunk({c2}, schema0);
-    Chunk c3_chunk({c3}, schema1);
+    Chunk c0_chunk({std::move(c0)}, schema0);
+    Chunk c1_chunk({std::move(c1)}, schema1);
+    Chunk c2_chunk({std::move(c2)}, schema0);
+    Chunk c3_chunk({std::move(c3)}, schema1);
 
     const int segment_rows = c0_chunk.num_rows() + c2_chunk.num_rows();
 
@@ -244,7 +244,7 @@ TEST_P(LakeTabletWriterTest, test_write_fail) {
     c0->append_numbers(k0.data(), k0.size() * sizeof(int));
     c1->append_numbers(v0.data(), v0.size() * sizeof(int));
 
-    Chunk chunk0({c0, c1}, _schema);
+    Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
 
     VersionedTablet tablet(_tablet_mgr.get(), _tablet_metadata);
     ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, next_id()));
@@ -263,7 +263,7 @@ TEST_P(LakeTabletWriterTest, test_close_without_finish) {
     c0->append_numbers(k0.data(), k0.size() * sizeof(int));
     c1->append_numbers(v0.data(), v0.size() * sizeof(int));
 
-    Chunk chunk0({c0, c1}, _schema);
+    Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
 
     VersionedTablet tablet(_tablet_mgr.get(), _tablet_metadata);
     ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, next_id()));
@@ -306,10 +306,10 @@ TEST_P(LakeTabletWriterTest, test_vertical_write_close_without_finish) {
     auto schema0 = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema, {0}));
     auto schema1 = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema, {1}));
 
-    Chunk c0_chunk({c0}, schema0);
-    Chunk c1_chunk({c1}, schema1);
-    Chunk c2_chunk({c2}, schema0);
-    Chunk c3_chunk({c3}, schema1);
+    Chunk c0_chunk({std::move(c0)}, schema0);
+    Chunk c1_chunk({std::move(c1)}, schema1);
+    Chunk c2_chunk({std::move(c2)}, schema0);
+    Chunk c3_chunk({std::move(c3)}, schema1);
 
     const int segment_rows = c0_chunk.num_rows() + c2_chunk.num_rows();
 

--- a/be/test/storage/merge_iterator_test.cpp
+++ b/be/test/storage/merge_iterator_test.cpp
@@ -135,7 +135,7 @@ TEST_F(MergeIteratorTest, merge_one) {
     ASSERT_TRUE(iter->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS).ok());
 
     auto get_row = [](const ChunkPtr& chunk, size_t row) -> int32_t {
-        auto c = std::dynamic_pointer_cast<FixedLengthColumn<int32_t>>(chunk->get_column_by_index(0));
+        auto c = FixedLengthColumn<int32_t>::dynamic_pointer_cast(chunk->get_column_by_index(0));
         return c->get_data()[row];
     };
 
@@ -174,7 +174,7 @@ TEST_F(MergeIteratorTest, test_issue_6167) {
     auto iter = new_heap_merge_iterator(subs);
 
     auto get_row = [](const ChunkPtr& chunk, size_t row) -> int32_t {
-        auto c = std::dynamic_pointer_cast<FixedLengthColumn<int32_t>>(chunk->get_column_by_index(0));
+        auto c = FixedLengthColumn<int32_t>::dynamic_pointer_cast(chunk->get_column_by_index(0));
         return c->get_data()[row];
     };
 

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -1465,8 +1465,7 @@ void build_persistent_index_from_tablet(size_t N) {
         LOG(WARNING) << "failed to load rowset update state: " << st.to_string();
         ASSERT_TRUE(false);
     }
-    using ColumnUniquePtr = std::unique_ptr<Column>;
-    const std::vector<ColumnUniquePtr>& upserts = state.upserts();
+    const std::vector<MutableColumnPtr>& upserts = state.upserts();
 
     PersistentIndex persistent_index(kPersistentIndexDir);
     ASSERT_TRUE(persistent_index.load_from_tablet(tablet.get()).ok());

--- a/be/test/storage/primary_index_test.cpp
+++ b/be/test/storage/primary_index_test.cpp
@@ -375,7 +375,7 @@ PARALLEL_TEST(PrimaryIndexTest, test_composite_key) {
         pk_col1->append(i * 2);
     }
 
-    std::unique_ptr<Column> pk_column;
+    MutableColumnPtr pk_column;
     PrimaryKeyEncoder::create_column(*schema, &pk_column);
     PrimaryKeyEncoder::encode(*schema, *chunk, 0, chunk->num_rows(), pk_column.get());
 

--- a/be/test/storage/primary_key_encoder_test.cpp
+++ b/be/test/storage/primary_key_encoder_test.cpp
@@ -45,7 +45,7 @@ static unique_ptr<Schema> create_key_schema(const vector<LogicalType>& types) {
 
 TEST(PrimaryKeyEncoderTest, testEncodeInt32) {
     auto sc = create_key_schema({TYPE_INT});
-    unique_ptr<Column> dest;
+    MutableColumnPtr dest;
     PrimaryKeyEncoder::create_column(*sc, &dest);
     const int n = 1000;
     auto pchunk = ChunkHelper::new_chunk(*sc, n);
@@ -66,7 +66,7 @@ TEST(PrimaryKeyEncoderTest, testEncodeInt32) {
 
 TEST(PrimaryKeyEncoderTest, testEncodeInt128) {
     auto sc = create_key_schema({TYPE_LARGEINT});
-    unique_ptr<Column> dest;
+    MutableColumnPtr dest;
     PrimaryKeyEncoder::create_column(*sc, &dest);
     const int n = 1000;
     auto pchunk = ChunkHelper::new_chunk(*sc, n);
@@ -91,7 +91,7 @@ TEST(PrimaryKeyEncoderTest, testEncodeInt128) {
 
 TEST(PrimaryKeyEncoderTest, testEncodeComposite) {
     auto sc = create_key_schema({TYPE_INT, TYPE_VARCHAR, TYPE_SMALLINT, TYPE_BOOLEAN});
-    unique_ptr<Column> dest;
+    MutableColumnPtr dest;
     PrimaryKeyEncoder::create_column(*sc, &dest);
     const int n = 1;
     auto pchunk = ChunkHelper::new_chunk(*sc, n);

--- a/be/test/storage/row_store_encoder_test.cpp
+++ b/be/test/storage/row_store_encoder_test.cpp
@@ -44,7 +44,7 @@ static unique_ptr<Schema> create_schema(const vector<pair<LogicalType, bool>>& t
 void common_encode_decode(RowStoreEncoderPtr& row_encoder, std::unique_ptr<Schema>& schema,
                           std::unique_ptr<Schema>& schema_with_row, ChunkUniquePtr& pchunk, const int n) {
     //encode
-    auto full_row_col = std::make_unique<BinaryColumn>();
+    auto full_row_col = BinaryColumn::create();
     row_encoder->encode_chunk_to_full_row_column(*schema, *pchunk, full_row_col.get());
     ASSERT_EQ(full_row_col->size(), pchunk->num_rows());
 

--- a/be/test/storage/rowset/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/column_reader_writer_test.cpp
@@ -324,9 +324,9 @@ protected:
         TabletColumn int_column = create_int_value(0, STORAGE_AGGREGATE_NONE, true);
         array_column.add_sub_column(int_column);
 
-        auto src_offsets = UInt32Column::create();
-        auto src_elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
-        ColumnPtr src_column = ArrayColumn::create(src_elements, src_offsets);
+        UInt32Column::Ptr src_offsets = UInt32Column::create();
+        NullableColumn::Ptr src_elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+        ArrayColumn::Ptr src_column = ArrayColumn::create(src_elements, src_offsets);
 
         // insert [1, 2, 3], [4, 5, 6]
         src_elements->append_datum(1);
@@ -404,9 +404,9 @@ protected:
                 auto st = iter->seek_to_first();
                 ASSERT_TRUE(st.ok()) << st.to_string();
 
-                auto dst_offsets = UInt32Column::create();
-                auto dst_elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
-                auto dst_column = ArrayColumn::create(dst_elements, dst_offsets);
+                UInt32Column::Ptr dst_offsets = UInt32Column::create();
+                NullableColumn::Ptr dst_elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+                ArrayColumn::Ptr dst_column = ArrayColumn::create(dst_elements, dst_offsets);
                 size_t rows_read = src_column->size();
                 st = iter->next_batch(&rows_read, dst_column.get());
                 ASSERT_TRUE(st.ok());

--- a/be/test/storage/rowset/default_value_column_iterator_test.cpp
+++ b/be/test/storage/rowset/default_value_column_iterator_test.cpp
@@ -43,7 +43,7 @@ TEST_F(DefaultValueColumnIteratorTest, delete_after_column) {
     ASSERT_TRUE(st.ok());
 
     TypeDescriptor type_desc(LogicalType::TYPE_INT);
-    ColumnPtr column = ColumnHelper::create_column(type_desc, true);
+    MutableColumnPtr column = ColumnHelper::create_column(type_desc, true);
 
     size_t num_rows = 10;
     st = iter.next_batch(&num_rows, column.get());

--- a/be/test/storage/rowset/flat_json_column_compact_test.cpp
+++ b/be/test/storage/rowset/flat_json_column_compact_test.cpp
@@ -77,7 +77,7 @@ protected:
         if (is_nullable) {
             auto null_col = NullColumn::create();
             null_col->append("NULL" == json);
-            return NullableColumn::create(json_col, null_col);
+            return NullableColumn::create(std::move(json_col), std::move(null_col));
         }
         return json_col;
     }
@@ -102,7 +102,7 @@ protected:
         if (is_nullable) {
             auto null_col = NullColumn::create();
             null_col->append("NULL" == json);
-            return NullableColumn::create(json_col, null_col);
+            return NullableColumn::create(std::move(json_col), std::move(null_col));
         }
         return json_col;
     }
@@ -131,7 +131,7 @@ protected:
         json_col->set_flat_columns(deriver.flat_paths(), deriver.flat_types(), flattener.mutable_result());
 
         if (is_nullable) {
-            return NullableColumn::create(json_col, null_col);
+            return NullableColumn::create(std::move(json_col), std::move(null_col));
         }
         return json_col;
     }

--- a/be/test/storage/rowset/flat_json_column_rw_test.cpp
+++ b/be/test/storage/rowset/flat_json_column_rw_test.cpp
@@ -140,7 +140,7 @@ protected:
         }
 
         if (is_nullable) {
-            return NullableColumn::create(json_col, null_col);
+            return NullableColumn::create(std::move(json_col), std::move(null_col));
         }
         return json_col;
     }
@@ -304,7 +304,7 @@ TEST_F(FlatJsonColumnRWTest, testNullNormalFlatJson) {
     null_col->append(1);
     null_col->append(0);
 
-    ColumnPtr write_nl_col = NullableColumn::create(write_col, null_col);
+    ColumnPtr write_nl_col = NullableColumn::create(std::move(write_col), std::move(null_col));
 
     ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
     ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.a", 0));

--- a/be/test/storage/rowset/map_column_rw_test.cpp
+++ b/be/test/storage/rowset/map_column_rw_test.cpp
@@ -64,9 +64,9 @@ protected:
         TabletColumn value_column = create_int_value(2, STORAGE_AGGREGATE_NONE, true);
         map_column.add_sub_column(value_column);
 
-        auto src_offsets = UInt32Column::create();
-        auto src_keys = NullableColumn::create(Int32Column::create(), NullColumn::create());
-        auto src_values = NullableColumn::create(Int32Column::create(), NullColumn::create());
+        UInt32Column::Ptr src_offsets = UInt32Column::create();
+        NullableColumn::Ptr src_keys = NullableColumn::create(Int32Column::create(), NullColumn::create());
+        NullableColumn::Ptr src_values = NullableColumn::create(Int32Column::create(), NullColumn::create());
 
         ColumnPtr src_column = MapColumn::create(src_keys, src_values, src_offsets);
 
@@ -167,7 +167,7 @@ protected:
                 auto dst_offsets = UInt32Column::create();
                 auto dst_keys = NullableColumn::create(Int32Column::create(), NullColumn::create());
                 auto dst_values = NullableColumn::create(Int32Column::create(), NullColumn::create());
-                auto dst_column = MapColumn::create(dst_keys, dst_values, dst_offsets);
+                auto dst_column = MapColumn::create(std::move(dst_keys), std::move(dst_values), std::move(dst_offsets));
                 size_t rows_read = src_column->size();
                 st = iter->next_batch(&rows_read, dst_column.get());
                 ASSERT_TRUE(st.ok());
@@ -202,7 +202,7 @@ protected:
                 auto dst_offsets = UInt32Column::create();
                 auto dst_keys = NullableColumn::create(Int32Column::create(), NullColumn::create());
                 auto dst_values = NullableColumn::create(Int32Column::create(), NullColumn::create());
-                auto dst_column = MapColumn::create(dst_keys, dst_values, dst_offsets);
+                auto dst_column = MapColumn::create(std::move(dst_keys), std::move(dst_values), std::move(dst_offsets));
                 size_t rows_read = src_column->size();
                 st = iter->next_batch(&rows_read, dst_column.get());
                 ASSERT_TRUE(st.ok());
@@ -240,7 +240,7 @@ protected:
                 auto dst_offsets = UInt32Column::create();
                 auto dst_keys = NullableColumn::create(Int32Column::create(), NullColumn::create());
                 auto dst_values = NullableColumn::create(Int32Column::create(), NullColumn::create());
-                auto dst_column = MapColumn::create(dst_keys, dst_values, dst_offsets);
+                auto dst_column = MapColumn::create(std::move(dst_keys), std::move(dst_values), std::move(dst_offsets));
                 size_t rows_read = src_column->size();
                 st = iter->next_batch(&rows_read, dst_column.get());
                 ASSERT_TRUE(st.ok());

--- a/be/test/storage/rowset/rowset_test.cpp
+++ b/be/test/storage/rowset/rowset_test.cpp
@@ -998,7 +998,7 @@ TEST_F(RowsetTest, SegmentRewriterAutoIncrementTest) {
     std::shared_ptr<TabletSchema> tablet_schema = TabletSchemaHelper::create_tablet_schema(
             {create_int_key_pb(1), create_int_key_pb(2), create_int_value_pb(3), create_int_value_pb(4)});
     std::vector<uint32_t> read_column_ids{2, 3};
-    std::vector<std::unique_ptr<Column>> write_columns(read_column_ids.size());
+    std::vector<MutableColumnPtr> write_columns(read_column_ids.size());
     for (auto i = 0; i < read_column_ids.size(); ++i) {
         const auto read_column_id = read_column_ids[i];
         auto tablet_column = tablet_schema->column(read_column_id);
@@ -1011,7 +1011,7 @@ TEST_F(RowsetTest, SegmentRewriterAutoIncrementTest) {
 
     AutoIncrementPartialUpdateState auto_increment_partial_update_state;
     auto_increment_partial_update_state.init(rowset.get(), partial_tablet_schema, 2, 0);
-    auto_increment_partial_update_state.write_column.reset(write_columns[0].release());
+    auto_increment_partial_update_state.write_column.reset(std::move(write_columns[0]));
     write_columns.erase(write_columns.begin());
     auto dst_file_name = Rowset::segment_temp_file_path(rowset->rowset_path(), rowset->rowset_id(), 0);
 

--- a/be/test/storage/rowset/segment_rewriter_test.cpp
+++ b/be/test/storage/rowset/segment_rewriter_test.cpp
@@ -112,7 +112,7 @@ TEST_F(SegmentRewriterTest, rewrite_test) {
              create_int_value_pb(5)});
     std::string dst_file_name = kSegmentDir + "/rewrite_rowset";
     std::vector<uint32_t> read_column_ids{2, 4};
-    std::vector<std::unique_ptr<Column>> write_columns(read_column_ids.size());
+    std::vector<MutableColumnPtr> write_columns(read_column_ids.size());
     for (auto i = 0; i < read_column_ids.size(); ++i) {
         const auto read_column_id = read_column_ids[i];
         auto tablet_column = tablet_schema->column(read_column_id);

--- a/be/test/storage/rowset/struct_column_rw_test.cpp
+++ b/be/test/storage/rowset/struct_column_rw_test.cpp
@@ -278,7 +278,7 @@ protected:
                 Columns dst_columns;
                 dst_columns.emplace_back(std::move(dst_f1_column));
 
-                ColumnPtr dst_column = StructColumn::create(dst_columns, std::vector<std::string>{"f1"});
+                auto dst_column = StructColumn::create(std::move(dst_columns), std::vector<std::string>{"f1"});
                 size_t rows_read = src_column->size();
                 st = iter->next_batch(&rows_read, dst_column.get());
                 ASSERT_TRUE(st.ok());

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -825,7 +825,7 @@ TEST_P(RowsetColumnPartialUpdateTest, test_get_column_values) {
             rowids_by_rssid[9].push_back(rowid);
         }
         auto read_column_schema = ChunkHelper::convert_schema(tablet->tablet_schema(), column_ids);
-        vector<std::unique_ptr<Column>> columns(column_ids.size());
+        vector<MutableColumnPtr> columns(column_ids.size());
         for (int colid = 0; colid < column_ids.size(); colid++) {
             auto column = ChunkHelper::column_from_field(*read_column_schema.field(colid).get());
             columns[colid] = column->clone_empty();

--- a/be/test/storage/rowset_merger_test.cpp
+++ b/be/test/storage/rowset_merger_test.cpp
@@ -96,10 +96,10 @@ public:
         return Status::OK();
     }
 
-    std::unique_ptr<Column> all_pks;
+    MutableColumnPtr all_pks;
     vector<uint32_t> all_rssids;
 
-    vector<std::unique_ptr<Column>> non_key_columns;
+    vector<MutableColumnPtr> non_key_columns;
 };
 
 class RowsetMergerTest : public testing::Test {
@@ -314,8 +314,8 @@ TEST_F(RowsetMergerTest, vertical_merge) {
     TestRowsetWriter writer;
     Schema schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
     ASSERT_TRUE(PrimaryKeyEncoder::create_column(schema, &writer.all_pks).ok());
-    writer.non_key_columns.emplace_back(Int16Column::create_mutable());
-    writer.non_key_columns.emplace_back(Int32Column::create_mutable());
+    writer.non_key_columns.emplace_back(Int16Column::create());
+    writer.non_key_columns.emplace_back(Int32Column::create());
     ASSERT_TRUE(compaction_merge_rowsets(*_tablet, version, rowsets, &writer, cfg).ok());
 
     ASSERT_EQ(pks.size(), writer.all_pks->size());
@@ -422,8 +422,8 @@ TEST_F(RowsetMergerTest, vertical_merge_seq) {
     TestRowsetWriter writer;
     Schema schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
     ASSERT_TRUE(PrimaryKeyEncoder::create_column(schema, &writer.all_pks).ok());
-    writer.non_key_columns.emplace_back(Int16Column::create_mutable());
-    writer.non_key_columns.emplace_back(Int32Column::create_mutable());
+    writer.non_key_columns.emplace_back(Int16Column::create());
+    writer.non_key_columns.emplace_back(Int32Column::create());
     ASSERT_TRUE(compaction_merge_rowsets(*_tablet, version, rowsets, &writer, cfg).ok());
 
     ASSERT_EQ(pks.size(), writer.all_pks->size());

--- a/be/test/storage/schema_change_test.cpp
+++ b/be/test/storage/schema_change_test.cpp
@@ -824,10 +824,10 @@ TEST_F(SchemaChangeTest, overlapping_direct_schema_change) {
         auto c1 = ColumnTestHelper::build_column<int32_t>({0, 1, 2, 3});
         auto c2 = ColumnTestHelper::build_column<int32_t>({0, 1, 2, 3});
         auto c3 = ColumnTestHelper::build_column<int32_t>({0, 1, 2, 3});
-        chunk.append_column(c0, 0);
-        chunk.append_column(c1, 1);
-        chunk.append_column(c2, 2);
-        chunk.append_column(c3, 3);
+        chunk.append_column(std::move(c0), 0);
+        chunk.append_column(std::move(c1), 1);
+        chunk.append_column(std::move(c2), 2);
+        chunk.append_column(std::move(c3), 3);
 
         std::vector<uint32_t> idxs{0, 1, 2, 3};
         ASSERT_OK(delta_writer->write(chunk, idxs.data(), 0, 4));

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -2795,7 +2795,7 @@ void TabletUpdatesTest::test_get_column_values(bool enable_persistent_index) {
     ASSERT_TRUE(tablet->rowset_commit(2, create_rowsets(tablet, keys, max_rows_per_segment)).ok());
     ASSERT_TRUE(tablet->rowset_commit(3, create_rowsets(tablet, keys, max_rows_per_segment)).ok());
     std::vector<uint32_t> read_column_ids = {1, 2};
-    std::vector<std::unique_ptr<Column>> read_columns(read_column_ids.size());
+    std::vector<MutableColumnPtr> read_columns(read_column_ids.size());
     const auto& tablet_schema = tablet->unsafe_tablet_schema_ref();
     for (auto i = 0; i < read_column_ids.size(); i++) {
         const auto read_column_id = read_column_ids[i];

--- a/be/test/storage/tablet_updates_test.h
+++ b/be/test/storage/tablet_updates_test.h
@@ -59,7 +59,7 @@ enum PartialUpdateCloneCase {
 };
 
 template <class T>
-static void append_datum_func(std::shared_ptr<Column> col, T val) {
+static void append_datum_func(ColumnPtr& col, T val) {
     if (val == -1) {
         col->append_nulls(1);
     } else {

--- a/be/test/storage/union_iterator_test.cpp
+++ b/be/test/storage/union_iterator_test.cpp
@@ -88,7 +88,7 @@ TEST_F(UnionIteratorTest, union_two) {
     auto iter = new_union_iterator({sub1, sub2});
 
     auto get_row = [](const ChunkPtr& chunk, size_t row) -> int32_t {
-        auto c = std::dynamic_pointer_cast<FixedLengthColumn<int32_t>>(chunk->get_column_by_index(0));
+        auto c = FixedLengthColumn<int32_t>::dynamic_pointer_cast(chunk->get_column_by_index(0));
         return c->get_data()[row];
     };
 
@@ -138,7 +138,7 @@ TEST_F(UnionIteratorTest, union_one) {
     ASSERT_TRUE(iter->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS).ok());
 
     auto get_row = [](const ChunkPtr& chunk, size_t row) -> int32_t {
-        auto c = std::dynamic_pointer_cast<FixedLengthColumn<int32_t>>(chunk->get_column_by_index(0));
+        auto c = FixedLengthColumn<int32_t>::dynamic_pointer_cast(chunk->get_column_by_index(0));
         return c->get_data()[row];
     };
 

--- a/format-sdk/src/main/cpp/convert/binary_converter.h
+++ b/format-sdk/src/main/cpp/convert/binary_converter.h
@@ -46,9 +46,9 @@ class BinaryConverter : public ColumnConverter {
 public:
     BinaryConverter(const std::shared_ptr<arrow::DataType> arrow_type, const std::shared_ptr<Field> sr_field,
                     const arrow::MemoryPool* pool)
-            : ColumnConverter(arrow_type, sr_field, pool) {};
+            : ColumnConverter(arrow_type, sr_field, pool){};
 
-    arrow::Status toSrColumn(const std::shared_ptr<arrow::Array> array, std::shared_ptr<Column>& column) override {
+    arrow::Status toSrColumn(const std::shared_ptr<arrow::Array> array, ColumnPtr& column) override {
         if (!column->is_nullable() && array->null_count() > 0) {
             return arrow::Status::Invalid("Column ", column->get_name(),
                                           " is non-nullable, but there are some null data in array.");

--- a/format-sdk/src/main/cpp/convert/column_converter.cpp
+++ b/format-sdk/src/main/cpp/convert/column_converter.cpp
@@ -199,7 +199,7 @@ arrow::Result<std::shared_ptr<arrow::Buffer>> ColumnConverter::convert_null_bitm
     return null_bitmap;
 }
 
-std::shared_ptr<Column> ColumnConverter::get_data_column(const std::shared_ptr<Column>& column) {
+ColumnPtr ColumnConverter::get_data_column(const ColumnPtr& column) {
     if (column->is_nullable()) {
         auto* nullable_column = down_cast<const NullableColumn*>(column.get());
         return nullable_column->data_column();

--- a/format-sdk/src/main/cpp/convert/column_converter.h
+++ b/format-sdk/src/main/cpp/convert/column_converter.h
@@ -47,7 +47,7 @@ public:
 public:
     ColumnConverter(const std::shared_ptr<arrow::DataType>& arrow_type, const std::shared_ptr<Field>& sr_field,
                     const arrow::MemoryPool* pool)
-            : _arrow_type(arrow_type), _sr_field(sr_field), _pool(pool) {};
+            : _arrow_type(arrow_type), _sr_field(sr_field), _pool(pool){};
 
     virtual ~ColumnConverter() = default;
 
@@ -56,12 +56,12 @@ public:
     /**
      * Convert arrow array to starrocks column.
      */
-    virtual arrow::Status toSrColumn(std::shared_ptr<arrow::Array> array, std::shared_ptr<Column>& column) = 0;
+    virtual arrow::Status toSrColumn(std::shared_ptr<arrow::Array> array, ColumnPtr& column) = 0;
 
 protected:
     arrow::Result<std::shared_ptr<arrow::Buffer> > convert_null_bitmap(const Buffer<uint8_t>& null_bytes);
 
-    static std::shared_ptr<Column> get_data_column(const std::shared_ptr<Column>& column);
+    static ColumnPtr get_data_column(const ColumnPtr& column);
 
 protected:
     const std::shared_ptr<arrow::DataType> _arrow_type;

--- a/format-sdk/src/main/cpp/convert/nested_converter.h
+++ b/format-sdk/src/main/cpp/convert/nested_converter.h
@@ -51,7 +51,7 @@ public:
                     const arrow::MemoryPool* pool)
             : ColumnConverter(arrow_type, sr_field, pool) {}
 
-    arrow::Status toSrColumn(const std::shared_ptr<arrow::Array> array, std::shared_ptr<Column>& column) override {
+    arrow::Status toSrColumn(const std::shared_ptr<arrow::Array> array, ColumnPtr& column) override {
         if (!column->is_nullable() && array->null_count() > 0) {
             return arrow::Status::Invalid("Column ", column->get_name(),
                                           " is non-nullable, but there are some null data in array.");
@@ -116,13 +116,13 @@ private:
     template <class SrColumnClass, typename = std::enable_if_t<std::is_same_v<SrColumnClass, ArrayColumn> ||
                                                                std::is_same_v<SrColumnClass, MapColumn> ||
                                                                std::is_same_v<SrColumnClass, StructColumn>>>
-    arrow::Result<std::vector<ColumnPtr>> get_children_columns(const std::shared_ptr<SrColumnClass> data_column) {
+    arrow::Result<Columns> get_children_columns(const std::shared_ptr<SrColumnClass> data_column) {
         if constexpr (std::is_same_v<SrColumnClass, ArrayColumn>) {
-            std::vector<ColumnPtr> all_sub_columns = {data_column->offsets_column(), data_column->elements_column()};
+            Columns all_sub_columns = {data_column->offsets_column(), data_column->elements_column()};
             return all_sub_columns;
         } else if constexpr (std::is_same_v<SrColumnClass, MapColumn>) {
-            std::vector<ColumnPtr> all_sub_columns = {data_column->offsets_column(), data_column->keys_column(),
-                                                      data_column->values_column()};
+            Columns all_sub_columns = {data_column->offsets_column(), data_column->keys_column(),
+                                       data_column->values_column()};
             return all_sub_columns;
         } else if constexpr (std::is_same_v<SrColumnClass, StructColumn>) {
             return data_column->fields();

--- a/format-sdk/src/main/cpp/convert/primitive_converter.h
+++ b/format-sdk/src/main/cpp/convert/primitive_converter.h
@@ -68,7 +68,7 @@ public:
         }
     };
 
-    arrow::Status toSrColumn(const std::shared_ptr<arrow::Array> array, std::shared_ptr<Column>& column) override {
+    arrow::Status toSrColumn(const std::shared_ptr<arrow::Array> array, ColumnPtr& column) override {
         if (!column->is_nullable() && array->null_count() > 0) {
             return arrow::Status::Invalid("Column ", column->get_name(),
                                           " is non-nullable, but there are some null data in array.");


### PR DESCRIPTION
## Why I'm doing:
- Implement COW columns by using COW & refactor existed codes into COW machinism, see more details: https://github.com/StarRocks/starrocks/issues/56147


## What I'm doing:
- redefine `ColumnPtr`/`MutableColumnPtr` by using `Cow`: 
  - `ColumnPtr` is used for read-only operations ideally ensuring immutability, but this will affects too much existed codes.
  - For now `ColumnPtr` can also call `non const` Column methods, but `const ColumnPtr`/`const ColumnPtr&`/`const Columns` or const method must be immutable which can only call `const` methods.
```
using ColumnPtr = Column::Ptr;
using Columns = std::vector<ColumnPtr>;
using MutableColumnPtr = Column::MutablePtr;
using MutableColumns = std::vector<MutableColumnPtr>;
```
- Rename `std::shared_ptr<Column>` to `ColumnPtr`
- Rename ` std::vector<ColumnPtr>` to `Columns`
- Rename `ColumnUniquePtr` to `MutablePtr`
- Rename `clone_shared()` to `clone`
- Use `std::move(MutableColumnPtr)` to `ColumnPtr` to ensure Column's ownership transferred correctly


#### Usage

1. Ownership Transfer
```
// it's fine to call non-const/const methods for mutable column ptr
MutableColumnPtr mut_col = XXXColumn::create();

mut_col->append(xx);
mut_col->append(xx);

// mut_col.get() return pointer rather than const pointer
auto* col_raw_ptr = mut_col.get();
....

// transfer mutable column ptr ownership to immutable ptr, original `mut_col` is reset
ColumnPtr immut_col = std::move(mut_col);
```

2. Visit ColumnPtr:

```
// Visit immutable column ptr
visit_immutable_ptr1(immut_col);

// `const Column`/`const ColumnPtr`/ const method can only call Column's const methods
void visit_immutable_ptr1(const ColumnPtr& col) {
   // col can only call const methods to avoid changing col
  // const ColumnPtr return `const auto*`
  const auto* col_raw_ptr = col.get();
}

// (not recommended)
void visit_immutable_ptr2(ColumnPtr& col) {
   // col can call non-const/const methods to be compatible with old codes
   auto* col_raw_ptr = col.get();
}
```

3. Mutate an immutable column ptr
```
// if immut_col needs to mutate, then:
// method1: trigger clone-on-write by using `mut_col1`'s ref counts, note: `immut_col` still lives 
MutableColumnPtr mut_col1 = (std::move(*immut_col)).mutate();

// method2: trigger clone-on-write by using `mut_col1`'s ref counts, note: `immut_col` is reset, and cannot be visited again.
MutableColumnPtr mut_col2 = Column::mutate(std::move(immut_col));

// method3: (not safe), we can directly treat `ColumnPtr` as `MutableColumnPtr` with counting ref counts
MutableColumnPtr mut_col3 = immut_col->as_mutable_ptr();

```

4. Cast ColumnPtr to a derived column
```
// like std::static_pointer_cast, col is casted to NullColumnPtr and col is not reset, ref count +1
NullColumnPtr null_column_ptr = NullColumn::static_pointer_cast(col);

// like std::static_pointer_cast, col is casted to NullColumnPtr and col is reset
NullColumnPtr null_column_ptr = NullColumn::static_pointer_cast(std::move(col));

// like std::dynamic_pointer_cast, col is casted to NullColumnPtr and col is not reset, ref count +1
NullColumnPtr null_column_ptr = NullColumn::dynamic_pointer_cast(col);

// like std::dynamic_pointer_cast, col is casted to NullColumnPtr and col is reset
NullColumnPtr null_column_ptr = NullColumn::dynamic_pointer_cast(std::move(col));
```

#### Further
- Better to use `MutableColumnPtr` and `ColumnPtr` for new codes.
- Refactor existed codes(change some `ColumnPtr` to `MutableColumnPtr`);
- Using more `Cow` to avoid deep clones.


Fixes https://github.com/StarRocks/starrocks/issues/56147

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0