### PR TITLE
[BugFix] fix struct subfield expr bugs

### DIFF
--- a/be/src/exprs/subfield_expr.cpp
+++ b/be/src/exprs/subfield_expr.cpp
@@ -42,6 +42,10 @@ public:
 
         // handle nullable column
         const size_t num_rows = col->size();
+        if (col->only_null()) {
+            return ColumnHelper::create_const_null_column(num_rows);
+        }
+
         NullColumnPtr union_null_column = NullColumn::create(num_rows, false);
 
         for (size_t i = 0; i < _used_subfield_names.size(); i++) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PushDownSubfieldRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PushDownSubfieldRule.java
@@ -390,6 +390,10 @@ public class PushDownSubfieldRule implements TreeRewriteRule {
                 // add child's output expression column
                 for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : context.pushDownExprRefs.entrySet()) {
                     ColumnRefOperator key = entry.getKey();
+                    if (alreadyExistsColumnRefs.contains(key)) {
+                        continue;
+                    }
+
                     ColumnRefOperator newChildOutputRef = factory.create(key, key.getType(), key.isNullable());
                     newChild.add(newChildOutputRef);
                     childContext.put(newChildOutputRef, rewriter.rewrite(entry.getValue()));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
@@ -706,4 +706,18 @@ public class SetTest extends PlanTestBase {
                 "         3 | 4\n" +
                 "         5 | 6\n");
     }
+
+    @Test
+    public void testStruct() throws Exception {
+        connectContext.getSessionVariable().setOptimizerExecuteTimeout(-1);
+        String sql = "with input as ("
+                + "select struct([1, 2, 3], [4, 5, 6]) as s "
+                + "union all "
+                + "select struct([5, 6, 7], [6, 7]) as s"
+                + ") select s, s.col1 from input;";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "constant exprs: \n"
+                + "         row([1,2,3], [4,5,6]) | row([1,2,3], [4,5,6]).col1[true]\n"
+                + "         row([5,6,7], [6,7]) | row([5,6,7], [6,7]).col1[true]");
+    }
 }

--- a/test/sql/test_semi/R/test_struct
+++ b/test/sql/test_semi/R/test_struct
@@ -293,3 +293,14 @@ select cast(named_struct('1', 1, '2', 2, '3', 3) as STRUCT<a double, b string, c
 -- result:
 {"a":1,"b":"2","c":3}
 -- !result
+with input as (select struct([1, 2, 3], [4, 5, 6]) as s union all select struct([5, 6, 7], [6, 7]) as s) select s, s.col1 from input;
+-- result:
+{"col1":[1,2,3],"col2":[4,5,6]}	[1,2,3]
+{"col1":[5,6,7],"col2":[6,7]}	[5,6,7]
+-- !result
+with input as (select struct([1, 2, 3], [4, 5, 6]) as s union all select null as s union all select struct([5, 6, 7], [6, 7]) as s) select s.col1 from input;
+-- result:
+[1,2,3]
+None
+[5,6,7]
+-- !result

--- a/test/sql/test_semi/T/test_struct
+++ b/test/sql/test_semi/T/test_struct
@@ -72,3 +72,6 @@ select named_struct('a', st1, 'b', st2)[1].sm2 from sc2;
 
 select cast(row(1,2,3) as STRUCT<a double, b string, c BIGINT>);
 select cast(named_struct('1', 1, '2', 2, '3', 3) as STRUCT<a double, b string, c BIGINT>);
+
+with input as (select struct([1, 2, 3], [4, 5, 6]) as s union all select struct([5, 6, 7], [6, 7]) as s) select s, s.col1 from input;
+with input as (select struct([1, 2, 3], [4, 5, 6]) as s union all select null as s union all select struct([5, 6, 7], [6, 7]) as s) select s.col1 from input;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

* push down subfield expr on union error
* subfield expr doesn't handle `only_null` col

Fixes 
https://github.com/StarRocks/starrocks/issues/56437
https://github.com/StarRocks/starrocks/issues/56436

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0