### PR TITLE
[BugFix] fix partial column update loss under fast schema evolution

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1976,10 +1976,8 @@ Status TabletUpdates::_do_compaction(std::unique_ptr<CompactionInfo>* pinfo, con
             auto itr = _rowsets.find(all_rowset_ids[i]);
             if (itr == _rowsets.end()) {
                 // rowset should exists
-                string msg = strings::Substitute("_do_compaction rowset $0 should exists $1", all_rowset_ids[i],
-                                                 _debug_string(false));
-                LOG(ERROR) << msg;
-                return Status::InternalError(msg);
+                return Status::InternalError(strings::Substitute("_do_compaction rowset $0 should exists $1",
+                                                                 all_rowset_ids[i], _debug_string(false)));
             } else {
                 all_rowsets[i] = itr->second;
             }

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -443,7 +443,7 @@ private:
 
     void _wait_apply_done();
 
-    Status _do_compaction(std::unique_ptr<CompactionInfo>* pinfo);
+    Status _do_compaction(std::unique_ptr<CompactionInfo>* pinfo, const vector<uint32_t>& all_rowset_ids);
 
     int32_t _calc_compaction_level(RowsetStats* stats);
     void _calc_compaction_score(RowsetStats* stats);


### PR DESCRIPTION
## Why I'm doing:
In current implementation, replica's update loss can occur when the following these conditions are met:
1. The table has a new add column and this column been updated by partial column update(column mode), generating corresponding delta column files.
2. Rowsets with old schema are subsequently merged into a segment through compaction, and the schema of the rowsets involved in the merge does not include the new add column.
3. Enable fast schema evolution.

## What I'm doing:
From the version which is used for compaction, it is necessary to identify all underlying rowsets, not only those input rowset. The schema with the highest version among these rowsets should be adopted as the schema used during the compaction process. This ensures that the use of an outdated schema does not result in the inability to access updated columns.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0