### PR TITLE
[BugFix] MV partitioned by non-SlotRef Expr can not be decomposed in query cache (backport #56871)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfo.java
@@ -183,6 +183,10 @@ public class ExpressionRangePartitionInfo extends RangePartitionInfo implements 
         return result;
     }
 
+    public List<ColumnIdExpr> getPartitionColumnIdExprs() {
+        return partitionExprs;
+    }
+
     @Override
     public List<Column> getPartitionColumns(Map<ColumnId, Column> idToColumn) {
         List<Column> columns = MetaUtils.getColumnsByColumnIds(idToColumn, partitionColumnIds);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfoV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfoV2.java
@@ -243,6 +243,10 @@ public class ExpressionRangePartitionInfoV2 extends RangePartitionInfo
         return result;
     }
 
+    public List<ColumnIdExpr> getPartitionColumnIdExprs() {
+        return partitionExprs;
+    }
+
     public int getPartitionExprsSize() {
         return partitionExprs.size();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
@@ -60,6 +60,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
 import java.util.stream.Collectors;
@@ -573,11 +574,17 @@ public class FragmentNormalizer {
             if (range.isEmpty()) {
                 continue;
             }
-            range = toClosedOpenRange(range);
+
+            Optional<Range> optRange = Optional.empty();
+            try {
+                optRange = Optional.ofNullable(toClosedOpenRange(range));
+            } catch (Throwable ignored) {
+            }
+
             Map.Entry<Long, Range<PartitionKey>> partitionKeyRange = rangeMap.get(i);
             // when the range is to total cover this partition, we also cache it
-            if (!range.isEmpty()) {
-                selectedRangeMap.put(partitionKeyRange.getKey(), range.toString());
+            if (optRange.isPresent() && !optRange.get().isEmpty()) {
+                selectedRangeMap.put(partitionKeyRange.getKey(), optRange.get().toString());
             }
         }
         // After we decompose the predicates, we should create a simple selectedRangeMap to turn on query cache if

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -45,14 +45,19 @@ import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.Analyzer;
 import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.SlotDescriptor;
 import com.starrocks.analysis.SlotId;
 import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.ExpressionRangePartitionInfo;
+import com.starrocks.catalog.ExpressionRangePartitionInfoV2;
+import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.LocalTablet;
@@ -76,6 +81,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.lake.LakeTablet;
+import com.starrocks.persist.ColumnIdExpr;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.rowstore.RowStoreUtils;
 import com.starrocks.server.GlobalStateMgr;
@@ -114,6 +120,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -1288,6 +1295,61 @@ public class OlapScanNode extends ScanNode {
         planNode.setConjuncts(normalizer.normalizeExprs(normalizer.getConjunctsByPlanNodeId(this)));
     }
 
+    // Partition by exprs as follows can be decomposed
+    // 1. SlotRef
+    // 2. date_trunc
+    // 3. str2date(dt, '%Y-%m-%d')
+    private boolean isDecomposablePartitionExpr(Expr expr) {
+        if (expr.getClass().equals(SlotRef.class)) {
+            return true;
+        }
+        if (!expr.getClass().equals(FunctionCallExpr.class)) {
+            return false;
+        }
+        FunctionCallExpr fcall = (FunctionCallExpr) expr;
+        String fname = fcall.getFnName().getFunction();
+        if (fname.equalsIgnoreCase(FunctionSet.DATE_TRUNC)) {
+            return true;
+        } else if (fname.equalsIgnoreCase(FunctionSet.STR2DATE)) {
+            return expr.getChild(1).getClass().equals(StringLiteral.class) &&
+                    ((StringLiteral) expr.getChild(1)).getValue().startsWith("%Y-%m-%d");
+        } else {
+            return false;
+        }
+    }
+
+    private boolean isDecomposablePartitionInfo(PartitionInfo partitionInfo) {
+        // TODO (by satanson): predicates' decomposition
+        //  At present, we support predicates' decomposition on RangePartition with single-column partition key.
+        //  in the future, predicates' decomposition on RangePartition with multi-column partition key will be
+        //  supported.
+        if (!partitionInfo.isRangePartition()) {
+            return false;
+        }
+        RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionInfo;
+        if (rangePartitionInfo.getPartitionColumnsSize() != 1) {
+            return false;
+        }
+        if (rangePartitionInfo.getClass().equals(RangePartitionInfo.class)) {
+            return true;
+        }
+
+        Predicate<List<ColumnIdExpr>> isDecomposable = exprs -> exprs.stream()
+                .map(ColumnIdExpr::getExpr)
+                .allMatch(this::isDecomposablePartitionExpr);
+
+        if (rangePartitionInfo.getClass().equals(ExpressionRangePartitionInfo.class)) {
+            ExpressionRangePartitionInfo exprRangePartitionInfo = (ExpressionRangePartitionInfo) rangePartitionInfo;
+            return isDecomposable.test(exprRangePartitionInfo.getPartitionColumnIdExprs());
+        }
+
+        if (rangePartitionInfo.getClass().equals(ExpressionRangePartitionInfoV2.class)) {
+            ExpressionRangePartitionInfoV2 exprRangePartitionInfo = (ExpressionRangePartitionInfoV2) rangePartitionInfo;
+            return isDecomposable.test(exprRangePartitionInfo.getPartitionColumnIdExprs());
+        }
+        return false;
+    }
+
     @Override
     public void normalizeConjuncts(FragmentNormalizer normalizer, TNormalPlanNode planNode, List<Expr> conjuncts) {
         if (!normalizer.isProcessingLeftNode()) {
@@ -1298,12 +1360,8 @@ public class OlapScanNode extends ScanNode {
         }
         PartitionInfo partitionInfo = olapTable.getPartitionInfo();
         List<Column> partitionColumns = partitionInfo.getPartitionColumns(olapTable.getIdToColumn());
-        // TODO (by satanson): predicates' decomposition
-        //  At present, we support predicates' decomposition on RangePartition with single-column partition key.
-        //  in the future, predicates' decomposition on RangePartition with multi-column partition key will be
-        //  supported.
-        if (partitionInfo.isRangePartition() &&
-                ((RangePartitionInfo) partitionInfo).getPartitionColumnsSize() == 1) {
+
+        if (isDecomposablePartitionInfo(partitionInfo)) {
             RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionInfo;
             conjuncts = decomposeRangePredicates(partitionColumns, normalizer, planNode, rangePartitionInfo, conjuncts);
         } else {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheAndMVTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheAndMVTest.java
@@ -1,0 +1,177 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.Partition;
+import com.starrocks.common.Pair;
+import com.starrocks.connector.iceberg.MockIcebergMetadata;
+import com.starrocks.scheduler.MVRefreshTestBase;
+import com.starrocks.scheduler.Task;
+import com.starrocks.scheduler.TaskBuilder;
+import com.starrocks.scheduler.TaskRun;
+import com.starrocks.scheduler.TaskRunBuilder;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+import java.util.Collection;
+import java.util.Optional;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class QueryCacheAndMVTest extends MVRefreshTestBase {
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        MVRefreshTestBase.beforeClass();
+        ConnectorPlanTestBase.mockCatalog(connectContext, MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME);
+    }
+
+    private static void triggerRefreshMv(Database testDb, MaterializedView partitionedMaterializedView)
+            throws Exception {
+        Task task = TaskBuilder.buildMvTask(partitionedMaterializedView, testDb.getFullName());
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        initAndExecuteTaskRun(taskRun);
+    }
+
+    @Test
+    public void testCreatePartitionedMVForIceberg() throws Exception {
+        String mvName = "iceberg_parttbl_mv1";
+        starRocksAssert.useDatabase("test")
+                .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_parttbl_mv1`\n" +
+                        "PARTITION BY str2date(`date`, '%Y-%m-%d')\n" +
+                        "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"storage_medium\" = \"HDD\"\n" +
+                        ")\n" +
+                        "AS SELECT id, data, date  FROM `iceberg0`.`partitioned_db`.`t1` as a;");
+
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView partitionedMaterializedView =
+                ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(testDb.getFullName(), mvName));
+        triggerRefreshMv(testDb, partitionedMaterializedView);
+
+        Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
+        Assert.assertEquals(4, partitions.size());
+
+        String query = "SELECT /*+SET_VAR(enable_query_cache=true) */ id, sum(data) " +
+                "FROM `iceberg0`.`partitioned_db`.`t1` " +
+                "where date = '2020-01-02' " +
+                "group by id";
+
+        Pair<String, ExecPlan> planAndExecPlan = UtFrameUtils.getPlanAndFragment(starRocksAssert.getCtx(), query);
+        Optional<PlanFragment> optFragment = planAndExecPlan.second.getFragments().stream()
+                .filter(planFragment -> planFragment.getCacheParam() != null)
+                .findFirst();
+        Assert.assertTrue(optFragment.isPresent());
+        PlanFragment fragment = optFragment.get();
+        String expectRange = "[types: [DATE]; keys: [2020-01-02]; ..types: [DATE]; keys: [2020-01-03]; )";
+        boolean exists = fragment.getCacheParam().getRegion_map()
+                .values().stream().anyMatch(value -> value.equals(expectRange));
+        Assert.assertTrue(exists);
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+
+    @Test
+    public void testCreatePartitionedMVForIceberg2() throws Exception {
+        String mvName = "iceberg_parttbl_mv2";
+        starRocksAssert.useDatabase("test")
+                .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_parttbl_mv2`\n" +
+                        "PARTITION BY str2date(`date`, '%Y%m%d')\n" +
+                        "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"storage_medium\" = \"HDD\"\n" +
+                        ")\n" +
+                        "AS SELECT id, data, date  FROM `iceberg0`.`partitioned_db`.`t1` as a;");
+
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView partitionedMaterializedView =
+                ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(testDb.getFullName(), mvName));
+        triggerRefreshMv(testDb, partitionedMaterializedView);
+
+        Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
+        Assert.assertEquals(4, partitions.size());
+
+        String query = "SELECT /*+SET_VAR(enable_query_cache=true) */ id, sum(data) " +
+                "FROM `iceberg0`.`partitioned_db`.`t1` " +
+                "where date = '20200102' " +
+                "group by id";
+
+        Pair<String, ExecPlan> planAndExecPlan = UtFrameUtils.getPlanAndFragment(starRocksAssert.getCtx(), query);
+        Optional<PlanFragment> optFragment = planAndExecPlan.second.getFragments().stream()
+                .filter(planFragment -> planFragment.getCacheParam() != null)
+                .findFirst();
+        Assert.assertTrue(optFragment.isPresent());
+        PlanFragment fragment = optFragment.get();
+        String expectRange = "[]";
+        boolean exists = fragment.getCacheParam().getRegion_map()
+                .values().stream().anyMatch(value -> value.equals(expectRange));
+        Assert.assertTrue(exists);
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+
+    @Test
+    public void testCreatePartitionedMVForIcebergWithPartitionTransform1() throws Exception {
+        // test partition by year(ts)
+        String mvName = "iceberg_year_mv1";
+        starRocksAssert.useDatabase("test")
+                .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_year_mv1`\n" +
+                        "PARTITION BY date_trunc('year', ts)\n" +
+                        "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"storage_medium\" = \"HDD\"\n" +
+                        ")\n" +
+                        "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_year` as a;");
+
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView partitionedMaterializedView =
+                ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(testDb.getFullName(), mvName));
+        triggerRefreshMv(testDb, partitionedMaterializedView);
+
+        String query = "SELECT /*+SET_VAR(enable_query_cache=true) */ id, sum(data) " +
+                "FROM `iceberg0`.`partitioned_transforms_db`.`t0_year`" +
+                "where ts between '2020-01-01 00:00:00'  and '2021-01-01 00:00:00' " +
+                "group by id";
+
+        Pair<String, ExecPlan> planAndExecPlan = UtFrameUtils.getPlanAndFragment(starRocksAssert.getCtx(), query);
+        Optional<PlanFragment> optFragment = planAndExecPlan.second.getFragments().stream()
+                .filter(planFragment -> planFragment.getCacheParam() != null)
+                .findFirst();
+        Assert.assertTrue(optFragment.isPresent());
+        PlanFragment fragment = optFragment.get();
+        String expectRange = "[types: [DATETIME]; keys: [2020-01-01 00:00:00]; " +
+                "..types: [DATETIME]; keys: [2021-01-01 00:00:00]; )";
+        boolean exists = fragment.getCacheParam().getRegion_map()
+                .values().stream().anyMatch(value -> value.equals(expectRange));
+        Assert.assertTrue(exists);
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+}


### PR DESCRIPTION
(cherry picked from commit 7b82d5fe2bf7655646a7894696f8e125002f36a4)
cp  #56871

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
