### PR TITLE
[BugFix]no sensitive info exposed when show create jdbc table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
@@ -51,7 +51,7 @@ public class JDBCTable extends Table {
     @SerializedName(value = "rn")
     private String resourceName;
 
-    private Map<String, String> properties;
+    private Map<String, String> connectInfo;
     private String catalogName;
     private String dbName;
     private List<Column> partitionColumns;
@@ -107,12 +107,11 @@ public class JDBCTable extends Table {
         return partitionColumns;
     }
 
-    @Override
-    public Map<String, String> getProperties() {
-        if (properties == null) {
-            this.properties = new HashMap<>();
+    public Map<String, String> getConnectInfo() {
+        if (connectInfo == null) {
+            this.connectInfo = new HashMap<>();
         }
-        return properties;
+        return connectInfo;
     }
 
     @Override
@@ -120,8 +119,8 @@ public class JDBCTable extends Table {
         return partitionColumns == null || partitionColumns.size() == 0;
     }
 
-    public String getProperty(String propertyKey) {
-        return properties.get(propertyKey);
+    public String getConnectInfo(String connectInfoKey) {
+        return connectInfo.get(connectInfoKey);
     }
 
     private void validate(Map<String, String> properties) throws DdlException {
@@ -146,7 +145,7 @@ public class JDBCTable extends Table {
             } else {
                 jdbcTable = properties.get(JDBCTable.JDBC_TABLENAME);
             }
-            this.properties = properties;
+            this.connectInfo = properties;
             return;
         }
 
@@ -220,14 +219,14 @@ public class JDBCTable extends Table {
             tJDBCTable.setJdbc_user(resource.getProperty(JDBCResource.USER));
             tJDBCTable.setJdbc_passwd(resource.getProperty(JDBCResource.PASSWORD));
         } else {
-            String uri = properties.get(JDBCResource.URI);
+            String uri = connectInfo.get(JDBCResource.URI);
             String driverName = buildCatalogDriveName(uri);
             tJDBCTable.setJdbc_driver_name(driverName);
-            tJDBCTable.setJdbc_driver_url(properties.get(JDBCResource.DRIVER_URL));
-            tJDBCTable.setJdbc_driver_checksum(properties.get(JDBCResource.CHECK_SUM));
-            tJDBCTable.setJdbc_driver_class(properties.get(JDBCResource.DRIVER_CLASS));
+            tJDBCTable.setJdbc_driver_url(connectInfo.get(JDBCResource.DRIVER_URL));
+            tJDBCTable.setJdbc_driver_checksum(connectInfo.get(JDBCResource.CHECK_SUM));
+            tJDBCTable.setJdbc_driver_class(connectInfo.get(JDBCResource.DRIVER_CLASS));
 
-            if (properties.get(JDBC_TABLENAME) != null) {
+            if (connectInfo.get(JDBC_TABLENAME) != null) {
                 tJDBCTable.setJdbc_url(uri);
             } else {
                 int delimiterIndex = uri.indexOf("?");
@@ -240,8 +239,8 @@ public class JDBCTable extends Table {
                 }
             }
             tJDBCTable.setJdbc_table(jdbcTable);
-            tJDBCTable.setJdbc_user(properties.get(JDBCResource.USER));
-            tJDBCTable.setJdbc_passwd(properties.get(JDBCResource.PASSWORD));
+            tJDBCTable.setJdbc_user(connectInfo.get(JDBCResource.USER));
+            tJDBCTable.setJdbc_passwd(connectInfo.get(JDBCResource.PASSWORD));
         }
 
         TTableDescriptor tTableDescriptor = new TTableDescriptor(getId(), TTableType.JDBC_TABLE,
@@ -256,7 +255,7 @@ public class JDBCTable extends Table {
     }
 
     public ProtocolType getProtocolType() {
-        String uri = properties.get(JDBCResource.URI);
+        String uri = connectInfo.get(JDBCResource.URI);
         if (StringUtils.isEmpty(uri)) {
             return ProtocolType.UNKNOWN;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
@@ -114,7 +114,7 @@ public class JDBCScanNode extends ScanNode {
         JDBCResource resource = (JDBCResource) GlobalStateMgr.getCurrentState().getResourceMgr()
                 .getResource(table.getResourceName());
         // Compatible with jdbc catalog
-        String jdbcURI = resource != null ? resource.getProperty(JDBCResource.URI) : table.getProperty(JDBCResource.URI);
+        String jdbcURI = resource != null ? resource.getProperty(JDBCResource.URI) : table.getConnectInfo(JDBCResource.URI);
         return jdbcURI.startsWith("jdbc:mysql");
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -1942,9 +1942,11 @@ public class AstToStringBuilder {
 
         // Properties
         Map<String, String> properties = new HashMap<>();
-        try {
-            properties = new HashMap<>(table.getProperties());
-        } catch (NotImplementedException e) {
+        if (table.getType() != JDBC) {
+            try {
+                properties = new HashMap<>(table.getProperties());
+            } catch (NotImplementedException e) {
+            }
         }
 
         // Location

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -1942,11 +1942,9 @@ public class AstToStringBuilder {
 
         // Properties
         Map<String, String> properties = new HashMap<>();
-        if (table.getType() != JDBC) {
-            try {
-                properties = new HashMap<>(table.getProperties());
-            } catch (NotImplementedException e) {
-            }
+        try {
+            properties = new HashMap<>(table.getProperties());
+        } catch (NotImplementedException e) {
         }
 
         // Location

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorJdbcTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorJdbcTest.java
@@ -105,11 +105,11 @@ public class PartitionBasedMvRefreshProcessorJdbcTest extends MVTestBase {
     @Test
     public void testJDBCProtocolType() {
         JDBCTable table = new JDBCTable();
-        table.getProperties().put(JDBCResource.URI, "jdbc:postgres:aaa");
+        table.getConnectInfo().put(JDBCResource.URI, "jdbc:postgres:aaa");
         Assert.assertEquals(JDBCTable.ProtocolType.POSTGRES, table.getProtocolType());
-        table.getProperties().put(JDBCResource.URI, "jdbc:mysql:aaa");
+        table.getConnectInfo().put(JDBCResource.URI, "jdbc:mysql:aaa");
         Assert.assertEquals(JDBCTable.ProtocolType.MYSQL, table.getProtocolType());
-        table.getProperties().put(JDBCResource.URI, "jdbc:h2:aaa");
+        table.getConnectInfo().put(JDBCResource.URI, "jdbc:h2:aaa");
         Assert.assertEquals(JDBCTable.ProtocolType.UNKNOWN, table.getProtocolType());
     }
 

--- a/test/sql/test_jdbc_catalog/R/test_json_type
+++ b/test/sql/test_jdbc_catalog/R/test_json_type
@@ -36,6 +36,13 @@ select * from db_json_${uuid0}.t1;
 -- result:
 1	{"c1": 1}
 -- !result
+show create table db_json_${uuid0}.t1;
+-- result:
+t1	CREATE TABLE `t1` (
+  `c1` int(11) DEFAULT NULL,
+  `c2` varchar(1073741824) DEFAULT NULL
+);
+-- !result
 set catalog default_catalog;
 -- result:
 -- !result

--- a/test/sql/test_jdbc_catalog/T/test_json_type
+++ b/test/sql/test_jdbc_catalog/T/test_json_type
@@ -20,6 +20,8 @@ properties
 -- query
 set catalog jdbc_catalog_${uuid0};
 select * from db_json_${uuid0}.t1;
+-- make sure no sensitive info exposed
+show create table db_json_${uuid0}.t1;
 set catalog default_catalog;
 
 -- drop mysql table


### PR DESCRIPTION
## Why I'm doing:
all jdbc table's properties are from catalog, and contain sensitive info
so there is no need to show properties for jdbc table.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0