### PR TITLE
[Enhancement] defensive strategy on on large mem allocation

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -83,6 +83,10 @@ CONF_String(mem_limit, "90%");
 // Enable the jemalloc tracker, which is responsible for reserving memory
 CONF_Bool(enable_jemalloc_memory_tracker, "true");
 
+// Whether abort the process if a large memory allocation is detected which the requested
+// size is larger than the available physical memory without wrapping with TRY_CATCH_BAD_ALLOC
+CONF_mBool(abort_on_large_memory_allocation, "false");
+
 // The port heartbeat service used.
 CONF_Int32(heartbeat_service_port, "9050");
 // The count of heart beat service.

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -50,6 +50,7 @@
 #include "runtime/time_types.h"
 #include "runtime/user_function_cache.h"
 #include "service/backend_options.h"
+#include "service/mem_hook.h"
 #include "storage/options.h"
 #include "storage/storage_engine.h"
 #include "util/cpu_info.h"
@@ -325,6 +326,12 @@ void Daemon::init(bool as_cn, const std::vector<StorePath>& paths) {
 
     init_signals();
     init_minidump();
+
+    // Don't bother set the limit if the process is running with very limited memory capacity
+    if (MemInfo::physical_mem() > 1024 * 1024 * 1024) {
+        // set mem hook to reject the memory allocation if large than available physical memory detected.
+        set_large_memory_alloc_failure_threshold(MemInfo::physical_mem());
+    }
 }
 
 void Daemon::stop() {

--- a/be/src/service/mem_hook.h
+++ b/be/src/service/mem_hook.h
@@ -1,0 +1,23 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+namespace starrocks {
+
+int64_t set_large_memory_alloc_failure_threshold(int64_t);
+
+} // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -498,6 +498,7 @@ set(EXEC_FILES
         ./gutil/cpu_test.cc
         ./gutil/sysinfo-test.cc
         ./service/lake_service_test.cpp
+        ./service/mem_hook_test.cpp
         ./service/service_be/internal_service_test.cpp
         ./service/staros_worker_test.cpp
         ./storage/metadata_util_test.cpp

--- a/be/test/service/mem_hook_test.cpp
+++ b/be/test/service/mem_hook_test.cpp
@@ -1,0 +1,78 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// FIXME: The case doesn't work on ASAN case since the malloc will be hooked
+// when doing the ASAN init. Can't make it work so just disable it for now.
+#ifndef ADDRESS_SANITIZER
+
+#include "service/mem_hook.h"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace starrocks {
+
+static void try_malloc_memory(size_t size) {
+    std::vector<int8_t> arr;
+    arr.reserve(size);
+    EXPECT_EQ(size, arr.capacity());
+}
+
+static void try_calloc_memory(size_t n, size_t size) {
+    void* ptr = calloc(n, size);
+    if (ptr == nullptr) {
+        throw std::bad_alloc();
+    }
+    free(ptr);
+}
+
+TEST(MemhookTest, test_malloc_mem_hook_block_without_try_catch) {
+    set_large_memory_alloc_failure_threshold(0);
+    int64_t blocking_size = 1024 * 1024;
+
+    set_large_memory_alloc_failure_threshold(blocking_size);
+    // successful because blocking_size <= g_large_memory_alloc_failure_threshold
+    EXPECT_NO_THROW(try_malloc_memory(blocking_size));
+
+    set_large_memory_alloc_failure_threshold(blocking_size - 1);
+    // fail with std::bad_alloc for the same size
+    EXPECT_THROW(try_malloc_memory(blocking_size), std::bad_alloc);
+
+    // reset to no limit
+    set_large_memory_alloc_failure_threshold(0);
+}
+
+TEST(MemhookTest, test_malloc_mem_hook_block_with_try_catch) {
+    // IS_BAD_ALLOC_CATCHED is always `false` when builds with -DBE_TEST.
+    // There is no easy way to simulate the mem_tracker limit check here.
+    // Leave the test body empty as intended for now.
+}
+
+TEST(MemhookTest, test_calloc_mem_hook_block_without_try_catch) {
+    int64_t blocking_size = 1024 * 1024;
+
+    set_large_memory_alloc_failure_threshold(blocking_size);
+    // successful because blocking_size <= g_large_memory_alloc_failure_threshold
+    EXPECT_NO_THROW(try_calloc_memory(blocking_size / sizeof(int), sizeof(int)));
+
+    set_large_memory_alloc_failure_threshold(blocking_size - 1);
+    // fail with std::bad_alloc for the same size
+    EXPECT_THROW(try_calloc_memory(blocking_size / sizeof(int), sizeof(int)), std::bad_alloc);
+
+    // reset to no limit
+    set_large_memory_alloc_failure_threshold(0);
+}
+} // namespace starrocks
+#endif


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

* check and reject large mem allocation if the upper level running without TRY_CATCH_BAD_ALLOC
* configurable parameter to return nullptr or crash directly
* don't bother turn on this check if available mem is less than 1GB

Fixes #56906

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0