### PR TITLE
[Enhancement] introduce more NDV estimators

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2172,7 +2172,7 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static double statistics_min_sample_row_ratio = 0.01;
 
-    @ConfField(mutable = true, comment = "The NDV estimator: DUJ1/LINEAR/POLYNOMIAL")
+    @ConfField(mutable = true, comment = "The NDV estimator: DUJ1/GEE/LINEAR/POLYNOMIAL")
     public static String statistics_sample_ndv_estimator =
             NDVEstimator.NDVEstimatorDesc.defaultConfig().name();
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -38,6 +38,7 @@ import com.starrocks.StarRocksFE;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.Replica;
 import com.starrocks.qe.scheduler.slot.QueryQueueOptions;
+import com.starrocks.statistic.sample.NDVEstimator;
 
 import static java.lang.Math.max;
 import static java.lang.Runtime.getRuntime;
@@ -2170,6 +2171,10 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true)
     public static double statistics_min_sample_row_ratio = 0.01;
+
+    @ConfField(mutable = true, comment = "The NDV estimator: DUJ1/LINEAR/POLYNOMIAL")
+    public static String statistics_sample_ndv_estimator =
+            NDVEstimator.NDVEstimatorDesc.defaultConfig().name();
 
     /**
      * The partition size of sample collect, default 1k partitions

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/sample/NDVEstimator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/sample/NDVEstimator.java
@@ -137,7 +137,7 @@ public abstract class NDVEstimator {
             String onceCount = "SUM(IF(t1.count = 1, 1, 0))";
             String sampleNdv = "COUNT(1)";
             double inverseRatio = 1 / sampleRatio;
-            double fold = Math.sqrt(inverseRatio - 1);
+            double fold = Math.sqrt(inverseRatio) - 1;
             String fn = MessageFormat.format("{0} + {1} * {2}", sampleNdv, fold, onceCount);
             return "IFNULL(" + fn + ", COUNT(1))";
         }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/sample/NDVEstimator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/sample/NDVEstimator.java
@@ -1,0 +1,138 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.statistic.sample;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.common.Config;
+import org.apache.commons.lang3.EnumUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.text.MessageFormat;
+
+public abstract class NDVEstimator {
+
+    private static final Logger LOG = LogManager.getLogger(NDVEstimator.class);
+
+    static NDVEstimator build() {
+        NDVEstimatorDesc desc = NDVEstimatorDesc.get();
+        switch (desc) {
+            case DUJ1 -> {
+                return new DUJ1Estimator();
+            }
+            case LINEAR -> {
+                return new LinearEstimator();
+            }
+            case POLYNOMIAL -> {
+                return new PolynomialEstimator();
+            }
+        }
+        throw new IllegalArgumentException("unknown estimator: " + desc);
+    }
+
+    public enum NDVEstimatorDesc {
+        DUJ1,
+        // GEE,
+        LINEAR,
+        POLYNOMIAL;
+
+        public static NDVEstimatorDesc defaultConfig() {
+            return DUJ1;
+        }
+
+        public static NDVEstimatorDesc get() {
+            NDVEstimatorDesc desc =
+                    EnumUtils.getEnumIgnoreCase(NDVEstimatorDesc.class, Config.statistics_sample_ndv_estimator);
+            if (desc != null) {
+                return desc;
+            }
+            LOG.warn("unknown NDV estimator {}, fallback to default", Config.statistics_sample_ndv_estimator);
+            return defaultConfig();
+        }
+    }
+
+    /**
+     * Generate the SQL query which implement the estimator algorithm
+     *
+     * @return sql
+     */
+    abstract String generateQuery(double sampleRatio);
+
+    /**
+     * From PostgreSQL: n*d / (n - f1 + f1*n/N)
+     * (https://github.com/postgres/postgres/blob/master/src/backend/commands/analyze.c)
+     * and paper: ESTIMATING THE NUMBER OF CLASSES IN A FINITE POPULATION
+     * (http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.93.8637&rep=rep1&type=pdf)
+     * sample_row * count_distinct / ( sample_row - once_count + once_count * sample_row / total_row)
+     */
+    static class DUJ1Estimator extends NDVEstimator {
+
+        @Override
+        String generateQuery(double sampleRatio) {
+            Preconditions.checkArgument(sampleRatio <= 1.0, "invalid sample ratio: " + sampleRatio);
+            String sampleRows = "SUM(t1.count)";
+            String onceCount = "SUM(IF(t1.count = 1, 1, 0))";
+            String countDistinct = "COUNT(1)";
+            String fn = MessageFormat.format("{0} * {1} / ({0} - {2} + {2} * {3})", sampleRows,
+                    countDistinct, onceCount, String.valueOf(sampleRatio));
+            return "IFNULL(" + fn + ", COUNT(1))";
+        }
+    }
+
+    /**
+     * sampleDistinct / sampleRatio
+     */
+    static class LinearEstimator extends NDVEstimator {
+
+        @Override
+        String generateQuery(double sampleRatio) {
+            return MessageFormat.format("COUNT(1) / {0}", sampleRatio);
+        }
+    }
+
+    /**
+     * sampleDistinct / (1 - (1-sampleRatio)^3)
+     */
+    static class PolynomialEstimator extends NDVEstimator {
+
+        @Override
+        String generateQuery(double sampleRatio) {
+            final int K = 3;
+            double ratio = 1 - Math.pow(1 - sampleRatio, K);
+            return "COUNT(1) / " + ratio;
+        }
+    }
+
+    // NOTE: GEE requires total number of rows in advance, we don't have that information now
+    // GEE (Guaranteed-Error Estimator) https://dl.acm.org/doi/pdf/10.1145/335168.335230
+    // D_GEE = d + (sqrt(n / r) - 1) * f1
+    // D_GEE is the estimated number of distinct values.
+    // n is the total number of rows in the table.
+    // r is the size of the random sample.
+    // d is the number of distinct values observed in the sample.
+    // f1 is the number of values that appear exactly once in the sample.
+    // static class GEEEstimator extends NDVEstimator {
+    //     @Override
+    //     String generate(double sampleRatio) {
+    //         String sampleRows = "SUM(t1.count)";
+    //         String onceCount = "SUM(IF(t1.count = 1, 1, 0))";
+    //         String sampleNdv = "COUNT(1)";
+    //         String fn = MessageFormat.format("{0} + (sqrt({1} / {2}) - 1) * {3}",
+    //                 sampleNdv, String.valueOf(info.getTotalRowCount()), sampleRows, onceCount);
+    //         return "IFNULL(" + fn + ", COUNT(1))";
+    //     }
+    // }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/sample/PrimitiveTypeColumnStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/sample/PrimitiveTypeColumnStats.java
@@ -17,10 +17,7 @@ package com.starrocks.statistic.sample;
 import com.google.common.base.Preconditions;
 import com.starrocks.catalog.Type;
 
-import java.text.MessageFormat;
-
 public class PrimitiveTypeColumnStats extends ColumnStats {
-
 
     public PrimitiveTypeColumnStats(String columnName, Type columnType) {
         super(columnName, columnType);
@@ -76,19 +73,10 @@ public class PrimitiveTypeColumnStats extends ColumnStats {
         return fn;
     }
 
-    // From PostgreSQL: n*d / (n - f1 + f1*n/N)
-    // (https://github.com/postgres/postgres/blob/master/src/backend/commands/analyze.c)
-    // and paper: ESTIMATING THE NUMBER OF CLASSES IN A FINITE POPULATION
-    // (http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.93.8637&rep=rep1&type=pdf)
-    // sample_row * count_distinct / ( sample_row - once_count + once_count * sample_row / total_row)
     @Override
     public String getDistinctCount(double rowSampleRatio) {
         Preconditions.checkArgument(rowSampleRatio <= 1.0, "invalid sample ratio: " + rowSampleRatio);
-        String sampleRows = "SUM(t1.count)";
-        String onceCount = "SUM(IF(t1.count = 1, 1, 0))";
-        String countDistinct = "COUNT(1)";
-        String fn = MessageFormat.format("{0} * {1} / ({0} - {2} + {2} * {3})", sampleRows,
-                countDistinct, onceCount, String.valueOf(rowSampleRatio));
-        return "IFNULL(" + fn + ", COUNT(1))";
+        return NDVEstimator.build().generateQuery(rowSampleRatio);
     }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/sample/PrimitiveTypeColumnStatsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/sample/PrimitiveTypeColumnStatsTest.java
@@ -1,0 +1,45 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.statistic.sample;
+
+import com.starrocks.catalog.Type;
+import com.starrocks.common.Config;
+import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class PrimitiveTypeColumnStatsTest extends PlanTestBase {
+
+    @ParameterizedTest
+    @CsvSource(delimiterString = "|", value = {
+            "DUJ1|IFNULL(SUM(t1.count) * COUNT(1) / (SUM(t1.count) - SUM(IF(t1.count = 1, 1, 0)) + SUM(IF(t1.count = " +
+                    "1, " +
+                    "1, 0)) * 0.01), COUNT(1))",
+            "LINEAR|COUNT(1) / 0.01",
+            "POLYNOMIAL|COUNT(1) / 0.029700999999999977",
+            "INVALID|IFNULL(SUM(t1.count) * COUNT(1) / (SUM(t1.count) - SUM(IF(t1.count = 1, 1, 0)) + SUM(IF(t1.count" +
+                    " = " +
+                    "1, 1, 0)) * 0.01), COUNT(1))"
+    })
+    public void getDistinctCount(String estimator, String expectedQuery) {
+        PrimitiveTypeColumnStats c1 = new PrimitiveTypeColumnStats("c1", Type.CHAR);
+        final double sampleRatio = 0.01;
+
+        Config.statistics_sample_ndv_estimator = estimator;
+        String query = c1.getDistinctCount(sampleRatio);
+        Assertions.assertEquals(expectedQuery, query);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/sample/PrimitiveTypeColumnStatsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/sample/PrimitiveTypeColumnStatsTest.java
@@ -26,13 +26,12 @@ class PrimitiveTypeColumnStatsTest extends PlanTestBase {
     @ParameterizedTest
     @CsvSource(delimiterString = "|", value = {
             "DUJ1|IFNULL(SUM(t1.count) * COUNT(1) / (SUM(t1.count) - SUM(IF(t1.count = 1, 1, 0)) + SUM(IF(t1.count = " +
-                    "1, " +
-                    "1, 0)) * 0.01), COUNT(1))",
+                    "1, 1, 0)) * 0.01), COUNT(1))",
             "LINEAR|COUNT(1) / 0.01",
             "POLYNOMIAL|COUNT(1) / 0.029700999999999977",
             "INVALID|IFNULL(SUM(t1.count) * COUNT(1) / (SUM(t1.count) - SUM(IF(t1.count = 1, 1, 0)) + SUM(IF(t1.count" +
-                    " = " +
-                    "1, 1, 0)) * 0.01), COUNT(1))"
+                    " = 1, 1, 0)) * 0.01), COUNT(1))",
+            "GEE|IFNULL(COUNT(1) + 9.95 * SUM(IF(t1.count = 1, 1, 0)), COUNT(1))"
     })
     public void getDistinctCount(String estimator, String expectedQuery) {
         PrimitiveTypeColumnStats c1 = new PrimitiveTypeColumnStats("c1", Type.CHAR);

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/sample/PrimitiveTypeColumnStatsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/sample/PrimitiveTypeColumnStatsTest.java
@@ -31,7 +31,7 @@ class PrimitiveTypeColumnStatsTest extends PlanTestBase {
             "POLYNOMIAL|COUNT(1) / 0.029700999999999977",
             "INVALID|IFNULL(SUM(t1.count) * COUNT(1) / (SUM(t1.count) - SUM(IF(t1.count = 1, 1, 0)) + SUM(IF(t1.count" +
                     " = 1, 1, 0)) * 0.01), COUNT(1))",
-            "GEE|IFNULL(COUNT(1) + 9.95 * SUM(IF(t1.count = 1, 1, 0)), COUNT(1))"
+            "GEE|IFNULL(COUNT(1) + 9 * SUM(IF(t1.count = 1, 1, 0)), COUNT(1))"
     })
     public void getDistinctCount(String estimator, String expectedQuery) {
         PrimitiveTypeColumnStats c1 = new PrimitiveTypeColumnStats("c1", Type.CHAR);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:


Introduce more NDV estimators to handle vary cases:
- `DUJ1`: current implementation, which is the default setting
- `GEE`: ` d + (sqrt(n / r) - 1) * f1`
- `LINEAR`: `sampleDistinct/sampleRatio`
- `POLYNOMIAL`: `sampleDistinct/(1-(1-sampleRatio)^3)`

Introduce a switch to control the behavior: `statistics_sample_ndv_estimator`.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0