### PR TITLE
[BugFix] Fix result error when use global dict for iceberg with equality delete

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -321,8 +321,8 @@ public class StatisticExecutor {
         ExecPlan execPlan = StatementPlanner.plan(parsedStmt, context, TResultSinkType.STATISTIC);
 
         assert execPlan != null;
-        ScanNode scanNode = execPlan.getScanNodes().get(0);
-        scanNode.setScanSampleStrategy(strategy);
+        List<ScanNode> scanNodes = execPlan.getScanNodes();
+        scanNodes.forEach(scanNode -> scanNode.setScanSampleStrategy(strategy));
 
         StmtExecutor executor = StmtExecutor.newInternalExecutor(context, parsedStmt);
         Pair<List<TResultBatch>, Status> sqlResult = executor.executeStmtWithExecPlan(context, execPlan);


### PR DESCRIPTION
## Why I'm doing:
we support global dict for iceberg in #56039,  iceberg table with equality delete could has  more than 1 iceberg scan node after paln rewrie, and should collect all scan node for iceberg.
## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/9323

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0