### PR TITLE
[BugFix] fix rowset verify

### DIFF
--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -1034,8 +1034,9 @@ Status Rowset::verify() {
             }
         }
     } else {
-        // non-overlapping segments will return one iterator, so segment idx is unknown
-        if (iters.size() != 1) {
+        if (iters.empty()) {
+            st = Status::OK();
+        } else if (iters.size() != 1) {
             st = Status::Corruption("non-overlapping segments should return one iterator");
         } else {
             st = is_ordered(iters[0], is_pk_ordered);


### PR DESCRIPTION
## Why I'm doing:
Rowset verify can't handle empty rowset situation. It will lead to unstable UT:
```
[ RUN      ] TabletUpdatesTest.horizontal_compaction_with_random_pick
...
/root/starrocks/be/test/storage/tablet_updates_test.cpp:1261: Failure
  Value of: best_tablet->verify().ok()
    Actual: false
  Expected: true
  I20250310 12:30:44.539109 140659780466816 tablet_manager.cpp:395] Start to drop tablet 445529006
  I20250310 12:30:44.539349 140659780466816 tablet_manager.cpp:470] Succeed to drop tablet 445529006
  [  FAILED  ] TabletUpdatesTest.horizontal_compaction_with_random_pick (1613 ms)
```

## What I'm doing:
fix it.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0