### PR TITLE
[Enhancement]DateUtil probeFormat parse Unsigned second-level date

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DateUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DateUtils.java
@@ -182,6 +182,8 @@ public class DateUtils {
             return DATE_TIME_FORMATTER_UNIX;
         } else if (dateTimeStr.length() == 26) {
             return DATE_TIME_MS_FORMATTER_UNIX;
+        } else if (dateTimeStr.length() == 14) {
+            return DATE_TIME_S_FORMATTER_UNIX;
         } else {
             throw new SemanticException("can not probe datetime format:" + dateTimeStr);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/DateUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/DateUtilsTest.java
@@ -39,6 +39,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 
 public class DateUtilsTest {
@@ -88,4 +89,16 @@ public class DateUtilsTest {
             Assert.fail();
         }
     }
+
+    @Test
+    public void testProbeFormat() {
+        try {
+            String datetime = "20250225112345";
+            DateTimeFormatter dateTimeFormatter = DateUtils.probeFormat(datetime);
+            Assert.assertEquals(dateTimeFormatter, DateUtils.DATE_TIME_S_FORMATTER_UNIX);
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/DateUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/DateUtilsTest.java
@@ -101,4 +101,36 @@ public class DateUtilsTest {
         }
     }
 
+    @Test
+    public void testParseStringWithDefaultHSM() {
+        try {
+            String datetime1 = "20250225112345";
+            LocalDateTime localDateTime1 =
+                    DateUtils.parseStringWithDefaultHSM(datetime1, DateUtils.probeFormat(datetime1));
+            Assert.assertTrue(localDateTime1.getYear() == 2025 && localDateTime1.getMonthValue() == 2 &&
+                    localDateTime1.getDayOfMonth() == 25
+                    && localDateTime1.getHour() == 11 && localDateTime1.getMinute() == 23 &&
+                    localDateTime1.getSecond() == 45);
+
+            String datetime2 = "2025-02-25 11:23:45";
+            LocalDateTime localDateTime2 =
+                    DateUtils.parseStringWithDefaultHSM(datetime2, DateUtils.probeFormat(datetime2));
+            Assert.assertTrue(localDateTime2.getYear() == 2025 && localDateTime2.getMonthValue() == 2 &&
+                    localDateTime2.getDayOfMonth() == 25
+                    && localDateTime2.getHour() == 11 && localDateTime2.getMinute() == 23 &&
+                    localDateTime2.getSecond() == 45);
+
+            String datetime3 = "2025-02-25";
+            LocalDateTime localDateTime3 =
+                    DateUtils.parseStringWithDefaultHSM(datetime3, DateUtils.probeFormat(datetime3));
+            Assert.assertTrue(localDateTime3.getYear() == 2025 && localDateTime3.getMonthValue() == 2 &&
+                    localDateTime3.getDayOfMonth() == 25
+                    && localDateTime3.getHour() == 0 && localDateTime3.getMinute() == 0 &&
+                    localDateTime3.getSecond() == 0);
+
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
+
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
The probeFormat method in com.starrocks.common.util.DateUtils supports unsigned second-level dates.
Fixes #issue

## What type of PR is this:
https://github.com/StarRocks/starrocks/issues/56339
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0