### PR TITLE
[UT] Fix the unstable UT for `CacheInputStream` which caused by the cache directory not existing.

### DIFF
--- a/be/test/cache/block_cache/block_cache_test.cpp
+++ b/be/test/cache/block_cache/block_cache_test.cpp
@@ -126,7 +126,7 @@ TEST_F(BlockCacheTest, hybrid_cache) {
     ASSERT_TRUE(res.status().is_not_found());
 
     cache->shutdown();
-    fs::remove_all(cache_dir).ok();
+    fs::remove_all(cache_dir);
 }
 
 TEST_F(BlockCacheTest, write_with_overwrite_option) {
@@ -241,7 +241,7 @@ TEST_F(BlockCacheTest, read_cache_with_adaptor) {
     }
 
     cache->shutdown();
-    fs::remove_all(cache_dir).ok();
+    fs::remove_all(cache_dir);
 }
 
 TEST_F(BlockCacheTest, update_cache_quota) {
@@ -286,7 +286,7 @@ TEST_F(BlockCacheTest, update_cache_quota) {
     }
 
     cache->shutdown();
-    fs::remove_all(cache_dir).ok();
+    fs::remove_all(cache_dir);
 }
 
 TEST_F(BlockCacheTest, clear_residual_blockfiles) {
@@ -337,7 +337,7 @@ TEST_F(BlockCacheTest, clear_residual_blockfiles) {
         ASSERT_EQ(files.size(), 0);
     }
 
-    fs::remove_all(cache_dir).ok();
+    fs::remove_all(cache_dir);
 }
 
 #endif

--- a/be/test/io/cache_input_stream_test.cpp
+++ b/be/test/io/cache_input_stream_test.cpp
@@ -328,9 +328,12 @@ TEST_F(CacheInputStreamTest, test_read_with_zero_range) {
 }
 
 TEST_F(CacheInputStreamTest, test_read_with_adaptor) {
+    const std::string cache_dir = "./cache_input_stream_cache_dir";
+    fs::create_directories(cache_dir);
+
     CacheOptions options = cache_options();
     // Because the cache adaptor only work for disk cache.
-    options.disk_spaces.push_back({.path = "./block_disk_cache", .size = 300 * 1024 * 1024});
+    options.disk_spaces.push_back({.path = cache_dir, .size = 300 * 1024 * 1024});
     options.enable_tiered_cache = false;
     ASSERT_OK(BlockCache::instance()->init(options));
 
@@ -393,6 +396,7 @@ TEST_F(CacheInputStreamTest, test_read_with_adaptor) {
         ASSERT_TRUE(check_data_content(buffer + block_size, block_size, 'b'));
         ASSERT_EQ(stats.read_cache_count, block_count);
     }
+    fs::remove_all(cache_dir);
 }
 
 TEST_F(CacheInputStreamTest, test_read_with_shared_buffer) {


### PR DESCRIPTION
## Why I'm doing:
We use the disk cache in `CacheInputStream` unittests, but did not manually create it.  Because the underlying starcache also will check its existence and create it if not exist, it can work well before. 
However, now we get the device id by the cache path before the cache instance is initialized, this may result in an invalid device id is returned.
 
## What I'm doing:
Create the cache directory manually before initializing the cache instance in the unittest. 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0