### PR TITLE
[Enhancement] Optimize append for binary and nullable column

### DIFF
--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -57,15 +57,27 @@ template <typename T>
 void BinaryColumnBase<T>::append(const Column& src, size_t offset, size_t count) {
     DCHECK(offset + count <= src.size());
     const auto& b = down_cast<const BinaryColumnBase<T>&>(src);
+
     const unsigned char* p = &b._bytes[b._offsets[offset]];
     const unsigned char* e = &b._bytes[b._offsets[offset + count]];
-
     _bytes.insert(_bytes.end(), p, e);
 
-    for (size_t i = offset; i < offset + count; i++) {
-        size_t l = b._offsets[i + 1] - b._offsets[i];
-        _offsets.emplace_back(_offsets.back() + l);
+    // `new_offsets[i] = offsets[num_prev_offsets + (i - 1) + 1]` is the end offset of the new i-th string.
+    // new_offsets[i] = new_offsets[i - 1] + (b._offsets[offset + i + 1] - b._offsets[offset + i])
+    //    = b._offsets[offset + i + 1] + (new_offsets[i - 1] - b._offsets[offset + i])
+    //    = b._offsets[offset + i + 1] + delta
+    // where `delta` is the difference between the start offset of the num_prev_offsets-th destination string
+    // and the start offset of the offset-th source string.
+    const size_t num_prev_offsets = _offsets.size();
+    _offsets.resize(num_prev_offsets + count);
+    auto* new_offsets = _offsets.data() + num_prev_offsets;
+    strings::memcpy_inlined(new_offsets, b._offsets.data() + offset + 1, count * sizeof(Offset));
+
+    const auto delta = _offsets[num_prev_offsets - 1] - b._offsets[offset];
+    for (size_t i = 0; i < count; i++) {
+        new_offsets[i] += delta;
     }
+
     _slices_cache = false;
 }
 

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -62,7 +62,7 @@ void BinaryColumnBase<T>::append(const Column& src, size_t offset, size_t count)
     const unsigned char* e = &b._bytes[b._offsets[offset + count]];
     _bytes.insert(_bytes.end(), p, e);
 
-    // `new_offsets[i] = offsets[num_prev_offsets + (i - 1) + 1]` is the end offset of the new i-th string.
+    // `new_offsets[i] = offsets[(num_prev_offsets + i - 1) + 1]` is the end offset of the new i-th string.
     // new_offsets[i] = new_offsets[i - 1] + (b._offsets[offset + i + 1] - b._offsets[offset + i])
     //    = b._offsets[offset + i + 1] + (new_offsets[i - 1] - b._offsets[offset + i])
     //    = b._offsets[offset + i + 1] + delta

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -66,7 +66,7 @@ void BinaryColumnBase<T>::append(const Column& src, size_t offset, size_t count)
     // new_offsets[i] = new_offsets[i - 1] + (b._offsets[offset + i + 1] - b._offsets[offset + i])
     //    = b._offsets[offset + i + 1] + (new_offsets[i - 1] - b._offsets[offset + i])
     //    = b._offsets[offset + i + 1] + delta
-    // where `delta` is the difference between the start offset of the num_prev_offsets-th destination string
+    // where `delta` is always the difference between the start offset of the num_prev_offsets-th destination string
     // and the start offset of the offset-th source string.
     const size_t num_prev_offsets = _offsets.size();
     _offsets.resize(num_prev_offsets + count);

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -68,13 +68,17 @@ void NullableColumn::append(const Column& src, size_t offset, size_t count) {
     if (src.only_null()) {
         append_nulls(count);
     } else if (src.is_nullable()) {
-        const auto& c = down_cast<const NullableColumn&>(src);
+        const auto& src_column = down_cast<const NullableColumn&>(src);
+        DCHECK_EQ(src_column._null_column->size(), src_column._data_column->size());
 
-        DCHECK_EQ(c._null_column->size(), c._data_column->size());
-
-        _null_column->append(*c._null_column, offset, count);
-        _data_column->append(*c._data_column, offset, count);
-        _has_null = _has_null || SIMD::contain_nonzero(c._null_column->get_data(), offset, count);
+        if (!src_column.has_null()) {
+            _null_column->resize(_null_column->size() + count);
+            _data_column->append(*src_column._data_column, offset, count);
+        } else {
+            _null_column->append(*src_column._null_column, offset, count);
+            _data_column->append(*src_column._data_column, offset, count);
+            _has_null = _has_null || SIMD::contain_nonzero(src_column._null_column->get_data(), offset, count);
+        }
     } else {
         _null_column->resize(_null_column->size() + count);
         _data_column->append(src, offset, count);
@@ -90,12 +94,16 @@ void NullableColumn::append_selective(const Column& src, const uint32_t* indexes
         append_nulls(size);
     } else if (src.is_nullable()) {
         const auto& src_column = down_cast<const NullableColumn&>(src);
-
         DCHECK_EQ(src_column._null_column->size(), src_column._data_column->size());
 
-        _null_column->append_selective(*src_column._null_column, indexes, from, size);
-        _data_column->append_selective(*src_column._data_column, indexes, from, size);
-        _has_null = _has_null || SIMD::contain_nonzero(_null_column->get_data(), orig_size, size);
+        if (!src_column.has_null()) {
+            _null_column->resize(orig_size + size);
+            _data_column->append_selective(*src_column._data_column, indexes, from, size);
+        } else {
+            _null_column->append_selective(*src_column._null_column, indexes, from, size);
+            _data_column->append_selective(*src_column._data_column, indexes, from, size);
+            _has_null = _has_null || SIMD::contain_nonzero(_null_column->get_data(), orig_size, size);
+        }
     } else {
         _null_column->resize(orig_size + size);
         _data_column->append_selective(src, indexes, from, size);

--- a/be/test/storage/chunk_helper_test.cpp
+++ b/be/test/storage/chunk_helper_test.cpp
@@ -240,7 +240,7 @@ TEST_F(ChunkHelperTest, SegmentedChunk) {
 
     EXPECT_EQ(409600, segmented_chunk->num_rows());
     EXPECT_EQ(7, segmented_chunk->num_segments());
-    EXPECT_EQ(8043542, segmented_chunk->memory_usage());
+    EXPECT_EQ(7781406, segmented_chunk->memory_usage());
     EXPECT_EQ(2, segmented_chunk->columns().size());
     auto column0 = segmented_chunk->columns()[0];
     EXPECT_EQ(false, column0->is_nullable());
@@ -254,7 +254,7 @@ TEST_F(ChunkHelperTest, SegmentedChunk) {
     segmented_chunk->reset();
     EXPECT_EQ(0, segmented_chunk->num_rows());
     EXPECT_EQ(7, segmented_chunk->num_segments());
-    EXPECT_EQ(8043542, segmented_chunk->memory_usage());
+    EXPECT_EQ(7781406, segmented_chunk->memory_usage());
 
     // slicing
     segmented_chunk = build_segmented_chunk();


### PR DESCRIPTION
## Why I'm doing:

**Optimize `NullableColumn`'s `append` and `append_selective`**:
If the source is a nullable column but contains no `null` values, there's no need to copy from the source's `_null_column`. Simply setting `count` default values will suffice.

**Optimize `BinaryColumn`'s `append`**:
`new_offsets[i] = dst_offsets[dst_offsets.size() + i]` is the end offset of the new i-th string, which can be calculated as follows:

```
new_offsets[i] = new_offsets[i - 1] + (src_offsets[offset + i + 1] + src_offsets[offset + i]) 
    = src_offsets[offset + i + 1] + (new_offsets[i - 1] - src_offsets[offset + i]) 
    = src_offsets[offset + i + 1] + delta
```
where `delta` is always the distance between the start offset of the `num_prev_offsets`-th destination string and the start offset of the `offset`-th source string.

Therefore, we only need to copy `count` offsets starting from `src_offsets + offset + 1` to `new_offsets`, then increment each `new_offsets` by `delta`.

## What I'm doing:



## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0