### PR TITLE
[BugFix] split_part function should not return null when delimiter is not matched

### DIFF
--- a/be/src/exprs/split_part.cpp
+++ b/be/src/exprs/split_part.cpp
@@ -122,7 +122,6 @@ static bool split_index(const Slice& haystack, const Slice& delimiter, int32_t p
  */
 StatusOr<ColumnPtr> StringFunctions::split_part(FunctionContext* context, const starrocks::Columns& columns) {
     DCHECK_EQ(columns.size(), 3);
-    RETURN_IF_COLUMNS_ONLY_NULL(columns);
 
     // TODO use SIMD algorithm to optimize
     if (columns[2]->is_constant()) {

--- a/be/src/exprs/split_part.cpp
+++ b/be/src/exprs/split_part.cpp
@@ -124,7 +124,7 @@ StatusOr<ColumnPtr> StringFunctions::split_part(FunctionContext* context, const 
     DCHECK_EQ(columns.size(), 3);
 
     // TODO use SIMD algorithm to optimize
-    if (columns[2]->is_constant()) {
+    if (!columns[2]->only_null() && columns[2]->is_constant()) {
         // if part_number is 0, return an empty string.
         int32_t part_number = ColumnHelper::get_const_value<TYPE_INT>(columns[2]);
         if (part_number == 0) {

--- a/be/test/exprs/string_fn_test.cpp
+++ b/be/test/exprs/string_fn_test.cpp
@@ -1047,7 +1047,7 @@ PARALLEL_TEST(VecStringFunctionsTest, splitPart) {
 
     ASSERT_EQ("hello", v->get(0).get<Slice>().to_string());
     ASSERT_EQ("word", v->get(1).get<Slice>().to_string());
-    ASSERT_TRUE(v->get(2).is_null());
+    ASSERT_TRUE(v->get(2).get<Slice>().empty());
     ASSERT_EQ("", v->get(3).get<Slice>().to_string());
     ASSERT_EQ(" word", v->get(4).get<Slice>().to_string());
     ASSERT_EQ("", v->get(5).get<Slice>().to_string());
@@ -1059,20 +1059,20 @@ PARALLEL_TEST(VecStringFunctionsTest, splitPart) {
     ASSERT_EQ("#123", v->get(11).get<Slice>().to_string());
     ASSERT_EQ("#234", v->get(12).get<Slice>().to_string());
     ASSERT_EQ("b", v->get(13).get<Slice>().to_string());
-    ASSERT_TRUE(v->get(14).is_null());
-    ASSERT_TRUE(v->get(15).is_null());
-    ASSERT_TRUE(v->get(16).is_null());
-    ASSERT_TRUE(v->get(17).is_null());
-    ASSERT_TRUE(v->get(18).is_null());
-    ASSERT_TRUE(v->get(19).is_null());
+    ASSERT_TRUE(v->get(14).get<Slice>().empty());
+    ASSERT_TRUE(v->get(15).get<Slice>().empty());
+    ASSERT_TRUE(v->get(16).get<Slice>().empty());
+    ASSERT_TRUE(v->get(17).get<Slice>().empty());
+    ASSERT_TRUE(v->get(18).get<Slice>().empty());
+    ASSERT_TRUE(v->get(19).get<Slice>().empty());
     ASSERT_EQ("9", v->get(20).get<Slice>().to_string());
     ASSERT_EQ("年", v->get(21).get<Slice>().to_string());
     ASSERT_EQ("9", v->get(22).get<Slice>().to_string());
     ASSERT_EQ("日", v->get(23).get<Slice>().to_string());
-    ASSERT_TRUE(v->get(24).is_null());
+    ASSERT_TRUE(v->get(24).get<Slice>().empty());
     ASSERT_EQ("word", v->get(25).get<Slice>().to_string());
     ASSERT_EQ("hello", v->get(26).get<Slice>().to_string());
-    ASSERT_TRUE(v->get(27).is_null());
+    ASSERT_TRUE(v->get(24).get<Slice>().empty());
     ASSERT_EQ("8日", v->get(28).get<Slice>().to_string());
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -645,6 +645,7 @@ public class FunctionSet {
                     .add(FunctionSet.EXCHANGE_BYTES)
                     .add(FunctionSet.EXCHANGE_SPEED)
                     .add(FunctionSet.FIELD)
+                    .add(FunctionSet.SPLIT_PART)
                     .build();
 
     public static final Set<String> DECIMAL_ROUND_FUNCTIONS =


### PR DESCRIPTION
split_part function should not return null when delimiter is not matched

## Why I'm doing:
There was an issue https://github.com/StarRocks/starrocks/issues/46774 long ago. I reopened PR for that issue.
![image](https://github.com/user-attachments/assets/19b2cfec-b8f3-4989-91f0-0a53b3d0cd13)

## What I'm doing:
![image](https://github.com/user-attachments/assets/ca3eb144-5d0a-467c-9376-ade0c3ce82db)

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0