### PR TITLE
[BugFix] Fix partial update for auto increment column can not triggered by insert stmt

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/FileListTableRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/FileListTableRepo.java
@@ -89,7 +89,7 @@ public class FileListTableRepo extends FileListRepo {
             "UPDATE " + FILE_LIST_FULL_NAME + " SET `state` = %s, `finish_load` = now() WHERE ";
 
     protected static final String INSERT_FILES =
-            "INSERT INTO " + FILE_LIST_FULL_NAME + "(" + ALL_COLUMNS + ")" + " VALUES ";
+            "INSERT INTO " + FILE_LIST_FULL_NAME + "(" + "`id`, " + ALL_COLUMNS + ")" + " VALUES ";
 
     protected static final String SELECTED_STAGED_FILES =
             "SELECT " + ALL_COLUMNS + " FROM " + FILE_LIST_FULL_NAME + " WHERE ";

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoAccessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoAccessor.java
@@ -170,7 +170,9 @@ public class RepoAccessor {
     protected String buildSqlAddFiles(List<PipeFileRecord> records) {
         StringBuilder sb = new StringBuilder();
         sb.append(FileListTableRepo.INSERT_FILES);
-        sb.append(records.stream().map(PipeFileRecord::toValueList).collect(Collectors.joining(",")));
+        List<String> valueLists = records.stream().map(PipeFileRecord::toValueList).collect(Collectors.toList());
+        sb.append(valueLists.stream().map(
+                        valueList -> "(" + "DEFAULT, " + valueList.substring(1)).collect(Collectors.joining(",")));
         return sb.toString();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -384,6 +384,9 @@ public class InsertPlanner {
                         nullExprInAutoIncrement, enableAutomaticPartition, session.getCurrentWarehouseId());
                 if (insertStmt.usePartialUpdate()) {
                     ((OlapTableSink) dataSink).setPartialUpdateMode(TPartialUpdateMode.AUTO_MODE);
+                    if (insertStmt.autoIncrementPartialUpdate()) {
+                        ((OlapTableSink) dataSink).setMissAutoIncrementColumn();
+                    }
                 }
                 if (olapTable.getAutomaticBucketSize() > 0) {
                     ((OlapTableSink) dataSink).setAutomaticBucketSize(olapTable.getAutomaticBucketSize());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -276,6 +276,11 @@ public class InsertAnalyzer {
                     }
                     if (targetColumns.size() < olapTable.getBaseSchemaWithoutGeneratedColumn().size()) {
                         insertStmt.setUsePartialUpdate();
+                        // mark if partial update for auto increment column
+                        if (olapTable.hasAutoIncrementColumn() &&
+                                !targetColumns.stream().anyMatch(col -> col.isAutoIncrement())) {
+                            insertStmt.setAutoIncrementPartialUpdate();
+                        }
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
@@ -61,6 +61,7 @@ public class InsertStmt extends DmlStmt {
     private List<Long> targetPartitionIds = Lists.newArrayList();
     private List<String> targetColumnNames;
     private boolean usePartialUpdate = false;
+    private boolean autoIncrementPartialUpdate = false;
     private QueryStatement queryStatement;
     private String label = null;
     private String targetBranch = null;
@@ -265,6 +266,14 @@ public class InsertStmt extends DmlStmt {
 
     public List<String> getTargetColumnNames() {
         return targetColumnNames;
+    }
+
+    public void setAutoIncrementPartialUpdate() {
+        this.autoIncrementPartialUpdate = true;
+    }
+
+    public boolean autoIncrementPartialUpdate() {
+        return this.autoIncrementPartialUpdate;
     }
 
     public void setUsePartialUpdate() {

--- a/fe/fe-core/src/test/java/com/starrocks/load/pipe/filelist/FileListRepoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/pipe/filelist/FileListRepoTest.java
@@ -149,11 +149,11 @@ public class FileListRepoTest {
         // add files
         sql = RepoAccessor.getInstance().buildSqlAddFiles(records);
         Assert.assertEquals("INSERT INTO _statistics_.pipe_file_list" +
-                        "(`pipe_id`, `file_name`, `file_version`, `file_size`, `state`, `last_modified`, " +
+                        "(`id`, `pipe_id`, `file_name`, `file_version`, `file_size`, `state`, `last_modified`, " +
                         "`staged_time`, `start_load`, `finish_load`, `error_info`, `insert_label`) VALUES " +
-                "(1, 'a.parquet', '123asdf', 1024, 'UNLOADED', '2023-07-01 01:01:01', " +
+                "(DEFAULT, 1, 'a.parquet', '123asdf', 1024, 'UNLOADED', '2023-07-01 01:01:01', " +
                         "'2023-07-01 01:01:01', '2023-07-01 01:01:01', '2023-07-01 01:01:01', '{\"errorMessage\":null}', '')," +
-                "(1, 'a.parquet', '123asdf', 1024, 'UNLOADED', '2023-07-01 01:01:01', " +
+                "(DEFAULT, 1, 'a.parquet', '123asdf', 1024, 'UNLOADED', '2023-07-01 01:01:01', " +
                         "'2023-07-01 01:01:01', '2023-07-01 01:01:01', '2023-07-01 01:01:01', '{\"errorMessage\":null}', '')",
                 sql);
 
@@ -298,10 +298,10 @@ public class FileListRepoTest {
         new Expectations(executor) {
             {
                 executor.executeDML(
-                        "INSERT INTO _statistics_.pipe_file_list(`pipe_id`, `file_name`, `file_version`, " +
+                        "INSERT INTO _statistics_.pipe_file_list(`id`, `pipe_id`, `file_name`, `file_version`, " +
                                 "`file_size`, `state`, `last_modified`, `staged_time`, `start_load`, `finish_load`, " +
                                 "`error_info`, `insert_label`) VALUES " +
-                                "(1, 'a.parquet', '1', 0, 'UNLOADED', NULL, NULL, " +
+                                "(DEFAULT, 1, 'a.parquet', '1', 0, 'UNLOADED', NULL, NULL, " +
                                 "NULL, NULL, '{\"errorMessage\":null}', '')");
                 result = Lists.newArrayList();
             }
@@ -386,10 +386,11 @@ public class FileListRepoTest {
         new Expectations(executor) {
             {
                 executor.executeDML(
-                        String.format("INSERT INTO _statistics_.pipe_file_list(`pipe_id`, `file_name`, `file_version`, " +
-                                "`file_size`, `state`, `last_modified`, `staged_time`, `start_load`, `finish_load`, " +
-                                "`error_info`, `insert_label`) VALUES (1, '%d.parquet', '%d', %d, 'UNLOADED', NULL, NULL, " +
-                                "NULL, NULL, '{\"errorMessage\":null}', '')", recordSize, recordSize, recordSize));
+                        String.format("INSERT INTO _statistics_.pipe_file_list(`id`, `pipe_id`, `file_name`, `file_version`, " +
+                            "`file_size`, `state`, `last_modified`, `staged_time`, `start_load`, `finish_load`, " +
+                                    "`error_info`, `insert_label`) VALUES (DEFAULT, 1, '%d.parquet', '%d', %d, 'UNLOADED', " +
+                                        "NULL, NULL, NULL, NULL, '{\"errorMessage\":null}', '')",
+                                            recordSize, recordSize, recordSize));
                 times = 1;
                 result = null;
             }

--- a/test/sql/test_auto_increment/R/test_auto_increment
+++ b/test/sql/test_auto_increment/R/test_auto_increment
@@ -646,3 +646,58 @@ DROP TABLE t_auto_increment_partial_update_only;
 DROP DATABASE test_auto_increment_partial_update_only;
 -- result:
 -- !result
+-- name: test_auto_increment_insert_partial_update
+ADMIN SET FRONTEND CONFIG ("auto_increment_cache_size" = "0");
+CREATE TABLE `t_auto_increment_insert_partial_update` (
+  `k` STRING NOT NULL COMMENT "",
+  `v1` BIGINT AUTO_INCREMENT,
+  `created` datetime NULL DEFAULT CURRENT_TIMESTAMP COMMENT ""
+) ENGINE=OLAP 
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "true",
+"replicated_storage" = "true"
+);
+-- result:
+-- !result
+insert into t_auto_increment_insert_partial_update (k) values (1);
+-- result:
+-- !result
+insert into t_auto_increment_insert_partial_update (k) values (1),(2);
+-- result:
+-- !result
+insert into t_auto_increment_insert_partial_update (k) values (1),(2),(3);
+-- result:
+-- !result
+insert into t_auto_increment_insert_partial_update (k) values (1),(2),(3),(4);
+-- result:
+-- !result
+insert into t_auto_increment_insert_partial_update (k) values (1),(2),(3),(4);
+-- result:
+-- !result
+insert into t_auto_increment_insert_partial_update (k) values (1),(2),(3),(4);
+-- result:
+-- !result
+insert into t_auto_increment_insert_partial_update (k) values (1),(2),(3),(4);
+-- result:
+-- !result
+insert into t_auto_increment_insert_partial_update (k) values (1),(2),(3),(4);
+-- result:
+-- !result
+insert into t_auto_increment_insert_partial_update (k) values (1),(2),(5);
+-- result:
+-- !result
+SELECT k, v1 from t_auto_increment_insert_partial_update ORDER BY k;
+-- result:
+1	1
+2	2
+3	3
+4	4
+5	5
+-- !result
+DROP TABLE t_auto_increment_insert_partial_update force;
+-- result:
+-- !result

--- a/test/sql/test_auto_increment/R/test_auto_increment
+++ b/test/sql/test_auto_increment/R/test_auto_increment
@@ -157,8 +157,8 @@ SELECT * FROM t1;
 -- result:
 1	5
 2	6
-10	7
-20	8
+10	1
+20	2
 -- !result
 DROP TABLE t1;
 -- result:
@@ -280,7 +280,7 @@ ADMIN SET FRONTEND CONFIG ("auto_increment_cache_size" = "0");
 CREATE TABLE t ( id BIGINT NOT NULL AUTO_INCREMENT,  name BIGINT NOT NULL, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
 -- result:
 -- !result
-INSERT INTO t (name,job1,job2) VALUES (1,1,1),(2,2,2);
+INSERT INTO t (id, name,job1,job2) VALUES (DEFAULT, 1,1,1),(DEFAULT, 2,2,2);
 -- result:
 -- !result
 SELECT * FROM t ORDER BY name;
@@ -336,7 +336,7 @@ SELECT * FROM t ORDER BY job1;
 1	1	1	1
 100000	1	2	2
 -- !result
-INSERT INTO t (name,job1,job2) VALUES (1,100,100);
+INSERT INTO t (id, name,job1,job2) VALUES (DEFAULT, 1,100,100);
 -- result:
 -- !result
 SELECT * FROM t ORDER BY job1;
@@ -444,18 +444,6 @@ INSERT INTO t3 (id,name,job1,job2) VALUES (1,1,DEFAULT,1);
 -- result:
 -- !result
 INSERT INTO t4 (id,name,job1,job2) VALUES (1,1,1,DEFAULT);
--- result:
--- !result
-INSERT INTO t1 (name,job1,job2) VALUES (1,1,1);
--- result:
--- !result
-INSERT INTO t2 (id,job1,job2) VALUES (1,1,1);
--- result:
--- !result
-INSERT INTO t3 (id,name,job2) VALUES (1,1,1);
--- result:
--- !result
-INSERT INTO t4 (id,name,job1) VALUES (1,1,1);
 -- result:
 -- !result
 DROP TABLE t1;
@@ -646,7 +634,7 @@ DROP TABLE t_auto_increment_partial_update_only;
 DROP DATABASE test_auto_increment_partial_update_only;
 -- result:
 -- !result
--- name: test_auto_increment_insert_partial_update
+-- name: test_auto_increment_insert_partial_update @sequential
 ADMIN SET FRONTEND CONFIG ("auto_increment_cache_size" = "0");
 CREATE TABLE `t_auto_increment_insert_partial_update` (
   `k` STRING NOT NULL COMMENT "",

--- a/test/sql/test_auto_increment/T/test_auto_increment
+++ b/test/sql/test_auto_increment/T/test_auto_increment
@@ -38,7 +38,7 @@ USE test_insert_auto_increment;
 ADMIN SET FRONTEND CONFIG ("auto_increment_cache_size" = "0");
 
 CREATE TABLE t ( id BIGINT NOT NULL AUTO_INCREMENT,  name BIGINT NOT NULL, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
-INSERT INTO t (name,job1,job2) VALUES (1,1,1),(2,2,2);
+INSERT INTO t (id, name,job1,job2) VALUES (DEFAULT, 1,1,1),(2,2,2);
 SELECT * FROM t ORDER BY name;
 
 INSERT INTO t (id,name,job1,job2) VALUES (DEFAULT,3,3,3),(DEFAULT,4,4,4);
@@ -57,7 +57,7 @@ CREATE TABLE t ( id BIGINT NOT NULL AUTO_INCREMENT,  name BIGINT NOT NULL, job1 
 INSERT INTO t (id,name,job1,job2) VALUES (1,1,1,1),(100000,1,2,2);
 SELECT * FROM t ORDER BY job1;
 
-INSERT INTO t (name,job1,job2) VALUES (1,100,100);
+INSERT INTO t (id, name,job1,job2) VALUES (DEFAULT, 1,100,100);
 SELECT * FROM t ORDER BY job1;
 
 INSERT INTO t (id,name,job1,job2) VALUES (100000,1,100,100);
@@ -95,11 +95,6 @@ INSERT INTO t1 (id,name,job1,job2) VALUES (DEFAULT,1,1,1);
 INSERT INTO t2 (id,name,job1,job2) VALUES (1,DEFAULT,1,1);
 INSERT INTO t3 (id,name,job1,job2) VALUES (1,1,DEFAULT,1);
 INSERT INTO t4 (id,name,job1,job2) VALUES (1,1,1,DEFAULT);
-
-INSERT INTO t1 (name,job1,job2) VALUES (1,1,1);
-INSERT INTO t2 (id,job1,job2) VALUES (1,1,1);
-INSERT INTO t3 (id,name,job2) VALUES (1,1,1);
-INSERT INTO t4 (id,name,job1) VALUES (1,1,1);
 
 DROP TABLE t1;
 DROP TABLE t2;
@@ -275,7 +270,7 @@ SELECT * FROM t_auto_increment_partial_update_only;
 DROP TABLE t_auto_increment_partial_update_only;
 DROP DATABASE test_auto_increment_partial_update_only;
 
--- name: test_auto_increment_insert_partial_update
+-- name: test_auto_increment_insert_partial_update @sequential
 ADMIN SET FRONTEND CONFIG ("auto_increment_cache_size" = "0");
 CREATE TABLE `t_auto_increment_insert_partial_update` (
   `k` STRING NOT NULL COMMENT "",

--- a/test/sql/test_auto_increment/T/test_auto_increment
+++ b/test/sql/test_auto_increment/T/test_auto_increment
@@ -274,3 +274,33 @@ SELECT * FROM t_auto_increment_partial_update_only;
 
 DROP TABLE t_auto_increment_partial_update_only;
 DROP DATABASE test_auto_increment_partial_update_only;
+
+-- name: test_auto_increment_insert_partial_update
+ADMIN SET FRONTEND CONFIG ("auto_increment_cache_size" = "0");
+CREATE TABLE `t_auto_increment_insert_partial_update` (
+  `k` STRING NOT NULL COMMENT "",
+  `v1` BIGINT AUTO_INCREMENT,
+  `created` datetime NULL DEFAULT CURRENT_TIMESTAMP COMMENT ""
+) ENGINE=OLAP 
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "true",
+"replicated_storage" = "true"
+);
+
+
+insert into t_auto_increment_insert_partial_update (k) values (1);
+insert into t_auto_increment_insert_partial_update (k) values (1),(2);
+insert into t_auto_increment_insert_partial_update (k) values (1),(2),(3);
+insert into t_auto_increment_insert_partial_update (k) values (1),(2),(3),(4);
+insert into t_auto_increment_insert_partial_update (k) values (1),(2),(3),(4);
+insert into t_auto_increment_insert_partial_update (k) values (1),(2),(3),(4);
+insert into t_auto_increment_insert_partial_update (k) values (1),(2),(3),(4);
+insert into t_auto_increment_insert_partial_update (k) values (1),(2),(3),(4);
+insert into t_auto_increment_insert_partial_update (k) values (1),(2),(5);
+
+SELECT k, v1 from t_auto_increment_insert_partial_update ORDER BY k;
+DROP TABLE t_auto_increment_insert_partial_update force;

--- a/test/sql/test_dml/R/test_update
+++ b/test/sql/test_dml/R/test_update
@@ -93,7 +93,7 @@ PRIMARY KEY(`k1`)
 DISTRIBUTED BY HASH(`k1`);
 -- result:
 -- !result
-insert into pk_tbl1(k2, k3, k4, k5) values('2024-01-01', 1, 2, 3), ('2024-01-01', 1, 2, 3);
+insert into pk_tbl1(k1, k2, k3, k4, k5) values(DEFAULT, '2024-01-01', 1, 2, 3), (DEFAULT, '2024-01-01', 1, 2, 3);
 -- result:
 -- !result
 update pk_tbl1 set K4 = 1, K3 = 1, K5 = 1 where K1 = 1;

--- a/test/sql/test_dml/T/test_update
+++ b/test/sql/test_dml/T/test_update
@@ -51,7 +51,7 @@ CREATE TABLE `pk_tbl1` (
 ) ENGINE=OLAP
 PRIMARY KEY(`k1`)
 DISTRIBUTED BY HASH(`k1`);
-insert into pk_tbl1(k2, k3, k4, k5) values('2024-01-01', 1, 2, 3), ('2024-01-01', 1, 2, 3);
+insert into pk_tbl1(k1, k2, k3, k4, k5) values(DEFAULT, '2024-01-01', 1, 2, 3), (DEFAULT, '2024-01-01', 1, 2, 3);
 update pk_tbl1 set K4 = 1, K3 = 1, K5 = 1 where K1 = 1;
 select * from pk_tbl1 order by k1;
 drop table if exists pk_tbl1;


### PR DESCRIPTION
## Why I'm doing:
Currently, SR support partial update using insert stmt. But partial update for auto increment column can not be triggered in a properly way. Becase the partial update for auto increment column need the additional flag MissAutoIncrementColumn in OlapTableSink.

## What I'm doing:
set MissAutoIncrementColumn if needed.

Fixes #58761

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5 
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0