### PR TITLE
[Enhancement] Delete shards meta from starmgr after recycling partition for cloud-native cluster

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
@@ -161,13 +161,12 @@ public class LakeTableHelper {
                 ret = false;
             }
         }
-        if (ret) {
-            // try to remove shard group meta (shards meta included)
-            deleteShardGroupMeta(partition);
-        }
         return ret;
     }
 
+    /**
+     * delete `partition`'s all shard group meta (shards meta included) from starmanager
+     */
     static void deleteShardGroupMeta(Partition partition)  {
         // use Set to avoid duplicate shard group id
         StarOSAgent starOSAgent = GlobalStateMgr.getCurrentState().getStarOSAgent();

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
@@ -175,8 +175,7 @@ public class LakeTableHelper {
         Set<Long> needRemoveShardGroupIdSet = new HashSet<>();
         for (PhysicalPartition subPartition : subPartitions) {
             for (MaterializedIndex index : subPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
-                long shardGroupId = index.getShardGroupId();
-                needRemoveShardGroupIdSet.add(shardGroupId);
+                needRemoveShardGroupIdSet.add(index.getShardGroupId());
             }
         }
         if (!needRemoveShardGroupIdSet.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeListPartitionInfo.java
@@ -40,6 +40,7 @@ public class RecycleLakeListPartitionInfo extends RecycleListPartitionInfo {
             Warehouse warehouse = manager.getBackgroundWarehouse();
             if (LakeTableHelper.removePartitionDirectory(partition, warehouse.getId())) {
                 GlobalStateMgr.getCurrentState().getLocalMetastore().onErasePartition(partition);
+                LakeTableHelper.deleteShardGroupMeta(partition);
                 return true;
             } else {
                 return false;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeRangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeRangePartitionInfo.java
@@ -43,6 +43,7 @@ public class RecycleLakeRangePartitionInfo extends RecycleRangePartitionInfo  {
             Warehouse warehouse = manager.getBackgroundWarehouse();
             if (LakeTableHelper.removePartitionDirectory(partition, warehouse.getId())) {
                 GlobalStateMgr.getCurrentState().getLocalMetastore().onErasePartition(partition);
+                LakeTableHelper.deleteShardGroupMeta(partition);
                 return true;
             } else {
                 return false;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeUnPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeUnPartitionInfo.java
@@ -42,6 +42,7 @@ public class RecycleLakeUnPartitionInfo extends RecycleUnPartitionInfo {
             Warehouse warehouse = manager.getBackgroundWarehouse();
             if (LakeTableHelper.removePartitionDirectory(partition, warehouse.getId())) {
                 GlobalStateMgr.getCurrentState().getLocalMetastore().onErasePartition(partition);
+                LakeTableHelper.deleteShardGroupMeta(partition);
                 return true;
             } else {
                 return false;

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
@@ -14,7 +14,16 @@
 
 package com.starrocks.lake;
 
+import com.google.common.collect.Lists;
+import com.staros.proto.ShardGroupInfo;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
@@ -24,10 +33,19 @@ import com.starrocks.sql.ast.CreateDbStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class LakeTableHelperTest {
     private static ConnectContext connectContext;
@@ -73,5 +91,55 @@ public class LakeTableHelperTest {
         Assert.assertFalse(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.MV_REFRESH));
         Config.lake_use_combined_txn_log = false;
         Assert.assertFalse(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.BACKEND_STREAMING));
+    }
+
+    @Test
+    public void testDeleteShardGroupMeta(@Mocked StarOSAgent starOSAgent) {
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public StarOSAgent getStarOSAgent() {
+                return starOSAgent;
+            }
+        };
+
+        long tableId = 1001L;
+        long partitionId = 1000L;
+        long physicalPartitionId = 1002L;
+        long groupIdToClear = 5100L;
+
+        DistributionInfo distributionInfo = new HashDistributionInfo(10, Lists.newArrayList());
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setReplicationNum(1000L, (short) 3);
+        Partition partition =
+                new Partition(partitionId, physicalPartitionId, "p1", new MaterializedIndex(), distributionInfo);
+        Collection<PhysicalPartition> subPartitions = partition.getSubPartitions();
+        subPartitions.forEach(physicalPartition -> {
+            MaterializedIndex materializedIndex =
+                    physicalPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL).get(0);
+            materializedIndex.setShardGroupId(groupIdToClear);
+        });
+
+        // build shardGroupInfos
+        List<Long> allShardIds = Stream.of(1000L, 1001L, 1002L, 1003L).collect(Collectors.toList());
+        List<ShardGroupInfo> shardGroupInfos = new ArrayList<>();
+        ShardGroupInfo info = ShardGroupInfo.newBuilder()
+                .setGroupId(groupIdToClear)
+                .putLabels("tableId", String.valueOf(tableId))
+                .putProperties("createTime", String.valueOf(System.currentTimeMillis() - 86400 * 1000))
+                .addAllShardIds(allShardIds)
+                .build();
+        shardGroupInfos.add(info);
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public void deleteShardGroup(List<Long> groupIds) {
+                for (long groupId : groupIds) {
+                    shardGroupInfos.removeIf(item -> item.getGroupId() == groupId);
+                }
+            }
+        };
+
+        LakeTableHelper.deleteShardGroupMeta(partition);
+        Assert.assertEquals(0, shardGroupInfos.size());
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Currently, the RecycleBin is responsible for removing partition directories from remote storage, but it relies on StarMgrMetaSyncer to clean up shard metadata from StarMgr. However, since StarMgrMetaSyncer was not designed to handle heavy cleanup tasks, it would be more efficient to remove the metadata immediately after the RecycleBin completes its work.
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0