### PR TITLE
[BugFix] Fix several bugs when restore table with random distribution

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -1078,9 +1078,9 @@ public class RestoreJob extends AbstractJob {
         PartitionInfo localPartitionInfo = localTbl.getPartitionInfo();
         Preconditions.checkState(localPartitionInfo.isRangePartition());
 
-        // generate new partition id
-        long newPartId = globalStateMgr.getNextId();
-        remotePart.getDefaultPhysicalPartition().setIdForRestore(newPartId);
+        // generate new logical partition id
+        long newLogicalPartId = globalStateMgr.getNextId();
+        remotePart.setIdForRestore(newLogicalPartId);
 
         // indexes
         Map<String, Long> localIdxNameToId = localTbl.getIndexNameToId();
@@ -1097,17 +1097,25 @@ public class RestoreJob extends AbstractJob {
             }
         }
 
-        for (PhysicalPartition physicalPartition : remotePart.getSubPartitions()) {
-            // generate new physical partition id
-            if (physicalPartition.getId() != newPartId) {
+        List<PhysicalPartition> origPhysicalPartitions = Lists.newArrayList(remotePart.getSubPartitions());
+        origPhysicalPartitions.forEach(physicalPartition -> {
+            // after refactor, the first physicalPartition id is different from logical partition id
+            if (physicalPartition.getParentId() != newLogicalPartId) {
                 remotePart.removeSubPartition(physicalPartition.getId());
-
-                long newPhysicalPartId = globalStateMgr.getNextId();
-                physicalPartition.setIdForRestore(newPhysicalPartId);
-                physicalPartition.setParentId(newPartId);
+                remoteTbl.removePhysicalPartition(physicalPartition);
+            }
+        });
+        origPhysicalPartitions.forEach(physicalPartition -> {
+            // after refactor, the first physicalPartition id is different from logical partition id
+            if (physicalPartition.getParentId() != newLogicalPartId) {
+                physicalPartition.setIdForRestore(globalStateMgr.getNextId());
+                physicalPartition.setParentId(newLogicalPartId);
                 remotePart.addSubPartition(physicalPartition);
                 remoteTbl.addPhysicalPartition(physicalPartition);
             }
+        });
+
+        for (PhysicalPartition physicalPartition : remotePart.getSubPartitions()) {
             // save version info for creating replicas
             long visibleVersion = physicalPartition.getVisibleVersion();
 
@@ -1282,17 +1290,18 @@ public class RestoreJob extends AbstractJob {
     }
 
     protected void modifyInvertedIndex(OlapTable restoreTbl, Partition restorePart) {
-        for (MaterializedIndex restoreIdx : restorePart.getDefaultPhysicalPartition()
-                .getMaterializedIndices(IndexExtState.VISIBLE)) {
-            int schemaHash = restoreTbl.getSchemaHashByIndexId(restoreIdx.getId());
-            TabletMeta tabletMeta = new TabletMeta(dbId, restoreTbl.getId(),
-                    restorePart.getDefaultPhysicalPartition().getId(),
-                    restoreIdx.getId(), schemaHash, TStorageMedium.HDD);
-            for (Tablet restoreTablet : restoreIdx.getTablets()) {
-                globalStateMgr.getTabletInvertedIndex().addTablet(restoreTablet.getId(), tabletMeta);
-                for (Replica restoreReplica : ((LocalTablet) restoreTablet).getImmutableReplicas()) {
-                    globalStateMgr.getTabletInvertedIndex()
-                            .addReplica(restoreTablet.getId(), restoreReplica);
+        // ensure modify for all physical partitions, not only for the first one (default physical partition)
+        for (PhysicalPartition physicalPartition : restorePart.getSubPartitions()) {
+            for (MaterializedIndex restoreIdx : physicalPartition.getMaterializedIndices(IndexExtState.VISIBLE)) {
+                int schemaHash = restoreTbl.getSchemaHashByIndexId(restoreIdx.getId());
+                TabletMeta tabletMeta = new TabletMeta(dbId, restoreTbl.getId(), physicalPartition.getId(),
+                        restoreIdx.getId(), schemaHash, TStorageMedium.HDD);
+                for (Tablet restoreTablet : restoreIdx.getTablets()) {
+                    globalStateMgr.getTabletInvertedIndex().addTablet(restoreTablet.getId(), tabletMeta);
+                    for (Replica restoreReplica : ((LocalTablet) restoreTablet).getImmutableReplicas()) {
+                        globalStateMgr.getTabletInvertedIndex()
+                                .addReplica(restoreTablet.getId(), restoreReplica);
+                    }
                 }
             }
         }
@@ -1809,10 +1818,12 @@ public class RestoreJob extends AbstractJob {
                 for (Table restoreTbl : restoredTbls) {
                     LOG.info("remove restored table when cancelled: {}", restoreTbl.getName());
                     for (Partition part : restoreTbl.getPartitions()) {
-                        for (MaterializedIndex idx : part.getDefaultPhysicalPartition()
-                                .getMaterializedIndices(IndexExtState.VISIBLE)) {
-                            for (Tablet tablet : idx.getTablets()) {
-                                globalStateMgr.getTabletInvertedIndex().deleteTablet(tablet.getId());
+                        // ensure clear all physical partitions, not only for the first one (default physical partition)
+                        for (PhysicalPartition physicalPartition : part.getSubPartitions()) {
+                            for (MaterializedIndex idx : physicalPartition.getMaterializedIndices(IndexExtState.VISIBLE)) {
+                                for (Tablet tablet : idx.getTablets()) {
+                                    globalStateMgr.getTabletInvertedIndex().deleteTablet(tablet.getId());
+                                }
                             }
                         }
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -1756,6 +1756,11 @@ public class RestoreJob extends AbstractJob {
         return jobInfo.getInfo();
     }
 
+    // for UT
+    protected void addRestoredTable(OlapTable table) {
+        this.restoredTbls.add(table);
+    }
+
     @Override
     public boolean isDone() {
         if (state == RestoreJobState.FINISHED || state == RestoreJobState.CANCELLED) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -881,12 +881,14 @@ public class OlapTable extends Table {
             idToPartition.put(newPartitionId, partition);
             List<PhysicalPartition> origPhysicalPartitions = Lists.newArrayList(partition.getSubPartitions());
             origPhysicalPartitions.forEach(physicalPartition -> {
-                if (physicalPartition.getId() != newPartitionId) {
+                // after refactor, the first physicalPartition id is different from logical partition id
+                if (physicalPartition.getParentId() != newPartitionId) {
                     partition.removeSubPartition(physicalPartition.getId());
                 }
             });
             origPhysicalPartitions.forEach(physicalPartition -> {
-                if (physicalPartition.getId() != newPartitionId) {
+                // after refactor, the first physicalPartition id is different from logical partition id
+                if (physicalPartition.getParentId() != newPartitionId) {
                     physicalPartition.setIdForRestore(GlobalStateMgr.getCurrentState().getNextId());
                     physicalPartition.setParentId(newPartitionId);
                     partition.addSubPartition(physicalPartition);
@@ -1410,6 +1412,11 @@ public class OlapTable extends Table {
             physicalPartitionIdToPartitionId.put(physicalPartition.getId(), partition.getId());
             physicalPartitionNameToPartitionId.put(physicalPartition.getName(), partition.getId());
         }
+    }
+
+    public void removePhysicalPartition(PhysicalPartition physicalPartition) {
+        physicalPartitionIdToPartitionId.remove(physicalPartition.getId());
+        physicalPartitionNameToPartitionId.remove(physicalPartition.getName());
     }
 
     public void addPhysicalPartition(PhysicalPartition physicalPartition) {

--- a/fe/fe-core/src/test/java/com/starrocks/backup/CatalogMocker.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/CatalogMocker.java
@@ -152,6 +152,7 @@ public class CatalogMocker {
     public static final String TEST_PARTITION2_NAME_PK = "p2_pk";
     public static final long TEST_PARTITION2_PK_ID = 40004;
     public static final long TEST_PH_PARTITION2_PK_ID = 40014;
+    public static final long TEST_PARTITION3_ID = 40015;
 
     public static final long TEST_BASE_TABLET_P1_ID = 60001;
     public static final long TEST_REPLICA3_ID = 70003;
@@ -312,6 +313,7 @@ public class CatalogMocker {
         // 3. range partition olap table
         MaterializedIndex baseIndexP1 = new MaterializedIndex(TEST_TBL2_ID, IndexState.NORMAL);
         MaterializedIndex baseIndexP2 = new MaterializedIndex(TEST_TBL2_ID, IndexState.NORMAL);
+        MaterializedIndex baseIndexP3 = new MaterializedIndex(TEST_TBL2_ID, IndexState.NORMAL);
         DistributionInfo distributionInfo2 =
                 new HashDistributionInfo(32, Lists.newArrayList(TEST_TBL_BASE_SCHEMA.get(1)));
         Partition partition1 =
@@ -483,14 +485,18 @@ public class CatalogMocker {
         {
             baseIndexP1 = new MaterializedIndex(TEST_TBL4_ID, IndexState.NORMAL);
             baseIndexP2 = new MaterializedIndex(TEST_TBL4_ID, IndexState.NORMAL);
+            baseIndexP3 = new MaterializedIndex(TEST_TBL4_ID, IndexState.NORMAL);
             DistributionInfo distributionInfo4 = new RandomDistributionInfo(1);
             partition1 =
                     new Partition(TEST_PARTITION1_ID, TEST_PH_PARTITION1_ID,
                             TEST_PARTITION1_NAME, baseIndexP1, distributionInfo4);
 
             PhysicalPartition physicalPartition2 = new PhysicalPartition(
-                        TEST_PARTITION2_ID, "", TEST_PARTITION1_ID, baseIndexP2);
+                        TEST_PARTITION2_ID, "pp2", TEST_PARTITION1_ID, baseIndexP2);
+            PhysicalPartition physicalPartition3 = new PhysicalPartition(
+                        TEST_PARTITION3_ID, "pp3", TEST_PARTITION1_ID, baseIndexP3);
             partition1.addSubPartition(physicalPartition2);
+            partition1.addSubPartition(physicalPartition3);
 
             rangePartitionInfo = new RangePartitionInfo(Lists.newArrayList(TEST_TBL_BASE_SCHEMA.get(0)));
             rangePartitionInfo.addPartition(TEST_PARTITION1_ID, false, rangeP1, dataPropertyP1, (short) 3, false);

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
@@ -215,13 +215,10 @@ public class RestoreJobTest {
     public void testModifyInvertedIndex() {
         expectedRestoreTbl = (OlapTable) db.getTable(CatalogMocker.TEST_TBL4_ID);
 
-        OlapTable localTbl = new OlapTable(expectedRestoreTbl.getId(), expectedRestoreTbl.getName(),
-                expectedRestoreTbl.getBaseSchema(), KeysType.DUP_KEYS, expectedRestoreTbl.getPartitionInfo(),
-                expectedRestoreTbl.getDefaultDistributionInfo());
-
         job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(),
                 new BackupJobInfo(), false, 3, 100000,
                 globalStateMgr, repo.getId(), backupMeta, new MvRestoreContext());
+        job.addRestoredTable(expectedRestoreTbl);
 
         new MockUp<LocalMetastore>() {
             @Mock
@@ -231,6 +228,7 @@ public class RestoreJobTest {
         };
         job.setState(RestoreJob.RestoreJobState.DOWNLOAD);
         job.replayRun();
+        job.cancelInternal(true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
@@ -94,6 +94,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 import java.util.zip.Adler32;
 
 public class RestoreJobTest {
@@ -173,6 +174,7 @@ public class RestoreJobTest {
         AgentTaskQueue.clearAllTasks();
     }
 
+    @Test
     public void testResetPartitionForRestore() {
         expectedRestoreTbl = (OlapTable) db.getTable(CatalogMocker.TEST_TBL4_ID);
 
@@ -184,7 +186,51 @@ public class RestoreJobTest {
                 jobInfo, false, 3, 100000,
                 globalStateMgr, repo.getId(), backupMeta, new MvRestoreContext());
 
+        new MockUp<OlapTable>() {
+            @Mock
+            public Status createTabletsForRestore(int tabletNum, MaterializedIndex index, GlobalStateMgr globalStateMgr,
+                                                  int replicationNum, long version, int schemaHash,
+                                                  long partitionId, Database db) {
+                return Status.OK;
+            }
+        };
+
+        Partition part = expectedRestoreTbl.getPartition(CatalogMocker.TEST_PARTITION1_NAME);
+        long oldPartId = part.getId();
+        long oldDefaultPartId = part.getDefaultPhysicalPartition().getId();
+        List<Long> oldPhysicalPartitionIds = part.getSubPartitions().stream().map(p -> p.getId()).collect(Collectors.toList());
         job.resetPartitionForRestore(localTbl, expectedRestoreTbl, CatalogMocker.TEST_PARTITION1_NAME, 3);
+        long newPartId = part.getId();
+        long newDefaultPartId = part.getDefaultPhysicalPartition().getId();
+        Assert.assertTrue(newPartId != oldPartId);
+        Assert.assertTrue(oldDefaultPartId != newDefaultPartId);
+
+        for (PhysicalPartition physicalPartition : part.getSubPartitions()) {
+            Assert.assertTrue(physicalPartition.getParentId() == newPartId);
+            Assert.assertTrue(!oldPhysicalPartitionIds.stream().anyMatch(id -> id.longValue() == physicalPartition.getId()));
+        }
+    }
+
+    @Test
+    public void testModifyInvertedIndex() {
+        expectedRestoreTbl = (OlapTable) db.getTable(CatalogMocker.TEST_TBL4_ID);
+
+        OlapTable localTbl = new OlapTable(expectedRestoreTbl.getId(), expectedRestoreTbl.getName(),
+                expectedRestoreTbl.getBaseSchema(), KeysType.DUP_KEYS, expectedRestoreTbl.getPartitionInfo(),
+                expectedRestoreTbl.getDefaultDistributionInfo());
+
+        job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(),
+                new BackupJobInfo(), false, 3, 100000,
+                globalStateMgr, repo.getId(), backupMeta, new MvRestoreContext());
+
+        new MockUp<LocalMetastore>() {
+            @Mock
+            public Database getDb(long dbId) {
+                return db;
+            }
+        };
+        job.setState(RestoreJob.RestoreJobState.DOWNLOAD);
+        job.replayRun();
     }
 
     @Test


### PR DESCRIPTION
`Bug 1:`
If we restore a table with random distribution which contains multiple physical partitions in a single logical partition, all physical partitions meta data will lost after FE restart exception the first one. This is because we just add the tablet meta into global manager for the first physical partition when we replay the editlog using `RestoreJob::modifyInvertedIndex`.

`Bug 2:`
If we restore a new partition into a existed table with random distribution, RestoreJob::resetPartitionForRestore will be used to reset some ids for the new coming partition. It does not reset the default physical partition id and even try to remove subpartition when we try to iterate it and get `ConcurrentModificationException`.

`Bug 3:`
After refactor for physical partition, ids for logical partition and physical partition are completely different. We need to check parentId instead of id for physical partition in OlapTable::resetIdsForRestore

## Solution:
For `bug 1`:
Make sure all physical partitions will be handled in `RestoreJob::modifyInvertedIndex`

For `bug 2`:
Reset ids in a suitable way

For `bug 3`:
Use parent id instead

Fixes #issue
https://github.com/StarRocks/StarRocksTest/issues/9397
https://github.com/StarRocks/StarRocksTest/issues/9397

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0