### PR TITLE
[Enhancement] Improve broker load job retry

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
@@ -52,6 +52,7 @@ import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.load.BrokerFileGroup;
 import com.starrocks.load.BrokerFileGroupAggInfo;
 import com.starrocks.load.FailMsg;
+import com.starrocks.load.routineload.TxnStatusChangeReason;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.OriginStatement;
 import com.starrocks.qe.SessionVariable;
@@ -237,9 +238,19 @@ public abstract class BulkLoadJob extends LoadJob {
         return failInfos;
     }
 
+    /**
+     * Not retryable cases
+     * 1. already retry too many times
+     * 2. BE parses data error, such as invalid json
+     */
+    protected boolean isRetryable(String failMsg) {
+        TxnStatusChangeReason reason = TxnStatusChangeReason.fromString(failMsg);
+        return retryTime > 0 && reason != TxnStatusChangeReason.PARSE_ERROR;
+    }
+
     @Override
     public void onTaskFailed(long taskId, FailMsg failMsg) {
-        boolean timeoutFailure = false;
+        boolean needRetry = false;
         writeLock();
         try {
             // check if job has been completed
@@ -251,20 +262,19 @@ public abstract class BulkLoadJob extends LoadJob {
                 return;
             }
 
-            if (!failMsg.getMsg().contains("timeout") || failMsg.getCancelType() == FailMsg.CancelType.USER_CANCEL) {
+            needRetry = isRetryable(failMsg.getMsg());
+            if (!needRetry) {
                 unprotectedExecuteCancel(failMsg, true);
                 logFinalOperation();
-            } else {
-                timeoutFailure = true;
             }
         } finally {
             writeUnlock();
         }
 
-        // For timeout failure, should abort the transaction and retry as soon as possible
-        if (timeoutFailure) {
+        // For retryable failure, should abort the transaction and retry as soon as possible
+        if (needRetry) {
             try {
-                LOG.debug("Loading task with timeout failure try to abort transaction, " +
+                LOG.debug("Loading task with retryable failure try to abort transaction, " +
                                 "job_id: {}, task_id: {}, txn_id: {}, task fail message: {}",
                         id, taskId, transactionId, failMsg.getMsg());
                 GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadErrorUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadErrorUtils.java
@@ -40,17 +40,6 @@ public class LoadErrorUtils {
     public static final ErrorMeta BACKEND_BRPC_TIMEOUT =
             new ErrorMeta("[E1008]Reached timeout", "Backend BRPC timeout");
 
-    private static final ErrorMeta[] LOADING_TASK_TIMEOUT_ERRORS = new ErrorMeta[] {BACKEND_BRPC_TIMEOUT};
-
-    public static boolean isTimeoutFromLoadingTaskExecution(String errorMsg) {
-        for (ErrorMeta errorMeta : LOADING_TASK_TIMEOUT_ERRORS) {
-            if (errorMsg.contains(errorMeta.keywords)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     public static boolean enableProfileAfterError(Coordinator coordinator) {
         if (!(coordinator instanceof DefaultCoordinator defaultCoordinator)) {
             return false;

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -198,7 +198,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     // this request id is only used for checking if a load begin request is a duplicate request.
     protected TUniqueId requestId;
 
-    protected int retryTime = 2; // retry time if timeout
+    protected int retryTime = 2;
 
     // only for persistence param. see readFields() for usage
     private boolean isJobTypeRead = false;

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadTask.java
@@ -73,13 +73,8 @@ public abstract class LoadTask extends PriorityLeaderTask {
             // callback on pending task finished
             callback.onTaskFinished(attachment);
             isFinished = true;
-        } catch (LoadException e) {
-            failMsg.setMsg(e.getMessage() == null ? "" : e.getMessage());
-            LOG.warn(new LogBuilder(LogKey.LOAD_JOB, callback.getCallbackId())
-                    .add("error_msg", "Failed to execute load task").build(), e);
         } catch (StarRocksException e) {
             failMsg.setMsg(e.getMessage() == null ? "" : e.getMessage());
-            failMsg.setCancelType(FailMsg.CancelType.USER_CANCEL);
             LOG.warn(new LogBuilder(LogKey.LOAD_JOB, callback.getCallbackId())
                     .add("error_msg", "Failed to execute load task").build(), e);
         } catch (Exception e) {

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
@@ -436,6 +436,17 @@ public class BrokerLoadJobTest {
         brokerLoadJob5.afterAborted(txnState, txnOperated, txnStatusChangeReason);
         idToTasks = Deencapsulation.getField(brokerLoadJob5, "idToTasks");
         Assert.assertEquals(1, idToTasks.size());
+
+        // test parse error, should not retry
+        BrokerLoadJob brokerLoadJob6 = new BrokerLoadJob();
+        brokerLoadJob6.retryTime = 1;
+        brokerLoadJob6.unprotectedExecuteJob();
+        txnOperated = true;
+        txnStatusChangeReason = "parse error, task failed";
+        brokerLoadJob6.afterAborted(txnState, txnOperated, txnStatusChangeReason);
+        Assert.assertEquals(JobState.CANCELLED, brokerLoadJob6.getState());
+        idToTasks = Deencapsulation.getField(brokerLoadJob6, "idToTasks");
+        Assert.assertEquals(0, idToTasks.size());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
@@ -468,7 +468,7 @@ public class BrokerLoadJobTest {
     }
 
     @Test
-    public void testTaskOnResourceGroupTaskFailed(@Injectable long taskId, @Injectable FailMsg failMsg) {
+    public void testTaskFailedUserCancelType(@Injectable long taskId, @Injectable FailMsg failMsg) {
         GlobalStateMgr.getCurrentState().setEditLog(new EditLog(new ArrayBlockingQueue<>(100)));
         new MockUp<EditLog>() {
             @Mock


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
currently, broker load job only retry only when meet timeout failure.

better to always retry broker load job except non-retryable cases, such as data parse error.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0