### PR TITLE
[Enhancement] Move delta write open out of brpc worker

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -416,7 +416,7 @@ CONF_mBool(enable_load_channel_rpc_async, "true");
 // switching from sync to async mode
 CONF_mInt32(load_channel_rpc_thread_pool_num, "-1");
 // The queue size for Load channel rpc thread pool
-CONF_Int32(load_channel_rpc_thread_pool_queue_size, "102400");
+CONF_Int32(load_channel_rpc_thread_pool_queue_size, "1024000");
 CONF_mInt32(number_tablet_writer_threads, "16");
 CONF_mInt64(max_queueing_memtable_per_tablet, "2");
 // when memory limit exceed and memtable last update time exceed this time, memtable will be flushed

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -408,6 +408,15 @@ CONF_Int32(arrow_flight_port, "-1");
 CONF_Int64(load_data_reserve_hours, "4");
 // log error log will be removed after this time
 CONF_mInt64(load_error_log_reserve_hours, "48");
+// Whether to execute load channel RPC requests asynchronously, that is,
+// to run RPCs in a separate thread pool instead of within BRPC workers
+CONF_mBool(enable_load_channel_rpc_async, "true");
+// Maximum threads in load channel RPC thread pool. Default: -1 (auto-set to CPU cores),
+// aligning with brpc workers' default (brpc_num_threads) to keep compatible after
+// switching from sync to async mode
+CONF_mInt32(load_channel_rpc_thread_pool_num, "-1");
+// The queue size for Load channel rpc thread pool
+CONF_Int32(load_channel_rpc_thread_pool_queue_size, "102400");
 CONF_mInt32(number_tablet_writer_threads, "16");
 CONF_mInt64(max_queueing_memtable_per_tablet, "2");
 // when memory limit exceed and memtable last update time exceed this time, memtable will be flushed

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -54,6 +54,7 @@
 #include "http/http_status.h"
 #include "runtime/batch_write/batch_write_mgr.h"
 #include "runtime/batch_write/txn_state_cache.h"
+#include "runtime/load_channel_mgr.h"
 #include "storage/compaction_manager.h"
 #include "storage/lake/compaction_scheduler.h"
 #include "storage/lake/load_spill_block_manager.h"
@@ -308,6 +309,11 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
         _config_callback.emplace("check_consistency_worker_count", [&]() -> Status {
             auto thread_pool = ExecEnv::GetInstance()->agent_server()->get_thread_pool(TTaskType::CHECK_CONSISTENCY);
             return thread_pool->update_max_threads(std::max(1, config::check_consistency_worker_count));
+        });
+        _config_callback.emplace("load_channel_rpc_thread_pool_num", [&]() -> Status {
+            LOG(INFO) << "set load_channel_rpc_thread_pool_num:" << config::load_channel_rpc_thread_pool_num;
+            return ExecEnv::GetInstance()->load_channel_mgr()->async_rpc_pool()->update_max_threads(
+                    config::load_channel_rpc_thread_pool_num);
         });
         _config_callback.emplace("number_tablet_writer_threads", [&]() -> Status {
             LOG(INFO) << "set number_tablet_writer_threads:" << config::number_tablet_writer_threads;

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -89,6 +89,8 @@ LoadChannel::LoadChannel(LoadChannelMgr* mgr, LakeTabletManager* lake_tablet_mgr
     _profile_report_count = ADD_COUNTER(_profile, "ProfileReportCount", TUnit::UNIT);
     _profile_report_timer = ADD_TIMER(_profile, "ProfileReportTime");
     _profile_serialized_size = ADD_COUNTER(_profile, "ProfileSerializedSize", TUnit::BYTES);
+    _open_request_count = ADD_COUNTER(_profile, "OpenRequestCount", TUnit::UNIT);
+    _open_request_pending_timer = ADD_TIMER(_profile, "OpenRequestPendingTime");
 }
 
 LoadChannel::~LoadChannel() {
@@ -110,11 +112,16 @@ void LoadChannel::set_profile_config(const PLoadChannelProfileConfig& config) {
     }
 }
 
-void LoadChannel::open(brpc::Controller* cntl, const PTabletWriterOpenRequest& request,
-                       PTabletWriterOpenResult* response, google::protobuf::Closure* done) {
+void LoadChannel::open(const LoadChannelOpenRequest& open_request) {
+    int64_t start_time_ns = MonotonicNanos();
+    COUNTER_UPDATE(_open_request_count, 1);
+    COUNTER_UPDATE(_open_request_pending_timer, (start_time_ns - open_request.receive_rpc_time_ns));
+    brpc::Controller* cntl = open_request.cntl;
+    const PTabletWriterOpenRequest& request = *open_request.request;
+    PTabletWriterOpenResult* response = open_request.response;
     _span->AddEvent("open_index", {{"index_id", request.index_id()}});
     auto scoped = trace::Scope(_span);
-    ClosureGuard done_guard(done);
+    ClosureGuard done_guard(open_request.done);
 
     _last_updated_time.store(time(nullptr), std::memory_order_relaxed);
     bool is_lake_tablet = request.has_is_lake_tablet() && request.is_lake_tablet();
@@ -155,6 +162,8 @@ void LoadChannel::open(brpc::Controller* cntl, const PTabletWriterOpenRequest& r
     if (config::enable_load_colocate_mv) {
         response->set_is_repeated_chunk(true);
     }
+    int64_t cost_ms = (MonotonicNanos() - start_time_ns) / 1000000;
+    _check_and_log_timeout_rpc("tablet writer open", cost_ms, request.timeout_ms());
 }
 
 void LoadChannel::_add_chunk(Chunk* chunk, const MonotonicStopWatch* watch, const PTabletWriterAddChunkRequest& request,
@@ -244,27 +253,7 @@ void LoadChannel::add_chunks(const PTabletWriterAddChunksRequest& req, PTabletWr
     StarRocksMetrics::instance()->load_channel_add_chunks_duration_us.increment(total_time_us);
 
     report_profile(response, config::pipeline_print_profile);
-
-    // log profile if rpc timeout
-    if (total_time_us > timeout_ms * 1000) {
-        // update profile
-        auto channels = _get_all_channels();
-        for (auto& channel : channels) {
-            channel->update_profile();
-        }
-
-        std::stringstream ss;
-        _root_profile->pretty_print(&ss);
-        if (timeout_ms > config::load_rpc_slow_log_frequency_threshold_seconds) {
-            LOG(WARNING) << "tablet writer add chunk timeout. txn_id=" << _txn_id << ", cost=" << total_time_us / 1000
-                         << "ms, timeout=" << timeout_ms << "ms, profile=" << ss.str();
-        } else {
-            // reduce slow log print frequency if the log job is small batch and high frequency
-            LOG_EVERY_N(WARNING, 10) << "tablet writer add chunk timeout. txn_id=" << _txn_id
-                                     << ", cost=" << total_time_us / 1000 << "ms, timeout=" << timeout_ms
-                                     << "ms, profile=" << ss.str();
-        }
-    }
+    _check_and_log_timeout_rpc("tablet writer add chunk", total_time_us / 1000, timeout_ms);
 }
 
 void LoadChannel::add_segment(brpc::Controller* cntl, const PTabletWriterAddSegmentRequest* request,
@@ -486,5 +475,27 @@ Status LoadChannel::_update_and_serialize_profile(std::string* result, bool prin
     result->append((char*)buf, len);
     VLOG(2) << "report profile, load_id: " << _load_id << ", txn_id: " << _txn_id << ", size: " << len;
     return Status::OK();
+}
+
+void LoadChannel::_check_and_log_timeout_rpc(const std::string& rpc_name, int64_t cost_ms, int64_t timeout_ms) {
+    if (cost_ms <= timeout_ms) {
+        return;
+    }
+    // update profile
+    auto channels = _get_all_channels();
+    for (auto& channel : channels) {
+        channel->update_profile();
+    }
+
+    std::stringstream ss;
+    _root_profile->pretty_print(&ss);
+    if (timeout_ms > config::load_rpc_slow_log_frequency_threshold_seconds * 1000) {
+        LOG(WARNING) << rpc_name << " timeout. txn_id=" << _txn_id << ", cost=" << cost_ms
+                     << "ms, timeout=" << timeout_ms << "ms, profile=" << ss.str();
+    } else {
+        // reduce slow log print frequency if the log job is small batch and high frequency
+        LOG_EVERY_N(WARNING, 10) << rpc_name << " timeout. txn_id=" << _txn_id << ", cost=" << cost_ms
+                                 << "ms, timeout=" << timeout_ms << "ms, profile=" << ss.str();
+    }
 }
 } // namespace starrocks

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -116,7 +116,6 @@ void LoadChannel::open(const LoadChannelOpenRequest& open_request) {
     int64_t start_time_ns = MonotonicNanos();
     COUNTER_UPDATE(_open_request_count, 1);
     COUNTER_UPDATE(_open_request_pending_timer, (start_time_ns - open_request.receive_rpc_time_ns));
-    brpc::Controller* cntl = open_request.cntl;
     const PTabletWriterOpenRequest& request = *open_request.request;
     PTabletWriterOpenResult* response = open_request.response;
     _span->AddEvent("open_index", {{"index_id", request.index_id()}});

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -112,15 +112,15 @@ void LoadChannel::set_profile_config(const PLoadChannelProfileConfig& config) {
     }
 }
 
-void LoadChannel::open(const LoadChannelOpenRequest& open_request) {
+void LoadChannel::open(const LoadChannelOpenContext& open_context) {
     int64_t start_time_ns = MonotonicNanos();
     COUNTER_UPDATE(_open_request_count, 1);
-    COUNTER_UPDATE(_open_request_pending_timer, (start_time_ns - open_request.receive_rpc_time_ns));
-    const PTabletWriterOpenRequest& request = *open_request.request;
-    PTabletWriterOpenResult* response = open_request.response;
+    COUNTER_UPDATE(_open_request_pending_timer, (start_time_ns - open_context.receive_rpc_time_ns));
+    const PTabletWriterOpenRequest& request = *open_context.request;
+    PTabletWriterOpenResult* response = open_context.response;
     _span->AddEvent("open_index", {{"index_id", request.index_id()}});
     auto scoped = trace::Scope(_span);
-    ClosureGuard done_guard(open_request.done);
+    ClosureGuard done_guard(open_context.done);
 
     _last_updated_time.store(time(nullptr), std::memory_order_relaxed);
     bool is_lake_tablet = request.has_is_lake_tablet() && request.is_lake_tablet();

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -71,7 +71,7 @@ namespace lake {
 class TabletManager;
 }
 
-struct LoadChannelOpenRequest {
+struct LoadChannelOpenContext {
     brpc::Controller* cntl;
     const PTabletWriterOpenRequest* request;
     PTabletWriterOpenResult* response;
@@ -96,7 +96,7 @@ public:
 
     // Open a new load channel if it does not exist.
     // NOTE: This method may be called multiple times, and each time with a different |request|.
-    void open(const LoadChannelOpenRequest& open_request);
+    void open(const LoadChannelOpenContext& open_context);
 
     void add_chunk(const PTabletWriterAddChunkRequest& request, PTabletWriterAddBatchResult* response);
 

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -71,6 +71,14 @@ namespace lake {
 class TabletManager;
 }
 
+struct LoadChannelOpenRequest {
+    brpc::Controller* cntl;
+    const PTabletWriterOpenRequest* request;
+    PTabletWriterOpenResult* response;
+    google::protobuf::Closure* done;
+    int64_t receive_rpc_time_ns;
+};
+
 // A LoadChannel manages tablets channels for all indexes
 // corresponding to a certain load job
 class LoadChannel {
@@ -88,8 +96,7 @@ public:
 
     // Open a new load channel if it does not exist.
     // NOTE: This method may be called multiple times, and each time with a different |request|.
-    void open(brpc::Controller* cntl, const PTabletWriterOpenRequest& request, PTabletWriterOpenResult* response,
-              google::protobuf::Closure* done);
+    void open(const LoadChannelOpenRequest& open_request);
 
     void add_chunk(const PTabletWriterAddChunkRequest& request, PTabletWriterAddBatchResult* response);
 
@@ -132,6 +139,7 @@ private:
     bool _should_enable_profile();
     std::vector<std::shared_ptr<TabletsChannel>> _get_all_channels();
     Status _update_and_serialize_profile(std::string* serialized_profile, bool print_profile);
+    void _check_and_log_timeout_rpc(const std::string& rpc_name, int64_t cost_ms, int64_t timeout_ms);
 
     LoadChannelMgr* _load_mgr;
     LakeTabletManager* _lake_tablet_mgr;
@@ -178,6 +186,8 @@ private:
     RuntimeProfile::Counter* _profile_report_count = nullptr;
     RuntimeProfile::Counter* _profile_report_timer = nullptr;
     RuntimeProfile::Counter* _profile_serialized_size = nullptr;
+    RuntimeProfile::Counter* _open_request_count = nullptr;
+    RuntimeProfile::Counter* _open_request_pending_timer = nullptr;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const LoadChannel& load_channel) {

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -101,10 +101,10 @@ Status LoadChannelMgr::init(MemTracker* mem_tracker) {
         num_threads = CpuInfo::num_cores();
     }
     RETURN_IF_ERROR(ThreadPoolBuilder("load_channel")
-                            .set_min_threads(5)
+                            .set_min_threads(std::min(5, num_threads))
                             .set_max_threads(num_threads)
                             .set_max_queue_size(config::load_channel_rpc_thread_pool_queue_size)
-                            .set_idle_timeout(MonoDelta::FromMilliseconds(10000))
+                            .set_idle_timeout(MonoDelta::FromMilliseconds(60000))
                             .build(&_async_rpc_pool));
     REGISTER_THREAD_POOL_METRICS(load_channel, _async_rpc_pool.get());
     return Status::OK();

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -85,16 +85,11 @@ LoadChannelMgr::~LoadChannelMgr() {
 }
 
 void LoadChannelMgr::close() {
-    {
-        std::lock_guard l(_lock);
-        for (auto iter = _load_channels.begin(); iter != _load_channels.end();) {
-            iter->second->cancel();
-            iter->second->abort();
-            iter = _load_channels.erase(iter);
-        }
-    }
-    if (_async_rpc_pool) {
-        _async_rpc_pool->shutdown();
+    std::lock_guard l(_lock);
+    for (auto iter = _load_channels.begin(); iter != _load_channels.end();) {
+        iter->second->cancel();
+        iter->second->abort();
+        iter = _load_channels.erase(iter);
     }
 }
 

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -51,6 +51,41 @@
 
 namespace starrocks {
 
+class ChannelOpenTask final : public Runnable {
+public:
+    ChannelOpenTask(LoadChannelMgr* load_channel_mgr, LoadChannelOpenContext open_context)
+            : _load_channel_mgr(load_channel_mgr), _open_context(std::move(open_context)) {}
+
+    ~ChannelOpenTask() override {
+        if (!_is_done) {
+            cancel(Status::ServiceUnavailable("Thread pool was shut down"));
+        }
+    }
+
+    void run() override {
+        if (_try_mark_done()) {
+            _load_channel_mgr->_open(_open_context);
+        }
+    }
+
+    void cancel(const Status& status) {
+        if (_try_mark_done()) {
+            ClosureGuard closure_guard(_open_context.done);
+            status.to_protobuf(_open_context.response->mutable_status());
+        }
+    }
+
+private:
+    bool _try_mark_done() {
+        bool old = false;
+        return _is_done.compare_exchange_strong(old, true);
+    }
+
+    LoadChannelMgr* _load_channel_mgr;
+    LoadChannelOpenContext _open_context;
+    std::atomic<bool> _is_done{false};
+};
+
 // Calculate the memory limit for a single load job.
 static int64_t calc_job_max_load_memory(int64_t mem_limit_in_req, int64_t total_mem_limit) {
     // mem_limit_in_req == -1 means no limit for single load.
@@ -85,6 +120,7 @@ LoadChannelMgr::~LoadChannelMgr() {
 }
 
 void LoadChannelMgr::close() {
+    _async_rpc_pool->shutdown();
     std::lock_guard l(_lock);
     for (auto iter = _load_channels.begin(); iter != _load_channels.end();) {
         iter->second->cancel();
@@ -122,11 +158,10 @@ void LoadChannelMgr::open(brpc::Controller* cntl, const PTabletWriterOpenRequest
         _open(open_context);
         return;
     }
-    auto task = [=]() { this->_open(open_context); };
-    Status status = _async_rpc_pool->submit_func(std::move(task));
+    auto task = std::make_shared<ChannelOpenTask>(this, std::move(open_context));
+    Status status = _async_rpc_pool->submit(task);
     if (!status.ok()) {
-        ClosureGuard closure_guard(done);
-        status.to_protobuf(response->mutable_status());
+        task->cancel(status);
     }
 }
 

--- a/be/src/runtime/load_channel_mgr.h
+++ b/be/src/runtime/load_channel_mgr.h
@@ -95,6 +95,12 @@ public:
 
     ThreadPool* async_rpc_pool() { return _async_rpc_pool.get(); }
 
+    std::shared_ptr<LoadChannel> TEST_get_load_channel(UniqueId load_id) {
+        std::lock_guard l(_lock);
+        auto it = _load_channels.find(load_id);
+        return it != _load_channels.end() ? it->second : nullptr;
+    }
+
 private:
     static void* load_channel_clean_bg_worker(void* arg);
 

--- a/be/src/runtime/load_channel_mgr.h
+++ b/be/src/runtime/load_channel_mgr.h
@@ -93,9 +93,12 @@ public:
 
     void close();
 
+    ThreadPool* async_rpc_pool() { return _async_rpc_pool.get(); }
+
 private:
     static void* load_channel_clean_bg_worker(void* arg);
 
+    void _open(LoadChannelOpenRequest open_request);
     Status _start_bg_worker();
     std::shared_ptr<LoadChannel> _find_load_channel(const UniqueId& load_id);
     std::shared_ptr<LoadChannel> _find_load_channel(int64_t txn_id);
@@ -111,6 +114,9 @@ private:
 
     // thread to clean timeout load channels
     bthread_t _load_channels_clean_thread;
+
+    // Thread pool used to handle rpc request asynchronously
+    std::unique_ptr<ThreadPool> _async_rpc_pool;
 };
 
 } // namespace starrocks

--- a/be/src/runtime/load_channel_mgr.h
+++ b/be/src/runtime/load_channel_mgr.h
@@ -104,7 +104,7 @@ public:
 private:
     static void* load_channel_clean_bg_worker(void* arg);
 
-    void _open(LoadChannelOpenRequest open_request);
+    void _open(LoadChannelOpenContext open_context);
     Status _start_bg_worker();
     std::shared_ptr<LoadChannel> _find_load_channel(const UniqueId& load_id);
     std::shared_ptr<LoadChannel> _find_load_channel(int64_t txn_id);

--- a/be/src/runtime/load_channel_mgr.h
+++ b/be/src/runtime/load_channel_mgr.h
@@ -102,6 +102,8 @@ public:
     }
 
 private:
+    friend class ChannelOpenTask;
+
     static void* load_channel_clean_bg_worker(void* arg);
 
     void _open(LoadChannelOpenContext open_context);

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -205,6 +205,7 @@ public:
     METRIC_DEFINE_INT_COUNTER(load_bytes_total, MetricUnit::BYTES);
 
     // Metrics for LoadChannel
+    METRICS_DEFINE_THREAD_POOL(load_channel_mgr);
     // The number that LoadChannel#add_chunks is accessed
     METRIC_DEFINE_INT_COUNTER(load_channel_add_chunks_total, MetricUnit::OPERATIONS);
     // The number that LoadChannel#add_chunks eos is accessed

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -205,7 +205,7 @@ public:
     METRIC_DEFINE_INT_COUNTER(load_bytes_total, MetricUnit::BYTES);
 
     // Metrics for LoadChannel
-    METRICS_DEFINE_THREAD_POOL(load_channel_mgr);
+    METRICS_DEFINE_THREAD_POOL(load_channel);
     // The number that LoadChannel#add_chunks is accessed
     METRIC_DEFINE_INT_COUNTER(load_channel_add_chunks_total, MetricUnit::OPERATIONS);
     // The number that LoadChannel#add_chunks eos is accessed

--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -125,14 +125,14 @@ Status ThreadPoolToken::submit_func(std::function<void()> f, ThreadPool::Priorit
 }
 
 void ThreadPoolToken::shutdown() {
+    // Define the to_release queue before acquiring the lock, so that tasks in the queue
+    // are destructed after the lock is released. This is important because the task's
+    // destructors may acquire locks, etc., so this also prevents lock inversions.
+    PriorityQueue<ThreadPool::NUM_PRIORITY, ThreadPool::Task> to_release;
     std::unique_lock l(_pool->_lock);
     _pool->check_not_pool_thread_unlocked();
 
-    // Clear the queue under the lock, but defer the releasing of the tasks
-    // outside the lock, in case there are concurrent threads wanting to access
-    // the ThreadPool. The task's destructors may acquire locks, etc, so this
-    // also prevents lock inversions.
-    PriorityQueue<ThreadPool::NUM_PRIORITY, ThreadPool::Task> to_release = std::move(_entries);
+    to_release = std::move(_entries);
     _pool->_total_queued_tasks -= to_release.size();
 
     switch (state()) {
@@ -172,8 +172,6 @@ void ThreadPoolToken::shutdown() {
     default:
         break;
     }
-    // releasing the tasks outside of lock
-    l.unlock();
 }
 
 void ThreadPoolToken::wait() {
@@ -294,6 +292,10 @@ bool ThreadPool::is_pool_status_ok() {
 }
 
 void ThreadPool::shutdown() {
+    // Define the to_release queue before acquiring the lock, so that tasks in the queue
+    // are destructed after the lock is released. This is important because the task's
+    // destructors may acquire locks, etc., so this also prevents lock inversions.
+    std::deque<PriorityQueue<NUM_PRIORITY, Task>> to_release;
     std::unique_lock l(_lock);
     check_not_pool_thread_unlocked();
 
@@ -302,13 +304,7 @@ void ThreadPool::shutdown() {
     // concern though because shutting down a pool typically requires clients to
     // be quiesced first, so there's no danger of a client getting confused.
     _pool_status = Status::ServiceUnavailable("The pool has been shut down.");
-
-    // Clear the various queues under the lock, but defer the releasing
-    // of the tasks outside the lock, in case there are concurrent threads
-    // wanting to access the ThreadPool. The task's destructors may acquire
-    // locks, etc, so this also prevents lock inversions.
     _queue.clear();
-    std::deque<PriorityQueue<NUM_PRIORITY, Task>> to_release;
     for (auto* t : _tokens) {
         if (!t->_entries.empty()) {
             to_release.emplace_back(std::move(t->_entries));
@@ -345,8 +341,6 @@ void ThreadPool::shutdown() {
     for (auto* t : _tokens) {
         DCHECK(t->state() == ThreadPoolToken::State::IDLE || t->state() == ThreadPoolToken::State::QUIESCED);
     }
-    // releasing the tasks outside of lock
-    l.unlock();
 }
 
 std::unique_ptr<ThreadPoolToken> ThreadPool::new_token(ExecutionMode mode) {

--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -345,6 +345,8 @@ void ThreadPool::shutdown() {
     for (auto* t : _tokens) {
         DCHECK(t->state() == ThreadPoolToken::State::IDLE || t->state() == ThreadPoolToken::State::QUIESCED);
     }
+    // releasing the tasks outside of lock
+    l.unlock();
 }
 
 std::unique_ptr<ThreadPoolToken> ThreadPool::new_token(ExecutionMode mode) {

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -386,6 +386,7 @@ set(EXEC_FILES
         ./runtime/lake_tablets_channel_test.cpp
         ./runtime/large_int_value_test.cpp
         ./runtime/load_channel_test.cpp
+        ./runtime/load_channel_mgr_test.cpp
         ./runtime/memory/mem_chunk_allocator_test.cpp
         ./runtime/memory/system_allocator_test.cpp
         ./runtime/memory/memory_resource_test.cpp

--- a/be/test/runtime/load_channel_mgr_test.cpp
+++ b/be/test/runtime/load_channel_mgr_test.cpp
@@ -1,0 +1,232 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runtime/load_channel_mgr.h"
+
+#include <brpc/controller.h>
+#include <gtest/gtest.h>
+
+#include "storage/chunk_helper.h"
+#include "storage/storage_engine.h"
+#include "storage/tablet_manager.h"
+#include "storage/tablet_schema.h"
+#include "testutil/assert.h"
+#include "util/await.h"
+
+namespace starrocks {
+
+class LoadChannelMgrTest : public testing::Test {
+public:
+    LoadChannelMgrTest() = default;
+    ~LoadChannelMgrTest() override = default;
+
+protected:
+    void SetUp() override {
+        _mem_tracker = std::make_unique<MemTracker>(-1);
+        _load_channel_mgr = std::make_unique<LoadChannelMgr>();
+        _node_id = 100;
+        _db_id = 100;
+        _table_id = 101;
+        _partition_id = 10;
+        _index_id = 1;
+        _tablet_id = rand();
+        _tablet = create_tablet(_tablet_id, rand());
+        _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet->tablet_schema()));
+    }
+    void TearDown() override {
+        if (_tablet) {
+            _tablet.reset();
+            ASSERT_OK(StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet_id));
+        }
+        if (_load_channel_mgr) {
+            _load_channel_mgr->close();
+        }
+    }
+
+    TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash) {
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(1);
+        request.tablet_schema.schema_hash = schema_hash;
+        request.tablet_schema.short_key_column_count = 1;
+        request.tablet_schema.keys_type = TKeysType::DUP_KEYS;
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        TColumn c0;
+        c0.column_name = "c0";
+        c0.__set_is_key(true);
+        c0.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(c0);
+
+        TColumn c1;
+        c1.column_name = "c1";
+        c1.__set_is_key(false);
+        c1.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(c1);
+
+        auto st = StorageEngine::instance()->create_tablet(request);
+        CHECK(st.ok()) << st.to_string();
+        return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    }
+
+    PTabletWriterOpenRequest create_open_request(PUniqueId load_id, int64_t txn_id) {
+        PTabletWriterOpenRequest request;
+        request.mutable_id()->CopyFrom(load_id);
+        request.set_index_id(_index_id);
+        request.set_txn_id(txn_id);
+        request.set_is_lake_tablet(false);
+        request.set_is_replicated_storage(true);
+        request.set_node_id(_node_id);
+        request.set_write_quorum(WriteQuorumTypePB::MAJORITY);
+        request.set_miss_auto_increment_column(false);
+        request.set_table_id(_table_id);
+        request.set_is_incremental(false);
+        request.set_num_senders(1);
+        request.set_sender_id(0);
+        request.set_need_gen_rollup(false);
+        request.set_load_channel_timeout_s(10);
+        request.set_is_vectorized(true);
+        request.set_timeout_ms(10000);
+
+        request.set_immutable_tablet_size(0);
+        auto tablet = request.add_tablets();
+        tablet->set_partition_id(_partition_id);
+        tablet->set_tablet_id(_tablet_id);
+        auto replica = tablet->add_replicas();
+        replica->set_host("127.0.0.1");
+        replica->set_port(8060);
+        replica->set_node_id(_node_id);
+
+        auto schema = request.mutable_schema();
+        schema->set_db_id(_db_id);
+        schema->set_table_id(_table_id);
+        schema->set_version(1);
+        auto index = schema->add_indexes();
+        index->set_id(_index_id);
+        index->set_schema_hash(0);
+        for (int i = 0, sz = _tablet->tablet_schema()->num_columns(); i < sz; i++) {
+            auto slot = request.mutable_schema()->add_slot_descs();
+            auto& column = _tablet->tablet_schema()->column(i);
+            slot->set_id(i);
+            slot->set_byte_offset(i * sizeof(int) /*unused*/);
+            slot->set_col_name(std::string(column.name()));
+            slot->set_slot_idx(i);
+            slot->set_is_materialized(true);
+            slot->mutable_slot_type()->add_types()->mutable_scalar_type()->set_type(column.type());
+            index->add_columns(std::string(column.name()));
+        }
+        auto tuple_desc = schema->mutable_tuple_desc();
+        tuple_desc->set_id(1);
+        tuple_desc->set_byte_size(8 /*unused*/);
+        tuple_desc->set_num_null_bytes(0 /*unused*/);
+        tuple_desc->set_table_id(_table_id);
+
+        return request;
+    }
+
+    std::unique_ptr<MemTracker> _mem_tracker;
+    std::unique_ptr<LoadChannelMgr> _load_channel_mgr;
+    TabletSharedPtr _tablet;
+
+    int64_t _node_id;
+    int64_t _db_id;
+    int64_t _table_id;
+    int64_t _partition_id;
+    int32_t _index_id;
+    int64_t _tablet_id;
+    std::shared_ptr<Schema> _schema;
+    std::shared_ptr<OlapTableSchemaParam> _schema_param;
+};
+
+class MockClosure : public ::google::protobuf::Closure {
+public:
+    MockClosure() = default;
+    ~MockClosure() override = default;
+
+    void Run() override { _run.store(true); }
+
+    bool has_run() { return _run.load(); }
+
+private:
+    std::atomic_bool _run = false;
+};
+
+TEST_F(LoadChannelMgrTest, async_open_success) {
+    ASSERT_OK(_load_channel_mgr->init(_mem_tracker.get()));
+    PUniqueId load_id;
+    load_id.set_hi(456789);
+    load_id.set_lo(987654);
+    brpc::Controller cntl;
+    MockClosure closure;
+    PTabletWriterOpenRequest request = create_open_request(load_id, rand());
+    PTabletWriterOpenResult result;
+    _load_channel_mgr->open(&cntl, request, &result, &closure);
+    ASSERT_TRUE(Awaitility().timeout(60000).until(
+            [&] { return _load_channel_mgr->async_rpc_pool()->total_executed_tasks() == 1; }));
+    ASSERT_TRUE(closure.has_run());
+    ASSERT_TRUE(result.status().status_code() == TStatusCode::OK);
+    auto load_channel = _load_channel_mgr->TEST_get_load_channel(UniqueId(load_id));
+    ASSERT_TRUE(load_channel != nullptr);
+}
+
+TEST_F(LoadChannelMgrTest, async_open_submit_task_fail) {
+    ASSERT_OK(_load_channel_mgr->init(_mem_tracker.get()));
+    PUniqueId load_id;
+    load_id.set_hi(456789);
+    load_id.set_lo(987654);
+    brpc::Controller cntl;
+    MockClosure closure;
+    PTabletWriterOpenRequest request = create_open_request(load_id, rand());
+    PTabletWriterOpenResult result;
+
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("ThreadPool::do_submit:1");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("ThreadPool::do_submit:1", [](void* arg) { *(int64_t*)arg = 0; });
+
+    _load_channel_mgr->open(&cntl, request, &result, &closure);
+    ASSERT_TRUE(closure.has_run());
+    ASSERT_TRUE(result.status().status_code() == TStatusCode::SERVICE_UNAVAILABLE);
+    auto load_channel = _load_channel_mgr->TEST_get_load_channel(UniqueId(load_id));
+    ASSERT_TRUE(load_channel == nullptr);
+}
+
+TEST_F(LoadChannelMgrTest, sync_open_success) {
+    ASSERT_OK(_load_channel_mgr->init(_mem_tracker.get()));
+    PUniqueId load_id;
+    load_id.set_hi(456789);
+    load_id.set_lo(987654);
+    brpc::Controller cntl;
+    MockClosure closure;
+    PTabletWriterOpenRequest request = create_open_request(load_id, rand());
+    PTabletWriterOpenResult result;
+
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("ThreadPool::do_submit:1");
+        SyncPoint::GetInstance()->DisableProcessing();
+        config::enable_load_channel_rpc_async = true;
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("ThreadPool::do_submit:1", [](void* arg) { *(int64_t*)arg = 0; });
+    config::enable_load_channel_rpc_async = false;
+    _load_channel_mgr->open(&cntl, request, &result, &closure);
+    ASSERT_TRUE(closure.has_run());
+    ASSERT_TRUE(result.status().status_code() == TStatusCode::OK);
+    auto load_channel = _load_channel_mgr->TEST_get_load_channel(UniqueId(load_id));
+    ASSERT_TRUE(load_channel != nullptr);
+}
+
+} // namespace starrocks

--- a/be/test/runtime/load_channel_mgr_test.cpp
+++ b/be/test/runtime/load_channel_mgr_test.cpp
@@ -17,6 +17,7 @@
 #include <brpc/controller.h>
 #include <gtest/gtest.h>
 
+#include "service/brpc_service_test_util.h"
 #include "storage/chunk_helper.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet_manager.h"
@@ -147,19 +148,6 @@ protected:
     int64_t _tablet_id;
     std::shared_ptr<Schema> _schema;
     std::shared_ptr<OlapTableSchemaParam> _schema_param;
-};
-
-class MockClosure : public ::google::protobuf::Closure {
-public:
-    MockClosure() = default;
-    ~MockClosure() override = default;
-
-    void Run() override { _run.store(true); }
-
-    bool has_run() { return _run.load(); }
-
-private:
-    std::atomic_bool _run = false;
 };
 
 TEST_F(LoadChannelMgrTest, async_open_success) {

--- a/be/test/runtime/load_channel_test.cpp
+++ b/be/test/runtime/load_channel_test.cpp
@@ -249,21 +249,21 @@ protected:
     std::shared_ptr<LoadChannel> _load_channel;
 };
 
-LoadChannelOpenRequest create_open_request(const PTabletWriterOpenRequest* request, PTabletWriterOpenResult* response) {
-    LoadChannelOpenRequest open_request;
-    open_request.cntl = nullptr;
-    open_request.request = request;
-    open_request.response = response;
-    open_request.done = nullptr;
-    open_request.receive_rpc_time_ns = MonotonicNanos();
-    return open_request;
+LoadChannelOpenContext create_open_context(const PTabletWriterOpenRequest* request, PTabletWriterOpenResult* response) {
+    LoadChannelOpenContext open_context;
+    open_context.cntl = nullptr;
+    open_context.request = request;
+    open_context.response = response;
+    open_context.done = nullptr;
+    open_context.receive_rpc_time_ns = MonotonicNanos();
+    return open_context;
 }
 
 TEST_F(LoadChannelTestForLakeTablet, test_simple_write) {
     PTabletWriterOpenRequest open_request = _open_request;
     PTabletWriterOpenResult open_response;
     open_request.set_num_senders(1);
-    _load_channel->open(create_open_request(&open_request, &open_response));
+    _load_channel->open(create_open_context(&open_request, &open_response));
     ASSERT_EQ(TStatusCode::OK, open_response.status().status_code());
 
     constexpr int kChunkSize = 128;
@@ -335,7 +335,7 @@ TEST_F(LoadChannelTestForLakeTablet, test_simple_write) {
 TEST_F(LoadChannelTestForLakeTablet, test_write_concurrently) {
     PTabletWriterOpenRequest open_request = _open_request;
     PTabletWriterOpenResult open_response;
-    _load_channel->open(create_open_request(&open_request, &open_response));
+    _load_channel->open(create_open_context(&open_request, &open_response));
     ASSERT_EQ(TStatusCode::OK, open_response.status().status_code());
 
     constexpr int kChunkSize = 128;
@@ -408,7 +408,7 @@ TEST_F(LoadChannelTestForLakeTablet, test_abort) {
     PTabletWriterOpenRequest open_request = _open_request;
     PTabletWriterOpenResult open_response;
     open_request.set_num_senders(1);
-    _load_channel->open(create_open_request(&open_request, &open_response));
+    _load_channel->open(create_open_context(&open_request, &open_response));
     ASSERT_EQ(TStatusCode::OK, open_response.status().status_code());
 
     constexpr int kChunkSize = 128;
@@ -479,7 +479,7 @@ TEST_F(LoadChannelTestForLakeTablet, test_incremental_open) {
         PTabletWriterOpenResult open_response;
         open_request.set_num_senders(1);
         open_request.set_is_incremental(true);
-        _load_channel->open(create_open_request(&open_request, &open_response));
+        _load_channel->open(create_open_context(&open_request, &open_response));
         ASSERT_EQ(TStatusCode::OK, open_response.status().status_code()) << open_response.status().error_msgs(0);
         ch = _load_channel->get_tablets_channel(TabletsChannelKey(open_request.id(), 0, kIndexId));
         ASSERT_NE(nullptr, ch.get());
@@ -492,7 +492,7 @@ TEST_F(LoadChannelTestForLakeTablet, test_incremental_open) {
         PTabletWriterOpenResult open_response;
         open_request.set_is_incremental(true);
         // open again with incremental info.
-        _load_channel->open(create_open_request(&open_request, &open_response));
+        _load_channel->open(create_open_context(&open_request, &open_response));
         EXPECT_EQ(TStatusCode::OK, open_response.status().status_code()) << open_response.status().error_msgs(0);
 
         auto ch2 = _load_channel->get_tablets_channel(TabletsChannelKey(open_request.id(), 0, kIndexId));
@@ -507,7 +507,7 @@ TEST_F(LoadChannelTestForLakeTablet, test_add_segment) {
         PTabletWriterOpenRequest open_request = _open_request;
         PTabletWriterOpenResult open_response;
         open_request.set_num_senders(1);
-        _load_channel->open(create_open_request(&open_request, &open_response));
+        _load_channel->open(create_open_context(&open_request, &open_response));
         ASSERT_EQ(TStatusCode::OK, open_response.status().status_code());
     }
 
@@ -607,7 +607,7 @@ TEST_F(LoadChannelTestForLakeTablet, test_final_profile) {
     open_request.mutable_load_channel_profile_config()->CopyFrom(profile_config);
 
     PTabletWriterOpenResult open_response;
-    _load_channel->open(create_open_request(&open_request, &open_response));
+    _load_channel->open(create_open_context(&open_request, &open_response));
     ASSERT_EQ(TStatusCode::OK, open_response.status().status_code());
 
     constexpr int kChunkSize = 128;
@@ -686,7 +686,7 @@ TEST_F(LoadChannelTestForLakeTablet, test_slow_log_profile) {
     open_request.mutable_load_channel_profile_config()->CopyFrom(profile_config);
 
     PTabletWriterOpenResult open_response;
-    _load_channel->open(create_open_request(&open_request, &open_response));
+    _load_channel->open(create_open_context(&open_request, &open_response));
     ASSERT_EQ(TStatusCode::OK, open_response.status().status_code());
 
     constexpr int kChunkSize = 128;
@@ -756,7 +756,7 @@ TEST_F(LoadChannelTestForLakeTablet, test_load_diagnose) {
     open_request.set_num_senders(1);
 
     PTabletWriterOpenResult open_response;
-    _load_channel->open(create_open_request(&open_request, &open_response));
+    _load_channel->open(create_open_context(&open_request, &open_response));
     ASSERT_EQ(TStatusCode::OK, open_response.status().status_code());
 
     constexpr int kChunkSize = 128;

--- a/be/test/runtime/load_channel_test.cpp
+++ b/be/test/runtime/load_channel_test.cpp
@@ -249,11 +249,21 @@ protected:
     std::shared_ptr<LoadChannel> _load_channel;
 };
 
+LoadChannelOpenRequest create_open_request(const PTabletWriterOpenRequest* request, PTabletWriterOpenResult* response) {
+    LoadChannelOpenRequest open_request;
+    open_request.cntl = nullptr;
+    open_request.request = request;
+    open_request.response = response;
+    open_request.done = nullptr;
+    open_request.receive_rpc_time_ns = MonotonicNanos();
+    return open_request;
+}
+
 TEST_F(LoadChannelTestForLakeTablet, test_simple_write) {
     PTabletWriterOpenRequest open_request = _open_request;
     PTabletWriterOpenResult open_response;
     open_request.set_num_senders(1);
-    _load_channel->open(nullptr, open_request, &open_response, nullptr);
+    _load_channel->open(create_open_request(&open_request, &open_response));
     ASSERT_EQ(TStatusCode::OK, open_response.status().status_code());
 
     constexpr int kChunkSize = 128;
@@ -325,7 +335,7 @@ TEST_F(LoadChannelTestForLakeTablet, test_simple_write) {
 TEST_F(LoadChannelTestForLakeTablet, test_write_concurrently) {
     PTabletWriterOpenRequest open_request = _open_request;
     PTabletWriterOpenResult open_response;
-    _load_channel->open(nullptr, open_request, &open_response, nullptr);
+    _load_channel->open(create_open_request(&open_request, &open_response));
     ASSERT_EQ(TStatusCode::OK, open_response.status().status_code());
 
     constexpr int kChunkSize = 128;
@@ -398,7 +408,7 @@ TEST_F(LoadChannelTestForLakeTablet, test_abort) {
     PTabletWriterOpenRequest open_request = _open_request;
     PTabletWriterOpenResult open_response;
     open_request.set_num_senders(1);
-    _load_channel->open(nullptr, open_request, &open_response, nullptr);
+    _load_channel->open(create_open_request(&open_request, &open_response));
     ASSERT_EQ(TStatusCode::OK, open_response.status().status_code());
 
     constexpr int kChunkSize = 128;
@@ -469,7 +479,7 @@ TEST_F(LoadChannelTestForLakeTablet, test_incremental_open) {
         PTabletWriterOpenResult open_response;
         open_request.set_num_senders(1);
         open_request.set_is_incremental(true);
-        _load_channel->open(nullptr, open_request, &open_response, nullptr);
+        _load_channel->open(create_open_request(&open_request, &open_response));
         ASSERT_EQ(TStatusCode::OK, open_response.status().status_code()) << open_response.status().error_msgs(0);
         ch = _load_channel->get_tablets_channel(TabletsChannelKey(open_request.id(), 0, kIndexId));
         ASSERT_NE(nullptr, ch.get());
@@ -482,7 +492,7 @@ TEST_F(LoadChannelTestForLakeTablet, test_incremental_open) {
         PTabletWriterOpenResult open_response;
         open_request.set_is_incremental(true);
         // open again with incremental info.
-        _load_channel->open(nullptr, open_request, &open_response, nullptr);
+        _load_channel->open(create_open_request(&open_request, &open_response));
         EXPECT_EQ(TStatusCode::OK, open_response.status().status_code()) << open_response.status().error_msgs(0);
 
         auto ch2 = _load_channel->get_tablets_channel(TabletsChannelKey(open_request.id(), 0, kIndexId));
@@ -497,7 +507,7 @@ TEST_F(LoadChannelTestForLakeTablet, test_add_segment) {
         PTabletWriterOpenRequest open_request = _open_request;
         PTabletWriterOpenResult open_response;
         open_request.set_num_senders(1);
-        _load_channel->open(nullptr, open_request, &open_response, nullptr);
+        _load_channel->open(create_open_request(&open_request, &open_response));
         ASSERT_EQ(TStatusCode::OK, open_response.status().status_code());
     }
 
@@ -597,7 +607,7 @@ TEST_F(LoadChannelTestForLakeTablet, test_final_profile) {
     open_request.mutable_load_channel_profile_config()->CopyFrom(profile_config);
 
     PTabletWriterOpenResult open_response;
-    _load_channel->open(nullptr, open_request, &open_response, nullptr);
+    _load_channel->open(create_open_request(&open_request, &open_response));
     ASSERT_EQ(TStatusCode::OK, open_response.status().status_code());
 
     constexpr int kChunkSize = 128;
@@ -676,7 +686,7 @@ TEST_F(LoadChannelTestForLakeTablet, test_slow_log_profile) {
     open_request.mutable_load_channel_profile_config()->CopyFrom(profile_config);
 
     PTabletWriterOpenResult open_response;
-    _load_channel->open(nullptr, open_request, &open_response, nullptr);
+    _load_channel->open(create_open_request(&open_request, &open_response));
     ASSERT_EQ(TStatusCode::OK, open_response.status().status_code());
 
     constexpr int kChunkSize = 128;
@@ -746,7 +756,7 @@ TEST_F(LoadChannelTestForLakeTablet, test_load_diagnose) {
     open_request.set_num_senders(1);
 
     PTabletWriterOpenResult open_response;
-    _load_channel->open(nullptr, open_request, &open_response, nullptr);
+    _load_channel->open(create_open_request(&open_request, &open_response));
     ASSERT_EQ(TStatusCode::OK, open_response.status().status_code());
 
     constexpr int kChunkSize = 128;

--- a/be/test/service/brpc_service_test_util.h
+++ b/be/test/service/brpc_service_test_util.h
@@ -1,0 +1,34 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <atomic>
+
+#include "google/protobuf/stubs/callback.h"
+
+namespace starrocks {
+
+class MockClosure : public ::google::protobuf::Closure {
+public:
+    MockClosure() = default;
+    ~MockClosure() override = default;
+
+    void Run() override { _run.store(true); }
+
+    bool has_run() { return _run.load(); }
+
+private:
+    std::atomic_bool _run = false;
+};
+
+} // namespace starrocks

--- a/be/test/service/service_be/internal_service_test.cpp
+++ b/be/test/service/service_be/internal_service_test.cpp
@@ -20,6 +20,7 @@
 #include "common/utils.h"
 #include "exec/tablet_sink_index_channel.h"
 #include "runtime/exec_env.h"
+#include "service/brpc_service_test_util.h"
 
 namespace starrocks {
 
@@ -33,19 +34,6 @@ TEST_F(InternalServiceTest, test_get_info_timeout_invalid) {
     auto st = Status(response.status());
     ASSERT_TRUE(st.is_time_out());
 }
-
-class MockClosure : public ::google::protobuf::Closure {
-public:
-    MockClosure() = default;
-    ~MockClosure() override = default;
-
-    void Run() override { _run.store(true); }
-
-    bool has_run() { return _run.load(); }
-
-private:
-    std::atomic_bool _run = false;
-};
 
 TEST_F(InternalServiceTest, test_tablet_writer_add_chunks_via_http) {
     BackendInternalServiceImpl<PInternalService> service(ExecEnv::GetInstance());

--- a/be/test/storage/segment_flush_executor_test.cpp
+++ b/be/test/storage/segment_flush_executor_test.cpp
@@ -23,6 +23,7 @@
 #include "fs/fs_util.h"
 #include "runtime/descriptor_helper.h"
 #include "runtime/runtime_state.h"
+#include "service/brpc_service_test_util.h"
 #include "storage/async_delta_writer.h"
 #include "storage/chunk_helper.h"
 #include "storage/rowset/rowset_factory.h"
@@ -231,19 +232,6 @@ protected:
     std::string _primary_tablet_segment_dir;
     RuntimeState _runtime_state;
     ObjectPool _pool;
-};
-
-class MockClosure : public ::google::protobuf::Closure {
-public:
-    MockClosure() = default;
-    ~MockClosure() override = default;
-
-    void Run() override { _run.store(true); }
-
-    bool has_run() { return _run.load(); }
-
-private:
-    std::atomic_bool _run = false;
 };
 
 TEST_F(SegmentFlushExecutorTest, test_write_and_commit_segment) {

--- a/be/test/util/starrocks_metrics_test.cpp
+++ b/be/test/util/starrocks_metrics_test.cpp
@@ -342,6 +342,7 @@ TEST_F(StarRocksMetricsTest, test_metrics_register) {
     assert_threadpool_metrics_register("clone", instance);
     assert_threadpool_metrics_register("remote_snapshot", instance);
     assert_threadpool_metrics_register("replicate_snapshot", instance);
+    assert_threadpool_metrics_register("load_channel_mgr", instance);
     ASSERT_NE(nullptr, instance->get_metric("load_channel_add_chunks_total"));
     ASSERT_NE(nullptr, instance->get_metric("load_channel_add_chunks_eos_total"));
     ASSERT_NE(nullptr, instance->get_metric("load_channel_add_chunks_duration_us"));

--- a/be/test/util/starrocks_metrics_test.cpp
+++ b/be/test/util/starrocks_metrics_test.cpp
@@ -342,7 +342,7 @@ TEST_F(StarRocksMetricsTest, test_metrics_register) {
     assert_threadpool_metrics_register("clone", instance);
     assert_threadpool_metrics_register("remote_snapshot", instance);
     assert_threadpool_metrics_register("replicate_snapshot", instance);
-    assert_threadpool_metrics_register("load_channel_mgr", instance);
+    assert_threadpool_metrics_register("load_channel", instance);
     ASSERT_NE(nullptr, instance->get_metric("load_channel_add_chunks_total"));
     ASSERT_NE(nullptr, instance->get_metric("load_channel_add_chunks_eos_total"));
     ASSERT_NE(nullptr, instance->get_metric("load_channel_add_chunks_duration_us"));


### PR DESCRIPTION
## Why I'm doing:
`tablet_writer_open` brpc request needs to initialize DeltaWriter (DeltaWriter::_init). The initialization can be heavy because it needs to hold many pthread locks, such as
- Tablet _schema_lock, _migration_lock, _ingest_lock
- TabletUpdates::_lock
- TabletManager：tablet shard lock 
- TxnManager: txn shard lock

Waiting lock can block brpc worker and make the whole brpc service unavailable. We need move the initialization out of brpc worker so that it won't affect the brpc service.

## What I'm doing:
when receiving the `tablet_writer_open` rpc request, submit it to a separate thread pool to process it

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0