### PR TITLE
[BugFix] Remove deprecated annotation in proto to avoid compiler warning

### DIFF
--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -250,7 +250,7 @@ message TabletInfoPB {
 
 message VacuumRequest {
     // This field is deprecated, use |tablet_infos| instead.
-    repeated int64 tablet_ids = 1 [deprecated = true]; // deprecated
+    repeated int64 tablet_ids = 1; // deprecated
     // Tablet metadata files with version numbers greater than or equals to min_retain_version
     // will NOT be vacuumed. For tablet metadata files with version numbers less than
     // min_retain_version, decide whether they should be deleted by comparing the create time


### PR DESCRIPTION
## Why I'm doing:
[deprecated = true] in proto will lead a compiler warning, branch3.3 will compile failed due to -Werror.

## What I'm doing:
Remove [deprecated = true] in proto to avoid compiler warning.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0