### PR TITLE
[BugFix] Revert "[BugFix] incorrect column merging in SelectOperator::pull_chunk (#56586)

### DIFF
--- a/be/src/exec/pipeline/select_operator.cpp
+++ b/be/src/exec/pipeline/select_operator.cpp
@@ -85,13 +85,18 @@ bool SelectOperator::need_input() const {
 }
 
 Status SelectOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
-    _curr_chunk = chunk;
     if (!_common_exprs.empty()) {
+        _curr_chunk = std::make_shared<Chunk>();
+        for (const auto& [slot_id, _] : chunk->get_slot_id_to_index_map()) {
+            _curr_chunk->append_column(chunk->get_column_by_slot_id(slot_id), slot_id);
+        }
         SCOPED_TIMER(_conjuncts_timer);
         for (const auto& [slot_id, expr] : _common_exprs) {
             ASSIGN_OR_RETURN(auto col, expr->evaluate(_curr_chunk.get()));
             _curr_chunk->append_column(col, slot_id);
         }
+    } else {
+        _curr_chunk = chunk;
     }
     RETURN_IF_ERROR(eval_conjuncts_and_in_filters(_conjunct_ctxs, _curr_chunk.get()));
     {


### PR DESCRIPTION
This reverts commit 7e0f85f27af13cd963bc4e44af984fc3464dded3.

## Why I'm doing:

## What I'm doing:

Reverts #56586

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0