### PR TITLE
[BugFix] fix runtime filter pushdown on unique/agg key table

### DIFF
--- a/be/src/exec/olap_scan_prepare.cpp
+++ b/be/src/exec/olap_scan_prepare.cpp
@@ -1259,6 +1259,9 @@ StatusOr<RuntimeFilterPredicates> ScanConjunctsManager::get_runtime_filter_predi
         if (desc->is_topn_filter()) {
             continue;
         }
+        if (!parser->can_pushdown(slot_desc)) {
+            continue;
+        }
         auto column_id = parser->column_id(*slot_desc);
         desc->set_has_push_down_to_storage(true);
         predicates.add_predicate(obj_pool->add(new RuntimeFilterPredicate(desc, column_id)));


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/9333

For aggregate/unique key tables, not all predicates on columns can be pushed down. This should also be considered when performing runtime filter pushdown.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0