### PR TITLE
[BugFix] Fix MaterializedView's getQueryRewriteStatus cost too much time

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1711,8 +1711,9 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      * Return the status and reason about query rewrite
      */
     public String getQueryRewriteStatus() {
-        Pair<Boolean, String> status =
-                MvRewritePreprocessor.isMVValidToRewriteQuery(ConnectContext.get(), this, true, Sets.newHashSet());
+        // since check mv valid to rewrite query is a heavy operation, we only check it when it's in the plan cache.
+        Pair<Boolean, String> status = MvRewritePreprocessor.isMVValidToRewriteQuery(ConnectContext.get(),
+                this, false, Sets.newHashSet(), true);
         if (status.first) {
             return "VALID";
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVPlanValidationResult.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVPlanValidationResult.java
@@ -22,9 +22,18 @@ public class MVPlanValidationResult {
         VALID,
         INVALID,
         UNKNOWN;
-        public boolean isValid() { return this == VALID; }
-        public boolean isInvalid() { return this == INVALID; }
-        public boolean isUnKnown() { return this == UNKNOWN; }
+
+        public boolean isValid() {
+            return this == VALID;
+        }
+
+        public boolean isInvalid() {
+            return this == INVALID;
+        }
+
+        public boolean isUnKnown() {
+            return this == UNKNOWN;
+        }
     }
 
     private final Status status;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVPlanValidationResult.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVPlanValidationResult.java
@@ -1,0 +1,69 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog.mv;
+
+/**
+ * MVPlanValidationResult is used to represent the validation result of a MV's defined query plan.
+ */
+public class MVPlanValidationResult {
+    public enum Status {
+        VALID,
+        INVALID,
+        UNKNOWN;
+        public boolean isValid() { return this == VALID; }
+        public boolean isInvalid() { return this == INVALID; }
+        public boolean isUnKnown() { return this == UNKNOWN; }
+    }
+
+    private final Status status;
+    private final String reason;
+
+    public MVPlanValidationResult(Status status, String message) {
+        this.status = status;
+        this.reason = message != null ? message : "";
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public boolean isValid() {
+        return status.isValid();
+    }
+
+    public static MVPlanValidationResult valid() {
+        return new MVPlanValidationResult(Status.VALID, null);
+    }
+
+    public static MVPlanValidationResult invalid(String message) {
+        return new MVPlanValidationResult(Status.INVALID, message);
+    }
+
+    public static MVPlanValidationResult unknown(String message) {
+        return new MVPlanValidationResult(Status.UNKNOWN, message);
+    }
+
+    @Override
+    public String toString() {
+        return "MVPlanValidationResult{" +
+                "status=" + status +
+                ", reason='" + reason + '\'' +
+                '}';
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -32,6 +32,7 @@ import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
 import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.mv.MVPlanValidationResult;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
@@ -4540,8 +4541,8 @@ public class CreateMaterializedViewTest extends MVTestBase {
                 starRocksAssert.showCreateTable("show create table mv_enable"));
         starRocksAssert.refreshMV("refresh materialized view mv_enable with sync mode");
         MaterializedView mv = starRocksAssert.getMv("test", "mv_enable");
-        Pair<Boolean, String> valid = MvRewritePreprocessor.isMVValidToRewriteQuery(connectContext, mv, true, null, false);
-        Assert.assertTrue(valid.first);
+        MVPlanValidationResult valid = MvRewritePreprocessor.isMVValidToRewriteQuery(connectContext, mv, true, null, false);
+        Assert.assertTrue(valid.getStatus().isValid());
 
         starRocksAssert.ddl("alter materialized view mv_enable set('enable_query_rewrite'='false') ");
         Assert.assertEquals("CREATE MATERIALIZED VIEW `mv_enable` (`c_1_0`, `c_1_1`, `c_1_2`, `c_1_3`, " +
@@ -4560,8 +4561,8 @@ public class CreateMaterializedViewTest extends MVTestBase {
                         "FROM `test`.`t1`;",
                 starRocksAssert.showCreateTable("show create table mv_enable"));
         valid = MvRewritePreprocessor.isMVValidToRewriteQuery(connectContext, mv, true, null, false);
-        Assert.assertFalse(valid.first);
-        Assert.assertEquals("enable_query_rewrite=FALSE", valid.second);
+        Assert.assertFalse(valid.getStatus().isValid());
+        Assert.assertEquals("enable_query_rewrite=FALSE", valid.getReason());
         starRocksAssert.dropMaterializedView("mv_enable");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -4540,7 +4540,7 @@ public class CreateMaterializedViewTest extends MVTestBase {
                 starRocksAssert.showCreateTable("show create table mv_enable"));
         starRocksAssert.refreshMV("refresh materialized view mv_enable with sync mode");
         MaterializedView mv = starRocksAssert.getMv("test", "mv_enable");
-        Pair<Boolean, String> valid = MvRewritePreprocessor.isMVValidToRewriteQuery(connectContext, mv, true, null);
+        Pair<Boolean, String> valid = MvRewritePreprocessor.isMVValidToRewriteQuery(connectContext, mv, true, null, false);
         Assert.assertTrue(valid.first);
 
         starRocksAssert.ddl("alter materialized view mv_enable set('enable_query_rewrite'='false') ");
@@ -4559,7 +4559,7 @@ public class CreateMaterializedViewTest extends MVTestBase {
                         "`t1`.`c_1_12`\n" +
                         "FROM `test`.`t1`;",
                 starRocksAssert.showCreateTable("show create table mv_enable"));
-        valid = MvRewritePreprocessor.isMVValidToRewriteQuery(connectContext, mv, true, null);
+        valid = MvRewritePreprocessor.isMVValidToRewriteQuery(connectContext, mv, true, null, false);
         Assert.assertFalse(valid.first);
         Assert.assertEquals("enable_query_rewrite=FALSE", valid.second);
         starRocksAssert.dropMaterializedView("mv_enable");

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -1043,7 +1043,7 @@ public class ShowExecutorTest {
         Assert.assertEquals("10", resultSet.getString(mvSchemaTable.size() - 5));
         Assert.assertEquals(expectedSqlText, resultSet.getString(mvSchemaTable.size() - 4));
         Assert.assertEquals("", resultSet.getString(mvSchemaTable.size() - 3));
-        Assert.assertEquals("VALID", resultSet.getString(mvSchemaTable.size() - 2));
+        Assert.assertTrue(resultSet.getString(mvSchemaTable.size() - 2).contains("UNKNOWN"));
         Assert.assertEquals("", resultSet.getString(mvSchemaTable.size() - 1));
         Assert.assertFalse(resultSet.next());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
@@ -697,4 +697,17 @@ public class MvRewritePreprocessorTest extends MVTestBase {
             Assert.assertEquals(1, mvWithPlanContexts.size());
         });
     }
+
+    @Test
+    public void testValidPlanWithoutForce() {
+        String sql = "create materialized view invalid_plan_mv distributed by random " +
+                "as select count(v1) as cnt from t1 group by k1";
+        starRocksAssert.withMaterializedView(sql, (obj) -> {
+            String mvName = (String) obj;
+            MaterializedView mv = getMv(DB_NAME, mvName);
+            CachingMvPlanContextBuilder.getInstance().invalidateAstFromCache(mv);
+            String status = mv.getQueryRewriteStatus();
+            Assert.assertTrue(status.equalsIgnoreCase("INVALID: MV plan is not in cache, valid check is unknown"));
+        });
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
@@ -707,7 +707,7 @@ public class MvRewritePreprocessorTest extends MVTestBase {
             MaterializedView mv = getMv(DB_NAME, mvName);
             CachingMvPlanContextBuilder.getInstance().invalidateAstFromCache(mv);
             String status = mv.getQueryRewriteStatus();
-            Assert.assertTrue(status.equalsIgnoreCase("INVALID: MV plan is not in cache, valid check is unknown"));
+            Assert.assertTrue(status.equalsIgnoreCase("UNKNOWN: MV plan is not in cache, valid check is unknown"));
         });
     }
 }


### PR DESCRIPTION
## Why I'm doing:


![image](https://github.com/user-attachments/assets/2da6bf00-ba83-49b6-9deb-e9a898c08b2c)

## What I'm doing:

- Since check mv valid to rewrite query is a heavy operation, we only check it when its validation in the plan cache.
- Add `MVPlanValidationResult` UNKNOWN state to mark mv plan's validation result if it's not in the plan cache.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0