### PR TITLE
[BugFix] Set timeout in TCreateTabletReq

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
@@ -107,6 +107,7 @@ public class CreateReplicaTask extends AgentTask {
         this.recoverySource = builder.getRecoverySource();
         this.inRestoreMode = builder.isInRestoreMode();
         this.gtid = builder.getGtid();
+        this.timeoutMs = builder.getTimeoutMs();
     }
 
     public static Builder newBuilder() {
@@ -185,6 +186,7 @@ public class CreateReplicaTask extends AgentTask {
         createTabletReq.setCreate_schema_file(createSchemaFile);
         createTabletReq.setEnable_tablet_creation_optimization(enableTabletCreationOptimization);
         createTabletReq.setGtid(gtid);
+        createTabletReq.setTimeout_ms(timeoutMs);
         return createTabletReq;
     }
 
@@ -214,6 +216,7 @@ public class CreateReplicaTask extends AgentTask {
         private boolean enableTabletCreationOptimization = false;
         private TTabletSchema tabletSchema;
         private long gtid = 0;
+        private long timeoutMs = -1;
 
         private Builder() {
         }
@@ -422,6 +425,15 @@ public class CreateReplicaTask extends AgentTask {
 
         public Builder setGtid(long gtid) {
             this.gtid = gtid;
+            return this;
+        }
+
+        public long getTimeoutMs() {
+            return timeoutMs;
+        }
+
+        public Builder setTimeoutMs(long timeoutMs) {
+            this.timeoutMs = timeoutMs;
             return this;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskTest.java
@@ -147,6 +147,7 @@ public class AgentTaskTest {
                 .setCompressionType(TCompressionType.LZ4_FRAME)
                 .setTabletSchema(tabletSchema)
                 .setEnableTabletCreationOptimization(false)
+                .setTimeoutMs(3600)
                 .build();
 
         // drop
@@ -220,6 +221,8 @@ public class AgentTaskTest {
         Assert.assertEquals(TTaskType.CREATE, request.getTask_type());
         Assert.assertEquals(createReplicaTask.getSignature(), request.getSignature());
         Assert.assertNotNull(request.getCreate_tablet_req());
+        Assert.assertTrue(request.getCreate_tablet_req().isSetTimeout_ms());
+        Assert.assertEquals(3600, request.getCreate_tablet_req().getTimeout_ms());
 
         // drop
         TAgentTaskRequest request2 = (TAgentTaskRequest) toAgentTaskRequest.invoke(agentBatchTask, dropTask);


### PR DESCRIPTION
## Why I'm doing:
In #53696, BE will cancel a create tablet task if the task already timeouts. But FE forgets to set timeout in TCreateTabletReq, so BE does not get a valid timeout, and will never cancel the task. 

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0