### PR TITLE
[Enhancement] use NEON intrinsics and bitmask for NullableAgg

### DIFF
--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -542,8 +542,8 @@ public:
         constexpr size_t kBatchNums = 128 / (8 * sizeof(uint8_t));
         while (start_offset + kBatchNums < to) {
             const uint8x16_t vfilter = vld1q_u8(filter_data);
-            // vfilter[i] != 0 ? 0xFF : 0x00
-            uint64_t nibble_mask = SIMD::get_nibble_mask(vmvnq_u8(vtstq_u8(vfilter, vfilter));
+            // nibble_mask[i] != 0 ? 0xFF : 0x00
+            uint64_t nibble_mask = SIMD::get_nibble_mask(vtstq_u8(vfilter, vfilter));
             if (nibble_mask == 0) {
                 // skip
             } else if (nibble_mask == 0xffff'ffff'ffff'ffffull) {

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -542,7 +542,8 @@ public:
         constexpr size_t kBatchNums = 128 / (8 * sizeof(uint8_t));
         while (start_offset + kBatchNums < to) {
             const uint8x16_t vfilter = vld1q_u8(filter_data);
-            uint64_t nibble_mask = SIMD::get_nibble_mask(vmvnq_u8(vceqzq_u8(vfilter)));
+            // vfilter[i] != 0 ? 0xFF : 0x00
+            uint64_t nibble_mask = SIMD::get_nibble_mask(vmvnq_u8(vtstq_u8(vfilter, vfilter));
             if (nibble_mask == 0) {
                 // skip
             } else if (nibble_mask == 0xffff'ffff'ffff'ffffull) {

--- a/test/sql/test_agg_function/R/test_approx_top_k_with_null
+++ b/test/sql/test_agg_function/R/test_approx_top_k_with_null
@@ -125,22 +125,13 @@ PROPERTIES (
 insert into t2 select idx, null, null from __row_util;
 -- result:
 -- !result
-with w1 as (select approx_top_k(c2, 3) as x from t1) -- non-group-by.
+with w1 as (select approx_top_k(c2, 3) as x from t2) -- non-group-by.
 select array_sortby((x) -> x.item, x) from w1;
 -- result:
-[{"item":null,"count":1281000},{"item":0,"count":640000},{"item":1,"count":640000}]
+[{"item":null,"count":1280000}]
 -- !result
-with w1 as (select approx_top_k(c2, 3) as x, c1 from t1 group by c1) -- group by.
+with w1 as (select approx_top_k(c2, 3) as x, c1 from t2 group by c1) -- group by.
 select c1, array_sortby((x) -> x.item, x) from w1 order by c1;
 -- result:
-0	[{"item":null,"count":128100},{"item":0,"count":128000}]
-1	[{"item":null,"count":128100},{"item":1,"count":128000}]
-2	[{"item":null,"count":128100},{"item":0,"count":128000}]
-3	[{"item":null,"count":128100},{"item":1,"count":128000}]
-4	[{"item":null,"count":128100},{"item":0,"count":128000}]
-5	[{"item":null,"count":128100},{"item":1,"count":128000}]
-6	[{"item":null,"count":128100},{"item":0,"count":128000}]
-7	[{"item":null,"count":128100},{"item":1,"count":128000}]
-8	[{"item":null,"count":128100},{"item":0,"count":128000}]
-9	[{"item":null,"count":128100},{"item":1,"count":128000}]
+None	[{"item":null,"count":1280000}]
 -- !result

--- a/test/sql/test_agg_function/R/test_approx_top_k_with_null
+++ b/test/sql/test_agg_function/R/test_approx_top_k_with_null
@@ -1,0 +1,146 @@
+-- name: test_approx_top_k_with_null
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+-- result:
+-- !result
+insert into __row_util_base select * from __row_util_base; -- 20000
+insert into __row_util_base select * from __row_util_base; -- 40000
+insert into __row_util_base select * from __row_util_base; -- 80000
+insert into __row_util_base select * from __row_util_base; -- 160000
+insert into __row_util_base select * from __row_util_base; -- 320000
+insert into __row_util_base select * from __row_util_base; -- 640000
+insert into __row_util_base select * from __row_util_base; -- 1280000
+CREATE TABLE __row_util (
+  idx bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into __row_util select row_number() over() as idx from __row_util_base;
+-- result:
+-- !result
+CREATE TABLE t1 (
+  k1 bigint NULL,
+  c1 bigint NULL,
+  c2 int NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 16
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1 select idx, idx % 10, idx % 2 from __row_util;
+-- result:
+-- !result
+with w1 as (select approx_top_k(c2, 3) as x from t1) -- non-group-by.
+select array_sortby((x) -> x.item, x) from w1;
+-- result:
+[{"item":0,"count":640000},{"item":1,"count":640000}]
+-- !result
+with w1 as (select approx_top_k(c2, 3) as x, c1 from t1 group by c1) -- group by.
+select c1, array_sortby((x) -> x.item, x) from w1 order by c1;
+-- result:
+0	[{"item":0,"count":128000}]
+1	[{"item":1,"count":128000}]
+2	[{"item":0,"count":128000}]
+3	[{"item":1,"count":128000}]
+4	[{"item":0,"count":128000}]
+5	[{"item":1,"count":128000}]
+6	[{"item":0,"count":128000}]
+7	[{"item":1,"count":128000}]
+8	[{"item":0,"count":128000}]
+9	[{"item":1,"count":128000}]
+-- !result
+insert into t1 select idx, idx % 10, null from __row_util order by idx limit 1000;
+-- result:
+-- !result
+with w1 as (select approx_top_k(c2, 3) as x from t1) -- non-group-by.
+select array_sortby((x) -> x.item, x) from w1;
+-- result:
+[{"item":null,"count":1000},{"item":0,"count":640000},{"item":1,"count":640000}]
+-- !result
+with w1 as (select approx_top_k(c2, 3) as x, c1 from t1 group by c1) -- group by.
+select c1, array_sortby((x) -> x.item, x) from w1 order by c1;
+-- result:
+0	[{"item":null,"count":100},{"item":0,"count":128000}]
+1	[{"item":null,"count":100},{"item":1,"count":128000}]
+2	[{"item":null,"count":100},{"item":0,"count":128000}]
+3	[{"item":null,"count":100},{"item":1,"count":128000}]
+4	[{"item":null,"count":100},{"item":0,"count":128000}]
+5	[{"item":null,"count":100},{"item":1,"count":128000}]
+6	[{"item":null,"count":100},{"item":0,"count":128000}]
+7	[{"item":null,"count":100},{"item":1,"count":128000}]
+8	[{"item":null,"count":100},{"item":0,"count":128000}]
+9	[{"item":null,"count":100},{"item":1,"count":128000}]
+-- !result
+insert into t1 select idx, idx % 10, null from __row_util;
+-- result:
+-- !result
+with w1 as (select approx_top_k(c2, 3) as x from t1) -- non-group-by.
+select array_sortby((x) -> x.item, x) from w1;
+-- result:
+[{"item":null,"count":1281000},{"item":0,"count":640000},{"item":1,"count":640000}]
+-- !result
+with w1 as (select approx_top_k(c2, 3) as x, c1 from t1 group by c1) -- group by.
+select c1, array_sortby((x) -> x.item, x) from w1 order by c1;
+-- result:
+0	[{"item":null,"count":128100},{"item":0,"count":128000}]
+1	[{"item":null,"count":128100},{"item":1,"count":128000}]
+2	[{"item":null,"count":128100},{"item":0,"count":128000}]
+3	[{"item":null,"count":128100},{"item":1,"count":128000}]
+4	[{"item":null,"count":128100},{"item":0,"count":128000}]
+5	[{"item":null,"count":128100},{"item":1,"count":128000}]
+6	[{"item":null,"count":128100},{"item":0,"count":128000}]
+7	[{"item":null,"count":128100},{"item":1,"count":128000}]
+8	[{"item":null,"count":128100},{"item":0,"count":128000}]
+9	[{"item":null,"count":128100},{"item":1,"count":128000}]
+-- !result
+CREATE TABLE t2 (
+  k1 bigint NULL,
+  c1 bigint NULL,
+  c2 int NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 16
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t2 select idx, null, null from __row_util;
+-- result:
+-- !result
+with w1 as (select approx_top_k(c2, 3) as x from t1) -- non-group-by.
+select array_sortby((x) -> x.item, x) from w1;
+-- result:
+[{"item":null,"count":1281000},{"item":0,"count":640000},{"item":1,"count":640000}]
+-- !result
+with w1 as (select approx_top_k(c2, 3) as x, c1 from t1 group by c1) -- group by.
+select c1, array_sortby((x) -> x.item, x) from w1 order by c1;
+-- result:
+0	[{"item":null,"count":128100},{"item":0,"count":128000}]
+1	[{"item":null,"count":128100},{"item":1,"count":128000}]
+2	[{"item":null,"count":128100},{"item":0,"count":128000}]
+3	[{"item":null,"count":128100},{"item":1,"count":128000}]
+4	[{"item":null,"count":128100},{"item":0,"count":128000}]
+5	[{"item":null,"count":128100},{"item":1,"count":128000}]
+6	[{"item":null,"count":128100},{"item":0,"count":128000}]
+7	[{"item":null,"count":128100},{"item":1,"count":128000}]
+8	[{"item":null,"count":128100},{"item":0,"count":128000}]
+9	[{"item":null,"count":128100},{"item":1,"count":128000}]
+-- !result

--- a/test/sql/test_agg_function/T/test_approx_top_k_with_null
+++ b/test/sql/test_agg_function/T/test_approx_top_k_with_null
@@ -78,8 +78,8 @@ PROPERTIES (
 -- All is null.
 insert into t2 select idx, null, null from __row_util;
 
-with w1 as (select approx_top_k(c2, 3) as x from t1) -- non-group-by.
+with w1 as (select approx_top_k(c2, 3) as x from t2) -- non-group-by.
 select array_sortby((x) -> x.item, x) from w1;
 
-with w1 as (select approx_top_k(c2, 3) as x, c1 from t1 group by c1) -- group by.
+with w1 as (select approx_top_k(c2, 3) as x, c1 from t2 group by c1) -- group by.
 select c1, array_sortby((x) -> x.item, x) from w1 order by c1;

--- a/test/sql/test_agg_function/T/test_approx_top_k_with_null
+++ b/test/sql/test_agg_function/T/test_approx_top_k_with_null
@@ -1,0 +1,85 @@
+-- name: test_approx_top_k_with_null
+
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+insert into __row_util_base select * from __row_util_base; -- 20000
+insert into __row_util_base select * from __row_util_base; -- 40000
+insert into __row_util_base select * from __row_util_base; -- 80000
+insert into __row_util_base select * from __row_util_base; -- 160000
+insert into __row_util_base select * from __row_util_base; -- 320000
+insert into __row_util_base select * from __row_util_base; -- 640000
+insert into __row_util_base select * from __row_util_base; -- 1280000
+CREATE TABLE __row_util (
+  idx bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util select row_number() over() as idx from __row_util_base;
+
+CREATE TABLE t1 (
+  k1 bigint NULL,
+  c1 bigint NULL,
+  c2 int NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 16
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+-- All is non-null.
+insert into t1 select idx, idx % 10, idx % 2 from __row_util;
+
+with w1 as (select approx_top_k(c2, 3) as x from t1) -- non-group-by.
+select array_sortby((x) -> x.item, x) from w1;
+
+with w1 as (select approx_top_k(c2, 3) as x, c1 from t1 group by c1) -- group by.
+select c1, array_sortby((x) -> x.item, x) from w1 order by c1;
+
+-- Some is null.
+insert into t1 select idx, idx % 10, null from __row_util order by idx limit 1000;
+
+with w1 as (select approx_top_k(c2, 3) as x from t1) -- non-group-by.
+select array_sortby((x) -> x.item, x) from w1;
+
+with w1 as (select approx_top_k(c2, 3) as x, c1 from t1 group by c1) -- group by.
+select c1, array_sortby((x) -> x.item, x) from w1 order by c1;
+
+-- The most is null.
+insert into t1 select idx, idx % 10, null from __row_util;
+
+with w1 as (select approx_top_k(c2, 3) as x from t1) -- non-group-by.
+select array_sortby((x) -> x.item, x) from w1;
+
+with w1 as (select approx_top_k(c2, 3) as x, c1 from t1 group by c1) -- group by.
+select c1, array_sortby((x) -> x.item, x) from w1 order by c1;
+
+CREATE TABLE t2 (
+  k1 bigint NULL,
+  c1 bigint NULL,
+  c2 int NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 16
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+-- All is null.
+insert into t2 select idx, null, null from __row_util;
+
+with w1 as (select approx_top_k(c2, 3) as x from t1) -- non-group-by.
+select array_sortby((x) -> x.item, x) from w1;
+
+with w1 as (select approx_top_k(c2, 3) as x, c1 from t1 group by c1) -- group by.
+select c1, array_sortby((x) -> x.item, x) from w1 order by c1;


### PR DESCRIPTION
## Why I'm doing:
- Use NEON SIMD intrinsics to implement `update_batch`, `update_batch_selectively`, and `update_batch_single_state` of `NullableAggregateFunctionUnary`.
- As for AVX2 implementation, use `bitmask` to traverse only non-null item when a batch of item contains both null and non-null. In this way, `is_nulls` needn't be accessed again and branch `if (is_nulls[i])` is eliminated.
    - The latency of following query decreases from 6299ms to 5868ms.
```sql
-- SSB 1T
-- 4 BE (m6id.4xlarge)
SELECT SUM(lo_revenue), SUM(p_size)  FROM lineorder  LEFT JOIN part ON lo_partkey=p_partkey   AND (p_mfgr='MFGR#3' or p_mfgr='MFGR#2' or p_mfgr='MFGR#1');
```

<img src="https://github.com/user-attachments/assets/55c350df-5a00-48ba-8399-75e8ca12fa83" width="50%">



## What I'm doing:


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0