### PR TITLE
[Enhancement] Avoid failure when dead BEs exist for /current_queries

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsInfo.java
@@ -339,9 +339,6 @@ public class QueryStatisticsInfo {
                         .collect(Collectors.toList());
         for (QueryStatisticsItem item : sorted) {
             final CurrentQueryInfoProvider.QueryStatistics statistics = statisticsMap.get(item.getQueryId());
-            if (statistics == null) {
-                continue;
-            }
 
             QueryStatisticsInfo info = new QueryStatisticsInfo()
                     .withQueryStartTime(item.getQueryStartTime())
@@ -350,15 +347,17 @@ public class QueryStatisticsInfo {
                     .withConnId(item.getConnId())
                     .withDb(item.getDb())
                     .withUser(item.getUser())
-                    .withScanBytes(statistics.getScanBytes())
-                    .withScanRows(statistics.getScanRows())
-                    .withMemUsageBytes(statistics.getMemUsageBytes())
-                    .withSpillBytes(statistics.getSpillBytes())
-                    .withCpuCostNs(statistics.getCpuCostNs())
                     .withExecTime(item.getQueryExecTime())
                     .withWareHouseName(item.getWarehouseName())
                     .withCustomQueryId(item.getCustomQueryId())
                     .withResourceGroupName(item.getResourceGroupName());
+            if (statistics != null) {
+                info.withScanBytes(statistics.getScanBytes())
+                        .withScanRows(statistics.getScanRows())
+                        .withMemUsageBytes(statistics.getMemUsageBytes())
+                        .withSpillBytes(statistics.getSpillBytes())
+                        .withCpuCostNs(statistics.getCpuCostNs());
+            }
             sortedRowData.add(info);
         }
 


### PR DESCRIPTION
## Why I'm doing:

When a query has not finished yet, but the BE has already crashed, running `show proc /current_queries` results in the error `Sending collect query statistics request fails`.

When the RPC request for statistics to the BE fails, we should skip this RPC instead of returning an error.

```
 2025-03-05 17:24:59.795+08:00 WARN (starrocks-mysql-nio-pool-0|210) [BackendServiceClient.collectQueryStatisticsAsync():197] collect query statistics catch an exception, address=172.26.80.104:8060
 java.lang.RuntimeException: Unable to validate object
        at com.baidu.jprotobuf.pbrpc.transport.ChannelPool.getChannel(ChannelPool.java:86)
        at com.baidu.jprotobuf.pbrpc.transport.RpcChannel.getConnection(RpcChannel.java:73)
        at com.baidu.jprotobuf.pbrpc.client.ProtobufRpcProxy.invoke(ProtobufRpcProxy.java:499)
        at jdk.proxy2/jdk.proxy2.$Proxy39.collectQueryStatistics(Unknown Source)
        at com.starrocks.rpc.BackendServiceClient.collectQueryStatisticsAsync(BackendServiceClient.java:195)
        at com.starrocks.common.proc.CurrentQueryInfoProvider.sendCollectQueryRequest(CurrentQueryInfoProvider.java:179)
        at com.starrocks.common.proc.CurrentQueryInfoProvider.collectQueryStatistics(CurrentQueryInfoProvider.java:161)
        at com.starrocks.common.proc.CurrentQueryInfoProvider.getQueryStatistics(CurrentQueryInfoProvider.java:77)
        at com.starrocks.qe.QueryStatisticsInfo.makeListFromMetricsAndMgrs(QueryStatisticsInfo.java:319)
        at com.starrocks.common.proc.CurrentQueryStatisticsProcDir.fetchResult(CurrentQueryStatisticsProcDir.java:94)
        at com.starrocks.sql.ast.ShowProcStmt.getMetaData(ShowProcStmt.java:75)
        at com.starrocks.qe.ShowExecutor$ShowExecutorVisitor.visitShowProcStmt(ShowExecutor.java:396)
        at com.starrocks.qe.ShowExecutor$ShowExecutorVisitor.visitShowProcStmt(ShowExecutor.java:286)
        at com.starrocks.sql.ast.ShowProcStmt.accept(ShowProcStmt.java:104)
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:71)
        at com.starrocks.qe.ShowExecutor.execute(ShowExecutor.java:283)
        at com.starrocks.qe.StmtExecutor.handleShow(StmtExecutor.java:1625)
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:692)
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:353)
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:548)
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:882)
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:69)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.util.NoSuchElementException: Unable to validate object
        at org.apache.commons.pool2.impl.GenericObjectPool.borrowObject(GenericObjectPool.java:506)
        at org.apache.commons.pool2.impl.GenericObjectPool.borrowObject(GenericObjectPool.java:363)
        at com.baidu.jprotobuf.pbrpc.transport.ChannelPool.getChannel(ChannelPool.java:80)
        ... 24 more
```

## What I'm doing:


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0