### PR TITLE
[Refactor] Passing ConnectContext to ConnectorMetadata interface

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authentication/UserProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/UserProperty.java
@@ -26,6 +26,7 @@ import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.Pair;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
@@ -241,7 +242,7 @@ public class UserProperty {
 
         // check whether the database exists
         MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
-        Database db = metadataMgr.getDb(newCatalog, newDatabase);
+        Database db = metadataMgr.getDb(new ConnectContext(), newCatalog, newDatabase);
         if (db == null) {
             String catalogDbName = newCatalog + "." + newDatabase;
             throw new StarRocksConnectorException(catalogDbName + " not exists");

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/AuthorizationProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/AuthorizationProvider.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.authorization;
 
-import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.UserIdentity;
 
 import java.util.List;
@@ -42,11 +41,12 @@ public interface AuthorizationProvider {
     /**
      * generate PEntryObject by tokenlist
      */
-    PEntryObject generateObject(ObjectType objectType, List<String> objectTokens, GlobalStateMgr mgr) throws PrivilegeException;
+    PEntryObject generateObject(ObjectType objectType, List<String> objectTokens)
+            throws PrivilegeException;
 
-    PEntryObject generateUserObject(ObjectType objectType, UserIdentity user, GlobalStateMgr mgr) throws PrivilegeException;
+    PEntryObject generateUserObject(ObjectType objectType, UserIdentity user) throws PrivilegeException;
 
-    PEntryObject generateFunctionObject(ObjectType objectType, Long databaseId, Long functionId, GlobalStateMgr globalStateMgr)
+    PEntryObject generateFunctionObject(ObjectType objectType, Long databaseId, Long functionId)
             throws PrivilegeException;
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/CatalogPEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/CatalogPEntryObject.java
@@ -42,7 +42,7 @@ public class CatalogPEntryObject implements PEntryObject {
         return id;
     }
 
-    public static CatalogPEntryObject generate(GlobalStateMgr mgr, List<String> tokens) throws PrivilegeException {
+    public static CatalogPEntryObject generate(List<String> tokens) throws PrivilegeException {
         if (tokens.size() != 1) {
             throw new PrivilegeException("invalid object tokens, should have only one, token: " + tokens);
         }
@@ -55,7 +55,7 @@ public class CatalogPEntryObject implements PEntryObject {
         if (CatalogMgr.isInternalCatalog(name)) {
             id = InternalCatalog.DEFAULT_INTERNAL_CATALOG_ID;
         } else {
-            Catalog catalog = mgr.getCatalogMgr().getCatalogByName(name);
+            Catalog catalog = GlobalStateMgr.getCurrentState().getCatalogMgr().getCatalogByName(name);
             if (catalog == null) {
                 throw new PrivObjNotFoundException("cannot find catalog: " + name);
             }
@@ -93,11 +93,11 @@ public class CatalogPEntryObject implements PEntryObject {
     }
 
     @Override
-    public boolean validate(GlobalStateMgr globalStateMgr) {
+    public boolean validate() {
         if (id == InternalCatalog.DEFAULT_INTERNAL_CATALOG_ID) {
             return true;
         } else {
-            return globalStateMgr.getCatalogMgr().checkCatalogExistsById(id);
+            return GlobalStateMgr.getCurrentState().getCatalogMgr().checkCatalogExistsById(id);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/ColumnPrivilege.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/ColumnPrivilege.java
@@ -155,8 +155,8 @@ public class ColumnPrivilege {
                             if (view.isSecurity()) {
                                 List<TableName> allTables = view.getTableRefs();
                                 for (TableName t : allTables) {
-                                    BasicTable basicTable = GlobalStateMgr.getCurrentState().getMetadataMgr().getBasicTable(
-                                            t.getCatalog(), t.getDb(), t.getTbl());
+                                    BasicTable basicTable = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                                            .getBasicTable(context, t.getCatalog(), t.getDb(), t.getTbl());
                                     if (basicTable.isOlapView()) {
                                         View subView = (View) basicTable;
                                         QueryStatement queryStatement = subView.getQueryStatement();

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/DefaultAuthorizationProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/DefaultAuthorizationProvider.java
@@ -15,7 +15,6 @@
 package com.starrocks.authorization;
 
 import com.google.common.collect.Lists;
-import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.UserIdentity;
 
@@ -168,46 +167,46 @@ public class DefaultAuthorizationProvider implements AuthorizationProvider {
     }
 
     @Override
-    public PEntryObject generateObject(ObjectType objectType, List<String> objectTokens, GlobalStateMgr mgr)
+    public PEntryObject generateObject(ObjectType objectType, List<String> objectTokens)
             throws PrivilegeException {
         if (ObjectType.TABLE.equals(objectType)) {
-            return TablePEntryObject.generate(mgr, objectTokens);
+            return TablePEntryObject.generate(objectTokens);
         } else if (ObjectType.DATABASE.equals(objectType)) {
-            return DbPEntryObject.generate(mgr, objectTokens);
+            return DbPEntryObject.generate(objectTokens);
         } else if (ObjectType.RESOURCE.equals(objectType)) {
-            return ResourcePEntryObject.generate(mgr, objectTokens);
+            return ResourcePEntryObject.generate(objectTokens);
         } else if (ObjectType.VIEW.equals(objectType)) {
-            return ViewPEntryObject.generate(mgr, objectTokens);
+            return ViewPEntryObject.generate(objectTokens);
         } else if (ObjectType.MATERIALIZED_VIEW.equals(objectType)) {
-            return MaterializedViewPEntryObject.generate(mgr, objectTokens);
+            return MaterializedViewPEntryObject.generate(objectTokens);
         } else if (ObjectType.CATALOG.equals(objectType)) {
-            return CatalogPEntryObject.generate(mgr, objectTokens);
+            return CatalogPEntryObject.generate(objectTokens);
         } else if (ObjectType.RESOURCE_GROUP.equals(objectType)) {
-            return ResourceGroupPEntryObject.generate(mgr, objectTokens);
+            return ResourceGroupPEntryObject.generate(objectTokens);
         } else if (ObjectType.STORAGE_VOLUME.equals(objectType)) {
-            return StorageVolumePEntryObject.generate(mgr, objectTokens);
+            return StorageVolumePEntryObject.generate(objectTokens);
         } else if (ObjectType.PIPE.equals(objectType)) {
-            return PipePEntryObject.generate(mgr, objectTokens);
+            return PipePEntryObject.generate(objectTokens);
         } else if (ObjectType.WAREHOUSE.equals(objectType)) {
-            return WarehousePEntryObject.generate(mgr, objectTokens);
+            return WarehousePEntryObject.generate(objectTokens);
         }
         throw new PrivilegeException(UNEXPECTED_TYPE + objectType.name());
     }
 
     @Override
     public PEntryObject generateUserObject(
-            ObjectType objectType, UserIdentity user, GlobalStateMgr globalStateMgr) throws PrivilegeException {
+            ObjectType objectType, UserIdentity user) throws PrivilegeException {
         if (objectType.equals(ObjectType.USER)) {
-            return UserPEntryObject.generate(globalStateMgr, user);
+            return UserPEntryObject.generate(user);
         }
         throw new PrivilegeException(UNEXPECTED_TYPE + objectType.name());
     }
 
     @Override
-    public PEntryObject generateFunctionObject(ObjectType objectType, Long databaseId, Long functionId,
-                                               GlobalStateMgr globalStateMgr) throws PrivilegeException {
+    public PEntryObject generateFunctionObject(ObjectType objectType, Long databaseId, Long functionId)
+            throws PrivilegeException {
         if (objectType.equals(ObjectType.FUNCTION) || objectType.equals(ObjectType.GLOBAL_FUNCTION)) {
-            return FunctionPEntryObject.generate(globalStateMgr, databaseId, functionId);
+            return FunctionPEntryObject.generate(databaseId, functionId);
         }
         throw new PrivilegeException(UNEXPECTED_TYPE + objectType.name());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/ForwardCompatiblePEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/ForwardCompatiblePEntryObject.java
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.authorization;
-
-import com.starrocks.server.GlobalStateMgr;
 
 /**
  * This class is existed for forward compatibility so that when we add a new type of {@link PEntryObject}
@@ -37,7 +34,7 @@ public class ForwardCompatiblePEntryObject implements PEntryObject {
     }
 
     @Override
-    public boolean validate(GlobalStateMgr globalStateMgr) {
+    public boolean validate() {
         throw new UnsupportedOperationException();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/FunctionPEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/FunctionPEntryObject.java
@@ -44,10 +44,10 @@ public class FunctionPEntryObject implements PEntryObject {
         this.functionId = functionId;
     }
 
-    public static FunctionPEntryObject generate(GlobalStateMgr mgr, Long databaseId, Long functionId) throws PrivilegeException {
+    public static FunctionPEntryObject generate(Long databaseId, Long functionId) throws PrivilegeException {
         FunctionPEntryObject functionPEntryObject = new FunctionPEntryObject(databaseId, functionId);
         if (functionId != PrivilegeBuiltinConstants.ALL_FUNCTIONS_ID) {
-            if (!functionPEntryObject.validate(mgr)) {
+            if (!functionPEntryObject.validate()) {
                 throw new PrivObjNotFoundException("cannot find function: " + functionId);
             }
         }
@@ -78,12 +78,12 @@ public class FunctionPEntryObject implements PEntryObject {
     }
 
     @Override
-    public boolean validate(GlobalStateMgr globalStateMgr) {
+    public boolean validate() {
         List<Function> allFunctions;
         if (databaseId == PrivilegeBuiltinConstants.GLOBAL_FUNCTION_DEFAULT_DATABASE_ID) {
-            allFunctions = globalStateMgr.getGlobalFunctionMgr().getFunctions();
+            allFunctions = GlobalStateMgr.getCurrentState().getGlobalFunctionMgr().getFunctions();
         } else {
-            Database db = globalStateMgr.getLocalMetastore().getDbIncludeRecycleBin(this.databaseId);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIncludeRecycleBin(this.databaseId);
             if (db == null) {
                 return false;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/GlobalFunctionPEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/GlobalFunctionPEntryObject.java
@@ -32,7 +32,7 @@ public class GlobalFunctionPEntryObject implements PEntryObject {
         return functionSig;
     }
 
-    public static GlobalFunctionPEntryObject generate(GlobalStateMgr mgr, List<String> tokens)
+    public static GlobalFunctionPEntryObject generate(List<String> tokens)
             throws PrivilegeException {
         if (tokens.size() != 1) {
             throw new PrivilegeException("invalid object tokens: " + tokens);
@@ -46,7 +46,7 @@ public class GlobalFunctionPEntryObject implements PEntryObject {
         } else {
             String funcSig = tokens.get(0);
             GlobalFunctionPEntryObject pEntryObject = new GlobalFunctionPEntryObject(funcSig);
-            if (!pEntryObject.validate(mgr)) {
+            if (!pEntryObject.validate()) {
                 throw new PrivObjNotFoundException("cannot find function: " + funcSig);
             }
             return pEntryObject;
@@ -75,9 +75,9 @@ public class GlobalFunctionPEntryObject implements PEntryObject {
     }
 
     @Override
-    public boolean validate(GlobalStateMgr globalStateMgr) {
+    public boolean validate() {
         Function targetFunc = null;
-        for (Function f : globalStateMgr.getGlobalFunctionMgr().getFunctions()) {
+        for (Function f : GlobalStateMgr.getCurrentState().getGlobalFunctionMgr().getFunctions()) {
             if (f.signatureString().equals(this.functionSig)) {
                 targetFunc = f;
                 break;

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/MaterializedViewPEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/MaterializedViewPEntryObject.java
@@ -15,7 +15,6 @@
 package com.starrocks.authorization;
 
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.Table;
 import com.starrocks.server.GlobalStateMgr;
 
@@ -28,7 +27,7 @@ public class MaterializedViewPEntryObject extends TablePEntryObject {
         super(dbUUID, tblUUID);
     }
 
-    public static MaterializedViewPEntryObject generate(GlobalStateMgr mgr, List<String> tokens)
+    public static MaterializedViewPEntryObject generate(List<String> tokens)
             throws PrivilegeException {
         if (tokens.size() != 2) {
             throw new PrivilegeException("invalid object tokens, should have two: " + tokens);
@@ -40,7 +39,7 @@ public class MaterializedViewPEntryObject extends TablePEntryObject {
             dbUUID = PrivilegeBuiltinConstants.ALL_DATABASES_UUID;
             tblUUID = PrivilegeBuiltinConstants.ALL_TABLES_UUID;
         } else {
-            Database database = mgr.getMetadataMgr().getDb(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, tokens.get(0));
+            Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(tokens.get(0));
             if (database == null) {
                 throw new PrivObjNotFoundException("cannot find db: " + tokens.get(0));
             }
@@ -49,8 +48,8 @@ public class MaterializedViewPEntryObject extends TablePEntryObject {
             if (Objects.equals(tokens.get(1), "*")) {
                 tblUUID = PrivilegeBuiltinConstants.ALL_TABLES_UUID;
             } else {
-                Table table = mgr.getMetadataMgr().getTable(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
-                        database.getFullName(), tokens.get(1));
+                Table table = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(database.getFullName(), tokens.get(1));
                 if (table == null || !table.isMaterializedView()) {
                     throw new PrivObjNotFoundException(
                             "cannot find materialized view " + tokens.get(1) + " in db " + tokens.get(0));

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/NativeAccessController.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/NativeAccessController.java
@@ -41,7 +41,7 @@ public class NativeAccessController implements AccessController {
     @Override
     public void checkSystemAction(ConnectContext context, PrivilegeType privilegeType)
             throws AccessDeniedException {
-        checkObjectTypeAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), privilegeType, ObjectType.SYSTEM,
+        checkObjectTypeAction(context, privilegeType, ObjectType.SYSTEM,
                 null);
     }
 
@@ -53,7 +53,7 @@ public class NativeAccessController implements AccessController {
         }
 
         AuthorizationMgr authorizationManager = GlobalStateMgr.getCurrentState().getAuthorizationMgr();
-        if (!authorizationManager.canExecuteAs(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), impersonateUser)) {
+        if (!authorizationManager.canExecuteAs(context, impersonateUser)) {
             throw new AccessDeniedException();
         }
     }
@@ -61,30 +61,28 @@ public class NativeAccessController implements AccessController {
     @Override
     public void checkCatalogAction(ConnectContext context, String catalogName, PrivilegeType privilegeType)
             throws AccessDeniedException {
-        checkObjectTypeAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), privilegeType, ObjectType.CATALOG,
+        checkObjectTypeAction(context, privilegeType, ObjectType.CATALOG,
                 Collections.singletonList(catalogName));
     }
 
     @Override
     public void checkAnyActionOnCatalog(ConnectContext context, String catalogName)
             throws AccessDeniedException {
-        checkAnyActionOnObject(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), ObjectType.CATALOG,
-                Collections.singletonList(catalogName));
+        checkAnyActionOnObject(context, ObjectType.CATALOG, Collections.singletonList(catalogName));
     }
 
     @Override
     public void checkDbAction(ConnectContext context, String catalogName, String db,
                               PrivilegeType privilegeType) throws AccessDeniedException {
         String catalog = catalogName == null ? InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME : catalogName;
-        checkObjectTypeAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), privilegeType, ObjectType.DATABASE,
+        checkObjectTypeAction(context, privilegeType, ObjectType.DATABASE,
                 Arrays.asList(catalog, db));
     }
 
     @Override
     public void checkAnyActionOnDb(ConnectContext context, String catalogName, String db)
             throws AccessDeniedException {
-        checkAnyActionOnObject(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), ObjectType.DATABASE,
-                Arrays.asList(catalogName, db));
+        checkAnyActionOnObject(context, ObjectType.DATABASE, Arrays.asList(catalogName, db));
     }
 
     @Override
@@ -93,7 +91,7 @@ public class NativeAccessController implements AccessController {
         String catalog = tableName.getCatalog() == null ? InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME : tableName.getCatalog();
         Preconditions.checkNotNull(tableName.getDb());
 
-        checkObjectTypeAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), privilegeType, ObjectType.TABLE,
+        checkObjectTypeAction(context, privilegeType, ObjectType.TABLE,
                 Arrays.asList(catalog, tableName.getDb(), tableName.getTbl()));
     }
 
@@ -103,8 +101,7 @@ public class NativeAccessController implements AccessController {
         String catalog = tableName.getCatalog() == null ? InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME : tableName.getCatalog();
         Preconditions.checkNotNull(tableName.getDb());
 
-        checkAnyActionOnObject(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), ObjectType.TABLE,
-                Lists.newArrayList(catalog, tableName.getDb(), tableName.getTbl()));
+        checkAnyActionOnObject(context, ObjectType.TABLE, Lists.newArrayList(catalog, tableName.getDb(), tableName.getTbl()));
     }
 
     @Override
@@ -116,15 +113,14 @@ public class NativeAccessController implements AccessController {
     @Override
     public void checkViewAction(ConnectContext context, TableName tableName, PrivilegeType privilegeType)
             throws AccessDeniedException {
-        checkObjectTypeAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), privilegeType, ObjectType.VIEW,
+        checkObjectTypeAction(context, privilegeType, ObjectType.VIEW,
                 Arrays.asList(tableName.getDb(), tableName.getTbl()));
     }
 
     @Override
     public void checkAnyActionOnView(ConnectContext context, TableName tableName)
             throws AccessDeniedException {
-        checkAnyActionOnObject(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), ObjectType.VIEW,
-                Lists.newArrayList(tableName.getDb(), tableName.getTbl()));
+        checkAnyActionOnObject(context, ObjectType.VIEW, Lists.newArrayList(tableName.getDb(), tableName.getTbl()));
     }
 
     @Override
@@ -135,7 +131,7 @@ public class NativeAccessController implements AccessController {
     @Override
     public void checkMaterializedViewAction(ConnectContext context, TableName tableName,
                                             PrivilegeType privilegeType) throws AccessDeniedException {
-        checkObjectTypeAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), privilegeType,
+        checkObjectTypeAction(context, privilegeType,
                 ObjectType.MATERIALIZED_VIEW,
                 Arrays.asList(tableName.getDb(), tableName.getTbl()));
     }
@@ -143,8 +139,7 @@ public class NativeAccessController implements AccessController {
     @Override
     public void checkAnyActionOnMaterializedView(ConnectContext context, TableName tableName)
             throws AccessDeniedException {
-        checkAnyActionOnObject(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), ObjectType.MATERIALIZED_VIEW,
-                Arrays.asList(tableName.getDb(), tableName.getTbl()));
+        checkAnyActionOnObject(context, ObjectType.MATERIALIZED_VIEW, Arrays.asList(tableName.getDb(), tableName.getTbl()));
     }
 
     @Override
@@ -163,15 +158,13 @@ public class NativeAccessController implements AccessController {
     @Override
     public void checkAnyActionOnFunction(ConnectContext context, String database, Function function)
             throws AccessDeniedException {
-        checkAnyActionOnFunctionObject(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), ObjectType.FUNCTION,
-                database, function);
+        checkAnyActionOnFunctionObject(context, ObjectType.FUNCTION, database, function);
     }
 
     @Override
     public void checkAnyActionOnAnyFunction(ConnectContext context, String database)
             throws AccessDeniedException {
-        checkAnyActionOnFunctionObject(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), ObjectType.FUNCTION,
-                database, null);
+        checkAnyActionOnFunctionObject(context, ObjectType.FUNCTION, database, null);
     }
 
     @Override
@@ -184,8 +177,7 @@ public class NativeAccessController implements AccessController {
     @Override
     public void checkAnyActionOnGlobalFunction(ConnectContext context, Function function)
             throws AccessDeniedException {
-        checkAnyActionOnFunctionObject(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), ObjectType.GLOBAL_FUNCTION,
-                null, function);
+        checkAnyActionOnFunctionObject(context, ObjectType.GLOBAL_FUNCTION, null, function);
     }
 
     @Override
@@ -199,8 +191,7 @@ public class NativeAccessController implements AccessController {
             if (manager.provider.isAvailablePrivType(ObjectType.TABLE, privilegeType)) {
                 PEntryObject allTableInDbObject = manager.provider.generateObject(
                         ObjectType.TABLE,
-                        Lists.newArrayList(db, "*"),
-                        GlobalStateMgr.getCurrentState());
+                        Lists.newArrayList(db, "*"));
                 if (manager.provider.searchActionOnObject(ObjectType.TABLE, allTableInDbObject, collection, privilegeType)) {
                     return;
                 }
@@ -210,8 +201,7 @@ public class NativeAccessController implements AccessController {
             if (manager.provider.isAvailablePrivType(ObjectType.VIEW, privilegeType)) {
                 PEntryObject allViewInDbObject = manager.provider.generateObject(
                         ObjectType.VIEW,
-                        Lists.newArrayList(db, "*"),
-                        GlobalStateMgr.getCurrentState());
+                        Lists.newArrayList(db, "*"));
                 if (manager.provider.searchActionOnObject(ObjectType.VIEW, allViewInDbObject, collection, privilegeType)) {
                     return;
                 }
@@ -221,8 +211,7 @@ public class NativeAccessController implements AccessController {
             if (manager.provider.isAvailablePrivType(ObjectType.MATERIALIZED_VIEW, privilegeType)) {
                 PEntryObject allMvInDbObject = manager.provider.generateObject(
                         ObjectType.MATERIALIZED_VIEW,
-                        Lists.newArrayList(db, "*"),
-                        GlobalStateMgr.getCurrentState());
+                        Lists.newArrayList(db, "*"));
                 if (manager.provider.searchActionOnObject(
                         ObjectType.MATERIALIZED_VIEW, allMvInDbObject, collection, privilegeType)) {
                     return;
@@ -241,49 +230,46 @@ public class NativeAccessController implements AccessController {
     @Override
     public void checkResourceAction(ConnectContext context, String name, PrivilegeType privilegeType)
             throws AccessDeniedException {
-        checkObjectTypeAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), privilegeType, ObjectType.RESOURCE,
+        checkObjectTypeAction(context, privilegeType, ObjectType.RESOURCE,
                 Collections.singletonList(name));
     }
 
     @Override
     public void checkAnyActionOnResource(ConnectContext context, String name) throws AccessDeniedException {
-        checkAnyActionOnObject(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), ObjectType.RESOURCE,
-                Collections.singletonList(name));
+        checkAnyActionOnObject(context, ObjectType.RESOURCE, Collections.singletonList(name));
     }
 
     @Override
     public void checkResourceGroupAction(ConnectContext context, String name, PrivilegeType privilegeType)
             throws AccessDeniedException {
-        checkObjectTypeAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), privilegeType,
+        checkObjectTypeAction(context, privilegeType,
                 ObjectType.RESOURCE_GROUP, Collections.singletonList(name));
     }
 
     @Override
     public void checkPipeAction(ConnectContext context, PipeName name, PrivilegeType privilegeType)
             throws AccessDeniedException {
-        checkObjectTypeAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), privilegeType, ObjectType.PIPE,
+        checkObjectTypeAction(context, privilegeType, ObjectType.PIPE,
                 Lists.newArrayList(name.getDbName(), name.getPipeName()));
     }
 
     @Override
     public void checkAnyActionOnPipe(ConnectContext context, PipeName name)
             throws AccessDeniedException {
-        checkAnyActionOnObject(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), ObjectType.PIPE,
-                Lists.newArrayList(name.getDbName(), name.getPipeName()));
+        checkAnyActionOnObject(context, ObjectType.PIPE, Lists.newArrayList(name.getDbName(), name.getPipeName()));
     }
 
     @Override
     public void checkStorageVolumeAction(ConnectContext context, String storageVolume,
                                          PrivilegeType privilegeType) throws AccessDeniedException {
-        checkObjectTypeAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
+        checkObjectTypeAction(context,
                 privilegeType, ObjectType.STORAGE_VOLUME, Collections.singletonList(storageVolume));
     }
 
     @Override
     public void checkAnyActionOnStorageVolume(ConnectContext context, String storageVolume)
             throws AccessDeniedException {
-        checkAnyActionOnObject(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), ObjectType.STORAGE_VOLUME,
-                Collections.singletonList(storageVolume));
+        checkAnyActionOnObject(context, ObjectType.STORAGE_VOLUME, Collections.singletonList(storageVolume));
     }
 
     @Override
@@ -305,8 +291,7 @@ public class NativeAccessController implements AccessController {
         AuthorizationMgr manager = GlobalStateMgr.getCurrentState().getAuthorizationMgr();
         try {
             PrivilegeCollectionV2 collection = manager.mergePrivilegeCollection(currentUser, roleIds);
-            PEntryObject object = manager.provider.generateFunctionObject(objectType, databaseId, function.getFunctionId(),
-                    GlobalStateMgr.getCurrentState());
+            PEntryObject object = manager.provider.generateFunctionObject(objectType, databaseId, function.getFunctionId());
             boolean checkResult = manager.provider.check(objectType, privilegeType, object, collection);
             if (!checkResult) {
                 throw new AccessDeniedException();
@@ -323,11 +308,12 @@ public class NativeAccessController implements AccessController {
         }
     }
 
-    protected static void checkObjectTypeAction(UserIdentity userIdentity, Set<Long> roleIds, PrivilegeType privilegeType,
+    protected static void checkObjectTypeAction(ConnectContext context, PrivilegeType privilegeType,
                                                 ObjectType objectType, List<String> objectTokens) throws AccessDeniedException {
         AuthorizationMgr manager = GlobalStateMgr.getCurrentState().getAuthorizationMgr();
         try {
-            PrivilegeCollectionV2 collection = manager.mergePrivilegeCollection(userIdentity, roleIds);
+            PrivilegeCollectionV2 collection = manager.mergePrivilegeCollection(
+                    context.getCurrentUserIdentity(), context.getCurrentRoleIds());
             boolean checkResult = manager.checkAction(collection, objectType, privilegeType, objectTokens);
             if (!checkResult) {
                 throw new AccessDeniedException();
@@ -353,13 +339,13 @@ public class NativeAccessController implements AccessController {
                 .collect(Collectors.joining("."));
     }
 
-    protected static void checkAnyActionOnObject(UserIdentity currentUser, Set<Long> roleIds, ObjectType objectType,
+    protected static void checkAnyActionOnObject(ConnectContext context, ObjectType objectType,
                                                  List<String> objectTokens) throws AccessDeniedException {
         AuthorizationMgr manager = GlobalStateMgr.getCurrentState().getAuthorizationMgr();
         try {
-            PrivilegeCollectionV2 collection = manager.mergePrivilegeCollection(currentUser, roleIds);
-            PEntryObject pEntryObject = manager.provider.generateObject(
-                    objectType, objectTokens, GlobalStateMgr.getCurrentState());
+            PrivilegeCollectionV2 collection = manager.mergePrivilegeCollection(
+                    context.getCurrentUserIdentity(), context.getCurrentRoleIds());
+            PEntryObject pEntryObject = manager.provider.generateObject(objectType, objectTokens);
             boolean checkResult = manager.provider.searchAnyActionOnObject(objectType, pEntryObject, collection);
             if (!checkResult) {
                 throw new AccessDeniedException();
@@ -374,7 +360,7 @@ public class NativeAccessController implements AccessController {
         }
     }
 
-    private static void checkAnyActionOnFunctionObject(UserIdentity currentUser, Set<Long> roleIds,
+    private static void checkAnyActionOnFunctionObject(ConnectContext context,
                                                        ObjectType objectType,
                                                        String dbName, Function function) throws AccessDeniedException {
         // database == null means global function
@@ -383,7 +369,7 @@ public class NativeAccessController implements AccessController {
             databaseId = PrivilegeBuiltinConstants.GLOBAL_FUNCTION_DEFAULT_DATABASE_ID;
         } else {
             Database database = GlobalStateMgr.getCurrentState().getMetadataMgr()
-                    .getDb(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, dbName);
+                    .getDb(context, InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, dbName);
             if (database == null) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
             }
@@ -399,9 +385,9 @@ public class NativeAccessController implements AccessController {
 
         AuthorizationMgr manager = GlobalStateMgr.getCurrentState().getAuthorizationMgr();
         try {
-            PrivilegeCollectionV2 collection = manager.mergePrivilegeCollection(currentUser, roleIds);
-            PEntryObject pEntryObject = manager.provider.generateFunctionObject(
-                    objectType, databaseId, functionId, GlobalStateMgr.getCurrentState());
+            PrivilegeCollectionV2 collection =
+                    manager.mergePrivilegeCollection(context.getCurrentUserIdentity(), context.getCurrentRoleIds());
+            PEntryObject pEntryObject = manager.provider.generateFunctionObject(objectType, databaseId, functionId);
             boolean checkResult = manager.provider.searchAnyActionOnObject(objectType, pEntryObject, collection);
             if (!checkResult) {
                 throw new AccessDeniedException();
@@ -419,13 +405,12 @@ public class NativeAccessController implements AccessController {
     @Override
     public void checkWarehouseAction(ConnectContext context, String name, PrivilegeType privilegeType)
             throws AccessDeniedException {
-        checkObjectTypeAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), privilegeType, ObjectType.WAREHOUSE,
+        checkObjectTypeAction(context, privilegeType, ObjectType.WAREHOUSE,
                 Collections.singletonList(name));
     }
 
     @Override
     public void checkAnyActionOnWarehouse(ConnectContext context, String name) throws AccessDeniedException {
-        checkAnyActionOnObject(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), ObjectType.WAREHOUSE,
-                Collections.singletonList(name));
+        checkAnyActionOnObject(context, ObjectType.WAREHOUSE, Collections.singletonList(name));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/PEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/PEntryObject.java
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.authorization;
-
-import com.starrocks.server.GlobalStateMgr;
 
 /**
  * Each `GRANT`/`REVOKE` statement will create some privilege entry object
@@ -60,7 +57,7 @@ public interface PEntryObject extends Comparable<PEntryObject> {
     /**
      * validate this object to see if still exists
      */
-    boolean validate(GlobalStateMgr globalStateMgr);
+    boolean validate();
 
     /**
      * used in Collections.sort() to accelerate lookup

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/PipePEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/PipePEntryObject.java
@@ -44,7 +44,7 @@ public class PipePEntryObject implements PEntryObject {
         this.dbUUID = dbUUID;
     }
 
-    public static PEntryObject generate(GlobalStateMgr mgr, List<String> tokens) throws PrivilegeException {
+    public static PEntryObject generate(List<String> tokens) throws PrivilegeException {
         if (tokens.size() != 2) {
             throw new PrivilegeException("invalid object tokens, should have two: " + tokens);
         }
@@ -56,7 +56,7 @@ public class PipePEntryObject implements PEntryObject {
             pipeId = PrivilegeBuiltinConstants.ALL_PIPES_ID;
         } else {
             String dbName = tokens.get(0);
-            Database database = mgr.getLocalMetastore().getDb(dbName);
+            Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
             if (database == null) {
                 throw new PrivObjNotFoundException("cannot find db: " + dbName);
             }
@@ -66,7 +66,7 @@ public class PipePEntryObject implements PEntryObject {
                 pipeId = PrivilegeBuiltinConstants.ALL_PIPES_ID;
             } else {
                 String name = tokens.get(1);
-                Optional<Pipe> pipe = mgr.getPipeManager().mayGetPipe(new PipeName(dbName, name));
+                Optional<Pipe> pipe = GlobalStateMgr.getCurrentState().getPipeManager().mayGetPipe(new PipeName(dbName, name));
 
                 pipe.orElseThrow(() ->
                         new PrivObjNotFoundException(
@@ -110,12 +110,12 @@ public class PipePEntryObject implements PEntryObject {
     }
 
     @Override
-    public boolean validate(GlobalStateMgr globalStateMgr) {
-        Database db = globalStateMgr.getLocalMetastore().getDbIncludeRecycleBin(Long.parseLong(this.dbUUID));
+    public boolean validate() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIncludeRecycleBin(Long.parseLong(this.dbUUID));
         if (db == null) {
             return false;
         }
-        return globalStateMgr.getPipeManager().mayGetPipe(getId()).isPresent();
+        return GlobalStateMgr.getCurrentState().getPipeManager().mayGetPipe(getId()).isPresent();
     }
 
     public List<List<String>> expandObjectNames() {

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/PrivilegeCollectionV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/PrivilegeCollectionV2.java
@@ -18,7 +18,6 @@ package com.starrocks.authorization;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.persist.gson.GsonUtils;
-import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -246,14 +245,14 @@ public class PrivilegeCollectionV2 implements GsonPostProcessable {
         return false; // cannot find all or some of the object in collection
     }
 
-    public void removeInvalidObject(GlobalStateMgr globalStateMgr) {
+    public void removeInvalidObject() {
         Iterator<Map.Entry<ObjectType, List<PrivilegeEntry>>> listIter = typeToPrivilegeEntryList.entrySet().iterator();
         while (listIter.hasNext()) {
             List<PrivilegeEntry> list = listIter.next().getValue();
             Iterator<PrivilegeEntry> entryIterator = list.iterator();
             while (entryIterator.hasNext()) {
                 PrivilegeEntry entry = entryIterator.next();
-                if (entry.object != null && !entry.object.isFuzzyMatching() && !entry.object.validate(globalStateMgr)) {
+                if (entry.object != null && !entry.object.isFuzzyMatching() && !entry.object.validate()) {
                     String entryStr = GsonUtils.GSON.toJson(entry);
                     LOG.info("find invalid object, will remove the entry now: {}", entryStr);
                     entryIterator.remove();

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/ResourceGroupPEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/ResourceGroupPEntryObject.java
@@ -32,8 +32,7 @@ public class ResourceGroupPEntryObject implements PEntryObject {
         return id;
     }
 
-    public static ResourceGroupPEntryObject generate(GlobalStateMgr mgr,
-                                                     List<String> tokens) throws PrivilegeException {
+    public static ResourceGroupPEntryObject generate(List<String> tokens) throws PrivilegeException {
         if (tokens.size() != 1) {
             throw new PrivilegeException("invalid object tokens, should have only one, token: " + tokens);
         }
@@ -41,7 +40,7 @@ public class ResourceGroupPEntryObject implements PEntryObject {
         if (name.equals("*")) {
             return new ResourceGroupPEntryObject(PrivilegeBuiltinConstants.ALL_RESOURCE_GROUP_ID);
         } else {
-            ResourceGroup resourceGroup = mgr.getResourceGroupMgr().getResourceGroup(name);
+            ResourceGroup resourceGroup = GlobalStateMgr.getCurrentState().getResourceGroupMgr().getResourceGroup(name);
             if (resourceGroup == null) {
                 throw new PrivObjNotFoundException("cannot find resource group: " + name);
             }
@@ -78,8 +77,8 @@ public class ResourceGroupPEntryObject implements PEntryObject {
     }
 
     @Override
-    public boolean validate(GlobalStateMgr globalStateMgr) {
-        return globalStateMgr.getResourceGroupMgr().getResourceGroup(id) != null;
+    public boolean validate() {
+        return GlobalStateMgr.getCurrentState().getResourceGroupMgr().getResourceGroup(id) != null;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/ResourcePEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/ResourcePEntryObject.java
@@ -29,7 +29,7 @@ public class ResourcePEntryObject implements PEntryObject {
         return name;
     }
 
-    public static ResourcePEntryObject generate(GlobalStateMgr mgr, List<String> tokens) throws PrivilegeException {
+    public static ResourcePEntryObject generate(List<String> tokens) throws PrivilegeException {
         if (tokens.size() != 1) {
             throw new PrivilegeException("invalid object tokens, should have one: " + tokens);
         }
@@ -37,7 +37,7 @@ public class ResourcePEntryObject implements PEntryObject {
         if (name.equals("*")) {
             return new ResourcePEntryObject(null);
         } else {
-            if (!mgr.getResourceMgr().containsResource(name)) {
+            if (!GlobalStateMgr.getCurrentState().getResourceMgr().containsResource(name)) {
                 throw new PrivObjNotFoundException("cannot find resource: " + tokens.get(0));
             }
             return new ResourcePEntryObject(name);
@@ -73,8 +73,8 @@ public class ResourcePEntryObject implements PEntryObject {
     }
 
     @Override
-    public boolean validate(GlobalStateMgr globalStateMgr) {
-        return globalStateMgr.getResourceMgr().containsResource(name);
+    public boolean validate() {
+        return GlobalStateMgr.getCurrentState().getResourceMgr().containsResource(name);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/StorageVolumePEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/StorageVolumePEntryObject.java
@@ -30,7 +30,7 @@ public class StorageVolumePEntryObject implements PEntryObject {
         this.id = id;
     }
 
-    public static PEntryObject generate(GlobalStateMgr mgr, List<String> tokens) throws PrivilegeException {
+    public static PEntryObject generate(List<String> tokens) throws PrivilegeException {
         if (tokens.size() != 1) {
             throw new PrivilegeException("invalid object tokens, should have one: " + tokens);
         }
@@ -39,7 +39,7 @@ public class StorageVolumePEntryObject implements PEntryObject {
             return new StorageVolumePEntryObject(PrivilegeBuiltinConstants.ALL_STORAGE_VOLUMES_ID);
         } else {
             StorageVolume sv = null;
-            sv = mgr.getStorageVolumeMgr().getStorageVolumeByName(name);
+            sv = GlobalStateMgr.getCurrentState().getStorageVolumeMgr().getStorageVolumeByName(name);
             // TODO: Change it to MetaNotFoundException
             if (sv == null) {
                 throw new PrivObjNotFoundException("cannot find storage volume: " + tokens.get(0));
@@ -70,8 +70,8 @@ public class StorageVolumePEntryObject implements PEntryObject {
     }
 
     @Override
-    public boolean validate(GlobalStateMgr globalStateMgr) {
-        return globalStateMgr.getStorageVolumeMgr().getStorageVolume(id) != null;
+    public boolean validate() {
+        return GlobalStateMgr.getCurrentState().getStorageVolumeMgr().getStorageVolume(id) != null;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/UserPEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/UserPEntryObject.java
@@ -33,12 +33,12 @@ public class UserPEntryObject implements PEntryObject {
         return userIdentity;
     }
 
-    public static UserPEntryObject generate(GlobalStateMgr mgr, UserIdentity user) throws PrivilegeException {
+    public static UserPEntryObject generate(UserIdentity user) throws PrivilegeException {
         if (user == null) {
             return new UserPEntryObject(null);
         }
 
-        if (!mgr.getAuthenticationMgr().doesUserExist(user)) {
+        if (!GlobalStateMgr.getCurrentState().getAuthenticationMgr().doesUserExist(user)) {
             throw new PrivObjNotFoundException("cannot find user " + user);
         }
         return new UserPEntryObject(user);
@@ -76,8 +76,9 @@ public class UserPEntryObject implements PEntryObject {
      * All validation are made in com.starrocks.privilege.AuthorizationManager#removeInvalidObject()
      */
     @Override
-    public boolean validate(GlobalStateMgr globalStateMgr) {
-        return globalStateMgr.getAuthorizationMgr().getUserPrivilegeCollectionUnlockedAllowNull(userIdentity) != null;
+    public boolean validate() {
+        return GlobalStateMgr.getCurrentState().getAuthorizationMgr()
+                .getUserPrivilegeCollectionUnlockedAllowNull(userIdentity) != null;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/ViewPEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/ViewPEntryObject.java
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.authorization;
 
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.Table;
 import com.starrocks.server.GlobalStateMgr;
 
@@ -31,7 +29,7 @@ public class ViewPEntryObject extends TablePEntryObject {
         super(dbUUID, tblUUID);
     }
 
-    public static ViewPEntryObject generate(GlobalStateMgr mgr, List<String> tokens) throws PrivilegeException {
+    public static ViewPEntryObject generate(List<String> tokens) throws PrivilegeException {
         if (tokens.size() != 2) {
             throw new PrivilegeException("invalid object tokens, should have two: " + tokens);
         }
@@ -42,7 +40,7 @@ public class ViewPEntryObject extends TablePEntryObject {
             dbUUID = PrivilegeBuiltinConstants.ALL_DATABASES_UUID;
             tblUUID = PrivilegeBuiltinConstants.ALL_TABLES_UUID;
         } else {
-            Database database = mgr.getMetadataMgr().getDb(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, tokens.get(0));
+            Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(tokens.get(0));
             if (database == null) {
                 throw new PrivObjNotFoundException("cannot find db: " + tokens.get(0));
             }
@@ -51,8 +49,8 @@ public class ViewPEntryObject extends TablePEntryObject {
             if (Objects.equals(tokens.get(1), "*")) {
                 tblUUID = PrivilegeBuiltinConstants.ALL_TABLES_UUID;
             } else {
-                Table table = mgr.getMetadataMgr().getTable(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
-                        database.getFullName(), tokens.get(1));
+                Table table = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(database.getFullName(), tokens.get(1));
                 if (table == null || !table.isOlapView()) {
                     throw new PrivObjNotFoundException("cannot find view " + tokens.get(1) + " in db " + tokens.get(0));
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/WarehousePEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/WarehousePEntryObject.java
@@ -31,8 +31,7 @@ public class WarehousePEntryObject implements PEntryObject {
         return id;
     }
 
-    public static WarehousePEntryObject generate(GlobalStateMgr mgr,
-                                                 List<String> tokens) throws PrivilegeException {
+    public static WarehousePEntryObject generate(List<String> tokens) throws PrivilegeException {
         if (tokens.size() != 1) {
             throw new PrivilegeException("invalid object tokens, should have only one, token: " + tokens);
         }
@@ -40,7 +39,7 @@ public class WarehousePEntryObject implements PEntryObject {
         if (name.equals("*")) {
             return new WarehousePEntryObject(PrivilegeBuiltinConstants.ALL_WAREHOUSES_ID);
         } else {
-            WarehouseManager warehouseMgr = mgr.getWarehouseMgr();
+            WarehouseManager warehouseMgr = GlobalStateMgr.getCurrentState().getWarehouseMgr();
             Warehouse warehouse = warehouseMgr.getWarehouseAllowNull(name);
             if (warehouse == null) {
                 throw new PrivObjNotFoundException("cannot find warehouse: " + name);
@@ -78,8 +77,8 @@ public class WarehousePEntryObject implements PEntryObject {
     }
 
     @Override
-    public boolean validate(GlobalStateMgr globalStateMgr) {
-        return globalStateMgr.getWarehouseMgr().getWarehouseAllowNull(id) != null;
+    public boolean validate() {
+        return GlobalStateMgr.getCurrentState().getWarehouseMgr().getWarehouseAllowNull(id) != null;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/ranger/starrocks/RangerStarRocksAccessController.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/ranger/starrocks/RangerStarRocksAccessController.java
@@ -135,7 +135,7 @@ public class RangerStarRocksAccessController extends RangerAccessController {
     @Override
     public void checkAnyActionOnAnyTable(ConnectContext context, String catalog, String db)
             throws AccessDeniedException {
-        Database database = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalog, db);
+        Database database = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(context, catalog, db);
         for (Table table : GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(database.getId())) {
             try {
                 hasPermission(

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -27,6 +27,7 @@ import com.starrocks.common.util.Util;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.IcebergApiConverter;
 import com.starrocks.connector.iceberg.IcebergCatalogType;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.rpc.ConfigurableSerDesFactory;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
@@ -300,7 +301,7 @@ public class IcebergTable extends Table {
         // For compatibility with the resource iceberg table. native table is lazy. Prevent failure during fe restarting.
         if (nativeTable == null) {
             IcebergTable resourceMappingTable = (IcebergTable) GlobalStateMgr.getCurrentState().getMetadataMgr()
-                    .getTable(getCatalogName(), catalogDBName, catalogTableName);
+                    .getTable(new ConnectContext(), getCatalogName(), catalogDBName, catalogTableName);
             if (resourceMappingTable == null) {
                 throw new StarRocksConnectorException("Can't find table %s.%s.%s",
                         getCatalogName(), catalogDBName, catalogTableName);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/constraint/ForeignKeyConstraint.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/constraint/ForeignKeyConstraint.java
@@ -27,6 +27,7 @@ import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
 import org.apache.commons.collections.CollectionUtils;
@@ -116,7 +117,8 @@ public class ForeignKeyConstraint extends Constraint {
             return table;
         } else {
             Table table = GlobalStateMgr.getCurrentState().getMetadataMgr()
-                    .getTable(parentTableInfo.getCatalogName(), parentTableInfo.getDbName(), parentTableInfo.getTableName());
+                    .getTable(new ConnectContext(), parentTableInfo.getCatalogName(), parentTableInfo.getDbName(),
+                            parentTableInfo.getTableName());
             if (table == null) {
                 throw new SemanticException("Table %s is not found", parentTableInfo.getTableName());
             }
@@ -134,7 +136,8 @@ public class ForeignKeyConstraint extends Constraint {
             return table;
         } else {
             Table table = GlobalStateMgr.getCurrentState().getMetadataMgr()
-                    .getTable(childTableInfo.getCatalogName(), childTableInfo.getDbName(), childTableInfo.getTableName());
+                    .getTable(new ConnectContext(), childTableInfo.getCatalogName(), childTableInfo.getDbName(),
+                            childTableInfo.getTableName());
             if (table == null) {
                 throw new SemanticException("Table %s is not found", childTableInfo.getTableName());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/constraint/UniqueConstraint.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/constraint/UniqueConstraint.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
 import org.apache.commons.collections.CollectionUtils;
@@ -56,7 +57,8 @@ public class UniqueConstraint extends Constraint {
     public List<String> getUniqueColumnNames(Table selfTable) {
         Table targetTable;
         if (selfTable.isMaterializedView()) {
-            targetTable = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(catalogName, dbName, tableName);
+            targetTable = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                    .getTable(new ConnectContext(), catalogName, dbName, tableName);
             if (targetTable == null) {
                 throw new SemanticException("Table %s.%s.%s is not found", catalogName, dbName, tableName);
             }
@@ -83,7 +85,8 @@ public class UniqueConstraint extends Constraint {
     // foreignKeys must be in lower case for case-insensitive
     public boolean isMatch(Table parentTable, Set<String> foreignKeys) {
         if (catalogName != null && dbName != null && tableName != null) {
-            Table uniqueTable = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(catalogName, dbName, tableName);
+            Table uniqueTable = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                    .getTable(new ConnectContext(), catalogName, dbName, tableName);
             if (uniqueTable == null) {
                 LOG.warn("can not find unique constraint table: {}.{}.{}", catalogName, dbName, tableName);
                 return false;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/AnalyzeStatusSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/AnalyzeStatusSystemTable.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.util.DateUtils;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.ShowAnalyzeStatusStmt;
 import com.starrocks.statistic.AnalyzeStatus;
@@ -97,7 +98,7 @@ public class AnalyzeStatusSystemTable extends SystemTable {
                 item.setTable_name(analyze.getTableName());
                 TableName name = new TableName(item.getCatalog_name(), item.getDatabase_name(), item.getTable_name());
                 table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(
-                        analyze.getCatalogName(), analyze.getDbName(), analyze.getTableName());
+                        new ConnectContext(), analyze.getCatalogName(), analyze.getDbName(), analyze.getTableName());
                 if (!predicate.test(name) || table == null) {
                     continue;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/DbsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/DbsProcDir.java
@@ -45,6 +45,7 @@ import com.starrocks.common.util.ListComparator;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 
 import java.util.ArrayList;
@@ -101,7 +102,8 @@ public class DbsProcDir implements ProcDirInterface {
         BaseProcResult result = new BaseProcResult();
         result.setNames(TITLE_NAMES);
 
-        List<String> dbNames = globalStateMgr.getLocalMetastore().listDbNames();
+        ConnectContext context = new ConnectContext();
+        List<String> dbNames = globalStateMgr.getLocalMetastore().listDbNames(context);
         if (dbNames == null || dbNames.isEmpty()) {
             // empty
             return result;

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ExternalDbsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ExternalDbsProcDir.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.Database;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.ProcResultUtils;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.analyzer.SemanticException;
@@ -45,7 +46,7 @@ public class ExternalDbsProcDir implements ProcDirInterface {
         result.setNames(TITLE_NAMES);
 
         List<String> dbNames;
-        dbNames = metadataMgr.listDbNames(catalogName);
+        dbNames = metadataMgr.listDbNames(new ConnectContext(), catalogName);
 
         if (dbNames == null || dbNames.isEmpty()) {
             // empty
@@ -58,7 +59,7 @@ public class ExternalDbsProcDir implements ProcDirInterface {
         if (Config.enable_check_db_state) {
             // if a large number of db under the catalog, this operation is very slow
             dbNames = dbNames.stream().filter(dbName -> {
-                Database db = metadataMgr.getDb(catalogName, dbName);
+                Database db = metadataMgr.getDb(new ConnectContext(), catalogName, dbName);
                 return db != null;
             }).collect(Collectors.toList());
         }
@@ -79,7 +80,7 @@ public class ExternalDbsProcDir implements ProcDirInterface {
 
     @Override
     public ProcNodeInterface lookup(String name) {
-        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalogName, name);
+        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(new ConnectContext(), catalogName, name);
         if (db == null) {
             throw new SemanticException("Database[" + name + "] does not exist.");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ExternalTablesProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ExternalTablesProcDir.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.ProcResultUtils;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
 
@@ -52,11 +53,11 @@ public class ExternalTablesProcDir implements ProcDirInterface {
             throw new AnalysisException("name is null");
         }
         MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
-        Database db = metadataMgr.getDb(catalogName, dbName);
+        Database db = metadataMgr.getDb(new ConnectContext(), catalogName, dbName);
         if (db == null) {
             throw new AnalysisException("db: " + dbName + " not exists");
         }
-        Table tbl = metadataMgr.getTable(catalogName, dbName, name);
+        Table tbl = metadataMgr.getTable(new ConnectContext(), catalogName, dbName, name);
         if (tbl == null) {
             throw new AnalysisException("table : " + name + " not exists");
         }
@@ -68,7 +69,7 @@ public class ExternalTablesProcDir implements ProcDirInterface {
         MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
         Preconditions.checkNotNull(metadataMgr);
         List<String> tables = null;
-        tables = metadataMgr.listTableNames(catalogName, dbName);
+        tables = metadataMgr.listTableNames(new ConnectContext(), catalogName, dbName);
 
         // get info
         List<List<Comparable>> tableInfos = new ArrayList<List<Comparable>>();

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/JobsDbProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/JobsDbProcDir.java
@@ -40,6 +40,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Database;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 
 import java.util.List;
@@ -91,7 +92,7 @@ public class JobsDbProcDir implements ProcDirInterface {
         BaseProcResult result = new BaseProcResult();
 
         result.setNames(TITLE_NAMES);
-        List<String> names = globalStateMgr.getLocalMetastore().listDbNames();
+        List<String> names = globalStateMgr.getLocalMetastore().listDbNames(new ConnectContext());
         if (names == null || names.isEmpty()) {
             // empty
             return result;

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -1131,6 +1131,7 @@ public class PropertyAnalyzer {
     public static List<UniqueConstraint> analyzeUniqueConstraint(Map<String, String> properties, Database db, Table table) {
         List<UniqueConstraint> uniqueConstraints = Lists.newArrayList();
         List<UniqueConstraint> analyzedUniqueConstraints = Lists.newArrayList();
+        ConnectContext context = new ConnectContext();
 
         if (properties != null && properties.containsKey(PROPERTIES_UNIQUE_CONSTRAINT)) {
             String constraintDescs = properties.get(PROPERTIES_UNIQUE_CONSTRAINT);
@@ -1149,7 +1150,7 @@ public class PropertyAnalyzer {
                 List<String> columnNames = parseResult.second;
                 if (table.isMaterializedView()) {
                     Table uniqueConstraintTable = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(
-                            tableName.getCatalog(), tableName.getDb(), tableName.getTbl());
+                            context, tableName.getCatalog(), tableName.getDb(), tableName.getTbl());
                     if (uniqueConstraintTable == null) {
                         throw new SemanticException(String.format("table: %s does not exist", tableName));
                     }
@@ -1191,13 +1192,15 @@ public class PropertyAnalyzer {
         if (!GlobalStateMgr.getCurrentState().getCatalogMgr().catalogExists(catalogName)) {
             throw new SemanticException(String.format("catalog: %s do not exist", catalogName));
         }
-        Database parentDb = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalogName, dbName);
+
+        ConnectContext context = new ConnectContext();
+        Database parentDb = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(context, catalogName, dbName);
         if (parentDb == null) {
             throw new SemanticException(
                     String.format("catalog: %s, database: %s do not exist", catalogName, dbName));
         }
         Table table = GlobalStateMgr.getCurrentState().getMetadataMgr()
-                .getTable(catalogName, dbName, tableName);
+                .getTable(context, catalogName, dbName, tableName);
         if (table == null) {
             throw new SemanticException(String.format("catalog:%s, database: %s, table:%s do not exist",
                     catalogName, dbName, tableName));

--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -18,14 +18,12 @@ import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.IcebergTable;
-import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AlreadyExistsException;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.MetaNotFoundException;
-import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.informationschema.InformationSchemaMetadata;
@@ -116,17 +114,17 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listDbNames() {
+    public List<String> listDbNames(ConnectContext context) {
         return ImmutableList.<String>builder()
-                .addAll(this.normal.listDbNames())
-                .addAll(this.informationSchema.listDbNames())
+                .addAll(this.normal.listDbNames(context))
+                .addAll(this.informationSchema.listDbNames(context))
                 .build();
     }
 
     @Override
-    public List<String> listTableNames(String dbName) {
+    public List<String> listTableNames(ConnectContext context, String dbName) {
         ConnectorMetadata metadata = metadataOfDb(dbName);
-        return metadata.listTableNames(dbName);
+        return metadata.listTableNames(context, dbName);
     }
 
     @Override
@@ -141,13 +139,13 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public Table getTable(String dbName, String tblName) {
+    public Table getTable(ConnectContext context, String dbName, String tblName) {
         ConnectorMetadata metadata = metadataOfTable(tblName);
         if (metadata == null) {
             metadata = metadataOfDb(dbName);
         }
 
-        return metadata.getTable(dbName, tblName);
+        return metadata.getTable(context, dbName, tblName);
     }
 
     @Override
@@ -163,14 +161,9 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public boolean tableExists(String dbName, String tblName) {
+    public boolean tableExists(ConnectContext context, String dbName, String tblName) {
         ConnectorMetadata metadata = metadataOfDb(dbName);
-        return metadata.tableExists(dbName, tblName);
-    }
-
-    @Override
-    public Pair<Table, MaterializedIndexMeta> getMaterializedViewIndex(String dbName, String tblName) {
-        return normal.getMaterializedViewIndex(dbName, tblName);
+        return metadata.tableExists(context, dbName, tblName);
     }
 
     @Override
@@ -232,9 +225,9 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public boolean dbExists(String dbName) {
+    public boolean dbExists(ConnectContext context, String dbName) {
         ConnectorMetadata metadata = metadataOfDb(dbName);
-        return metadata.dbExists(dbName);
+        return metadata.dbExists(context, dbName);
     }
 
     @Override
@@ -243,14 +236,14 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public void dropDb(String dbName, boolean isForceDrop) throws DdlException, MetaNotFoundException {
-        normal.dropDb(dbName, isForceDrop);
+    public void dropDb(ConnectContext context, String dbName, boolean isForceDrop) throws DdlException, MetaNotFoundException {
+        normal.dropDb(context, dbName, isForceDrop);
     }
 
     @Override
-    public Database getDb(String name) {
+    public Database getDb(ConnectContext context, String name) {
         ConnectorMetadata metadata = metadataOfDb(name);
-        return metadata.getDb(name);
+        return metadata.getDb(context, name);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -18,14 +18,12 @@ import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.IcebergTable;
-import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AlreadyExistsException;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.MetaNotFoundException;
-import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.exception.StarRocksConnectorException;
@@ -79,7 +77,7 @@ public interface ConnectorMetadata {
      *
      * @return a list of string containing all database names of connector
      */
-    default List<String> listDbNames() {
+    default List<String> listDbNames(ConnectContext context) {
         return Lists.newArrayList();
     }
 
@@ -89,7 +87,7 @@ public interface ConnectorMetadata {
      * @param dbName - the string of which all table names are listed
      * @return a list of string containing all table names of `dbName`
      */
-    default List<String> listTableNames(String dbName) {
+    default List<String> listTableNames(ConnectContext context, String dbName) {
         return Lists.newArrayList();
     }
 
@@ -126,7 +124,7 @@ public interface ConnectorMetadata {
      * @param tblName - the string represents the table name
      * @return a Table instance
      */
-    default Table getTable(String dbName, String tblName) {
+    default Table getTable(ConnectContext context, String dbName, String tblName) {
         return null;
     }
 
@@ -136,19 +134,8 @@ public interface ConnectorMetadata {
         return TableVersionRange.empty();
     }
 
-    default boolean tableExists(String dbName, String tblName) {
-        return listTableNames(dbName).contains(tblName);
-    }
-
-    /**
-     * Get Table descriptor and materialized index for the materialized view index specific by `dbName`.`tblName`
-     *
-     * @param dbName  - the string represents the database name
-     * @param tblName - the string represents the table name
-     * @return a Table instance
-     */
-    default Pair<Table, MaterializedIndexMeta> getMaterializedViewIndex(String dbName, String tblName) {
-        return null;
+    default boolean tableExists(ConnectContext context, String dbName, String tblName) {
+        return listTableNames(context, dbName).contains(tblName);
     }
 
     /**
@@ -237,15 +224,15 @@ public interface ConnectorMetadata {
         createDb(dbName, new HashMap<>());
     }
 
-    default boolean dbExists(String dbName) {
-        return listDbNames().contains(dbName.toLowerCase(Locale.ROOT));
+    default boolean dbExists(ConnectContext context, String dbName) {
+        return listDbNames(context).contains(dbName.toLowerCase(Locale.ROOT));
     }
 
     default void createDb(String dbName, Map<String, String> properties) throws DdlException, AlreadyExistsException {
         throw new StarRocksConnectorException("This connector doesn't support creating databases");
     }
 
-    default void dropDb(String dbName, boolean isForceDrop) throws DdlException, MetaNotFoundException {
+    default void dropDb(ConnectContext context, String dbName, boolean isForceDrop) throws DdlException, MetaNotFoundException {
         throw new StarRocksConnectorException("This connector doesn't support dropping databases");
     }
 
@@ -253,7 +240,7 @@ public interface ConnectorMetadata {
         return null;
     }
 
-    default Database getDb(String name) {
+    default Database getDb(ConnectContext context, String name) {
         return null;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
@@ -98,17 +98,17 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listDbNames() {
+    public List<String> listDbNames(ConnectContext context) {
         return deltaOps.getAllDatabaseNames();
     }
 
     @Override
-    public List<String> listTableNames(String dbName) {
+    public List<String> listTableNames(ConnectContext context, String dbName) {
         return deltaOps.getAllTableNames(dbName);
     }
 
     @Override
-    public Database getDb(String dbName) {
+    public Database getDb(ConnectContext context, String dbName) {
         return deltaOps.getDb(dbName);
     }
 
@@ -340,7 +340,7 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public Table getTable(String dbName, String tblName) {
+    public Table getTable(ConnectContext context, String dbName, String tblName) {
         try {
             return deltaOps.getTable(dbName, tblName);
         } catch (Exception e) {
@@ -350,7 +350,7 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public boolean tableExists(String dbName, String tblName) {
+    public boolean tableExists(ConnectContext context, String dbName, String tblName) {
         return deltaOps.tableExists(dbName, tblName);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadata.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.EsTable;
 import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.qe.ConnectContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -54,22 +55,22 @@ public class ElasticsearchMetadata
     }
 
     @Override
-    public List<String> listDbNames() {
+    public List<String> listDbNames(ConnectContext context) {
         return Arrays.asList(DEFAULT_DB);
     }
 
     @Override
-    public List<String> listTableNames(String dbName) {
+    public List<String> listTableNames(ConnectContext context, String dbName) {
         return esRestClient.listTables();
     }
 
     @Override
-    public Database getDb(String dbName) {
+    public Database getDb(ConnectContext context, String dbName) {
         return new Database(DEFAULT_DB_ID, DEFAULT_DB);
     }
 
     @Override
-    public Table getTable(String dbName, String tblName) {
+    public Table getTable(ConnectContext context, String dbName, String tblName) {
         if (!DEFAULT_DB.equalsIgnoreCase(dbName)) {
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/ConnectorTableMetadataProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/ConnectorTableMetadataProcessor.java
@@ -28,6 +28,7 @@ import com.starrocks.connector.CacheUpdateProcessor;
 import com.starrocks.connector.DatabaseTableName;
 import com.starrocks.connector.iceberg.CachingIcebergCatalog;
 import com.starrocks.connector.iceberg.IcebergCatalog;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
@@ -119,6 +120,7 @@ public class ConnectorTableMetadataProcessor extends FrontendDaemon {
 
     private void refreshCatalogTable() {
         MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
+        ConnectContext context = new ConnectContext();
         List<CatalogNameType> catalogNameTypes = Lists.newArrayList(cacheUpdateProcessors.keySet());
         for (CatalogNameType catalogNameType : catalogNameTypes) {
             String catalogName = catalogNameType.getCatalogName();
@@ -134,7 +136,7 @@ public class ConnectorTableMetadataProcessor extends FrontendDaemon {
                 String tableName = cachedTableName.getTableName();
                 Table table;
                 try {
-                    table = metadataMgr.getTable(catalogName, dbName, tableName);
+                    table = metadataMgr.getTable(context, catalogName, dbName, tableName);
                 } catch (Exception e) {
                     LOG.warn("can't get table of {}.{}.{}，msg: ", catalogName, dbName, tableName, e);
                     continue;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
@@ -38,6 +38,7 @@ import com.starrocks.connector.hive.HiveStatisticsProvider;
 import com.starrocks.connector.hive.Partition;
 import com.starrocks.connector.statistics.StatisticsUtils;
 import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.DropTableStmt;
@@ -90,12 +91,12 @@ public class HudiMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listDbNames() {
+    public List<String> listDbNames(ConnectContext context) {
         return hmsOps.getAllDatabaseNames();
     }
 
     @Override
-    public List<String> listTableNames(String dbName) {
+    public List<String> listTableNames(ConnectContext context, String dbName) {
         return hmsOps.getAllTableNames(dbName);
     }
 
@@ -111,7 +112,7 @@ public class HudiMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public Database getDb(String dbName) {
+    public Database getDb(ConnectContext context, String dbName) {
         Database database;
         try {
             database = hmsOps.getDb(dbName);
@@ -124,7 +125,7 @@ public class HudiMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public Table getTable(String dbName, String tblName) {
+    public Table getTable(ConnectContext context, String dbName, String tblName) {
         Table table;
         try {
             table = hmsOps.getTable(dbName, tblName);
@@ -137,7 +138,7 @@ public class HudiMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public boolean tableExists(String dbName, String tblName) {
+    public boolean tableExists(ConnectContext context, String dbName, String tblName) {
         return hmsOps.tableExists(dbName, tblName);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/informationschema/InformationSchemaMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/informationschema/InformationSchemaMetadata.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector.informationschema;
 
 import com.google.common.collect.Lists;
@@ -20,6 +19,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.information.InfoSchemaDb;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.qe.ConnectContext;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -39,17 +39,17 @@ public class InformationSchemaMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listDbNames() {
+    public List<String> listDbNames(ConnectContext context) {
         return Lists.newArrayList(InfoSchemaDb.DATABASE_NAME);
     }
 
     @Override
-    public List<String> listTableNames(String dbName) {
+    public List<String> listTableNames(ConnectContext context, String dbName) {
         return infoSchemaDb.getTables().stream().map(Table::getName).collect(Collectors.toList());
     }
 
     @Override
-    public Table getTable(String dbName, String tblName) {
+    public Table getTable(ConnectContext context, String dbName, String tblName) {
         if (isInfoSchemaDb(dbName)) {
             return infoSchemaDb.getTable(tblName);
         }
@@ -57,12 +57,12 @@ public class InformationSchemaMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public boolean dbExists(String dbName) {
+    public boolean dbExists(ConnectContext context, String dbName) {
         return isInfoSchemaDb(dbName);
     }
 
     @Override
-    public Database getDb(String name) {
+    public Database getDb(ConnectContext context, String name) {
         if (isInfoSchemaDb(name)) {
             return this.infoSchemaDb;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
@@ -32,6 +32,7 @@ import com.starrocks.connector.ConnectorTableId;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.qe.ConnectContext;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.apache.logging.log4j.LogManager;
@@ -154,7 +155,7 @@ public class JDBCMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listDbNames() {
+    public List<String> listDbNames(ConnectContext context) {
         try (Connection connection = getConnection()) {
             return Lists.newArrayList(schemaResolver.listSchemas(connection));
         } catch (SQLException e) {
@@ -163,9 +164,9 @@ public class JDBCMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public Database getDb(String name) {
+    public Database getDb(ConnectContext context, String name) {
         try {
-            if (listDbNames().contains(name)) {
+            if (listDbNames(context).contains(name)) {
                 return new Database(0, name);
             } else {
                 return null;
@@ -176,7 +177,7 @@ public class JDBCMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listTableNames(String dbName) {
+    public List<String> listTableNames(ConnectContext context, String dbName) {
         try (Connection connection = getConnection()) {
             try (ResultSet resultSet = schemaResolver.getTables(connection, dbName)) {
                 ImmutableList.Builder<String> list = ImmutableList.builder();
@@ -192,7 +193,7 @@ public class JDBCMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public Table getTable(String dbName, String tblName) {
+    public Table getTable(ConnectContext context, String dbName, String tblName) {
         JDBCTableName jdbcTable = new JDBCTableName(null, dbName, tblName);
         return tableInstanceCache.get(jdbcTable,
                 k -> {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/kudu/KuduMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/kudu/KuduMetadata.java
@@ -35,6 +35,7 @@ import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.HivePartitionStats;
 import com.starrocks.connector.hive.IHiveMetastore;
 import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -91,7 +92,7 @@ public class KuduMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listDbNames() {
+    public List<String> listDbNames(ConnectContext context) {
         if (metastore.isPresent()) {
             return metastore.get().getAllDatabaseNames().stream()
                     .filter(schemaName -> !HIVE_SYSTEM_SCHEMA.contains((schemaName)))
@@ -140,7 +141,7 @@ public class KuduMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listTableNames(String dbName) {
+    public List<String> listTableNames(ConnectContext context, String dbName) {
         if (metastore.isPresent()) {
             List<String> allTableNames = metastore.get().getAllTableNames(dbName);
             return allTableNames.stream().filter(tableName -> {
@@ -170,7 +171,7 @@ public class KuduMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public Database getDb(String dbName) {
+    public Database getDb(ConnectContext context, String dbName) {
         if (metastore.isPresent()) {
             return metastore.get().getDb(dbName);
         }
@@ -198,7 +199,7 @@ public class KuduMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public Table getTable(String dbName, String tblName) {
+    public Table getTable(ConnectContext context, String dbName, String tblName) {
         if (metastore.isPresent()) {
             return metastore.get().getTable(dbName, tblName);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/AbstractMetadataTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/AbstractMetadataTableFactory.java
@@ -15,7 +15,8 @@
 package com.starrocks.connector.metadata;
 
 import com.starrocks.catalog.Table;
+import com.starrocks.qe.ConnectContext;
 
 public interface AbstractMetadataTableFactory {
-    Table createTable(String catalogName, String dbName, String tableName, MetadataTableType tableType);
+    Table createTable(ConnectContext context, String catalogName, String dbName, String tableName, MetadataTableType tableType);
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/TableMetaMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/TableMetaMetadata.java
@@ -19,6 +19,7 @@ import com.starrocks.catalog.Type;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.ConnectorTableVersion;
 import com.starrocks.connector.TableVersionRange;
+import com.starrocks.qe.ConnectContext;
 
 import java.util.Optional;
 
@@ -39,12 +40,12 @@ public class TableMetaMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public Table getTable(String dbName, String tblName) {
+    public Table getTable(ConnectContext context, String dbName, String tblName) {
         MetadataTableName metadataTableName = MetadataTableName.from(tblName);
         MetadataTableType tableType = metadataTableName.getTableType();
         String tableName = metadataTableName.getTableName();
         AbstractMetadataTableFactory tableFactory = MetadataTableFactoryProvider.getFactory(catalogType);
-        return tableFactory.createTable(catalogName, dbName, tableName, tableType);
+        return tableFactory.createTable(context, catalogName, dbName, tableName, tableType);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergMetadataTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergMetadataTableFactory.java
@@ -18,6 +18,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.metadata.AbstractMetadataTableFactory;
 import com.starrocks.connector.metadata.MetadataTableType;
+import com.starrocks.qe.ConnectContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -26,7 +27,8 @@ public class IcebergMetadataTableFactory implements AbstractMetadataTableFactory
     public static final IcebergMetadataTableFactory INSTANCE = new IcebergMetadataTableFactory();
 
     @Override
-    public Table createTable(String catalogName, String dbName, String tableName, MetadataTableType tableType) {
+    public Table createTable(ConnectContext context, String catalogName, String dbName, String tableName,
+                             MetadataTableType tableType) {
         switch (tableType) {
             case LOGICAL_ICEBERG_METADATA:
                 return LogicalIcebergMetadataTable.create(catalogName, dbName, tableName);
@@ -43,7 +45,7 @@ public class IcebergMetadataTableFactory implements AbstractMetadataTableFactory
             case FILES:
                 return IcebergFilesTable.create(catalogName, dbName, tableName);
             case PARTITIONS:
-                return IcebergPartitionsTable.create(catalogName, dbName, tableName);
+                return IcebergPartitionsTable.create(context, catalogName, dbName, tableName);
             default:
                 LOG.error("Unrecognized iceberg metadata table type {}", tableType);
                 throw new StarRocksConnectorException("Unrecognized iceberg metadata table type %s", tableType);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergPartitionsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergPartitionsTable.java
@@ -27,6 +27,7 @@ import com.starrocks.connector.iceberg.IcebergApiConverter;
 import com.starrocks.connector.metadata.MetadataTable;
 import com.starrocks.connector.metadata.MetadataTableType;
 import com.starrocks.connector.share.iceberg.IcebergPartitionUtils;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.THdfsTable;
 import com.starrocks.thrift.TTableDescriptor;
@@ -47,8 +48,9 @@ public class IcebergPartitionsTable extends MetadataTable {
         super(catalogName, id, name, type, baseSchema, originDb, originTable, metadataTableType);
     }
 
-    public static IcebergPartitionsTable create(String catalogName, String originDb, String originTable) {
-        Table icebergTable = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(catalogName, originDb, originTable);
+    public static IcebergPartitionsTable create(ConnectContext context, String catalogName, String originDb, String originTable) {
+        Table icebergTable = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                .getTable(context, catalogName, originDb, originTable);
         if (icebergTable == null) {
             throw new StarRocksConnectorException("table [%s.%s.%s] does not exist", catalogName, originDb, originTable);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/odps/OdpsMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/odps/OdpsMetadata.java
@@ -57,6 +57,7 @@ import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.aliyun.AliyunCloudConfiguration;
 import com.starrocks.credential.aliyun.AliyunCloudCredential;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
@@ -152,7 +153,7 @@ public class OdpsMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listDbNames() {
+    public List<String> listDbNames(ConnectContext context) {
         ImmutableList.Builder<String> builder = ImmutableList.builder();
         try {
             if (StringUtils.isNullOrEmpty(catalogOwner)) {
@@ -178,7 +179,7 @@ public class OdpsMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public Database getDb(String name) {
+    public Database getDb(ConnectContext context, String name) {
         try {
             return new Database(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(), name);
         } catch (StarRocksConnectorException e) {
@@ -188,7 +189,7 @@ public class OdpsMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listTableNames(String dbName) {
+    public List<String> listTableNames(ConnectContext context, String dbName) {
         try {
             return new ArrayList<>(tableNameCache.get(dbName));
         } catch (ExecutionException e) {
@@ -207,7 +208,7 @@ public class OdpsMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public Table getTable(String dbName, String tblName) {
+    public Table getTable(ConnectContext context, String dbName, String tblName) {
         return get(tableCache, OdpsTableName.of(dbName, tblName));
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -39,6 +39,7 @@ import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.statistics.StatisticsUtils;
 import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
@@ -120,12 +121,12 @@ public class PaimonMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listDbNames() {
+    public List<String> listDbNames(ConnectContext context) {
         return paimonNativeCatalog.listDatabases();
     }
 
     @Override
-    public List<String> listTableNames(String dbName) {
+    public List<String> listTableNames(ConnectContext context, String dbName) {
         try {
             return paimonNativeCatalog.listTables(dbName);
         } catch (Catalog.DatabaseNotExistException e) {
@@ -215,7 +216,7 @@ public class PaimonMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public Database getDb(String dbName) {
+    public Database getDb(ConnectContext context, String dbName) {
         if (databases.containsKey(dbName)) {
             return databases.get(dbName);
         }
@@ -232,7 +233,7 @@ public class PaimonMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public Table getTable(String dbName, String tblName) {
+    public Table getTable(ConnectContext context, String dbName, String tblName) {
         Identifier identifier = new Identifier(dbName, tblName);
         if (tables.containsKey(identifier)) {
             return tables.get(identifier);
@@ -265,7 +266,7 @@ public class PaimonMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public boolean tableExists(String dbName, String tableName) {
+    public boolean tableExists(ConnectContext context, String dbName, String tableName) {
         try {
             paimonNativeCatalog.getTable(Identifier.create(dbName, tableName));
             return true;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorHistogramColumnStatsCacheLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorHistogramColumnStatsCacheLoader.java
@@ -58,7 +58,7 @@ public class ConnectorHistogramColumnStatsCacheLoader implements
                         queryHistogramStatistics(connectContext, cacheKey.tableUUID, Lists.newArrayList(cacheKey.column));
                 // check TStatisticData is not empty, There may be no such column Statistics in BE
                 if (!statisticData.isEmpty()) {
-                    return Optional.of(convert2Histogram(cacheKey.tableUUID, statisticData.get(0)));
+                    return Optional.of(convert2Histogram(connectContext, cacheKey.tableUUID, statisticData.get(0)));
                 } else {
                     return Optional.empty();
                 }
@@ -95,7 +95,7 @@ public class ConnectorHistogramColumnStatsCacheLoader implements
 
                 List<TStatisticData> histogramStatsDataList = queryHistogramStatistics(connectContext, tableUUID, columns);
                 for (TStatisticData histogramStatsData : histogramStatsDataList) {
-                    Histogram histogram = convert2Histogram(tableUUID, histogramStatsData);
+                    Histogram histogram = convert2Histogram(connectContext, tableUUID, histogramStatsData);
                     result.put(new ConnectorTableColumnKey(tableUUID, histogramStatsData.columnName),
                             Optional.of(histogram));
                 }
@@ -123,8 +123,9 @@ public class ConnectorHistogramColumnStatsCacheLoader implements
         return statisticExecutor.queryHistogram(context, tableUUID, column);
     }
 
-    private Histogram convert2Histogram(String tableUUID, TStatisticData statisticData) throws AnalysisException {
-        Table table = getTableByUUID(tableUUID);
+    private Histogram convert2Histogram(ConnectContext context, String tableUUID, TStatisticData statisticData)
+            throws AnalysisException {
+        Table table = getTableByUUID(context, tableUUID);
         Type columnType = StatisticUtils.getQueryStatisticsColumnType(table, statisticData.columnName);
 
         List<Bucket> buckets = HistogramUtils.convertBuckets(statisticData.histogram, columnType);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorTableTriggerAnalyzeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorTableTriggerAnalyzeMgr.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.util.DateUtils;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.statistic.StatisticExecutor;
 import io.trino.hive.$internal.org.apache.commons.lang3.tuple.Triple;
@@ -90,7 +91,7 @@ public class ConnectorTableTriggerAnalyzeMgr {
             // first check table exist
             if (!tableExist) {
                 try {
-                    tableTriple = StatisticsUtils.getTableTripleByUUID(columnKey.tableUUID);
+                    tableTriple = StatisticsUtils.getTableTripleByUUID(new ConnectContext(), columnKey.tableUUID);
                     // check table could run analyze
                     if (!tableTriple.getRight().isAnalyzableExternalTable()) {
                         return;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/statistics/StatisticsUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/statistics/StatisticsUtils.java
@@ -18,6 +18,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -35,11 +36,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class StatisticsUtils {
-    public static Table getTableByUUID(String tableUUID) {
+    public static Table getTableByUUID(ConnectContext context, String tableUUID) {
         String[] splits = tableUUID.split("\\.");
 
         Preconditions.checkState(splits.length == 4);
-        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(splits[0], splits[1], splits[2]);
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(context, splits[0], splits[1], splits[2]);
         if (table == null) {
             throw new SemanticException("Table [%s.%s.%s] is not existed", splits[0], splits[1], splits[2]);
         }
@@ -50,16 +51,16 @@ public class StatisticsUtils {
         }
     }
 
-    public static Triple<String, Database, Table> getTableTripleByUUID(String tableUUID) {
+    public static Triple<String, Database, Table> getTableTripleByUUID(ConnectContext context, String tableUUID) {
         String[] splits = tableUUID.split("\\.");
 
         Preconditions.checkState(splits.length == 4);
-        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(splits[0], splits[1]);
+        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(context, splits[0], splits[1]);
         if (db == null) {
             throw new SemanticException("Database [%s.%s] is not existed", splits[0], splits[1]);
         }
 
-        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(splits[0], splits[1], splits[2]);
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(context, splits[0], splits[1], splits[2]);
         if (table == null) {
             throw new SemanticException("Table [%s.%s.%s] is not existed", splits[0], splits[1], splits[2]);
         }
@@ -86,7 +87,7 @@ public class StatisticsUtils {
 
     public static ConnectorTableColumnStats estimateColumnStatistics(Table table, String columnName,
                                                                      ConnectorTableColumnStats connectorTableColumnStats) {
-        Triple<String, Database, Table> tableIdentifier = getTableTripleByUUID(table.getUUID());
+        Triple<String, Database, Table> tableIdentifier = getTableTripleByUUID(new ConnectContext(), table.getUUID());
         ExternalBasicStatsMeta externalBasicStatsMeta = GlobalStateMgr.getCurrentState().getAnalyzeMgr().
                 getExternalTableBasicStatsMeta(tableIdentifier.getLeft(), tableIdentifier.getMiddle().getFullName(),
                         tableIdentifier.getRight().getName());

--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
@@ -88,7 +88,7 @@ public class UnifiedMetadata implements ConnectorMetadata {
     }
 
     private Table.TableType getTableType(String dbName, String tblName) {
-        Table table = hiveMetadata.getTable(dbName, tblName);
+        Table table = hiveMetadata.getTable(new ConnectContext(), dbName, tblName);
         if (table == null || table.isHiveView()) {
             return HIVE; // use hive metadata by default
         }
@@ -141,13 +141,13 @@ public class UnifiedMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listDbNames() {
-        return hiveMetadata.listDbNames();
+    public List<String> listDbNames(ConnectContext context) {
+        return hiveMetadata.listDbNames(context);
     }
 
     @Override
-    public List<String> listTableNames(String dbName) {
-        return hiveMetadata.listTableNames(dbName);
+    public List<String> listTableNames(ConnectContext context, String dbName) {
+        return hiveMetadata.listTableNames(context, dbName);
     }
 
     @Override
@@ -164,14 +164,14 @@ public class UnifiedMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public Table getTable(String dbName, String tblName) {
+    public Table getTable(ConnectContext context, String dbName, String tblName) {
         ConnectorMetadata metadata = metadataOfTable(dbName, tblName);
-        return metadata.getTable(dbName, tblName);
+        return metadata.getTable(context, dbName, tblName);
     }
 
     @Override
-    public boolean tableExists(String dbName, String tblName) {
-        return hiveMetadata.tableExists(dbName, tblName);
+    public boolean tableExists(ConnectContext context, String dbName, String tblName) {
+        return hiveMetadata.tableExists(context, dbName, tblName);
     }
 
     @Override
@@ -230,8 +230,8 @@ public class UnifiedMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public boolean dbExists(String dbName) {
-        return hiveMetadata.dbExists(dbName);
+    public boolean dbExists(ConnectContext context, String dbName) {
+        return hiveMetadata.dbExists(context, dbName);
     }
 
     @Override
@@ -240,13 +240,13 @@ public class UnifiedMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public void dropDb(String dbName, boolean isForceDrop) throws DdlException, MetaNotFoundException {
-        hiveMetadata.dropDb(dbName, isForceDrop);
+    public void dropDb(ConnectContext context, String dbName, boolean isForceDrop) throws DdlException, MetaNotFoundException {
+        hiveMetadata.dropDb(context, dbName, isForceDrop);
     }
 
     @Override
-    public Database getDb(String name) {
-        return hiveMetadata.getDb(name);
+    public Database getDb(ConnectContext context, String name) {
+        return hiveMetadata.getDb(context, name);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowMetaInfoAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowMetaInfoAction.java
@@ -185,11 +185,11 @@ public class ShowMetaInfoAction extends RestBaseAction {
 
     public Map<String, Long> getDataSize(boolean singleReplica) {
         Map<String, Long> result = new HashMap<String, Long>();
-        List<String> dbNames = GlobalStateMgr.getCurrentState().getLocalMetastore().listDbNames();
 
-        for (int i = 0; i < dbNames.size(); i++) {
-            String dbName = dbNames.get(i);
-            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+        for (Map.Entry<String, Database> dbs : GlobalStateMgr.getCurrentState().getLocalMetastore().getFullNameToDb()
+                .entrySet()) {
+            String dbName = dbs.getKey();
+            Database db = dbs.getValue();
 
             long totalSize = 0;
             List<Table> tables = GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId());

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -70,6 +70,7 @@ import com.starrocks.monitor.jvm.JvmStatCollector;
 import com.starrocks.monitor.jvm.JvmStats;
 import com.starrocks.proto.PKafkaOffsetProxyRequest;
 import com.starrocks.proto.PKafkaOffsetProxyResult;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.ExecuteEnv;
 import com.starrocks.staros.StarMgrServer;
@@ -915,7 +916,7 @@ public final class MetricRepo {
     // collect table-level metrics
     private static void collectTableMetrics(MetricVisitor visitor, boolean minifyTableMetrics) {
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
-        List<String> dbNames = globalStateMgr.getLocalMetastore().listDbNames();
+        List<String> dbNames = globalStateMgr.getLocalMetastore().listDbNames(new ConnectContext());
         for (String dbName : dbNames) {
             Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
             if (null == db) {
@@ -960,7 +961,7 @@ public final class MetricRepo {
 
     private static void collectDatabaseMetrics(MetricVisitor visitor) {
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
-        List<String> dbNames = globalStateMgr.getLocalMetastore().listDbNames();
+        List<String> dbNames = globalStateMgr.getLocalMetastore().listDbNames(new ConnectContext());
         GaugeMetricImpl<Integer> databaseNum = new GaugeMetricImpl<>(
                 "database_num", MetricUnit.OPERATIONS, "count of database");
         int dbNum = 0;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DictionaryCacheSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DictionaryCacheSink.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Dictionary;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TColumn;
 import com.starrocks.thrift.TDataSink;
@@ -128,10 +129,10 @@ public class DictionaryCacheSink extends DataSink {
     }
 
     private TOlapTableSchemaParam buildTSchema() {
-        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(
+        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(new ConnectContext(),
                                         dictionary.getCatalogName(), dictionary.getDbName());
         String queryableObject = dictionary.getQueryableObject();
-        Table tbl = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(
+        Table tbl = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(new ConnectContext(),
                                         dictionary.getCatalogName(), dictionary.getDbName(), queryableObject);
         Preconditions.checkNotNull(tbl);
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -1221,7 +1221,7 @@ public class ConnectContext {
             dbName = parts[1];
         }
 
-        if (!Strings.isNullOrEmpty(dbName) && metadataMgr.getDb(this.getCurrentCatalog(), dbName) == null) {
+        if (!Strings.isNullOrEmpty(dbName) && metadataMgr.getDb(this, this.getCurrentCatalog(), dbName) == null) {
             LOG.debug("Unknown catalog {} and db {}", this.getCurrentCatalog(), dbName);
             ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -418,7 +418,7 @@ public class ConnectProcessor {
             ctx.getState().setError("Empty tableName");
             return;
         }
-        Database db = ctx.getGlobalStateMgr().getMetadataMgr().getDb(ctx.getCurrentCatalog(), ctx.getDatabase());
+        Database db = ctx.getGlobalStateMgr().getMetadataMgr().getDb(ctx, ctx.getCurrentCatalog(), ctx.getDatabase());
         if (db == null) {
             ctx.getState().setError("Unknown database(" + ctx.getDatabase() + ")");
             return;
@@ -428,7 +428,7 @@ public class ConnectProcessor {
         try {
             // we should get table through metadata manager
             Table table = ctx.getGlobalStateMgr().getMetadataMgr().getTable(
-                    ctx.getCurrentCatalog(), ctx.getDatabase(), tableName);
+                    ctx, ctx.getCurrentCatalog(), ctx.getDatabase(), tableName);
             if (table == null) {
                 ctx.getState().setError("Unknown table(" + tableName + ")");
                 return;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -240,7 +240,7 @@ public class DDLStmtExecutor {
                 String dbName = stmt.getDbName();
                 boolean isForceDrop = stmt.isForceDrop();
                 try {
-                    context.getGlobalStateMgr().getMetadataMgr().dropDb(catalogName, dbName, isForceDrop);
+                    context.getGlobalStateMgr().getMetadataMgr().dropDb(context, catalogName, dbName, isForceDrop);
                 } catch (MetaNotFoundException e) {
                     if (stmt.isSetIfExists()) {
                         LOG.info("drop database[{}] which does not exist", dbName);
@@ -292,7 +292,7 @@ public class DDLStmtExecutor {
         @Override
         public ShowResultSet visitCreateTableStatement(CreateTableStmt stmt, ConnectContext context) {
             ErrorReport.wrapWithRuntimeException(() -> {
-                context.getGlobalStateMgr().getMetadataMgr().createTable(stmt);
+                context.getGlobalStateMgr().getMetadataMgr().createTable(context, stmt);
             });
             return null;
         }
@@ -308,7 +308,7 @@ public class DDLStmtExecutor {
         @Override
         public ShowResultSet visitCreateTableLikeStatement(CreateTableLikeStmt stmt, ConnectContext context) {
             ErrorReport.wrapWithRuntimeException(() -> {
-                context.getGlobalStateMgr().getMetadataMgr().createTableLike(stmt);
+                context.getGlobalStateMgr().getMetadataMgr().createTableLike(context, stmt);
             });
             return null;
         }
@@ -952,7 +952,7 @@ public class DDLStmtExecutor {
         @Override
         public ShowResultSet visitRefreshTableStatement(RefreshTableStmt stmt, ConnectContext context) {
             ErrorReport.wrapWithRuntimeException(() -> {
-                context.getGlobalStateMgr().refreshExternalTable(stmt);
+                context.getGlobalStateMgr().refreshExternalTable(context, stmt);
             });
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -972,7 +972,7 @@ public class StmtExecutor {
                 createTemporaryTableStmt.setSessionId(context.getSessionId());
                 return context.getGlobalStateMgr().getMetadataMgr().createTemporaryTable(createTemporaryTableStmt);
             } else {
-                return context.getGlobalStateMgr().getMetadataMgr().createTable(stmt.getCreateTableStmt());
+                return context.getGlobalStateMgr().getMetadataMgr().createTable(context, stmt.getCreateTableStmt());
             }
         } catch (DdlException e) {
             throw new AnalysisException(e.getMessage());
@@ -1468,7 +1468,7 @@ public class StmtExecutor {
         AnalyzeStmt analyzeStmt = (AnalyzeStmt) parsedStmt;
         TableName tableName = analyzeStmt.getTableName();
         Database db =
-                GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(tableName.getCatalog(), tableName.getDb());
+                GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(context, tableName.getCatalog(), tableName.getDb());
         if (db == null) {
             throw new SemanticException("Database %s is not found", tableName.getCatalogAndDb());
         }
@@ -1636,7 +1636,7 @@ public class StmtExecutor {
     private void handleDropStatsStmt() {
         DropStatsStmt dropStatsStmt = (DropStatsStmt) parsedStmt;
         TableName tableName = dropStatsStmt.getTableName();
-        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(tableName.getCatalog(),
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(context, tableName.getCatalog(),
                 tableName.getDb(), tableName.getTbl());
         if (table == null) {
             throw new SemanticException("Table %s is not found", tableName.toString());
@@ -1668,7 +1668,7 @@ public class StmtExecutor {
     private void handleDropHistogramStmt() {
         DropHistogramStmt dropHistogramStmt = (DropHistogramStmt) parsedStmt;
         TableName tableName = dropHistogramStmt.getTableName();
-        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(tableName.getCatalog(),
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(context, tableName.getCatalog(),
                 tableName.getDb(), tableName.getTbl());
         if (table == null) {
             throw new SemanticException("Table %s is not found", tableName.toString());
@@ -1704,12 +1704,12 @@ public class StmtExecutor {
 
     private void checkTblPrivilegeForKillAnalyzeStmt(ConnectContext context, String catalogName, String dbName,
                                                      String tableName) {
-        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalogName, dbName);
+        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(context, catalogName, dbName);
         if (db == null) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
         }
 
-        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(catalogName, dbName, tableName);
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(context, catalogName, dbName, tableName);
         if (table == null) {
             throw new SemanticException("Table %s is not found", tableName);
         }
@@ -2231,7 +2231,7 @@ public class StmtExecutor {
     public void handleInsertOverwrite(InsertStmt insertStmt) throws Exception {
         TableName tableName = insertStmt.getTableName();
         Database db =
-                GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(tableName.getCatalog(), tableName.getDb());
+                GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(context, tableName.getCatalog(), tableName.getDb());
         if (db == null) {
             throw new SemanticException("Database %s is not found", tableName.getCatalogAndDb());
         }
@@ -2332,7 +2332,7 @@ public class StmtExecutor {
         String catalogName = stmt.getTableName().getCatalog();
         String dbName = stmt.getTableName().getDb();
         String tableName = stmt.getTableName().getTbl();
-        Database database = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalogName, dbName);
+        Database database = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(context, catalogName, dbName);
         GlobalTransactionMgr transactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
         final Table targetTable;
         if (stmt instanceof InsertStmt && ((InsertStmt) stmt).getTargetTable() != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -728,7 +728,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         ConnectContext connectContext = context.getCtx();
         List<Pair<Table, BaseTableInfo>> toRepairTables = new ArrayList<>();
         for (BaseTableInfo baseTableInfo : baseTableInfos) {
-            Optional<Database> dbOpt = GlobalStateMgr.getCurrentState().getMetadataMgr().getDatabase(baseTableInfo);
+            Optional<Database> dbOpt =
+                    GlobalStateMgr.getCurrentState().getMetadataMgr().getDatabase(connectContext, baseTableInfo);
             if (dbOpt.isEmpty()) {
                 logger.warn("database {} do not exist in refreshing materialized view", baseTableInfo.getDbInfoStr());
                 throw new DmlException("database " + baseTableInfo.getDbInfoStr() + " do not exist.");
@@ -1169,7 +1170,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     private LockParams collectDatabases(MaterializedView mv) {
         LockParams lockParams = new LockParams();
         for (BaseTableInfo baseTableInfo : mv.getBaseTableInfos()) {
-            Optional<Database> dbOpt = GlobalStateMgr.getCurrentState().getMetadataMgr().getDatabase(baseTableInfo);
+            Optional<Database> dbOpt =
+                    GlobalStateMgr.getCurrentState().getMetadataMgr().getDatabase(new ConnectContext(), baseTableInfo);
             if (dbOpt.isEmpty()) {
                 logger.warn("database {} do not exist", baseTableInfo.getDbInfoStr());
                 throw new DmlException("database " + baseTableInfo.getDbInfoStr() + " do not exist.");

--- a/fe/fe-core/src/main/java/com/starrocks/server/ExternalTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/ExternalTableFactory.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.catalog.Resource;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.DdlException;
+import com.starrocks.qe.ConnectContext;
 
 import java.util.Map;
 
@@ -32,8 +33,8 @@ public abstract class ExternalTableFactory implements AbstractTableFactory {
             "Remote %s is null. Please add properties('%s'='xxx') when create table";
 
     protected static Table getTableFromResourceMappingCatalog(Map<String, String> properties,
-                                                           Table.TableType tableType,
-                                                           Resource.ResourceType resourceType) throws DdlException {
+                                                              Table.TableType tableType,
+                                                              Resource.ResourceType resourceType) throws DdlException {
         GlobalStateMgr gsm = GlobalStateMgr.getCurrentState();
 
         if (properties == null) {
@@ -61,7 +62,7 @@ public abstract class ExternalTableFactory implements AbstractTableFactory {
 
         checkResource(resourceName, resourceType);
         String resourceMappingCatalogName = getResourceMappingCatalogName(resourceName, resourceType.name());
-        return gsm.getMetadataMgr().getTable(resourceMappingCatalogName, remoteDbName, remoteTableName);
+        return gsm.getMetadataMgr().getTable(new ConnectContext(), resourceMappingCatalogName, remoteDbName, remoteTableName);
     }
 
     protected static void checkResource(String resourceName, Resource.ResourceType type) throws DdlException {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -67,7 +67,6 @@ import com.starrocks.catalog.DomainResolver;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.GlobalFunctionMgr;
-import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MetaReplayState;
 import com.starrocks.catalog.PrimitiveType;
@@ -454,7 +453,7 @@ public class GlobalStateMgr {
     private final TaskManager taskManager;
     private final InsertOverwriteJobMgr insertOverwriteJobMgr;
 
-    private final LocalMetastore localMetastore;
+    private LocalMetastore localMetastore;
     private final GlobalFunctionMgr globalFunctionMgr;
 
     @Deprecated
@@ -596,6 +595,10 @@ public class GlobalStateMgr {
         return localMetastore;
     }
 
+    public void setLocalMetastore(LocalMetastore localMetastore) {
+        this.localMetastore = localMetastore;
+    }
+
     public TemporaryTableMgr getTemporaryTableMgr() {
         return temporaryTableMgr;
     }
@@ -697,7 +700,7 @@ public class GlobalStateMgr {
         this.tabletStatMgr = new TabletStatMgr();
         this.authenticationMgr = new AuthenticationMgr();
         this.domainResolver = new DomainResolver(authenticationMgr);
-        this.authorizationMgr = new AuthorizationMgr(this, new DefaultAuthorizationProvider());
+        this.authorizationMgr = new AuthorizationMgr(new DefaultAuthorizationProvider());
 
         this.resourceGroupMgr = new ResourceGroupMgr();
 
@@ -1669,12 +1672,7 @@ public class GlobalStateMgr {
      */
     private void onReloadTables() {
         TemporaryTableMgr temporaryTableMgr = GlobalStateMgr.getCurrentState().getTemporaryTableMgr();
-        List<String> dbNames = metadataMgr.listDbNames(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME);
-        for (String dbName : dbNames) {
-            Database db = metadataMgr.getDb(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, dbName);
-            if (db == null) {
-                continue;
-            }
+        for (Database db : localMetastore.getIdToDb().values()) {
             for (Table table : db.getTables()) {
                 try {
                     table.onReload();
@@ -1691,11 +1689,8 @@ public class GlobalStateMgr {
     }
 
     private void processMvRelatedMeta() {
-        List<String> dbNames = metadataMgr.listDbNames(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME);
-
         long startMillis = System.currentTimeMillis();
-        for (String dbName : dbNames) {
-            Database db = metadataMgr.getDb(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, dbName);
+        for (Database db : localMetastore.getIdToDb().values()) {
             for (MaterializedView mv : db.getMaterializedViews()) {
                 mv.onReload();
             }
@@ -2451,10 +2446,10 @@ public class GlobalStateMgr {
         return functionSet.isNotAlwaysNullResultWithNullParamFunctions(funcName);
     }
 
-    public void refreshExternalTable(RefreshTableStmt stmt) throws DdlException {
+    public void refreshExternalTable(ConnectContext context, RefreshTableStmt stmt) throws DdlException {
         TableName tableName = stmt.getTableName();
         List<String> partitionNames = stmt.getPartitions();
-        refreshExternalTable(tableName, partitionNames);
+        refreshExternalTable(context, tableName, partitionNames);
         refreshOthersFeTable(tableName, partitionNames, true);
     }
 
@@ -2535,17 +2530,17 @@ public class GlobalStateMgr {
                 || table.isJDBCTable() || table.isDeltalakeTable() || table.isPaimonTable();
     }
 
-    public void refreshExternalTable(TableName tableName, List<String> partitions) {
+    public void refreshExternalTable(ConnectContext context, TableName tableName, List<String> partitions) {
         String catalogName = tableName.getCatalog();
         String dbName = tableName.getDb();
         String tblName = tableName.getTbl();
-        Database db = metadataMgr.getDb(catalogName, tableName.getDb());
+        Database db = metadataMgr.getDb(context, catalogName, tableName.getDb());
         if (db == null) {
             throw new StarRocksConnectorException("db: " + tableName.getDb() + " not exists");
         }
 
         Table table;
-        table = metadataMgr.getTable(catalogName, dbName, tblName);
+        table = metadataMgr.getTable(context, catalogName, dbName, tblName);
         if (table == null) {
             throw new StarRocksConnectorException("table %s.%s.%s not exists", catalogName, dbName,
                     tblName);

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -434,7 +434,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
     }
 
     @Override
-    public void dropDb(String dbName, boolean isForceDrop) throws DdlException, MetaNotFoundException {
+    public void dropDb(ConnectContext context, String dbName, boolean isForceDrop) throws DdlException, MetaNotFoundException {
         // 1. check if database exists
         Database db;
         if (!tryLock(false)) {
@@ -2404,6 +2404,10 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
     }
 
     @Override
+    public Database getDb(ConnectContext context, String name) {
+        return getDb(name);
+    }
+
     public Database getDb(String name) {
         if (name == null) {
             return null;
@@ -2458,8 +2462,8 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
     }
 
     @Override
-    public boolean tableExists(String dbName, String tblName) {
-        Database database = getDb(dbName);
+    public boolean tableExists(ConnectContext context, String dbName, String tblName) {
+        Database database = getDb(context, dbName);
         if (database == null) {
             return false;
         }
@@ -2467,6 +2471,10 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
     }
 
     @Override
+    public Table getTable(ConnectContext context, String dbName, String tblName) {
+        return getTable(dbName, tblName);
+    }
+
     public Table getTable(String dbName, String tblName) {
         Database database = getDb(dbName);
         if (database == null) {
@@ -2492,13 +2500,19 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         }
     }
 
-    @Override
-    public Pair<Table, MaterializedIndexMeta> getMaterializedViewIndex(String dbName, String indexName) {
+    /**
+     * Get Table descriptor and materialized index for the materialized view index specific by `dbName`.`tblName`
+     *
+     * @param dbName  - the string represents the database name
+     * @param tblName - the string represents the table name
+     * @return a Table instance
+     */
+    public Pair<Table, MaterializedIndexMeta> getMaterializedViewIndex(String dbName, String tblName) {
         Database database = getDb(dbName);
         if (database == null) {
             return null;
         }
-        return database.getMaterializedViewIndex(indexName);
+        return database.getMaterializedViewIndex(tblName);
     }
 
     public Table getTableIncludeRecycleBin(Database db, long tableId) {
@@ -2568,12 +2582,12 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
     }
 
     @Override
-    public List<String> listDbNames() {
+    public List<String> listDbNames(ConnectContext context) {
         return Lists.newArrayList(fullNameToDb.keySet());
     }
 
     @Override
-    public List<String> listTableNames(String dbName) {
+    public List<String> listTableNames(ConnectContext context, String dbName) {
         Database database = getDb(dbName);
         if (database != null) {
             return database.getTables().stream()

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -420,23 +420,23 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             catalogName = params.getCatalog_name();
         }
 
-        MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
-        List<String> dbNames = metadataMgr.listDbNames(catalogName);
-        LOG.debug("get db names: {}", dbNames);
-
         UserIdentity currentUser;
         if (params.isSetCurrent_user_ident()) {
             currentUser = UserIdentity.fromThrift(params.current_user_ident);
         } else {
             currentUser = UserIdentity.createAnalyzedUserIdentWithIp(params.user, params.user_ip);
         }
+        ConnectContext context = new ConnectContext();
+        context.setCurrentUserIdentity(currentUser);
+        context.setCurrentRoleIds(currentUser);
+
+        MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
+        List<String> dbNames = metadataMgr.listDbNames(context, catalogName);
+        LOG.debug("get db names: {}", dbNames);
 
         List<String> dbs = new ArrayList<>();
         for (String fullName : dbNames) {
             try {
-                ConnectContext context = new ConnectContext();
-                context.setCurrentUserIdentity(currentUser);
-                context.setCurrentRoleIds(currentUser);
                 Authorizer.checkAnyActionOnOrInDb(context, catalogName, fullName);
             } catch (AccessDeniedException e) {
                 continue;
@@ -476,9 +476,6 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             catalogName = params.getCatalog_name();
         }
 
-        MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
-        Database db = metadataMgr.getDb(catalogName, params.db);
-
         UserIdentity currentUser = null;
         if (params.isSetCurrent_user_ident()) {
             currentUser = UserIdentity.fromThrift(params.current_user_ident);
@@ -486,12 +483,19 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             currentUser = UserIdentity.createAnalyzedUserIdentWithIp(params.user, params.user_ip);
         }
 
+        ConnectContext context = new ConnectContext();
+        context.setCurrentUserIdentity(currentUser);
+        context.setCurrentRoleIds(currentUser);
+
+        MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
+        Database db = metadataMgr.getDb(context, catalogName, params.db);
+
         if (db != null) {
-            for (String tableName : metadataMgr.listTableNames(catalogName, params.db)) {
+            for (String tableName : metadataMgr.listTableNames(context, catalogName, params.db)) {
                 LOG.debug("get table: {}, wait to check", tableName);
                 Table tbl = null;
                 try {
-                    tbl = metadataMgr.getTable(catalogName, params.db, tableName);
+                    tbl = metadataMgr.getTable(context, catalogName, params.db, tableName);
                 } catch (Exception e) {
                     LOG.warn(e.getMessage(), e);
                 }
@@ -501,9 +505,6 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                 }
 
                 try {
-                    ConnectContext context = new ConnectContext();
-                    context.setCurrentUserIdentity(currentUser);
-                    context.setCurrentRoleIds(currentUser);
                     Authorizer.checkAnyActionOnTableLikeObject(context, params.db, tbl);
                 } catch (AccessDeniedException e) {
                     continue;
@@ -985,6 +986,10 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         } else {
             currentUser = UserIdentity.createAnalyzedUserIdentWithIp(params.user, params.user_ip);
         }
+        ConnectContext context = new ConnectContext();
+        context.setCurrentUserIdentity(currentUser);
+        context.setCurrentRoleIds(currentUser);
+
         long limit = params.isSetLimit() ? params.getLimit() : -1;
 
         // if user query schema meta such as "select * from information_schema.columns limit 10;",
@@ -1002,20 +1007,17 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         }
 
         MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
-        Database db = metadataMgr.getDb(catalogName, params.db);
+        Database db = metadataMgr.getDb(context, catalogName, params.db);
 
         if (db != null) {
             Locker locker = new Locker();
             try {
                 locker.lockDatabase(db.getId(), LockType.READ);
-                Table table = metadataMgr.getTable(catalogName, params.db, params.table_name);
+                Table table = metadataMgr.getTable(context, catalogName, params.db, params.table_name);
                 if (table == null) {
                     return result;
                 }
                 try {
-                    ConnectContext context = new ConnectContext();
-                    context.setCurrentUserIdentity(currentUser);
-                    context.setCurrentRoleIds(currentUser);
                     Authorizer.checkAnyActionOnTableLikeObject(context, params.db, table);
                 } catch (AccessDeniedException e) {
                     return result;
@@ -1032,13 +1034,14 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     // dbs and tables, when reach limit, we break;
     private void describeWithoutDbAndTable(UserIdentity currentUser, List<TColumnDef> columns, long limit) {
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
-        List<String> dbNames = globalStateMgr.getLocalMetastore().listDbNames();
+        ConnectContext context = new ConnectContext();
+        context.setCurrentUserIdentity(currentUser);
+        context.setCurrentRoleIds(currentUser);
+
+        List<String> dbNames = globalStateMgr.getLocalMetastore().listDbNames(context);
         boolean reachLimit;
         for (String fullName : dbNames) {
             try {
-                ConnectContext context = new ConnectContext();
-                context.setCurrentUserIdentity(currentUser);
-                context.setCurrentRoleIds(currentUser);
                 Authorizer.checkAnyActionOnOrInDb(context,
                         InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, fullName);
             } catch (AccessDeniedException e) {
@@ -1056,9 +1059,6 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                         }
 
                         try {
-                            ConnectContext context = new ConnectContext();
-                            context.setCurrentUserIdentity(currentUser);
-                            context.setCurrentRoleIds(currentUser);
                             Authorizer.checkAnyActionOnTableLikeObject(context, fullName, table);
                         } catch (AccessDeniedException e) {
                             continue;
@@ -1842,7 +1842,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             String table = request.getTable_name();
             List<String> partitions = request.getPartitions() == null ? new ArrayList<>() : request.getPartitions();
             LOG.info("Start to refresh external table {}.{}.{}.{}", catalog, db, table, partitions);
-            GlobalStateMgr.getCurrentState().refreshExternalTable(new TableName(catalog, db, table), partitions);
+            GlobalStateMgr.getCurrentState().refreshExternalTable(new ConnectContext(),
+                    new TableName(catalog, db, table), partitions);
             LOG.info("Finish to refresh external table {}.{}.{}.{}", catalog, db, table, partitions);
             return new TRefreshTableResponse(new TStatus(TStatusCode.OK));
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -110,22 +110,23 @@ public class InformationSchemaDataSource {
             catalogName = authInfo.getCatalog_name();
         }
 
-        MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
-        List<String> dbNames = metadataMgr.listDbNames(catalogName);
-        LOG.debug("get db names: {}", dbNames);
-
         UserIdentity currentUser;
         if (authInfo.isSetCurrent_user_ident()) {
             currentUser = UserIdentity.fromThrift(authInfo.current_user_ident);
         } else {
             currentUser = UserIdentity.createAnalyzedUserIdentWithIp(authInfo.user, authInfo.user_ip);
         }
+        ConnectContext context = new ConnectContext();
+        context.setCurrentUserIdentity(currentUser);
+        context.setCurrentRoleIds(currentUser);
+
+        MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
+        List<String> dbNames = metadataMgr.listDbNames(context, catalogName);
+        LOG.debug("get db names: {}", dbNames);
+
         for (String fullName : dbNames) {
 
             try {
-                ConnectContext context = new ConnectContext();
-                context.setCurrentUserIdentity(currentUser);
-                context.setCurrentRoleIds(currentUser);
                 Authorizer.checkAnyActionOnOrInDb(context, catalogName, fullName);
             } catch (AccessDeniedException e) {
                 continue;
@@ -495,6 +496,9 @@ public class InformationSchemaDataSource {
 
         TAuthInfo authInfo = request.getAuth_info();
         AuthDbRequestResult result = getAuthDbRequestResult(authInfo);
+        ConnectContext context = new ConnectContext();
+        context.setCurrentUserIdentity(result.currentUser);
+        context.setCurrentRoleIds(result.currentUser);
 
         String catalogName = InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
         if (authInfo.isSetCatalog_name()) {
@@ -504,7 +508,7 @@ public class InformationSchemaDataSource {
         MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
 
         for (String dbName : result.authorizedDbs) {
-            Database db = metadataMgr.getDb(catalogName, dbName);
+            Database db = metadataMgr.getDb(context, catalogName, dbName);
             if (db == null) {
                 continue;
             }
@@ -513,7 +517,7 @@ public class InformationSchemaDataSource {
             Locker locker = new Locker();
             try {
                 locker.lockDatabase(db.getId(), LockType.READ);
-                List<String> tableNames = metadataMgr.listTableNames(catalogName, dbName);
+                List<String> tableNames = metadataMgr.listTableNames(context, catalogName, dbName);
                 for (String tableName : tableNames) {
                     if (request.isSetTable_name()) {
                         if (!tableName.equals(request.getTable_name())) {
@@ -523,7 +527,7 @@ public class InformationSchemaDataSource {
 
                     BasicTable table = null;
                     try {
-                        table = metadataMgr.getBasicTable(catalogName, dbName, tableName);
+                        table = metadataMgr.getBasicTable(context, catalogName, dbName, tableName);
                     } catch (Exception e) {
                         LOG.warn(e.getMessage(), e);
                     }
@@ -532,9 +536,6 @@ public class InformationSchemaDataSource {
                     }
 
                     try {
-                        ConnectContext context = new ConnectContext();
-                        context.setCurrentUserIdentity(result.currentUser);
-                        context.setCurrentRoleIds(result.currentUser);
                         Authorizer.checkAnyActionOnTableLikeObject(context, dbName, table);
                     } catch (AccessDeniedException e) {
                         continue;
@@ -611,6 +612,9 @@ public class InformationSchemaDataSource {
         TemporaryTableMgr temporaryTableMgr = GlobalStateMgr.getCurrentState().getTemporaryTableMgr();
         TAuthInfo authInfo = request.getAuth_info();
         AuthDbRequestResult result = getAuthDbRequestResult(authInfo);
+        ConnectContext context = new ConnectContext();
+        context.setCurrentUserIdentity(result.currentUser);
+        context.setCurrentRoleIds(result.currentUser);
 
         String catalogName = InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
         if (authInfo.isSetCatalog_name()) {
@@ -621,7 +625,7 @@ public class InformationSchemaDataSource {
 
         Set<Long> requiredDbIds = new HashSet<>();
         for (String dbName : result.authorizedDbs) {
-            Database db = metadataMgr.getDb(catalogName, dbName);
+            Database db = metadataMgr.getDb(context, catalogName, dbName);
             if (db != null) {
                 requiredDbIds.add(db.getId());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
@@ -117,8 +117,8 @@ public class DeletePlanner {
             session.getSessionVariable().setUseComputeNodes(0);
             OlapTableSink olapTableSink = (OlapTableSink) dataSink;
             TableName catalogDbTable = deleteStatement.getTableName();
-            Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalogDbTable.getCatalog(),
-                    catalogDbTable.getDb());
+            Database db = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                    .getDb(session, catalogDbTable.getCatalog(), catalogDbTable.getDb());
             try {
                 olapTableSink.init(session.getExecutionId(), deleteStatement.getTxnId(), db.getId(), session.getExecTimeout());
                 olapTableSink.complete();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -400,7 +400,7 @@ public class InsertPlanner {
                 session.getSessionVariable().setUseComputeNodes(0);
                 OlapTableSink olapTableSink = (OlapTableSink) dataSink;
                 TableName catalogDbTable = insertStmt.getTableName();
-                Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalogDbTable.getCatalog(),
+                Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(session, catalogDbTable.getCatalog(),
                         catalogDbTable.getDb());
                 try {
                     olapTableSink.init(session.getExecutionId(), insertStmt.getTxnId(), db.getId(), session.getExecTimeout());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -480,7 +480,7 @@ public class StatementPlanner {
         String dbName = stmt.getTableName().getDb();
         String tableName = stmt.getTableName().getTbl();
 
-        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalogName, dbName);
+        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(session, catalogName, dbName);
         if (db == null) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
         }
@@ -572,7 +572,7 @@ public class StatementPlanner {
         stmt.getTableName().normalization(session);
         String catalogName = stmt.getTableName().getCatalog();
         String dbName = stmt.getTableName().getDb();
-        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalogName, dbName);
+        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(session, catalogName, dbName);
         if (db == null) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
@@ -153,7 +153,7 @@ public class UpdatePlanner {
                 session.getSessionVariable().setUseComputeNodes(0);
                 OlapTableSink olapTableSink = (OlapTableSink) dataSink;
                 TableName catalogDbTable = updateStmt.getTableName();
-                Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalogDbTable.getCatalog(),
+                Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(session, catalogDbTable.getCatalog(),
                         catalogDbTable.getDb());
                 try {
                     olapTableSink.init(session.getExecutionId(), updateStmt.getTxnId(), db.getId(), session.getExecTimeout());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -54,6 +54,7 @@ import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.WriteQuorum;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.AddColumnClause;
 import com.starrocks.sql.ast.AddColumnsClause;
@@ -1249,8 +1250,8 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
                 throw new SemanticException("Can't drop partitions with where expression and `IF EXISTS` keyword");
             }
             Expr expr = clause.getDropWhereExpr();
-            Database db = context.getGlobalStateMgr().getMetadataMgr()
-                    .getDb(context.getCurrentCatalog(), context.getDatabase());
+            Database db = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                    .getDb(context, context.getCurrentCatalog(), context.getDatabase());
             TableName tableName = new TableName(db.getFullName(), table.getName());
             List<String> dropPartitionNames = PartitionSelector.getPartitionNamesByExpr(context, tableName,
                     olapTable, expr, true);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableStatementAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableStatementAnalyzer.java
@@ -50,7 +50,7 @@ public class AlterTableStatementAnalyzer {
 
         checkAlterOpConflict(alterClauseList);
 
-        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(tbl.getCatalog(), tbl.getDb());
+        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(context, tbl.getCatalog(), tbl.getDb());
         if (db == null) {
             throw new SemanticException("Database %s is not found", tbl.getCatalogAndDb());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
@@ -248,7 +248,7 @@ public class AnalyzeStmtAnalyzer {
                 }
 
                 if (null != tbl.getDb() && null == tbl.getTbl()) {
-                    Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(tbl.getCatalog(), tbl.getDb());
+                    Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(session, tbl.getCatalog(), tbl.getDb());
                     if (db == null) {
                         throw new SemanticException("Database %s is not found", tbl.getCatalogAndDb());
                     }
@@ -262,7 +262,7 @@ public class AnalyzeStmtAnalyzer {
                 } else if (null != statement.getTableName().getTbl()) {
                     statement.getTableName().normalization(session);
                     Database db = GlobalStateMgr.getCurrentState().getMetadataMgr()
-                            .getDb(statement.getTableName().getCatalog(), statement.getTableName().getDb());
+                            .getDb(session, statement.getTableName().getCatalog(), statement.getTableName().getDb());
                     if (db == null) {
                         throw new SemanticException("Database %s is not found", statement.getTableName().getCatalogAndDb());
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Authorizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Authorizer.java
@@ -101,7 +101,7 @@ public class Authorizer {
     public static void checkTableAction(ConnectContext context, String db, String table,
                                         PrivilegeType privilegeType) throws AccessDeniedException {
         TableName tableName = new TableName(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, db, table);
-        Optional<Table> tableObj = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(tableName);
+        Optional<Table> tableObj = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(context, tableName);
         if (tableObj.isPresent() && !tableObj.get().isTable() && privilegeType.equals(PrivilegeType.INSERT)) {
             return;
         }
@@ -113,7 +113,7 @@ public class Authorizer {
     public static void checkTableAction(ConnectContext context, String catalog, String db,
                                         String table, PrivilegeType privilegeType) throws AccessDeniedException {
         TableName tableName = new TableName(catalog, db, table);
-        Optional<Table> tableObj = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(tableName);
+        Optional<Table> tableObj = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(context, tableName);
         if (tableObj.isPresent() && !tableObj.get().isTable() && privilegeType.equals(PrivilegeType.INSERT)) {
             return;
         }
@@ -123,7 +123,7 @@ public class Authorizer {
 
     public static void checkTableAction(ConnectContext context, TableName tableName,
                                         PrivilegeType privilegeType) throws AccessDeniedException {
-        Optional<Table> table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(tableName);
+        Optional<Table> table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(context, tableName);
         if (table.isPresent() && !table.get().isTable() && privilegeType.equals(PrivilegeType.INSERT)) {
             return;
         }
@@ -171,7 +171,7 @@ public class Authorizer {
 
     public static void checkActionOnTableLikeObject(ConnectContext context, TableName tableName,
                                                     PrivilegeType privilegeType) throws AccessDeniedException {
-        Optional<Table> table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(tableName);
+        Optional<Table> table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(context, tableName);
         if (table.isPresent()) {
             doCheckTableLikeObject(context, tableName.getDb(), table.get(), privilegeType);
         }
@@ -246,7 +246,7 @@ public class Authorizer {
                     context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
                     PrivilegeType.SELECT.name(), ObjectType.TABLE.name(), tableName.getTbl());
         }
-        Optional<Table> table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(tableName);
+        Optional<Table> table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(context, tableName);
         if (table.isPresent() && table.get().isTable()) {
             try {
                 Authorizer.checkActionOnTableLikeObject(context, tableName, PrivilegeType.INSERT);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
@@ -1679,7 +1679,7 @@ public class AuthorizerStmtVisitor implements AstVisitor<Void, ConnectContext> {
     public Void visitShowCreateTableStatement(ShowCreateTableStmt statement, ConnectContext context) {
         try {
             BasicTable basicTable = GlobalStateMgr.getCurrentState().getMetadataMgr().getBasicTable(
-                    statement.getTbl().getCatalog(), statement.getTbl().getDb(), statement.getTbl().getTbl());
+                    context, statement.getTbl().getCatalog(), statement.getTbl().getDb(), statement.getTbl().getTbl());
             Authorizer.checkAnyActionOnTableLikeObject(context,
                     statement.getDb(), basicTable);
         } catch (AccessDeniedException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/BackupRestoreAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/BackupRestoreAnalyzer.java
@@ -270,7 +270,8 @@ public class BackupRestoreAnalyzer {
             if (mvPartsMap.containsKey(tableName)) {
                 MaterializedView mv = mvPartsMap.get(tableName);
                 for (BaseTableInfo baseTableInfo : mv.getBaseTableInfos()) {
-                    Optional<Database> dbOpt = GlobalStateMgr.getCurrentState().getMetadataMgr().getDatabase(baseTableInfo);
+                    Optional<Database> dbOpt = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                            .getDatabase(new ConnectContext(), baseTableInfo);
                     if (dbOpt.isEmpty()) {
                         LOG.warn("database {} do not exist when collect table info for table: {}",
                                 baseTableInfo.getDbInfoStr(), tableName);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -89,7 +89,7 @@ public class CreateTableAnalyzer {
         final String tableName = tableNameObject.getTbl();
         FeNameFormat.checkTableName(tableName);
 
-        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalogName, tableNameObject.getDb());
+        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(context, catalogName, tableNameObject.getDb());
         if (db == null) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_DB_ERROR, tableNameObject.getDb());
         }
@@ -97,7 +97,7 @@ public class CreateTableAnalyzer {
             analyzeTemporaryTable(statement, context, catalogName, db, tableName);
         } else {
             if (GlobalStateMgr.getCurrentState().getMetadataMgr()
-                    .tableExists(catalogName, tableNameObject.getDb(), tableName) && !statement.isSetIfNotExists()) {
+                    .tableExists(context, catalogName, tableNameObject.getDb(), tableName) && !statement.isSetIfNotExists()) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_TABLE_EXISTS_ERROR, tableName);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableLikeAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableLikeAnalyzer.java
@@ -41,7 +41,7 @@ public class CreateTableLikeAnalyzer {
         FeNameFormat.checkTableName(tableName);
 
         MetaUtils.checkNotSupportCatalog(existedDbTbl.getCatalog(), "CREATE TABLE LIKE");
-        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(existedDbTbl.getCatalog(),
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(context, existedDbTbl.getCatalog(),
                 existedDbTbl.getDb(), existedDbTbl.getTbl());
         if (table == null) {
             throw new SemanticException("Table %s is not found", tableName);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DataCacheStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DataCacheStmtAnalyzer.java
@@ -85,7 +85,7 @@ public class DataCacheStmtAnalyzer {
             throwExceptionIfTargetIsInvalid(catalogName, dbName, tblName);
 
             // If catalog/db/tbl does not exist, it will throw exception
-            Optional<Table> optionalTable = getTable(catalogName, dbName, tblName);
+            Optional<Table> optionalTable = getTable(context, catalogName, dbName, tblName);
 
             // Check new dataCache rule is conflicted with existed rule
             dataCacheMgr.throwExceptionIfRuleIsConflicted(catalogName, dbName, tblName);
@@ -195,7 +195,8 @@ public class DataCacheStmtAnalyzer {
         }
     }
 
-    private static Optional<Table> getTable(String catalogName, String dbName, String tblName) throws SemanticException {
+    private static Optional<Table> getTable(ConnectContext context, String catalogName, String dbName, String tblName)
+            throws SemanticException {
         MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
 
         // Check target is existed
@@ -208,14 +209,14 @@ public class DataCacheStmtAnalyzer {
 
             if (!isSelectAll(dbName)) {
                 // Check db is existed
-                Database db = metadataMgr.getDb(catalogName, dbName);
+                Database db = metadataMgr.getDb(context, catalogName, dbName);
                 if (db == null) {
                     throw new SemanticException(String.format("DataCache target database: %s does not exist " +
                             "in [catalog: %s]", dbName, catalogName));
                 }
                 if (!isSelectAll(tblName)) {
                     // Check tbl is existed
-                    table = metadataMgr.getTable(catalogName, dbName, tblName);
+                    table = metadataMgr.getTable(context, catalogName, dbName, tblName);
                     if (table == null) {
                         throw new SemanticException(String.format("DataCache target table: %s does not exist in " +
                                 "[catalog: %s, database: %s]", tblName, catalogName, dbName));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DeleteAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DeleteAnalyzer.java
@@ -200,7 +200,7 @@ public class DeleteAnalyzer {
         TableName tableName = deleteStatement.getTableName();
         MetaUtils.checkNotSupportCatalog(tableName.getCatalog(), "DELETE");
         Database db = GlobalStateMgr.getCurrentState().getMetadataMgr()
-                .getDb(tableName.getCatalog(), tableName.getDb());
+                .getDb(session, tableName.getCatalog(), tableName.getDb());
         if (db == null) {
             throw new SemanticException("Database %s is not found", tableName.getCatalogAndDb());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DictionaryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DictionaryAnalyzer.java
@@ -48,13 +48,13 @@ public class DictionaryAnalyzer {
             }
 
             String queryableObject = statement.getQueryableObject();
-            Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalogName, context.getDatabase());
+            Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(context, catalogName, context.getDatabase());
             if (db == null) {
                 throw new SemanticException("USE a Database before CREATE DICTIONARY");
             }
             
             Table tbl = GlobalStateMgr.getCurrentState().getMetadataMgr().
-                                getTable(catalogName, context.getDatabase(), queryableObject);
+                                getTable(context, catalogName, context.getDatabase(), queryableObject);
             if (tbl == null) {
                 throw new SemanticException(queryableObject + " does not exist");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DropStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DropStmtAnalyzer.java
@@ -71,7 +71,7 @@ public class DropStmtAnalyzer {
 
             String dbName = statement.getDbName();
             // check database
-            Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalogName, dbName);
+            Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(context, catalogName, dbName);
             if (db == null) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
             }
@@ -127,7 +127,7 @@ public class DropStmtAnalyzer {
 
             String dbName = statement.getDbName();
             // check database
-            Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalogName, dbName);
+            Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(context, catalogName, dbName);
             if (db == null) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -1750,7 +1750,7 @@ public class ExpressionAnalyzer {
             }
 
             Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(
-                    dictionary.getCatalogName(), dictionary.getDbName(), dictionary.getQueryableObject());
+                    session, dictionary.getCatalogName(), dictionary.getDbName(), dictionary.getQueryableObject());
             if (table == null) {
                 throw new SemanticException("dict table %s is not found", table.getName());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -547,7 +547,7 @@ public class InsertAnalyzer {
 
         MetaUtils.checkCatalogExistAndReport(catalogName);
 
-        Database database = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalogName, dbName);
+        Database database = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(session, catalogName, dbName);
         if (database == null) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -239,7 +239,7 @@ public class MaterializedViewAnalyzer {
 
     private static BaseTableInfo fromTableName(TableName name, Table table) {
         if (isInternalCatalog(name.getCatalog())) {
-            Database database = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(name.getCatalog(), name.getDb());
+            Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(name.getDb());
             return new BaseTableInfo(database.getId(), database.getFullName(), table.getName(), table.getId());
         } else {
             return new BaseTableInfo(name.getCatalog(), name.getDb(), table.getName(), table.getTableIdentifier());
@@ -799,7 +799,7 @@ public class MaterializedViewAnalyzer {
                 String catalog = tableName.getCatalog() == null ?
                         InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME : tableName.getCatalog();
                 table = connectContext.getGlobalStateMgr()
-                        .getMetadataMgr().getTable(catalog, tableName.getDb(), tableName.getTbl());
+                        .getMetadataMgr().getTable(connectContext, catalog, tableName.getDb(), tableName.getTbl());
             }
             return table;
         }
@@ -1446,7 +1446,7 @@ public class MaterializedViewAnalyzer {
         public Void visitAlterMaterializedViewStatement(AlterMaterializedViewStmt statement, ConnectContext context) {
             TableName mvName = statement.getMvName();
             mvName.normalization(context);
-            Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(statement.getMvName().getCatalog(),
+            Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(context, statement.getMvName().getCatalog(),
                     statement.getMvName().getDb(), statement.getMvName().getTbl());
             if (table == null) {
                 throw new SemanticException("Table %s is not found", mvName);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
@@ -158,12 +158,12 @@ public class PlannerMetaLocker {
             return null;
         }
 
-        Database db = metadataMgr.getDb(catalogName, dbName);
+        Database db = metadataMgr.getDb(session, catalogName, dbName);
         if (db == null) {
             return null;
         }
 
-        Table table = metadataMgr.getTable(catalogName, dbName, tbName);
+        Table table = metadataMgr.getTable(session, catalogName, dbName, tbName);
         if (table == null) {
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -1394,7 +1394,7 @@ public class QueryAnalyzer {
 
             Database db;
             try (Timer ignored = Tracers.watchScope("AnalyzeDatabase")) {
-                db = metadataMgr.getDb(catalogName, dbName);
+                db = metadataMgr.getDb(session, catalogName, dbName);
             }
 
             MetaUtils.checkDbNullAndReport(db, dbName);
@@ -1403,7 +1403,7 @@ public class QueryAnalyzer {
             if (tableRelation.isSyncMVQuery()) {
                 try (Timer ignored = Tracers.watchScope("AnalyzeSyncMV")) {
                     Pair<Table, MaterializedIndexMeta> materializedIndex =
-                            metadataMgr.getMaterializedViewIndex(catalogName, dbName, tbName);
+                            GlobalStateMgr.getCurrentState().getLocalMetastore().getMaterializedViewIndex(dbName, tbName);
                     if (materializedIndex != null) {
                         Table mvTable = materializedIndex.first;
                         Preconditions.checkState(mvTable != null);
@@ -1423,7 +1423,7 @@ public class QueryAnalyzer {
                 }
                 if (table == null) {
                     try (Timer ignored = Tracers.watchScope("AnalyzeTable")) {
-                        table = metadataMgr.getTable(catalogName, dbName, tbName);
+                        table = metadataMgr.getTable(session, catalogName, dbName, tbName);
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/RefreshTableStatementAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/RefreshTableStatementAnalyzer.java
@@ -52,10 +52,10 @@ public class RefreshTableStatementAnalyzer {
             if (!GlobalStateMgr.getCurrentState().getCatalogMgr().catalogExists(catalogName)) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_CATALOG_ERROR, catalogName);
             }
-            if (metadataMgr.getDb(catalogName, dbName) == null) {
+            if (metadataMgr.getDb(context, catalogName, dbName) == null) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_TABLE_ERROR, dbName);
             }
-            if (metadataMgr.getTable(catalogName, dbName, tblName) == null) {
+            if (metadataMgr.getTable(context, catalogName, dbName, tblName) == null) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_TABLE_ERROR, tblName);
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtAnalyzer.java
@@ -572,7 +572,7 @@ public class ShowStmtAnalyzer {
             if (statement.getWhereClause() != null) {
                 analyzeSubPredicate(filterMap, statement.getWhereClause());
             }
-            Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(tbl.getCatalog(), dbName);
+            Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(context, tbl.getCatalog(), dbName);
             if (db == null) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/UpdateAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/UpdateAnalyzer.java
@@ -74,7 +74,7 @@ public class UpdateAnalyzer {
 
         TableName tableName = updateStmt.getTableName();
         Database db = GlobalStateMgr.getCurrentState().getMetadataMgr()
-                .getDb(tableName.getCatalog(), tableName.getDb());
+                .getDb(session, tableName.getCatalog(), tableName.getDb());
         if (db == null) {
             throw new SemanticException("Database %s is not found", tableName.getCatalogAndDb());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ViewAnalyzer.java
@@ -66,8 +66,9 @@ public class ViewAnalyzer {
             final String tableName = stmt.getTableName().getTbl();
             FeNameFormat.checkTableName(tableName);
 
-            Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(stmt.getTableName().getCatalog(),
-                    stmt.getTableName().getDb(), stmt.getTableName().getTbl());
+            Table table = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                    .getTable(context, stmt.getTableName().getCatalog(), stmt.getTableName().getDb(),
+                            stmt.getTableName().getTbl());
             if (table == null) {
                 throw new SemanticException("Table %s is not found", tableName);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowAnalyzeJobStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowAnalyzeJobStmt.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.ast;
 
 import com.google.common.collect.Lists;
@@ -70,7 +69,7 @@ public class ShowAnalyzeJobStmt extends ShowStmt {
 
         if (!analyzeJob.isAnalyzeAllDb()) {
             String dbName = analyzeJob.getDbName();
-            Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(analyzeJob.getCatalogName(), dbName);
+            Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(context, analyzeJob.getCatalogName(), dbName);
 
             if (db == null) {
                 throw new MetaNotFoundException("No found database: " + dbName);
@@ -80,8 +79,8 @@ public class ShowAnalyzeJobStmt extends ShowStmt {
 
             if (!analyzeJob.isAnalyzeAllTable()) {
                 String tableName = analyzeJob.getTableName();
-                Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(analyzeJob.getCatalogName(),
-                        dbName, tableName);
+                Table table = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                        .getTable(context, analyzeJob.getCatalogName(), dbName, tableName);
 
                 if (table == null) {
                     throw new MetaNotFoundException("No found table: " + tableName);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowAnalyzeStatusStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowAnalyzeStatusStmt.java
@@ -77,7 +77,7 @@ public class ShowAnalyzeStatusStmt extends ShowStmt {
         // In new privilege framework(RBAC), user needs any action on the table to show analysis status for it.
         try {
             table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(
-                    analyzeStatus.getCatalogName(), analyzeStatus.getDbName(), analyzeStatus.getTableName());
+                    context, analyzeStatus.getCatalogName(), analyzeStatus.getDbName(), analyzeStatus.getTableName());
             if (table == null) {
                 throw new SemanticException("Table %s is not found", analyzeStatus.getTableName());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowBasicStatsMetaStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowBasicStatsMetaStmt.java
@@ -107,12 +107,12 @@ public class ShowBasicStatsMetaStmt extends ShowStmt {
 
         List<String> columns = basicStatsMeta.getColumns();
 
-        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalogName, dbName);
+        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(context, catalogName, dbName);
         if (db == null) {
             throw new MetaNotFoundException("No found database: " + catalogName + "." + dbName);
         }
         row.set(0, catalogName + "." + dbName);
-        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(catalogName, dbName, tableName);
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(context, catalogName, dbName, tableName);
         if (table == null) {
             throw new MetaNotFoundException("No found table: " + catalogName + "." + dbName + "." + tableName);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowHistogramStatsMetaStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowHistogramStatsMetaStmt.java
@@ -95,12 +95,12 @@ public class ShowHistogramStatsMetaStmt extends ShowStmt {
         String dbName = histogramStatsMeta.getDbName();
         String tableName = histogramStatsMeta.getTableName();
 
-        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalogName, dbName);
+        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(context, catalogName, dbName);
         if (db == null) {
             throw new MetaNotFoundException("No found database: " + catalogName + "." + dbName);
         }
         row.set(0, catalogName + "." + dbName);
-        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(catalogName, dbName, tableName);
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(context, catalogName, dbName, tableName);
         if (table == null) {
             throw new MetaNotFoundException("No found table: " + catalogName + "." + dbName + "." + tableName);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
@@ -101,7 +101,8 @@ public class MetaUtils {
             if (Strings.isNullOrEmpty(tableName.getCatalog())) {
                 tableName.setCatalog(session.getCurrentCatalog());
             }
-            database = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(tableName.getCatalog(), tableName.getDb());
+            database = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                    .getDb(session, tableName.getCatalog(), tableName.getDb());
             if (database == null) {
                 throw new SemanticException("Database %s is not found", tableName.getCatalogAndDb());
             }
@@ -113,7 +114,7 @@ public class MetaUtils {
             return table;
         }
         table = session.getGlobalStateMgr().getMetadataMgr().getTable(
-                tableName.getCatalog(), tableName.getDb(), tableName.getTbl());
+                session, tableName.getCatalog(), tableName.getDb(), tableName.getTbl());
         if (table == null) {
             throw new SemanticException("Table %s is not found", tableName.getTbl());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
@@ -44,6 +44,7 @@ import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.connector.PartitionUtil;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.PartitionValue;
@@ -106,7 +107,6 @@ public class SyncPartitionUtils {
                 RangePartitionDiffer.simpleDiff(unique, mvRangeMap);
     }
 
-
     public static boolean hasRangePartitionChanged(Map<String, Range<PartitionKey>> baseRangeMap,
                                                    Map<String, Range<PartitionKey>> mvRangeMap) {
         PartitionDiff diff = RangePartitionDiffer.simpleDiff(baseRangeMap, mvRangeMap);
@@ -115,7 +115,6 @@ public class SyncPartitionUtils {
         }
         return false;
     }
-
 
     public static PartitionDiff getRangePartitionDiffOfExpr(Map<String, Range<PartitionKey>> baseRangeMap,
                                                             Map<String, Range<PartitionKey>> mvRangeMap,
@@ -196,8 +195,8 @@ public class SyncPartitionUtils {
     /**
      * Convert base table with partition expression with the associated partition expressions.
      * eg: Create MV mv1
-     *      partition by tbl1.dt
-     *      as select * from tbl1 join on tbl2 on tbl1.dt = date_trunc('month', tbl2.dt)
+     * partition by tbl1.dt
+     * as select * from tbl1 join on tbl2 on tbl1.dt = date_trunc('month', tbl2.dt)
      * This method will format tbl1's range partition key directly, and will format tbl2's partition range key by
      * using `date_trunc('month', tbl2.dt)`.
      * TODO: now `date_trunc` is supported, should support like to_date(ds) + 1 day ?
@@ -605,7 +604,7 @@ public class SyncPartitionUtils {
         for (String refBaseTableAssociatedPartition : refBaseTableAssociatedPartitions) {
             if (!baseTableVersionInfoMap.containsKey(refBaseTableAssociatedPartition)) {
                 LOG.warn("WARNING: mvPartitionNameRefBaseTablePartitionMap {} failed to tracked the materialized view {} " +
-                        "partition {}", Joiner.on(",").join(mvPartitionNameRefBaseTablePartitionMap.keySet()),
+                                "partition {}", Joiner.on(",").join(mvPartitionNameRefBaseTablePartitionMap.keySet()),
                         mv.getName(), mvPartitionName);
                 continue;
             }
@@ -615,7 +614,6 @@ public class SyncPartitionUtils {
         // finally remove the dropped materialized view partition
         mvPartitionNameRefBaseTablePartitionMap.remove(mvPartitionName);
     }
-
 
     private static boolean isMVPartitionNameRefBaseTablePartitionMapEnough(
             Map<String, MaterializedView.BasePartitionInfo> baseTableVersionInfoMap,
@@ -674,7 +672,7 @@ public class SyncPartitionUtils {
         if (!versionMap.containsKey(baseTableInfo)) {
             // version map should always contain ref base table's version info.
             LOG.warn("Base ref table {} is not found in the base table version info map when " +
-                    "materialized view {} drops partition:{}",
+                            "materialized view {} drops partition:{}",
                     baseTableInfo, mv.getName(), mvPartitionName);
             return;
         }
@@ -761,8 +759,8 @@ public class SyncPartitionUtils {
             return;
         }
         Expr expr = mv.getPartitionRefTableExprs().get(0);
-        Table baseTable = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(tableName.getCatalog(),
-                tableName.getDb(), tableName.getTbl());
+        Table baseTable = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                .getTable(new ConnectContext(), tableName.getCatalog(), tableName.getDb(), tableName.getTbl());
 
         if (baseTable == null) {
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -672,7 +672,7 @@ public class MvRewritePreprocessor {
                     continue;
                 }
                 Set<String> partitionNamesToRefresh = mvUpdateInfo.getMvToRefreshPartitionNames();
-                if (!checkMvPartitionNamesToRefresh(mv, partitionNamesToRefresh, mvPlanContext)) {
+                if (!checkMvPartitionNamesToRefresh(connectContext, mv, partitionNamesToRefresh, mvPlanContext)) {
                     continue;
                 }
                 logMVPrepare(mv, "MV' partitions to refresh: {}/{}", partitionNamesToRefresh.size(),
@@ -709,7 +709,8 @@ public class MvRewritePreprocessor {
      * @param mvPlanContext: the associated materialized view context
      * @return partition names to refresh if the mv is valid for rewrite, otherwise null
      */
-    public static boolean checkMvPartitionNamesToRefresh(MaterializedView mv,
+    public static boolean checkMvPartitionNamesToRefresh(ConnectContext context,
+                                                         MaterializedView mv,
                                                          Set<String> partitionNamesToRefresh,
                                                          MvPlanContext mvPlanContext) {
         Preconditions.checkState(mvPlanContext != null);
@@ -720,7 +721,7 @@ public class MvRewritePreprocessor {
             if (!partitionNamesToRefresh.isEmpty()) {
                 StringBuilder sb = new StringBuilder();
                 for (BaseTableInfo base : mv.getBaseTableInfos()) {
-                    Optional<Table> baseTable = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(base);
+                    Optional<Table> baseTable = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(context, base);
                     if (!baseTable.isPresent() || baseTable.get().isView()) {
                         continue;
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/QueryDumper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/QueryDumper.java
@@ -63,7 +63,7 @@ public class QueryDumper {
             }
 
             if (!StringUtils.isEmpty(dbName)) {
-                Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalogName, dbName);
+                Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(context, catalogName, dbName);
                 if (db == null) {
                     return Pair.create(HttpResponseStatus.NOT_FOUND,
                             String.format("Database [%s.%s] does not exists", catalogName, dbName));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
@@ -84,7 +84,7 @@ import static com.starrocks.catalog.PrimitiveType.VARCHAR;
 public class MetaFunctions {
 
     public static Table inspectExternalTable(TableName tableName) {
-        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(tableName)
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(new ConnectContext(), tableName)
                 .orElseThrow(() -> ErrorReport.buildSemanticException(ErrorCode.ERR_BAD_TABLE_ERROR, tableName));
         ConnectContext connectContext = ConnectContext.get();
         try {
@@ -421,7 +421,8 @@ public class MetaFunctions {
                                                  ConstantOperator lookupKey,
                                                  ConstantOperator returnColumn) {
         TableName tableNameValue = TableName.fromString(tableName.getVarchar());
-        Optional<Table> maybeTable = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(tableNameValue);
+        Optional<Table> maybeTable = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                .getTable(new ConnectContext(), tableNameValue);
         maybeTable.orElseThrow(() -> ErrorReport.buildSemanticException(ErrorCode.ERR_BAD_TABLE_ERROR, tableNameValue));
         if (!(maybeTable.get() instanceof OlapTable)) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_INVALID_PARAMETER, "must be OLAP_TABLE");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -1354,15 +1354,15 @@ public class MvUtils {
     }
 
     public static Optional<Table> getTable(BaseTableInfo baseTableInfo) {
-        return GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(baseTableInfo);
+        return GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(new ConnectContext(), baseTableInfo);
     }
 
     public static Optional<Table> getTableWithIdentifier(BaseTableInfo baseTableInfo) {
-        return GlobalStateMgr.getCurrentState().getMetadataMgr().getTableWithIdentifier(baseTableInfo);
+        return GlobalStateMgr.getCurrentState().getMetadataMgr().getTableWithIdentifier(new ConnectContext(), baseTableInfo);
     }
 
     public static Table getTableChecked(BaseTableInfo baseTableInfo) {
-        return GlobalStateMgr.getCurrentState().getMetadataMgr().getTableChecked(baseTableInfo);
+        return GlobalStateMgr.getCurrentState().getMetadataMgr().getTableChecked(new ConnectContext(), baseTableInfo);
     }
 
     public static Optional<FunctionCallExpr> getStr2DateExpr(Expr partitionExpr) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rule.transformation.materialization;
 
 import com.google.common.base.Preconditions;
@@ -28,6 +27,7 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.UnionFind;
 import com.starrocks.connector.TableVersionRange;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.MaterializationContext;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -117,10 +117,11 @@ public class OptExpressionDuplicator {
 
     /**
      * Duplicate the OptExpression tree.
-     * @param source: source OptExpression
-     * @param prevColumnRefFactory: column ref factory where source OptExpression is from
+     *
+     * @param source:                    source OptExpression
+     * @param prevColumnRefFactory:      column ref factory where source OptExpression is from
      * @param isResetSelectedPartitions: whether to reset selected partitions
-     * @param isRefreshExternalTable: whether to refresh external table
+     * @param isRefreshExternalTable:    whether to refresh external table
      * @return
      */
     public OptExpression duplicate(OptExpression source,
@@ -252,7 +253,9 @@ public class OptExpressionDuplicator {
                     String catalogName = cachedIcebergTable.getCatalogName();
                     String dbName = cachedIcebergTable.getCatalogDBName();
                     TableName tableName = new TableName(catalogName, dbName, cachedIcebergTable.getName());
-                    Table currentTable = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(tableName).orElse(null);
+                    Table currentTable =
+                            GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(new ConnectContext(), tableName)
+                                    .orElse(null);
                     if (currentTable == null) {
                         return null;
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/ExternalTableCompensation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/ExternalTableCompensation.java
@@ -115,7 +115,8 @@ public final class ExternalTableCompensation extends TableCompensation {
             String catalogName = cachedIcebergTable.getCatalogName();
             String dbName = cachedIcebergTable.getCatalogDBName();
             TableName refTableName = new TableName(catalogName, dbName, cachedIcebergTable.getName());
-            Table currentTable = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(refTableName).orElse(null);
+            Table currentTable = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                    .getTable(new ConnectContext(), refTableName).orElse(null);
             if (currentTable == null) {
                 return null;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
@@ -311,7 +311,8 @@ public class AnalyzeMgr implements Writable {
 
     public void refreshConnectorTableBasicStatisticsCache(String catalogName, String dbName, String tableName,
                                                           List<String> columns, boolean async) {
-        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(catalogName, dbName, tableName);
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                .getTable(new ConnectContext(), catalogName, dbName, tableName);
         if (table == null) {
             return;
         }
@@ -420,7 +421,8 @@ public class AnalyzeMgr implements Writable {
 
     public void refreshConnectorTableHistogramStatisticsCache(String catalogName, String dbName, String tableName,
                                                               List<String> columns, boolean async) {
-        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(catalogName, dbName, tableName);
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                .getTable(new ConnectContext(), catalogName, dbName, tableName);
         if (table == null) {
             return;
         }
@@ -477,8 +479,8 @@ public class AnalyzeMgr implements Writable {
         for (Map.Entry<StatsMetaKey, ExternalBasicStatsMeta> entry : externalBasicStatsMetaMap.entrySet()) {
             StatsMetaKey tableKey = entry.getKey();
             try {
-                Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(tableKey.getCatalogName(),
-                        tableKey.getDbName(), tableKey.getTableName());
+                Table table = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                        .getTable(new ConnectContext(), tableKey.getCatalogName(), tableKey.getDbName(), tableKey.getTableName());
                 if (table == null) {
                     LOG.warn("Table {}.{}.{} not exists, clear it's statistics", tableKey.getCatalogName(),
                             tableKey.getDbName(), tableKey.getTableName());

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
@@ -26,6 +26,7 @@ import com.starrocks.common.Config;
 import com.starrocks.connector.ConnectorPartitionTraits;
 import com.starrocks.connector.statistics.ConnectorTableColumnStats;
 import com.starrocks.monitor.unit.ByteSizeUnit;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
@@ -162,22 +163,24 @@ public class StatisticsCollectJobFactory {
     }
 
     public static List<StatisticsCollectJob> buildExternalStatisticsCollectJob(ExternalAnalyzeJob externalAnalyzeJob) {
+        ConnectContext context = new ConnectContext();
+
         List<StatisticsCollectJob> statsJobs = Lists.newArrayList();
         if (externalAnalyzeJob.isAnalyzeAllDb()) {
             List<String> dbNames = GlobalStateMgr.getCurrentState().getMetadataMgr().
-                    listDbNames(externalAnalyzeJob.getCatalogName());
+                    listDbNames(context, externalAnalyzeJob.getCatalogName());
             for (String dbName : dbNames) {
                 Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().
-                        getDb(externalAnalyzeJob.getCatalogName(), dbName);
+                        getDb(context, externalAnalyzeJob.getCatalogName(), dbName);
                 if (null == db || StatisticUtils.statisticDatabaseBlackListCheck(db.getFullName())) {
                     continue;
                 }
 
                 List<String> tableNames = GlobalStateMgr.getCurrentState().getMetadataMgr().
-                        listTableNames(externalAnalyzeJob.getCatalogName(), dbName);
+                        listTableNames(context, externalAnalyzeJob.getCatalogName(), dbName);
                 for (String tableName : tableNames) {
                     Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().
-                            getTable(externalAnalyzeJob.getCatalogName(), dbName, tableName);
+                            getTable(context, externalAnalyzeJob.getCatalogName(), dbName, tableName);
                     if (null == table) {
                         continue;
                     }
@@ -187,16 +190,16 @@ public class StatisticsCollectJobFactory {
             }
         } else if (externalAnalyzeJob.isAnalyzeAllTable()) {
             Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().
-                    getDb(externalAnalyzeJob.getCatalogName(), externalAnalyzeJob.getDbName());
+                    getDb(context, externalAnalyzeJob.getCatalogName(), externalAnalyzeJob.getDbName());
             if (null == db) {
                 return Collections.emptyList();
             }
 
             List<String> tableNames = GlobalStateMgr.getCurrentState().getMetadataMgr().
-                    listTableNames(externalAnalyzeJob.getCatalogName(), externalAnalyzeJob.getDbName());
+                    listTableNames(context, externalAnalyzeJob.getCatalogName(), externalAnalyzeJob.getDbName());
             for (String tableName : tableNames) {
                 Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().
-                        getTable(externalAnalyzeJob.getCatalogName(), externalAnalyzeJob.getDbName(), tableName);
+                        getTable(context, externalAnalyzeJob.getCatalogName(), externalAnalyzeJob.getDbName(), tableName);
                 if (null == table) {
                     continue;
                 }
@@ -205,13 +208,13 @@ public class StatisticsCollectJobFactory {
             }
         } else {
             Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().
-                    getDb(externalAnalyzeJob.getCatalogName(), externalAnalyzeJob.getDbName());
+                    getDb(context, externalAnalyzeJob.getCatalogName(), externalAnalyzeJob.getDbName());
             if (null == db) {
                 return Collections.emptyList();
             }
 
             Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().
-                    getTable(externalAnalyzeJob.getCatalogName(), externalAnalyzeJob.getDbName(),
+                    getTable(context, externalAnalyzeJob.getCatalogName(), externalAnalyzeJob.getDbName(),
                             externalAnalyzeJob.getTableName());
             if (null == table) {
                 return Collections.emptyList();

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
@@ -90,7 +90,7 @@ public class LakeTableAlterMetaJobTest {
     public void tearDown() throws DdlException, MetaNotFoundException {
         db.dropTable(table.getName());
         try {
-            GlobalStateMgr.getCurrentState().getLocalMetastore().dropDb(DB_NAME, true);
+            GlobalStateMgr.getCurrentState().getLocalMetastore().dropDb(connectContext, DB_NAME, true);
         } catch (MetaNotFoundException ignored) {
         }
     }
@@ -218,7 +218,7 @@ public class LakeTableAlterMetaJobTest {
 
     @Test
     public void testDropDb01() throws DdlException, MetaNotFoundException {
-        GlobalStateMgr.getCurrentState().getLocalMetastore().dropDb(db.getFullName(), true);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().dropDb(connectContext, db.getFullName(), true);
         job.run();
         Assert.assertEquals(AlterJobV2.JobState.CANCELLED, job.getJobState());
     }
@@ -238,7 +238,7 @@ public class LakeTableAlterMetaJobTest {
         job.runPendingJob();
         Assert.assertEquals(AlterJobV2.JobState.RUNNING, job.getJobState());
 
-        GlobalStateMgr.getCurrentState().getLocalMetastore().dropDb(db.getFullName(), true);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().dropDb(connectContext, db.getFullName(), true);
         job.run();
         Assert.assertEquals(AlterJobV2.JobState.CANCELLED, job.getJobState());
     }
@@ -264,7 +264,7 @@ public class LakeTableAlterMetaJobTest {
         job.runRunningJob();
         Assert.assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, job.getJobState());
 
-        GlobalStateMgr.getCurrentState().getLocalMetastore().dropDb(db.getFullName(), true);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().dropDb(connectContext, db.getFullName(), true);
         job.run();
         Assert.assertEquals(AlterJobV2.JobState.CANCELLED, job.getJobState());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
@@ -107,7 +107,7 @@ public class LakeTableSchemaChangeJobTest {
 
     @After
     public void after() throws Exception {
-        GlobalStateMgr.getCurrentState().getLocalMetastore().dropDb(DB_NAME, true);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().dropDb(connectContext, DB_NAME, true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
@@ -46,6 +46,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AlterTableStmt;
@@ -182,7 +183,7 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
 
     @Test
     public void testAggAddOrDropColumn() throws Exception {
-        LOG.info("dbName: {}", GlobalStateMgr.getCurrentState().getLocalMetastore().listDbNames());
+        LOG.info("dbName: {}", GlobalStateMgr.getCurrentState().getLocalMetastore().listDbNames(new ConnectContext()));
 
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "sc_agg");
@@ -289,7 +290,7 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
     @Test
     public void testUniqAddOrDropColumn() throws Exception {
 
-        LOG.info("dbName: {}", GlobalStateMgr.getCurrentState().getLocalMetastore().listDbNames());
+        LOG.info("dbName: {}", GlobalStateMgr.getCurrentState().getLocalMetastore().listDbNames(new ConnectContext()));
 
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "sc_uniq");
@@ -347,7 +348,7 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
     @Test
     public void testDupAddOrDropColumn() throws Exception {
 
-        LOG.info("dbName: {}", GlobalStateMgr.getCurrentState().getLocalMetastore().listDbNames());
+        LOG.info("dbName: {}", GlobalStateMgr.getCurrentState().getLocalMetastore().listDbNames(new ConnectContext()));
 
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "sc_dup");
@@ -444,7 +445,7 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
     @Test
     public void testSetPrimaryIndexCacheExpireSec() throws Exception {
 
-        LOG.info("dbName: {}", GlobalStateMgr.getCurrentState().getLocalMetastore().listDbNames());
+        LOG.info("dbName: {}", GlobalStateMgr.getCurrentState().getLocalMetastore().listDbNames(new ConnectContext()));
 
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "sc_pk");
@@ -486,7 +487,7 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
     @Test
     public void testAddReserveColumn() throws Exception {
 
-        LOG.info("dbName: {}", GlobalStateMgr.getCurrentState().getLocalMetastore().listDbNames());
+        LOG.info("dbName: {}", GlobalStateMgr.getCurrentState().getLocalMetastore().listDbNames(new ConnectContext()));
 
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "sc_pk");

--- a/fe/fe-core/src/test/java/com/starrocks/alter/lake/AlterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/lake/AlterTest.java
@@ -55,7 +55,7 @@ public class AlterTest {
 
     @After
     public void after() throws Exception {
-        GlobalStateMgr.getCurrentState().getLocalMetastore().dropDb(DB_NAME, true);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().dropDb(connectContext, DB_NAME, true);
     }
 
     private static LakeTable createTable(ConnectContext connectContext, String sql) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshTableStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshTableStmtTest.java
@@ -17,6 +17,7 @@ package com.starrocks.analysis;
 
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
@@ -54,10 +55,10 @@ public class RefreshTableStmtTest {
                 GlobalStateMgr.getCurrentState().getMetadataMgr();
                 result = metadataMgr;
 
-                metadataMgr.getTable(anyString, anyString, anyString);
+                metadataMgr.getTable((ConnectContext) any, anyString, anyString, anyString);
                 result = table;
 
-                metadataMgr.getDb(anyString, anyString);
+                metadataMgr.getDb((ConnectContext) any, anyString, anyString);
                 result = database;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/UseDbStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/UseDbStmtTest.java
@@ -75,7 +75,7 @@ public class UseDbStmtTest {
                 result = true;
                 minTimes = 0;
 
-                metadataMgr.getDb("default_catalog", "db");
+                metadataMgr.getDb((ConnectContext) any, "default_catalog", "db");
                 result = db;
                 minTimes = 0;
             }
@@ -83,6 +83,7 @@ public class UseDbStmtTest {
 
         ctx.setQueryId(UUIDUtil.genUUID());
         ctx.setCurrentUserIdentity(UserIdentity.ROOT);
+        ctx.setCurrentRoleIds(UserIdentity.ROOT);
         StatementBase statement = SqlParser.parseSingleStatement("use default_catalog.db",
                 ctx.getSessionVariable().getSqlMode());
 

--- a/fe/fe-core/src/test/java/com/starrocks/authorization/AuthorizationMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authorization/AuthorizationMgrTest.java
@@ -100,13 +100,16 @@ public class AuthorizationMgrTest {
         }
 
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        MockedLocalMetaStore localMetastore = new MockedLocalMetaStore(globalStateMgr, globalStateMgr.getRecycleBin(), null);
+        localMetastore.init();
+        globalStateMgr.setLocalMetastore(localMetastore);
+
         RBACMockedMetadataMgr metadataMgr =
-                new RBACMockedMetadataMgr(globalStateMgr.getLocalMetastore(), globalStateMgr.getConnectorMgr());
-        metadataMgr.init();
+                new RBACMockedMetadataMgr(localMetastore, globalStateMgr.getConnectorMgr());
         globalStateMgr.setMetadataMgr(metadataMgr);
 
         globalStateMgr.setAuthenticationMgr(new AuthenticationMgr());
-        globalStateMgr.setAuthorizationMgr(new AuthorizationMgr(globalStateMgr, new DefaultAuthorizationProvider()));
+        globalStateMgr.setAuthorizationMgr(new AuthorizationMgr(new DefaultAuthorizationProvider()));
 
         CreateUserStmt createUserStmt = (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(
                 "create user test_user", ctx);
@@ -1652,12 +1655,12 @@ public class AuthorizationMgrTest {
         new MockUp<LocalMetastore>() {
             @Mock
             public Table getTable(String dbName, String tblName) {
-                return GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(new TableName("db", "tbl1")).get();
+                return GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(ctx, new TableName("db", "tbl1")).get();
             }
 
             @Mock
             public Table getTable(Long dbId, Long tableId) {
-                return GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(new TableName("db", "tbl1")).get();
+                return GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(ctx, new TableName("db", "tbl1")).get();
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/authorization/MockedLocalMetaStore.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authorization/MockedLocalMetaStore.java
@@ -1,0 +1,119 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.authorization;
+
+import com.starrocks.catalog.CatalogRecycleBin;
+import com.starrocks.catalog.ColocateTableIndex;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.View;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class MockedLocalMetaStore extends LocalMetastore {
+    private final Map<String, Database> databaseSet;
+    private final Map<String, Table> tableMap;
+    private final IdGenerator idGenerator;
+
+    public MockedLocalMetaStore(GlobalStateMgr globalStateMgr,
+                                CatalogRecycleBin recycleBin,
+                                ColocateTableIndex colocateTableIndex) {
+        super(globalStateMgr, recycleBin, colocateTableIndex);
+
+        this.databaseSet = new HashMap<>();
+        this.tableMap = new HashMap<>();
+        this.idGenerator = new IdGenerator();
+    }
+
+    public void init() {
+        Database db = new Database(idGenerator.getNextId(), "db");
+        databaseSet.put("db", db);
+
+        Database db1 = new Database(idGenerator.getNextId(), "db3");
+        databaseSet.put("db1", db1);
+
+        Database db3 = new Database(idGenerator.getNextId(), "db3");
+        databaseSet.put("db3", db3);
+
+        OlapTable t0 = new OlapTable();
+        t0.setId(idGenerator.getNextId());
+        t0.setName("tbl0");
+        tableMap.put("tbl0", t0);
+
+        OlapTable t1 = new OlapTable();
+        t1.setId(idGenerator.getNextId());
+        t1.setName("tbl1");
+        tableMap.put("tbl1", t1);
+
+        OlapTable t2 = new OlapTable();
+        t2.setId(idGenerator.getNextId());
+        t2.setName("tbl2");
+        tableMap.put("tbl2", t2);
+
+        OlapTable t3 = new OlapTable();
+        t3.setId(idGenerator.getNextId());
+        t3.setName("tbl3");
+        tableMap.put("tbl3", t3);
+
+        MaterializedView mv = new MaterializedView();
+        mv.setId(idGenerator.getNextId());
+        mv.setName("mv1");
+        tableMap.put("mv1", mv);
+
+        View view = new View();
+        view.setId(idGenerator.getNextId());
+        view.setName("view1");
+        tableMap.put("view1", view);
+    }
+
+    @Override
+    public Database getDb(String dbName) {
+        return databaseSet.get(dbName);
+    }
+
+    @Override
+    public Database getDb(long databaseId) {
+        for (Database database : databaseSet.values()) {
+            if (database.getId() == databaseId) {
+                return database;
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public ConcurrentHashMap<String, Database> getFullNameToDb() {
+        return new ConcurrentHashMap<>(databaseSet);
+    }
+
+    @Override
+    public Table getTable(String dbName, String tblName) {
+        return tableMap.get(tblName);
+    }
+
+    @Override
+    public List<Table> getTables(Long dbId) {
+        return new ArrayList<>(tableMap.values());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/backup/CatalogMocker.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/CatalogMocker.java
@@ -71,6 +71,7 @@ import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.Util;
 import com.starrocks.load.Load;
 import com.starrocks.persist.EditLog;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.PartitionValue;
 import com.starrocks.system.SystemInfoService;
@@ -610,7 +611,7 @@ public class CatalogMocker {
                 minTimes = 0;
                 result = new Database();
 
-                globalStateMgr.getLocalMetastore().listDbNames();
+                globalStateMgr.getLocalMetastore().listDbNames((ConnectContext) any);
                 minTimes = 0;
                 result = Lists.newArrayList(TEST_DB_NAME);
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinLakeTableTest.java
@@ -322,7 +322,7 @@ public class CatalogRecycleBinLakeTableTest {
                 ") distributed by hash(key1) buckets 3 " +
                 "properties('replication_num' = '1');", dbName));
 
-        GlobalStateMgr.getCurrentState().getLocalMetastore().dropDb(dbName, false);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().dropDb(new ConnectContext(), dbName, false);
         Assert.assertNotNull(recycleBin.getTable(db.getId(), table1.getId()));
         Assert.assertNotNull(recycleBin.getTable(db.getId(), table2.getId()));
 
@@ -333,7 +333,7 @@ public class CatalogRecycleBinLakeTableTest {
         Assert.assertNull(recycleBin.getTable(db.getId(), table2.getId()));
 
         // Drop the database again.
-        GlobalStateMgr.getCurrentState().getLocalMetastore().dropDb(dbName, false);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().dropDb(new ConnectContext(), dbName, false);
         Assert.assertNotNull(recycleBin.getTable(db.getId(), table1.getId()));
         Assert.assertNotNull(recycleBin.getTable(db.getId(), table2.getId()));
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ChangeCatalogDBTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ChangeCatalogDBTest.java
@@ -73,10 +73,10 @@ public class ChangeCatalogDBTest {
     void testChangeDB(@Mocked MetadataMgr metadataMgr) throws DdlException {
         new Expectations() {
             {
-                metadataMgr.getDb("default_catalog", "db");
+                metadataMgr.getDb(ctx, "default_catalog", "db");
                 result = new Database(101, "db");
 
-                metadataMgr.getDb("default_catalog", "nonexistent_db");
+                metadataMgr.getDb(ctx, "default_catalog", "nonexistent_db");
                 result = null;
             }
         };
@@ -101,16 +101,16 @@ public class ChangeCatalogDBTest {
             }
 
             {
-                metadataMgr.getDb("default_catalog", "db");
+                metadataMgr.getDb(ctx, "default_catalog", "db");
                 result = new Database(101, "db");
 
-                metadataMgr.getDb("default_catalog", "nonexistent_db");
+                metadataMgr.getDb(ctx, "default_catalog", "nonexistent_db");
                 result = null;
 
-                metadataMgr.getDb("hive_catalog", "db");
+                metadataMgr.getDb(ctx, "hive_catalog", "db");
                 result = new Database(101, "db");
 
-                metadataMgr.getDb("hive_catalog", "nonexistent_db");
+                metadataMgr.getDb(ctx, "hive_catalog", "nonexistent_db");
                 result = null;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
@@ -85,10 +85,10 @@ public class ColocateTableIndexTest {
 
         // create table1_1->group1
         String sql = "CREATE TABLE db1.table1_1 (k1 int, k2 int, k3 varchar(32))\n" +
-                    "PRIMARY KEY(k1)\n" +
-                    "DISTRIBUTED BY HASH(k1)\n" +
-                    "BUCKETS 4\n" +
-                    "PROPERTIES(\"colocate_with\"=\"group1\", \"replication_num\" = \"1\");\n";
+                "PRIMARY KEY(k1)\n" +
+                "DISTRIBUTED BY HASH(k1)\n" +
+                "BUCKETS 4\n" +
+                "PROPERTIES(\"colocate_with\"=\"group1\", \"replication_num\" = \"1\");\n";
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
         List<List<String>> infos = GlobalStateMgr.getCurrentState().getColocateTableIndex().getInfos();
@@ -101,10 +101,10 @@ public class ColocateTableIndexTest {
 
         // create table1_2->group1
         sql = "CREATE TABLE db1.table1_2 (k1 int, k2 int, k3 varchar(32))\n" +
-                    "PRIMARY KEY(k1)\n" +
-                    "DISTRIBUTED BY HASH(k1)\n" +
-                    "BUCKETS 4\n" +
-                    "PROPERTIES(\"colocate_with\"=\"group1\", \"replication_num\" = \"1\");\n";
+                "PRIMARY KEY(k1)\n" +
+                "DISTRIBUTED BY HASH(k1)\n" +
+                "BUCKETS 4\n" +
+                "PROPERTIES(\"colocate_with\"=\"group1\", \"replication_num\" = \"1\");\n";
         createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
         // group1 -> table1To1, table1To2
@@ -121,10 +121,10 @@ public class ColocateTableIndexTest {
         GlobalStateMgr.getCurrentState().getLocalMetastore().createDb(createDbStmt.getFullDbName());
         // create table2_1 -> group2
         sql = "CREATE TABLE db2.table2_1 (k1 int, k2 int, k3 varchar(32))\n" +
-                    "PRIMARY KEY(k1)\n" +
-                    "DISTRIBUTED BY HASH(k1)\n" +
-                    "BUCKETS 4\n" +
-                    "PROPERTIES(\"colocate_with\"=\"group2\", \"replication_num\" = \"1\");\n";
+                "PRIMARY KEY(k1)\n" +
+                "DISTRIBUTED BY HASH(k1)\n" +
+                "BUCKETS 4\n" +
+                "PROPERTIES(\"colocate_with\"=\"group2\", \"replication_num\" = \"1\");\n";
         createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
         // group1 -> table1_1, table1_2
@@ -161,7 +161,7 @@ public class ColocateTableIndexTest {
         Assert.assertEquals(2, infos.size());
         Assert.assertEquals(String.format("%d*, %d*", table1To1.getId(), table1To2.getId()), map.get("group1").get(2));
         Assert.assertEquals(String.format("[deleted], [deleted]", table1To1.getId(), table1To2.getId()),
-                    map.get("group1").get(3));
+                map.get("group1").get(3));
 
         Assert.assertEquals(String.format("%d", table2To1.getId()), map.get("group2").get(2));
         Assert.assertEquals(String.format("table2_1", table2To1.getId()), map.get("group2").get(3));
@@ -171,7 +171,8 @@ public class ColocateTableIndexTest {
         // drop db2
         sql = "DROP DATABASE db2;";
         DropDbStmt dropDbStmt = (DropDbStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().dropDb(dropDbStmt.getDbName(), dropDbStmt.isForceDrop());
+        GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .dropDb(connectContext, dropDbStmt.getDbName(), dropDbStmt.isForceDrop());
         // group1 -> table1_1*, table1_2*
         // group2 -> table2_l*
         infos = GlobalStateMgr.getCurrentState().getColocateTableIndex().getInfos();
@@ -187,16 +188,17 @@ public class ColocateTableIndexTest {
         GlobalStateMgr.getCurrentState().getLocalMetastore().createDb(createDbStmt.getFullDbName());
         // create table2_1 -> group2
         sql = "CREATE TABLE db2.table2_3 (k1 int, k2 int, k3 varchar(32))\n" +
-                    "PRIMARY KEY(k1)\n" +
-                    "DISTRIBUTED BY HASH(k1)\n" +
-                    "BUCKETS 4\n" +
-                    "PROPERTIES(\"colocate_with\"=\"group3\", \"replication_num\" = \"1\");\n";
+                "PRIMARY KEY(k1)\n" +
+                "DISTRIBUTED BY HASH(k1)\n" +
+                "BUCKETS 4\n" +
+                "PROPERTIES(\"colocate_with\"=\"group3\", \"replication_num\" = \"1\");\n";
         createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
         Table table2To3 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db2").getTable("table2_3");
         sql = "DROP DATABASE db2;";
         dropDbStmt = (DropDbStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().dropDb(dropDbStmt.getDbName(), dropDbStmt.isForceDrop());
+        GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .dropDb(connectContext, dropDbStmt.getDbName(), dropDbStmt.isForceDrop());
         infos = GlobalStateMgr.getCurrentState().getColocateTableIndex().getInfos();
         map = groupByName(infos);
         LOG.info("after create & drop db2: {}", infos);
@@ -205,10 +207,10 @@ public class ColocateTableIndexTest {
         Assert.assertEquals("[deleted], [deleted]", map.get("group1").get(3));
         Assert.assertEquals(String.format("%d*", table2To1.getId()), map.get("group2").get(2));
         Assert.assertEquals(String.format("[deleted], [deleted]", table1To1.getId(), table1To2.getId()),
-                    map.get("group1").get(3));
+                map.get("group1").get(3));
         Assert.assertEquals(String.format("%d*", table2To3.getId()), map.get("group3").get(2));
         Assert.assertEquals(String.format("[deleted], [deleted]", table1To1.getId(), table1To2.getId()),
-                    map.get("group1").get(3));
+                map.get("group1").get(3));
     }
 
     @Test
@@ -222,15 +224,15 @@ public class ColocateTableIndexTest {
         Database goodDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("goodDb");
         // create goodtable
         String sql = "CREATE TABLE " +
-                    "goodDb.goodTable (k1 int, k2 int, k3 varchar(32))\n" +
-                    "PRIMARY KEY(k1)\n" +
-                    "DISTRIBUTED BY HASH(k1)\n" +
-                    "BUCKETS 4\n" +
-                    "PROPERTIES(\"colocate_with\"=\"goodGroup\", \"replication_num\" = \"1\");\n";
+                "goodDb.goodTable (k1 int, k2 int, k3 varchar(32))\n" +
+                "PRIMARY KEY(k1)\n" +
+                "DISTRIBUTED BY HASH(k1)\n" +
+                "BUCKETS 4\n" +
+                "PROPERTIES(\"colocate_with\"=\"goodGroup\", \"replication_num\" = \"1\");\n";
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
         OlapTable table =
-                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(goodDb.getFullName(), "goodTable");
+                (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(goodDb.getFullName(), "goodTable");
         ColocateTableIndex.GroupId goodGroup = GlobalStateMgr.getCurrentState().getColocateTableIndex().getGroup(table.getId());
 
         // create a bad db
@@ -238,12 +240,12 @@ public class ColocateTableIndexTest {
         table.id = 4001;
         table.name = "goodTableOfBadDb";
         colocateTableIndex.addTableToGroup(
-                    badDbId, table, "badGroupOfBadDb", new ColocateTableIndex.GroupId(badDbId, 4002), false);
+                badDbId, table, "badGroupOfBadDb", new ColocateTableIndex.GroupId(badDbId, 4002), false);
         // create a bad table in good db
         table.id = 4003;
         table.name = "badTable";
         colocateTableIndex.addTableToGroup(
-                    goodDb.getId(), table, "badGroupOfBadTable", new ColocateTableIndex.GroupId(goodDb.getId(), 4004), false);
+                goodDb.getId(), table, "badGroupOfBadTable", new ColocateTableIndex.GroupId(goodDb.getId(), 4004), false);
 
         Map<String, List<String>> map = groupByName(GlobalStateMgr.getCurrentState().getColocateTableIndex().getInfos());
         Assert.assertTrue(map.containsKey("goodGroup"));
@@ -297,11 +299,11 @@ public class ColocateTableIndexTest {
         };
 
         colocateTableIndex.addTableToGroup(
-                    dbId, (OlapTable) olapTable, "lakeGroup", new ColocateTableIndex.GroupId(dbId, 10000), false /* isReplay */);
+                dbId, (OlapTable) olapTable, "lakeGroup", new ColocateTableIndex.GroupId(dbId, 10000), false /* isReplay */);
         Assert.assertTrue(colocateTableIndex.isLakeColocateTable(tableId));
         colocateTableIndex.addTableToGroup(
-                    dbId2, (OlapTable) olapTable, "lakeGroup", new ColocateTableIndex.GroupId(dbId2, 10000),
-                    false /* isReplay */);
+                dbId2, (OlapTable) olapTable, "lakeGroup", new ColocateTableIndex.GroupId(dbId2, 10000),
+                false /* isReplay */);
         Assert.assertTrue(colocateTableIndex.isLakeColocateTable(tableId));
 
         Assert.assertTrue(colocateTableIndex.isGroupUnstable(new ColocateTableIndex.GroupId(dbId, 10000)));
@@ -318,16 +320,16 @@ public class ColocateTableIndexTest {
 
         // create goodDb
         CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils
-                    .parseStmtWithNewParser("create database db_image;", connectContext);
+                .parseStmtWithNewParser("create database db_image;", connectContext);
         GlobalStateMgr.getCurrentState().getLocalMetastore().createDb(createDbStmt.getFullDbName());
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db_image");
         // create goodtable
         String sql = "CREATE TABLE " +
-                    "db_image.tbl1 (k1 int, k2 int, k3 varchar(32))\n" +
-                    "PRIMARY KEY(k1)\n" +
-                    "DISTRIBUTED BY HASH(k1)\n" +
-                    "BUCKETS 4\n" +
-                    "PROPERTIES(\"colocate_with\"=\"goodGroup\", \"replication_num\" = \"1\");\n";
+                "db_image.tbl1 (k1 int, k2 int, k3 varchar(32))\n" +
+                "PRIMARY KEY(k1)\n" +
+                "DISTRIBUTED BY HASH(k1)\n" +
+                "BUCKETS 4\n" +
+                "PROPERTIES(\"colocate_with\"=\"goodGroup\", \"replication_num\" = \"1\");\n";
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
         OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tbl1");

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableTest.java
@@ -88,7 +88,8 @@ public class ColocateTableTest {
     public void dropDb() throws Exception {
         String dropDbStmtStr = "drop database " + dbName;
         DropDbStmt dropDbStmt = (DropDbStmt) UtFrameUtils.parseStmtWithNewParser(dropDbStmtStr, connectContext);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().dropDb(dropDbStmt.getDbName(), dropDbStmt.isForceDrop());
+        GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .dropDb(connectContext, dropDbStmt.getDbName(), dropDbStmt.isForceDrop());
     }
 
     private static void createTable(String sql) throws Exception {
@@ -243,7 +244,7 @@ public class ColocateTableTest {
 
     @Test
     public void testReplicationNum() throws Exception {
-        
+
         createTable("create table " + dbName + "." + tableName1 + " (\n" +
                 " `k1` int NULL COMMENT \"\",\n" +
                 " `k2` varchar(10) NULL COMMENT \"\"\n" +
@@ -262,7 +263,7 @@ public class ColocateTableTest {
         new MockUp<SystemInfoService>() {
             @Mock
             public List<Long> getAvailableBackendIds() {
-                return Arrays.asList(10001L, 10002L, 10003L);       
+                return Arrays.asList(10001L, 10002L, 10003L);
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/HiveTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/HiveTableTest.java
@@ -119,7 +119,7 @@ public class HiveTableTest {
                 result = metadataMgr;
                 minTimes = 0;
 
-                metadataMgr.getTable(anyString, anyString, anyString);
+                metadataMgr.getTable((ConnectContext) any, anyString, anyString, anyString);
                 result = oTable;
             }
         };
@@ -195,7 +195,7 @@ public class HiveTableTest {
                 result = metadataMgr;
                 minTimes = 0;
 
-                metadataMgr.getTable(anyString, anyString, anyString);
+                metadataMgr.getTable((ConnectContext) any, anyString, anyString, anyString);
                 result = oTable;
             }
         };
@@ -272,7 +272,7 @@ public class HiveTableTest {
                     result = metadataMgr;
                     minTimes = 0;
 
-                    metadataMgr.getTable(anyString, anyString, anyString);
+                    metadataMgr.getTable((ConnectContext) any, anyString, anyString, anyString);
                     result = oTable;
                 }
             };

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/HudiTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/HudiTableTest.java
@@ -115,7 +115,7 @@ public class HudiTableTest {
                 result = metadataMgr;
                 minTimes = 0;
 
-                metadataMgr.getTable(anyString, anyString, anyString);
+                metadataMgr.getTable((ConnectContext) any, anyString, anyString, anyString);
                 result = oTable;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/InfoSchemaDbTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/InfoSchemaDbTest.java
@@ -84,8 +84,7 @@ public class InfoSchemaDbTest {
                 "create materialized view db.mv distributed by hash(k4) buckets 10 REFRESH ASYNC as select * from db.tbl");
 
         GlobalStateMgr.getCurrentState().setAuthenticationMgr(new AuthenticationMgr());
-        GlobalStateMgr.getCurrentState().setAuthorizationMgr(new AuthorizationMgr(GlobalStateMgr.getCurrentState(),
-                new DefaultAuthorizationProvider()));
+        GlobalStateMgr.getCurrentState().setAuthorizationMgr(new AuthorizationMgr(new DefaultAuthorizationProvider()));
         CreateUserStmt createUserStmt = (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(
                 "create user test_user", ctx);
         globalStateMgr.getAuthenticationMgr().createUser(createUserStmt);
@@ -349,11 +348,11 @@ public class InfoSchemaDbTest {
         MetadataMgr metadataMgr = ctx.getGlobalStateMgr().getMetadataMgr();
         new Expectations(metadataMgr) {
             {
-                metadataMgr.getDb((String) any, (String) any);
+                metadataMgr.getDb((ConnectContext) any, (String) any, (String) any);
                 result = new com.starrocks.catalog.Database(0, "db");
                 minTimes = 0;
 
-                metadataMgr.getTable((String) any, (String) any, (String) any);
+                metadataMgr.getTable((ConnectContext) any, (String) any, (String) any, (String) any);
                 result = HiveTable.builder().setHiveTableName("tbl")
                         .setFullSchema(Lists.newArrayList(new Column("v1", Type.INT))).build();
                 minTimes = 0;

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/DbsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/DbsProcDirTest.java
@@ -38,6 +38,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.catalog.Database;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.FeConstants;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -160,7 +161,7 @@ public class DbsProcDirTest {
     public void testFetchResultNormal() throws AnalysisException {
         new Expectations(globalStateMgr) {
             {
-                globalStateMgr.getLocalMetastore().listDbNames();
+                globalStateMgr.getLocalMetastore().listDbNames((ConnectContext) any);
                 minTimes = 0;
                 result = Lists.newArrayList("db1", "db2");
 
@@ -213,7 +214,7 @@ public class DbsProcDirTest {
     public void testFetchResultInvalid() throws AnalysisException {
         new Expectations(globalStateMgr) {
             {
-                globalStateMgr.getLocalMetastore().listDbNames();
+                globalStateMgr.getLocalMetastore().listDbNames(new ConnectContext());
                 minTimes = 0;
                 result = null;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/ExternalProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/ExternalProcDirTest.java
@@ -27,6 +27,7 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.MetadataMgr;
 import mockit.Mock;
 import mockit.MockUp;
@@ -44,19 +45,19 @@ public class ExternalProcDirTest {
     public void setUp() throws Exception {
         new MockUp<MetadataMgr>() {
             @Mock
-            public List<String> listDbNames(String catalogName) throws DdlException {
+            public List<String> listDbNames(ConnectContext context, String catalogName) throws DdlException {
                 ImmutableSet.Builder<String> dbNames = ImmutableSet.builder();
                 dbNames.add("hive_test").add("temp_db").add("ods");
                 return ImmutableList.copyOf(dbNames.build());
             }
 
             @Mock
-            public Database getDb(String catalogName, String dbName) {
+            public Database getDb(ConnectContext context, String catalogName, String dbName) {
                 return new Database();
             }
 
             @Mock
-            public List<String> listTableNames(String catalogName, String dbName) throws DdlException {
+            public List<String> listTableNames(ConnectContext context, String catalogName, String dbName) throws DdlException {
                 ImmutableSet.Builder<String> tableNames = ImmutableSet.builder();
                 tableNames.add("test1");
                 tableNames.add("sr");
@@ -64,7 +65,7 @@ public class ExternalProcDirTest {
                 return ImmutableList.copyOf(tableNames.build());
             }
             @Mock
-            public Table getTable(String catalogName, String dbName, String tblName) {
+            public Table getTable(ConnectContext context, String catalogName, String dbName, String tblName) {
                 return new HiveTable();
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/PaimonPartitionsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/PaimonPartitionsProcDirTest.java
@@ -30,6 +30,7 @@ import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.paimon.PaimonMetadata;
 import com.starrocks.connector.paimon.Partition;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.parser.NodePosition;
 import mockit.Mock;
@@ -68,12 +69,12 @@ public class PaimonPartitionsProcDirTest {
 
         new MockUp<MetadataMgr>() {
             @Mock
-            public Database getDb(String catalogName, String dbName) {
+            public Database getDb(ConnectContext context, String catalogName, String dbName) {
                 return new Database(1L, "db1");
             }
 
             @Mock
-            public Table getTable(String catalogName, String dbName, String tblName) {
+            public Table getTable(ConnectContext context, String catalogName, String dbName, String tblName) {
                 return new PaimonTable("paimon_catalog", "db1", "tb1", null, nativeTable, 1L);
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
@@ -46,7 +46,7 @@ public class CatalogConnectorMetadataTest {
     void testListDbNames(@Mocked ConnectorMetadata connectorMetadata) {
         new Expectations() {
             {
-                connectorMetadata.listDbNames();
+                connectorMetadata.listDbNames((ConnectContext) any);
                 result = ImmutableList.of("test_db1", "test_db2");
                 times = 1;
             }
@@ -58,7 +58,7 @@ public class CatalogConnectorMetadataTest {
                 metaMetadata
         );
 
-        List<String> dbNames = catalogConnectorMetadata.listDbNames();
+        List<String> dbNames = catalogConnectorMetadata.listDbNames(new ConnectContext());
         List<String> expected = ImmutableList.of("test_db1", "test_db2", InfoSchemaDb.DATABASE_NAME);
         assertEquals(expected, dbNames);
     }
@@ -67,7 +67,7 @@ public class CatalogConnectorMetadataTest {
     void testListTableNames(@Mocked ConnectorMetadata connectorMetadata) {
         new Expectations() {
             {
-                connectorMetadata.listTableNames("test_db");
+                connectorMetadata.listTableNames((ConnectContext) any, "test_db");
                 result = ImmutableList.of("test_tbl1", "test_tbl2");
                 times = 1;
             }
@@ -79,7 +79,7 @@ public class CatalogConnectorMetadataTest {
                 metaMetadata
         );
 
-        List<String> tblNames = catalogConnectorMetadata.listTableNames(InfoSchemaDb.DATABASE_NAME);
+        List<String> tblNames = catalogConnectorMetadata.listTableNames(new ConnectContext(), InfoSchemaDb.DATABASE_NAME);
         List<String> expected = ImmutableList.of("tables", "table_privileges", "referential_constraints",
                 "key_column_usage", "routines", "schemata", "columns", "character_sets", "collations",
                 "table_constraints", "engines", "user_privileges", "schema_privileges", "statistics",
@@ -87,7 +87,7 @@ public class CatalogConnectorMetadataTest {
         );
         assertEquals(expected, tblNames);
 
-        tblNames = catalogConnectorMetadata.listTableNames("test_db");
+        tblNames = catalogConnectorMetadata.listTableNames(new ConnectContext(), "test_db");
         expected = ImmutableList.of("test_tbl1", "test_tbl2");
         assertEquals(expected, tblNames);
     }
@@ -96,7 +96,7 @@ public class CatalogConnectorMetadataTest {
     void testGetDb(@Mocked ConnectorMetadata connectorMetadata) {
         new Expectations() {
             {
-                connectorMetadata.getDb("test_db");
+                connectorMetadata.getDb((ConnectContext) any, "test_db");
                 result = null;
                 times = 1;
             }
@@ -108,16 +108,16 @@ public class CatalogConnectorMetadataTest {
                 metaMetadata
         );
 
-        Database db = catalogConnectorMetadata.getDb("test_db");
+        Database db = catalogConnectorMetadata.getDb(new ConnectContext(), "test_db");
         assertNull(db);
-        assertNotNull(catalogConnectorMetadata.getDb(InfoSchemaDb.DATABASE_NAME));
+        assertNotNull(catalogConnectorMetadata.getDb(new ConnectContext(), InfoSchemaDb.DATABASE_NAME));
     }
 
     @Test
     void testDbExists(@Mocked ConnectorMetadata connectorMetadata) {
         new Expectations() {
             {
-                connectorMetadata.dbExists("test_db");
+                connectorMetadata.dbExists((ConnectContext) any, "test_db");
                 result = true;
                 times = 1;
             }
@@ -129,21 +129,21 @@ public class CatalogConnectorMetadataTest {
                 metaMetadata
         );
 
-        assertTrue(catalogConnectorMetadata.dbExists("test_db"));
-        assertTrue(catalogConnectorMetadata.dbExists(InfoSchemaDb.DATABASE_NAME));
+        assertTrue(catalogConnectorMetadata.dbExists(new ConnectContext(), "test_db"));
+        assertTrue(catalogConnectorMetadata.dbExists(new ConnectContext(), InfoSchemaDb.DATABASE_NAME));
     }
 
     @Test
     void testTableExists() {
         MockedJDBCMetadata mockedJDBCMetadata = new MockedJDBCMetadata(new HashMap<>());
-        assertTrue(mockedJDBCMetadata.tableExists("db1", "tbl1"));
+        assertTrue(mockedJDBCMetadata.tableExists(new ConnectContext(), "db1", "tbl1"));
     }
 
     @Test
     void testGetTable(@Mocked ConnectorMetadata connectorMetadata) {
         new Expectations() {
             {
-                connectorMetadata.getTable("test_db", "test_tbl");
+                connectorMetadata.getTable((ConnectContext) any, "test_db", "test_tbl");
                 result = null;
                 times = 1;
             }
@@ -155,9 +155,9 @@ public class CatalogConnectorMetadataTest {
                 metaMetadata
         );
 
-        Table table = catalogConnectorMetadata.getTable("test_db", "test_tbl");
+        Table table = catalogConnectorMetadata.getTable(new ConnectContext(), "test_db", "test_tbl");
         assertNull(table);
-        assertNotNull(catalogConnectorMetadata.getTable(InfoSchemaDb.DATABASE_NAME, "tables"));
+        assertNotNull(catalogConnectorMetadata.getTable(new ConnectContext(), InfoSchemaDb.DATABASE_NAME, "tables"));
     }
 
     @Test
@@ -196,10 +196,9 @@ public class CatalogConnectorMetadataTest {
                 connectorMetadata.createTableLike(null);
                 connectorMetadata.createTable(null);
                 connectorMetadata.createDb("test_db");
-                connectorMetadata.dropDb("test_db", false);
+                connectorMetadata.dropDb((ConnectContext) any, "test_db", false);
                 connectorMetadata.getRemoteFiles(null, getRemoteFilesParams);
                 connectorMetadata.getPartitions(null, null);
-                connectorMetadata.getMaterializedViewIndex("test_db", "test_tbl");
                 connectorMetadata.getTableStatistics(null, null, null, null, null, -1, TableVersionRange.empty());
             }
         };
@@ -233,10 +232,9 @@ public class CatalogConnectorMetadataTest {
         catalogConnectorMetadata.createTableLike(null);
         catalogConnectorMetadata.createTable(null);
         catalogConnectorMetadata.createDb("test_db");
-        catalogConnectorMetadata.dropDb("test_db", false);
+        catalogConnectorMetadata.dropDb(new ConnectContext(), "test_db", false);
         connectorMetadata.getRemoteFiles(null, getRemoteFilesParams);
         catalogConnectorMetadata.getPartitions(null, null);
-        catalogConnectorMetadata.getMaterializedViewIndex("test_db", "test_tbl");
         catalogConnectorMetadata.getTableStatistics(null, null, null, null, null, -1, TableVersionRange.empty());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorColumnStatsCacheLoaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorColumnStatsCacheLoaderTest.java
@@ -81,9 +81,9 @@ public class ConnectorColumnStatsCacheLoaderTest {
 
         new MockUp<StatisticsUtils>() {
             @Mock
-            public Table getTableByUUID(String tableUUID) {
+            public Table getTableByUUID(ConnectContext context, String tableUUID) {
                 return connectContext.getGlobalStateMgr().getMetadataMgr().
-                        getTable("hive0", "tpch", "region");
+                        getTable(connectContext, "hive0", "tpch", "region");
             }
 
         };
@@ -139,9 +139,9 @@ public class ConnectorColumnStatsCacheLoaderTest {
 
         new MockUp<StatisticsUtils>() {
             @Mock
-            public Table getTableByUUID(String tableUUID) {
+            public Table getTableByUUID(ConnectContext context, String tableUUID) {
                 return connectContext.getGlobalStateMgr().getMetadataMgr().
-                        getTable("hive0", "tpch", "region");
+                        getTable(connectContext, "hive0", "tpch", "region");
             }
 
         };
@@ -204,9 +204,9 @@ public class ConnectorColumnStatsCacheLoaderTest {
 
         new MockUp<StatisticsUtils>() {
             @Mock
-            public Table getTableByUUID(String tableUUID) {
+            public Table getTableByUUID(ConnectContext context, String tableUUID) {
                 return connectContext.getGlobalStateMgr().getMetadataMgr().
-                        getTable("hive0", "partitioned_db", "t1_par");
+                        getTable(connectContext, "hive0", "partitioned_db", "t1_par");
             }
 
         };
@@ -237,9 +237,9 @@ public class ConnectorColumnStatsCacheLoaderTest {
     public void testConvert2ColumnStatistics() {
         new MockUp<StatisticsUtils>() {
             @Mock
-            public Table getTableByUUID(String tableUUID) {
+            public Table getTableByUUID(ConnectContext context, String tableUUID) {
                 return connectContext.getGlobalStateMgr().getMetadataMgr().
-                        getTable("hive0", "partitioned_db", "t1");
+                        getTable(connectContext, "hive0", "partitioned_db", "t1");
             }
         };
         ConnectorColumnStatsCacheLoader cachedStatisticStorage =
@@ -252,6 +252,7 @@ public class ConnectorColumnStatsCacheLoaderTest {
 
         ConnectorTableColumnStats columnStatistic =
                 Deencapsulation.invoke(cachedStatisticStorage, "convert2ColumnStatistics",
+                        connectContext,
                         "hive0.partitioned_db.t1.1234",
                         statisticData);
         Assert.assertEquals(123, columnStatistic.getColumnStatistic().getMaxValue(), 0.001);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
@@ -28,6 +28,7 @@ import com.starrocks.connector.hive.HiveMetaClient;
 import com.starrocks.connector.hive.HiveMetastore;
 import com.starrocks.connector.hive.HiveMetastoreTest;
 import com.starrocks.connector.hive.IHiveMetastore;
+import com.starrocks.qe.ConnectContext;
 import io.delta.kernel.Scan;
 import io.delta.kernel.ScanBuilder;
 import io.delta.kernel.data.ColumnVector;
@@ -81,7 +82,7 @@ public class DeltaLakeMetadataTest {
 
     @Test
     public void testListDbNames() {
-        List<String> dbNames = deltaLakeMetadata.listDbNames();
+        List<String> dbNames = deltaLakeMetadata.listDbNames(new ConnectContext());
         Assert.assertEquals(2, dbNames.size());
         Assert.assertEquals("db1", dbNames.get(0));
         Assert.assertEquals("db2", dbNames.get(1));
@@ -89,7 +90,7 @@ public class DeltaLakeMetadataTest {
 
     @Test
     public void testListTableNames() {
-        List<String> tableNames = deltaLakeMetadata.listTableNames("db1");
+        List<String> tableNames = deltaLakeMetadata.listTableNames(new ConnectContext(), "db1");
         Assert.assertEquals(2, tableNames.size());
         Assert.assertEquals("table1", tableNames.get(0));
         Assert.assertEquals("table2", tableNames.get(1));
@@ -188,7 +189,7 @@ public class DeltaLakeMetadataTest {
 
     @Test
     public void testTableExists() {
-        Assert.assertTrue(deltaLakeMetadata.tableExists("db1", "table1"));
+        Assert.assertTrue(deltaLakeMetadata.tableExists(new ConnectContext(), "db1", "table1"));
     }
 
     @Test
@@ -208,7 +209,7 @@ public class DeltaLakeMetadataTest {
                         Lists.newArrayList("col1"), null, "path/to/table", null, 0);
             }
         };
-        DeltaLakeTable deltaTable = (DeltaLakeTable) deltaLakeMetadata.getTable("db1", "table1");
+        DeltaLakeTable deltaTable = (DeltaLakeTable) deltaLakeMetadata.getTable(new ConnectContext(), "db1", "table1");
         Assert.assertNotNull(deltaTable);
         Assert.assertEquals("table1", deltaTable.getName());
         Assert.assertEquals(Table.TableType.DELTALAKE, deltaTable.getType());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadataTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.connector.elasticsearch;
 
+import com.starrocks.qe.ConnectContext;
 import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
@@ -25,7 +26,7 @@ public class ElasticsearchMetadataTest {
     @Test
     public void testGetTable(@Mocked EsRestClient client) {
         ElasticsearchMetadata metadata = new ElasticsearchMetadata(client, new HashMap<>(), "catalog");
-        Assert.assertNull(metadata.getTable("default_db", "not_exist_index"));
-        Assert.assertNull(metadata.getTable("aaaa", "tbl"));
+        Assert.assertNull(metadata.getTable(new ConnectContext(), "default_db", "not_exist_index"));
+        Assert.assertNull(metadata.getTable(new ConnectContext(), "aaaa", "tbl"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveConnectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveConnectorTest.java
@@ -25,6 +25,7 @@ import com.starrocks.connector.CachingRemoteFileIO;
 import com.starrocks.connector.ConnectorContext;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.MetastoreType;
+import com.starrocks.qe.ConnectContext;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.apache.hadoop.conf.Configuration;
@@ -104,7 +105,7 @@ public class HiveConnectorTest {
         HiveConnector hiveConnector = new HiveConnector(new ConnectorContext("hive_catalog", "hive", properties));
         ConnectorMetadata metadata = hiveConnector.getMetadata();
         Assert.assertTrue(metadata instanceof HiveMetadata);
-        com.starrocks.catalog.Table table = metadata.getTable("db1", "tbl1");
+        com.starrocks.catalog.Table table = metadata.getTable(new ConnectContext(), "db1", "tbl1");
         HiveTable hiveTable = (HiveTable) table;
         Assert.assertEquals("db1", hiveTable.getCatalogDBName());
         Assert.assertEquals("tbl1", hiveTable.getCatalogTableName());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
@@ -148,7 +148,7 @@ public class HiveMetadataTest {
 
     @Test
     public void testListDbNames() {
-        List<String> databaseNames = hiveMetadata.listDbNames();
+        List<String> databaseNames = hiveMetadata.listDbNames(new ConnectContext());
         Assert.assertEquals(Lists.newArrayList("db1", "db2"), databaseNames);
         CachingHiveMetastore queryLevelCache = CachingHiveMetastore.createQueryLevelInstance(cachingHiveMetastore, 100);
         Assert.assertEquals(Lists.newArrayList("db1", "db2"), queryLevelCache.getAllDatabaseNames());
@@ -156,7 +156,7 @@ public class HiveMetadataTest {
 
     @Test
     public void testListTableNames() {
-        List<String> databaseNames = hiveMetadata.listTableNames("db1");
+        List<String> databaseNames = hiveMetadata.listTableNames(new ConnectContext(), "db1");
         Assert.assertEquals(Lists.newArrayList("table1", "table2"), databaseNames);
     }
 
@@ -169,14 +169,14 @@ public class HiveMetadataTest {
 
     @Test
     public void testGetDb() {
-        Database database = hiveMetadata.getDb("db1");
+        Database database = hiveMetadata.getDb(new ConnectContext(), "db1");
         Assert.assertEquals("db1", database.getFullName());
 
     }
 
     @Test
     public void testGetTable() {
-        com.starrocks.catalog.Table table = hiveMetadata.getTable("db1", "tbl1");
+        com.starrocks.catalog.Table table = hiveMetadata.getTable(new ConnectContext(), "db1", "tbl1");
         HiveTable hiveTable = (HiveTable) table;
         Assert.assertEquals("db1", hiveTable.getCatalogDBName());
         Assert.assertEquals("tbl1", hiveTable.getCatalogTableName());
@@ -199,12 +199,12 @@ public class HiveMetadataTest {
         };
 
         Assert.assertThrows(StarRocksConnectorException.class,
-                () -> hiveMetadata.getTable("acid_db", "acid_table"));
+                () -> hiveMetadata.getTable(new ConnectContext(), "acid_db", "acid_table"));
     }
 
     @Test
     public void testTableExists() {
-        boolean exists = hiveMetadata.tableExists("db1", "tbl1");
+        boolean exists = hiveMetadata.tableExists(new ConnectContext(), "db1", "tbl1");
         Assert.assertTrue(exists);
     }
 
@@ -216,7 +216,7 @@ public class HiveMetadataTest {
         HiveMetastore metastore = new HiveMetastore(client, "hive_catalog", null);
         List<String> partitionNames = Lists.newArrayList("col1=1", "col1=2");
         Map<String, Partition> partitions = metastore.getPartitionsByNames("db1", "table1", partitionNames);
-        HiveTable hiveTable = (HiveTable) hiveMetadata.getTable("db1", "table1");
+        HiveTable hiveTable = (HiveTable) hiveMetadata.getTable(new ConnectContext(), "db1", "table1");
 
         PartitionKey hivePartitionKey1 = PartitionUtil.createPartitionKey(
                 Lists.newArrayList("1"), hiveTable.getPartitionColumns());
@@ -285,7 +285,7 @@ public class HiveMetadataTest {
 
     @Test
     public void testShowCreateHiveTbl() {
-        HiveTable hiveTable = (HiveTable) hiveMetadata.getTable("db1", "table1");
+        HiveTable hiveTable = (HiveTable) hiveMetadata.getTable(new ConnectContext(), "db1", "table1");
         Assert.assertEquals("CREATE TABLE `table1` (\n" +
                         "  `col2` int(11) DEFAULT NULL,\n" +
                         "  `col1` int(11) DEFAULT NULL\n" +
@@ -302,7 +302,7 @@ public class HiveMetadataTest {
 
     @Test
     public void testGetTableStatisticsNormal() throws AnalysisException {
-        HiveTable hiveTable = (HiveTable) hiveMetadata.getTable("db1", "table1");
+        HiveTable hiveTable = (HiveTable) hiveMetadata.getTable(new ConnectContext(), "db1", "table1");
         ColumnRefOperator partColumnRefOperator = new ColumnRefOperator(0, Type.INT, "col1", true);
         ColumnRefOperator dataColumnRefOperator = new ColumnRefOperator(1, Type.INT, "col2", true);
         PartitionKey hivePartitionKey1 = PartitionUtil.createPartitionKey(
@@ -365,11 +365,11 @@ public class HiveMetadataTest {
     public void dropDbTest() {
         ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class,
                 "Database d1 not empty",
-                () -> hiveMetadata.dropDb("d1", true));
+                () -> hiveMetadata.dropDb(new ConnectContext(), "d1", true));
 
         ExceptionChecker.expectThrowsWithMsg(MetaNotFoundException.class,
                 "Failed to access database empty_db",
-                () -> hiveMetadata.dropDb("empty_db", true));
+                () -> hiveMetadata.dropDb(new ConnectContext(), "empty_db", true));
     }
 
     @Test
@@ -734,7 +734,7 @@ public class HiveMetadataTest {
         starRocksAssert.withCatalog(sql);
         new MockUp<HiveMetadata>() {
             @Mock
-            public Database getDb(String dbName) {
+            public Database getDb(ConnectContext context, String dbName) {
                 return new Database();
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveViewTest.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.Type;
 import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.ConnectorType;
 import com.starrocks.connector.MetastoreType;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.AstToStringBuilder;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.common.StarRocksPlannerException;
@@ -63,7 +64,7 @@ public class HiveViewTest extends PlanTestBase {
         assertContains(sqlPlan, "1:HdfsScanNode\n" +
                         "     TABLE: customer",
                 "0:HdfsScanNode\n" +
-                "     TABLE: nation");
+                        "     TABLE: nation");
     }
 
     @Test
@@ -72,9 +73,9 @@ public class HiveViewTest extends PlanTestBase {
                 "on orders.o_custkey = customer_nation_view.c_custkey";
         String sqlPlan = getFragmentPlan(sql);
         assertContains(sqlPlan, "4:HASH JOIN\n" +
-                "  |  join op: INNER JOIN (BROADCAST)\n" +
-                "  |  colocate: false, reason: \n" +
-                "  |  equal join conjunct: 11: c_custkey = 2: O_CUSTKEY",
+                        "  |  join op: INNER JOIN (BROADCAST)\n" +
+                        "  |  colocate: false, reason: \n" +
+                        "  |  equal join conjunct: 11: c_custkey = 2: O_CUSTKEY",
                 " 7:HASH JOIN\n" +
                         "  |  join op: INNER JOIN (BROADCAST)\n" +
                         "  |  colocate: false, reason: \n" +
@@ -85,10 +86,10 @@ public class HiveViewTest extends PlanTestBase {
     public void testHiveViewParseFail() throws Exception {
         HiveView hiveView = new HiveView(1, "hive0", "testDb", "test", null,
                 "select\n" +
-                 "    t1b,t1a\n" +
-                 "from\n" +
-                 "    test_all_type\n" +
-                 "    lateral view explode(split(t1a,',')) t1a", HiveView.Type.Hive);
+                        "    t1b,t1a\n" +
+                        "from\n" +
+                        "    test_all_type\n" +
+                        "    lateral view explode(split(t1a,',')) t1a", HiveView.Type.Hive);
         expectedException.expect(StarRocksPlannerException.class);
         expectedException.expectMessage("Failed to parse view-definition statement of view");
         hiveView.getQueryStatement();
@@ -132,7 +133,8 @@ public class HiveViewTest extends PlanTestBase {
                 Optional.of(hiveCacheUpdateProcessor), null, null,
                 new ConnectorProperties(ConnectorType.HIVE));
 
-        Table hiveView = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("hive0", "tpch", "customer_view");
+        Table hiveView = connectContext.getGlobalStateMgr().getMetadataMgr()
+                .getTable(new ConnectContext(), "hive0", "tpch", "customer_view");
         new Expectations() {
             {
                 hiveMetastore.refreshView(anyString, anyString);
@@ -150,7 +152,8 @@ public class HiveViewTest extends PlanTestBase {
         HiveMetastore hiveMetastore1 = new HiveMetastore(null, "hive0", MetastoreType.HMS);
         Assert.assertTrue(hiveMetastore1.refreshView("tpch", "customer_view"));
 
-        Table table  = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("hive0", "tpch", "customer");
+        Table table =
+                connectContext.getGlobalStateMgr().getMetadataMgr().getTable(new ConnectContext(), "hive0", "tpch", "customer");
 
         new Expectations() {
             {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
@@ -46,6 +46,7 @@ import com.starrocks.connector.RemoteFileInfoSource;
 import com.starrocks.connector.RemoteFileOperations;
 import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
@@ -105,7 +106,7 @@ public class MockedHiveMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public com.starrocks.catalog.Table getTable(String dbName, String tblName) {
+    public com.starrocks.catalog.Table getTable(ConnectContext context, String dbName, String tblName) {
         readLock();
         try {
             if (!MOCK_TABLE_MAP.containsKey(dbName)) {
@@ -122,7 +123,7 @@ public class MockedHiveMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public Database getDb(String dbName) {
+    public Database getDb(ConnectContext context, String dbName) {
         return new Database(idGen.getAndIncrement(), dbName);
     }
 
@@ -176,12 +177,12 @@ public class MockedHiveMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listTableNames(String dbName) {
+    public List<String> listTableNames(ConnectContext context, String dbName) {
         return new ArrayList<>(MOCK_TABLE_MAP.get(dbName).keySet());
     }
 
     @Override
-    public List<String> listDbNames() {
+    public List<String> listDbNames(ConnectContext context) {
         return new ArrayList<>(MOCK_TABLE_MAP.keySet());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/ReplayMetadataMgr.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/ReplayMetadataMgr.java
@@ -31,6 +31,7 @@ import com.starrocks.connector.ConnectorMgr;
 import com.starrocks.connector.ConnectorTblMetaInfoMgr;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.RemoteFileInfo;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.LocalMetastore;
 import com.starrocks.server.MetadataMgr;
@@ -146,17 +147,17 @@ public class ReplayMetadataMgr extends MetadataMgr {
     }
 
     @Override
-    public Database getDb(String catalogName, String dbName) {
+    public Database getDb(ConnectContext context, String catalogName, String dbName) {
         if (CatalogMgr.isInternalCatalog(catalogName)) {
-            return super.getDb(catalogName, dbName);
+            return super.getDb(context, catalogName, dbName);
         }
         return new Database(idGen++, dbName);
     }
 
     @Override
-    public Table getTable(String catalogName, String dbName, String tblName) {
+    public Table getTable(ConnectContext context, String catalogName, String dbName, String tblName) {
         if (CatalogMgr.isInternalCatalog(catalogName)) {
-            return super.getTable(catalogName, dbName, tblName);
+            return super.getTable(context, catalogName, dbName, tblName);
         }
 
         if (!CatalogMgr.ResourceMappingCatalog.isResourceMappingCatalog(catalogName)) {
@@ -168,7 +169,7 @@ public class ReplayMetadataMgr extends MetadataMgr {
             return tableInfo.table;
         }
         // probably it's a hive view but being created in default catalog.
-        return super.getTable(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, dbName, tblName);
+        return super.getTable(context, InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, dbName, tblName);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hudi/HudiMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hudi/HudiMetadataTest.java
@@ -73,7 +73,7 @@ public class HudiMetadataTest {
         client = new HiveMetastoreTest.MockedHiveMetaClient();
         metastore = new HiveMetastore(client, "hive_catalog", MetastoreType.HMS);
         cachingHiveMetastore = CachingHiveMetastore.createCatalogLevelInstance(
-                metastore, executorForHmsRefresh,  executorForHmsRefresh,
+                metastore, executorForHmsRefresh, executorForHmsRefresh,
                 100, 10, 1000, false);
         hmsOps = new HiveMetastoreOperations(cachingHiveMetastore, true, new Configuration(), MetastoreType.HMS, "hive_catalog");
 
@@ -102,7 +102,7 @@ public class HudiMetadataTest {
 
     @Test
     public void testListDbNames() {
-        List<String> databaseNames = hudiMetadata.listDbNames();
+        List<String> databaseNames = hudiMetadata.listDbNames(new ConnectContext());
         Assert.assertEquals(Lists.newArrayList("db1", "db2"), databaseNames);
         CachingHiveMetastore queryLevelCache = CachingHiveMetastore.createQueryLevelInstance(cachingHiveMetastore, 100);
         Assert.assertEquals(Lists.newArrayList("db1", "db2"), queryLevelCache.getAllDatabaseNames());
@@ -110,13 +110,13 @@ public class HudiMetadataTest {
 
     @Test
     public void testListTableNames() {
-        List<String> databaseNames = hudiMetadata.listTableNames("db1");
+        List<String> databaseNames = hudiMetadata.listTableNames(new ConnectContext(), "db1");
         Assert.assertEquals(Lists.newArrayList("table1", "table2"), databaseNames);
     }
 
     @Test
     public void testTableExists() {
-        boolean exists = hudiMetadata.tableExists("db1", "table1");
+        boolean exists = hudiMetadata.tableExists(new ConnectContext(), "db1", "table1");
         Assert.assertTrue(exists);
     }
 
@@ -129,7 +129,7 @@ public class HudiMetadataTest {
 
     @Test
     public void testGetDb() {
-        Database database = hudiMetadata.getDb("db1");
+        Database database = hudiMetadata.getDb(new ConnectContext(), "db1");
         Assert.assertEquals("db1", database.getFullName());
 
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -173,7 +173,7 @@ public class IcebergMetadataTest extends TableTestBase {
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergCatalog,
                 Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
         List<String> expectResult = Lists.newArrayList("db1", "db2");
-        Assert.assertEquals(expectResult, metadata.listDbNames());
+        Assert.assertEquals(expectResult, metadata.listDbNames(new ConnectContext()));
     }
 
     @Test
@@ -191,7 +191,7 @@ public class IcebergMetadataTest extends TableTestBase {
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
                 Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
         Database expectResult = new Database(0, db);
-        Assert.assertEquals(expectResult, metadata.getDb(db));
+        Assert.assertEquals(expectResult, metadata.getDb(new ConnectContext(), db));
     }
 
     @Test
@@ -208,7 +208,7 @@ public class IcebergMetadataTest extends TableTestBase {
 
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
                 Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
-        Assert.assertNull(metadata.getDb(db));
+        Assert.assertNull(metadata.getDb(new ConnectContext(), db));
     }
 
     @Test
@@ -228,7 +228,7 @@ public class IcebergMetadataTest extends TableTestBase {
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
                 Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
         List<String> expectResult = Lists.newArrayList("tbl1", "tbl2");
-        Assert.assertEquals(expectResult, metadata.listTableNames(db1));
+        Assert.assertEquals(expectResult, metadata.listTableNames(new ConnectContext(), db1));
     }
 
     @Test
@@ -245,7 +245,7 @@ public class IcebergMetadataTest extends TableTestBase {
 
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
                 Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
-        Table actual = metadata.getTable("db", "tbl");
+        Table actual = metadata.getTable(new ConnectContext(), "db", "tbl");
         Assert.assertEquals("tbl", actual.getName());
         Assert.assertEquals(ICEBERG, actual.getType());
     }
@@ -267,7 +267,7 @@ public class IcebergMetadataTest extends TableTestBase {
 
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
                 Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
-        Table actual = metadata.getTable("DB", "TBL");
+        Table actual = metadata.getTable(new ConnectContext(), "DB", "TBL");
         Assert.assertTrue(actual instanceof IcebergTable);
         IcebergTable icebergTable = (IcebergTable) actual;
         Assert.assertEquals("db", icebergTable.getCatalogDBName());
@@ -286,7 +286,7 @@ public class IcebergMetadataTest extends TableTestBase {
         };
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
                 Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
-        Assert.assertTrue(metadata.tableExists("db", "tbl"));
+        Assert.assertTrue(metadata.tableExists(new ConnectContext(), "db", "tbl"));
     }
 
     @Test
@@ -318,7 +318,7 @@ public class IcebergMetadataTest extends TableTestBase {
 
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
                 Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
-        Assert.assertNull(metadata.getTable("db", "tbl2"));
+        Assert.assertNull(metadata.getTable(new ConnectContext(), "db", "tbl2"));
     }
 
     @Test(expected = AlreadyExistsException.class)
@@ -418,7 +418,7 @@ public class IcebergMetadataTest extends TableTestBase {
         };
 
         try {
-            metadata.dropDb("iceberg_db", true);
+            metadata.dropDb(new ConnectContext(), "iceberg_db", true);
             Assert.fail();
         } catch (Exception e) {
             Assert.assertTrue(e instanceof StarRocksConnectorException);
@@ -466,7 +466,7 @@ public class IcebergMetadataTest extends TableTestBase {
 
         new MockUp<IcebergMetadata>() {
             @Mock
-            Table getTable(String dbName, String tblName) {
+            Table getTable(ConnectContext context, String dbName, String tblName) {
                 return new IcebergTable(1, "table1", CATALOG_NAME,
                         CATALOG_NAME, "iceberg_db",
                         "table1", "", Lists.newArrayList(), mockedNativeTableA, Maps.newHashMap());
@@ -521,7 +521,7 @@ public class IcebergMetadataTest extends TableTestBase {
         };
 
         try {
-            metadata.dropDb("iceberg_db", true);
+            metadata.dropDb(new ConnectContext(), "iceberg_db", true);
             Assert.fail();
         } catch (Exception e) {
             Assert.assertTrue(e instanceof MetaNotFoundException);
@@ -537,7 +537,7 @@ public class IcebergMetadataTest extends TableTestBase {
         };
 
         try {
-            metadata.dropDb("iceberg_db", true);
+            metadata.dropDb(new ConnectContext(), "iceberg_db", true);
             Assert.fail();
         } catch (Exception e) {
             Assert.assertTrue(e instanceof MetaNotFoundException);
@@ -553,7 +553,7 @@ public class IcebergMetadataTest extends TableTestBase {
         };
 
         try {
-            metadata.dropDb("iceberg_db", true);
+            metadata.dropDb(new ConnectContext(), "iceberg_db", true);
             Assert.fail();
         } catch (Exception e) {
             Assert.assertTrue(e instanceof MetaNotFoundException);
@@ -586,7 +586,7 @@ public class IcebergMetadataTest extends TableTestBase {
             }
         };
 
-        metadata.dropDb("iceberg_db", true);
+        metadata.dropDb(new ConnectContext(), "iceberg_db", true);
     }
 
     @Test
@@ -600,7 +600,7 @@ public class IcebergMetadataTest extends TableTestBase {
 
         new Expectations(metadata) {
             {
-                metadata.getTable(anyString, anyString);
+                metadata.getTable((ConnectContext) any, anyString, anyString);
                 result = icebergTable;
                 minTimes = 0;
             }
@@ -696,7 +696,7 @@ public class IcebergMetadataTest extends TableTestBase {
 
         new Expectations(metadata) {
             {
-                metadata.getTable(anyString, anyString);
+                metadata.getTable((ConnectContext) any, anyString, anyString);
                 result = icebergTable;
                 minTimes = 0;
 
@@ -1384,7 +1384,7 @@ public class IcebergMetadataTest extends TableTestBase {
 
         new MockUp<IcebergMetadata>() {
             @Mock
-            public Database getDb(String dbName) {
+            public Database getDb(ConnectContext context, String dbName) {
                 return new Database(1, "db");
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.IcebergView;
 import com.starrocks.catalog.Table;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.iceberg.rest.IcebergRESTCatalog;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.ast.ColWithComment;
 import com.starrocks.sql.ast.CreateViewStmt;
@@ -146,7 +147,7 @@ public class IcebergRESTCatalogTest {
             }
         };
 
-        List<String> tables = metadata.listTableNames("db");
+        List<String> tables = metadata.listTableNames(new ConnectContext(), "db");
         Assert.assertEquals(2, tables.size());
         Assert.assertEquals(tables, Lists.newArrayList("tbl1", "view1"));
     }
@@ -156,7 +157,7 @@ public class IcebergRESTCatalogTest {
         IcebergMetadata metadata = buildIcebergMetadata(restCatalog);
         new MockUp<IcebergMetadata>() {
             @Mock
-            Table getTable(String dbName, String tblName) {
+            Table getTable(ConnectContext context, String dbName, String tblName) {
                 return new IcebergView(1, "iceberg_rest_catalog", "db", "view",
                         Lists.newArrayList(), "mocked", "iceberg_rest_catalog", "db",
                         "location");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
@@ -28,6 +28,7 @@ import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.TableVersionRange;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
@@ -426,12 +427,12 @@ public class MockIcebergMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public Database getDb(String dbName) {
+    public Database getDb(ConnectContext context, String dbName) {
         return new Database(idGen.getAndIncrement(), dbName);
     }
 
     @Override
-    public com.starrocks.catalog.Table getTable(String dbName, String tblName) {
+    public com.starrocks.catalog.Table getTable(ConnectContext context, String dbName, String tblName) {
         readLock();
         try {
             return MOCK_TABLE_MAP.get(dbName).get(tblName).icebergTable;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolverTest.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.JDBCResource;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.qe.ConnectContext;
 import com.zaxxer.hikari.HikariDataSource;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -104,7 +105,7 @@ public class ClickhouseSchemaResolverTest {
         };
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            List<String> result = jdbcMetadata.listDbNames();
+            List<String> result = jdbcMetadata.listDbNames(new ConnectContext());
             List<String> expectResult = Lists.newArrayList("clickhouse", "template1", "test");
             Assert.assertEquals(expectResult, result);
         } catch (Exception e) {
@@ -127,7 +128,7 @@ public class ClickhouseSchemaResolverTest {
         };
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            Database db = jdbcMetadata.getDb("test");
+            Database db = jdbcMetadata.getDb(new ConnectContext(), "test");
             Assert.assertEquals("test", db.getOriginName());
         } catch (Exception e) {
             Assert.fail();
@@ -154,7 +155,7 @@ public class ClickhouseSchemaResolverTest {
         };
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "t1", dataSource);
-            List<String> result = jdbcMetadata.listTableNames("test");
+            List<String> result = jdbcMetadata.listTableNames(new ConnectContext(), "test");
             List<String> expectResult = Lists.newArrayList("tbl1", "tbl2", "tbl3");
             Assert.assertEquals(expectResult, result);
         } catch (Exception e) {
@@ -182,7 +183,7 @@ public class ClickhouseSchemaResolverTest {
         };
 
         JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-        List<String> result = jdbcMetadata.listTableNames("test");
+        List<String> result = jdbcMetadata.listTableNames(new ConnectContext(), "test");
         List<String> expectResult = Lists.newArrayList("tbl1", "tbl2", "tbl3");
         Assert.assertEquals(expectResult, result);
 
@@ -207,7 +208,7 @@ public class ClickhouseSchemaResolverTest {
         };
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            Table table = jdbcMetadata.getTable("test", "tbl1");
+            Table table = jdbcMetadata.getTable(new ConnectContext(), "test", "tbl1");
             Assert.assertTrue(table instanceof JDBCTable);
             Assert.assertEquals("catalog.test.tbl1", table.getUUID());
             Assert.assertEquals("tbl1", table.getName());
@@ -238,7 +239,7 @@ public class ClickhouseSchemaResolverTest {
             }
         };
         JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-        List<String> result = jdbcMetadata.listDbNames();
+        List<String> result = jdbcMetadata.listDbNames(new ConnectContext());
         List<String> expectResult = Lists.newArrayList("clickhouse", "template1", "test");
         Assert.assertEquals(expectResult, result);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetaCacheTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetaCacheTest.java
@@ -132,7 +132,7 @@ public class JDBCMetaCacheTest {
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
             dbResult.beforeFirst();
-            List<String> result = jdbcMetadata.listDbNames();
+            List<String> result = jdbcMetadata.listDbNames(connectContext);
             List<String> expectResult = Lists.newArrayList("test");
             Assert.assertEquals(expectResult, result);
         } catch (Exception e) {
@@ -145,7 +145,7 @@ public class JDBCMetaCacheTest {
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
             dbResult.beforeFirst();
-            Database db = jdbcMetadata.getDb("test");
+            Database db = jdbcMetadata.getDb(connectContext, "test");
             Assert.assertEquals("test", db.getOriginName());
         } catch (Exception e) {
             Assert.fail();
@@ -156,7 +156,7 @@ public class JDBCMetaCacheTest {
     public void testListTableNames() {
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            List<String> result = jdbcMetadata.listTableNames("test");
+            List<String> result = jdbcMetadata.listTableNames(connectContext, "test");
             List<String> expectResult = Lists.newArrayList("tbl1", "tbl2", "tbl3");
             Assert.assertEquals(expectResult, result);
         } catch (Exception e) {
@@ -168,14 +168,14 @@ public class JDBCMetaCacheTest {
     public void testGetTable() {
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            Table table = jdbcMetadata.getTable("test", "tbl1");
+            Table table = jdbcMetadata.getTable(connectContext, "test", "tbl1");
             Assert.assertTrue(table instanceof JDBCTable);
-            Table table2 = jdbcMetadata.getTable("test", "tbl1");
+            Table table2 = jdbcMetadata.getTable(connectContext, "test", "tbl1");
             Assert.assertTrue(table2 instanceof JDBCTable);
             JDBCCacheTestUtil.closeCacheEnable(connectContext);
             Map<String, String> properties = new HashMap<>();
             jdbcMetadata.refreshCache(properties);
-            Table table3 = jdbcMetadata.getTable("test", "tbl1");
+            Table table3 = jdbcMetadata.getTable(connectContext, "test", "tbl1");
             Assert.assertFalse(table3 instanceof JDBCTable);
         } catch (Exception e) {
             System.out.println(e.getMessage());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
+import com.starrocks.qe.ConnectContext;
 import com.zaxxer.hikari.HikariDataSource;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -120,7 +121,7 @@ public class JDBCMetadataTest {
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
             dbResult.beforeFirst();
-            List<String> result = jdbcMetadata.listDbNames();
+            List<String> result = jdbcMetadata.listDbNames(new ConnectContext());
             List<String> expectResult = Lists.newArrayList("test");
             Assert.assertEquals(expectResult, result);
         } catch (Exception e) {
@@ -133,7 +134,7 @@ public class JDBCMetadataTest {
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
             dbResult.beforeFirst();
-            Database db = jdbcMetadata.getDb("test");
+            Database db = jdbcMetadata.getDb(new ConnectContext(), "test");
             Assert.assertEquals("test", db.getOriginName());
         } catch (Exception e) {
             Assert.fail();
@@ -144,7 +145,7 @@ public class JDBCMetadataTest {
     public void testListTableNames() {
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            List<String> result = jdbcMetadata.listTableNames("test");
+            List<String> result = jdbcMetadata.listTableNames(new ConnectContext(), "test");
             List<String> expectResult = Lists.newArrayList("tbl1", "tbl2", "tbl3");
             Assert.assertEquals(expectResult, result);
         } catch (Exception e) {
@@ -163,7 +164,7 @@ public class JDBCMetadataTest {
         };
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            Table table = jdbcMetadata.getTable("test", "tbl1");
+            Table table = jdbcMetadata.getTable(new ConnectContext(), "test", "tbl1");
             Assert.assertTrue(table instanceof JDBCTable);
             Assert.assertTrue(table.getPartitionColumns().isEmpty());
         } catch (Exception e) {
@@ -189,7 +190,7 @@ public class JDBCMetadataTest {
         };
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            Table table = jdbcMetadata.getTable("test", "tbl1");
+            Table table = jdbcMetadata.getTable(new ConnectContext(), "test", "tbl1");
             Assert.assertTrue(table instanceof JDBCTable);
             Assert.assertFalse(table.getPartitionColumns().isEmpty());
         } catch (Exception e) {
@@ -201,7 +202,7 @@ public class JDBCMetadataTest {
     @Test
     public void testColumnTypes() {
         JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-        Table table = jdbcMetadata.getTable("test", "tbl1");
+        Table table = jdbcMetadata.getTable(new ConnectContext(), "test", "tbl1");
         List<Column> columns = table.getColumns();
         Assert.assertEquals(columns.size(), columnResult.getRowCount());
         Assert.assertTrue(columns.get(0).getType().equals(ScalarType.createType(PrimitiveType.INT)));
@@ -227,7 +228,7 @@ public class JDBCMetadataTest {
         properties.put(JDBCResource.USER, "");
         properties.put(JDBCResource.PASSWORD, "");
         JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-        Table table = jdbcMetadata.getTable("test", "tbl1");
+        Table table = jdbcMetadata.getTable(new ConnectContext(), "test", "tbl1");
         Assert.assertNotNull(table);
     }
 
@@ -235,9 +236,9 @@ public class JDBCMetadataTest {
     public void testCacheTableId() {
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            Table table1 = jdbcMetadata.getTable("test", "tbl1");
+            Table table1 = jdbcMetadata.getTable(new ConnectContext(), "test", "tbl1");
             columnResult.beforeFirst();
-            Table table2 = jdbcMetadata.getTable("test", "tbl1");
+            Table table2 = jdbcMetadata.getTable(new ConnectContext(), "test", "tbl1");
             Assert.assertTrue(table1.getId() == table2.getId());
         } catch (Exception e) {
             System.out.println(e.getMessage());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MockedJDBCMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MockedJDBCMetadata.java
@@ -23,6 +23,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.PartitionInfo;
+import com.starrocks.qe.ConnectContext;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -142,7 +143,7 @@ public class MockedJDBCMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public com.starrocks.catalog.Table getTable(String dbName, String tblName) {
+    public com.starrocks.catalog.Table getTable(ConnectContext context, String dbName, String tblName) {
         readLock();
         try {
             return getJDBCTable(tblName);
@@ -152,7 +153,7 @@ public class MockedJDBCMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public Database getDb(String dbName) {
+    public Database getDb(ConnectContext context, String dbName) {
         readLock();
         try {
             return new Database(idGen.getAndIncrement(), dbName);
@@ -179,7 +180,7 @@ public class MockedJDBCMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listTableNames(String dbName) {
+    public List<String> listTableNames(ConnectContext context, String dbName) {
         readLock();
         try {
             return Arrays.asList(MOCKED_PARTITIONED_TABLE_NAME0, MOCKED_PARTITIONED_TABLE_NAME1,
@@ -192,7 +193,7 @@ public class MockedJDBCMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listDbNames() {
+    public List<String> listDbNames(ConnectContext context) {
         readLock();
         try {
             return Arrays.asList(MOCKED_PARTITIONED_DB_NAME);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/OracleSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/OracleSchemaResolverTest.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.qe.ConnectContext;
 import com.zaxxer.hikari.HikariDataSource;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -113,7 +114,7 @@ public class OracleSchemaResolverTest {
         };
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            List<String> result = jdbcMetadata.listDbNames();
+            List<String> result = jdbcMetadata.listDbNames(new ConnectContext());
             List<String> expectResult = Lists.newArrayList("oracle", "template1", "test");
             Assert.assertEquals(expectResult, result);
         } catch (Exception e) {
@@ -136,7 +137,7 @@ public class OracleSchemaResolverTest {
         };
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            Database db = jdbcMetadata.getDb("test");
+            Database db = jdbcMetadata.getDb(new ConnectContext(), "test");
             Assert.assertEquals("test", db.getOriginName());
         } catch (Exception e) {
             Assert.fail();
@@ -163,7 +164,7 @@ public class OracleSchemaResolverTest {
         };
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            List<String> result = jdbcMetadata.listTableNames("test");
+            List<String> result = jdbcMetadata.listTableNames(new ConnectContext(), "test");
             List<String> expectResult = Lists.newArrayList("tbl1", "tbl2", "tbl3");
             Assert.assertEquals(expectResult, result);
         } catch (Exception e) {
@@ -190,7 +191,7 @@ public class OracleSchemaResolverTest {
         };
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            Table table = jdbcMetadata.getTable("test", "tbl1");
+            Table table = jdbcMetadata.getTable(new ConnectContext(), "test", "tbl1");
             Assert.assertTrue(table instanceof JDBCTable);
             Assert.assertEquals("catalog.test.tbl1", table.getUUID());
             Assert.assertEquals("tbl1", table.getName());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/PostgresSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/PostgresSchemaResolverTest.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.JDBCResource;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.qe.ConnectContext;
 import com.zaxxer.hikari.HikariDataSource;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -86,7 +87,7 @@ public class PostgresSchemaResolverTest {
         };
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            List<String> result = jdbcMetadata.listDbNames();
+            List<String> result = jdbcMetadata.listDbNames(new ConnectContext());
             List<String> expectResult = Lists.newArrayList("postgres", "template1", "test");
             Assert.assertEquals(expectResult, result);
         } catch (Exception e) {
@@ -109,7 +110,7 @@ public class PostgresSchemaResolverTest {
         };
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            Database db = jdbcMetadata.getDb("test");
+            Database db = jdbcMetadata.getDb(new ConnectContext(), "test");
             Assert.assertEquals("test", db.getOriginName());
         } catch (Exception e) {
             Assert.fail();
@@ -136,7 +137,7 @@ public class PostgresSchemaResolverTest {
         };
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            List<String> result = jdbcMetadata.listTableNames("test");
+            List<String> result = jdbcMetadata.listTableNames(new ConnectContext(), "test");
             List<String> expectResult = Lists.newArrayList("tbl1", "tbl2", "tbl3");
             Assert.assertEquals(expectResult, result);
         } catch (Exception e) {
@@ -163,7 +164,7 @@ public class PostgresSchemaResolverTest {
         };
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            Table table = jdbcMetadata.getTable("test", "tbl1");
+            Table table = jdbcMetadata.getTable(new ConnectContext(), "test", "tbl1");
             Assert.assertTrue(table instanceof JDBCTable);
             Assert.assertEquals("catalog.test.tbl1", table.getUUID());
             Assert.assertEquals("tbl1", table.getName());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/SqlServerSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/SqlServerSchemaResolverTest.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.JDBCResource;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.qe.ConnectContext;
 import com.zaxxer.hikari.HikariDataSource;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -112,7 +113,7 @@ public class SqlServerSchemaResolverTest {
         };
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            List<String> result = jdbcMetadata.listDbNames();
+            List<String> result = jdbcMetadata.listDbNames(new ConnectContext());
             List<String> expectResult = Lists.newArrayList("sqlserver", "template1", "test");
             Assert.assertEquals(expectResult, result);
         } catch (Exception e) {
@@ -135,7 +136,7 @@ public class SqlServerSchemaResolverTest {
         };
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            Database db = jdbcMetadata.getDb("test");
+            Database db = jdbcMetadata.getDb(new ConnectContext(), "test");
             Assert.assertEquals("test", db.getOriginName());
         } catch (Exception e) {
             Assert.fail();
@@ -162,7 +163,7 @@ public class SqlServerSchemaResolverTest {
         };
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            List<String> result = jdbcMetadata.listTableNames("test");
+            List<String> result = jdbcMetadata.listTableNames(new ConnectContext(), "test");
             List<String> expectResult = Lists.newArrayList("tbl1", "tbl2", "tbl3");
             Assert.assertEquals(expectResult, result);
         } catch (Exception e) {
@@ -189,7 +190,7 @@ public class SqlServerSchemaResolverTest {
         };
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            Table table = jdbcMetadata.getTable("test", "tbl1");
+            Table table = jdbcMetadata.getTable(new ConnectContext(), "test", "tbl1");
             Assert.assertTrue(table instanceof JDBCTable);
             Assert.assertEquals("catalog.test.tbl1", table.getUUID());
             Assert.assertEquals("tbl1", table.getName());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/kudu/KuduMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/kudu/KuduMetadataTest.java
@@ -22,6 +22,7 @@ import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.TableVersionRange;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -96,7 +97,7 @@ public class KuduMetadataTest {
                 result = EMPTY_PARTITION_SCHEMA;
             }
         };
-        Table table = metadata.getTable("db1", "tbl1");
+        Table table = metadata.getTable(new ConnectContext(), "db1", "tbl1");
         KuduTable kuduTable = (KuduTable) table;
         Assert.assertEquals("test_kudu_catalog", kuduTable.getCatalogName());
         Assert.assertEquals("db1", kuduTable.getCatalogDBName());
@@ -121,7 +122,7 @@ public class KuduMetadataTest {
                 result = tableNames;
             }
         };
-        List<String> tables = metadata.listTableNames("db1");
+        List<String> tables = metadata.listTableNames(new ConnectContext(), "db1");
         Assert.assertEquals(1, tables.size());
         Assert.assertEquals("tbl1", tables.get(0));
     }
@@ -143,7 +144,7 @@ public class KuduMetadataTest {
                 result = tokens;
             }
         };
-        Table table = metadata.getTable("db1", "tbl1");
+        Table table = metadata.getTable(new ConnectContext(), "db1", "tbl1");
         KuduTable kuduTable = (KuduTable) table;
         GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder().setFieldNames(requiredNames).build();
         List<RemoteFileInfo> remoteFileInfos = metadata.getRemoteFiles(kuduTable, params);
@@ -170,7 +171,7 @@ public class KuduMetadataTest {
                 result = exception;
             }
         };
-        Table table = metadata.getTable("db1", "tbl1");
+        Table table = metadata.getTable(new ConnectContext(), "db1", "tbl1");
         KuduTable kuduTable = (KuduTable) table;
         Statistics statistics = metadata.getTableStatistics(
                 null, kuduTable, Collections.emptyMap(), Collections.emptyList(), null, -1, TableVersionRange.empty());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonConnectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonConnectorTest.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.connector.ConnectorContext;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.qe.ConnectContext;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.apache.paimon.catalog.Catalog;
@@ -109,7 +110,7 @@ public class PaimonConnectorTest {
 
         ConnectorMetadata metadata = connector.getMetadata();
         Assert.assertTrue(metadata instanceof PaimonMetadata);
-        com.starrocks.catalog.Table table = metadata.getTable("db1", "tbl1");
+        com.starrocks.catalog.Table table = metadata.getTable(new ConnectContext(), "db1", "tbl1");
         PaimonTable paimonTable = (PaimonTable) table;
         Assert.assertEquals("db1", paimonTable.getCatalogDBName());
         Assert.assertEquals("tbl1", paimonTable.getCatalogTableName());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -177,9 +177,9 @@ public class PaimonMetadataTest {
                 result = "hdfs://127.0.0.1:10000/paimon";
             }
         };
-        com.starrocks.catalog.Table table = metadata.getTable("db1", "tbl1");
+        com.starrocks.catalog.Table table = metadata.getTable(connectContext, "db1", "tbl1");
         PaimonTable paimonTable = (PaimonTable) table;
-        Assert.assertTrue(metadata.tableExists("db1", "tbl1"));
+        Assert.assertTrue(metadata.tableExists(connectContext, "db1", "tbl1"));
         Assert.assertEquals("db1", paimonTable.getCatalogDBName());
         Assert.assertEquals("tbl1", paimonTable.getCatalogTableName());
         Assert.assertEquals(Lists.newArrayList("col1"), paimonTable.getPartitionColumnNames());
@@ -201,7 +201,7 @@ public class PaimonMetadataTest {
                 result = new Catalog.DatabaseNotExistException("Database does not exist");
             }
         };
-        Assert.assertNull(metadata.getDb("nonexistentDb"));
+        Assert.assertNull(metadata.getDb(connectContext, "nonexistentDb"));
     }
 
     @Test
@@ -213,8 +213,8 @@ public class PaimonMetadataTest {
                 result = new Catalog.TableNotExistException(identifier);
             }
         };
-        Assert.assertFalse(metadata.tableExists("nonexistentDb", "nonexistentTbl"));
-        Assert.assertNull(metadata.getTable("nonexistentDb", "nonexistentTbl"));
+        Assert.assertFalse(metadata.tableExists(connectContext, "nonexistentDb", "nonexistentTbl"));
+        Assert.assertNull(metadata.getTable(connectContext, "nonexistentDb", "nonexistentTbl"));
     }
 
     @Test
@@ -233,7 +233,7 @@ public class PaimonMetadataTest {
                 result = scan;
             }
         };
-        PaimonTable paimonTable = (PaimonTable) metadata.getTable("db1", "tbl1$manifests");
+        PaimonTable paimonTable = (PaimonTable) metadata.getTable(connectContext, "db1", "tbl1$manifests");
         List<String> requiredNames = Lists.newArrayList("file_name", "file_size");
         List<RemoteFileInfo> result =
                 metadata.getRemoteFiles(paimonTable, GetRemoteFilesParams.newBuilder().setFieldNames(requiredNames).build());
@@ -272,8 +272,8 @@ public class PaimonMetadataTest {
         List<String> expectations = Lists.newArrayList("year=2020/month=1", "year=2020/month=2");
         Assertions.assertThat(result).hasSameElementsAs(expectations);
         Config.enable_paimon_refresh_manifest_files = true;
-        metadata.refreshTable("db1", metadata.getTable("db1", "tbl1"), new ArrayList<>(), false);
-        metadata.refreshTable("db1", metadata.getTable("db1", "tbl1"), expectations, false);
+        metadata.refreshTable("db1", metadata.getTable(connectContext, "db1", "tbl1"), new ArrayList<>(), false);
+        metadata.refreshTable("db1", metadata.getTable(connectContext, "db1", "tbl1"), expectations, false);
 
     }
 
@@ -315,7 +315,7 @@ public class PaimonMetadataTest {
                 result = scan;
             }
         };
-        PaimonTable paimonTable = (PaimonTable) metadata.getTable("db1", "tbl1");
+        PaimonTable paimonTable = (PaimonTable) metadata.getTable(connectContext, "db1", "tbl1");
         List<String> requiredNames = Lists.newArrayList("f2", "dt");
         List<RemoteFileInfo> result =
                 metadata.getRemoteFiles(paimonTable, GetRemoteFilesParams.newBuilder().setFieldNames(requiredNames).build());
@@ -460,7 +460,7 @@ public class PaimonMetadataTest {
             }
         };
 
-        PaimonTable paimonTable = (PaimonTable) metadata.getTable("db1", "tbl1");
+        PaimonTable paimonTable = (PaimonTable) metadata.getTable(connectContext, "db1", "tbl1");
 
         ExternalScanPartitionPruneRule rule0 = new ExternalScanPartitionPruneRule();
 
@@ -482,6 +482,7 @@ public class PaimonMetadataTest {
         assertEquals(1, ((LogicalPaimonScanOperator) scan.getOp()).getScanOperatorPredicates()
                 .getSelectedPartitionIds().size());
     }
+
     @Test
     public void testGetTableStatistics() {
         String stats = "{\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/connector/statistics/ConnectorAnalyzeTaskQueueTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/statistics/ConnectorAnalyzeTaskQueueTest.java
@@ -39,10 +39,10 @@ public class ConnectorAnalyzeTaskQueueTest {
 
     @Test
     public void testAddPendingTaskWithMerge() {
-        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("hive0",
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(ctx, "hive0",
                 "partitioned_db", "orders");
         String tableUUID = table.getUUID();
-        Triple<String, Database, Table> tableTriple = StatisticsUtils.getTableTripleByUUID(tableUUID);
+        Triple<String, Database, Table> tableTriple = StatisticsUtils.getTableTripleByUUID(ctx, tableUUID);
         ConnectorAnalyzeTask task1 = new ConnectorAnalyzeTask(tableTriple, Sets.newHashSet("o_orderkey", "o_custkey"));
 
         ConnectorAnalyzeTaskQueue queue = new ConnectorAnalyzeTaskQueue();
@@ -54,13 +54,12 @@ public class ConnectorAnalyzeTaskQueueTest {
         Assert.assertEquals(1, queue.getPendingTaskSize());
     }
 
-
     @Test
     public void testAddPendingTaskExceedLimit() {
-        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("hive0",
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(ctx, "hive0",
                 "partitioned_db", "orders");
         String tableUUID = table.getUUID();
-        Triple<String, Database, Table> tableTriple = StatisticsUtils.getTableTripleByUUID(tableUUID);
+        Triple<String, Database, Table> tableTriple = StatisticsUtils.getTableTripleByUUID(ctx, tableUUID);
         ConnectorAnalyzeTask task1 = new ConnectorAnalyzeTask(tableTriple, Sets.newHashSet("o_orderkey", "o_custkey"));
 
         Config.connector_table_query_trigger_analyze_max_pending_task_num = 1;
@@ -75,10 +74,10 @@ public class ConnectorAnalyzeTaskQueueTest {
 
     @Test
     public void testScheduledPendingTask() {
-        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("hive0",
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(ctx, "hive0",
                 "partitioned_db", "orders");
         String tableUUID = table.getUUID();
-        Triple<String, Database, Table> tableTriple = StatisticsUtils.getTableTripleByUUID(tableUUID);
+        Triple<String, Database, Table> tableTriple = StatisticsUtils.getTableTripleByUUID(ctx, tableUUID);
         ConnectorAnalyzeTask task1 = new ConnectorAnalyzeTask(tableTriple, Sets.newHashSet("o_orderkey", "o_custkey"));
 
         ConnectorAnalyzeTaskQueue queue = new ConnectorAnalyzeTaskQueue();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/statistics/ConnectorAnalyzeTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/statistics/ConnectorAnalyzeTaskTest.java
@@ -63,10 +63,10 @@ public class ConnectorAnalyzeTaskTest {
 
     @Test
     public void testMergeTask() {
-        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("hive0",
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(ctx, "hive0",
                 "partitioned_db", "orders");
         String tableUUID = table.getUUID();
-        Triple<String, Database, Table> tableTriple = StatisticsUtils.getTableTripleByUUID(tableUUID);
+        Triple<String, Database, Table> tableTriple = StatisticsUtils.getTableTripleByUUID(ctx, tableUUID);
         ConnectorAnalyzeTask task1 = new ConnectorAnalyzeTask(tableTriple, Sets.newHashSet("o_orderkey", "o_custkey"));
 
         ConnectorAnalyzeTask task2 = new ConnectorAnalyzeTask(tableTriple, Sets.newHashSet("o_custkey", "o_orderstatus"));
@@ -76,7 +76,7 @@ public class ConnectorAnalyzeTaskTest {
 
     @Test
     public void testTaskRun() {
-        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("hive0",
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(ctx, "hive0",
                 "partitioned_db", "orders");
         String tableUUID = table.getUUID();
         ExternalAnalyzeStatus externalAnalyzeStatus = new ExternalAnalyzeStatus(1, "hive0", "partitioned_db", "orders",
@@ -85,7 +85,7 @@ public class ConnectorAnalyzeTaskTest {
         externalAnalyzeStatus.setStatus(StatsConstants.ScheduleStatus.RUNNING);
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().addAnalyzeStatus(externalAnalyzeStatus);
 
-        Triple<String, Database, Table> tableTriple = StatisticsUtils.getTableTripleByUUID(tableUUID);
+        Triple<String, Database, Table> tableTriple = StatisticsUtils.getTableTripleByUUID(ctx, tableUUID);
         ConnectorAnalyzeTask task1 = new ConnectorAnalyzeTask(tableTriple, Sets.newHashSet("o_orderkey", "o_custkey"));
         Optional<AnalyzeStatus> result = task1.run();
         Assert.assertTrue(result.isEmpty());
@@ -125,10 +125,10 @@ public class ConnectorAnalyzeTaskTest {
 
     @Test
     public void testTaskRunWithStructSubfield() {
-        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("hive0",
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(ctx, "hive0",
                 "subfield_db", "subfield");
         String tableUUID = table.getUUID();
-        Triple<String, Database, Table> tableTriple = StatisticsUtils.getTableTripleByUUID(tableUUID);
+        Triple<String, Database, Table> tableTriple = StatisticsUtils.getTableTripleByUUID(ctx, tableUUID);
         ConnectorAnalyzeTask task = new ConnectorAnalyzeTask(tableTriple, Sets.newHashSet("col_int", "col_struct.c0"));
         Optional<AnalyzeStatus> result = task.run();
         Assert.assertTrue(result.isPresent());
@@ -139,11 +139,11 @@ public class ConnectorAnalyzeTaskTest {
 
     @Test
     public void testTaskRunWithTableUpdate() {
-        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("hive0",
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(ctx, "hive0",
                 "partitioned_db", "orders");
         String tableUUID = table.getUUID();
 
-        Triple<String, Database, Table> tableTriple = StatisticsUtils.getTableTripleByUUID(tableUUID);
+        Triple<String, Database, Table> tableTriple = StatisticsUtils.getTableTripleByUUID(ctx, tableUUID);
         ConnectorAnalyzeTask task1 = new ConnectorAnalyzeTask(tableTriple, Sets.newHashSet("o_orderkey", "o_custkey"));
         new MockUp<ExternalFullStatisticsCollectJob>() {
             @Mock
@@ -189,11 +189,11 @@ public class ConnectorAnalyzeTaskTest {
 
     @Test
     public void testSampleTaskRun() {
-        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("hive0",
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(ctx, "hive0",
                 "partitioned_db", "orders");
         String tableUUID = table.getUUID();
 
-        Triple<String, Database, Table> tableTriple = StatisticsUtils.getTableTripleByUUID(tableUUID);
+        Triple<String, Database, Table> tableTriple = StatisticsUtils.getTableTripleByUUID(ctx, tableUUID);
         ConnectorAnalyzeTask task1 = new ConnectorAnalyzeTask(tableTriple, Sets.newHashSet("o_orderkey", "o_custkey"));
         new MockUp<ExternalSampleStatisticsCollectJob>() {
             @Mock

--- a/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
@@ -41,6 +41,7 @@ import com.starrocks.connector.kudu.KuduMetadata;
 import com.starrocks.connector.paimon.PaimonMetadata;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudType;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.CreateTableStmt;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -103,13 +104,13 @@ public class UnifiedMetadataTest {
     public void testAlwaysRouteToHiveConnector() throws DdlException, AlreadyExistsException, MetaNotFoundException {
         new Expectations() {
             {
-                hiveMetadata.listDbNames();
+                hiveMetadata.listDbNames((ConnectContext) any);
                 result = ImmutableList.of("test_db1", "test_db2");
                 times = 1;
             }
 
             {
-                hiveMetadata.listTableNames("test_db");
+                hiveMetadata.listTableNames((ConnectContext) any, "test_db");
                 result = ImmutableList.of("test_tbl1", "test_tbl2");
             }
 
@@ -124,13 +125,13 @@ public class UnifiedMetadataTest {
             }
 
             {
-                hiveMetadata.dbExists("test_db");
+                hiveMetadata.dbExists((ConnectContext) any, "test_db");
                 result = true;
                 times = 1;
             }
 
             {
-                hiveMetadata.dropDb("test_db", false);
+                hiveMetadata.dropDb((ConnectContext) any, "test_db", false);
                 times = 1;
             }
 
@@ -141,14 +142,14 @@ public class UnifiedMetadataTest {
             }
         };
 
-        List<String> dbNames = unifiedMetadata.listDbNames();
+        List<String> dbNames = unifiedMetadata.listDbNames(new ConnectContext());
         assertEquals(ImmutableList.of("test_db1", "test_db2"), dbNames);
-        List<String> tblNames = unifiedMetadata.listTableNames("test_db");
+        List<String> tblNames = unifiedMetadata.listTableNames(new ConnectContext(), "test_db");
         assertEquals(ImmutableList.of("test_tbl1", "test_tbl2"), tblNames);
         unifiedMetadata.createDb("test_db");
         unifiedMetadata.createDb("test_db", ImmutableMap.of("key", "value"));
-        assertTrue(unifiedMetadata.dbExists("test_db"));
-        unifiedMetadata.dropDb("test_db", false);
+        assertTrue(unifiedMetadata.dbExists(new ConnectContext(), "test_db"));
+        unifiedMetadata.dropDb(new ConnectContext(), "test_db", false);
         CloudConfiguration cloudConfiguration = unifiedMetadata.getCloudConfiguration();
         assertEquals(CloudType.DEFAULT, cloudConfiguration.getCloudType());
     }
@@ -159,7 +160,7 @@ public class UnifiedMetadataTest {
 
         new Expectations() {
             {
-                hiveMetadata.getTable("test_db", "test_tbl");
+                hiveMetadata.getTable((ConnectContext) any, "test_db", "test_tbl");
                 result = hiveTable;
                 minTimes = 1;
             }
@@ -205,7 +206,7 @@ public class UnifiedMetadataTest {
             }
         };
 
-        Table table = unifiedMetadata.getTable("test_db", "test_tbl");
+        Table table = unifiedMetadata.getTable(new ConnectContext(), "test_db", "test_tbl");
         assertTrue(table instanceof HiveTable);
         List<String> partitionNames =
                 unifiedMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadatRequestContext.DEFAULT);
@@ -235,13 +236,13 @@ public class UnifiedMetadataTest {
             }
 
             {
-                hiveMetadata.getTable("test_db", "test_tbl");
+                hiveMetadata.getTable((ConnectContext) any, "test_db", "test_tbl");
                 result = hiveTable;
                 minTimes = 1;
             }
 
             {
-                icebergMetadata.getTable("test_db", "test_tbl");
+                icebergMetadata.getTable((ConnectContext) any, "test_db", "test_tbl");
                 result = icebergTable;
                 times = 1;
             }
@@ -299,7 +300,7 @@ public class UnifiedMetadataTest {
             }
         };
 
-        Table table = unifiedMetadata.getTable("test_db", "test_tbl");
+        Table table = unifiedMetadata.getTable(new ConnectContext(), "test_db", "test_tbl");
         assertTrue(table instanceof IcebergTable);
         List<String> partitionNames =
                 unifiedMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadatRequestContext.DEFAULT);
@@ -325,13 +326,13 @@ public class UnifiedMetadataTest {
 
         new Expectations() {
             {
-                hiveMetadata.getTable("test_db", "test_tbl");
+                hiveMetadata.getTable((ConnectContext) any, "test_db", "test_tbl");
                 result = hudiTable;
                 minTimes = 1;
             }
 
             {
-                hudiMetadata.getTable("test_db", "test_tbl");
+                hudiMetadata.getTable((ConnectContext) any, "test_db", "test_tbl");
                 result = hudiTable;
                 times = 1;
             }
@@ -377,7 +378,7 @@ public class UnifiedMetadataTest {
             }
         };
 
-        Table table = unifiedMetadata.getTable("test_db", "test_tbl");
+        Table table = unifiedMetadata.getTable(new ConnectContext(), "test_db", "test_tbl");
         assertTrue(table instanceof HudiTable);
         List<String> partitionNames =
                 unifiedMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadatRequestContext.DEFAULT);
@@ -406,13 +407,13 @@ public class UnifiedMetadataTest {
             }
 
             {
-                hiveMetadata.getTable("test_db", "test_tbl");
+                hiveMetadata.getTable((ConnectContext) any, "test_db", "test_tbl");
                 result = hiveTable;
                 minTimes = 1;
             }
 
             {
-                deltaLakeMetadata.getTable("test_db", "test_tbl");
+                deltaLakeMetadata.getTable((ConnectContext) any, "test_db", "test_tbl");
                 result = deltaLakeTable;
                 times = 1;
             }
@@ -458,7 +459,7 @@ public class UnifiedMetadataTest {
             }
         };
 
-        Table table = unifiedMetadata.getTable("test_db", "test_tbl");
+        Table table = unifiedMetadata.getTable(new ConnectContext(), "test_db", "test_tbl");
         assertTrue(table instanceof DeltaLakeTable);
         List<String> partitionNames =
                 unifiedMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadatRequestContext.DEFAULT);
@@ -481,13 +482,13 @@ public class UnifiedMetadataTest {
 
         new Expectations() {
             {
-                hiveMetadata.getTable("test_db", "test_tbl");
+                hiveMetadata.getTable((ConnectContext) any, "test_db", "test_tbl");
                 result = kuduTable;
                 minTimes = 1;
             }
 
             {
-                kuduMetadata.getTable("test_db", "test_tbl");
+                kuduMetadata.getTable((ConnectContext) any, "test_db", "test_tbl");
                 result = kuduTable;
                 minTimes = 1;
             }
@@ -517,7 +518,7 @@ public class UnifiedMetadataTest {
             }
         };
 
-        Table table = unifiedMetadata.getTable("test_db", "test_tbl");
+        Table table = unifiedMetadata.getTable(new ConnectContext(), "test_db", "test_tbl");
         assertTrue(table instanceof KuduTable);
         List<String> partitionNames =
                 unifiedMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadatRequestContext.DEFAULT);
@@ -534,12 +535,12 @@ public class UnifiedMetadataTest {
     public void testTableExists(@Mocked HiveTable hiveTable) {
         new Expectations() {
             {
-                hiveMetadata.tableExists("test_db", "test_tbl");
+                hiveMetadata.tableExists((ConnectContext) any, "test_db", "test_tbl");
                 result = true;
                 minTimes = 1;
             }
         };
-        boolean exists = unifiedMetadata.tableExists("test_db", "test_tbl");
+        boolean exists = unifiedMetadata.tableExists(new ConnectContext(), "test_db", "test_tbl");
         Assert.assertTrue(exists);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/http/QueryDumpActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/QueryDumpActionTest.java
@@ -16,6 +16,7 @@ package com.starrocks.http;
 
 import com.starrocks.http.rest.QueryDumpAction;
 import com.starrocks.metric.MetricRepo;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.ExecuteEnv;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -38,7 +39,8 @@ public class QueryDumpActionTest extends StarRocksHttpTestCase {
     public void setUp() throws Exception {
         setUpWithCatalog();
         Awaitility.await().atMost(5, TimeUnit.SECONDS)
-                .until(() -> GlobalStateMgr.getCurrentState().getMetadataMgr().getDb("default_catalog", DB_NAME) != null);
+                .until(() -> GlobalStateMgr.getCurrentState().getMetadataMgr()
+                        .getDb(new ConnectContext(), "default_catalog", DB_NAME) != null);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -63,6 +63,7 @@ import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.load.Load;
 import com.starrocks.persist.EditLog;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
 import com.starrocks.server.MetadataMgr;
@@ -381,15 +382,15 @@ public abstract class StarRocksHttpTestCase {
 
         new Expectations(metadataMgr) {
             {
-                metadataMgr.getDb("default_catalog", "testDb");
+                metadataMgr.getDb((ConnectContext) any, "default_catalog", "testDb");
                 minTimes = 0;
                 result = db;
 
-                metadataMgr.getTable("default_catalog", "testDb", "testTbl");
+                metadataMgr.getTable((ConnectContext) any, "default_catalog", "testDb", "testTbl");
                 minTimes = 0;
                 result = table;
 
-                metadataMgr.getTable("default_catalog", "testDb", "test_empty_table");
+                metadataMgr.getTable((ConnectContext) any, "default_catalog", "testDb", "test_empty_table");
                 minTimes = 0;
                 result = newEmptyTable;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlanLockFreeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlanLockFreeTest.java
@@ -83,7 +83,7 @@ public class QueryPlanLockFreeTest {
     public void testPlanStrategy() throws Exception {
         String sql = "select * from t0";
         OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getMetadataMgr()
-                .getTable("default_catalog", DB_NAME, "t0");
+                .getTable(new ConnectContext(), "default_catalog", DB_NAME, "t0");
         table.lastSchemaUpdateTime.set(System.nanoTime() + 10000000000L);
         Assert.assertThrows("schema of [t0] had been updated frequently during the plan generation",
                 StarRocksPlannerException.class, () -> UtFrameUtils.getPlanAndFragment(connectContext, sql));
@@ -103,7 +103,7 @@ public class QueryPlanLockFreeTest {
     public void testCopiedTable() throws Exception {
         String sql = "select t1.* from t1 t1 join t1 t2 on t1.k1 = t2.k2";
         OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getMetadataMgr()
-                .getTable("default_catalog", DB_NAME, "t1");
+                .getTable(new ConnectContext(), "default_catalog", DB_NAME, "t1");
         Pair<String, ExecPlan> plan = UtFrameUtils.getPlanAndFragment(connectContext, sql);
         OlapScanNode node1 = (OlapScanNode) plan.second.getScanNodes().get(0);
         OlapScanNode node2 = (OlapScanNode) plan.second.getScanNodes().get(1);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/RBACExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/RBACExecutorTest.java
@@ -76,7 +76,7 @@ public class RBACExecutorTest {
         GlobalStateMgr globalStateMgr = starRocksAssert.getCtx().getGlobalStateMgr();
 
         GlobalStateMgr.getCurrentState()
-                .setAuthorizationMgr(new AuthorizationMgr(globalStateMgr, new DefaultAuthorizationProvider()));
+                .setAuthorizationMgr(new AuthorizationMgr(new DefaultAuthorizationProvider()));
         GlobalStateMgr.getCurrentState().setAuthenticationMgr(new AuthenticationMgr());
 
         for (int i = 0; i < 5; i++) {

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -265,7 +265,7 @@ public class ShowExecutorTest {
         };
 
         BaseTableInfo baseTableInfo = new BaseTableInfo(
-                    "default_catalog", "testDb", "testTbl", null);
+                "default_catalog", "testDb", "testTbl", null);
 
         // mock materialized view
         MaterializedView mv = new MaterializedView();
@@ -314,10 +314,10 @@ public class ShowExecutorTest {
                 mv.getPartitionInfo();
                 minTimes = 0;
                 result = new ExpressionRangePartitionInfo(
-                            Collections.singletonList(
-                                        ColumnIdExpr.create(new SlotRef(
-                                                    new TableName("test", "testMv"), column1.getName()))),
-                            Collections.singletonList(column1), PartitionType.RANGE);
+                        Collections.singletonList(
+                                ColumnIdExpr.create(new SlotRef(
+                                        new TableName("test", "testMv"), column1.getName()))),
+                        Collections.singletonList(column1), PartitionType.RANGE);
 
                 mv.getDefaultDistributionInfo();
                 minTimes = 0;
@@ -338,7 +338,7 @@ public class ShowExecutorTest {
                 mv.getTableProperty();
                 minTimes = 0;
                 result = new TableProperty(
-                            Collections.singletonMap(PROPERTIES_STORAGE_COOLDOWN_TIME, "100"));
+                        Collections.singletonMap(PROPERTIES_STORAGE_COOLDOWN_TIME, "100"));
 
                 mv.getIdToColumn();
                 minTimes = 0;
@@ -405,20 +405,19 @@ public class ShowExecutorTest {
                 minTimes = 0;
                 result = metadataMgr;
 
-                metadataMgr.listDbNames("default_catalog");
+                metadataMgr.listDbNames((ConnectContext) any, "default_catalog");
                 minTimes = 0;
                 result = Lists.newArrayList("testDb");
 
-                metadataMgr.getDb("default_catalog", "testDb");
+                metadataMgr.getDb((ConnectContext) any, "default_catalog", "testDb");
                 minTimes = 0;
                 result = db;
 
-                metadataMgr.getDb("default_catalog", "emptyDb");
+                metadataMgr.getDb((ConnectContext) any, "default_catalog", "emptyDb");
                 minTimes = 0;
                 result = null;
 
-                metadataMgr.getTable("default_catalog", "testDb",
-                            "testTbl");
+                metadataMgr.getTable((ConnectContext) any, "default_catalog", "testDb", "testTbl");
                 minTimes = 0;
                 result = table;
             }
@@ -550,7 +549,7 @@ public class ShowExecutorTest {
 
         // Ok to test
         ShowPartitionsStmt stmt = new ShowPartitionsStmt(new TableName("testDb", "testTbl"),
-                    null, null, null, false);
+                null, null, null, false);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
 
         ShowResultSet resultSet = ShowExecutor.execute(stmt, ctx);
@@ -597,7 +596,7 @@ public class ShowExecutorTest {
         ctx.setQualifiedUser("testUser");
 
         DescribeStmt stmt = (DescribeStmt) com.starrocks.sql.parser.SqlParser.parse("desc testTbl",
-                    ctx.getSessionVariable().getSqlMode()).get(0);
+                ctx.getSessionVariable().getSqlMode()).get(0);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
 
         ShowResultSet resultSet;
@@ -661,7 +660,7 @@ public class ShowExecutorTest {
     @Test(expected = SemanticException.class)
     public void testShowCreateTableEmptyDb() throws SemanticException, DdlException {
         ShowCreateTableStmt stmt = new ShowCreateTableStmt(new TableName("emptyDb", "testTable"),
-                    ShowCreateTableStmt.CreateTableType.TABLE);
+                ShowCreateTableStmt.CreateTableType.TABLE);
 
         ShowResultSet resultSet = ShowExecutor.execute(stmt, ctx);
 
@@ -674,7 +673,7 @@ public class ShowExecutorTest {
         ctx.setQualifiedUser("testUser");
 
         ShowColumnStmt stmt = (ShowColumnStmt) com.starrocks.sql.parser.SqlParser.parse("show columns from testTbl in testDb",
-                    ctx.getSessionVariable()).get(0);
+                ctx.getSessionVariable()).get(0);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
 
         ShowResultSet resultSet = ShowExecutor.execute(stmt, ctx);
@@ -688,7 +687,7 @@ public class ShowExecutorTest {
 
         // verbose
         stmt = (ShowColumnStmt) com.starrocks.sql.parser.SqlParser.parse("show full columns from testTbl in testDb",
-                    ctx.getSessionVariable()).get(0);
+                ctx.getSessionVariable()).get(0);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
 
         resultSet = ShowExecutor.execute(stmt, ctx);
@@ -703,7 +702,7 @@ public class ShowExecutorTest {
 
         // show full fields
         stmt = (ShowColumnStmt) com.starrocks.sql.parser.SqlParser.parse("show full fields from testTbl in testDb",
-                    ctx.getSessionVariable()).get(0);
+                ctx.getSessionVariable()).get(0);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
 
         resultSet = ShowExecutor.execute(stmt, ctx);
@@ -718,7 +717,7 @@ public class ShowExecutorTest {
 
         // pattern
         stmt = (ShowColumnStmt) com.starrocks.sql.parser.SqlParser.parse("show full columns from testTbl in testDb like \"%1\"",
-                    ctx.getSessionVariable().getSqlMode()).get(0);
+                ctx.getSessionVariable().getSqlMode()).get(0);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
 
         resultSet = ShowExecutor.execute(stmt, ctx);
@@ -901,10 +900,10 @@ public class ShowExecutorTest {
         ShowResultSet resultSet = ShowExecutor.execute(stmt, ctx);
 
         Assert.assertEquals(ComputeNodeProcDir.TITLE_NAMES_SHARED_DATA.size(),
-                    resultSet.getMetaData().getColumnCount());
+                resultSet.getMetaData().getColumnCount());
         for (int i = 0; i < ComputeNodeProcDir.TITLE_NAMES_SHARED_DATA.size(); ++i) {
             Assert.assertEquals(ComputeNodeProcDir.TITLE_NAMES_SHARED_DATA.get(i),
-                        resultSet.getMetaData().getColumn(i).getName());
+                    resultSet.getMetaData().getColumn(i).getName());
         }
 
         Assert.assertTrue(resultSet.next());
@@ -1009,15 +1008,15 @@ public class ShowExecutorTest {
 
     private void verifyShowMaterializedViewResult(ShowResultSet resultSet) throws AnalysisException, DdlException {
         String expectedSqlText = "CREATE MATERIALIZED VIEW `testMv` (`col1`, `col2`)\n" +
-                    "COMMENT \"TEST MATERIALIZED VIEW\"\n" +
-                    "PARTITION BY (`col1`)\n" +
-                    "DISTRIBUTED BY HASH(`col1`) BUCKETS 10 \n" +
-                    "REFRESH ASYNC\n" +
-                    "PROPERTIES (\n" +
-                    "\"storage_cooldown_time\" = \"1970-01-01 08:00:00\",\n" +
-                    "\"storage_medium\" = \"SSD\"\n" +
-                    ")\n" +
-                    "AS select col1, col2 from table1;";
+                "COMMENT \"TEST MATERIALIZED VIEW\"\n" +
+                "PARTITION BY (`col1`)\n" +
+                "DISTRIBUTED BY HASH(`col1`) BUCKETS 10 \n" +
+                "REFRESH ASYNC\n" +
+                "PROPERTIES (\n" +
+                "\"storage_cooldown_time\" = \"1970-01-01 08:00:00\",\n" +
+                "\"storage_medium\" = \"SSD\"\n" +
+                ")\n" +
+                "AS select col1, col2 from table1;";
 
         Assert.assertTrue(resultSet.next());
         List<Column> mvSchemaTable = MaterializedViewsSystemTable.create().getFullSchema();
@@ -1060,7 +1059,7 @@ public class ShowExecutorTest {
     public void testShowAlterTable() throws AnalysisException, DdlException {
         ShowAlterStmt stmt = new ShowAlterStmt(ShowAlterStmt.AlterType.OPTIMIZE, "testDb", null, null, null);
         stmt.setNode(new OptimizeProcDir(globalStateMgr.getSchemaChangeHandler(),
-                    globalStateMgr.getLocalMetastore().getDb("testDb")));
+                globalStateMgr.getLocalMetastore().getDb("testDb")));
 
         ShowExecutor.execute(stmt, ctx);
     }
@@ -1069,12 +1068,12 @@ public class ShowExecutorTest {
     public void testShowCreateExternalCatalogTable() throws DdlException, AnalysisException {
         new MockUp<MetadataMgr>() {
             @Mock
-            public Database getDb(String catalogName, String dbName) {
+            public Database getDb(ConnectContext context, String catalogName, String dbName) {
                 return new Database();
             }
 
             @Mock
-            public Table getTable(String catalogName, String dbName, String tblName) {
+            public Table getTable(ConnectContext context, String catalogName, String dbName, String tblName) {
                 List<Column> fullSchema = new ArrayList<>();
                 Column columnId = new Column("id", Type.INT, true);
                 columnId.setComment("id");
@@ -1089,46 +1088,46 @@ public class ShowExecutorTest {
                 partitions.add("year");
                 partitions.add("dt");
                 HiveTable.Builder tableBuilder = HiveTable.builder()
-                            .setId(1)
-                            .setTableName("test_table")
-                            .setCatalogName("hive_catalog")
-                            .setResourceName(toResourceName("hive_catalog", "hive"))
-                            .setHiveDbName("hive_db")
-                            .setHiveTableName("test_table")
-                            .setPartitionColumnNames(partitions)
-                            .setFullSchema(fullSchema)
-                            .setTableLocation("hdfs://hadoop/hive/warehouse/test.db/test")
-                            .setCreateTime(10000);
+                        .setId(1)
+                        .setTableName("test_table")
+                        .setCatalogName("hive_catalog")
+                        .setResourceName(toResourceName("hive_catalog", "hive"))
+                        .setHiveDbName("hive_db")
+                        .setHiveTableName("test_table")
+                        .setPartitionColumnNames(partitions)
+                        .setFullSchema(fullSchema)
+                        .setTableLocation("hdfs://hadoop/hive/warehouse/test.db/test")
+                        .setCreateTime(10000);
                 return tableBuilder.build();
             }
         };
 
         ShowCreateTableStmt stmt = new ShowCreateTableStmt(new TableName("hive_catalog", "hive_db", "test_table"),
-                    ShowCreateTableStmt.CreateTableType.TABLE);
+                ShowCreateTableStmt.CreateTableType.TABLE);
 
         ShowResultSet resultSet = ShowExecutor.execute(stmt, ctx);
         Assert.assertEquals("test_table", resultSet.getResultRows().get(0).get(0));
         Assert.assertEquals("CREATE TABLE `test_table` (\n" +
-                                "  `id` int(11) DEFAULT NULL COMMENT \"id\",\n" +
-                                "  `name` varchar DEFAULT NULL,\n" +
-                                "  `year` int(11) DEFAULT NULL,\n" +
-                                "  `dt` int(11) DEFAULT NULL\n" +
-                                ")\n" +
-                                "PARTITION BY (year, dt)\n" +
-                                "PROPERTIES (\"location\" = \"hdfs://hadoop/hive/warehouse/test.db/test\");",
-                    resultSet.getResultRows().get(0).get(1));
+                        "  `id` int(11) DEFAULT NULL COMMENT \"id\",\n" +
+                        "  `name` varchar DEFAULT NULL,\n" +
+                        "  `year` int(11) DEFAULT NULL,\n" +
+                        "  `dt` int(11) DEFAULT NULL\n" +
+                        ")\n" +
+                        "PARTITION BY (year, dt)\n" +
+                        "PROPERTIES (\"location\" = \"hdfs://hadoop/hive/warehouse/test.db/test\");",
+                resultSet.getResultRows().get(0).get(1));
     }
 
     @Test
     public void testShowCreateHiveExternalTable() {
         new MockUp<MetadataMgr>() {
             @Mock
-            public Database getDb(String catalogName, String dbName) {
+            public Database getDb(ConnectContext context, String catalogName, String dbName) {
                 return new Database();
             }
 
             @Mock
-            public Table getTable(String catalogName, String dbName, String tblName) {
+            public Table getTable(ConnectContext context, String catalogName, String dbName, String tblName) {
                 List<Column> fullSchema = new ArrayList<>();
                 Column columnId = new Column("id", Type.INT, true);
                 columnId.setComment("id");
@@ -1143,35 +1142,35 @@ public class ShowExecutorTest {
                 partitions.add("year");
                 partitions.add("dt");
                 HiveTable.Builder tableBuilder = HiveTable.builder()
-                            .setId(1)
-                            .setTableName("test_table")
-                            .setCatalogName("hive_catalog")
-                            .setResourceName(toResourceName("hive_catalog", "hive"))
-                            .setHiveDbName("hive_db")
-                            .setHiveTableName("test_table")
-                            .setPartitionColumnNames(partitions)
-                            .setFullSchema(fullSchema)
-                            .setTableLocation("hdfs://hadoop/hive/warehouse/test.db/test")
-                            .setCreateTime(10000)
-                            .setHiveTableType(HiveTable.HiveTableType.EXTERNAL_TABLE);
+                        .setId(1)
+                        .setTableName("test_table")
+                        .setCatalogName("hive_catalog")
+                        .setResourceName(toResourceName("hive_catalog", "hive"))
+                        .setHiveDbName("hive_db")
+                        .setHiveTableName("test_table")
+                        .setPartitionColumnNames(partitions)
+                        .setFullSchema(fullSchema)
+                        .setTableLocation("hdfs://hadoop/hive/warehouse/test.db/test")
+                        .setCreateTime(10000)
+                        .setHiveTableType(HiveTable.HiveTableType.EXTERNAL_TABLE);
                 return tableBuilder.build();
             }
         };
 
         ShowCreateTableStmt stmt = new ShowCreateTableStmt(new TableName("hive_catalog", "hive_db", "test_table"),
-                    ShowCreateTableStmt.CreateTableType.TABLE);
+                ShowCreateTableStmt.CreateTableType.TABLE);
 
         ShowResultSet resultSet = ShowExecutor.execute(stmt, ctx);
         Assert.assertEquals("test_table", resultSet.getResultRows().get(0).get(0));
         Assert.assertEquals("CREATE EXTERNAL TABLE `test_table` (\n" +
-                                "  `id` int(11) DEFAULT NULL COMMENT \"id\",\n" +
-                                "  `name` varchar DEFAULT NULL,\n" +
-                                "  `year` int(11) DEFAULT NULL,\n" +
-                                "  `dt` int(11) DEFAULT NULL\n" +
-                                ")\n" +
-                                "PARTITION BY (year, dt)\n" +
-                                "PROPERTIES (\"location\" = \"hdfs://hadoop/hive/warehouse/test.db/test\");",
-                    resultSet.getResultRows().get(0).get(1));
+                        "  `id` int(11) DEFAULT NULL COMMENT \"id\",\n" +
+                        "  `name` varchar DEFAULT NULL,\n" +
+                        "  `year` int(11) DEFAULT NULL,\n" +
+                        "  `dt` int(11) DEFAULT NULL\n" +
+                        ")\n" +
+                        "PARTITION BY (year, dt)\n" +
+                        "PROPERTIES (\"location\" = \"hdfs://hadoop/hive/warehouse/test.db/test\");",
+                resultSet.getResultRows().get(0).get(1));
     }
 
     @Test
@@ -1200,10 +1199,10 @@ public class ShowExecutorTest {
 
         Assert.assertEquals("test_hive", resultSet.getResultRows().get(0).get(0));
         Assert.assertEquals("CREATE EXTERNAL CATALOG `test_hive`\n" +
-                    "comment \"hive_test\"\n" +
-                    "PROPERTIES (\"type\"  =  \"hive\",\n" +
-                    "\"hive.metastore.uris\"  =  \"thrift://hadoop:9083\"\n" +
-                    ")", resultSet.getResultRows().get(0).get(1));
+                "comment \"hive_test\"\n" +
+                "PROPERTIES (\"type\"  =  \"hive\",\n" +
+                "\"hive.metastore.uris\"  =  \"thrift://hadoop:9083\"\n" +
+                ")", resultSet.getResultRows().get(0).get(1));
     }
 
     @Test
@@ -1218,7 +1217,7 @@ public class ShowExecutorTest {
         ShowCreateExternalCatalogStmt stmt = new ShowCreateExternalCatalogStmt("catalog_not_exist");
 
         ExceptionChecker.expectThrowsWithMsg(SemanticException.class, "Unknown catalog 'catalog_not_exist'",
-                    () -> ShowExecutor.execute(stmt, ctx));
+                () -> ShowExecutor.execute(stmt, ctx));
     }
 
     @Test
@@ -1228,8 +1227,8 @@ public class ShowExecutorTest {
             public Map<AnalyzeMgr.StatsMetaKey, ExternalBasicStatsMeta> getExternalBasicStatsMetaMap() {
                 Map<AnalyzeMgr.StatsMetaKey, ExternalBasicStatsMeta> map = new HashMap<>();
                 map.put(new AnalyzeMgr.StatsMetaKey("hive0", "testDb", "testTable"),
-                            new ExternalBasicStatsMeta("hive0", "testDb", "testTable", null,
-                                        StatsConstants.AnalyzeType.FULL, LocalDateTime.now(), Maps.newHashMap()));
+                        new ExternalBasicStatsMeta("hive0", "testDb", "testTable", null,
+                                StatsConstants.AnalyzeType.FULL, LocalDateTime.now(), Maps.newHashMap()));
                 return map;
             }
         };
@@ -1250,13 +1249,13 @@ public class ShowExecutorTest {
         ShowResultSet resultSet = ShowExecutor.execute(stmt, ctx);
         resultSet.getResultRows().forEach(System.out::println);
         String expectString1 = "root, null, GRANT CREATE TABLE, DROP, ALTER, CREATE VIEW, CREATE FUNCTION, " +
-                    "CREATE MATERIALIZED VIEW, CREATE PIPE ON ALL DATABASES TO ROLE 'root'";
+                "CREATE MATERIALIZED VIEW, CREATE PIPE ON ALL DATABASES TO ROLE 'root'";
         Assert.assertTrue(resultSet.getResultRows().stream().anyMatch(l ->
-                    l.toString().contains(expectString1)));
+                l.toString().contains(expectString1)));
         String expectString2 = "root, null, GRANT DELETE, DROP, INSERT, SELECT, ALTER, EXPORT, " +
-                    "UPDATE ON ALL TABLES IN ALL DATABASES TO ROLE 'root'";
+                "UPDATE ON ALL TABLES IN ALL DATABASES TO ROLE 'root'";
         Assert.assertTrue(resultSet.getResultRows().stream().anyMatch(l ->
-                    l.toString().contains(expectString2)));
+                l.toString().contains(expectString2)));
     }
 
     @Test
@@ -1279,12 +1278,12 @@ public class ShowExecutorTest {
 
         Assert.assertEquals("test_hive", resultSet.getResultRows().get(0).get(0));
         Assert.assertEquals("CREATE EXTERNAL CATALOG `test_hive`\n" +
-                    "comment \"hive_test\"\n" +
-                    "PROPERTIES (\"aws.s3.access_key\"  =  \"ia******ey\",\n" +
-                    "\"aws.s3.secret_key\"  =  \"ia******ey\",\n" +
-                    "\"hive.metastore.uris\"  =  \"thrift://hadoop:9083\",\n" +
-                    "\"type\"  =  \"hive\"\n" +
-                    ")", resultSet.getResultRows().get(0).get(1));
+                "comment \"hive_test\"\n" +
+                "PROPERTIES (\"aws.s3.access_key\"  =  \"ia******ey\",\n" +
+                "\"aws.s3.secret_key\"  =  \"ia******ey\",\n" +
+                "\"hive.metastore.uris\"  =  \"thrift://hadoop:9083\",\n" +
+                "\"type\"  =  \"hive\"\n" +
+                ")", resultSet.getResultRows().get(0).get(1));
     }
 
     @Test
@@ -1297,7 +1296,7 @@ public class ShowExecutorTest {
         properties.put("ni", "hao");
         StringLiteral stringLiteral = new StringLiteral("hello");
         dataCacheMgr.createCacheRule(QualifiedName.of(ImmutableList.of("test2", "test2", "test2")),
-                    stringLiteral, -1, properties);
+                stringLiteral, -1, properties);
 
         ShowDataCacheRulesStmt stmt = new ShowDataCacheRulesStmt(NodePosition.ZERO);
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowTablesTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowTablesTest.java
@@ -14,10 +14,19 @@
 package com.starrocks.qe;
 
 import com.google.common.collect.Sets;
+import com.starrocks.authorization.IdGenerator;
 import com.starrocks.authorization.PrivilegeBuiltinConstants;
+import com.starrocks.catalog.CatalogRecycleBin;
+import com.starrocks.catalog.ColocateTableIndex;
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.InternalCatalog;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorReportException;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
 import com.starrocks.sql.ast.CreateUserStmt;
 import com.starrocks.sql.ast.GrantPrivilegeStmt;
 import com.starrocks.sql.ast.ShowDataStmt;
@@ -29,6 +38,12 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 public class ShowTablesTest {
     private static ConnectContext ctx;
 
@@ -38,8 +53,16 @@ public class ShowTablesTest {
         UtFrameUtils.setUpForPersistTest();
 
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        IdGenerator idGenerator = new IdGenerator();
+
+        MockedLocalMetastore mockedLocalMetastore = new MockedLocalMetastore(idGenerator,
+                globalStateMgr, null, null);
+        mockedLocalMetastore.init();
+
+        globalStateMgr.setLocalMetastore(mockedLocalMetastore);
+
         ShowTableMockMeta metadataMgr =
-                new ShowTableMockMeta(globalStateMgr.getLocalMetastore(), globalStateMgr.getConnectorMgr());
+                new ShowTableMockMeta(idGenerator, mockedLocalMetastore, globalStateMgr.getConnectorMgr());
         metadataMgr.init();
         globalStateMgr.setMetadataMgr(metadataMgr);
 
@@ -115,5 +138,70 @@ public class ShowTablesTest {
         ctx.setCurrentUserIdentity(UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%"));
         ShowDataStmt stmt = new ShowDataStmt("test", "testTbl", null);
         Assert.assertThrows(ErrorReportException.class, () -> ShowExecutor.execute(stmt, ctx));
+    }
+
+    static class MockedLocalMetastore extends LocalMetastore {
+        private final IdGenerator idGenerator;
+        private final Map<String, Database> databaseSet;
+        private final Map<String, Table> tableMap;
+
+        public MockedLocalMetastore(
+                IdGenerator idGenerator,
+                GlobalStateMgr globalStateMgr, CatalogRecycleBin recycleBin,
+                ColocateTableIndex colocateTableIndex) {
+            super(globalStateMgr, recycleBin, colocateTableIndex);
+            this.databaseSet = new HashMap<>();
+            this.tableMap = new HashMap<>();
+            this.idGenerator = idGenerator;
+        }
+
+        public void init() throws DdlException {
+            Database db = new Database(idGenerator.getNextId(), "testDb");
+            databaseSet.put("testDb", db);
+
+            Database db2 = new Database(idGenerator.getNextId(), "test");
+            databaseSet.put("test", db2);
+
+            OlapTable t0 = new OlapTable();
+            t0.setId(idGenerator.getNextId());
+            t0.setName("testTbl");
+            tableMap.put("testTbl", t0);
+
+            MaterializedView mv = new MaterializedView();
+            mv.setId(idGenerator.getNextId());
+            mv.setName("testMv");
+            tableMap.put("testMv", mv);
+        }
+
+        @Override
+        public Database getDb(String dbName) {
+            return databaseSet.get(dbName);
+        }
+
+        @Override
+        public Database getDb(long databaseId) {
+            for (Database database : databaseSet.values()) {
+                if (database.getId() == databaseId) {
+                    return database;
+                }
+            }
+
+            return null;
+        }
+
+        @Override
+        public ConcurrentHashMap<String, Database> getFullNameToDb() {
+            return new ConcurrentHashMap<>(databaseSet);
+        }
+
+        @Override
+        public Table getTable(String dbName, String tblName) {
+            return tableMap.get(tblName);
+        }
+
+        @Override
+        public List<Table> getTables(Long dbId) {
+            return new ArrayList<>(tableMap.values());
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -611,7 +611,8 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                 Map<Long, TableSnapshotInfo> olapTables = Maps.newHashMap();
                 List<BaseTableInfo> baseTableInfos = materializedView.getBaseTableInfos();
                 for (BaseTableInfo baseTableInfo : baseTableInfos) {
-                    Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTableChecked(baseTableInfo);
+                    Table table = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                            .getTableChecked(new ConnectContext(), baseTableInfo);
                     if (!table.isOlapTable()) {
                         continue;
                     }
@@ -1771,6 +1772,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         Assert.assertEquals(debugOptions.getMaxRefreshMaterializedViewRetryNum(), 3);
         Assert.assertEquals(debugOptions.isEnableNormalizePredicateAfterMVRewrite(), false);
     }
+
     @Test
     public void testMVPartitionMappingWithManyToMany() {
         starRocksAssert.withTable(new MTable("mock_tbl", "k2",

--- a/fe/fe-core/src/test/java/com/starrocks/server/CatalogLevelTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/CatalogLevelTest.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.Type;
 import com.starrocks.connector.hive.HiveMetaClient;
 import com.starrocks.connector.hive.HiveMetastoreApiConverter;
 import com.starrocks.connector.hive.HiveMetastoreTest;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.analyzer.Authorizer;
@@ -64,11 +65,11 @@ public class CatalogLevelTest {
         GlobalStateMgr.getCurrentState().setMetadataMgr(metadataMgr);
         new Expectations(metadataMgr) {
             {
-                metadataMgr.getDb("hive_catalog", "hive_db");
+                metadataMgr.getDb((ConnectContext) any, "hive_catalog", "hive_db");
                 result = new Database(111, "hive_db");
                 minTimes = 0;
 
-                metadataMgr.getTable("hive_catalog", "hive_db", "hive_table");
+                metadataMgr.getTable((ConnectContext) any, "hive_catalog", "hive_db", "hive_table");
                 result = hiveTable;
             }
         };
@@ -118,11 +119,11 @@ public class CatalogLevelTest {
         GlobalStateMgr.getCurrentState().setMetadataMgr(metadataMgr);
         new Expectations(metadataMgr) {
             {
-                metadataMgr.getDb("iceberg_catalog", "iceberg_db");
+                metadataMgr.getDb((ConnectContext) any, "iceberg_catalog", "iceberg_db");
                 result = new Database(111, "iceberg_db");
                 minTimes = 0;
 
-                metadataMgr.getTable("iceberg_catalog", "iceberg_db", "iceberg_table");
+                metadataMgr.getTable((ConnectContext) any, "iceberg_catalog", "iceberg_db", "iceberg_table");
                 result = icebergTable;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.server;
 
 import com.google.common.collect.Lists;
@@ -66,7 +65,8 @@ public class MetadataMgrTest {
         AnalyzeTestUtil.init();
         String createTbl = "create table db1.tbl1(k1 varchar(32), catalog varchar(32), external varchar(32), k4 int) "
                 + "distributed by hash(k1) buckets 3 properties('replication_num' = '1')";
-        String createCatalog = "CREATE EXTERNAL CATALOG hive_catalog PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")";
+        String createCatalog =
+                "CREATE EXTERNAL CATALOG hive_catalog PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")";
         StarRocksAssert starRocksAssert = new StarRocksAssert();
         starRocksAssert.withCatalog(createCatalog);
         starRocksAssert.withDatabase("db1").useDatabase("tbl1");
@@ -84,10 +84,10 @@ public class MetadataMgrTest {
         };
 
         MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
-        List<String> internalListDbs = metadataMgr.listDbNames("default_catalog");
+        List<String> internalListDbs = metadataMgr.listDbNames(AnalyzeTestUtil.getConnectContext(), "default_catalog");
         Assert.assertTrue(internalListDbs.contains("db1"));
 
-        List<String> externalListDbs = metadataMgr.listDbNames("hive_catalog");
+        List<String> externalListDbs = metadataMgr.listDbNames(AnalyzeTestUtil.getConnectContext(), "hive_catalog");
         Assert.assertTrue(externalListDbs.contains("db2"));
     }
 
@@ -103,19 +103,18 @@ public class MetadataMgrTest {
 
         MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
 
-        List<String> internalTables = metadataMgr.listTableNames("default_catalog", "db1");
+        List<String> internalTables = metadataMgr.listTableNames(AnalyzeTestUtil.getConnectContext(), "default_catalog", "db1");
         Assert.assertTrue(internalTables.contains("tbl1"));
         try {
-            metadataMgr.listTableNames("default_catalog", "db_foo");
+            metadataMgr.listTableNames(AnalyzeTestUtil.getConnectContext(), "default_catalog", "db_foo");
             Assert.fail();
         } catch (StarRocksConnectorException e) {
             Assert.assertTrue(e.getMessage().contains("Database db_foo doesn't exist"));
         }
 
-
-        List<String> externalTables = metadataMgr.listTableNames("hive_catalog", "db2");
+        List<String> externalTables = metadataMgr.listTableNames(AnalyzeTestUtil.getConnectContext(), "hive_catalog", "db2");
         Assert.assertTrue(externalTables.contains("tbl2"));
-        externalTables = metadataMgr.listTableNames("hive_catalog", "db3");
+        externalTables = metadataMgr.listTableNames(AnalyzeTestUtil.getConnectContext(), "hive_catalog", "db3");
         Assert.assertTrue(externalTables.isEmpty());
     }
 
@@ -131,26 +130,28 @@ public class MetadataMgrTest {
 
         MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
 
-        com.starrocks.catalog.Database database = metadataMgr.getDb("default_catalog", "db1");
+        com.starrocks.catalog.Database database =
+                metadataMgr.getDb(AnalyzeTestUtil.getConnectContext(), "default_catalog", "db1");
         Assert.assertNotNull(database);
-        database = metadataMgr.getDb("default_catalog", "db1");
+        database = metadataMgr.getDb(AnalyzeTestUtil.getConnectContext(), "default_catalog", "db1");
         Assert.assertNotNull(database);
 
-        com.starrocks.catalog.Database database1 = metadataMgr.getDb("hive_catalog", "db2");
+        com.starrocks.catalog.Database database1 = metadataMgr.getDb(AnalyzeTestUtil.getConnectContext(), "hive_catalog", "db2");
         Assert.assertNotNull(database1);
         Assert.assertEquals("hive_catalog.db2", database1.getUUID());
 
-        com.starrocks.catalog.Database database2 = metadataMgr.getDb("hive_catalog", "db3");
+        com.starrocks.catalog.Database database2 = metadataMgr.getDb(AnalyzeTestUtil.getConnectContext(), "hive_catalog", "db3");
         Assert.assertNull(database2);
 
-        Assert.assertNull(metadataMgr.getDb("not_exist_catalog", "xxx"));
+        Assert.assertNull(metadataMgr.getDb(AnalyzeTestUtil.getConnectContext(), "not_exist_catalog", "xxx"));
     }
 
     @Test
     public void testGetTableWithDefaultCatalog() {
         MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
         Assert.assertTrue(metadataMgr.getOptionalMetadata("").isPresent());
-        com.starrocks.catalog.Table internalTable = metadataMgr.getTable("default_catalog", "db1", "tbl1");
+        com.starrocks.catalog.Table internalTable =
+                metadataMgr.getTable(AnalyzeTestUtil.getConnectContext(), "default_catalog", "db1", "tbl1");
         Assert.assertEquals(internalTable.getName(), "tbl1");
     }
 
@@ -179,22 +180,25 @@ public class MetadataMgrTest {
 
         MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
 
-        com.starrocks.catalog.Table internalTable = metadataMgr.getTable("default_catalog", "db1", "tbl1");
+        com.starrocks.catalog.Table internalTable =
+                metadataMgr.getTable(AnalyzeTestUtil.getConnectContext(), "default_catalog", "db1", "tbl1");
         Assert.assertNotNull(internalTable);
-        Assert.assertNull(metadataMgr.getTable("default_catalog", "not_exist_db", "xxx"));
-        Assert.assertNull(metadataMgr.getTable("default_catalog", "db1", "not_exist_table"));
+        Assert.assertNull(metadataMgr.getTable(AnalyzeTestUtil.getConnectContext(), "default_catalog", "not_exist_db", "xxx"));
+        Assert.assertNull(metadataMgr.getTable(AnalyzeTestUtil.getConnectContext(), "default_catalog", "db1", "not_exist_table"));
 
-        com.starrocks.catalog.Table tbl1 = metadataMgr.getTable("hive_catalog", "hive_db", "hive_table");
+        com.starrocks.catalog.Table tbl1 =
+                metadataMgr.getTable(AnalyzeTestUtil.getConnectContext(), "hive_catalog", "hive_db", "hive_table");
         Assert.assertNotNull(tbl1);
         Assert.assertEquals("hive_catalog.hive_db.hive_table.20201010", tbl1.getUUID());
 
-        com.starrocks.catalog.Table tbl2 = metadataMgr.getTable("not_exist_catalog", "xxx", "xxx");
+        com.starrocks.catalog.Table tbl2 =
+                metadataMgr.getTable(AnalyzeTestUtil.getConnectContext(), "not_exist_catalog", "xxx", "xxx");
         Assert.assertNull(tbl2);
 
         Assert.assertThrows(StarRocksConnectorException.class,
-                () -> metadataMgr.getTable("hive_catalog", "not_exist_db", "xxx"));
+                () -> metadataMgr.getTable(AnalyzeTestUtil.getConnectContext(), "hive_catalog", "not_exist_db", "xxx"));
         Assert.assertThrows(StarRocksConnectorException.class,
-                () -> metadataMgr.getTable("hive_catalog", "hive_db", "not_exist_tbl"));
+                () -> metadataMgr.getTable(AnalyzeTestUtil.getConnectContext(), "hive_catalog", "hive_db", "not_exist_tbl"));
     }
 
     @Test
@@ -202,11 +206,12 @@ public class MetadataMgrTest {
         MetadataMgr metadataMgr = AnalyzeTestUtil.getConnectContext().getGlobalStateMgr().getMetadataMgr();
         new Expectations(metadataMgr) {
             {
-                metadataMgr.tableExists("iceberg_catalog", "iceberg_db", "iceberg_tbl");
+                metadataMgr.tableExists(AnalyzeTestUtil.getConnectContext(), "iceberg_catalog", "iceberg_db", "iceberg_tbl");
                 result = true;
             }
         };
-        Assert.assertTrue(metadataMgr.tableExists("iceberg_catalog", "iceberg_db", "iceberg_tbl"));
+        Assert.assertTrue(
+                metadataMgr.tableExists(AnalyzeTestUtil.getConnectContext(), "iceberg_catalog", "iceberg_db", "iceberg_tbl"));
     }
 
     @Test
@@ -217,11 +222,11 @@ public class MetadataMgrTest {
         MetadataMgr metadataMgr = AnalyzeTestUtil.getConnectContext().getGlobalStateMgr().getMetadataMgr();
         new Expectations(metadataMgr) {
             {
-                metadataMgr.getDb("iceberg_catalog", "iceberg_db");
+                metadataMgr.getDb(AnalyzeTestUtil.getConnectContext(), "iceberg_catalog", "iceberg_db");
                 result = new com.starrocks.catalog.Database();
                 minTimes = 0;
 
-                metadataMgr.tableExists("iceberg_catalog", "iceberg_db", "iceberg_table");
+                metadataMgr.tableExists(AnalyzeTestUtil.getConnectContext(), "iceberg_catalog", "iceberg_db", "iceberg_table");
                 result = false;
             }
         };
@@ -232,14 +237,14 @@ public class MetadataMgrTest {
 
         new Expectations(metadataMgr) {
             {
-                metadataMgr.getDb("iceberg_catalog", "iceberg_db");
+                metadataMgr.getDb(AnalyzeTestUtil.getConnectContext(), "iceberg_catalog", "iceberg_db");
                 result = null;
                 minTimes = 0;
             }
         };
 
         try {
-            metadataMgr.createTable(createTableStmt);
+            metadataMgr.createTable(AnalyzeTestUtil.getConnectContext(), createTableStmt);
             Assert.fail();
         } catch (Exception e) {
             Assert.assertTrue(e instanceof DdlException);
@@ -248,18 +253,18 @@ public class MetadataMgrTest {
 
         new Expectations(metadataMgr) {
             {
-                metadataMgr.getDb("iceberg_catalog", "iceberg_db");
+                metadataMgr.getDb(AnalyzeTestUtil.getConnectContext(), "iceberg_catalog", "iceberg_db");
                 result = new com.starrocks.catalog.Database();
                 minTimes = 0;
 
-                metadataMgr.tableExists("iceberg_catalog", "iceberg_db", "iceberg_table");
+                metadataMgr.tableExists(AnalyzeTestUtil.getConnectContext(), "iceberg_catalog", "iceberg_db", "iceberg_table");
                 result = true;
                 minTimes = 0;
             }
         };
 
         try {
-            metadataMgr.createTable(createTableStmt);
+            metadataMgr.createTable(AnalyzeTestUtil.getConnectContext(), createTableStmt);
             Assert.fail();
         } catch (Exception e) {
             Assert.assertTrue(e instanceof DdlException);
@@ -267,7 +272,7 @@ public class MetadataMgrTest {
         }
 
         createTableStmt.setIfNotExists();
-        Assert.assertFalse(metadataMgr.createTable(createTableStmt));
+        Assert.assertFalse(metadataMgr.createTable(AnalyzeTestUtil.getConnectContext(), createTableStmt));
         AnalyzeTestUtil.getStarRocksAssert().dropCatalog("iceberg_catalog");
     }
 
@@ -280,12 +285,13 @@ public class MetadataMgrTest {
             }
 
             @Override
-            public com.starrocks.catalog.Database getDb(String catalogName, String dbName) {
+            public com.starrocks.catalog.Database getDb(ConnectContext context, String catalogName, String dbName) {
                 return new com.starrocks.catalog.Database(0, "hive_db", "s3://test-db/");
             }
 
             @Override
-            public com.starrocks.catalog.Table getTable(String catalogName, String dbName, String tblName) {
+            public com.starrocks.catalog.Table getTable(ConnectContext context, String catalogName, String dbName,
+                                                        String tblName) {
                 List<FieldSchema> partKeys = Lists.newArrayList(new FieldSchema("col1", "INT", ""));
                 List<FieldSchema> unPartKeys = Lists.newArrayList(new FieldSchema("col2", "INT", ""));
                 String hdfsPath = "hdfs://127.0.0.1:10000/hive";
@@ -306,7 +312,7 @@ public class MetadataMgrTest {
             }
 
             @Override
-            public boolean tableExists(String catalogName, String dbName, String tblName) {
+            public boolean tableExists(ConnectContext context, String catalogName, String dbName, String tblName) {
                 return (catalogName.equals("hive_catalog") && dbName.equals("hive_db") && tblName.equals("hive_tbl")) ||
                         (catalogName.equals("hive_catalog") && dbName.equals("hive_db") && tblName.equals("hive_tbl_1"));
             }
@@ -328,7 +334,7 @@ public class MetadataMgrTest {
                 (CreateTableLikeStmt) UtFrameUtils.parseStmtWithNewParser(stmt, AnalyzeTestUtil.getConnectContext());
 
         try {
-            mockedHiveMetadataMgr.createTableLike(createTableLikeStmt);
+            mockedHiveMetadataMgr.createTableLike(connectContext, createTableLikeStmt);
         } catch (Exception e) {
             Assert.assertTrue(e instanceof DdlException);
             Assert.assertTrue(e.getMessage().contains("Invalid catalog hive_catalog_1"));
@@ -339,7 +345,7 @@ public class MetadataMgrTest {
                 (CreateTableLikeStmt) UtFrameUtils.parseStmtWithNewParser(stmt, AnalyzeTestUtil.getConnectContext());
 
         try {
-            mockedHiveMetadataMgr.createTableLike(createTableLikeStmt);
+            mockedHiveMetadataMgr.createTableLike(connectContext, createTableLikeStmt);
         } catch (Exception e) {
             Assert.assertTrue(e instanceof DdlException);
             Assert.assertTrue(e.getMessage().contains("Table 'hive_tbl_1' already exists"));
@@ -350,7 +356,7 @@ public class MetadataMgrTest {
                 (CreateTableLikeStmt) UtFrameUtils.parseStmtWithNewParser(stmt, AnalyzeTestUtil.getConnectContext());
 
         try {
-            mockedHiveMetadataMgr.createTableLike(createTableLikeStmt);
+            mockedHiveMetadataMgr.createTableLike(connectContext, createTableLikeStmt);
         } catch (Exception e) {
             Assert.assertNull(e);
         }
@@ -360,7 +366,7 @@ public class MetadataMgrTest {
                 (CreateTableLikeStmt) UtFrameUtils.parseStmtWithNewParser(stmt, AnalyzeTestUtil.getConnectContext());
 
         try {
-            mockedHiveMetadataMgr.createTableLike(createTableLikeStmt);
+            mockedHiveMetadataMgr.createTableLike(connectContext, createTableLikeStmt);
         } catch (Exception e) {
             Assert.assertNull(e);
         }
@@ -370,7 +376,7 @@ public class MetadataMgrTest {
                 (CreateTableLikeStmt) UtFrameUtils.parseStmtWithNewParser(stmt, AnalyzeTestUtil.getConnectContext());
 
         try {
-            mockedHiveMetadataMgr.createTableLike(createTableLikeStmt);
+            mockedHiveMetadataMgr.createTableLike(connectContext, createTableLikeStmt);
         } catch (Exception e) {
             Assert.assertNull(e);
         }
@@ -415,12 +421,12 @@ public class MetadataMgrTest {
         MetadataMgr metadataMgr = AnalyzeTestUtil.getConnectContext().getGlobalStateMgr().getMetadataMgr();
         new Expectations(metadataMgr) {
             {
-                metadataMgr.getDb("hive_catalog", "hive_db");
+                metadataMgr.getDb(AnalyzeTestUtil.getConnectContext(), "hive_catalog", "hive_db");
                 result = null;
                 minTimes = 0;
             }
         };
-        metadataMgr.dropDb("hive_catalog", "hive_db", false);
+        metadataMgr.dropDb(AnalyzeTestUtil.getConnectContext(), "hive_catalog", "hive_db", false);
     }
 
     @Test
@@ -436,7 +442,9 @@ public class MetadataMgrTest {
                 "\"hive.metastore.uris\"=\"thrift://hms:9083\", \"iceberg.catalog.type\"=\"hive\")";
         AnalyzeTestUtil.getStarRocksAssert().withCatalog(createIcebergCatalogStmt);
         MetadataMgr metadataMgr = AnalyzeTestUtil.getConnectContext().getGlobalStateMgr().getMetadataMgr();
-        com.starrocks.catalog.Table table = metadataMgr.getTable("iceberg_catalog", "iceberg_db", "t1$logical_iceberg_metadata");
+        com.starrocks.catalog.Table table =
+                metadataMgr.getTable(AnalyzeTestUtil.getConnectContext(), "iceberg_catalog", "iceberg_db",
+                        "t1$logical_iceberg_metadata");
         Assert.assertTrue(table instanceof LogicalIcebergMetadataTable);
         LogicalIcebergMetadataTable metadataTable = (LogicalIcebergMetadataTable) table;
         Assert.assertEquals("iceberg_db", metadataTable.getOriginDb());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateTableTest.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.analyzer;
 
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.InternalCatalog;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.ast.CreateTableStmt;
 import mockit.Expectations;
@@ -325,7 +326,7 @@ public class AnalyzeCreateTableTest {
         MetadataMgr metadata = AnalyzeTestUtil.getConnectContext().getGlobalStateMgr().getMetadataMgr();
         new Expectations(metadata) {
             {
-                metadata.getDb("iceberg_catalog", "not_exist_db");
+                metadata.getDb((ConnectContext) any, "iceberg_catalog", "not_exist_db");
                 result = null;
                 minTimes = 0;
             }
@@ -334,11 +335,11 @@ public class AnalyzeCreateTableTest {
 
         new Expectations(metadata) {
             {
-                metadata.getDb("iceberg_catalog", "iceberg_db");
+                metadata.getDb((ConnectContext) any, "iceberg_catalog", "iceberg_db");
                 result = new Database();
                 minTimes = 0;
 
-                metadata.tableExists("iceberg_catalog", "iceberg_db", anyString);
+                metadata.tableExists((ConnectContext) any, "iceberg_catalog", "iceberg_db", anyString);
                 result = false;
             }
         };
@@ -364,7 +365,7 @@ public class AnalyzeCreateTableTest {
         AnalyzeTestUtil.getStarRocksAssert().withCatalog(createHiveCatalogStmt);
         new Expectations(metadata) {
             {
-                metadata.getDb("hive_catalog", "hive_db");
+                metadata.getDb((ConnectContext) any, "hive_catalog", "hive_db");
                 result = new Database();
                 minTimes = 0;
             }
@@ -376,18 +377,18 @@ public class AnalyzeCreateTableTest {
 
     @Test
     public void testGeneratedColumnWithExternalTable() throws Exception {
-        analyzeFail("create external table ex_hive_tbl0 (col_tinyint tinyint null comment \"column tinyint\"," + 
-                    "col_varchar varchar(5), col_boolean boolean null comment \"column boolean\", col_new int" + 
-                    "as col_tinyint+1) ENGINE=hive properties (\"resource\" = \"hive_resource\"," +
-                    "\"table\" = \"hive_hdfs_orc_nocompress\"," +
-                    "\"database\" = \"hive_extbl_test\");");
+        analyzeFail("create external table ex_hive_tbl0 (col_tinyint tinyint null comment \"column tinyint\"," +
+                "col_varchar varchar(5), col_boolean boolean null comment \"column boolean\", col_new int" +
+                "as col_tinyint+1) ENGINE=hive properties (\"resource\" = \"hive_resource\"," +
+                "\"table\" = \"hive_hdfs_orc_nocompress\"," +
+                "\"database\" = \"hive_extbl_test\");");
     }
 
     @Test
     public void testGeneratedColumnOnAGGTable() throws Exception {
         analyzeFail("CREATE TABLE t ( id BIGINT NOT NULL,  name BIGINT NOT NULL, v1 BIGINT SUM as id)" +
-                    "AGGREGATE KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 " +
-                    "PROPERTIES(\"replication_num\" = \"1\", \"replicated_storage\"=\"true\");");
+                "AGGREGATE KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 " +
+                "PROPERTIES(\"replication_num\" = \"1\", \"replicated_storage\"=\"true\");");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDropTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDropTableTest.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.analyzer;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.utframe.StarRocksAssert;
 import mockit.Expectations;
@@ -48,7 +49,7 @@ public class AnalyzeDropTableTest {
         MetadataMgr metadata = AnalyzeTestUtil.getConnectContext().getGlobalStateMgr().getMetadataMgr();
         new Expectations(metadata) {
             {
-                metadata.getDb(anyString, anyString);
+                metadata.getDb((ConnectContext) any, anyString, anyString);
                 result = null;
                 minTimes = 0;
             }
@@ -57,11 +58,11 @@ public class AnalyzeDropTableTest {
 
         new Expectations(metadata) {
             {
-                metadata.getDb(anyString, anyString);
+                metadata.getDb((ConnectContext) any, anyString, anyString);
                 result = new Database();
                 minTimes = 0;
 
-                metadata.getTable(anyString, anyString, anyString);
+                metadata.getTable((ConnectContext) any, anyString, anyString, anyString);
                 result = null;
                 minTimes = 0;
             }
@@ -70,7 +71,7 @@ public class AnalyzeDropTableTest {
 
         new Expectations(metadata) {
             {
-                metadata.getTable(anyString, anyString, anyString);
+                metadata.getTable((ConnectContext) any, anyString, anyString, anyString);
                 result = new Table(Table.TableType.ICEBERG);
                 minTimes = 0;
             }
@@ -84,11 +85,11 @@ public class AnalyzeDropTableTest {
 
         new Expectations(metadata, hiveTable) {
             {
-                metadata.getDb(anyString, anyString);
+                metadata.getDb((ConnectContext) any, anyString, anyString);
                 result = new Database();
                 minTimes = 0;
 
-                metadata.getTable(anyString, anyString, anyString);
+                metadata.getTable((ConnectContext) any, anyString, anyString, anyString);
                 result = hiveTable;
                 minTimes = 0;
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
@@ -117,7 +117,7 @@ public class AnalyzeInsertTest {
 
         new MockUp<MetadataMgr>() {
             @Mock
-            public Database getDb(String catalogName, String dbName) {
+            public Database getDb(ConnectContext context, String catalogName, String dbName) {
                 return new Database();
             }
         };
@@ -139,7 +139,7 @@ public class AnalyzeInsertTest {
         };
         new Expectations(metadata) {
             {
-                metadata.getDb(anyString, anyString);
+                metadata.getDb((ConnectContext) any, anyString, anyString);
                 minTimes = 0;
                 result = new Database();
 
@@ -153,7 +153,7 @@ public class AnalyzeInsertTest {
 
         new Expectations(metadata) {
             {
-                metadata.getDb(anyString, anyString);
+                metadata.getDb((ConnectContext) any, anyString, anyString);
                 minTimes = 0;
                 result = new Database();
 
@@ -185,7 +185,7 @@ public class AnalyzeInsertTest {
 
         new Expectations(metadata) {
             {
-                metadata.getDb(anyString, anyString);
+                metadata.getDb((ConnectContext) any, anyString, anyString);
                 minTimes = 0;
                 result = new Database();
 
@@ -261,7 +261,7 @@ public class AnalyzeInsertTest {
     public void testInsertHiveNonManagedTable(@Mocked HiveTable hiveTable) {
         new MockUp<MetadataMgr>() {
             @Mock
-            public Database getDb(String catalogName, String dbName) {
+            public Database getDb(ConnectContext context, String catalogName, String dbName) {
                 return new Database();
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -548,29 +548,26 @@ public class PrivilegeCheckerTest {
         starRocksAssert.withCatalog("create external catalog test_iceberg properties (" +
                 "\"type\"=\"iceberg\", \"iceberg.catalog.type\"=\"hive\")");
         DbPEntryObject dbPEntryObject =
-                DbPEntryObject.generate(GlobalStateMgr.getCurrentState(), List.of("test_iceberg", "*"));
-        Assert.assertTrue(dbPEntryObject.validate(GlobalStateMgr.getCurrentState()));
-        TablePEntryObject tablePEntryObject = TablePEntryObject.generate(GlobalStateMgr.getCurrentState(),
-                List.of("test_iceberg", "*", "*"));
-        Assert.assertTrue(tablePEntryObject.validate(GlobalStateMgr.getCurrentState()));
+                DbPEntryObject.generate(List.of("test_iceberg", "*"));
+        Assert.assertTrue(dbPEntryObject.validate());
+        TablePEntryObject tablePEntryObject = TablePEntryObject.generate(List.of("test_iceberg", "*", "*"));
+        Assert.assertTrue(tablePEntryObject.validate());
 
         dbPEntryObject =
-                DbPEntryObject.generate(GlobalStateMgr.getCurrentState(), List.of("test_iceberg", "iceberg_db"));
+                DbPEntryObject.generate(List.of("test_iceberg", "iceberg_db"));
         Assert.assertEquals(dbPEntryObject.getUUID(), "iceberg_db");
-        Assert.assertTrue(dbPEntryObject.validate(GlobalStateMgr.getCurrentState()));
-        tablePEntryObject = TablePEntryObject.generate(GlobalStateMgr.getCurrentState(),
-                List.of("test_iceberg", "iceberg_db", "iceberg_tbl"));
+        Assert.assertTrue(dbPEntryObject.validate());
+        tablePEntryObject = TablePEntryObject.generate(List.of("test_iceberg", "iceberg_db", "iceberg_tbl"));
         Assert.assertEquals(tablePEntryObject.getDatabaseUUID(), "iceberg_db");
         Assert.assertEquals(tablePEntryObject.getTableUUID(), "iceberg_tbl");
-        Assert.assertTrue(tablePEntryObject.validate(GlobalStateMgr.getCurrentState()));
+        Assert.assertTrue(tablePEntryObject.validate());
     }
 
     @Test
     public void testGetResourceMappingExternalTableException() throws Exception {
         ctxToTestUser();
         // no throw
-        TablePEntryObject.generate(GlobalStateMgr.getCurrentState(),
-                Arrays.asList("resource_mapping_inside_catalog_iceberg0", "db1", "tbl1"));
+        TablePEntryObject.generate(Arrays.asList("resource_mapping_inside_catalog_iceberg0", "db1", "tbl1"));
 
         new MockUp<MetadataMgr>() {
             @Mock
@@ -581,8 +578,7 @@ public class PrivilegeCheckerTest {
 
         // throw
         try {
-            TablePEntryObject.generate(GlobalStateMgr.getCurrentState(),
-                    Arrays.asList("resource_mapping_inside_catalog_iceberg0", "db1", "tbl1"));
+            TablePEntryObject.generate(Arrays.asList("resource_mapping_inside_catalog_iceberg0", "db1", "tbl1"));
         } catch (PrivObjNotFoundException e) {
             System.out.println(e.getMessage());
             e.getMessage().contains("cannot find table tbl1 in db db1, msg: test");
@@ -3683,20 +3679,20 @@ public class PrivilegeCheckerTest {
         starRocksAssert.withTable("create table db1.tbl_pipe (id int, str string) properties('replication_num'='1') ");
 
         // invalid token
-        Assert.assertThrows(PrivilegeException.class, () -> PipePEntryObject.generate(mgr, ImmutableList.of("*")));
+        Assert.assertThrows(PrivilegeException.class, () -> PipePEntryObject.generate(ImmutableList.of("*")));
         Assert.assertThrows(PrivilegeException.class, () ->
-                PipePEntryObject.generate(mgr, ImmutableList.of("not_existing_database", "*")));
+                PipePEntryObject.generate(ImmutableList.of("not_existing_database", "*")));
         Assert.assertThrows(PrivilegeException.class, () ->
-                PipePEntryObject.generate(mgr, ImmutableList.of("db1", "not_existing_pipe")));
+                PipePEntryObject.generate(ImmutableList.of("db1", "not_existing_pipe")));
 
         starRocksAssert.ddl("create pipe db1.p1 as insert into tbl_pipe " +
                 "select * from files('path'='fake://dir/', 'format'='parquet', 'auto_ingest'='false') ");
         starRocksAssert.ddl("create pipe db1.p2 as insert into tbl_pipe " +
                 "select * from files('path'='fake://dir/', 'format'='parquet', 'auto_ingest'='false') ");
-        PipePEntryObject p1 = (PipePEntryObject) PipePEntryObject.generate(mgr, ImmutableList.of("db1", "p1"));
-        PipePEntryObject p2 = (PipePEntryObject) PipePEntryObject.generate(mgr, ImmutableList.of("db1", "p2"));
-        PipePEntryObject pAll = (PipePEntryObject) PipePEntryObject.generate(mgr, ImmutableList.of("db1", "*"));
-        PipePEntryObject pAllDb = (PipePEntryObject) PipePEntryObject.generate(mgr, ImmutableList.of("*", "*"));
+        PipePEntryObject p1 = (PipePEntryObject) PipePEntryObject.generate(ImmutableList.of("db1", "p1"));
+        PipePEntryObject p2 = (PipePEntryObject) PipePEntryObject.generate(ImmutableList.of("db1", "p2"));
+        PipePEntryObject pAll = (PipePEntryObject) PipePEntryObject.generate(ImmutableList.of("db1", "*"));
+        PipePEntryObject pAllDb = (PipePEntryObject) PipePEntryObject.generate(ImmutableList.of("*", "*"));
 
         // compareTo
         Assert.assertEquals(-1, p1.compareTo(p2));
@@ -3721,8 +3717,8 @@ public class PrivilegeCheckerTest {
         Assert.assertNotEquals(p1, p2);
 
         // validate
-        Assert.assertTrue(p1.validate(GlobalStateMgr.getCurrentState()));
-        Assert.assertFalse(pAll.validate(GlobalStateMgr.getCurrentState()));
+        Assert.assertTrue(p1.validate());
+        Assert.assertFalse(pAll.validate());
 
         // getDatabase
         Assert.assertTrue(p1.getDatabase().isPresent());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorageTest.java
@@ -182,7 +182,7 @@ public class CachedStatisticStorageTest {
 
     @Test
     public void testGetHiveColumnStatistics(@Mocked CachedStatisticStorage cachedStatisticStorage) {
-        Table table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("hive0", "tpch", "region");
+        Table table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable(connectContext, "hive0", "tpch", "region");
 
         ColumnStatistic columnStatistic1 = ColumnStatistic.builder().setDistinctValuesCount(888).build();
         ColumnStatistic columnStatistic2 = ColumnStatistic.builder().setDistinctValuesCount(999).build();
@@ -255,9 +255,9 @@ public class CachedStatisticStorageTest {
 
         new MockUp<StatisticsUtils>() {
             @Mock
-            public Table getTableByUUID(String tableUUID) {
+            public Table getTableByUUID(ConnectContext context, String tableUUID) {
                 return connectContext.getGlobalStateMgr().getMetadataMgr().
-                        getTable("hive0", "partitioned_db", "t1");
+                        getTable(connectContext, "hive0", "partitioned_db", "t1");
             }
 
         };
@@ -272,13 +272,13 @@ public class CachedStatisticStorageTest {
 
         Assert.assertEquals(3, result.size());
         Assert.assertEquals(5, result.get(new ConnectorTableColumnKey("hive0.partitioned_db.t1.1234",
-                        "c1")).get().getRowCount());
+                "c1")).get().getRowCount());
         Assert.assertEquals(20, result.get(new ConnectorTableColumnKey("hive0.partitioned_db.t1.1234",
-                        "c1")).get().getColumnStatistic().getAverageRowSize(), 0.0001);
+                "c1")).get().getColumnStatistic().getAverageRowSize(), 0.0001);
         Assert.assertEquals(10, result.get(new ConnectorTableColumnKey("hive0.partitioned_db.t1.1234",
-                        "c1")).get().getColumnStatistic().getMaxValue(), 0.0001);
+                "c1")).get().getColumnStatistic().getMaxValue(), 0.0001);
         Assert.assertEquals(0, result.get(new ConnectorTableColumnKey("hive0.partitioned_db.t1.1234",
-                        "c1")).get().getColumnStatistic().getMinValue(), 0.0001);
+                "c1")).get().getColumnStatistic().getMinValue(), 0.0001);
     }
 
     @Test
@@ -287,7 +287,8 @@ public class CachedStatisticStorageTest {
                     Optional<ConnectorTableColumnStats>> connectorTableCachedStatistics,
             @Mocked LoadingCache<ConnectorTableColumnKey,
                     Optional<ConnectorTableColumnStats>> connectorTableTableSyncCachedStatistics) {
-        Table table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("hive0", "partitioned_db", "t1");
+        Table table =
+                connectContext.getGlobalStateMgr().getMetadataMgr().getTable(connectContext, "hive0", "partitioned_db", "t1");
         List<ConnectorTableColumnKey> cacheKeys =
                 ImmutableList.of(new ConnectorTableColumnKey(table.getUUID(), "c1"),
                         new ConnectorTableColumnKey(table.getUUID(), "c2"));
@@ -327,7 +328,8 @@ public class CachedStatisticStorageTest {
 
     @Test
     public void testExpireConnectorTableColumnStatistics() {
-        Table table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("hive0", "partitioned_db", "t1");
+        Table table =
+                connectContext.getGlobalStateMgr().getMetadataMgr().getTable(connectContext, "hive0", "partitioned_db", "t1");
         CachedStatisticStorage cachedStatisticStorage = new CachedStatisticStorage();
         try {
             cachedStatisticStorage.expireConnectorTableColumnStatistics(table, ImmutableList.of("c1", "c2"));
@@ -338,8 +340,9 @@ public class CachedStatisticStorageTest {
 
     @Test
     public void testGetConnectorHistogramStatistics(@Mocked AsyncLoadingCache<ConnectorTableColumnKey, Optional<Histogram>>
-                                                    histogramCache) {
-        Table table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("hive0", "partitioned_db", "t1");
+                                                            histogramCache) {
+        Table table =
+                connectContext.getGlobalStateMgr().getMetadataMgr().getTable(connectContext, "hive0", "partitioned_db", "t1");
         ConnectorTableColumnKey key = new ConnectorTableColumnKey("hive0.partitioned_db.t1.1234", "c1");
         new Expectations() {
             {
@@ -356,7 +359,8 @@ public class CachedStatisticStorageTest {
 
     @Test
     public void testExpireConnectorHistogramStatistics() {
-        Table table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("hive0", "partitioned_db", "t1");
+        Table table =
+                connectContext.getGlobalStateMgr().getMetadataMgr().getTable(connectContext, "hive0", "partitioned_db", "t1");
         CachedStatisticStorage cachedStatisticStorage = new CachedStatisticStorage();
         try {
             cachedStatisticStorage.expireConnectorHistogramStatistics(table, ImmutableList.of("c1", "c2"));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
@@ -289,7 +289,7 @@ public class StatisticsCalculatorTest {
     @Test
     public void testLogicalIcebergTableScan() {
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
-        Table icebergTable = globalStateMgr.getMetadataMgr().getTable("iceberg0", "partitioned_db", "t1");
+        Table icebergTable = globalStateMgr.getMetadataMgr().getTable(connectContext, "iceberg0", "partitioned_db", "t1");
         List<Column> columns = icebergTable.getColumns();
 
         Map<ColumnRefOperator, Column> refToColumn = Maps.newHashMap();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConnectorPlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConnectorPlanTestBase.java
@@ -310,12 +310,12 @@ public class ConnectorPlanTestBase extends PlanTestBase {
         }
 
         @Override
-        public com.starrocks.catalog.Table getTable(String dbName, String tblName) {
+        public com.starrocks.catalog.Table getTable(ConnectContext context, String dbName, String tblName) {
             return MOCK_TABLE_MAP.get(tblName);
         }
 
         @Override
-        public Database getDb(String dbName) {
+        public Database getDb(ConnectContext context, String dbName) {
             return new Database(GlobalStateMgr.getCurrentState().getNextId(), dbName);
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergEqualityDeletePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergEqualityDeletePlanTest.java
@@ -26,6 +26,7 @@ import com.starrocks.connector.iceberg.hive.IcebergHiveCatalog;
 import com.starrocks.planner.IcebergScanNode;
 import com.starrocks.planner.PlanNodeId;
 import com.starrocks.planner.ScanNode;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.utframe.StarRocksAssert;
@@ -62,7 +63,7 @@ public class IcebergEqualityDeletePlanTest extends TableTestBase {
         starRocksAssert.withCatalog(createCatalog);
         new MockUp<IcebergMetadata>() {
             @Mock
-            public Database getDb(String dbName) {
+            public Database getDb(ConnectContext context, String dbName) {
                 return new Database(1, "db");
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -850,26 +850,24 @@ public class InsertPlanTest extends PlanTestBase {
             }
         };
 
-
         new Expectations(metadata) {
             {
-                metadata.getDb("iceberg_catalog", "iceberg_db");
+                metadata.getDb((ConnectContext) any, "iceberg_catalog", "iceberg_db");
                 result = new Database(12345566, "iceberg_db");
                 minTimes = 0;
 
-
-                metadata.getTable("iceberg_catalog", "iceberg_db", "iceberg_table");
+                metadata.getTable((ConnectContext) any, "iceberg_catalog", "iceberg_db", "iceberg_table");
                 result = icebergTable;
                 minTimes = 0;
             }
         };
-
 
         new MockUp<MetaUtils>() {
             @Mock
             public Database getDatabase(String catalogName, String tableName) {
                 return new Database(12345566, "iceberg_db");
             }
+
             @Mock
             public com.starrocks.catalog.Table getSessionAwareTable(
                     ConnectContext context, Database database, TableName tableName) {

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/AnalyzeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/AnalyzeMgrTest.java
@@ -64,7 +64,8 @@ public class AnalyzeMgrTest {
 
     @Test
     public void testRefreshConnectorTableBasicStatisticsCache(@Mocked CachedStatisticStorage cachedStatisticStorage) {
-        Table table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("hive0", "partitioned_db", "t1");
+        Table table =
+                connectContext.getGlobalStateMgr().getMetadataMgr().getTable(connectContext, "hive0", "partitioned_db", "t1");
 
         AnalyzeMgr analyzeMgr = new AnalyzeMgr();
         analyzeMgr.refreshConnectorTableBasicStatisticsCache("hive0", "partitioned_db", "t1",
@@ -85,7 +86,8 @@ public class AnalyzeMgrTest {
     @Test
     public void testAnalyzeMgrBasicStatsPersist() throws Exception {
         UtFrameUtils.PseudoJournalReplayer.resetFollowerJournalQueue();
-        Table table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("hive0", "partitioned_db", "t1");
+        Table table =
+                connectContext.getGlobalStateMgr().getMetadataMgr().getTable(connectContext, "hive0", "partitioned_db", "t1");
 
         AnalyzeMgr analyzeMgr = new AnalyzeMgr();
         AnalyzeStatus analyzeStatus = new ExternalAnalyzeStatus(100,
@@ -237,7 +239,8 @@ public class AnalyzeMgrTest {
     @Test
     public void testAnalyzeMgrHistogramStatsPersist() throws Exception {
         UtFrameUtils.PseudoJournalReplayer.resetFollowerJournalQueue();
-        Table table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("hive0", "partitioned_db", "t1");
+        Table table =
+                connectContext.getGlobalStateMgr().getMetadataMgr().getTable(connectContext, "hive0", "partitioned_db", "t1");
 
         AnalyzeMgr analyzeMgr = new AnalyzeMgr();
         ExternalHistogramStatsMeta externalHistogramStatsMeta = new ExternalHistogramStatsMeta("hive0", "hive_db",
@@ -288,7 +291,8 @@ public class AnalyzeMgrTest {
 
     @Test
     public void testExternalAnalyzeStatusPersist() throws Exception {
-        Table table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("hive0", "partitioned_db", "t1");
+        Table table =
+                connectContext.getGlobalStateMgr().getMetadataMgr().getTable(connectContext, "hive0", "partitioned_db", "t1");
 
         ExternalAnalyzeStatus analyzeStatus = new ExternalAnalyzeStatus(100,
                 "hive0", "partitioned_db", "t1",
@@ -307,7 +311,8 @@ public class AnalyzeMgrTest {
 
     @Test
     public void testDropExternalAnalyzeStatus() {
-        Table table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("hive0", "partitioned_db", "t1");
+        Table table =
+                connectContext.getGlobalStateMgr().getMetadataMgr().getTable(connectContext, "hive0", "partitioned_db", "t1");
 
         AnalyzeMgr analyzeMgr = new AnalyzeMgr();
         AnalyzeStatus analyzeStatus = new ExternalAnalyzeStatus(100,

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/BasicStatsMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/BasicStatsMetaTest.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.io.Text;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.plan.PlanTestBase;
 import mockit.Expectations;
@@ -53,8 +54,10 @@ public class BasicStatsMetaTest extends PlanTestBase {
     public void testHealthy() {
         {
             // total row in cached table statistic is 6, the updated row is 100.
-            Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb("default_catalog", "test");
-            Table tbl = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("default_catalog", "test", "region");
+            Database db =
+                    GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(new ConnectContext(), "default_catalog", "test");
+            Table tbl = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                    .getTable(new ConnectContext(), "default_catalog", "test", "region");
             List<Partition> partitions = Lists.newArrayList(tbl.getPartitions());
             new Expectations(partitions.get(0)) {
                 {
@@ -70,9 +73,11 @@ public class BasicStatsMetaTest extends PlanTestBase {
 
         {
             // total row in cached table statistic is 10000, the updated row is 10000, the delta row is 5000.
-            Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb("default_catalog", "test");
+            Database db =
+                    GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(new ConnectContext(), "default_catalog", "test");
             Table tbl =
-                    GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("default_catalog", "test", "supplier");
+                    GlobalStateMgr.getCurrentState().getMetadataMgr()
+                            .getTable(new ConnectContext(), "default_catalog", "test", "supplier");
             List<Partition> partitions = Lists.newArrayList(tbl.getPartitions());
             new Expectations(partitions.get(0)) {
                 {
@@ -98,8 +103,9 @@ public class BasicStatsMetaTest extends PlanTestBase {
 
     @Test
     public void testSerialization() throws IOException {
-        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb("default_catalog", "test");
-        Table tbl = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("default_catalog", "test", "region");
+        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(new ConnectContext(), "default_catalog", "test");
+        Table tbl = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                .getTable(new ConnectContext(), "default_catalog", "test", "region");
         {
             ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
             DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/CacheRelaxDictManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/CacheRelaxDictManagerTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.statistic;
 
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
@@ -71,7 +70,8 @@ public class CacheRelaxDictManagerTest {
     }
 
     @After
-    public void tearDown() {}
+    public void tearDown() {
+    }
 
     private TResultBatch generateDictResult(int size) throws TException {
         TStatisticData sd = new TStatisticData();
@@ -103,11 +103,11 @@ public class CacheRelaxDictManagerTest {
     }
 
     @Test
-    public void  testLoader() throws ExecutionException, InterruptedException {
+    public void testLoader() throws ExecutionException, InterruptedException {
         AsyncLoadingCache<ConnectorTableColumnKey, Optional<ColumnDict>> dictStatistics = Caffeine.newBuilder()
                 .maximumSize(Config.statistic_dict_columns)
                 .buildAsync(new CacheRelaxDictManager.DictLoader());
-        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("hive0",
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(ctx, "hive0",
                 "tpch", "part");
         String tableUUID = table.getUUID();
         ConnectorTableColumnKey key = new ConnectorTableColumnKey(tableUUID, "p_mfgr");
@@ -123,11 +123,11 @@ public class CacheRelaxDictManagerTest {
     }
 
     @Test
-    public void  testLoaderError() throws ExecutionException, InterruptedException {
+    public void testLoaderError() throws ExecutionException, InterruptedException {
         AsyncLoadingCache<ConnectorTableColumnKey, Optional<ColumnDict>> dictStatistics = Caffeine.newBuilder()
                 .maximumSize(Config.statistic_dict_columns)
                 .buildAsync(new CacheRelaxDictManager.DictLoader());
-        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("hive0",
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(ctx, "hive0",
                 "tpch", "part");
         String tableUUID = table.getUUID();
         ConnectorTableColumnKey key = new ConnectorTableColumnKey(tableUUID, "p_mfgr");
@@ -143,12 +143,12 @@ public class CacheRelaxDictManagerTest {
     }
 
     @Test
-    public void  testLoaderDeserialize() throws ExecutionException, InterruptedException {
+    public void testLoaderDeserialize() throws ExecutionException, InterruptedException {
         AsyncLoadingCache<ConnectorTableColumnKey, Optional<ColumnDict>> dictStatistics = Caffeine.newBuilder()
                 .maximumSize(Config.statistic_dict_columns)
                 .refreshAfterWrite(1, TimeUnit.SECONDS)
                 .buildAsync(new CacheRelaxDictManager.DictLoader());
-        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("hive0",
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(ctx, "hive0",
                 "tpch", "part");
         String tableUUID = table.getUUID();
         ConnectorTableColumnKey key = new ConnectorTableColumnKey(tableUUID, "p_mfgr");
@@ -169,11 +169,11 @@ public class CacheRelaxDictManagerTest {
     }
 
     @Test
-    public void  testLoaderOversize() throws ExecutionException, InterruptedException {
+    public void testLoaderOversize() throws ExecutionException, InterruptedException {
         AsyncLoadingCache<ConnectorTableColumnKey, Optional<ColumnDict>> dictStatistics = Caffeine.newBuilder()
                 .maximumSize(Config.statistic_dict_columns)
                 .buildAsync(new CacheRelaxDictManager.DictLoader());
-        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("hive0",
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(ctx, "hive0",
                 "tpch", "part");
         String tableUUID = table.getUUID();
         ConnectorTableColumnKey key = new ConnectorTableColumnKey(tableUUID, "p_mfgr");
@@ -192,7 +192,7 @@ public class CacheRelaxDictManagerTest {
 
     @Test
     public void testHasGlobalDict() {
-        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("hive0",
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(ctx, "hive0",
                 "tpch", "part");
         String tableUUID = table.getUUID();
         // clear
@@ -206,7 +206,7 @@ public class CacheRelaxDictManagerTest {
 
     @Test
     public void testGlobalDict() throws InterruptedException, TException {
-        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("hive0",
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(ctx, "hive0",
                 "tpch", "part");
         String tableUUID = table.getUUID();
         // clear

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -477,15 +477,15 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         sql = Deencapsulation.invoke(histogramStatisticsCollectJob, "buildCollectHistogram",
                 db, olapTable, 0.1, 64L, mostCommonValues, "v4", Type.DATE);
         Assert.assertEquals(normalize.apply(String.format("INSERT INTO histogram_statistics(" +
-                        "table_id, column_name, db_id, table_name, buckets, mcv, update_time) SELECT %d, 'v4', %d, " +
-                        "'test" +
-                        ".t0_stats', " +
-                "histogram(`column_key`, cast(64 as int), cast(0.1 as double)),  " +
-                "'[[\"0000-01-01\",\"10\"],[\"1991-01-01\",\"20\"]]', NOW() FROM " +
-                        "( SELECT `v4` as column_key FROM `test`.`t0_stats` where rand() <= 0.100000 and `v4` is not " +
-                        "null  " +
-                        "and `v4` " +
-                        "not in (\"0000-01-01\",\"1991-01-01\") ORDER BY `v4` LIMIT 10000000) t", t0StatsTableId,
+                                "table_id, column_name, db_id, table_name, buckets, mcv, update_time) SELECT %d, 'v4', %d, " +
+                                "'test" +
+                                ".t0_stats', " +
+                                "histogram(`column_key`, cast(64 as int), cast(0.1 as double)),  " +
+                                "'[[\"0000-01-01\",\"10\"],[\"1991-01-01\",\"20\"]]', NOW() FROM " +
+                                "( SELECT `v4` as column_key FROM `test`.`t0_stats` where rand() <= 0.100000 and `v4` is not " +
+                                "null  " +
+                                "and `v4` " +
+                                "not in (\"0000-01-01\",\"1991-01-01\") ORDER BY `v4` LIMIT 10000000) t", t0StatsTableId,
                         dbid)),
                 normalize.apply(sql));
 
@@ -583,8 +583,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
     @Test
     public void testExternalAnalyzeJob() {
-        Database database = connectContext.getGlobalStateMgr().getMetadataMgr().getDb("hive0", "partitioned_db");
-        Table table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("hive0", "partitioned_db", "t1");
+        Database database = connectContext.getGlobalStateMgr().getMetadataMgr().getDb(connectContext, "hive0", "partitioned_db");
+        Table table =
+                connectContext.getGlobalStateMgr().getMetadataMgr().getTable(connectContext, "hive0", "partitioned_db", "t1");
 
         ExternalAnalyzeJob externalAnalyzeJob = new ExternalAnalyzeJob("hive0", database.getFullName(),
                 table.getName(), null, null,
@@ -610,8 +611,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
     @Test
     public void testExternalAnalyzeJobCollect() {
-        Database database = connectContext.getGlobalStateMgr().getMetadataMgr().getDb("hive0", "partitioned_db");
-        Table table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("hive0", "partitioned_db", "t1");
+        Database database = connectContext.getGlobalStateMgr().getMetadataMgr().getDb(connectContext, "hive0", "partitioned_db");
+        Table table =
+                connectContext.getGlobalStateMgr().getMetadataMgr().getTable(connectContext, "hive0", "partitioned_db", "t1");
 
         ExternalAnalyzeJob externalAnalyzeJob = new ExternalAnalyzeJob("hive0", database.getFullName(),
                 table.getName(), null, null,
@@ -809,7 +811,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                 Map<AnalyzeMgr.StatsMetaKey, ExternalBasicStatsMeta> metaMap = Maps.newHashMap();
 
                 ExternalBasicStatsMeta externalBasicStatsMeta = new ExternalBasicStatsMeta("iceberg0",
-                        "partitioned_db", "t1",  List.of("id"), StatsConstants.AnalyzeType.FULL,
+                        "partitioned_db", "t1", List.of("id"), StatsConstants.AnalyzeType.FULL,
                         LocalDateTime.now().plusHours(2), Maps.newHashMap());
                 externalBasicStatsMeta.addColumnStatsMeta(new ColumnStatsMeta("id", StatsConstants.AnalyzeType.FULL,
                         LocalDateTime.now().plusHours(2)));
@@ -915,7 +917,6 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         List<StatisticsCollectJob> statsJobs = StatisticsCollectJobFactory.buildExternalStatisticsCollectJob(analyzeJob);
         Assert.assertEquals(1, statsJobs.size());
 
-
         // test collect statistics time after table update time
         new MockUp<AnalyzeMgr>() {
             @Mock
@@ -924,9 +925,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                 ExternalBasicStatsMeta externalBasicStatsMeta =
                         new ExternalBasicStatsMeta("paimon0", "pmn_db1", "partitioned_table", null,
                                 StatsConstants.AnalyzeType.FULL, LocalDateTime.now().plusHours(20), Maps.newHashMap());
-                externalBasicStatsMeta.addColumnStatsMeta(new ColumnStatsMeta("pk", null,  LocalDateTime.now().plusHours(20)));
-                externalBasicStatsMeta.addColumnStatsMeta(new ColumnStatsMeta("d", null,  LocalDateTime.now().plusHours(20)));
-                externalBasicStatsMeta.addColumnStatsMeta(new ColumnStatsMeta("pt", null,  LocalDateTime.now().plusHours(20)));
+                externalBasicStatsMeta.addColumnStatsMeta(new ColumnStatsMeta("pk", null, LocalDateTime.now().plusHours(20)));
+                externalBasicStatsMeta.addColumnStatsMeta(new ColumnStatsMeta("d", null, LocalDateTime.now().plusHours(20)));
+                externalBasicStatsMeta.addColumnStatsMeta(new ColumnStatsMeta("pt", null, LocalDateTime.now().plusHours(20)));
 
                 metaMap.put(new AnalyzeMgr.StatsMetaKey("paimon0", "pmn_db1", "partitioned_table"), externalBasicStatsMeta);
                 return metaMap;
@@ -967,8 +968,8 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                 ExternalBasicStatsMeta externalBasicStatsMeta =
                         new ExternalBasicStatsMeta("paimon0", "pmn_db1", "unpartitioned_table", null,
                                 StatsConstants.AnalyzeType.FULL, LocalDateTime.now().plusHours(20), Maps.newHashMap());
-                externalBasicStatsMeta.addColumnStatsMeta(new ColumnStatsMeta("pk", null,  LocalDateTime.now().plusHours(20)));
-                externalBasicStatsMeta.addColumnStatsMeta(new ColumnStatsMeta("d", null,  LocalDateTime.now().plusHours(20)));
+                externalBasicStatsMeta.addColumnStatsMeta(new ColumnStatsMeta("pk", null, LocalDateTime.now().plusHours(20)));
+                externalBasicStatsMeta.addColumnStatsMeta(new ColumnStatsMeta("d", null, LocalDateTime.now().plusHours(20)));
                 Map<AnalyzeMgr.StatsMetaKey, ExternalBasicStatsMeta> metaMap = Maps.newHashMap();
                 metaMap.put(new AnalyzeMgr.StatsMetaKey("paimon0", "pmn_db1", "unpartitioned_table"),
                         externalBasicStatsMeta);
@@ -1030,8 +1031,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
     @Test
     public void testExternalFullStatisticsBuildCollectSQLList() {
-        Database database = connectContext.getGlobalStateMgr().getMetadataMgr().getDb("hive0", "partitioned_db");
-        Table table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("hive0", "partitioned_db", "t1");
+        Database database = connectContext.getGlobalStateMgr().getMetadataMgr().getDb(connectContext, "hive0", "partitioned_db");
+        Table table =
+                connectContext.getGlobalStateMgr().getMetadataMgr().getTable(connectContext, "hive0", "partitioned_db", "t1");
 
         ExternalFullStatisticsCollectJob collectJob = (ExternalFullStatisticsCollectJob)
                 StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("hive0",
@@ -1052,8 +1054,8 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         collectSqlList = collectJob.buildCollectSQLList(3);
         Assert.assertEquals(4, collectSqlList.size());
 
-        database = connectContext.getGlobalStateMgr().getMetadataMgr().getDb("hive0", "tpch");
-        table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("hive0", "tpch", "region");
+        database = connectContext.getGlobalStateMgr().getMetadataMgr().getDb(connectContext, "hive0", "tpch");
+        table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable(connectContext, "hive0", "tpch", "region");
         collectJob = (ExternalFullStatisticsCollectJob)
                 StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("hive0",
                         database,
@@ -1070,8 +1072,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         assertContains(collectSqlList.get(0).toString(), "r_regionkey", "r_name", "r_comment");
         assertContains(collectSqlList.get(0).toString(), "1=1");
 
-        database = connectContext.getGlobalStateMgr().getMetadataMgr().getDb("hive0", "partitioned_db");
-        table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("hive0", "partitioned_db", "t1_par_null");
+        database = connectContext.getGlobalStateMgr().getMetadataMgr().getDb(connectContext, "hive0", "partitioned_db");
+        table = connectContext.getGlobalStateMgr().getMetadataMgr()
+                .getTable(connectContext, "hive0", "partitioned_db", "t1_par_null");
         collectJob = (ExternalFullStatisticsCollectJob)
                 StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("hive0",
                         database,
@@ -1094,10 +1097,12 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
     public void testIcebergPartitionTransformFullStatisticsBuildCollectSQLList() {
         // test partition column type is timestamp without time zone
         Database database =
-                connectContext.getGlobalStateMgr().getMetadataMgr().getDb("iceberg0", "partitioned_transforms_db");
+                connectContext.getGlobalStateMgr().getMetadataMgr()
+                        .getDb(connectContext, "iceberg0", "partitioned_transforms_db");
         Table table =
-                connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
-                        "t0_year");
+                connectContext.getGlobalStateMgr().getMetadataMgr()
+                        .getTable(connectContext, "iceberg0", "partitioned_transforms_db",
+                                "t0_year");
 
         ExternalFullStatisticsCollectJob collectJob = (ExternalFullStatisticsCollectJob)
                 StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("iceberg0",
@@ -1111,8 +1116,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         assertContains(collectSqlList.get(0).toString(),
                 "`ts` >= '2019-01-01 00:00:00' and `ts` < '2020-01-01 00:00:00'");
 
-        table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
-                "t0_month");
+        table = connectContext.getGlobalStateMgr().getMetadataMgr()
+                .getTable(connectContext, "iceberg0", "partitioned_transforms_db",
+                        "t0_month");
         collectJob = (ExternalFullStatisticsCollectJob)
                 StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("iceberg0",
                         database,
@@ -1125,8 +1131,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         assertContains(collectSqlList.get(0).toString(),
                 "ts` >= '2022-01-01 00:00:00' and `ts` < '2022-02-01 00:00:00'");
 
-        table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
-                "t0_day");
+        table = connectContext.getGlobalStateMgr().getMetadataMgr()
+                .getTable(connectContext, "iceberg0", "partitioned_transforms_db",
+                        "t0_day");
         collectJob = (ExternalFullStatisticsCollectJob)
                 StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("iceberg0",
                         database,
@@ -1139,8 +1146,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         assertContains(collectSqlList.get(0).toString(),
                 "`ts` >= '2022-01-01 00:00:00' and `ts` < '2022-01-02 00:00:00'");
 
-        table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
-                "t0_hour");
+        table = connectContext.getGlobalStateMgr().getMetadataMgr()
+                .getTable(connectContext, "iceberg0", "partitioned_transforms_db",
+                        "t0_hour");
         collectJob = (ExternalFullStatisticsCollectJob)
                 StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("iceberg0",
                         database,
@@ -1158,8 +1166,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         connectContext.getSessionVariable().setTimeZone("America/New_York");
         connectContext.setThreadLocalInfo();
 
-        table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
-                "t0_year_tz");
+        table = connectContext.getGlobalStateMgr().getMetadataMgr()
+                .getTable(connectContext, "iceberg0", "partitioned_transforms_db",
+                        "t0_year_tz");
         collectJob = (ExternalFullStatisticsCollectJob)
                 StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("iceberg0",
                         database,
@@ -1172,8 +1181,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         assertContains(collectSqlList.get(0).toString(),
                 "`ts` >= '2018-12-31 19:00:00' and `ts` < '2019-12-31 19:00:00'");
 
-        table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
-                "t0_month_tz");
+        table = connectContext.getGlobalStateMgr().getMetadataMgr()
+                .getTable(connectContext, "iceberg0", "partitioned_transforms_db",
+                        "t0_month_tz");
         collectJob = (ExternalFullStatisticsCollectJob)
                 StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("iceberg0",
                         database,
@@ -1186,8 +1196,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         assertContains(collectSqlList.get(0).toString(),
                 "`ts` >= '2021-12-31 19:00:00' and `ts` < '2022-01-31 19:00:00'");
 
-        table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
-                "t0_day_tz");
+        table = connectContext.getGlobalStateMgr().getMetadataMgr()
+                .getTable(connectContext, "iceberg0", "partitioned_transforms_db",
+                        "t0_day_tz");
         collectJob = (ExternalFullStatisticsCollectJob)
                 StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("iceberg0",
                         database,
@@ -1200,8 +1211,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         assertContains(collectSqlList.get(0).toString(),
                 "`ts` >= '2021-12-31 19:00:00' and `ts` < '2022-01-01 19:00:00'");
 
-        table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
-                "t0_hour_tz");
+        table = connectContext.getGlobalStateMgr().getMetadataMgr()
+                .getTable(connectContext, "iceberg0", "partitioned_transforms_db",
+                        "t0_hour_tz");
         collectJob = (ExternalFullStatisticsCollectJob)
                 StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("iceberg0",
                         database,
@@ -1216,8 +1228,8 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         connectContext.getSessionVariable().setTimeZone(oldTimeZone);
 
         // test partition transform is identity
-        database = connectContext.getGlobalStateMgr().getMetadataMgr().getDb("iceberg0", "partitioned_db");
-        table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_db",
+        database = connectContext.getGlobalStateMgr().getMetadataMgr().getDb(connectContext, "iceberg0", "partitioned_db");
+        table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable(connectContext, "iceberg0", "partitioned_db",
                 "t1");
         collectJob = (ExternalFullStatisticsCollectJob)
                 StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("iceberg0",
@@ -1235,10 +1247,12 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
     public void testExternalFullStatisticsBuildCollectSQLWithException1() {
         // test partition transform is bucket
         Database database =
-                connectContext.getGlobalStateMgr().getMetadataMgr().getDb("iceberg0", "partitioned_transforms_db");
+                connectContext.getGlobalStateMgr().getMetadataMgr()
+                        .getDb(connectContext, "iceberg0", "partitioned_transforms_db");
         Table table =
-                connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
-                        "t0_bucket");
+                connectContext.getGlobalStateMgr().getMetadataMgr()
+                        .getTable(connectContext, "iceberg0", "partitioned_transforms_db",
+                                "t0_bucket");
         ExternalFullStatisticsCollectJob collectJob = (ExternalFullStatisticsCollectJob)
                 StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("iceberg0",
                         database,
@@ -1257,9 +1271,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
     public void testExternalFullStatisticsBuildCollectSQLWithException2() {
         // test partition field is null
         Database database =
-                connectContext.getGlobalStateMgr().getMetadataMgr().getDb("iceberg0", "partitioned_db");
+                connectContext.getGlobalStateMgr().getMetadataMgr().getDb(connectContext, "iceberg0", "partitioned_db");
         Table table =
-                connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_db",
+                connectContext.getGlobalStateMgr().getMetadataMgr().getTable(connectContext, "iceberg0", "partitioned_db",
                         "t1");
         ExternalFullStatisticsCollectJob collectJob = (ExternalFullStatisticsCollectJob)
                 StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("iceberg0",
@@ -1285,10 +1299,12 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
     public void testExternalFullStatisticsBuildCollectSQLWithException3() {
         // test partition transform is bucket
         Database database =
-                connectContext.getGlobalStateMgr().getMetadataMgr().getDb("iceberg0", "partitioned_transforms_db");
+                connectContext.getGlobalStateMgr().getMetadataMgr()
+                        .getDb(connectContext, "iceberg0", "partitioned_transforms_db");
         Table table =
-                connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
-                        "t0_date_month_identity_evolution");
+                connectContext.getGlobalStateMgr().getMetadataMgr()
+                        .getTable(connectContext, "iceberg0", "partitioned_transforms_db",
+                                "t0_date_month_identity_evolution");
         ExternalFullStatisticsCollectJob collectJob = (ExternalFullStatisticsCollectJob)
                 StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("iceberg0",
                         database,
@@ -1308,9 +1324,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
     public void testExternalPaimonFullStatisticsBuildCollectSQL() {
         // test partition
         Database database =
-                connectContext.getGlobalStateMgr().getMetadataMgr().getDb("paimon0", "pmn_db1");
+                connectContext.getGlobalStateMgr().getMetadataMgr().getDb(connectContext, "paimon0", "pmn_db1");
         Table table =
-                connectContext.getGlobalStateMgr().getMetadataMgr().getTable("paimon0", "pmn_db1",
+                connectContext.getGlobalStateMgr().getMetadataMgr().getTable(connectContext, "paimon0", "pmn_db1",
                         "partitioned_table");
         ExternalFullStatisticsCollectJob collectJob = (ExternalFullStatisticsCollectJob)
                 StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("paimon0",
@@ -1336,7 +1352,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         Assert.assertEquals(3, lists.size());
 
         //test unpartitioned table
-        table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("paimon0", "pmn_db1",
+        table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable(connectContext, "paimon0", "pmn_db1",
                 "unpartitioned_table");
         //test partition is null
         collectJob = (ExternalFullStatisticsCollectJob)
@@ -1717,7 +1733,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                 " PARTITION BY (c2, c3) " +
                 " PROPERTIES('replication_num'='1')");
         Table table = starRocksAssert.getTable("test", "t_gen_col");
-        List<String> cols =  StatisticUtils.getCollectibleColumns(table);
+        List<String> cols = StatisticUtils.getCollectibleColumns(table);
         Assert.assertTrue(cols.size() == 3);
         Assert.assertTrue(cols.contains("c3"));
         starRocksAssert.dropTable("test.t_gen_col");
@@ -1733,7 +1749,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                 " PARTITION BY c2, date_trunc('month', c1) " +
                 " PROPERTIES('replication_num'='1')");
         Table table = starRocksAssert.getTable("test", "t_gen_col");
-        List<String> cols =  StatisticUtils.getCollectibleColumns(table);
+        List<String> cols = StatisticUtils.getCollectibleColumns(table);
         Assert.assertTrue(cols.size() == 2);
         starRocksAssert.dropTable("test.t_gen_col");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
@@ -77,7 +77,7 @@ public class StatisticsExecutorTest extends PlanTestBase {
         Partition partition = new ArrayList<>(t0.getPartitions()).get(0);
         partition.getDefaultPhysicalPartition()
                 .updateVisibleVersion(2, LocalDateTime.of(2022, 1, 1, 1, 1, 1)
-                .atZone(Clock.systemDefaultZone().getZone()).toEpochSecond() * 1000);
+                        .atZone(Clock.systemDefaultZone().getZone()).toEpochSecond() * 1000);
         setTableStatistics(t0, 20000000);
     }
 
@@ -157,7 +157,7 @@ public class StatisticsExecutorTest extends PlanTestBase {
         };
 
         ConnectContext context = StatisticUtils.buildConnectContext();
-        Table table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("hive0", "partitioned_db",
+        Table table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable(connectContext, "hive0", "partitioned_db",
                 "t1");
         String tableUUID = table.getUUID();
         StatisticExecutor statisticExecutor = new StatisticExecutor();
@@ -203,8 +203,9 @@ public class StatisticsExecutorTest extends PlanTestBase {
                 "test123", Lists.newArrayList(), StatsConstants.AnalyzeType.FULL,
                 StatsConstants.ScheduleType.SCHEDULE, Maps.newHashMap(), LocalDateTime.MIN);
 
-        Database db = connectContext.getGlobalStateMgr().getMetadataMgr().getDb("hive0", "partitioned_db");
-        Table table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("hive0", "partitioned_db", "t1");
+        Database db = connectContext.getGlobalStateMgr().getMetadataMgr().getDb(connectContext, "hive0", "partitioned_db");
+        Table table =
+                connectContext.getGlobalStateMgr().getMetadataMgr().getTable(connectContext, "hive0", "partitioned_db", "t1");
 
         Deencapsulation.invoke(executor, "executeAnalyze", connectContext, stmt, pendingStatus, db, table);
         Assert.assertTrue(stmt.isExternal());
@@ -233,7 +234,7 @@ public class StatisticsExecutorTest extends PlanTestBase {
         StatisticsCollectJob statisticsCollectJob = new ExternalFullStatisticsCollectJob("test_catalog",
                 database, table, List.of(), Lists.newArrayList("col1", "col2"),
                 Lists.newArrayList(Type.INT, Type.INT),
-                StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.ONCE,  Maps.newHashMap());
+                StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.ONCE, Maps.newHashMap());
 
         new MockUp<ExternalFullStatisticsCollectJob>() {
             @Mock
@@ -257,7 +258,7 @@ public class StatisticsExecutorTest extends PlanTestBase {
         statisticsCollectJob = new ExternalFullStatisticsCollectJob("test_catalog",
                 database, table, List.of(), Lists.newArrayList("col1", "col3"),
                 Lists.newArrayList(Type.INT, Type.STRING),
-                StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.ONCE,  Maps.newHashMap());
+                StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.ONCE, Maps.newHashMap());
         statisticExecutor.collectStatistics(connectContext, statisticsCollectJob, status, false);
         externalBasicStatsMeta = GlobalStateMgr.getCurrentState().getAnalyzeMgr().
                 getExternalTableBasicStatsMeta("test_catalog", "test_db", "test_table");

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
@@ -240,9 +240,9 @@ public class StatisticsSQLTest extends PlanTestBase {
 
     @Test
     public void testHiveHistogramStatisticsSQLWithStruct() throws Exception {
-        Table t0 = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("hive0", "subfield_db",
+        Table t0 = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(connectContext, "hive0", "subfield_db",
                 "subfield");
-        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb("hive0", "subfield_db");
+        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(connectContext, "hive0", "subfield_db");
 
         List<String> columnNames = Lists.newArrayList("col_struct.c0", "col_struct.c1.c11");
         ExternalHistogramStatisticsCollectJob hiveHistogramStatisticsCollectJob = new ExternalHistogramStatisticsCollectJob(

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -183,7 +183,7 @@ public class StarRocksAssert {
         DropDbStmt dropDbStmt =
                     (DropDbStmt) UtFrameUtils.parseStmtWithNewParser("drop database if exists `" + dbName + "`;", ctx);
         try {
-            GlobalStateMgr.getCurrentState().getLocalMetastore().dropDb(dropDbStmt.getDbName(), dropDbStmt.isForceDrop());
+            GlobalStateMgr.getCurrentState().getLocalMetastore().dropDb(ctx, dropDbStmt.getDbName(), dropDbStmt.isForceDrop());
         } catch (MetaNotFoundException e) {
             if (!dropDbStmt.isSetIfExists()) {
                 ErrorReport.reportDdlException(ErrorCode.ERR_DB_DROP_EXISTS, dbName);
@@ -760,7 +760,7 @@ public class StarRocksAssert {
     public StarRocksAssert dropDatabase(String dbName) throws Exception {
         DropDbStmt dropDbStmt =
                     (DropDbStmt) UtFrameUtils.parseStmtWithNewParser("drop database " + dbName + ";", ctx);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().dropDb(dropDbStmt.getDbName(), dropDbStmt.isForceDrop());
+        GlobalStateMgr.getCurrentState().getLocalMetastore().dropDb(ctx, dropDbStmt.getDbName(), dropDbStmt.isForceDrop());
         return this;
     }
 


### PR DESCRIPTION
## Why I'm doing:
refer #56921 Fixes #56921
## What I'm doing:

1. Modified some interfaces in ConnectorMetadata, mainly including listDbNames, getDb, listTableNames, getTable, tableExists and related upstream calling codes.
2. Some of the logic flow modifications were incomplete, for example, Not use the ConnectContext created when the connection was established , but a new ConnectContext was used (because the Context was lost or could not be obtained at the current code location, which required case-by-case modifications). This requires subsequent optimization, but at least we have completed the most complex part.
3. No existing logic has been modified, only the parameter passing has been added


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0