### PR TITLE
[BugFix] Fix the stub reset error

### DIFF
--- a/be/src/util/brpc_stub_cache.h
+++ b/be/src/util/brpc_stub_cache.h
@@ -163,7 +163,7 @@ public:
         }
         // create
         auto stub = std::make_shared<PInternalService_RecoverableStub>(endpoint);
-        if (!stub->reset_channel().ok()) {
+        if (!stub->reset_channel("http").ok()) {
             return Status::RuntimeError("init brpc http channel error on " + taddr.hostname + ":" +
                                         std::to_string(taddr.port));
         }

--- a/be/src/util/internal_service_recoverable_stub.cpp
+++ b/be/src/util/internal_service_recoverable_stub.cpp
@@ -14,6 +14,8 @@
 
 #include "util/internal_service_recoverable_stub.h"
 
+#include <utility>
+
 #include "common/config.h"
 
 namespace starrocks {
@@ -22,7 +24,7 @@ class RecoverableClosure : public ::google::protobuf::Closure {
 public:
     RecoverableClosure(std::shared_ptr<starrocks::PInternalService_RecoverableStub> stub,
                        ::google::protobuf::RpcController* controller, ::google::protobuf::Closure* done)
-            : _stub(stub), _controller(controller), _done(done) {}
+            : _stub(std::move(std::move(stub))), _controller(controller), _done(done) {}
 
     void Run() override {
         auto* cntl = static_cast<brpc::Controller*>(_controller);
@@ -45,15 +47,20 @@ private:
 PInternalService_RecoverableStub::PInternalService_RecoverableStub(const butil::EndPoint& endpoint)
         : _endpoint(endpoint) {}
 
-PInternalService_RecoverableStub::~PInternalService_RecoverableStub() {}
+PInternalService_RecoverableStub::~PInternalService_RecoverableStub() = default;
 
-Status PInternalService_RecoverableStub::reset_channel() {
+Status PInternalService_RecoverableStub::reset_channel(const std::string& protocol) {
     std::lock_guard<std::mutex> l(_mutex);
     brpc::ChannelOptions options;
     options.connect_timeout_ms = config::rpc_connect_timeout_ms;
+    if (protocol == "http") {
+        options.protocol = protocol;
+    } else {
+        // http does not support these.
+        options.connection_type = config::brpc_connection_type;
+        options.connection_group = std::to_string(_connection_group++);
+    }
     options.max_retry = 3;
-    options.connection_type = config::brpc_connection_type;
-    options.connection_group = std::to_string(_connection_group++);
     std::unique_ptr<brpc::Channel> channel(new brpc::Channel());
     if (channel->Init(_endpoint, &options)) {
         LOG(WARNING) << "Fail to init channel " << _endpoint;

--- a/be/src/util/internal_service_recoverable_stub.h
+++ b/be/src/util/internal_service_recoverable_stub.h
@@ -29,7 +29,7 @@ public:
     PInternalService_RecoverableStub(const butil::EndPoint& endpoint);
     ~PInternalService_RecoverableStub();
 
-    Status reset_channel();
+    Status reset_channel(const std::string& protocol = "");
 
 #ifdef BE_TEST
     PInternalService_Stub* stub() { return _stub.get(); }


### PR DESCRIPTION
## Why I'm doing:
#51195 ignore the `reset_channel("http")`. When the packet is larger than 2G, it need to use the http protocol.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr
