### PR TITLE
[BugFix] Fix the crash issue when update datacache_mem_tracker when be start

### DIFF
--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -303,7 +303,7 @@ void SystemMetrics::_update_datacache_mem_tracker() {
     auto* datacache_mem_tracker = GlobalEnv::GetInstance()->datacache_mem_tracker();
     if (datacache_mem_tracker) {
         BlockCache* block_cache = BlockCache::instance();
-        if (block_cache->is_initialized()) {
+        if (block_cache != nullptr && block_cache->is_initialized()) {
             auto datacache_metrics = block_cache->cache_metrics();
             datacache_mem_bytes = datacache_metrics.mem_used_bytes + datacache_metrics.meta_used_bytes;
         }


### PR DESCRIPTION
## Why I'm doing:

The Daemon thread crashed when updating metrics because the block_cache had not been initialized during the startup process.

## What I'm doing:

```
tracker:replication consumption: 0
*** Aborted at 1740988060 (unix time) try "date -d @1740988060" if you are using GNU date ***
PC: @          0x3e1ca16 starrocks::SystemMetrics::_update_datacache_mem_tracker()
*** SIGSEGV (@0x38) received by PID 2848 (TID 0x7f1b580ea700) LWP(2860) from PID 56; stack trace: ***
    @     0x7f1b6365520b __pthread_once_slow
    @          0xb3b6c54 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f1b6365e630 (/usr/lib64/libpthread-2.17.so+0xf62f)
    @          0x3e1ca16 starrocks::SystemMetrics::_update_datacache_mem_tracker()
    @          0x3e1cd45 starrocks::SystemMetrics::_update_memory_metrics()
    @          0x3e200bc std::_Function_handler<void (), starrocks::SystemMetrics::install(starrocks::MetricRegistry*, std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::@
    @          0x450d403 starrocks::calculate_metrics(void*)
    @          0xea794c0 execute_native_thread_routine
    @     0x7f1b63656ea5 start_thread
    @     0x7f1b61287b0d __clone
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0