### PR TITLE
[BugFix][branch-3.4] fix parquet timezone conversion (backport #55899)

### DIFF
--- a/be/src/formats/parquet/level_builder.cpp
+++ b/be/src/formats/parquet/level_builder.cpp
@@ -355,7 +355,7 @@ Status LevelBuilder::_write_datetime_column_chunk(const LevelBuilderContext& ctx
     DeferOp defer([&] { delete[] values; });
 
     for (size_t i = 0; i < col->size(); i++) {
-        auto offset = timestamp::get_offset_by_timezone(data_col[i]._timestamp, _ctz);
+        auto offset = timestamp::get_timezone_offset_by_timestamp(data_col[i]._timestamp, _ctz);
 
         auto timestamp = use_int96_timestamp_encoding ? timestamp::sub<TimeUnit::SECOND>(data_col[i]._timestamp, offset)
                                                       : data_col[i]._timestamp;

--- a/be/src/formats/parquet/level_builder.cpp
+++ b/be/src/formats/parquet/level_builder.cpp
@@ -60,14 +60,9 @@ LevelBuilder::LevelBuilder(TypeDescriptor type_desc, ::parquet::schema::NodePtr 
           _use_int96_timestamp_encoding(use_int96_timestamp_encoding) {}
 
 Status LevelBuilder::init() {
-    cctz::time_zone ctz;
-    if (!TimezoneUtils::find_cctz_time_zone(_timezone, ctz)) {
+    if (!TimezoneUtils::find_cctz_time_zone(_timezone, _ctz)) {
         return Status::InternalError(fmt::format("can not find cctz time zone {}", timezone));
     }
-
-    const auto tp = std::chrono::system_clock::now();
-    const cctz::time_zone::absolute_lookup al = ctz.lookup(tp);
-    _offset = al.offset;
     return Status::OK();
 }
 
@@ -360,9 +355,11 @@ Status LevelBuilder::_write_datetime_column_chunk(const LevelBuilderContext& ctx
     DeferOp defer([&] { delete[] values; });
 
     for (size_t i = 0; i < col->size(); i++) {
-        auto timestamp = use_int96_timestamp_encoding
-                                 ? timestamp::sub<TimeUnit::SECOND>(data_col[i]._timestamp, _offset)
-                                 : data_col[i]._timestamp;
+        auto offset = timestamp::get_offset_by_timezone(data_col[i]._timestamp, _ctz);
+
+        auto timestamp = use_int96_timestamp_encoding ? timestamp::sub<TimeUnit::SECOND>(data_col[i]._timestamp, offset)
+                                                      : data_col[i]._timestamp;
+
         if constexpr (use_int96_timestamp_encoding) {
             auto date = reinterpret_cast<int32_t*>(values[i].value + 2);
             auto nanosecond = reinterpret_cast<int64_t*>(values[i].value);

--- a/be/src/formats/parquet/level_builder.h
+++ b/be/src/formats/parquet/level_builder.h
@@ -178,7 +178,7 @@ private:
     TypeDescriptor _type_desc;
     ::parquet::schema::NodePtr _root;
     std::string _timezone;
-    int _offset{0};
+    cctz::time_zone _ctz;
     bool _use_legacy_decimal_encoding = false;
     bool _use_int96_timestamp_encoding = false;
 };

--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -380,7 +380,6 @@ void LakeTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequ
         response->mutable_status()->add_error_msgs("out-of-order packet");
         return;
     }
-    size_t chunk_size = chunk != nullptr ? chunk->bytes_usage() : 0;
 
     auto res = _create_write_context(chunk, request, response);
     if (!res.ok()) {
@@ -553,6 +552,7 @@ void LakeTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequ
     auto wait_writer_ns = finish_wait_writer_ts - start_wait_writer_ts;
 #ifndef BE_TEST
     _table_metrics->load_rows.increment(total_row_num);
+    size_t chunk_size = chunk != nullptr ? chunk->bytes_usage() : 0;
     _table_metrics->load_bytes.increment(chunk_size);
 #endif
     COUNTER_UPDATE(_add_chunk_counter, 1);

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -223,8 +223,6 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
         }
     }
 
-    size_t chunk_size = chunk != nullptr ? chunk->bytes_usage() : 0;
-
     auto res = _create_write_context(chunk, request, response);
     if (!res.ok()) {
         res.status().to_protobuf(response->mutable_status());
@@ -447,6 +445,7 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
     StarRocksMetrics::instance()->load_channel_add_chunks_wait_replica_duration_us.increment(wait_replica_ns / 1000);
 #ifndef BE_TEST
     _table_metrics->load_rows.increment(total_row_num);
+    size_t chunk_size = chunk != nullptr ? chunk->bytes_usage() : 0;
     _table_metrics->load_bytes.increment(chunk_size);
 #endif
 

--- a/be/test/column/date_value_test.cpp
+++ b/be/test/column/date_value_test.cpp
@@ -179,7 +179,7 @@ TEST(DateValueTest, getOffsetByTimezone) {
         cctz::time_zone ctz;
         TimezoneUtils::find_cctz_time_zone(timezone, ctz);
 
-        auto offset = timestamp::get_offset_by_timezone(timestampInDST, ctz);
+        auto offset = timestamp::get_timezone_offset_by_timestamp(timestampInDST, ctz);
 
         ASSERT_EQ(32400, offset);
     }
@@ -190,7 +190,7 @@ TEST(DateValueTest, getOffsetByTimezone) {
         cctz::time_zone ctz;
         TimezoneUtils::find_cctz_time_zone(timezone, ctz);
 
-        auto offset = timestamp::get_offset_by_timezone(timestampOutOfDST, ctz);
+        auto offset = timestamp::get_timezone_offset_by_timestamp(timestampOutOfDST, ctz);
 
         ASSERT_EQ(28800, offset);
     }

--- a/be/test/column/date_value_test.cpp
+++ b/be/test/column/date_value_test.cpp
@@ -172,6 +172,30 @@ TEST(DateValueTest, normalTimestamp) {
     }
 }
 
+TEST(DateValueTest, getOffsetByTimezone) {
+    {
+        auto timestampInDST = timestamp::from_datetime(1986, 8, 25, 0, 0, 0, 0);
+        auto timezone = "Asia/Shanghai";
+        cctz::time_zone ctz;
+        TimezoneUtils::find_cctz_time_zone(timezone, ctz);
+
+        auto offset = timestamp::get_offset_by_timezone(timestampInDST, ctz);
+
+        ASSERT_EQ(32400, offset);
+    }
+
+    {
+        auto timestampOutOfDST = timestamp::from_datetime(2004, 8, 25, 0, 0, 0, 0);
+        auto timezone = "Asia/Shanghai";
+        cctz::time_zone ctz;
+        TimezoneUtils::find_cctz_time_zone(timezone, ctz);
+
+        auto offset = timestamp::get_offset_by_timezone(timestampOutOfDST, ctz);
+
+        ASSERT_EQ(28800, offset);
+    }
+}
+
 TEST(DateValueTest, calculate) {
     DateValue dv;
     {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

backport two prs:
- https://github.com/StarRocks/starrocks/pull/55899
- https://github.com/StarRocks/starrocks/pull/56395

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
