### PR TITLE
[Doc] Fix code-style-guides' titles for protobuf and thrift.

### DIFF
--- a/docs/en/developers/code-style-guides/protobuf-guides.md
+++ b/docs/en/developers/code-style-guides/protobuf-guides.md
@@ -2,7 +2,7 @@
 displayed_sidebar: docs
 ---
 
-# Rules
+# Protobuf Guides
 
 ## Never use required
 

--- a/docs/en/developers/code-style-guides/thrift-guides.md
+++ b/docs/en/developers/code-style-guides/thrift-guides.md
@@ -2,7 +2,7 @@
 displayed_sidebar: docs
 ---
 
-# Rules
+# Thrift Guides
 
 ## Never use required
 


### PR DESCRIPTION
## Why I'm doing:

The table-of-content for `code-style-guides` is not really helpful in its current form: 

![image](https://github.com/user-attachments/assets/539f3cbf-e820-4962-9cd7-be8d187f5a00)


## What I'm doing:

Renamed the titles of the files to be more explicit (keeping the same naming as the `.md` files) :

1. `Rules` -> `Protobuf Guides` 
2. `Rules` -> `Thrift Guides` 

Fixes [#56323](https://github.com/StarRocks/starrocks/issues/56323)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0