### PR TITLE
[BugFix] fix load blocks merge crash when close

### DIFF
--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -254,7 +254,7 @@ inline Status AsyncDeltaWriterImpl::do_open() {
         _queue_id.value = kInvalidQueueId;
         return Status::InternalError(fmt::format("fail to create bthread execution queue: {}", r));
     }
-    if (_block_merge_token == NULL) {
+    if (_block_merge_token == nullptr) {
         _block_merge_token = StorageEngine::instance()->load_spill_block_merge_executor()->create_token();
     }
     return _writer->open();
@@ -318,7 +318,7 @@ inline void AsyncDeltaWriterImpl::close() {
         TEST_SYNC_POINT("AsyncDeltaWriterImpl::close:2");
 
         // Wait for block merge finished.
-        if (_block_merge_token != NULL) {
+        if (_block_merge_token != nullptr) {
             _block_merge_token->shutdown();
             _block_merge_token.reset();
         }

--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -123,6 +123,7 @@ private:
 
     std::unique_ptr<DeltaWriter> _writer{};
     bthread::ExecutionQueueId<TaskPtr> _queue_id{kInvalidQueueId};
+    std::unique_ptr<ThreadPoolToken> _block_merge_token{};
     StackTraceMutex<bthread::Mutex> _mtx{};
     // _status、_opened and _closed are protected by _mtx
     Status _status{};
@@ -206,8 +207,7 @@ inline int AsyncDeltaWriterImpl::execute(void* meta, bthread::TaskIterator<Async
             } else if (delta_writer->has_spill_block()) {
                 // If there are spill blocks, we merge them using another thread pool
                 auto merge_task = std::make_shared<MergeBlockTask>(finish_task, async_writer);
-                auto res = StorageEngine::instance()->load_spill_block_merge_executor()->get_thread_pool()->submit(
-                        merge_task);
+                auto res = async_writer->_block_merge_token->submit(merge_task);
                 if (!res.ok()) {
                     st.update(res);
                     LOG_IF(ERROR, !st.ok()) << "Fail to submit merge task: " << st;
@@ -253,6 +253,9 @@ inline Status AsyncDeltaWriterImpl::do_open() {
     if (int r = bthread::execution_queue_start(&_queue_id, &opts, execute, this); r != 0) {
         _queue_id.value = kInvalidQueueId;
         return Status::InternalError(fmt::format("fail to create bthread execution queue: {}", r));
+    }
+    if (_block_merge_token == NULL) {
+        _block_merge_token = StorageEngine::instance()->load_spill_block_merge_executor()->create_token();
     }
     return _writer->open();
 }
@@ -313,6 +316,12 @@ inline void AsyncDeltaWriterImpl::close() {
         l.unlock();
 
         TEST_SYNC_POINT("AsyncDeltaWriterImpl::close:2");
+
+        // Wait for block merge finished.
+        if (_block_merge_token != NULL) {
+            _block_merge_token->shutdown();
+            _block_merge_token.reset();
+        }
 
         // After the execution_queue been `stop()`ed all incoming `write()` and `finish()` requests
         // will fail immediately.

--- a/be/src/storage/lake/load_spill_block_manager.cpp
+++ b/be/src/storage/lake/load_spill_block_manager.cpp
@@ -22,6 +22,7 @@
 #include "fs/fs_util.h"
 #include "fs/key_cache.h"
 #include "runtime/exec_env.h"
+#include "util/threadpool.h"
 
 namespace starrocks::lake {
 
@@ -56,6 +57,10 @@ Status LoadSpillBlockMergeExecutor::refresh_max_thread_num() {
         return _merge_pool->update_max_threads(calc_max_merge_blocks_thread());
     }
     return Status::OK();
+}
+
+std::unique_ptr<ThreadPoolToken> LoadSpillBlockMergeExecutor::create_token() {
+    return _merge_pool->new_token(ThreadPool::ExecutionMode::SERIAL);
 }
 
 void LoadSpillBlockContainer::append_block(const spill::BlockPtr& block) {

--- a/be/src/storage/lake/load_spill_block_manager.h
+++ b/be/src/storage/lake/load_spill_block_manager.h
@@ -20,6 +20,9 @@
 #include "util/threadpool.h"
 
 namespace starrocks {
+
+class ThreadPoolToken;
+
 namespace lake {
 
 class LoadSpillBlockMergeExecutor {
@@ -30,6 +33,8 @@ public:
 
     ThreadPool* get_thread_pool() { return _merge_pool.get(); }
     Status refresh_max_thread_num();
+
+    std::unique_ptr<ThreadPoolToken> create_token();
 
 private:
     // ThreadPool for merge.

--- a/be/src/storage/lake/spill_mem_table_sink.cpp
+++ b/be/src/storage/lake/spill_mem_table_sink.cpp
@@ -203,6 +203,7 @@ private:
 };
 
 Status SpillMemTableSink::merge_blocks_to_segments() {
+    TEST_SYNC_POINT_CALLBACK("SpillMemTableSink::merge_blocks_to_segments", this);
     SCOPED_THREAD_LOCAL_MEM_SETTER(_merge_mem_tracker.get(), false);
     auto& groups = _block_manager->block_container()->block_groups();
     RETURN_IF(groups.empty(), Status::OK());


### PR DESCRIPTION
## Why I'm doing:
In some case, after `AsyncDeltaWriter` close, the `MergeBlockTask` could be still running and it will lead to invalid memory access. It will lead to crash like:
```
@     0x7bca07a287f3 abort
    @         0x10ec7af3 __gnu_cxx::__verbose_terminate_handler() [clone .cold]
    @         0x10ec610c __cxxabiv1::__terminate(void (*)())
    @         0x10ec6177 std::terminate()
    @         0x10ec6d85 __cxa_pure_virtual
    @          0x6328525 starrocks::MapColumnWriter::append(starrocks::Column const&)
    @          0x62d06b4 starrocks::SegmentWriter::append_chunk(starrocks::Chunk const&)
    @          0x63887b9 starrocks::lake::HorizontalGeneralTabletWriter::write(starrocks::Chunk const&, starrocks::SegmentPB*)
    @          0x90b5a0b starrocks::lake::SpillMemTableSink::merge_blocks_to_segments()::{lambda()#1}::operator()() const
    @          0x90b7609 starrocks::lake::SpillMemTableSink::merge_blocks_to_segments()
    @          0x90af761 starrocks::lake::DeltaWriterImpl::finish()
    @          0x90afdfc starrocks::lake::DeltaWriterImpl::finish_with_txnlog(starrocks::lake::DeltaWriterFinishMode)
    @          0x90b1798 starrocks::lake::DeltaWriter::finish_with_txnlog(starrocks::lake::DeltaWriterFinishMode)
    @          0x92c05a1 starrocks::lake::MergeBlockTask::run()
    @          0x94e33f3 starrocks::ThreadPool::dispatch_thread()
    @          0x94daa39 starrocks::Thread::supervise_thread(void*)
```

## What I'm doing:
Fix it by waiting task finish while `AsyncDeltaWriter` close.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0