### PR TITLE
[Enhancement] Support paimon show partitions (backport #55785)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ExternalTableProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ExternalTableProcDir.java
@@ -19,6 +19,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.starrocks.catalog.PaimonTable;
+import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 
@@ -30,6 +32,7 @@ public class ExternalTableProcDir implements ProcDirInterface {
             .build();
 
     public static final String SCHEMA = "schema";
+    public static final String PARTITIONS = "partitions";
 
     // TODO implementing show proc external table partitions
     private static final ImmutableList<String> CHILDREN_NODES = new ImmutableList.Builder<String>()
@@ -68,6 +71,15 @@ public class ExternalTableProcDir implements ProcDirInterface {
 
         if (entryName.equals(SCHEMA)) {
             return new ExternalSchemaProcNode(table);
+        } else if (entryName.equals(PARTITIONS)) {
+            if (table instanceof PaimonTable) {
+                PaimonTable paimonTable = (PaimonTable) table;
+                PartitionType partitionType = paimonTable.isUnPartitioned() ?
+                        PartitionType.UNPARTITIONED : PartitionType.LIST;
+                return new PaimonTablePartitionsProcDir(table, partitionType);
+            } else {
+                throw new AnalysisException("table is not support: " + entryName);
+            }
         } else {
             throw new AnalysisException("Not implemented yet: " + entryName);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/PaimonTablePartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/PaimonTablePartitionsProcDir.java
@@ -1,0 +1,97 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.proc;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.starrocks.catalog.PaimonTable;
+import com.starrocks.catalog.PartitionType;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.util.TimeUtils;
+import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.connector.PartitionInfo;
+import com.starrocks.connector.paimon.Partition;
+import com.starrocks.server.GlobalStateMgr;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PaimonTablePartitionsProcDir extends PartitionsProcDir {
+    private Table table;
+
+    public PaimonTablePartitionsProcDir(Table table, PartitionType partitionType) {
+        super(partitionType);
+        this.table = table;
+        this.createTitleNames();
+    }
+
+    @Override
+    public void createTitleNames() {
+        ImmutableList.Builder<String> builder =
+                new ImmutableList.Builder<String>().add("PartitionName").add("VisibleVersionTime").add("State")
+                        .add("PartitionKey").add("RowCount").add("DataSize").add("FileCount");
+        this.titleNames = builder.build();
+
+    }
+
+    public List<List<Comparable>> getPartitionInfos() {
+        Preconditions.checkNotNull(table);
+        PaimonTable paimonTable = (PaimonTable) table;
+        // get info
+        List<List<Comparable>> partitionInfos = new ArrayList<List<Comparable>>();
+        List<String> listPartitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                .listPartitionNames(table.getCatalogName(), paimonTable.getCatalogDBName(),
+                        paimonTable.getCatalogTableName(), ConnectorMetadatRequestContext.DEFAULT);
+
+        List<PartitionInfo> tblPartitionInfo = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                .getPartitions(table.getCatalogName(), table, listPartitionNames);
+
+        for (PartitionInfo partitionInfo : tblPartitionInfo) {
+            partitionInfos.add(getPartitionInfo(partitionInfo));
+        }
+        return partitionInfos;
+    }
+
+    private List<Comparable> getPartitionInfo(PartitionInfo tblPartitionInfo) {
+        List<Comparable> partitionInfo = new ArrayList<Comparable>();
+        Partition partition = (Partition) tblPartitionInfo;
+        // PartitionName
+        partitionInfo.add(partition.getPartitionName());
+        // VisibleVersionTime
+        partitionInfo.add(TimeUtils.longToTimeString(partition.getModifiedTime()));
+        // State
+        partitionInfo.add("Normal");
+        // partition key
+        partitionInfo.add(table.isUnPartitioned() ? "" : String.join(",", table.getPartitionColumnNames()));
+
+        partitionInfo.add(partition.getRecordCount());
+        partitionInfo.add(partition.getFileSizeInBytes());
+        partitionInfo.add(partition.getFileCount());
+
+        return partitionInfo;
+    }
+
+
+    @Override
+    public boolean register(String name, ProcNodeInterface node) {
+        return false;
+    }
+
+    @Override
+    public ProcNodeInterface lookup(String partitionIdOrName) throws AnalysisException {
+        throw new AnalysisException("paimon not support");
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
@@ -90,7 +90,7 @@ import java.util.stream.Collectors;
  */
 public class PartitionsProcDir implements ProcDirInterface {
     private final PartitionType partitionType;
-    private ImmutableList<String> titleNames;
+    public ImmutableList<String> titleNames;
     private Database db;
     private OlapTable table;
     private boolean isTempPartition = false;
@@ -103,7 +103,11 @@ public class PartitionsProcDir implements ProcDirInterface {
         this.createTitleNames();
     }
 
-    private void createTitleNames() {
+    public PartitionsProcDir(PartitionType partitionType) {
+        this.partitionType = partitionType;
+    }
+
+    public void createTitleNames() {
         if (table.isCloudNativeTableOrMaterializedView()) {
             ImmutableList.Builder<String> builder = new ImmutableList.Builder<String>()
                     .add("PartitionId")
@@ -273,7 +277,7 @@ public class PartitionsProcDir implements ProcDirInterface {
         return result;
     }
 
-    private List<List<Comparable>> getPartitionInfos() {
+    public List<List<Comparable>> getPartitionInfos() {
         Preconditions.checkNotNull(db);
         Preconditions.checkNotNull(table);
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/Partition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/Partition.java
@@ -24,9 +24,18 @@ public class Partition implements PartitionInfo {
     private final String partitionName;
     private final long lastUpdateTime;
 
-    public Partition(String name, long lastUpdateTime) {
+    private final Long recordCount;
+    private final Long fileSizeInBytes;
+    private final Long fileCount;
+
+    public Partition(String name, long lastUpdateTime, Long recordCount,
+                     Long fileSizeInBytes, Long fileCount) {
         this.partitionName = name;
         this.lastUpdateTime = lastUpdateTime;
+        this.recordCount = recordCount;
+        this.fileSizeInBytes = fileSizeInBytes;
+        this.fileCount = fileCount;
+
     }
 
     public String getPartitionName() {
@@ -43,11 +52,26 @@ public class Partition implements PartitionInfo {
         return lastUpdateTime;
     }
 
+    public Long getRecordCount() {
+        return recordCount;
+    }
+
+    public Long getFileSizeInBytes() {
+        return fileSizeInBytes;
+    }
+
+    public Long getFileCount() {
+        return fileCount;
+    }
+
     @Override
     public String toString() {
         return "PaimonPartitionInfo{" +
                 "partitionName='" + partitionName + '\'' +
                 ", lastUpdateTime=" + lastUpdateTime +
+                ", recordCount=" + recordCount +
+                ", fileSizeInBytes=" + fileSizeInBytes +
+                ", fileCount=" + fileCount +
                 '}';
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtAnalyzer.java
@@ -33,6 +33,7 @@ import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.MysqlTable;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PaimonTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableFunctionTable;
 import com.starrocks.catalog.Type;
@@ -553,6 +554,8 @@ public class ShowStmtAnalyzer {
 
         @Override
         public Void visitShowPartitionsStatement(ShowPartitionsStmt statement, ConnectContext context) {
+            TableName tbl = statement.getTbl();
+            tbl.normalization(context);
             String dbName = statement.getDbName();
             dbName = getDatabaseName(dbName, context);
             statement.setDbName(dbName);
@@ -560,7 +563,7 @@ public class ShowStmtAnalyzer {
             if (statement.getWhereClause() != null) {
                 analyzeSubPredicate(filterMap, statement.getWhereClause());
             }
-            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+            Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(tbl.getCatalog(), dbName);
             if (db == null) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
             }
@@ -570,19 +573,27 @@ public class ShowStmtAnalyzer {
             Locker locker = new Locker();
             locker.lockDatabase(db.getId(), LockType.READ);
             try {
-                Table table = MetaUtils.getSessionAwareTable(context, db, new TableName(dbName, tableName));
-                if (!(table instanceof OlapTable)) {
-                    throw new SemanticException("Table[" + tableName + "] does not exists or is not OLAP table");
+                Table table =
+                        MetaUtils.getSessionAwareTable(context, db, new TableName(tbl.getCatalog(), dbName, tableName));
+                if (!(table instanceof OlapTable) && !(table instanceof PaimonTable)) {
+                    throw new SemanticException("Table[" + tableName + "] does not exists or is not OLAP/Paimon table");
                 }
-
                 // build proc path
                 StringBuilder stringBuilder = new StringBuilder();
-                stringBuilder.append("/dbs/");
-                stringBuilder.append(db.getId());
-                stringBuilder.append("/").append(table.getId());
-                if (isTempPartition) {
-                    stringBuilder.append("/temp_partitions");
-                } else {
+                if (table instanceof OlapTable) {
+                    stringBuilder.append("/dbs/");
+                    stringBuilder.append(db.getId());
+                    stringBuilder.append("/").append(table.getId());
+                    if (isTempPartition) {
+                        stringBuilder.append("/temp_partitions");
+                    } else {
+                        stringBuilder.append("/partitions");
+                    }
+                } else if (table instanceof PaimonTable) {
+                    stringBuilder.append("/catalog/");
+                    stringBuilder.append(tbl.getCatalog());
+                    stringBuilder.append("/").append(dbName);
+                    stringBuilder.append("/").append(tableName);
                     stringBuilder.append("/partitions");
                 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowPartitionsStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowPartitionsStmt.java
@@ -49,6 +49,7 @@ public class ShowPartitionsStmt extends ShowStmt {
             .add(FILTER_REPLICATION_NUM)
             .add(FILTER_LAST_CONSISTENCY_CHECK_TIME).build();
 
+    private TableName tbl;
     private String dbName;
     private final String tableName;
     private final Expr whereClause;
@@ -69,6 +70,7 @@ public class ShowPartitionsStmt extends ShowStmt {
     public ShowPartitionsStmt(TableName tableName, Expr whereClause, List<OrderByElement> orderByElements,
                               LimitElement limitElement, boolean isTempPartition, NodePosition pos) {
         super(pos);
+        this.tbl = tableName;
         this.dbName = tableName.getDb();
         this.tableName = tableName.getTbl();
         this.whereClause = whereClause;
@@ -111,6 +113,10 @@ public class ShowPartitionsStmt extends ShowStmt {
             builder.addColumn(new Column(col, ScalarType.createVarchar(30)));
         }
         return builder.build();
+    }
+
+    public TableName getTbl() {
+        return tbl;
     }
 
     public String getDbName() {

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/PaimonPartitionsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/PaimonPartitionsProcDirTest.java
@@ -1,0 +1,115 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.proc;
+
+import com.starrocks.analysis.BinaryPredicate;
+import com.starrocks.analysis.BinaryType;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.LimitElement;
+import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.StringLiteral;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.PaimonTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.util.OrderByPair;
+import com.starrocks.connector.HdfsEnvironment;
+import com.starrocks.connector.PartitionInfo;
+import com.starrocks.connector.paimon.PaimonMetadata;
+import com.starrocks.connector.paimon.Partition;
+import com.starrocks.server.MetadataMgr;
+import com.starrocks.sql.parser.NodePosition;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.apache.hadoop.util.Lists;
+import org.apache.paimon.catalog.Catalog;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class PaimonPartitionsProcDirTest {
+    @Mocked
+    Catalog paimonNativeCatalog;
+    @Mocked
+    org.apache.paimon.table.Table nativeTable;
+    private PaimonMetadata metadata;
+
+    @Before
+    public void setUp() throws DdlException, AnalysisException {
+        this.metadata = new PaimonMetadata("paimon_catalog", new HdfsEnvironment(), paimonNativeCatalog, null);
+    }
+
+    @Test
+    public void testFetchResult() throws AnalysisException {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("/catalog/");
+        stringBuilder.append("paimon_catalog");
+        stringBuilder.append("/").append("db1");
+        stringBuilder.append("/").append("tb1");
+        stringBuilder.append("/partitions");
+
+        new MockUp<MetadataMgr>() {
+            @Mock
+            public Database getDb(String catalogName, String dbName) {
+                return new Database(1L, "db1");
+            }
+
+            @Mock
+            public Table getTable(String catalogName, String dbName, String tblName) {
+                return new PaimonTable("paimon_catalog", "db1", "tb1", null, nativeTable, 1L);
+            }
+
+            @Mock
+            public List<PartitionInfo> getPartitions(String catalogName, Table table, List<String> partitionNames) {
+                Partition p1 = new Partition("dt=20240903", 1727079167000L, 5L, 12112L, 11L);
+                Partition p2 = new Partition("dt=null", 1727079167000L, 1L, 12L, 1L);
+                Partition p3 = new Partition("dt=20240902", 1727079167000L, 1L, 12L, 1L);
+
+                return Lists.newArrayList(p1, p2, p3);
+            }
+        };
+
+        ProcNodeInterface paimonProc = ProcService.getInstance().open(stringBuilder.toString());
+        Assert.assertTrue(paimonProc instanceof PaimonTablePartitionsProcDir);
+
+        ProcResult procResult = ((PartitionsProcDir) paimonProc).fetchResultByFilter(null, null, null);
+        Assert.assertEquals(procResult.getRows().size(), 3);
+        Assert.assertEquals(procResult.getRows().get(0).size(), 7);
+        Assert.assertEquals(procResult.getColumnNames().size(), 7);
+
+        LimitElement limitElement = new LimitElement(0, 2);
+        ProcResult limitProcResult = ((PartitionsProcDir) paimonProc).fetchResultByFilter(null, null, limitElement);
+        Assert.assertEquals(limitProcResult.getRows().size(), 2);
+
+        OrderByPair orderByPair = new OrderByPair(0);
+        ProcResult orderProcResult =
+                ((PartitionsProcDir) paimonProc).fetchResultByFilter(null, Lists.newArrayList(orderByPair), null);
+        Assert.assertEquals(orderProcResult.getRows().get(0).get(0), "dt=20240902");
+
+        BinaryPredicate filter = new BinaryPredicate(BinaryType.EQ, new SlotRef(null, "PartitionName"),
+                new StringLiteral("dt=20240902", NodePosition.ZERO));
+        Map<String, Expr> filterMap = new HashMap<>();
+        filterMap.put("partitionname", filter);
+        ProcResult filterProcResult = ((PartitionsProcDir) paimonProc).fetchResultByFilter(filterMap, null, null);
+        Assert.assertEquals(filterProcResult.getRows().size(), 1);
+
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorPartitionTraitsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorPartitionTraitsTest.java
@@ -47,8 +47,8 @@ public class ConnectorPartitionTraitsTest {
     public void testMaxPartitionRefreshTs() {
 
         Map<String, PartitionInfo> fakePartitionInfo = new HashMap<>();
-        Partition p1 = new Partition("p1", 100);
-        Partition p2 = new Partition("p2", 200);
+        Partition p1 = new Partition("p1", 100, null, null, null);
+        Partition p2 = new Partition("p2", 200, null, null, null);
         fakePartitionInfo.put("p1", p1);
         fakePartitionInfo.put("p2", p2);
         new MockUp<DefaultTraits>() {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -258,13 +258,19 @@ public class PaimonMetadataTest {
                         new DataField(4, "last_update_time", DataTypes.TIMESTAMP_MILLIS())
                 ));
 
-        GenericRow row1 = new GenericRow(2);
+        GenericRow row1 = new GenericRow(5);
         row1.setField(0, BinaryString.fromString("[2020, 1]"));
-        row1.setField(1, Timestamp.fromLocalDateTime(LocalDateTime.of(2023, 1, 1, 0, 0, 0, 0)));
+        row1.setField(1, 100L);
+        row1.setField(2, 1L);
+        row1.setField(3, 1L);
+        row1.setField(4, Timestamp.fromLocalDateTime(LocalDateTime.of(2023, 1, 1, 0, 0, 0, 0)));
 
-        GenericRow row2 = new GenericRow(2);
+        GenericRow row2 = new GenericRow(5);
         row2.setField(0, BinaryString.fromString("[2020, 2]"));
-        row2.setField(1, Timestamp.fromLocalDateTime(LocalDateTime.of(2023, 2, 1, 0, 0, 0, 0)));
+        row2.setField(1, 100L);
+        row2.setField(2, 1L);
+        row2.setField(3, 1L);
+        row2.setField(4, Timestamp.fromLocalDateTime(LocalDateTime.of(2023, 2, 1, 0, 0, 0, 0)));
         new MockUp<RecordReaderIterator>() {
             private int callCount;
             private final GenericRow[] elements = {row1, row2};


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Support paimon show partitions, can query the following information: PartitionName、VisibleVersionTime、State、PartitionKey、RowCount、DataSize、FileCount
![image](https://github.com/user-attachments/assets/af7ff33e-9a2d-4f6d-bf50-9e05284c2f8f)

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

