### PR TITLE
[BugFix] Fix the issue that the dynamic modification of datacache_disk_adjust_interval_seconds does not take effect

### DIFF
--- a/be/src/cache/block_cache/disk_space_monitor.cpp
+++ b/be/src/cache/block_cache/disk_space_monitor.cpp
@@ -273,7 +273,7 @@ void DiskSpaceMonitor::_adjust_datacache_callback() {
         }
         lck.unlock();
 
-        static const int64_t kWaitTimeout = config::datacache_disk_adjust_interval_seconds * 1000 * 1000;
+        int64_t kWaitTimeout = config::datacache_disk_adjust_interval_seconds * 1000 * 1000;
         static const int64_t kCheckInterval = 1000 * 1000;
         auto cond = [this]() { return is_stopped(); };
         auto ret = Awaitility().timeout(kWaitTimeout).interval(kCheckInterval).until(cond);

--- a/be/test/cache/block_cache/test_cache_utils.h
+++ b/be/test/cache/block_cache/test_cache_utils.h
@@ -38,7 +38,6 @@ CacheOptions create_simple_options(size_t block_size, size_t mem_quota, ssize_t 
     options.block_size = block_size;
     options.skip_read_factor = 1.0;
     return options;
-    return options;
 }
 
 std::shared_ptr<BlockCache> create_cache(const CacheOptions& options) {


### PR DESCRIPTION
## Why I'm doing:

how to reproduce:

```
update information_schema.be_configs set value="1" where name="datacache_disk_adjust_interval_seconds";
```

## What I'm doing:

Fix the issue that the modification of `datacache_disk_adjust_interval_seconds` does not take effect.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0