### PR TITLE
[Enhancement] optimize the performance of multi_count_distinct high cardinality string

### DIFF
--- a/be/src/exprs/agg/aggregate_state_allocator.h
+++ b/be/src/exprs/agg/aggregate_state_allocator.h
@@ -90,6 +90,9 @@ using HashSetWithAggStateAllocator =
 
 using SliceHashSetWithAggStateAllocator = phmap::flat_hash_set<SliceWithHash, HashOnSliceWithHash, EqualOnSliceWithHash,
                                                                AggregateStateAllocator<SliceWithHash>>;
+using SliceTwoLevelHashSetWithAggStateAllocator =
+        phmap::parallel_flat_hash_set<SliceWithHash, HashOnSliceWithHash, EqualOnSliceWithHash,
+                                      AggregateStateAllocator<SliceWithHash>>;
 
 template <typename T>
 using VectorWithAggStateAllocator = std::vector<T, AggregateStateAllocator<T>>;

--- a/be/src/exprs/agg/distinct.h
+++ b/be/src/exprs/agg/distinct.h
@@ -537,7 +537,7 @@ class DecimalDistinctAggregateFunction
 struct DictMergeState : DistinctAggregateStateV2<TYPE_VARCHAR, SumResultLT<TYPE_VARCHAR>> {
     DictMergeState() = default;
 
-    void update_over_limit() { over_limit = set.size() > dict_threshold; }
+    void update_over_limit() { over_limit = set.distinct_size > dict_threshold; }
 
     bool over_limit = false;
     int dict_threshold = 255;

--- a/be/src/exprs/agg/distinct.h
+++ b/be/src/exprs/agg/distinct.h
@@ -235,9 +235,7 @@ struct AdaptiveSliceHashSet {
     std::shared_ptr<SliceTwoLevelHashSetWithAggStateAllocator> two_level_set;
     int64_t distinct_size = 0;
 
-    HashOnSliceWithHash hash_function() const {
-        return HashOnSliceWithHash();
-    }
+    HashOnSliceWithHash hash_function() const { return HashOnSliceWithHash(); }
 };
 
 template <LogicalType LT, LogicalType SumLT>


### PR DESCRIPTION
## Why I'm doing:

Sometimes, the optimizer will optimize multiple count(distinct) into `multi_count_distinct` instead of a four-stage aggregation, or users may directly use `multi_count_distinct`. For high-cardinality strings, the performance of using a one-level hash map will be very poor.

Performance test:

```
create table t_id(id bigint, c1 bigint, c2 bigint) duplicate key(id) distributed by hash(id) buckets 16 properties("replication_num"="1");

insert into t_id select rand()*10000000000, rand()*10000000000, rand()*10000000000 from table(generate_series(1,100000000));

create table t_10(id bigint, c1 string, c2 string) duplicate key(id) distributed by hash(id) buckets 16 properties("replication_num"="1");
create table t_100(id bigint, c1 string, c2 string) duplicate key(id) distributed by hash(id) buckets 16 properties("replication_num"="1");
create table t_1000(id bigint, c1 string, c2 string) duplicate key(id) distributed by hash(id) buckets 16 properties("replication_num"="1");
create table t_10000(id bigint, c1 string, c2 string) duplicate key(id) distributed by hash(id) buckets 16 properties("replication_num"="1");
create table t_100000(id bigint, c1 string, c2 string) duplicate key(id) distributed by hash(id) buckets 16 properties("replication_num"="1");
create table t_1000000(id bigint, c1 string, c2 string) duplicate key(id) distributed by hash(id) buckets 16 properties("replication_num"="1");
create table t_10000000(id bigint, c1 string, c2 string) duplicate key(id) distributed by hash(id) buckets 16 properties("replication_num"="1");
create table t_20000000(id bigint, c1 string, c2 string) duplicate key(id) distributed by hash(id) buckets 16 properties("replication_num"="1");
create table t_30000000(id bigint, c1 string, c2 string) duplicate key(id) distributed by hash(id) buckets 16 properties("replication_num"="1");
create table t_40000000(id bigint, c1 string, c2 string) duplicate key(id) distributed by hash(id) buckets 16 properties("replication_num"="1");
create table t_50000000(id bigint, c1 string, c2 string) duplicate key(id) distributed by hash(id) buckets 16 properties("replication_num"="1");
create table t_100000000(id bigint, c1 string, c2 string) duplicate key(id) distributed by hash(id) buckets 16 properties("replication_num"="1");

insert into t_10 select id, concat("str1:", c1%10), concat("str2:", c2%10) from t_id;
insert into t_100 select id, concat("str1:", c1%100), concat("str2:", c2%100) from t_id;
insert into t_1000 select id, concat("str1:", c1%1000), concat("str2:", c2%1000) from t_id;
insert into t_10000 select id, concat("str1:", c1%10000), concat("str2:", c2%10000) from t_id;
insert into t_100000 select id, concat("str1:", c1%100000), concat("str2:", c2%100000) from t_id;
insert into t_1000000 select id, concat("str1:", c1%1000000), concat("str2:", c2%1000000) from t_id;
insert into t_10000000 select id, concat("str1:", c1%10000000), concat("str2:", c2%10000000) from t_id;
insert into t_20000000 select id, concat("str1:", c1%20000000), concat("str2:", c2%20000000) from t_id;
insert into t_30000000 select id, concat("str1:", c1%30000000), concat("str2:", c2%30000000) from t_id;
insert into t_40000000 select id, concat("str1:", c1%40000000), concat("str2:", c2%40000000) from t_id;
insert into t_50000000 select id, concat("str1:", c1%50000000), concat("str2:", c2%50000000) from t_id;
insert into t_100000000 select id, concat("str1:", c1), concat("str2:", c2) from t_id;


select count(distinct c1), count(distinct c2) from t_10 group by id%1 limit 10;
```
|cardinality|current implement|After optimization|
|--|--|--|
|10|0.97s|0.92s|
|100|1.01s|0.99s|
|1000|1.08s|1.08s|
|10000|1.56s|1.47s|
|100000|4.49s|3.92s|
|1000000|7.3s|6.92s|
|10000000|11.74s|11.89s| 
|20000000|26.02s|18s|
|30000000|34.69s|21.22s|
|40000000|230s|26.38s|
|50000000|749s|27.87s|
|100000000|So slowly|38.85s|

plan:

```
mysql> explain select count(distinct c1), count(distinct c2) from t_10 group by id%1 limit 10;
+---------------------------------------------------------------------------------+
| Explain String                                                                  |
+---------------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                                 |
|  OUTPUT EXPRS:5: count | 6: count                                               |
|   PARTITION: UNPARTITIONED                                                      |
|                                                                                 |
|   RESULT SINK                                                                   |
|                                                                                 |
|   6:EXCHANGE                                                                    |
|      limit: 10                                                                  |
|                                                                                 |
| PLAN FRAGMENT 1                                                                 |
|  OUTPUT EXPRS:                                                                  |
|   PARTITION: HASH_PARTITIONED: 4: expr                                          |
|                                                                                 |
|   STREAM DATA SINK                                                              |
|     EXCHANGE ID: 06                                                             |
|     UNPARTITIONED                                                               |
|                                                                                 |
|   5:Project                                                                     |
|   |  <slot 5> : 5: count                                                        |
|   |  <slot 6> : 6: count                                                        |
|   |  limit: 10                                                                  |
|   |                                                                             |
|   4:AGGREGATE (merge finalize)                                                  |
|   |  output: multi_distinct_count(5: count), multi_distinct_count(6: count)     |
|   |  group by: 4: expr                                                          |
|   |  limit: 10                                                                  |
|   |                                                                             |
|   3:EXCHANGE                                                                    |
|                                                                                 |
| PLAN FRAGMENT 2                                                                 |
|  OUTPUT EXPRS:                                                                  |
|   colocate exec groups: ExecGroup{groupId=2, nodeIds=[0, 1, 2]}                 |
|   PARTITION: RANDOM                                                             |
|                                                                                 |
|   STREAM DATA SINK                                                              |
|     EXCHANGE ID: 03                                                             |
|     HASH_PARTITIONED: 4: expr                                                   |
|                                                                                 |
|   2:AGGREGATE (update serialize)                                                |
|   |  STREAMING                                                                  |
|   |  output: multi_distinct_count(2: c1), multi_distinct_count(3: c2)           |
|   |  group by: 4: expr                                                          |
|   |                                                                             |
|   1:Project                                                                     |
|   |  <slot 2> : 2: c1                                                           |
|   |  <slot 3> : 3: c2                                                           |
|   |  <slot 4> : 1: id % 1                                                       |
|   |                                                                             |
|   0:OlapScanNode                                                                |
|      TABLE: t_10                                                                |
|      PREAGGREGATION: ON                                                         |
|      partitions=1/1                                                             |
|      rollup: t_10                                                               |
|      tabletRatio=16/16                                                          |
|      tabletList=10233,10235,10237,10239,10241,10243,10245,10247,10249,10251 ... |
|      cardinality=100000000                                                      |
|      avgRowSize=4.0                                                             |
+---------------------------------------------------------------------------------+
57 rows in set (0.00 sec)

```

## What I'm doing:

optimize the performance of multi_count_distinct high cardinality string 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0