### PR TITLE
[Enhancement] Implement starcache based object cache

### DIFF
--- a/be/src/cache/CMakeLists.txt
+++ b/be/src/cache/CMakeLists.txt
@@ -31,6 +31,7 @@ set(CACHE_FILES
 
 if (${WITH_STARCACHE} STREQUAL "ON")
     list(APPEND CACHE_FILES block_cache/starcache_wrapper.cpp)
+    list(APPEND CACHE_FILES object_cache/starcache_module.cpp)
 endif()
 
 add_library(Cache STATIC

--- a/be/src/cache/block_cache/block_cache.cpp
+++ b/be/src/cache/block_cache/block_cache.cpp
@@ -124,7 +124,7 @@ Status BlockCache::read_object(const CacheKey& cache_key, DataCacheHandle* handl
     return _kv_cache->read_object(cache_key, handle, options);
 }
 
-bool BlockCache::exist(const starcache::CacheKey& cache_key, off_t offset, size_t size) const {
+bool BlockCache::exist(const CacheKey& cache_key, off_t offset, size_t size) const {
     if (size == 0) {
         return true;
     }

--- a/be/src/cache/block_cache/block_cache.h
+++ b/be/src/cache/block_cache/block_cache.h
@@ -60,7 +60,7 @@ public:
     // function, the corresponding pointer will never be freed by the cache system.
     Status read_object(const CacheKey& cache_key, DataCacheHandle* handle, ReadCacheOptions* options = nullptr);
 
-    bool exist(const starcache::CacheKey& cache_key, off_t offset, size_t size) const;
+    bool exist(const CacheKey& cache_key, off_t offset, size_t size) const;
 
     // Remove data from cache. The offset and size must be aligned by block size
     Status remove(const CacheKey& cache_key, off_t offset, size_t size);
@@ -94,7 +94,9 @@ public:
 
     DataCacheEngineType engine_type();
 
+#ifdef WITH_STARCACHE
     std::shared_ptr<starcache::StarCache> starcache_instance() { return _kv_cache->starcache_instance(); }
+#endif
 
     static const size_t MAX_BLOCK_SIZE;
 

--- a/be/src/cache/block_cache/kv_cache.h
+++ b/be/src/cache/block_cache/kv_cache.h
@@ -82,7 +82,9 @@ public:
 
     virtual DataCacheEngineType engine_type() = 0;
 
+#ifdef WITH_STARCACHE
     virtual std::shared_ptr<starcache::StarCache> starcache_instance() = 0;
+#endif
 };
 
 } // namespace starrocks

--- a/be/src/cache/block_cache/starcache_wrapper.h
+++ b/be/src/cache/block_cache/starcache_wrapper.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include "cache/block_cache/kv_cache.h"
-#include "common/status.h"
+#include "cache/status.h"
 #include "starcache/star_cache.h"
 #include "starcache/time_based_cache_adaptor.h"
 
@@ -64,32 +64,4 @@ private:
     bool _enable_tiered_cache = false;
     bool _enable_datacache_persistence = false;
 };
-
-// In order to split the starcache library to a separate registry for other users such as the cloud team,
-// we decouple it from starrocks as much as possible. So we use the butil::Status in starcache instead
-// of starrocks::Status.
-// This function is used to convert the butil::Status from starcache to starrocks::Status.
-inline Status to_status(const butil::Status& st) {
-    switch (st.error_code()) {
-    case 0:
-        return Status::OK();
-    case ENOENT:
-        return Status::NotFound(st.error_str());
-    case EEXIST:
-        return Status::AlreadyExist(st.error_str());
-    case EINVAL:
-        return Status::InvalidArgument(st.error_str());
-    case EIO:
-        return Status::IOError(st.error_str());
-    case ENOMEM:
-        return Status::MemoryLimitExceeded(st.error_str());
-    case ENOSPC:
-        return Status::CapacityLimitExceed(st.error_str());
-    case EBUSY:
-        return Status::ResourceBusy(st.error_str());
-    default:
-        return Status::InternalError(st.error_str());
-    }
-}
-
 } // namespace starrocks

--- a/be/src/cache/object_cache/cache_module.h
+++ b/be/src/cache/object_cache/cache_module.h
@@ -24,8 +24,6 @@ class ObjectCacheModule {
 public:
     virtual ~ObjectCacheModule() = default;
 
-    virtual Status init() = 0;
-
     virtual Status insert(const std::string& key, void* value, size_t size, size_t charge, ObjectCacheDeleter deleter,
                           ObjectCacheHandlePtr* handle, ObjectCacheWriteOptions* options) = 0;
 

--- a/be/src/cache/object_cache/lrucache_module.cpp
+++ b/be/src/cache/object_cache/lrucache_module.cpp
@@ -20,17 +20,14 @@
 
 namespace starrocks {
 
+LRUCacheModule::LRUCacheModule(const ObjectCacheOptions& options) : _options(options) {
+    _cache.reset(new_lru_cache(_options.capacity));
+}
+
 LRUCacheModule::~LRUCacheModule() {
     if (_cache) {
         _cache->prune();
     }
-}
-
-Status LRUCacheModule::init() {
-    if (!_cache) {
-        _cache.reset(new_lru_cache(_options.capacity));
-    }
-    return Status::OK();
 }
 
 Status LRUCacheModule::insert(const std::string& key, void* value, size_t size, size_t charge,

--- a/be/src/cache/object_cache/object_cache.cpp
+++ b/be/src/cache/object_cache/object_cache.cpp
@@ -49,7 +49,7 @@ Status ObjectCache::init(const ObjectCacheOptions& options) {
 }
 
 #ifdef WITH_STARCACHE
-Status ObjectCache::init(std::shared_ptr<starcache::StarCache> star_cache) {
+Status ObjectCache::init(const std::shared_ptr<starcache::StarCache>& star_cache) {
     if (_initialized.load(std::memory_order_acquire)) {
         LOG(WARNING) << "fail to initialize because it has already been initialized before";
         return Status::AlreadyExist("already initialized");

--- a/be/src/cache/object_cache/object_cache.cpp
+++ b/be/src/cache/object_cache/object_cache.cpp
@@ -21,6 +21,10 @@
 #include "common/statusor.h"
 #include "runtime/exec_env.h"
 
+#ifdef WITH_STARCACHE
+#include "cache/object_cache/starcache_module.h"
+#endif
+
 namespace starrocks {
 
 ObjectCache::~ObjectCache() {
@@ -40,10 +44,22 @@ Status ObjectCache::init(const ObjectCacheOptions& options) {
         LOG(ERROR) << "Unsupported cache module";
         return Status::NotSupported("unsupported block cache engine");
     }
-    RETURN_IF_ERROR(_cache_module->init());
     _initialized.store(true, std::memory_order_release);
     return Status::OK();
 }
+
+#ifdef WITH_STARCACHE
+Status ObjectCache::init(std::shared_ptr<starcache::StarCache> star_cache) {
+    if (_initialized.load(std::memory_order_acquire)) {
+        LOG(WARNING) << "fail to initialize because it has already been initialized before";
+        return Status::AlreadyExist("already initialized");
+    }
+    _cache_module = std::make_shared<StarCacheModule>(star_cache);
+    _initialized.store(true, std::memory_order_release);
+    LOG(INFO) << "init object cache with an exist block cache module";
+    return Status::OK();
+}
+#endif
 
 Status ObjectCache::insert(const std::string& key, void* value, size_t size, size_t charge, ObjectCacheDeleter deleter,
                            ObjectCacheHandlePtr* handle, ObjectCacheWriteOptions* options) {

--- a/be/src/cache/object_cache/object_cache.h
+++ b/be/src/cache/object_cache/object_cache.h
@@ -22,6 +22,10 @@
 #include "common/status.h"
 #include "util/lru_cache.h"
 
+#ifdef WITH_STARCACHE
+#include "starcache/star_cache.h"
+#endif
+
 namespace starrocks {
 
 class ObjectCache {
@@ -32,9 +36,14 @@ public:
     // Init the object cache instance with options.
     Status init(const ObjectCacheOptions& options);
 
+#ifdef WITH_STARCACHE
+    // Init the object cache instance with an exist block cache module.
+    Status init(std::shared_ptr<starcache::StarCache> star_cache);
+#endif
+
     // Insert object to cache, the `ptr` is the object pointer.
     // size: the size of the value.
-    // charge: the actual memory size mallocated for this value.
+    // charge: the actual memory size allocated for this value.
     Status insert(const std::string& key, void* value, size_t size, size_t charge, ObjectCacheDeleter deleter,
                   ObjectCacheHandlePtr* handle, ObjectCacheWriteOptions* options = nullptr);
 
@@ -59,7 +68,7 @@ public:
     Slice value_slice(ObjectCacheHandlePtr handle);
 
     // Adjust the cache quota by delta bytes.
-    // If the new capcity is less than `min_capacity`, skip adjusting it.
+    // If the new capacity is less than `min_capacity`, skip adjusting it.
     Status adjust_capacity(int64_t delta, size_t min_capacity);
 
     // Set the cache capacity to a target value.

--- a/be/src/cache/object_cache/object_cache.h
+++ b/be/src/cache/object_cache/object_cache.h
@@ -38,7 +38,7 @@ public:
 
 #ifdef WITH_STARCACHE
     // Init the object cache instance with an exist block cache module.
-    Status init(std::shared_ptr<starcache::StarCache> star_cache);
+    Status init(const std::shared_ptr<starcache::StarCache>& star_cache);
 #endif
 
     // Insert object to cache, the `ptr` is the object pointer.

--- a/be/src/cache/object_cache/starcache_module.cpp
+++ b/be/src/cache/object_cache/starcache_module.cpp
@@ -53,7 +53,6 @@ Status StarCacheModule::lookup(const std::string& key, ObjectCacheHandlePtr* han
     starcache::ObjectHandle* obj_hdl = new starcache::ObjectHandle;
     // Skip checking options temporarily because there is no valid members in `ObjectCacheReadOptions` now.
     Status st = to_status(_cache->get_object(key, obj_hdl, nullptr));
-    LOG(ERROR) << "LOOKUP: " << st;
     if (!st.ok()) {
         delete obj_hdl;
     } else if (handle) {

--- a/be/src/cache/object_cache/starcache_module.cpp
+++ b/be/src/cache/object_cache/starcache_module.cpp
@@ -1,0 +1,150 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cache/object_cache/starcache_module.h"
+
+#include "cache/status.h"
+#include "common/logging.h"
+
+namespace starrocks {
+
+Status StarCacheModule::insert(const std::string& key, void* value, size_t size, size_t charge,
+                               ObjectCacheDeleter deleter, ObjectCacheHandlePtr* handle,
+                               ObjectCacheWriteOptions* options) {
+    starcache::ObjectHandle* obj_hdl = new starcache::ObjectHandle;
+    auto obj_deleter = [deleter, key, value] {
+        // For temporary compatibility with old deleters.
+        CacheKey cache_key(key);
+        deleter(cache_key, value);
+    };
+    Status st;
+    if (!options) {
+        st = to_status(_cache->set_object(key, value, charge, obj_deleter, obj_hdl, nullptr));
+    } else {
+        starcache::WriteOptions opts;
+        opts.priority = options->priority;
+        opts.ttl_seconds = options->ttl_seconds;
+        opts.overwrite = options->overwrite;
+        opts.evict_probability = options->evict_probability;
+        st = to_status(_cache->set_object(key, value, charge, obj_deleter, obj_hdl, &opts));
+    }
+    if (!st.ok()) {
+        delete obj_hdl;
+    } else if (handle) {
+        // Try release the old handle before fill it with a new one.
+        _try_release_obj_handle(*handle);
+        *handle = reinterpret_cast<ObjectCacheHandlePtr>(obj_hdl);
+    }
+    return st;
+}
+
+Status StarCacheModule::lookup(const std::string& key, ObjectCacheHandlePtr* handle, ObjectCacheReadOptions* options) {
+    starcache::ObjectHandle* obj_hdl = new starcache::ObjectHandle;
+    // Skip checking options temporarily because there is no valid members in `ObjectCacheReadOptions` now.
+    Status st = to_status(_cache->get_object(key, obj_hdl, nullptr));
+    LOG(ERROR) << "LOOKUP: " << st;
+    if (!st.ok()) {
+        delete obj_hdl;
+    } else if (handle) {
+        _try_release_obj_handle(*handle);
+        *handle = reinterpret_cast<ObjectCacheHandlePtr>(obj_hdl);
+    }
+    return st;
+}
+
+Status StarCacheModule::remove(const std::string& key) {
+    return to_status(_cache->remove(key));
+}
+
+void StarCacheModule::release(ObjectCacheHandlePtr handle) {
+    auto obj_hdl = reinterpret_cast<starcache::ObjectHandle*>(handle);
+    obj_hdl->release();
+    delete obj_hdl;
+}
+
+const void* StarCacheModule::value(ObjectCacheHandlePtr handle) {
+    auto obj_hdl = reinterpret_cast<starcache::ObjectHandle*>(handle);
+    return obj_hdl->ptr();
+}
+
+Slice StarCacheModule::value_slice(ObjectCacheHandlePtr handle) {
+    auto obj_hdl = reinterpret_cast<starcache::ObjectHandle*>(handle);
+    Slice slice((char*)obj_hdl->ptr(), obj_hdl->size());
+    return slice;
+}
+
+Status StarCacheModule::adjust_capacity(int64_t delta, size_t min_capacity) {
+    auto starcache_metrics = _cache->metrics();
+    size_t capacity = starcache_metrics.mem_quota_bytes;
+    int64_t new_capacity = capacity + delta;
+    if (new_capacity < (int64_t)min_capacity) {
+        return Status::InvalidArgument("target capacity is less than the minimum capacity");
+    }
+    return to_status(_cache->update_mem_quota(new_capacity, false));
+}
+
+Status StarCacheModule::set_capacity(size_t capacity) {
+    return to_status(_cache->update_mem_quota(capacity, false));
+}
+
+size_t StarCacheModule::capacity() const {
+    starcache::CacheMetrics metrics = _cache->metrics(0);
+    // TODO: optimizer later
+    return metrics.mem_quota_bytes;
+}
+
+size_t StarCacheModule::usage() const {
+    // TODO: add meta size?
+    starcache::CacheMetrics metrics = _cache->metrics(0);
+    return metrics.mem_used_bytes;
+}
+
+size_t StarCacheModule::lookup_count() const {
+    starcache::CacheMetrics metrics = _cache->metrics(1);
+    return metrics.detail_l1->hit_count + metrics.detail_l1->miss_count;
+}
+
+size_t StarCacheModule::hit_count() const {
+    starcache::CacheMetrics metrics = _cache->metrics(1);
+    return metrics.detail_l1->hit_count;
+}
+
+const ObjectCacheMetrics StarCacheModule::metrics() const {
+    auto starcache_metrics = _cache->metrics(2);
+    ObjectCacheMetrics m;
+    m.capacity = starcache_metrics.mem_quota_bytes;
+    m.usage = starcache_metrics.mem_used_bytes;
+    m.lookup_count = starcache_metrics.detail_l1->hit_count + starcache_metrics.detail_l1->miss_count;
+    m.hit_count = starcache_metrics.detail_l1->hit_count;
+    m.object_item_count = starcache_metrics.detail_l2->object_item_count;
+    return m;
+}
+
+Status StarCacheModule::prune() {
+    return to_status(_cache->update_mem_quota(0, false));
+}
+
+Status StarCacheModule::shutdown() {
+    return prune();
+}
+
+bool StarCacheModule::_try_release_obj_handle(ObjectCacheHandlePtr handle) {
+    if (handle) {
+        release(handle);
+        return true;
+    }
+    return false;
+}
+
+} // namespace starrocks

--- a/be/src/cache/object_cache/starcache_module.h
+++ b/be/src/cache/object_cache/starcache_module.h
@@ -15,17 +15,15 @@
 #pragma once
 
 #include "cache/object_cache/cache_module.h"
-#include "util/lru_cache.h"
+#include "starcache/star_cache.h"
 
 namespace starrocks {
 
-class Cache;
-
-class LRUCacheModule : public ObjectCacheModule {
+class StarCacheModule : public ObjectCacheModule {
 public:
-    LRUCacheModule(const ObjectCacheOptions& options);
+    StarCacheModule(std::shared_ptr<starcache::StarCache> star_cache) : _cache(star_cache) {}
 
-    ~LRUCacheModule();
+    ~StarCacheModule() = default;
 
     Status insert(const std::string& key, void* value, size_t size, size_t charge, ObjectCacheDeleter deleter,
                   ObjectCacheHandlePtr* handle, ObjectCacheWriteOptions* options) override;
@@ -59,10 +57,11 @@ public:
     Status shutdown() override;
 
 private:
-    bool _check_write(size_t charge, ObjectCacheWriteOptions* options) const;
+    bool _try_release_obj_handle(ObjectCacheHandlePtr handle);
 
     ObjectCacheOptions _options;
-    std::shared_ptr<Cache> _cache;
+    std::shared_ptr<starcache::StarCache> _cache;
+    bool _own_star_cache = false;
 };
 
 } // namespace starrocks

--- a/be/src/cache/object_cache/starcache_module.h
+++ b/be/src/cache/object_cache/starcache_module.h
@@ -61,7 +61,6 @@ private:
 
     ObjectCacheOptions _options;
     std::shared_ptr<starcache::StarCache> _cache;
-    bool _own_star_cache = false;
 };
 
 } // namespace starrocks

--- a/be/src/cache/status.h
+++ b/be/src/cache/status.h
@@ -1,0 +1,50 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <butil/status.h>
+
+#include "common/status.h"
+
+namespace starrocks {
+
+// In order to split the starcache library to a separate registry for other users such as the cloud team,
+// we decouple it from starrocks as much as possible. So we use the butil::Status in starcache instead
+// of starrocks::Status.
+// This function is used to convert the butil::Status from starcache to starrocks::Status.
+inline Status to_status(const butil::Status& st) {
+    switch (st.error_code()) {
+    case 0:
+        return Status::OK();
+    case ENOENT:
+        return Status::NotFound(st.error_str());
+    case EEXIST:
+        return Status::AlreadyExist(st.error_str());
+    case EINVAL:
+        return Status::InvalidArgument(st.error_str());
+    case EIO:
+        return Status::IOError(st.error_str());
+    case ENOMEM:
+        return Status::MemoryLimitExceeded(st.error_str());
+    case ENOSPC:
+        return Status::CapacityLimitExceed(st.error_str());
+    case EBUSY:
+        return Status::ResourceBusy(st.error_str());
+    default:
+        return Status::InternalError(st.error_str());
+    }
+}
+
+} // namespace starrocks

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -71,7 +71,7 @@ Status FileReader::init(HdfsScannerContext* ctx) {
 #ifdef WITH_STARCACHE
     // Only support file metacache in starcache engine
     if (ctx->use_file_metacache && config::datacache_enable) {
-        _cache = BlockCache::instance();
+        _cache = CacheEnv::GetInstance()->external_table_meta_cache();
     }
 #endif
     // parse FileMetadata

--- a/be/src/formats/parquet/file_reader.h
+++ b/be/src/formats/parquet/file_reader.h
@@ -51,6 +51,7 @@ namespace parquet {
 struct ParquetField;
 } // namespace parquet
 struct TypeDescriptor;
+class ObjectCache;
 
 } // namespace starrocks
 
@@ -125,7 +126,7 @@ private:
     size_t _scan_row_count = 0;
     bool _no_materialized_column_scan = false;
 
-    BlockCache* _cache = nullptr;
+    ObjectCache* _cache = nullptr;
     FileMetaDataPtr _file_metadata = nullptr;
 
     // not exist column conjuncts eval false, file can be skipped

--- a/be/src/formats/parquet/metadata.cpp
+++ b/be/src/formats/parquet/metadata.cpp
@@ -457,7 +457,7 @@ StatusOr<FileMetaDataPtr> FileMetaDataParser::get_file_metadata() {
             auto file_metadata = *(static_cast<const FileMetaDataPtr*>(_cache->value(cache_handle)));
             _scanner_ctx->stats->footer_cache_read_count += 1;
             _cache->release(cache_handle);
-            return st;
+            return file_metadata;
         }
     }
 

--- a/be/src/formats/parquet/metadata.cpp
+++ b/be/src/formats/parquet/metadata.cpp
@@ -447,15 +447,15 @@ StatusOr<FileMetaDataPtr> FileMetaDataParser::get_file_metadata() {
         return file_metadata_ptr;
     }
 
-    DataCacheHandle cache_handle;
+    ObjectCacheHandle* cache_handle = nullptr;
     std::string metacache_key =
             _build_metacache_key(_file->filename(), _datacache_options->modification_time, _file_size);
     {
         SCOPED_RAW_TIMER(&_scanner_ctx->stats->footer_cache_read_ns);
-        Status st = _cache->read_object(metacache_key, &cache_handle);
+        Status st = _cache->lookup(metacache_key, &cache_handle);
         if (st.ok()) {
             _scanner_ctx->stats->footer_cache_read_count += 1;
-            return *(static_cast<const FileMetaDataPtr*>(cache_handle.ptr()));
+            return *(static_cast<const FileMetaDataPtr*>(_cache->value(cache_handle)));
         }
     }
 
@@ -464,7 +464,7 @@ StatusOr<FileMetaDataPtr> FileMetaDataParser::get_file_metadata() {
     RETURN_IF_ERROR(_parse_footer(&file_metadata, &file_metadata_size));
     if (file_metadata_size > 0) {
         // cache does not understand shared ptr at all.
-        // so we have to new a object to hold this shared ptr.
+        // so we have to new an object to hold this shared ptr.
         FileMetaDataPtr* capture = new FileMetaDataPtr(file_metadata);
         Status st = Status::InternalError("write footer cache failed");
         DeferOp op([&st, this, capture, file_metadata_size]() {
@@ -476,10 +476,11 @@ StatusOr<FileMetaDataPtr> FileMetaDataParser::get_file_metadata() {
                 delete capture;
             }
         });
-        auto deleter = [capture]() { delete capture; };
-        WriteCacheOptions options;
+        auto deleter = [](const CacheKey& key, void* value) { delete (FileMetaDataPtr*)value; };
+        ObjectCacheWriteOptions options;
         options.evict_probability = _datacache_options->datacache_evict_probability;
-        st = _cache->write_object(metacache_key, capture, file_metadata_size, deleter, &cache_handle, &options);
+        st = _cache->insert(metacache_key, capture, file_metadata_size, file_metadata_size, deleter, &cache_handle,
+                            &options);
     } else {
         LOG(ERROR) << "Parsing unexpected parquet file metadata size";
     }

--- a/be/src/formats/parquet/metadata.h
+++ b/be/src/formats/parquet/metadata.h
@@ -106,7 +106,7 @@ using FileMetaDataPtr = std::shared_ptr<FileMetaData>;
 // 2. if DataCache is enabled, retrieve FileMetaData from DataCache. Otherwise, parse FileMetaData normally
 class FileMetaDataParser {
 public:
-    FileMetaDataParser(RandomAccessFile* file, const HdfsScannerContext* scanner_context, BlockCache* cache,
+    FileMetaDataParser(RandomAccessFile* file, const HdfsScannerContext* scanner_context, ObjectCache* cache,
                        const DataCacheOptions* datacache_options, uint64_t file_size)
             : _file(file),
               _scanner_ctx(scanner_context),
@@ -122,7 +122,7 @@ private:
     static std::string _build_metacache_key(const std::string& filename, int64_t modification_time, uint64_t file_size);
     RandomAccessFile* _file = nullptr;
     const HdfsScannerContext* _scanner_ctx = nullptr;
-    BlockCache* _cache = nullptr;
+    ObjectCache* _cache = nullptr;
     const DataCacheOptions* _datacache_options = nullptr;
     uint64_t _file_size = 0;
 

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -251,10 +251,12 @@ public:
     void try_release_resource_before_core_dump();
 
     BlockCache* block_cache() const { return _block_cache.get(); }
+    ObjectCache* external_table_meta_cache() const { return _starcache_based_object_cache.get(); }
     StoragePageCache* page_cache() const { return _page_cache.get(); }
 
 private:
     Status _init_datacache();
+    Status _init_starcache_based_object_cache();
     Status _init_lru_base_object_cache();
     Status _init_page_cache();
 
@@ -262,6 +264,7 @@ private:
     std::vector<StorePath> _store_paths;
 
     std::shared_ptr<BlockCache> _block_cache;
+    std::shared_ptr<ObjectCache> _starcache_based_object_cache;
     std::shared_ptr<ObjectCache> _lru_based_object_cache;
     std::shared_ptr<StoragePageCache> _page_cache;
 };

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -303,7 +303,7 @@ void SystemMetrics::_update_datacache_mem_tracker() {
     auto* datacache_mem_tracker = GlobalEnv::GetInstance()->datacache_mem_tracker();
     if (datacache_mem_tracker) {
         BlockCache* block_cache = BlockCache::instance();
-        if (block_cache->is_initialized()) {
+        if (block_cache != nullptr && block_cache->is_initialized()) {
             auto datacache_metrics = block_cache->cache_metrics();
             datacache_mem_bytes = datacache_metrics.mem_used_bytes + datacache_metrics.meta_used_bytes;
         }

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -509,6 +509,7 @@ set(EXEC_FILES
 
 if ("${WITH_STARCACHE}" STREQUAL "ON")
     list(APPEND EXEC_FILES ./cache/block_cache/block_cache_test.cpp)
+    list(APPEND EXEC_FILES ./cache/object_cache/starcache_module_test.cpp)
     list(APPEND EXEC_FILES ./cache/block_cache/disk_space_monitor_test.cpp)
     list(APPEND EXEC_FILES ./io/cache_input_stream_test.cpp)
 endif ()

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -509,8 +509,9 @@ set(EXEC_FILES
 
 if ("${WITH_STARCACHE}" STREQUAL "ON")
     list(APPEND EXEC_FILES ./cache/block_cache/block_cache_test.cpp)
-    list(APPEND EXEC_FILES ./cache/object_cache/starcache_module_test.cpp)
     list(APPEND EXEC_FILES ./cache/block_cache/disk_space_monitor_test.cpp)
+    list(APPEND EXEC_FILES ./cache/object_cache/starcache_module_test.cpp)
+    list(APPEND EXEC_FILES ./cache/object_cache/object_cache_test.cpp)
     list(APPEND EXEC_FILES ./io/cache_input_stream_test.cpp)
 endif ()
 

--- a/be/test/cache/object_cache/lrucache_module_test.cpp
+++ b/be/test/cache/object_cache/lrucache_module_test.cpp
@@ -23,7 +23,6 @@ class LRUCacheModuleTest : public ::testing::Test {
 protected:
     void SetUp() override {
         _cache = std::make_shared<LRUCacheModule>(_cache_opt);
-        ASSERT_OK(_cache->init());
     }
     void TearDown() override {}
 

--- a/be/test/cache/object_cache/lrucache_module_test.cpp
+++ b/be/test/cache/object_cache/lrucache_module_test.cpp
@@ -21,9 +21,7 @@
 namespace starrocks {
 class LRUCacheModuleTest : public ::testing::Test {
 protected:
-    void SetUp() override {
-        _cache = std::make_shared<LRUCacheModule>(_cache_opt);
-    }
+    void SetUp() override { _cache = std::make_shared<LRUCacheModule>(_cache_opt); }
     void TearDown() override {}
 
 protected:

--- a/be/test/cache/object_cache/object_cache_test.cpp
+++ b/be/test/cache/object_cache/object_cache_test.cpp
@@ -15,9 +15,9 @@
 #include "cache/object_cache/object_cache.h"
 
 #include <gtest/gtest.h>
-#include "fs/fs_util.h"
-#include "cache/block_cache/block_cache.h"
 
+#include "cache/block_cache/block_cache.h"
+#include "fs/fs_util.h"
 #include "testutil/assert.h"
 
 namespace starrocks {

--- a/be/test/cache/object_cache/object_cache_test.cpp
+++ b/be/test/cache/object_cache/object_cache_test.cpp
@@ -15,19 +15,44 @@
 #include "cache/object_cache/object_cache.h"
 
 #include <gtest/gtest.h>
+#include "fs/fs_util.h"
+#include "cache/block_cache/block_cache.h"
 
 #include "testutil/assert.h"
 
 namespace starrocks {
-class ObjectCacheTest : public ::testing::Test {
+class ObjectCacheTest : public ::testing::TestWithParam<ObjectCacheModuleType> {
 protected:
-    void SetUp() override { ASSERT_OK(_cache.init(_cache_opt)); }
-    void TearDown() override {}
+    void SetUp() override {
+        _mode = GetParam();
+        if (_mode == ObjectCacheModuleType::LRUCACHE) {
+            _value_size = 4;
+            _kv_size = _key_size + _value_size;
+            _mem_quota = 16384;
+            _cache_opt.capacity = _mem_quota;
+            ASSERT_OK(_cache.init(_cache_opt));
+        } else {
+            _value_size = 300 * 1024;
+            _kv_size = _value_size;
+            _mem_quota = 64 * 1024 * 1024;
+            _cache_opt.capacity = _mem_quota;
+            ASSERT_OK(fs::create_directories(_cache_dir));
+            _init_block_cache();
+            ASSERT_OK(_cache.init(_block_cache->starcache_instance()));
+        }
+    }
+    void TearDown() override {
+        if (_mode == ObjectCacheModuleType::STARCACHE) {
+            ASSERT_OK(_block_cache->shutdown());
+            ASSERT_OK(fs::remove_all(_cache_dir));
+        }
+    }
 
     static void Deleter(const CacheKey& k, void* v) { free(v); }
     void _insert_data();
     void _check_not_found(int value);
     void _check_found(int value);
+    void _init_block_cache();
 
     static std::string int_to_string(size_t length, int num) {
         std::ostringstream oss;
@@ -35,15 +60,33 @@ protected:
         return oss.str();
     }
 
+    ObjectCacheModuleType _mode;
+    std::string _cache_dir = "./object_cache_test";
+    int64_t _mem_quota = 0;
+    std::shared_ptr<BlockCache> _block_cache;
     ObjectCache _cache;
-    ObjectCacheOptions _cache_opt{.capacity = 16384, .module = ObjectCacheModuleType::LRUCACHE};
+    ObjectCacheOptions _cache_opt{.module = ObjectCacheModuleType::LRUCACHE};
     ObjectCacheWriteOptions _write_opt;
     ObjectCacheReadOptions _read_opt;
 
     size_t _key_size = sizeof(LRUHandle) - 1 + 6;
-    size_t _value_size = 4;
-    size_t _kv_size = _key_size + _value_size;
+    size_t _value_size = 0;
+    size_t _kv_size = 0;
 };
+
+void ObjectCacheTest::_init_block_cache() {
+    _block_cache = std::make_shared<BlockCache>();
+
+    CacheOptions options;
+    options.mem_space_size = _mem_quota;
+    size_t quota = 50 * 1024 * 1024;
+    options.disk_spaces.push_back({.path = _cache_dir, .size = quota});
+    options.block_size = 256 * 1024;
+    options.max_concurrent_inserts = 100000;
+    options.max_flying_memory_mb = 100;
+    options.engine = "starcache";
+    ASSERT_OK(_block_cache->init(options));
+}
 
 void ObjectCacheTest::_insert_data() {
     // insert
@@ -60,19 +103,20 @@ void ObjectCacheTest::_insert_data() {
 
 void ObjectCacheTest::_check_not_found(int value) {
     std::string key = int_to_string(6, value);
-    Status st = _cache.lookup(key, nullptr, &_read_opt);
+    ObjectCacheHandlePtr handle = nullptr;
+    Status st = _cache.lookup(key, &handle, &_read_opt);
     ASSERT_TRUE(st.is_not_found());
 }
 
 void ObjectCacheTest::_check_found(int value) {
     std::string key = int_to_string(6, value);
-    ObjectCacheHandlePtr handle;
+    ObjectCacheHandlePtr handle = nullptr;
     ASSERT_OK(_cache.lookup(key, &handle, &_read_opt));
     ASSERT_EQ(*(int*)(_cache.value(handle)), value);
     _cache.release(handle);
 }
 
-TEST_F(ObjectCacheTest, test_init) {
+TEST_P(ObjectCacheTest, test_init) {
     ObjectCache cache;
     ASSERT_FALSE(cache.initialized());
 
@@ -85,7 +129,7 @@ TEST_F(ObjectCacheTest, test_init) {
     ASSERT_FALSE(cache.available());
 }
 
-TEST_F(ObjectCacheTest, test_insert_lookup) {
+TEST_P(ObjectCacheTest, test_insert_lookup) {
     // insert
     _insert_data();
 
@@ -105,7 +149,7 @@ TEST_F(ObjectCacheTest, test_insert_lookup) {
     _check_not_found(30);
 }
 
-TEST_F(ObjectCacheTest, test_value_slice) {
+TEST_P(ObjectCacheTest, test_value_slice) {
     _insert_data();
 
     std::string key = int_to_string(6, 30);
@@ -118,17 +162,17 @@ TEST_F(ObjectCacheTest, test_value_slice) {
     _cache.release(handle);
 }
 
-TEST_F(ObjectCacheTest, test_set_capacity) {
+TEST_P(ObjectCacheTest, test_set_capacity) {
     // insert
     _insert_data();
 
     ASSERT_EQ(_cache.capacity(), _cache_opt.capacity);
     ASSERT_EQ(_cache.usage(), _kv_size * 128);
 
-    ASSERT_OK(_cache.set_capacity(8192));
-    ASSERT_EQ(_cache.capacity(), 8192);
+    ASSERT_OK(_cache.set_capacity(_mem_quota / 2));
+    ASSERT_EQ(_cache.capacity(), _mem_quota / 2);
     ASSERT_GT(_cache.usage(), 0);
-    ASSERT_LT(_cache.usage(), 8192);
+    ASSERT_LE(_cache.usage(), _mem_quota / 2);
 
     // not found
     _check_not_found(0);
@@ -137,17 +181,17 @@ TEST_F(ObjectCacheTest, test_set_capacity) {
     _check_found(127);
 }
 
-TEST_F(ObjectCacheTest, test_adjust_capacity) {
+TEST_P(ObjectCacheTest, test_adjust_capacity) {
     // insert
     _insert_data();
 
     ASSERT_EQ(_cache.capacity(), _cache_opt.capacity);
     ASSERT_EQ(_cache.usage(), _kv_size * 128);
 
-    ASSERT_OK(_cache.adjust_capacity(-8192, 1024));
-    ASSERT_EQ(_cache.capacity(), 8192);
+    ASSERT_OK(_cache.adjust_capacity(-_mem_quota / 2, 1024));
+    ASSERT_EQ(_cache.capacity(), _mem_quota / 2);
     ASSERT_GT(_cache.usage(), 0);
-    ASSERT_LT(_cache.usage(), 8192);
+    ASSERT_LE(_cache.usage(), _mem_quota / 2);
 
     // not found
     _check_not_found(0);
@@ -156,7 +200,7 @@ TEST_F(ObjectCacheTest, test_adjust_capacity) {
     _check_found(127);
 }
 
-TEST_F(ObjectCacheTest, test_prune) {
+TEST_P(ObjectCacheTest, test_prune) {
     // insert
     _insert_data();
 
@@ -165,7 +209,7 @@ TEST_F(ObjectCacheTest, test_prune) {
     ASSERT_EQ(_cache.usage(), 0);
 }
 
-TEST_F(ObjectCacheTest, test_shutdown) {
+TEST_P(ObjectCacheTest, test_shutdown) {
     // insert
     _insert_data();
 
@@ -174,7 +218,7 @@ TEST_F(ObjectCacheTest, test_shutdown) {
     ASSERT_EQ(_cache.usage(), 0);
 }
 
-TEST_F(ObjectCacheTest, test_metrics) {
+TEST_P(ObjectCacheTest, test_metrics) {
     // insert
     _insert_data();
 
@@ -193,6 +237,13 @@ TEST_F(ObjectCacheTest, test_metrics) {
     ASSERT_EQ(metrics.hit_count, 50);
     ASSERT_EQ(metrics.usage, _kv_size * 128);
     ASSERT_EQ(metrics.capacity, _cache_opt.capacity);
-    ASSERT_EQ(metrics.object_item_count, 0);
+    if (_mode == ObjectCacheModuleType::STARCACHE) {
+        ASSERT_EQ(metrics.object_item_count, 128);
+    } else {
+        ASSERT_EQ(metrics.object_item_count, 0);
+    }
 }
+
+INSTANTIATE_TEST_SUITE_P(ObjectCacheTest, ObjectCacheTest,
+                         ::testing::Values(ObjectCacheModuleType::LRUCACHE, ObjectCacheModuleType::STARCACHE));
 } // namespace starrocks

--- a/be/test/cache/object_cache/starcache_module_test.cpp
+++ b/be/test/cache/object_cache/starcache_module_test.cpp
@@ -1,0 +1,236 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cache/object_cache/starcache_module.h"
+
+#include <gtest/gtest.h>
+
+#include "cache/block_cache/block_cache.h"
+#include "fs/fs_util.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+class StarCacheModuleTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        ASSERT_OK(fs::create_directories(cache_dir));
+
+        _init_block_cache();
+        _cache = std::make_shared<StarCacheModule>(_block_cache->starcache_instance());
+    }
+    void TearDown() override {
+        ASSERT_OK(_block_cache->shutdown());
+        ASSERT_OK(fs::remove_all(cache_dir));
+    }
+
+    static void Deleter(const CacheKey& k, void* v) { free(v); }
+    void _init_block_cache();
+
+    static std::string int_to_string(size_t length, int num) {
+        std::ostringstream oss;
+        oss << std::setw(length) << std::setfill('0') << num;
+        return oss.str();
+    }
+
+    void _check_not_found(int value) {
+        std::string key = int_to_string(6, value);
+        ObjectCacheHandlePtr handle = nullptr;
+        Status st = _cache->lookup(key, &handle, nullptr);
+        ASSERT_TRUE(st.is_not_found());
+    }
+
+    void _check_found(int value) {
+        std::string key = int_to_string(6, value);
+        ObjectCacheHandlePtr handle = nullptr;
+        ASSERT_OK(_cache->lookup(key, &handle, nullptr));
+        ASSERT_EQ(*(int*)(_cache->value(handle)), value);
+        _cache->release(handle);
+    }
+
+    void insert_value(int i);
+
+    std::string cache_dir = "./starcache_module_test";
+    std::shared_ptr<BlockCache> _block_cache;
+    std::shared_ptr<StarCacheModule> _cache;
+    ObjectCacheWriteOptions _write_opt;
+    size_t _value_size = 256 * 1024;
+    int64_t _mem_quota = 64 * 1024 * 1024;
+};
+
+void StarCacheModuleTest::_init_block_cache() {
+    _block_cache = std::make_shared<BlockCache>();
+
+    CacheOptions options;
+    options.mem_space_size = _mem_quota;
+    size_t quota = 50 * 1024 * 1024;
+    options.disk_spaces.push_back({.path = cache_dir, .size = quota});
+    options.block_size = 256 * 1024;
+    options.max_concurrent_inserts = 100000;
+    options.max_flying_memory_mb = 100;
+    options.engine = "starcache";
+    ASSERT_OK(_block_cache->init(options));
+}
+
+void StarCacheModuleTest::insert_value(int i) {
+    std::string key = int_to_string(6, i);
+    int* ptr = (int*)malloc(_value_size);
+    *ptr = i;
+    ObjectCacheHandlePtr handle = nullptr;
+    ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, _value_size, &Deleter, &handle, &_write_opt));
+    _cache->release(handle);
+}
+
+TEST_F(StarCacheModuleTest, insert_success) {
+    insert_value(0);
+    size_t kv_size = _cache->usage();
+
+    for (int i = 1; i < 20; i++) {
+        insert_value(i);
+    }
+    ASSERT_EQ(_cache->usage(), kv_size * 20);
+}
+
+TEST_F(StarCacheModuleTest, insert_with_null_options) {
+    std::string key = int_to_string(6, 0);
+    int* ptr = (int*)malloc(_value_size);
+    *ptr = 0;
+    ObjectCacheHandlePtr handle = nullptr;
+    ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, _value_size, &Deleter, &handle, nullptr));
+    _cache->release(handle);
+}
+
+TEST_F(StarCacheModuleTest, insert_and_release_old_handle) {
+    std::string key = int_to_string(6, 0);
+    int* ptr = (int*)malloc(_value_size);
+    *ptr = 0;
+    ObjectCacheHandlePtr handle = nullptr;
+    ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, _value_size, &Deleter, &handle, &_write_opt));
+
+    key = int_to_string(6, 1);
+    ptr = (int*)malloc(_value_size);
+    *ptr = 1;
+    ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, _value_size, &Deleter, &handle, &_write_opt));
+    _cache->release(handle);
+}
+
+TEST_F(StarCacheModuleTest, lookup) {
+    insert_value(0);
+    insert_value(1);
+
+    ObjectCacheHandlePtr handle = nullptr;
+    std::string key = int_to_string(6, 1);
+    ASSERT_OK(_cache->lookup(key, &handle, nullptr));
+    ASSERT_EQ(*(int*)_cache->value(handle), 1);
+
+    ASSERT_OK(_cache->lookup(key, &handle, nullptr));
+    ASSERT_EQ(*(int*)_cache->value(handle), 1);
+    _cache->release(handle);
+
+    _check_not_found(2);
+}
+
+TEST_F(StarCacheModuleTest, remove) {
+    insert_value(0);
+    insert_value(1);
+
+    ASSERT_OK(_cache->remove(int_to_string(6, 1)));
+    _check_not_found(1);
+}
+
+TEST_F(StarCacheModuleTest, value_slice) {
+    insert_value(1);
+
+    ObjectCacheHandlePtr handle = nullptr;
+    std::string key = int_to_string(6, 1);
+    ASSERT_OK(_cache->lookup(key, &handle, nullptr));
+    Slice slice = _cache->value_slice(handle);
+    ASSERT_EQ(*(int*)slice.data, 1);
+    _cache->release(handle);
+}
+
+TEST_F(StarCacheModuleTest, set_capacity) {
+    insert_value(0);
+    size_t kv_size = _cache->usage();
+
+    size_t num = _mem_quota / kv_size;
+
+    for (size_t i = 1; i < num; i++) {
+        insert_value(i);
+    }
+    _check_found(0);
+    ASSERT_LE(_cache->usage(), num * kv_size);
+    ASSERT_EQ(_cache->capacity(), _mem_quota);
+
+    ASSERT_OK(_cache->set_capacity(_mem_quota / 2));
+    _check_not_found(1);
+    ASSERT_EQ(_cache->capacity(), _mem_quota / 2);
+    ASSERT_LE(_cache->usage(), _mem_quota / 2);
+}
+
+TEST_F(StarCacheModuleTest, adjust_capacity) {
+    insert_value(0);
+    size_t kv_size = _cache->usage();
+
+    size_t num = _mem_quota / kv_size;
+
+    for (size_t i = 1; i < num; i++) {
+        insert_value(i);
+    }
+    _check_found(0);
+    ASSERT_LE(_cache->usage(), _mem_quota);
+    ASSERT_EQ(_cache->capacity(), _mem_quota);
+
+    ASSERT_OK(_cache->adjust_capacity(-1 * _mem_quota / 2, 0));
+    _check_not_found(1);
+    ASSERT_LE(_cache->usage(), _mem_quota / 2);
+    ASSERT_EQ(_cache->capacity(), _mem_quota / 2);
+
+    ASSERT_TRUE(_cache->adjust_capacity(-1 * _mem_quota / 3, _mem_quota / 2).is_invalid_argument());
+}
+
+TEST_F(StarCacheModuleTest, metrics) {
+    insert_value(0);
+    size_t kv_size = _cache->usage();
+
+    for (size_t i = 1; i < 128; i++) {
+        insert_value(i);
+    }
+    for (size_t i = 0; i < 10; i++) {
+        _check_found(i);
+    }
+    for (size_t i = 200; i < 210; i++) {
+        _check_not_found(i);
+    }
+
+    ASSERT_EQ(_cache->capacity(), _mem_quota);
+    ASSERT_EQ(_cache->usage(), kv_size * 128);
+    ASSERT_EQ(_cache->lookup_count(), 20);
+    ASSERT_EQ(_cache->hit_count(), 10);
+
+    auto metrics = _cache->metrics();
+    ASSERT_EQ(metrics.capacity, _mem_quota);
+    ASSERT_EQ(metrics.usage, kv_size * 128);
+    ASSERT_EQ(metrics.lookup_count, 20);
+    ASSERT_EQ(metrics.hit_count, 10);
+    ASSERT_EQ(metrics.object_item_count, 128);
+}
+
+TEST_F(StarCacheModuleTest, prune) {
+    for (size_t i = 0; i < 128; i++) {
+        insert_value(i);
+    }
+    ASSERT_OK(_cache->prune());
+    ASSERT_EQ(_cache->usage(), 0);
+}
+} // namespace starrocks

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -2922,13 +2922,15 @@ TEST_F(FileReaderTest, TestStructSubfieldNoDecodeNotOutput) {
 }
 
 TEST_F(FileReaderTest, TestReadFooterCache) {
-    std::unique_ptr<BlockCache> cache(new BlockCache);
+    auto block_cache = std::make_shared<BlockCache>();
     CacheOptions options;
     options.mem_space_size = 100 * 1024 * 1024;
     options.max_concurrent_inserts = 100000;
     options.engine = "starcache";
-    Status status = cache->init(options);
+    Status status = block_cache->init(options);
     ASSERT_TRUE(status.ok());
+    auto cache = std::make_shared<ObjectCache>();
+    ASSERT_OK(cache->init(block_cache->starcache_instance()));
 
     auto file = _create_file(_file1_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),


### PR DESCRIPTION
## Why I'm doing:

This PR is split from the following PR from @GavinMar: https://github.com/StarRocks/starrocks/pull/51156.

In order to unify the `BlockCache` and `PageCache`, Metadata of external table will use the interface of object cache, later the external table metadata and the page cache for internal table will use the same object instance. Currently, there is two object instance, one for external table metadata, one for page of internal table.

![image](https://github.com/user-attachments/assets/80606af7-eb82-41c9-8e73-4b9ecd5cdfc0)

Currently `starcache_based_object_cache` has some performance and memory usage gaps compared to `lru_based_object_cache`, and subsequent PRs will optimize this.


## What I'm doing:

Implement startcache based object cache.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0