### PR TITLE
[Enhancement] Removes reserve() from array_agg().

### DIFF
--- a/be/src/exprs/agg/array_agg.h
+++ b/be/src/exprs/agg/array_agg.h
@@ -408,7 +408,6 @@ public:
             index.resize(res_num);
             elem_size = res_num;
         }
-        array_col->elements_column()->reserve(array_col->elements_column()->size() + elem_size);
         if (index.empty()) {
             array_col->elements_column()->append(*res, 0, elem_size);
         } else {


### PR DESCRIPTION
## Why I'm doing:

While debugging a slow query which took a few minutes, we found that it was due to skewed data.
But it was not clear why the skewed data caused such a long latency. After further investigation, I found that it was due to unnecessary `reserve()` calls in `array_agg()`.

After appending a large array to a result column in one aggregated row, following `finalize_to_column()`s even with a small number of elements took a few ms likely to allocate new memory and copy existing values. Thousands of aggregated rows with a few ms added a lot of latency.
Repeatedly calling `reserve()` with small increases is harmful. Without `reserve()`, in the following append calls, std::vector would be able to increase the capacity exponentially efficiently.

## What I'm doing:

Removes `reserve()`.

In a test on skewed data, a latency of a query with array_agg() decreased from 2m45s to 21s.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0