### PR TITLE
[BugFix] fix concat_ws(',', 1, NULL) incorrect result when last element is NULL

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -77,10 +77,12 @@ import java.time.temporal.ChronoUnit;
 import java.time.temporal.IsoFields;
 import java.time.temporal.TemporalAdjusters;
 import java.time.temporal.TemporalUnit;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.starrocks.catalog.PrimitiveType.BIGINT;
 import static com.starrocks.catalog.PrimitiveType.BITMAP;
@@ -1298,20 +1300,12 @@ public class ScalarOperatorFunctions {
             return ConstantOperator.createNull(Type.VARCHAR);
         }
         String separator = split.getVarchar();
-        final StringBuilder resultBuilder = new StringBuilder();
-        boolean first = true;
-        for (ConstantOperator value : values) {
-            if (value.isNull()) {
-                continue;
-            }
-            if (first) {
-                first = false;
-            } else {
-                resultBuilder.append(separator);
-            }
-            resultBuilder.append(value.getVarchar());
-        }
-        return ConstantOperator.createVarchar(resultBuilder.toString());
+        return ConstantOperator.createVarchar(
+                Arrays.stream(values)
+                        .filter(v -> !v.isNull())
+                        .map(ConstantOperator::getVarchar)
+                        .collect(Collectors.joining(separator))
+        );
     }
 
     @ConstantFunction(name = "version", argTypes = {}, returnType = VARCHAR)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -1297,14 +1297,20 @@ public class ScalarOperatorFunctions {
         if (split.isNull()) {
             return ConstantOperator.createNull(Type.VARCHAR);
         }
+        String separator = split.getVarchar();
         final StringBuilder resultBuilder = new StringBuilder();
-        for (int i = 0; i < values.length - 1; i++) {
-            if (values[i].isNull()) {
+        boolean first = true;
+        for (ConstantOperator value : values) {
+            if (value.isNull()) {
                 continue;
             }
-            resultBuilder.append(values[i].getVarchar()).append(split.getVarchar());
+            if (first) {
+                first = false;
+            } else {
+                resultBuilder.append(separator);
+            }
+            resultBuilder.append(value.getVarchar());
         }
-        resultBuilder.append(values[values.length - 1].getVarchar());
         return ConstantOperator.createVarchar(resultBuilder.toString());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -1322,22 +1322,42 @@ public class ScalarOperatorFunctionsTest {
 
     @Test
     public void concat_ws_with_null() {
-        ConstantOperator[] argWithNull = {ConstantOperator.createVarchar("star"),
-                ConstantOperator.createNull(Type.VARCHAR),
-                ConstantOperator.createVarchar("cks")};
-        ConstantOperator result =
-                ScalarOperatorFunctions.concat_ws(ConstantOperator.createVarchar("ro"), argWithNull);
-        assertEquals(Type.VARCHAR, result.getType());
-        assertEquals("starrocks", result.getVarchar());
+        {
+            ConstantOperator[] argWithNull = {ConstantOperator.createVarchar("star"),
+                    ConstantOperator.createNull(Type.VARCHAR),
+                    ConstantOperator.createVarchar("cks")};
+            ConstantOperator result =
+                    ScalarOperatorFunctions.concat_ws(ConstantOperator.createVarchar("ro"), argWithNull);
+            assertEquals(Type.VARCHAR, result.getType());
+            assertEquals("starrocks", result.getVarchar());
+        }
+        {
+            ConstantOperator[] argWithNull = {ConstantOperator.createVarchar("1"),
+                    ConstantOperator.createNull(Type.VARCHAR)};
+            ConstantOperator result =
+                    ScalarOperatorFunctions.concat_ws(ConstantOperator.createVarchar(","), argWithNull);
+            assertEquals(Type.VARCHAR, result.getType());
+            assertEquals("1", result.getVarchar());
+        }
+        {
+            ConstantOperator[] argWithNull = {ConstantOperator.createVarchar("1"),
+                    ConstantOperator.createNull(Type.VARCHAR),
+                    ConstantOperator.createNull(Type.VARCHAR)};
+            ConstantOperator result =
+                    ScalarOperatorFunctions.concat_ws(ConstantOperator.createVarchar(","), argWithNull);
+            assertEquals(Type.VARCHAR, result.getType());
+            assertEquals("1", result.getVarchar());
+        }
+        {
+            ConstantOperator result = ScalarOperatorFunctions.concat_ws(ConstantOperator.createVarchar(","),
+                    ConstantOperator.createNull(Type.VARCHAR));
+            assertEquals("", result.getVarchar());
 
-        result = ScalarOperatorFunctions.concat_ws(ConstantOperator.createVarchar(","),
-                ConstantOperator.createNull(Type.VARCHAR));
-        assertEquals("", result.getVarchar());
-
-        ConstantOperator[] argWithoutNull = {ConstantOperator.createVarchar("star"),
-                ConstantOperator.createVarchar("cks")};
-        result = ScalarOperatorFunctions.concat_ws(ConstantOperator.createNull(Type.VARCHAR), argWithoutNull);
-        assertTrue(result.isNull());
+            ConstantOperator[] argWithoutNull = {ConstantOperator.createVarchar("star"),
+                    ConstantOperator.createVarchar("cks")};
+            result = ScalarOperatorFunctions.concat_ws(ConstantOperator.createNull(Type.VARCHAR), argWithoutNull);
+            assertTrue(result.isNull());
+        }
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
`concat_ws(',', 1, NULL)` is `1,`
the correct result should be `1`
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0