### PR TITLE
[Enhancement] Enable enable_materialized_view_multi_stages_rewrite by default

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -2055,7 +2055,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
      * Materialized view rewrite related mv limit: how many related MVs would be considered for rewrite to a query?
      */
     @VarAttr(name = CBO_MATERIALIZED_VIEW_REWRITE_RELATED_MVS_LIMIT, flag = VariableMgr.INVISIBLE)
-    private int cboMaterializedViewRewriteRelatedMVsLimit = 64;
+    private int cboMaterializedViewRewriteRelatedMVsLimit = 16;
 
     @VarAttr(name = QUERY_EXCLUDING_MV_NAMES, flag = VariableMgr.INVISIBLE)
     private String queryExcludingMVNames = "";

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -634,7 +634,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_MATERIALIZED_VIEW_VIEW_DELTA_REWRITE =
             "enable_materialized_view_view_delta_rewrite";
-
+    public static final String ENABLE_MATERIALIZED_VIEW_MULTI_STAGES_REWRITE =
+            "enable_materialized_view_multi_stages_rewrite";
     public static final String MATERIALIZED_VIEW_MAX_RELATION_MAPPING_SIZE =
             "materialized_view_max_relation_mapping_size";
 
@@ -2001,6 +2002,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_MATERIALIZED_VIEW_VIEW_DELTA_REWRITE)
     private boolean enableMaterializedViewViewDeltaRewrite = true;
+
+    @VarAttr(name = ENABLE_MATERIALIZED_VIEW_MULTI_STAGES_REWRITE)
+    private boolean enableMaterializedViewMultiStagesRewrite = true;
 
     @VarAttr(name = MATERIALIZED_VIEW_MAX_RELATION_MAPPING_SIZE)
     private int materializedViewMaxRelationMappingSize = 10;
@@ -3980,6 +3984,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableMaterializedViewViewDeltaRewrite(boolean enableMaterializedViewViewDeltaRewrite) {
         this.enableMaterializedViewViewDeltaRewrite = enableMaterializedViewViewDeltaRewrite;
+    }
+
+    public boolean isEnableMaterializedViewMultiStagesRewrite() {
+        return enableMaterializedViewMultiStagesRewrite;
+    }
+
+    public void setEnableMaterializedViewMultiStagesRewrite(boolean enableMaterializedViewMultiStagesRewrite) {
+        this.enableMaterializedViewMultiStagesRewrite = enableMaterializedViewMultiStagesRewrite;
     }
 
     public int getMaterializedViewMaxRelationMappingSize() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -623,10 +623,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
     private boolean isEnableMVRefreshQueryRewrite(ConnectContext ctx,
                                                   Set<Table> baseTables) {
-        Set<MaterializedView> relatedMvs = MvUtils.getRelatedMvs(ctx, 1, baseTables);
-        logger.info("refresh mv with related mvs: {}", relatedMvs);
-        // only enable mv rewrite when there are more than one related mvs
-        return relatedMvs.size() > 1;
+        return MvUtils.getRelatedMvs(ctx, 1, baseTables).size() > 1;
     }
 
     public MVTaskRunExtraMessage getMVTaskRunExtraMessage() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
@@ -100,6 +100,7 @@ public class MaterializationContext {
 
     // Cache partition compensates predicates for each ScanNode and isCompensate pair.
     private Map<LogicalScanOperator, List<ScalarOperator>> scanOpToPartitionCompensatePredicates;
+    private final int level;
 
     public MaterializationContext(OptimizerContext optimizerContext,
                                   MaterializedView mv,
@@ -109,7 +110,8 @@ public class MaterializationContext {
                                   List<Table> baseTables,
                                   List<Table> intersectingTables,
                                   MvUpdateInfo mvUpdateInfo,
-                                  List<ColumnRefOperator> mvOutputColumnRefs) {
+                                  List<ColumnRefOperator> mvOutputColumnRefs,
+                                  int level) {
         this.optimizerContext = optimizerContext;
         this.mv = mv;
         this.mvExpression = mvExpression;
@@ -121,6 +123,7 @@ public class MaterializationContext {
         this.mvUpdateInfo = mvUpdateInfo;
         this.mvOutputColumnRefs = mvOutputColumnRefs;
         this.scanOpToPartitionCompensatePredicates = Maps.newHashMap();
+        this.level = level;
     }
 
     public MaterializedView getMv() {
@@ -210,6 +213,10 @@ public class MaterializationContext {
 
     public List<ColumnRefOperator> getMvOutputColumnRefs() {
         return mvOutputColumnRefs;
+    }
+
+    public int getLevel() {
+        return level;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -65,17 +65,18 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalViewScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.rule.mv.MVCorrelation;
 import com.starrocks.sql.optimizer.rule.mv.MVUtils;
+import com.starrocks.sql.optimizer.rule.mv.MaterializedViewWrapper;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -106,121 +107,6 @@ public class MvRewritePreprocessor {
                 new QueryMaterializationContext() : context.getQueryMaterializationContext();
     }
 
-    @VisibleForTesting
-    public class MvWithPlanContext {
-        private final MaterializedView mv;
-        private final MvPlanContext mvPlanContext;
-        public MvWithPlanContext(MaterializedView mv, MvPlanContext mvPlanContext) {
-            this.mv = mv;
-            this.mvPlanContext = mvPlanContext;
-        }
-
-        public MaterializedView getMv() {
-            return mv;
-        }
-
-        public MvPlanContext getMvPlanContext() {
-            return mvPlanContext;
-        }
-    }
-
-    /**
-     * To avoid MvRewriteProcessor cost too much optimizer time, reduce all related mvs to a limited size.
-     * <h3>Why to Choose The Best Related MVs Strategy</h3>
-     *
-     * <p>Why still to choose limited related mvs from all active mvs?</p>
-     *
-     * <p>1. optimizer time cost. Even there is MVPlanCache to reduce mv optimizer plan time, but it still may cost
-     * too much time for mv preprocessor, because mv optimizer plan costs too much time because of cold start when
-     * MVPlanCache has no cache, or MVPlanCache has exceeded limited capacity which is 1000 by default.</p>
-     *
-     * <p>2. check mv's freshness for each mv will cost too much time if there are too many mvs.</p>
-     *
-     * <h3>How to Choose The Best Related MVs Strategy</h3>
-     * <p>
-     *     Choose the best related mvs from all active mvs as following order:
-     *     1. find the max intersected table num between mv and query which means it's better for rewrite.
-     *     2. find the latest fresh mv which means its freshness is better.
-     * </p>
-     *
-     * <h3>More Information</h3>
-     * <p>
-     *  NOTE: there are still some limitations about this ordering algorithm:
-     *  1. consider repeated tables in one mv later which one table can be used repeatedly in one mv.
-     *  2. consider random factor so can cache and use more mvs.
-     * </p>
-     */
-    public static class MVCorrelation implements Comparable<MVCorrelation> {
-        private final MaterializedView mv;
-        private final long mvQueryIntersectedTablesNum;
-        private final int mvQueryScanOpNumDiff;
-        private final long mvRefreshTimestamp;
-
-        public MVCorrelation(MaterializedView mv,
-                             long mvQueryIntersectedTablesNum,
-                             int mvQueryScanOpNumDiff,
-                             long mvRefreshTimestamp) {
-            this.mv = mv;
-            this.mvQueryIntersectedTablesNum = mvQueryIntersectedTablesNum;
-            this.mvQueryScanOpNumDiff = mvQueryScanOpNumDiff;
-            this.mvRefreshTimestamp = mvRefreshTimestamp;
-        }
-
-        public MaterializedView getMv() {
-            return this.mv;
-        }
-
-        public static long getMvQueryIntersectedTableNum(List<BaseTableInfo> baseTableInfos,
-                                                         Set<String> queryTableNames) {
-            return baseTableInfos.stream()
-                    .filter(baseTableInfo -> {
-                        String baseTableName = baseTableInfo.getTableName();
-                        // assert not null
-                        if (Strings.isNullOrEmpty(baseTableName)) {
-                            return false;
-                        }
-                        return queryTableNames.contains(baseTableName);
-                    }).count();
-        }
-
-        public static int getMvQueryScanOpDiff(List<MvPlanContext> planContexts,
-                                               int mvBaseTableSize,
-                                               int queryScanOpNum) {
-            int diff = Math.abs(queryScanOpNum - mvBaseTableSize);
-            if (planContexts == null || planContexts.isEmpty()) {
-                return diff;
-            }
-            return planContexts.stream()
-                    .map(mvPlanContext -> mvPlanContext.getMvScanOpNum())
-                    .map(num -> Math.abs(queryScanOpNum - num))
-                    .min(Comparator.comparing(Integer::intValue))
-                    .orElse(diff);
-        }
-
-        @Override
-        public int compareTo(@NotNull MVCorrelation other) {
-            // 1. compare intersected table nums, larger is better.
-            int result = Long.compare(this.mvQueryIntersectedTablesNum, other.mvQueryIntersectedTablesNum);
-            if (result != 0) {
-                return result;
-            }
-            // 2. compare base table num diff,  less is better
-            result = Integer.compare(other.mvQueryScanOpNumDiff, this.mvQueryScanOpNumDiff);
-            if (result != 0) {
-                return result;
-            }
-            // 3. compare refresh timestamp, larger is better.
-            return Long.compare(this.mvRefreshTimestamp, other.mvRefreshTimestamp);
-        }
-
-        @Override
-        public String toString() {
-            return String.format("Correlation: mv=%s, mvQueryInteractedTablesNum=%s, " +
-                    "mvQueryScanOpNumDiff=%s, mvRefreshTimestamp=%s", mv.getName(),
-                    mvQueryIntersectedTablesNum, mvQueryScanOpNumDiff, mvRefreshTimestamp);
-        }
-    }
-
     public void prepare(OptExpression queryOptExpression) {
         try (Timer ignored = Tracers.watchScope("MVPreprocess")) {
             Set<Table> queryTables = MvUtils.getAllTables(queryOptExpression).stream().collect(Collectors.toSet());
@@ -229,33 +115,35 @@ public class MvRewritePreprocessor {
             // use a new context rather than reuse the existed context to avoid cache conflict.
             try {
                 // 1. get related mvs for all input tables
-                Set<MaterializedView> relatedMVs =
+                Set<MaterializedViewWrapper> relatedMVs =
                         getRelatedMVs(queryTables, context.getOptimizerOptions().isRuleBased());
                 if (relatedMVs.isEmpty()) {
                     return;
                 }
 
                 // filter mvs which is set by config: including/excluding mvs
-                Set<MaterializedView> selectedRelatedMVs = getRelatedMVsByConfig(relatedMVs);
-                logMVPrepare(connectContext, "Choose {}/{} mvs after user config", selectedRelatedMVs.size(), relatedMVs.size());
+                Set<MaterializedViewWrapper> relatedMVWrappers = getRelatedMVsByConfig(relatedMVs);
+                logMVPrepare(connectContext, "Choose {}/{} mvs after user config", relatedMVWrappers.size(), relatedMVs.size());
                 // add into queryMaterializationContext for later use
-                this.queryMaterializationContext.addRelatedMVs(selectedRelatedMVs);
-                if (selectedRelatedMVs.isEmpty()) {
+                if (relatedMVWrappers.isEmpty()) {
                     return;
                 }
+                this.queryMaterializationContext.addRelatedMVs(
+                        relatedMVWrappers.stream().map(MaterializedViewWrapper::getMV).collect(Collectors.toSet()));
 
                 // 2. choose best related mvs by user's config or related mv limit
+                List<MaterializedViewWrapper> candidateMVs;
                 try (Timer t1 = Tracers.watchScope("MVChooseCandidates")) {
-                    selectedRelatedMVs = chooseBestRelatedMVs(queryTables, selectedRelatedMVs, queryOptExpression);
+                    candidateMVs = chooseBestRelatedMVs(queryTables, relatedMVWrappers, queryOptExpression);
                 }
-                if (selectedRelatedMVs.isEmpty()) {
+                if (candidateMVs.isEmpty()) {
                     return;
                 }
 
                 // 3. convert to mv with planContext, skip if mv has no valid plan(not SPJG)
-                Set<MvWithPlanContext> mvWithPlanContexts;
+                List<MaterializedViewWrapper> mvWithPlanContexts;
                 try (Timer t2 = Tracers.watchScope("MVGenerateMvPlan")) {
-                    mvWithPlanContexts = getMvWithPlanContext(selectedRelatedMVs);
+                    mvWithPlanContexts = getMvWithPlanContext(candidateMVs);
                 }
                 if (mvWithPlanContexts.isEmpty()) {
                     return;
@@ -324,6 +212,8 @@ public class MvRewritePreprocessor {
                 sessionVariable.isEnableViewBasedMvRewrite());
         logMVPrepare(connectContext, "  enable_materialized_view_text_match_rewrite: {}",
                 sessionVariable.isEnableMaterializedViewTextMatchRewrite());
+        logMVPrepare(connectContext, "  enable_materialized_view_multi_stages_rewrite: {}",
+                sessionVariable.isEnableMaterializedViewMultiStagesRewrite());
 
         // limit
         logMVPrepare(connectContext, "---------------------------------");
@@ -429,13 +319,13 @@ public class MvRewritePreprocessor {
     }
 
     @VisibleForTesting
-    public Set<MaterializedView> getRelatedMVs(Set<Table> queryTables,
-                                               boolean isRuleBased) {
+    public Set<MaterializedViewWrapper> getRelatedMVs(Set<Table> queryTables,
+                                                      boolean isRuleBased) {
         if (Config.enable_experimental_mv
                 && connectContext.getSessionVariable().isEnableMaterializedViewRewrite()
                 && !isRuleBased) {
             // related asynchronous materialized views
-            Set<MaterializedView> relatedMVs = getRelatedAsyncMVs(queryTables);
+            Set<MaterializedViewWrapper> relatedMVs = getRelatedAsyncMVs(queryTables);
 
             // related synchronous materialized views
             if (connectContext.getSessionVariable().isEnableSyncMaterializedViewRewrite()) {
@@ -454,7 +344,7 @@ public class MvRewritePreprocessor {
         return Arrays.stream(str.split(",")).map(String::trim).collect(Collectors.toSet());
     }
 
-    private Set<MaterializedView> getRelatedMVsByConfig(Set<MaterializedView> relatedMVs) {
+    private Set<MaterializedViewWrapper> getRelatedMVsByConfig(Set<MaterializedViewWrapper> relatedMVs) {
         // filter mvs by including/excluding settings
         String queryExcludingMVNames = connectContext.getSessionVariable().getQueryExcludingMVNames();
         String queryIncludingMVNames = connectContext.getSessionVariable().getQueryIncludingMVNames();
@@ -467,13 +357,17 @@ public class MvRewritePreprocessor {
         final Set<String> queryExcludingMVNamesSet = splitQueryMVNamesConfig(queryExcludingMVNames);
         final Set<String> queryIncludingMVNamesSet = splitQueryMVNamesConfig(queryIncludingMVNames);
 
-        return relatedMVs.stream()
-                .filter(mv -> queryIncludingMVNamesSet.isEmpty() || queryIncludingMVNamesSet.contains(mv.getName()))
-                .filter(mv -> queryExcludingMVNamesSet.isEmpty() || !queryExcludingMVNamesSet.contains(mv.getName()))
+        return relatedMVs
+                .stream()
+                .filter(wrapper -> queryIncludingMVNamesSet.isEmpty()
+                        || queryIncludingMVNamesSet.contains(wrapper.getMV().getName()))
+                .filter(wrapper -> queryExcludingMVNamesSet.isEmpty()
+                        || !queryExcludingMVNamesSet.contains(wrapper.getMV().getName()))
                 .collect(Collectors.toSet());
     }
 
-    private List<MvWithPlanContext> getMVWithContext(MaterializedView mv) {
+    private List<MaterializedViewWrapper> getMVWithContext(MaterializedViewWrapper wrapper) {
+        final MaterializedView mv = wrapper.getMV();
         if (!mv.isActive()) {
             OptimizerTraceUtil.logMVRewriteFailReason(mv.getName(), "inactive");
             return null;
@@ -485,7 +379,7 @@ public class MvRewritePreprocessor {
             OptimizerTraceUtil.logMVRewriteFailReason(mv.getName(), "invalid query plan");
             return null;
         }
-        List<MvWithPlanContext> mvWithPlanContexts = Lists.newArrayList();
+        List<MaterializedViewWrapper> mvWithPlanContexts = Lists.newArrayList();
         for (int i = 0; i < mvPlanContexts.size(); i++) {
             MvPlanContext mvPlanContext = mvPlanContexts.get(i);
             if (!mvPlanContext.isValidMvPlan()) {
@@ -493,7 +387,7 @@ public class MvRewritePreprocessor {
                         i, mvPlanContexts.size(), mvPlanContext.getInvalidReason());
                 continue;
             }
-            mvWithPlanContexts.add(new MvWithPlanContext(mv, mvPlanContext));
+            mvWithPlanContexts.add(MaterializedViewWrapper.create(mv, wrapper.getLevel(), mvPlanContext));
         }
         return mvWithPlanContexts;
     }
@@ -575,62 +469,81 @@ public class MvRewritePreprocessor {
         return MVPlanValidationResult.valid();
     }
 
-    private Set<MaterializedView> chooseBestRelatedMVsByCorrelations(Set<Table> queryTables,
-                                                                     Set<MaterializedView> validMVs,
-                                                                     OptExpression queryOptExpression,
-                                                                     int maxRelatedMVsLimit) {
+    private List<MaterializedViewWrapper> chooseBestRelatedMVsByCorrelations(Set<Table> queryTables,
+                                                                             Set<MaterializedViewWrapper> validMVs,
+                                                                             OptExpression queryOptExpression,
+                                                                             int maxRelatedMVsLimit) {
         int queryScanOpNum = MvUtils.getOlapScanNode(queryOptExpression).size();
         Set<String> queryTableNames = queryTables.stream().map(t -> t.getName()).collect(Collectors.toSet());
-        Queue<MVCorrelation> bestRelatedMVs = new PriorityQueue<>(maxRelatedMVsLimit);
-        for (MaterializedView mv : validMVs) {
+        List<MVCorrelation> mvCorrelations = Lists.newArrayList();
+        for (MaterializedViewWrapper wrapper : validMVs) {
+            MaterializedView mv = wrapper.getMV();
             List<BaseTableInfo> baseTableInfos = mv.getBaseTableInfos();
             long mvQueryInteractedTableNum = MVCorrelation.getMvQueryIntersectedTableNum(baseTableInfos, queryTableNames);
             List<MvPlanContext> planContexts = CachingMvPlanContextBuilder.getInstance()
                             .getPlanContextIfPresent(connectContext.getSessionVariable(), mv);
             int mvQueryScanOpDiff = MVCorrelation.getMvQueryScanOpDiff(planContexts, baseTableInfos.size(), queryScanOpNum);
             MVCorrelation mvCorrelation = new MVCorrelation(mv, mvQueryInteractedTableNum,
-                    mvQueryScanOpDiff, mv.getLastRefreshTime());
-            if (bestRelatedMVs.size() < maxRelatedMVsLimit) {
-                bestRelatedMVs.add(mvCorrelation);
-            } else if (bestRelatedMVs.peek().compareTo(mvCorrelation) < 0) {
+                    mvQueryScanOpDiff, mv.getLastRefreshTime(), wrapper.getLevel());
+            mvCorrelations.add(mvCorrelation);
+        }
+        return chooseBestRelatedMVsByCorrelations(mvCorrelations, maxRelatedMVsLimit);
+    }
+
+    @VisibleForTesting
+    public List<MaterializedViewWrapper> chooseBestRelatedMVsByCorrelations(Collection<MVCorrelation> mvCorrelations,
+                                                                            int maxRelatedMVsLimit) {
+        Queue<MVCorrelation> queue = new PriorityQueue<>(maxRelatedMVsLimit);
+        for (MVCorrelation mvCorrelation : mvCorrelations) {
+            if (queue.size() < maxRelatedMVsLimit) {
+                queue.add(mvCorrelation);
+            } else if (queue.peek().compareTo(mvCorrelation) < 0) {
                 // if the peek is less than new mv(larger is better), poll it and add new one
-                bestRelatedMVs.poll();
-                bestRelatedMVs.add(mvCorrelation);
+                queue.poll();
+                queue.add(mvCorrelation);
             }
         }
         logMVPrepare(connectContext, "Choose the best {} related mvs from all {} mvs because related " +
                         "mv exceeds max config limit {}",
-                bestRelatedMVs.size(), validMVs.size(), maxRelatedMVsLimit);
-        return bestRelatedMVs.stream().map(cor -> cor.getMv()).collect(Collectors.toSet());
+                queue.size(), mvCorrelations.size(), maxRelatedMVsLimit);
+        // ensure the best related mv is at the first
+        List<MaterializedViewWrapper> result = Lists.newArrayList();
+        while (!queue.isEmpty()) {
+            result.add(queue.poll().getWrapper());
+        }
+        Collections.reverse(result);
+        return result;
     }
 
+    /**
+     * Choose the best related mvs for the query rewrite that ensures the best related mv is at the first.
+     */
     @VisibleForTesting
-    public Set<MaterializedView> chooseBestRelatedMVs(Set<Table> queryTables,
-                                                      Set<MaterializedView> relatedMVs,
-                                                      OptExpression queryOptExpression) {
+    public List<MaterializedViewWrapper> chooseBestRelatedMVs(Set<Table> queryTables,
+                                                              Set<MaterializedViewWrapper> relatedMVs,
+                                                              OptExpression queryOptExpression) {
         // choose all valid mvs and filter mvs that cannot be rewritten for the query
-        Set<MaterializedView> validMVs = relatedMVs.stream()
-                .filter(mv -> isMVValidToRewriteQuery(connectContext, mv, false, queryTables, false).isValid())
+        Set<MaterializedViewWrapper> validMVs = relatedMVs.stream()
+                .filter(wrapper ->
+                        isMVValidToRewriteQuery(connectContext, wrapper.getMV(), false, queryTables, false).isValid())
                 .collect(Collectors.toSet());
         logMVPrepare(connectContext, "Choose {}/{} valid mvs after checking valid",
                 validMVs.size(), relatedMVs.size());
 
         // choose max config related mvs for mv rewrite to avoid too much optimize time
         int maxRelatedMVsLimit = connectContext.getSessionVariable().getCboMaterializedViewRewriteRelatedMVsLimit();
-        if (validMVs.size() <= maxRelatedMVsLimit) {
-            return validMVs;
-        }
         return chooseBestRelatedMVsByCorrelations(queryTables, validMVs, queryOptExpression, maxRelatedMVsLimit);
     }
 
     @VisibleForTesting
-    public Set<MvWithPlanContext> getMvWithPlanContext(Set<MaterializedView> validMVs) {
+    public List<MaterializedViewWrapper> getMvWithPlanContext(List<MaterializedViewWrapper> validMVs) {
         // filter mvs which are active and have valid plans
-        Set<MvWithPlanContext> mvWithPlanContexts = Sets.newHashSet();
-        for (MaterializedView mv : validMVs) {
+        final List<MaterializedViewWrapper> mvWithPlanContexts = Lists.newArrayList();
+        for (MaterializedViewWrapper wrapper : validMVs) {
+            MaterializedView mv = wrapper.getMV();
             try {
-                List<MvWithPlanContext> mvWithPlanContext = getMVWithContext(mv);
-                if (mvWithPlanContext != null) {
+                final List<MaterializedViewWrapper> mvWithPlanContext = getMVWithContext(wrapper);
+                if (CollectionUtils.isNotEmpty(mvWithPlanContext)) {
                     mvWithPlanContexts.addAll(mvWithPlanContext);
                 }
             } catch (Exception e) {
@@ -644,23 +557,20 @@ public class MvRewritePreprocessor {
         return mvWithPlanContexts;
     }
 
-    private Set<MaterializedView> getRelatedAsyncMVs(Set<Table> queryTables) {
+    private Set<MaterializedViewWrapper> getRelatedAsyncMVs(Set<Table> queryTables) {
         int maxLevel = connectContext.getSessionVariable().getNestedMvRewriteMaxLevel();
         // get all related materialized views, include nested mvs
         return MvUtils.getRelatedMvs(connectContext, maxLevel, queryTables);
     }
 
-    private Set<MaterializedView> getRelatedSyncMVs(Set<Table> queryTables) {
-        Set<MaterializedView> relatedMvs = Sets.newHashSet();
+    private Set<MaterializedViewWrapper> getRelatedSyncMVs(Set<Table> queryTables) {
         // get all related materialized views, include nested mvs
-        for (Table table : queryTables) {
-            if (!(table instanceof OlapTable)) {
-                continue;
-            }
-            OlapTable olapTable = (OlapTable) table;
-            relatedMvs.addAll(getTableRelatedSyncMVs(olapTable));
-        }
-        return relatedMvs;
+        return queryTables.stream()
+                .filter(table -> table instanceof OlapTable)
+                .map(table -> getTableRelatedSyncMVs((OlapTable) table))
+                .flatMap(Set::stream)
+                .map(mv -> MaterializedViewWrapper.create(mv, 0))
+                .collect(Collectors.toSet());
     }
 
     private Set<MaterializedView> getTableRelatedSyncMVs(OlapTable olapTable) {
@@ -746,14 +656,14 @@ public class MvRewritePreprocessor {
     }
 
     public void prepareRelatedMVs(Set<Table> queryTables,
-                                  Set<MvWithPlanContext> mvWithPlanContexts) {
+                                  List<MaterializedViewWrapper> mvWithPlanContexts) {
         if (mvWithPlanContexts.isEmpty()) {
             return;
         }
 
-        for (MvWithPlanContext mvWithPlanContext : mvWithPlanContexts) {
-            MaterializedView mv = mvWithPlanContext.getMv();
-            MvPlanContext mvPlanContext = mvWithPlanContext.getMvPlanContext();
+        for (MaterializedViewWrapper wrapper : mvWithPlanContexts) {
+            MaterializedView mv = wrapper.getMV();
+            MvPlanContext mvPlanContext = wrapper.getMvPlanContext();
             try {
                 // mv's partitions to refresh
                 MvUpdateInfo mvUpdateInfo = queryMaterializationContext.getOrInitMVTimelinessInfos(mv);
@@ -769,7 +679,7 @@ public class MvRewritePreprocessor {
                         MvUtils.shrinkToSize(partitionNamesToRefresh, Config.max_mv_task_run_meta_message_values_length));
 
                 MaterializationContext materializationContext = buildMaterializationContext(context, mv, mvPlanContext,
-                        mvUpdateInfo, queryTables);
+                        mvUpdateInfo, queryTables, wrapper.getLevel());
                 if (materializationContext == null) {
                     continue;
                 }
@@ -783,7 +693,7 @@ public class MvRewritePreprocessor {
         }
         // all base table related mvs
         List<String> relatedMvNames = mvWithPlanContexts.stream()
-                .map(mvWithPlanContext -> mvWithPlanContext.getMv().getName())
+                .map(mvWithPlanContext -> mvWithPlanContext.getMV().getName())
                 .collect(Collectors.toList());
         // all mvs that match SPJG pattern and can ben used to try mv rewrite
         List<String> candidateMvNames = context.getCandidateMvs().stream()
@@ -857,7 +767,8 @@ public class MvRewritePreprocessor {
                                                                      MaterializedView mv,
                                                                      MvPlanContext mvPlanContext,
                                                                      MvUpdateInfo mvUpdateInfo,
-                                                                     Set<Table> queryTables) {
+                                                                     Set<Table> queryTables,
+                                                                     int level) {
         Preconditions.checkState(mvPlanContext != null);
         OptExpression mvPlan = mvPlanContext.getLogicalPlan();
         Preconditions.checkState(mvPlan != null);
@@ -878,7 +789,7 @@ public class MvRewritePreprocessor {
         MaterializationContext materializationContext =
                 new MaterializationContext(context, copiedMV, mvPlan, context.getColumnRefFactory(),
                         mvPlanContext.getRefFactory(), baseTables, intersectingTables,
-                        mvUpdateInfo, mvOutputColumns);
+                        mvUpdateInfo, mvOutputColumns, level);
         // generate scan mv plan here to reuse it in rule applications
         LogicalOlapScanOperator scanMvOp = createScanMvOperator(mv,
                 materializationContext.getQueryRefFactory(), mvUpdateInfo.getMvToRefreshPartitionNames());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
@@ -78,10 +78,25 @@ public class OptimizerTraceUtil {
     /**
      * NOTE: Carefully use it, because the log would be print into the query profile, to help understanding why a
      * materialized view is not chose to rewrite the query.
+     *
+     * Used for mv preprocessor log, the log would be print into the query profile.
      */
     public static void logMVRewriteFailReason(String mvName, String format, Object... objects) {
         String str = MessageFormatter.arrayFormat(format, objects).getMessage();
         Tracers.reasoning(Tracers.Module.MV, "MV rewrite fail for {}: {} ", mvName, str);
+        logMVRewrite(mvName, format, objects);
+    }
+
+    /**
+     * Used for mv rewrite reason log, the log would be print into the query profile.
+     */
+    public static void logMVRewriteFailReason(MvRewriteContext mvContext, String format, Object... objects) {
+        final String mvName = mvContext.getMVName();
+        final String str = MessageFormatter.arrayFormat(format, objects).getMessage();
+        final OptimizerContext optimizerContext = mvContext.getMaterializationContext().getOptimizerContext();
+        final String memoPhase = optimizerContext.isInMemoPhase() ? "CBO" : "RBO";
+        final String stage = optimizerContext.getQueryMaterializationContext().getCurrentRewriteStage().name();
+        Tracers.reasoning(Tracers.Module.MV, "[{}] [{}] MV rewrite fail for {}: {} ", memoPhase, stage, mvName, str);
         logMVRewrite(mvName, format, objects);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryMaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryMaterializationContext.java
@@ -36,6 +36,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalViewScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvRewriteStrategy;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.PredicateSplit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -78,6 +79,8 @@ public class QueryMaterializationContext {
 
     // mv contexts that query has been rewritten successfully by materialized view
     private Set<MaterializationContext> rewrittenSuccessMVContexts = Sets.newHashSet();
+
+    private MvRewriteStrategy.MVRewriteStage currentRewriteStage = MvRewriteStrategy.MVRewriteStage.PHASE0;
 
     /**
      * It's used to record the cache stats of `mvQueryContextCache`.
@@ -280,5 +283,13 @@ public class QueryMaterializationContext {
                     final int level = mvContext.getLevel();
                     return validCandidateMVs.stream().anyMatch(mv -> mv.getLevel() > level);
                 });
+    }
+
+    public MvRewriteStrategy.MVRewriteStage getCurrentRewriteStage() {
+        return currentRewriteStage;
+    }
+
+    public void setCurrentRewriteStage(MvRewriteStrategy.MVRewriteStage currentRewriteStage) {
+        this.currentRewriteStage = currentRewriteStage;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -404,7 +404,7 @@ public class QueryOptimizer extends Optimizer {
         }
 
         // do rule based mv rewrite if needed
-        if (!context.getQueryMaterializationContext().hasRewrittenSuccess()) {
+        if (context.getQueryMaterializationContext().isNeedsFurtherMVRewrite()) {
             doRuleBasedMaterializedViewRewrite(tree, rootTaskContext);
         }
 
@@ -597,7 +597,8 @@ public class QueryOptimizer extends Optimizer {
 
         // Add a config to decide whether to rewrite sync mv.
         if (!optimizerOptions.isRuleDisable(TF_MATERIALIZED_VIEW)
-                && sessionVariable.isEnableSyncMaterializedViewRewrite()) {
+                && sessionVariable.isEnableSyncMaterializedViewRewrite()
+                && !context.getQueryMaterializationContext().hasRewrittenSuccess()) {
             // Split or predicates to union all so can be used by mv rewrite to choose the best sort key indexes.
             // TODO: support adaptive for or-predicates to union all.
             if (SplitScanORToUnionRule.isForceRewrite()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -395,13 +395,14 @@ public class QueryOptimizer extends Optimizer {
         return tree;
     }
 
-    private void ruleBasedMaterializedViewRewrite(OptExpression tree,
-                                                  TaskContext rootTaskContext,
-                                                  ColumnRefSet requiredColumns) {
+    private void ruleBasedMaterializedViewRewriteStage2(OptExpression tree,
+                                                        TaskContext rootTaskContext,
+                                                        ColumnRefSet requiredColumns) {
         // skip if mv rewrite is disabled
         if (!mvRewriteStrategy.enableMaterializedViewRewrite || context.getQueryMaterializationContext() == null) {
             return;
         }
+        context.getQueryMaterializationContext().setCurrentRewriteStage(MvRewriteStrategy.MVRewriteStage.PHASE2);
 
         // do rule based mv rewrite if needed
         if (context.getQueryMaterializationContext().isNeedsFurtherMVRewrite()) {
@@ -455,11 +456,13 @@ public class QueryOptimizer extends Optimizer {
         }
     }
 
-    private void doMVRewriteWithMultiStages(OptExpression tree,
-                                            TaskContext rootTaskContext) {
+    private void ruleBasedMaterializedViewRewriteStage1(OptExpression tree,
+                                                        TaskContext rootTaskContext) {
         if (!mvRewriteStrategy.enableMaterializedViewRewrite || !mvRewriteStrategy.mvStrategy.isMultiStages()) {
             return;
         }
+        context.getQueryMaterializationContext().setCurrentRewriteStage(MvRewriteStrategy.MVRewriteStage.PHASE1);
+
         scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.PARTITION_PRUNE_RULES);
         scheduler.rewriteIterative(tree, rootTaskContext, new MergeTwoProjectRule());
         scheduler.rewriteIterative(tree, rootTaskContext, new MergeProjectWithChildRule());
@@ -548,7 +551,7 @@ public class QueryOptimizer extends Optimizer {
         scheduler.rewriteIterative(tree, rootTaskContext, new MergeTwoProjectRule());
 
         // rule-based materialized view rewrite: early stage
-        doMVRewriteWithMultiStages(tree, rootTaskContext);
+        ruleBasedMaterializedViewRewriteStage1(tree, rootTaskContext);
         context.setEnableJoinEquivalenceDerive(true);
         context.setEnableJoinPredicatePushDown(true);
 
@@ -659,7 +662,7 @@ public class QueryOptimizer extends Optimizer {
         scheduler.rewriteOnce(tree, rootTaskContext, new PushDownTopNBelowUnionRule());
 
         // rule based materialized view rewrite
-        ruleBasedMaterializedViewRewrite(tree, rootTaskContext, requiredColumns);
+        ruleBasedMaterializedViewRewriteStage2(tree, rootTaskContext, requiredColumns);
 
         // this rewrite rule should be after mv.
         scheduler.rewriteOnce(tree, rootTaskContext, RewriteSimpleAggToHDFSScanRule.SCAN_NO_PROJECT);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MVCorrelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MVCorrelation.java
@@ -1,0 +1,145 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.mv;
+
+import com.google.common.base.Strings;
+import com.starrocks.catalog.BaseTableInfo;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvPlanContext;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * To avoid MvRewriteProcessor cost too much optimizer time, reduce all related mvs to a limited size.
+ * <h3>Why to Choose The Best Related MVs Strategy</h3>
+ *
+ * <p>Why still to choose limited related mvs from all active mvs?</p>
+ *
+ * <p>1. optimizer time cost. Even there is MVPlanCache to reduce mv optimizer plan time, but it still may cost
+ * too much time for mv preprocessor, because mv optimizer plan costs too much time because of cold start when
+ * MVPlanCache has no cache, or MVPlanCache has exceeded limited capacity which is 1000 by default.</p>
+ *
+ * <p>2. check mv's freshness for each mv will cost too much time if there are too many mvs.</p>
+ *
+ * <h3>How to Choose The Best Related MVs Strategy</h3>
+ * <p>
+ *     Choose the best related mvs from all active mvs as following order:
+ *     1. find the max intersected table num between mv and query which means it's better for rewrite.
+ *     2. find the latest fresh mv which means its freshness is better.
+ * </p>
+ *
+ * <h3>More Information</h3>
+ * <p>
+ *  NOTE: there are still some limitations about this ordering algorithm:
+ *  1. consider repeated tables in one mv later which one table can be used repeatedly in one mv.
+ *  2. consider random factor so can cache and use more mvs.
+ * </p>
+ */
+public class MVCorrelation implements Comparable<MVCorrelation> {
+    private final MaterializedView mv;
+    private final long mvQueryIntersectedTablesNum;
+    private final int mvQueryScanOpNumDiff;
+    private final long mvRefreshTimestamp;
+    private final int level;
+
+    public MVCorrelation(MaterializedView mv,
+                         long mvQueryIntersectedTablesNum,
+                         int mvQueryScanOpNumDiff,
+                         long mvRefreshTimestamp,
+                         int level) {
+        this.mv = mv;
+        this.level = level;
+        this.mvQueryIntersectedTablesNum = mvQueryIntersectedTablesNum;
+        this.mvQueryScanOpNumDiff = mvQueryScanOpNumDiff;
+        this.mvRefreshTimestamp = mvRefreshTimestamp;
+    }
+
+    public MVCorrelation(MaterializedView mv,
+                         long mvQueryIntersectedTablesNum,
+                         int mvQueryScanOpNumDiff,
+                         long mvRefreshTimestamp) {
+        this(mv, mvQueryIntersectedTablesNum, mvQueryScanOpNumDiff, mvRefreshTimestamp, 0);
+    }
+
+    public MaterializedView getMv() {
+        return this.mv;
+    }
+
+    public MaterializedViewWrapper getWrapper() {
+        return MaterializedViewWrapper.create(mv, level);
+    }
+
+    public static long getMvQueryIntersectedTableNum(List<BaseTableInfo> baseTableInfos,
+                                                     Set<String> queryTableNames) {
+        return baseTableInfos.stream()
+                .filter(baseTableInfo -> {
+                    String baseTableName = baseTableInfo.getTableName();
+                    // assert not null
+                    if (Strings.isNullOrEmpty(baseTableName)) {
+                        return false;
+                    }
+                    return queryTableNames.contains(baseTableName);
+                }).count();
+    }
+
+    public static int getMvQueryScanOpDiff(List<MvPlanContext> planContexts,
+                                           int mvBaseTableSize,
+                                           int queryScanOpNum) {
+        int diff = Math.abs(queryScanOpNum - mvBaseTableSize);
+        if (planContexts == null || planContexts.isEmpty()) {
+            return diff;
+        }
+        return planContexts.stream()
+                .map(mvPlanContext -> mvPlanContext.getMvScanOpNum())
+                .map(num -> Math.abs(queryScanOpNum - num))
+                .min(Comparator.comparing(Integer::intValue))
+                .orElse(diff);
+    }
+
+    /**
+     * MVCorrelation is a min heap, so the first element is the largest one, we need to keep the best mv in the last and
+     * remove the worst mv in the first.
+     */
+    @Override
+    public int compareTo(@NotNull MVCorrelation other) {
+        // compare level, less is better
+        int result = Integer.compare(other.level, this.level);
+        if (result != 0) {
+            return result;
+        }
+        // compare intersected table nums, larger is better.
+        result = Long.compare(this.mvQueryIntersectedTablesNum, other.mvQueryIntersectedTablesNum);
+        if (result != 0) {
+            return result;
+        }
+        // compare base table num diff,  less is better
+        result = Integer.compare(other.mvQueryScanOpNumDiff, this.mvQueryScanOpNumDiff);
+        if (result != 0) {
+            return result;
+        }
+        // compare refresh timestamp, larger is better.
+        return Long.compare(this.mvRefreshTimestamp, other.mvRefreshTimestamp);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Correlation: mv=%s, mvQueryInteractedTablesNum=%s, " +
+                        "mvQueryScanOpNumDiff=%s, mvRefreshTimestamp=%s", mv.getName(),
+                mvQueryIntersectedTablesNum, mvQueryScanOpNumDiff, mvRefreshTimestamp);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewWrapper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewWrapper.java
@@ -1,0 +1,92 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.mv;
+
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvPlanContext;
+
+import java.util.Objects;
+
+public class MaterializedViewWrapper {
+    private final MaterializedView mv;
+    private final int level;
+    private final MvPlanContext mvPlanContext;
+
+    public MaterializedViewWrapper(MaterializedView mv, int level) {
+        this.mv = mv;
+        this.level = level;
+        this.mvPlanContext = null;
+    }
+
+    public MaterializedViewWrapper(MaterializedView mv, int level, MvPlanContext mvPlanContext) {
+        this.mv = mv;
+        this.level = level;
+        this.mvPlanContext = mvPlanContext;
+    }
+
+    public MaterializedView getMV() {
+        return mv;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+
+    public MvPlanContext getMvPlanContext() {
+        return mvPlanContext;
+    }
+
+    public static MaterializedViewWrapper create(MaterializedView mv, int level) {
+        return new MaterializedViewWrapper(mv, level);
+    }
+
+    public static MaterializedViewWrapper create(MaterializedView mv, int level, MvPlanContext mvPlanContext) {
+        return new MaterializedViewWrapper(mv, level, mvPlanContext);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = mv.hashCode();
+        result = 31 * result + level;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        MaterializedViewWrapper mvWrapper = (MaterializedViewWrapper) o;
+        if (level != mvWrapper.level) {
+            return false;
+        }
+        if (!mv.equals(mvWrapper.mv)) {
+            return false;
+        }
+        return Objects.equals(mvPlanContext, mvWrapper.mvPlanContext);
+    }
+
+    @Override
+    public String toString() {
+        return "MVWrapper{" +
+                "mv=" + mv +
+                ", level=" + level +
+                '}';
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
@@ -165,7 +165,7 @@ public class MaterializedViewTransparentRewriteRule extends TransformationRule {
         logMVRewrite(context, this, "MV to refresh partition info: {}", mvUpdateInfo);
 
         MaterializationContext mvContext = MvRewritePreprocessor.buildMaterializationContext(context,
-                mv, mvPlanContext, mvUpdateInfo, queryTables);
+                mv, mvPlanContext, mvUpdateInfo, queryTables, 0);
 
         Map<Column, ColumnRefOperator> columnToColumnRefMap = olapScanOperator.getColumnMetaToColRefMap();
         // use ordered output columns to ensure the order of output columns if the mv contains order-by clause.
@@ -213,7 +213,7 @@ public class MaterializedViewTransparentRewriteRule extends TransformationRule {
         mvUpdateInfo.addMvToRefreshPartitionNames(mv.getPartitionNames());
 
         MaterializationContext mvContext = MvRewritePreprocessor.buildMaterializationContext(context,
-                mv, mvPlanContext, mvUpdateInfo, queryTables);
+                mv, mvPlanContext, mvUpdateInfo, queryTables, 0);
         logMVRewrite(mvContext, "Get mv transparent plan failed, and redirect to mv's defined query");
         Map<Column, ColumnRefOperator> columnToColumnRefMap = olapScanOperator.getColumnMetaToColRefMap();
         List<Column> mvColumns = mv.getBaseSchemaWithoutGeneratedColumn();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteStrategy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteStrategy.java
@@ -146,7 +146,8 @@ public class MvRewriteStrategy {
         SessionVariable sessionVariable = connectContext.getSessionVariable();
 
         // only enable multi-stages when force rewrite is enabled
-        if (sessionVariable.isEnableMaterializedViewForceRewrite()) {
+        if (sessionVariable.isEnableMaterializedViewMultiStagesRewrite() ||
+                sessionVariable.isEnableMaterializedViewForceRewrite()) {
             strategy.mvStrategy = MVStrategy.MULTI_STAGES;
         }
         strategy.enableForceRBORewrite = sessionVariable.isEnableForceRuleBasedMvRewrite();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteStrategy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteStrategy.java
@@ -48,6 +48,19 @@ public class MvRewriteStrategy {
         }
     }
 
+    public enum MVRewriteStage {
+        PHASE0(0),
+        PHASE1(1),
+        PHASE2(2);
+        private int ordinal;
+        MVRewriteStage(int ordinal) {
+            this.ordinal = ordinal;
+        }
+        public int getOrdinal() {
+            return this.ordinal;
+        }
+    }
+
     // general config
     public boolean enableMaterializedViewRewrite = false;
     // Whether enable force rewrite for query plans with join operator by rule based mv rewrite

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -105,12 +105,14 @@ import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.sql.optimizer.rule.Rule;
 import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.sql.optimizer.rule.mv.MVUtils;
+import com.starrocks.sql.optimizer.rule.mv.MaterializedViewWrapper;
 import com.starrocks.sql.optimizer.transformer.LogicalPlan;
 import com.starrocks.sql.optimizer.transformer.RelationTransformer;
 import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
 import com.starrocks.sql.optimizer.transformer.TransformerContext;
 import com.starrocks.sql.parser.ParsingException;
 import com.starrocks.sql.util.Box;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.SetUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -135,20 +137,33 @@ import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
 public class MvUtils {
     private static final Logger LOG = LogManager.getLogger(MvUtils.class);
 
-    public static Set<MaterializedView> getRelatedMvs(ConnectContext connectContext,
-                                                      int maxLevel,
-                                                      Set<Table> tablesToCheck) {
+    public static boolean hasRelatedMVs(Set<Table> tablesToCheck) {
+        if (tablesToCheck.isEmpty()) {
+            return false;
+        }
+        for (Table table : tablesToCheck) {
+            Set<MvId> mvIds = table.getRelatedMaterializedViews();
+            if (CollectionUtils.isNotEmpty(mvIds)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static Set<MaterializedViewWrapper> getRelatedMvs(ConnectContext connectContext,
+                                                             int maxLevel,
+                                                             Set<Table> tablesToCheck) {
         if (tablesToCheck.isEmpty()) {
             return Sets.newHashSet();
         }
-        Set<MaterializedView> mvs = Sets.newHashSet();
+        Set<MaterializedViewWrapper> mvs = Sets.newHashSet();
         getRelatedMvs(connectContext, maxLevel, 0, tablesToCheck, mvs);
         return mvs;
     }
 
     public static void getRelatedMvs(ConnectContext connectContext,
                                      int maxLevel, int currentLevel,
-                                     Set<Table> tablesToCheck, Set<MaterializedView> mvs) {
+                                     Set<Table> tablesToCheck, Set<MaterializedViewWrapper> mvs) {
         if (currentLevel >= maxLevel) {
             logMVPrepare("Current level {} is greater than max level {}", currentLevel, maxLevel);
             return;
@@ -181,7 +196,7 @@ public class MvUtils {
                 continue;
             }
             newMvs.add(table);
-            mvs.add((MaterializedView) table);
+            mvs.add(MaterializedViewWrapper.create((MaterializedView) table, currentLevel));
         }
         getRelatedMvs(connectContext, maxLevel, currentLevel + 1, newMvs, mvs);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -112,7 +112,6 @@ import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
 import com.starrocks.sql.optimizer.transformer.TransformerContext;
 import com.starrocks.sql.parser.ParsingException;
 import com.starrocks.sql.util.Box;
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.SetUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -136,19 +135,6 @@ import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
 
 public class MvUtils {
     private static final Logger LOG = LogManager.getLogger(MvUtils.class);
-
-    public static boolean hasRelatedMVs(Set<Table> tablesToCheck) {
-        if (tablesToCheck.isEmpty()) {
-            return false;
-        }
-        for (Table table : tablesToCheck) {
-            Set<MvId> mvIds = table.getRelatedMaterializedViews();
-            if (CollectionUtils.isNotEmpty(mvIds)) {
-                return true;
-            }
-        }
-        return false;
-    }
 
     public static Set<MaterializedViewWrapper> getRelatedMvs(ConnectContext connectContext,
                                                              int maxLevel,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -234,7 +234,7 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
                     MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mvContext.getMv().getMvId());
             mvEntity.increaseQueryMatchedCount(1L);
             // mark: query has been rewritten by mv success.
-            context.getQueryMaterializationContext().markRewriteSuccess(true);
+            context.getQueryMaterializationContext().addRewrittenSuccessMVContext(mvContext);
 
             // Do not try to enumerate all plans, it would take a lot of time
             int limit = context.getSessionVariable().getCboMaterializedViewRewriteRuleOutputLimit();

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewHiveTPCHTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewHiveTPCHTest.java
@@ -26,6 +26,7 @@ public class MaterializedViewHiveTPCHTest extends MaterializedViewTestBase {
         MaterializedViewTestBase.beforeClass();
         starRocksAssert.useDatabase(MATERIALIZED_DB_NAME);
 
+        connectContext.getSessionVariable().setEnableMaterializedViewMultiStagesRewrite(false);
         executeSqlFile("sql/materialized-view/tpch-hive/ddl_tpch_mv1.sql");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -907,16 +907,15 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 "select abs(empid), sum(salary) from emps group by abs(empid), deptno")
                 .contains("  0:OlapScanNode\n" +
                         "     TABLE: mv0")
-                .contains("  1:Project\n" +
-                        "  |  <slot 9> : 9: empid\n" +
-                        "  |  <slot 10> : 10: deptno\n" +
-                        "  |  <slot 11> : 11: total\n" +
-                        "  |  <slot 14> : abs(9: empid)\n" +
-                        "  |  ")
-                .contains("  2:AGGREGATE (update serialize)\n" +
+                .contains("2:AGGREGATE (update serialize)\n" +
                         "  |  STREAMING\n" +
                         "  |  output: sum(11: total)\n" +
-                        "  |  group by: 14: abs, 10: deptno");
+                        "  |  group by: 14: abs, 10: deptno\n" +
+                        "  |  \n" +
+                        "  1:Project\n" +
+                        "  |  <slot 10> : 10: deptno\n" +
+                        "  |  <slot 11> : 11: total\n" +
+                        "  |  <slot 14> : abs(9: empid)");
     }
 
     @Test
@@ -931,16 +930,15 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 .contains("  0:OlapScanNode\n" +
                         "     TABLE: mv0")
                 // only contains required columns from mv scan operator.
-                .contains("  1:Project\n" +
-                        "  |  <slot 9> : 9: empid\n" +
-                        "  |  <slot 10> : 10: deptno\n" +
-                        "  |  <slot 11> : 11: total\n" +
-                        "  |  <slot 16> : abs(9: empid)\n" +
-                        "  |  ")
                 .contains("  2:AGGREGATE (update serialize)\n" +
                         "  |  STREAMING\n" +
                         "  |  output: sum(11: total)\n" +
-                        "  |  group by: 14: abs, 10: deptno");
+                        "  |  group by: 16: abs, 10: deptno\n" +
+                        "  |  \n" +
+                        "  1:Project\n" +
+                        "  |  <slot 10> : 10: deptno\n" +
+                        "  |  <slot 11> : 11: total\n" +
+                        "  |  <slot 16> : abs(9: empid)");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithPartitionTest.java
@@ -419,7 +419,7 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                         "     PREAGGREGATION: ON\n" +
                         "     partitions=4/5\n" +
                         "     rollup: partial_mv_7\n" +
-                        "     tabletRatio=4/8");
+                        "     tabletRatio=8/8");
 
         // query delta: with more partition predicates
         sql("select c1, c3, c2 from test_base_part where c3 < 1000 and c1 = 1")
@@ -427,7 +427,7 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                         "     PREAGGREGATION: ON\n" +
                         "     partitions=3/5\n" +
                         "     rollup: partial_mv_7\n" +
-                        "     tabletRatio=3/6");
+                        "     tabletRatio=6/6");
 
         // no match
         sql("select c1, c3, c2 from test_base_part where c3 < 1000")

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -2131,7 +2131,7 @@ public class MvRewriteTest extends MVTestBase {
      */
     @Test
     public void testCandidateOrdering_ManyDimensions() throws Exception {
-        final int numDimensions = 50;
+        final int numDimensions = connectContext.getSessionVariable().getCboMaterializedViewRewriteRelatedMVsLimit();
         StringBuilder createTableBuilder = new StringBuilder("create table t_many_dimensions ( ");
         Function<Integer, String> columnNameGen = (i) -> "c" + i;
         for (int i = 0; i < numDimensions; i++) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/PushDownAggregationWithMVTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/PushDownAggregationWithMVTest.java
@@ -77,17 +77,15 @@ public class PushDownAggregationWithMVTest extends MVTestBase {
 
         // Get the execution plan with push down enabled
         String planWithPushDown = getFragmentPlan(sql);
-        Assert.assertTrue(planWithPushDown, planWithPushDown.contains("  2:AGGREGATE (update finalize)\n" +
-                "  |  output: sum(4: amount)\n" +
-                "  |  group by: 1: id, 3: city\n" +
-                "  |  \n" +
-                "  1:Project\n" +
-                "  |  <slot 1> : 10: id\n" +
-                "  |  <slot 3> : 12: city\n" +
-                "  |  <slot 4> : 13: amount\n" +
+        Assert.assertTrue(planWithPushDown, planWithPushDown.contains("  1:AGGREGATE (update finalize)\n" +
+                "  |  output: sum(17: amount)\n" +
+                "  |  group by: 14: id, 16: city\n" +
                 "  |  \n" +
                 "  0:OlapScanNode\n" +
-                "     TABLE: mv1\n"));
+                "     TABLE: mv1\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     partitions=1/1\n" +
+                "     rollup: mv1"));
         // Now test with push down disabled
         testContext.getSessionVariable().setCboPushDownAggregateMode(-1);
         String planWithoutPushDown = getFragmentPlan(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPushAggTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPushAggTest.java
@@ -31,11 +31,13 @@ public class TPCDSPushAggTest extends TPCDS1TTestBase {
     @BeforeAll
     public static void beforeAll() {
         FeConstants.unitTestView = false;
+        connectContext.getSessionVariable().setEnableMaterializedViewRewrite(false);
     }
 
     @AfterAll
     public static void afterAll() {
         FeConstants.unitTestView = true;
+        connectContext.getSessionVariable().setEnableMaterializedViewRewrite(true);
     }
 
     private String check(int mode, String sql, int aggNum) throws Exception {

--- a/test/sql/test_materialized_view/R/test_mv_reasoning
+++ b/test/sql/test_materialized_view/R/test_mv_reasoning
@@ -67,8 +67,10 @@ TRACE REASON MV
     WHERE c2 > 1
     GROUP BY c4;
 -- result:
-    MV rewrite fail for mv1: Rewrite group by key failed: 4: c4 
-    MV rewrite fail for mv1: Rewrite rollup aggregate failed, cannot rewrite group by keys: [4: c4] 
+    [RBO] [PHASE1] MV rewrite fail for mv1: Rewrite group by key failed: 4: c4 
+    [RBO] [PHASE1] MV rewrite fail for mv1: Rewrite rollup aggregate failed, cannot rewrite group by keys: [4: c4] 
+    [RBO] [PHASE2] MV rewrite fail for mv1: Rewrite group by key failed: 4: c4 
+    [RBO] [PHASE2] MV rewrite fail for mv1: Rewrite rollup aggregate failed, cannot rewrite group by keys: [4: c4] 
 -- !result
 TRACE REASON MV
     SELECT c1, sum(c3), count(c3)
@@ -76,7 +78,8 @@ TRACE REASON MV
     WHERE c4 > 'a'
     GROUP BY c1;
 -- result:
-    MV rewrite fail for mv1: Rewrite scalar operator failed: 4: c4 > a cannot be rewritten 
+    [RBO] [PHASE1] MV rewrite fail for mv1: Rewrite scalar operator failed: 4: c4 > a cannot be rewritten 
+    [RBO] [PHASE2] MV rewrite fail for mv1: Rewrite scalar operator failed: 4: c4 > a cannot be rewritten 
 -- !result
 DROP MATERIALIZED VIEW mv1;
 -- result:
@@ -101,20 +104,23 @@ TRACE REASON MV
     FROM t1
     GROUP BY c1, c2, c4;
 -- result:
-    MV rewrite fail for mv1: Rewrite projection failed: cannot totally rewrite expr 4: c4 
+    [RBO] [PHASE1] MV rewrite fail for mv1: Rewrite projection failed: cannot totally rewrite expr 4: c4 
+    [RBO] [PHASE2] MV rewrite fail for mv1: Rewrite projection failed: cannot totally rewrite expr 4: c4 
 -- !result
 TRACE REASON MV
     SELECT c1, c2, c4
     FROM t1;
 -- result:
-    MV rewrite fail for mv1: Rewrite projection failed: cannot totally rewrite expr 4: c4 
+    [RBO] [PHASE1] MV rewrite fail for mv1: Rewrite projection failed: cannot totally rewrite expr 4: c4 
+    [RBO] [PHASE2] MV rewrite fail for mv1: Rewrite projection failed: cannot totally rewrite expr 4: c4 
 -- !result
 TRACE REASON MV
     SELECT c1, c2
     FROM t1
     WHERE c4='a';
 -- result:
-    MV rewrite fail for mv1: Rewrite scalar operator failed: 4: c4 = a cannot be rewritten 
+    [RBO] [PHASE1] MV rewrite fail for mv1: Rewrite scalar operator failed: 4: c4 = a cannot be rewritten 
+    [RBO] [PHASE2] MV rewrite fail for mv1: Rewrite scalar operator failed: 4: c4 = a cannot be rewritten 
 -- !result
 ALTER MATERIALIZED VIEW mv1 INACTIVE;
 -- result:

--- a/test/sql/test_materialized_view_rewrite/R/test_mv_rewrite_with_time_series_multi_mvs
+++ b/test/sql/test_materialized_view_rewrite/R/test_mv_rewrite_with_time_series_multi_mvs
@@ -53,17 +53,23 @@ from t0 group by date_trunc('month', ts);
 refresh materialized view test_mv3 with sync mode;
 [UC]analyze table test_mv1 WITH SYNC MODE;
 -- result:
-test_db_8d93f2d33c72496aa3925e2bb2c40af3.test_mv1	analyze	status	OK
+test_db_821db0e543014d6d8c356e450d1ab264.test_mv1	analyze	status	OK
 -- !result
 [UC]analyze table test_mv2 WITH SYNC MODE;
 -- result:
-test_db_8d93f2d33c72496aa3925e2bb2c40af3.test_mv2	analyze	status	OK
+test_db_821db0e543014d6d8c356e450d1ab264.test_mv2	analyze	status	OK
 -- !result
 [UC]analyze table test_mv3 WITH SYNC MODE;
 -- result:
-test_db_8d93f2d33c72496aa3925e2bb2c40af3.test_mv3	analyze	status	OK
+test_db_821db0e543014d6d8c356e450d1ab264.test_mv3	analyze	status	OK
 -- !result
 set enable_materialized_view_rewrite=true;
+-- result:
+-- !result
+set enable_materialized_view_timeseries_agg_pushdown_rewrite=true;
+-- result:
+-- !result
+set enable_materialized_view_multi_stages_rewrite=false;
 -- result:
 -- !result
 function: print_hit_materialized_views("select sum(v1), sum(v2) from t0 where ts > '2020-02-23 12:12:00' order by 1;")
@@ -178,15 +184,15 @@ from test_mv2 group by date_trunc('month', dt);
 refresh materialized view test_mv3 with sync mode;
 [UC]analyze table test_mv1 WITH SYNC MODE;
 -- result:
-test_db_8d93f2d33c72496aa3925e2bb2c40af3.test_mv1	analyze	status	OK
+test_db_821db0e543014d6d8c356e450d1ab264.test_mv1	analyze	status	OK
 -- !result
 [UC]analyze table test_mv2 WITH SYNC MODE;
 -- result:
-test_db_8d93f2d33c72496aa3925e2bb2c40af3.test_mv2	analyze	status	OK
+test_db_821db0e543014d6d8c356e450d1ab264.test_mv2	analyze	status	OK
 -- !result
 [UC]analyze table test_mv3 WITH SYNC MODE;
 -- result:
-test_db_8d93f2d33c72496aa3925e2bb2c40af3.test_mv3	analyze	status	OK
+test_db_821db0e543014d6d8c356e450d1ab264.test_mv3	analyze	status	OK
 -- !result
 function: print_hit_materialized_views("select sum(v1), sum(v2) from t0 where ts > '2020-02-23 12:12:00' order by 1;")
 -- result:

--- a/test/sql/test_materialized_view_rewrite/T/test_mv_rewrite_with_time_series_multi_mvs
+++ b/test/sql/test_materialized_view_rewrite/T/test_mv_rewrite_with_time_series_multi_mvs
@@ -53,6 +53,8 @@ refresh materialized view test_mv3 with sync mode;
 [UC]analyze table test_mv3 WITH SYNC MODE;
 
 set enable_materialized_view_rewrite=true;
+set enable_materialized_view_timeseries_agg_pushdown_rewrite=true;
+set enable_materialized_view_multi_stages_rewrite=false;
 
 function: print_hit_materialized_views("select sum(v1), sum(v2) from t0 where ts > '2020-02-23 12:12:00' order by 1;")
 function: print_hit_materialized_views("select sum(v1), sum(v2) from t0 where ts >= '2020-03-23 12:12:00' order by 1;")


### PR DESCRIPTION
## Why I'm doing:

Many optimizer rules will cause mv rewrite fail (eg: topn push down/join predicates push down) because rewritten plan can not be used for mv rewrite any more.
```
    @Test
    public void testMVRewriteJoinWithTopN1() throws Exception {
        createAndRefreshMv("CREATE MATERIALIZED VIEW test_mv1\n" +
                "PARTITION BY k1\n" +
                "DISTRIBUTED BY HASH(k1) BUCKETS 10\n" +
                "REFRESH MANUAL\n" +
                "AS SELECT a.k1, a.v1, a.v2, b.v1 as b_v1\n" +
                "FROM test_partition_tbl1 as a left join test_partition_tbl2 as b on a.k1=b.k1;");

        {
            // if mv rewrite mode is default, should not be rewritten
            connectContext.getSessionVariable().setEnableMaterializedViewMultiStagesRewrite(false);
            String query = "select a.k1, a.v2 FROM test_partition_tbl1 as a left join test_partition_tbl2 as b " +
                    "on a.k1=b.k1 order by 1 limit 3;";
            String plan = getFragmentPlan(query);
            System.out.println(plan);
            PlanTestBase.assertNotContains("test_mv1");
        }
        connectContext.getSessionVariable().setEnableMaterializedViewMultiStagesRewrite(true);
        {
            // if mv rewrite mode is force, should be rewritten
            String query = "select a.k1, a.v2 FROM test_partition_tbl1 as a left join test_partition_tbl2 as b " +
                    "on a.k1=b.k1 order by 1 limit 3;";
            String plan = getFragmentPlan(query);
            System.out.println(plan);
            PlanTestBase.assertContains(plan, "test_mv1");
        }
        {
            // if mv rewrite mode is force, should be rewritten
            String query = "select a.k1, a.v2 FROM test_partition_tbl1 as a left join test_partition_tbl2 as b " +
                    "on a.k1=b.k1 order by 1 limit 3;";
            String plan = getFragmentPlan(query);
            System.out.println(plan);
            PlanTestBase.assertContains(plan, "test_mv1");
        }
        connectContext.getSessionVariable().setEnableMaterializedViewMultiStagesRewrite(false);
        starRocksAssert.dropMaterializedView("test_mv1");
    }

```
## What I'm doing:
- Refactor MvRewritePreprocessor to support  order candidates by `level` for multi related mvs;
- Enable multi stages mv rewrite by default to ensure mv rewrite more stable.

Further
- Fix  issue https://github.com/StarRocks/starrocks/issues/56855 which found by test.

### Test result

I added 16 mvs for tpch benchmark, and only check FE Optimizer  Time costs(ms) for different scens:
- MV Rewerite Enable, Multi Stage Enable
- MV Rewerite Enable, Multi Stage Disable
-  MV Rewerite Disable

result as below:
- there is no much diff between multi stage on or off;
- mv rewrite will take extra optimizer cost with no mv rewrite.

1 FE: 8C16G
| Query | MultiStage(true) | MultiStage(false) | MV Rewrite(OFF) | Query can be rewritten by MV |
|------|------|-------|--------|------|
| Q01  | 11   | 7     | 7      | Y    |
| Q02  | 11   | 10    | 7      | Y    |
| Q03  | 9    | 7     | 11     |      |
| Q04  | 8    | 7     | 6      | Y    |
| Q05  | 22   | 22    | 17     |      |
| Q06  | 7    | 7     | 5      | Y    |
| Q07  | 25   | 25    | 18     |      |
| Q08  | 56   | 71    | 43     |      |
| Q09  | 23   | 22    | 16     |      |
| Q10  | 11   | 11    | 8      |      |
| Q11  | 10   | 10    | 7      |      |
| Q12  | 8    | 8     | 6      |      |
| Q13  | 6    | 6     | 4      |      |
| Q14  | 6    | 6     | 4      |      |
| Q15  | 25   | 24    | 14     | Y    |
| Q16  | 7    | 7     | 5      |      |
| Q17  | 6    | 7     | 4      |      |
| Q18  | 13   | 13    | 9      | Y    |
| Q19  | 9    | 10    | 11     |      |
| Q20  | 15   | 14    | 12     | Y    |
| Q21  | 10   | 11    | 6      | Y    |
| Q22  | 12   | 12    | 8      | Y    |
| Total | 310 | 317 | 228 | 0 |

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0