### PR TITLE
[BugFix] prohibit lambda function in generated column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -528,6 +528,10 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
                 }
             }
 
+            if (ExpressionAnalyzer.containsHighOrderFunctionWithLambda(expr)) {
+                throw new SemanticException("Generated Column don't support high order function with lambda");
+            }
+
             // check if the expression refers to other generated columns
             List<SlotRef> slots = Lists.newArrayList();
             expr.collect(SlotRef.class, slots);
@@ -634,6 +638,10 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
                     if (fn.isAggregateFunction()) {
                         throw new SemanticException("Generated Column don't support aggregation function");
                     }
+                }
+
+                if (ExpressionAnalyzer.containsHighOrderFunctionWithLambda(expr)) {
+                    throw new SemanticException("Generated Column don't support high order function with lambda");
                 }
 
                 // check if the expression refers to other generated columns
@@ -791,6 +799,10 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
                 if (fn.isAggregateFunction()) {
                     throw new SemanticException("Generated Column don't support aggregation function");
                 }
+            }
+
+            if (ExpressionAnalyzer.containsHighOrderFunctionWithLambda(expr)) {
+                throw new SemanticException("Generated Column don't support high order function with lambda");
             }
 
             // check if the expression refers to other generated columns

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -235,6 +235,11 @@ public class CreateTableAnalyzer {
                 throw new SemanticException(e.getMessage());
             }
 
+            if (columnDef.isGeneratedColumn() &&
+                    ExpressionAnalyzer.containsHighOrderFunctionWithLambda(columnDef.generatedColumnExpr())) {
+                throw new SemanticException("Generated Column don't support high order function with lambda");
+            }
+
             if (columnDef.isAutoIncrement()) {
                 if (columnDef.getType() != Type.BIGINT) {
                     throw new SemanticException("The AUTO_INCREMENT column must be BIGINT", columnDef.getPos());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -155,7 +155,20 @@ public class ExpressionAnalyzer {
         bottomUpAnalyze(visitor, expression, scope);
     }
 
-    private boolean isArrayHighOrderFunction(Expr expr) {
+    public static boolean containsHighOrderFunctionWithLambda(Expr expr) {
+        List<FunctionCallExpr> functions = Lists.newArrayList();
+        expr.collect(FunctionCallExpr.class, functions);
+        List<FunctionCallExpr> highOrderFunctions = functions.stream()
+                                                    .filter(f -> isHighOrderFunction(f)).collect(Collectors.toList());
+        for (FunctionCallExpr highOrderFunction : highOrderFunctions) {
+            if (highOrderFunction.hasLambdaFunction(highOrderFunction)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isArrayHighOrderFunction(Expr expr) {
         if (expr instanceof FunctionCallExpr) {
             if (((FunctionCallExpr) expr).getFnName().getFunction().equals(FunctionSet.ARRAY_MAP) ||
                     ((FunctionCallExpr) expr).getFnName().getFunction().equals(FunctionSet.ARRAY_FILTER) ||
@@ -172,7 +185,7 @@ public class ExpressionAnalyzer {
         return false;
     }
 
-    private boolean isMapHighOrderFunction(Expr expr) {
+    private static boolean isMapHighOrderFunction(Expr expr) {
         if (expr instanceof FunctionCallExpr) {
             if (((FunctionCallExpr) expr).getFnName().getFunction().equals(FunctionSet.MAP_FILTER) ||
                     ((FunctionCallExpr) expr).getFnName().getFunction().equals(FunctionSet.TRANSFORM_VALUES) ||
@@ -184,7 +197,7 @@ public class ExpressionAnalyzer {
         return false;
     }
 
-    private boolean isHighOrderFunction(Expr expr) {
+    private static boolean isHighOrderFunction(Expr expr) {
         return isArrayHighOrderFunction(expr) || isMapHighOrderFunction(expr);
     }
 

--- a/test/sql/test_materialized_column/R/test_materialized_column
+++ b/test/sql/test_materialized_column/R/test_materialized_column
@@ -1145,3 +1145,32 @@ select * from t_fix_adding_and_col_partial_update_conflict;
 drop table t_fix_adding_and_col_partial_update_conflict;
 -- result:
 -- !result
+-- name: prohibit_lambda_for_generated_column
+CREATE TABLE t_prohibit_lambda_for_generated_column ( id BIGINT NOT NULL, v1 ARRAY<int> NOT NULL, gc_1 ARRAY<BIGINT> AS array_map(x -> x + 1, v1)) Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage" = "true", "fast_schema_evolution" = "true");
+-- result:
+E: (1064, "Generated Column don't support high order function with lambda.")
+-- !result
+CREATE TABLE t_prohibit_lambda_for_generated_column ( id BIGINT NOT NULL, v1 ARRAY<int> NOT NULL) Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage" = "true", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+alter table t_prohibit_lambda_for_generated_column add column gc_1 ARRAY<BIGINT> AS array_map(x -> x + 1, v1);
+-- result:
+E: (1064, "Generated Column don't support high order function with lambda.")
+-- !result
+alter table t_prohibit_lambda_for_generated_column add column (gc_1 ARRAY<BIGINT> AS array_map(x -> x + 1, v1), gc_2 ARRAY<BIGINT> AS array_map(x -> x + 2, v1));
+-- result:
+E: (1064, "Generated Column don't support high order function with lambda.")
+-- !result
+drop table t_prohibit_lambda_for_generated_column;
+-- result:
+-- !result
+CREATE TABLE t_prohibit_lambda_for_generated_column ( id BIGINT NOT NULL, v1 ARRAY<int> NOT NULL, gc_1 BIGINT AS array_sum(v1)) Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage" = "true", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+alter table t_prohibit_lambda_for_generated_column modify column gc_1 ARRAY<BIGINT> AS array_map(x -> x + 1, v1);
+-- result:
+E: (1064, "Generated Column don't support high order function with lambda.")
+-- !result
+drop table t_prohibit_lambda_for_generated_column;
+-- result:
+-- !result

--- a/test/sql/test_materialized_column/T/test_materialized_column
+++ b/test/sql/test_materialized_column/T/test_materialized_column
@@ -458,3 +458,15 @@ alter table t_fix_adding_and_col_partial_update_conflict add column newcol bigin
 function: wait_alter_table_finish()
 select * from t_fix_adding_and_col_partial_update_conflict;
 drop table t_fix_adding_and_col_partial_update_conflict;
+
+-- name: prohibit_lambda_for_generated_column
+CREATE TABLE t_prohibit_lambda_for_generated_column ( id BIGINT NOT NULL, v1 ARRAY<int> NOT NULL, gc_1 ARRAY<BIGINT> AS array_map(x -> x + 1, v1)) Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage" = "true", "fast_schema_evolution" = "true");
+CREATE TABLE t_prohibit_lambda_for_generated_column ( id BIGINT NOT NULL, v1 ARRAY<int> NOT NULL) Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage" = "true", "fast_schema_evolution" = "true");
+
+alter table t_prohibit_lambda_for_generated_column add column gc_1 ARRAY<BIGINT> AS array_map(x -> x + 1, v1);
+alter table t_prohibit_lambda_for_generated_column add column (gc_1 ARRAY<BIGINT> AS array_map(x -> x + 1, v1), gc_2 ARRAY<BIGINT> AS array_map(x -> x + 2, v1));
+drop table t_prohibit_lambda_for_generated_column;
+
+CREATE TABLE t_prohibit_lambda_for_generated_column ( id BIGINT NOT NULL, v1 ARRAY<int> NOT NULL, gc_1 BIGINT AS array_sum(v1)) Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage" = "true", "fast_schema_evolution" = "true");
+alter table t_prohibit_lambda_for_generated_column modify column gc_1 ARRAY<BIGINT> AS array_map(x -> x + 1, v1);
+drop table t_prohibit_lambda_for_generated_column;


### PR DESCRIPTION
## Why I'm doing:
Lambda function can not work well in generated column context for both expression analyze and query rewrite And will hit some NPE problem in DDL statement.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [x] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0