### PR TITLE
[BugFix] Fix the NPE issue with cast filter condition querying the JDBC data source

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -1114,7 +1114,11 @@ public class AstToStringBuilder {
             if (isImplicit) {
                 return visit(node.getChild(0));
             }
-            return "CAST(" + printWithParentheses(node.getChild(0)) + " AS " + node.getTargetTypeDef().toString() + ")";
+            if (node.getTargetTypeDef() == null) {
+                return "CAST(" + printWithParentheses(node.getChild(0)) + " AS " + node.getType().toString() + ")";
+            } else {
+                return "CAST(" + printWithParentheses(node.getChild(0)) + " AS " + node.getTargetTypeDef().toString() + ")";
+            }
         }
 
         public String visitCompoundPredicate(CompoundPredicate node, Void context) {


### PR DESCRIPTION
## Why I'm doing:

Fix the NPE issue with cast filter condition querying the JDBC data source

```
MySQL [mytest]> desc aaa;
+-------+------------+------+-------+---------+-------+---------+
| Field | Type       | Null | Key   | Default | Extra | Comment |
+-------+------------+------+-------+---------+-------+---------+
| id    | BIGINT     | No   | false | NULL    |       |         |
| sss   | VARCHAR(5) | No   | false | NULL    |       |         |
+-------+------------+------+-------+---------+-------+---------+

select * from aaa where cast(sss as int) = 30;
```

```
java.lang.NullPointerException: Cannot invoke "com.starrocks.analysis.TypeDef.toString()" because the return value of "com.starrocks.analysis.CastExpr.getTargetTypeDef()" is null
        at com.starrocks.sql.analyzer.AstToStringBuilder$AST2StringBuilderVisitor.visitCastExpr(AstToStringBuilder.java:1117) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.AstToStringBuilder$AST2StringBuilderVisitor.visitCastExpr(AstToStringBuilder.java:182) ~[starrocks-fe.jar:?]
        at com.starrocks.analysis.CastExpr.accept(CastExpr.java:240) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:93) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:89) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.AstToStringBuilder$AST2StringBuilderVisitor.printWithParentheses(AstToStringBuilder.java:1493) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.AstToStringBuilder$AST2StringBuilderVisitor.visitBinaryPredicate(AstToStringBuilder.java:1086) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.AstToStringBuilder$AST2StringBuilderVisitor.visitBinaryPredicate(AstToStringBuilder.java:182) ~[starrocks-fe.jar:?]
        at com.starrocks.analysis.BinaryPredicate.accept(BinaryPredicate.java:251) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:93) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:89) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.AstToStringBuilder.toString(AstToStringBuilder.java:175) ~[starrocks-fe.jar:?]
        at com.starrocks.planner.JDBCScanNode.createJDBCTableFilters(JDBCScanNode.java:143) ~[starrocks-fe.jar:?]
        at com.starrocks.planner.JDBCScanNode.computeColumnsAndFilters(JDBCScanNode.java:74) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.visitPhysicalJDBCScan(PlanFragmentBuilder.java:1905) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.visitPhysicalJDBCScan(PlanFragmentBuilder.java:428) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.operator.physical.PhysicalJDBCScanOperator.accept(PhysicalJDBCScanOperator.java:35) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.visit(PlanFragmentBuilder.java:496) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.translate(PlanFragmentBuilder.java:443) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.plan.PlanFragmentBuilder.createPhysicalPlan(PlanFragmentBuilder.java:247) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.createQueryPlan(StatementPlanner.java:279) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:140) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:101) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:604) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:394) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:605) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:943) ~[starrocks-fe.jar:?]
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:69) ~[starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
```

## What I'm doing:

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0