### PR TITLE
[BugFix] Fix ConcurrentModification issue for buildExplain to query detail 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -152,6 +152,7 @@ public class StatementPlanner {
             } else if (stmt instanceof InsertStmt) {
                 ExecPlan plan = planInsertStmt(plannerMetaLocker, (InsertStmt) stmt, session);
                 setExplainToQueryDetail(plan, stmt, session, ResourceGroupClassifier.QueryType.INSERT);
+                return plan;
             } else if (stmt instanceof UpdateStmt) {
                 return new UpdatePlanner().plan((UpdateStmt) stmt, session);
             } else if (stmt instanceof DeleteStmt) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.ExternalOlapTable;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.ResourceGroupClassifier;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.common.AnalysisException;
@@ -88,6 +89,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.starrocks.qe.StmtExecutor.buildExplainString;
+
 public class StatementPlanner {
     private static final Logger LOG = LogManager.getLogger(StatementPlanner.class);
 
@@ -144,9 +147,11 @@ public class StatementPlanner {
                     plan = createQueryPlanWithReTry(queryStmt, session, resultSinkType, plannerMetaLocker, planStartTime);
                 }
                 setOutfileSink(queryStmt, plan);
+                setExplainToQueryDetail(plan, stmt, session, ResourceGroupClassifier.QueryType.SELECT);
                 return plan;
             } else if (stmt instanceof InsertStmt) {
-                return planInsertStmt(plannerMetaLocker, (InsertStmt) stmt, session);
+                ExecPlan plan = planInsertStmt(plannerMetaLocker, (InsertStmt) stmt, session);
+                setExplainToQueryDetail(plan, stmt, session, ResourceGroupClassifier.QueryType.INSERT);
             } else if (stmt instanceof UpdateStmt) {
                 return new UpdatePlanner().plan((UpdateStmt) stmt, session);
             } else if (stmt instanceof DeleteStmt) {
@@ -168,6 +173,25 @@ public class StatementPlanner {
         }
 
         return null;
+    }
+
+    /**
+     * Generate a query plan for query detail.
+     * Explaining internal table is very quick, we prefer to use EXPLAIN COSTS.
+     * But explaining external table is expensive, may need to access lots of metadata, so have to use EXPLAIN.
+     *
+     * <p> NOTE that `buildExplainString` will access table metadata, so need be called in the critical section of the lock.
+     */
+    private static void setExplainToQueryDetail(ExecPlan plan, StatementBase stmt, ConnectContext session,
+                                                ResourceGroupClassifier.QueryType queryType) {
+        if (plan == null || session.getQueryDetail() == null) {
+            return;
+        }
+
+        StatementBase.ExplainLevel level = AnalyzerUtils.hasExternalTables(stmt) ?
+                StatementBase.ExplainLevel.defaultValue() :
+                StatementBase.ExplainLevel.parse(Config.query_detail_explain_level);
+        session.getQueryDetail().setExplain(buildExplainString(plan, stmt, session, queryType, level));
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/QueryDetailTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/QueryDetailTest.java
@@ -1,0 +1,95 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.common.Config;
+import com.starrocks.connector.hive.MockedHiveMetadata;
+import com.starrocks.qe.QueryDetail;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class QueryDetailTest extends PlanTestBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+
+        ConnectorPlanTestBase.mockCatalog(connectContext, MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME);
+
+        Config.enable_collect_query_detail_info = true;
+        Config.query_detail_explain_level = "NORMAL";
+        QueryDetail startQueryDetail = new QueryDetail("219a2d5443c542d4-8fc938db37c892e3", false, 1, "127.0.0.1",
+                System.currentTimeMillis(), -1, -1, QueryDetail.QueryMemState.RUNNING,
+                "testDb", "select * from table1 limit 1",
+                "root", "", "default_catalog");
+        connectContext.setQueryDetail(startQueryDetail);
+    }
+
+    @Test
+    public void testInsert() throws Exception {
+        String plan = getFragmentPlan("insert into t0 select * from t0");
+        Assert.assertEquals(plan, connectContext.getQueryDetail().getExplain());
+        assertContains(plan, "  OLAP TABLE SINK\n" +
+                "    TABLE: t0\n" +
+                "    TUPLE ID: 1\n" +
+                "    RANDOM\n" +
+                "\n" +
+                "  0:OlapScanNode\n" +
+                "     TABLE: t0");
+    }
+
+    @Test
+    public void testQuery() throws Exception {
+        String plan = getFragmentPlan("SELECT DISTINCT t0.v1 FROM t0 RIGHT JOIN[BUCKET] t1 ON t0.v1 = t1.v4");
+        assertContains(plan, "  6:AGGREGATE (update serialize)\n" +
+                "  |  STREAMING\n" +
+                "  |  group by: 1: v1");
+        Assert.assertEquals(plan, connectContext.getQueryDetail().getExplain());
+    }
+
+    @Test
+    public void testExternalTable() throws Exception {
+        // Explaining external table always use `NORMAL` level regardless of the config.
+        Config.query_detail_explain_level = "COSTS";
+        try {
+            String plan = getFragmentPlan("SELECT count(1) FROM hive0.tpch.lineitem t1 " +
+                    "join [shuffle] hive0.tpch.lineitem t2 on t1.l_orderkey = t2.l_orderkey");
+            assertContains(plan, "  6:AGGREGATE (update serialize)\n" +
+                    "  |  output: count(1)\n" +
+                    "  |  group by: ");
+            Assert.assertEquals(plan, connectContext.getQueryDetail().getExplain());
+        } finally {
+            Config.query_detail_explain_level = "NORMAL";
+        }
+    }
+
+    @Test
+    public void testExplainCosts() throws Exception {
+        Config.query_detail_explain_level = "COSTS";
+        try {
+            String plan = getCostExplain("SELECT DISTINCT t0.v1 FROM t0 RIGHT JOIN[BUCKET] t1 ON t0.v1 = t1.v4");
+            Assert.assertEquals(plan, connectContext.getQueryDetail().getExplain());
+            assertContains(plan, " 6:AGGREGATE (update serialize)\n" +
+                    "  |  STREAMING\n" +
+                    "  |  group by: [1: v1, BIGINT, true]\n" +
+                    "  |  hasNullableGenerateChild: true\n" +
+                    "  |  cardinality: 1\n" +
+                    "  |  column statistics: \n" +
+                    "  |  * v1-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN");
+        } finally {
+            Config.query_detail_explain_level = "NORMAL";
+        }
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

To collect the execution plan of a task, `StarRocksManager` enforces a call to `buildExplainString` after the planner phase but before `Coordinator::exec` when `enable_collect_query_detail_info` is enabled.

However, `OlapScanNode::getNodeExplainString` accesses `OlapTable.nameToPartition` without proper locking, leading to a `ConcurrentModification` issue.

## What I'm doing:

Move `buildExplainString` to critical section of the lock in `StatementPlanner::plan`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0