### PR TITLE
[Enhancement] Support automatically choosing the latest automated cluster snapshot to restore

### DIFF
--- a/conf/cluster_snapshot.yaml
+++ b/conf/cluster_snapshot.yaml
@@ -2,7 +2,7 @@
 
 # information about the cluster snapshot to be downloaded and restored
 #cluster_snapshot:
-#    cluster_snapshot_path: s3://defaultbucket/test/f7265e80-631c-44d3-a8ac-cf7cdc7adec811019/meta/image/automated_cluster_snapshot_1704038400000
+#    cluster_snapshot_path: s3://defaultbucket/test/f7265e80-631c-44d3-a8ac-cf7cdc7adec811019/meta
 #    storage_volume_name: my_s3_volume #defined in storage_volumes
 
 # do not include leader fe

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
@@ -49,7 +49,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
 // only used for AUTOMATED snapshot for now
 public class ClusterSnapshotMgr implements GsonPostProcessable {
     public static final Logger LOG = LogManager.getLogger(ClusterSnapshotMgr.class);
-    public static final String AUTOMATED_NAME_PREFIX = "automated_cluster_snapshot";
+    public static final String AUTOMATED_NAME_PREFIX = "automated_cluster_snapshot_";
 
     @SerializedName(value = "storageVolumeName")
     private volatile String storageVolumeName;
@@ -130,7 +130,7 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
     public ClusterSnapshotJob createAutomatedSnapshotJob() {
         long createTimeMs = System.currentTimeMillis();
         long id = GlobalStateMgr.getCurrentState().getNextId();
-        String snapshotName = AUTOMATED_NAME_PREFIX + '_' + String.valueOf(createTimeMs);
+        String snapshotName = AUTOMATED_NAME_PREFIX + String.valueOf(createTimeMs);
         ClusterSnapshotJob job = new ClusterSnapshotJob(id, snapshotName, storageVolumeName, createTimeMs);
         job.logJob();
 
@@ -246,7 +246,7 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
         Entry<Long, ClusterSnapshotJob> entry = automatedSnapshotJobs.lastEntry();
         if (entry != null) {
             ClusterSnapshotJob job = entry.getValue();
-            // Last snapshot may in init state, because the last snapshot checkpoint does not include the
+            // Last snapshot may in init state, because it does not include the
             // editlog for the state transtition after ClusterSnapshotJobState.INITIALIZING
             if (job.getSnapshotName().equals(restoredSnapshotName) && job.isInitializing()) {
                 job.setJournalIds(feJournalId, starMgrJournalId);


### PR DESCRIPTION
## Why I'm doing:
Previously users must specify a complete cluster snapshot path to restore, for example:

`s3://defaultbucket/test/f7265e80-631c-44d3-a8ac-cf7cdc7adec811019/meta/image/automated_cluster_snapshot_1704038400000`

Now users can specify a fixed cluster snapshot path to restore to the latest automated cluster snapshot, for example:

`s3://defaultbucket/test/f7265e80-631c-44d3-a8ac-cf7cdc7adec811019/meta`

## What I'm doing:
Support automatically choosing the latest automated cluster snapshot to restore

Fixes https://github.com/StarRocks/starrocks/issues/53867

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0