### PR TITLE
[BugFix] Fix _wait_for_version timeout caused by compaction

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1895,10 +1895,10 @@ Status TabletUpdates::_wait_for_version(const EditVersion& version, int64_t time
             LOG(WARNING) << msg;
             return Status::InternalError(msg);
         }
-        if (now - wait_start > timeout_ms) {
+        if (!is_compaction && now - wait_start > timeout_ms) {
             string msg = strings::Substitute("wait_for_version timeout($0ms) version:$1 $2", now - wait_start,
                                              version.to_string(), _debug_string(false, true));
-            LOG_IF(WARNING, !is_compaction) << msg;
+            LOG_IF(WARNING) << msg;
             return Status::TimedOut(msg);
         }
     }

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1898,7 +1898,7 @@ Status TabletUpdates::_wait_for_version(const EditVersion& version, int64_t time
         if (!is_compaction && now - wait_start > timeout_ms) {
             string msg = strings::Substitute("wait_for_version timeout($0ms) version:$1 $2", now - wait_start,
                                              version.to_string(), _debug_string(false, true));
-            LOG(WARNING) << msg;
+            LOG_IF(WARNING, !is_compaction) << msg;
             return Status::TimedOut(msg);
         }
     }

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1898,7 +1898,7 @@ Status TabletUpdates::_wait_for_version(const EditVersion& version, int64_t time
         if (!is_compaction && now - wait_start > timeout_ms) {
             string msg = strings::Substitute("wait_for_version timeout($0ms) version:$1 $2", now - wait_start,
                                              version.to_string(), _debug_string(false, true));
-            LOG_IF(WARNING) << msg;
+            LOG(WARNING) << msg;
             return Status::TimedOut(msg);
         }
     }


### PR DESCRIPTION
## Why I'm doing:

During compaction, there is a high probability that `TabletUpdates::_wait_for_version` will time out, causing query failures. When determining whether `TabletUpdates::_wait_for_version` has timed out, the compaction scenario needs to be excluded.

![image](https://github.com/user-attachments/assets/df60558c-23c2-4eaf-b2a6-2ed763955fd3)


In the current implementation, the `is_compaction` parameter only affects logging behavior. When `is_compaction` is true, warning logs are not recorded, but the timeout status is still returned.

![image](https://github.com/user-attachments/assets/a1286f99-eb7d-41e4-adb0-cd2e525a0368)




## What I'm doing:

Exclude the compaction scenario when determining whether `TabletUpdates::_wait_for_version` has timed out to avoid query task failures.

![image](https://github.com/user-attachments/assets/aeb114b1-c0be-4d24-9c28-7f0737db9e7f)

![image](https://github.com/user-attachments/assets/16591040-b93b-4b9e-afd9-9689686373e1)


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0