### PR TITLE
[Feature][SPM] Add SPM optimizer

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -55,6 +55,7 @@ import com.starrocks.sql.optimizer.rewrite.ScalarOperatorEvaluator;
 import com.starrocks.sql.optimizer.transformer.ExpressionMapping;
 import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
 import com.starrocks.sql.parser.NodePosition;
+import com.starrocks.sql.spm.SPMFunctions;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -677,6 +678,10 @@ public class FunctionAnalyzer {
             return fn;
         }
 
+        fn = SPMFunctions.getSPMFunction(node.getFnName().getFunction());
+        if (fn != null) {
+            return fn;
+        }
         // get fn from builtin functions
         fn = getAnalyzedBuiltInFunction(session, fnName, params, argumentTypes, node.getPos());
         if (fn != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerFactory.java
@@ -56,6 +56,8 @@ public class OptimizerFactory {
     public static Optimizer create(OptimizerContext context) {
         if (context.getOptimizerOptions().isShortCircuit()) {
             return new ShortCircuitOptimizer(context);
+        } else if (context.getOptimizerOptions().isBaselinePlan()) {
+            return new SPMOptimizer(context);
         }
         return new QueryOptimizer(context);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerOptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerOptions.java
@@ -23,6 +23,7 @@ public class OptimizerOptions {
         RULE_BASED,
         COST_BASED,
         SHORT_CIRCUIT,
+        BASELINE_PLAN,
     }
 
     private final OptimizerStrategy optimizerStrategy;
@@ -45,6 +46,10 @@ public class OptimizerOptions {
 
     public boolean isShortCircuit() {
         return optimizerStrategy.equals(OptimizerStrategy.SHORT_CIRCUIT);
+    }
+
+    public boolean isBaselinePlan() {
+        return optimizerStrategy.equals(OptimizerStrategy.BASELINE_PLAN);
     }
 
     public void disableRule(RuleType ruleType) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -680,6 +680,13 @@ public class QueryOptimizer extends Optimizer {
 
         tree = SimplifyCaseWhenPredicateRule.INSTANCE.rewrite(tree, rootTaskContext);
         deriveLogicalProperty(tree);
+
+        // TODO(packy92)
+        //  The tree-based rewriting rules in RBO may modify the child node but not update the
+        //  parent node, resulting in the statistical cache calculated by the previous rules
+        //  not being refreshed, which may affect the calculation of statistical information in memo.
+        //  Just clear it before into memo.
+        tree.getInputs().get(0).clearStatsAndInitOutputInfo();
         return tree.getInputs().get(0);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SPMOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SPMOptimizer.java
@@ -1,0 +1,319 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer;
+
+import com.google.common.collect.Lists;
+import com.starrocks.analysis.JoinOperator;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
+import com.starrocks.sql.optimizer.operator.logical.LogicalTreeAnchorOperator;
+import com.starrocks.sql.optimizer.rule.RuleSet;
+import com.starrocks.sql.optimizer.rule.join.JoinReorderFactory;
+import com.starrocks.sql.optimizer.rule.join.ReorderJoinRule;
+import com.starrocks.sql.optimizer.rule.transformation.ApplyExceptionRule;
+import com.starrocks.sql.optimizer.rule.transformation.ConvertToEqualForNullRule;
+import com.starrocks.sql.optimizer.rule.transformation.EliminateAggRule;
+import com.starrocks.sql.optimizer.rule.transformation.EliminateConstantCTERule;
+import com.starrocks.sql.optimizer.rule.transformation.ForceCTEReuseRule;
+import com.starrocks.sql.optimizer.rule.transformation.JoinLeftAsscomRule;
+import com.starrocks.sql.optimizer.rule.transformation.MergeProjectWithChildRule;
+import com.starrocks.sql.optimizer.rule.transformation.MergeTwoAggRule;
+import com.starrocks.sql.optimizer.rule.transformation.MergeTwoProjectRule;
+import com.starrocks.sql.optimizer.rule.transformation.PruneEmptyWindowRule;
+import com.starrocks.sql.optimizer.rule.transformation.PushDownJoinOnExpressionToChildProject;
+import com.starrocks.sql.optimizer.rule.transformation.PushDownProjectLimitRule;
+import com.starrocks.sql.optimizer.rule.transformation.PushDownTopNBelowOuterJoinRule;
+import com.starrocks.sql.optimizer.rule.transformation.PushDownTopNBelowUnionRule;
+import com.starrocks.sql.optimizer.rule.transformation.PushLimitAndFilterToCTEProduceRule;
+import com.starrocks.sql.optimizer.rule.transformation.RewriteMultiDistinctRule;
+import com.starrocks.sql.optimizer.rule.transformation.SeparateProjectRule;
+import com.starrocks.sql.optimizer.rule.transformation.UnionToValuesRule;
+import com.starrocks.sql.optimizer.rule.transformation.pruner.CboTablePruneRule;
+import com.starrocks.sql.optimizer.rule.tree.PushDownAggregateRule;
+import com.starrocks.sql.optimizer.rule.tree.PushDownDistinctAggregateRule;
+import com.starrocks.sql.optimizer.task.OptimizeGroupTask;
+import com.starrocks.sql.optimizer.task.TaskContext;
+import com.starrocks.sql.optimizer.task.TaskScheduler;
+
+import java.util.List;
+
+public class SPMOptimizer extends Optimizer {
+    private final TaskScheduler scheduler = new TaskScheduler();
+    private final Memo memo = new Memo();
+    private ColumnRefSet requiredColumns;
+
+    SPMOptimizer(OptimizerContext context) {
+        super(context);
+    }
+
+    @Override
+    public OptExpression optimize(OptExpression tree, PhysicalPropertySet requiredProperty,
+                                  ColumnRefSet requiredColumns) {
+
+        context.setMemo(memo);
+        context.setTaskScheduler(scheduler);
+        this.requiredColumns = requiredColumns;
+
+        TaskContext taskContext = new TaskContext(context, requiredProperty, requiredColumns.clone(), Double.MAX_VALUE);
+        tree = optimizeByRule(tree, taskContext);
+
+        memo.init(tree);
+        memo.deriveAllGroupLogicalProperty();
+        memoOptimize(memo, taskContext);
+
+        return extractBestPlan(requiredProperty, memo.getRootGroup());
+    }
+
+    /*
+    Remove:
+    isEnableFineGrainedRangePredicate
+    isEnableRewriteGroupingsetsToUnionAll
+    isCboPushDownGroupingSet
+    isEnableStatsToOptimizeSkewJoin
+    MVRewrite
+    PruneTable
+    PRUNE_UKFK_JOIN_RULES
+     */
+    private OptExpression optimizeByRule(OptExpression tree,
+                                         TaskContext rootTaskContext) {
+        tree = OptExpression.create(new LogicalTreeAnchorOperator(), tree);
+        deriveLogicalProperty(tree);
+
+        CTEContext cteContext = context.getCteContext();
+        CTEUtils.collectCteOperators(tree, context);
+
+        // inline CTE if consume use once
+        while (cteContext.hasInlineCTE()) {
+            scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.INLINE_CTE_RULES);
+            CTEUtils.collectCteOperators(tree, context);
+        }
+
+        scheduler.rewriteIterative(tree, rootTaskContext, new EliminateConstantCTERule());
+        CTEUtils.collectCteOperators(tree, context);
+
+        scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.AGGREGATE_REWRITE_RULES);
+        scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.PUSH_DOWN_SUBQUERY_RULES);
+        scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.SUBQUERY_REWRITE_COMMON_RULES);
+        scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.SUBQUERY_REWRITE_TO_WINDOW_RULES);
+        scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.SUBQUERY_REWRITE_TO_JOIN_RULES);
+        scheduler.rewriteOnce(tree, rootTaskContext, new ApplyExceptionRule());
+        CTEUtils.collectCteOperators(tree, context);
+
+        // Note: PUSH_DOWN_PREDICATE tasks should be executed before MERGE_LIMIT tasks
+        // because of the Filter node needs to be merged first to avoid the Limit node
+        // cannot merge
+        scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.PUSH_DOWN_PREDICATE_RULES);
+
+        scheduler.rewriteIterative(tree, rootTaskContext, new MergeTwoProjectRule());
+        scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.ELIMINATE_OP_WITH_CONSTANT_RULES);
+
+        scheduler.rewriteOnce(tree, rootTaskContext, new ConvertToEqualForNullRule());
+        scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.PRUNE_COLUMNS_RULES);
+        // Put EliminateAggRule after PRUNE_COLUMNS to give a chance to prune group bys before eliminate aggregations.
+        scheduler.rewriteOnce(tree, rootTaskContext, EliminateAggRule.getInstance());
+        deriveLogicalProperty(tree);
+
+        scheduler.rewriteOnce(tree, rootTaskContext, new PushDownJoinOnExpressionToChildProject());
+
+        scheduler.rewriteIterative(tree, rootTaskContext, new PruneEmptyWindowRule());
+        // @todo: resolve recursive optimization question:
+        //  MergeAgg -> PruneColumn -> PruneEmptyWindow -> MergeAgg/Project -> PruneColumn...
+        scheduler.rewriteIterative(tree, rootTaskContext, new MergeTwoAggRule());
+
+        rootTaskContext.setRequiredColumns(requiredColumns.clone());
+        scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.PRUNE_COLUMNS_RULES);
+
+        scheduler.rewriteIterative(tree, rootTaskContext, new PruneEmptyWindowRule());
+        scheduler.rewriteIterative(tree, rootTaskContext, new MergeTwoProjectRule());
+
+        // Limit push must be after the column prune,
+        // otherwise the Node containing limit may be prune
+        scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.MERGE_LIMIT_RULES);
+        scheduler.rewriteIterative(tree, rootTaskContext, new PushDownProjectLimitRule());
+
+        scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.PRUNE_ASSERT_ROW_RULES);
+        scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.PRUNE_PROJECT_RULES);
+
+        CTEUtils.collectCteOperators(tree, context);
+        if (cteContext.needOptimizeCTE()) {
+            cteContext.reset();
+            scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.COLLECT_CTE_RULES);
+            rootTaskContext.setRequiredColumns(requiredColumns.clone());
+            scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.PRUNE_COLUMNS_RULES);
+            if (cteContext.needPushLimit() || cteContext.needPushPredicate()) {
+                scheduler.rewriteOnce(tree, rootTaskContext, new PushLimitAndFilterToCTEProduceRule());
+            }
+
+            if (cteContext.needPushPredicate()) {
+                scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.PUSH_DOWN_PREDICATE_RULES);
+            }
+
+            if (cteContext.needPushLimit()) {
+                scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.MERGE_LIMIT_RULES);
+            }
+
+            scheduler.rewriteOnce(tree, rootTaskContext, new ForceCTEReuseRule());
+        }
+
+        scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.PARTITION_PRUNE_RULES);
+        scheduler.rewriteIterative(tree, rootTaskContext, new RewriteMultiDistinctRule());
+        scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.PUSH_DOWN_PREDICATE_RULES);
+        scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.PRUNE_PROJECT_RULES);
+
+        tree = pushDownAggregation(tree, rootTaskContext, requiredColumns);
+        scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.MERGE_LIMIT_RULES);
+
+        CTEUtils.collectCteOperators(tree, context);
+        // inline CTE if consume use once
+        while (cteContext.hasInlineCTE()) {
+            scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.INLINE_CTE_RULES);
+            CTEUtils.collectCteOperators(tree, context);
+        }
+
+        scheduler.rewriteIterative(tree, rootTaskContext, new MergeTwoProjectRule());
+
+        // After this rule, we shouldn't generate logical project operator
+        scheduler.rewriteIterative(tree, rootTaskContext, new MergeProjectWithChildRule());
+
+        scheduler.rewriteOnce(tree, rootTaskContext, new PushDownTopNBelowOuterJoinRule());
+        // intersect rewrite depend on statistics
+        Utils.calculateStatistics(tree, rootTaskContext.getOptimizerContext());
+        scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.INTERSECT_REWRITE_RULES);
+        scheduler.rewriteOnce(tree, rootTaskContext, new PushDownTopNBelowUnionRule());
+
+        scheduler.rewriteOnce(tree, rootTaskContext, UnionToValuesRule.getInstance());
+        deriveLogicalProperty(tree);
+
+        tree.getInputs().get(0).clearStatsAndInitOutputInfo();
+        return tree.getInputs().get(0);
+    }
+
+    private OptExpression pushDownAggregation(OptExpression tree, TaskContext rootTaskContext,
+                                              ColumnRefSet requiredColumns) {
+        boolean pushDistinctFlag = false;
+        boolean pushAggFlag = false;
+        if (context.getSessionVariable().isCboPushDownDistinctBelowWindow()) {
+            // TODO(by satanson): in future, PushDownDistinctAggregateRule and PushDownAggregateRule should be
+            //  fused one rule to tackle with all scenarios of agg push-down.
+            PushDownDistinctAggregateRule rule = new PushDownDistinctAggregateRule(rootTaskContext);
+            tree = rule.rewrite(tree, rootTaskContext);
+            pushDistinctFlag = rule.getRewriter().hasRewrite();
+        }
+
+        if (context.getSessionVariable().getCboPushDownAggregateMode() != -1) {
+            if (context.getSessionVariable().isCboPushDownAggregateOnBroadcastJoin()) {
+                // Reorder joins before applying PushDownAggregateRule to better decide where to push down aggregator.
+                // For example, do not push down a not very efficient aggregator below a very small broadcast join.
+                scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.PARTITION_PRUNE_RULES);
+                scheduler.rewriteIterative(tree, rootTaskContext, new MergeTwoProjectRule());
+                scheduler.rewriteIterative(tree, rootTaskContext, new MergeProjectWithChildRule());
+                CTEUtils.collectForceCteStatisticsOutsideMemo(tree, context);
+                deriveLogicalProperty(tree);
+                tree = new ReorderJoinRule().rewrite(tree, JoinReorderFactory.createJoinReorderAdaptive(), context);
+                tree = new SeparateProjectRule().rewrite(tree, rootTaskContext);
+                deriveLogicalProperty(tree);
+                Utils.calculateStatistics(tree, context);
+            }
+
+            PushDownAggregateRule rule = new PushDownAggregateRule(rootTaskContext);
+            rule.getRewriter().collectRewriteContext(tree);
+            if (rule.getRewriter().isNeedRewrite()) {
+                pushAggFlag = true;
+                tree = rule.rewrite(tree, rootTaskContext);
+            }
+        }
+
+        if (pushDistinctFlag || pushAggFlag) {
+            deriveLogicalProperty(tree);
+            rootTaskContext.setRequiredColumns(requiredColumns.clone());
+            scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.PRUNE_COLUMNS_RULES);
+            scheduler.rewriteOnce(tree, rootTaskContext, EliminateAggRule.getInstance());
+        }
+
+        return tree;
+    }
+
+    private void memoOptimize(Memo memo, TaskContext rootTaskContext) {
+        context.setInMemoPhase(true);
+        OptExpression tree = memo.getRootGroup().extractLogicalTree();
+        SessionVariable sessionVariable = context.getSessionVariable();
+        // add CboTablePruneRule
+        if (Utils.countJoinNodeSize(tree, CboTablePruneRule.JOIN_TYPES) < 10 &&
+                sessionVariable.isEnableCboTablePrune()) {
+            context.getRuleSet().addCboTablePruneRule();
+        }
+        // Join reorder
+        int innerCrossJoinNode = Utils.countJoinNodeSize(tree, JoinOperator.innerCrossJoinSet());
+        if (!sessionVariable.isDisableJoinReorder() && innerCrossJoinNode < sessionVariable.getCboMaxReorderNode()) {
+            if (innerCrossJoinNode > sessionVariable.getCboMaxReorderNodeUseExhaustive()) {
+                CTEUtils.collectForceCteStatistics(memo, context);
+
+                OptimizerTraceUtil.logOptExpression("before ReorderJoinRule:\n%s", tree);
+                new ReorderJoinRule().transform(tree, context);
+                OptimizerTraceUtil.logOptExpression("after ReorderJoinRule:\n%s", tree);
+
+                context.getRuleSet().addJoinCommutativityWithoutInnerRule();
+            } else {
+                if (Utils.countJoinNodeSize(tree, JoinOperator.semiAntiJoinSet()) <
+                        sessionVariable.getCboMaxReorderNodeUseExhaustive()) {
+                    context.getRuleSet().getTransformRules().add(JoinLeftAsscomRule.INNER_JOIN_LEFT_ASSCOM_RULE);
+                }
+                context.getRuleSet().addJoinTransformationRules();
+            }
+        }
+
+        if (!sessionVariable.isDisableJoinReorder() && sessionVariable.isEnableOuterJoinReorder()
+                && Utils.capableOuterReorder(tree, sessionVariable.getCboReorderThresholdUseExhaustive())) {
+            context.getRuleSet().addOuterJoinTransformationRules();
+        }
+
+        // add join implementRule
+        String joinImplementationMode = context.getSessionVariable().getJoinImplementationMode();
+        if ("merge".equalsIgnoreCase(joinImplementationMode)) {
+            context.getRuleSet().addMergeJoinImplementationRule();
+        } else if ("hash".equalsIgnoreCase(joinImplementationMode)) {
+            context.getRuleSet().addHashJoinImplementationRule();
+        } else if ("nestloop".equalsIgnoreCase(joinImplementationMode)) {
+            context.getRuleSet().addNestLoopJoinImplementationRule();
+        } else {
+            context.getRuleSet().addAutoJoinImplementationRule();
+        }
+
+        scheduler.pushTask(new OptimizeGroupTask(rootTaskContext, memo.getRootGroup()));
+        scheduler.executeTasks(rootTaskContext);
+    }
+
+    private OptExpression extractBestPlan(PhysicalPropertySet requiredProperty,
+                                          Group rootGroup) {
+        GroupExpression groupExpression = rootGroup.getBestExpression(requiredProperty);
+        if (groupExpression == null) {
+            String msg = "no executable plan for this sql. group: %s. required property: %s";
+            throw new IllegalArgumentException(String.format(msg, rootGroup, requiredProperty));
+        }
+        List<PhysicalPropertySet> inputProperties = groupExpression.getInputProperties(requiredProperty);
+
+        List<OptExpression> childPlans = Lists.newArrayList();
+        for (int i = 0; i < groupExpression.arity(); ++i) {
+            OptExpression childPlan = extractBestPlan(inputProperties.get(i), groupExpression.inputAt(i));
+            childPlans.add(childPlan);
+        }
+
+        OptExpression expression = OptExpression.create(groupExpression.getOp(), childPlans);
+        expression.setCost(groupExpression.getCost(requiredProperty));
+        expression.setRequiredProperties(inputProperties);
+        return expression;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
@@ -59,6 +59,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorEvaluator;
 import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
+import com.starrocks.sql.spm.SPMFunctions;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -193,6 +194,10 @@ public class ColumnFilterConverter {
 
         if (!checkColumnRefCanPartition(predicate.getChild(0), table)) {
             return;
+        }
+
+        if (predicate.getChildren().stream().skip(1).anyMatch(SPMFunctions::isSPMFunctions)) {
+            predicate = SPMFunctions.revertSPMFunctions(predicate);
         }
 
         if (predicate.getChildren().stream().skip(1).anyMatch(d -> !OperatorType.CONSTANT.equals(d.getOpType()))) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalRepeatOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalRepeatOperator.java
@@ -27,22 +27,25 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class LogicalRepeatOperator extends LogicalOperator {
     private List<ColumnRefOperator> outputGrouping;
     private List<List<ColumnRefOperator>> repeatColumnRefList;
     private List<List<Long>> groupingIds;
+    private Map<ColumnRefOperator, List<ColumnRefOperator>> groupingsFnArgs; // SPM use
     private boolean hasPushDown;
 
     public LogicalRepeatOperator(List<ColumnRefOperator> outputGrouping,
-                                 List<List<ColumnRefOperator>> repeatColumnRefList,
-                                 List<List<Long>> groupingIds) {
+                                 List<List<ColumnRefOperator>> repeatColumnRefList, List<List<Long>> groupingIds,
+                                 Map<ColumnRefOperator, List<ColumnRefOperator>> groupingsFnArgs) {
         super(OperatorType.LOGICAL_REPEAT);
         this.outputGrouping = outputGrouping;
         this.repeatColumnRefList = repeatColumnRefList;
         this.groupingIds = groupingIds;
         this.hasPushDown = false;
+        this.groupingsFnArgs = groupingsFnArgs;
     }
 
     private LogicalRepeatOperator() {
@@ -63,6 +66,10 @@ public class LogicalRepeatOperator extends LogicalOperator {
 
     public boolean hasPushDown() {
         return hasPushDown;
+    }
+
+    public Map<ColumnRefOperator, List<ColumnRefOperator>> getGroupingsFnArgs() {
+        return groupingsFnArgs;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalRepeatOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalRepeatOperator.java
@@ -27,17 +27,19 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class PhysicalRepeatOperator extends PhysicalOperator {
     private final List<ColumnRefOperator> outputGrouping;
     private final List<List<ColumnRefOperator>> repeatColumnRef;
     private final List<List<Long>> groupingIds;
+    private final Map<ColumnRefOperator, List<ColumnRefOperator>> groupingsFnArgs; // SPM use
 
     public PhysicalRepeatOperator(List<ColumnRefOperator> outputGrouping, List<List<ColumnRefOperator>> repeatColumnRef,
-                                  List<List<Long>> groupingIds, long limit,
-                                  ScalarOperator predicate,
-                                  Projection projection) {
+                                  List<List<Long>> groupingIds,
+                                  Map<ColumnRefOperator, List<ColumnRefOperator>> groupingsFnArgs, long limit,
+                                  ScalarOperator predicate, Projection projection) {
         super(OperatorType.PHYSICAL_REPEAT);
         this.outputGrouping = outputGrouping;
         this.repeatColumnRef = repeatColumnRef;
@@ -45,6 +47,7 @@ public class PhysicalRepeatOperator extends PhysicalOperator {
         this.limit = limit;
         this.predicate = predicate;
         this.projection = projection;
+        this.groupingsFnArgs = groupingsFnArgs;
     }
 
     @Override
@@ -77,6 +80,10 @@ public class PhysicalRepeatOperator extends PhysicalOperator {
 
     public List<List<Long>> getGroupingIds() {
         return groupingIds;
+    }
+
+    public Map<ColumnRefOperator, List<ColumnRefOperator>> getGroupingsFnArgs() {
+        return groupingsFnArgs;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
@@ -24,6 +24,7 @@ import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
+import com.starrocks.sql.spm.SPMFunctions;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -52,6 +53,9 @@ public class ReduceCastRule extends TopDownScalarOperatorRewriteRule {
 
     @Override
     public ScalarOperator visitCastOperator(CastOperator operator, ScalarOperatorRewriteContext context) {
+        if (SPMFunctions.isSPMFunctions(operator.getChild(0))) {
+            return SPMFunctions.castSPMFunctions(operator.getChild(0), operator.getType());
+        }
         // remove duplicate cast
         if (operator.getChild(0) instanceof CastOperator && checkCastTypeReduceAble(operator.getType(),
                 operator.getChild(0).getType(), operator.getChild(0).getChild(0).getType())) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
@@ -36,6 +36,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.SubqueryOperator;
 import com.starrocks.sql.optimizer.rewrite.EliminateNegationsRewriter;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
+import com.starrocks.sql.spm.SPMFunctions;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.text.StrTokenizer;
 
@@ -333,6 +334,10 @@ public class SimplifiedPredicateRule extends BottomUpScalarOperatorRewriteRule {
         }
 
         if (predicate.getChild(1) instanceof SubqueryOperator) {
+            return predicate;
+        }
+
+        if (SPMFunctions.isSPMFunctions(predicate.getChild(1))) {
             return predicate;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/RepeatImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/RepeatImplementationRule.java
@@ -35,7 +35,8 @@ public class RepeatImplementationRule extends ImplementationRule {
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalRepeatOperator repeatOperator = (LogicalRepeatOperator) input.getOp();
         PhysicalRepeatOperator physicalRepeat = new PhysicalRepeatOperator(repeatOperator.getOutputGrouping(),
-                repeatOperator.getRepeatColumnRef(), repeatOperator.getGroupingIds(), repeatOperator.getLimit(),
+                repeatOperator.getRepeatColumnRef(), repeatOperator.getGroupingIds(),
+                repeatOperator.getGroupingsFnArgs(), repeatOperator.getLimit(),
                 repeatOperator.getPredicate(), repeatOperator.getProjection());
         return Lists.newArrayList(OptExpression.create(physicalRepeat, input.getInputs()));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -27,6 +27,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
+import com.starrocks.sql.spm.SPMFunctions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -191,7 +192,9 @@ public class ExpressionStatisticCalculator {
                 return deriveBasicColStats(call);
             }
 
-            if (call.getChildren().size() == 0) {
+            if (SPMFunctions.isSPMFunctions(call)) {
+                return SPMFunctions.getSPMFunctionStatistics(call, childrenColumnStatistics).get(0);
+            } else if (call.getChildren().isEmpty()) {
                 return nullaryExpressionCalculate(call);
             } else if (call.getChildren().size() == 1) {
                 return unaryExpressionCalculate(call, childrenColumnStatistics.get(0));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
@@ -26,6 +26,7 @@ import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
+import com.starrocks.sql.spm.SPMFunctions;
 import org.apache.commons.math3.util.Precision;
 
 import java.util.List;
@@ -102,13 +103,21 @@ public class PredicateStatisticsCalculator {
             double selectivity;
 
             ScalarOperator firstChild = getChildForCastOperator(predicate.getChild(0));
-            List<ScalarOperator> otherChildrenList =
-                    predicate.getChildren().stream().skip(1).map(this::getChildForCastOperator).distinct()
-                            .collect(Collectors.toList());
             // 1. compute the inPredicate children column statistics
             ColumnStatistic inColumnStatistic = getExpressionStatistic(firstChild);
+
+            List<ScalarOperator> children = predicate.getChildren();
+            List<ScalarOperator> otherChildrenList = predicate.getChildren().stream().skip(1).toList();
+            if (children.size() == 2 && SPMFunctions.isSPMFunctions(children.get(1))) {
+                otherChildrenList = children.get(1).getChildren().stream().skip(1).collect(Collectors.toList());
+                if (otherChildrenList.isEmpty()) {
+                    return statistics;
+                }
+            }
+            otherChildrenList = otherChildrenList.stream().map(this::getChildForCastOperator).distinct().collect(
+                    Collectors.toList());
             List<ColumnStatistic> otherChildrenColumnStatisticList =
-                    otherChildrenList.stream().distinct().map(this::getExpressionStatistic).collect(Collectors.toList());
+                    otherChildrenList.stream().distinct().map(this::getExpressionStatistic).toList();
 
             // using ndv to estimate string col inPredicate
             if (!predicate.isNotIn() && firstChild.getType().getPrimitiveType().isCharFamily()

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/OptExpressionValidator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/OptExpressionValidator.java
@@ -51,12 +51,6 @@ public class OptExpressionValidator extends OptExpressionVisitor<OptExpression, 
     }
 
     public void validate(OptExpression root) {
-        // TODO(packy92)
-        //  The tree-based rewriting rules in RBO may modify the child node but not update the
-        //  parent node, resulting in the statistical cache calculated by the previous rules
-        //  not being refreshed, which may affect the calculation of statistical information in memo.
-        //  Just clear it before into memo.
-        root.clearStatsAndInitOutputInfo();
         visit(root, null);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMFunctions.java
@@ -1,0 +1,135 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.spm;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.FunctionCallExpr;
+import com.starrocks.analysis.FunctionName;
+import com.starrocks.analysis.IntLiteral;
+import com.starrocks.catalog.Function;
+import com.starrocks.catalog.ScalarFunction;
+import com.starrocks.catalog.Type;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.List;
+import java.util.Set;
+
+// SPMFunction to mark the variables in plan
+public class SPMFunctions {
+    // spm function: NULL_TYPE _spm_xxx(placeholderID, actual parameters),
+    // the actual parameters used to compute statistics
+    // NULL_TYPE _spm_const_list(placeholderID)
+    static final String CONST_LIST_FUNC = "_spm_const_list";
+    // NULL_TYPE _spm_const_var(placeholderID)
+    static final String CONST_VAR_FUNC = "_spm_const_var";
+
+    // for ut test
+    public static boolean enableSPMParamsPrint = false;
+
+    private static final Set<String> SPM_FUNCTIONS = Set.of(CONST_LIST_FUNC, CONST_VAR_FUNC);
+
+    public static Function getSPMFunction(String fnName) {
+        return getSPMFunction(fnName, Type.NULL);
+    }
+
+    private static Function getSPMFunction(String fnName, Type type) {
+        if (!SPM_FUNCTIONS.contains(StringUtils.lowerCase(fnName))) {
+            return null;
+        }
+
+        return new ScalarFunction(new FunctionName(StringUtils.lowerCase(fnName)),
+                new Type[] {Type.BIGINT}, type, false);
+    }
+
+    public static FunctionCallExpr newFunc(String func, long placeholderID, List<Expr> children) {
+        FunctionCallExpr expr =
+                new FunctionCallExpr(func, Lists.newArrayList(new IntLiteral(placeholderID, Type.BIGINT)));
+        expr.setFn(getSPMFunction(func, Type.NULL));
+        expr.setType(Type.NULL);
+        expr.addChildren(children);
+        return expr;
+    }
+
+    public static boolean isSPMFunctions(Expr expr) {
+        if (!(expr instanceof FunctionCallExpr)) {
+            return false;
+        }
+
+        return SPM_FUNCTIONS.contains(((FunctionCallExpr) expr).getFnName()
+                .getFunction().toLowerCase());
+    }
+
+    public static boolean isSPMFunctions(ScalarOperator operator) {
+        if (!(operator.getOpType() == OperatorType.CALL)) {
+            return false;
+        }
+
+        return SPM_FUNCTIONS.contains(((CallOperator) operator).getFnName().toLowerCase());
+    }
+
+    public static ScalarOperator castSPMFunctions(ScalarOperator operator, Type type) {
+        CallOperator call = (CallOperator) operator;
+        call.setType(type);
+        call.setFunction(getSPMFunction(call.getFunction().functionName(), type));
+        for (int i = 1; i < call.getChildren().size(); i++) {
+            call.setChild(i, new CastOperator(type, call.getChild(i)));
+        }
+        return call;
+    }
+
+    // SPM operator revert to scalar operator
+    public static ScalarOperator revertSPMFunctions(ScalarOperator operator) {
+        ScalarOperator clone = operator.clone();
+        List<ScalarOperator> newChildren = Lists.newArrayList();
+        for (ScalarOperator child : clone.getChildren()) {
+            if (!isSPMFunctions(child)) {
+                newChildren.add(child);
+            } else {
+                CallOperator call = (CallOperator) child;
+                if (call.getChildren().size() <= 1) {
+                    return operator;
+                } else {
+                    call.getChildren().stream().skip(1).forEach(newChildren::add);
+                }
+            }
+        }
+        clone.getChildren().clear();
+        clone.getChildren().addAll(newChildren);
+        return clone;
+    }
+
+    public static String toSQL(String function, List<String> children) {
+        if (enableSPMParamsPrint) {
+            return function + "(" + String.join(", ", children) + ")";
+        }
+        return function + "(" + children.get(0) + ")";
+    }
+
+    public static List<ColumnStatistic> getSPMFunctionStatistics(CallOperator operator,
+                                                                 List<ColumnStatistic> children) {
+        Preconditions.checkState(CONST_VAR_FUNC.equals(operator.getFnName()));
+        if (children.size() <= 1) {
+            return List.of(ColumnStatistic.unknown());
+        }
+        return List.of(children.get(1));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

* SPMOptimizer: remove unuse rules (prune table relation/MV/physical rule)
* **SPMFunctions**: SPM core code, use to mark the replaced expressions/literal, and to bind real values in query
  now, support `_spm_const_var` to mark `LiteralExpr`, `_spm_const_list` to mark a list of `ConstantExpr`
  the function signature: `_spm_xx(id, arguments)`, 
  
  The first parameter is placeholderID, used to mark different expressions. The other parameters are define by SPMFunction. The parameters of _spm_const_var and _spm_const_list are the original expressions that have been replaced, will use in statsitics calculate.

  we can support different feature by more and more SPMFunction in future, like `_spm_range_var(id, min, max)` to limit the range of expr, `_spm_enum_var(id, enum...)` to limit the value of expr

* Analyzer: support SPMFunctions analyzer
* Statistic: support SPMFunctions
* ScalarOperatorRule: forbidden optimize SPMFunctions
* PartitionPrune: support SPMFunctions
* RepeatOperator: recorde grouping function to print SQL

## What I'm doing:

Fixes https://github.com/StarRocks/starrocks/issues/56310

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0