### PR TITLE
[BugFix] fix complex type subfield pruning on lambda function

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneComplexTypeUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneComplexTypeUtil.java
@@ -219,7 +219,8 @@ public class PruneComplexTypeUtil {
                 return null;
             }
 
-            if (scalarOperator.getType().isMapType() || scalarOperator.getType().isStructType()) {
+            if (scalarOperator.getType().isMapType() || scalarOperator.getType().isStructType() ||
+                    scalarOperator.getType().isFunctionType()) {
                 // New expression maybe added, and it's not be handled when go here, so we need disable prune subfields
                 // to prevent error prune.
                 context.setEnablePruneComplexTypes(false);

--- a/test/sql/test_iceberg/R/test_iceberg_catalog_complex_type
+++ b/test/sql/test_iceberg/R/test_iceberg_catalog_complex_type
@@ -1,0 +1,53 @@
+-- name: test_iceberg_catalog_complex_type
+create external catalog ice_cat_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog ice_cat_${uuid0};
+-- result:
+-- !result
+create database ice_db_${uuid0};
+-- result:
+-- !result
+use ice_db_${uuid0};
+-- result:
+-- !result
+create table ice_tbl_${uuid0} (
+    name ARRAY<STRUCT<
+        user STRING,
+        family STRING,
+        given ARRAY<STRING>,
+        prefix ARRAY<STRING>,
+        suffix ARRAY<STRING>
+    >>
+);
+-- result:
+-- !result
+insert into ice_tbl_${uuid0} values ([named_struct('user', 'official', 'family', 'Glover433', 'given', ['Kira861'], 'prefix', ['Ms.'], 'suffix', NULL)]);
+-- result:
+-- !result
+select array_filter(x->x.`user` = 'official', name)[1].family from ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0};
+-- result:
+Glover433
+-- !result
+function: assert_explain_verbose_contains("select array_filter(x->x.`user` = 'official', name)[1].family from ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0}", "Pruned type: 1 <-> [ARRAY<struct<user varchar(1073741824), family varchar(1073741824), given array<varchar(1073741824)>, prefix array<varchar(1073741824)>, suffix array<varchar(1073741824)>>>]")
+-- result:
+None
+-- !result
+drop table ice_tbl_${uuid0} force;
+-- result:
+-- !result
+drop database ice_db_${uuid0};
+-- result:
+-- !result
+drop catalog ice_cat_${uuid0};
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_catalog_complex_type
+++ b/test/sql/test_iceberg/T/test_iceberg_catalog_complex_type
@@ -1,0 +1,31 @@
+-- name: test_iceberg_catalog_complex_type
+create external catalog ice_cat_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog ice_cat_${uuid0};
+create database ice_db_${uuid0};
+use ice_db_${uuid0};
+create table ice_tbl_${uuid0} (
+    name ARRAY<STRUCT<
+        user STRING,
+        family STRING,
+        given ARRAY<STRING>,
+        prefix ARRAY<STRING>,
+        suffix ARRAY<STRING>
+    >>
+);
+insert into ice_tbl_${uuid0} values ([named_struct('user', 'official', 'family', 'Glover433', 'given', ['Kira861'], 'prefix', ['Ms.'], 'suffix', NULL)]);
+
+select array_filter(x->x.`user` = 'official', name)[1].family from ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0};
+
+function: assert_explain_verbose_contains("select array_filter(x->x.`user` = 'official', name)[1].family from ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0}", "Pruned type: 1 <-> [ARRAY<struct<user varchar(1073741824), family varchar(1073741824), given array<varchar(1073741824)>, prefix array<varchar(1073741824)>, suffix array<varchar(1073741824)>>>]")
+
+drop table ice_tbl_${uuid0} force;
+drop database ice_db_${uuid0};
+drop catalog ice_cat_${uuid0};
+
+set catalog default_catalog;


### PR DESCRIPTION
## Why I'm doing:

We don't support complex type subfield pruning on lambda function

## What I'm doing:

Fixes #56435

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0