### PR TITLE
[BugFix] Fix spill task never finished when query context released

### DIFF
--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -314,6 +314,8 @@ Status SpillableHashJoinProbeOperator::_load_all_partition_build_side(RuntimeSta
                 if (yield_ctx.need_yield) {
                     defer.cancel();
                 }
+            } else {
+                yield_ctx.set_finished();
             }
         };
         auto yield_func = [&](workgroup::ScanTask&& task) { spill::IOTaskExecutor::force_submit(std::move(task)); };

--- a/be/src/exec/workgroup/scan_task_queue.h
+++ b/be/src/exec/workgroup/scan_task_queue.h
@@ -26,6 +26,7 @@
 #include "common/statusor.h"
 #include "exec/workgroup/work_group_fwd.h"
 #include "util/blocking_priority_queue.hpp"
+#include "util/defer_op.h"
 #include "util/race_detect.h"
 #include "util/runtime_profile.h"
 
@@ -52,6 +53,9 @@ struct YieldContext {
     void set_finished() {
         yield_point = total_yield_point_cnt = 0;
         task_context_data.reset();
+    }
+    auto defer_finished() {
+        return CancelableDefer([this]() { set_finished(); });
     }
 
     std::any task_context_data;

--- a/be/test/io/spill_test.cpp
+++ b/be/test/io/spill_test.cpp
@@ -431,6 +431,67 @@ TEST_F(SpillTest, unsorted_process) {
     }
 }
 
+struct FailedGuard {
+    bool scoped_begin() const { return false; }
+    void scoped_end() const {}
+};
+
+TEST_F(SpillTest, yield_with_failed_guard) {
+    ObjectPool pool;
+    // order by id_int
+    TExprBuilder order_by_slots_builder;
+    order_by_slots_builder << TYPE_INT;
+    auto order_by_slots = order_by_slots_builder.get_res();
+    // full data id_int, id_smallint
+    std::vector<bool> nullables = {false, false};
+    TExprBuilder tuple_slots_builder;
+    tuple_slots_builder << TYPE_INT << TYPE_SMALLINT;
+    auto tuple_slots = tuple_slots_builder.get_res();
+
+    auto ctx_st = no_partition_context(&pool, &dummy_rt_st, order_by_slots, tuple_slots);
+    ASSERT_OK(ctx_st.status());
+    auto ctx = ctx_st.value();
+
+    auto& tuple = ctx->sort_exprs.sort_tuple_slot_expr_ctxs();
+
+    // create chunk
+    RandomChunkBuilder chunk_builder;
+
+    // create spilled factory
+    // auto factory_options = SpilledFactoryOptions(ctx->partition_nums, ctx->parition_exprs, ctx->sort_exprs, ctx->sort_descs, false);
+    auto factory = spill::make_spilled_factory();
+
+    // create spiller
+    SpilledOptions spill_options;
+    // 4 buffer chunk
+    spill_options.mem_table_pool_size = 4;
+    // file size: 1M
+    spill_options.spill_mem_table_bytes_size = 1 * 1024 * 1024;
+    // spill format type
+    spill_options.spill_type = spill::SpillFormaterType::SPILL_BY_COLUMN;
+
+    spill_options.block_manager = dummy_block_mgr.get();
+
+    auto chunk_empty = chunk_builder.gen(tuple, nullables);
+
+    auto spiller = factory->create(spill_options);
+    spiller->set_metrics(metrics);
+    SpillerCaller<spill::RawSpillerWriter*, spill::SpillerReader*> caller(spiller.get());
+    ASSERT_OK(spiller->prepare(&dummy_rt_st));
+
+    size_t test_loop = 1024;
+    std::vector<ChunkPtr> holder;
+    {
+        for (size_t i = 0; i < test_loop; ++i) {
+            auto chunk = chunk_builder.gen(tuple, nullables);
+            ASSERT_OK(caller.spill<SyncExecutor>(&dummy_rt_st, chunk, EmptyMemGuard{}));
+            ASSERT_OK(spiller->_spilled_task_status);
+            holder.push_back(chunk);
+        }
+        ASSERT_OK(caller.flush<SyncExecutor>(&dummy_rt_st, FailedGuard{}));
+    }
+}
+
 TEST_F(SpillTest, order_by_process) {
     ObjectPool pool;
     // order by id_int
@@ -570,6 +631,18 @@ TEST_F(SpillTest, partition_process) {
             holder.push_back(chunk);
         }
         ASSERT_OK(spiller->flush<SyncExecutor>(&dummy_rt_st, EmptyMemGuard{}));
+    }
+
+    {
+        for (size_t i = 0; i < test_loop; ++i) {
+            auto chunk = chunk_builder.gen(tuple, nullables);
+            auto hash_column = spill::SpillHashColumn::create(chunk->num_rows());
+            chunk->append_column(std::move(hash_column), -1);
+            ASSERT_OK(spiller->spill<SyncExecutor>(&dummy_rt_st, chunk, EmptyMemGuard{}));
+            ASSERT_OK(spiller->_spilled_task_status);
+            holder.push_back(chunk);
+        }
+        ASSERT_OK(spiller->flush<SyncExecutor>(&dummy_rt_st, FailedGuard{}));
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:

when query context release. yield_context.set_finished(); will never called, which will cause scan_io thread always active.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0