### PR TITLE
[BugFix] Fix files deleted incorrectly under cluster snapshot

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -202,9 +202,9 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
         long nowMs = System.currentTimeMillis();
         List<Long> emptyShardGroup = new ArrayList<>();
         for (long groupId : diffList) {
-            long tableId = groupIdToTableId.get(groupId);
-            if (!GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().isTableSafeToDeleteTablet(tableId)) {
-                LOG.debug("table with id: {} can not be delete shard for now, because of automated cluster snapshot", tableId);
+            Long tableId = groupIdToTableId.get(groupId);
+            if (tableId != null && !GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().isTableSafeToDeleteTablet(tableId.longValue())) {
+                LOG.debug("table with id: {} can not be delete shard for now, because of automated cluster snapshot", tableId.longValue());
                 continue;
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -63,7 +63,7 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
         super("StarMgrMetaSyncer", Config.star_mgr_meta_sync_interval_sec * 1000L);
     }
 
-    private List<Long> getAllPartitionShardGroupId() {
+    public List<Long> getAllPartitionShardGroupId() {
         List<Long> groupIds = new ArrayList<>();
         List<Long> dbIds = GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIdsIncludeRecycleBin();
         for (Long dbId : dbIds) {
@@ -161,7 +161,7 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
      * 2. Compare the list and get a list of shard groups that in StarMgr but not in FE
      * 3. shard groups with empty shards and older than threshold, will be permanently deleted.
      */
-    private void deleteUnusedShardAndShardGroup() {
+    public void deleteUnusedShardAndShardGroup() {
         StarOSAgent starOSAgent = GlobalStateMgr.getCurrentState().getStarOSAgent();
 
         List<Long> groupIdFe = getAllPartitionShardGroupId();
@@ -221,7 +221,7 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
         }
     }
 
-    private void cleanOneGroup(long groupId, StarOSAgent starOSAgent, List<Long> emptyShardGroup) {
+    public void cleanOneGroup(long groupId, StarOSAgent starOSAgent, List<Long> emptyShardGroup) {
         try {
             List<Long> shardIds = starOSAgent.listShard(groupId);
             if (shardIds.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -204,7 +204,7 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
         for (long groupId : diffList) {
             Long tableId = groupIdToTableId.get(groupId);
             if (tableId != null &&
-                !GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().isTableSafeToDeleteTablet(tableId.longValue())) {
+                    !GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().isTableSafeToDeleteTablet(tableId.longValue())) {
                 LOG.debug("table with id: {} can not be delete shard for now, because of automated cluster snapshot",
                           tableId.longValue());
                 continue;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -190,10 +190,24 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
                 .collect(Collectors.toList());
         LOG.debug("diff.size is {}, diff: {}", diffList.size(), diffList);
 
+        Map<Long, Long> groupIdToTableId = new HashMap<>();
+        for (ShardGroupInfo shardInfo : shardGroupsInfo) {
+            String tableIdString = shardInfo.getLabels().get("tableId");
+            if (tableIdString != null) {
+                groupIdToTableId.put(shardInfo.getGroupId(), Long.parseLong(tableIdString));
+            }
+        }
+
         // 1.4.collect redundant shard groups and delete
         long nowMs = System.currentTimeMillis();
         List<Long> emptyShardGroup = new ArrayList<>();
         for (long groupId : diffList) {
+            long tableId = groupIdToTableId.get(groupId);
+            if (!GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().isTableSafeToDeleteTablet(tableId)) {
+                LOG.debug("table with id: {} can not be delete shard for now, because of automated cluster snapshot", tableId);
+                continue;
+            }
+
             if (Config.shard_group_clean_threshold_sec * 1000L + Long.parseLong(groupToCreateTimeMap.get(groupId)) < nowMs) {
                 cleanOneGroup(groupId, starOSAgent, emptyShardGroup);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -203,8 +203,10 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
         List<Long> emptyShardGroup = new ArrayList<>();
         for (long groupId : diffList) {
             Long tableId = groupIdToTableId.get(groupId);
-            if (tableId != null && !GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().isTableSafeToDeleteTablet(tableId.longValue())) {
-                LOG.debug("table with id: {} can not be delete shard for now, because of automated cluster snapshot", tableId.longValue());
+            if (tableId != null &&
+                !GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().isTableSafeToDeleteTablet(tableId.longValue())) {
+                LOG.debug("table with id: {} can not be delete shard for now, because of automated cluster snapshot",
+                          tableId.longValue());
                 continue;
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -63,7 +63,7 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
         super("StarMgrMetaSyncer", Config.star_mgr_meta_sync_interval_sec * 1000L);
     }
 
-    public List<Long> getAllPartitionShardGroupId() {
+    private List<Long> getAllPartitionShardGroupId() {
         List<Long> groupIds = new ArrayList<>();
         List<Long> dbIds = GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIdsIncludeRecycleBin();
         for (Long dbId : dbIds) {
@@ -161,7 +161,7 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
      * 2. Compare the list and get a list of shard groups that in StarMgr but not in FE
      * 3. shard groups with empty shards and older than threshold, will be permanently deleted.
      */
-    public void deleteUnusedShardAndShardGroup() {
+    private void deleteUnusedShardAndShardGroup() {
         StarOSAgent starOSAgent = GlobalStateMgr.getCurrentState().getStarOSAgent();
 
         List<Long> groupIdFe = getAllPartitionShardGroupId();
@@ -221,7 +221,7 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
         }
     }
 
-    public void cleanOneGroup(long groupId, StarOSAgent starOSAgent, List<Long> emptyShardGroup) {
+    private void cleanOneGroup(long groupId, StarOSAgent starOSAgent, List<Long> emptyShardGroup) {
         try {
             List<Long> shardIds = starOSAgent.listShard(groupId);
             if (shardIds.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -472,11 +472,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             // save table names for recycling
             Set<String> tableNames = new HashSet<>(db.getTableNamesViewWithLock());
             unprotectDropDb(db, isForceDrop, false);
-            if (!isForceDrop) {
-                recycleBin.recycleDatabase(db, tableNames);
-            } else {
-                stateMgr.getLocalMetastore().onEraseDatabase(db.getId());
-            }
+            recycleBin.recycleDatabase(db, tableNames, !isForceDrop);
             db.setExist(false);
 
             // 3. remove db from globalStateMgr
@@ -528,11 +524,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             try {
                 Set<String> tableNames = new HashSet(db.getTableNamesViewWithLock());
                 unprotectDropDb(db, isForceDrop, true);
-                if (!isForceDrop) {
-                    recycleBin.recycleDatabase(db, tableNames);
-                } else {
-                    stateMgr.getLocalMetastore().onEraseDatabase(db.getId());
-                }
+                recycleBin.recycleDatabase(db, tableNames, !isForceDrop);
                 db.setExist(false);
             } finally {
                 locker.unLockDatabase(db.getId(), LockType.WRITE);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
@@ -86,9 +86,9 @@ public class CatalogRecycleBinTest {
     public void testGetDb() {
         CatalogRecycleBin bin = new CatalogRecycleBin();
         Database database = new Database(1, "db");
-        bin.recycleDatabase(database, Sets.newHashSet());
+        bin.recycleDatabase(database, Sets.newHashSet(), true);
         Database database2 = new Database(2, "db");
-        bin.recycleDatabase(database2, Sets.newHashSet());
+        bin.recycleDatabase(database2, Sets.newHashSet(), true);
 
         Database recycledDb = bin.getDatabase(1);
         Assert.assertNull(recycledDb);
@@ -373,7 +373,7 @@ public class CatalogRecycleBinTest {
         Config.catalog_trash_expire_second = 600; // set expire in 10 minutes
         CatalogRecycleBin recycleBin = new CatalogRecycleBin();
         Database db = new Database(111, "uno");
-        recycleBin.recycleDatabase(db, new HashSet<>());
+        recycleBin.recycleDatabase(db, new HashSet<>(), true);
 
         // no need to set enable erase later if there are a lot of time left
         long now = System.currentTimeMillis();
@@ -403,9 +403,9 @@ public class CatalogRecycleBinTest {
 
         // 1. recycle 2 dbs
         CatalogRecycleBin recycleBin = new CatalogRecycleBin();
-        recycleBin.recycleDatabase(db1, new HashSet<>());
-        recycleBin.recycleDatabase(db2SameName, new HashSet<>());  // will remove same name
-        recycleBin.recycleDatabase(db2, new HashSet<>());
+        recycleBin.recycleDatabase(db1, new HashSet<>(), true);
+        recycleBin.recycleDatabase(db2SameName, new HashSet<>(), true);  // will remove same name
+        recycleBin.recycleDatabase(db2, new HashSet<>(), true);
 
         Assert.assertEquals(recycleBin.getDatabase(db1.getId()), db1);
         Assert.assertEquals(recycleBin.getDatabase(db2.getId()), db2);

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
@@ -167,7 +167,7 @@ public class TabletSchedulerTest {
 
         long now = System.currentTimeMillis();
         CatalogRecycleBin recycleBin = new CatalogRecycleBin();
-        recycleBin.recycleDatabase(badDb, new HashSet<>());
+        recycleBin.recycleDatabase(badDb, new HashSet<>(), true);
         recycleBin.recycleTable(goodDB.getId(), badTable, true);
         RecyclePartitionInfo recyclePartitionInfo = new RecycleRangePartitionInfo(goodDB.getId(), goodTable.getId(),
                 badPartition, null, new DataProperty(TStorageMedium.HDD), (short) 2, false, null);

--- a/fe/fe-core/src/test/java/com/starrocks/lake/ClusterSnapshotTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/ClusterSnapshotTest.java
@@ -474,6 +474,7 @@ public class ClusterSnapshotTest {
             }
             localClusterSnapshotMgr.setAutomatedSnapshotOff();
         }
+        Config.shard_group_clean_threshold_sec = oldConfig;
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/lake/ClusterSnapshotTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/ClusterSnapshotTest.java
@@ -473,8 +473,8 @@ public class ClusterSnapshotTest {
                 syncer.deleteUnusedShardAndShardGroup();
             }
             localClusterSnapshotMgr.setAutomatedSnapshotOff();
+            Config.shard_group_clean_threshold_sec = oldConfig;
         }
-        Config.shard_group_clean_threshold_sec = oldConfig;
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -23,6 +23,10 @@ import com.staros.proto.S3FileStoreInfo;
 import com.staros.proto.ShardGroupInfo;
 import com.staros.proto.ShardInfo;
 import com.staros.proto.StatusCode;
+import com.starrocks.alter.AlterJobV2;
+import com.starrocks.alter.MaterializedViewHandler;
+import com.starrocks.alter.SchemaChangeHandler;
+import com.starrocks.alter.SchemaChangeJobV2;
 import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.ColocateTableIndex.GroupId;
 import com.starrocks.catalog.Column;
@@ -42,7 +46,11 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.concurrent.lock.LockManager;
+import com.starrocks.lake.snapshot.ClusterSnapshotJob;
+import com.starrocks.lake.snapshot.ClusterSnapshotJob.ClusterSnapshotJobState;
 import com.starrocks.lake.snapshot.ClusterSnapshotMgr;
+import com.starrocks.lake.snapshot.ClusterSnapshotUtils;
+import com.starrocks.persist.EditLog;
 import com.starrocks.proto.DeleteTabletRequest;
 import com.starrocks.proto.DeleteTabletResponse;
 import com.starrocks.proto.StatusPB;
@@ -75,6 +83,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -100,9 +109,16 @@ public class StarMgrMetaSyncerTest {
     @Mocked
     private LocalMetastore localMetastore;
 
+    @Mocked
+    private EditLog editLog;
+
+    private ClusterSnapshotMgr clusterSnapshotMgr = new ClusterSnapshotMgr();
+
     long shardGroupId = 12L;
 
     long tableId = 15L;
+
+    private AtomicLong nextId = new AtomicLong(0);
 
     @Before
     public void setUp() throws Exception {
@@ -144,7 +160,7 @@ public class StarMgrMetaSyncerTest {
 
                 globalStateMgr.getClusterSnapshotMgr();
                 minTimes = 0;
-                result = new ClusterSnapshotMgr();
+                result = clusterSnapshotMgr;
             }
         };
 
@@ -897,5 +913,111 @@ public class StarMgrMetaSyncerTest {
         shards.add(333L);
         starMgrMetaSyncer.syncTableMetaInternal(db, (OlapTable) table, true);
         Assert.assertEquals(3, shards.size());
+    }
+
+    @Test
+    public void testSyncerRejectByClusterSnapshot() {
+        final ClusterSnapshotMgr localClusterSnapshotMgr = new ClusterSnapshotMgr();
+        final StarMgrMetaSyncer syncer = new StarMgrMetaSyncer();
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public ClusterSnapshotMgr getClusterSnapshotMgr() {
+                return localClusterSnapshotMgr;
+            }
+        };
+
+        MaterializedViewHandler rollupHandler = new MaterializedViewHandler();
+        SchemaChangeHandler schemaChangeHandler = new SchemaChangeHandler();
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public EditLog getEditLog() {
+                return editLog;
+            }
+
+            @Mock
+            public SchemaChangeHandler getSchemaChangeHandler() {
+                return schemaChangeHandler;
+            }
+
+            @Mock
+            public MaterializedViewHandler getRollupHandler() {
+                return rollupHandler;
+            }
+        };
+
+        AlterJobV2 alterjob = new SchemaChangeJobV2(1, 2, 100L, "table3", 100000);
+        alterjob.setJobState(AlterJobV2.JobState.FINISHED);
+        alterjob.setFinishedTimeMs(1000);
+        schemaChangeHandler.addAlterJobV2(alterjob);
+
+        ShardGroupInfo info1 = ShardGroupInfo.newBuilder()
+                .setGroupId(99L)
+                .putLabels("tableId", String.valueOf(100L))
+                .putProperties("createTime", String.valueOf(System.currentTimeMillis()))
+                .build();
+        ShardGroupInfo info2 = ShardGroupInfo.newBuilder()
+                .setGroupId(100L)
+                .putLabels("tableId", String.valueOf(111L))
+                .putProperties("createTime", String.valueOf(System.currentTimeMillis()))
+                .build();
+        List<ShardGroupInfo> shardGroupsInfo = new ArrayList();
+        shardGroupsInfo.add(info1);
+        shardGroupsInfo.add(info2);
+        
+        new MockUp<LocalMetastore>() {
+            @Mock
+            public List<Table> getTablesIncludeRecycleBin(Database db) {
+                List<Column> baseSchema = new ArrayList<>();
+                KeysType keysType = KeysType.AGG_KEYS;
+                PartitionInfo partitionInfo = new PartitionInfo(PartitionType.RANGE);
+                DistributionInfo defaultDistributionInfo = new HashDistributionInfo();
+                Table table = new LakeTable(100, "lake_table", baseSchema, keysType, partitionInfo, defaultDistributionInfo);
+                List<Table> tableList = new ArrayList<>();
+                tableList.add(table);
+                return tableList;
+            }
+        };
+    
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<ShardGroupInfo> listShardGroup() {
+                return shardGroupsInfo;
+            }
+        };
+
+        new MockUp<ClusterSnapshotMgr>() {
+            @Mock
+            public boolean isAutomatedSnapshotOn() {
+                return true;
+            }
+        };
+
+        new MockUp<ClusterSnapshotUtils>() {
+            @Mock
+            public static void clearAutomatedSnapshotFromRemote(String snapshotName) {
+                return;
+            }
+        };
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public long getNextId() {
+                long id = nextId.incrementAndGet();
+                return id;
+            }
+        };
+
+        long oldConfig = Config.shard_group_clean_threshold_sec;
+        Config.shard_group_clean_threshold_sec = 0;
+        syncer.runAfterCatalogReady();
+        ClusterSnapshotJob j3 = localClusterSnapshotMgr.createAutomatedSnapshotJob();
+        j3.setState(ClusterSnapshotJobState.FINISHED);
+        syncer.runAfterCatalogReady();
+        ClusterSnapshotJob j4 = localClusterSnapshotMgr.createAutomatedSnapshotJob();
+        j4.setState(ClusterSnapshotJobState.FINISHED);
+        syncer.runAfterCatalogReady();
+        Config.shard_group_clean_threshold_sec = oldConfig;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -102,6 +102,8 @@ public class StarMgrMetaSyncerTest {
 
     long shardGroupId = 12L;
 
+    long tableId = 15L;
+
     @Before
     public void setUp() throws Exception {
         long dbId = 1L;
@@ -222,6 +224,7 @@ public class StarMgrMetaSyncerTest {
         for (long groupId : allShardGroupId) {
             ShardGroupInfo info = ShardGroupInfo.newBuilder()
                     .setGroupId(groupId)
+                    .putLabels("tableId", String.valueOf(tableId))
                     .putProperties("createTime", String.valueOf(System.currentTimeMillis()))
                     .build();
             shardGroupInfos.add(info);
@@ -461,6 +464,7 @@ public class StarMgrMetaSyncerTest {
         for (long groupId : allShardGroupId) {
             ShardGroupInfo info = ShardGroupInfo.newBuilder()
                     .setGroupId(groupId)
+                    .putLabels("tableId", String.valueOf(tableId))
                     .putProperties("createTime", String.valueOf(System.currentTimeMillis() - 86400 * 1000))
                     .addAllShardIds(allShardIds)
                     .build();
@@ -543,6 +547,7 @@ public class StarMgrMetaSyncerTest {
         List<ShardGroupInfo> shardGroupInfos = new ArrayList<>();
         ShardGroupInfo info = ShardGroupInfo.newBuilder()
                 .setGroupId(groupIdToClear)
+                .putLabels("tableId", String.valueOf(tableId))
                 .putProperties("createTime", String.valueOf(System.currentTimeMillis() - 86400 * 1000))
                 .addAllShardIds(allShardIds)
                 .build();
@@ -589,6 +594,7 @@ public class StarMgrMetaSyncerTest {
         List<ShardGroupInfo> shardGroupInfos = new ArrayList<>();
         ShardGroupInfo info = ShardGroupInfo.newBuilder()
                 .setGroupId(groupIdToClear)
+                .putLabels("tableId", String.valueOf(tableId))
                 .putProperties("createTime", String.valueOf(System.currentTimeMillis() - 86400 * 1000))
                 .addAllShardIds(allShardIds)
                 .build();
@@ -653,6 +659,7 @@ public class StarMgrMetaSyncerTest {
         List<ShardGroupInfo> shardGroupInfos = new ArrayList<>();
         ShardGroupInfo info = ShardGroupInfo.newBuilder()
                 .setGroupId(groupIdToClear)
+                .putLabels("tableId", String.valueOf(tableId))
                 .putProperties("createTime", String.valueOf(System.currentTimeMillis() - 86400 * 1000))
                 .addAllShardIds(allShardIds)
                 .build();
@@ -730,6 +737,7 @@ public class StarMgrMetaSyncerTest {
         List<ShardGroupInfo> shardGroupInfos = new ArrayList<>();
         ShardGroupInfo info = ShardGroupInfo.newBuilder()
                 .setGroupId(groupIdToClear)
+                .putLabels("tableId", String.valueOf(tableId))
                 .putProperties("createTime", String.valueOf(System.currentTimeMillis() - 86400 * 1000))
                 .addAllShardIds(allShardIds)
                 .build();


### PR DESCRIPTION
This pr fix several cases which will cause problem:

case 1: In current impl, database deletion in Recycle Bin does not controlled by cluster snapshot. If the database meta was deleted but the table should not be deleted. The StarMgrSyncer will get the wrong shard diff list and delete the table data incorrectly.
Solution: Make sure database deletion was controlled by cluster snapshot.

case 2: StarMgrSyncer::deleteUnusedShardAndShardGroup was not controlled by cluster snapshot which maybe delete the data incorrectly
Solution: Make sure the table owned the group will be controled by cluster snapshot.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0