### PR TITLE
[BugFix] Fix Paimon TimeStamp timezone converter problem

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonPredicateConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonPredicateConverter.java
@@ -17,6 +17,7 @@ package com.starrocks.connector.paimon;
 
 import com.starrocks.analysis.BoolLiteral;
 import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
@@ -52,10 +53,8 @@ import org.apache.paimon.types.TinyIntType;
 import org.apache.paimon.types.VarCharType;
 
 import java.math.BigDecimal;
-import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -63,7 +62,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.apache.paimon.data.Timestamp.fromSQLTimestamp;
+import static org.apache.paimon.data.Timestamp.fromEpochMillis;
 
 public class PaimonPredicateConverter extends ScalarOperatorVisitor<Predicate, Void> {
     private static final Logger LOG = LogManager.getLogger(PaimonPredicateConverter.class);
@@ -262,8 +261,9 @@ public class PaimonPredicateConverter extends ScalarOperatorVisitor<Predicate, V
                     LocalDate epochDay = Instant.ofEpochSecond(0).atOffset(ZoneOffset.UTC).toLocalDate();
                     return (int) ChronoUnit.DAYS.between(epochDay, localDate);
                 case DATETIME:
-                    LocalDateTime localDateTime = operator.getDatetime();
-                    return fromSQLTimestamp(Timestamp.valueOf((localDateTime)));
+                    long localDateTime = operator.getDatetime().atZone(TimeUtils.getTimeZone().toZoneId()).toInstant()
+                            .toEpochMilli();
+                    return fromEpochMillis(localDateTime);
                 default:
                     return null;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonPredicateConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonPredicateConverterTest.java
@@ -365,7 +365,7 @@ public class PaimonPredicateConverterTest {
         result = CONVERTER.convert(new BinaryPredicateOperator(BinaryType.EQ, cast8, stringTime));
         Assert.assertTrue(result instanceof LeafPredicate);
         LeafPredicate leafPredicate8 = (LeafPredicate) result;
-        Assert.assertEquals(1735689600000L, ((Timestamp) (leafPredicate8.literals().get(0))).getMillisecond());
+        Assert.assertEquals(1735660800000L, ((Timestamp) (leafPredicate8.literals().get(0))).getMillisecond());
         // smallInt to string
         ConstantOperator si = ConstantOperator.createSmallInt((short) 200);
         CastOperator cast9 = new CastOperator(Type.VARCHAR, F1);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

use millisecond instead of timestamp to avoid time zone problem.
Before:
```
MySQL [(none)]> select * from  paimon_fs.`default`.dwd_my_gamedb_g_money_time where dt > "1970-08-23 14:33:47";
Empty set (0.313 sec)

MySQL [(none)]> select * from  paimon_fs.`default`.dwd_my_gamedb_g_money_time where dt > "1970-08-23 06:33:47";
+------+------+-----------+-----------+--------+---------+------------+---------------+---------------+-----------+-------------+-------+---------------+--------------+---------------------+
| id   | type | id_source | id_target | number | chk_sum | time_stamp | source_gmoney | target_gmoney | server_id | server_name | ext   | _identify_id_ | _product_id_ | dt                  |
+------+------+-----------+-----------+--------+---------+------------+---------------+---------------+-----------+-------------+-------+---------------+--------------+---------------------+
|    9 |    9 |         9 |         9 |    900 |      90 |  123456797 |         21000 |         22000 |         9 | Server9     | ext9  | ident9        |          109 | 1970-08-23 14:33:48 |
|   10 |   10 |        10 |        10 |   1000 |     100 |  123456798 |         23000 |         24000 |        10 | Server10    | ext10 | ident10       |          110 | 1970-08-23 14:33:49 |
+------+------+-----------+-----------+--------+---------+------------+---------------+---------------+-----------+-------------+-------+---------------+--------------+---------------------+
```

After:
```
MySQL [(none)]> select * from  paimon_fs.`default`.dwd_my_gamedb_g_money_time where dt > "1970-08-23 14:33:47";
+------+------+-----------+-----------+--------+---------+------------+---------------+---------------+-----------+-------------+-------+---------------+--------------+---------------------+
| id   | type | id_source | id_target | number | chk_sum | time_stamp | source_gmoney | target_gmoney | server_id | server_name | ext   | _identify_id_ | _product_id_ | dt                  |
+------+------+-----------+-----------+--------+---------+------------+---------------+---------------+-----------+-------------+-------+---------------+--------------+---------------------+
|    9 |    9 |         9 |         9 |    900 |      90 |  123456797 |         21000 |         22000 |         9 | Server9     | ext9  | ident9        |          109 | 1970-08-23 14:33:48 |
|   10 |   10 |        10 |        10 |   1000 |     100 |  123456798 |         23000 |         24000 |        10 | Server10    | ext10 | ident10       |          110 | 1970-08-23 14:33:49 |
+------+------+-----------+-----------+--------+---------+------------+---------------+---------------+-----------+-------------+-------+---------------+--------------+---------------------+
2 rows in set (3.633 sec)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0