### PR TITLE
[Enhancement] adjust agg pushdown strategy according to multi-column combined stats

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -383,6 +383,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CBO_PRUNE_SUBFIELD = "cbo_prune_subfield";
     public static final String CBO_PRUNE_JSON_SUBFIELD = "cbo_prune_json_subfield";
     public static final String CBO_PRUNE_JSON_SUBFIELD_DEPTH = "cbo_prune_json_subfield_depth";
+    public static final String CBO_PUSH_DOWN_AGG_WITH_MULTI_COLUMN_STATS = "cbo_push_down_aggregate_with_multi_column_stats";
     public static final String ENABLE_OPTIMIZER_REWRITE_GROUPINGSETS_TO_UNION_ALL =
             "enable_rewrite_groupingsets_to_union_all";
     public static final String ENABLE_PARTITION_LEVEL_CARDINALITY_ESTIMATION =
@@ -1588,6 +1589,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = CBO_PUSH_DOWN_GROUPINGSET_RESHUFFLE, flag = VariableMgr.INVISIBLE)
     private boolean cboPushDownGroupingSetReshuffle = true;
+
+    @VarAttr(name = CBO_PUSH_DOWN_AGG_WITH_MULTI_COLUMN_STATS)
+    private boolean cboPushDownAggWithMultiColumnStats = true;
 
     @VariableMgr.VarAttr(name = PARSE_TOKENS_LIMIT)
     private int parseTokensLimit = 3500000;
@@ -3747,6 +3751,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setCboPushDownGroupingSetReshuffle(boolean cboPushDownGroupingSetReshuffle) {
         this.cboPushDownGroupingSetReshuffle = cboPushDownGroupingSetReshuffle;
+    }
+
+    public boolean isCboPushDownAggWithMultiColumnStats() {
+        return cboPushDownAggWithMultiColumnStats;
+    }
+
+    public void setCboPushDownAggWithMultiColumnStats(boolean cboPushDownAggWithMultiColumnStats) {
+        this.cboPushDownAggWithMultiColumnStats = cboPushDownAggWithMultiColumnStats;
     }
 
     public void setCboPushDownDistinctBelowWindow(boolean flag) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
@@ -635,6 +635,7 @@ public class CachedStatisticStorage implements StatisticStorage, MemoryTrackable
                 .put("HistogramStats", histogramCache.synchronous().estimatedSize())
                 .put("ConnectorTableStats", connectorTableCachedStatistics.synchronous().estimatedSize())
                 .put("ConnectorHistogramStats", connectorHistogramCache.synchronous().estimatedSize())
+                .put("MultiColumnCombinedStats", multiColumnStats.synchronous().estimatedSize())
                 .build();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/MultiColumnCombinedStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/MultiColumnCombinedStats.java
@@ -29,7 +29,7 @@ public class MultiColumnCombinedStats {
 
     @Override
     public String toString() {
-        return new StringJoiner(", ", MultiColumnCombinedStats.class.getSimpleName() + "[", "]")
+        return new StringJoiner(", ", "[", "]")
                 .add("ndv=" + ndv)
                 .toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Statistics.java
@@ -109,6 +109,10 @@ public class Statistics {
         return columnStatistics;
     }
 
+    public Map<Set<ColumnRefOperator>, MultiColumnCombinedStats> getMultiColumnCombinedStats() {
+        return multiColumnCombinedStats;
+    }
+
     public Map<ColumnRefOperator, ColumnStatistic> getOutputColumnsStatistics(ColumnRefSet outputColumns) {
         Map<ColumnRefOperator, ColumnStatistic> outputColumnsStatistics = Maps.newHashMap();
         for (Map.Entry<ColumnRefOperator, ColumnStatistic> entry : columnStatistics.entrySet()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
@@ -48,6 +48,7 @@ public class StatisticsEstimateCoefficient {
     public static final double LOW_AGGREGATE_EFFECT_COEFFICIENT = 1000;
     public static final double MEDIUM_AGGREGATE_EFFECT_COEFFICIENT = 100;
     public static final int SMALL_BROADCAST_JOIN_MAX_NDV_LIMIT = 100000;
+    public static final int SMALL_BROADCAST_JOIN_MAX_COMBINED_NDV_LIMIT = 1000000;
 
     public static final double EXTREME_HIGH_AGGREGATE_EFFECT_COEFFICIENT = 3;
     // default selectivity for anti join

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
@@ -720,9 +720,9 @@ public class AnalyzeMgr implements Writable {
             MultiColumnStatsMeta value = entry.getValue();
 
             StatisticExecutor statisticExecutor = new StatisticExecutor();
-            statisticExecutor.dropTableMultiColumnStatistics(statsConnectCtx, key.tableId);
 
             if (tableIdHasDeleted.contains(key.tableId)) {
+                statisticExecutor.dropTableMultiColumnStatistics(statsConnectCtx, key.tableId);
                 GlobalStateMgr.getCurrentState().getEditLog().logRemoveMultiColumnStatsMeta(value);
                 keysToRemove.add(key);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregatePushDownWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregatePushDownWithCostTest.java
@@ -87,17 +87,6 @@ public class AggregatePushDownWithCostTest extends PlanWithCostTestBase {
                 ss.getColumnStatistic(t3, "v12");
                 result = new ColumnStatistic(1, 200000, 0, 4, t3Rows / 20000.0);
                 minTimes = 0;
-
-                // for multi-column statistics
-                ss.getMultiColumnCombinedStatistics(t0.getId());
-                result = new MultiColumnCombinedStatistics(Sets.newHashSet(t0.getColumn("v1").getUniqueId(),
-                        t0.getColumn("v3").getUniqueId()), 5555555);
-                minTimes = 0;
-
-                ss.getMultiColumnCombinedStatistics(t3.getId());
-                result = new MultiColumnCombinedStatistics(Sets.newHashSet(t3.getColumn("v10").getUniqueId(),
-                        t3.getColumn("v11").getUniqueId()), 1);
-                minTimes = 0;
             }
         };
 
@@ -352,6 +341,26 @@ public class AggregatePushDownWithCostTest extends PlanWithCostTestBase {
 
     @Test
     public void testAggWithMultiColumnStats() throws Exception {
+        StatisticStorage ss = GlobalStateMgr.getCurrentState().getStatisticStorage();
+        OlapTable t0 = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getTable("t0");
+        OlapTable t3 = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getTable("t3");
+
+        new Expectations(ss) {
+            {
+                // for multi-column statistics
+                ss.getMultiColumnCombinedStatistics(t0.getId());
+                result = new MultiColumnCombinedStatistics(Sets.newHashSet(t0.getColumn("v1").getUniqueId(),
+                        t0.getColumn("v3").getUniqueId()), 5555555);
+                minTimes = 0;
+
+                ss.getMultiColumnCombinedStatistics(t3.getId());
+                result = new MultiColumnCombinedStatistics(Sets.newHashSet(t3.getColumn("v10").getUniqueId(),
+                        t3.getColumn("v11").getUniqueId()), 100_000);
+                minTimes = 0;
+
+            }
+        };
+
         String sql = "select count(1) from t0 group by v1, v3";
         String plan = getCostExplain(sql);
         assertCContains(plan, "1:AGGREGATE (update finalize)\n" +
@@ -375,6 +384,33 @@ public class AggregatePushDownWithCostTest extends PlanWithCostTestBase {
         assertCContains(plan, "1:AGGREGATE (update finalize)\n" +
                 "  |  aggregate: count[(1); args: TINYINT; result: BIGINT; args nullable: false; result nullable: false]\n" +
                 "  |  group by: [1: v10, BIGINT, true], [2: v11, BIGINT, true], [3: v12, BIGINT, true]\n" +
-                "  |  cardinality: 3750");
+                "  |  cardinality: 100000000");
+
+        connectContext.getSessionVariable().setCboPushDownAggregateOnBroadcastJoin(false);
+        sql = "select sum(t3.v12) from t3 join t1 on t3.v10=t1.v4 group by t3.v11";
+        plan = getFragmentPlan(sql);
+        assertCContains(plan, "1:AGGREGATE (update finalize)\n" +
+                "  |  output: sum(3: v12)\n" +
+                "  |  group by: 1: v10, 2: v11\n" +
+                "  |  \n" +
+                "  0:OlapScanNode\n" +
+                "     TABLE: t3");
+
+        sql = "select sum(t3.v12) from t3 join t1 on t3.v10=t1.v4 group by t3.v11, t3.v12";
+        plan = getFragmentPlan(sql);
+        assertCContains(plan, "1:AGGREGATE (update finalize)\n" +
+                "  |  output: sum(3: v12)\n" +
+                "  |  group by: 1: v10, 2: v11, 3: v12\n" +
+                "  |  \n" +
+                "  0:OlapScanNode\n" +
+                "     TABLE: t3");
+        plan = getCostExplain(sql);
+        assertCContains(plan, "column statistics: \n" +
+                "     * v10-->[1.0, 2.0, 0.0, 4.0, 1.0E7] ESTIMATE\n" +
+                "     * v11-->[1.0, 100000.0, 0.0, 4.0, 500000.0] ESTIMATE\n" +
+                "     * v12-->[1.0, 200000.0, 0.0, 4.0, 5000.0] ESTIMATE\n" +
+                "     multi-column statistics: \n" +
+                "     * [v10, v11]-->[ndv=100000]");
+        connectContext.getSessionVariable().setCboPushDownAggregateOnBroadcastJoin(true);
     }
 }


### PR DESCRIPTION
## Why I'm doing:
currently, we use some heuristic rules to decide the aggregate pushdown strategy according to the standard test set.  we could use multi-column combined stats to make aggregation pushdown strategy more accurate. 

## What I'm doing:
we keep the original strategy. we use multi-column which have combined stats as one column. 
added config:
`cbo_push_down_aggregate_with_multi_column_stats` if aggregation pushdown strategy consider multi-column combined stats.

Fixes #issue
https://github.com/StarRocks/starrocks/issues/56358

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0