### PR TITLE
[Enhancement] Mask sensitive information for azure adls2 storage volume

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/AuditEncryptionChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/AuditEncryptionChecker.java
@@ -118,7 +118,9 @@ public class AuditEncryptionChecker implements AstVisitor<Boolean, Void> {
         if (properties.containsKey(CloudConfigurationConstants.AWS_S3_ACCESS_KEY) ||
                 properties.containsKey(CloudConfigurationConstants.AWS_S3_SECRET_KEY) ||
                 properties.containsKey(CloudConfigurationConstants.AZURE_BLOB_SHARED_KEY) ||
-                properties.containsKey(CloudConfigurationConstants.AZURE_BLOB_SAS_TOKEN)) {
+                properties.containsKey(CloudConfigurationConstants.AZURE_BLOB_SAS_TOKEN) ||
+                properties.containsKey(CloudConfigurationConstants.AZURE_ADLS2_SHARED_KEY) ||
+                properties.containsKey(CloudConfigurationConstants.AZURE_ADLS2_SAS_TOKEN)) {
             return true;
         }
         return false;
@@ -131,7 +133,9 @@ public class AuditEncryptionChecker implements AstVisitor<Boolean, Void> {
         if (properties.containsKey(CloudConfigurationConstants.AWS_S3_ACCESS_KEY) ||
                 properties.containsKey(CloudConfigurationConstants.AWS_S3_SECRET_KEY) ||
                 properties.containsKey(CloudConfigurationConstants.AZURE_BLOB_SHARED_KEY) ||
-                properties.containsKey(CloudConfigurationConstants.AZURE_BLOB_SAS_TOKEN)) {
+                properties.containsKey(CloudConfigurationConstants.AZURE_BLOB_SAS_TOKEN) ||
+                properties.containsKey(CloudConfigurationConstants.AZURE_ADLS2_SHARED_KEY) ||
+                properties.containsKey(CloudConfigurationConstants.AZURE_ADLS2_SAS_TOKEN)) {
             return true;
         }
         return false;


### PR DESCRIPTION
## Why I'm doing:
The sensitive information will be printed in audit log when create a adls2 storage volume.

## What I'm doing:
Mask sensitive information for azure adls2 storage volume

Fixes https://github.com/StarRocks/StarRocksTest/issues/9324

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0