### PR TITLE
[Enhancement] fix jprotobuf-precompile-plugin not work with scope provided

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -1132,9 +1132,9 @@ under the License.
                 <artifactId>jprotobuf-precompile-plugin</artifactId>
                 <version>2.2.12</version>
                 <configuration>
-                    <filterClassPackage>com.starrocks.proto</filterClassPackage>
+                    <filterClassPackage>com.starrocks.proto;com.starrocks.rpc;com.starrocks.server</filterClassPackage>
                     <generateProtoFile>true</generateProtoFile>
-                    <compileDependencies>false</compileDependencies>
+                    <compileDependencies>true</compileDependencies>
                 </configuration>
                 <executions>
                     <execution>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -1134,7 +1134,7 @@ under the License.
                 <configuration>
                     <filterClassPackage>com.starrocks.proto</filterClassPackage>
                     <generateProtoFile>true</generateProtoFile>
-                    <compileDependencies>true</compileDependencies>
+                    <compileDependencies>false</compileDependencies>
                 </configuration>
                 <executions>
                     <execution>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -1132,7 +1132,7 @@ under the License.
                 <artifactId>jprotobuf-precompile-plugin</artifactId>
                 <version>2.2.12</version>
                 <configuration>
-                    <filterClassPackage>com.starrocks</filterClassPackage>
+                    <filterClassPackage>com.starrocks.proto</filterClassPackage>
                     <generateProtoFile>true</generateProtoFile>
                     <compileDependencies>true</compileDependencies>
                 </configuration>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -539,6 +539,7 @@ under the License.
                 <groupId>org.apache.spark</groupId>
                 <artifactId>spark-core_2.12</artifactId>
                 <version>${spark.version}</version>
+                <scope>provided</scope>
                 <exclusions>
                     <exclusion>
                         <groupId>org.slf4j</groupId>
@@ -560,6 +561,7 @@ under the License.
                 <groupId>org.apache.spark</groupId>
                 <artifactId>spark-launcher_2.12</artifactId>
                 <version>${spark.version}</version>
+                <scope>provided</scope>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/org.apache.spark/spark-sql_2.12 -->
@@ -567,6 +569,7 @@ under the License.
                 <groupId>org.apache.spark</groupId>
                 <artifactId>spark-sql_2.12</artifactId>
                 <version>${spark.version}</version>
+                <scope>provided</scope>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/org.apache.spark/spark-catalyst -->
@@ -574,6 +577,7 @@ under the License.
                 <groupId>org.apache.spark</groupId>
                 <artifactId>spark-catalyst_2.12</artifactId>
                 <version>${spark.version}</version>
+                <scope>provided</scope>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/io.trino.hive/hive-apache -->

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -539,7 +539,6 @@ under the License.
                 <groupId>org.apache.spark</groupId>
                 <artifactId>spark-core_2.12</artifactId>
                 <version>${spark.version}</version>
-                <scope>provided</scope>
                 <exclusions>
                     <exclusion>
                         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
## Why I'm doing:

packages can not be scoped as provided any more.

## What I'm doing:

just need to precompile "com.starrocks.proto" namespace.

Fixes #50277

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0