### PR TITLE
[BugFix] fix ObjectColumn::max_one_element_serialize_size

### DIFF
--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -569,11 +569,8 @@ const uint8_t* BinaryColumnBase<T>::deserialize_and_append(const uint8_t* pos) {
 template <typename T>
 void BinaryColumnBase<T>::deserialize_and_append_batch(Buffer<Slice>& srcs, size_t chunk_size) {
     // max size of one string is 2^32, so use uint32_t not T
-    T string_size = 0;
-    for (size_t i = 0; i < chunk_size; i++) {
-        string_size += *((uint32_t*)srcs[i].data);
-    }
-    _bytes.reserve(_bytes.size() + string_size);
+    uint32_t string_size = *((uint32_t*)srcs[0].data);
+    _bytes.reserve(chunk_size * string_size * 2);
     for (size_t i = 0; i < chunk_size; ++i) {
         srcs[i].data = (char*)deserialize_and_append((uint8_t*)srcs[i].data);
     }

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -569,8 +569,11 @@ const uint8_t* BinaryColumnBase<T>::deserialize_and_append(const uint8_t* pos) {
 template <typename T>
 void BinaryColumnBase<T>::deserialize_and_append_batch(Buffer<Slice>& srcs, size_t chunk_size) {
     // max size of one string is 2^32, so use uint32_t not T
-    uint32_t string_size = *((uint32_t*)srcs[0].data);
-    _bytes.reserve(chunk_size * string_size * 2);
+    T string_size = 0;
+    for (size_t i = 0; i < chunk_size; i++) {
+        string_size += *((uint32_t*)srcs[i].data);
+    }
+    _bytes.reserve(_bytes.size() + string_size);
     for (size_t i = 0; i < chunk_size; ++i) {
         srcs[i].data = (char*)deserialize_and_append((uint8_t*)srcs[i].data);
     }

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -286,9 +286,7 @@ public:
     // we need one buffer to hold tmp serialize data,
     // So we need to know the max serialize_size for all column element
     // The bad thing is we couldn't get the string defined len from FE when query
-    virtual uint32_t max_one_element_serialize_size() const {
-        return 16; // For Non-string type, 16 is enough.
-    }
+    virtual uint32_t max_one_element_serialize_size() const = 0;
 
     // serialize one data,The memory must allocate firstly from mempool
     virtual uint32_t serialize(size_t idx, uint8_t* pos) const = 0;

--- a/be/src/column/object_column.cpp
+++ b/be/src/column/object_column.cpp
@@ -174,6 +174,15 @@ uint32_t ObjectColumn<T>::serialize(size_t idx, uint8_t* pos) const {
 }
 
 template <typename T>
+uint32_t ObjectColumn<T>::max_one_element_serialize_size() const {
+    uint32_t max_size = 0;
+    for (size_t idx = 0; idx < size(); idx++) {
+        max_size = std::max(serialize_size(idx), max_size);
+    }
+    return max_size;
+}
+
+template <typename T>
 uint32_t ObjectColumn<T>::serialize_default(uint8_t* pos) const {
     DCHECK(false) << "Don't support object column serialize";
     return 0;

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -129,6 +129,7 @@ public:
     void deserialize_and_append_batch(Buffer<Slice>& srcs, size_t chunk_size) override;
 
     uint32_t serialize_size(size_t idx) const override;
+    uint32_t max_one_element_serialize_size() const override;
 
     MutableColumnPtr clone_empty() const override { return this->create(); }
 

--- a/be/src/exec/except_hash_set.cpp
+++ b/be/src/exec/except_hash_set.cpp
@@ -94,6 +94,7 @@ Status ExceptHashSet<HashSet>::erase_duplicate_row(RuntimeState* state, const Ch
 
 template <typename HashSet>
 Status ExceptHashSet<HashSet>::deserialize_to_columns(KeyVector& keys, Columns& key_columns, size_t chunk_size) {
+    TRY_CATCH_ALLOC_SCOPE_START()
     for (auto& key_column : key_columns) {
         DCHECK(!key_column->is_constant());
         // Because the serialized key is always nullable,
@@ -104,9 +105,10 @@ Status ExceptHashSet<HashSet>::deserialize_to_columns(KeyVector& keys, Columns& 
             }
         }
 
-        TRY_CATCH_BAD_ALLOC(key_column->deserialize_and_append_batch(keys, chunk_size));
+        key_column->deserialize_and_append_batch(keys, chunk_size);
         ASSIGN_OR_RETURN(key_column, key_column->upgrade_if_overflow());
     }
+    TRY_CATCH_ALLOC_SCOPE_END()
     return Status::OK();
 }
 

--- a/be/src/exec/except_hash_set.cpp
+++ b/be/src/exec/except_hash_set.cpp
@@ -94,7 +94,6 @@ Status ExceptHashSet<HashSet>::erase_duplicate_row(RuntimeState* state, const Ch
 
 template <typename HashSet>
 Status ExceptHashSet<HashSet>::deserialize_to_columns(KeyVector& keys, Columns& key_columns, size_t chunk_size) {
-    TRY_CATCH_ALLOC_SCOPE_START()
     for (auto& key_column : key_columns) {
         DCHECK(!key_column->is_constant());
         // Because the serialized key is always nullable,
@@ -105,10 +104,8 @@ Status ExceptHashSet<HashSet>::deserialize_to_columns(KeyVector& keys, Columns& 
             }
         }
 
-        key_column->deserialize_and_append_batch(keys, chunk_size);
-        ASSIGN_OR_RETURN(key_column, key_column->upgrade_if_overflow());
+        TRY_CATCH_BAD_ALLOC(key_column->deserialize_and_append_batch(keys, chunk_size));
     }
-    TRY_CATCH_ALLOC_SCOPE_END()
     return Status::OK();
 }
 

--- a/be/src/exec/except_hash_set.cpp
+++ b/be/src/exec/except_hash_set.cpp
@@ -16,6 +16,7 @@
 
 #include "exec/aggregate/agg_hash_set.h"
 #include "exec/exec_node.h"
+#include "runtime/current_thread.h"
 #include "runtime/mem_tracker.h"
 
 namespace starrocks {
@@ -92,7 +93,7 @@ Status ExceptHashSet<HashSet>::erase_duplicate_row(RuntimeState* state, const Ch
 }
 
 template <typename HashSet>
-void ExceptHashSet<HashSet>::deserialize_to_columns(KeyVector& keys, Columns& key_columns, size_t chunk_size) {
+Status ExceptHashSet<HashSet>::deserialize_to_columns(KeyVector& keys, Columns& key_columns, size_t chunk_size) {
     for (auto& key_column : key_columns) {
         DCHECK(!key_column->is_constant());
         // Because the serialized key is always nullable,
@@ -103,8 +104,10 @@ void ExceptHashSet<HashSet>::deserialize_to_columns(KeyVector& keys, Columns& ke
             }
         }
 
-        key_column->deserialize_and_append_batch(keys, chunk_size);
+        TRY_CATCH_BAD_ALLOC(key_column->deserialize_and_append_batch(keys, chunk_size));
+        ASSIGN_OR_RETURN(key_column, key_column->upgrade_if_overflow());
     }
+    return Status::OK();
 }
 
 template <typename HashSet>

--- a/be/src/exec/except_hash_set.h
+++ b/be/src/exec/except_hash_set.h
@@ -84,7 +84,7 @@ public:
     Status erase_duplicate_row(RuntimeState* state, const ChunkPtr& chunk, const std::vector<ExprContext*>& exprs,
                                BufferState* buffer_state);
 
-    void deserialize_to_columns(KeyVector& keys, Columns& key_columns, size_t chunk_size);
+    Status deserialize_to_columns(KeyVector& keys, Columns& key_columns, size_t chunk_size);
 
     int64_t mem_usage(BufferState* buffer_state);
 

--- a/be/src/exec/except_node.cpp
+++ b/be/src/exec/except_node.cpp
@@ -187,7 +187,7 @@ Status ExceptNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
 
         {
             SCOPED_TIMER(_get_result_timer);
-            _hash_set->deserialize_to_columns(_remained_keys, result_columns, read_index);
+            RETURN_IF_ERROR(_hash_set->deserialize_to_columns(_remained_keys, result_columns, read_index));
         }
 
         for (size_t i = 0; i < result_columns.size(); i++) {

--- a/be/src/exec/pipeline/set/except_context.cpp
+++ b/be/src/exec/pipeline/set/except_context.cpp
@@ -92,7 +92,7 @@ StatusOr<ChunkPtr> ExceptContext::pull_chunk(RuntimeState* state) {
         }
 
         // 3. Serialize remained keys to the dest columns.
-        _hash_set->deserialize_to_columns(_remained_keys, dst_columns, num_remained_keys);
+        RETURN_IF_ERROR(_hash_set->deserialize_to_columns(_remained_keys, dst_columns, num_remained_keys));
 
         // 4. Add dest columns to the dest chunk.
         for (size_t i = 0; i < dst_columns.size(); i++) {

--- a/test/sql/test_set_operation/R/test_except
+++ b/test/sql/test_set_operation/R/test_except
@@ -27,6 +27,9 @@ set @uuid_val = uuid();
 set @json_val = JSON_OBJECT('k', floor(rand() * 100), 'v', repeat(floor(rand() * 10), 1000));
 -- result:
 -- !result
+set query_timeout=300;
+-- result:
+-- !result
 insert into `t1` (`c0`,`c1`,`c2`,`data`) select @uuid_val, @uuid_val, '2020-01-01 00:00:00', @json_val from table(generate_series(1, 1000000, 1));
 -- result:
 -- !result

--- a/test/sql/test_set_operation/R/test_except
+++ b/test/sql/test_set_operation/R/test_except
@@ -1,0 +1,38 @@
+-- name: test_except_with_json
+create table `t1` (
+  `c0` string not null,
+  `c1` string not null,
+  `c2` datetime null,
+  `data` json null,
+  `id` bigint  not null auto_increment
+) duplicate key(`c0`)
+distributed by hash(`c0`) buckets 1
+properties('replication_num'='1');
+-- result:
+-- !result
+create table `t2` (
+  `c0` string not null,
+  `c1` string not null,
+  `c2` datetime null,
+  `data` json null,
+  `id` bigint  not null auto_increment
+) duplicate key(`c0`)
+distributed by hash(`c0`) buckets 1
+properties('replication_num'='1');
+-- result:
+-- !result
+set @uuid_val = uuid();
+-- result:
+-- !result
+set @json_val = JSON_OBJECT('k', floor(rand() * 100), 'v', repeat(floor(rand() * 10), 1000));
+-- result:
+-- !result
+insert into `t1` (`c0`,`c1`,`c2`,`data`) select @uuid_val, @uuid_val, '2020-01-01 00:00:00', @json_val from table(generate_series(1, 5000000, 1));
+-- result:
+-- !result
+insert into `t2` select * from t1;
+-- result:
+-- !result
+select t1.c0, t1.c1, t1.c2,t1.data,t1.id from t1 minus select t2.c0, t2.c1,t2.c2, t2.data,t2.id from t2;
+-- result:
+-- !result

--- a/test/sql/test_set_operation/R/test_except
+++ b/test/sql/test_set_operation/R/test_except
@@ -27,7 +27,7 @@ set @uuid_val = uuid();
 set @json_val = JSON_OBJECT('k', floor(rand() * 100), 'v', repeat(floor(rand() * 10), 1000));
 -- result:
 -- !result
-insert into `t1` (`c0`,`c1`,`c2`,`data`) select @uuid_val, @uuid_val, '2020-01-01 00:00:00', @json_val from table(generate_series(1, 5000000, 1));
+insert into `t1` (`c0`,`c1`,`c2`,`data`) select @uuid_val, @uuid_val, '2020-01-01 00:00:00', @json_val from table(generate_series(1, 1000000, 1));
 -- result:
 -- !result
 insert into `t2` select * from t1;

--- a/test/sql/test_set_operation/T/test_except
+++ b/test/sql/test_set_operation/T/test_except
@@ -21,6 +21,7 @@ properties('replication_num'='1');
 
 set @uuid_val = uuid();
 set @json_val = JSON_OBJECT('k', floor(rand() * 100), 'v', repeat(floor(rand() * 10), 1000));
+set query_timeout=300;
 insert into `t1` (`c0`,`c1`,`c2`,`data`) select @uuid_val, @uuid_val, '2020-01-01 00:00:00', @json_val from table(generate_series(1, 1000000, 1));
 insert into `t2` select * from t1;
 select t1.c0, t1.c1, t1.c2,t1.data,t1.id from t1 minus select t2.c0, t2.c1,t2.c2, t2.data,t2.id from t2;

--- a/test/sql/test_set_operation/T/test_except
+++ b/test/sql/test_set_operation/T/test_except
@@ -1,0 +1,26 @@
+-- name: test_except_with_json
+create table `t1` (
+  `c0` string not null,
+  `c1` string not null,
+  `c2` datetime null,
+  `data` json null,
+  `id` bigint  not null auto_increment
+) duplicate key(`c0`)
+distributed by hash(`c0`) buckets 1
+properties('replication_num'='1');
+
+create table `t2` (
+  `c0` string not null,
+  `c1` string not null,
+  `c2` datetime null,
+  `data` json null,
+  `id` bigint  not null auto_increment
+) duplicate key(`c0`)
+distributed by hash(`c0`) buckets 1
+properties('replication_num'='1');
+
+set @uuid_val = uuid();
+set @json_val = JSON_OBJECT('k', floor(rand() * 100), 'v', repeat(floor(rand() * 10), 1000));
+insert into `t1` (`c0`,`c1`,`c2`,`data`) select @uuid_val, @uuid_val, '2020-01-01 00:00:00', @json_val from table(generate_series(1, 5000000, 1));
+insert into `t2` select * from t1;
+select t1.c0, t1.c1, t1.c2,t1.data,t1.id from t1 minus select t2.c0, t2.c1,t2.c2, t2.data,t2.id from t2;

--- a/test/sql/test_set_operation/T/test_except
+++ b/test/sql/test_set_operation/T/test_except
@@ -21,6 +21,6 @@ properties('replication_num'='1');
 
 set @uuid_val = uuid();
 set @json_val = JSON_OBJECT('k', floor(rand() * 100), 'v', repeat(floor(rand() * 10), 1000));
-insert into `t1` (`c0`,`c1`,`c2`,`data`) select @uuid_val, @uuid_val, '2020-01-01 00:00:00', @json_val from table(generate_series(1, 5000000, 1));
+insert into `t1` (`c0`,`c1`,`c2`,`data`) select @uuid_val, @uuid_val, '2020-01-01 00:00:00', @json_val from table(generate_series(1, 1000000, 1));
 insert into `t2` select * from t1;
 select t1.c0, t1.c1, t1.c2,t1.data,t1.id from t1 minus select t2.c0, t2.c1,t2.c2, t2.data,t2.id from t2;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #56917

Root Cause:

when building ExceptHashSet, we will allocate serialize buffer memory based on the result of `_get_max_serialize_size` which will invoke `Column::max_one_element_serialize_size`.
But we didn't implement this interface for ObjectColumn and the default return result is 16, which is incorrect for JsonColumn.
This will lead to illegal memory access later, and the allocation of oversized memory is due to this.

![image](https://github.com/user-attachments/assets/9697ab61-e76a-4f88-bab5-63f2a1905400)


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0