### PR TITLE
[Feature] Support Iceberg jdbc Catalog

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -949,6 +949,11 @@ under the License.
             <artifactId>mssql-jdbc</artifactId>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/com.mysql/mysql-connector-j -->
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/com.mockrunner/mockrunner-jdbc -->
         <dependency>
             <groupId>com.mockrunner</groupId>

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalogType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalogType.java
@@ -21,6 +21,8 @@ public enum IcebergCatalogType {
     GLUE_CATALOG,
     REST_CATALOG,
     HADOOP_CATALOG,
+    JDBC_CATALOG,
+
     UNKNOWN;
     // TODO: add more iceberg catalog type
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
@@ -26,6 +26,7 @@ import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.glue.IcebergGlueCatalog;
 import com.starrocks.connector.iceberg.hadoop.IcebergHadoopCatalog;
 import com.starrocks.connector.iceberg.hive.IcebergHiveCatalog;
+import com.starrocks.connector.iceberg.jdbc.IcebergJdbcCatalog;
 import com.starrocks.connector.iceberg.rest.IcebergRESTCatalog;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationFactory;
@@ -83,6 +84,8 @@ public class IcebergConnector implements Connector {
                 return new IcebergRESTCatalog(catalogName, conf, properties);
             case HADOOP_CATALOG:
                 return new IcebergHadoopCatalog(catalogName, conf, properties);
+            case JDBC_CATALOG:
+                return new IcebergJdbcCatalog(catalogName, conf, properties);
             default:
                 throw new StarRocksConnectorException("Property %s is missing or not supported now.", ICEBERG_CATALOG_TYPE);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/jdbc/IcebergJdbcCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/jdbc/IcebergJdbcCatalog.java
@@ -79,7 +79,7 @@ public class IcebergJdbcCatalog implements IcebergCatalog {
         }
 
         if (!copiedProperties.containsKey(CatalogProperties.URI)) {
-            throw new IllegalArgumentException(String.format("Iceberg jdbc catalog must set uri  (\"%s\" = \"jdbc:mysql://host:port/db_name\").",
+            throw new IllegalArgumentException(String.format("Iceberg jdbc catalog must set uri  (\"%s\" = \"jdbc:[mysql|postgresql]://host:port/db_name\").",
                     ICEBERG_CUSTOM_PROPERTIES_PREFIX + CatalogProperties.URI));
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/jdbc/IcebergJdbcCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/jdbc/IcebergJdbcCatalog.java
@@ -1,0 +1,224 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg.jdbc;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Database;
+import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.iceberg.IcebergCatalog;
+import com.starrocks.connector.iceberg.IcebergCatalogType;
+import com.starrocks.connector.iceberg.cost.IcebergMetricsReporter;
+import com.starrocks.connector.iceberg.io.IcebergCachingFileIO;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.jdbc.JdbcCatalog;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.starrocks.connector.ConnectorTableId.CONNECTOR_ID_GENERATOR;
+import static com.starrocks.connector.iceberg.IcebergCatalogProperties.ICEBERG_CUSTOM_PROPERTIES_PREFIX;
+import static com.starrocks.connector.iceberg.IcebergMetadata.LOCATION_PROPERTY;
+import static org.apache.iceberg.CatalogProperties.WAREHOUSE_LOCATION;
+
+public class IcebergJdbcCatalog implements IcebergCatalog {
+    private static final Logger LOG = LogManager.getLogger(IcebergJdbcCatalog.class);
+
+    private final Configuration conf;
+    private final JdbcCatalog delegate;
+
+    @VisibleForTesting
+    public IcebergJdbcCatalog(String name, Configuration conf, Map<String, String> properties) {
+        this.conf = conf;
+
+        Map<String, String> copiedProperties = Maps.newHashMap(properties);
+        properties.forEach((key, value) -> {
+            String newKey = key.toLowerCase();
+            if (newKey.startsWith(ICEBERG_CUSTOM_PROPERTIES_PREFIX)) {
+                newKey = newKey.substring(ICEBERG_CUSTOM_PROPERTIES_PREFIX.length());
+                copiedProperties.put(newKey, value);
+            }
+        });
+
+        copiedProperties.put(CatalogProperties.FILE_IO_IMPL, IcebergCachingFileIO.class.getName());
+        copiedProperties.put(CatalogProperties.METRICS_REPORTER_IMPL, IcebergMetricsReporter.class.getName());
+
+        // init catalog tables set default value false
+        if (!copiedProperties.containsKey(JdbcCatalog.PROPERTY_PREFIX + "init-catalog-tables")) {
+            copiedProperties.put(JdbcCatalog.PROPERTY_PREFIX + "init-catalog-tables", "false");
+        }
+
+        if (!copiedProperties.containsKey(CatalogProperties.URI)) {
+            throw new IllegalArgumentException(String.format("Iceberg jdbc catalog must set uri  (\"%s\" = \"jdbc:mysql://host:port/db_name\").",
+                    ICEBERG_CUSTOM_PROPERTIES_PREFIX + CatalogProperties.URI));
+        }
+
+        if (!copiedProperties.containsKey(WAREHOUSE_LOCATION)) {
+            throw new IllegalArgumentException(String.format("Iceberg jdbc catalog must set warehouse location (\"%s\" = \"s3://path/to/warehouse\").",
+                    ICEBERG_CUSTOM_PROPERTIES_PREFIX + WAREHOUSE_LOCATION));
+        }
+
+        this.delegate = (JdbcCatalog) CatalogUtil.loadCatalog(JdbcCatalog.class.getName(), name, copiedProperties, conf);
+
+    }
+
+
+    @Override
+    public IcebergCatalogType getIcebergCatalogType() {
+        return IcebergCatalogType.JDBC_CATALOG;
+    }
+
+    @Override
+    public Table getTable(String dbName, String tableName) throws StarRocksConnectorException {
+        return delegate.loadTable(TableIdentifier.of(dbName, tableName));
+    }
+
+    @Override
+    public boolean tableExists(String dbName, String tableName) throws StarRocksConnectorException {
+        return delegate.tableExists(TableIdentifier.of(dbName, tableName));
+    }
+
+    @Override
+    public List<String> listAllDatabases() {
+        return delegate.listNamespaces().stream()
+                .map(ns -> ns.level(0))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void createDB(String dbName, Map<String, String> properties) {
+        properties = properties == null ? new HashMap<>() : properties;
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            if (key.equalsIgnoreCase(LOCATION_PROPERTY)) {
+                try {
+                    URI uri = new Path(value).toUri();
+                    FileSystem fileSystem = FileSystem.get(uri, conf);
+                    fileSystem.exists(new Path(value));
+                } catch (Exception e) {
+                    LOG.error("Invalid location URI: {}", value, e);
+                    throw new StarRocksConnectorException("Invalid location URI: %s. msg: %s", value, e.getMessage());
+                }
+            } else {
+                throw new IllegalArgumentException("Unrecognized property: " + key);
+            }
+        }
+        Namespace ns = Namespace.of(dbName);
+        delegate.createNamespace(ns, properties);
+    }
+
+    @Override
+    public void dropDB(String dbName) throws MetaNotFoundException {
+        Database database;
+        try {
+            database = getDB(dbName);
+        } catch (Exception e) {
+            LOG.error("Failed to access database {}", dbName, e);
+            throw new MetaNotFoundException("Failed to access database " + dbName);
+        }
+
+        if (database == null) {
+            throw new MetaNotFoundException("Not found database " + dbName);
+        }
+
+        String dbLocation = database.getLocation();
+        if (Strings.isNullOrEmpty(dbLocation)) {
+            throw new MetaNotFoundException("Database location is empty");
+        }
+
+        delegate.dropNamespace(Namespace.of(dbName));
+    }
+
+    @Override
+    public Database getDB(String dbName) {
+        Map<String, String> dbMeta = delegate.loadNamespaceMetadata(Namespace.of(dbName));
+        Preconditions.checkNotNull(dbMeta.get(LOCATION_PROPERTY), "Database " + dbName + " doesn't exist location");
+        return new Database(CONNECTOR_ID_GENERATOR.getNextId().asInt(), dbName, dbMeta.get(LOCATION_PROPERTY));
+    }
+
+    @Override
+    public List<String> listTables(String dbName) {
+        List<TableIdentifier> tableIdentifiers = delegate.listTables(Namespace.of(dbName));
+        return tableIdentifiers.stream().map(TableIdentifier::name).collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    @Override
+    public boolean createTable(
+            String dbName,
+            String tableName,
+            Schema schema,
+            PartitionSpec partitionSpec,
+            String location,
+            Map<String, String> properties) {
+        Table nativeTable = delegate.buildTable(TableIdentifier.of(dbName, tableName), schema)
+                .withLocation(location)
+                .withPartitionSpec(partitionSpec)
+                .withProperties(properties)
+                .create();
+
+        return nativeTable != null;
+    }
+
+    @Override
+    public boolean dropTable(String dbName, String tableName, boolean purge) {
+        return delegate.dropTable(TableIdentifier.of(dbName, tableName), purge);
+    }
+
+    @Override
+    public void renameTable(String dbName, String tblName, String newTblName) throws StarRocksConnectorException {
+        delegate.renameTable(TableIdentifier.of(dbName, tblName), TableIdentifier.of(dbName, newTblName));
+    }
+
+    @Override
+    public void deleteUncommittedDataFiles(List<String> fileLocations) {
+        if (fileLocations.isEmpty()) {
+            return;
+        }
+
+        URI uri = new Path(fileLocations.get(0)).toUri();
+        try {
+            FileSystem fileSystem = FileSystem.get(uri, conf);
+            for (String location : fileLocations) {
+                Path path = new Path(location);
+                fileSystem.delete(path, false);
+            }
+        } catch (Exception e) {
+            LOG.error("Failed to delete uncommitted files", e);
+        }
+    }
+
+    public String toString() {
+        return delegate.toString();
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergJdbcCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergJdbcCatalogTest.java
@@ -12,49 +12,75 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector.iceberg;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Database;
+import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.jdbc.IcebergJdbcCatalog;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.BaseMetastoreTableOperations;
+import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.jdbc.JdbcCatalog;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 
 import static com.starrocks.connector.iceberg.IcebergCatalogProperties.ICEBERG_CUSTOM_PROPERTIES_PREFIX;
+import static com.starrocks.connector.iceberg.IcebergMetadata.LOCATION_PROPERTY;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class IcebergJdbcCatalogTest {
-    @Test
-    public void testNewIcebergJdbcCatalog(@Mocked JdbcCatalog jdbcCatalog)  {
-        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new IcebergJdbcCatalog("catalog",
-                new Configuration(), ImmutableMap.of("iceberg.catalog.warehouse", "s3://path/to/warehouse")));
-        assertEquals(e.getMessage(), String.format("Iceberg jdbc catalog must set uri  (\"%s\" = \"jdbc:mysql://host:port/db_name\").",
-                ICEBERG_CUSTOM_PROPERTIES_PREFIX + CatalogProperties.URI));
 
-        IllegalArgumentException e1 = assertThrows(IllegalArgumentException.class, () -> new IcebergJdbcCatalog("catalog",
-                new Configuration(), ImmutableMap.of("iceberg.catalog.uri", "jdbc:mysql://host:port/db_name")));
+    private static String LOCATION = "s3://path/to/warehouse";
+    private static String URI = "jdbc:mysql://host:port/db_name";
+
+    @Test
+    public void testNewIcebergJdbcCatalog(@Mocked JdbcCatalog jdbcCatalog) {
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> new IcebergJdbcCatalog("catalog",
+                        new Configuration(), ImmutableMap.of("iceberg.catalog.warehouse", LOCATION)));
+        assertEquals(e.getMessage(),
+                String.format("Iceberg jdbc catalog must set uri  (\"%s\" = \"jdbc:mysql://host:port/db_name\").",
+                        ICEBERG_CUSTOM_PROPERTIES_PREFIX + CatalogProperties.URI));
+
+        IllegalArgumentException e1 =
+                assertThrows(IllegalArgumentException.class, () -> new IcebergJdbcCatalog("catalog",
+                        new Configuration(), ImmutableMap.of("iceberg.catalog.uri", URI)));
         assertEquals(e1.getMessage(), "Iceberg jdbc catalog must set warehouse location " +
                 "(\"iceberg.catalog.warehouse\" = \"s3://path/to/warehouse\").");
 
         assertDoesNotThrow(() -> new IcebergJdbcCatalog("catalog", new Configuration(),
-                ImmutableMap.of("iceberg.catalog.warehouse", "s3://path/to/warehouse",
-                        "iceberg.catalog.uri", "jdbc:mysql://host:port/db_name")));
+                ImmutableMap.of("iceberg.catalog.warehouse", LOCATION,
+                        "iceberg.catalog.uri", URI)));
     }
 
+    @Test
+    public void testGetIcebergCatalogType(@Mocked JdbcCatalog jdbcCatalog) {
+        IcebergJdbcCatalog icebergJdbcCatalog = new IcebergJdbcCatalog("catalog", new Configuration(),
+                ImmutableMap.of("iceberg.catalog.warehouse", LOCATION,
+                        "iceberg.catalog.uri", URI));
+
+        assertEquals(IcebergCatalogType.JDBC_CATALOG, icebergJdbcCatalog.getIcebergCatalogType());
+    }
 
     @Test
     public void testListAllDatabases(@Mocked JdbcCatalog jdbcCatalog) {
@@ -67,10 +93,118 @@ public class IcebergJdbcCatalogTest {
         };
 
         IcebergJdbcCatalog icebergJdbcCatalog = new IcebergJdbcCatalog("catalog",
-                new Configuration(), ImmutableMap.of("iceberg.catalog.warehouse", "s3://path/to/warehouse",
-                "iceberg.catalog.uri", "jdbc:mysql://host:port/db_name"));
+                new Configuration(), ImmutableMap.of("iceberg.catalog.warehouse", LOCATION,
+                "iceberg.catalog.uri", URI));
         List<String> dbs = icebergJdbcCatalog.listAllDatabases();
         assertEquals(Arrays.asList("db1", "db2"), dbs);
+    }
+
+    @Test
+    public void testNormalCreateAndDropDBTable(@Mocked JdbcCatalog jdbcCatalog)
+            throws MetaNotFoundException {
+        new Expectations() {
+            {
+                jdbcCatalog.loadNamespaceMetadata(Namespace.of("db"));
+                result = ImmutableMap.of(LOCATION_PROPERTY, LOCATION);
+                minTimes = 0;
+
+                jdbcCatalog.dropNamespace(Namespace.of("db"));
+                result = true;
+                minTimes = 0;
+
+                jdbcCatalog.dropTable(TableIdentifier.of("db", "table"));
+                result = true;
+                minTimes = 0;
+            }
+        };
+        IcebergJdbcCatalog icebergJdbcCatalog = new IcebergJdbcCatalog("catalog",
+                new Configuration(), ImmutableMap.of("iceberg.catalog.warehouse", LOCATION,
+                "iceberg.catalog.uri", URI));
+        icebergJdbcCatalog.createDB("db", new HashMap<>());
+        Database db = icebergJdbcCatalog.getDB("db");
+        assertEquals("db", db.getFullName());
+        icebergJdbcCatalog.dropTable("db", "table", true);
+        icebergJdbcCatalog.dropDB("db");
+    }
+
+    @Test
+    public void testCreateDB(@Mocked JdbcCatalog jdbcCatalog, @Mocked FileSystem fileSystem)
+            throws MetaNotFoundException {
+        new Expectations() {
+            {
+                jdbcCatalog.loadNamespaceMetadata(Namespace.of("db"));
+                result = ImmutableMap.of(LOCATION_PROPERTY, LOCATION);
+                minTimes = 0;
+
+                try {
+                    fileSystem.exists((Path) any);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+                result = true;
+                minTimes = 0;
+            }
+        };
+        IcebergJdbcCatalog icebergJdbcCatalog = new IcebergJdbcCatalog("catalog",
+                new Configuration(), ImmutableMap.of("iceberg.catalog.warehouse", LOCATION,
+                "iceberg.catalog.uri", URI));
+        icebergJdbcCatalog.createDB("db", ImmutableMap.of(LOCATION_PROPERTY, LOCATION));
+    }
+
+    @Test
+    public void testCreateDBWithException(@Mocked JdbcCatalog jdbcCatalog)
+            throws MetaNotFoundException {
+        new Expectations() {
+            {
+                jdbcCatalog.loadNamespaceMetadata(Namespace.of("db"));
+                result = ImmutableMap.of(LOCATION_PROPERTY, LOCATION);
+                minTimes = 0;
+            }
+        };
+        IcebergJdbcCatalog icebergJdbcCatalog = new IcebergJdbcCatalog("catalog",
+                new Configuration(), ImmutableMap.of("iceberg.catalog.warehouse", LOCATION,
+                "iceberg.catalog.uri", URI));
+        StarRocksConnectorException e =
+                assertThrows(StarRocksConnectorException.class,
+                        () -> icebergJdbcCatalog.createDB("db", ImmutableMap.of(LOCATION_PROPERTY, LOCATION)));
+        String msg = String.format("Invalid location URI: %s. msg: No FileSystem for scheme \"s3\"", LOCATION);
+        assertEquals(msg, e.getMessage());
+    }
+
+    @Test
+    public void testListTableNames(@Mocked JdbcCatalog jdbcCatalog) {
+        String db1 = "db1";
+        String tbl1 = "tbl1";
+        String tbl2 = "tbl2";
+
+        new Expectations() {
+            {
+                jdbcCatalog.listTables(Namespace.of(db1));
+                result = Lists.newArrayList(TableIdentifier.of(tbl1), TableIdentifier.of(tbl2));
+                minTimes = 0;
+            }
+        };
+        IcebergJdbcCatalog icebergJdbcCatalog = new IcebergJdbcCatalog("catalog",
+                new Configuration(), ImmutableMap.of("iceberg.catalog.warehouse", LOCATION,
+                "iceberg.catalog.uri", URI));
+        List<String> expectResult = Lists.newArrayList("tbl1", "tbl2");
+        Assert.assertEquals(expectResult, icebergJdbcCatalog.listTables(db1));
+    }
+
+    @Test
+    public void testGetTable(@Mocked JdbcCatalog jdbcCatalog,
+                             @Mocked BaseMetastoreTableOperations jdbcTableOperations) {
+        new Expectations() {
+            {
+                jdbcCatalog.loadTable(TableIdentifier.of("db", "tbl1"));
+                result = new BaseTable(jdbcTableOperations, "tbl1");
+            }
+        };
+        IcebergJdbcCatalog icebergJdbcCatalog = new IcebergJdbcCatalog("catalog",
+                new Configuration(), ImmutableMap.of("iceberg.catalog.warehouse", LOCATION,
+                "iceberg.catalog.uri", URI));
+        Table table = icebergJdbcCatalog.getTable("db", "tbl1");
+        assertEquals("tbl1", table.name());
     }
 
     @Test
@@ -82,8 +216,8 @@ public class IcebergJdbcCatalogTest {
             }
         };
         IcebergJdbcCatalog icebergJdbcCatalog = new IcebergJdbcCatalog("catalog",
-                new Configuration(), ImmutableMap.of("iceberg.catalog.warehouse", "s3://path/to/warehouse",
-                "iceberg.catalog.uri", "jdbc:mysql://host:port/db_name"));
+                new Configuration(), ImmutableMap.of("iceberg.catalog.warehouse", LOCATION,
+                "iceberg.catalog.uri", URI));
         assertTrue(icebergJdbcCatalog.tableExists("db1", "tbl1"));
     }
 
@@ -96,10 +230,47 @@ public class IcebergJdbcCatalogTest {
             }
         };
         IcebergJdbcCatalog icebergJdbcCatalog = new IcebergJdbcCatalog("catalog",
-                new Configuration(), ImmutableMap.of("iceberg.catalog.warehouse", "s3://path/to/warehouse",
-                "iceberg.catalog.uri", "jdbc:mysql://host:port/db_name"));
+                new Configuration(), ImmutableMap.of("iceberg.catalog.warehouse", LOCATION,
+                "iceberg.catalog.uri", URI));
         icebergJdbcCatalog.renameTable("db", "tb1", "tb2");
         boolean exists = icebergJdbcCatalog.tableExists("db", "tbl2");
         Assert.assertTrue(exists);
+
+        boolean createTableFlag = icebergJdbcCatalog.createTable("db", "tb2", null, null, LOCATION, new HashMap<>());
+        assertEquals(true, createTableFlag);
     }
+
+    @Test
+    public void testCreateTable(@Mocked JdbcCatalog jdbcCatalog) {
+        new Expectations() {
+            {
+            }
+        };
+        IcebergJdbcCatalog icebergJdbcCatalog = new IcebergJdbcCatalog("catalog",
+                new Configuration(), ImmutableMap.of("iceberg.catalog.warehouse", LOCATION,
+                "iceberg.catalog.uri", URI));
+        boolean createTableFlag = icebergJdbcCatalog.createTable("db", "tb2", null, null, LOCATION, new HashMap<>());
+        assertEquals(true, createTableFlag);
+    }
+
+    @Test
+    public void testDeleteUncommittedDataFiles(@Mocked JdbcCatalog jdbcCatalog, @Mocked FileSystem fileSystem) {
+        new Expectations() {
+            {
+                try {
+                    fileSystem.delete((Path) any, false);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+                result = true;
+                minTimes = 0;
+            }
+        };
+        IcebergJdbcCatalog icebergJdbcCatalog = new IcebergJdbcCatalog("catalog",
+                new Configuration(), ImmutableMap.of("iceberg.catalog.warehouse", LOCATION,
+                "iceberg.catalog.uri", URI));
+        icebergJdbcCatalog.deleteUncommittedDataFiles(
+                Arrays.asList("/tmp/iceberg/db/table/part-00000", "/tmp/iceberg/db/table/part-00001"));
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergJdbcCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergJdbcCatalogTest.java
@@ -59,7 +59,7 @@ public class IcebergJdbcCatalogTest {
                 assertThrows(IllegalArgumentException.class, () -> new IcebergJdbcCatalog("catalog",
                         new Configuration(), ImmutableMap.of("iceberg.catalog.warehouse", LOCATION)));
         assertEquals(e.getMessage(),
-                String.format("Iceberg jdbc catalog must set uri  (\"%s\" = \"jdbc:mysql://host:port/db_name\").",
+                String.format("Iceberg jdbc catalog must set uri  (\"%s\" = \"jdbc:[mysql|postgresql]://host:port/db_name\").",
                         ICEBERG_CUSTOM_PROPERTIES_PREFIX + CatalogProperties.URI));
 
         IllegalArgumentException e1 =

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergJdbcCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergJdbcCatalogTest.java
@@ -1,0 +1,105 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.connector.iceberg;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.connector.iceberg.jdbc.IcebergJdbcCatalog;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.jdbc.JdbcCatalog;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.starrocks.connector.iceberg.IcebergCatalogProperties.ICEBERG_CUSTOM_PROPERTIES_PREFIX;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class IcebergJdbcCatalogTest {
+    @Test
+    public void testNewIcebergJdbcCatalog(@Mocked JdbcCatalog jdbcCatalog)  {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new IcebergJdbcCatalog("catalog",
+                new Configuration(), ImmutableMap.of("iceberg.catalog.warehouse", "s3://path/to/warehouse")));
+        assertEquals(e.getMessage(), String.format("Iceberg jdbc catalog must set uri  (\"%s\" = \"jdbc:mysql://host:port/db_name\").",
+                ICEBERG_CUSTOM_PROPERTIES_PREFIX + CatalogProperties.URI));
+
+        IllegalArgumentException e1 = assertThrows(IllegalArgumentException.class, () -> new IcebergJdbcCatalog("catalog",
+                new Configuration(), ImmutableMap.of("iceberg.catalog.uri", "jdbc:mysql://host:port/db_name")));
+        assertEquals(e1.getMessage(), "Iceberg jdbc catalog must set warehouse location " +
+                "(\"iceberg.catalog.warehouse\" = \"s3://path/to/warehouse\").");
+
+        assertDoesNotThrow(() -> new IcebergJdbcCatalog("catalog", new Configuration(),
+                ImmutableMap.of("iceberg.catalog.warehouse", "s3://path/to/warehouse",
+                        "iceberg.catalog.uri", "jdbc:mysql://host:port/db_name")));
+    }
+
+
+    @Test
+    public void testListAllDatabases(@Mocked JdbcCatalog jdbcCatalog) {
+        new Expectations() {
+            {
+                jdbcCatalog.listNamespaces();
+                result = ImmutableList.of(Namespace.of("db1"), Namespace.of("db2"));
+                minTimes = 0;
+            }
+        };
+
+        IcebergJdbcCatalog icebergJdbcCatalog = new IcebergJdbcCatalog("catalog",
+                new Configuration(), ImmutableMap.of("iceberg.catalog.warehouse", "s3://path/to/warehouse",
+                "iceberg.catalog.uri", "jdbc:mysql://host:port/db_name"));
+        List<String> dbs = icebergJdbcCatalog.listAllDatabases();
+        assertEquals(Arrays.asList("db1", "db2"), dbs);
+    }
+
+    @Test
+    public void testTableExists(@Mocked JdbcCatalog jdbcCatalog) {
+        new Expectations() {
+            {
+                jdbcCatalog.tableExists((TableIdentifier) any);
+                result = true;
+            }
+        };
+        IcebergJdbcCatalog icebergJdbcCatalog = new IcebergJdbcCatalog("catalog",
+                new Configuration(), ImmutableMap.of("iceberg.catalog.warehouse", "s3://path/to/warehouse",
+                "iceberg.catalog.uri", "jdbc:mysql://host:port/db_name"));
+        assertTrue(icebergJdbcCatalog.tableExists("db1", "tbl1"));
+    }
+
+    @Test
+    public void testRenameTable(@Mocked JdbcCatalog jdbcCatalog) {
+        new Expectations() {
+            {
+                jdbcCatalog.tableExists((TableIdentifier) any);
+                result = true;
+            }
+        };
+        IcebergJdbcCatalog icebergJdbcCatalog = new IcebergJdbcCatalog("catalog",
+                new Configuration(), ImmutableMap.of("iceberg.catalog.warehouse", "s3://path/to/warehouse",
+                "iceberg.catalog.uri", "jdbc:mysql://host:port/db_name"));
+        icebergJdbcCatalog.renameTable("db", "tb1", "tb2");
+        boolean exists = icebergJdbcCatalog.tableExists("db", "tbl2");
+        Assert.assertTrue(exists);
+    }
+}

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -839,6 +839,13 @@ under the License.
                 <version>12.4.2.jre11</version>
             </dependency>
 
+            <!-- https://mvnrepository.com/artifact/com.mysql/mysql-connector-j -->
+            <dependency>
+                <groupId>com.mysql</groupId>
+                <artifactId>mysql-connector-j</artifactId>
+                <version>9.2.0</version>
+            </dependency>
+
             <!-- https://mvnrepository.com/artifact/com.mockrunner/mockrunner-jdbc -->
             <dependency>
                 <groupId>com.mockrunner</groupId>


### PR DESCRIPTION
## Why I'm doing:

Currently, StarRocks does not support JDBC catalog for Iceberg integration. However, since JDBC catalog is one of the catalog implementations for Iceberg and has many use cases, we hope to see support for it.

## What I'm doing:

Add support for Iceberg's JDBC catalog.

```sql
CREATE EXTERNAL CATALOG iceberg_jdbc
PROPERTIES
(
    "type" = "iceberg",
    "iceberg.catalog.type" = "jdbc",
    "iceberg.catalog.warehouse" = "hdfs:///jdbc_iceberg/warehouse/ ",
    "iceberg.catalog.uri" = "jdbc:mysql://ip:port/db_name",
    "iceberg.catalog.jdbc.user" = "username",
    "iceberg.catalog.jdbc.password" = "password"
);
```

Fixes #56438

Issue: https://github.com/StarRocks/starrocks/issues/56438

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0