### PR TITLE
[Refactor] Remove the read_object/write_object from KvCache

### DIFF
--- a/be/src/cache/block_cache/block_cache.h
+++ b/be/src/cache/block_cache/block_cache.h
@@ -37,28 +37,18 @@ public:
     Status init(const CacheOptions& options);
 
     // Write data buffer to cache, the `offset` must be aligned by block size
-    Status write_buffer(const CacheKey& cache_key, off_t offset, const IOBuffer& buffer,
-                        WriteCacheOptions* options = nullptr);
+    Status write(const CacheKey& cache_key, off_t offset, const IOBuffer& buffer, WriteCacheOptions* options = nullptr);
 
-    Status write_buffer(const CacheKey& cache_key, off_t offset, size_t size, const char* data,
-                        WriteCacheOptions* options = nullptr);
-
-    // Write object to cache, the `ptr` is the object pointer.
-    Status write_object(const CacheKey& cache_key, const void* ptr, size_t size, DeleterFunc deleter,
-                        DataCacheHandle* handle, WriteCacheOptions* options = nullptr);
+    Status write(const CacheKey& cache_key, off_t offset, size_t size, const char* data,
+                 WriteCacheOptions* options = nullptr);
 
     // Read data from cache, it returns the data size if successful; otherwise the error status
     // will be returned. The offset and size must be aligned by block size.
-    Status read_buffer(const CacheKey& cache_key, off_t offset, size_t size, IOBuffer* buffer,
-                       ReadCacheOptions* options = nullptr);
+    Status read(const CacheKey& cache_key, off_t offset, size_t size, IOBuffer* buffer,
+                ReadCacheOptions* options = nullptr);
 
-    StatusOr<size_t> read_buffer(const CacheKey& cache_key, off_t offset, size_t size, char* data,
-                                 ReadCacheOptions* options = nullptr);
-
-    // Read object from cache, the `handle` wraps the object pointer.
-    // As long as the handle object is not destroyed and the user does not manully call the `handle->release()`
-    // function, the corresponding pointer will never be freed by the cache system.
-    Status read_object(const CacheKey& cache_key, DataCacheHandle* handle, ReadCacheOptions* options = nullptr);
+    StatusOr<size_t> read(const CacheKey& cache_key, off_t offset, size_t size, char* data,
+                          ReadCacheOptions* options = nullptr);
 
     bool exist(const CacheKey& cache_key, off_t offset, size_t size) const;
 
@@ -95,7 +85,9 @@ public:
     DataCacheEngineType engine_type();
 
 #ifdef WITH_STARCACHE
-    std::shared_ptr<starcache::StarCache> starcache_instance() { return _kv_cache->starcache_instance(); }
+    std::shared_ptr<starcache::StarCache> starcache_instance() {
+        return _kv_cache->starcache_instance();
+    }
 #endif
 
     static const size_t MAX_BLOCK_SIZE;

--- a/be/src/cache/block_cache/block_cache.h
+++ b/be/src/cache/block_cache/block_cache.h
@@ -85,9 +85,7 @@ public:
     DataCacheEngineType engine_type();
 
 #ifdef WITH_STARCACHE
-    std::shared_ptr<starcache::StarCache> starcache_instance() {
-        return _kv_cache->starcache_instance();
-    }
+    std::shared_ptr<starcache::StarCache> starcache_instance() { return _kv_cache->starcache_instance(); }
 #endif
 
     static const size_t MAX_BLOCK_SIZE;

--- a/be/src/cache/block_cache/dummy_types.h
+++ b/be/src/cache/block_cache/dummy_types.h
@@ -18,15 +18,6 @@
 
 namespace starrocks {
 
-class DummyCacheHandle {
-public:
-    DummyCacheHandle() = default;
-    ~DummyCacheHandle() = default;
-
-    const void* ptr() { return nullptr; }
-    void release() {}
-};
-
 enum class DummyCacheStatus { NORMAL, UPDATING, ABNORMAL, LOADING };
 
 struct DummyCacheMetrics {

--- a/be/src/cache/block_cache/kv_cache.h
+++ b/be/src/cache/block_cache/kv_cache.h
@@ -30,11 +30,9 @@ namespace starrocks {
 // object cache and we'll deprecate it for some performance reasons. Now there is no need to
 // pay too much attention to the compatibility and upper-level abstraction of the cachelib interface.
 #ifdef WITH_STARCACHE
-using DataCacheHandle = starcache::ObjectHandle;
 using DataCacheMetrics = starcache::CacheMetrics;
 using DataCacheStatus = starcache::CacheStatus;
 #else
-using DataCacheHandle = DummyCacheHandle;
 using DataCacheMetrics = DummyCacheMetrics;
 using DataCacheStatus = DummyCacheStatus;
 #endif
@@ -49,17 +47,12 @@ public:
     virtual Status init(const CacheOptions& options) = 0;
 
     // Write data to cache
-    virtual Status write_buffer(const std::string& key, const IOBuffer& buffer, WriteCacheOptions* options) = 0;
-
-    virtual Status write_object(const std::string& key, const void* ptr, size_t size, std::function<void()> deleter,
-                                DataCacheHandle* handle, WriteCacheOptions* options) = 0;
+    virtual Status write(const std::string& key, const IOBuffer& buffer, WriteCacheOptions* options) = 0;
 
     // Read data from cache, it returns the data size if successful; otherwise the error status
     // will be returned.
-    virtual Status read_buffer(const std::string& key, size_t off, size_t size, IOBuffer* buffer,
-                               ReadCacheOptions* options) = 0;
-
-    virtual Status read_object(const std::string& key, DataCacheHandle* handle, ReadCacheOptions* options) = 0;
+    virtual Status read(const std::string& key, size_t off, size_t size, IOBuffer* buffer,
+                        ReadCacheOptions* options) = 0;
 
     virtual bool exist(const std::string& key) const = 0;
 

--- a/be/src/cache/block_cache/starcache_wrapper.cpp
+++ b/be/src/cache/block_cache/starcache_wrapper.cpp
@@ -58,7 +58,7 @@ Status StarCacheWrapper::init(const CacheOptions& options) {
     return to_status(_cache->init(opt));
 }
 
-Status StarCacheWrapper::write_buffer(const std::string& key, const IOBuffer& buffer, WriteCacheOptions* options) {
+Status StarCacheWrapper::write(const std::string& key, const IOBuffer& buffer, WriteCacheOptions* options) {
     if (!options) {
         return to_status(_cache->set(key, buffer.const_raw_buf(), nullptr));
     }
@@ -92,29 +92,8 @@ Status StarCacheWrapper::write_buffer(const std::string& key, const IOBuffer& bu
     return st;
 }
 
-Status StarCacheWrapper::write_object(const std::string& key, const void* ptr, size_t size,
-                                      std::function<void()> deleter, DataCacheHandle* handle,
-                                      WriteCacheOptions* options) {
-    if (!options) {
-        return to_status(_cache->set_object(key, ptr, size, deleter, handle, nullptr));
-    }
-    starcache::WriteOptions opts;
-    opts.ttl_seconds = options->ttl_seconds;
-    opts.overwrite = options->overwrite;
-    opts.evict_probability = options->evict_probability;
-    Status st;
-    {
-        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
-        st = to_status(_cache->set_object(key, ptr, size, deleter, handle, &opts));
-    }
-    if (st.ok()) {
-        options->stats.write_mem_bytes = size;
-    }
-    return st;
-}
-
-Status StarCacheWrapper::read_buffer(const std::string& key, size_t off, size_t size, IOBuffer* buffer,
-                                     ReadCacheOptions* options) {
+Status StarCacheWrapper::read(const std::string& key, size_t off, size_t size, IOBuffer* buffer,
+                              ReadCacheOptions* options) {
     if (!options) {
         return to_status(_cache->read(key, off, size, &buffer->raw_buf(), nullptr));
     }
@@ -126,18 +105,6 @@ Status StarCacheWrapper::read_buffer(const std::string& key, size_t off, size_t 
     if (st.ok()) {
         options->stats.read_mem_bytes = opts.stats.read_mem_bytes;
         options->stats.read_disk_bytes = opts.stats.read_disk_bytes;
-    }
-    return st;
-}
-
-Status StarCacheWrapper::read_object(const std::string& key, DataCacheHandle* handle, ReadCacheOptions* options) {
-    if (!options) {
-        return to_status(_cache->get_object(key, handle, nullptr));
-    }
-    starcache::ReadOptions opts;
-    auto st = to_status(_cache->get_object(key, handle, &opts));
-    if (st.ok()) {
-        options->stats.read_mem_bytes = opts.stats.read_mem_bytes;
     }
     return st;
 }

--- a/be/src/cache/block_cache/starcache_wrapper.h
+++ b/be/src/cache/block_cache/starcache_wrapper.h
@@ -28,15 +28,9 @@ public:
 
     Status init(const CacheOptions& options) override;
 
-    Status write_buffer(const std::string& key, const IOBuffer& buffer, WriteCacheOptions* options) override;
+    Status write(const std::string& key, const IOBuffer& buffer, WriteCacheOptions* options) override;
 
-    Status write_object(const std::string& key, const void* ptr, size_t size, std::function<void()> deleter,
-                        DataCacheHandle* handle, WriteCacheOptions* options) override;
-
-    Status read_buffer(const std::string& key, size_t off, size_t size, IOBuffer* buffer,
-                       ReadCacheOptions* options) override;
-
-    Status read_object(const std::string& key, DataCacheHandle* handle, ReadCacheOptions* options) override;
+    Status read(const std::string& key, size_t off, size_t size, IOBuffer* buffer, ReadCacheOptions* options) override;
 
     bool exist(const std::string& key) const override;
 

--- a/be/src/io/cache_input_stream.cpp
+++ b/be/src/io/cache_input_stream.cpp
@@ -113,10 +113,10 @@ Status CacheInputStream::_read_block_from_local(const int64_t offset, const int6
         options.use_adaptor = _enable_cache_io_adaptor;
         SCOPED_RAW_TIMER(&read_cache_ns);
         if (_enable_block_buffer) {
-            res = _cache->read_buffer(_cache_key, block_offset, load_size, &block.buffer, &options);
+            res = _cache->read(_cache_key, block_offset, load_size, &block.buffer, &options);
             read_size = load_size;
         } else {
-            StatusOr<size_t> r = _cache->read_buffer(_cache_key, offset, size, out, &options);
+            StatusOr<size_t> r = _cache->read(_cache_key, offset, size, out, &options);
             res = r.status();
             read_size = size;
         }
@@ -403,7 +403,7 @@ void CacheInputStream::_populate_to_cache(const char* p, int64_t offset, int64_t
             options.callback = cb;
             options.allow_zero_copy = true;
         }
-        Status r = _cache->write_buffer(_cache_key, off, size, buf, &options);
+        Status r = _cache->write(_cache_key, off, size, buf, &options);
         if (r.ok() || r.is_already_exist()) {
             _already_populated_blocks.emplace(off / _block_size);
         }

--- a/be/test/cache/block_cache/block_cache_test.cpp
+++ b/be/test/cache/block_cache/block_cache_test.cpp
@@ -99,7 +99,7 @@ TEST_F(BlockCacheTest, hybrid_cache) {
     for (size_t i = 0; i < rounds; ++i) {
         char ch = 'a' + i % 26;
         std::string value(batch_size, ch);
-        Status st = cache->write_buffer(cache_key + std::to_string(i), 0, batch_size, value.c_str());
+        Status st = cache->write(cache_key + std::to_string(i), 0, batch_size, value.c_str());
         ASSERT_TRUE(st.ok()) << st.message();
     }
 
@@ -108,7 +108,7 @@ TEST_F(BlockCacheTest, hybrid_cache) {
         char ch = 'a' + i % 26;
         std::string expect_value(batch_size, ch);
         char value[batch_size] = {0};
-        auto res = cache->read_buffer(cache_key + std::to_string(i), 0, batch_size, value);
+        auto res = cache->read(cache_key + std::to_string(i), 0, batch_size, value);
         ASSERT_TRUE(res.status().ok()) << res.status().message();
         ASSERT_EQ(memcmp(value, expect_value.c_str(), batch_size), 0);
     }
@@ -118,11 +118,11 @@ TEST_F(BlockCacheTest, hybrid_cache) {
     status = cache->remove(cache_key, 0, batch_size);
     ASSERT_TRUE(status.ok());
 
-    auto res = cache->read_buffer(cache_key, 0, batch_size, value);
+    auto res = cache->read(cache_key, 0, batch_size, value);
     ASSERT_TRUE(res.status().is_not_found());
 
     // not found
-    res = cache->read_buffer(cache_key, block_size * 1000, batch_size, value);
+    res = cache->read(cache_key, block_size * 1000, batch_size, value);
     ASSERT_TRUE(res.status().is_not_found());
 
     cache->shutdown();
@@ -147,27 +147,27 @@ TEST_F(BlockCacheTest, write_with_overwrite_option) {
     const std::string cache_key = "test_file";
 
     std::string value(cache_size, 'a');
-    Status st = cache->write_buffer(cache_key, 0, cache_size, value.c_str());
+    Status st = cache->write(cache_key, 0, cache_size, value.c_str());
     ASSERT_TRUE(st.ok());
 
     WriteCacheOptions write_options;
     std::string value2(cache_size, 'b');
-    st = cache->write_buffer(cache_key, 0, cache_size, value2.c_str(), &write_options);
+    st = cache->write(cache_key, 0, cache_size, value2.c_str(), &write_options);
     ASSERT_TRUE(st.is_already_exist());
 
     write_options.overwrite = true;
-    st = cache->write_buffer(cache_key, 0, cache_size, value2.c_str(), &write_options);
+    st = cache->write(cache_key, 0, cache_size, value2.c_str(), &write_options);
     ASSERT_TRUE(st.ok());
 
     char rvalue[cache_size] = {0};
-    auto res = cache->read_buffer(cache_key, 0, cache_size, rvalue);
+    auto res = cache->read(cache_key, 0, cache_size, rvalue);
     ASSERT_TRUE(res.status().ok());
     std::string expect_value(cache_size, 'b');
     ASSERT_EQ(memcmp(rvalue, expect_value.c_str(), cache_size), 0);
 
     write_options.overwrite = false;
     std::string value3(cache_size, 'c');
-    st = cache->write_buffer(cache_key, 0, cache_size, value3.c_str(), &write_options);
+    st = cache->write(cache_key, 0, cache_size, value3.c_str(), &write_options);
     ASSERT_TRUE(st.is_already_exist());
 
     cache->shutdown();
@@ -200,7 +200,7 @@ TEST_F(BlockCacheTest, read_cache_with_adaptor) {
     for (size_t i = 0; i < rounds; ++i) {
         char ch = 'a' + i % 26;
         std::string value(batch_size, ch);
-        Status st = cache->write_buffer(cache_key + std::to_string(i), 0, batch_size, value.c_str());
+        Status st = cache->write(cache_key + std::to_string(i), 0, batch_size, value.c_str());
         ASSERT_TRUE(st.ok());
     }
 
@@ -219,7 +219,7 @@ TEST_F(BlockCacheTest, read_cache_with_adaptor) {
         char value[batch_size] = {0};
         ReadCacheOptions opts;
         opts.use_adaptor = true;
-        auto res = cache->read_buffer(cache_key + std::to_string(i), 0, batch_size, value, &opts);
+        auto res = cache->read(cache_key + std::to_string(i), 0, batch_size, value, &opts);
         ASSERT_TRUE(res.status().is_resource_busy());
     }
 
@@ -236,7 +236,7 @@ TEST_F(BlockCacheTest, read_cache_with_adaptor) {
         char value[batch_size] = {0};
         ReadCacheOptions opts;
         opts.use_adaptor = true;
-        auto res = cache->read_buffer(cache_key + std::to_string(i), 0, batch_size, value, &opts);
+        auto res = cache->read(cache_key + std::to_string(i), 0, batch_size, value, &opts);
         ASSERT_TRUE(res.status().ok());
     }
 
@@ -317,7 +317,7 @@ TEST_F(BlockCacheTest, clear_residual_blockfiles) {
         for (size_t i = 0; i < rounds; ++i) {
             char ch = 'a' + i % 26;
             std::string value(batch_size, ch);
-            Status st = cache->write_buffer(cache_key + std::to_string(i), 0, batch_size, value.c_str());
+            Status st = cache->write(cache_key + std::to_string(i), 0, batch_size, value.c_str());
             ASSERT_TRUE(st.ok());
         }
     }

--- a/be/test/cache/block_cache/disk_space_monitor_test.cpp
+++ b/be/test/cache/block_cache/disk_space_monitor_test.cpp
@@ -188,7 +188,7 @@ TEST_F(DiskSpaceMonitorTest, auto_increase_cache_quota) {
         for (size_t i = 0; i < 20; ++i) {
             char ch = 'a' + i % 26;
             std::string value(batch_size, ch);
-            Status st = cache->write_buffer(cache_key + std::to_string(i), 0, batch_size, value.c_str());
+            Status st = cache->write(cache_key + std::to_string(i), 0, batch_size, value.c_str());
             ASSERT_TRUE(st.ok()) << st.message();
         }
         auto metrics = cache->cache_metrics();
@@ -248,7 +248,7 @@ TEST_F(DiskSpaceMonitorTest, auto_decrease_cache_quota) {
         for (size_t i = 0; i < 50; ++i) {
             char ch = 'a' + i % 26;
             std::string value(batch_size, ch);
-            Status st = cache->write_buffer(cache_key + std::to_string(i), 0, batch_size, value.c_str());
+            Status st = cache->write(cache_key + std::to_string(i), 0, batch_size, value.c_str());
             ASSERT_TRUE(st.ok());
         }
         auto metrics = cache->cache_metrics();
@@ -309,7 +309,7 @@ TEST_F(DiskSpaceMonitorTest, auto_decrease_cache_quota_to_zero) {
         for (size_t i = 0; i < 50; ++i) {
             char ch = 'a' + i % 26;
             std::string value(batch_size, ch);
-            Status st = cache->write_buffer(cache_key + std::to_string(i), 0, batch_size, value.c_str());
+            Status st = cache->write(cache_key + std::to_string(i), 0, batch_size, value.c_str());
             ASSERT_TRUE(st.ok());
         }
         auto metrics = cache->cache_metrics();
@@ -359,7 +359,7 @@ TEST_F(DiskSpaceMonitorTest, get_directory_capacity) {
         for (size_t i = 0; i < 20; ++i) {
             char ch = 'a' + i % 26;
             std::string value(batch_size, ch);
-            Status st = cache->write_buffer(cache_key + std::to_string(i), 0, batch_size, value.c_str());
+            Status st = cache->write(cache_key + std::to_string(i), 0, batch_size, value.c_str());
             ASSERT_TRUE(st.ok());
         }
 


### PR DESCRIPTION
## Why I'm doing:

This PR is split from the following PR from @GavinMar: https://github.com/StarRocks/starrocks/pull/51156.

## What I'm doing:

* Remove the read_object/write_object from KvCache
* Rename write_buffer to write
* Rename read_buffer to read

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0