### PR TITLE
[BugFix] Fix array contains reuse null column

### DIFF
--- a/be/src/exprs/array_functions.cpp
+++ b/be/src/exprs/array_functions.cpp
@@ -58,7 +58,7 @@ StatusOr<ColumnPtr> ArrayFunctions::array_length([[maybe_unused]] FunctionContex
         if (arg0->has_null()) {
             // Copy null flags.
             return NullableColumn::create(std::move(col_result),
-                                          down_cast<const NullableColumn*>(arg0)->null_column()->as_mutable_ptr());
+                                          down_cast<const NullableColumn*>(arg0)->null_column()->clone());
         } else {
             return col_result;
         }
@@ -698,7 +698,7 @@ private:
         if (data_column->is_nullable()) {
             DCHECK_EQ(nullable_column->size(), result->size());
             if (nullable_column->has_null()) {
-                result = NullableColumn::create(std::move(result), nullable_column->null_column());
+                result = NullableColumn::create(std::move(result), nullable_column->null_column()->clone());
             }
         }
 

--- a/be/src/exprs/array_functions.tpp
+++ b/be/src/exprs/array_functions.tpp
@@ -1824,7 +1824,7 @@ public:
 
         // wrap nullable and const column for result
         if (is_nullable_array) {
-            result_column = NullableColumn::create(std::move(result_column), std::move(array_null_column));
+            result_column = NullableColumn::create(std::move(result_column), array_null_column->clone());
             result_column->check_or_die();
         }
         if (is_const_array && is_const_target) {

--- a/test/sql/test_array_fn/R/test_array_contains
+++ b/test/sql/test_array_fn/R/test_array_contains
@@ -2118,6 +2118,8 @@ SELECT id FROM test_array_contains WHERE array_contains_seq(array_varchar, ['a',
 -- !result
 
 
+
+
 -- name: test_array_contains_complex_type
 CREATE TABLE test_array_contains_complex_type (
     id INT,
@@ -2364,6 +2366,8 @@ select array_contains([null], null), array_position([null], null);
 1	1
 -- !result
 
+
+
 -- name: test_array_contains_with_null
 CREATE TABLE t ( 
 pk bigint not null ,
@@ -2388,4 +2392,8 @@ insert into t select 1, null, null, null, null;
 select /*+ set_var(pipeline_dop=1) */ pk, array_contains(arr_bigint, 1000), arr_bigint from t order by pk limit 1;
 -- result:
 0	0	[0,0,0,0,0,0,0,0,0,0]
+-- !result
+select /*+ set_var(pipeline_dop=1) */ pk, array_length(arr_bigint), arr_bigint from t order by pk limit 1;
+-- result:
+0	10	[0,0,0,0,0,0,0,0,0,0]
 -- !result

--- a/test/sql/test_array_fn/R/test_array_contains
+++ b/test/sql/test_array_fn/R/test_array_contains
@@ -193,6 +193,8 @@ select sum(array_contains(@arr, str)) from t;
 -- result:
 0
 -- !result
+
+
 -- name: test_array_contains_with_decimal
 create table t (
     k bigint,
@@ -247,6 +249,8 @@ select array_position(v3, v2) from t;
 -- result:
 1
 -- !result
+
+
 -- name: test_array_contains_all_and_seq
 CREATE TABLE t (
   k bigint(20) NOT NULL,
@@ -667,6 +671,8 @@ select array_contains_seq('abc',['a']);
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 7 to line 1, column 37. Detail message: 1-th input of array_contains_seq should be an array, rather than varchar.')
 -- !result
+
+
 -- name: test_array_contains_all_type
 CREATE TABLE test_array_contains (
     id INT,
@@ -2110,6 +2116,8 @@ SELECT id FROM test_array_contains WHERE array_contains_all(array_varchar, ['a',
 SELECT id FROM test_array_contains WHERE array_contains_seq(array_varchar, ['a', 'b', 'c', 'd', 'e']) ORDER BY id;
 -- result:
 -- !result
+
+
 -- name: test_array_contains_complex_type
 CREATE TABLE test_array_contains_complex_type (
     id INT,
@@ -2354,4 +2362,30 @@ SELECT id, array_position(array_struct, NULL) FROM test_array_contains_complex_t
 select array_contains([null], null), array_position([null], null);
 -- result:
 1	1
+-- !result
+
+-- name: test_array_contains_with_null
+CREATE TABLE t ( 
+pk bigint not null ,
+str string,
+arr_bigint array<bigint>,
+arr_str array<string>,
+arr_decimal array<decimal(38,5)>
+) ENGINE=OLAP
+DUPLICATE KEY(`pk`)
+DISTRIBUTED BY HASH(`pk`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t select generate_series, md5sum(generate_series), array_repeat(generate_series, 10),array_repeat(md5sum(generate_series), 10), array_repeat(generate_series, 1000) from table(generate_series(0, 9999));
+-- result:
+-- !result
+insert into t select 1, null, null, null, null;
+-- result:
+-- !result
+select /*+ set_var(pipeline_dop=1) */ pk, array_contains(arr_bigint, 1000), arr_bigint from t order by pk limit 1;
+-- result:
+0	0	[0,0,0,0,0,0,0,0,0,0]
 -- !result

--- a/test/sql/test_array_fn/T/test_array_contains
+++ b/test/sql/test_array_fn/T/test_array_contains
@@ -540,3 +540,20 @@ SELECT id, array_position(array_struct, row(40, 'database')) FROM test_array_con
 SELECT id, array_position(array_struct, NULL) FROM test_array_contains_complex_type ORDER BY id;
 
 select array_contains([null], null), array_position([null], null);
+
+-- name: test_array_contains_with_null
+CREATE TABLE t ( 
+pk bigint not null ,
+str string,
+arr_bigint array<bigint>,
+arr_str array<string>,
+arr_decimal array<decimal(38,5)>
+) ENGINE=OLAP
+DUPLICATE KEY(`pk`)
+DISTRIBUTED BY HASH(`pk`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1"
+);
+insert into t select generate_series, md5sum(generate_series), array_repeat(generate_series, 10),array_repeat(md5sum(generate_series), 10), array_repeat(generate_series, 1000) from table(generate_series(0, 9999));
+insert into t select 1, null, null, null, null;
+select /*+ set_var(pipeline_dop=1) */ pk, array_contains(arr_bigint, 1000), arr_bigint from t order by pk limit 1;

--- a/test/sql/test_array_fn/T/test_array_contains
+++ b/test/sql/test_array_fn/T/test_array_contains
@@ -557,3 +557,5 @@ PROPERTIES (
 insert into t select generate_series, md5sum(generate_series), array_repeat(generate_series, 10),array_repeat(md5sum(generate_series), 10), array_repeat(generate_series, 1000) from table(generate_series(0, 9999));
 insert into t select 1, null, null, null, null;
 select /*+ set_var(pipeline_dop=1) */ pk, array_contains(arr_bigint, 1000), arr_bigint from t order by pk limit 1;
+select /*+ set_var(pipeline_dop=1) */ pk, array_length(arr_bigint), arr_bigint from t order by pk limit 1;
+


### PR DESCRIPTION
## Why I'm doing:
array_contains/array_length may reuse input nullable column's null column, but it's not safe.
like 'select nullable_array_col, array_contains(nullable_array_col) order by xxx", two output column will reuse same null column

## What I'm doing:
fix https://github.com/StarRocks/StarRocksTest/issues/9367



## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0