### PR TITLE
[BugFix] fix min/max profile counter

### DIFF
--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -551,6 +551,12 @@ void RuntimeProfile::copy_all_counters_from(RuntimeProfile* src_profile, const s
             }
             auto* new_counter = add_counter_unlock(name, src_counter->type(), src_counter->strategy(), parent_name);
             new_counter->set(src_counter->value());
+            if (src_counter->min_value().has_value()) {
+                new_counter->set_min(src_counter->min_value().value());
+            }
+            if (src_counter->max_value().has_value()) {
+                new_counter->set_max(src_counter->max_value().value());
+            }
         }
 
         auto names_it = src_profile->_child_counter_map.find(name);

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/Counter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/Counter.java
@@ -160,9 +160,15 @@ public class Counter {
             if (counter.getValue() < minValue) {
                 minValue = counter.getValue();
             }
+            if (counter.getMinValue().isPresent() && counter.getMinValue().get() < minValue) {
+                minValue = counter.getMinValue().get();
+            }
 
             if (counter.getValue() > maxValue) {
                 maxValue = counter.getValue();
+            }
+            if (counter.getMaxValue().isPresent() && counter.getMaxValue().get() > maxValue) {
+                maxValue = counter.getMaxValue().get();
             }
 
             mergedValue += counter.getValue();

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -226,6 +226,12 @@ public class RuntimeProfile {
                 Counter srcCounter = srcProfile.counterMap.get(name).first;
                 Counter newCounter = addCounter(name, srcCounter.getType(), srcCounter.getStrategy(), parentName);
                 newCounter.setValue(srcCounter.getValue());
+                if (srcCounter.getMinValue().isPresent()) {
+                    newCounter.setMinValue(srcCounter.getMinValue().get());
+                }
+                if (srcCounter.getMaxValue().isPresent()) {
+                    newCounter.setMaxValue(srcCounter.getMaxValue().get());
+                }
             }
 
             Set<String> childNames = srcProfile.childCounterMap.get(name);
@@ -296,6 +302,12 @@ public class RuntimeProfile {
                                 addCounter(topName, tcounter.type, tcounter.strategy, parentName);
                         counter.setValue(tcounter.value);
                         counter.setStrategy(tcounter.strategy);
+                        if (tcounter.isSetMin_value()) {
+                            counter.setMinValue(tcounter.getMin_value());
+                        }
+                        if (tcounter.isSetMax_value()) {
+                            counter.setMaxValue(tcounter.getMax_value());
+                        }
                         tCounterMap.remove(topName);
                     } else if (pair != null && tcounter != null) {
                         if (pair.first.getType() != tcounter.type) {
@@ -619,6 +631,8 @@ public class RuntimeProfile {
             tCounter.setValue(counter.getValue());
             tCounter.setType(counter.getType());
             tCounter.setStrategy(counter.getStrategy());
+            counter.getMinValue().ifPresent(tCounter::setMin_value);
+            counter.getMaxValue().ifPresent(tCounter::setMax_value);
             node.addToCounters(tCounter);
         }
 
@@ -767,7 +781,7 @@ public class RuntimeProfile {
                     }
                     if (counter.getMaxValue().isPresent()) {
                         alreadyMerged = true;
-                        maxValue = Math.max(counter.getMinValue().get(), maxValue);
+                        maxValue = Math.max(counter.getMaxValue().get(), maxValue);
                     } else {
                         // TODO: keep compatible with older version backend, can be removed in next version
                         Counter maxCounter = profile.getCounter(MERGED_INFO_PREFIX_MAX + name);

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileTest.java
@@ -373,6 +373,69 @@ public class RuntimeProfileTest {
         Assert.assertEquals(6, mergedMaxOfCount1.getValue());
     }
 
+    /**
+     * Embed the MIN/MAX in counter instead of individual counter like MIN_OF/MAX_OF
+     */
+    @Test
+    public void testMergeIsomorphicProfiles3() {
+        List<RuntimeProfile> profiles = Lists.newArrayList();
+
+        RuntimeProfile profile1 = new RuntimeProfile("profile");
+        {
+            Counter time1 = profile1.addCounter("time1", TUnit.TIME_NS, null);
+            time1.setValue(2000000000L);
+            time1.setMinValue(1500000000L);
+            time1.setMaxValue(5000000000L);
+
+            Counter count1 = profile1.addCounter("count1", TUnit.UNIT, null);
+            count1.setValue(6);
+            count1.setMinValue(1);
+            count1.setMaxValue(3);
+
+            profiles.add(profile1);
+        }
+
+        RuntimeProfile profile2 = new RuntimeProfile("profile");
+        {
+            Counter time1 = profile2.addCounter("time1", TUnit.TIME_NS, null);
+            time1.setValue(3000000000L);
+            time1.setMinValue(100000000L);
+            time1.setMaxValue(4000000000L);
+
+            Counter count1 = profile2.addCounter("count1", TUnit.UNIT, null);
+            count1.setValue(15);
+            count1.setMinValue(4);
+            count1.setMaxValue(6);
+
+            profiles.add(profile2);
+        }
+
+        RuntimeProfile mergedProfile = RuntimeProfile.mergeIsomorphicProfiles(profiles, null);
+        Assert.assertNotNull(mergedProfile);
+
+        Counter mergedTime1 = mergedProfile.getCounter("time1");
+        Assert.assertEquals(2500000000L, mergedTime1.getValue());
+        Counter mergedMinOfTime1 = mergedProfile.getCounter("__MIN_OF_time1");
+        Counter mergedMaxOfTime1 = mergedProfile.getCounter("__MAX_OF_time1");
+        Assert.assertNotNull(mergedMinOfTime1);
+        Assert.assertNotNull(mergedMaxOfTime1);
+        Assert.assertEquals(100000000L, mergedMinOfTime1.getValue());
+        Assert.assertEquals(5000000000L, mergedMaxOfTime1.getValue());
+        Assert.assertEquals(100000000L, mergedTime1.getMinValue().get().longValue());
+        Assert.assertEquals(5000000000L, mergedTime1.getMaxValue().get().longValue());
+
+        Counter mergedCount1 = mergedProfile.getCounter("count1");
+        Assert.assertEquals(21, mergedCount1.getValue());
+        Counter mergedMinOfCount1 = mergedProfile.getCounter("__MIN_OF_count1");
+        Counter mergedMaxOfCount1 = mergedProfile.getCounter("__MAX_OF_count1");
+        Assert.assertNotNull(mergedMinOfCount1);
+        Assert.assertNotNull(mergedMaxOfCount1);
+        Assert.assertEquals(1, mergedMinOfCount1.getValue());
+        Assert.assertEquals(6, mergedMaxOfCount1.getValue());
+        Assert.assertEquals(1, mergedCount1.getMinValue().get().longValue());
+        Assert.assertEquals(6, mergedCount1.getMaxValue().get().longValue());
+    }
+
     @Test
     public void testProfileMergeStrategy() {
         testProfileMergeStrategy(TCounterAggregateType.SUM, TCounterAggregateType.AVG);
@@ -782,5 +845,17 @@ public class RuntimeProfileTest {
         Assert.assertEquals(2, counter2.getValue());
         Assert.assertEquals(1, profile.getVersion());
         Assert.assertEquals(1, childProfile.getVersion());
+
+        // update the MIN/MAX of counter
+        counter1.setMinValue(1);
+        counter1.setMaxValue(11);
+        tree = profile.toThrift();
+        {
+            RuntimeProfile profile1 = new RuntimeProfile("profile");
+            profile1.update(tree);
+            Counter c1 = profile1.getCounter("counter1");
+            Assert.assertEquals(1L, c1.getMinValue().get().longValue());
+            Assert.assertEquals(11L, c1.getMaxValue().get().longValue());
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Introduced by https://github.com/StarRocks/starrocks/pull/53759, min/max counters are not processed correctly, may resulting in incorrect driver-level min/max value.

One case is when the data is highly skewed, the counters should varies significantly among pipeline-drivers, but in the query profile the min/max is incorrect.

Affected version:
- 3.3.8+
- 3.4.0+

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0