### PR TITLE
[BugFix] fix complex type subfield pruning on lambda function for olap table 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldExpressionCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldExpressionCollector.java
@@ -35,6 +35,7 @@ public class SubfieldExpressionCollector extends ScalarOperatorVisitor<Void, Voi
     private final List<ScalarOperator> complexExpressions = Lists.newArrayList();
     private Set<String> checkFunctions;
     private final boolean enableJsonCollect;
+    private boolean forPushDownSubFiled;
 
     public List<ScalarOperator> getComplexExpressions() {
         return complexExpressions;
@@ -58,6 +59,7 @@ public class SubfieldExpressionCollector extends ScalarOperatorVisitor<Void, Voi
     public static SubfieldExpressionCollector buildPushdownCollector() {
         SubfieldExpressionCollector collector = new SubfieldExpressionCollector();
         collector.checkFunctions = Sets.newHashSet(PruneSubfieldRule.PUSHDOWN_FUNCTIONS);
+        collector.forPushDownSubFiled = true;
         return collector;
     }
 
@@ -97,7 +99,11 @@ public class SubfieldExpressionCollector extends ScalarOperatorVisitor<Void, Voi
 
     @Override
     public Void visitLambdaFunctionOperator(LambdaFunctionOperator operator, Void context) {
-        return null;
+        // we should not collect subfield expression in lambda when push down sub filed
+        if (forPushDownSubFiled) {
+            return null;
+        }
+        return visit(operator, context);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
@@ -762,5 +762,12 @@ public class ArrayTypeTest extends PlanTestBase {
         assertContains(plan, "3:Project\n" +
                 "  |  <slot 4> : 4: dense_rank()\n" +
                 "  |  <slot 6> : array_filter(3: v3, array_map(<slot 5> -> array_contains(3: v3, <slot 5>), 3: v3))");
+
+        sql =
+                "explain costs SELECT array_filter( s_1, " +
+                        "x -> array_length(array_filter(d_1, y -> y > 0)) > 0 ) AS filtered_activity_name," +
+                        " array_length(d_1) AS col_double_length FROM adec;";
+        plan = getCostExplain(sql);
+        assertNotContains(plan, "ColumnAccessPath: [/d_1/OFFSET]");
     }
 }


### PR DESCRIPTION
## Why I'm doing:
https://github.com/StarRocks/starrocks/pull/55367 let SubfieldExpressionCollector not visit LambdaFunctionOperator's children, which is correct for subfield expr push down. But for PruneSubfieldRule, if doesn't visit LambdaFunctionOperator's children, and LambdaFunctionOperator's children will use array colb's element column, and there is another function like array_length(col_b), then PruneSubfieldRule will mark ColumnAccessPath: [/col_b/OFFSET]

fix https://github.com/StarRocks/StarRocksTest/issues/9294

## What I'm doing:
do not visit d LambdaFunctionOperator's children  only in subfield expr push down

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0