### PR TITLE
[UT] fix timezone ut in debug/asan mode because of seconds overflow

### DIFF
--- a/be/src/exec/schema_scanner/schema_dummy_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_dummy_scanner.cpp
@@ -18,10 +18,7 @@
 
 namespace starrocks {
 
-SchemaScanner::ColumnDesc SchemaDummyScanner::_s_dummy_columns[] = {};
-
-SchemaDummyScanner::SchemaDummyScanner()
-        : SchemaScanner(_s_dummy_columns, sizeof(_s_dummy_columns) / sizeof(SchemaScanner::ColumnDesc)) {}
+SchemaDummyScanner::SchemaDummyScanner() : SchemaScanner(nullptr, 0) {}
 
 SchemaDummyScanner::~SchemaDummyScanner() = default;
 

--- a/be/src/exec/schema_scanner/schema_dummy_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_dummy_scanner.cpp
@@ -18,7 +18,10 @@
 
 namespace starrocks {
 
-SchemaDummyScanner::SchemaDummyScanner() : SchemaScanner(nullptr, 0) {}
+SchemaScanner::ColumnDesc SchemaDummyScanner::_s_dummy_columns[] = {};
+
+SchemaDummyScanner::SchemaDummyScanner()
+        : SchemaScanner(_s_dummy_columns, sizeof(_s_dummy_columns) / sizeof(SchemaScanner::ColumnDesc)) {}
 
 SchemaDummyScanner::~SchemaDummyScanner() = default;
 

--- a/be/src/formats/parquet/level_builder.cpp
+++ b/be/src/formats/parquet/level_builder.cpp
@@ -355,7 +355,7 @@ Status LevelBuilder::_write_datetime_column_chunk(const LevelBuilderContext& ctx
     DeferOp defer([&] { delete[] values; });
 
     for (size_t i = 0; i < col->size(); i++) {
-        auto offset = timestamp::get_offset_by_timezone(data_col[i]._timestamp, _ctz);
+        auto offset = timestamp::get_timezone_offset_by_timestamp(data_col[i]._timestamp, _ctz);
 
         auto timestamp = use_int96_timestamp_encoding ? timestamp::sub<TimeUnit::SECOND>(data_col[i]._timestamp, offset)
                                                       : data_col[i]._timestamp;

--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -395,7 +395,6 @@ void LakeTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequ
         response->mutable_status()->add_error_msgs("out-of-order packet");
         return;
     }
-    size_t chunk_size = chunk != nullptr ? chunk->bytes_usage() : 0;
 
     auto res = _create_write_context(chunk, request, response);
     if (!res.ok()) {
@@ -566,6 +565,7 @@ void LakeTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequ
     auto wait_writer_ns = finish_wait_writer_ts - start_wait_writer_ts;
 #ifndef BE_TEST
     _table_metrics->load_rows.increment(total_row_num);
+    size_t chunk_size = chunk != nullptr ? chunk->bytes_usage() : 0;
     _table_metrics->load_bytes.increment(chunk_size);
 #endif
     COUNTER_UPDATE(_add_chunk_counter, 1);

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -233,8 +233,6 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
         }
     }
 
-    size_t chunk_size = chunk != nullptr ? chunk->bytes_usage() : 0;
-
     auto res = _create_write_context(chunk, request, response);
     if (!res.ok()) {
         res.status().to_protobuf(response->mutable_status());
@@ -466,6 +464,7 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
     StarRocksMetrics::instance()->load_channel_add_chunks_wait_replica_duration_us.increment(wait_replica_ns / 1000);
 #ifndef BE_TEST
     _table_metrics->load_rows.increment(total_row_num);
+    size_t chunk_size = chunk != nullptr ? chunk->bytes_usage() : 0;
     _table_metrics->load_bytes.increment(chunk_size);
 #endif
 

--- a/be/src/runtime/time_types.h
+++ b/be/src/runtime/time_types.h
@@ -216,7 +216,8 @@ public:
 
     inline static bool check(int year, int month, int day, int hour, int minute, int second, int microsecond);
 
-    inline static int get_offset_by_timezone(Timestamp timestamp, const cctz::time_zone& ctz);
+    inline static int get_timezone_offset_by_timestamp(Timestamp timestamp, const cctz::time_zone& ctz);
+    inline static int get_timezone_offset_by_epoch_seconds(int64_t seconds_from_epoch, const cctz::time_zone& ctz);
 
     template <TimeUnit UNIT>
     static Timestamp add(Timestamp timestamp, int count);
@@ -368,10 +369,18 @@ bool timestamp::check(int year, int month, int day, int hour, int minute, int se
     return date::check(year, month, day) && check_time(hour, minute, second, microsecond);
 }
 
-int timestamp::get_offset_by_timezone(Timestamp timestamp, const cctz::time_zone& ctz) {
+int timestamp::get_timezone_offset_by_timestamp(Timestamp timestamp, const cctz::time_zone& ctz) {
     int64_t days = timestamp::to_julian(timestamp);
     int64_t seconds_from_epoch = (days - date::UNIX_EPOCH_JULIAN) * SECS_PER_DAY;
+    return get_timezone_offset_by_epoch_seconds(seconds_from_epoch, ctz);
+}
 
+int timestamp::get_timezone_offset_by_epoch_seconds(int64_t seconds_from_epoch, const cctz::time_zone& ctz) {
+    // if system_clock duration is nanoseconds(libstdc++), and to avoid overflow
+    // followings are min and max values. how I get these values? ask deepseek.
+    static constexpr int64_t MIN_SECONDS = -9223372036;
+    static constexpr int64_t MAX_SECONDS = 9223372036;
+    seconds_from_epoch = std::max(MIN_SECONDS, std::min(MAX_SECONDS, seconds_from_epoch));
     std::chrono::system_clock::time_point tp = std::chrono::system_clock::from_time_t(seconds_from_epoch);
     return ctz.lookup(tp).offset;
 }

--- a/be/src/runtime/time_types.h
+++ b/be/src/runtime/time_types.h
@@ -377,7 +377,8 @@ int timestamp::get_timezone_offset_by_timestamp(Timestamp timestamp, const cctz:
 
 int timestamp::get_timezone_offset_by_epoch_seconds(int64_t seconds_from_epoch, const cctz::time_zone& ctz) {
     // if system_clock duration is nanoseconds(libstdc++), and to avoid overflow
-    // followings are min and max values. how I get these values? ask deepseek.
+    // std::numeric_limits<int64_t>::max() / 1'000'000'000
+    // std::numeric_limits<int64_t>::min() / 1'000'000'000
     static constexpr int64_t MIN_SECONDS = -9223372036;
     static constexpr int64_t MAX_SECONDS = 9223372036;
     seconds_from_epoch = std::max(MIN_SECONDS, std::min(MAX_SECONDS, seconds_from_epoch));

--- a/be/test/column/date_value_test.cpp
+++ b/be/test/column/date_value_test.cpp
@@ -179,7 +179,7 @@ TEST(DateValueTest, getOffsetByTimezone) {
         cctz::time_zone ctz;
         TimezoneUtils::find_cctz_time_zone(timezone, ctz);
 
-        auto offset = timestamp::get_offset_by_timezone(timestampInDST, ctz);
+        auto offset = timestamp::get_timezone_offset_by_timestamp(timestampInDST, ctz);
 
         ASSERT_EQ(32400, offset);
     }
@@ -190,7 +190,7 @@ TEST(DateValueTest, getOffsetByTimezone) {
         cctz::time_zone ctz;
         TimezoneUtils::find_cctz_time_zone(timezone, ctz);
 
-        auto offset = timestamp::get_offset_by_timezone(timestampOutOfDST, ctz);
+        auto offset = timestamp::get_timezone_offset_by_timestamp(timestampOutOfDST, ctz);
 
         ASSERT_EQ(28800, offset);
     }


### PR DESCRIPTION
## Why I'm doing:

this ut `HdfsScannerTest.TestParquetTimestampToDatetime` fails in asan/debug mode.

it's because if `seconds_from_epoch` is too large,  there could be overflow.

> std::chrono::system_clock::time_point tp = std::chrono::system_clock::from_time_t(seconds_from_epoch);

And when overflow happens,  behaviour changes.

## What I'm doing:

Cap the seconds by min/max value to make behaviour consistent.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0