### PR TITLE
[Enhancement] Support percentile_approx_weighted function

### DIFF
--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -159,7 +159,8 @@ void AggregatorParams::init() {
         VLOG_ROW << fn.name.function_name << ", arg nullable " << desc.nodes[0].has_nullable_child
                  << ", result nullable " << desc.nodes[0].is_nullable;
 
-        if (fn.name.function_name == FUNCTION_COUNT) {
+        auto& func_name = fn.name.function_name;
+        if (func_name == FUNCTION_COUNT) {
             // count function is always not nullable
             agg_fn_types[i] = {TypeDescriptor(TYPE_BIGINT), TypeDescriptor(TYPE_BIGINT), {}, false, false};
         } else {
@@ -175,9 +176,8 @@ void AggregatorParams::init() {
             TypeDescriptor return_type = TypeDescriptor::from_thrift(fn.ret_type);
             TypeDescriptor serde_type = TypeDescriptor::from_thrift(fn.aggregate_fn.intermediate_type);
             agg_fn_types[i] = {return_type, serde_type, arg_typedescs, has_nullable_child, is_nullable};
-            agg_fn_types[i].is_always_nullable_result =
-                    ALWAYS_NULLABLE_RESULT_AGG_FUNCS.contains(fn.name.function_name);
-            if (fn.name.function_name == "array_agg" || fn.name.function_name == "group_concat") {
+            agg_fn_types[i].is_always_nullable_result = ALWAYS_NULLABLE_RESULT_AGG_FUNCS.contains(func_name);
+            if (func_name == "array_agg" || func_name == "group_concat") {
                 // set order by info
                 if (fn.aggregate_fn.__isset.is_asc_order && fn.aggregate_fn.__isset.nulls_first &&
                     !fn.aggregate_fn.is_asc_order.empty()) {

--- a/be/src/exprs/agg/array_agg.h
+++ b/be/src/exprs/agg/array_agg.h
@@ -115,7 +115,7 @@ struct ArrayAggAggregateState {
 };
 
 template <LogicalType LT, bool is_distinct, typename MyHashSet = std::set<int>>
-class ArrayAggAggregateFunction
+class ArrayAggAggregateFunction final
         : public AggregateFunctionBatchHelper<ArrayAggAggregateState<LT, is_distinct, MyHashSet>,
                                               ArrayAggAggregateFunction<LT, is_distinct, MyHashSet>> {
 public:
@@ -226,7 +226,7 @@ struct ArrayAggAggregateStateV2 {
     Columns data_columns;
 };
 
-class ArrayAggAggregateFunctionV2
+class ArrayAggAggregateFunctionV2 final
         : public AggregateFunctionBatchHelper<ArrayAggAggregateStateV2, ArrayAggAggregateFunctionV2> {
 public:
     void create(FunctionContext* ctx, AggDataPtr __restrict ptr) const override {

--- a/be/src/exprs/agg/array_union_agg.h
+++ b/be/src/exprs/agg/array_union_agg.h
@@ -105,7 +105,7 @@ struct ArrayUnionAggAggregateState {
 };
 
 template <LogicalType LT, bool is_distinct, typename MyHashSet = std::set<int>>
-class ArrayUnionAggAggregateFunction
+class ArrayUnionAggAggregateFunction final
         : public AggregateFunctionBatchHelper<ArrayUnionAggAggregateState<LT, is_distinct, MyHashSet>,
                                               ArrayUnionAggAggregateFunction<LT, is_distinct, MyHashSet>> {
 public:

--- a/be/src/exprs/agg/distinct.h
+++ b/be/src/exprs/agg/distinct.h
@@ -433,15 +433,15 @@ public:
 };
 
 template <LogicalType LT, AggDistinctType DistinctType, typename T = RunTimeCppType<LT>>
-class DistinctAggregateFunction
+class DistinctAggregateFunction final
         : public TDistinctAggregateFunction<LT, SumResultLT<LT>, DistinctAggregateState, DistinctType, T> {};
 
 template <LogicalType LT, AggDistinctType DistinctType, typename T = RunTimeCppType<LT>>
-class DistinctAggregateFunctionV2
+class DistinctAggregateFunctionV2 final
         : public TDistinctAggregateFunction<LT, SumResultLT<LT>, DistinctAggregateStateV2, DistinctType, T> {};
 
 template <LogicalType LT, AggDistinctType DistinctType, typename T = RunTimeCppType<LT>>
-class DecimalDistinctAggregateFunction
+class DecimalDistinctAggregateFunction final
         : public TDistinctAggregateFunction<LT, TYPE_DECIMAL128, DistinctAggregateStateV2, DistinctType, T> {};
 
 // now we only support String

--- a/be/src/exprs/agg/factory/aggregate_factory.cpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.cpp
@@ -72,6 +72,10 @@ AggregateFunctionPtr AggregateFactory::MakePercentileApproxAggregateFunction() {
     return std::make_shared<PercentileApproxAggregateFunction>();
 }
 
+AggregateFunctionPtr AggregateFactory::MakePercentileApproxWeightedAggregateFunction() {
+    return std::make_shared<PercentileApproxWeightedAggregateFunction>();
+}
+
 AggregateFunctionPtr AggregateFactory::MakePercentileUnionAggregateFunction() {
     return std::make_shared<PercentileUnionAggregateFunction>();
 }

--- a/be/src/exprs/agg/factory/aggregate_factory.hpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.hpp
@@ -197,6 +197,8 @@ public:
 
     static AggregateFunctionPtr MakePercentileApproxAggregateFunction();
 
+    static AggregateFunctionPtr MakePercentileApproxWeightedAggregateFunction();
+
     static AggregateFunctionPtr MakePercentileUnionAggregateFunction();
 
     template <LogicalType LT>

--- a/be/src/exprs/agg/factory/aggregate_resolver_others.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_others.cpp
@@ -52,6 +52,12 @@ void AggregateFuncResolver::register_others() {
                                                             AggregateFactory::MakePercentileApproxAggregateFunction());
     add_aggregate_mapping_notnull<TYPE_DOUBLE, TYPE_DOUBLE>("percentile_approx", false,
                                                             AggregateFactory::MakePercentileApproxAggregateFunction());
+
+    add_aggregate_mapping_notnull<TYPE_BIGINT, TYPE_DOUBLE>(
+            "percentile_approx_weighted", false, AggregateFactory::MakePercentileApproxWeightedAggregateFunction());
+    add_aggregate_mapping_notnull<TYPE_DOUBLE, TYPE_DOUBLE>(
+            "percentile_approx_weighted", false, AggregateFactory::MakePercentileApproxWeightedAggregateFunction());
+
     add_aggregate_mapping<TYPE_PERCENTILE, TYPE_PERCENTILE, PercentileValue>(
             "percentile_union", false, AggregateFactory::MakePercentileUnionAggregateFunction());
 

--- a/be/src/exprs/agg/factory/aggregate_resolver_others.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_others.cpp
@@ -48,14 +48,14 @@ struct LowCardPercentileDispatcher {
 };
 
 void AggregateFuncResolver::register_others() {
-    add_aggregate_mapping_notnull<TYPE_BIGINT, TYPE_DOUBLE>("percentile_approx", false,
-                                                            AggregateFactory::MakePercentileApproxAggregateFunction());
-    add_aggregate_mapping_notnull<TYPE_DOUBLE, TYPE_DOUBLE>("percentile_approx", false,
-                                                            AggregateFactory::MakePercentileApproxAggregateFunction());
+    add_aggregate_mapping_variadic<TYPE_BIGINT, TYPE_DOUBLE, PercentileApproxState>(
+            "percentile_approx", false, AggregateFactory::MakePercentileApproxAggregateFunction());
+    add_aggregate_mapping_variadic<TYPE_DOUBLE, TYPE_DOUBLE, PercentileApproxState>(
+            "percentile_approx", false, AggregateFactory::MakePercentileApproxAggregateFunction());
 
-    add_aggregate_mapping_notnull<TYPE_BIGINT, TYPE_DOUBLE>(
+    add_aggregate_mapping_variadic<TYPE_BIGINT, TYPE_DOUBLE, PercentileApproxState>(
             "percentile_approx_weighted", false, AggregateFactory::MakePercentileApproxWeightedAggregateFunction());
-    add_aggregate_mapping_notnull<TYPE_DOUBLE, TYPE_DOUBLE>(
+    add_aggregate_mapping_variadic<TYPE_DOUBLE, TYPE_DOUBLE, PercentileApproxState>(
             "percentile_approx_weighted", false, AggregateFactory::MakePercentileApproxWeightedAggregateFunction());
 
     add_aggregate_mapping<TYPE_PERCENTILE, TYPE_PERCENTILE, PercentileValue>(

--- a/be/src/exprs/agg/group_concat.h
+++ b/be/src/exprs/agg/group_concat.h
@@ -42,7 +42,7 @@ struct GroupConcatAggregateState {
 
 template <LogicalType LT, typename T = RunTimeCppType<LT>, LogicalType ResultLT = GroupConcatResultLT<LT>,
           typename TResult = RunTimeCppType<ResultLT>>
-class GroupConcatAggregateFunction
+class GroupConcatAggregateFunction final
         : public AggregateFunctionBatchHelper<GroupConcatAggregateState,
                                               GroupConcatAggregateFunction<LT, T, ResultLT, TResult>> {
 public:
@@ -336,7 +336,7 @@ struct GroupConcatAggregateStateV2 {
 // group_concat(cast(a to string), cast(b to string) order by a, b), resulting to keeping 4 columns, but it only needs
 // keep 2 columns in intermediate results.
 // 3. refactor order-by and distinct function to a combinator to clean the code.
-class GroupConcatAggregateFunctionV2
+class GroupConcatAggregateFunctionV2 final
         : public AggregateFunctionBatchHelper<GroupConcatAggregateStateV2, GroupConcatAggregateFunctionV2> {
 public:
     // group_concat(a, b order by c, d), the arguments are a,b,',',c,d

--- a/be/src/exprs/agg/intersect_count.h
+++ b/be/src/exprs/agg/intersect_count.h
@@ -56,7 +56,7 @@ using BitmapRuntimeCppType = typename BitmapIntersectInternalKey<LT>::InternalKe
 
 template <LogicalType LT, typename T = BitmapRuntimeCppType<LT>, LogicalType ResultLT = IntersectCountResultLT<LT>,
           typename TResult = RunTimeCppType<ResultLT>>
-class IntersectCountAggregateFunction
+class IntersectCountAggregateFunction final
         : public AggregateFunctionBatchHelper<BitmapIntersectAggregateState<BitmapRuntimeCppType<LT>>,
                                               IntersectCountAggregateFunction<LT, T, ResultLT, TResult>> {
 public:

--- a/be/src/exprs/agg/mann_whitney.h
+++ b/be/src/exprs/agg/mann_whitney.h
@@ -199,7 +199,7 @@ private:
     }
 };
 
-class MannWhitneyUTestAggregateFunction
+class MannWhitneyUTestAggregateFunction final
         : public AggregateFunctionBatchHelper<MannWhitneyAggregateState, MannWhitneyUTestAggregateFunction> {
 public:
     using DataColumn = RunTimeColumnType<TYPE_DOUBLE>;

--- a/be/src/exprs/agg/percentile_approx.h
+++ b/be/src/exprs/agg/percentile_approx.h
@@ -48,17 +48,8 @@ public:
     virtual double get_compression_factor(FunctionContext* ctx) const = 0;
 
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
-        Slice src;
-        if (column->is_nullable()) {
-            if (column->is_null(row_num)) {
-                return;
-            }
-            const auto* nullable_column = down_cast<const NullableColumn*>(column);
-            src = nullable_column->data_column()->get(row_num).get_slice();
-        } else {
-            const auto* binary_column = down_cast<const BinaryColumn*>(column);
-            src = binary_column->get_slice(row_num);
-        }
+        const auto* binary_column = down_cast<const BinaryColumn*>(column);
+        Slice src = binary_column->get_slice(row_num);
         double quantile;
         memcpy(&quantile, src.data, sizeof(double));
 
@@ -78,41 +69,18 @@ public:
         uint8_t result[size + sizeof(double)];
         memcpy(result, &(data(state).targetQuantile), sizeof(double));
         data(state).percentile->serialize(result + sizeof(double));
-
-        if (to->is_nullable()) {
-            auto* column = down_cast<NullableColumn*>(to);
-            if (data(state).is_null) {
-                column->append_default();
-            } else {
-                down_cast<BinaryColumn*>(column->data_column().get())->append(Slice(result, size));
-                column->null_column_data().push_back(0);
-            }
-        } else {
-            auto* column = down_cast<BinaryColumn*>(to);
-            column->append(Slice(result, size));
-        }
+        auto* column = down_cast<BinaryColumn*>(to);
+        column->append(Slice(result, size));
     }
 
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
-        if (to->is_nullable()) {
-            auto* nullable_column = down_cast<NullableColumn*>(to);
-            if (data(state).is_null) {
-                nullable_column->append_default();
-                return;
-            }
-
-            double result = data(state).percentile->quantile(data(state).targetQuantile);
-            (void)nullable_column->data_column()->append_numbers(&result, sizeof(result));
-            nullable_column->null_column_data().push_back(0);
-        } else {
-            auto* data_column = down_cast<DoubleColumn*>(to);
-            if (data(state).is_null) {
-                return;
-            }
-
-            double result = data(state).percentile->quantile(data(state).targetQuantile);
-            data_column->append_numbers(&result, sizeof(result));
+        auto* data_column = down_cast<DoubleColumn*>(to);
+        if (data(state).is_null) {
+            data_column->append_default();
+            return;
         }
+        double result = data(state).percentile->quantile(data(state).targetQuantile);
+        data_column->append_numbers(&result, sizeof(result));
     }
 };
 
@@ -212,23 +180,24 @@ public:
         // argument 0
         const auto* data_column = down_cast<const DoubleColumn*>(columns[0]);
         // argument 1: weight can be const or int64 column
-        auto weight_viewer = ColumnViewer<TYPE_BIGINT>(columns[1]);
-        int64_t weight = weight_viewer.value(row_num);
+        size_t real_row_num = columns[1]->is_constant() ? 0 : row_num;
+        int64_t weight = columns[1]->get(real_row_num).get_int64();
         // argument 2
+        DCHECK(columns[2]->is_constant());
         if (columns[2]->only_null()) {
             ctx->set_error("For percentile_approx the second argument is expected to be non-null.", false);
             return;
         }
         DCHECK(!columns[2]->is_null(0));
+        data(state).targetQuantile = columns[2]->get(0).get_double();
+
         double column_value = data_column->get_data()[row_num];
         int64_t prev_memory = data(state).percentile->mem_usage();
-
         // add value with weight
-        data(state).targetQuantile = columns[2]->get(0).get_double();
-        data(state).is_null = false;
         if (LIKELY(weight != 0)) {
             data(state).percentile->add(implicit_cast<float>(column_value), weight);
         }
+        data(state).is_null = false;
         ctx->add_mem_usage(data(state).percentile->mem_usage() - prev_memory);
     }
 
@@ -236,34 +205,59 @@ public:
                                      ColumnPtr* dst) const override {
         // argument 0
         const auto* data_column = down_cast<const DoubleColumn*>(src[0].get());
-        // argument 1, weight column can be int64 or const column
-        auto weight_viewer = ColumnViewer<TYPE_BIGINT>(src[1]);
         // argument 2
         DCHECK(src[2]->is_constant());
-        const auto* const_column = down_cast<const ConstColumn*>(src[2].get());
-        double quantile = const_column->get(0).get_double();
+        double quantile = src[2]->get(0).get_double();
         // result
         BinaryColumn* result = down_cast<BinaryColumn*>((*dst).get());
         Bytes& bytes = result->get_bytes();
         bytes.reserve(chunk_size * 20);
         result->get_offset().resize(chunk_size + 1);
 
+        // argument 1, weight column can be int64 or const column
         // serialize percentile one by one
         size_t old_size = bytes.size();
-        for (size_t i = 0; i < chunk_size; ++i) {
-            PercentileValue percentile;
-            double value = data_column->get_data()[i];
-            int64_t weight = weight_viewer.value(i);
+        if (src[1]->is_constant()) {
+            int64_t weight = src[1]->get(0).get_int64();
             if (LIKELY(weight != 0)) {
-                percentile.add(value, weight);
+                for (size_t i = 0; i < chunk_size; ++i) {
+                    PercentileValue percentile;
+                    double value = data_column->get_data()[i];
+                    percentile.add(value, weight);
+                    size_t new_size = old_size + sizeof(double) + percentile.serialize_size();
+                    bytes.resize(new_size);
+                    memcpy(bytes.data() + old_size, &quantile, sizeof(double));
+                    percentile.serialize(bytes.data() + old_size + sizeof(double));
+                    old_size = new_size;
+                    result->get_offset()[i + 1] = new_size;
+                }
+            } else {
+                for (size_t i = 0; i < chunk_size; ++i) {
+                    PercentileValue percentile;
+                    size_t new_size = old_size + sizeof(double) + percentile.serialize_size();
+                    bytes.resize(new_size);
+                    memcpy(bytes.data() + old_size, &quantile, sizeof(double));
+                    percentile.serialize(bytes.data() + old_size + sizeof(double));
+                    old_size = new_size;
+                    result->get_offset()[i + 1] = new_size;
+                }
             }
-            size_t new_size = old_size + sizeof(double) + percentile.serialize_size();
-            bytes.resize(new_size);
-            memcpy(bytes.data() + old_size, &quantile, sizeof(double));
-            percentile.serialize(bytes.data() + old_size + sizeof(double));
-
-            result->get_offset()[i + 1] = new_size;
-            old_size = new_size;
+        } else {
+            const auto* weight_column = down_cast<const Int64Column*>(src[1].get());
+            for (size_t i = 0; i < chunk_size; ++i) {
+                int64_t weight = weight_column->get_data()[i];
+                PercentileValue percentile;
+                double value = data_column->get_data()[i];
+                if (LIKELY(weight != 0)) {
+                    percentile.add(value, weight);
+                }
+                size_t new_size = old_size + sizeof(double) + percentile.serialize_size();
+                bytes.resize(new_size);
+                memcpy(bytes.data() + old_size, &quantile, sizeof(double));
+                percentile.serialize(bytes.data() + old_size + sizeof(double));
+                old_size = new_size;
+                result->get_offset()[i + 1] = new_size;
+            }
         }
     }
     std::string get_name() const override { return "percentile_approx_weighted"; }

--- a/be/src/util/percentile_value.h
+++ b/be/src/util/percentile_value.h
@@ -36,6 +36,8 @@ public:
 
     void add(float value) { _tdigest.add(value); }
 
+    void add(float value, int64_t weight) { _tdigest.add(value, static_cast<float>(weight)); }
+
     void merge(const PercentileValue* other) { _tdigest.merge(&other->_tdigest); }
 
     uint64_t serialize_size() const {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -265,6 +265,7 @@ public class FunctionSet {
     public static final String MIN_BY_V2 = "min_by_v2";
     public static final String MIN = "min";
     public static final String PERCENTILE_APPROX = "percentile_approx";
+    public static final String PERCENTILE_APPROX_WEIGHTED = "percentile_approx_weighted";
     public static final String PERCENTILE_CONT = "percentile_cont";
     public static final String PERCENTILE_DISC = "percentile_disc";
     public static final String LC_PERCENTILE_DISC = "percentile_disc_lc";
@@ -1545,6 +1546,14 @@ public class FunctionSet {
                 false, false, false));
         addBuiltin(AggregateFunction.createBuiltin(PERCENTILE_APPROX,
                 Lists.newArrayList(Type.DOUBLE, Type.DOUBLE, Type.DOUBLE), Type.DOUBLE, Type.VARBINARY,
+                false, false, false));
+        // percentile_approx_weighted
+        addBuiltin(AggregateFunction.createBuiltin(PERCENTILE_APPROX_WEIGHTED,
+                Lists.newArrayList(Type.DOUBLE, Type.BIGINT, Type.DOUBLE), Type.DOUBLE, Type.VARBINARY,
+                false, false, false));
+        // percentile_approx_weighted
+        addBuiltin(AggregateFunction.createBuiltin(PERCENTILE_APPROX_WEIGHTED,
+                Lists.newArrayList(Type.DOUBLE, Type.BIGINT, Type.DOUBLE, Type.DOUBLE), Type.DOUBLE, Type.VARBINARY,
                 false, false, false));
 
         addBuiltin(AggregateFunction.createBuiltin(PERCENTILE_UNION,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -427,7 +427,8 @@ public class FunctionAnalyzer {
         }
 
         if (fnName.getFunction().equals(FunctionSet.PERCENTILE_APPROX)) {
-            if (functionCallExpr.getChildren().size() != 2 && functionCallExpr.getChildren().size() != 3) {
+            List<Expr> children = functionCallExpr.getChildren();
+            if (children.size() != 2 && children.size() != 3) {
                 throw new SemanticException("percentile_approx(expr, DOUBLE [, B]) requires two or three parameters",
                         functionCallExpr.getPos());
             }
@@ -438,11 +439,36 @@ public class FunctionAnalyzer {
             if (!functionCallExpr.getChild(1).getType().isNumericType()) {
                 throw new SemanticException("percentile_approx requires the second parameter's type is numeric type");
             }
-
-            if (functionCallExpr.getChildren().size() == 3) {
+            if (children.size() == 3) {
                 if (!functionCallExpr.getChild(2).getType().isNumericType()) {
                     throw new SemanticException(
                             "percentile_approx requires the third parameter's type is numeric type");
+                }
+            }
+        }
+
+        if (fnName.getFunction().equals(FunctionSet.PERCENTILE_APPROX_WEIGHTED)) {
+            List<Expr> children = functionCallExpr.getChildren();
+            if (children.size() != 3 && children.size() != 4) {
+                throw new SemanticException("percentile_approx(expr, DOUBLE [, B]) requires two or three parameters",
+                        functionCallExpr.getPos());
+            }
+            if (!functionCallExpr.getChild(0).getType().isNumericType()) {
+                throw new SemanticException(
+                        "percentile_approx requires the first parameter's type is numeric type");
+            }
+            // 1th column cannot be constant
+            if (!functionCallExpr.getChild(1).getType().isNumericType()) {
+                throw new SemanticException("percentile_approx requires the second parameter's type is bigint type column");
+            }
+            if (!functionCallExpr.getChild(2).getType().isNumericType()) {
+                throw new SemanticException(
+                        "percentile_approx requires the third parameter's type is numeric type");
+            }
+            if (children.size() == 4) {
+                if (!functionCallExpr.getChild(3).getType().isNumericType()) {
+                    throw new SemanticException(
+                            "percentile_approx requires the fourth parameter's type is numeric type");
                 }
             }
         }

--- a/test/sql/test_agg_function/R/test_percentile_approx_weighted
+++ b/test/sql/test_agg_function/R/test_percentile_approx_weighted
@@ -1,7 +1,18 @@
 -- name: test_percentile_approx 
 CREATE TABLE t1 (
     c1 int,
-    c2 double
+    c2 double,
+    c3 tinyint,
+    c4 int,
+    c5 bigint,
+    c6 largeint,
+    c7 string,
+    c8 double,
+    c9 date,
+    c10 datetime,
+    c11 array<int>,
+    c12 map<double, double>,
+    c13 struct<a bigint, b double>
     )
 DUPLICATE KEY(c1)
 DISTRIBUTED BY HASH(c1)
@@ -9,16 +20,42 @@ BUCKETS 1
 PROPERTIES ("replication_num" = "1");
 -- result:
 -- !result
-insert into t1 select generate_series, generate_series from table(generate_series(1, 50000, 3));
+insert into t1 
+    select generate_series, generate_series,  11, 111, 1111, 11111, "111111", 1.1, "2024-09-01", "2024-09-01 18:00:00", [1, 2, 3], map(1, 5.5), row(100, 100)
+    from table(generate_series(1, 50000, 3));
 -- result:
+-- !result
+insert into t1 values
+    (1, 1, 11, 111, 1111, 11111, "111111", 1.1, "2024-09-01", "2024-09-01 18:00:00", [1, 2, 3], map(1, 5.5), row(100, 100)),
+    (2, 2, 22, 222, 2222, 22222, "222222", 2.2, "2024-09-02", "2024-09-02 11:00:00", [3, 4, 5], map(1, 511.2), row(200, 200)),
+    (3, 3, 33, 333, 3333, 33333, "333333", 3.3,  "2024-09-03", "2024-09-03 00:00:00", [4, 1, 2], map(1, 666.6), row(300, 300)),
+    (4, 4, 11, 444, 4444, 44444, "444444", 4.4, "2024-09-04", "2024-09-04 12:00:00", [7, 7, 5], map(1, 444.4), row(400, 400)),
+    (5, null, null, null, null, null, null, null, null, null, null, null, null);
+-- result:
+-- !result
+select percentile_approx_weighted(c1, c2, 0.5) from t1;
+-- result:
+35355.9765625
+-- !result
+select percentile_approx_weighted(c1, 1, 0.9) from t1;
+-- result:
+44998.8984375
+-- !result
+select percentile_approx_weighted(c1, NULL, 0.9) from t1;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: percentile_approx requires the second parameter's type is bigint type column.")
+-- !result
+select percentile_approx_weighted(c1, c1, 0.9, 10000) from t1;
+-- result:
+47435.01171875
 -- !result
 select percentile_approx_weighted(c2, c1, 0.5) from t1;
 -- result:
-35355.97265625
+35355.9765625
 -- !result
 select percentile_approx_weighted(c2, 1, 0.9) from t1;
 -- result:
-45000.3984375
+44999.1953125
 -- !result
 select percentile_approx_weighted(c2, 0, 0.9, 2048) from t1;
 -- result:
@@ -26,22 +63,163 @@ select percentile_approx_weighted(c2, 0, 0.9, 2048) from t1;
 -- !result
 select percentile_approx_weighted(c2, 10, 0.9, 5000) from t1;
 -- result:
-45000.3984375
+44999.19921875
 -- !result
 select percentile_approx_weighted(c2, c1, 0.9, 10000) from t1;
 -- result:
 47435.01171875
+-- !result
+select percentile_approx_weighted(c3, c1, 0.5) from t1;
+-- result:
+11.0
+-- !result
+select percentile_approx_weighted(c3, 1, 0.9) from t1;
+-- result:
+11.0
+-- !result
+select percentile_approx_weighted(c3, 0, 0.9, 2048) from t1;
+-- result:
+33.0
+-- !result
+select percentile_approx_weighted(c3, 10, 0.9, 5000) from t1;
+-- result:
+11.0
+-- !result
+select percentile_approx_weighted(c3, c1, 0.9, 10000) from t1;
+-- result:
+11.0
+-- !result
+select percentile_approx_weighted(c4, c1, 0.5) from t1;
+-- result:
+111.0
+-- !result
+select percentile_approx_weighted(c4, 1, 0.9) from t1;
+-- result:
+111.0
+-- !result
+select percentile_approx_weighted(c4, 0, 0.9, 2048) from t1;
+-- result:
+444.0
+-- !result
+select percentile_approx_weighted(c4, 10, 0.9, 5000) from t1;
+-- result:
+111.0
+-- !result
+select percentile_approx_weighted(c4, c1, 0.9, 10000) from t1;
+-- result:
+111.0
+-- !result
+select percentile_approx_weighted(c5, c1, 0.5) from t1;
+-- result:
+1111.0
+-- !result
+select percentile_approx_weighted(c5, c1, 0.9, 10000) from t1;
+-- result:
+1111.0
+-- !result
+select percentile_approx_weighted(c5, 1, 0.9) from t1;
+-- result:
+1111.0
+-- !result
+select percentile_approx_weighted(c5, 0, 0.9, 2048) from t1;
+-- result:
+4444.0
+-- !result
+select percentile_approx_weighted(c5, 10, 0.9, 5000) from t1;
+-- result:
+1111.0
+-- !result
+select percentile_approx_weighted(c6, c1, 0.5) from t1;
+-- result:
+11111.0
+-- !result
+select percentile_approx_weighted(c6, c1, 0.9, 10000) from t1; 
+select percentile_approx_weighted(c6, 1, 0.9) from t1;
+-- result:
+11111.0
+-- !result
+select percentile_approx_weighted(c6, 0, 0.9, 2048) from t1;
+-- result:
+44444.0
+-- !result
+select percentile_approx_weighted(c6, 10, 0.9, 5000) from t1;
+-- result:
+11111.0
+-- !result
+select percentile_approx_weighted(c7, c1, 0.5) from t1;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: percentile_approx requires the first parameter's type is numeric type.")
+-- !result
+select percentile_approx_weighted(c9, c1, 0.5) from t1;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: percentile_approx requires the first parameter's type is numeric type.")
+-- !result
+select percentile_approx_weighted(c10, c1, 0.5) from t1;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: percentile_approx requires the first parameter's type is numeric type.")
+-- !result
+select percentile_approx_weighted(c11[0], c1, 0.5) from t1;
+-- result:
+None
+-- !result
+select percentile_approx_weighted(c11[0], 1, 0.5) from t1;
+-- result:
+None
+-- !result
+select percentile_approx_weighted(c12[1], c1, 0.5) from t1;
+-- result:
+5.5
+-- !result
+select percentile_approx_weighted(c12[2], c1, 0.5) from t1;
+-- result:
+None
+-- !result
+select percentile_approx_weighted(c12[1], 1, 0.5) from t1;
+-- result:
+5.5
+-- !result
+select percentile_approx_weighted(c13.a, c1, 0.5) from t1;
+-- result:
+100.0
+-- !result
+select percentile_approx_weighted(c13.b, c1, 0.5) from t1;
+-- result:
+100.0
+-- !result
+select percentile_approx_weighted(c13.a, 1, 0.5) from t1;
+-- result:
+100.0
+-- !result
+select percentile_approx_weighted(c13.b, 1, 0.5) from t1;
+-- result:
+100.0
 -- !result
 set pipeline_dop=1;
 -- result:
 -- !result
+select percentile_approx_weighted(c1, c2, 0.5) from t1;
+-- result:
+35355.9765625
+-- !result
+select percentile_approx_weighted(c1, 1, 0.9) from t1;
+-- result:
+44998.8984375
+-- !result
+select percentile_approx_weighted(c1, NULL, 0.9) from t1;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: percentile_approx requires the second parameter's type is bigint type column.")
+-- !result
+select percentile_approx_weighted(c1, c1, 0.9, 10000) from t1;
+-- result:
+47435.01171875
+-- !result
 select percentile_approx_weighted(c2, c1, 0.5) from t1;
 -- result:
-35355.97265625
+35355.9765625
 -- !result
 select percentile_approx_weighted(c2, 1, 0.9) from t1;
 -- result:
-45000.3984375
+44999.1953125
 -- !result
 select percentile_approx_weighted(c2, 0, 0.9, 2048) from t1;
 -- result:
@@ -49,17 +227,142 @@ select percentile_approx_weighted(c2, 0, 0.9, 2048) from t1;
 -- !result
 select percentile_approx_weighted(c2, 10, 0.9, 5000) from t1;
 -- result:
-45000.3984375
+44999.19921875
 -- !result
 select percentile_approx_weighted(c2, c1, 0.9, 10000) from t1;
 -- result:
 47435.01171875
 -- !result
+select percentile_approx_weighted(c3, c1, 0.5) from t1;
+-- result:
+11.0
+-- !result
+select percentile_approx_weighted(c3, 1, 0.9) from t1;
+-- result:
+11.0
+-- !result
+select percentile_approx_weighted(c3, 0, 0.9, 2048) from t1;
+-- result:
+33.0
+-- !result
+select percentile_approx_weighted(c3, 10, 0.9, 5000) from t1;
+-- result:
+11.0
+-- !result
+select percentile_approx_weighted(c3, c1, 0.9, 10000) from t1;
+-- result:
+11.0
+-- !result
+select percentile_approx_weighted(c4, c1, 0.5) from t1;
+-- result:
+111.0
+-- !result
+select percentile_approx_weighted(c4, 1, 0.9) from t1;
+-- result:
+111.0
+-- !result
+select percentile_approx_weighted(c4, 0, 0.9, 2048) from t1;
+-- result:
+444.0
+-- !result
+select percentile_approx_weighted(c4, 10, 0.9, 5000) from t1;
+-- result:
+111.0
+-- !result
+select percentile_approx_weighted(c4, c1, 0.9, 10000) from t1;
+-- result:
+111.0
+-- !result
+select percentile_approx_weighted(c5, c1, 0.5) from t1;
+-- result:
+1111.0
+-- !result
+select percentile_approx_weighted(c5, c1, 0.9, 10000) from t1;
+-- result:
+1111.0
+-- !result
+select percentile_approx_weighted(c5, 1, 0.9) from t1;
+-- result:
+1111.0
+-- !result
+select percentile_approx_weighted(c5, 0, 0.9, 2048) from t1;
+-- result:
+4444.0
+-- !result
+select percentile_approx_weighted(c5, 10, 0.9, 5000) from t1;
+-- result:
+1111.0
+-- !result
+select percentile_approx_weighted(c6, c1, 0.5) from t1;
+-- result:
+11111.0
+-- !result
+select percentile_approx_weighted(c6, c1, 0.9, 10000) from t1; 
+select percentile_approx_weighted(c6, 1, 0.9) from t1;
+-- result:
+11111.0
+-- !result
+select percentile_approx_weighted(c6, 0, 0.9, 2048) from t1;
+-- result:
+44444.0
+-- !result
+select percentile_approx_weighted(c6, 10, 0.9, 5000) from t1;
+-- result:
+11111.0
+-- !result
+select percentile_approx_weighted(c7, c1, 0.5) from t1;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: percentile_approx requires the first parameter's type is numeric type.")
+-- !result
+select percentile_approx_weighted(c9, c1, 0.5) from t1;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: percentile_approx requires the first parameter's type is numeric type.")
+-- !result
+select percentile_approx_weighted(c10, c1, 0.5) from t1;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: percentile_approx requires the first parameter's type is numeric type.")
+-- !result
+select percentile_approx_weighted(c11[0], c1, 0.5) from t1;
+-- result:
+None
+-- !result
+select percentile_approx_weighted(c11[0], 1, 0.5) from t1;
+-- result:
+None
+-- !result
+select percentile_approx_weighted(c12[1], c1, 0.5) from t1;
+-- result:
+5.5
+-- !result
+select percentile_approx_weighted(c12[2], c1, 0.5) from t1;
+-- result:
+None
+-- !result
+select percentile_approx_weighted(c12[1], 1, 0.5) from t1;
+-- result:
+5.5
+-- !result
+select percentile_approx_weighted(c13.a, c1, 0.5) from t1;
+-- result:
+100.0
+-- !result
+select percentile_approx_weighted(c13.b, c1, 0.5) from t1;
+-- result:
+100.0
+-- !result
+select percentile_approx_weighted(c13.a, 1, 0.5) from t1;
+-- result:
+100.0
+-- !result
+select percentile_approx_weighted(c13.b, 1, 0.5) from t1;
+-- result:
+100.0
+-- !result
 with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1 = 0.5) */ percentile_approx_weighted(c2, c1, v1) from tt;
 -- result:
-35355.97265625
+35355.9765625
 -- !result
 with tt as (select @v1 as v1, @v2 as v2, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4096) */ percentile_approx_weighted(c2, c1, v1, v2 + 1) from tt;
 -- result:
-35355.97265625
+35355.9765625
 -- !result

--- a/test/sql/test_agg_function/R/test_percentile_approx_weighted
+++ b/test/sql/test_agg_function/R/test_percentile_approx_weighted
@@ -1,0 +1,65 @@
+-- name: test_percentile_approx 
+CREATE TABLE t1 (
+    c1 int,
+    c2 double
+    )
+DUPLICATE KEY(c1)
+DISTRIBUTED BY HASH(c1)
+BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into t1 select generate_series, generate_series from table(generate_series(1, 50000, 3));
+-- result:
+-- !result
+select percentile_approx_weighted(c2, c1, 0.5) from t1;
+-- result:
+35355.97265625
+-- !result
+select percentile_approx_weighted(c2, 1, 0.9) from t1;
+-- result:
+45000.3984375
+-- !result
+select percentile_approx_weighted(c2, 0, 0.9, 2048) from t1;
+-- result:
+49999.0
+-- !result
+select percentile_approx_weighted(c2, 10, 0.9, 5000) from t1;
+-- result:
+45000.3984375
+-- !result
+select percentile_approx_weighted(c2, c1, 0.9, 10000) from t1;
+-- result:
+47435.01171875
+-- !result
+set pipeline_dop=1;
+-- result:
+-- !result
+select percentile_approx_weighted(c2, c1, 0.5) from t1;
+-- result:
+35355.97265625
+-- !result
+select percentile_approx_weighted(c2, 1, 0.9) from t1;
+-- result:
+45000.3984375
+-- !result
+select percentile_approx_weighted(c2, 0, 0.9, 2048) from t1;
+-- result:
+49999.0
+-- !result
+select percentile_approx_weighted(c2, 10, 0.9, 5000) from t1;
+-- result:
+45000.3984375
+-- !result
+select percentile_approx_weighted(c2, c1, 0.9, 10000) from t1;
+-- result:
+47435.01171875
+-- !result
+with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1 = 0.5) */ percentile_approx_weighted(c2, c1, v1) from tt;
+-- result:
+35355.97265625
+-- !result
+with tt as (select @v1 as v1, @v2 as v2, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4096) */ percentile_approx_weighted(c2, c1, v1, v2 + 1) from tt;
+-- result:
+35355.97265625
+-- !result

--- a/test/sql/test_agg_function/R/test_percentile_approx_weighted
+++ b/test/sql/test_agg_function/R/test_percentile_approx_weighted
@@ -133,7 +133,10 @@ select percentile_approx_weighted(c6, c1, 0.5) from t1;
 -- result:
 11111.0
 -- !result
-select percentile_approx_weighted(c6, c1, 0.9, 10000) from t1; 
+select percentile_approx_weighted(c6, c1, 0.9, 10000) from t1;
+-- result:
+11111.0
+-- !result
 select percentile_approx_weighted(c6, 1, 0.9) from t1;
 -- result:
 11111.0
@@ -166,6 +169,14 @@ select percentile_approx_weighted(c11[0], 1, 0.5) from t1;
 -- result:
 None
 -- !result
+select percentile_approx_weighted(c11[1], 1, 0.5) from t1;
+-- result:
+1.0
+-- !result
+select percentile_approx_weighted(c11[1], 1, 0.5) from t1;
+-- result:
+1.0
+-- !result
 select percentile_approx_weighted(c12[1], c1, 0.5) from t1;
 -- result:
 5.5
@@ -193,6 +204,14 @@ select percentile_approx_weighted(c13.a, 1, 0.5) from t1;
 select percentile_approx_weighted(c13.b, 1, 0.5) from t1;
 -- result:
 100.0
+-- !result
+with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1 = 0.5) */ percentile_approx_weighted(c2, c1, v1) from tt;
+-- result:
+35355.9765625
+-- !result
+with tt as (select @v1 as v1, @v2 as v2, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4096) */ percentile_approx_weighted(c2, c1, v1, v2 + 1) from tt;
+-- result:
+35355.9765625
 -- !result
 set pipeline_dop=1;
 -- result:
@@ -297,7 +316,10 @@ select percentile_approx_weighted(c6, c1, 0.5) from t1;
 -- result:
 11111.0
 -- !result
-select percentile_approx_weighted(c6, c1, 0.9, 10000) from t1; 
+select percentile_approx_weighted(c6, c1, 0.9, 10000) from t1;
+-- result:
+11111.0
+-- !result
 select percentile_approx_weighted(c6, 1, 0.9) from t1;
 -- result:
 11111.0
@@ -329,6 +351,14 @@ None
 select percentile_approx_weighted(c11[0], 1, 0.5) from t1;
 -- result:
 None
+-- !result
+select percentile_approx_weighted(c11[1], 1, 0.5) from t1;
+-- result:
+1.0
+-- !result
+select percentile_approx_weighted(c11[1], 1, 0.5) from t1;
+-- result:
+1.0
 -- !result
 select percentile_approx_weighted(c12[1], c1, 0.5) from t1;
 -- result:

--- a/test/sql/test_agg_function/R/test_percentile_approx_weighted
+++ b/test/sql/test_agg_function/R/test_percentile_approx_weighted
@@ -35,11 +35,11 @@ insert into t1 values
 -- !result
 select percentile_approx_weighted(c1, c2, 0.5) from t1;
 -- result:
-35355.9765625
+35355.93359375
 -- !result
 select percentile_approx_weighted(c1, 1, 0.9) from t1;
 -- result:
-44998.8984375
+44998.89453125
 -- !result
 select percentile_approx_weighted(c1, NULL, 0.9) from t1;
 -- result:
@@ -47,19 +47,19 @@ E: (1064, "Getting analyzing error. Detail message: percentile_approx requires t
 -- !result
 select percentile_approx_weighted(c1, c1, 0.9, 10000) from t1;
 -- result:
-47435.01171875
+47434.98828125
 -- !result
 select percentile_approx_weighted(c2, c1, 0.5) from t1;
 -- result:
-35355.9765625
+35355.93359375
 -- !result
 select percentile_approx_weighted(c2, 1, 0.9) from t1;
 -- result:
-44999.1953125
+44999.19921875
 -- !result
 select percentile_approx_weighted(c2, 0, 0.9, 2048) from t1;
 -- result:
-49999.0
+nan
 -- !result
 select percentile_approx_weighted(c2, 10, 0.9, 5000) from t1;
 -- result:
@@ -67,7 +67,7 @@ select percentile_approx_weighted(c2, 10, 0.9, 5000) from t1;
 -- !result
 select percentile_approx_weighted(c2, c1, 0.9, 10000) from t1;
 -- result:
-47435.01171875
+47434.98828125
 -- !result
 select percentile_approx_weighted(c3, c1, 0.5) from t1;
 -- result:
@@ -79,7 +79,7 @@ select percentile_approx_weighted(c3, 1, 0.9) from t1;
 -- !result
 select percentile_approx_weighted(c3, 0, 0.9, 2048) from t1;
 -- result:
-33.0
+nan
 -- !result
 select percentile_approx_weighted(c3, 10, 0.9, 5000) from t1;
 -- result:
@@ -99,7 +99,7 @@ select percentile_approx_weighted(c4, 1, 0.9) from t1;
 -- !result
 select percentile_approx_weighted(c4, 0, 0.9, 2048) from t1;
 -- result:
-444.0
+nan
 -- !result
 select percentile_approx_weighted(c4, 10, 0.9, 5000) from t1;
 -- result:
@@ -123,7 +123,7 @@ select percentile_approx_weighted(c5, 1, 0.9) from t1;
 -- !result
 select percentile_approx_weighted(c5, 0, 0.9, 2048) from t1;
 -- result:
-4444.0
+nan
 -- !result
 select percentile_approx_weighted(c5, 10, 0.9, 5000) from t1;
 -- result:
@@ -143,7 +143,7 @@ select percentile_approx_weighted(c6, 1, 0.9) from t1;
 -- !result
 select percentile_approx_weighted(c6, 0, 0.9, 2048) from t1;
 -- result:
-44444.0
+nan
 -- !result
 select percentile_approx_weighted(c6, 10, 0.9, 5000) from t1;
 -- result:
@@ -207,22 +207,22 @@ select percentile_approx_weighted(c13.b, 1, 0.5) from t1;
 -- !result
 with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1 = 0.5) */ percentile_approx_weighted(c2, c1, v1) from tt;
 -- result:
-35355.9765625
+35355.93359375
 -- !result
 with tt as (select @v1 as v1, @v2 as v2, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4096) */ percentile_approx_weighted(c2, c1, v1, v2 + 1) from tt;
 -- result:
-35355.9765625
+35355.93359375
 -- !result
 set pipeline_dop=1;
 -- result:
 -- !result
 select percentile_approx_weighted(c1, c2, 0.5) from t1;
 -- result:
-35355.9765625
+35355.93359375
 -- !result
 select percentile_approx_weighted(c1, 1, 0.9) from t1;
 -- result:
-44998.8984375
+44998.89453125
 -- !result
 select percentile_approx_weighted(c1, NULL, 0.9) from t1;
 -- result:
@@ -230,19 +230,19 @@ E: (1064, "Getting analyzing error. Detail message: percentile_approx requires t
 -- !result
 select percentile_approx_weighted(c1, c1, 0.9, 10000) from t1;
 -- result:
-47435.01171875
+47434.98828125
 -- !result
 select percentile_approx_weighted(c2, c1, 0.5) from t1;
 -- result:
-35355.9765625
+35355.93359375
 -- !result
 select percentile_approx_weighted(c2, 1, 0.9) from t1;
 -- result:
-44999.1953125
+44999.19921875
 -- !result
 select percentile_approx_weighted(c2, 0, 0.9, 2048) from t1;
 -- result:
-49999.0
+nan
 -- !result
 select percentile_approx_weighted(c2, 10, 0.9, 5000) from t1;
 -- result:
@@ -250,7 +250,7 @@ select percentile_approx_weighted(c2, 10, 0.9, 5000) from t1;
 -- !result
 select percentile_approx_weighted(c2, c1, 0.9, 10000) from t1;
 -- result:
-47435.01171875
+47434.98828125
 -- !result
 select percentile_approx_weighted(c3, c1, 0.5) from t1;
 -- result:
@@ -262,7 +262,7 @@ select percentile_approx_weighted(c3, 1, 0.9) from t1;
 -- !result
 select percentile_approx_weighted(c3, 0, 0.9, 2048) from t1;
 -- result:
-33.0
+nan
 -- !result
 select percentile_approx_weighted(c3, 10, 0.9, 5000) from t1;
 -- result:
@@ -282,7 +282,7 @@ select percentile_approx_weighted(c4, 1, 0.9) from t1;
 -- !result
 select percentile_approx_weighted(c4, 0, 0.9, 2048) from t1;
 -- result:
-444.0
+nan
 -- !result
 select percentile_approx_weighted(c4, 10, 0.9, 5000) from t1;
 -- result:
@@ -306,7 +306,7 @@ select percentile_approx_weighted(c5, 1, 0.9) from t1;
 -- !result
 select percentile_approx_weighted(c5, 0, 0.9, 2048) from t1;
 -- result:
-4444.0
+nan
 -- !result
 select percentile_approx_weighted(c5, 10, 0.9, 5000) from t1;
 -- result:
@@ -326,7 +326,7 @@ select percentile_approx_weighted(c6, 1, 0.9) from t1;
 -- !result
 select percentile_approx_weighted(c6, 0, 0.9, 2048) from t1;
 -- result:
-44444.0
+nan
 -- !result
 select percentile_approx_weighted(c6, 10, 0.9, 5000) from t1;
 -- result:
@@ -390,9 +390,9 @@ select percentile_approx_weighted(c13.b, 1, 0.5) from t1;
 -- !result
 with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1 = 0.5) */ percentile_approx_weighted(c2, c1, v1) from tt;
 -- result:
-35355.9765625
+35355.93359375
 -- !result
 with tt as (select @v1 as v1, @v2 as v2, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4096) */ percentile_approx_weighted(c2, c1, v1, v2 + 1) from tt;
 -- result:
-35355.9765625
+35355.93359375
 -- !result

--- a/test/sql/test_agg_function/T/test_percentile_approx_weighted
+++ b/test/sql/test_agg_function/T/test_percentile_approx_weighted
@@ -60,7 +60,7 @@ select percentile_approx_weighted(c5, 0, 0.9, 2048) from t1;
 select percentile_approx_weighted(c5, 10, 0.9, 5000) from t1;
 -- largeint
 select percentile_approx_weighted(c6, c1, 0.5) from t1;
-select percentile_approx_weighted(c6, c1, 0.9, 10000) from t1; 
+select percentile_approx_weighted(c6, c1, 0.9, 10000) from t1;
 select percentile_approx_weighted(c6, 1, 0.9) from t1;
 select percentile_approx_weighted(c6, 0, 0.9, 2048) from t1;
 select percentile_approx_weighted(c6, 10, 0.9, 5000) from t1;
@@ -73,6 +73,8 @@ select percentile_approx_weighted(c10, c1, 0.5) from t1;
 -- array<int>
 select percentile_approx_weighted(c11[0], c1, 0.5) from t1;
 select percentile_approx_weighted(c11[0], 1, 0.5) from t1;
+select percentile_approx_weighted(c11[1], 1, 0.5) from t1;
+select percentile_approx_weighted(c11[1], 1, 0.5) from t1;
 -- map<double, double>
 select percentile_approx_weighted(c12[1], c1, 0.5) from t1;
 select percentile_approx_weighted(c12[2], c1, 0.5) from t1;
@@ -82,6 +84,9 @@ select percentile_approx_weighted(c13.a, c1, 0.5) from t1;
 select percentile_approx_weighted(c13.b, c1, 0.5) from t1;
 select percentile_approx_weighted(c13.a, 1, 0.5) from t1;
 select percentile_approx_weighted(c13.b, 1, 0.5) from t1;
+
+with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1 = 0.5) */ percentile_approx_weighted(c2, c1, v1) from tt;
+with tt as (select @v1 as v1, @v2 as v2, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4096) */ percentile_approx_weighted(c2, c1, v1, v2 + 1) from tt;
 
 set pipeline_dop=1;
 
@@ -116,7 +121,7 @@ select percentile_approx_weighted(c5, 0, 0.9, 2048) from t1;
 select percentile_approx_weighted(c5, 10, 0.9, 5000) from t1;
 -- largeint
 select percentile_approx_weighted(c6, c1, 0.5) from t1;
-select percentile_approx_weighted(c6, c1, 0.9, 10000) from t1; 
+select percentile_approx_weighted(c6, c1, 0.9, 10000) from t1;
 select percentile_approx_weighted(c6, 1, 0.9) from t1;
 select percentile_approx_weighted(c6, 0, 0.9, 2048) from t1;
 select percentile_approx_weighted(c6, 10, 0.9, 5000) from t1;
@@ -129,6 +134,8 @@ select percentile_approx_weighted(c10, c1, 0.5) from t1;
 -- array<int>
 select percentile_approx_weighted(c11[0], c1, 0.5) from t1;
 select percentile_approx_weighted(c11[0], 1, 0.5) from t1;
+select percentile_approx_weighted(c11[1], 1, 0.5) from t1;
+select percentile_approx_weighted(c11[1], 1, 0.5) from t1;
 -- map<double, double>
 select percentile_approx_weighted(c12[1], c1, 0.5) from t1;
 select percentile_approx_weighted(c12[2], c1, 0.5) from t1;
@@ -138,7 +145,6 @@ select percentile_approx_weighted(c13.a, c1, 0.5) from t1;
 select percentile_approx_weighted(c13.b, c1, 0.5) from t1;
 select percentile_approx_weighted(c13.a, 1, 0.5) from t1;
 select percentile_approx_weighted(c13.b, 1, 0.5) from t1;
-
 
 with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1 = 0.5) */ percentile_approx_weighted(c2, c1, v1) from tt;
 with tt as (select @v1 as v1, @v2 as v2, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4096) */ percentile_approx_weighted(c2, c1, v1, v2 + 1) from tt;

--- a/test/sql/test_agg_function/T/test_percentile_approx_weighted
+++ b/test/sql/test_agg_function/T/test_percentile_approx_weighted
@@ -1,0 +1,26 @@
+-- name: test_percentile_approx 
+CREATE TABLE t1 (
+    c1 int,
+    c2 double
+    )
+DUPLICATE KEY(c1)
+DISTRIBUTED BY HASH(c1)
+BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+insert into t1 select generate_series, generate_series from table(generate_series(1, 50000, 3));
+
+select percentile_approx_weighted(c2, c1, 0.5) from t1;
+select percentile_approx_weighted(c2, 1, 0.9) from t1;
+select percentile_approx_weighted(c2, 0, 0.9, 2048) from t1;
+select percentile_approx_weighted(c2, 10, 0.9, 5000) from t1;
+select percentile_approx_weighted(c2, c1, 0.9, 10000) from t1;
+
+set pipeline_dop=1;
+select percentile_approx_weighted(c2, c1, 0.5) from t1;
+select percentile_approx_weighted(c2, 1, 0.9) from t1;
+select percentile_approx_weighted(c2, 0, 0.9, 2048) from t1;
+select percentile_approx_weighted(c2, 10, 0.9, 5000) from t1;
+select percentile_approx_weighted(c2, c1, 0.9, 10000) from t1;
+
+with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1 = 0.5) */ percentile_approx_weighted(c2, c1, v1) from tt;
+with tt as (select @v1 as v1, @v2 as v2, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4096) */ percentile_approx_weighted(c2, c1, v1, v2 + 1) from tt;

--- a/test/sql/test_agg_function/T/test_percentile_approx_weighted
+++ b/test/sql/test_agg_function/T/test_percentile_approx_weighted
@@ -1,26 +1,144 @@
 -- name: test_percentile_approx 
 CREATE TABLE t1 (
     c1 int,
-    c2 double
+    c2 double,
+    c3 tinyint,
+    c4 int,
+    c5 bigint,
+    c6 largeint,
+    c7 string,
+    c8 double,
+    c9 date,
+    c10 datetime,
+    c11 array<int>,
+    c12 map<double, double>,
+    c13 struct<a bigint, b double>
     )
 DUPLICATE KEY(c1)
 DISTRIBUTED BY HASH(c1)
 BUCKETS 1
 PROPERTIES ("replication_num" = "1");
-insert into t1 select generate_series, generate_series from table(generate_series(1, 50000, 3));
 
+insert into t1 
+    select generate_series, generate_series,  11, 111, 1111, 11111, "111111", 1.1, "2024-09-01", "2024-09-01 18:00:00", [1, 2, 3], map(1, 5.5), row(100, 100)
+    from table(generate_series(1, 50000, 3));
+
+insert into t1 values
+    (1, 1, 11, 111, 1111, 11111, "111111", 1.1, "2024-09-01", "2024-09-01 18:00:00", [1, 2, 3], map(1, 5.5), row(100, 100)),
+    (2, 2, 22, 222, 2222, 22222, "222222", 2.2, "2024-09-02", "2024-09-02 11:00:00", [3, 4, 5], map(1, 511.2), row(200, 200)),
+    (3, 3, 33, 333, 3333, 33333, "333333", 3.3,  "2024-09-03", "2024-09-03 00:00:00", [4, 1, 2], map(1, 666.6), row(300, 300)),
+    (4, 4, 11, 444, 4444, 44444, "444444", 4.4, "2024-09-04", "2024-09-04 12:00:00", [7, 7, 5], map(1, 444.4), row(400, 400)),
+    (5, null, null, null, null, null, null, null, null, null, null, null, null);
+-- int
+select percentile_approx_weighted(c1, c2, 0.5) from t1;
+select percentile_approx_weighted(c1, 1, 0.9) from t1;
+select percentile_approx_weighted(c1, NULL, 0.9) from t1;
+select percentile_approx_weighted(c1, c1, 0.9, 10000) from t1;
+-- double
 select percentile_approx_weighted(c2, c1, 0.5) from t1;
 select percentile_approx_weighted(c2, 1, 0.9) from t1;
 select percentile_approx_weighted(c2, 0, 0.9, 2048) from t1;
 select percentile_approx_weighted(c2, 10, 0.9, 5000) from t1;
 select percentile_approx_weighted(c2, c1, 0.9, 10000) from t1;
+-- tinyint
+select percentile_approx_weighted(c3, c1, 0.5) from t1;
+select percentile_approx_weighted(c3, 1, 0.9) from t1;
+select percentile_approx_weighted(c3, 0, 0.9, 2048) from t1;
+select percentile_approx_weighted(c3, 10, 0.9, 5000) from t1;
+select percentile_approx_weighted(c3, c1, 0.9, 10000) from t1;
+-- int
+select percentile_approx_weighted(c4, c1, 0.5) from t1;
+select percentile_approx_weighted(c4, 1, 0.9) from t1;
+select percentile_approx_weighted(c4, 0, 0.9, 2048) from t1;
+select percentile_approx_weighted(c4, 10, 0.9, 5000) from t1;
+select percentile_approx_weighted(c4, c1, 0.9, 10000) from t1;
+-- bigint
+select percentile_approx_weighted(c5, c1, 0.5) from t1;
+select percentile_approx_weighted(c5, c1, 0.9, 10000) from t1;
+select percentile_approx_weighted(c5, 1, 0.9) from t1;
+select percentile_approx_weighted(c5, 0, 0.9, 2048) from t1;
+select percentile_approx_weighted(c5, 10, 0.9, 5000) from t1;
+-- largeint
+select percentile_approx_weighted(c6, c1, 0.5) from t1;
+select percentile_approx_weighted(c6, c1, 0.9, 10000) from t1; 
+select percentile_approx_weighted(c6, 1, 0.9) from t1;
+select percentile_approx_weighted(c6, 0, 0.9, 2048) from t1;
+select percentile_approx_weighted(c6, 10, 0.9, 5000) from t1;
+-- string
+select percentile_approx_weighted(c7, c1, 0.5) from t1;
+-- date
+select percentile_approx_weighted(c9, c1, 0.5) from t1;
+-- datetime
+select percentile_approx_weighted(c10, c1, 0.5) from t1;
+-- array<int>
+select percentile_approx_weighted(c11[0], c1, 0.5) from t1;
+select percentile_approx_weighted(c11[0], 1, 0.5) from t1;
+-- map<double, double>
+select percentile_approx_weighted(c12[1], c1, 0.5) from t1;
+select percentile_approx_weighted(c12[2], c1, 0.5) from t1;
+select percentile_approx_weighted(c12[1], 1, 0.5) from t1;
+-- struct<a bigint, b double>
+select percentile_approx_weighted(c13.a, c1, 0.5) from t1;
+select percentile_approx_weighted(c13.b, c1, 0.5) from t1;
+select percentile_approx_weighted(c13.a, 1, 0.5) from t1;
+select percentile_approx_weighted(c13.b, 1, 0.5) from t1;
 
 set pipeline_dop=1;
+
+-- int
+select percentile_approx_weighted(c1, c2, 0.5) from t1;
+select percentile_approx_weighted(c1, 1, 0.9) from t1;
+select percentile_approx_weighted(c1, NULL, 0.9) from t1;
+select percentile_approx_weighted(c1, c1, 0.9, 10000) from t1;
+-- double
 select percentile_approx_weighted(c2, c1, 0.5) from t1;
 select percentile_approx_weighted(c2, 1, 0.9) from t1;
 select percentile_approx_weighted(c2, 0, 0.9, 2048) from t1;
 select percentile_approx_weighted(c2, 10, 0.9, 5000) from t1;
 select percentile_approx_weighted(c2, c1, 0.9, 10000) from t1;
+-- tinyint
+select percentile_approx_weighted(c3, c1, 0.5) from t1;
+select percentile_approx_weighted(c3, 1, 0.9) from t1;
+select percentile_approx_weighted(c3, 0, 0.9, 2048) from t1;
+select percentile_approx_weighted(c3, 10, 0.9, 5000) from t1;
+select percentile_approx_weighted(c3, c1, 0.9, 10000) from t1;
+-- int
+select percentile_approx_weighted(c4, c1, 0.5) from t1;
+select percentile_approx_weighted(c4, 1, 0.9) from t1;
+select percentile_approx_weighted(c4, 0, 0.9, 2048) from t1;
+select percentile_approx_weighted(c4, 10, 0.9, 5000) from t1;
+select percentile_approx_weighted(c4, c1, 0.9, 10000) from t1;
+-- bigint
+select percentile_approx_weighted(c5, c1, 0.5) from t1;
+select percentile_approx_weighted(c5, c1, 0.9, 10000) from t1;
+select percentile_approx_weighted(c5, 1, 0.9) from t1;
+select percentile_approx_weighted(c5, 0, 0.9, 2048) from t1;
+select percentile_approx_weighted(c5, 10, 0.9, 5000) from t1;
+-- largeint
+select percentile_approx_weighted(c6, c1, 0.5) from t1;
+select percentile_approx_weighted(c6, c1, 0.9, 10000) from t1; 
+select percentile_approx_weighted(c6, 1, 0.9) from t1;
+select percentile_approx_weighted(c6, 0, 0.9, 2048) from t1;
+select percentile_approx_weighted(c6, 10, 0.9, 5000) from t1;
+-- string
+select percentile_approx_weighted(c7, c1, 0.5) from t1;
+-- date
+select percentile_approx_weighted(c9, c1, 0.5) from t1;
+-- datetime
+select percentile_approx_weighted(c10, c1, 0.5) from t1;
+-- array<int>
+select percentile_approx_weighted(c11[0], c1, 0.5) from t1;
+select percentile_approx_weighted(c11[0], 1, 0.5) from t1;
+-- map<double, double>
+select percentile_approx_weighted(c12[1], c1, 0.5) from t1;
+select percentile_approx_weighted(c12[2], c1, 0.5) from t1;
+select percentile_approx_weighted(c12[1], 1, 0.5) from t1;
+-- struct<a bigint, b double>
+select percentile_approx_weighted(c13.a, c1, 0.5) from t1;
+select percentile_approx_weighted(c13.b, c1, 0.5) from t1;
+select percentile_approx_weighted(c13.a, 1, 0.5) from t1;
+select percentile_approx_weighted(c13.b, 1, 0.5) from t1;
+
 
 with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1 = 0.5) */ percentile_approx_weighted(c2, c1, v1) from tt;
 with tt as (select @v1 as v1, @v2 as v2, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4096) */ percentile_approx_weighted(c2, c1, v1, v2 + 1) from tt;

--- a/test/sql/test_agg_state/R/test_agg_state_table_percentile_approx_weighted.sql
+++ b/test/sql/test_agg_state/R/test_agg_state_table_percentile_approx_weighted.sql
@@ -1,0 +1,159 @@
+-- name: test_agg_state_table_percentile_approx_weighted
+CREATE TABLE t1 (
+    c1 int,
+    c2 double,
+    c3 tinyint,
+    c4 int,
+    c5 bigint,
+    c6 largeint,
+    c7 string,
+    c8 double,
+    c9 date,
+    c10 datetime,
+    c11 array<int>,
+    c12 map<double, double>,
+    c13 struct<a bigint, b double>
+    )
+DUPLICATE KEY(c1)
+DISTRIBUTED BY HASH(c1)
+BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into t1 
+    select generate_series, generate_series,  11, 111, 1111, 11111, "111111", 1.1, "2024-09-01", "2024-09-01 18:00:00", [1, 2, 3], map(1, 5.5), row(100, 100)
+    from table(generate_series(1, 500, 3));
+-- result:
+-- !result
+insert into t1 values
+    (1, 1, 11, 111, 1111, 11111, "111111", 1.1, "2024-09-01", "2024-09-01 18:00:00", [1, 2, 3], map(1, 5.5), row(100, 100)),
+    (2, 2, 22, 222, 2222, 22222, "222222", 2.2, "2024-09-02", "2024-09-02 11:00:00", [3, 4, 5], map(1, 511.2), row(200, 200)),
+    (3, 3, 33, 333, 3333, 33333, "333333", 3.3,  "2024-09-03", "2024-09-03 00:00:00", [4, 1, 2], map(1, 666.6), row(300, 300)),
+    (4, 4, 11, 444, 4444, 44444, "444444", 4.4, "2024-09-04", "2024-09-04 12:00:00", [7, 7, 5], map(1, 444.4), row(400, 400)),
+    (5, null, null, null, null, null, null, null, null, null, null, null, null);
+-- result:
+-- !result
+CREATE TABLE test_agg_state_percentile_approx_weighted(
+  c1 VARCHAR(10),
+  c2 percentile_approx_weighted(double, bigint, double),
+  c3 percentile_approx_weighted(double, bigint, double),
+  c4 percentile_approx_weighted(double, bigint, double),
+  c5 percentile_approx_weighted(double, bigint, double),
+  c6 percentile_approx_weighted(double, bigint, double),
+  c11 percentile_approx_weighted(double, bigint, double),
+  c12 percentile_approx_weighted(double, bigint, double),
+  c13 percentile_approx_weighted(double, bigint, double),
+  c14 percentile_approx_weighted(double, bigint, double)
+)
+AGGREGATE KEY(c1)
+DISTRIBUTED BY HASH(c1) BUCKETS 3;
+-- result:
+-- !result
+INSERT INTO test_agg_state_percentile_approx_weighted
+SELECT 
+  c1,
+  percentile_approx_weighted_state(c1, c1, 0.5),
+  percentile_approx_weighted_state(c2, 1, 0.7),
+  percentile_approx_weighted_state(c3, c1, 0.8, 10000),
+  percentile_approx_weighted_state(c4, c1, 1),
+  percentile_approx_weighted_state(c5, c1, 0.1),
+  percentile_approx_weighted_state(c6, c1, 0.5),
+  percentile_approx_weighted_state(c11[1], c1, 0.5),
+  percentile_approx_weighted_state(c12[1], c12[2], 0.5),
+  percentile_approx_weighted_state(c13.a, c13.b, 0.5)
+FROM t1;
+-- result:
+-- !result
+SELECT c1,
+  percentile_approx_weighted_merge(c2),
+  percentile_approx_weighted_merge(c3),
+  percentile_approx_weighted_merge(c4),
+  percentile_approx_weighted_merge(c5),
+  percentile_approx_weighted_merge(c6),
+  percentile_approx_weighted_merge(c11),
+  percentile_approx_weighted_merge(c12),
+  percentile_approx_weighted_merge(c13),
+  percentile_approx_weighted_merge(c14)
+FROM test_agg_state_percentile_approx_weighted
+GROUP BY c1 ORDER BY c1 limit 10;
+-- result:
+1	1.0	1.0	11.0	111.0	1111.0	11111.0	1.0	None	100.0
+10	10.0	10.0	11.0	111.0	1111.0	11111.0	1.0	None	100.0
+100	100.0	100.0	11.0	111.0	1111.0	11111.0	1.0	None	100.0
+103	103.0	103.0	11.0	111.0	1111.0	11111.0	1.0	None	100.0
+106	106.0	106.0	11.0	111.0	1111.0	11111.0	1.0	None	100.0
+109	109.0	109.0	11.0	111.0	1111.0	11111.0	1.0	None	100.0
+112	112.0	112.0	11.0	111.0	1111.0	11111.0	1.0	None	100.0
+115	115.0	115.0	11.0	111.0	1111.0	11111.0	1.0	None	100.0
+118	118.0	118.0	11.0	111.0	1111.0	11111.0	1.0	None	100.0
+121	121.0	121.0	11.0	111.0	1111.0	11111.0	1.0	None	100.0
+-- !result
+SELECT percentile_approx_weighted_merge(c2),
+  percentile_approx_weighted_merge(c3),
+  percentile_approx_weighted_merge(c4),
+  percentile_approx_weighted_merge(c5),
+  percentile_approx_weighted_merge(c6),
+  percentile_approx_weighted_merge(c11),
+  percentile_approx_weighted_merge(c12),
+  percentile_approx_weighted_merge(c13),
+  percentile_approx_weighted_merge(c14)
+FROM test_agg_state_percentile_approx_weighted;
+-- result:
+353.83734130859375	346.5999755859375	11.0	444.0	1111.0	11111.0	1.0	None	100.0
+-- !result
+insert into t1 values
+    (1, 1, 11, 111, 1111, 11111, "111111", 1.1, "2024-09-01", "2024-09-01 18:00:00", [1, 2, 3], map(1, 5.5), row(100, 100)),
+    (2, 2, 22, 222, 2222, 22222, "222222", 2.2, "2024-09-02", "2024-09-02 11:00:00", [3, 4, 5], map(1, 511.2), row(200, 200)),
+    (3, 3, 33, 333, 3333, 33333, "333333", 3.3,  "2024-09-03", "2024-09-03 00:00:00", [4, 1, 2], map(1, 666.6), row(300, 300)),
+    (4, 4, 11, 444, 4444, 44444, "444444", 4.4, "2024-09-04", "2024-09-04 12:00:00", [7, 7, 5], map(1, 444.4), row(400, 400)),
+    (5, null, null, null, null, null, null, null, null, null, null, null, null);
+-- result:
+-- !result
+insert into t1 values
+    (1, 1, 11, 111, 1111, 11111, "111111", 1.1, "2024-09-01", "2024-09-01 18:00:00", [1, 2, 3], map(1, 5.5), row(100, 100)),
+    (2, 2, 22, 222, 2222, 22222, "222222", 2.2, "2024-09-02", "2024-09-02 11:00:00", [3, 4, 5], map(1, 511.2), row(200, 200)),
+    (3, 3, 33, 333, 3333, 33333, "333333", 3.3,  "2024-09-03", "2024-09-03 00:00:00", [4, 1, 2], map(1, 666.6), row(300, 300)),
+    (4, 4, 11, 444, 4444, 44444, "444444", 4.4, "2024-09-04", "2024-09-04 12:00:00", [7, 7, 5], map(1, 444.4), row(400, 400)),
+    (5, null, null, null, null, null, null, null, null, null, null, null, null);
+-- result:
+-- !result
+ALTER TABLE test_agg_state_percentile_approx_weighted COMPACT;
+-- result:
+-- !result
+SELECT c1,
+  percentile_approx_weighted_merge(c2),
+  percentile_approx_weighted_merge(c3),
+  percentile_approx_weighted_merge(c4),
+  percentile_approx_weighted_merge(c5),
+  percentile_approx_weighted_merge(c6),
+  percentile_approx_weighted_merge(c11),
+  percentile_approx_weighted_merge(c12),
+  percentile_approx_weighted_merge(c13),
+  percentile_approx_weighted_merge(c14)
+FROM test_agg_state_percentile_approx_weighted
+GROUP BY c1 ORDER BY c1 limit 10;
+-- result:
+1	1.0	1.0	11.0	111.0	1111.0	11111.0	1.0	None	100.0
+10	10.0	10.0	11.0	111.0	1111.0	11111.0	1.0	None	100.0
+100	100.0	100.0	11.0	111.0	1111.0	11111.0	1.0	None	100.0
+103	103.0	103.0	11.0	111.0	1111.0	11111.0	1.0	None	100.0
+106	106.0	106.0	11.0	111.0	1111.0	11111.0	1.0	None	100.0
+109	109.0	109.0	11.0	111.0	1111.0	11111.0	1.0	None	100.0
+112	112.0	112.0	11.0	111.0	1111.0	11111.0	1.0	None	100.0
+115	115.0	115.0	11.0	111.0	1111.0	11111.0	1.0	None	100.0
+118	118.0	118.0	11.0	111.0	1111.0	11111.0	1.0	None	100.0
+121	121.0	121.0	11.0	111.0	1111.0	11111.0	1.0	None	100.0
+-- !result
+SELECT percentile_approx_weighted_merge(c2),
+  percentile_approx_weighted_merge(c3),
+  percentile_approx_weighted_merge(c4),
+  percentile_approx_weighted_merge(c5),
+  percentile_approx_weighted_merge(c6),
+  percentile_approx_weighted_merge(c11),
+  percentile_approx_weighted_merge(c12),
+  percentile_approx_weighted_merge(c13),
+  percentile_approx_weighted_merge(c14)
+FROM test_agg_state_percentile_approx_weighted;
+-- result:
+353.83734130859375	346.5999755859375	11.0	444.0	1111.0	11111.0	1.0	None	100.0
+-- !result

--- a/test/sql/test_agg_state/T/test_agg_state_table_percentile_approx_weighted.sql
+++ b/test/sql/test_agg_state/T/test_agg_state_table_percentile_approx_weighted.sql
@@ -1,0 +1,122 @@
+-- name: test_agg_state_table_percentile_approx_weighted
+CREATE TABLE t1 (
+    c1 int,
+    c2 double,
+    c3 tinyint,
+    c4 int,
+    c5 bigint,
+    c6 largeint,
+    c7 string,
+    c8 double,
+    c9 date,
+    c10 datetime,
+    c11 array<int>,
+    c12 map<double, double>,
+    c13 struct<a bigint, b double>
+    )
+DUPLICATE KEY(c1)
+DISTRIBUTED BY HASH(c1)
+BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+insert into t1 
+    select generate_series, generate_series,  11, 111, 1111, 11111, "111111", 1.1, "2024-09-01", "2024-09-01 18:00:00", [1, 2, 3], map(1, 5.5), row(100, 100)
+    from table(generate_series(1, 500, 3));
+
+insert into t1 values
+    (1, 1, 11, 111, 1111, 11111, "111111", 1.1, "2024-09-01", "2024-09-01 18:00:00", [1, 2, 3], map(1, 5.5), row(100, 100)),
+    (2, 2, 22, 222, 2222, 22222, "222222", 2.2, "2024-09-02", "2024-09-02 11:00:00", [3, 4, 5], map(1, 511.2), row(200, 200)),
+    (3, 3, 33, 333, 3333, 33333, "333333", 3.3,  "2024-09-03", "2024-09-03 00:00:00", [4, 1, 2], map(1, 666.6), row(300, 300)),
+    (4, 4, 11, 444, 4444, 44444, "444444", 4.4, "2024-09-04", "2024-09-04 12:00:00", [7, 7, 5], map(1, 444.4), row(400, 400)),
+    (5, null, null, null, null, null, null, null, null, null, null, null, null);
+
+CREATE TABLE test_agg_state_percentile_approx_weighted(
+  c1 VARCHAR(10),
+  c2 percentile_approx_weighted(double, bigint, double),
+  c3 percentile_approx_weighted(double, bigint, double),
+  c4 percentile_approx_weighted(double, bigint, double),
+  c5 percentile_approx_weighted(double, bigint, double),
+  c6 percentile_approx_weighted(double, bigint, double),
+  c11 percentile_approx_weighted(double, bigint, double),
+  c12 percentile_approx_weighted(double, bigint, double),
+  c13 percentile_approx_weighted(double, bigint, double),
+  c14 percentile_approx_weighted(double, bigint, double)
+)
+AGGREGATE KEY(c1)
+DISTRIBUTED BY HASH(c1) BUCKETS 3;
+
+INSERT INTO test_agg_state_percentile_approx_weighted
+SELECT 
+  c1,
+  percentile_approx_weighted_state(c1, c1, 0.5),
+  percentile_approx_weighted_state(c2, 1, 0.7),
+  percentile_approx_weighted_state(c3, c1, 0.8, 10000),
+  percentile_approx_weighted_state(c4, c1, 1),
+  percentile_approx_weighted_state(c5, c1, 0.1),
+  percentile_approx_weighted_state(c6, c1, 0.5),
+  percentile_approx_weighted_state(c11[1], c1, 0.5),
+  percentile_approx_weighted_state(c12[1], c12[2], 0.5),
+  percentile_approx_weighted_state(c13.a, c13.b, 0.5)
+FROM t1;
+
+SELECT c1,
+  percentile_approx_weighted_merge(c2),
+  percentile_approx_weighted_merge(c3),
+  percentile_approx_weighted_merge(c4),
+  percentile_approx_weighted_merge(c5),
+  percentile_approx_weighted_merge(c6),
+  percentile_approx_weighted_merge(c11),
+  percentile_approx_weighted_merge(c12),
+  percentile_approx_weighted_merge(c13),
+  percentile_approx_weighted_merge(c14)
+FROM test_agg_state_percentile_approx_weighted
+GROUP BY c1 ORDER BY c1 limit 10;
+
+SELECT percentile_approx_weighted_merge(c2),
+  percentile_approx_weighted_merge(c3),
+  percentile_approx_weighted_merge(c4),
+  percentile_approx_weighted_merge(c5),
+  percentile_approx_weighted_merge(c6),
+  percentile_approx_weighted_merge(c11),
+  percentile_approx_weighted_merge(c12),
+  percentile_approx_weighted_merge(c13),
+  percentile_approx_weighted_merge(c14)
+FROM test_agg_state_percentile_approx_weighted;
+
+insert into t1 values
+    (1, 1, 11, 111, 1111, 11111, "111111", 1.1, "2024-09-01", "2024-09-01 18:00:00", [1, 2, 3], map(1, 5.5), row(100, 100)),
+    (2, 2, 22, 222, 2222, 22222, "222222", 2.2, "2024-09-02", "2024-09-02 11:00:00", [3, 4, 5], map(1, 511.2), row(200, 200)),
+    (3, 3, 33, 333, 3333, 33333, "333333", 3.3,  "2024-09-03", "2024-09-03 00:00:00", [4, 1, 2], map(1, 666.6), row(300, 300)),
+    (4, 4, 11, 444, 4444, 44444, "444444", 4.4, "2024-09-04", "2024-09-04 12:00:00", [7, 7, 5], map(1, 444.4), row(400, 400)),
+    (5, null, null, null, null, null, null, null, null, null, null, null, null);
+insert into t1 values
+    (1, 1, 11, 111, 1111, 11111, "111111", 1.1, "2024-09-01", "2024-09-01 18:00:00", [1, 2, 3], map(1, 5.5), row(100, 100)),
+    (2, 2, 22, 222, 2222, 22222, "222222", 2.2, "2024-09-02", "2024-09-02 11:00:00", [3, 4, 5], map(1, 511.2), row(200, 200)),
+    (3, 3, 33, 333, 3333, 33333, "333333", 3.3,  "2024-09-03", "2024-09-03 00:00:00", [4, 1, 2], map(1, 666.6), row(300, 300)),
+    (4, 4, 11, 444, 4444, 44444, "444444", 4.4, "2024-09-04", "2024-09-04 12:00:00", [7, 7, 5], map(1, 444.4), row(400, 400)),
+    (5, null, null, null, null, null, null, null, null, null, null, null, null);
+ALTER TABLE test_agg_state_percentile_approx_weighted COMPACT;
+
+SELECT c1,
+  percentile_approx_weighted_merge(c2),
+  percentile_approx_weighted_merge(c3),
+  percentile_approx_weighted_merge(c4),
+  percentile_approx_weighted_merge(c5),
+  percentile_approx_weighted_merge(c6),
+  percentile_approx_weighted_merge(c11),
+  percentile_approx_weighted_merge(c12),
+  percentile_approx_weighted_merge(c13),
+  percentile_approx_weighted_merge(c14)
+FROM test_agg_state_percentile_approx_weighted
+GROUP BY c1 ORDER BY c1 limit 10;
+
+SELECT percentile_approx_weighted_merge(c2),
+  percentile_approx_weighted_merge(c3),
+  percentile_approx_weighted_merge(c4),
+  percentile_approx_weighted_merge(c5),
+  percentile_approx_weighted_merge(c6),
+  percentile_approx_weighted_merge(c11),
+  percentile_approx_weighted_merge(c12),
+  percentile_approx_weighted_merge(c13),
+  percentile_approx_weighted_merge(c14)
+FROM test_agg_state_percentile_approx_weighted;

--- a/test/sql/test_user_variables/R/test_user_variable
+++ b/test/sql/test_user_variables/R/test_user_variable
@@ -85,7 +85,7 @@ E: (1064, "Getting analyzing error. Detail message: percentile_approx requires t
 -- !result
 select      percentile_approx(c0, cast(null as double))  from t0;
 -- result:
-[REGEX] .*percentile_approx the second argument is expected to be non-null.*
+None
 -- !result
 CREATE TABLE `pk1` (
   `c0` int(11) COMMENT "",


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

- Add `percentile_approx_weighted` to support `percentile` + `weight`;

NOTE:
- percentile_approx/percentile_approx_weighted is not determinstic because tdigest's merge sort + compression different from different input and parallels.

### Data&Machine
data: TPCH 100g
FE: 8c16g * 1
BE: 8c16g*3
```
mysql> select count(distinct l_orderkey) from lineitem;

+----------------------------+
| count(DISTINCT l_orderkey) |
+----------------------------+
|                  150000000 |
+----------------------------+
1 row in set (1.54 sec)

mysql> select count(distinct l_linenumber) from lineitem;
+------------------------------+
| count(DISTINCT l_linenumber) |
+------------------------------+
|                            7 |
+------------------------------+
1 row in set (0.40 sec)

mysql> select count(distinct l_partkey) from lineitem;
+---------------------------+
| count(DISTINCT l_partkey) |
+---------------------------+
|                  20000000 |
+---------------------------+
1 row in set (3.08 sec)

mysql> select count(distinct l_suppkey) from lineitem;
+---------------------------+
| count(DISTINCT l_suppkey) |
+---------------------------+
|                   1000000 |
+---------------------------+
1 row in set (1.49 sec)


```
### percentile_approx
- Before
```
mysql> select percentile_approx(l_orderkey, 0.5) from lineitem;

+------------------------------------+
| percentile_approx(l_orderkey, 0.5) |
+------------------------------------+
|                          299995968 |
+------------------------------------+
1 row in set (5.80 sec)

mysql> select percentile_approx(l_linenumber, 0.5) from lineitem;
+--------------------------------------+
| percentile_approx(l_linenumber, 0.5) |
+--------------------------------------+
|                                    3 |
+--------------------------------------+
1 row in set (3.95 sec)

mysql> select percentile_approx(l_partkey, 0.5) from lineitem;
+-----------------------------------+
| percentile_approx(l_partkey, 0.5) |
+-----------------------------------+
|                           9999467 |
+-----------------------------------+
1 row in set (7.91 sec)

mysql> select percentile_approx(l_suppkey, 0.5) from lineitem;
+-----------------------------------+
| percentile_approx(l_suppkey, 0.5) |
+-----------------------------------+
|                      499965.53125 |
+-----------------------------------+
1 row in set (6.84 sec)

```

After:
```
mysql> select percentile_approx(l_orderkey, 0.5) from lineitem;

+------------------------------------+
| percentile_approx(l_orderkey, 0.5) |
+------------------------------------+
|                          299845504 |
+------------------------------------+
1 row in set (5.22 sec)

mysql> select percentile_approx(l_linenumber, 0.5) from lineitem;
+--------------------------------------+
| percentile_approx(l_linenumber, 0.5) |
+--------------------------------------+
|                                    3 |
+--------------------------------------+
1 row in set (4.11 sec)

mysql> select percentile_approx(l_partkey, 0.5) from lineitem;
+-----------------------------------+
| percentile_approx(l_partkey, 0.5) |
+-----------------------------------+
|                           9994217 |
+-----------------------------------+
1 row in set (6.68 sec)

mysql> select percentile_approx(l_partkey, 0.5) from lineitem;
+-----------------------------------+
| percentile_approx(l_partkey, 0.5) |
+-----------------------------------+
|                           9993922 |
+-----------------------------------+
1 row in set (6.65 sec)
```
### percentile_approx_weighted with constant weight

```
mysql>  select percentile_approx_weighted(l_orderkey, 1, 0.5) from lineitem;

+------------------------------------------------+
| percentile_approx_weighted(l_orderkey, 1, 0.5) |
+------------------------------------------------+
|                                      299841344 |
+------------------------------------------------+
1 row in set (6.49 sec)

mysql>  select percentile_approx_weighted(l_linenumber, 1, 0.5) from lineitem;
+--------------------------------------------------+
| percentile_approx_weighted(l_linenumber, 1, 0.5) |
+--------------------------------------------------+
|                                                3 |
+--------------------------------------------------+
1 row in set (5.37 sec)

mysql>  select percentile_approx_weighted(l_partkey, 1, 0.5) from lineitem;
+-----------------------------------------------+
| percentile_approx_weighted(l_partkey, 1, 0.5) |
+-----------------------------------------------+
|                                       9994612 |
+-----------------------------------------------+
1 row in set (7.72 sec)

mysql>   select percentile_approx_weighted(l_suppkey, 1, 0.5) from lineitem;
+-----------------------------------------------+
| percentile_approx_weighted(l_suppkey, 1, 0.5) |
+-----------------------------------------------+
|                                   499912.8125 |
+-----------------------------------------------+
1 row in set (7.72 sec)

```
### percentile_approx_weighted with non-constant weight
```
mysql>  select percentile_approx_weighted(l_orderkey, l_linenumber, 0.5) from lineitem;

+-----------------------------------------------------------+
| percentile_approx_weighted(l_orderkey, l_linenumber, 0.5) |
+-----------------------------------------------------------+
|                                                 299881216 |
+-----------------------------------------------------------+
1 row in set (5.98 sec)

mysql>  select percentile_approx_weighted(l_linenumber, l_linenumber, 0.5) from lineitem;
+-------------------------------------------------------------+
| percentile_approx_weighted(l_linenumber, l_linenumber, 0.5) |
+-------------------------------------------------------------+
|                                                           4 |
+-------------------------------------------------------------+
1 row in set (4.73 sec)

mysql>  select percentile_approx_weighted(l_partkey, l_linenumber, 0.5) from lineitem;
+----------------------------------------------------------+
| percentile_approx_weighted(l_partkey, l_linenumber, 0.5) |
+----------------------------------------------------------+
|                                                  9995324 |
+----------------------------------------------------------+
1 row in set (7.20 sec)

mysql>   select percentile_approx_weighted(l_suppkey, l_linenumber, 0.5) from lineitem;
+----------------------------------------------------------+
| percentile_approx_weighted(l_suppkey, l_linenumber, 0.5) |
+----------------------------------------------------------+
|                                              499946.5625 |
+----------------------------------------------------------+
1 row in set (7.20 sec)

```

### Perf

![image](https://github.com/user-attachments/assets/3de9c73f-dc8b-4590-8a5a-e3a9ec4401f7)

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0