### PR TITLE
[BugFix] collect statistics after insert overwrite skip shadow partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
@@ -30,11 +30,14 @@ import org.apache.commons.collections4.MapUtils;
 import java.io.DataInput;
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import static com.starrocks.catalog.ExpressionRangePartitionInfo.SHADOW_PARTITION_PREFIX;
 
 public class BasicStatsMeta implements Writable {
     @SerializedName("dbId")
@@ -143,7 +146,6 @@ public class BasicStatsMeta implements Writable {
     public double getHealthy() {
         Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getId(), tableId);
-        long totalPartitionCount = table.getPartitions().size();
 
         long tableRowCount = 1L;
         long cachedTableRowCount = 1L;
@@ -153,7 +155,11 @@ public class BasicStatsMeta implements Writable {
         Map<Long, Optional<Long>> tableStatistics = GlobalStateMgr.getCurrentState().getStatisticStorage()
                 .getTableStatistics(table.getId(), table.getPartitions());
 
-        for (Partition partition : table.getPartitions()) {
+        Collection<Partition> allPartitions = table.getPartitions().stream()
+                .filter(p -> !(p.getName().startsWith(SHADOW_PARTITION_PREFIX)))
+                .collect(Collectors.toSet());
+        long totalPartitionCount = allPartitions.size();
+        for (Partition partition : allPartitions) {
             tableRowCount += partition.getRowCount();
             Optional<Long> statistic = tableStatistics.getOrDefault(partition.getId(), Optional.empty());
             cachedTableRowCount += statistic.orElse(0L);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
@@ -51,6 +51,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.starrocks.catalog.ExpressionRangePartitionInfo.SHADOW_PARTITION_PREFIX;
 import static com.starrocks.statistic.StatsConstants.AnalyzeType.SAMPLE;
 
 /**
@@ -151,6 +152,10 @@ public class StatisticsCollectionTrigger {
                 for (int i = 0; i < overwriteJobStats.getSourcePartitionIds().size(); i++) {
                     long sourcePartitionId = overwriteJobStats.getSourcePartitionIds().get(i);
                     long targetPartitionId = overwriteJobStats.getTargetPartitionIds().get(i);
+                    if (table.getPartition(targetPartitionId) == null ||
+                            table.getPartition(targetPartitionId).getName().startsWith(SHADOW_PARTITION_PREFIX)) {
+                        continue;
+                    }
                     StatisticExecutor.overwritePartitionStatistics(
                             statsConnectCtx, db.getId(), table.getId(), sourcePartitionId, targetPartitionId);
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectionTriggerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectionTriggerTest.java
@@ -33,8 +33,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 public class StatisticsCollectionTriggerTest extends PlanTestBase {
 
@@ -128,11 +126,6 @@ public class StatisticsCollectionTriggerTest extends PlanTestBase {
         {
             InsertOverwriteJobStats stats = new InsertOverwriteJobStats(
                     List.of(sourceId), List.of(targetId), 1000, 1001);
-            StatisticsCollectionTrigger.triggerOnInsertOverwrite(stats, db, table, true, true);
-            Partition targetPartition = new Partition(targetId, targetId + 100, "p1", null, null);
-            Map<Long, Optional<Long>> tableStats =
-                    storage.getTableStatistics(table.getId(), List.of(targetPartition));
-            Assert.assertEquals(Map.of(targetId, Optional.of(1000L)), tableStats);
 
             List<String> insertOverwriteSQLs = FullStatisticsCollectJob.buildOverwritePartitionSQL(
                     table.getId(), sourceId, targetId);
@@ -142,6 +135,10 @@ public class StatisticsCollectionTriggerTest extends PlanTestBase {
             Assert.assertTrue(insertOverwriteSQLs.get(0).contains(String.format("`partition_id`=%d", sourceId)));
             Assert.assertTrue(insertOverwriteSQLs.get(1).contains(String.format("DELETE FROM column_statistics\n" +
                     "WHERE `table_id`=%d AND `partition_id`=%d", table.getId(), sourceId)));
+
+            StatisticsCollectionTrigger trigger =
+                    StatisticsCollectionTrigger.triggerOnInsertOverwrite(stats, db, table, true, true);
+            Assert.assertNull(trigger.getAnalyzeType());
         }
 
         // case: overwrite a lot of data, need to re-collect statistics


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
When collecting statistics after an insert overwrite, shadow partition should be skipped
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0