### PR TITLE
[BugFix] Fix the temporary partition residue caused by optimize duplicate partitions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/persist/DropPartitionsInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/DropPartitionsInfo.java
@@ -56,16 +56,24 @@ public class DropPartitionsInfo implements Writable {
     private boolean forceDrop = false;
     @SerializedName(value = "partitionNames")
     private List<String> partitionNames = new ArrayList<>();
+    @SerializedName(value = "isDropAll")
+    private boolean isDropAll = false;
 
     private DropPartitionsInfo() {
     }
 
     public DropPartitionsInfo(Long dbId, Long tableId, boolean isTempPartition, boolean forceDrop, List<String> partitionNames) {
+        this(dbId, tableId, isTempPartition, forceDrop, partitionNames, false);
+    }
+
+    public DropPartitionsInfo(Long dbId, Long tableId, boolean isTempPartition,
+                              boolean forceDrop, List<String> partitionNames, boolean isDropAll) {
         this.dbId = dbId;
         this.tableId = tableId;
         this.isTempPartition = isTempPartition;
         this.forceDrop = forceDrop;
         this.partitionNames = partitionNames;
+        this.isDropAll = isDropAll;
     }
 
     public Long getDbId() {
@@ -86,6 +94,10 @@ public class DropPartitionsInfo implements Writable {
 
     public List<String> getPartitionNames() {
         return partitionNames;
+    }
+
+    public boolean isDropAll() {
+        return isDropAll;
     }
 
     public void setPartitionNames(List<String> partitionNames) {
@@ -109,11 +121,12 @@ public class DropPartitionsInfo implements Writable {
         }
         DropPartitionsInfo that = (DropPartitionsInfo) o;
         return isTempPartition == that.isTempPartition && forceDrop == that.forceDrop && Objects.equals(dbId, that.dbId) &&
-                Objects.equals(tableId, that.tableId) && Objects.equals(partitionNames, that.partitionNames);
+                Objects.equals(tableId, that.tableId) && Objects.equals(partitionNames, that.partitionNames) &&
+                isDropAll == that.isDropAll;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(dbId, tableId, isTempPartition, forceDrop, partitionNames);
+        return Objects.hash(dbId, tableId, isTempPartition, forceDrop, partitionNames, isDropAll);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1354,14 +1354,29 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         OlapTable olapTable = (OlapTable) table;
         Preconditions.checkArgument(locker.isDbWriteLockHeldByCurrentThread(db));
         PartitionInfo partitionInfo = olapTable.getPartitionInfo();
+        boolean isTempPartition = clause.isTempPartition();
+        boolean isDropAll = clause.isDropAll();
+        long dbId = db.getId();
+        long tableId = olapTable.getId();
+        EditLog editLog = GlobalStateMgr.getCurrentState().getEditLog();
 
         if (olapTable.getState() != OlapTable.OlapTableState.NORMAL) {
             throw InvalidOlapTableStateException.of(olapTable.getState(), olapTable.getName());
         }
+
+        if (isDropAll && isTempPartition) {
+            olapTable.dropAllTempPartitions();
+            DropPartitionsInfo info =
+                    new DropPartitionsInfo(dbId, tableId, isTempPartition, clause.isForceDrop(), null, true);
+            editLog.logDropPartitions(info);
+            LOG.info("succeed in dropping all partitions, is temp : {}, is force : {}", isTempPartition,
+                    clause.isForceDrop());
+            return;
+        }
+
         if (!partitionInfo.isRangePartition() && partitionInfo.getType() != PartitionType.LIST) {
             throw new DdlException("Alter table [" + olapTable.getName() + "] failed. Not a partitioned table");
         }
-        boolean isTempPartition = clause.isTempPartition();
 
         List<String> existPartitions = Lists.newArrayList();
         List<String> notExistPartitions = Lists.newArrayList();
@@ -1430,9 +1445,6 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                 throw new DdlException("fail to refresh materialized views when dropping partition", e);
             }
         }
-        long dbId = db.getId();
-        long tableId = olapTable.getId();
-        EditLog editLog = GlobalStateMgr.getCurrentState().getEditLog();
 
         if (clause.getPartitionName() != null) {
             String partitionName = clause.getPartitionName();
@@ -1473,12 +1485,20 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         try {
             LOG.info("Begin to unprotect drop partitions. db = " + info.getDbId()
                     + " table = " + info.getTableId()
-                    + " partitionNames = " + info.getPartitionNames());
+                    + " partitionNames = " + info.getPartitionNames()
+                    + " isTempPartition = " + info.isTempPartition()
+                    + " isForceDrop = " + info.isForceDrop()
+                    + " isDropAll = " + info.isDropAll());
             List<String> partitionNames = info.getPartitionNames();
             OlapTable olapTable = (OlapTable) getTable(db.getId(), info.getTableId());
             boolean isTempPartition = info.isTempPartition();
             long dbId = info.getDbId();
             boolean isForceDrop = info.isForceDrop();
+            boolean isDropAll = info.isDropAll();
+            if (isDropAll && isTempPartition) {
+                olapTable.dropAllTempPartitions();
+                return;
+            }
             partitionNames.stream().forEach(partitionName -> {
                 if (isTempPartition) {
                     olapTable.dropTempPartition(partitionName, true);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropPartitionClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropPartitionClause.java
@@ -30,9 +30,22 @@ public class DropPartitionClause extends AlterTableClause {
     private final MultiRangePartitionDesc multiRangePartitionDesc;
     private final List<String> partitionNames;
     private final Expr dropWhereExpr;
+    private final boolean isDropAll;
 
     //Object Resolved by Analyzer
     private List<String> resolvedPartitionNames;
+
+    public DropPartitionClause(boolean isTempPartition, boolean forceDrop, boolean isDropAll, NodePosition pos) {
+        super(AlterOpType.DROP_PARTITION, pos);
+        this.ifExists = false;
+        this.isDropAll = isDropAll;
+        this.partitionName = null;
+        this.isTempPartition = isTempPartition;
+        this.forceDrop = forceDrop;
+        this.multiRangePartitionDesc = null;
+        this.partitionNames = null;
+        this.dropWhereExpr = null;
+    }
 
     public DropPartitionClause(boolean ifExists, String partitionName, boolean isTempPartition, boolean forceDrop) {
         this(ifExists, partitionName, isTempPartition, forceDrop, NodePosition.ZERO);
@@ -48,6 +61,7 @@ public class DropPartitionClause extends AlterTableClause {
         this.multiRangePartitionDesc = null;
         this.partitionNames = null;
         this.dropWhereExpr = null;
+        this.isDropAll = false;
     }
 
     public DropPartitionClause(boolean ifExists, List<String> partitionNames, boolean isTempPartition,
@@ -60,6 +74,7 @@ public class DropPartitionClause extends AlterTableClause {
         this.multiRangePartitionDesc = null;
         this.partitionNames = partitionNames;
         this.dropWhereExpr = null;
+        this.isDropAll = false;
     }
 
     public DropPartitionClause(boolean ifExists, MultiRangePartitionDesc multiRangePartitionDesc, boolean isTempPartition,
@@ -72,6 +87,7 @@ public class DropPartitionClause extends AlterTableClause {
         this.multiRangePartitionDesc = multiRangePartitionDesc;
         this.partitionNames = null;
         this.dropWhereExpr = null;
+        this.isDropAll = false;
     }
 
     public DropPartitionClause(boolean ifExists, Expr whereExpr, boolean isTempPartition,
@@ -84,6 +100,7 @@ public class DropPartitionClause extends AlterTableClause {
         this.multiRangePartitionDesc = null;
         this.partitionNames = null;
         this.dropWhereExpr = whereExpr;
+        this.isDropAll = false;
     }
 
     public Expr getDropWhereExpr() {
@@ -120,6 +137,10 @@ public class DropPartitionClause extends AlterTableClause {
 
     public List<String> getPartitionNames() {
         return partitionNames;
+    }
+
+    public boolean isDropAll() {
+        return isDropAll;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -4915,6 +4915,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         boolean temp = context.TEMPORARY() != null;
         boolean force = context.FORCE() != null;
         boolean exists = context.EXISTS() != null;
+        boolean dropAll = context.ALL() != null;
         Identifier identifier = null;
         StarRocksParser.IdentifierContext identifierContext = context.identifier();
         if (identifierContext != null) {
@@ -4935,6 +4936,8 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         } else if (context.where != null) {
             Expr whereExpr = (Expr) visitIfPresent(context.where);
             return new DropPartitionClause(exists, whereExpr, temp, force, createPos(context));
+        } else if (dropAll) {
+            return new DropPartitionClause(temp, force, dropAll, createPos(context));
         } else {
             if (CollectionUtils.isNotEmpty(identifierList)) {
                 List<String> partitionNames = identifierList.stream().map(i -> i.getValue()).collect(toList());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1189,6 +1189,7 @@ dropPartitionClause
     : DROP TEMPORARY? (PARTITION (IF EXISTS)? identifier | PARTITIONS (IF EXISTS)? identifierList) FORCE?
     | DROP TEMPORARY? PARTITIONS (IF EXISTS)? multiRangePartition FORCE?
     | DROP TEMPORARY? PARTITIONS (IF EXISTS)? WHERE where=expression FORCE?
+    | DROP ALL TEMPORARY PARTITIONS FORCE?
     ;
 
 truncatePartitionClause

--- a/test/sql/test_optimize_table/R/test_optimize_table
+++ b/test/sql/test_optimize_table/R/test_optimize_table
@@ -7,16 +7,6 @@ alter table t distributed by random buckets 10;
 E: (5064, 'Getting analyzing error. Detail message: Random distribution table already supports automatic scaling and does not require optimization.')
 -- !result
 
-
-
-
-
-
-
-
-
-
-
 -- name: test_change_partial_partition_distribution
 create table t(k int, k1 date) PARTITION BY RANGE(`k1`)
 (
@@ -108,8 +98,6 @@ PROPERTIES (
 );
 -- !result
 
-
-
 -- name: test_alter_key_buckets
 CREATE TABLE demo2_alter_0 (    
     `user_name` VARCHAR(32) DEFAULT '',
@@ -129,10 +117,6 @@ function: wait_optimize_table_finish()
 -- result:
 None
 -- !result
-
-
-
-
 
 -- name: test_online_optimize_table_pk @sequential
 create table tpk(k int) primary key(k) distributed by hash(k) buckets 10;
@@ -666,20 +650,6 @@ select count(*) from t;
 63
 -- !result
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 -- name: test_optimize_table_with_special_characters @sequential
 create table `t#t`(k int) distributed by hash(k) buckets 10;
 -- result:
@@ -746,6 +716,7 @@ PROPERTIES (
 admin set frontend config ('enable_online_optimize_table'='true');
 -- result:
 -- !result
+
 -- name: test_online_optimize_table_expr_partition @sequential
 create table t(k int, k1 date) PARTITION BY date_trunc('day', k1)
 distributed by hash(k) buckets 10;
@@ -941,17 +912,6 @@ select count(*) from t;
 -- result:
 63
 -- !result
-
-
-
-
-
-
-
-
-
-
-
 
 -- name: test_cancel_optimize
 create table t(k int) distributed by hash(k) buckets 10;
@@ -1627,4 +1587,74 @@ select * from t;
 select count(*) from t;
 -- result:
 300
+-- !result
+
+-- name: test_optimize_duplicate_partitions
+CREATE TABLE `duplicate_table_with_null_partition` (
+    `k1` date,
+    `k2` datetime,
+    `k3` char(20),
+    `k4` varchar(20),
+    `k5` boolean,
+    `k6` tinyint,
+    `k7` smallint,
+    `k8` int,
+    `k9` bigint,
+    `k10` largeint,
+    `k11` float,
+    `k12` double,
+    `k13` decimal(27,9)
+)
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`)
+PARTITION BY RANGE(`k1`)
+(
+    PARTITION `p202006` VALUES LESS THAN ("2020-07-01"),
+    PARTITION `p202007` VALUES LESS THAN ("2020-08-01"),
+    PARTITION `p202008` VALUES LESS THAN ("2020-09-01")
+)
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`, `k4`, `k5`) BUCKETS 3;
+-- result:
+-- !result
+alter table duplicate_table_with_null_partition PARTITIONS(p202006,p202006,p202007) DISTRIBUTED BY HASH(`k1`, `k2`, `k3`, `k4`, `k5`) BUCKETS 4;
+-- result:
+-- !result
+function: wait_optimize_table_finish()
+-- result:
+None
+-- !result
+show temporary partitions from duplicate_table_with_null_partition;
+-- result:
+-- !result
+show partitions from duplicate_table_with_null_partition;
+-- result:
+[REGEX].*p202006.*k1, k2, k3, k4, k5	4.*
+.*p202007.*k1, k2, k3, k4, k5	4.*
+.*p202008.*k1, k2, k3, k4, k5	3.*
+-- !result
+
+-- name: test_drop_all_temporary_partitions
+create table t(k int, k1 date) PARTITION BY RANGE(`k1`)
+(
+    PARTITION `p202006` VALUES LESS THAN ("2020-07-01"),
+    PARTITION `p202007` VALUES LESS THAN ("2020-08-01"),
+    PARTITION `p202008` VALUES LESS THAN ("2020-09-01")
+) distributed by hash(k) buckets 10;
+-- result:
+-- !result
+alter table t add temporary partition tp202008 VALUES LESS THAN ("2020-09-01");
+-- result:
+-- !result
+alter table t add temporary partition tp202009 VALUES LESS THAN ("2020-10-01");
+-- result:
+-- !result
+show temporary partitions from t;
+-- result:
+[REGEX].*tp202008.*
+.*tp202009.*
+-- !result
+alter table t drop all temporary partitions;
+-- result:
+-- !result
+show temporary partitions from t;
+-- result:
 -- !result

--- a/test/sql/test_optimize_table/T/test_optimize_table
+++ b/test/sql/test_optimize_table/T/test_optimize_table
@@ -376,3 +376,45 @@ function: wait_optimize_table_finish()
 show create table t;
 select * from t;
 select count(*) from t;
+
+-- name: test_optimize_duplicate_partitions
+CREATE TABLE `duplicate_table_with_null_partition` (
+    `k1` date,
+    `k2` datetime,
+    `k3` char(20),
+    `k4` varchar(20),
+    `k5` boolean,
+    `k6` tinyint,
+    `k7` smallint,
+    `k8` int,
+    `k9` bigint,
+    `k10` largeint,
+    `k11` float,
+    `k12` double,
+    `k13` decimal(27,9)
+)
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`)
+PARTITION BY RANGE(`k1`)
+(
+    PARTITION `p202006` VALUES LESS THAN ("2020-07-01"),
+    PARTITION `p202007` VALUES LESS THAN ("2020-08-01"),
+    PARTITION `p202008` VALUES LESS THAN ("2020-09-01")
+)
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`, `k4`, `k5`) BUCKETS 3;
+alter table duplicate_table_with_null_partition PARTITIONS(p202006,p202006,p202007) DISTRIBUTED BY HASH(`k1`, `k2`, `k3`, `k4`, `k5`) BUCKETS 4;
+function: wait_optimize_table_finish()
+show temporary partitions from duplicate_table_with_null_partition;
+show partitions from duplicate_table_with_null_partition;
+
+-- name: test_drop_all_temporary_partitions
+create table t(k int, k1 date) PARTITION BY RANGE(`k1`)
+(
+    PARTITION `p202006` VALUES LESS THAN ("2020-07-01"),
+    PARTITION `p202007` VALUES LESS THAN ("2020-08-01"),
+    PARTITION `p202008` VALUES LESS THAN ("2020-09-01")
+) distributed by hash(k) buckets 10;
+alter table t add temporary partition tp202008 VALUES LESS THAN ("2020-09-01");
+alter table t add temporary partition tp202009 VALUES LESS THAN ("2020-10-01");
+show temporary partitions from t;
+alter table t drop all temporary partitions;
+show temporary partitions from t;


### PR DESCRIPTION
## Why I'm doing:
When running OPTIMIZE TABLE with duplicate partitions specified, the operation will fail and leave behind temporary partition remnants.

## What I'm doing:
Use SET for deduplication, and add a SQL interface in the ALTER operation to drop all temporary partitions

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0