### PR TITLE
[Enhancement] Support modification of storage volume type and location in cluster snapshot restoration

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -170,6 +170,15 @@ public class StarOSAgent {
         }
     }
 
+    public void replaceFileStore(FileStoreInfo fsInfo) throws DdlException {
+        prepare();
+        try {
+            client.replaceFileStore(fsInfo, serviceId);
+        } catch (StarClientException e) {
+            throw new DdlException("Failed to update file store, error: " + e.getMessage());
+        }
+    }
+
     public FileStoreInfo getFileStoreByName(String fsName) throws DdlException {
         prepare();
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StorageInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StorageInfo.java
@@ -51,6 +51,10 @@ public class StorageInfo implements GsonPreProcessable, GsonPostProcessable {
         return storeInfo;
     }
 
+    public void setFilePathInfo(FilePathInfo filePathInfo) {
+        this.storeInfo = filePathInfo;
+    }
+
     public FileCacheInfo getCacheInfo() {
         return cacheInfo;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgr.java
@@ -243,12 +243,19 @@ public class RestoreClusterSnapshotMgr {
             return;
         }
 
-        StorageVolumeMgr storageVolumeMgr = GlobalStateMgr.getCurrentState().getStorageVolumeMgr();
-        for (ClusterSnapshotConfig.StorageVolume storageVolume : storageVolumes) {
-            LOG.info("Update storage volume {}", storageVolume.getName());
-            storageVolumeMgr.updateStorageVolume(storageVolume.getName(), storageVolume.getType(),
-                    Collections.singletonList(storageVolume.getLocation()), storageVolume.getProperties(),
-                    storageVolume.getComment());
+        boolean oldValue = com.staros.util.Config.STARMGR_REPLACE_FILESTORE_ENABLED;
+        com.staros.util.Config.STARMGR_REPLACE_FILESTORE_ENABLED = true;
+        try {
+            StorageVolumeMgr storageVolumeMgr = GlobalStateMgr.getCurrentState().getStorageVolumeMgr();
+            for (ClusterSnapshotConfig.StorageVolume storageVolume : storageVolumes) {
+                LOG.info("Update storage volume {}", storageVolume.getName());
+                List<String> locations = storageVolume.getLocation() == null ? null
+                        : Collections.singletonList(storageVolume.getLocation());
+                storageVolumeMgr.replaceStorageVolume(storageVolume.getName(), storageVolume.getType(),
+                        locations, storageVolume.getProperties(), storageVolume.getComment());
+            }
+        } finally {
+            com.staros.util.Config.STARMGR_REPLACE_FILESTORE_ENABLED = oldValue;
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -1053,6 +1053,11 @@ public class EditLog {
                     globalStateMgr.getStorageVolumeMgr().replayDropStorageVolume(log);
                     break;
                 }
+                case OperationType.OP_UPDATE_TABLE_STORAGE_INFOS: {
+                    TableStorageInfos tableStorageInfos = (TableStorageInfos) journal.data();
+                    globalStateMgr.getStorageVolumeMgr().replayUpdateTableStorageInfos(tableStorageInfos);
+                    break;
+                }
                 case OperationType.OP_PIPE: {
                     PipeOpEntry opEntry = (PipeOpEntry) journal.data();
                     globalStateMgr.getPipeManager().getRepo().replay(opEntry);
@@ -2030,6 +2035,10 @@ public class EditLog {
 
     public void logDropStorageVolume(DropStorageVolumeLog log) {
         logEdit(OperationType.OP_DROP_STORAGE_VOLUME, log);
+    }
+
+    public void logUpdateTableStorageInfos(TableStorageInfos tableStorageInfos) {
+        logEdit(OperationType.OP_UPDATE_TABLE_STORAGE_INFOS, tableStorageInfos);
     }
 
     public void logReplicationJob(ReplicationJob replicationJob) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLogDeserializer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLogDeserializer.java
@@ -230,6 +230,7 @@ public class EditLogDeserializer {
             .put(OperationType.OP_DROP_STORAGE_VOLUME, DropStorageVolumeLog.class)
             .put(OperationType.OP_CREATE_STORAGE_VOLUME, StorageVolume.class)
             .put(OperationType.OP_UPDATE_STORAGE_VOLUME, StorageVolume.class)
+            .put(OperationType.OP_UPDATE_TABLE_STORAGE_INFOS, TableStorageInfos.class)
             .put(OperationType.OP_PIPE, PipeOpEntry.class)
             .put(OperationType.OP_CREATE_DICTIONARY, Dictionary.class)
             .put(OperationType.OP_DROP_DICTIONARY, DropDictionaryInfo.class)

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -551,6 +551,9 @@ public class OperationType {
     @IgnorableOnReplayFailed
     public static final short OP_DROP_STORAGE_VOLUME = 13103;
 
+    @IgnorableOnReplayFailed
+    public static final short OP_UPDATE_TABLE_STORAGE_INFOS = 13104;
+
     // Pipe operations log
     @IgnorableOnReplayFailed
     public static final short OP_PIPE = 12200;

--- a/fe/fe-core/src/main/java/com/starrocks/persist/TableStorageInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/TableStorageInfo.java
@@ -1,0 +1,69 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.persist;
+
+import com.google.gson.annotations.SerializedName;
+import com.staros.proto.FilePathInfo;
+import com.starrocks.common.io.Text;
+import com.starrocks.common.io.Writable;
+import com.starrocks.persist.gson.GsonPostProcessable;
+import com.starrocks.persist.gson.GsonPreProcessable;
+import com.starrocks.persist.gson.GsonUtils;
+
+import java.io.DataInput;
+import java.io.IOException;
+
+public class TableStorageInfo implements Writable, GsonPreProcessable, GsonPostProcessable {
+    @SerializedName(value = "tableId")
+    private long tableId;
+
+    private FilePathInfo filePathInfo;
+    @SerializedName(value = "filePathInfoBytes")
+    private byte[] filePathInfoBytes;
+
+    public TableStorageInfo(long tableId, FilePathInfo filePathInfo) {
+        this.tableId = tableId;
+        this.filePathInfo = filePathInfo;
+    }
+
+    public long getTableId() {
+        return tableId;
+    }
+
+    public FilePathInfo getFilePathInfo() {
+        return filePathInfo;
+    }
+
+    @Override
+    public void gsonPreProcess() throws IOException {
+        if (filePathInfo != null) {
+            filePathInfoBytes = filePathInfo.toByteArray();
+        }
+    }
+
+    @Override
+    public void gsonPostProcess() throws IOException {
+        if (filePathInfoBytes != null) {
+            filePathInfo = FilePathInfo.parseFrom(filePathInfoBytes);
+        }
+    }
+
+    public static TableStorageInfo read(DataInput in) throws IOException {
+        return GsonUtils.GSON.fromJson(Text.readString(in), TableStorageInfo.class);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/TableStorageInfos.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/TableStorageInfos.java
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.persist;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.io.Text;
+import com.starrocks.common.io.Writable;
+import com.starrocks.persist.gson.GsonUtils;
+
+import java.io.DataInput;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class TableStorageInfos implements Writable {
+
+    @SerializedName(value = "dbToTableStorageInfos")
+    private Map<Long, List<TableStorageInfo>> dbToTableStorageInfos;
+
+    public TableStorageInfos() {
+    }
+
+    public TableStorageInfos(Map<Long, List<TableStorageInfo>> dbToTableStorageInfos) {
+        this.dbToTableStorageInfos = dbToTableStorageInfos;
+    }
+
+    public Map<Long, List<TableStorageInfo>> getDbToTableStorageInfos() {
+        return dbToTableStorageInfos;
+    }
+
+    public static TableStorageInfos read(DataInput in) throws IOException {
+        return GsonUtils.GSON.fromJson(Text.readString(in), TableStorageInfos.class);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/server/SharedNothingStorageVolumeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/SharedNothingStorageVolumeMgr.java
@@ -82,6 +82,12 @@ public class SharedNothingStorageVolumeMgr extends StorageVolumeMgr {
     }
 
     @Override
+    protected void replaceInternalNoLock(StorageVolume sv) {
+        GlobalStateMgr.getCurrentState().getEditLog().logUpdateStorageVolume(sv);
+        idToSV.put(sv.getId(), sv);
+    }
+
+    @Override
     protected void removeInternalNoLock(StorageVolume sv) {
         DropStorageVolumeLog log = new DropStorageVolumeLog(sv.getId());
         GlobalStateMgr.getCurrentState().getEditLog().logDropStorageVolume(log);
@@ -162,5 +168,10 @@ public class SharedNothingStorageVolumeMgr extends StorageVolumeMgr {
     @Override
     protected List<List<Long>> getBindingsOfBuiltinStorageVolume() {
         return new ArrayList<>(Arrays.asList(new ArrayList<Long>(), new ArrayList<Long>()));
+    }
+
+    @Override
+    protected void updateTableStorageInfo(String storageVolumeId) throws DdlException {
+
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
+++ b/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
@@ -197,7 +197,7 @@ public class StorageVolume implements Writable, GsonPostProcessable {
         return params;
     }
 
-    private StorageVolumeType toStorageVolumeType(String svt) {
+    public static StorageVolumeType toStorageVolumeType(String svt) {
         switch (svt.toLowerCase()) {
             case "s3":
                 return StorageVolumeType.S3;

--- a/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgrTest.java
@@ -14,29 +14,102 @@
 
 package com.starrocks.lake.snapshot;
 
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.DdlException;
 import com.starrocks.common.StarRocksException;
-import com.starrocks.fs.hdfs.HdfsFsManager;
+import com.starrocks.fs.HdfsUtil;
+import com.starrocks.ha.FrontendNodeType;
+import com.starrocks.journal.JournalEntity;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.OperationType;
 import com.starrocks.persist.Storage;
+import com.starrocks.persist.TableStorageInfos;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.NodeMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.storagevolume.StorageVolume;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Invocation;
 import mockit.Mock;
 import mockit.MockUp;
+import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
 public class RestoreClusterSnapshotMgrTest {
+    protected static ConnectContext connectContext;
+    protected static StarRocksAssert starRocksAssert;
+    protected static String DB_NAME = "test";
+
     @BeforeClass
     public static void beforeClass() throws Exception {
-        UtFrameUtils.createMinStarRocksCluster();
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withDatabase(DB_NAME).useDatabase(DB_NAME);
+
+        new MockUp<FileUtils>() {
+            @Mock
+            public boolean deleteQuietly(File file) {
+                return true;
+            }
+        };
+
+        new MockUp<NodeMgr>() {
+            @Mock
+            public void dropFrontend(FrontendNodeType role, String host, int port) throws DdlException {
+                return;
+            }
+
+            @Mock
+            public void addFrontend(FrontendNodeType role, String host, int editLogPort) throws DdlException {
+                return;
+            }
+
+        };
+
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public void dropBackend(String host, int heartbeatPort, String warehouse, boolean needCheckWithoutForce)
+                    throws DdlException {
+                return;
+            }
+
+            @Mock
+            public void dropComputeNode(String host, int heartbeatPort, String warehouse) throws DdlException {
+                return;
+            }
+
+            @Mock
+            public void addComputeNode(String host, int heartbeatPort, String warehouse) throws DdlException {
+                return;
+            }
+        };
     }
 
     @Test
     public void testDownloadSnapshotFailed() throws Exception {
+        new MockUp<HdfsUtil>() {
+            @Mock
+            public void copyToLocal(String srcPath, String destPath, Map<String, String> properties)
+                    throws StarRocksException {
+                throw new StarRocksException("Copy failed");
+            }
+        };
+
         Assert.assertThrows(StarRocksException.class, () -> {
             RestoreClusterSnapshotMgr.init("src/test/resources/conf/cluster_snapshot.yaml",
                     new String[] { "-cluster_snapshot" });
@@ -48,7 +121,15 @@ public class RestoreClusterSnapshotMgrTest {
     }
 
     @Test
-    public void testNormal() throws Exception {
+    public void testUpdateStorageVolume() throws Exception {
+        new MockUp<HdfsUtil>() {
+            @Mock
+            public void copyToLocal(String srcPath, String destPath, Map<String, String> properties)
+                    throws StarRocksException {
+                return;
+            }
+        };
+
         new MockUp<Storage>() {
             @Mock
             public long getImageJournalId() {
@@ -56,28 +137,64 @@ public class RestoreClusterSnapshotMgrTest {
             }
         };
 
-        new MockUp<HdfsFsManager>() {
+        new MockUp<EditLog>() {
             @Mock
-            public void copyToLocal(String srcPath, String destPath, Map<String, String> properties) {
-                return;
-            } // IOException
+            public void logUpdateTableStorageInfos(Invocation invocation, TableStorageInfos tableStorageInfos) {
+                invocation.proceed();
+                ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+                try (DataOutputStream out = new DataOutputStream(byteOut)) {
+                    tableStorageInfos.write(out);
+                    try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(byteOut.toByteArray()))) {
+                        TableStorageInfos newTableStorageInfos = TableStorageInfos.read(in);
+                        GlobalStateMgr.getCurrentState().getEditLog().loadJournal(GlobalStateMgr.getCurrentState(),
+                                new JournalEntity(OperationType.OP_UPDATE_TABLE_STORAGE_INFOS, newTableStorageInfos));
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
         };
 
         RestoreClusterSnapshotMgr.init("src/test/resources/conf/cluster_snapshot.yaml",
                 new String[] { "-cluster_snapshot" });
+
         Assert.assertTrue(RestoreClusterSnapshotMgr.getRestoredSnapshotInfo().getSnapshotName()
                 .equals("automated_cluster_snapshot_1704038400000"));
         Assert.assertTrue(RestoreClusterSnapshotMgr.getRestoredSnapshotInfo().getFeJournalId() == 10L);
         Assert.assertTrue(RestoreClusterSnapshotMgr.getRestoredSnapshotInfo().getStarMgrJournalId() == 10L);
         Assert.assertTrue(RestoreClusterSnapshotMgr.isRestoring());
 
-        for (ClusterSnapshotConfig.StorageVolume sv : RestoreClusterSnapshotMgr.getConfig().getStorageVolumes()) {
-            GlobalStateMgr.getCurrentState().getStorageVolumeMgr().createStorageVolume(sv.getName(), sv.getType(),
-                    Collections.singletonList(sv.getLocation()), sv.getProperties(), Optional.of(true),
-                    sv.getComment());
-        }
+        ClusterSnapshotConfig.StorageVolume sv1 = RestoreClusterSnapshotMgr.getConfig().getStorageVolumes().get(0);
+        ClusterSnapshotConfig.StorageVolume sv2 = RestoreClusterSnapshotMgr.getConfig().getStorageVolumes().get(1);
+        RestoreClusterSnapshotMgr.getConfig().getStorageVolumes().remove(0);
+
+        GlobalStateMgr.getCurrentState().getStorageVolumeMgr().createStorageVolume(sv2.getName(), sv1.getType(),
+                Collections.singletonList(sv1.getLocation()), sv1.getProperties(), Optional.of(true),
+                sv1.getComment());
+
+        String sql = "create table single_partition_duplicate_key (key1 int, key2 varchar(10))\n" +
+                "distributed by hash(key1) buckets 1\n" +
+                "properties('replication_num' = '1', 'storage_volume' = '" + sv2.getName() + "'); ";
+        starRocksAssert.withTable(sql);
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(DB_NAME, "single_partition_duplicate_key");
+
+        String oldStoragePath = table.getTableProperty().getStorageInfo().getFilePathInfo().getFullPath();
 
         RestoreClusterSnapshotMgr.finishRestoring();
         Assert.assertFalse(RestoreClusterSnapshotMgr.isRestoring());
+
+        StorageVolume storageVolume = GlobalStateMgr.getCurrentState().getStorageVolumeMgr()
+                .getStorageVolumeByName(sv2.getName());
+
+        Assert.assertEquals(storageVolume.getName(), sv2.getName());
+        Assert.assertEquals(storageVolume.getType(), sv2.getType());
+        Assert.assertEquals(storageVolume.getLocations().get(0), sv2.getLocation());
+        Assert.assertEquals(storageVolume.getComment(), sv2.getComment());
+
+        String newStoragePath = table.getTableProperty().getStorageInfo().getFilePathInfo().getFullPath();
+        Assert.assertNotEquals(oldStoragePath, newStoragePath);
+        Assert.assertTrue(oldStoragePath.startsWith(sv1.getLocation()));
+        Assert.assertTrue(newStoragePath.startsWith(sv2.getLocation()));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/persist/OperationTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/OperationTypeTest.java
@@ -140,6 +140,7 @@ public class OperationTypeTest {
         Assert.assertTrue(OperationType.IGNORABLE_OPERATIONS.contains(OperationType.OP_CREATE_STORAGE_VOLUME));
         Assert.assertTrue(OperationType.IGNORABLE_OPERATIONS.contains(OperationType.OP_UPDATE_STORAGE_VOLUME));
         Assert.assertTrue(OperationType.IGNORABLE_OPERATIONS.contains(OperationType.OP_DROP_STORAGE_VOLUME));
+        Assert.assertTrue(OperationType.IGNORABLE_OPERATIONS.contains(OperationType.OP_UPDATE_TABLE_STORAGE_INFOS));
         Assert.assertTrue(OperationType.IGNORABLE_OPERATIONS.contains(OperationType.OP_PIPE));
         Assert.assertTrue(OperationType.IGNORABLE_OPERATIONS.contains(
                 OperationType.OP_MODIFY_PRIMARY_INDEX_CACHE_EXPIRE_SEC));


### PR DESCRIPTION
## Why I'm doing:
When restored from a cloned snapshot, the storage volume type and location have to support modification.

## What I'm doing:
Support modification of storage volume type and location in cluster snapshot restoration.
After restored from a cloned snapshot, the storage infos of related tables are also updated.

Fixes https://github.com/StarRocks/starrocks/issues/53867

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0