### PR TITLE
[Refactor] Rename&mv RepoExecutor to SimpleExecutor

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadsHistorySyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadsHistorySyncer.java
@@ -21,7 +21,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.FrontendDaemon;
-import com.starrocks.load.pipe.filelist.RepoExecutor;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.scheduler.history.TableKeeper;
 import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
@@ -103,7 +103,7 @@ public class LoadsHistorySyncer extends FrontendDaemon {
         }
 
         try {
-            RepoExecutor.getInstance().executeDML(SQLBuilder.buildSyncSql());
+            SimpleExecutor.getRepoExecutor().executeDML(SQLBuilder.buildSyncSql());
         } catch (Exception e) {
             LOG.error("Failed to sync loads history", e); 
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoAccessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoAccessor.java
@@ -16,6 +16,7 @@ package com.starrocks.load.pipe.filelist;
 
 import com.google.common.base.Preconditions;
 import com.starrocks.load.pipe.PipeFileRecord;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.thrift.TResultBatch;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -41,7 +42,7 @@ public class RepoAccessor {
 
     public List<PipeFileRecord> listAllFiles() {
         try {
-            List<TResultBatch> batch = RepoExecutor.getInstance().executeDQL(
+            List<TResultBatch> batch = SimpleExecutor.getRepoExecutor().executeDQL(
                     FileListTableRepo.SELECT_FILES);
             return PipeFileRecord.fromResultBatch(batch);
         } catch (Exception e) {
@@ -54,7 +55,7 @@ public class RepoAccessor {
         List<PipeFileRecord> res = null;
         try {
             String sql = buildListFileByState(pipeId, state, limit);
-            List<TResultBatch> batch = RepoExecutor.getInstance().executeDQL(sql);
+            List<TResultBatch> batch = SimpleExecutor.getRepoExecutor().executeDQL(sql);
             res = PipeFileRecord.fromResultBatch(batch);
         } catch (Exception e) {
             LOG.error("listUnloadedFiles failed", e);
@@ -67,7 +68,7 @@ public class RepoAccessor {
         PipeFileRecord res = null;
         try {
             String sql = buildListFileByPath(pipeId, path);
-            List<TResultBatch> batch = RepoExecutor.getInstance().executeDQL(sql);
+            List<TResultBatch> batch = SimpleExecutor.getRepoExecutor().executeDQL(sql);
             if (CollectionUtils.isEmpty(batch)) {
                 throw new IllegalArgumentException("file not found: " + path);
             } else if (batch.size() > 1) {
@@ -84,7 +85,7 @@ public class RepoAccessor {
     public List<PipeFileRecord> selectStagedFiles(List<PipeFileRecord> records) {
         try {
             String sql = buildSelectStagedFiles(records);
-            List<TResultBatch> batch = RepoExecutor.getInstance().executeDQL(sql);
+            List<TResultBatch> batch = SimpleExecutor.getRepoExecutor().executeDQL(sql);
             return PipeFileRecord.fromResultBatch(batch);
         } catch (Exception e) {
             LOG.error("selectStagedFiles failed", e);
@@ -95,7 +96,7 @@ public class RepoAccessor {
     public void addFiles(List<PipeFileRecord> records) {
         try {
             String sql = buildSqlAddFiles(records);
-            RepoExecutor.getInstance().executeDML(sql);
+            SimpleExecutor.getRepoExecutor().executeDML(sql);
             LOG.info("addFiles into repo: {}", records);
             return;
         } catch (Exception e) {
@@ -126,7 +127,7 @@ public class RepoAccessor {
                     Preconditions.checkState(false, "not supported");
                     break;
             }
-            RepoExecutor.getInstance().executeDML(sql);
+            SimpleExecutor.getRepoExecutor().executeDML(sql);
             LOG.info("update files state to {}: {}", state, records);
         } catch (Exception e) {
             LOG.error("update files state failed: {}", records, e);
@@ -137,7 +138,7 @@ public class RepoAccessor {
     public void deleteByPipe(long pipeId) {
         try {
             String sql = String.format(FileListTableRepo.DELETE_BY_PIPE, pipeId);
-            RepoExecutor.getInstance().executeDML(sql);
+            SimpleExecutor.getRepoExecutor().executeDML(sql);
             LOG.info("delete pipe files {}", pipeId);
         } catch (Exception e) {
             LOG.error("delete file of pipe {} failed", pipeId, e);

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoCreator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoCreator.java
@@ -15,6 +15,7 @@
 package com.starrocks.load.pipe.filelist;
 
 import com.starrocks.common.StarRocksException;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.statistic.StatisticUtils;
 import org.apache.logging.log4j.LogManager;
@@ -63,7 +64,7 @@ public class RepoCreator {
         int expectedReplicationNum =
                 GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getSystemTableExpectedReplicationNum();
         String sql = FileListTableRepo.SQLBuilder.buildCreateTableSql(expectedReplicationNum);
-        RepoExecutor.getInstance().executeDDL(sql);
+        SimpleExecutor.getRepoExecutor().executeDDL(sql);
     }
 
     public static boolean correctTable() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
@@ -20,7 +20,7 @@ import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.load.loadv2.LoadsHistorySyncer;
-import com.starrocks.load.pipe.filelist.RepoExecutor;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.statistic.columns.PredicateColumnsStorage;
 import jdk.jshell.spi.ExecutionControl;
@@ -93,7 +93,7 @@ public class TableKeeper {
     }
 
     public void createTable() throws ExecutionControl.UserException {
-        RepoExecutor.getInstance().executeDDL(createTableSql);
+        SimpleExecutor.getRepoExecutor().executeDDL(createTableSql);
     }
 
     public void correctTable() {
@@ -107,7 +107,7 @@ public class TableKeeper {
         if (replica != expectedReplicationNum) {
             String sql = alterTableReplicas(expectedReplicationNum);
             if (StringUtils.isNotEmpty(sql)) {
-                RepoExecutor.getInstance().executeDDL(sql);
+                SimpleExecutor.getRepoExecutor().executeDDL(sql);
             }
             LOG.info("changed replication_number of table {} from {} to {}",
                     tableName, replica, expectedReplicationNum);
@@ -130,7 +130,7 @@ public class TableKeeper {
         }
         String sql = alterTableTTL(expectedTTLDays);
         try {
-            RepoExecutor.getInstance().executeDDL(sql);
+            SimpleExecutor.getRepoExecutor().executeDDL(sql);
             LOG.info("change table {}.{} TTL from {} to {}",
                     databaseName, tableName, currentTTLNumber, expectedTTLDays);
         } catch (Throwable e) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
@@ -20,7 +20,7 @@ import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.DateUtils;
-import com.starrocks.load.pipe.filelist.RepoExecutor;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.scheduler.ExecuteOption;
 import com.starrocks.scheduler.TaskRun;
 import com.starrocks.scheduler.persist.TaskRunStatus;
@@ -152,7 +152,7 @@ public class TaskRunHistoryTable {
             }).collect(Collectors.joining(", "));
 
             String sql = insert + values;
-            RepoExecutor.getInstance().executeDML(sql);
+            SimpleExecutor.getRepoExecutor().executeDML(sql);
         }
     }
 
@@ -211,7 +211,7 @@ public class TaskRunHistoryTable {
         }
         sql += Joiner.on(" AND ").join(predicates);
 
-        List<TResultBatch> batch = RepoExecutor.getInstance().executeDQL(sql);
+        List<TResultBatch> batch = SimpleExecutor.getRepoExecutor().executeDQL(sql);
         List<TaskRunStatus> result = TaskRunStatus.fromResultBatch(batch);
         // sort results by create time desc to make the result more stable.
         Collections.sort(result, TaskRunStatus.COMPARATOR_BY_CREATE_TIME_DESC);
@@ -230,7 +230,7 @@ public class TaskRunHistoryTable {
         }
 
         String sql = LOOKUP + Joiner.on(" AND ").join(predicates);
-        List<TResultBatch> batch = RepoExecutor.getInstance().executeDQL(sql);
+        List<TResultBatch> batch = SimpleExecutor.getRepoExecutor().executeDQL(sql);
         List<TaskRunStatus> result = TaskRunStatus.fromResultBatch(batch);
         // sort results by create time desc to make the result more stable.
         Collections.sort(result, TaskRunStatus.COMPARATOR_BY_CREATE_TIME_DESC);
@@ -277,7 +277,7 @@ public class TaskRunHistoryTable {
         DEFAULT_VELOCITY_ENGINE.evaluate(context, sw, "", template);
         String sql = sw.toString();
 
-        List<TResultBatch> batch = RepoExecutor.getInstance().executeDQL(sql);
+        List<TResultBatch> batch = SimpleExecutor.getRepoExecutor().executeDQL(sql);
         return TaskRunStatus.fromResultBatch(batch);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
@@ -39,12 +39,12 @@ import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.hive.Partition;
-import com.starrocks.load.pipe.filelist.RepoExecutor;
 import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.memory.MemoryUsageTracker;
 import com.starrocks.monitor.unit.ByteSizeValue;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.scheduler.TaskRunManager;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Authorizer;
@@ -443,7 +443,7 @@ public class MetaFunctions {
         String sql = String.format("select cast(`%s` as string) from %s where `%s` = '%s' limit 1",
                 returnColumn.getVarchar(), tableNameValue.toString(), keyColumn.getName(), lookupKey.getVarchar());
         try {
-            List<TResultBatch> result = RepoExecutor.getInstance().executeDQL(sql);
+            List<TResultBatch> result = SimpleExecutor.getRepoExecutor().executeDQL(sql);
             return deserializeLookupResult(result);
         } catch (Throwable e) {
             final String notFoundMessage = "query failed if record not exist in dict table";

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/partition/PartitionSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/partition/PartitionSelector.java
@@ -38,11 +38,11 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.information.InfoSchemaDb;
 import com.starrocks.catalog.system.information.PartitionsMetaSystemTable;
 import com.starrocks.common.Pair;
-import com.starrocks.load.pipe.filelist.RepoExecutor;
 import com.starrocks.planner.PartitionColumnFilter;
 import com.starrocks.planner.PartitionPruner;
 import com.starrocks.planner.RangePartitionPruner;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AnalyzeState;
@@ -608,7 +608,7 @@ public class PartitionSelector {
         String newWhereSql = newExpr.toSql();
         String sql = String.format(PARTITIONS_META_TEMPLATE, dbName, olapTable.getName(), newWhereSql);
         LOG.info("Get partition ids by sql: {}", sql);
-        List<TResultBatch> batch = RepoExecutor.getInstance().executeDQL(sql);
+        List<TResultBatch> batch = SimpleExecutor.getRepoExecutor().executeDQL(sql);
         List<String> partitionNames = deserializeLookupResult(batch);
         // multi items in the single partition is not supported yet since `JSON_QUERY_TEMPLATE` is constructed the first element.
         Set<Long> excludedPartitionIds = Sets.newHashSet();

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -48,8 +48,8 @@ import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.ConnectorPartitionTraits;
 import com.starrocks.http.HttpConnectContext;
-import com.starrocks.load.pipe.filelist.RepoExecutor;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.service.arrow.flight.sql.ArrowFlightSqlConnectContext;
@@ -551,7 +551,7 @@ public class StatisticUtils {
             String sql = String.format("ALTER TABLE %s.%s SET ('replication_num'='%d')",
                     StatsConstants.STATISTICS_DB_NAME, tableName, expectedReplicationNum);
             if (StringUtils.isNotEmpty(sql)) {
-                RepoExecutor.getInstance().executeDDL(sql);
+                SimpleExecutor.getRepoExecutor().executeDDL(sql);
             }
             LOG.info("changed replication_number of table {} from {} to {}",
                     tableName, replica, expectedReplicationNum);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/columns/PredicateColumnsStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/columns/PredicateColumnsStorage.java
@@ -26,7 +26,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.TimeUtils;
-import com.starrocks.load.pipe.filelist.RepoExecutor;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.scheduler.history.TableKeeper;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
@@ -121,7 +121,7 @@ public class PredicateColumnsStorage {
     private final LocalDateTime systemStartTime = TimeUtils.getSystemNow();
     private volatile LocalDateTime lastPersist = LocalDateTime.MIN;
 
-    private final RepoExecutor executor;
+    private final SimpleExecutor executor;
 
     public static TableKeeper createKeeper() {
         return KEEPER;
@@ -132,10 +132,10 @@ public class PredicateColumnsStorage {
     }
 
     public PredicateColumnsStorage() {
-        this.executor = RepoExecutor.getInstance();
+        this.executor = SimpleExecutor.getRepoExecutor();
     }
 
-    public PredicateColumnsStorage(RepoExecutor executor) {
+    public PredicateColumnsStorage(SimpleExecutor executor) {
         this.executor = executor;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/pipe/PipeManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/pipe/PipeManagerTest.java
@@ -26,7 +26,6 @@ import com.starrocks.fs.HdfsUtil;
 import com.starrocks.load.pipe.filelist.FileListRepo;
 import com.starrocks.load.pipe.filelist.FileListTableRepo;
 import com.starrocks.load.pipe.filelist.RepoAccessor;
-import com.starrocks.load.pipe.filelist.RepoExecutor;
 import com.starrocks.persist.OperationType;
 import com.starrocks.persist.PipeOpEntry;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
@@ -35,6 +34,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.ShowExecutor;
 import com.starrocks.qe.ShowResultSet;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.ExecuteOption;
 import com.starrocks.scheduler.SubmitResult;
@@ -354,7 +354,7 @@ public class PipeManagerTest {
     }
 
     public static void mockRepoExecutorDML() {
-        new MockUp<RepoExecutor>() {
+        new MockUp<SimpleExecutor>() {
             @Mock
             public void executeDML(String sql) {
             }
@@ -371,7 +371,7 @@ public class PipeManagerTest {
     }
 
     private void mockRepoExecutor() {
-        new MockUp<RepoExecutor>() {
+        new MockUp<SimpleExecutor>() {
             @Mock
             public void executeDML(String sql) {
             }

--- a/fe/fe-core/src/test/java/com/starrocks/load/pipe/filelist/FileListRepoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/pipe/filelist/FileListRepoTest.java
@@ -23,6 +23,7 @@ import com.starrocks.common.util.DateUtils;
 import com.starrocks.load.pipe.PipeFileRecord;
 import com.starrocks.load.pipe.PipeId;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.sql.plan.ExecPlan;
@@ -182,7 +183,7 @@ public class FileListRepoTest {
     }
 
     private void mockExecutor() {
-        new MockUp<RepoExecutor>() {
+        new MockUp<SimpleExecutor>() {
             private boolean ddlExecuted = false;
 
             @Mock
@@ -213,11 +214,11 @@ public class FileListRepoTest {
                 return true;
             }
         };
-        RepoExecutor executor = RepoExecutor.getInstance();
+        SimpleExecutor executor = SimpleExecutor.getRepoExecutor();
         RepoCreator creator = RepoCreator.getInstance();
 
         // failed for the first time
-        new MockUp<RepoExecutor>() {
+        new MockUp<SimpleExecutor>() {
             @Mock
             public void executeDDL(String sql) {
                 throw new RuntimeException("ddl failed");
@@ -235,7 +236,7 @@ public class FileListRepoTest {
             }
         };
         AtomicInteger changed = new AtomicInteger(0);
-        new MockUp<RepoExecutor>() {
+        new MockUp<SimpleExecutor>() {
             @Mock
             public void executeDDL(String sql) {
                 changed.addAndGet(1);
@@ -264,7 +265,7 @@ public class FileListRepoTest {
         FileListTableRepo repo = new FileListTableRepo();
         repo.setPipeId(new PipeId(1, 1));
         RepoAccessor accessor = RepoAccessor.getInstance();
-        RepoExecutor executor = RepoExecutor.getInstance();
+        SimpleExecutor executor = SimpleExecutor.getRepoExecutor();
         new Expectations(executor) {
             {
                 executor.executeDQL(anyString);
@@ -381,7 +382,7 @@ public class FileListRepoTest {
             }
         };
 
-        RepoExecutor executor = RepoExecutor.getInstance();
+        SimpleExecutor executor = SimpleExecutor.getRepoExecutor();
         new Expectations(executor) {
             {
                 executor.executeDML(
@@ -409,7 +410,7 @@ public class FileListRepoTest {
             }
         };
 
-        RepoExecutor executor = RepoExecutor.getInstance();
+        SimpleExecutor executor = SimpleExecutor.getRepoExecutor();
 
         Assert.assertTrue(executor.executeDQL("select now()").isEmpty());
 
@@ -422,7 +423,7 @@ public class FileListRepoTest {
         FileListTableRepo repo = new FileListTableRepo();
         repo.setPipeId(new PipeId(1, 1));
         RepoAccessor accessor = RepoAccessor.getInstance();
-        RepoExecutor executor = RepoExecutor.getInstance();
+        SimpleExecutor executor = SimpleExecutor.getRepoExecutor();
 
         new Expectations(executor) {
             {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
@@ -17,8 +17,8 @@ package com.starrocks.scheduler.history;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.common.Config;
-import com.starrocks.load.pipe.filelist.RepoExecutor;
 import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.statistic.StatisticsMetaManager;
@@ -71,7 +71,7 @@ public class TaskRunHistoryTest {
     }
 
     @Test
-    public void testCRUD(@Mocked RepoExecutor repo) {
+    public void testCRUD(@Mocked SimpleExecutor repo) {
         TaskRunStatus status = new TaskRunStatus();
         status.setQueryId("aaa");
         status.setTaskName("t1");
@@ -153,7 +153,7 @@ public class TaskRunHistoryTest {
     }
 
     @Test
-    public void testKeeper(@Mocked RepoExecutor repo) {
+    public void testKeeper(@Mocked SimpleExecutor repo) {
         TableKeeper keeper = TaskRunHistoryTable.createKeeper();
         assertEquals(StatsConstants.STATISTICS_DB_NAME, keeper.getDatabaseName());
         assertEquals(TaskRunHistoryTable.TABLE_NAME, keeper.getTableName());
@@ -196,7 +196,7 @@ public class TaskRunHistoryTest {
     }
 
     @Test
-    public void testHistoryVacuum(@Mocked RepoExecutor repo) {
+    public void testHistoryVacuum(@Mocked SimpleExecutor repo) {
         new MockUp<TableKeeper>() {
             @Mock
             public boolean isReady() {
@@ -337,7 +337,7 @@ public class TaskRunHistoryTest {
     }
 
     @Test
-    public void testLookByTaskNamesOrder(@Mocked RepoExecutor repo) {
+    public void testLookByTaskNamesOrder(@Mocked SimpleExecutor repo) {
         new MockUp<TableKeeper>() {
             @Mock
             public boolean isReady() {
@@ -353,7 +353,7 @@ public class TaskRunHistoryTest {
         }
         // shuffle the taskRuns' order
         Collections.shuffle(taskRuns);
-        new MockUp<RepoExecutor>() {
+        new MockUp<SimpleExecutor>() {
             @Mock
             public List<TResultBatch> executeDQL(String sql) {
                 TaskRunStatus.TaskRunStatusJSONRecord record = new TaskRunStatus.TaskRunStatusJSONRecord();
@@ -378,7 +378,7 @@ public class TaskRunHistoryTest {
     }
 
     @Test
-    public void testLookOrder(@Mocked RepoExecutor repo) {
+    public void testLookOrder(@Mocked SimpleExecutor repo) {
         new MockUp<TableKeeper>() {
             @Mock
             public boolean isReady() {
@@ -396,7 +396,7 @@ public class TaskRunHistoryTest {
         // shuffle the taskRuns' order
         Collections.shuffle(taskRuns);
 
-        new MockUp<RepoExecutor>() {
+        new MockUp<SimpleExecutor>() {
             @Mock
             public List<TResultBatch> executeDQL(String sql) {
                 TaskRunStatus.TaskRunStatusJSONRecord record = new TaskRunStatus.TaskRunStatusJSONRecord();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/MetaFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/MetaFunctionsTest.java
@@ -21,10 +21,10 @@ import com.starrocks.common.Config;
 import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.leader.ReportHandler;
-import com.starrocks.load.pipe.filelist.RepoExecutor;
 import com.starrocks.memory.MemoryUsageTracker;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.sql.optimizer.function.MetaFunctions;
@@ -197,7 +197,7 @@ public class MetaFunctionsTest {
             Assert.assertNull(lookupString("t1", "v1", "c1"));
 
             // normal
-            new MockUp<RepoExecutor>() {
+            new MockUp<SimpleExecutor>() {
                 @Mock
                 public List<TResultBatch> executeDQL(String sql) {
                     MetaFunctions.LookupRecord record = new MetaFunctions.LookupRecord();
@@ -213,7 +213,7 @@ public class MetaFunctionsTest {
             Assert.assertEquals("v1", lookupString("t1", "v1", "c1"));
 
             // record not found
-            new MockUp<RepoExecutor>() {
+            new MockUp<SimpleExecutor>() {
                 @Mock
                 public List<TResultBatch> executeDQL(String sql) {
                     throw new RuntimeException("query failed if record not exist in dict table");

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/columns/PredicateColumnsStorageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/columns/PredicateColumnsStorageTest.java
@@ -19,8 +19,8 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.util.DateUtils;
-import com.starrocks.load.pipe.filelist.RepoExecutor;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.scheduler.history.TableKeeper;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.plan.PlanTestBase;
@@ -59,7 +59,7 @@ class PredicateColumnsStorageTest extends PlanTestBase {
                 PredicateColumnsStorage.TABLE_NAME));
         ConnectContext.ScopeGuard guard = connectContext.bindScope();
 
-        RepoExecutor repo = Mockito.mock(RepoExecutor.class);
+        SimpleExecutor repo = Mockito.mock(SimpleExecutor.class);
         PredicateColumnsStorage instance = new PredicateColumnsStorage(repo);
 
         // restore


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

core:
load/pipe/filelist/RepoExecutor.java → .qe/SimpleExecutor.java

to reuse `RepoExecutor` in other moulde， no logical update

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0