### PR TITLE
[Enhancement] optimize the performance for max(varchar)

### DIFF
--- a/be/src/exprs/agg/stream/retract_maxmin.h
+++ b/be/src/exprs/agg/stream/retract_maxmin.h
@@ -50,21 +50,29 @@ struct MaxAggregateDataRetractable<LT, FixedLengthLTGuard<LT>> : public StreamDe
 
 template <LogicalType LT>
 struct MaxAggregateDataRetractable<LT, StringLTGuard<LT>> : public StreamDetailState<LT> {
-    int32_t size = -1;
-    raw::RawVector<uint8_t> buffer;
+    void assign(const Slice& slice) {
+        _buffer.resize(slice.size);
+        size_t length = std::min<size_t>(PADDED_SIZE, slice.size);
+        memcpy(_buffer.data(), slice.data, length);
+        _size = slice.size;
+    }
 
-    bool has_value() const { return buffer.size() > 0; }
+    bool has_value() const { return _size > -1; }
 
-    Slice slice() const { return {buffer.data(), buffer.size()}; }
+    Slice slice() const { return {_buffer.data(), (size_t)_size}; }
 
     void reset_result() {
-        buffer.clear();
-        size = -1;
+        _buffer.clear();
+        _size = -1;
     }
     void reset() {
         StreamDetailState<LT>::reset();
         reset_result();
     }
+
+private:
+    int32_t _size = -1;
+    raw::RawVector<uint8_t> _buffer;
 };
 
 template <LogicalType LT, typename = guard::Guard>
@@ -83,21 +91,29 @@ struct MinAggregateDataRetractable<LT, FixedLengthLTGuard<LT>> : public StreamDe
 
 template <LogicalType LT>
 struct MinAggregateDataRetractable<LT, StringLTGuard<LT>> : public StreamDetailState<LT> {
-    int32_t size = -1;
-    Buffer<uint8_t> buffer;
+    void assign(const Slice& slice) {
+        _buffer.resize(slice.size);
+        size_t length = std::min<size_t>(PADDED_SIZE, slice.size);
+        memcpy(_buffer.data(), slice.data, length);
+        _size = slice.size;
+    }
 
-    bool has_value() const { return size > -1; }
+    bool has_value() const { return _size > -1; }
 
-    Slice slice() const { return {buffer.data(), buffer.size()}; }
+    Slice slice() const { return {_buffer.data(), (size_t)_size}; }
 
     void reset_result() {
-        buffer.clear();
-        size = -1;
+        _buffer.clear();
+        _size = -1;
     }
     void reset() {
         StreamDetailState<LT>::reset();
         reset_result();
     }
+
+private:
+    int32_t _size = -1;
+    raw::RawVector<uint8_t> _buffer;
 };
 
 template <LogicalType LT, typename State, class OP, typename T = RunTimeCppType<LT>>

--- a/be/src/util/memcmp.h
+++ b/be/src/util/memcmp.h
@@ -38,6 +38,8 @@
 #include <cstring>
 #include <type_traits>
 
+#include "gutil/strings/fastmem.h"
+
 // Must include headers out of namespace
 #if defined(__SSE4_1__) && !defined(ADDRESS_SANITIZER)
 #include <smmintrin.h>
@@ -152,6 +154,36 @@ inline bool memequal(const char* p1, size_t size1, const char* p2, size_t size2)
 
 inline int memcompare(const char* p1, size_t size1, const char* p2, size_t size2) {
     size_t min_size = std::min(size1, size2);
+    auto res = memcmp(p1, p2, min_size);
+    if (res != 0) {
+        return res > 0 ? 1 : -1;
+    }
+    return compare(size1, size2);
+}
+
+#if defined(__SSE4_2__)
+inline int sse_memcmp2(const char* p1, const char* p2, size_t size) {
+    __m128i left = _mm_lddqu_si128((__m128i*)(p1));
+    __m128i right = _mm_lddqu_si128((__m128i*)(p2));
+    __m128i nz = ~_mm_cmpeq_epi8(left, right);
+    unsigned short mask = _mm_movemask_epi8(nz);
+    volatile int index = __builtin_ctz(mask);
+    if (index >= size) return 0;
+    return (int)(uint8_t)p1[index] - (int)(uint8_t)p2[index];
+}
+#endif
+
+// memcmp has special inline optimizations for bytes <= 16.
+// Requires input to be overflow readable. (Allocate memory aligned to 16 byte size or tail length of 16.)
+inline int memcompare_padded(const char* p1, size_t size1, const char* p2, size_t size2) {
+    size_t min_size = std::min(size1, size2);
+#if defined(__SSE4_2__)
+    if (min_size <= 16) {
+        auto res = sse_memcmp2(p1, p2, min_size);
+        if (res == 0) return compare(size1, size2);
+        return res > 0 ? 1 : -1;
+    }
+#endif
     auto res = memcmp(p1, p2, min_size);
     if (res != 0) {
         return res > 0 ? 1 : -1;

--- a/be/src/util/memcmp.h
+++ b/be/src/util/memcmp.h
@@ -167,8 +167,8 @@ inline int sse_memcmp2(const char* p1, const char* p2, size_t size) {
     __m128i right = _mm_lddqu_si128((__m128i*)(p2));
     __m128i nz = ~_mm_cmpeq_epi8(left, right);
     unsigned short mask = _mm_movemask_epi8(nz);
-    volatile int index = __builtin_ctz(mask);
-    if (index >= size) return 0;
+    int index = __builtin_ctz(mask);
+    if (mask == 0 || index >= size) return 0;
     return (int)(uint8_t)p1[index] - (int)(uint8_t)p2[index];
 }
 #endif

--- a/be/src/util/memcmp.h
+++ b/be/src/util/memcmp.h
@@ -173,12 +173,13 @@ inline int sse_memcmp2(const char* p1, const char* p2, size_t size) {
 }
 #endif
 
+constexpr size_t PADDED_SIZE = 16;
 // memcmp has special inline optimizations for bytes <= 16.
 // Requires input to be overflow readable. (Allocate memory aligned to 16 byte size or tail length of 16.)
 inline int memcompare_padded(const char* p1, size_t size1, const char* p2, size_t size2) {
     size_t min_size = std::min(size1, size2);
 #if defined(__SSE4_2__)
-    if (min_size <= 16) {
+    if (min_size > 0 && min_size <= 16) {
         auto res = sse_memcmp2(p1, p2, min_size);
         if (res == 0) return compare(size1, size2);
         return res > 0 ? 1 : -1;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -454,6 +454,7 @@ set(EXEC_FILES
         ./util/json_util_test.cpp
         ./util/json_flattener_test.cpp
         ./util/md5_test.cpp
+        ./util/memcmp_test.cpp
         ./util/monotime_test.cpp
         ./util/mysql_row_buffer_test.cpp
         ./util/new_metrics_test.cpp

--- a/be/test/util/memcmp_test.cpp
+++ b/be/test/util/memcmp_test.cpp
@@ -1,0 +1,103 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "util/memcmp.h"
+
+#include <gtest/gtest.h>
+
+namespace starrocks {
+
+template <class T>
+int vsigned(T v) {
+    return (v >> (sizeof(T) * 8 - 1)) & 1;
+}
+
+TEST(sse_memcmp, Test) {
+    ASSERT_EQ(vsigned((int)-1), 1);
+    ASSERT_EQ(vsigned((int)1), 0);
+
+    {
+        const char c1[32] = "ABC";
+        const char c2[32] = "CBA";
+
+        int res = memcmp(c1, c2, 3);
+        int res2 = sse_memcmp2(c1, c2, 3);
+        ASSERT_EQ(vsigned(res), vsigned(res2));
+    }
+    {
+        const char c1[32] = "AAB";
+        const char c2[32] = "ABA";
+
+        int res = memcmp(c1, c2, 3);
+        int res2 = sse_memcmp2(c1, c2, 3);
+        ASSERT_EQ(vsigned(res), vsigned(res2));
+    }
+    {
+        const char c1[32] = "ABC";
+        const char c2[32] = "ABA";
+
+        int res = memcmp(c1, c2, 3);
+        int res2 = sse_memcmp2(c1, c2, 3);
+        ASSERT_EQ(vsigned(res), vsigned(res2));
+    }
+    {
+        const char c1[32] = "ABC";
+        const char c2[32] = "ABC";
+
+        int res = memcmp(c1, c2, 3);
+        int res2 = sse_memcmp2(c1, c2, 3);
+        ASSERT_EQ(res, res2);
+    }
+
+    {
+        const char c1[32] = "ABC";
+        const char c2[32] = "你好";
+
+        int res = memcmp(c1, c2, 3);
+        int res2 = sse_memcmp2(c1, c2, 3);
+        ASSERT_EQ(vsigned(res), vsigned(res2));
+    }
+
+    {
+        const char c1[32] = "";
+        const char c2[32] = "你好";
+
+        int res = memcmp(c1, c2, 3);
+        int res2 = sse_memcmp2(c1, c2, 3);
+        ASSERT_EQ(vsigned(res), vsigned(res2));
+    }
+
+    {
+        const char c1[32] = "0123456789abcdef";
+        const char c2[32] = "0123456789abcdff";
+
+        int res = memcmp(c1, c2, 3);
+        int res2 = sse_memcmp2(c1, c2, 3);
+        ASSERT_EQ(vsigned(res), vsigned(res2));
+    }
+
+    {
+        const char c1[32] = "0123456789abcdef";
+        const char c2[32] = "0123456789abcdef";
+
+        int res = memcmp(c1, c2, 3);
+        int res2 = sse_memcmp2(c1, c2, 3);
+        ASSERT_EQ(res, res2);
+    }
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

1. avoid init std::vector<Slice> in PlainPage::next_batch
2. avoid call virtual call in Max Aggregate Function
3. optimize the memcmp in small strings

baseline: SSB 1BE dop=4 `set cbo_enable_low_cardinality_optimize=false;`
```
   18.29%  libc.so.6         [.] __memcmp_evex_movbe
   18.17%  starrocks_be      [.] starrocks::AggregateFunctionBatchHelper<starrocks::MaxAggregateData<(starrocks::LogicalT
   11.39%  starrocks_be      [.] starrocks::append_fixed_length<unsigned int, 8ul>
    6.29%  starrocks_be      [.] starrocks::BinaryDictPageDecoder<(starrocks::LogicalType)17>::next_batch
    6.10%  starrocks_be      [.] starrocks::BinaryColumnBase<unsignedint>::get
```

```
   mysql>  select max(lo_shipmode) from lineorder;
   +------------------+
   | max(lo_shipmode) |
   +------------------+
   | TRUCK            |
   +------------------+
   1 row in set (1.46 sec)
```

patched:

   avoid virtual function call and avoid init slice contribute about 0.3 sec.
   SSEMemCmp contribute about 0.2 sec.
```
  29.07%  starrocks_be      [.] starrocks::AggregateFunctionBatchHelper<starrocks::MaxAggregateData<(starrocks::LogicalT
  17.35%  starrocks_be      [.] starrocks::append_fixed_length<unsigned int, 8ul>
   8.53%  starrocks_be      [.] starrocks::BinaryPlainPageDecoder<(starrocks::LogicalType)17>::batch_string_at_index
   4.86%  libc.so.6         [.] __memmove_evex_unaligned_erms
```

```
   mysql>  select max(lo_shipmode) from lineorder;
   +------------------+
   | max(lo_shipmode) |
   +------------------+
   | TRUCK            |
   +------------------+
   1 row in set (0.71 sec)
```

benchmark for SSE memcmp
```
   --------------------------------------------------------
   Benchmark              Time             CPU   Iterations
   --------------------------------------------------------
   GlibcCmpImpl        40.2 ns         40.2 ns     17368765
   SSEMemCmpImpl       25.4 ns         25.4 ns     27569981
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0