### PR TITLE
[BugFix] Fix replay external table stats meta takes long time

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
@@ -301,7 +301,7 @@ public class AnalyzeMgr implements Writable {
             return;
         }
         GlobalStateMgr.getCurrentState().getStatisticStorage()
-                .refreshConnectorTableColumnStatistics(table, columns, async);
+                .refreshConnectorTableColumnStatistics(table, columns, !async);
     }
 
     public void replayRemoveBasicStatsMeta(BasicStatsMeta basicStatsMeta) {


### PR DESCRIPTION
## Why I'm doing:
Fix #https://github.com/StarRocks/StarRocksTest/issues/9359

because this PR https://github.com/StarRocks/starrocks/pull/53344, 
![image](https://github.com/user-attachments/assets/1f0883a8-1720-4e65-9459-46d1c96ad4f5)
![image](https://github.com/user-attachments/assets/782d28ab-85ef-4eac-be36-f61956e0e976)

Using  async to indicate  isSync, it's wrong

## What I'm doing:
use !async

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0