### PR TITLE
[BugFix] Fix Superset `LARGEINT` compatibility

### DIFF
--- a/contrib/starrocks-python-client/starrocks/reflection.py
+++ b/contrib/starrocks-python-client/starrocks/reflection.py
@@ -400,7 +400,10 @@ class StarRocksTableDefinitionParser(object):
             if issubclass(col_type, SET) and "" in type_args:
                 type_kw["retrieve_as_bitwise"] = True
 
-        type_instance = col_type(*type_args, **type_kw)
+        if col_type.__name__ == "LARGEINT":
+            type_instance = col_type()
+        else:
+            type_instance = col_type(*type_args, **type_kw)
 
         col_kw = {}
 


### PR DESCRIPTION
## Why I'm doing:
superset version: 3.0.4
starrocks plugin version: 1.0.6
Add a table and insert a piece of data in SQL in starrocks:
```SQL
CREATE TABLE duplicate_table_demo_datatype (
    AAA DATE not NULL COMMENT '',
    BBB SMALLINT not NULL COMMENT '',
    CCC INT(10) not NULL COMMENT '',
    DDD BIGINT(20)  NULL COMMENT '',
    EEE LARGEINT  NULL COMMENT '',
    FFF DECIMAL(20,10) NULL COMMENT '',
    GGG DOUBLE  NULL COMMENT '',
    HHH FLOAT  NULL COMMENT '',
    III BOOLEAN  NULL COMMENT '',
    KKK CHAR(20)   NULL COMMENT '',
    LLL STRING   NULL COMMENT '',
    MMM VARCHAR(20)   NULL COMMENT '',
    NNN BINARY  NULL COMMENT '',
    OOO TINYINT NULL COMMENT '',
    PPP DATETIME NULL COMMENT '',
    QQQ ARRAY<INT> NULL COMMENT '',
    RRR JSON NULL COMMENT '',
    SSS MAP<INT,INT> NULL COMMENT '',
    TTT STRUCT<a INT, b INT> NULL COMMENT ''
)
duplicate KEY(AAA, BBB, CCC)
PARTITION BY RANGE (`AAA`) (
    START ('1970-01-01') END ('2030-01-01') EVERY (INTERVAL 30 YEAR)
)
DISTRIBUTED BY HASH(`AAA`, `BBB`) BUCKETS 3
PROPERTIES (
  'replication_num' = '1',
  'storage_format' = 'v2',
  'enable_persistent_index' = 'true',
  'bloom_filter_columns' = 'DDD,EEE',
  'unique_constraints' = 'GGG'
);


insert into duplicate_table_demo_datatype values(
    '2024-01-01',
    1,
    10,
    100,
    1000,
    1.1,
    1.11,
    1.111,
    true,
    'a',
    'a1',
    'a11',
    to_binary('a111', 'utf8'),
    127,
    '2024-02-01 00:00:00',
    [1, 2, 3],
    json_object('a', 4, 'b', false),
    map{1:1, 2:2, 3:3},
    row(1, 1)
);
```
1. When I selected this TABLE in SEE TABLE SCHEMA, An error occurred while fetching table metadata popped up at the bottom right of superset
2. RESULTS displays the warning: No stored results found, you need to re-run your query
## What I'm doing:
`LARGEINT` is directly instantiated without parameters.

Fixes #57022 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0