### PR TITLE
[BugFix]  Fix fk/uk constraints invalidation with swap table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -36,12 +36,15 @@ import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.catalog.View;
+import com.starrocks.catalog.constraint.ForeignKeyConstraint;
+import com.starrocks.catalog.constraint.UniqueConstraint;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.InvalidOlapTableStateException;
 import com.starrocks.common.MaterializedViewExceptions;
+import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.DynamicPartitionUtil;
@@ -103,6 +106,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -336,6 +340,57 @@ public class AlterJobExecutor implements AstVisitor<Void, ConnectContext> {
                 if (origTable.isMaterializedView() || newTbl.isMaterializedView()) {
                     if (!(origTable.isMaterializedView() && newTbl.isMaterializedView())) {
                         throw new AlterJobException("Materialized view can only SWAP WITH materialized view");
+                    }
+                }
+
+                // check unique constraints: if old table contains constraints, new table must contain the same constraints
+                final List<UniqueConstraint> origUKConstraints = Optional.ofNullable(origTable.getUniqueConstraints())
+                        .orElse(Lists.newArrayList());
+                final List<UniqueConstraint> newUKConstraints = Optional.ofNullable(olapNewTbl.getUniqueConstraints())
+                        .orElse(Lists.newArrayList());
+                if (origUKConstraints.size() != newUKConstraints.size()) {
+                    throw new AlterJobException("Table " + newTblName + " does not contain the same unique constraints, " +
+                            "origin: " + origUKConstraints + ", new: " + newUKConstraints);
+                }
+                for (UniqueConstraint origUniqueConstraint : origUKConstraints) {
+                    final List<String> originUKNames = origUniqueConstraint.getUniqueColumnNames(origTable);
+                    final List<String> newUKNames = origUniqueConstraint.getUniqueColumnNames(olapNewTbl);
+                    if (originUKNames.size() != newUKNames.size()) {
+                        throw new AlterJobException("Table " + newTblName + " does not contain the same unique constraints" +
+                                ", origin: " + origUKConstraints + ", new: " + newUKConstraints);
+                    }
+                    for (int i = 0; i < originUKNames.size(); i++) {
+                        if (!originUKNames.get(i).equals(newUKNames.get(i))) {
+                            throw new AlterJobException("Table " + newTblName + " does not contain the same unique constraints" +
+                                    ", origin: " + origUKConstraints + ", new: " + newUKConstraints);
+                        }
+                    }
+                }
+                // check foreign constraints: if old table contains constraints, new table must contain the same constraints
+                final List<ForeignKeyConstraint> origFKConstraints = Optional.ofNullable(origTable.getForeignKeyConstraints())
+                        .orElse(Lists.newArrayList());
+                final List<ForeignKeyConstraint> newFKConstraints = Optional.ofNullable(olapNewTbl.getForeignKeyConstraints())
+                        .orElse(Lists.newArrayList());
+                if (origFKConstraints.size() != newFKConstraints.size()) {
+                    throw new AlterJobException("Table " + newTblName + " does not contain the same foreign key " +
+                            "constraints, origin: " + origFKConstraints + ", new: " + newFKConstraints);
+                }
+                for (int i = 0; i < origFKConstraints.size(); i++) {
+                    final ForeignKeyConstraint originFKConstraint = origFKConstraints.get(i);
+                    final ForeignKeyConstraint newFKConstraint = newFKConstraints.get(i);
+                    final List<Pair<String, String>> originFKCNPairs = originFKConstraint.getColumnNameRefPairs(origTable);
+                    final List<Pair<String, String>> newFKCNPairs = newFKConstraint.getColumnNameRefPairs(origTable);
+                    if (originFKCNPairs.size() != newFKCNPairs.size()) {
+                        throw new AlterJobException("Table " + newTblName + " does not contain the same foreign key " +
+                                "constraints, origin: " + origFKConstraints + ", new: " + newFKConstraints);
+                    }
+                    for (int j = 0; j < originFKCNPairs.size(); j++) {
+                        final Pair<String, String> originPair = originFKCNPairs.get(j);
+                        final Pair<String, String> newPair = newFKCNPairs.get(j);
+                        if (!originPair.first.equals(newPair.first) || !originPair.second.equals(newPair.second)) {
+                            throw new AlterJobException("Table " + newTblName + " does not contain the same foreign key " +
+                                    "constraints, origin: " + origFKConstraints + ", new: " + newFKConstraints);
+                        }
                     }
                 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -37,6 +37,7 @@ import com.starrocks.backup.mv.MvBackupInfo;
 import com.starrocks.backup.mv.MvBaseTableBackupInfo;
 import com.starrocks.backup.mv.MvRestoreContext;
 import com.starrocks.catalog.constraint.ForeignKeyConstraint;
+import com.starrocks.catalog.constraint.GlobalConstraintManager;
 import com.starrocks.catalog.mv.MVPlanValidationResult;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
@@ -1032,6 +1033,10 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                 setActive();
             }
             analyzePartitionExprs();
+
+            // register constraints from global state manager
+            GlobalConstraintManager globalConstraintManager = GlobalStateMgr.getCurrentState().getGlobalConstraintManager();
+            globalConstraintManager.registerConstraint(this);
         } catch (Throwable e) {
             LOG.error("reload mv failed: {}", this, e);
             setInactiveAndReason("reload failed: " + e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/constraint/GlobalConstraintManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/constraint/GlobalConstraintManager.java
@@ -152,4 +152,12 @@ public class GlobalConstraintManager {
         }
         return globalTableFKConstraintMap.get(table);
     }
+
+    public void updateConstraint(Table table, Set<TableWithFKConstraint> relatedConstrains) {
+        if (CollectionUtils.isEmpty(relatedConstrains)) {
+            globalTableFKConstraintMap.remove(table);
+        } else {
+            globalTableFKConstraintMap.put(table, relatedConstrains);
+        }
+    }
 }

--- a/test/sql/test_ddl/R/test_alter_swap_table
+++ b/test/sql/test_ddl/R/test_alter_swap_table
@@ -41,6 +41,20 @@ INSERT INTO s2 values (1, 1, 1), (2, 2, 2);
 INSERT INTO s3 values (1, 1, 1), (2, 2, 2);
 -- result:
 -- !result
+create materialized view test_mv12
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+    "replication_num" = "1",
+     'foreign_key_constraints'='s2(k1) REFERENCES s1(k1)',
+     'unique_constraints'='s1.k1'
+) 
+as select s1.k1 as s11, s1.k2 as s12, s1.k3 as s13, s2.k1 s21, s2.k2 s22, s2.k3 s23 from s1 join s2 on s1.k1 = s2.k1;
+-- result:
+-- !result
+[UC]REFRESH materialized view test_mv12 with sync mode;
+-- result:
+de2d3fd3-f8d3-11ef-95e1-461f20abc3f0
+-- !result
 set enable_rbo_table_prune = true;
 -- result:
 -- !result
@@ -55,6 +69,10 @@ function: assert_explain_not_contains('select s3.k1, s3.k2 from s1 join s3 on s1
 -- result:
 None
 -- !result
+function: assert_explain_contains('select s2.k1, s2.k2 from s2 order by 1, 2;', 'test_mv12')
+-- result:
+None
+-- !result
 select s2.k1, s2.k2 from s1 join s2 on s1.k1 = s2.k1 order by 1, 2;
 -- result:
 1	1
@@ -65,7 +83,15 @@ select s3.k1, s3.k2 from s1 join s3 on s1.k1 = s3.k1 order by 1, 2;
 1	1
 2	2
 -- !result
+select s2.k1, s2.k2 from s2 order by 1, 2;
+-- result:
+1	1
+2	2
+-- !result
 ALTER TABLE s2 SWAP WITH s3;
+-- result:
+-- !result
+ALTER materialized view test_mv12 active;
 -- result:
 -- !result
 SHOW CREATE TABLE s2;
@@ -112,6 +138,10 @@ function: assert_explain_not_contains('select s3.k1, s3.k2 from s1 join s3 on s1
 -- result:
 None
 -- !result
+function: assert_explain_not_contains('select s2.k1, s2.k2 from s2 order by 1, 2;', 'test_mv12')
+-- result:
+None
+-- !result
 select s2.k1, s2.k2 from s1 join s2 on s1.k1 = s2.k1 order by 1, 2;
 -- result:
 1	1
@@ -122,22 +152,33 @@ select s3.k1, s3.k2 from s1 join s3 on s1.k1 = s3.k1 order by 1, 2;
 1	1
 2	2
 -- !result
+select s2.k1, s2.k2 from s2 order by 1, 2;
+-- result:
+1	1
+2	2
+-- !result
 CREATE TABLE s1_new
 (
-    k1 int, k2 int, k3 int
+    k1 int not null, k2 int, k3 int
 )
 DUPLICATE KEY(k1, k2)
 DISTRIBUTED BY RANDOM 
 PROPERTIES("replication_num" = "1", 'unique_constraints'='s1_new.k1');
 -- result:
 -- !result
+INSERT INTO s1_new values (1, 2, 3), (2, 3, 4);
+-- result:
+-- !result
 ALTER TABLE s1 SWAP WITH s1_new;
+-- result:
+-- !result
+ALTER materialized view test_mv12 active;
 -- result:
 -- !result
 SHOW CREATE TABLE s1;
 -- result:
 s1	CREATE TABLE `s1` (
-  `k1` int(11) NULL COMMENT "",
+  `k1` int(11) NOT NULL COMMENT "",
   `k2` int(11) NULL COMMENT "",
   `k3` int(11) NULL COMMENT ""
 ) ENGINE=OLAP 
@@ -214,11 +255,24 @@ function: assert_explain_not_contains('select s3.k1, s3.k2 from s1 join s3 on s1
 -- result:
 None
 -- !result
+function: assert_explain_not_contains('select s2.k1, s2.k2 from s2 order by 1, 2;', 'test_mv12')
+-- result:
+None
+-- !result
 select s2.k1, s2.k2 from s1 join s2 on s1.k1 = s2.k1 order by 1, 2;
 -- result:
+1	1
+2	2
 -- !result
 select s3.k1, s3.k2 from s1 join s3 on s1.k1 = s3.k1 order by 1, 2;
 -- result:
+1	1
+2	2
+-- !result
+select s2.k1, s2.k2 from s2 order by 1, 2;
+-- result:
+1	1
+2	2
 -- !result
 DROP TABLE s1;
 -- result:
@@ -236,7 +290,6 @@ PROPERTIES (
 "bucket_size" = "4294967296",
 "compression" = "LZ4",
 "fast_schema_evolution" = "true",
-"foreign_key_constraints" = "(k1) REFERENCES default_catalog.db_test_alter_swap_table.s1(k1)",
 "replicated_storage" = "true",
 "replication_num" = "1"
 );
@@ -254,7 +307,6 @@ PROPERTIES (
 "bucket_size" = "4294967296",
 "compression" = "LZ4",
 "fast_schema_evolution" = "true",
-"foreign_key_constraints" = "(k1) REFERENCES default_catalog.db_test_alter_swap_table.s1(k1)",
 "replicated_storage" = "true",
 "replication_num" = "1"
 );

--- a/test/sql/test_ddl/T/test_alter_swap_table
+++ b/test/sql/test_ddl/T/test_alter_swap_table
@@ -30,34 +30,53 @@ INSERT INTO s1 values (1, 1, 1), (2, 2, 2);
 INSERT INTO s2 values (1, 1, 1), (2, 2, 2);
 INSERT INTO s3 values (1, 1, 1), (2, 2, 2);
 
+create materialized view test_mv12
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+    "replication_num" = "1",
+     'foreign_key_constraints'='s2(k1) REFERENCES s1(k1)',
+     'unique_constraints'='s1.k1'
+) 
+as select s1.k1 as s11, s1.k2 as s12, s1.k3 as s13, s2.k1 s21, s2.k2 s22, s2.k3 s23 from s1 join s2 on s1.k1 = s2.k1;
+[UC]REFRESH materialized view test_mv12 with sync mode;
+
 set enable_rbo_table_prune = true;
 set enable_cbo_table_prune = true;
 
 function: assert_explain_not_contains('select s2.k1, s2.k2 from s1 join s2 on s1.k1 = s2.k1 order by 1, 2;', 's1')
 function: assert_explain_not_contains('select s3.k1, s3.k2 from s1 join s3 on s1.k1 = s3.k1 order by 1, 2;', 's1')
+function: assert_explain_contains('select s2.k1, s2.k2 from s2 order by 1, 2;', 'test_mv12')
 
 select s2.k1, s2.k2 from s1 join s2 on s1.k1 = s2.k1 order by 1, 2;
 select s3.k1, s3.k2 from s1 join s3 on s1.k1 = s3.k1 order by 1, 2;
+select s2.k1, s2.k2 from s2 order by 1, 2;
 
 ALTER TABLE s2 SWAP WITH s3;
+ALTER materialized view test_mv12 active;
 SHOW CREATE TABLE s2;
 SHOW CREATE TABLE s3;
 
 function: assert_explain_not_contains('select s2.k1, s2.k2 from s1 join s2 on s1.k1 = s2.k1 order by 1, 2;', 's1')
 function: assert_explain_not_contains('select s3.k1, s3.k2 from s1 join s3 on s1.k1 = s3.k1 order by 1, 2;', 's1')
+-- TODO(FIXME): This should be fixed in the future
+function: assert_explain_not_contains('select s2.k1, s2.k2 from s2 order by 1, 2;', 'test_mv12')
 
 select s2.k1, s2.k2 from s1 join s2 on s1.k1 = s2.k1 order by 1, 2;
 select s3.k1, s3.k2 from s1 join s3 on s1.k1 = s3.k1 order by 1, 2;
+select s2.k1, s2.k2 from s2 order by 1, 2;
 
 CREATE TABLE s1_new
 (
-    k1 int, k2 int, k3 int
+    k1 int not null, k2 int, k3 int
 )
 DUPLICATE KEY(k1, k2)
 DISTRIBUTED BY RANDOM 
 PROPERTIES("replication_num" = "1", 'unique_constraints'='s1_new.k1');
 
+INSERT INTO s1_new values (1, 2, 3), (2, 3, 4);
+
 ALTER TABLE s1 SWAP WITH s1_new;
+ALTER materialized view test_mv12 active;
 SHOW CREATE TABLE s1;
 SHOW CREATE TABLE s1_new;
 SHOW CREATE TABLE s2;
@@ -65,9 +84,12 @@ SHOW CREATE TABLE s3;
 
 function: assert_explain_not_contains('select s2.k1, s2.k2 from s1 join s2 on s1.k1 = s2.k1 order by 1, 2;', 's1')
 function: assert_explain_not_contains('select s3.k1, s3.k2 from s1 join s3 on s1.k1 = s3.k1 order by 1, 2;', 's1')
+-- TODO(FIXME): This should be fixed in the future
+function: assert_explain_not_contains('select s2.k1, s2.k2 from s2 order by 1, 2;', 'test_mv12')
 
 select s2.k1, s2.k2 from s1 join s2 on s1.k1 = s2.k1 order by 1, 2;
 select s3.k1, s3.k2 from s1 join s3 on s1.k1 = s3.k1 order by 1, 2;
+select s2.k1, s2.k2 from s2 order by 1, 2;
 
 DROP TABLE s1;
 SHOW CREATE TABLE s2;

--- a/test/sql/test_information_schema/R/test_object_dependencies
+++ b/test/sql/test_information_schema/R/test_object_dependencies
@@ -37,8 +37,8 @@ select
     ref_object_type
 from sys.object_dependencies where object_database = 'db_${uuid0}';
 -- result:
-mv2	default_catalog	MATERIALIZED_VIEW	t1	default_catalog	OLAP
 mv1	default_catalog	MATERIALIZED_VIEW	t1	default_catalog	OLAP
+mv2	default_catalog	MATERIALIZED_VIEW	t1	default_catalog	OLAP
 -- !result
 create materialized view mv3 refresh async as select * from mv2;
 -- result:
@@ -52,9 +52,9 @@ select
     ref_object_type
 from sys.object_dependencies where object_database = 'db_${uuid0}';
 -- result:
-mv2	default_catalog	MATERIALIZED_VIEW	t1	default_catalog	OLAP
-mv3	default_catalog	MATERIALIZED_VIEW	mv2	default_catalog	MATERIALIZED_VIEW
 mv1	default_catalog	MATERIALIZED_VIEW	t1	default_catalog	OLAP
+mv3	default_catalog	MATERIALIZED_VIEW	mv2	default_catalog	MATERIALIZED_VIEW
+mv2	default_catalog	MATERIALIZED_VIEW	t1	default_catalog	OLAP
 -- !result
 alter table t1 rename t2;
 -- result:
@@ -84,6 +84,9 @@ from sys.object_dependencies where object_database = 'db_${uuid0}' and object_na
 mv1	default_catalog	MATERIALIZED_VIEW	t1	default_catalog	UNKNOWN
 -- !result
 alter table t2 rename t1;
+-- result:
+-- !result
+alter materialized view mv1 active;
 -- result:
 -- !result
 refresh materialized view mv1 with sync mode;

--- a/test/sql/test_information_schema/T/test_object_dependencies
+++ b/test/sql/test_information_schema/T/test_object_dependencies
@@ -50,6 +50,7 @@ drop table t1;
 select object_name, object_catalog, object_type, ref_object_name, ref_object_catalog, ref_object_type 
 from sys.object_dependencies where object_database = 'db_${uuid0}' and object_name = 'mv1';
 alter table t2 rename t1;
+alter materialized view mv1 active;
 refresh materialized view mv1 with sync mode;
 select object_name, object_catalog, object_type, ref_object_name, ref_object_catalog, ref_object_type 
 from sys.object_dependencies where object_database = 'db_${uuid0}' and object_name = 'mv1';

--- a/test/sql/test_materialized_view/R/test_mv_swap
+++ b/test/sql/test_materialized_view/R/test_mv_swap
@@ -1,4 +1,4 @@
--- name: test_mv_swap @sequential
+-- name: test_mv_swap 
 admin set frontend config('enable_mv_automatic_active_check'='false');
 -- result:
 -- !result
@@ -116,11 +116,11 @@ AS SELECT sum_sum_pv + 1 FROM mv_on_mv_1;
 ALTER MATERIALIZED VIEW mv1 SWAP WITH mv2;
 -- result:
 -- !result
-SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_1';
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_1' and TABLE_SCHEMA='db_${uuid0}';
 -- result:
 false	base-table swapped: mv1
 -- !result
-SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_2';
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_2' and TABLE_SCHEMA='db_${uuid0}';
 -- result:
 false	base-mv inactive: mv_on_mv_1
 -- !result
@@ -132,11 +132,11 @@ ALTER MATERIALIZED VIEW mv_on_mv_2 ACTIVE;
 -- result:
 [REGEX].*Can not active materialized view.*
 -- !result
-SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_1';
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_1' and TABLE_SCHEMA='db_${uuid0}';
 -- result:
 false	base-table swapped: mv1
 -- !result
-SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_2';
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_2' and TABLE_SCHEMA='db_${uuid0}';
 -- result:
 false	base-mv inactive: mv_on_mv_1
 -- !result
@@ -149,11 +149,11 @@ ALTER MATERIALIZED VIEW mv_on_mv_1 ACTIVE;
 ALTER MATERIALIZED VIEW mv_on_mv_2 ACTIVE;
 -- result:
 -- !result
-SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_1';
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_1' and TABLE_SCHEMA='db_${uuid0}';
 -- result:
 true	
 -- !result
-SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_2';
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_2' and TABLE_SCHEMA='db_${uuid0}';
 -- result:
 true	
 -- !result
@@ -167,14 +167,14 @@ AS SELECT ss.event_day, sum(ss.pv) as ss_sum_pv, sum(jj.pv) as jj_sum_pv
 ALTER TABLE ss SWAP WITH jj;
 -- result:
 -- !result
-SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_table_1';
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_table_1' and TABLE_SCHEMA='db_${uuid0}';
 -- result:
 false	base-table swapped: jj
 -- !result
 ALTER MATERIALIZED VIEW mv_on_table_1 ACTIVE;
 -- result:
 -- !result
-SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_table_1';
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_table_1' and TABLE_SCHEMA='db_${uuid0}';
 -- result:
 true	
 -- !result

--- a/test/sql/test_materialized_view/T/test_mv_swap
+++ b/test/sql/test_materialized_view/T/test_mv_swap
@@ -1,4 +1,4 @@
--- name: test_mv_swap @sequential
+-- name: test_mv_swap 
 
 admin set frontend config('enable_mv_automatic_active_check'='false');
 
@@ -51,18 +51,18 @@ AS SELECT sum_sum_pv + 1 FROM mv_on_mv_1;
 [UC]REFRESH MATERIALIZED VIEW mv_on_mv_2 with sync mode;
 -- swap intermediate MV
 ALTER MATERIALIZED VIEW mv1 SWAP WITH mv2;
-SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_1';
-SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_2';
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_1' and TABLE_SCHEMA='db_${uuid0}';
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_2' and TABLE_SCHEMA='db_${uuid0}';
 ALTER MATERIALIZED VIEW mv_on_mv_1 ACTIVE;
 ALTER MATERIALIZED VIEW mv_on_mv_2 ACTIVE;
-SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_1';
-SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_2';
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_1' and TABLE_SCHEMA='db_${uuid0}';
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_2' and TABLE_SCHEMA='db_${uuid0}';
 -- swap back
 ALTER MATERIALIZED VIEW mv1 SWAP WITH mv2;
 ALTER MATERIALIZED VIEW mv_on_mv_1 ACTIVE;
 ALTER MATERIALIZED VIEW mv_on_mv_2 ACTIVE;
-SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_1';
-SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_2';
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_1' and TABLE_SCHEMA='db_${uuid0}';
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_2' and TABLE_SCHEMA='db_${uuid0}';
 
 -- swap base table
 CREATE MATERIALIZED VIEW mv_on_table_1 REFRESH ASYNC 
@@ -71,9 +71,9 @@ AS SELECT ss.event_day, sum(ss.pv) as ss_sum_pv, sum(jj.pv) as jj_sum_pv
     GROUP BY ss.event_day;
 [UC]REFRESH MATERIALIZED VIEW mv_on_table_1 with sync mode ;
 ALTER TABLE ss SWAP WITH jj;
-SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_table_1';
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_table_1' and TABLE_SCHEMA='db_${uuid0}';
 ALTER MATERIALIZED VIEW mv_on_table_1 ACTIVE;
-SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_table_1';
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_table_1' and TABLE_SCHEMA='db_${uuid0}';
 
 [UC]drop database db_${uuid0} force;
 


### PR DESCRIPTION
## Why I'm doing:
- After Swapping table, mv's uk/fk constraints will be invalid, and there are warning logs in fe.warn.log:
```
2025-02-27 13:01:39.933-08:00 WARN (starrocks-mysql-nio-pool-1632|55314) [TableProperty.buildConstraint():751] Failed to parse foreign key constraints, ignore this foreign key constraints
java.lang.IllegalArgumentException: BaseInfo's baseTable 209503733 should not null
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:204)
        at com.starrocks.catalog.constraint.ForeignKeyConstraint.getTableBaseInfo(ForeignKeyConstraint.java:228)
        at com.starrocks.catalog.constraint.ForeignKeyConstraint.parse(ForeignKeyConstraint.java:189)
        at com.starrocks.catalog.TableProperty.buildConstraint(TableProperty.java:748)
        at com.starrocks.catalog.TableProperty.buildMvProperties(TableProperty.java:410)
        at com.starrocks.catalog.TableProperty.gsonPostProcess(TableProperty.java:1095)
        at com.starrocks.catalog.TableProperty.copy(TableProperty.java:320)
        at com.starrocks.catalog.OlapTable.copyOnlyForQuery(OlapTable.java:404)
        at com.starrocks.sql.analyzer.AnalyzerUtils$OlapTableCollector.copyTable(AnalyzerUtils.java:998)
        at com.starrocks.sql.analyzer.AnalyzerUtils$OlapTableCollector.visitTable(AnalyzerUtils.java:969)
        at com.starrocks.sql.analyzer.AnalyzerUtils$OlapTableCollector.visitTable(AnalyzerUtils.java:919)
        at com.starrocks.sql.ast.TableRelation.accept(TableRelation.java:193)
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:80)
        at com.starrocks.sql.ast.AstTraverser.visitJoin(AstTraverser.java:158)
        at com.starrocks.sql.ast.JoinRelation.accept(JoinRelation.java:134)
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:80)
        at com.starrocks.sql.ast.AstTraverser.visitJoin(AstTraverser.java:157)
        at com.starrocks.sql.ast.JoinRelation.accept(JoinRelation.java:134)
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:80)
        at com.starrocks.sql.ast.AstTraverser.visitJoin(AstTraverser.java:157)
        at com.starrocks.sql.ast.JoinRelation.accept(JoinRelation.java:134)
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:80)
        at com.starrocks.sql.ast.AstTraverser.visitJoin(AstTraverser.java:157)
        at com.starrocks.sql.ast.JoinRelation.accept(JoinRelation.java:134)
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:80)
        at com.starrocks.sql.ast.AstTraverser.visitSelect(AstTraverser.java:148)
        at com.starrocks.sql.ast.SelectRelation.accept(SelectRelation.java:232)
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:80)
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:76)
        at com.starrocks.sql.analyzer.AnalyzerUtils$TableCollector.visitQueryStatement(AnalyzerUtils.java:701)
        at com.starrocks.sql.analyzer.AnalyzerUtils$TableCollector.visitQueryStatement(AnalyzerUtils.java:686)
        at com.starrocks.sql.ast.QueryStatement.accept(QueryStatement.java:70)
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:80)
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:76)
        at com.starrocks.sql.analyzer.AnalyzerUtils.copyOlapTable(AnalyzerUtils.java:804)
        at com.starrocks.sql.StatementPlanner.collectOriginalOlapTables(StatementPlanner.java:369)
        at com.starrocks.sql.StatementPlanner.createQueryPlanWithReTry(StatementPlanner.java:295)
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:135)
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:92)
        at com.starrocks.sql.PrepareStmtPlanner.plan(PrepareStmtPlanner.java:48)
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:563)
        at com.starrocks.qe.ConnectProcessor.handleExecute(ConnectProcessor.java:529)
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:602)
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:918)
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:69)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
```
## What I'm doing:

- The UK/FK constraints between OLAP tables will be validated during SwapTable to ensure that the constraints of the two tables being swapped are consistent. If they are inconsistent, an automatic error will be triggered, and the defined UK/FK constraints will also be automatically switched.
- The materialized views (MVs) that depend on the SwapTable will be automatically set to inactive, and the UK/FK constraints that the MVs depend on will be removed and will no longer be available.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0