### PR TITLE
[BugFix] should not clean data when commited iceberg snapshot

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -108,6 +108,7 @@ import org.apache.iceberg.StructLike;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.expressions.Expression;
@@ -1190,10 +1191,12 @@ public class IcebergMetadata implements ConnectorMetadata {
             transaction.commitTransaction();
             asyncRefreshOthersFeMetadataCache(dbName, tableName);
         } catch (Exception e) {
-            List<String> toDeleteFiles = dataFiles.stream()
-                    .map(TIcebergDataFile::getPath)
-                    .collect(Collectors.toList());
-            icebergCatalog.deleteUncommittedDataFiles(toDeleteFiles);
+            if (!(e instanceof CommitStateUnknownException)) {
+                List<String> toDeleteFiles = dataFiles.stream()
+                        .map(TIcebergDataFile::getPath)
+                        .collect(Collectors.toList());
+                icebergCatalog.deleteUncommittedDataFiles(toDeleteFiles);
+            }
             LOG.error("Failed to commit iceberg transaction on {}.{}", dbName, tableName, e);
             throw new StarRocksConnectorException(e.getMessage());
         } finally {

--- a/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -72,6 +72,7 @@ import org.apache.hadoop.hive.metastore.api.GetPrincipalsInRoleResponse;
 import org.apache.hadoop.hive.metastore.api.GetRoleGrantsForPrincipalRequest;
 import org.apache.hadoop.hive.metastore.api.GetRoleGrantsForPrincipalResponse;
 import org.apache.hadoop.hive.metastore.api.GetTableRequest;
+import org.apache.hadoop.hive.metastore.api.HeartbeatRequest;
 import org.apache.hadoop.hive.metastore.api.HeartbeatTxnRangeResponse;
 import org.apache.hadoop.hive.metastore.api.HiveObjectPrivilege;
 import org.apache.hadoop.hive.metastore.api.HiveObjectRef;
@@ -2066,7 +2067,10 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     @Override
     public void heartbeat(long txnid, long lockid)
             throws NoSuchLockException, NoSuchTxnException, TxnAbortedException, TException {
-        throw new TException("method not implemented");
+        HeartbeatRequest heartbeatRequest = new HeartbeatRequest();
+        heartbeatRequest.setTxnid(txnid);
+        heartbeatRequest.setLockid(lockid);
+        client.heartbeat(heartbeatRequest);
 
     }
 


### PR DESCRIPTION
HiveMetaStoreClient send heartbeat

## Why I'm doing:
if commitTransaction occur error like hive heartbeat error will clean snapshot files，next time query will be error with file not found
<img width="1208" alt="image" src="https://github.com/user-attachments/assets/91db8343-62ac-45ef-b2c6-2e8fbae09ae7" />

if snapshot already created, but hms lock time over 240s will reproduce this bug
insert error org.apache.iceberg.hive.LockException: Failed to heartbeat for hive lock. method not implemented
<img width="1665" alt="image" src="https://github.com/user-attachments/assets/f0046f02-8e7f-4c97-9323-c1f4ecc51da6" />

## What I'm doing:
move out commitSnapshot, if snapshot already create should not clean datafiles
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0