### PR TITLE
[BugFix] Reset index information when creating tablet in rollup job

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
@@ -183,7 +183,7 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
                         .setStorageType(TStorageType.COLUMN)
                         .setBloomFilterColumnNames(table.getBfColumnIds())
                         .setBloomFilterFpp(table.getBfFpp())
-                        .setIndexes(table.getCopiedIndexes())
+                        .setIndexes(OlapTable.getIndexesBySchema(table.getCopiedIndexes(), rollupSchema))
                         .setSortKeyIndexes(null) // Rollup tablets does not have sort key
                         .setSortKeyUniqueIds(null)
                         .addColumns(rollupSchema)

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -383,7 +383,8 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
                             .setShortKeyColumnCount(shadowShortKeyColumnCount)
                             .setSortKeyIndexes(originIndexId == baseIndexId ? sortKeyIdxes : null)
                             .setSortKeyUniqueIds(originIndexId == baseIndexId ? sortKeyUniqueIds : null)
-                            .setIndexes(OlapTable.getIndexesBySchema(indexes, shadowSchema))
+                            .setIndexes(originIndexId == baseIndexId ?
+                                        indexes : OlapTable.getIndexesBySchema(indexes, shadowSchema))
                             .setBloomFilterColumnNames(bfColumns)
                             .setBloomFilterFpp(bfFpp)
                             .setStorageType(TStorageType.COLUMN)

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -383,7 +383,7 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
                             .setShortKeyColumnCount(shadowShortKeyColumnCount)
                             .setSortKeyIndexes(originIndexId == baseIndexId ? sortKeyIdxes : null)
                             .setSortKeyUniqueIds(originIndexId == baseIndexId ? sortKeyUniqueIds : null)
-                            .setIndexes(indexes)
+                            .setIndexes(OlapTable.getIndexesBySchema(indexes, shadowSchema))
                             .setBloomFilterColumnNames(bfColumns)
                             .setBloomFilterFpp(bfFpp)
                             .setStorageType(TStorageType.COLUMN)

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -306,7 +306,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                             .setStorageType(TStorageType.COLUMN)
                             .setBloomFilterColumnNames(tbl.getBfColumnIds())
                             .setBloomFilterFpp(tbl.getBfFpp())
-                            .setIndexes(tbl.getCopiedIndexes())
+                            .setIndexes(OlapTable.getIndexesBySchema(tbl.getCopiedIndexes(), rollupSchema))
                             .setSortKeyIndexes(null) // Rollup tablets does not have sort key
                             .setSortKeyUniqueIds(null)
                             .addColumns(rollupSchema)

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -352,7 +352,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                             .setStorageType(tbl.getStorageType())
                             .setBloomFilterColumnNames(bfColumns)
                             .setBloomFilterFpp(bfFpp)
-                            .setIndexes(indexes)
+                            .setIndexes(OlapTable.getIndexesBySchema(indexes, shadowSchema))
                             .setSortKeyIndexes(originIndexId == baseIndexId ? sortKeyIdxes : null)
                             .setSortKeyUniqueIds(originIndexId == baseIndexId ? sortKeyUniqueIds : null)
                             .addColumns(shadowSchema)

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -352,7 +352,8 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                             .setStorageType(tbl.getStorageType())
                             .setBloomFilterColumnNames(bfColumns)
                             .setBloomFilterFpp(bfFpp)
-                            .setIndexes(OlapTable.getIndexesBySchema(indexes, shadowSchema))
+                            .setIndexes(originIndexId == baseIndexId ?
+                                        indexes : OlapTable.getIndexesBySchema(indexes, shadowSchema))
                             .setSortKeyIndexes(originIndexId == baseIndexId ? sortKeyIdxes : null)
                             .setSortKeyUniqueIds(originIndexId == baseIndexId ? sortKeyUniqueIds : null)
                             .addColumns(shadowSchema)

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -353,6 +353,20 @@ public class OlapTable extends Table {
         this.tableProperty = null;
     }
 
+    public static List<Index> getIndexesBySchema(List<Index> indexes, List<Column> schema) {
+        List<Index> hitIndexes = Lists.newArrayList();
+        Set<ColumnId> columnIdsSetForSchema =
+                            schema.stream().map(col -> col.getColumnId()).collect(Collectors.toSet());
+
+        for (Index index : indexes) {
+            Set<ColumnId> columnIdsSetForIndex = index.getColumns().stream().collect(Collectors.toSet());
+            if (columnIdsSetForSchema.containsAll​(columnIdsSetForIndex)) {
+                hitIndexes.add(index);
+            }
+        }
+        return hitIndexes;
+    }
+
     @Override
     public synchronized Optional<String> mayGetDatabaseName() {
         return Optional.ofNullable(dbName);

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -1216,7 +1216,10 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                                             .addColumns(indexMeta.getSchema())
                                             .setBloomFilterColumnNames(bfColumns)
                                             .setBloomFilterFpp(bfFpp)
-                                            .setIndexes(olapTable.getCopiedIndexes())
+                                            .setIndexes(indexId == olapTable.getBaseIndexId() ?
+                                                        olapTable.getCopiedIndexes() :
+                                                        OlapTable.getIndexesBySchema(
+                                                        olapTable.getCopiedIndexes(), indexMeta.getSchema()))
                                             .setSortKeyIndexes(indexMeta.getSortKeyIdxes())
                                             .setSortKeyUniqueIds(indexMeta.getSortKeyUniqueIds())
                                             .build().toTabletSchema();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/OlapTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/OlapTableTest.java
@@ -404,4 +404,33 @@ public class OlapTableTest {
             Assert.assertNull(partition);
         }
     }
+
+    @Test
+    public void testGetIndexesBySchema() {
+        List<Index> indexesInTable = Lists.newArrayList();
+        Column k1 = new Column("k1", new ScalarType(PrimitiveType.VARCHAR), true, null, "", "");
+        Column k2 = new Column("k2", new ScalarType(PrimitiveType.DATETIME), true, null, "", "");
+        Column k3 = new Column("k3", new ScalarType(PrimitiveType.DATE), true, null, "", "");
+        List<Column> schema = new LinkedList<Column>();
+        schema.add(k1);
+        schema.add(k2);
+        schema.add(k3);
+
+        Index index1 = new Index(1L, "index1", Lists.newArrayList(ColumnId.create("k1"), ColumnId.create("k2")),
+                                 IndexDef.IndexType.BITMAP, "comment", null);
+
+        Index index2 = new Index(2L, "index2", Lists.newArrayList(ColumnId.create("k2"), ColumnId.create("k3")),
+                                 IndexDef.IndexType.BITMAP, "comment", null);
+
+        Index index3 = new Index(3L, "index3", Lists.newArrayList(ColumnId.create("k4")), IndexDef.IndexType.BITMAP,
+                                 "comment", null);
+        indexesInTable.add(index1);
+        indexesInTable.add(index2);
+        indexesInTable.add(index3);
+
+        List<Index> result = OlapTable.getIndexesBySchema(indexesInTable, schema);
+        Assert.assertTrue(result.size() == 2);
+        Assert.assertTrue(result.get(0).getIndexName().equals("index1"));
+        Assert.assertTrue(result.get(1).getIndexName().equals("index2"));
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
When creating tablet in rollup job, the tablet has index information which is the same as the base table even if the rollup schema does not contain the index column. This will cause link inverted index files failed because no ivt files will be generated.

## What I'm doing:
Reset index information based on the rollup schema when creating tablet in rollup job.

Fixes #issue
https://github.com/StarRocks/StarRocksTest/issues/7905

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0