### PR TITLE
[BugFix] Ranger view/MV authorization for external tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authorization/ColumnPrivilege.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/ColumnPrivilege.java
@@ -15,7 +15,6 @@
 package com.starrocks.authorization;
 
 import com.google.common.collect.Maps;
-import com.starrocks.catalog.BasicTable;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.Table;
@@ -24,7 +23,6 @@ import com.starrocks.catalog.View;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.connector.metadata.MetadataTable;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.sql.ast.AstTraverser;
@@ -50,6 +48,8 @@ import com.starrocks.sql.optimizer.transformer.LogicalPlan;
 import com.starrocks.sql.optimizer.transformer.MVTransformerContext;
 import com.starrocks.sql.optimizer.transformer.RelationTransformer;
 import com.starrocks.sql.optimizer.transformer.TransformerContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -58,6 +58,8 @@ import java.util.Map;
 import java.util.Set;
 
 public class ColumnPrivilege {
+    private static final Logger LOG = LogManager.getLogger(ColumnPrivilege.class);
+
     public static void check(ConnectContext context, QueryStatement stmt, List<TableName> excludeTables) {
         if (stmt == null) {
             return;
@@ -190,34 +192,53 @@ public class ColumnPrivilege {
      * For a security view, the user must have SELECT privilege on the view itself AND
      * all the underlying tables/views referenced by the view. This rule applies to
      * both internal access controllers and external access controllers (e.g. Ranger).
-     * Connector views are treated as tables for privilege checking.
+     *
+     * Note on Ranger service type consistency:
+     *   - With the StarRocks Ranger service type, views are a first-class object and
+     *     are checked via {@code checkViewAction} (object-level on VIEW).
+     *   - With the Hive Ranger service type, Hive views are modeled as TABLE objects,
+     *     so a connector view is treated as a table for privilege checking
+     *     (see the {@code isConnectorView()} branch below).
+     * This keeps the privilege model aligned with the underlying Ranger object type.
+     *
+     * Note on column-level granularity for security views:
+     *   For a security view we re-check the view's underlying query statement so that
+     *   every base table reached through the view is checked at the same granularity
+     *   it would be if it were referenced directly (i.e. column-level under Ranger).
+     *   Otherwise the granularity would drift with reference depth and a user without
+     *   column access on t1.c1 but with table access on t1 could read t1.c1 indirectly
+     *   through a security view, effectively bypassing column-level policies.
      */
     public static void checkViewPrivilege(ConnectContext context, TableName tableName, View view) {
-        try {
-            // for privilege checking, treat connector view as table
-            if (view.isConnectorView()) {
+        // For privilege checking, treat connector view as table to stay consistent with
+        // the Hive Ranger service type, where Hive views are modeled as TABLE objects.
+        if (view.isConnectorView()) {
+            try {
                 Authorizer.checkTableAction(context, tableName, PrivilegeType.SELECT);
-                return;
+            } catch (AccessDeniedException e) {
+                AccessDeniedException.reportAccessDenied(
+                        tableName.getCatalog(),
+                        context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
+                        PrivilegeType.SELECT.name(), ObjectType.TABLE.name(), tableName.getTbl());
             }
+            return;
+        }
 
-            if (view.isSecurity()) {
-                List<TableName> allTables = view.getTableRefs();
-                for (TableName t : allTables) {
-                    BasicTable basicTable = GlobalStateMgr.getCurrentState().getMetadataMgr()
-                            .getBasicTable(context, t.getCatalog(), t.getDb(), t.getTbl());
-                    if (basicTable.isOlapView()) {
-                        View subView = (View) basicTable;
-                        QueryStatement queryStatement = subView.getQueryStatement();
-                        Analyzer.analyze(queryStatement, context);
-                        Authorizer.check(queryStatement, context);
-                    } else if (basicTable.isMaterializedView()) {
-                        Authorizer.checkMaterializedViewAction(context, t, PrivilegeType.SELECT);
-                    } else {
-                        Authorizer.checkTableAction(context, t, PrivilegeType.SELECT);
-                    }
-                }
-            }
+        // For a security view, recursively check the view's query statement so all base
+        // tables (direct refs and transitive refs through intermediate views) are
+        // verified at column granularity uniformly. Failures from base objects will be
+        // reported by the recursive checks themselves with the correct ObjectType
+        // (TABLE / MATERIALIZED_VIEW / VIEW), so we deliberately do NOT wrap this call
+        // in a catch that re-reports as VIEW.
+        if (view.isSecurity()) {
+            QueryStatement queryStatement = view.getQueryStatement();
+            Analyzer.analyze(queryStatement, context);
+            Authorizer.check(queryStatement, context);
+        }
 
+        // Finally check SELECT privilege on the view object itself. Only failures here
+        // should be reported as ObjectType.VIEW.
+        try {
             Authorizer.checkViewAction(context, tableName, PrivilegeType.SELECT);
         } catch (AccessDeniedException e) {
             AccessDeniedException.reportAccessDenied(
@@ -251,6 +272,21 @@ public class ColumnPrivilege {
             LogicalScanOperator operator = (LogicalScanOperator) node.getOp();
             Table table = operator.getTable();
             TableName tableName = tableObjToTableName.get(table);
+
+            // Views and materialized views are intentionally not validated through
+            // scanColumns: their base tables are expanded by the optimizer, so the
+            // scan node's table is the underlying base table rather than the
+            // view/MV that appeared in the original AST. In that case
+            // tableObjToTableName.get(...) returns null because TableNameCollector
+            // only records tables/views referenced directly in the AST. View/MV
+            // privileges are handled via checkViewPrivilege /
+            // checkMaterializedViewAction instead, so we silently skip here.
+            if (tableName == null) {
+                LOG.debug("skip column privilege collection for scan table {} that is not " +
+                        "directly referenced in the AST (likely expanded from a view or MV)",
+                        table == null ? "null" : table.getName());
+                return null;
+            }
 
             if (!scanColumns.containsKey(tableName)) {
                 scanColumns.put(tableName, new HashSet<>());

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/ColumnPrivilege.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/ColumnPrivilege.java
@@ -132,54 +132,34 @@ public class ColumnPrivilege {
             }
 
             if (tableUsedExternalAccessController.contains(tableName)) {
-                Set<String> columns = scanColumns.getOrDefault(tableName, new HashSet<>());
-                for (String column : columns) {
+                if (table instanceof View view) {
+                    checkViewPrivilege(context, tableName, view);
+                } else if (table.isMaterializedView()) {
                     try {
-                        Authorizer.checkColumnAction(context,
-                                tableName, column, PrivilegeType.SELECT);
+                        Authorizer.checkMaterializedViewAction(context, tableName, PrivilegeType.SELECT);
                     } catch (AccessDeniedException e) {
                         AccessDeniedException.reportAccessDenied(
                                 tableName.getCatalog(),
                                 context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
-                                PrivilegeType.SELECT.name(), ObjectType.COLUMN.name(), column);
+                                PrivilegeType.SELECT.name(), ObjectType.MATERIALIZED_VIEW.name(), tableName.getTbl());
+                    }
+                } else {
+                    Set<String> columns = scanColumns.getOrDefault(tableName, new HashSet<>());
+                    for (String column : columns) {
+                        try {
+                            Authorizer.checkColumnAction(context,
+                                    tableName, column, PrivilegeType.SELECT);
+                        } catch (AccessDeniedException e) {
+                            AccessDeniedException.reportAccessDenied(
+                                    tableName.getCatalog(),
+                                    context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
+                                    PrivilegeType.SELECT.name(), ObjectType.COLUMN.name(), column);
+                        }
                     }
                 }
             } else {
-                if (table instanceof View) {
-                    try {
-                        // for privilege checking, treat connector view as table
-                        if (table.isConnectorView()) {
-                            Authorizer.checkTableAction(context,
-                                    tableName, PrivilegeType.SELECT);
-                        } else {
-                            View view = (View) table;
-                            if (view.isSecurity()) {
-                                List<TableName> allTables = view.getTableRefs();
-                                for (TableName t : allTables) {
-                                    BasicTable basicTable = GlobalStateMgr.getCurrentState().getMetadataMgr()
-                                            .getBasicTable(context, t.getCatalog(), t.getDb(), t.getTbl());
-                                    if (basicTable.isOlapView()) {
-                                        View subView = (View) basicTable;
-                                        QueryStatement queryStatement = subView.getQueryStatement();
-                                        Analyzer.analyze(queryStatement, context);
-                                        Authorizer.check(queryStatement, context);
-                                    } else if (basicTable.isMaterializedView()) {
-                                        Authorizer.checkMaterializedViewAction(context, t, PrivilegeType.SELECT);
-                                    } else {
-                                        Authorizer.checkTableAction(context, t, PrivilegeType.SELECT);
-                                    }
-                                }
-                            }
-
-                            Authorizer.checkViewAction(context,
-                                    tableName, PrivilegeType.SELECT);
-                        }
-                    } catch (AccessDeniedException e) {
-                        AccessDeniedException.reportAccessDenied(
-                                InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
-                                context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
-                                PrivilegeType.SELECT.name(), ObjectType.VIEW.name(), tableName.getTbl());
-                    }
+                if (table instanceof View view) {
+                    checkViewPrivilege(context, tableName, view);
                 } else if (table.isMaterializedView()) {
                     try {
                         Authorizer.checkMaterializedViewAction(context,
@@ -202,6 +182,48 @@ public class ColumnPrivilege {
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * Check privilege for a view (including security view).
+     * For a security view, the user must have SELECT privilege on the view itself AND
+     * all the underlying tables/views referenced by the view. This rule applies to
+     * both internal access controllers and external access controllers (e.g. Ranger).
+     * Connector views are treated as tables for privilege checking.
+     */
+    public static void checkViewPrivilege(ConnectContext context, TableName tableName, View view) {
+        try {
+            // for privilege checking, treat connector view as table
+            if (view.isConnectorView()) {
+                Authorizer.checkTableAction(context, tableName, PrivilegeType.SELECT);
+                return;
+            }
+
+            if (view.isSecurity()) {
+                List<TableName> allTables = view.getTableRefs();
+                for (TableName t : allTables) {
+                    BasicTable basicTable = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                            .getBasicTable(context, t.getCatalog(), t.getDb(), t.getTbl());
+                    if (basicTable.isOlapView()) {
+                        View subView = (View) basicTable;
+                        QueryStatement queryStatement = subView.getQueryStatement();
+                        Analyzer.analyze(queryStatement, context);
+                        Authorizer.check(queryStatement, context);
+                    } else if (basicTable.isMaterializedView()) {
+                        Authorizer.checkMaterializedViewAction(context, t, PrivilegeType.SELECT);
+                    } else {
+                        Authorizer.checkTableAction(context, t, PrivilegeType.SELECT);
+                    }
+                }
+            }
+
+            Authorizer.checkViewAction(context, tableName, PrivilegeType.SELECT);
+        } catch (AccessDeniedException e) {
+            AccessDeniedException.reportAccessDenied(
+                    tableName.getCatalog(),
+                    context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
+                    PrivilegeType.SELECT.name(), ObjectType.VIEW.name(), tableName.getTbl());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/authorization/ranger/RangerInterfaceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authorization/ranger/RangerInterfaceTest.java
@@ -16,15 +16,23 @@ package com.starrocks.authorization.ranger;
 import com.google.common.collect.Lists;
 import com.starrocks.authorization.AccessControlProvider;
 import com.starrocks.authorization.AccessDeniedException;
+import com.starrocks.authorization.ColumnPrivilege;
 import com.starrocks.authorization.NativeAccessController;
 import com.starrocks.authorization.PrivilegeType;
 import com.starrocks.authorization.ranger.hive.RangerHiveAccessController;
 import com.starrocks.authorization.ranger.starrocks.RangerStarRocksAccessController;
 import com.starrocks.authorization.ranger.starrocks.RangerStarRocksResource;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.InternalCatalog;
+import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
 import com.starrocks.catalog.UserIdentity;
+import com.starrocks.catalog.View;
+import com.starrocks.common.ErrorReportException;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.sql.ast.AstTraverser;
 import com.starrocks.sql.ast.QueryStatement;
@@ -46,6 +54,7 @@ import org.apache.ranger.plugin.model.RangerPolicy;
 import org.apache.ranger.plugin.model.RangerServiceDef;
 import org.apache.ranger.plugin.policyengine.RangerAccessRequest;
 import org.apache.ranger.plugin.policyengine.RangerAccessRequestImpl;
+import org.apache.ranger.plugin.policyengine.RangerAccessResourceImpl;
 import org.apache.ranger.plugin.policyengine.RangerAccessResult;
 import org.apache.ranger.plugin.policyengine.RangerAccessResultProcessor;
 import org.apache.ranger.plugin.service.RangerBasePlugin;
@@ -56,6 +65,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -92,6 +102,27 @@ public class RangerInterfaceTest {
                 "\"replication_num\" = \"1\",\n" +
                 "\"in_memory\" = \"false\"\n" +
                 ");");
+
+        // Create view and materialized view for ColumnPrivilege integration tests
+        starRocksAssert.withView("create view db.test_view as select v4, v5 from db.t1");
+        starRocksAssert.withMaterializedView("create materialized view db.test_mv " +
+                "distributed by hash(v4) " +
+                "refresh async START('9999-12-31') EVERY(INTERVAL 1 HOUR) " +
+                "PROPERTIES (\"replication_num\" = \"1\") " +
+                "as select v4, v5 from db.t1;");
+
+        // Create a security view used for checkViewPrivilege unit tests
+        starRocksAssert.withView("create view db.test_security_view as select v4, v5 from db.t1");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db");
+        Table secTbl = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_security_view");
+        ((View) secTbl).setSecurity(true);
+
+        // Create a security view referencing a materialized view, used for covering the
+        // checkViewPrivilege branch where the underlying table is a materialized view.
+        starRocksAssert.withView("create view db.test_security_view_mv as select v4, v5 from db.test_mv");
+        Table secMvTbl = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "test_security_view_mv");
+        ((View) secMvTbl).setSecurity(true);
     }
 
     @Test
@@ -306,5 +337,360 @@ public class RangerInterfaceTest {
         Assertions.assertEquals("refresh", controller.convertToAccessType(PrivilegeType.REFRESH));
         Assertions.assertEquals("drop", controller.convertToAccessType(PrivilegeType.DROP));
         Assertions.assertEquals("alter", controller.convertToAccessType(PrivilegeType.ALTER));
+    }
+
+    @Test
+    public void testColumnPrivilegeCheckViewWithExternalAccessController() throws Exception {
+        // Mock Ranger to allow all requests, and track whether Ranger was actually called
+        final List<RangerAccessResourceImpl> capturedResources = new ArrayList<>();
+        new MockUp<RangerBasePlugin>() {
+            @Mock
+            RangerAccessResult isAccessAllowed(RangerAccessRequest request) {
+                capturedResources.add((RangerAccessResourceImpl) request.getResource());
+                RangerAccessResult result = new RangerAccessResult(1, "starrocks",
+                        new RangerServiceDef(), new RangerAccessRequestImpl());
+                result.setIsAllowed(true);
+                return result;
+            }
+        };
+
+        // Set ExternalAccessController for default_catalog to trigger the branch
+        AccessControlProvider provider = Authorizer.getInstance();
+        RangerStarRocksAccessController rangerController = new RangerStarRocksAccessController();
+        provider.setAccessControl(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, rangerController);
+
+        try {
+            // Use non-ROOT user to avoid bypassing Ranger
+            ConnectContext ctx = new ConnectContext();
+            ctx.setCurrentUserIdentity(new UserIdentity("test_user", "%"));
+            ctx.setDatabase("db");
+            ctx.setThreadLocalInfo();
+
+            // Parse and analyze a SELECT on the view
+            StatementBase stmt = SqlParser.parse("select * from db.test_view",
+                    ctx.getSessionVariable().getSqlMode()).get(0);
+            Analyzer.analyze(stmt, ctx);
+
+            // ColumnPrivilege.check should succeed (Ranger allows)
+            QueryStatement queryStmt = (QueryStatement) stmt;
+            Assertions.assertDoesNotThrow(() ->
+                    ColumnPrivilege.check(ctx, queryStmt, Collections.emptyList()));
+
+            // Verify Ranger was actually called for the view.
+            // Before the fix, Ranger was never invoked (privilege silently bypassed).
+            Assertions.assertFalse(capturedResources.isEmpty(),
+                    "Ranger must be called for View privilege check; if empty, privilege was silently bypassed");
+        } finally {
+            // Restore NativeAccessController
+            provider.setAccessControl(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, new NativeAccessController());
+        }
+    }
+
+    @Test
+    public void testColumnPrivilegeCheckViewDeniedWithExternalAccessController() throws Exception {
+        // Mock Ranger to deny all requests
+        new MockUp<RangerBasePlugin>() {
+            @Mock
+            RangerAccessResult isAccessAllowed(RangerAccessRequest request) {
+                RangerAccessResult result = new RangerAccessResult(1, "starrocks",
+                        new RangerServiceDef(), new RangerAccessRequestImpl());
+                result.setIsAllowed(false);
+                return result;
+            }
+        };
+
+        // Set ExternalAccessController for default_catalog
+        AccessControlProvider provider = Authorizer.getInstance();
+        RangerStarRocksAccessController rangerController = new RangerStarRocksAccessController();
+        provider.setAccessControl(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, rangerController);
+
+        try {
+            ConnectContext ctx = new ConnectContext();
+            ctx.setCurrentUserIdentity(new UserIdentity("denied_user", "%"));
+            ctx.setDatabase("db");
+            ctx.setThreadLocalInfo();
+
+            // Parse and analyze a SELECT on the view
+            StatementBase stmt = SqlParser.parse("select * from db.test_view",
+                    ctx.getSessionVariable().getSqlMode()).get(0);
+            Analyzer.analyze(stmt, ctx);
+
+            // ColumnPrivilege.check should throw ErrorReportException (Ranger denies, reportAccessDenied wraps it)
+            QueryStatement queryStmt = (QueryStatement) stmt;
+            Assertions.assertThrows(ErrorReportException.class, () ->
+                    ColumnPrivilege.check(ctx, queryStmt, Collections.emptyList()));
+        } finally {
+            provider.setAccessControl(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, new NativeAccessController());
+        }
+    }
+
+    @Test
+    public void testColumnPrivilegeCheckMaterializedViewWithExternalAccessController() throws Exception {
+        // Mock Ranger to allow all requests, and track whether Ranger was actually called
+        final List<RangerAccessResourceImpl> capturedResources = new ArrayList<>();
+        new MockUp<RangerBasePlugin>() {
+            @Mock
+            RangerAccessResult isAccessAllowed(RangerAccessRequest request) {
+                capturedResources.add((RangerAccessResourceImpl) request.getResource());
+                RangerAccessResult result = new RangerAccessResult(1, "starrocks",
+                        new RangerServiceDef(), new RangerAccessRequestImpl());
+                result.setIsAllowed(true);
+                return result;
+            }
+        };
+
+        // Set ExternalAccessController for default_catalog
+        AccessControlProvider provider = Authorizer.getInstance();
+        RangerStarRocksAccessController rangerController = new RangerStarRocksAccessController();
+        provider.setAccessControl(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, rangerController);
+
+        try {
+            // Use non-ROOT user to avoid bypassing Ranger
+            ConnectContext ctx = new ConnectContext();
+            ctx.setCurrentUserIdentity(new UserIdentity("test_user", "%"));
+            ctx.setDatabase("db");
+            ctx.setThreadLocalInfo();
+
+            // Parse and analyze a SELECT on the materialized view
+            StatementBase stmt = SqlParser.parse("select * from db.test_mv",
+                    ctx.getSessionVariable().getSqlMode()).get(0);
+            Analyzer.analyze(stmt, ctx);
+
+            // ColumnPrivilege.check should succeed (Ranger allows)
+            QueryStatement queryStmt = (QueryStatement) stmt;
+            Assertions.assertDoesNotThrow(() ->
+                    ColumnPrivilege.check(ctx, queryStmt, Collections.emptyList()));
+
+            // Verify Ranger was actually called for the materialized view.
+            // Before the fix, Ranger was never invoked (privilege silently bypassed).
+            Assertions.assertFalse(capturedResources.isEmpty(),
+                    "Ranger must be called for MV privilege check; if empty, privilege was silently bypassed");
+        } finally {
+            provider.setAccessControl(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, new NativeAccessController());
+        }
+    }
+
+    @Test
+    public void testColumnPrivilegeCheckMaterializedViewDeniedWithExternalAccessController() throws Exception {
+        // Mock Ranger to deny all requests
+        new MockUp<RangerBasePlugin>() {
+            @Mock
+            RangerAccessResult isAccessAllowed(RangerAccessRequest request) {
+                RangerAccessResult result = new RangerAccessResult(1, "starrocks",
+                        new RangerServiceDef(), new RangerAccessRequestImpl());
+                result.setIsAllowed(false);
+                return result;
+            }
+        };
+
+        // Set ExternalAccessController for default_catalog
+        AccessControlProvider provider = Authorizer.getInstance();
+        RangerStarRocksAccessController rangerController = new RangerStarRocksAccessController();
+        provider.setAccessControl(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, rangerController);
+
+        try {
+            ConnectContext ctx = new ConnectContext();
+            ctx.setCurrentUserIdentity(new UserIdentity("denied_user", "%"));
+            ctx.setDatabase("db");
+            ctx.setThreadLocalInfo();
+
+            // Parse and analyze a SELECT on the materialized view
+            StatementBase stmt = SqlParser.parse("select * from db.test_mv",
+                    ctx.getSessionVariable().getSqlMode()).get(0);
+            Analyzer.analyze(stmt, ctx);
+
+            // ColumnPrivilege.check should throw ErrorReportException (Ranger denies, reportAccessDenied wraps it)
+            QueryStatement queryStmt = (QueryStatement) stmt;
+            Assertions.assertThrows(ErrorReportException.class, () ->
+                    ColumnPrivilege.check(ctx, queryStmt, Collections.emptyList()));
+        } finally {
+            provider.setAccessControl(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, new NativeAccessController());
+        }
+    }
+
+    @Test
+    public void testCheckViewPrivilegeSecurityViewWithRanger() {
+        final List<RangerAccessResourceImpl> capturedResources = new ArrayList<>();
+        new MockUp<RangerBasePlugin>() {
+            @Mock
+            RangerAccessResult isAccessAllowed(RangerAccessRequest request) {
+                capturedResources.add((RangerAccessResourceImpl) request.getResource());
+                RangerAccessResult result = new RangerAccessResult(1, "starrocks",
+                        new RangerServiceDef(), new RangerAccessRequestImpl());
+                result.setIsAllowed(true);
+                return result;
+            }
+        };
+
+        AccessControlProvider provider = Authorizer.getInstance();
+        provider.setAccessControl(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, new RangerStarRocksAccessController());
+
+        try {
+            ConnectContext ctx = new ConnectContext();
+            ctx.setCurrentUserIdentity(new UserIdentity("test_user", "%"));
+            ctx.setDatabase("db");
+            ctx.setThreadLocalInfo();
+
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db");
+            View secView = (View) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), "test_security_view");
+            Assertions.assertTrue(secView.isSecurity(),
+                    "test_security_view must be marked as security view in beforeClass");
+
+            TableName tableName = new TableName(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, "db", "test_security_view");
+            Assertions.assertDoesNotThrow(() ->
+                    ColumnPrivilege.checkViewPrivilege(ctx, tableName, secView));
+
+            // For a security view referencing db.t1, Ranger must be called for both the
+            // underlying base table t1 and the view itself.
+            Assertions.assertFalse(capturedResources.isEmpty(),
+                    "Ranger must be called for security view privilege check");
+            boolean checkedUnderlyingTable = capturedResources.stream()
+                    .anyMatch(r -> "t1".equals(r.getValue("table")));
+            boolean checkedView = capturedResources.stream()
+                    .anyMatch(r -> "test_security_view".equals(r.getValue("view")));
+            Assertions.assertTrue(checkedUnderlyingTable,
+                    "Security view must trigger underlying table 't1' privilege check");
+            Assertions.assertTrue(checkedView,
+                    "Security view must also trigger privilege check on the view itself");
+        } finally {
+            provider.setAccessControl(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, new NativeAccessController());
+        }
+    }
+
+    @Test
+    public void testColumnPrivilegeCheckTableColumnWithExternalAccessController() throws Exception {
+        // Mock Ranger to allow all requests, and track whether Ranger was actually called
+        final List<RangerAccessResourceImpl> capturedResources = new ArrayList<>();
+        new MockUp<RangerBasePlugin>() {
+            @Mock
+            RangerAccessResult isAccessAllowed(RangerAccessRequest request) {
+                capturedResources.add((RangerAccessResourceImpl) request.getResource());
+                RangerAccessResult result = new RangerAccessResult(1, "starrocks",
+                        new RangerServiceDef(), new RangerAccessRequestImpl());
+                result.setIsAllowed(true);
+                return result;
+            }
+        };
+
+        // Set ExternalAccessController for default_catalog to trigger the column-level branch
+        AccessControlProvider provider = Authorizer.getInstance();
+        provider.setAccessControl(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, new RangerStarRocksAccessController());
+
+        try {
+            // Use non-ROOT user to avoid bypassing Ranger
+            ConnectContext ctx = new ConnectContext();
+            ctx.setCurrentUserIdentity(new UserIdentity("test_user", "%"));
+            ctx.setDatabase("db");
+            ctx.setThreadLocalInfo();
+
+            // Select specific columns from a regular OLAP table to trigger column-level privilege check.
+            StatementBase stmt = SqlParser.parse("select v4, v5 from db.t1",
+                    ctx.getSessionVariable().getSqlMode()).get(0);
+            Analyzer.analyze(stmt, ctx);
+
+            QueryStatement queryStmt = (QueryStatement) stmt;
+            Assertions.assertDoesNotThrow(() ->
+                    ColumnPrivilege.check(ctx, queryStmt, Collections.emptyList()));
+
+            // Verify Ranger was actually called for column-level access on t1
+            Assertions.assertFalse(capturedResources.isEmpty(),
+                    "Ranger must be called for column-level privilege check on regular table");
+            boolean checkedColumn = capturedResources.stream()
+                    .anyMatch(r -> "t1".equals(r.getValue("table"))
+                            && r.getValue("column") != null);
+            Assertions.assertTrue(checkedColumn,
+                    "Ranger must be invoked with column-level resource on table 't1'");
+        } finally {
+            provider.setAccessControl(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, new NativeAccessController());
+        }
+    }
+
+    @Test
+    public void testColumnPrivilegeCheckTableColumnDeniedWithExternalAccessController() throws Exception {
+        // Mock Ranger to deny all requests so column-level check throws AccessDeniedException
+        new MockUp<RangerBasePlugin>() {
+            @Mock
+            RangerAccessResult isAccessAllowed(RangerAccessRequest request) {
+                RangerAccessResult result = new RangerAccessResult(1, "starrocks",
+                        new RangerServiceDef(), new RangerAccessRequestImpl());
+                result.setIsAllowed(false);
+                return result;
+            }
+        };
+
+        AccessControlProvider provider = Authorizer.getInstance();
+        provider.setAccessControl(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, new RangerStarRocksAccessController());
+
+        try {
+            ConnectContext ctx = new ConnectContext();
+            ctx.setCurrentUserIdentity(new UserIdentity("denied_user", "%"));
+            ctx.setDatabase("db");
+            ctx.setThreadLocalInfo();
+
+            StatementBase stmt = SqlParser.parse("select v4, v5 from db.t1",
+                    ctx.getSessionVariable().getSqlMode()).get(0);
+            Analyzer.analyze(stmt, ctx);
+
+            // Column-level check denied -> reportAccessDenied wraps it into ErrorReportException
+            QueryStatement queryStmt = (QueryStatement) stmt;
+            Assertions.assertThrows(ErrorReportException.class, () ->
+                    ColumnPrivilege.check(ctx, queryStmt, Collections.emptyList()));
+        } finally {
+            provider.setAccessControl(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, new NativeAccessController());
+        }
+    }
+
+    @Test
+    public void testCheckViewPrivilegeSecurityViewReferencingMv() {
+        // Mock Ranger to allow all requests, and track whether Ranger was actually called
+        final List<RangerAccessResourceImpl> capturedResources = new ArrayList<>();
+        new MockUp<RangerBasePlugin>() {
+            @Mock
+            RangerAccessResult isAccessAllowed(RangerAccessRequest request) {
+                capturedResources.add((RangerAccessResourceImpl) request.getResource());
+                RangerAccessResult result = new RangerAccessResult(1, "starrocks",
+                        new RangerServiceDef(), new RangerAccessRequestImpl());
+                result.setIsAllowed(true);
+                return result;
+            }
+        };
+
+        AccessControlProvider provider = Authorizer.getInstance();
+        provider.setAccessControl(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, new RangerStarRocksAccessController());
+
+        try {
+            ConnectContext ctx = new ConnectContext();
+            ctx.setCurrentUserIdentity(new UserIdentity("test_user", "%"));
+            ctx.setDatabase("db");
+            ctx.setThreadLocalInfo();
+
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db");
+            View secView = (View) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), "test_security_view_mv");
+            Assertions.assertTrue(secView.isSecurity(),
+                    "test_security_view_mv must be marked as security view in beforeClass");
+
+            TableName tableName = new TableName(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
+                    "db", "test_security_view_mv");
+            Assertions.assertDoesNotThrow(() ->
+                    ColumnPrivilege.checkViewPrivilege(ctx, tableName, secView));
+
+            // For a security view referencing a materialized view, Ranger must be invoked
+            // for both the underlying MV and the view itself.
+            // RangerStarRocksResource uses key "materialized_view" for MVs (not "table").
+            Assertions.assertFalse(capturedResources.isEmpty(),
+                    "Ranger must be called for security view privilege check");
+            boolean checkedUnderlyingMv = capturedResources.stream()
+                    .anyMatch(r -> "test_mv".equals(r.getValue("materialized_view")));
+            boolean checkedView = capturedResources.stream()
+                    .anyMatch(r -> "test_security_view_mv".equals(r.getValue("view")));
+            Assertions.assertTrue(checkedUnderlyingMv,
+                    "Security view must trigger underlying materialized view 'test_mv' privilege check");
+            Assertions.assertTrue(checkedView,
+                    "Security view must also trigger privilege check on the view itself");
+        } finally {
+            provider.setAccessControl(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, new NativeAccessController());
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/authorization/ranger/RangerInterfaceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authorization/ranger/RangerInterfaceTest.java
@@ -44,6 +44,8 @@ import com.starrocks.sql.ast.expression.ArithmeticExpr;
 import com.starrocks.sql.ast.expression.BinaryPredicate;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.NullLiteral;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.type.IntegerType;
 import com.starrocks.utframe.StarRocksAssert;
@@ -674,6 +676,7 @@ public class RangerInterfaceTest {
             TableName tableName = new TableName(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
                     "db", "test_security_view_mv");
             Assertions.assertDoesNotThrow(() ->
+
                     ColumnPrivilege.checkViewPrivilege(ctx, tableName, secView));
 
             // For a security view referencing a materialized view, Ranger must be invoked
@@ -692,5 +695,211 @@ public class RangerInterfaceTest {
         } finally {
             provider.setAccessControl(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, new NativeAccessController());
         }
+    }
+
+    /**
+     * Regression test for the should-fix item: when a security view's underlying base
+     * table is denied, the error must be reported against the base object (TABLE or,
+     * since the fix routes security-view refs through column-level checks, COLUMN of
+     * the base table) — never as ObjectType.VIEW with the security view's name.
+     */
+    @Test
+    public void testCheckViewPrivilegeSecurityViewBaseTableDeniedReportsAsTable() {
+        // Ranger denies every request -> base table t1 access will be denied
+        new MockUp<RangerBasePlugin>() {
+            @Mock
+            RangerAccessResult isAccessAllowed(RangerAccessRequest request) {
+                RangerAccessResult result = new RangerAccessResult(1, "starrocks",
+                        new RangerServiceDef(), new RangerAccessRequestImpl());
+                result.setIsAllowed(false);
+                return result;
+            }
+        };
+
+        AccessControlProvider provider = Authorizer.getInstance();
+        provider.setAccessControl(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, new RangerStarRocksAccessController());
+
+        try {
+            ConnectContext ctx = new ConnectContext();
+            ctx.setCurrentUserIdentity(new UserIdentity("denied_user", "%"));
+            ctx.setDatabase("db");
+            ctx.setThreadLocalInfo();
+
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db");
+            View secView = (View) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), "test_security_view");
+            Assertions.assertTrue(secView.isSecurity());
+
+            TableName tableName = new TableName(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
+                    "db", "test_security_view");
+
+            ErrorReportException ex = Assertions.assertThrows(ErrorReportException.class, () ->
+                    ColumnPrivilege.checkViewPrivilege(ctx, tableName, secView));
+
+            // The base failure must surface against the base object (TABLE or COLUMN of
+            // the base table) — never as VIEW <security_view>. Under the column-level
+            // unification fix, a security view's refs are checked via
+            // ColumnPrivilege.check(view.getQueryStatement()), so the first deny lands
+            // on a base column (e.g. "on COLUMN v4").
+            String msg = ex.getMessage();
+            Assertions.assertTrue(msg.contains("on TABLE") || msg.contains("on COLUMN"),
+                    "base failure must be reported against the base object (TABLE or COLUMN), got: " + msg);
+            Assertions.assertFalse(msg.contains("on VIEW test_security_view"),
+                    "base failure must NOT be misreported as VIEW <security_view>, got: " + msg);
+        } finally {
+            provider.setAccessControl(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, new NativeAccessController());
+        }
+    }
+
+    /**
+     * Regression test for the should-fix item: when a security view's underlying
+     * materialized view is denied, the error must be reported as
+     * ObjectType.MATERIALIZED_VIEW, not ObjectType.VIEW.
+     */
+    @Test
+    public void testCheckViewPrivilegeSecurityViewBaseMvDeniedReportsAsMaterializedView() {
+        new MockUp<RangerBasePlugin>() {
+            @Mock
+            RangerAccessResult isAccessAllowed(RangerAccessRequest request) {
+                RangerAccessResult result = new RangerAccessResult(1, "starrocks",
+                        new RangerServiceDef(), new RangerAccessRequestImpl());
+                result.setIsAllowed(false);
+                return result;
+            }
+        };
+
+        AccessControlProvider provider = Authorizer.getInstance();
+        provider.setAccessControl(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, new RangerStarRocksAccessController());
+
+        try {
+            ConnectContext ctx = new ConnectContext();
+            ctx.setCurrentUserIdentity(new UserIdentity("denied_user", "%"));
+            ctx.setDatabase("db");
+            ctx.setThreadLocalInfo();
+
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db");
+            View secView = (View) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), "test_security_view_mv");
+            Assertions.assertTrue(secView.isSecurity());
+
+            TableName tableName = new TableName(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
+                    "db", "test_security_view_mv");
+
+            ErrorReportException ex = Assertions.assertThrows(ErrorReportException.class, () ->
+                    ColumnPrivilege.checkViewPrivilege(ctx, tableName, secView));
+
+            // ObjectType.MATERIALIZED_VIEW is rendered as "MATERIALIZED VIEW" (with a
+            // space, no underscore) in user-facing error messages; see ObjectType.java.
+            String msg = ex.getMessage();
+            Assertions.assertTrue(msg.contains("on MATERIALIZED VIEW"),
+                    "base MV failure must be reported with ObjectType.MATERIALIZED_VIEW, got: " + msg);
+            Assertions.assertTrue(msg.contains("test_mv"),
+                    "base MV failure must mention the base MV name 'test_mv', got: " + msg);
+            Assertions.assertFalse(msg.contains("on VIEW test_security_view_mv"),
+                    "base MV failure must NOT be misreported as VIEW <security_view>, got: " + msg);
+        } finally {
+            provider.setAccessControl(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, new NativeAccessController());
+        }
+    }
+
+    /**
+     * Cover the {@code isConnectorView()} branch of checkViewPrivilege without
+     * requiring a real Hive/Iceberg/Paimon catalog. We mock View#isConnectorView to
+     * return true and verify that:
+     *   1) the call routes through the TABLE path (Authorizer.checkTableAction),
+     *      consistent with the Hive Ranger service type which models views as TABLE;
+     *   2) on deny, the error is reported as ObjectType.TABLE, not VIEW.
+     */
+    @Test
+    public void testCheckViewPrivilegeConnectorViewGoesThroughTablePath() {
+        // Ranger denies every request so we can observe how the failure is reported
+        new MockUp<RangerBasePlugin>() {
+            @Mock
+            RangerAccessResult isAccessAllowed(RangerAccessRequest request) {
+                RangerAccessResult result = new RangerAccessResult(1, "starrocks",
+                        new RangerServiceDef(), new RangerAccessRequestImpl());
+                result.setIsAllowed(false);
+                return result;
+            }
+        };
+
+        // Force the existing internal view to behave like a connector (Hive/Iceberg/Paimon) view
+        new MockUp<View>() {
+            @Mock
+            public boolean isConnectorView() {
+                return true;
+            }
+
+            @Mock
+            public boolean isSecurity() {
+                // Connector view branch returns early; security must not interfere.
+                return false;
+            }
+        };
+
+        AccessControlProvider provider = Authorizer.getInstance();
+        provider.setAccessControl(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, new RangerStarRocksAccessController());
+
+        try {
+            ConnectContext ctx = new ConnectContext();
+            ctx.setCurrentUserIdentity(new UserIdentity("denied_user", "%"));
+            ctx.setDatabase("db");
+            ctx.setThreadLocalInfo();
+
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db");
+            View view = (View) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), "test_view");
+            Assertions.assertTrue(view.isConnectorView(),
+                    "MockUp must make isConnectorView() return true");
+
+            TableName tableName = new TableName(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
+                    "db", "test_view");
+
+            ErrorReportException ex = Assertions.assertThrows(ErrorReportException.class, () ->
+                    ColumnPrivilege.checkViewPrivilege(ctx, tableName, view));
+
+            // Connector view must surface as TABLE (Hive Ranger service type consistency),
+            // not as VIEW.
+            String msg = ex.getMessage();
+            Assertions.assertTrue(msg.contains("on TABLE"),
+                    "connector view failure must be reported with ObjectType.TABLE, got: " + msg);
+            Assertions.assertTrue(msg.contains("test_view"),
+                    "connector view failure must mention the view name 'test_view', got: " + msg);
+            Assertions.assertFalse(msg.contains("on VIEW"),
+                    "connector view must NOT be reported as ObjectType.VIEW, got: " + msg);
+        } finally {
+            provider.setAccessControl(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, new NativeAccessController());
+        }
+    }
+
+    /**
+     * Regression test for the silent-drop minor item: when ScanColumnCollector hits a
+     * scan node whose Table is not present in tableObjToTableName (which happens after
+     * a view/MV is expanded by the optimizer), it must skip silently instead of
+     * inserting a {@code null} key into scanColumns or throwing NPE. Privilege for
+     * views/MVs is handled separately by checkViewPrivilege / checkMaterializedViewAction.
+     */
+    @Test
+    public void testScanColumnCollectorSkipsNullTableName() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db");
+        Table t1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t1");
+
+        // Empty mapping — simulates the case where the scan table was expanded from a
+        // view/MV and was therefore never recorded by TableNameCollector.
+        Map<Table, TableName> emptyTableObjToTableName = new HashMap<>();
+        Map<TableName, Set<String>> scanColumns = new HashMap<>();
+
+        ColumnPrivilege.ScanColumnCollector collector =
+                new ColumnPrivilege.ScanColumnCollector(emptyTableObjToTableName, scanColumns);
+
+        OptExpression scanExpr = new OptExpression(new LogicalOlapScanOperator(t1));
+
+        Assertions.assertDoesNotThrow(() -> collector.visitLogicalTableScan(scanExpr, null));
+
+        Assertions.assertTrue(scanColumns.isEmpty(),
+                "scanColumns must stay empty when tableObjToTableName has no entry; "
+                        + "must NOT silently insert a null key. Got: " + scanColumns);
+        Assertions.assertFalse(scanColumns.containsKey(null),
+                "scanColumns must NOT contain a null key (silent drop guard). Got: " + scanColumns);
     }
 }

--- a/test/sql/test_view/R/test_security_view
+++ b/test/sql/test_view/R/test_security_view
@@ -52,7 +52,7 @@ select * from v1;
 -- !result
 select * from v2;
 -- result:
-E: (5203, 'Access denied; you need (at least one of) the SELECT privilege(s) on VIEW v2 for this operation. Please ask the admin to grant permission(s) or try activating existing roles using <set [default] role>. Current role(s): NONE. Inactivated role(s): NONE.')
+E: (5203, 'Access denied; you need (at least one of) the SELECT privilege(s) on TABLE t1 for this operation. Please ask the admin to grant permission(s) or try activating existing roles using <set [default] role>. Current role(s): NONE. Inactivated role(s): NONE.')
 -- !result
 select * from v3;
 -- result:
@@ -84,7 +84,7 @@ execute as u1_${uuid} with no revert;
 -- !result
 select * from v1;
 -- result:
-E: (5203, 'Access denied; you need (at least one of) the SELECT privilege(s) on VIEW v1 for this operation. Please ask the admin to grant permission(s) or try activating existing roles using <set [default] role>. Current role(s): NONE. Inactivated role(s): NONE.')
+E: (5203, 'Access denied; you need (at least one of) the SELECT privilege(s) on TABLE t1 for this operation. Please ask the admin to grant permission(s) or try activating existing roles using <set [default] role>. Current role(s): NONE. Inactivated role(s): NONE.')
 -- !result
 select * from v2;
 -- result:


### PR DESCRIPTION
## What I'm doing:

Fixes #72910

## 1. Problem Description

In Ranger (external access controller) mode, `ColumnPrivilege.check()` mishandled `View` and `MaterializedView` objects.

## 2. Code Changes

File modified: `fe/fe-core/src/main/java/com/starrocks/authorization/ColumnPrivilege.java`

### 2.1 Route Views and MVs explicitly in the Ranger branch

Inside `check()`, the `tableUsedExternalAccessController.contains(tableName)` branch now dispatches by table type instead of unconditionally calling `checkColumnAction`:

```java
if (tableUsedExternalAccessController.contains(tableName)) {
    if (table instanceof View view) {
        checkViewPrivilege(context, tableName, view);            // NEW
    } else if (table.isMaterializedView()) {
        Authorizer.checkMaterializedViewAction(...);             // NEW (resource = materialized_view)
    } else {
        // existing column-level check for regular tables
    }
}
```

This ensures Ranger receives the correct resource type (`view` /`materialized_view`) for each object kind.

### 2.2 Extract a public `checkViewPrivilege` helper

The security-view handling logic, previously inlined only in the native branch, is now a single `public static` method shared by both branches:

```java
public static void checkViewPrivilege(ConnectContext context,
                                      TableName tableName, View view) {
    try {
        // connector views are checked as tables
        if (view.isConnectorView()) {
            Authorizer.checkTableAction(context, tableName, PrivilegeType.SELECT);
            return;
        }

        // security views: recursively verify SELECT on all referenced objects
        if (view.isSecurity()) {
            for (TableName t : view.getTableRefs()) {
                BasicTable basicTable = GlobalStateMgr.getCurrentState()
                        .getMetadataMgr()
                        .getBasicTable(context, t.getCatalog(), t.getDb(), t.getTbl());
                if (basicTable.isOlapView()) {
                    QueryStatement qs = ((View) basicTable).getQueryStatement();
                    Analyzer.analyze(qs, context);
                    Authorizer.check(qs, context);
                } else if (basicTable.isMaterializedView()) {
                    Authorizer.checkMaterializedViewAction(context, t, PrivilegeType.SELECT);
                } else {
                    Authorizer.checkTableAction(context, t, PrivilegeType.SELECT);
                }
            }
        }

        // and SELECT on the view itself
        Authorizer.checkViewAction(context, tableName, PrivilegeType.SELECT);
    } catch (AccessDeniedException e) {
        AccessDeniedException.reportAccessDenied(
                tableName.getCatalog(),                          // FIXED: was hard-coded internal catalog
                context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
                PrivilegeType.SELECT.name(), ObjectType.VIEW.name(), tableName.getTbl());
    }
}
```

Both the native branch and the Ranger branch now delegate to this method, so security view semantics are applied uniformly regardless of access controller.

### 2.3 Behavior comparison

| Scenario                          | Before                                       | After                                                       |
|-----------------------------------|----------------------------------------------|-------------------------------------------------------------|
| Ranger + normal View              | `checkColumnAction` (resource = `table`)     | `checkViewAction` (resource = `view`)                       |
| Ranger + Materialized View        | `checkColumnAction` (resource = `table`)     | `checkMaterializedViewAction` (resource = `materialized_view`) |
| Ranger + Security View            | No pass-through to base tables               | Recursive SELECT check on all base tables/views/MVs + the view itself |
| Native + Security View            | Inline implementation                        | Same behavior, now shared via `checkViewPrivilege`          |
| Catalog reported on view denial   | Hard-coded internal catalog                  | Uses `tableName.getCatalog()` (correct for external catalogs) |

## 3. Core Unit Tests

File modified: `fe/fe-core/src/test/java/com/starrocks/authorization/ranger/RangerInterfaceTest.java`

### 3.1 Test fixtures (added in `beforeClass`)

Three objects are pre-created for view/MV/security-view coverage:

- `db.test_view` — regular OLAP view referencing `db.t1`
- `db.test_mv` — materialized view referencing `db.t1`
- `db.test_security_view` — view marked as security via `setSecurity(true)`

### 3.2 Retained tests (5 cases, one per independent code path)

| # | Test method                                                              | Path under test                          | Key assertions                                                                                          |
|---|--------------------------------------------------------------------------|------------------------------------------|---------------------------------------------------------------------------------------------------------|
| 1 | `testColumnPrivilegeCheckViewWithExternalAccessController`               | Ranger + View, allow                     | Ranger plugin is actually invoked with resource type `view` (proves the bypass is fixed)                |
| 2 | `testColumnPrivilegeCheckViewDeniedWithExternalAccessController`         | Ranger + View, deny                      | `ErrorReportException` is thrown on Ranger denial                                                       |
| 3 | `testColumnPrivilegeCheckMaterializedViewWithExternalAccessController`   | Ranger + MV, allow                       | Ranger plugin is invoked with resource type `materialized_view`                                         |
| 4 | `testColumnPrivilegeCheckMaterializedViewDeniedWithExternalAccessController` | Ranger + MV, deny                    | `ErrorReportException` is thrown on Ranger denial                                                       |
| 5 | `testCheckViewPrivilegeSecurityViewWithRanger`                           | Ranger + Security View (core fix)        | Ranger receives BOTH the underlying base table `t1` (resource = `table`) AND the view `test_security_view` (resource = `view`) |

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
