### PR TITLE
[BugFix] Fix generated column comment parsing and partition parsing

### DIFF
--- a/contrib/starrocks-python-client/starrocks/reflection.py
+++ b/contrib/starrocks-python-client/starrocks/reflection.py
@@ -570,7 +570,7 @@ class StarRocksTableDefinitionParser(object):
             r"(?:NULL|'(?:''|[^'])*'|[\-\w\.\(\)]+"
             r"(?: +ON UPDATE [\-\w\.\(\)]+)?)"
             r"))?"
-            r"(?: +(?:GENERATED ALWAYS)? ?AS +(?P<generated>\("
+            r"(?: +(?:GENERATED ALWAYS)? ?AS +(?P<generated>"
             r".*\))? ?(?P<persistence>VIRTUAL|STORED)?)?"
             r"(?: +(?P<autoincr>AUTO_INCREMENT))?"
             r"(?: +COMMENT +\"(?P<comment>(?:\"\"|[^\"])*)\")?"
@@ -666,7 +666,7 @@ class StarRocksTableDefinitionParser(object):
         self._re_engine = _re_compile(r"ENGINE%s" r"(?P<val>\w+)\s*" % (self._optional_equals))
         self._re_key_desc = _re_compile(r"(?P<key_type>[A-Z]+)\s*KEY\s*\((?P<columns>.+?)\)\s*")
         self._re_comment = _re_compile(r'COMMENT(?:\s*(?:=\s*)|\s+)"(?P<val>(?:[^"\\]|\\.)*?)"(?!")\s*')
-        self._re_partition = _re_compile(r"(?:.*)?PARTITION(?:.*)")
+        self._re_partition = _re_compile(r"(?:.*)?PARTITION BY (?P<partition>.*)\b(?:DISTRIBUTED|ORDER|PROPERTIRS|BROKER)\b")
 
         self._re_distribution = _re_compile(r"DISTRIBUTED BY (?P<val>.*)")
         # self._re_roll_up_index = _re_compile(r"undefined")


### PR DESCRIPTION
## Why I'm doing:
I have realised that Starrocks SQLAlchemy reflection module has at least following bugs:

* It is not reflecting comments for views [returns no comments]
* It is not reflecting comments for generated columns [returns no comments]
* It cannot parse properly CREATE TABLE with PARTITION BY [raises an error like in linked issues]
## What I'm doing:
I am changing reflection regexps to address these issues.
Fixes #issue
https://github.com/StarRocks/starrocks/issues/52138
https://github.com/StarRocks/starrocks/issues/45149
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.
- [x] SQLAlchemy reflection module
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0