### PR TITLE
[BugFix] fix pk table compaction conflict check with partial update

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2059,6 +2059,7 @@ Status TabletUpdates::_do_compaction(std::unique_ptr<CompactionInfo>* pinfo, con
 // at last, we will commit this compaction in version (3.1). But this compaction will miss the partial update.
 // So we need `_check_conflict_with_partial_update` to detect this conflict and cancel this compaction.
 Status TabletUpdates::_check_conflict_with_partial_update(CompactionInfo* info) {
+    TEST_SYNC_POINT_CALLBACK("TabletUpdates::_check_conflict_with_partial_update", &info->start_version);
     // check if compaction's start version is too old to decide whether conflict happens
     if (info->start_version < _edit_version_infos[0]->version) {
         std::string msg = strings::Substitute(

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2059,10 +2059,10 @@ Status TabletUpdates::_do_compaction(std::unique_ptr<CompactionInfo>* pinfo, con
 // at last, we will commit this compaction in version (3.1). But this compaction will miss the partial update.
 // So we need `_check_conflict_with_partial_update` to detect this conflict and cancel this compaction.
 Status TabletUpdates::_check_conflict_with_partial_update(CompactionInfo* info) {
-    // check if compaction's start version is too old to decide whether conflict with partial update
+    // check if compaction's start version is too old to decide whether conflict happens
     if (info->start_version < _edit_version_infos[0]->version) {
         std::string msg = strings::Substitute(
-                "compaction's start version is too old to decide whether conflict with partial update, so abort it, "
+                "compaction's start version is too old to decide whether conflict happens, so abort it, "
                 "tabletid:$0 ver:$1-$2",
                 _tablet.tablet_id(), info->start_version.major_number(),
                 _edit_version_infos[0]->version.major_number());

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -5725,6 +5725,11 @@ void TabletUpdates::_reset_apply_status(const EditVersionInfo& version_info_appl
         if (state_entry != nullptr) {
             manager->update_state_cache().remove(state_entry);
         }
+        auto column_state_entry = manager->update_column_state_cache().get(
+                strings::Substitute("$0_$1", _tablet.tablet_id(), rowset->rowset_id().to_string()));
+        if (column_state_entry != nullptr) {
+            manager->update_column_state_cache().remove(column_state_entry);
+        }
     } else if (version_info_apply.compaction) {
         // reset compaction state
         _compaction_state.reset();

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -1301,6 +1301,119 @@ TEST_P(RowsetColumnPartialUpdateTest, partial_update_with_fast_schema_evolution)
     config::enable_light_pk_compaction_publish = true;
 }
 
+TEST_P(RowsetColumnPartialUpdateTest, partial_update_with_compaction) {
+    config::enable_light_pk_compaction_publish = false;
+    const int N = 100;
+    auto tablet = create_tablet(rand(), rand());
+    ASSERT_EQ(1, tablet->updates()->version_history_count());
+
+    // create full rowsets first
+    std::vector<int64_t> keys(N);
+    for (int i = 0; i < N; i++) {
+        keys[i] = i;
+    }
+    std::vector<RowsetSharedPtr> rowsets;
+    rowsets.reserve(10);
+    for (int i = 0; i < 10; i++) {
+        rowsets.emplace_back(create_rowset(tablet, keys));
+    }
+    int64_t version = 1;
+    commit_rowsets(tablet, rowsets, version);
+    // check data
+    ASSERT_TRUE(check_tablet(tablet, version, N, [](int64_t k1, int64_t v1, int32_t v2, int32_t v3) {
+        return (int16_t)(k1 % 100 + 1) == v1 && (int32_t)(k1 % 1000 + 2) == v2;
+    }));
+
+    std::vector<int32_t> column_indexes = {0, 1};
+    auto v1_func = [](int64_t k1) { return (int16_t)(k1 % 100 + 3); };
+    auto v2_func = [](int64_t k1) { return (int32_t)(k1 % 1000 + 4); };
+    std::shared_ptr<TabletSchema> partial_schema = TabletSchema::create(tablet->tablet_schema(), column_indexes);
+    RowsetSharedPtr partial_rowset =
+            create_partial_rowset(tablet, keys, column_indexes, v1_func, v2_func, partial_schema, 1);
+    // commit partial update
+    auto st = tablet->rowset_commit(++version, partial_rowset, 10000);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    // check data
+    ASSERT_TRUE(check_tablet(tablet, version, N, [](int64_t k1, int64_t v1, int32_t v2, int32_t v3) {
+        return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 2) == v2;
+    }));
+    // compaction with rowset 0 - 9
+    vector<uint32_t> input_rowset_ids;
+    for (int i = 0; i <= 9; i++) {
+        input_rowset_ids.push_back(i);
+    }
+    ASSERT_TRUE(tablet->updates()->compaction(_compaction_mem_tracker.get(), input_rowset_ids).ok());
+    // check data
+    ASSERT_TRUE(check_tablet(tablet, version, N, [](int64_t k1, int64_t v1, int32_t v2, int32_t v3) {
+        return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 2) == v2;
+    }));
+
+    config::enable_light_pk_compaction_publish = true;
+}
+
+TEST_P(RowsetColumnPartialUpdateTest, partial_update_with_compaction_conflict_check) {
+    config::enable_light_pk_compaction_publish = false;
+    const int N = 100;
+    auto tablet = create_tablet(rand(), rand());
+    ASSERT_EQ(1, tablet->updates()->version_history_count());
+
+    // create full rowsets first
+    std::vector<int64_t> keys(N);
+    for (int i = 0; i < N; i++) {
+        keys[i] = i;
+    }
+    std::vector<RowsetSharedPtr> rowsets;
+    rowsets.reserve(10);
+    for (int i = 0; i < 10; i++) {
+        rowsets.emplace_back(create_rowset(tablet, keys));
+    }
+    int64_t version = 1;
+    commit_rowsets(tablet, rowsets, version);
+    // check data
+    ASSERT_TRUE(check_tablet(tablet, version, N, [](int64_t k1, int64_t v1, int32_t v2, int32_t v3) {
+        return (int16_t)(k1 % 100 + 1) == v1 && (int32_t)(k1 % 1000 + 2) == v2;
+    }));
+
+    std::vector<int32_t> column_indexes = {0, 1};
+    auto v1_func = [](int64_t k1) { return (int16_t)(k1 % 100 + 3); };
+    auto v2_func = [](int64_t k1) { return (int32_t)(k1 % 1000 + 4); };
+    std::shared_ptr<TabletSchema> partial_schema = TabletSchema::create(tablet->tablet_schema(), column_indexes);
+    RowsetSharedPtr partial_rowset =
+            create_partial_rowset(tablet, keys, column_indexes, v1_func, v2_func, partial_schema, 1);
+    // commit partial update
+    auto st = tablet->rowset_commit(++version, partial_rowset, 10000);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    // check data
+    ASSERT_TRUE(check_tablet(tablet, version, N, [](int64_t k1, int64_t v1, int32_t v2, int32_t v3) {
+        return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 2) == v2;
+    }));
+
+    SyncPoint::GetInstance()->SetCallBack("TabletUpdates::_check_conflict_with_partial_update", [](void* arg) {
+        EditVersion* v = (EditVersion*)arg;
+        (*v) = EditVersion(1, 1);
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("TabletUpdates::_check_conflict_with_partial_update");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+    // remove history versions
+    tablet->updates()->remove_expired_versions(INT64_MAX);
+    // compaction with rowset 0 - 9
+    vector<uint32_t> input_rowset_ids;
+    for (int i = 0; i <= 9; i++) {
+        input_rowset_ids.push_back(i);
+    }
+    ASSERT_FALSE(tablet->updates()->compaction(_compaction_mem_tracker.get(), input_rowset_ids).ok());
+    // check data
+    ASSERT_TRUE(check_tablet(tablet, version, N, [](int64_t k1, int64_t v1, int32_t v2, int32_t v3) {
+        return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 2) == v2;
+    }));
+
+    config::enable_light_pk_compaction_publish = true;
+}
+
 INSTANTIATE_TEST_SUITE_P(RowsetColumnPartialUpdateTest, RowsetColumnPartialUpdateTest,
                          ::testing::Values(RowsetColumnPartialUpdateParam{1, false},
                                            RowsetColumnPartialUpdateParam{1024, true},


### PR DESCRIPTION
## Why I'm doing:
In the PK table, there might be conflicts between partial column updates and compaction execution. For example, compaction is performed based on version N, while partial column updates occur in version N+1. If the compaction task is submitted without conflict checking, the updates in version N+1 could be lost. Therefore, we implement conflict checking logic in `TabletUpdates::_check_conflict_with_partial_update`.

However, there is an extreme case: if the compaction execution takes too long (exceeding the default version retention time of 30 minutes `tablet_rowset_stale_sweep_time_sec`), the version information might become insufficient to determine whether a conflict exists, leading to misjudgment.

## What I'm doing:
In this PR, I have fixed this misjudgment. If the compaction execution takes too long and the version information is no longer sufficient to determine conflicts, we assume a conflict exists and retry the compaction.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0