### PR TITLE
[BugFix] prevents filling empty to stats cache when an async task throws an exception

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
+++ b/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
@@ -114,6 +114,9 @@ public class StarRocksFE {
             checkCommandLineOptions(cmdLineOpts);
 
             Log4jConfig.initLogging();
+            // We have already output the caffine's error message to Log4j2.
+            // we turn off the java.util.logging.Logger of caffine to reduce the output log of the console
+            java.util.logging.Logger.getLogger("com.github.benmanes.caffeine").setLevel(java.util.logging.Level.OFF);
 
             // set dns cache ttl
             java.security.Security.setProperty("networkaddress.cache.ttl", "60");

--- a/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorColumnStatsCacheLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorColumnStatsCacheLoader.java
@@ -100,7 +100,7 @@ public class ConnectorColumnStatsCacheLoader implements
                 return result;
             } catch (RuntimeException e) {
                 LOG.error(e);
-                return result;
+                throw new CompletionException(e);
             } catch (Exception e) {
                 throw new CompletionException(e);
             } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorHistogramColumnStatsCacheLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorHistogramColumnStatsCacheLoader.java
@@ -64,7 +64,7 @@ public class ConnectorHistogramColumnStatsCacheLoader implements
                 }
             } catch (RuntimeException e) {
                 LOG.error(e);
-                return Optional.empty();
+                throw new CompletionException(e);
             } catch (Exception e) {
                 throw new CompletionException(e);
             } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnBasicStatsCacheLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnBasicStatsCacheLoader.java
@@ -121,7 +121,7 @@ public class ColumnBasicStatsCacheLoader implements AsyncCacheLoader<ColumnStats
                 return result;
             } catch (RuntimeException e) {
                 LOG.error(e);
-                return result;
+                throw new CompletionException(e);
             } catch (Exception e) {
                 throw new CompletionException(e);
             } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnHistogramStatsCacheLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnHistogramStatsCacheLoader.java
@@ -100,7 +100,7 @@ public class ColumnHistogramStatsCacheLoader implements AsyncCacheLoader<ColumnS
                 return result;
             } catch (RuntimeException e) {
                 LOG.error(e);
-                return result;
+                throw new CompletionException(e);
             } catch (Exception e) {
                 throw new CompletionException(e);
             } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PartitionStatsCacheLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PartitionStatsCacheLoader.java
@@ -72,10 +72,7 @@ public class PartitionStatsCacheLoader implements AsyncCacheLoader<ColumnStatsCa
                 return result;
             } catch (RuntimeException e) {
                 LOG.error(e);
-                for (ColumnStatsCacheKey key : cacheKey) {
-                    result.put(key, Optional.empty());
-                }
-                return result;
+                throw new CompletionException(e);
             } catch (Exception e) {
                 throw new CompletionException(e);
             } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/TableStatsCacheLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/TableStatsCacheLoader.java
@@ -81,10 +81,7 @@ public class TableStatsCacheLoader implements AsyncCacheLoader<TableStatsCacheKe
                 return result;
             } catch (RuntimeException e) {
                 LOG.error(e);
-                for (TableStatsCacheKey key : cacheKey) {
-                    result.put(key, Optional.empty());
-                }
-                return result;
+                throw new CompletionException(e);
             } catch (Exception e) {
                 throw new CompletionException(e);
             } finally {


### PR DESCRIPTION
## Why I'm doing:
if asyc task of collection stats throw an exception, we will fill empty to the cache. it will prevent subsequent async jobs on the cache from triggering. so we throw an exception to prevent filling empty to cache. 

we turn off the java.util.logging.Logger of caffine to reduce the output log of the console. becase we have already output the caffine's error message to Log4j2.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0