### PR TITLE
[BugFix] Fix deployer hung caused by ForkJoinPool.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3579,4 +3579,10 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static long max_graceful_exit_time_second = 60;
+
+    /**
+     * The maximum number of threads used to serialize fragments.
+     */
+    @ConfField(mutable = true)
+    public static int max_fragment_deploy_threads = getRuntime().availableProcessors();
 }


### PR DESCRIPTION
## Why I'm doing:

Some customers meet a scenario that a materialized view task never changes to a 'Finished' state. That will cause subsequent tasks not to be started. When we check the log, we find the corresponding query which is expected to be a 'RUNNING' state has already been aborted due to timeout.

When we try to abort the mv task manually, it still hung. So we check the result of executing `jstack`, and the result is shown below:
![Image](https://github.com/user-attachments/assets/4a039bf8-15f2-4628-b6e8-b500c8fd22c2)

It might be caused by the nested use of `.stream().parallel()`. The JAVA implements it through executing methods in a common pool. When the outside `.stream().parallel()` is executing in the pool, the inside `.stream().parallel()` might not acquire any threads from this pool.

## What I'm doing:

Use a configurable thread pool to execute `serializedRequest`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0