### PR TITLE
[BugFix] Fix NPE when CREATE TABLE LIKE AS from a table with generated column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -761,7 +761,7 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         if (isGeneratedColumn()) {
             String generatedColumnSql;
             if (idToColumn != null) {
-                generatedColumnSql = AstToSQLBuilder.toSQL(generatedColumnExpr.convertToColumnNameExpr(idToColumn));
+                generatedColumnSql = generatedColumnExpr.convertToColumnNameExpr(idToColumn).toSql();
             } else {
                 generatedColumnSql = generatedColumnExpr.toSql();
             }

--- a/test/sql/test_automatic_partition/R/test_multi_expr
+++ b/test/sql/test_automatic_partition/R/test_multi_expr
@@ -405,7 +405,7 @@ multi_level_expr_par_tbl_1	CREATE TABLE `multi_level_expr_par_tbl_1` (
   `c1` bigint(20) NOT NULL COMMENT "",
   `c2` varchar(65533) NULL COMMENT "",
   `c3` date NULL COMMENT "",
-  `__generated_partition_column_0` varchar(1048576) NULL AS from_unixtime(`c1`) COMMENT ""
+  `__generated_partition_column_0` varchar(1048576) NULL AS from_unixtime(c1) COMMENT ""
 ) ENGINE=OLAP 
 PRIMARY KEY(`c1`)
 PARTITION BY (`__generated_partition_column_0`)
@@ -460,8 +460,8 @@ multi_level_expr_par_tbl_2	CREATE TABLE `multi_level_expr_par_tbl_2` (
   `k11` decimal(38, 9) NULL COMMENT "",
   `k12` decimal(38, 9) NULL COMMENT "",
   `k13` decimal(27, 9) NULL COMMENT "",
-  `__generated_partition_column_0` varchar(1048576) NULL AS substring(`k4`, 1, 5) COMMENT "",
-  `__generated_partition_column_1` date NULL AS date_trunc('month', `k1`) COMMENT ""
+  `__generated_partition_column_0` varchar(1048576) NULL AS substring(k4, 1, 5) COMMENT "",
+  `__generated_partition_column_1` date NULL AS date_trunc('month', k1) COMMENT ""
 ) ENGINE=OLAP 
 PRIMARY KEY(`k1`, `k2`, `k3`, `k4`, `k5`)
 COMMENT "OLAP"

--- a/test/sql/test_materialized_column/R/test_materialized_column
+++ b/test/sql/test_materialized_column/R/test_materialized_column
@@ -538,8 +538,8 @@ t	CREATE TABLE `t` (
   `id` bigint(20) NOT NULL COMMENT "",
   `newcol3` bigint(20) NULL DEFAULT "0" COMMENT "",
   `newcol4` bigint(20) NULL DEFAULT "0" COMMENT "",
-  `newcol1` bigint(20) NULL AS id * 10 COMMENT "",
-  `newcol2` bigint(20) NULL AS id * 100 COMMENT ""
+  `newcol1` bigint(20) NULL AS `id` * 10 COMMENT "",
+  `newcol2` bigint(20) NULL AS `id` * 100 COMMENT ""
 ) ENGINE=OLAP 
 UNIQUE KEY(`id`)
 DISTRIBUTED BY HASH(`id`) BUCKETS 7 

--- a/test/sql/test_materialized_column/R/test_materialized_column
+++ b/test/sql/test_materialized_column/R/test_materialized_column
@@ -49,7 +49,7 @@ SHOW CREATE TABLE t;
 t	CREATE TABLE `t` (
   `id` bigint(20) NOT NULL COMMENT "",
   `array_data` array<int(11)> NOT NULL COMMENT "",
-  `mc` double NULL AS array_avg(`array_data`) COMMENT ""
+  `mc` double NULL AS array_avg(array_data) COMMENT ""
 ) ENGINE=OLAP 
 PRIMARY KEY(`id`)
 DISTRIBUTED BY HASH(`id`) BUCKETS 7 
@@ -438,7 +438,7 @@ t	CREATE TABLE `t` (
   `name` bigint(20) NOT NULL COMMENT "",
   `job` int(11) NOT NULL COMMENT "",
   `newcol` int(11) NULL DEFAULT "0" COMMENT "",
-  `mc` int(11) NULL AS `job` COMMENT ""
+  `mc` int(11) NULL AS job COMMENT ""
 ) ENGINE=OLAP 
 PRIMARY KEY(`id`)
 DISTRIBUTED BY HASH(`id`) BUCKETS 7 
@@ -507,8 +507,8 @@ SHOW CREATE TABLE t;
 -- result:
 t	CREATE TABLE `t` (
   `id` bigint(20) NOT NULL COMMENT "",
-  `newcol1` bigint(20) NULL AS `id` * 10 COMMENT "",
-  `newcol2` bigint(20) NULL AS `id` * 100 COMMENT ""
+  `newcol1` bigint(20) NULL AS id * 10 COMMENT "",
+  `newcol2` bigint(20) NULL AS id * 100 COMMENT ""
 ) ENGINE=OLAP 
 UNIQUE KEY(`id`)
 DISTRIBUTED BY HASH(`id`) BUCKETS 7 
@@ -538,8 +538,8 @@ t	CREATE TABLE `t` (
   `id` bigint(20) NOT NULL COMMENT "",
   `newcol3` bigint(20) NULL DEFAULT "0" COMMENT "",
   `newcol4` bigint(20) NULL DEFAULT "0" COMMENT "",
-  `newcol1` bigint(20) NULL AS `id` * 10 COMMENT "",
-  `newcol2` bigint(20) NULL AS `id` * 100 COMMENT ""
+  `newcol1` bigint(20) NULL AS id * 10 COMMENT "",
+  `newcol2` bigint(20) NULL AS id * 100 COMMENT ""
 ) ENGINE=OLAP 
 UNIQUE KEY(`id`)
 DISTRIBUTED BY HASH(`id`) BUCKETS 7 
@@ -992,7 +992,7 @@ t0	CREATE TABLE `t0` (
   `v2` bigint(20) NOT NULL COMMENT "",
   `v3` bigint(20) NOT NULL COMMENT "",
   `testcol5` bigint(20) NULL COMMENT "",
-  `testcol6` bigint(20) NULL AS `v1` * 10 COMMENT ""
+  `testcol6` bigint(20) NULL AS v1 * 10 COMMENT ""
 ) ENGINE=OLAP 
 DUPLICATE KEY(`v1`)
 DISTRIBUTED BY HASH(`v1`) BUCKETS 1 

--- a/test/sql/test_materialized_column/R/test_materialized_column
+++ b/test/sql/test_materialized_column/R/test_materialized_column
@@ -1165,6 +1165,13 @@ CREATE TABLE `t1_create_like_error` (
 create table t2_create_like_error like t1_create_like_error;
 -- result:
 -- !result
+INSERT INTO t2_create_like_error values(now(), 1, 2, 3);
+-- result:
+-- !result
+SELECT k5, k6, k7, col_array from t2_create_like_error;
+-- result:
+1	2	3	[1,2,3]
+-- !result
 DROP TABLE t1_create_like_error;
 -- result:
 -- !result

--- a/test/sql/test_materialized_column/R/test_materialized_column
+++ b/test/sql/test_materialized_column/R/test_materialized_column
@@ -1145,3 +1145,29 @@ select * from t_fix_adding_and_col_partial_update_conflict;
 drop table t_fix_adding_and_col_partial_update_conflict;
 -- result:
 -- !result
+-- name: test_create_like_error
+CREATE TABLE `t1_create_like_error` (
+                `k1` date,
+                `k5` boolean,
+                `k6` tinyint,
+                `k7` smallint,
+                `col_array` array<smallint> as [k5,k6,k7]
+                )
+                PRIMARY KEY(`k1`)
+                COMMENT "OLAP"
+                DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+                PROPERTIES (
+                "replication_num" = "1",
+                "storage_format" = "v2"
+                );
+-- result:
+-- !result
+create table t2_create_like_error like t1_create_like_error;
+-- result:
+-- !result
+DROP TABLE t1_create_like_error;
+-- result:
+-- !result
+DROP TABLE t2_create_like_error;
+-- result:
+-- !result

--- a/test/sql/test_materialized_column/R/test_materialized_column
+++ b/test/sql/test_materialized_column/R/test_materialized_column
@@ -507,8 +507,8 @@ SHOW CREATE TABLE t;
 -- result:
 t	CREATE TABLE `t` (
   `id` bigint(20) NOT NULL COMMENT "",
-  `newcol1` bigint(20) NULL AS id * 10 COMMENT "",
-  `newcol2` bigint(20) NULL AS id * 100 COMMENT ""
+  `newcol1` bigint(20) NULL AS `id` * 10 COMMENT "",
+  `newcol2` bigint(20) NULL AS `id` * 100 COMMENT ""
 ) ENGINE=OLAP 
 UNIQUE KEY(`id`)
 DISTRIBUTED BY HASH(`id`) BUCKETS 7 
@@ -992,7 +992,7 @@ t0	CREATE TABLE `t0` (
   `v2` bigint(20) NOT NULL COMMENT "",
   `v3` bigint(20) NOT NULL COMMENT "",
   `testcol5` bigint(20) NULL COMMENT "",
-  `testcol6` bigint(20) NULL AS v1 * 10 COMMENT ""
+  `testcol6` bigint(20) NULL AS `v1` * 10 COMMENT ""
 ) ENGINE=OLAP 
 DUPLICATE KEY(`v1`)
 DISTRIBUTED BY HASH(`v1`) BUCKETS 1 

--- a/test/sql/test_materialized_column/T/test_materialized_column
+++ b/test/sql/test_materialized_column/T/test_materialized_column
@@ -475,5 +475,7 @@ CREATE TABLE `t1_create_like_error` (
                 "storage_format" = "v2"
                 );
 create table t2_create_like_error like t1_create_like_error;
+INSERT INTO t2_create_like_error values(now(), 1, 2, 3);
+SELECT k5, k6, k7, col_array from t2_create_like_error;
 DROP TABLE t1_create_like_error;
 DROP TABLE t2_create_like_error;

--- a/test/sql/test_materialized_column/T/test_materialized_column
+++ b/test/sql/test_materialized_column/T/test_materialized_column
@@ -458,3 +458,22 @@ alter table t_fix_adding_and_col_partial_update_conflict add column newcol bigin
 function: wait_alter_table_finish()
 select * from t_fix_adding_and_col_partial_update_conflict;
 drop table t_fix_adding_and_col_partial_update_conflict;
+
+-- name: test_create_like_error
+CREATE TABLE `t1_create_like_error` (
+                `k1` date,
+                `k5` boolean,
+                `k6` tinyint,
+                `k7` smallint,
+                `col_array` array<smallint> as [k5,k6,k7]
+                )
+                PRIMARY KEY(`k1`)
+                COMMENT "OLAP"
+                DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+                PROPERTIES (
+                "replication_num" = "1",
+                "storage_format" = "v2"
+                );
+create table t2_create_like_error like t1_create_like_error;
+DROP TABLE t1_create_like_error;
+DROP TABLE t2_create_like_error;


### PR DESCRIPTION
## Why I'm doing:
Sometime `CREATE TABLE LIKE AS` from a table with generated column will get NPE because `AstToSQLBuilder.toSQL` need the analyzed expression to finish the SQL transformation but the generated column saved in `ColumnIdExpr` is the unanalyzed one.

## What I'm doing:
Use `Expr.toSql()` instead

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0