### PR TITLE
[Enhancement]add Parse "20250225112345" to DateTime(#56339)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DateUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DateUtils.java
@@ -64,6 +64,7 @@ public class DateUtils {
     public static final DateTimeFormatter DATE_TIME_MS_FORMATTER_UNIX = unixDatetimeFormatter("%Y-%m-%d %H:%i:%s.%f");
     public static final DateTimeFormatter SECOND_FORMATTER_UNIX = unixDatetimeFormatter("%Y%m%d%H%i%s");
     public static final DateTimeFormatter MINUTE_FORMATTER_UNIX = unixDatetimeFormatter("%Y%m%d%H%i");
+    public static final DateTimeFormatter DATE_TIME_S_FORMATTER_UNIX = unixDatetimeFormatter("%Y%m%d%H%i%s");
     public static final DateTimeFormatter HOUR_FORMATTER_UNIX = unixDatetimeFormatter("%Y%m%d%H");
     public static final DateTimeFormatter YEAR_FORMATTER_UNIX = unixDatetimeFormatter("%Y");
     public static final DateTimeFormatter MONTH_FORMATTER_UNIX = unixDatetimeFormatter("%Y%m");
@@ -151,6 +152,8 @@ public class DateUtils {
             } else if (str.length() == 8) {
                 // 20200202
                 formatter = STRICT_DATE_NO_SPLIT_FORMATTER;
+            } else if (str.length() == 14) {
+                formatter = DATE_TIME_S_FORMATTER_UNIX;
             } else {
                 formatter = STRICT_DATE_FORMATTER;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/DateUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/DateUtilsTest.java
@@ -79,6 +79,9 @@ public class DateUtilsTest {
                 String datetime3 = "2024-01-27 21:06:01";
                 LocalDateTime lt3 = DateUtils.parseStrictDateTime(datetime3);
                 Assert.assertEquals(lt3.toString(), "2024-01-27T21:06:01");
+                String datetime4 = "20250225112345";
+                LocalDateTime lt4 = DateUtils.parseStrictDateTime(datetime4);
+                Assert.assertEquals(lt4.toString(), "2025-02-25T11:23:45");
             }
 
         } catch (Exception e) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
@@ -63,6 +63,18 @@ public class PartitionUtilTest {
             new Column("k4", Type.INT));
 
     @Test
+    public void testStringPartitionKeyConvertToDatePartitionKey() {
+        try{
+            PartitionKey partitionKey = createPartitionKey(
+                    Lists.newArrayList("1", "20250225112345", "3.0", HiveMetaClient.PARTITION_NULL_VALUE), partColumns);
+            PartitionUtil.convertToDateLiteral(partitionKey.getKeys().get(1));
+        }catch (Exception e){
+            Assert.fail();
+        }
+    }
+
+
+    @Test
     public void testCreatePartitionKey() throws Exception {
         PartitionKey partitionKey = createPartitionKey(
                 Lists.newArrayList("1", "a", "3.0", HiveMetaClient.PARTITION_NULL_VALUE), partColumns);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
@@ -64,15 +64,14 @@ public class PartitionUtilTest {
 
     @Test
     public void testStringPartitionKeyConvertToDatePartitionKey() {
-        try{
+        try {
             PartitionKey partitionKey = createPartitionKey(
                     Lists.newArrayList("1", "20250225112345", "3.0", HiveMetaClient.PARTITION_NULL_VALUE), partColumns);
             PartitionUtil.convertToDateLiteral(partitionKey.getKeys().get(1));
-        }catch (Exception e){
+        } catch (Exception e) {
             Assert.fail();
         }
     }
-
 
     @Test
     public void testCreatePartitionKey() throws Exception {
@@ -288,7 +287,8 @@ public class PartitionUtilTest {
             }
         };
 
-        Map<String, Range<PartitionKey>> partitionMap = PartitionUtil.getPartitionKeyRange(table, partitionColumn, null);
+        Map<String, Range<PartitionKey>> partitionMap =
+                PartitionUtil.getPartitionKeyRange(table, partitionColumn, null);
         Assert.assertEquals(partitionMap.size(), partitionNames.size());
         Assert.assertTrue(partitionMap.containsKey("p20221202"));
         PartitionKey upperBound = new PartitionKey();

--- a/test/sql/test_function/R/test_cast_string_to_datetime
+++ b/test/sql/test_function/R/test_cast_string_to_datetime
@@ -198,7 +198,7 @@ select cast("  20200101 " as datetime);
 -- !result
 select cast("  20200101010203   " as datetime);
 -- result:
-None
+2020-01-01 01:02:03
 -- !result
 select cast("  20200101T010203" as datetime);
 -- result:


### PR DESCRIPTION
## Why I'm doing:
When converting a string type to a time type using the method com.starrocks.common.util.DateUtils#parseStrictDateTime, the method does not handle the format "20250225112345". Therefore, if a string in this format is input, it will cause an exception. It is necessary to add logic in the method com.starrocks.common.util.DateUtils#parseStrictDateTime to handle the format "20250225112345".
## What I'm doing:
add parse "20250225112345" rule
Fixes #issue
https://github.com/StarRocks/starrocks/issues/56339
## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0