### PR TITLE
[Enhancement] support short-job-first query schedule strategy

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -37,6 +37,7 @@ package com.starrocks.common;
 import com.starrocks.StarRocksFE;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.Replica;
+import com.starrocks.qe.scheduler.slot.QueryQueueOptions;
 
 import static java.lang.Math.max;
 import static java.lang.Runtime.getRuntime;
@@ -715,8 +716,8 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int query_queue_v2_concurrency_level = 4;
 
-    @ConfField(mutable = true, comment = "Schedule policy of pending queries: SWRR/SJF")
-    public static String query_queue_v2_schedule_policy = "SWRR";
+    @ConfField(mutable = true, comment = "Schedule strategy of pending queries: SWRR/SJF")
+    public static String query_queue_v2_schedule_strategy = QueryQueueOptions.SchedulePolicy.createDefault().name();
 
     /**
      * Used to estimate the number of slots of a query based on the cardinality of the Source Node. It is equal to the

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -714,6 +714,10 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static int query_queue_v2_concurrency_level = 4;
+
+    @ConfField(mutable = true, comment = "Schedule policy of pending queries: SWRR/SJF")
+    public static String query_queue_v2_schedule_policy = "SWRR";
+
     /**
      * Used to estimate the number of slots of a query based on the cardinality of the Source Node. It is equal to the
      * cardinality of the Source Node divided by the configuration value and is limited to between [1, DOP*numBEs].

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -859,7 +859,9 @@ public class ShowExecutor {
             List<List<String>> rows = Lists.newArrayList();
 
             List<LogicalSlot> slots = GlobalStateMgr.getCurrentState().getSlotManager().getSlots();
-            slots.sort(Comparator.comparingLong(LogicalSlot::getStartTimeMs)
+            slots.sort(
+                    Comparator.<LogicalSlot>comparingInt(x -> x.getState().getSortOrder())
+                            .thenComparing(LogicalSlot::getStartTimeMs)
                     .thenComparingLong(LogicalSlot::getExpiredAllocatedTimeMs));
 
             for (LogicalSlot slot : slots) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/LogicalSlot.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/LogicalSlot.java
@@ -21,6 +21,8 @@ import com.starrocks.qe.GlobalVariable;
 import com.starrocks.thrift.TResourceLogicalSlot;
 import com.starrocks.thrift.TUniqueId;
 
+import java.util.Map;
+
 /**
  * A logical slot represents resources which is required by a query from the {@link SlotManager}.
  * <p> It contains multiple physical slots. A physical slot represents a part of resource from the cluster. There are a total of
@@ -204,6 +206,19 @@ public class LogicalSlot {
 
         boolean isTerminal() {
             return this == RELEASED || this == CANCELLED;
+        }
+
+        // Put RUNNING State at first
+        private static final Map<State, Integer> SORT_ORDER = Map.of(
+                ALLOCATED, 1,
+                REQUIRING, 2,
+                CREATED, 3,
+                CANCELLED, 4,
+                RELEASED, 5
+        );
+
+        public int getSortOrder() {
+            return SORT_ORDER.getOrDefault(this, SORT_ORDER.size());
         }
 
         public String toQueryStateString() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/QueryQueueOptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/QueryQueueOptions.java
@@ -18,13 +18,20 @@ import com.google.common.annotations.VisibleForTesting;
 import com.starrocks.common.Config;
 import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.system.BackendResourceStat;
+import org.apache.commons.lang3.EnumUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Arrays;
 import java.util.Objects;
 
 public class QueryQueueOptions {
+
+    private static final Logger LOG = LogManager.getLogger(QueryQueueOptions.class);
+
     private final boolean enableQueryQueueV2;
     private final V2 v2;
+    private final SchedulePolicy policy;
 
     public static QueryQueueOptions createFromEnvAndQuery(DefaultCoordinator coord) {
         if (!coord.getJobSpec().isEnableQueue() || !coord.getJobSpec().isNeedQueued()) {
@@ -45,13 +52,25 @@ public class QueryQueueOptions {
                 BackendResourceStat.getInstance().getAvgMemLimitBytes(),
                 Config.query_queue_v2_num_rows_per_slot,
                 Config.query_queue_v2_cpu_costs_per_slot);
-        return new QueryQueueOptions(true, v2);
+        SchedulePolicy policy = SchedulePolicy.create(Config.query_queue_v2_schedule_policy);
+        if (policy == null) {
+            LOG.error("unknown query_queue_v2_schedule_policy: {}", Config.query_queue_v2_schedule_policy);
+            policy = SchedulePolicy.createDefault();
+        }
+        return new QueryQueueOptions(true, v2, policy);
     }
 
     @VisibleForTesting
     QueryQueueOptions(boolean enableQueryQueueV2, V2 v2) {
         this.enableQueryQueueV2 = enableQueryQueueV2 && v2 != null;
         this.v2 = v2;
+        this.policy = SchedulePolicy.SWRR;
+    }
+
+    QueryQueueOptions(boolean enableQueryQueueV2, V2 v2, SchedulePolicy policy) {
+        this.enableQueryQueueV2 = enableQueryQueueV2 && v2 != null;
+        this.v2 = v2;
+        this.policy = policy;
     }
 
     public boolean isEnableQueryQueueV2() {
@@ -60,6 +79,10 @@ public class QueryQueueOptions {
 
     public V2 v2() {
         return v2;
+    }
+
+    public SchedulePolicy getPolicy() {
+        return policy;
     }
 
     @Override
@@ -71,12 +94,24 @@ public class QueryQueueOptions {
             return false;
         }
         QueryQueueOptions that = (QueryQueueOptions) o;
-        return enableQueryQueueV2 == that.enableQueryQueueV2 && Objects.equals(v2, that.v2);
+        return enableQueryQueueV2 == that.enableQueryQueueV2
+                && Objects.equals(v2, that.v2)
+                && policy.equals(that.policy);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(enableQueryQueueV2, v2);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("QueryQueueOptions{");
+        sb.append("enableQueryQueueV2=").append(enableQueryQueueV2);
+        sb.append(", v2=").append(v2);
+        sb.append(", policy=").append(policy);
+        sb.append('}');
+        return sb.toString();
     }
 
     public static class V2 {
@@ -159,8 +194,33 @@ public class QueryQueueOptions {
         public int hashCode() {
             return Objects.hash(numWorkers, numRowsPerSlot, totalSlots, memBytesPerSlot, totalSmallSlots, cpuCostsPerSlot);
         }
+
+        @Override
+        public String toString() {
+            final StringBuffer sb = new StringBuffer("V2{");
+            sb.append("numWorkers=").append(numWorkers);
+            sb.append(", numRowsPerSlot=").append(numRowsPerSlot);
+            sb.append(", totalSlots=").append(totalSlots);
+            sb.append(", memBytesPerSlot=").append(memBytesPerSlot);
+            sb.append(", cpuCostsPerSlot=").append(cpuCostsPerSlot);
+            sb.append(", totalSmallSlots=").append(totalSmallSlots);
+            sb.append('}');
+            return sb.toString();
+        }
     }
 
+    public enum SchedulePolicy {
+        SWRR, // Smooth Weighted Round Robin, which is suitable for hybrid workload without significant priority
+        SJF; // Short Job First + Aging, which is suitable for workload needs significant priority
+
+        public static SchedulePolicy createDefault() {
+            return SWRR;
+        }
+
+        public static SchedulePolicy create(String value) {
+            return EnumUtils.getEnumIgnoreCase(SchedulePolicy.class, value);
+        }
+    }
     private static boolean isAnyZero(long... values) {
         return Arrays.stream(values).anyMatch(val -> val == 0);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/QueryQueueOptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/QueryQueueOptions.java
@@ -52,9 +52,9 @@ public class QueryQueueOptions {
                 BackendResourceStat.getInstance().getAvgMemLimitBytes(),
                 Config.query_queue_v2_num_rows_per_slot,
                 Config.query_queue_v2_cpu_costs_per_slot);
-        SchedulePolicy policy = SchedulePolicy.create(Config.query_queue_v2_schedule_policy);
+        SchedulePolicy policy = SchedulePolicy.create(Config.query_queue_v2_schedule_strategy);
         if (policy == null) {
-            LOG.error("unknown query_queue_v2_schedule_policy: {}", Config.query_queue_v2_schedule_policy);
+            LOG.error("unknown query_queue_v2_schedule_policy: {}", Config.query_queue_v2_schedule_strategy);
             policy = SchedulePolicy.createDefault();
         }
         return new QueryQueueOptions(true, v2, policy);
@@ -64,7 +64,7 @@ public class QueryQueueOptions {
     QueryQueueOptions(boolean enableQueryQueueV2, V2 v2) {
         this.enableQueryQueueV2 = enableQueryQueueV2 && v2 != null;
         this.v2 = v2;
-        this.policy = SchedulePolicy.SWRR;
+        this.policy = SchedulePolicy.createDefault();
     }
 
     QueryQueueOptions(boolean enableQueryQueueV2, V2 v2, SchedulePolicy policy) {
@@ -101,7 +101,7 @@ public class QueryQueueOptions {
 
     @Override
     public int hashCode() {
-        return Objects.hash(enableQueryQueueV2, v2);
+        return Objects.hash(enableQueryQueueV2, v2, policy);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/ShortJobFirstAlgo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/ShortJobFirstAlgo.java
@@ -1,0 +1,124 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler.slot;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.starrocks.sql.optimizer.Utils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Comparator;
+import java.util.PriorityQueue;
+import java.util.stream.Collectors;
+
+/**
+ * Short Job First + Aging
+ */
+class ShortJobFirstAlgo implements SlotScheduleAlgorithm {
+
+    private static final Logger LOG = LogManager.getLogger(ShortJobFirstAlgo.class);
+    public static final double AGING_WEIGHT = 1; // Weight factor for aging effect
+    private static final long AGING_UPDATE_INTERVAL_MS = 1000; // Update aging score every second
+    private static final long AGING_GRANULARITY_MS = 100; // Aging calculation granularity: 100ms
+
+    private PriorityQueue<SlotSelectionStrategyV2.SlotContext> q;
+    private long lastUpdateTime;
+    private long baseTime;  // Base time for aging calculation
+
+    private static final Comparator<SlotSelectionStrategyV2.SlotContext> COMPARATOR = (lhs, rhs) -> {
+        double lhsScore = lhs.getSlot().getNumPhysicalSlots();
+        double rhsScore = rhs.getSlot().getNumPhysicalSlots();
+        return Double.compare(lhsScore, rhsScore);
+    };
+
+    public ShortJobFirstAlgo() {
+        baseTime = currentTime();
+        lastUpdateTime = baseTime;
+        q = new PriorityQueue<>(COMPARATOR);
+    }
+
+    @Override
+    public int size() {
+        return q.size();
+    }
+
+    @Override
+    public void add(SlotSelectionStrategyV2.SlotContext slotContext) {
+        q.add(slotContext);
+        updateAgingIfNeeded();
+    }
+
+    @Override
+    public boolean remove(SlotSelectionStrategyV2.SlotContext slotContext) {
+        return q.remove(slotContext);
+    }
+
+    @Override
+    public SlotSelectionStrategyV2.SlotContext poll() {
+        updateAgingIfNeeded();
+        return q.poll();
+    }
+
+    @Override
+    public SlotSelectionStrategyV2.SlotContext peak() {
+        updateAgingIfNeeded();
+        return q.peek();
+    }
+
+    private static long roundToGranularity(long timeMs) {
+        return (timeMs / AGING_GRANULARITY_MS) * AGING_GRANULARITY_MS;
+    }
+
+    protected double calculateScore(SlotSelectionStrategyV2.SlotContext slot) {
+        // Aging calculation examples:
+        // 100ms -> 0, 200ms -> 1, 400ms -> 2...
+        // 10s -> 6, 30s -> 8, 60s -> 9
+        // The longer the wait time, the higher the aging score
+        long age = (baseTime - roundToGranularity(slot.getCreateTime())) / AGING_GRANULARITY_MS;
+        age = Utils.log2(Math.max(1, age));
+        return slot.getSlot().getNumPhysicalSlots() - age * AGING_WEIGHT;
+    }
+
+    @VisibleForTesting
+    protected void updateBaseTime(long millis) {
+        this.baseTime = millis;
+    }
+
+    public long currentTime() {
+        return System.currentTimeMillis();
+    }
+
+    private void updateAgingIfNeeded() {
+        long currentTime = roundToGranularity(currentTime());
+        if (currentTime - lastUpdateTime >= AGING_UPDATE_INTERVAL_MS) {
+            baseTime = currentTime;
+            // Rebuild queue with updated aging scores
+            PriorityQueue<SlotSelectionStrategyV2.SlotContext> newQueue = new PriorityQueue<>(
+                    (lhs, rhs) -> Double.compare(calculateScore(lhs), calculateScore(rhs)));
+            newQueue.addAll(q);
+            q = newQueue;
+            lastUpdateTime = currentTime;
+
+            if (LOG.isDebugEnabled()) {
+                String str =
+                        q.stream().map(x -> String.format("[slot %d score %.1f]",
+                                        x.getSlot().getNumPhysicalSlots(),
+                                        calculateScore(x)))
+                                .collect(Collectors.joining(", "));
+                LOG.debug("ShortJobFirstQueue: {}", str);
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotScheduleAlgorithm.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotScheduleAlgorithm.java
@@ -1,0 +1,36 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler.slot;
+
+/**
+ * The algorithm/queue for slot schedule
+ */
+interface SlotScheduleAlgorithm {
+
+    int size();
+
+    default boolean isEmpty() {
+        return size() == 0;
+    }
+
+    void add(SlotSelectionStrategyV2.SlotContext slotContext);
+
+    boolean remove(SlotSelectionStrategyV2.SlotContext slotContext);
+
+    SlotSelectionStrategyV2.SlotContext poll();
+
+    SlotSelectionStrategyV2.SlotContext peak();
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2.java
@@ -171,7 +171,7 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
                 Preconditions.checkState(false, "unknown schedule policy: " + opts.getPolicy());
             }
             if (requiringQueue != null) {
-                while (requiringQueue.isEmpty()) {
+                while (!requiringQueue.isEmpty()) {
                     newQueue.add(requiringQueue.poll());
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2.java
@@ -170,8 +170,10 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
             } else {
                 Preconditions.checkState(false, "unknown schedule policy: " + opts.getPolicy());
             }
-            while (requiringQueue.isEmpty()) {
-                newQueue.add(requiringQueue.poll());
+            if (requiringQueue != null) {
+                while (requiringQueue.isEmpty()) {
+                    newQueue.add(requiringQueue.poll());
+                }
             }
             requiringQueue = newQueue;
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2.java
@@ -150,6 +150,11 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
         return slotsToAllocate;
     }
 
+    @VisibleForTesting
+    protected QueryQueueOptions getCurrentOptions() {
+        return opts;
+    }
+
     private void updateOptionsPeriodically() {
         long now = System.currentTimeMillis();
         if (now - lastUpdateOptionsTime < UPDATE_OPTIONS_INTERVAL_MS) {
@@ -181,7 +186,7 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
                     .filter(slotContext -> slotContext.getSlot().getState() == LogicalSlot.State.REQUIRING)
                     .forEach(slotContext -> requiringQueue.add(slotContext));
 
-            LOG.info("updated SlotSelectionStrategy to {}", newOpts);
+            LOG.info("updated SlotSelectionStrategy to {}", newOpts.toString());
 
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2.java
@@ -15,12 +15,15 @@
 package com.starrocks.qe.scheduler.slot;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.starrocks.metric.LongCounterMetric;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.thrift.TUniqueId;
 import org.apache.commons.compress.utils.Lists;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -38,6 +41,9 @@ import java.util.Map;
  * Each sub-queue has a different weight. See {@link WeightedRoundRobinQueue} for details.
  */
 public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
+
+    private static final Logger LOG = LogManager.getLogger(SlotSelectionStrategyV2.class);
+
     private static final long UPDATE_OPTIONS_INTERVAL_MS = 1000;
 
     /**
@@ -45,7 +51,7 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
      */
     private long lastUpdateOptionsTime = 0;
     private QueryQueueOptions opts = null;
-    private WeightedRoundRobinQueue requiringQueue = null;
+    private SlotScheduleAlgorithm requiringQueue = null;
 
     private final Map<TUniqueId, SlotContext> slotContexts = Maps.newHashMap();
 
@@ -154,10 +160,27 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
         QueryQueueOptions newOpts = QueryQueueOptions.createFromEnv();
         if (!newOpts.equals(opts)) {
             opts = newOpts;
-            requiringQueue = new WeightedRoundRobinQueue(opts.v2().getTotalSlots(), opts.v2().getNumWorkers());
+
+            // Change the schedule algorithm, move pending slots to new queue
+            SlotScheduleAlgorithm newQueue = null;
+            if (opts.getPolicy().equals(QueryQueueOptions.SchedulePolicy.SWRR)) {
+                newQueue = new WeightedRoundRobinQueue(opts.v2().getTotalSlots(), opts.v2().getNumWorkers());
+            } else if (opts.getPolicy().equals(QueryQueueOptions.SchedulePolicy.SJF)) {
+                newQueue = new ShortJobFirstAlgo();
+            } else {
+                Preconditions.checkState(false, "unknown schedule policy: " + opts.getPolicy());
+            }
+            while (requiringQueue.isEmpty()) {
+                newQueue.add(requiringQueue.poll());
+            }
+            requiringQueue = newQueue;
+
             slotContexts.values().stream()
                     .filter(slotContext -> slotContext.getSlot().getState() == LogicalSlot.State.REQUIRING)
                     .forEach(slotContext -> requiringQueue.add(slotContext));
+
+            LOG.info("updated SlotSelectionStrategy to {}", newOpts);
+
         }
     }
 
@@ -179,15 +202,18 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
      *
      * <p> The rules to divide sub-queues are as follows:
      * <ul>
-     * <li> The minimum slots of {@code subQueues[i]} is {@code 2^(lastSubQueueLog2Bound-(NUM_SUB_QUEUES-1-i) )}, that is, the
-     * minimum slots of 0~7 sub-queues are 2^(b-7), 2^(b-6), 2^(b-5), 2^(b-4), 2^(b-3), 2^(b-2), 2^(b-1), 2^b, respectively.
+     * <li> The minimum slots of {@code subQueues[i]} is {@code 2^(lastSubQueueLog2Bound-(NUM_SUB_QUEUES-1-i) )},
+     * that is, the
+     * minimum slots of 0~7 sub-queues are 2^(b-7), 2^(b-6), 2^(b-5), 2^(b-4), 2^(b-3), 2^(b-2), 2^(b-1), 2^b,
+     * respectively.
      * where {@code b} denotes {@code lastSubQueueLog2Bound}.
-     * <li> The weight of {@code subQueues[i]} is {@code 2.5^(NUM_SUB_QUEUES-1-i)}, that is, the weights of 0~7 sub-queues
+     * <li> The weight of {@code subQueues[i]} is {@code 2.5^(NUM_SUB_QUEUES-1-i)}, that is, the weights of 0~7
+     * sub-queues
      * are 2.5^7, 2.5^6, 2.5^5, 2.5^4, 2.5^3, 2.5^2, 2.5^1, 2.5^0 respectively.
      * </ul>
      */
     @VisibleForTesting
-    static class WeightedRoundRobinQueue {
+    static class WeightedRoundRobinQueue implements SlotScheduleAlgorithm {
         private static final int NUM_SUB_QUEUES = 8;
 
         private final int lastSubQueueLog2Bound;
@@ -219,7 +245,8 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
                 m = MetricRepo.COUNTER_QUERY_QUEUE_CATEGORY_SLOT_STATE.getMetric(category);
                 m.increase(-m.getValue());  // Reset.
                 MetricRepo.GAUGE_QUERY_QUEUE_CATEGORY_WEIGHT.getMetric(category).setValue(curWeight);
-                MetricRepo.GAUGE_QUERY_QUEUE_CATEGORY_SLOT_MIN_SLOTS.getMetric(category).setValue(curMinSlots * numWorkers);
+                MetricRepo.GAUGE_QUERY_QUEUE_CATEGORY_SLOT_MIN_SLOTS.getMetric(category)
+                        .setValue(curMinSlots * numWorkers);
 
                 curWeight = (curWeight >>> 1) + (curWeight << 1); // curWeight*=2.5
                 curMinSlots = curMinSlots >>> 1;
@@ -253,7 +280,8 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
             subQueue.comeback();
 
             if (nextSlotToPeak != null) {
-                // If the previous peaked slot is in a lower priority sub-queue due to this higher priority sub-queue is empty,
+                // If the previous peaked slot is in a lower priority sub-queue due to this higher priority sub-queue
+                // is empty,
                 // peak the slot in this higher priority sub-queue instead.
                 SlotSubQueue prevPeakSubQueue = subQueues[nextSlotToPeak.getSubQueueIndex()];
                 if (prevPeakSubQueue.state + totalWeight < subQueue.state) {
@@ -372,10 +400,13 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
 
                 // The queue_s is in a higher priority than queue_i, until `state_i + weight_i >= state_s + weight_s`,
                 // that is `deltaState >= deltaWeight`.
-                // When peaking queue_s one time, state_s decreases `totalWeight - weight_s`, and state_i increases `weight_i`.
-                // Therefore, queue_i increases `weight_i + (totalWeight - weight_s)` = `totalWeight - deltaWeight` each time
+                // When peaking queue_s one time, state_s decreases `totalWeight - weight_s`, and state_i increases
+                // `weight_i`.
+                // Therefore, queue_i increases `weight_i + (totalWeight - weight_s)` = `totalWeight - deltaWeight`
+                // each time
                 // compared to queue_s.
-                // Thus, the times of peaking queue_s before queue_i is `deltaWeight - deltaState / (totalWeight - deltaWeight)`.
+                // Thus, the times of peaking queue_s before queue_i is `deltaWeight - deltaState / (totalWeight -
+                // deltaWeight)`.
                 int deltaWeight = selectQueue.weight - queue.weight;
                 int deltaState = queue.state - selectQueue.state;
                 int incrStatePerTime = totalWeight - deltaWeight;
@@ -424,7 +455,8 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
 
             public void incrState(int incr) {
                 this.state += incr;
-                MetricRepo.COUNTER_QUERY_QUEUE_CATEGORY_SLOT_STATE.getMetric(String.valueOf(queueIndex)).increase((long) incr);
+                MetricRepo.COUNTER_QUERY_QUEUE_CATEGORY_SLOT_STATE.getMetric(String.valueOf(queueIndex))
+                        .increase((long) incr);
             }
 
             public boolean isEmpty() {
@@ -458,9 +490,11 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
         private final LogicalSlot slot;
         private boolean allocatedAsSmallSlot = false;
         private int subQueueIndex = 0;
+        private long createTime;
 
         public SlotContext(LogicalSlot slot) {
             this.slot = slot;
+            this.createTime = System.currentTimeMillis();
         }
 
         public boolean isAllocatedAsSmallSlot() {
@@ -485,6 +519,15 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
 
         public void setSubQueueIndex(int subQueueIndex) {
             this.subQueueIndex = subQueueIndex;
+        }
+
+        public long getCreateTime() {
+            return createTime;
+        }
+
+        @VisibleForTesting
+        public void setCreateTime(long createTime) {
+            this.createTime = createTime;
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -617,6 +617,10 @@ public class Utils {
         return 31 - Integer.numberOfLeadingZeros(n);
     }
 
+    public static long log2(long n) {
+        return 63 - Long.numberOfLeadingZeros(n);
+    }
+
     /**
      * Check the input expression is not nullable or not.
      * @param nullOutputColumnOps the nullable column reference operators.

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/ShortJobFirstAlgoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/ShortJobFirstAlgoTest.java
@@ -72,6 +72,7 @@ public class ShortJobFirstAlgoTest {
         algo.add(slots[1]);  // 200ms
         algo.add(slots[4]);  // 5s
         algo.add(slots[2]);  // 500ms
+        Assertions.assertEquals(6, algo.size());
 
         algo.updateBaseTime(startTime);
 
@@ -91,6 +92,7 @@ public class ShortJobFirstAlgoTest {
                     "Score mismatch for wait time " + waitTimes[i] + "ms");
         }
 
+        Assertions.assertEquals(slots[5], algo.peak(), "Should poll 10s wait task first");
         Assertions.assertEquals(slots[5], algo.poll(), "Should poll 10s wait task first");
         Assertions.assertEquals(slots[4], algo.poll(), "Should poll 5s wait task second");
         Assertions.assertEquals(slots[3], algo.poll(), "Should poll 1s wait task third");

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/ShortJobFirstAlgoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/ShortJobFirstAlgoTest.java
@@ -1,0 +1,123 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler.slot;
+
+import com.starrocks.thrift.TUniqueId;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static com.starrocks.qe.scheduler.slot.ShortJobFirstAlgo.AGING_WEIGHT;
+
+public class ShortJobFirstAlgoTest {
+
+    private LogicalSlot createLogicalSlot(int numSlots) {
+        return new LogicalSlot(new TUniqueId(1L, 1L), "fe1", 1, numSlots,
+                1000L, 1, 1, 1, 1);
+    }
+
+    @Test
+    public void testScore() {
+        LogicalSlot logicalSlot = createLogicalSlot(16);
+        SlotSelectionStrategyV2.SlotContext slot = new SlotSelectionStrategyV2.SlotContext(logicalSlot);
+        slot.setCreateTime(100);
+
+        ShortJobFirstAlgo algo = new ShortJobFirstAlgo();
+        algo.updateBaseTime(100);
+        Assertions.assertEquals(16.0, algo.calculateScore(slot));
+
+        algo.updateBaseTime(1000);
+        Assertions.assertEquals(13.0, algo.calculateScore(slot));
+
+        algo.updateBaseTime(10000);
+        Assertions.assertEquals(10.0, algo.calculateScore(slot));
+    }
+
+    @Test
+    public void testAgingScores() {
+        long startTime = 10_000_000L;
+        TestShortJobFirstAlgo algo = new TestShortJobFirstAlgo(startTime);
+
+        // create slots with different waiting time
+        SlotSelectionStrategyV2.SlotContext[] slots = new SlotSelectionStrategyV2.SlotContext[6];
+        long[] waitTimes = {
+                100,    // 100ms -> log2(1) = 0
+                200,    // 200ms -> log2(2) = 1
+                500,    // 500ms -> log2(5) = 2
+                1000,   // 1s -> log2(10) = 3
+                5000,   // 5s -> log2(50) = 5
+                10000   // 10s -> log2(100) = 6
+        };
+
+        for (int i = 0; i < slots.length; i++) {
+            slots[i] = createMockSlot(4);  // all tasks have 4 slots
+            Mockito.when(slots[i].getCreateTime()).thenReturn(startTime - waitTimes[i]);
+        }
+
+        algo.add(slots[3]);  // 1s
+        algo.add(slots[0]);  // 100ms
+        algo.add(slots[5]);  // 10s
+        algo.add(slots[1]);  // 200ms
+        algo.add(slots[4]);  // 5s
+        algo.add(slots[2]);  // 500ms
+
+        algo.updateBaseTime(startTime);
+
+        double[] expectedScores = {
+                4 - 0 * AGING_WEIGHT,  // 100ms
+                4 - 1 * AGING_WEIGHT,  // 200ms
+                4 - 2 * AGING_WEIGHT,  // 500ms
+                4 - 3 * AGING_WEIGHT,  // 1s
+                4 - 5 * AGING_WEIGHT,  // 5s
+                4 - 6 * AGING_WEIGHT   // 10s
+        };
+
+        // Verify the scores
+        for (int i = 0; i < slots.length; i++) {
+            double actualScore = algo.calculateScore(slots[i]);
+            Assertions.assertEquals(expectedScores[i], actualScore, 0.01,
+                    "Score mismatch for wait time " + waitTimes[i] + "ms");
+        }
+
+        Assertions.assertEquals(slots[5], algo.poll(), "Should poll 10s wait task first");
+        Assertions.assertEquals(slots[4], algo.poll(), "Should poll 5s wait task second");
+        Assertions.assertEquals(slots[3], algo.poll(), "Should poll 1s wait task third");
+        Assertions.assertEquals(slots[2], algo.poll(), "Should poll 500ms wait task fourth");
+        Assertions.assertEquals(slots[1], algo.poll(), "Should poll 200ms wait task fifth");
+        Assertions.assertEquals(slots[0], algo.poll(), "Should poll 100ms wait task last");
+    }
+
+    private static class TestShortJobFirstAlgo extends ShortJobFirstAlgo {
+        private final long mockCurrentTime;
+
+        public TestShortJobFirstAlgo(long initialTime) {
+            super();
+            this.mockCurrentTime = initialTime;
+        }
+
+        @Override
+        public long currentTime() {
+            return mockCurrentTime;
+        }
+    }
+
+    private SlotSelectionStrategyV2.SlotContext createMockSlot(int numPhysicalSlots) {
+        SlotSelectionStrategyV2.SlotContext context = Mockito.mock(SlotSelectionStrategyV2.SlotContext.class);
+        LogicalSlot slot = Mockito.mock(LogicalSlot.class);
+        Mockito.when(slot.getNumPhysicalSlots()).thenReturn(numPhysicalSlots);
+        Mockito.when(context.getSlot()).thenReturn(slot);
+        return context;
+    }
+}


### PR DESCRIPTION
## Why I'm doing:


Trying to improve the schedule strategy for the case of hybrid big-query and small-query.

## What I'm doing:

**Changes:**
1. add a FE config `query_queue_v2_schedule_strategy ` to choose the schedule algorithm, whose default value is still SWRR. The switch can be changed without restarting FE
2. Introduce the SJF schedule strategy, which will prefer short-job over big-job unless the big-job get waited for a long time

The pseudo code of SJF algorithm is as follows, which will calculate the score based on `numSlots` and `age`:
```
age = (baseTime - createTime) / 100ms
age = log2(max(1, age))
score = numSlots - age * AGING_WEIGHT
```


**Hybrid Big-Query and Small-Query Example: TPC-DS Q1 and Q67**
- **Scenario**: 
  - Based on CostPredictor & Query Queue functionalities
  - Running Q1 with 20 concurrency and 100 total queries.
  - Running Q67 with 4 concurrency.

- **Results**:
  - **Only Q1**: 15 seconds to complete.
  - **Q1 & Q67 with SWRR algorithm**: 50-60 seconds to complete Q1.
  - **Q1 & Q67 with SJF algorithm**: 30-45 seconds to complete Q1.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0