### PR TITLE
[BugFix] Fix data unconsistent if add a new generated column which ref a normal column which contains cols file for pk table

### DIFF
--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -840,6 +840,7 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_segment_iterators2(const Sch
     if (chunk_size > 0) {
         seg_options.chunk_size = chunk_size;
     }
+    seg_options.read_by_generated_column_adding = (dcg_meta != nullptr);
 
     std::vector<ChunkIteratorPtr> seg_iterators(num_segments());
     TabletSegmentId tsid;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -454,7 +454,9 @@ SegmentIterator::SegmentIterator(std::shared_ptr<Segment> segment, Schema schema
     }
     if (_opts.dcg_loader != nullptr) {
         SCOPED_RAW_TIMER(&_opts.stats->get_delta_column_group_ns);
-        if (_opts.is_primary_keys) {
+        if (_opts.is_primary_keys ||
+            (_opts.read_by_generated_column_adding && _opts.tablet_schema != nullptr &&
+             _opts.tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) /* for adding generated column */) {
             TabletSegmentId tsid;
             tsid.tablet_id = _opts.tablet_id;
             tsid.segment_id = _opts.rowset_id + segment_id();

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -121,6 +121,8 @@ public:
 
     bool enable_join_runtime_filter_pushdown = false;
 
+    bool read_by_generated_column_adding = false;
+
 public:
     Status convert_to(SegmentReadOptions* dst, const std::vector<LogicalType>& new_types, ObjectPool* obj_pool) const;
 

--- a/test/sql/test_materialized_column/R/test_materialized_column
+++ b/test/sql/test_materialized_column/R/test_materialized_column
@@ -1115,3 +1115,33 @@ select COLUMN_NAME, GENERATION_EXPRESSION from information_schema.columns where 
 select COLUMN_NAME, GENERATION_EXPRESSION from information_schema.columns where TABLE_NAME = 't_information_schema_generated_column_2';
 -- result:
 -- !result
+-- name: test_fix_adding_and_col_partial_update_conflict
+CREATE TABLE t_fix_adding_and_col_partial_update_conflict ( id BIGINT NOT NULL, v1 BIGINT NOT NULL, v2 BIGINT NOT NULL) Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage" = "true", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+insert into t_fix_adding_and_col_partial_update_conflict values (1,2,3),(2,3,4),(3,4,5);
+-- result:
+-- !result
+SET partial_update_mode = "column";
+-- result:
+-- !result
+UPDATE t_fix_adding_and_col_partial_update_conflict SET v2 = 400 where id = 2;
+-- result:
+-- !result
+delete from t_fix_adding_and_col_partial_update_conflict where id % 2 = 1;
+-- result:
+-- !result
+alter table t_fix_adding_and_col_partial_update_conflict add column newcol bigint as v2 * 100;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from t_fix_adding_and_col_partial_update_conflict;
+-- result:
+2	3	400	40000
+-- !result
+drop table t_fix_adding_and_col_partial_update_conflict;
+-- result:
+-- !result

--- a/test/sql/test_materialized_column/T/test_materialized_column
+++ b/test/sql/test_materialized_column/T/test_materialized_column
@@ -447,3 +447,14 @@ DROP TABLE t_information_schema_generated_column_2;
 
 select COLUMN_NAME, GENERATION_EXPRESSION from information_schema.columns where TABLE_NAME = 't_information_schema_generated_column_1';
 select COLUMN_NAME, GENERATION_EXPRESSION from information_schema.columns where TABLE_NAME = 't_information_schema_generated_column_2';
+
+-- name: test_fix_adding_and_col_partial_update_conflict
+CREATE TABLE t_fix_adding_and_col_partial_update_conflict ( id BIGINT NOT NULL, v1 BIGINT NOT NULL, v2 BIGINT NOT NULL) Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage" = "true", "fast_schema_evolution" = "true");
+insert into t_fix_adding_and_col_partial_update_conflict values (1,2,3),(2,3,4),(3,4,5);
+SET partial_update_mode = "column";
+UPDATE t_fix_adding_and_col_partial_update_conflict SET v2 = 400 where id = 2;
+delete from t_fix_adding_and_col_partial_update_conflict where id % 2 = 1;
+alter table t_fix_adding_and_col_partial_update_conflict add column newcol bigint as v2 * 100;
+function: wait_alter_table_finish()
+select * from t_fix_adding_and_col_partial_update_conflict;
+drop table t_fix_adding_and_col_partial_update_conflict;


### PR DESCRIPTION
## Why I'm doing:
In current impl, when we adding generated column, we get segment iterator as a non-primary key segment which means that we do not want to apply the del vector on it to generate a cols file with the same row size as the segment file. But the problem is, the flag is_primary_keys in segment read option is always false and no dcg will be load from rocksdb. If the new added generated column has ref a column which has been updated in partial update column mode with cols files, the result of the generated column will lost the updated value.

## What I'm doing:
Ensure the dcg will be load when adding generated column for pk table.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0