### PR TITLE
[BugFix] fix cardinality estimation on boolean constant value using mcv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -374,6 +374,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CBO_PUSH_DOWN_AGGREGATE_ON_BROADCAST_JOIN = "cbo_push_down_aggregate_on_broadcast_join";
     public static final String CBO_PUSH_DOWN_AGGREGATE_ON_BROADCAST_JOIN_ROW_COUNT_LIMIT =
             "cbo_push_down_aggregate_on_broadcast_join_row_count_limit";
+    public static final String CBO_ENABLE_INTERSECT_ADD_DISTINCT = "cbo_enable_intersect_add_distinct";
 
     public static final String CBO_PUSH_DOWN_DISTINCT_BELOW_WINDOW = "cbo_push_down_distinct_below_window";
     public static final String CBO_PUSH_DOWN_AGGREGATE = "cbo_push_down_aggregate";
@@ -1583,6 +1584,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = CBO_PUSH_DOWN_AGGREGATE_ON_BROADCAST_JOIN_ROW_COUNT_LIMIT, flag = VariableMgr.INVISIBLE)
     private long cboPushDownAggregateOnBroadcastJoinRowCountLimit = 250000;
 
+    @VarAttr(name = CBO_ENABLE_INTERSECT_ADD_DISTINCT)
+    private boolean cboEnableIntersectAddDistinct = true;
+
     // auto, global, local
     @VarAttr(name = CBO_PUSH_DOWN_AGGREGATE, flag = VariableMgr.INVISIBLE)
     private String cboPushDownAggregate = "global";
@@ -1799,6 +1803,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableGroupExecution(boolean enableGroupExecution) {
         this.enableGroupExecution = enableGroupExecution;
+    }
+
+    public boolean isCboEnableIntersectAddDistinct() {
+        return cboEnableIntersectAddDistinct;
+    }
+
+    public void setCboEnableIntersectAddDistinct(boolean cboEnableIntersectAddDistinct) {
+        this.cboEnableIntersectAddDistinct = cboEnableIntersectAddDistinct;
     }
 
     // runtime dop requires join probe to wait for all builds to complete before executing.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/IntersectAddDistinctRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/IntersectAddDistinctRule.java
@@ -45,6 +45,10 @@ public class IntersectAddDistinctRule extends TransformationRule {
 
     @Override
     public List<OptExpression> transform(OptExpression intersectOpt, OptimizerContext context) {
+        if (!context.getSessionVariable().isCboEnableIntersectAddDistinct()) {
+            return Lists.newArrayList(intersectOpt);
+        }
+
         List<OptExpression> newInputs = Lists.newArrayList();
         for (int i = 0; i < intersectOpt.getInputs().size(); i++) {
             newInputs.add(addDistinct(intersectOpt, i, context));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ReorderIntersectRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ReorderIntersectRule.java
@@ -41,6 +41,7 @@ public class ReorderIntersectRule extends TransformationRule {
     public List<OptExpression> transform(OptExpression intersectOpt, OptimizerContext context) {
         LogicalIntersectOperator intersectOperator = (LogicalIntersectOperator) intersectOpt.getOp();
         calculateStatistics(intersectOpt, context);
+
         Optional<OptExpression> optO = intersectOpt.getInputs().stream().min(
                 Comparator.comparingDouble(c -> c.getStatistics().getOutputRowCount()));
         Preconditions.checkState(optO.isPresent());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
@@ -243,4 +243,27 @@ public class HistogramStatisticsTest {
                 columnStatistic, eq35, Optional.of(ConstantOperator.createBigint(35)), statistics);
         Assert.assertEquals(961.53846, estimated.getOutputRowCount(), 0.001);
     }
+
+    @Test
+    public void testHitMCV() {
+        Map<String, Long> mcv = Maps.newHashMap();
+        mcv.put("0", 500L);
+        Histogram histogram = new Histogram(new ArrayList<>(), mcv);
+        ColumnRefOperator columnRefOperator = new ColumnRefOperator(0, Type.BOOLEAN, "b1", true);
+        ColumnStatistic columnStatistic = new ColumnStatistic(0, 1, 0, 4, 2, histogram, ColumnStatistic.StatisticType.ESTIMATE);
+        BinaryPredicateOperator eq10 = new BinaryPredicateOperator(
+                BinaryType.EQ,
+                columnRefOperator,
+                ConstantOperator.createBoolean(false));
+        Statistics.Builder builder = Statistics.builder();
+        builder.setOutputRowCount(100000);
+        builder.addColumnStatistic(columnRefOperator, columnStatistic);
+        Statistics statistics = builder.build();
+
+        // hit upper bound
+        Statistics estimated = BinaryPredicateStatisticCalculator.estimateColumnToConstantComparison(
+                Optional.of(columnRefOperator),
+                columnStatistic, eq10, Optional.of(ConstantOperator.createBoolean(false)), statistics);
+        Assert.assertEquals(500L, estimated.getOutputRowCount(), 0.001);
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
1. convert boolean constant value to '0' or '1' when estimating cardinality using mcv. 
2. add a session variable to control `IntersectAddDistinctRule`

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0