### PR TITLE
[BugFix] Fix the issue the JDBC tables which contains `$` character in table name are treated as iceberg metadata tables.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/MetadataTableName.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/MetadataTableName.java
@@ -30,7 +30,24 @@ public class MetadataTableName {
     private final MetadataTableType tableType;
 
     public static boolean isMetadataTable(String tableName) {
-        return TABLE_PATTERN.matcher(tableName).matches();
+        Matcher match = TABLE_PATTERN.matcher(tableName);
+        if (!match.matches()) {
+            return false;
+        }
+
+        String typeString = match.group("type");
+        if (typeString == null) {
+            return false;
+        }
+
+        MetadataTableType type;
+        try {
+            type = MetadataTableType.get(typeString);
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+
+        return true;
     }
 
     public MetadataTableName(String tableName, MetadataTableType tableType) {

--- a/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
@@ -461,5 +461,10 @@ public class MetadataMgrTest {
         Assert.assertEquals(LOGICAL_ICEBERG_METADATA, metadataTableName.getTableType());
         Assert.assertEquals("iceberg_table$logical_iceberg_metadata", metadataTableName.getTableNameWithType());
         Assert.assertEquals("iceberg_table$logical_iceberg_metadata", metadataTableName.toString());
+
+        Assert.assertFalse(MetadataTableName.isMetadataTable("aaaaaaa"));
+        Assert.assertFalse(MetadataTableName.isMetadataTable("table$"));
+        Assert.assertFalse(MetadataTableName.isMetadataTable("table$unknown_type"));
+        Assert.assertTrue(MetadataTableName.isMetadataTable("table$logical_iceberg_metadata"));
     }
 }


### PR DESCRIPTION
## Why I'm doing:
Currently, we use fixed regular matching to determine if a table is an iceberg metadata table. For a jdbc table, which contains `$` character in table name, will be mistakenly treated as an iceberg metadata table. However, the metadata table name is invalid, and finally result in query errors.

## What I'm doing:
Check the table type field to determine whether a table is an iceberg metadata table, instead of just simple regular expression validation.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0