### PR TITLE
[Enhancement] Support at time zone expression for trino parser

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
@@ -101,6 +101,7 @@ import io.trino.sql.tree.ArithmeticBinaryExpression;
 import io.trino.sql.tree.ArithmeticUnaryExpression;
 import io.trino.sql.tree.ArrayConstructor;
 import io.trino.sql.tree.AstVisitor;
+import io.trino.sql.tree.AtTimeZone;
 import io.trino.sql.tree.BetweenPredicate;
 import io.trino.sql.tree.BinaryLiteral;
 import io.trino.sql.tree.BooleanLiteral;
@@ -1009,6 +1010,13 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
         } catch (AnalysisException e) {
             throw unsupportedException(PARSER_ERROR_MSG.invalidDateFormat(node.getValue()));
         }
+    }
+
+    @Override
+    protected ParseNode visitAtTimeZone(AtTimeZone node, ParseTreeContext context) {
+        Expr dt = (Expr) visit(node.getValue(), context);
+        Expr tz = (Expr) visit(node.getTimeZone(), context);
+        return new FunctionCallExpr("convert_tz", List.of(dt, new VariableExpr("time_zone"), tz));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoParserNotSupportTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoParserNotSupportTest.java
@@ -78,9 +78,6 @@ public class TrinoParserNotSupportTest extends TrinoTestBase {
 
         sql = "select TIMESTAMP '2014-09-17 Europe/Berlin'";
         analyzeSuccess(sql);
-
-        sql = "SELECT TIMESTAMP '2014-03-14 09:30:00' AT TIME ZONE 'America/Los_Angeles'";
-        analyzeFail(sql, "Unsupported expression [TIMESTAMP '2014-03-14 09:30:00' AT TIME ZONE 'America/Los_Angeles']");
     }
 
     // refer to https://trino.io/docs/current/functions/conversion.html#format

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -108,6 +108,12 @@ public class TrinoQueryTest extends TrinoTestBase {
     }
 
     @Test
+    public void testAtTimezone() {
+        String sql = "select now() AT TIME ZONE 'Asia/Hong_Kong';";
+        analyzeSuccess(sql);
+    }
+
+    @Test
     public void testCastExpression() throws Exception {
         String sql = "select cast(tb as varchar(10)) from tall";
         assertPlanContains(sql, "CAST(2: tb AS VARCHAR(10))");


### PR DESCRIPTION
## Why I'm doing:

```
set sql_dialect='trino';
select now() AT TIME ZONE 'Asia/Hong_Kong';
```

```
ERROR 1064 (HY000): Unexpected exception: Trino parser parse sql error: [com.starrocks.connector.trino.TrinoParserUnsupportedException: Unsupported expression [now() AT TIME ZONE 'Asia/Hong_Kong']], and StarRocks parser also can not parse: [com.starrocks.sql.parser.ParsingException: Getting syntax error at line 1, column 16. Detail message: Unexpected input 'TIME', the most similar input is {<EOF>, ';'}.]
```

## What I'm doing:

![image](https://github.com/user-attachments/assets/fcfa34a4-99d6-4958-b5d6-fa21ac0d1556)


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0