### PR TITLE
[Refactor] Rename visitSubquery

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/BetweenPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/BetweenPredicate.java
@@ -101,7 +101,7 @@ public class BetweenPredicate extends Predicate {
             return false;
         }
         BetweenPredicate that = (BetweenPredicate) obj;
-        return super.equals(that) && isNotBetween == that.isNotBetween;
+        return super.equalsWithoutChild(that) && isNotBetween == that.isNotBetween;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ExistsPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ExistsPredicate.java
@@ -110,7 +110,7 @@ public class ExistsPredicate extends Predicate {
 
         ExistsPredicate that = (ExistsPredicate) obj;
 
-        return super.equals(that) && notExists == that.notExists;
+        return super.equalsWithoutChild(that) && notExists == that.notExists;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/InPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/InPredicate.java
@@ -117,9 +117,9 @@ public class InPredicate extends Predicate {
         return isNotIn;
     }
 
-    public boolean isLiteralChildren() {
+    public boolean isConstantValues() {
         for (int i = 1; i < children.size(); ++i) {
-            if (!(children.get(i) instanceof LiteralExpr)) {
+            if (!(children.get(i).isConstant())) {
                 return false;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Subquery.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Subquery.java
@@ -127,6 +127,6 @@ public class Subquery extends Expr {
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) throws SemanticException {
-        return visitor.visitSubquery(this, context);
+        return visitor.visitSubqueryExpr(this, context);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/mv/analyzer/MVPartitionExprResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/analyzer/MVPartitionExprResolver.java
@@ -330,7 +330,7 @@ public class MVPartitionExprResolver {
         }
 
         @Override
-        public Exprs visitSubquery(SubqueryRelation node, MVExprContext context) {
+        public Exprs visitSubqueryRelation(SubqueryRelation node, MVExprContext context) {
             SlotRef slot = context.getSlotRef();
             if (slot.getTblNameWithoutAnalyzed() != null) {
                 String tableName = slot.getTblNameWithoutAnalyzed().getTbl();

--- a/fe/fe-core/src/main/java/com/starrocks/mv/analyzer/MVPartitionSlotRefResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/analyzer/MVPartitionSlotRefResolver.java
@@ -127,7 +127,7 @@ public class MVPartitionSlotRefResolver {
         }
 
         @Override
-        public Expr visitSubquery(SubqueryRelation node, SlotRef slot) {
+        public Expr visitSubqueryRelation(SubqueryRelation node, SlotRef slot) {
             if (slot.getTblNameWithoutAnalyzed() != null) {
                 String tableName = slot.getTblNameWithoutAnalyzed().getTbl();
                 if (!node.getAlias().getTbl().equalsIgnoreCase(tableName)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
@@ -314,7 +314,7 @@ public class AggregationAnalyzer {
         }
 
         @Override
-        public Boolean visitSubquery(Subquery node, Void context) {
+        public Boolean visitSubqueryExpr(Subquery node, Void context) {
             QueryStatement queryStatement = node.getQueryStatement();
             for (Map.Entry<Expr, FieldId> entry : queryStatement.getQueryRelation().getColumnReferences().entrySet()) {
                 Expr expr = entry.getKey();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeState.java
@@ -22,7 +22,6 @@ import com.starrocks.analysis.LimitElement;
 import com.starrocks.analysis.OrderByElement;
 import com.starrocks.common.IdGenerator;
 import com.starrocks.sql.ast.Relation;
-import com.starrocks.sql.ast.SelectRelation;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -38,6 +37,7 @@ public class AnalyzeState {
     /**
      * Structure used to build QueryBlock
      */
+    private List<String> outputAlias;
     private List<Expr> outputExpressions;
     private Scope outputScope;
     private boolean isDistinct = false;
@@ -100,19 +100,6 @@ public class AnalyzeState {
 
     public Map<Expr, FieldId> getColumnReferences() {
         return columnReferences;
-    }
-
-    public SelectRelation build() {
-        SelectRelation selectRelation = new SelectRelation(
-                outputExpressions, isDistinct,
-                orderScope, orderSourceExpressions,
-                relation, predicate, limit,
-                groupBy, aggregate, groupingSetsList, groupingFunctionCallExprs,
-                orderBy, having,
-                outputAnalytic, orderByAnalytic,
-                columnReferences);
-        selectRelation.setScope(new Scope(RelationId.of(selectRelation), outputScope.getRelationFields()));
-        return selectRelation;
     }
 
     public Scope getOrderScope() {
@@ -253,5 +240,13 @@ public class AnalyzeState {
 
     public List<Expr> getColumnNotInGroupBy() {
         return columnNotInGroupBy;
+    }
+
+    public List<String> getOutputAlias() {
+        return outputAlias;
+    }
+
+    public void setOutputAlias(List<String> outputAlias) {
+        this.outputAlias = outputAlias;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeState.java
@@ -37,7 +37,6 @@ public class AnalyzeState {
     /**
      * Structure used to build QueryBlock
      */
-    private List<String> outputAlias;
     private List<Expr> outputExpressions;
     private Scope outputScope;
     private boolean isDistinct = false;
@@ -240,13 +239,5 @@ public class AnalyzeState {
 
     public List<Expr> getColumnNotInGroupBy() {
         return columnNotInGroupBy;
-    }
-
-    public List<String> getOutputAlias() {
-        return outputAlias;
-    }
-
-    public void setOutputAlias(List<String> outputAlias) {
-        this.outputAlias = outputAlias;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -402,7 +402,7 @@ public class AnalyzerUtils {
         }
 
         @Override
-        public Void visitSubquery(SubqueryRelation node, Void context) {
+        public Void visitSubqueryRelation(SubqueryRelation node, Void context) {
             return visit(node.getQueryStatement());
         }
 
@@ -579,9 +579,9 @@ public class AnalyzerUtils {
         }
 
         @Override
-        public Void visitSubquery(SubqueryRelation node, Void context) {
+        public Void visitSubqueryRelation(SubqueryRelation node, Void context) {
             ctes.add(node.getResolveTableName());
-            return super.visitSubquery(node, context);
+            return super.visitSubqueryRelation(node, context);
         }
 
         @Override
@@ -1148,7 +1148,7 @@ public class AnalyzerUtils {
         }
 
         @Override
-        public Void visitSubquery(SubqueryRelation node, Void context) {
+        public Void visitSubqueryRelation(SubqueryRelation node, Void context) {
             subQueryRelations.put(node.getResolveTableName(), node);
             return visit(node.getQueryStatement());
         }
@@ -1168,7 +1168,7 @@ public class AnalyzerUtils {
         }
 
         @Override
-        public Void visitSubquery(SubqueryRelation node, Void context) {
+        public Void visitSubqueryRelation(SubqueryRelation node, Void context) {
             // no recursive
             subQueryRelations.put(node.getResolveTableName(), node);
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
@@ -109,7 +109,7 @@ public class AstToSQLBuilder {
             }
 
             res += '`' + fieldName + '`';
-            if (!fieldName.equalsIgnoreCase(columnName)) {
+            if (columnName != null && !fieldName.equalsIgnoreCase(columnName)) {
                 res += " AS `" + columnName + "`";
             }
             return res;
@@ -127,11 +127,13 @@ public class AstToSQLBuilder {
             }
 
             fieldName = handleColumnName(fieldName);
-            columnName = handleColumnName(columnName);
-
             res += fieldName;
-            if (!fieldName.equalsIgnoreCase(columnName)) {
-                res += " AS " + columnName;
+            
+            if (columnName != null) {
+                columnName = handleColumnName(columnName);
+                if (!fieldName.equalsIgnoreCase(columnName)) {
+                    res += " AS " + columnName;
+                }
             }
             return res;
         }
@@ -171,48 +173,7 @@ public class AstToSQLBuilder {
                 sqlBuilder.append("DISTINCT ");
             }
 
-            List<String> selectListString = new ArrayList<>();
-            if (CollectionUtils.isNotEmpty(stmt.getOutputExpression())) {
-                for (int i = 0; i < stmt.getOutputExpression().size(); ++i) {
-                    Expr expr = stmt.getOutputExpression().get(i);
-                    String columnName = stmt.getColumnOutputNames().get(i);
-
-                    if (expr instanceof FieldReference) {
-                        Field field = stmt.getScope().getRelationFields().getFieldByIndex(i);
-                        selectListString.add(buildColumnName(field.getRelationAlias(), field.getName(), columnName));
-                    } else if (expr instanceof SlotRef) {
-                        SlotRef slot = (SlotRef) expr;
-                        if (slot.getOriginType().isStructType()) {
-                            selectListString.add(buildStructColumnName(slot.getTblNameWithoutAnalyzed(),
-                                    slot.getColumnName(), columnName));
-                        } else {
-                            selectListString.add(buildColumnName(slot.getTblNameWithoutAnalyzed(), slot.getColumnName(),
-                                    columnName));
-                        }
-                    } else {
-                        selectListString.add(visit(expr) + " AS `" + columnName + "`");
-                    }
-                }
-            } else {
-                for (SelectListItem item : stmt.getSelectList().getItems()) {
-                    if (item.isStar()) {
-                        if (item.getTblName() != null) {
-                            selectListString.add(item.getTblName() + ".*");
-                        } else {
-                            selectListString.add("*");
-                        }
-                    } else if (item.getExpr() != null) {
-                        Expr expr = item.getExpr();
-                        String str = visit(expr);
-                        if (StringUtils.isNotEmpty(item.getAlias())) {
-                            str += " AS " + ParseUtil.backquote(item.getAlias());
-                        }
-                        selectListString.add(str);
-                    }
-                }
-            }
-
-            sqlBuilder.append(Joiner.on(", ").join(selectListString));
+            sqlBuilder.append(Joiner.on(", ").join(visitSelectItemList(stmt)));
 
             String fromClause = visit(stmt.getRelation());
             if (fromClause != null) {
@@ -238,6 +199,54 @@ public class AstToSQLBuilder {
             return sqlBuilder.toString();
         }
 
+        protected List<String> visitSelectItemList(SelectRelation stmt) {
+            if (CollectionUtils.isNotEmpty(stmt.getOutputExpression())) {
+                List<String> selectListString = new ArrayList<>();
+                List<String> columnNameList = stmt.getOutputAlias();
+                for (int i = 0; i < stmt.getOutputExpression().size(); ++i) {
+                    Expr expr = stmt.getOutputExpression().get(i);
+                    String columnName = columnNameList.get(i);
+
+                    if (expr instanceof FieldReference) {
+                        Field field = stmt.getScope().getRelationFields().getFieldByIndex(i);
+                        selectListString.add(buildColumnName(field.getRelationAlias(), field.getName(), columnName));
+                    } else if (expr instanceof SlotRef slot) {
+                        if (slot.getOriginType().isStructType()) {
+                            selectListString.add(buildStructColumnName(slot.getTblNameWithoutAnalyzed(),
+                                    slot.getColumnName(), columnName));
+                        } else {
+                            selectListString.add(buildColumnName(slot.getTblNameWithoutAnalyzed(), slot.getColumnName(),
+                                    columnName));
+                        }
+                    } else if (columnName != null) {
+                        selectListString.add(visit(expr) + " AS `" + columnName + "`");
+                    } else {
+                        selectListString.add(visit(expr));
+                    }
+                }
+                return selectListString;
+            } else {
+                List<String> selectListString = new ArrayList<>();
+                for (SelectListItem item : stmt.getSelectList().getItems()) {
+                    if (item.isStar()) {
+                        if (item.getTblName() != null) {
+                            selectListString.add(item.getTblName() + ".*");
+                        } else {
+                            selectListString.add("*");
+                        }
+                    } else if (item.getExpr() != null) {
+                        Expr expr = item.getExpr();
+                        String str = visit(expr);
+                        if (StringUtils.isNotEmpty(item.getAlias())) {
+                            str += " AS " + ParseUtil.backquote(item.getAlias());
+                        }
+                        selectListString.add(str);
+                    }
+                }
+                return selectListString;
+            }
+        }
+
         @Override
         public String visitCTE(CTERelation relation, Void context) {
             StringBuilder sqlBuilder = new StringBuilder();
@@ -261,7 +270,7 @@ public class AstToSQLBuilder {
         }
 
         @Override
-        public String visitSubquery(SubqueryRelation node, Void context) {
+        public String visitSubqueryRelation(SubqueryRelation node, Void context) {
             StringBuilder sqlBuilder = new StringBuilder("(" + visit(node.getQueryStatement()) + ")");
 
             if (node.getAlias() != null) {
@@ -304,7 +313,7 @@ public class AstToSQLBuilder {
                     sqlBuilder.append(")");
                 }
             }
-            
+
             for (TableRelation.TableHint hint : CollectionUtils.emptyIfNull(node.getTableHints())) {
                 sqlBuilder.append(" [");
                 sqlBuilder.append(hint.name());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
@@ -202,7 +202,7 @@ public class AstToSQLBuilder {
         protected List<String> visitSelectItemList(SelectRelation stmt) {
             if (CollectionUtils.isNotEmpty(stmt.getOutputExpression())) {
                 List<String> selectListString = new ArrayList<>();
-                List<String> columnNameList = stmt.getOutputAlias();
+                List<String> columnNameList = stmt.getColumnOutputNames();
                 for (int i = 0; i < stmt.getOutputExpression().size(); ++i) {
                     Expr expr = stmt.getOutputExpression().get(i);
                     String columnName = columnNameList.get(i);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -636,7 +636,7 @@ public class AstToStringBuilder {
         }
 
         @Override
-        public String visitSubquery(SubqueryRelation node, Void context) {
+        public String visitSubqueryRelation(SubqueryRelation node, Void context) {
             StringBuilder sqlBuilder = new StringBuilder("(" + visit(node.getQueryStatement()) + ")");
 
             if (node.getAlias() != null) {
@@ -1309,7 +1309,7 @@ public class AstToStringBuilder {
         }
 
         @Override
-        public String visitSubquery(Subquery node, Void context) {
+        public String visitSubqueryExpr(Subquery node, Void context) {
             return "(" + visit(node.getQueryStatement()) + ")";
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -1395,7 +1395,7 @@ public class ExpressionAnalyzer {
         }
 
         @Override
-        public Void visitSubquery(Subquery node, Scope context) {
+        public Void visitSubqueryExpr(Subquery node, Scope context) {
             QueryAnalyzer queryAnalyzer = new QueryAnalyzer(session);
             queryAnalyzer.analyze(node.getQueryStatement(), context);
             node.setType(node.getQueryStatement().getQueryRelation().getRelationFields().getFieldByIndex(0).getType());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -240,7 +240,7 @@ public class QueryAnalyzer {
         }
 
         @Override
-        public Void visitSubquery(SubqueryRelation subquery, Scope scope) {
+        public Void visitSubqueryRelation(SubqueryRelation subquery, Scope scope) {
             QueryRelation queryRelation = subquery.getQueryStatement().getQueryRelation();
             if (queryRelation instanceof SelectRelation) {
                 SelectRelation childSelectRelation = (SelectRelation) queryRelation;
@@ -927,7 +927,7 @@ public class QueryAnalyzer {
         }
 
         @Override
-        public Scope visitSubquery(SubqueryRelation subquery, Scope context) {
+        public Scope visitSubqueryRelation(SubqueryRelation subquery, Scope context) {
             if (subquery.getResolveTableName() != null && subquery.getResolveTableName().getTbl() == null) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_DERIVED_MUST_HAVE_ALIAS);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
@@ -203,6 +203,7 @@ public class SelectAnalyzer {
     private List<Expr> analyzeSelect(SelectList selectList, Relation fromRelation, AnalyzeState analyzeState, Scope scope) {
         ImmutableList.Builder<Expr> outputExpressionBuilder = ImmutableList.builder();
         ImmutableList.Builder<Field> outputFields = ImmutableList.builder();
+        List<String> outputAlias = Lists.newArrayList();
         List<Integer> outputExprInOrderByScope = new ArrayList<>();
 
         for (SelectListItem item : selectList.getItems()) {
@@ -214,7 +215,7 @@ public class SelectAnalyzer {
                         .collect(Collectors.toList());
                 List<String> unknownTypeFields = fields.stream()
                         .filter(field -> field.getType().getPrimitiveType().equals(PrimitiveType.UNKNOWN_TYPE))
-                        .map(Field::getName).collect(Collectors.toList());
+                        .map(Field::getName).toList();
                 if (!unknownTypeFields.isEmpty()) {
                     throw new SemanticException("Datatype of external table column " + unknownTypeFields
                             + " is not supported!");
@@ -241,6 +242,7 @@ public class SelectAnalyzer {
                     FieldReference fieldReference = new FieldReference(fieldIndex, item.getTblName());
                     analyzeExpression(fieldReference, analyzeState, scope);
                     outputExpressionBuilder.add(fieldReference);
+                    outputAlias.add(null);
                 }
                 outputFields.addAll(fields);
 
@@ -253,6 +255,7 @@ public class SelectAnalyzer {
                             AstToStringBuilder.getAliasName(item.getExpr(), false, false) : item.getAlias();
                 }
 
+                outputAlias.add(item.getAlias());
                 analyzeExpression(item.getExpr(), analyzeState, scope);
                 outputExpressionBuilder.add(item.getExpr());
 
@@ -309,6 +312,7 @@ public class SelectAnalyzer {
         analyzeState.setOutputExpression(outputExpressions);
         analyzeState.setOutputExprInOrderByScope(outputExprInOrderByScope);
         analyzeState.setOutputScope(new Scope(RelationId.anonymous(), new RelationFields(outputFields.build())));
+        analyzeState.setOutputAlias(outputAlias);
         return outputExpressions;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
@@ -203,7 +203,6 @@ public class SelectAnalyzer {
     private List<Expr> analyzeSelect(SelectList selectList, Relation fromRelation, AnalyzeState analyzeState, Scope scope) {
         ImmutableList.Builder<Expr> outputExpressionBuilder = ImmutableList.builder();
         ImmutableList.Builder<Field> outputFields = ImmutableList.builder();
-        List<String> outputAlias = Lists.newArrayList();
         List<Integer> outputExprInOrderByScope = new ArrayList<>();
 
         for (SelectListItem item : selectList.getItems()) {
@@ -242,7 +241,6 @@ public class SelectAnalyzer {
                     FieldReference fieldReference = new FieldReference(fieldIndex, item.getTblName());
                     analyzeExpression(fieldReference, analyzeState, scope);
                     outputExpressionBuilder.add(fieldReference);
-                    outputAlias.add(null);
                 }
                 outputFields.addAll(fields);
 
@@ -255,7 +253,6 @@ public class SelectAnalyzer {
                             AstToStringBuilder.getAliasName(item.getExpr(), false, false) : item.getAlias();
                 }
 
-                outputAlias.add(item.getAlias());
                 analyzeExpression(item.getExpr(), analyzeState, scope);
                 outputExpressionBuilder.add(item.getExpr());
 
@@ -312,7 +309,6 @@ public class SelectAnalyzer {
         analyzeState.setOutputExpression(outputExpressions);
         analyzeState.setOutputExprInOrderByScope(outputExprInOrderByScope);
         analyzeState.setOutputScope(new Scope(RelationId.anonymous(), new RelationFields(outputFields.build())));
-        analyzeState.setOutputAlias(outputAlias);
         return outputExpressions;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstTraverser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstTraverser.java
@@ -160,7 +160,7 @@ public class AstTraverser<R, C> implements AstVisitor<R, C> {
     }
 
     @Override
-    public R visitSubquery(SubqueryRelation node, C context) {
+    public R visitSubqueryRelation(SubqueryRelation node, C context) {
         return visit(node.getQueryStatement(), context);
     }
 
@@ -192,7 +192,7 @@ public class AstTraverser<R, C> implements AstVisitor<R, C> {
     }
 
     @Override
-    public R visitSubquery(Subquery node, C context) {
+    public R visitSubqueryExpr(Subquery node, C context) {
         return visit(node.getQueryStatement(), context);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -1334,7 +1334,7 @@ public interface AstVisitor<R, C> {
         return visitRelation(node, context);
     }
 
-    default R visitSubquery(SubqueryRelation node, C context) {
+    default R visitSubqueryRelation(SubqueryRelation node, C context) {
         return visitRelation(node, context);
     }
 
@@ -1500,7 +1500,7 @@ public interface AstVisitor<R, C> {
         return visitExpression(node, context);
     }
 
-    default R visitSubquery(Subquery node, C context) {
+    default R visitSubqueryExpr(Subquery node, C context) {
         return visitExpression(node, context);
     }
 
@@ -1602,4 +1602,17 @@ public interface AstVisitor<R, C> {
         return visitNode(node, context);
     }
 
+    // ------------------------------------------- BaselinePlan -------------------------------------------------------
+    //
+    //    default R visitCreateBaselinePlanStatement(CreateBaselinePlanStmt statement, C context) {
+    //        return visitDDLStatement(statement, context);
+    //    }
+    //
+    //    default R visitDropBaselinePlanStatement(DropBaselinePlanStmt statement, C context) {
+    //        return visitDDLStatement(statement, context);
+    //    }
+    //
+    //    default R visitShowBaselinePlanStatement(ShowBaselinePlanStmt statement, C context) {
+    //        return visitShowStatement(statement, context);
+    //    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SelectRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SelectRelation.java
@@ -41,6 +41,12 @@ public class SelectRelation extends QueryRelation {
      */
     private List<Expr> outputExpr;
 
+    /**
+     * outputAlias is different with output field name, use for construct sql
+     * e.g. select k+1, k+1 is the output name, but the alias is null
+     */
+    private List<String> outputAlias;
+
     private Expr predicate;
 
     /**
@@ -151,6 +157,7 @@ public class SelectRelation extends QueryRelation {
         this.orderByAnalytic = analyzeState.getOrderByAnalytic();
 
         this.columnReferences = analyzeState.getColumnReferences();
+        this.outputAlias = analyzeState.getOutputAlias();
 
         this.setScope(analyzeState.getOutputScope());
     }
@@ -296,5 +303,9 @@ public class SelectRelation extends QueryRelation {
     @Override
     public List<Expr> getOutputExpression() {
         return outputExpr;
+    }
+
+    public List<String> getOutputAlias() {
+        return outputAlias;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SelectRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SelectRelation.java
@@ -41,12 +41,6 @@ public class SelectRelation extends QueryRelation {
      */
     private List<Expr> outputExpr;
 
-    /**
-     * outputAlias is different with output field name, use for construct sql
-     * e.g. select k+1, k+1 is the output name, but the alias is null
-     */
-    private List<String> outputAlias;
-
     private Expr predicate;
 
     /**
@@ -157,7 +151,6 @@ public class SelectRelation extends QueryRelation {
         this.orderByAnalytic = analyzeState.getOrderByAnalytic();
 
         this.columnReferences = analyzeState.getColumnReferences();
-        this.outputAlias = analyzeState.getOutputAlias();
 
         this.setScope(analyzeState.getOutputScope());
     }
@@ -303,9 +296,5 @@ public class SelectRelation extends QueryRelation {
     @Override
     public List<Expr> getOutputExpression() {
         return outputExpr;
-    }
-
-    public List<String> getOutputAlias() {
-        return outputAlias;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SubqueryRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SubqueryRelation.java
@@ -63,6 +63,6 @@ public class SubqueryRelation extends QueryRelation {
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return visitor.visitSubquery(this, context);
+        return visitor.visitSubqueryRelation(this, context);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/AuditEncryptionChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/AuditEncryptionChecker.java
@@ -209,7 +209,7 @@ public class AuditEncryptionChecker implements AstVisitor<Boolean, Void> {
     }
 
     @Override
-    public Boolean visitSubquery(SubqueryRelation relation, Void context) {
+    public Boolean visitSubqueryRelation(SubqueryRelation relation, Void context) {
         QueryStatement queryStatement = relation.getQueryStatement();
         return visit(queryStatement);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/DebugRelationTracer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/DebugRelationTracer.java
@@ -71,7 +71,7 @@ public class DebugRelationTracer implements AstVisitor<String, String> {
     }
 
     @Override
-    public String visitSubquery(SubqueryRelation node, String indent) {
+    public String visitSubqueryRelation(SubqueryRelation node, String indent) {
         return "SubqueryRelation{\n" + indent + "  alias=" +
                 (node.getAlias() == null ? "anonymous" : node.getAlias()) + "\n" +
                 indent + "  query=" +

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SqlDigestBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SqlDigestBuilder.java
@@ -45,7 +45,7 @@ public class SqlDigestBuilder {
 
         @Override
         public String visitInPredicate(InPredicate node, Void context) {
-            if (!node.isLiteralChildren()) {
+            if (!node.isConstantValues()) {
                 return super.visitInPredicate(node, context);
             } else {
                 StringBuilder strBuilder = new StringBuilder();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/DesensitizedInfoCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/DesensitizedInfoCollector.java
@@ -148,9 +148,9 @@ public class DesensitizedInfoCollector {
         }
 
         @Override
-        public Void visitSubquery(SubqueryRelation relation, Void context) {
+        public Void visitSubqueryRelation(SubqueryRelation relation, Void context) {
             collectRelationDict(relation);
-            super.visitSubquery(relation, context);
+            super.visitSubqueryRelation(relation, context);
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/DesensitizedSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/DesensitizedSQLBuilder.java
@@ -347,7 +347,7 @@ public class DesensitizedSQLBuilder {
         }
 
         @Override
-        public String visitSubquery(SubqueryRelation node, Void context) {
+        public String visitSubqueryRelation(SubqueryRelation node, Void context) {
             StringBuilder sqlBuilder = new StringBuilder("(" + visit(node.getQueryStatement()) + ")");
 
             if (node.getAlias() != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -809,7 +809,7 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
     }
 
     @Override
-    public LogicalPlan visitSubquery(SubqueryRelation node, ExpressionMapping context) {
+    public LogicalPlan visitSubqueryRelation(SubqueryRelation node, ExpressionMapping context) {
         LogicalPlan logicalPlan = transform(node.getQueryStatement().getQueryRelation());
         OptExpression subQueryOptExpression = logicalPlan.getRoot();
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -798,7 +798,7 @@ public final class SqlToScalarOperatorTranslator {
         }
 
         @Override
-        public ScalarOperator visitSubquery(Subquery node, Context context) {
+        public ScalarOperator visitSubqueryExpr(Subquery node, Context context) {
             Preconditions.checkNotNull(context);
             QueryStatement queryStatement = node.getQueryStatement();
             QueryRelation queryRelation = queryStatement.getQueryRelation();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/analyzer/SimpleExpressionAnalyzer.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/analyzer/SimpleExpressionAnalyzer.java
@@ -742,7 +742,7 @@ public class SimpleExpressionAnalyzer {
         }
 
         @Override
-        public Void visitSubquery(Subquery node, Scope context) {
+        public Void visitSubqueryExpr(Subquery node, Scope context) {
             SimpleQueryAnalyzer queryAnalyzer = new SimpleQueryAnalyzer();
             queryAnalyzer.analyze(node.getQueryStatement());
             // Do not know the subquery type, use string as default

--- a/fe/fe-core/src/test/java/com/starrocks/connector/analyzer/SimpleQueryAnalyzer.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/analyzer/SimpleQueryAnalyzer.java
@@ -194,7 +194,7 @@ public class SimpleQueryAnalyzer {
 
 
         @Override
-        public Void visitSubquery(SubqueryRelation subquery, Void context) {
+        public Void visitSubqueryRelation(SubqueryRelation subquery, Void context) {
             if (subquery.getResolveTableName() != null && subquery.getResolveTableName().getTbl() == null) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_DERIVED_MUST_HAVE_ALIAS);
             }

--- a/test/sql/test_automatic_partition/R/test_partition_prune
+++ b/test/sql/test_automatic_partition/R/test_partition_prune
@@ -152,7 +152,7 @@ explain select * from o where ts>cast(unix_timestamp() as STRING);
 -- !result
 explain select * from o where ts>'1740108713';
 -- result:
-[REGEX].*partitions=2/3.*
+[REGEX].*partitions=3/3.*
 -- !result
 
 -- name: test_prune_convert_tz


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

* Standardize the name of `visitSubquery` methods:
  * to `visitSubqueryRelation` and `visitSubqueryExpr`
* Fix `BetweenPredicate` and `ExistsPredicate` equals bug
* refactor `InPredicate.isLiteralChildren` to `isConstantValues`
* refactor `AstToSQLBuilder.visitSelect` method
  * extract common method

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0