### PR TITLE
[BugFix] set defaultTableLocation to null when create iceberg view for rest catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -284,4 +284,10 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
         return properties;
     }
+
+    @Override
+    public String defaultTableLocation(Namespace ns, String tableName) {
+        // iceberg rest catalog doesn't require location property, and could choose the default location.
+        return null;
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
@@ -179,14 +179,6 @@ public class IcebergRESTCatalogTest {
                                @Mocked ImmutableSQLViewRepresentation representation) throws Exception {
         IcebergMetadata metadata = buildIcebergMetadata(restCatalog);
 
-        new Expectations() {
-            {
-                restCatalog.loadNamespaceMetadata(Namespace.of("db"));
-                result = ImmutableMap.of("location", "xxxxx");
-                minTimes = 1;
-            }
-        };
-
         CreateViewStmt stmt = new CreateViewStmt(false, false, new TableName("catalog", "db", "table"),
                 Lists.newArrayList(new ColWithComment("k1", "", NodePosition.ZERO)), "", false, null, NodePosition.ZERO);
         stmt.setColumns(Lists.newArrayList(new Column("k1", INT)));
@@ -215,7 +207,7 @@ public class IcebergRESTCatalogTest {
                 minTimes = 1;
 
                 baseView.location();
-                result = "xxx";
+                result = null;
                 minTimes = 1;
 
                 restCatalog.loadView(TableIdentifier.of("db", "view"));
@@ -226,6 +218,6 @@ public class IcebergRESTCatalogTest {
 
         Table table = metadata.getView("db", "view");
         Assert.assertEquals(ICEBERG_VIEW, table.getType());
-        Assert.assertEquals("xxx", table.getTableLocation());
+        Assert.assertNull(table.getTableLocation());
     }
 }


### PR DESCRIPTION
## Why I'm doing:
Fix #56600
## What I'm doing:
set rest catalog default table location to null, let rest catalog to determine the location.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0