### PR TITLE
[BugFix] Fix parallel fail when deploy large plan

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Deployer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Deployer.java
@@ -19,6 +19,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.Status;
+import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.qe.ConnectContext;
@@ -40,9 +41,13 @@ import org.apache.logging.log4j.Logger;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.stream.Collectors;
 
 import static com.starrocks.qe.scheduler.dag.FragmentInstanceExecState.DeploymentResult;
@@ -52,6 +57,9 @@ import static com.starrocks.qe.scheduler.dag.FragmentInstanceExecState.Deploymen
  */
 public class Deployer {
     private static final Logger LOG = LogManager.getLogger(Deployer.class);
+    private static final ThreadPoolExecutor EXECUTOR =
+            ThreadPoolManager.newDaemonCacheThreadPool(ThreadPoolManager.cpuCores(),
+                    Integer.MAX_VALUE, "deployer", true);
 
     private final JobSpec jobSpec;
     private final ExecutionDAG executionDAG;
@@ -107,9 +115,20 @@ public class Deployer {
 
         if (enablePlanSerializeConcurrently) {
             try (Timer ignored = Tracers.watchScope(Tracers.Module.SCHEDULER, "DeploySerializeConcurrencyTime")) {
-                threeStageExecutionsToDeploy.stream().parallel().forEach(
-                        executions -> executions.stream().parallel()
-                                .forEach(FragmentInstanceExecState::serializeRequest));
+                List<Future<?>> futures = new LinkedList<>();
+                threeStageExecutionsToDeploy.forEach(
+                        executions -> executions.forEach(e ->
+                            futures.add(EXECUTOR.submit(e::serializeRequest))
+                        )
+                );
+                for (Future<?> future : futures) {
+                    future.get();
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (ExecutionException e) {
+                LOG.warn("Error serialize request during deployFragments", e);
+                throw new StarRocksException(e);
             }
         }
 


### PR DESCRIPTION
## Why I'm doing:
`Thread limit exceeded replacing blocked worker` exception is thrown when plan is large.

```
com.starrocks.common.UserException: java.util.concurrent.RejectedExecutionException: Thread limit exceeded replacing blocked worker
        at com.starrocks.qe.StmtExecutor.handleDMLStmt(StmtExecutor.java:2515) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.handleDMLStmtWithProfile(StmtExecutor.java:2055) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:696) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.proxyExecute(ConnectProcessor.java:843) ~[starrocks-fe.jar:?]
        at com.starrocks.service.FrontendServiceImpl.forward(FrontendServiceImpl.java:1137) ~[starrocks-fe.jar:?]
        at com.starrocks.thrift.FrontendService$Processor$forward.getResult(FrontendService.java:4937) ~[starrocks-fe.jar:?]
        at com.starrocks.thrift.FrontendService$Processor$forward.getResult(FrontendService.java:4914) ~[starrocks-fe.jar:?]
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:40) ~[libthrift-0.20.0.jar:0.20.0]
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:40) ~[libthrift-0.20.0.jar:0.20.0]
        at com.starrocks.common.SRTThreadPoolServer$WorkerProcess.run(SRTThreadPoolServer.java:311) ~[starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
        at java.lang.Thread.run(Thread.java:834) ~[?:?]
Caused by: java.util.concurrent.RejectedExecutionException: java.util.concurrent.RejectedExecutionException: Thread limit exceeded replacing blocked worker
        at jdk.internal.reflect.GeneratedConstructorAccessor231.newInstance(Unknown Source) ~[?:?]
        at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:?]
        at java.lang.reflect.Constructor.newInstance(Constructor.java:490) ~[?:?]
        at java.util.concurrent.ForkJoinTask.getThrowableException(ForkJoinTask.java:600) ~[?:?]
        at java.util.concurrent.ForkJoinTask.reportException(ForkJoinTask.java:678) ~[?:?]
        at java.util.concurrent.ForkJoinTask.invoke(ForkJoinTask.java:737) ~[?:?]
        at java.util.stream.ForEachOps$ForEachOp.evaluateParallel(ForEachOps.java:159) ~[?:?]
        at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateParallel(ForEachOps.java:173) ~[?:?]
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:233) ~[?:?]
        at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497) ~[?:?]
        at java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:661) ~[?:?]
        at com.starrocks.qe.scheduler.Deployer.deployFragments(Deployer.java:110) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.scheduler.dag.AllAtOnceExecutionSchedule.schedule(AllAtOnceExecutionSchedule.java:40) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DefaultCoordinator.deliverExecFragments(DefaultCoordinator.java:643) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DefaultCoordinator.startScheduling(DefaultCoordinator.java:541) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.scheduler.Coordinator.startScheduling(Coordinator.java:113) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.scheduler.Coordinator.exec(Coordinator.java:92) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.handleDMLStmt(StmtExecutor.java:2242) ~[starrocks-fe.jar:?]
```
## What I'm doing:
```java
        if (enablePlanSerializeConcurrently) {
            try (Timer ignored = Tracers.watchScope(Tracers.Module.SCHEDULER, "DeploySerializeConcurrencyTime")) {
                threeStageExecutionsToDeploy.stream().parallel().forEach(
                        executions -> executions.stream().parallel()
                                .forEach(FragmentInstanceExecState::serializeRequest));
            }
        }
```

`threeStageExecutionsToDeploy.stream().parallel()` uses `ForkJoinPool` whose thread limit is `#cpu - 1`
When number of executions is more than `#cpu - 1`, `ForkJoinPool` will throw `Thread limit exceeded replacing blocked worker` exception.

This patchs use a new thread pool to avoid this exception
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0