### PR TITLE
[BugFix] fix incorrect column merging in SelectOperator::pull_chunk

### DIFF
--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -101,6 +101,7 @@ public:
 
     const SchemaPtr& schema() const { return _schema; }
     SchemaPtr& schema() { return _schema; }
+    void reset_schema() { _schema.reset(); }
 
     const Columns& columns() const { return _columns; }
     Columns& columns() { return _columns; }

--- a/be/src/exec/pipeline/scan/chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/chunk_source.cpp
@@ -88,6 +88,8 @@ Status ChunkSource::buffer_next_batch_chunks_blocking(RuntimeState* state, size_
                 break;
             }
 
+            // schema won't be used by the computing layer, here we just reset it.
+            chunk->reset_schema();
             chunk->owner_info().set_owner_id(owner_id, false);
             _chunk_buffer.put(_scan_operator_seq, std::move(chunk), std::move(_chunk_token));
         }

--- a/be/src/exec/pipeline/select_operator.cpp
+++ b/be/src/exec/pipeline/select_operator.cpp
@@ -87,7 +87,6 @@ bool SelectOperator::need_input() const {
 Status SelectOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
     _curr_chunk = chunk;
     if (!_common_exprs.empty()) {
-        _curr_chunk->reset_schema();
         SCOPED_TIMER(_conjuncts_timer);
         for (const auto& [slot_id, expr] : _common_exprs) {
             ASSIGN_OR_RETURN(auto col, expr->evaluate(_curr_chunk.get()));

--- a/be/src/exec/pipeline/select_operator.cpp
+++ b/be/src/exec/pipeline/select_operator.cpp
@@ -85,18 +85,14 @@ bool SelectOperator::need_input() const {
 }
 
 Status SelectOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
+    _curr_chunk = chunk;
     if (!_common_exprs.empty()) {
-        _curr_chunk = std::make_shared<Chunk>();
-        for (const auto& [slot_id, _] : chunk->get_slot_id_to_index_map()) {
-            _curr_chunk->append_column(chunk->get_column_by_slot_id(slot_id), slot_id);
-        }
+        _curr_chunk->reset_schema();
         SCOPED_TIMER(_conjuncts_timer);
         for (const auto& [slot_id, expr] : _common_exprs) {
             ASSIGN_OR_RETURN(auto col, expr->evaluate(_curr_chunk.get()));
             _curr_chunk->append_column(col, slot_id);
         }
-    } else {
-        _curr_chunk = chunk;
     }
     RETURN_IF_ERROR(eval_conjuncts_and_in_filters(_conjunct_ctxs, _curr_chunk.get()));
     {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #56588

This is a further fix for #56588. I reverted the previous PR #56586 because it would cause BE to crash.

In this PR, I restored the changes in #56586 and fixed the crash.

The Chunk returned by the storage layer may contain _schema. SelectOperator will remove the slots of the common expr that are no longer needed by the downstream through the `Chunk::remove_column_by_slot_id` interface, and these slots are not in the Schema, causing BE to crash.


<img width="655" alt="image" src="https://github.com/user-attachments/assets/d531a483-f58f-4454-bae0-45c18d5e1cec" />


Considering that the computing layer does not need the schema in the chunk at all, I choose to reset it when the scan operator returns.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0