### PR TITLE
[Refactor] Abstract a class named CacheEnv to uniformly manage the initialization of the cache

### DIFF
--- a/be/src/cache/block_cache/block_cache.cpp
+++ b/be/src/cache/block_cache/block_cache.cpp
@@ -16,6 +16,8 @@
 
 #include <fmt/format.h>
 
+#include "runtime/exec_env.h"
+
 #ifdef WITH_STARCACHE
 #include "cache/block_cache/starcache_wrapper.h"
 #endif
@@ -31,8 +33,7 @@ namespace fs = std::filesystem;
 const size_t BlockCache::MAX_BLOCK_SIZE = 2 * 1024 * 1024;
 
 BlockCache* BlockCache::instance() {
-    static BlockCache cache;
-    return &cache;
+    return CacheEnv::GetInstance()->block_cache();
 }
 
 BlockCache::~BlockCache() {

--- a/be/src/cache/block_cache/block_cache.h
+++ b/be/src/cache/block_cache/block_cache.h
@@ -30,6 +30,7 @@ public:
     // Return a singleton block cache instance
     static BlockCache* instance();
 
+    BlockCache() = default;
     ~BlockCache();
 
     // Init the block cache instance
@@ -98,9 +99,6 @@ public:
     static const size_t MAX_BLOCK_SIZE;
 
 private:
-#ifndef BE_TEST
-    BlockCache() = default;
-#endif
     void _refresh_quota();
 
     size_t _block_size = 0;

--- a/be/src/cache/object_cache/object_cache.cpp
+++ b/be/src/cache/object_cache/object_cache.cpp
@@ -19,13 +19,9 @@
 #include "cache/object_cache/lrucache_module.h"
 #include "common/logging.h"
 #include "common/statusor.h"
+#include "runtime/exec_env.h"
 
 namespace starrocks {
-
-ObjectCache* ObjectCache::instance() {
-    static ObjectCache cache;
-    return &cache;
-}
 
 ObjectCache::~ObjectCache() {
     (void)shutdown();

--- a/be/src/cache/object_cache/object_cache.h
+++ b/be/src/cache/object_cache/object_cache.h
@@ -26,9 +26,7 @@ namespace starrocks {
 
 class ObjectCache {
 public:
-    // Return a singleton object cache instance.
-    static ObjectCache* instance();
-
+    ObjectCache() = default;
     ~ObjectCache();
 
     // Init the object cache instance with options.

--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -150,6 +150,7 @@ static void failure_handler_after_output_log() {
     static bool start_dump = false;
     if (!start_dump && config::enable_core_file_size_optimization && base::get_cur_core_file_limit() != 0) {
         ExecEnv::GetInstance()->try_release_resource_before_core_dump();
+        CacheEnv::GetInstance()->try_release_resource_before_core_dump();
         dontdump_unused_pages();
     }
     start_dump = true;

--- a/be/src/http/action/datacache_action.h
+++ b/be/src/http/action/datacache_action.h
@@ -31,7 +31,7 @@ namespace starrocks {
 class BlockCache;
 class DataCacheAction : public HttpHandler {
 public:
-    explicit DataCacheAction(ExecEnv* exec_env) : _exec_env(exec_env) {}
+    explicit DataCacheAction(BlockCache* block_cache) : _block_cache(block_cache) {}
     ~DataCacheAction() override = default;
 
     void handle(HttpRequest* req) override;
@@ -39,11 +39,11 @@ public:
 private:
     bool _check_request(HttpRequest* req);
     void _handle(HttpRequest* req, const std::function<void(rapidjson::Document& root)>& func);
-    void _handle_stat(HttpRequest* req, BlockCache* cache);
+    void _handle_stat(HttpRequest* req);
     void _handle_app_stat(HttpRequest* req);
     void _handle_error(HttpRequest* req, const std::string& error_msg);
 
-    ExecEnv* _exec_env;
+    BlockCache* _block_cache;
 };
 
 } // namespace starrocks

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -311,6 +311,197 @@ int64_t GlobalEnv::calc_max_query_memory(int64_t process_mem_limit, int64_t perc
     return process_mem_limit * percent / 100;
 }
 
+bool parse_resource_str(const string& str, string* value) {
+    if (!str.empty()) {
+        std::string tmp_str = str;
+        StripLeadingWhiteSpace(&tmp_str);
+        StripTrailingWhitespace(&tmp_str);
+        if (tmp_str.empty()) {
+            return false;
+        } else {
+            *value = tmp_str;
+            std::transform(value->begin(), value->end(), value->begin(), [](char c) { return std::tolower(c); });
+            return true;
+        }
+    } else {
+        return false;
+    }
+}
+
+CacheEnv* CacheEnv::GetInstance() {
+    static CacheEnv s_cache_env;
+    return &s_cache_env;
+}
+
+Status CacheEnv::init(const std::vector<StorePath>& store_paths) {
+    _global_env = GlobalEnv::GetInstance();
+    _store_paths = store_paths;
+
+    RETURN_IF_ERROR(_init_datacache());
+    RETURN_IF_ERROR(_init_lru_base_object_cache());
+    RETURN_IF_ERROR(_init_page_cache());
+
+    return Status::OK();
+}
+
+void CacheEnv::destroy() {
+    _page_cache.reset();
+    LOG(INFO) << "pagecache shutdown successfully";
+
+    _lru_based_object_cache.reset();
+    LOG(INFO) << "lru based object cache shutdown successfully";
+
+    _block_cache.reset();
+    LOG(INFO) << "datacache shutdown successfully";
+}
+
+Status CacheEnv::_init_lru_base_object_cache() {
+    _lru_based_object_cache = std::make_shared<ObjectCache>();
+
+    ObjectCacheOptions options;
+    int64_t storage_cache_limit = _global_env->get_storage_page_cache_size();
+    storage_cache_limit = _global_env->check_storage_page_cache_size(storage_cache_limit);
+    options.capacity = storage_cache_limit;
+    RETURN_IF_ERROR(_lru_based_object_cache->init(options));
+
+    LOG(INFO) << "object cache init successfully";
+    return Status::OK();
+}
+
+Status CacheEnv::_init_page_cache() {
+    _page_cache = std::make_shared<StoragePageCache>(_lru_based_object_cache.get());
+    _page_cache->init_metrics();
+    LOG(INFO) << "storage page cache init successfully";
+    return Status::OK();
+}
+
+Status CacheEnv::_init_datacache() {
+    _block_cache = std::make_shared<BlockCache>();
+
+    // When configured old `block_cache` configurations, use the old items for compatibility.
+    if (config::block_cache_enable) {
+        config::datacache_enable = true;
+        config::datacache_mem_size = std::to_string(config::block_cache_mem_size);
+        config::datacache_disk_size = std::to_string(config::block_cache_disk_size);
+        config::datacache_block_size = config::block_cache_block_size;
+        config::datacache_max_concurrent_inserts = config::block_cache_max_concurrent_inserts;
+        config::datacache_checksum_enable = config::block_cache_checksum_enable;
+        config::datacache_direct_io_enable = config::block_cache_direct_io_enable;
+        config::datacache_engine = config::block_cache_engine;
+        LOG(WARNING) << "The configuration items prefixed with `block_cache_` will be deprecated soon"
+                     << ", you'd better use the configuration items prefixed `datacache` instead!";
+    }
+
+#if !defined(WITH_STARCACHE)
+    if (config::datacache_enable) {
+        LOG(WARNING) << "No valid engines supported, skip initializing datacache module";
+        config::datacache_enable = false;
+    }
+#endif
+
+    if (config::datacache_enable) {
+        CacheOptions cache_options;
+        int64_t mem_limit = MemInfo::physical_mem();
+        if (_global_env->process_mem_tracker()->has_limit()) {
+            mem_limit = _global_env->process_mem_tracker()->limit();
+        }
+        RETURN_IF_ERROR(DataCacheUtils::parse_conf_datacache_mem_size(config::datacache_mem_size, mem_limit,
+                                                                      &cache_options.mem_space_size));
+
+        size_t total_quota_bytes = 0;
+        for (auto& root_path : _store_paths) {
+            // Because we have unified the datacache between datalake and starlet, we also need to unify the
+            // cache path and quota.
+            // To reuse the old cache data in `starlet_cache` directory, we try to rename it to the new `datacache`
+            // directory if it exists. To avoid the risk of cross disk renaming of a large amount of cached data,
+            // we do not automatically rename it when the source and destination directories are on different disks.
+            // In this case, users should manually remount the directories and restart them.
+            std::string datacache_path = root_path.path + "/datacache";
+            std::string starlet_cache_path = root_path.path + "/starlet_cache/star_cache";
+#ifdef USE_STAROS
+            if (config::datacache_unified_instance_enable) {
+                RETURN_IF_ERROR(DataCacheUtils::change_disk_path(starlet_cache_path, datacache_path));
+            }
+#endif
+            // Create it if not exist
+            Status st = FileSystem::Default()->create_dir_if_missing(datacache_path);
+            if (!st.ok()) {
+                LOG(ERROR) << "Fail to create datacache directory: " << datacache_path << ", reason: " << st.message();
+                return Status::InternalError("Fail to create datacache directory");
+            }
+
+            int64_t disk_size =
+                    DataCacheUtils::parse_conf_datacache_disk_size(datacache_path, config::datacache_disk_size, -1);
+#ifdef USE_STAROS
+            // If the `datacache_disk_size` is manually set a positive value, we will use the maximum cache quota between
+            // dataleke and starlet cache as the quota of the unified cache. Otherwise, the cache quota will remain zero
+            // and then automatically adjusted based on the current avalible disk space.
+            if (config::datacache_unified_instance_enable && (!config::datacache_auto_adjust_enable || disk_size > 0)) {
+                int64_t starlet_cache_size = DataCacheUtils::parse_conf_datacache_disk_size(
+                        datacache_path, fmt::format("{}%", config::starlet_star_cache_disk_size_percent), -1);
+                disk_size = std::max(disk_size, starlet_cache_size);
+            }
+#endif
+            cache_options.disk_spaces.push_back({.path = datacache_path, .size = static_cast<size_t>(disk_size)});
+            total_quota_bytes += disk_size;
+        }
+
+        if (cache_options.disk_spaces.empty() || total_quota_bytes != 0) {
+            config::datacache_auto_adjust_enable = false;
+        }
+
+        // Adjust the default engine based on build switches.
+        if (config::datacache_engine == "") {
+#if defined(WITH_STARCACHE)
+            config::datacache_engine = "starcache";
+#endif
+        }
+        cache_options.block_size = config::datacache_block_size;
+        cache_options.max_flying_memory_mb = config::datacache_max_flying_memory_mb;
+        cache_options.max_concurrent_inserts = config::datacache_max_concurrent_inserts;
+        cache_options.enable_checksum = config::datacache_checksum_enable;
+        cache_options.enable_direct_io = config::datacache_direct_io_enable;
+        cache_options.enable_tiered_cache = config::datacache_tiered_cache_enable;
+        cache_options.skip_read_factor = config::datacache_skip_read_factor;
+        cache_options.scheduler_threads_per_cpu = config::datacache_scheduler_threads_per_cpu;
+        cache_options.enable_datacache_persistence = config::datacache_persistence_enable;
+        cache_options.inline_item_count_limit = config::datacache_inline_item_count_limit;
+        cache_options.engine = config::datacache_engine;
+        cache_options.eviction_policy = config::datacache_eviction_policy;
+        RETURN_IF_ERROR(_block_cache->init(cache_options));
+        LOG(INFO) << "datacache init successfully";
+    } else {
+        LOG(INFO) << "starts by skipping the datacache initialization";
+    }
+    return Status::OK();
+}
+
+void CacheEnv::try_release_resource_before_core_dump() {
+    std::set<std::string> modules;
+    bool release_all = false;
+    if (config::try_release_resource_before_core_dump.value() == "*") {
+        release_all = true;
+    } else {
+        SplitStringAndParseToContainer(StringPiece(config::try_release_resource_before_core_dump), ",",
+                                       &parse_resource_str, &modules);
+    }
+
+    auto need_release = [&release_all, &modules](const std::string& name) {
+        return release_all || modules.contains(name);
+    };
+
+    if (_page_cache != nullptr && need_release("data_cache")) {
+        _page_cache->set_capacity(0);
+        LOG(INFO) << "release storage page cache memory";
+    }
+    if (_block_cache != nullptr && _block_cache->available() && need_release("data_cache")) {
+        // TODO: Currently, block cache don't support shutdown now,
+        //  so here will temporary use update_mem_quota instead to release memory.
+        (void)_block_cache->update_mem_quota(0, false);
+        LOG(INFO) << "release block cache";
+    }
+}
+
 ExecEnv* ExecEnv::GetInstance() {
     static ExecEnv s_exec_env;
     return &s_exec_env;
@@ -576,8 +767,6 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
     auto capacity = std::max<size_t>(config::query_cache_capacity, 4L * 1024 * 1024);
     _cache_mgr = new query_cache::CacheManager(capacity);
 
-    _block_cache = BlockCache::instance();
-
     _spill_dir_mgr = std::make_shared<spill::DirManager>();
     RETURN_IF_ERROR(_spill_dir_mgr->init(config::spill_local_storage_dir));
 
@@ -803,23 +992,6 @@ ThreadPool* ExecEnv::delete_file_thread_pool() {
     return _agent_server ? _agent_server->get_thread_pool(TTaskType::DROP) : nullptr;
 }
 
-bool parse_resource_str(const string& str, string* value) {
-    if (!str.empty()) {
-        std::string tmp_str = str;
-        StripLeadingWhiteSpace(&tmp_str);
-        StripTrailingWhitespace(&tmp_str);
-        if (tmp_str.empty()) {
-            return false;
-        } else {
-            *value = tmp_str;
-            std::transform(value->begin(), value->end(), value->begin(), [](char c) { return std::tolower(c); });
-            return true;
-        }
-    } else {
-        return false;
-    }
-}
-
 void ExecEnv::try_release_resource_before_core_dump() {
     std::set<std::string> modules;
     bool release_all = false;
@@ -866,29 +1038,6 @@ void ExecEnv::try_release_resource_before_core_dump() {
         _workgroup_manager->for_each_executors([](auto& executors) { executors.driver_executor()->close(); });
         LOG(INFO) << "stop worker group driver executor";
     }
-    auto* storage_page_cache = StoragePageCache::instance();
-    if (storage_page_cache != nullptr && need_release("data_cache")) {
-        storage_page_cache->set_capacity(0);
-        LOG(INFO) << "release storage page cache memory";
-    }
-    if (_block_cache != nullptr && _block_cache->available() && need_release("data_cache")) {
-        // TODO: Currently, block cache don't support shutdown now,
-        //  so here will temporary use update_mem_quota instead to release memory.
-        (void)_block_cache->update_mem_quota(0, false);
-        LOG(INFO) << "release block cache";
-    }
-}
-
-Status ExecEnv::init_object_cache(GlobalEnv* global_env) {
-    ObjectCache* object_cache = ObjectCache::instance();
-    if (object_cache->initialized()) {
-        return Status::OK();
-    }
-    ObjectCacheOptions options;
-    int64_t storage_cache_limit = global_env->get_storage_page_cache_size();
-    storage_cache_limit = global_env->check_storage_page_cache_size(storage_cache_limit);
-    options.capacity = storage_cache_limit;
-    return object_cache->init(options);
 }
 
 pipeline::DriverExecutor* ExecEnv::wg_driver_executor() {

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -183,7 +183,7 @@ public:
                                   PProcessDictionaryCacheResult* response, google::protobuf::Closure* done) override;
 
     void fetch_arrow_schema(google::protobuf::RpcController* controller, const PFetchArrowSchemaRequest* request,
-                            PFetchArrowSchemaResult* result, google::protobuf::Closure* done);
+                            PFetchArrowSchemaResult* result, google::protobuf::Closure* done) override;
 
     void stream_load(google::protobuf::RpcController* controller, const PStreamLoadRequest* request,
                      PStreamLoadResponse* response, google::protobuf::Closure* done) override;

--- a/be/src/service/service_be/http_service.cpp
+++ b/be/src/service/service_be/http_service.cpp
@@ -68,8 +68,9 @@
 
 namespace starrocks {
 
-HttpServiceBE::HttpServiceBE(ExecEnv* env, int port, int num_threads)
-        : _env(env),
+HttpServiceBE::HttpServiceBE(CacheEnv* cache_env, ExecEnv* env, int port, int num_threads)
+        : _cache_env(cache_env),
+          _env(env),
           _ev_http_server(new EvHttpServer(port, num_threads)),
           _web_page_handler(new WebPageHandler(_ev_http_server.get())),
           _http_concurrent_limiter(new ConcurrentLimiter(config::be_http_num_workers - 1)) {}
@@ -262,7 +263,7 @@ Status HttpServiceBE::start() {
     _ev_http_server->register_handler(HttpMethod::PUT, "/api/query_cache/{action}", query_cache_action);
     _http_handlers.emplace_back(query_cache_action);
 
-    auto* datacache_action = new DataCacheAction(_env);
+    auto* datacache_action = new DataCacheAction(_cache_env->block_cache());
     _ev_http_server->register_handler(HttpMethod::GET, "/api/datacache/{action}", datacache_action);
     _http_handlers.emplace_back(datacache_action);
 

--- a/be/src/service/service_be/http_service.h
+++ b/be/src/service/service_be/http_service.h
@@ -42,6 +42,7 @@
 namespace starrocks {
 
 class ExecEnv;
+class CacheEnv;
 class EvHttpServer;
 class HttpHandler;
 class WebPageHandler;
@@ -49,7 +50,7 @@ class WebPageHandler;
 // HTTP service for StarRocks BE
 class HttpServiceBE {
 public:
-    HttpServiceBE(ExecEnv* env, int port, int num_threads);
+    HttpServiceBE(CacheEnv* cache_env, ExecEnv* env, int port, int num_threads);
     ~HttpServiceBE();
 
     Status start();
@@ -57,6 +58,7 @@ public:
     void join();
 
 private:
+    CacheEnv* _cache_env;
     ExecEnv* _env;
 
     std::unique_ptr<EvHttpServer> _ev_http_server;

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -57,104 +57,6 @@ DECLARE_bool(socket_keepalive);
 
 namespace starrocks {
 
-Status init_datacache(GlobalEnv* global_env, const std::vector<StorePath>& storage_paths) {
-    // When configured old `block_cache` configurations, use the old items for compatibility.
-    if (config::block_cache_enable) {
-        config::datacache_enable = true;
-        config::datacache_mem_size = std::to_string(config::block_cache_mem_size);
-        config::datacache_disk_size = std::to_string(config::block_cache_disk_size);
-        config::datacache_block_size = config::block_cache_block_size;
-        config::datacache_max_concurrent_inserts = config::block_cache_max_concurrent_inserts;
-        config::datacache_checksum_enable = config::block_cache_checksum_enable;
-        config::datacache_direct_io_enable = config::block_cache_direct_io_enable;
-        config::datacache_engine = config::block_cache_engine;
-        LOG(WARNING) << "The configuration items prefixed with `block_cache_` will be deprecated soon"
-                     << ", you'd better use the configuration items prefixed `datacache` instead!";
-    }
-
-#if !defined(WITH_STARCACHE)
-    if (config::datacache_enable) {
-        LOG(WARNING) << "No valid engines supported, skip initializing datacache module";
-        config::datacache_enable = false;
-    }
-#endif
-
-    if (config::datacache_enable) {
-        BlockCache* cache = BlockCache::instance();
-
-        CacheOptions cache_options;
-        int64_t mem_limit = MemInfo::physical_mem();
-        if (global_env->process_mem_tracker()->has_limit()) {
-            mem_limit = global_env->process_mem_tracker()->limit();
-        }
-        RETURN_IF_ERROR(DataCacheUtils::parse_conf_datacache_mem_size(config::datacache_mem_size, mem_limit,
-                                                                      &cache_options.mem_space_size));
-
-        size_t total_quota_bytes = 0;
-        for (auto& root_path : storage_paths) {
-            // Because we have unified the datacache between datalake and starlet, we also need to unify the
-            // cache path and quota.
-            // To reuse the old cache data in `starlet_cache` directory, we try to rename it to the new `datacache`
-            // directory if it exists. To avoid the risk of cross disk renaming of a large amount of cached data,
-            // we do not automatically rename it when the source and destination directories are on different disks.
-            // In this case, users should manually remount the directories and restart them.
-            std::string datacache_path = root_path.path + "/datacache";
-            std::string starlet_cache_path = root_path.path + "/starlet_cache/star_cache";
-#ifdef USE_STAROS
-            if (config::datacache_unified_instance_enable) {
-                RETURN_IF_ERROR(DataCacheUtils::change_disk_path(starlet_cache_path, datacache_path));
-            }
-#endif
-            // Create it if not exist
-            Status st = FileSystem::Default()->create_dir_if_missing(datacache_path);
-            if (!st.ok()) {
-                LOG(ERROR) << "Fail to create datacache directory: " << datacache_path << ", reason: " << st.message();
-                return Status::InternalError("Fail to create datacache directory");
-            }
-
-            int64_t disk_size =
-                    DataCacheUtils::parse_conf_datacache_disk_size(datacache_path, config::datacache_disk_size, -1);
-#ifdef USE_STAROS
-            // If the `datacache_disk_size` is manually set a positive value, we will use the maximum cache quota between
-            // dataleke and starlet cache as the quota of the unified cache. Otherwise, the cache quota will remain zero
-            // and then automatically adjusted based on the current avalible disk space.
-            if (config::datacache_unified_instance_enable && (!config::datacache_auto_adjust_enable || disk_size > 0)) {
-                int64_t starlet_cache_size = DataCacheUtils::parse_conf_datacache_disk_size(
-                        datacache_path, fmt::format("{}%", config::starlet_star_cache_disk_size_percent), -1);
-                disk_size = std::max(disk_size, starlet_cache_size);
-            }
-#endif
-            cache_options.disk_spaces.push_back({.path = datacache_path, .size = static_cast<size_t>(disk_size)});
-            total_quota_bytes += disk_size;
-        }
-
-        if (cache_options.disk_spaces.empty() || total_quota_bytes != 0) {
-            config::datacache_auto_adjust_enable = false;
-        }
-
-        // Adjust the default engine based on build switches.
-        if (config::datacache_engine == "") {
-#if defined(WITH_STARCACHE)
-            config::datacache_engine = "starcache";
-#endif
-        }
-        cache_options.block_size = config::datacache_block_size;
-        cache_options.max_flying_memory_mb = config::datacache_max_flying_memory_mb;
-        cache_options.max_concurrent_inserts = config::datacache_max_concurrent_inserts;
-        cache_options.enable_checksum = config::datacache_checksum_enable;
-        cache_options.enable_direct_io = config::datacache_direct_io_enable;
-        cache_options.enable_tiered_cache = config::datacache_tiered_cache_enable;
-        cache_options.skip_read_factor = config::datacache_skip_read_factor;
-        cache_options.scheduler_threads_per_cpu = config::datacache_scheduler_threads_per_cpu;
-        cache_options.enable_datacache_persistence = config::datacache_persistence_enable;
-        cache_options.inline_item_count_limit = config::datacache_inline_item_count_limit;
-        cache_options.engine = config::datacache_engine;
-        cache_options.eviction_policy = config::datacache_eviction_policy;
-        return cache->init(cache_options);
-    }
-    return Status::OK();
-}
-
 StorageEngine* init_storage_engine(GlobalEnv* global_env, std::vector<StorePath> paths, bool as_cn) {
     // Init and open storage engine.
     EngineOptions options;
@@ -201,6 +103,10 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     CHECK(global_vars->is_init()) << "global variables not initialized";
     LOG(INFO) << process_name << " start step " << start_step++ << ": global variables init successfully";
 
+    auto* cache_env = CacheEnv::GetInstance();
+    EXIT_IF_ERROR(cache_env->init(paths));
+    LOG(INFO) << process_name << " start step " << start_step++ << ": cache env init successfully";
+
     auto* storage_engine = init_storage_engine(global_env, paths, as_cn);
     LOG(INFO) << process_name << " start step " << start_step++ << ": storage engine init successfully";
 
@@ -213,25 +119,8 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     EXIT_IF_ERROR(storage_engine->start_bg_threads());
     LOG(INFO) << process_name << " start step " << start_step++ << ": storage engine start bg threads successfully";
 
-    if (!init_datacache(global_env, paths).ok()) {
-        LOG(ERROR) << "Fail to init datacache";
-        exit(1);
-    }
-    if (config::datacache_enable) {
-        LOG(INFO) << process_name << " start step " << start_step++ << ": datacache init successfully";
-    } else {
-        LOG(INFO) << process_name << " starts by skipping the datacache initialization";
-    }
-
-    EXIT_IF_ERROR(ExecEnv::init_object_cache(global_env));
-    LOG(INFO) << process_name << " start step " << start_step++ << ": object cache init successfully";
-
-    // Init storage page cache.
-    StoragePageCache::create_global_cache(ObjectCache::instance());
-    LOG(INFO) << process_name << " start step " << start_step++ << ": storage page cache init successfully";
-
 #ifdef USE_STAROS
-    BlockCache* block_cache = BlockCache::instance();
+    auto* block_cache = cache_env->block_cache();
     if (config::datacache_unified_instance_enable && block_cache->is_initialized()) {
         init_staros_worker(block_cache->starcache_instance());
     } else {
@@ -304,7 +193,8 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     LOG(INFO) << process_name << " start step " << start_step++ << ": start brpc server successfully";
 
     // Start HTTP server
-    auto http_server = std::make_unique<HttpServiceBE>(exec_env, config::be_http_port, config::be_http_num_workers);
+    auto http_server =
+            std::make_unique<HttpServiceBE>(cache_env, exec_env, config::be_http_port, config::be_http_num_workers);
     if (auto status = http_server->start(); !status.ok()) {
         LOG(ERROR) << process_name << " http server did not start correctly, exiting: " << status.message();
         shutdown_logging();
@@ -383,13 +273,6 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     LOG(INFO) << process_name << " exit step " << exit_step++ << ": staros worker exit successfully";
 #endif
 
-#if defined(WITH_STARCACHE)
-    if (config::datacache_enable) {
-        (void)BlockCache::instance()->shutdown();
-        LOG(INFO) << process_name << " exit step " << exit_step++ << ": datacache shutdown successfully";
-    }
-#endif
-
     if (config::enable_poco_client_for_aws_sdk) {
         starrocks::poco::HTTPSessionPools::instance().shutdown();
         LOG(INFO) << process_name << " exit step " << exit_step++ << ": poco connection pool shutdown successfully";
@@ -411,6 +294,9 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     LOG(INFO) << process_name << " exit step " << exit_step++ << ": exec env destroy successfully";
 
     delete storage_engine;
+
+    cache_env->destroy();
+    LOG(ERROR) << process_name << " exit step " << exit_step++ << ": cache env destroy successfully";
 
     // Unbind with MemTracker
     tls_mem_tracker = nullptr;

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -103,12 +103,12 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     CHECK(global_vars->is_init()) << "global variables not initialized";
     LOG(INFO) << process_name << " start step " << start_step++ << ": global variables init successfully";
 
+    auto* storage_engine = init_storage_engine(global_env, paths, as_cn);
+    LOG(INFO) << process_name << " start step " << start_step++ << ": storage engine init successfully";
+
     auto* cache_env = CacheEnv::GetInstance();
     EXIT_IF_ERROR(cache_env->init(paths));
     LOG(INFO) << process_name << " start step " << start_step++ << ": cache env init successfully";
-
-    auto* storage_engine = init_storage_engine(global_env, paths, as_cn);
-    LOG(INFO) << process_name << " start step " << start_step++ << ": storage engine init successfully";
 
     auto* exec_env = ExecEnv::GetInstance();
     EXIT_IF_ERROR(exec_env->init(paths, as_cn));

--- a/be/src/storage/page_cache.cpp
+++ b/be/src/storage/page_cache.cpp
@@ -49,37 +49,18 @@ METRIC_DEFINE_UINT_GAUGE(page_cache_lookup_count, MetricUnit::OPERATIONS);
 METRIC_DEFINE_UINT_GAUGE(page_cache_hit_count, MetricUnit::OPERATIONS);
 METRIC_DEFINE_UINT_GAUGE(page_cache_capacity, MetricUnit::BYTES);
 
-StoragePageCache* StoragePageCache::_s_instance = nullptr;
-
-static void init_metrics() {
+void StoragePageCache::init_metrics() {
     StarRocksMetrics::instance()->metrics()->register_metric("page_cache_lookup_count", &page_cache_lookup_count);
-    StarRocksMetrics::instance()->metrics()->register_hook("page_cache_lookup_count", []() {
-        page_cache_lookup_count.set_value(StoragePageCache::instance()->get_lookup_count());
-    });
+    StarRocksMetrics::instance()->metrics()->register_hook(
+            "page_cache_lookup_count", [this]() { page_cache_lookup_count.set_value(get_lookup_count()); });
 
     StarRocksMetrics::instance()->metrics()->register_metric("page_cache_hit_count", &page_cache_hit_count);
-    StarRocksMetrics::instance()->metrics()->register_hook("page_cache_hit_count", []() {
-        page_cache_hit_count.set_value(StoragePageCache::instance()->get_hit_count());
-    });
+    StarRocksMetrics::instance()->metrics()->register_hook(
+            "page_cache_hit_count", [this]() { page_cache_hit_count.set_value(get_hit_count()); });
 
     StarRocksMetrics::instance()->metrics()->register_metric("page_cache_capacity", &page_cache_capacity);
-    StarRocksMetrics::instance()->metrics()->register_hook("page_cache_capacity", []() {
-        page_cache_capacity.set_value(StoragePageCache::instance()->get_capacity());
-    });
-}
-
-void StoragePageCache::create_global_cache(ObjectCache* obj_cache) {
-    if (_s_instance == nullptr) {
-        _s_instance = new StoragePageCache(obj_cache);
-        init_metrics();
-    }
-}
-
-void StoragePageCache::release_global_cache() {
-    if (_s_instance != nullptr) {
-        delete _s_instance;
-        _s_instance = nullptr;
-    }
+    StarRocksMetrics::instance()->metrics()->register_hook("page_cache_capacity",
+                                                           [this]() { page_cache_capacity.set_value(get_capacity()); });
 }
 
 void StoragePageCache::prune() {

--- a/be/src/storage/page_cache.h
+++ b/be/src/storage/page_cache.h
@@ -77,14 +77,11 @@ public:
         }
     };
 
-    // Create global instance of this class
-    static void create_global_cache(ObjectCache* obj_cache);
-
-    static void release_global_cache();
+    void init_metrics();
 
     // Return global instance.
     // Client should call create_global_cache before.
-    static StoragePageCache* instance() { return _s_instance; }
+    static StoragePageCache* instance() { return CacheEnv::GetInstance()->page_cache(); }
 
     StoragePageCache(ObjectCache* obj_cache) : _cache(obj_cache) {}
 
@@ -119,8 +116,6 @@ public:
     void prune();
 
 private:
-    static StoragePageCache* _s_instance;
-
     ObjectCache* _cache = nullptr;
 };
 

--- a/be/src/testutil/init_test_env.h
+++ b/be/src/testutil/init_test_env.h
@@ -102,8 +102,8 @@ int init_test_env(int argc, char** argv) {
     // initialization. If there are test cases that require Pagecache, it must be responsible
     // for managing it.
     auto* cache_env = CacheEnv::GetInstance();
-    std::vector<StorePath> datacache_paths;
-    st = cache_env->init(datacache_paths);
+    config::datacache_enable = false;
+    st = cache_env->init(paths);
     CHECK(st.ok()) << st;
 
     auto* exec_env = ExecEnv::GetInstance();

--- a/be/src/testutil/init_test_env.h
+++ b/be/src/testutil/init_test_env.h
@@ -102,7 +102,8 @@ int init_test_env(int argc, char** argv) {
     // initialization. If there are test cases that require Pagecache, it must be responsible
     // for managing it.
     auto* cache_env = CacheEnv::GetInstance();
-    st = cache_env->init(paths);
+    std::vector<StorePath> datacache_paths;
+    st = cache_env->init(datacache_paths);
     CHECK(st.ok()) << st;
 
     auto* exec_env = ExecEnv::GetInstance();

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -409,7 +409,7 @@ public:
     pipeline::PipelineExecutorMetrics* get_pipeline_executor_metrics() { return &pipeline_executor_metrics; }
 
 private:
-    // Don't allow constrctor
+    // Don't allow constructor
     StarRocksMetrics();
 
     void _update();

--- a/be/test/storage/lake/tablet_writer_test.cpp
+++ b/be/test/storage/lake/tablet_writer_test.cpp
@@ -343,7 +343,6 @@ TEST_P(LakeTabletWriterTest, test_write_sdk) {
 
     Tablet tablet(_tablet_mgr.get(), next_id(), provider, _tablet_metadata);
     auto meta_location = tablet.metadata_location(0);
-    auto column_size = tablet.get_schema()->get()->num_columns();
     auto txn_log_location = tablet.txn_log_location(0);
     auto txn_vlog_location = tablet.txn_vlog_location(0);
     auto test_segment_location = tablet.segment_location("test_segment");


### PR DESCRIPTION
## Why I'm doing:

Later, we will implement some functions related to cache compatibility, cache unification, and adjustment of memory allocation for different caches. To facilitate management, we will abstract a class named `CacheEnv` to uniformly manage the initialization of the cache.

## What I'm doing:

Abstract a class named `CacheEnv` to uniformly manage the initialization of the cache.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0