### PR TITLE
[BugFix] Fix some odps bug (backport #55802)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/odps/EntityConvertUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/odps/EntityConvertUtils.java
@@ -49,6 +49,11 @@ public class EntityConvertUtils {
                 return Type.FLOAT;
             case DECIMAL:
                 DecimalTypeInfo decimalTypeInfo = (DecimalTypeInfo) typeInfo;
+                //In odps 2.0, the maximum length of decimal is 38, while in 1.0 it is 54. You need to convert it to String type for processing.
+                //https://help.aliyun.com/zh/maxcompute/user-guide/maxcompute-v2-0-data-type-edition?spm=a2c4g.11186623.help-menu-27797.d_2_15_0_2.1c01123dDL8rEV
+                if (decimalTypeInfo.getPrecision() > 38) {
+                    return ScalarType.createDefaultCatalogString();
+                }
                 return ScalarType.createUnifiedDecimalType(decimalTypeInfo.getPrecision(), decimalTypeInfo.getScale());
             case DOUBLE:
                 return Type.DOUBLE;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/odps/OdpsMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/odps/OdpsMetadata.java
@@ -406,12 +406,12 @@ public class OdpsMetadata implements ConnectorMetadata {
         long numRecord = 0;
         for (long i = rowsPerSplit; i < totalRowCount; i += rowsPerSplit) {
             InputSplitWithRowRange splitByRowOffset =
-                    (InputSplitWithRowRange) inputSplitAssigner.getSplitByRowOffset(numRecord, i);
+                    (InputSplitWithRowRange) inputSplitAssigner.getSplitByRowOffset(numRecord, rowsPerSplit);
             splits.add(splitByRowOffset);
             numRecord = i;
         }
         InputSplitWithRowRange splitByRowOffset =
-                (InputSplitWithRowRange) inputSplitAssigner.getSplitByRowOffset(numRecord, totalRowCount);
+                (InputSplitWithRowRange) inputSplitAssigner.getSplitByRowOffset(numRecord, totalRowCount - numRecord);
         splits.add(splitByRowOffset);
         odpsSplitsInfo = new OdpsSplitsInfo(splits, rowScan,
                 OdpsSplitsInfo.SplitPolicy.ROW_OFFSET, splitProperties);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OdpsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OdpsScanNode.java
@@ -111,11 +111,13 @@ public class OdpsScanNode extends ScanNode {
                 case SIZE:
                     IndexedInputSplit split = (IndexedInputSplit) inputSplit;
                     splitInfo.put("split_index", String.valueOf(split.getSplitIndex()));
+                    hdfsScanRange.setOffset(split.getSplitIndex());
                     break;
                 case ROW_OFFSET:
                     RowRangeInputSplit split1 = (RowRangeInputSplit) inputSplit;
                     splitInfo.put("start_index", String.valueOf(split1.getRowRange().getStartIndex()));
                     splitInfo.put("num_record", String.valueOf(split1.getRowRange().getNumRecord()));
+                    hdfsScanRange.setOffset(split1.getRowRange().getStartIndex());
                     break;
                 default:
                     throw new StarRocksConnectorException(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/pattern/Pattern.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/pattern/Pattern.java
@@ -42,6 +42,7 @@ public class Pattern {
             .add(OperatorType.LOGICAL_BINLOG_SCAN)
             .add(OperatorType.LOGICAL_VIEW_SCAN)
             .add(OperatorType.LOGICAL_PAIMON_SCAN)
+            .add(OperatorType.LOGICAL_ODPS_SCAN)
             .build();
 
     private final OperatorType opType;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
@@ -314,6 +314,7 @@ public class RuleSet {
                 PushDownPredicateScanRule.DELTALAKE_SCAN,
                 PushDownPredicateScanRule.FILE_SCAN,
                 PushDownPredicateScanRule.PAIMON_SCAN,
+                PushDownPredicateScanRule.ODPS_SCAN,
                 PushDownPredicateScanRule.ICEBERG_METADATA_SCAN,
                 PushDownPredicateScanRule.KUDU_SCAN,
                 PushDownPredicateScanRule.SCHEMA_SCAN,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateScanRule.java
@@ -52,6 +52,8 @@ public class PushDownPredicateScanRule extends TransformationRule {
             new PushDownPredicateScanRule(OperatorType.LOGICAL_FILE_SCAN);
     public static final PushDownPredicateScanRule PAIMON_SCAN =
             new PushDownPredicateScanRule(OperatorType.LOGICAL_PAIMON_SCAN);
+    public static final PushDownPredicateScanRule ODPS_SCAN =
+            new PushDownPredicateScanRule(OperatorType.LOGICAL_ODPS_SCAN);
     public static final PushDownPredicateScanRule ICEBERG_METADATA_SCAN =
             new PushDownPredicateScanRule(OperatorType.LOGICAL_ICEBERG_METADATA_SCAN);
     public static final PushDownPredicateScanRule KUDU_SCAN =

--- a/java-extensions/odps-reader/src/main/java/com/starrocks/odps/reader/OdpsColumnValue.java
+++ b/java-extensions/odps-reader/src/main/java/com/starrocks/odps/reader/OdpsColumnValue.java
@@ -98,8 +98,8 @@ public class OdpsColumnValue implements ColumnValue {
         MapTypeInfo mapTypeInfo = (MapTypeInfo) dataType;
         Map data = (Map) fieldData;
         data.forEach((key, value) -> {
-            keys.add(new OdpsColumnValue(key, mapTypeInfo.getKeyTypeInfo(), timezone));
-            values.add(new OdpsColumnValue(value, mapTypeInfo.getValueTypeInfo(), timezone));
+            keys.add(key == null ? null : new OdpsColumnValue(key, mapTypeInfo.getKeyTypeInfo(), timezone));
+            values.add(value == null ? null : new OdpsColumnValue(value, mapTypeInfo.getValueTypeInfo(), timezone));
         });
     }
 


### PR DESCRIPTION
Signed-off-by: wanyou <liaowanyou.lwy@alibaba-inc.com>
Co-authored-by: liaowanyou <liaowanyou.lwy@alibaba-inc.com>
(cherry picked from commit f671639257494a5d192e1cac529249118cd26da9)

## Why I'm doing:
1、all splits of ODPS are assigned to the same backend.
2、ODPS decimal type can exceeds 38
3、ODPS row offset execution error
4、{"k":"v1", "k":null}, An error occurs when key/value data in the ODPS map is empty
## What I'm doing:
1、use SplitIndex as the backend selection condition
2、convert ODPS decimal types that exceed 38 to string
3、row offset parameter is set incorrectly and needs to be readjusted
4、in the ODPS map，add null checks for key/value.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr


