### PR TITLE
[BugFix] reset delta rows of the BasicStatsMeta when sync tablet meta in the background

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
@@ -244,6 +244,7 @@ public class TabletStatMgr extends FrontendDaemon {
         BasicStatsMeta meta = GlobalStateMgr.getCurrentState().getAnalyzeMgr().getTableBasicStatsMeta(tableId);
         if (meta != null) {
             meta.setUpdateRows(totalRowCount);
+            meta.resetDeltaRows();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
@@ -185,7 +185,7 @@ public class BasicStatsMeta implements Writable {
     }
 
     public void setUpdateRows(Long updateRows) {
-        this.updateRows = updateRows;
+         this.updateRows = updateRows;
     }
 
     public void increaseDeltaRows(Long delta) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -551,7 +551,6 @@ public class StatisticExecutor {
                         basicStatsMeta.setUpdateTime(analyzeStatus.getEndTime());
                         basicStatsMeta.setProperties(statsJob.getProperties());
                         basicStatsMeta.setAnalyzeType(statsJob.getAnalyzeType());
-                        basicStatsMeta.resetDeltaRows();
                     }
 
                     for (String column : ListUtils.emptyIfNull(statsJob.getColumnNames())) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
the `updateRows` and `deltaRows` of BasicStatsMeta will increase immediately after loading data.

Synchronizing tabletStats in the background will update `updateRows`, which is the exact number of table rows.
so we need to reset the `deltaRows` of BasicStatsMeta according to the healthy formula. 
```
updatePartitionRowCount = Math.max(1, Math.max(tableRowCount + deltaRows, updateRows) - cachedTableRowCount)
```
The `tableRowCount` will be the exact value of the latest snapshot after tablet meta synchronization

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0