### PR TITLE
[Enhancement] Support writing parquet json type when unloading data using FILES()

### DIFF
--- a/be/src/formats/parquet/file_writer.cpp
+++ b/be/src/formats/parquet/file_writer.cpp
@@ -356,6 +356,10 @@ arrow::Result<::parquet::schema::NodePtr> ParquetBuildHelper::_make_schema_node(
                 name, rep_type, ::parquet::LogicalType::Time(false, ::parquet::LogicalType::TimeUnit::MICROS),
                 ::parquet::Type::INT64, -1, file_column_id.field_id);
     }
+    case TYPE_JSON: {
+        return ::parquet::schema::PrimitiveNode::Make(name, rep_type, ::parquet::LogicalType::JSON(),
+                                                      ::parquet::Type::BYTE_ARRAY, -1, file_column_id.field_id);
+    }
     default: {
         return arrow::Status::TypeError(fmt::format("Doesn't support to write {} type data", type_desc.debug_string()));
     }

--- a/be/src/formats/parquet/level_builder.cpp
+++ b/be/src/formats/parquet/level_builder.cpp
@@ -151,6 +151,9 @@ Status LevelBuilder::_write_column_chunk(const LevelBuilderContext& ctx, const T
     case TYPE_TIME: {
         return _write_time_column_chunk(ctx, type_desc, node, col, write_leaf_callback);
     }
+    case TYPE_JSON: {
+        return _write_json_column_chunk(ctx, type_desc, node, col, write_leaf_callback);
+    }
     default: {
         return Status::NotSupported(fmt::format("Doesn't support to write {} type data", type_desc.debug_string()));
     }
@@ -596,6 +599,41 @@ Status LevelBuilder::_write_struct_column_chunk(const LevelBuilderContext& ctx, 
         RETURN_IF_ERROR(_write_column_chunk(derived_ctx, type_desc.children[i], struct_node->field(i), sub_col,
                                             write_leaf_callback));
     }
+    return Status::OK();
+}
+
+Status LevelBuilder::_write_json_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
+                                              const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
+                                              const CallbackFunction& write_leaf_callback) {
+    const auto* data_col = down_cast<const JsonColumn*>(ColumnHelper::get_data_column(col.get()));
+    const auto* null_col = get_raw_null_column(col);
+
+    // Use the rep_levels in the context from caller since node is primitive.
+    auto& rep_levels = ctx._rep_levels;
+    auto def_levels = _make_def_levels(ctx, node, null_col, col->size());
+    auto null_bitset = _make_null_bitset(ctx, null_col, col->size());
+
+    auto values = new ::parquet::ByteArray[col->size()];
+    DeferOp defer([&] { delete[] values; });
+
+    std::vector<std::string> datas;
+    datas.reserve(col->size());
+    for (size_t i = 0; i < col->size(); i++) {
+        auto json_value = data_col->get_object(i);
+        datas.emplace_back(json_value->to_string_uncheck());
+        const std::string& v = datas.back();
+        values[i].len = static_cast<uint32_t>(v.size());
+        values[i].ptr = reinterpret_cast<const uint8_t*>(v.c_str());
+    }
+
+    write_leaf_callback(LevelBuilderResult{
+            .num_levels = ctx._num_levels,
+            .def_levels = def_levels ? def_levels->data() : nullptr,
+            .rep_levels = rep_levels ? rep_levels->data() : nullptr,
+            .values = reinterpret_cast<uint8_t*>(values),
+            .null_bitset = null_bitset ? null_bitset->data() : nullptr,
+    });
+
     return Status::OK();
 }
 

--- a/be/src/formats/parquet/level_builder.h
+++ b/be/src/formats/parquet/level_builder.h
@@ -163,6 +163,10 @@ private:
                                     const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
                                     const CallbackFunction& write_leaf_callback);
 
+    Status _write_json_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
+                                    const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
+                                    const CallbackFunction& write_leaf_callback);
+
     std::shared_ptr<std::vector<uint8_t>> _make_null_bitset(const LevelBuilderContext& ctx, const uint8_t* nulls,
                                                             const size_t col_size) const;
 

--- a/be/src/formats/parquet/parquet_file_writer.cpp
+++ b/be/src/formats/parquet/parquet_file_writer.cpp
@@ -400,6 +400,10 @@ arrow::Result<::parquet::schema::NodePtr> ParquetFileWriter::_make_schema_node(c
                 name, rep_type, ::parquet::LogicalType::Time(false, ::parquet::LogicalType::TimeUnit::MICROS),
                 ::parquet::Type::INT64, -1, file_column_id.field_id);
     }
+    case TYPE_JSON: {
+        return ::parquet::schema::PrimitiveNode::Make(name, rep_type, ::parquet::LogicalType::JSON(),
+                                                      ::parquet::Type::BYTE_ARRAY, -1, file_column_id.field_id);
+    }
     default: {
         return arrow::Status::TypeError(fmt::format("Doesn't support to write {} type data", type_desc.debug_string()));
     }

--- a/test/sql/test_sink/R/test_files_sink_parquet_json
+++ b/test/sql/test_sink/R/test_files_sink_parquet_json
@@ -1,0 +1,95 @@
+-- name: test_files_sink_parquet_json
+
+create database db_${uuid0};
+use db_${uuid0};
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_files/parquet_format/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+create table t1 (k1 int, k2 json);
+-- result:
+-- !result
+
+insert into t1 values (1, parse_json('{"a": 1, "b": true}')), (2, null), (3, parse_json('{"a": 3, "b": false}'));
+-- result:
+-- !result
+
+insert into files(
+    "path" = "oss://${oss_bucket}/test_files/parquet_format/${uuid0}/",
+    "format" = "parquet",
+    "compression" = "zstd",
+    "single" = "true",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}") select * from t1;
+-- result:
+-- !result
+
+desc files(
+    "path" = "oss://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+k1	int	YES
+k2	json	YES
+-- !result
+
+select * from files(
+    "path" = "oss://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+1	{"a": 1, "b": true}
+2	None
+3	{"a": 3, "b": false}
+-- !result
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/parquet_format/${uuid0}/ > /dev/null
+
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_files/parquet_format/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+create table t2 (k1 int, k2 array<json>);
+-- result:
+-- !result
+
+insert into t2 values (1, [parse_json('{"a": 1, "b": "b1"}'), parse_json('{"a": 2, "b": "b2"}')]), (2, null), (3, [parse_json('{"a": 3, "b": "b3"}')]);
+-- result:
+-- !result
+
+insert into files(
+    "path" = "oss://${oss_bucket}/test_files/parquet_format/${uuid0}/",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}") select * from t2;
+-- result:
+-- !result
+
+desc files(
+    "path" = "oss://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+k1	int	YES
+k2	array<json>	YES
+-- !result
+
+select * from files(
+    "path" = "oss://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+1	['{"a": 1, "b": "b1"}','{"a": 2, "b": "b2"}']
+2	None
+3	['{"a": 3, "b": "b3"}']
+-- !result
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/parquet_format/${uuid0}/ > /dev/null

--- a/test/sql/test_sink/T/test_files_sink_parquet_json
+++ b/test/sql/test_sink/T/test_files_sink_parquet_json
@@ -1,0 +1,59 @@
+-- name: test_files_sink_parquet_json
+
+create database db_${uuid0};
+use db_${uuid0};
+
+-- json type
+shell: ossutil64 mkdir oss://${oss_bucket}/test_files/parquet_format/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+create table t1 (k1 int, k2 json);
+insert into t1 values (1, parse_json('{"a": 1, "b": true}')), (2, null), (3, parse_json('{"a": 3, "b": false}'));
+insert into files(
+    "path" = "oss://${oss_bucket}/test_files/parquet_format/${uuid0}/",
+    "format" = "parquet",
+    "compression" = "zstd",
+    "single" = "true",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}") select * from t1;
+desc files(
+    "path" = "oss://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+select * from files(
+    "path" = "oss://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/parquet_format/${uuid0}/ > /dev/null
+
+
+-- array<json> type
+shell: ossutil64 mkdir oss://${oss_bucket}/test_files/parquet_format/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+create table t2 (k1 int, k2 array<json>);
+insert into t2 values (1, [parse_json('{"a": 1, "b": "b1"}'), parse_json('{"a": 2, "b": "b2"}')]), (2, null), (3, [parse_json('{"a": 3, "b": "b3"}')]);
+insert into files(
+    "path" = "oss://${oss_bucket}/test_files/parquet_format/${uuid0}/",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}") select * from t2;
+desc files(
+    "path" = "oss://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+select * from files(
+    "path" = "oss://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/parquet_format/${uuid0}/ > /dev/null


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

support writing json type in parquet format when unloading data using `insert into files()`

Fixes #53897

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0