### PR TITLE
[BugFix] Support list mv refresh with null partition value

### DIFF
--- a/test/sql/test_transparent_mv/R/test_mv_with_multi_partition_columns_iceberg1_nulls
+++ b/test/sql/test_transparent_mv/R/test_mv_with_multi_partition_columns_iceberg1_nulls
@@ -1,0 +1,169 @@
+-- name: test_mv_with_multi_partition_columns_iceberg1_nulls
+set new_planner_optimize_timeout=10000;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+CREATE TABLE t1 (
+      id BIGINT,
+      province VARCHAR(64),
+      age SMALLINT,
+      dt datetime
+) DUPLICATE KEY(id)
+PARTITION BY province, date_trunc('day', dt)
+DISTRIBUTED BY RANDOM;
+-- result:
+-- !result
+INSERT INTO t1 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02'), (4, NULL, NULL, NULL),
+                      (1, 'beijing1', 20, '2024-01-01'), (2, 'guangdong1', 20, '2024-01-01'), (3, 'guangdong1', 20, '2024-01-02'), (4, 'beijing', NULL, NULL),
+                      (1, 'beijing2', 20, '2024-01-01'), (2, 'guangdong2', 20, '2024-01-01'), (3, 'guangdong2', 20, '2024-01-02'), (4, 'nanjing', NULL, NULL);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1
+PARTITION BY (province, date_trunc('day', dt))
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+	"replication_num" = "1"
+)
+AS SELECT * FROM t1;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 with SYNC MODE;
+function: print_hit_materialized_views("SELECT count(*) FROM t1;")
+-- result:
+test_mv1
+-- !result
+function: print_hit_materialized_views("SELECT * FROM t1 order by id, province, dt limit 3;")
+-- result:
+test_mv1
+-- !result
+function: print_hit_materialized_views("SELECT * FROM t1 where province = 'beijing' order by id, province, dt limit 3;")
+-- result:
+test_mv1
+-- !result
+function: print_hit_materialized_views("SELECT * FROM t1 where province = 'nanjing' order by id, province, dt limit 3;")
+-- result:
+test_mv1
+-- !result
+SELECT count(1) FROM t1;
+-- result:
+12
+-- !result
+SELECT * FROM t1 order by id, province, dt limit 3;
+-- result:
+1	beijing	20	2024-01-01 00:00:00
+1	beijing1	20	2024-01-01 00:00:00
+1	beijing2	20	2024-01-01 00:00:00
+-- !result
+SELECT * FROM t1 where province = 'beijing' order by id, province, dt limit 3;
+-- result:
+1	beijing	20	2024-01-01 00:00:00
+4	beijing	None	None
+-- !result
+SELECT * FROM t1 where province = 'nanjing' order by id, province, dt limit 3;
+-- result:
+4	nanjing	None	None
+-- !result
+select count(*) from test_mv1;
+-- result:
+12
+-- !result
+select * from test_mv1 order by id, province, dt limit 1;
+-- result:
+1	beijing	20	2024-01-01 00:00:00
+-- !result
+INSERT INTO t1 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02'), (4, NULL, NULL, NULL);
+-- result:
+-- !result
+function: print_hit_materialized_views("SELECT count(*) FROM t1;")
+-- result:
+test_mv1
+-- !result
+function: print_hit_materialized_views("SELECT * FROM t1 order by id, province, dt limit 3;")
+-- result:
+test_mv1
+-- !result
+function: print_hit_materialized_views("SELECT * FROM t1 where province = 'beijing' order by id, province, dt limit 3;")
+-- result:
+test_mv1
+-- !result
+function: print_hit_materialized_views("SELECT * FROM t1 where province = 'nanjing' order by id, province, dt limit 3;")
+-- result:
+test_mv1
+-- !result
+SELECT count(1) FROM t1;
+-- result:
+16
+-- !result
+SELECT * FROM t1 order by id, province, dt limit 3;
+-- result:
+1	beijing	20	2024-01-01 00:00:00
+1	beijing	20	2024-01-01 00:00:00
+1	beijing1	20	2024-01-01 00:00:00
+-- !result
+SELECT * FROM t1 where province = 'beijing' order by id, province, dt limit 3;
+-- result:
+1	beijing	20	2024-01-01 00:00:00
+1	beijing	20	2024-01-01 00:00:00
+4	beijing	None	None
+-- !result
+SELECT * FROM t1 where province = 'nanjing' order by id, province, dt limit 3;
+-- result:
+4	nanjing	None	None
+-- !result
+select count(*) from test_mv1;
+-- result:
+12
+-- !result
+select * from test_mv1 order by id, province, dt limit 1;
+-- result:
+1	beijing	20	2024-01-01 00:00:00
+-- !result
+CREATE MATERIALIZED VIEW test_datetime_partitioned_table_with_null_mv
+PARTITION BY (l_returnflag, l_linestatus, date_trunc('day', l_shipdate))
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+	"replication_num" = "1"
+)
+AS
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.test_datetime_partitioned_table_with_null;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_datetime_partitioned_table_with_null_mv with SYNC MODE;
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.test_datetime_partitioned_table_with_null;")
+-- result:
+test_datetime_partitioned_table_with_null_mv
+-- !result
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.test_datetime_partitioned_table_with_null order by l_orderkey, l_returnflag, l_linestatus, l_shipdate limit 3;
+-- result:
+370113	38890	43691	8	51.68	964.44	0.09	0.20	2000-01-18 16:00:00	2000-01-23 16:00:00	DELIVER IN PERSON	TRUCK	Generated comment 9	A	F	2000-01-09 16:00:00
+371745	41519	23805	1	11.13	856.24	0.10	0.17	2000-01-09 16:00:00	2000-01-12 16:00:00	COLLECT FROM STORE	TRUCK	Generated comment 1	C	O	2000-01-01 16:00:00
+408650	53924	11526	5	54.33	668.13	0.05	0.03	2000-01-13 16:00:00	2000-01-14 16:00:00	DELIVER IN PERSON	TRUCK	Generated comment 6	A	F	2000-01-06 16:00:00
+-- !result
+select count(*) from test_datetime_partitioned_table_with_null_mv;
+-- result:
+14
+-- !result
+select * from test_datetime_partitioned_table_with_null_mv order by l_orderkey, l_returnflag, l_linestatus, l_shipdate limit 1;
+-- result:
+370113	38890	43691	8	51.68	964.44	0.09	0.20	2000-01-18 16:00:00	2000-01-23 16:00:00	DELIVER IN PERSON	TRUCK	Generated comment 9	A	F	2000-01-09 16:00:00
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result
+drop catalog mv_iceberg_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_transparent_mv/T/test_mv_with_multi_partition_columns_iceberg1_nulls
+++ b/test/sql/test_transparent_mv/T/test_mv_with_multi_partition_columns_iceberg1_nulls
@@ -1,0 +1,78 @@
+-- name: test_mv_with_multi_partition_columns_iceberg1_nulls
+
+set new_planner_optimize_timeout=10000;
+
+-- create mv
+create database db_${uuid0};
+use db_${uuid0};
+
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+
+CREATE TABLE t1 (
+      id BIGINT,
+      province VARCHAR(64),
+      age SMALLINT,
+      dt datetime
+) DUPLICATE KEY(id)
+PARTITION BY province, date_trunc('day', dt)
+DISTRIBUTED BY RANDOM;
+
+INSERT INTO t1 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02'), (4, NULL, NULL, NULL),
+                      (1, 'beijing1', 20, '2024-01-01'), (2, 'guangdong1', 20, '2024-01-01'), (3, 'guangdong1', 20, '2024-01-02'), (4, 'beijing', NULL, NULL),
+                      (1, 'beijing2', 20, '2024-01-01'), (2, 'guangdong2', 20, '2024-01-01'), (3, 'guangdong2', 20, '2024-01-02'), (4, 'nanjing', NULL, NULL);
+
+CREATE MATERIALIZED VIEW test_mv1
+PARTITION BY (province, date_trunc('day', dt))
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+	"replication_num" = "1"
+)
+AS SELECT * FROM t1;
+REFRESH MATERIALIZED VIEW test_mv1 with SYNC MODE;
+
+function: print_hit_materialized_views("SELECT count(*) FROM t1;")
+function: print_hit_materialized_views("SELECT * FROM t1 order by id, province, dt limit 3;")
+function: print_hit_materialized_views("SELECT * FROM t1 where province = 'beijing' order by id, province, dt limit 3;")
+function: print_hit_materialized_views("SELECT * FROM t1 where province = 'nanjing' order by id, province, dt limit 3;")
+SELECT count(1) FROM t1;
+SELECT * FROM t1 order by id, province, dt limit 3;
+SELECT * FROM t1 where province = 'beijing' order by id, province, dt limit 3;
+SELECT * FROM t1 where province = 'nanjing' order by id, province, dt limit 3;
+select count(*) from test_mv1;
+select * from test_mv1 order by id, province, dt limit 1;
+
+INSERT INTO t1 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02'), (4, NULL, NULL, NULL);
+function: print_hit_materialized_views("SELECT count(*) FROM t1;")
+function: print_hit_materialized_views("SELECT * FROM t1 order by id, province, dt limit 3;")
+function: print_hit_materialized_views("SELECT * FROM t1 where province = 'beijing' order by id, province, dt limit 3;")
+function: print_hit_materialized_views("SELECT * FROM t1 where province = 'nanjing' order by id, province, dt limit 3;")
+SELECT count(1) FROM t1;
+SELECT * FROM t1 order by id, province, dt limit 3;
+SELECT * FROM t1 where province = 'beijing' order by id, province, dt limit 3;
+SELECT * FROM t1 where province = 'nanjing' order by id, province, dt limit 3;
+select count(*) from test_mv1;
+select * from test_mv1 order by id, province, dt limit 1;
+
+CREATE MATERIALIZED VIEW test_datetime_partitioned_table_with_null_mv
+PARTITION BY (l_returnflag, l_linestatus, date_trunc('day', l_shipdate))
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+	"replication_num" = "1"
+)
+AS
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.test_datetime_partitioned_table_with_null;
+REFRESH MATERIALIZED VIEW test_datetime_partitioned_table_with_null_mv with SYNC MODE;
+
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.test_datetime_partitioned_table_with_null;")
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.test_datetime_partitioned_table_with_null order by l_orderkey, l_returnflag, l_linestatus, l_shipdate limit 3;
+select count(*) from test_datetime_partitioned_table_with_null_mv;
+select * from test_datetime_partitioned_table_with_null_mv order by l_orderkey, l_returnflag, l_linestatus, l_shipdate limit 1;
+
+drop database db_${uuid0} force;
+drop catalog mv_iceberg_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

```
mysql> REFRESH MATERIALIZED VIEW harness_internal.mv_leadtime_test FORCE WITH  SYNC MODE;
ERROR 1064 (HY000): execute task mv-90631 failed: Refresh materialized view mv_leadtime_test failed after retrying 1 times(try-lock 0 times), error-msg : com.starrocks.common.DdlException: date literal [NULL] is invalid
        at com.starrocks.catalog.CatalogUtils.checkPartitionValuesExistForAddListPartition(CatalogUtils.java:291)
        at com.starrocks.sql.analyzer.AlterTableClauseAnalyzer.analyzeAddPartition(AlterTableClauseAnalyzer.java:1194)
        at com.starrocks.sql.analyzer.AlterTableClauseAnalyzer.visitAddPartitionClause(AlterTableCl
mysql>
```
## What I'm doing:
- need to handle `null` partition value for list partition by using `STARROCKS_DEFAULT_PARTITION_VALUE `

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0