### PR TITLE
[Enhancement] Add groovy unix socket debug server

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
+++ b/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
@@ -57,6 +57,7 @@ import com.starrocks.server.RunMode;
 import com.starrocks.service.ExecuteEnv;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.service.FrontendThriftServer;
+import com.starrocks.service.GroovyUDSServer;
 import com.starrocks.service.arrow.flight.sql.ArrowFlightSqlService;
 import com.starrocks.staros.StarMgrServer;
 import org.apache.commons.cli.BasicParser;
@@ -177,6 +178,10 @@ public class StarRocksFE {
             httpServer.start();
             qeService.start();
             arrowFlightSqlService.start();
+
+            if (Config.enable_groovy_debug_server) {
+                GroovyUDSServer.getInstance().start();
+            }
 
             ThreadPoolManager.registerAllThreadPoolMetric();
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3133,6 +3133,12 @@ public class Config extends ConfigBase {
     @ConfField
     public static boolean enable_execute_script_on_frontend = true;
 
+    /**
+     * Enable groovy server for debugging
+     */
+    @ConfField
+    public static boolean enable_groovy_debug_server = false;
+
     @ConfField(mutable = true)
     public static short default_replication_num = 3;
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteScriptExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteScriptExecutor.java
@@ -69,6 +69,7 @@ public class ExecuteScriptExecutor {
             binding.setVariable("LOG", LOG);
             binding.setVariable("out", sb);
             binding.setVariable("globalState", GlobalStateMgr.getCurrentState());
+            binding.setVariable("metastore", GlobalStateMgr.getCurrentState().getLocalMetastore());
             GroovyShell shell = new GroovyShell(binding);
             shell.evaluate(stmt.getScript());
             ctx.getState().setOk();

--- a/fe/fe-core/src/main/java/com/starrocks/service/GroovyUDSServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/GroovyUDSServer.java
@@ -1,0 +1,109 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.service;
+
+import com.starrocks.StarRocksFE;
+import com.starrocks.common.util.Daemon;
+import com.starrocks.server.GlobalStateMgr;
+import groovy.lang.Binding;
+import org.apache.groovy.groovysh.Groovysh;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.codehaus.groovy.tools.shell.IO;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.StandardProtocolFamily;
+import java.net.UnixDomainSocketAddress;
+import java.nio.channels.Channels;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+
+public class GroovyUDSServer extends Daemon {
+    private static final Logger LOG = LogManager.getLogger(GroovyUDSServer.class);
+    private static GroovyUDSServer instance = new GroovyUDSServer();
+
+    public static GroovyUDSServer getInstance() {
+        return instance;
+    }
+
+    private String socketPath =
+            (StarRocksFE.STARROCKS_HOME_DIR == null ? "/tmp" : StarRocksFE.STARROCKS_HOME_DIR) + "/groovy_debug.sock";
+
+    GroovyUDSServer() {
+        super("GroovyUDSServer");
+    }
+
+    public String getSocketPath() {
+        return socketPath;
+    }
+
+    @Override
+    protected void runOneCycle() {
+        try {
+            // Ensure previous socket is removed
+            Files.deleteIfExists(Path.of(socketPath));
+
+            // Create the Unix Domain Socket server
+            UnixDomainSocketAddress address = UnixDomainSocketAddress.of(socketPath);
+            try (ServerSocketChannel serverChannel = ServerSocketChannel.open(StandardProtocolFamily.UNIX)) {
+                serverChannel.bind(address);
+
+                LOG.info("Groovy Shell Server started on {}", socketPath);
+                Files.setPosixFilePermissions(Path.of(socketPath), PosixFilePermissions.fromString("rw-------"));
+
+                while (this.isRunning()) {
+                    SocketChannel client = serverChannel.accept();
+                    new Thread(new ShellSession(client), "GroovySession").start();
+                }
+            }
+        } catch (IOException e) {
+            LOG.warn(e.getMessage(), e);
+        }
+    }
+
+    static class ShellSession implements Runnable {
+        private final SocketChannel client;
+
+        ShellSession(SocketChannel client) {
+            this.client = client;
+        }
+
+        @Override
+        public void run() {
+            LOG.info("New Groovy Shell session opened");
+            try (InputStream in = Channels.newInputStream(client);
+                    OutputStream out = Channels.newOutputStream(client)) {
+                IO io = new IO(in, out, out);
+                Binding binding = new Binding();
+                binding.setVariable("LOG", LOG);
+                binding.setVariable("out", io.out);
+                binding.setVariable("globalState", GlobalStateMgr.getCurrentState());
+                binding.setVariable("metastore", GlobalStateMgr.getCurrentState().getLocalMetastore());
+                Groovysh shell = new Groovysh(binding, io);
+                shell.run("");
+                client.close();
+            } catch (Exception e) {
+                LOG.warn(e.getMessage(), e);
+            } finally {
+                LOG.info("Groovy Shell session closed");
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/service/GroovyUDSServerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/GroovyUDSServerTest.java
@@ -1,0 +1,108 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.net.StandardProtocolFamily;
+import java.net.UnixDomainSocketAddress;
+import java.nio.channels.Channels;
+import java.nio.channels.SocketChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class GroovyUDSServerTest {
+
+    private GroovyUDSServer server;
+
+    @BeforeEach
+    void setUp() {
+        server = GroovyUDSServer.getInstance();
+    }
+
+    @Test
+    void testSingletonInstance() {
+        assertNotNull(server);
+        assertSame(server, GroovyUDSServer.getInstance());
+    }
+
+    @Test
+    void testRunOneCycleSocketCreation() throws IOException, InterruptedException {
+        String socketPath = server.getSocketPath();
+        Path socketFile = Path.of(socketPath);
+
+        // Start the GroovyUDSServer in a separate thread
+        server.start();
+
+        // wait for Files.exists(socketFile) at most 20s
+        for (int i = 0; i < 10; i++) {
+            Thread.sleep(2000);
+            if (Files.exists(socketFile)) {
+                break;
+            }
+        }
+
+        // Connect to the server and send a command
+        UnixDomainSocketAddress address = UnixDomainSocketAddress.of(socketPath);
+        try (SocketChannel client = SocketChannel.open(StandardProtocolFamily.UNIX)) {
+            for (int i = 0; i < 10; i++) {
+                try {
+                    client.connect(address);
+                    break;
+                } catch (IOException e) {
+                    Thread.sleep(1000);
+                    if (i == 9) {
+                        throw e;
+                    }
+                }
+            }
+            OutputStream out = Channels.newOutputStream(client);
+            InputStream in = Channels.newInputStream(client);
+            BufferedReader reader = new BufferedReader(new InputStreamReader(in));
+            PrintWriter writer = new PrintWriter(out, true);
+
+            // Send a Groovy command and read response
+            writer.println("1+1");
+            writer.flush();
+            assertNotNull(reader.readLine());
+            assertNotNull(reader.readLine());
+            // Exit the shell
+            writer.println(":exit");
+            writer.flush();
+            try {
+                while (true) {
+                    String line = reader.readLine();
+                    if (line == null) {
+                        break;
+                    }
+                }
+            } catch (IOException e) {
+                // ignore
+            }
+        }
+        server.setStop();
+        Thread.sleep(500);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Easy to debug FE in env that only has host shell access and sql client is not availble.

## What I'm doing:

Add a unix-socket based groovy shell server, so FE jvm can be connectted using unix domain socket from FE host and user can perform some debug operations. 

Some predefined binding var for easy of use:
```
    binding.setVariable("LOG", LOG);  // log to FE log
    binding.setVariable("out", io.out); // printwriter to output to console, do not use System.out which will output to FE process's stdout
    binding.setVariable("globalState", GlobalStateMgr.getCurrentState()); // GlobalStateMgr env root
    binding.setVariable("metastore", GlobalStateMgr.getCurrentState().getLocalMetastore());
```

```
(py3) decster@decster-MS-7C94:~/projects/starrocks/localrun$ nc -U fe/groovy_debug.sock 

or using rlwrap for better interaction

(py3) decster@decster-MS-7C94:~/projects/starrocks/localrun$ rlwrap nc -U fe/groovy_debug.sock 
Groovy Shell (4.0.9, JVM: 17.0.6)
Type ':help' or ':h' for help.
-------------------------------------------------------------------------------------------------------------------------------------------
groovy:000> :h
:h

For information about Groovy, visit:
    http://groovy-lang.org 

Available commands:
  :help      (:h ) Display this help message
  ?          (:? ) Alias to: :help
  :exit      (:x ) Exit the shell
  :quit      (:q ) Alias to: :exit
  import     (:i ) Import a class into the namespace
  :display   (:d ) Display the current buffer
  :clear     (:c ) Clear the buffer and reset the prompt counter
  :show      (:S ) Show variables, classes or imports
  :inspect   (:n ) Inspect a variable or the last result with the GUI object browser
  :purge     (:p ) Purge variables, classes, imports or preferences
  :edit      (:e ) Edit the current buffer
  :load      (:l ) Load a file or URL into the buffer
  .          (:. ) Alias to: :load
  :save      (:s ) Save the current buffer to a file
  :record    (:r ) Record the current session to a file
  :history   (:H ) Display, manage and recall edit-line history
  :alias     (:a ) Create an alias
  :set       (:= ) Set (or list) preferences
  :grab      (:g ) Add a dependency to the shell environment
  :register  (:rc) Register a new command with the shell
  :doc       (:D ) Open a browser window displaying the doc for the argument

For help on a specific command type:
    :help command 

groovy:000> 1+1
1+1
===> 2
groovy:000> def getAllFieldsAsString(obj) {
def clazz = obj.getClass()
def result = new StringBuilder("Class: ${clazz.name}\n")
clazz.declaredFields.each { field ->
field.setAccessible(true)
result.append("${field.name} = ${field.get(obj)}\n")
}
return result.toString()
}
def getAllFieldsAsString(obj) {
groovy:001> def clazz = obj.getClass()
groovy:002> def result = new StringBuilder("Class: ${clazz.name}\n")
groovy:003> clazz.declaredFields.each { field ->
groovy:004> field.setAccessible(true)
groovy:005> result.append("${field.name} = ${field.get(obj)}\n")
groovy:006> }
groovy:007> return result.toString()
groovy:008> }
===> true
groovy:000> out.println(getAllFieldsAsString(globalState))
out.println(getAllFieldsAsString(globalState))
Class: com.starrocks.server.GlobalStateMgr
LOG = com.starrocks.server.GlobalStateMgr:INFO in 5cb0d902
NEXT_ID_INIT_VALUE = 10000
REPLAY_INTERVAL_MS = 1
IMAGE_DIR = /image
REPLAYER_MAX_MS_PER_LOOP = 1000
REPLAYER_MAX_LOGS_PER_LOOP = 100000
imageDir = /home/decster/projects/starrocks/localrun/fe/meta/image
epoch = 0
lock = com.starrocks.common.util.concurrent.QueryableReentrantLock@1920ea15[Unlocked]
nodeMgr = com.starrocks.server.NodeMgr@2effe44c
...
sqlPlanStorage = com.starrocks.sql.spm.SQLPlanGlobalStorage@7a938001
jwkMgr = com.starrocks.authentication.JwkMgr@6a01e407

===> null
groovy:000> :exit
:exit


```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0