### PR TITLE
[BugFix] fix wrong result when evaluating runtime filter under branchless mode

### DIFF
--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -748,6 +748,9 @@ public:
             }
             return new_size;
         } else {
+            if (sel != dst_sel) {
+                memcpy(dst_sel, sel, sel_size * sizeof(uint16_t));
+            }
             return sel_size;
         }
     }
@@ -1358,6 +1361,9 @@ private:
                         new_size += _rf_test_data<multi_partition>(data[idx], multi_partition ? hash_values[idx] : 0);
                     }
                 } else {
+                    if (sel != dst_sel) {
+                        memcpy(dst_sel, sel, sel_size * sizeof(uint16_t));
+                    }
                     new_size = sel_size;
                 }
             }
@@ -1370,6 +1376,9 @@ private:
                     new_size += _rf_test_data<multi_partition>(data[idx], multi_partition ? hash_values[idx] : 0);
                 }
             } else {
+                if (sel != dst_sel) {
+                    memcpy(dst_sel, sel, sel_size * sizeof(uint16_t));
+                }
                 new_size = sel_size;
             }
         }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/9346

The runtime filter pushed down to the storage layer may be executed in branchless mode. The sel and dst_sel in the parameters may be different. If the execution of runtime filter is skipped, the content in sel needs to be copied to dst_sel.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0