### PR TITLE
[BugFix] Fix prepare stmt name out of range in MySQL protocol

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/qe/StmtExecutorPrepareStmtIdTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/StmtExecutorPrepareStmtIdTest.java
@@ -1,0 +1,124 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.qe;
+
+import com.starrocks.mysql.MysqlChannel;
+import com.starrocks.mysql.MysqlCodec;
+import com.starrocks.mysql.MysqlCommand;
+import com.starrocks.sql.ast.PrepareStmt;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Unit tests for {@link StmtExecutor#sendStmtPrepareOK(PrepareStmt)}.
+ *
+ * <p>This test focuses on the logic that converts {@link PrepareStmt#getName()} into the statement_id
+ * returned to the client. 3 scenarios are covered:
+ * 1. name is a numeric string within 4-byte range.
+ * 2. name is a numeric string beyond 4-byte range.
+ * 3. name is not a numeric string.</p>
+ */
+public class StmtExecutorPrepareStmtIdTest {
+
+    // Minimal dummy MysqlChannel to capture packets without touching real network.
+    private static class DummyMysqlChannel extends MysqlChannel {
+        private final List<ByteBuffer> packets = new ArrayList<>();
+        DummyMysqlChannel() {
+            super(null);
+        }
+        @Override
+        public void sendOnePacket(ByteBuffer packet) throws IOException {
+            // Keep an independent copy for inspection
+            ByteBuffer dup = ByteBuffer.allocate(packet.remaining());
+            dup.put(packet);
+            dup.flip();
+            packets.add(dup);
+        }
+        @Override
+        public void flush() {
+            // no-op
+        }
+        List<ByteBuffer> getPackets() {
+            return packets;
+        }
+    }
+
+    @BeforeClass
+    public static void beforeClass() {
+        UtFrameUtils.createMinStarRocksCluster();
+    }
+
+    private static int executePrepareAndGetStmtId(String stmtName) throws Exception {
+        // Build context and inject dummy channel
+        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
+        DummyMysqlChannel channel = new DummyMysqlChannel();
+        Field channelField = ConnectContext.class.getDeclaredField("mysqlChannel");
+        channelField.setAccessible(true);
+        channelField.set(ctx, channel);
+        // Mark this request as coming from binary protocol so subsequent logic (if any) knows.
+        ctx.setCommand(MysqlCommand.COM_STMT_PREPARE);
+
+        // Build a simple query statement: SELECT 1
+        QueryStatement query = (QueryStatement) UtFrameUtils.parseStmtWithNewParser("select 1", ctx);
+        PrepareStmt prepareStmt = new PrepareStmt(stmtName, query, null);
+
+        // Create executor and invoke private method via reflection
+        StmtExecutor executor = new StmtExecutor(ctx, prepareStmt);
+        Method m = StmtExecutor.class.getDeclaredMethod("sendStmtPrepareOK", PrepareStmt.class);
+        m.setAccessible(true);
+        m.invoke(executor, prepareStmt);
+
+        // First packet is OK packet containing statement_id at bytes 1-4 (little-endian)
+        ByteBuffer first = channel.getPackets().get(0).duplicate();
+        // Read OK header byte
+        MysqlCodec.readByte(first);
+        return MysqlCodec.readInt4(first);
+    }
+
+    @Test
+    public void testNumericWithinRange() throws Exception {
+        int id = executePrepareAndGetStmtId("123");
+        Assert.assertEquals(123, id);
+    }
+
+    @Test
+    public void testNumericOutOfRange() throws Exception {
+        String largeNum = "5000000000"; // > 0xFFFFFFFF
+        int expected = largeNum.hashCode() & 0x7FFFFFFF;
+        int id = executePrepareAndGetStmtId(largeNum);
+        Assert.assertEquals(expected, id);
+    }
+
+    @Test
+    public void testNonNumericName() throws Exception {
+        String name = "notNumber";
+        int expected = name.hashCode() & 0x7FFFFFFF;
+        int id = executePrepareAndGetStmtId(name);
+        Assert.assertEquals(expected, id);
+    }
+} 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/StmtExecutorPrepareStmtIdTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/StmtExecutorPrepareStmtIdTest.java
@@ -1,19 +1,16 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package com.starrocks.qe;
 


### PR DESCRIPTION
## Why I'm doing:
Try to fix prepare stmt name out of range in MySQL protocol

## What I'm doing:

Fixes #56440

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0