### PR TITLE
[BugFix] fix partition stats healthy

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
@@ -158,7 +158,7 @@ public class BasicStatsMeta implements Writable {
             Optional<Long> statistic = tableStatistics.getOrDefault(partition.getId(), Optional.empty());
             cachedTableRowCount += statistic.orElse(0L);
 
-            if (!StatisticUtils.isPartitionStatsHealthy(table, partition, this, statistic.orElse(0L))) {
+            if (!StatisticUtils.isPartitionStatsHealthy(partition, this, statistic.orElse(0L))) {
                 updatePartitionCount++;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -261,12 +261,11 @@ public class StatisticUtils {
             statsRowCount = tableStatistics.getOrDefault(partition.getId(), Optional.empty()).orElse(0L);
         }
 
-        return isPartitionStatsHealthy(table, partition, stats, statsRowCount);
+        return isPartitionStatsHealthy(partition, stats, statsRowCount);
     }
 
-    public static boolean isPartitionStatsHealthy(Table table, Partition partition, BasicStatsMeta stats,
-                                                  long statsRowCount) {
-        if (stats == null || stats.isInitJobMeta()) {
+    public static boolean isPartitionStatsHealthy(Partition partition, BasicStatsMeta stats, long statsRowCount) {
+        if (stats == null) {
             return false;
         }
         if (!partition.hasData()) {

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/BasicStatsMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/BasicStatsMetaTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.statistic;
 
+import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.Database;
@@ -39,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.starrocks.persist.gson.GsonUtils.GSON;
+import static com.starrocks.statistic.StatsConstants.INIT_SAMPLE_STATS_JOB;
 
 public class BasicStatsMetaTest extends PlanTestBase {
 
@@ -85,6 +87,11 @@ public class BasicStatsMetaTest extends PlanTestBase {
             basicStatsMeta.setUpdateRows(10000L);
             Assert.assertEquals(1.0, basicStatsMeta.getHealthy(), 0.01);
             basicStatsMeta.resetDeltaRows();
+            Assert.assertEquals(1.0, basicStatsMeta.getHealthy(), 0.01);
+
+            basicStatsMeta.setProperties(ImmutableBiMap.of(INIT_SAMPLE_STATS_JOB, "true"));
+            basicStatsMeta.increaseDeltaRows(5000L);
+            basicStatsMeta.setUpdateRows(10000L);
             Assert.assertEquals(1.0, basicStatsMeta.getHealthy(), 0.01);
         }
     }


### PR DESCRIPTION
## Why I'm doing:
currently, we will classify all partitions stats as unhealthy when basic meta is init job.  basic meta of a table will have a init_job flag after loading a new partition. then we will auto collect all partitions stats due to this bug.  this will also lead to healthy incorrect.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0