### PR TITLE
[Enhancement] add random compaction strategy for chaos test

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -383,6 +383,10 @@ CONF_mInt64(size_tiered_level_multiple, "5");
 CONF_mInt64(size_tiered_level_multiple_dupkey, "10");
 CONF_mInt64(size_tiered_level_num, "7");
 
+// random compaction strategy is only used for chaos test,
+// should never be true in prodution.
+CONF_mBool(enable_random_compaction_strategy, "false");
+
 CONF_Bool(enable_check_string_lengths, "true");
 
 // Max row source mask memory bytes, default is 200M.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -385,7 +385,7 @@ CONF_mInt64(size_tiered_level_num, "7");
 
 // random compaction strategy is only used for chaos test,
 // should never be true in prodution.
-CONF_mBool(enable_random_compaction_strategy, "false");
+CONF_mBool(chaos_test_enable_random_compaction_strategy, "false");
 
 CONF_Bool(enable_check_string_lengths, "true");
 

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -5814,7 +5814,7 @@ Status TabletUpdates::compaction_random(MemTracker* mem_tracker) {
     MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(mem_tracker);
     DeferOp op([&] { tls_thread_status.set_mem_tracker(prev_tracker); });
 
-    Status st = _do_compaction(&info);
+    Status st = _do_compaction(&info, rowsets);
     if (!st.ok()) {
         _compaction_running = false;
         _last_compaction_failure_millis = UnixMillis();

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2897,6 +2897,10 @@ static std::string int_list_to_string(const std::vector<T>& l) {
 }
 
 Status TabletUpdates::compaction(MemTracker* mem_tracker) {
+    if (config::enable_random_compaction_strategy) {
+        // chaos engineering
+        return compaction_random(mem_tracker);
+    }
     if (config::enable_pk_size_tiered_compaction_strategy) {
         return compaction_for_size_tiered(mem_tracker);
     }
@@ -5750,6 +5754,74 @@ Status TabletUpdates::recover() {
     _error = false;
 
     return Status::OK();
+}
+
+Status TabletUpdates::compaction_random(MemTracker* mem_tracker) {
+    if (_error) {
+        return Status::InternalError(strings::Substitute(
+                "compaction failed, tablet updates is in error state: tablet:$0 $1", _tablet.tablet_id(), _error_msg));
+    }
+    bool was_runing = false;
+    if (!_compaction_running.compare_exchange_strong(was_runing, true)) {
+        return Status::AlreadyExist("illegal state: another compaction is running");
+    }
+    std::unique_ptr<CompactionInfo> info = std::make_unique<CompactionInfo>();
+    vector<uint32_t> rowsets;
+    {
+        std::lock_guard rl(_lock);
+        if (_edit_version_infos.empty()) {
+            string msg = strings::Substitute("tablet deleted when compaction tablet:$0", _tablet.tablet_id());
+            LOG(WARNING) << msg;
+            return Status::InternalError(msg);
+        }
+        // 1. start compaction at current apply version
+        info->start_version = _edit_version_infos[_apply_version_idx]->version;
+        rowsets = _edit_version_infos[_apply_version_idx]->rowsets;
+    }
+
+    // random pick N rowsets from this version.
+    {
+        std::lock_guard lg(_rowset_stats_lock);
+        for (auto rowsetid : rowsets) {
+            auto itr = _rowset_stats.find(rowsetid);
+            if (itr == _rowset_stats.end()) {
+                // should not happen
+                string msg = strings::Substitute("rowset not found in rowset stats tablet=$0 rowset=$1",
+                                                 _tablet.tablet_id(), rowsetid);
+                DCHECK(false) << msg;
+                LOG(WARNING) << msg;
+            } else if (itr->second->compaction_score > 0) {
+                // 30% chance to pick this rowset
+                if (rand() % 100 < 30) {
+                    info->inputs.push_back(rowsetid);
+                    if (info->inputs.size() >= config::max_update_compaction_num_singleton_deltas) {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    // give 10s time gitter, so same table's compaction don't start at same time
+    _last_compaction_time_ms = UnixMillis() + rand() % 10000;
+    if (info->inputs.empty()) {
+        VLOG(2) << "no candidate rowset to do update compaction, tablet:" << _tablet.tablet_id();
+        _compaction_running = false;
+        return Status::OK();
+    }
+    std::sort(info->inputs.begin(), info->inputs.end());
+
+    MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(mem_tracker);
+    DeferOp op([&] { tls_thread_status.set_mem_tracker(prev_tracker); });
+
+    Status st = _do_compaction(&info);
+    if (!st.ok()) {
+        _compaction_running = false;
+        _last_compaction_failure_millis = UnixMillis();
+    } else {
+        _last_compaction_success_millis = UnixMillis();
+    }
+    return st;
 }
 
 void TabletUpdates::_reset_apply_status(const EditVersionInfo& version_info_apply) {

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2897,7 +2897,7 @@ static std::string int_list_to_string(const std::vector<T>& l) {
 }
 
 Status TabletUpdates::compaction(MemTracker* mem_tracker) {
-    if (config::enable_random_compaction_strategy) {
+    if (config::chaos_test_enable_random_compaction_strategy) {
         // chaos engineering
         return compaction_random(mem_tracker);
     }

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -387,6 +387,7 @@ public:
     void stop_and_wait_apply_done();
 
     Status breakpoint_check();
+    Status compaction_random(MemTracker* mem_tracker);
 
 private:
     friend class Tablet;

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -1348,6 +1348,12 @@ TEST_F(TabletUpdatesTest, horizontal_compaction_with_persistent_index_with_rows_
     test_horizontal_compaction_with_rows_mapper(true);
 }
 
+TEST_F(TabletUpdatesTest, horizontal_compaction_with_random_pick) {
+    config::enable_random_compaction_strategy = true;
+    test_horizontal_compaction(true);
+    config::enable_random_compaction_strategy = false;
+}
+
 TEST_F(TabletUpdatesTest, horizontal_compaction_with_sort_key) {
     auto orig = config::vertical_compaction_max_columns_per_group;
     config::vertical_compaction_max_columns_per_group = 5;

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -1349,9 +1349,9 @@ TEST_F(TabletUpdatesTest, horizontal_compaction_with_persistent_index_with_rows_
 }
 
 TEST_F(TabletUpdatesTest, horizontal_compaction_with_random_pick) {
-    config::enable_random_compaction_strategy = true;
+    config::chaos_test_enable_random_compaction_strategy = true;
     test_horizontal_compaction(true);
-    config::enable_random_compaction_strategy = false;
+    config::chaos_test_enable_random_compaction_strategy = false;
 }
 
 TEST_F(TabletUpdatesTest, horizontal_compaction_with_sort_key) {

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -1211,7 +1211,7 @@ TEST_F(TabletUpdatesTest, compaction_score_enough_normal) {
 
 // NOLINTNEXTLINE
 void TabletUpdatesTest::test_horizontal_compaction(bool enable_persistent_index, bool show_status,
-                                                   bool skip_rowset_cnt_check) {
+                                                   bool random_compaction) {
     auto orig = config::vertical_compaction_max_columns_per_group;
     config::vertical_compaction_max_columns_per_group = 5;
     DeferOp unset_config([&] { config::vertical_compaction_max_columns_per_group = orig; });
@@ -1239,12 +1239,12 @@ void TabletUpdatesTest::test_horizontal_compaction(bool enable_persistent_index,
     ASSERT_TRUE(best_tablet->updates()->compaction(_compaction_mem_tracker.get()).ok());
     std::this_thread::sleep_for(std::chrono::seconds(1));
     EXPECT_EQ(100, read_tablet_and_compare(best_tablet, 4, keys));
-    if (!skip_rowset_cnt_check) {
+    if (!random_compaction) {
         ASSERT_EQ(best_tablet->updates()->num_rowsets(), 1);
+        ASSERT_EQ(best_tablet->updates()->version_history_count(), 5);
+        // the time interval is not enough after last compaction
+        EXPECT_EQ(best_tablet->updates()->get_compaction_score(), -1);
     }
-    ASSERT_EQ(best_tablet->updates()->version_history_count(), 5);
-    // the time interval is not enough after last compaction
-    EXPECT_EQ(best_tablet->updates()->get_compaction_score(), -1);
     EXPECT_TRUE(best_tablet->verify().ok());
 
     if (show_status) {

--- a/be/test/storage/tablet_updates_test.h
+++ b/be/test/storage/tablet_updates_test.h
@@ -798,7 +798,8 @@ public:
     void test_compaction_score_not_enough(bool enable_persistent_index);
     void test_compaction_score_enough_duplicate(bool enable_persistent_index);
     void test_compaction_score_enough_normal(bool enable_persistent_index);
-    void test_horizontal_compaction(bool enable_persistent_index, bool show_status = false);
+    void test_horizontal_compaction(bool enable_persistent_index, bool show_status = false,
+                                    bool skip_rowset_cnt_check = false);
     void test_vertical_compaction(bool enable_persistent_index);
     void test_horizontal_compaction_with_rows_mapper(bool enable_persistent_index);
     void test_vertical_compaction_with_rows_mapper(bool enable_persistent_index);

--- a/be/test/storage/tablet_updates_test.h
+++ b/be/test/storage/tablet_updates_test.h
@@ -799,7 +799,7 @@ public:
     void test_compaction_score_enough_duplicate(bool enable_persistent_index);
     void test_compaction_score_enough_normal(bool enable_persistent_index);
     void test_horizontal_compaction(bool enable_persistent_index, bool show_status = false,
-                                    bool skip_rowset_cnt_check = false);
+                                    bool random_compaction = false);
     void test_vertical_compaction(bool enable_persistent_index);
     void test_horizontal_compaction_with_rows_mapper(bool enable_persistent_index);
     void test_vertical_compaction_with_rows_mapper(bool enable_persistent_index);


### PR DESCRIPTION
## Why I'm doing:
Add random compaction strategy so we can do some chaos test by pick some random rowsets, thereby uncovering bugs that are difficult to reproduce under normal compaction strategies.

## What I'm doing:
Start from PK table first.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0