### PR TITLE
[Enhancement] add probe memory limit before building partition hash table

### DIFF
--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.h
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.h
@@ -51,6 +51,7 @@ struct SpillableHashJoinProbeMetrics {
     RuntimeProfile::Counter* probe_shuffle_timer = nullptr;
     RuntimeProfile::HighWaterMarkCounter* prober_peak_memory_usage = nullptr;
     RuntimeProfile::HighWaterMarkCounter* build_partition_peak_memory_usage = nullptr;
+    RuntimeProfile::HighWaterMarkCounter* peak_processing_partition_count = nullptr;
 };
 
 class SpillableHashJoinProbeOperator final : public HashJoinProbeOperator {
@@ -78,6 +79,10 @@ public:
     StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
 
     void set_probe_spiller(std::shared_ptr<spill::Spiller> spiller) { _probe_spiller = std::move(spiller); }
+
+    void set_degree_of_parallelism(int32_t degree_of_parallelism) { _degree_of_parallelism = degree_of_parallelism; }
+
+    void set_spill_hash_join_probe_op_max_bytes(int64_t op_bytes) { _spill_hash_join_probe_op_max_bytes = op_bytes; }
 
 private:
     bool spilled() const;
@@ -129,6 +134,9 @@ private:
 
     bool _is_finished = false;
     bool _is_finishing = false;
+
+    int32_t _degree_of_parallelism;
+    int64_t _spill_hash_join_probe_op_max_bytes;
 
     NoBlockCountDownLatch _latch;
     mutable std::mutex _mutex;

--- a/be/src/exec/spill/options.h
+++ b/be/src/exec/spill/options.h
@@ -107,6 +107,8 @@ struct SpilledOptions {
 
     bool enable_buffer_read = false;
     size_t max_read_buffer_bytes = UINT64_MAX;
+
+    int64_t spill_hash_join_probe_op_max_bytes = 1LL << 31;
 };
 
 // spill strategy

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -389,6 +389,9 @@ public:
     int64_t max_spill_read_buffer_bytes_per_driver() const {
         return _spill_options.has_value() ? _spill_options->max_spill_read_buffer_bytes_per_driver : INT64_MAX;
     }
+    int64_t spill_hash_join_probe_op_max_bytes() const {
+        return _spill_options.has_value() ? _spill_options->spill_hash_join_probe_op_max_bytes : 1LL << 31;
+    }
 
     bool error_if_overflow() const {
         return _query_options.__isset.overflow_mode && _query_options.overflow_mode == TOverflowMode::REPORT_ERROR;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -206,6 +206,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_AGG_SPILL_PREAGGREGATION = "enable_agg_spill_preaggregation";
     public static final String ENABLE_SPILL_BUFFER_READ = "enable_spill_buffer_read";
     public static final String MAX_SPILL_READ_BUFFER_BYTES_PER_DRIVER = "max_spill_read_buffer_bytes_per_driver";
+    public static final String SPILL_HASH_JOIN_PROBE_OP_MAX_BYTES = "spill_hash_join_probe_op_max_bytes";
     // enable table pruning(RBO) in cardinality-preserving joins
     public static final String ENABLE_RBO_TABLE_PRUNE = "enable_rbo_table_prune";
 
@@ -1290,6 +1291,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = MAX_SPILL_READ_BUFFER_BYTES_PER_DRIVER, flag = VariableMgr.INVISIBLE)
     public long maxSpillReadBufferBytesPerDriver = 1024 * 1024 * 16;
+
+    @VarAttr(name = SPILL_HASH_JOIN_PROBE_OP_MAX_BYTES, flag = VariableMgr.INVISIBLE)
+    public long spillHashJoinProbeOpMaxBytes = 1L << 31;
 
     @VarAttr(name = ENABLE_RBO_TABLE_PRUNE)
     private boolean enableRboTablePrune = false;

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -169,6 +169,7 @@ struct TSpillOptions {
   22: optional TSpillToRemoteStorageOptions spill_to_remote_storage_options;
   23: optional bool enable_spill_buffer_read;
   24: optional i64 max_spill_read_buffer_bytes_per_driver;
+  25: optional i64 spill_hash_join_probe_op_max_bytes;
 }
 
 // Query options with their respective defaults


### PR DESCRIPTION
## Why I'm doing:
Fixes #56491 

`SpillableHashJoinProbeOperator` will take much memory to restore/rebuild the partition hash table when DoP is elevated. Although there is a Memory Resource Manager that could help to control the memory usage in `SpillableHashJoinProbeOperators` ( _by limiting the size of selected partition to smaller than 2 * spill_mem_table_size_ ), Memory Resource Manager hasn't considered multi-operators. 

Considering Q97 in TPC-DS, it will take about 3-4 GB to rebuild the partition hash table at a time

Memory is calculated as below:
```
56 (DoP) * 4 MB (size of the hash table in this case) * 16 (partition from build operator)) = 3.5 GB
```

This PR will introduce a config called `spillHashJoinProbeOpMaxBytes` to help reduce memory consumption when building the partition hash table by limiting memory usage across all probe operators.

## What I'm doing:

Fixes #56491 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0