### PR TITLE
[Enhancement] Resolve absl conflicts between staros and opentelemetry

### DIFF
--- a/be/src/common/tracer.h
+++ b/be/src/common/tracer.h
@@ -18,10 +18,9 @@
 #include <opentelemetry/trace/span.h>
 #include <opentelemetry/trace/span_context.h>
 
+#include "common/tracer_fwd.h"
+
 namespace starrocks {
-namespace trace = opentelemetry::trace;
-using Span = opentelemetry::nostd::shared_ptr<trace::Span>;
-using SpanContext = trace::SpanContext;
 
 /**
  * Handles span creation and provides a compatible interface to `opentelemetry::trace::Tracer`.

--- a/be/src/common/tracer_fwd.h
+++ b/be/src/common/tracer_fwd.h
@@ -1,0 +1,30 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <opentelemetry/nostd/shared_ptr.h>
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace {
+class Span;
+class SpanContext;
+} // namespace trace
+OPENTELEMETRY_END_NAMESPACE
+
+namespace starrocks {
+namespace trace = opentelemetry::trace;
+using Span = opentelemetry::nostd::shared_ptr<trace::Span>;
+using SpanContext = trace::SpanContext;
+} // namespace starrocks

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -47,6 +47,7 @@
 #include "column/map_column.h"
 #include "column/nullable_column.h"
 #include "common/statusor.h"
+#include "common/tracer.h"
 #include "config.h"
 #include "exec/pipeline/query_context.h"
 #include "exec/tablet_sink_colocate_sender.h"

--- a/be/src/exec/tablet_sink_index_channel.cpp
+++ b/be/src/exec/tablet_sink_index_channel.cpp
@@ -20,6 +20,7 @@
 #include "column/column_viewer.h"
 #include "column/nullable_column.h"
 #include "common/statusor.h"
+#include "common/tracer.h"
 #include "common/utils.h"
 #include "config.h"
 #include "exec/tablet_sink.h"

--- a/be/src/exec/tablet_sink_index_channel.h
+++ b/be/src/exec/tablet_sink_index_channel.h
@@ -24,7 +24,7 @@
 #include <vector>
 
 #include "common/status.h"
-#include "common/tracer.h"
+#include "common/tracer_fwd.h"
 #include "exec/async_data_sink.h"
 #include "exec/tablet_info.h"
 #include "gen_cpp/Types_types.h"

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -37,6 +37,7 @@
 #include <memory>
 
 #include "common/closure_guard.h"
+#include "common/tracer.h"
 #include "fmt/format.h"
 #include "runtime/lake_tablets_channel.h"
 #include "runtime/load_channel_mgr.h"

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -44,7 +44,7 @@
 #include "column/chunk.h"
 #include "common/compiler_util.h"
 #include "common/status.h"
-#include "common/tracer.h"
+#include "common/tracer_fwd.h"
 #include "gen_cpp/InternalService_types.h"
 #include "gen_cpp/Types_types.h"
 #include "gen_cpp/internal_service.pb.h"

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -16,6 +16,7 @@
 
 #include <utility>
 
+#include "common/tracer.h"
 #include "io/io_profiler.h"
 #include "runtime/current_thread.h"
 #include "runtime/descriptors.h"

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -16,7 +16,7 @@
 
 #include "column/chunk.h"
 #include "column/vectorized_fwd.h"
-#include "common/tracer.h"
+#include "common/tracer_fwd.h"
 #include "gen_cpp/internal_service.pb.h"
 #include "gen_cpp/olap_common.pb.h"
 #include "gutil/macros.h"


### PR DESCRIPTION
## Why I'm doing:
Both staros and opentelemetry depend on absl, but the absl versions are different, so there can be conflicts if one cpp file includes header files from both absl versions. One compile error can be the following (from #56517), and the dependency is as the following. A similar problem has been fixed by #24552 in previous,  but the fix does not apply to #56517 because `update_config_action.cpp` needs  `load_channel_mgr.h`, and can not just remove it. Here we need to come up with a new approach to solve this.
```mermaid
graph TD
    update_config_action.cpp --> load_channel_mgr.h --> load_channel.h --> tracer.h --> opentelemetry/trace/scope.h --> m1["......"] --> absl::otel_v1
    update_config_action.cpp --> staros_worker.h --> m2["......"]  --> absl::lts_20220623
```

```
  In file included from /var/local/thirdparty/installed/include/absl/base/call_once.h:38,
                   from /var/local/thirdparty/installed/include/absl/status/statusor.h:47,
                   from /var/local/thirdparty/installed/starlet/starlet_install/include/starlet.h:23,
                   from /root/starrocks/be/src/service/staros_worker.h:19,
                   from /root/starrocks/be/src/http/action/update_config_action.cpp:75:
  /var/local/thirdparty/installed/include/absl/base/internal/spinlock_wait.h:80:11: error: reference to ‘base_internal’ is ambiguous
     80 |     absl::base_internal::SchedulingMode scheduling_mode);
        |           ^~~~~~~~~~~~~
  In file included from /var/local/thirdparty/installed/include/opentelemetry/nostd/internal/absl/utility/utility.h:50,
                   from /var/local/thirdparty/installed/include/opentelemetry/nostd/internal/absl/types/variant.h:46,
                   from /var/local/thirdparty/installed/include/opentelemetry/nostd/variant.h:52,
                   from /var/local/thirdparty/installed/include/opentelemetry/common/attribute_value.h:10,
                   from /var/local/thirdparty/installed/include/opentelemetry/common/key_value_iterable.h:6,
                   from /var/local/thirdparty/installed/include/opentelemetry/common/key_value_iterable_view.h:10,
                   from /var/local/thirdparty/installed/include/opentelemetry/common/kv_properties.h:6,
                   from /var/local/thirdparty/installed/include/opentelemetry/baggage/baggage.h:8,
                   from /var/local/thirdparty/installed/include/opentelemetry/context/context_value.h:8,
                   from /var/local/thirdparty/installed/include/opentelemetry/context/context.h:7,
                   from /var/local/thirdparty/installed/include/opentelemetry/context/runtime_context.h:6,
                   from /var/local/thirdparty/installed/include/opentelemetry/trace/scope.h:6,
                   from /root/starrocks/be/src/common/tracer.h:17,
                   from /root/starrocks/be/src/runtime/load_channel.h:47,
                   from /root/starrocks/be/src/runtime/load_channel_mgr.h:51,
                   from /root/starrocks/be/src/http/action/update_config_action.cpp:57:
  /var/local/thirdparty/installed/include/opentelemetry/nostd/internal/absl/base/internal/invoke.h:49:11: note: candidates are: ‘namespace absl::otel_v1::base_internal { }’
     49 | namespace base_internal {
        |           ^~~~~~~~~~~~~
  In file included from /var/local/thirdparty/installed/include/absl/base/call_once.h:34,
                   from /var/local/thirdparty/installed/include/absl/status/statusor.h:47,
                   from /var/local/thirdparty/installed/starlet/starlet_install/include/starlet.h:23,
                   from /root/starrocks/be/src/service/staros_worker.h:19,
                   from /root/starrocks/be/src/http/action/update_config_action.cpp:75:
  /var/local/thirdparty/installed/include/absl/base/internal/invoke.h:48:11: note:                 ‘namespace absl::lts_20220623::base_internal { }’
     48 | namespace base_internal {
        |           ^~~~~~~~~~~~~
  In file included from /var/local/thirdparty/installed/include/absl/base/call_once.h:38,
                   from /var/local/thirdparty/installed/include/absl/status/statusor.h:47,
                   from /var/local/thirdparty/installed/starlet/starlet_install/include/starlet.h:23,
                   from /root/starrocks/be/src/service/staros_worker.h:19,
                   from /root/starrocks/be/src/http/action/update_config_action.cpp:75:

```

## What I'm doing:
A more comprehensive solution is to let opentelemetry uses the absl provided by starrocks so that there won't be different versions. It seems feasible according to [3063](https://github.com/open-telemetry/opentelemetry-cpp/issues/3063), and we need to update the build image. But I don't use this method in this PR because if we want to backport #56517 to the previous versions, we also need to backport this pr and update build images for previous version. I think the cost is too much if only #56517 can benefit from it. This can be a long term solution, and now we want to come up a simple solution to not block #56517.

The idea is that remove the opentelemetry headers that depends on the absl from `load_channel_mgr.h`, and use forward declarations in header files to solve the dependency, see `tracer_fwd.h`. As a result, update_config_action.cpp will not include asbl header files from load_channel_mgr.h

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0