### PR TITLE
[BugFix] fix parse ES properties

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/EsUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/EsUtilTest.java
@@ -17,6 +17,8 @@
 
 package com.starrocks.connector.elasticsearch;
 
+import com.starrocks.common.AnalysisException;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
 
@@ -24,6 +26,7 @@ import static com.starrocks.connector.elasticsearch.EsUtil.getFromJSONArray;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class EsUtilTest {
 
@@ -95,4 +98,131 @@ public class EsUtilTest {
         EsRestClient.EsIndex[] esIndices = getFromJSONArray(jsonArray, EsRestClient.EsIndex[].class);
         System.out.println(JSONObject.valueToString(esIndices));
     }
+
+    @Test
+    public void testParseProperties_8x() throws AnalysisException {
+        String mappings = "{\n" +
+                "  \"idx\": {\n" +
+                "    \"mappings\": {\n" +
+                "      \"dynamic\": \"strict\",\n" +
+                "      \"properties\": {\n" +
+                "        \"id\": { \"type\": \"long\" },\n" +
+                "        \"name\": { \"type\": \"keyword\" },\n" +
+                "        \"description\": { \"type\": \"text\" },\n" +
+                "        \"price\": { \"type\": \"double\" },\n" +
+                "        \"created\": { \"type\": \"date\" },\n" +
+                "        \"tags\": { \"type\": \"keyword\" },\n" +
+                "        \"location\": { \"type\": \"geo_point\" }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+
+        JSONObject props = EsUtil.parseProperties("idx", mappings);
+
+        assertNotNull(props);
+
+        assertEquals("long", props.getJSONObject("id").getString("type"));
+        assertEquals("keyword", props.getJSONObject("name").getString("type"));
+        assertEquals("text", props.getJSONObject("description").getString("type"));
+        assertEquals("double", props.getJSONObject("price").getString("type"));
+        assertEquals("date", props.getJSONObject("created").getString("type"));
+        assertEquals("keyword", props.getJSONObject("tags").getString("type"));
+        assertEquals("geo_point", props.getJSONObject("location").getString("type"));
+    }
+
+    @Test
+    public void testParseProperties_7x() throws AnalysisException {
+        String mappings = "{\n" +
+                "  \"idx\": {\n" +
+                "    \"mappings\": {\n" +
+                "      \"properties\": {\n" +
+                "        \"id\": { \"type\": \"long\" },\n" +
+                "        \"name\": { \"type\": \"keyword\" },\n" +
+                "        \"description\": { \"type\": \"text\" },\n" +
+                "        \"nested_field\": {\n" +
+                "          \"type\": \"nested\",\n" +
+                "          \"properties\": {\n" +
+                "            \"inner_field\": { \"type\": \"keyword\" }\n" +
+                "          }\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+
+        JSONObject props = EsUtil.parseProperties("idx", mappings);
+
+        assertEquals("long", props.getJSONObject("id").getString("type"));
+        assertEquals("keyword", props.getJSONObject("name").getString("type"));
+        assertEquals("text", props.getJSONObject("description").getString("type"));
+
+        JSONObject nested = props.getJSONObject("nested_field");
+        assertEquals("nested", nested.getString("type"));
+        assertEquals("keyword", nested.getJSONObject("properties").getJSONObject("inner_field").getString("type"));
+    }
+
+    @Test
+    public void testParseProperties_6x() throws AnalysisException {
+        String mappings = "{\n" +
+                "  \"idx\": {\n" +
+                "    \"mappings\": {\n" +
+                "      \"_doc\": {\n" +
+                "        \"properties\": {\n" +
+                "          \"id\": { \"type\": \"long\" },\n" +
+                "          \"name\": { \"type\": \"keyword\" },\n" +
+                "          \"description\": { \"type\": \"text\" },\n" +
+                "          \"object_field\": {\n" +
+                "            \"type\": \"object\",\n" +
+                "            \"properties\": {\n" +
+                "              \"sub_field\": { \"type\": \"integer\" }\n" +
+                "            }\n" +
+                "          }\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+
+        JSONObject props = EsUtil.parseProperties("idx", mappings);
+
+        assertEquals("long", props.getJSONObject("id").getString("type"));
+        assertEquals("keyword", props.getJSONObject("name").getString("type"));
+        assertEquals("text", props.getJSONObject("description").getString("type"));
+
+        JSONObject objField = props.getJSONObject("object_field");
+        assertEquals("object", objField.getString("type"));
+        assertEquals("integer", objField.getJSONObject("properties").getJSONObject("sub_field").getString("type"));
+    }
+
+    @Test(expected = JSONException.class)
+    public void testParseProperties_InvalidMapping() throws AnalysisException {
+        String mappings = "{\n" +
+                "  \"idx\": {\n" +
+                "    \"invalid_field\": {\n" + // Invalid mapping structure
+                "      \"properties\": {\n" +
+                "        \"id\": { \"type\": \"long\" }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+
+        EsUtil.parseProperties("idx", mappings);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testParseProperties_NoProperties() throws AnalysisException {
+        String mappings = "{\n" +
+                "  \"idx\": {\n" +
+                "    \"mappings\": {\n" +
+                "      \"_doc\": {\n" +
+                "        \"type\": \"long\"\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+
+        EsUtil.parseProperties("idx", mappings);
+    }
+    
 }


### PR DESCRIPTION
## Why I'm doing:

```
"mappings": {
  "dynamic": "false",
  "properties" : {...}
}
```

This type of schema is not handled effectively, as the `properties` field might not appear first.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0