### PR TITLE
[Enhancement] Reduce varchar cast inside date/datetime cast

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
@@ -60,6 +60,18 @@ public class ReduceCastRule extends TopDownScalarOperatorRewriteRule {
             return newCastOperator;
         }
 
+        // remove varchar cast inside date/datetime cast
+        if (operator.getType().isDate() || operator.getType().isDatetime()) {
+            ScalarOperator castChild = operator.getChild(0);
+            if (castChild instanceof CastOperator
+                    && castChild.getType().isVarchar()
+                    && (castChild.getChild(0).getType().isDate() || castChild.getChild(0).getType().isDatetime())) {
+                CastOperator newCastOperator = (CastOperator) operator.clone();
+                newCastOperator.setChild(0, castChild.getChild(0));
+                operator = newCastOperator;
+            }
+        }
+
         // remove same type cast
         if (operator.getType().isDecimalOfAnyVersion()) {
             if (operator.getType().getPrimitiveType().equals(operator.getChild(0).getType().getPrimitiveType())

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -1295,7 +1295,7 @@ public class ExpressionTest extends PlanTestBase {
 
         sql = "select cast(cast(id_datetime as string) as date) from test_all_type;";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "CAST(CAST(8: id_datetime AS VARCHAR(65533)) AS DATE)");
+        assertContains(plan, "CAST(8: id_datetime AS DATE)");
 
         sql = "select cast(cast(t1d as int) as boolean) from test_all_type;";
         plan = getFragmentPlan(sql);


### PR DESCRIPTION
## Why I'm doing:
`pt` is `datetime` type

```sql
SELECT  COUNT(*)
FROM test_tbl
WHERE date_format(cast(cast(pt as varchar) as Datetime), '%Y-%m-%d') between '2024-12-31' and '2025-02-04'
```

Some generated sql can't do partition prune.

## What I'm doing:
rewrite to final sql 

```sql
SELECT  COUNT(*)
FROM test_tbl
WHERE date_format(pt, '%Y-%m-%d') between '2024-12-31' and '2025-02-04'
```

reduce the `cast pt as varchar` when it is inside `cast as datetime` when `pt` is `date/datetime` type

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0