### PR TITLE
[Enhancement] Improve create table failed message when BE has no available disk space

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -2298,8 +2298,8 @@ public class CreateTableTest {
             Deencapsulation.invoke(metastore, "chosenBackendIdBySeq", 3, HashMultimap.create());
             Assert.fail();
         } catch (Exception e) {
-            Assert.assertTrue(e.getMessage().contains(
-                    "Current available backends(not decommissioned and have enough disk space) are [10000,10001]"));
+            Assert.assertTrue(e.getMessage().contains("Current available backends: [10000,10001]"));
+            Assert.assertTrue(e.getMessage().contains("backends without enough disk space: [10002]"));
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -34,6 +34,9 @@
 
 package com.starrocks.catalog;
 
+import com.google.api.client.util.Lists;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableMap;
 import com.starrocks.alter.AlterJobException;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.catalog.constraint.UniqueConstraint;
@@ -42,6 +45,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.ConfigBase;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker;
+import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.DynamicPartitionUtil;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.persist.CreateTableInfo;
@@ -2262,6 +2266,40 @@ public class CreateTableTest {
         } catch (Exception e) {
             Assert.assertTrue(e.getMessage().contains("Partition column[dt] could not be null but contains null " +
                     "value in partition[p1]."));
+        }
+    }
+
+    @Test
+    public void testChosenBackendIdBySeqWhenDiskOffline() {
+        List<Backend> backends = Lists.newArrayList();
+        Backend be0 = new Backend(10000, "127.0.0.1", 9050);
+        DiskInfo disk = new DiskInfo("/path");
+        disk.setState(DiskInfo.DiskState.ONLINE);
+        be0.setDisks(ImmutableMap.of("/path", disk));
+        backends.add(be0);
+        Backend be1 = new Backend(10001, "127.0.0.2", 9050);
+        be1.setDisks(ImmutableMap.of("/path", disk));
+        backends.add(be1);
+        Backend be2 = new Backend(10002, "127.0.0.3", 9050);
+        DiskInfo disk2 = new DiskInfo("/path");
+        disk2.setState(DiskInfo.DiskState.OFFLINE);
+        be2.setDisks(ImmutableMap.of("/path", disk2));
+        backends.add(be2);
+
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public List<Backend> getAvailableBackends() {
+                return backends;
+            }
+        };
+
+        try {
+            LocalMetastore metastore = new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
+            Deencapsulation.invoke(metastore, "chosenBackendIdBySeq", 3, HashMultimap.create());
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains(
+                    "Current available backends(not decommissioned and have enough disk space) are [10000,10001]"));
         }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

improve create table failed message.
get the real available backends, except decommissioned and not have enough disk space.

`ERROR 1064 (HY000): Table replication num should be less than or equal to the number of available backends. You can change this default by setting the replication_num table properties. Current available backends: [10001], decommissioned backends: [10002], backends without enough disk space: [10003], table=t, replication_num=2, default_replication_num=1`

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0