### PR TITLE
[BugFix] Fixed the issue that the column_name returned by MCV of histogram was unstable when the data remained unchanged

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/HistogramStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/HistogramStatisticsCollectJob.java
@@ -58,7 +58,7 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
                     "FROM `$dbName`.`$tableName` $sampleClause " +
                     "WHERE $columnName is not null " +
                     "GROUP BY $columnName " +
-                    "ORDER BY count($columnName) desc limit $topN ) t";
+                    "ORDER BY count($columnName) desc, $columnName limit $topN ) t";
 
     public HistogramStatisticsCollectJob(Database db, Table table, List<String> columnNames, List<Type> columnTypes,
                                          StatsConstants.ScheduleType scheduleType, Map<String, String> properties) {

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -525,7 +525,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                 " as db_id, " + t0StatsTableId +
                 " as table_id, `v2` as column_key, count(`v2`) as column_value from `test`.`t0_stats` sample" +
                 "('percent'='10') " +
-                "where `v2` is not null group by `v2` order by count(`v2`) desc limit 100 ) t"), normalize.apply(sql));
+                "where `v2` is not null group by `v2` order by count(`v2`), `v2` desc limit 100 ) t"), normalize.apply(sql));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -525,7 +525,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                 " as db_id, " + t0StatsTableId +
                 " as table_id, `v2` as column_key, count(`v2`) as column_value from `test`.`t0_stats` sample" +
                 "('percent'='10') " +
-                "where `v2` is not null group by `v2` order by count(`v2`), `v2` desc limit 100 ) t"), normalize.apply(sql));
+                "where `v2` is not null group by `v2` order by count(`v2`) desc, `v2` limit 100 ) t"), normalize.apply(sql));
     }
 
     @Test


### PR DESCRIPTION
Fixed the issue that the returned column_name field was unstable when the number of count(column_name) rows was the same.
```sql
+----------------------+-----------------------+--------------------------+-----------------------------+-------------------------------+
| CAST(version AS INT) | CAST(db_id AS BIGINT) | CAST(table_id AS BIGINT) | CAST(column_key AS VARCHAR) | CAST(column_value AS VARCHAR) |
+----------------------+-----------------------+--------------------------+-----------------------------+-------------------------------+
|                    2 |                 10238 |                  5683195 | 5105235199998               | 47                            |
|                    2 |                 10238 |                  5683195 | 5305623758197               | 47                            |
|                    2 |                 10238 |                  5683195 | 5312244911480               | 47                            |
|                    2 |                 10238 |                  5683195 | 5650545796119               | 47                            |
|                    2 |                 10238 |                  5683195 | 5671483624631               | 47                            |
|                    2 |                 10238 |                  5683195 | 5743754003624               | 47                            |
|                    2 |                 10238 |                  5683195 | 5743754003625               | 47                            |
+----------------------+-----------------------+--------------------------+-----------------------------+-------------------------------+
```

```sql
+----------------------+-----------------------+--------------------------+-----------------------------+-------------------------------+
| CAST(version AS INT) | CAST(db_id AS BIGINT) | CAST(table_id AS BIGINT) | CAST(column_key AS VARCHAR) | CAST(column_value AS VARCHAR) |
+----------------------+-----------------------+--------------------------+-----------------------------+-------------------------------+
|                    2 |                 10238 |                  5683195 | 5305623758197               | 47                            |
|                    2 |                 10238 |                  5683195 | 5743754003624               | 47                            |
|                    2 |                 10238 |                  5683195 | 5743754003625               | 47                            |
|                    2 |                 10238 |                  5683195 | 5650545796119               | 47                            |
|                    2 |                 10238 |                  5683195 | 5312244911480               | 47                            |
|                    2 |                 10238 |                  5683195 | 5671483624631               | 47                            |
|                    2 |                 10238 |                  5683195 | 5869551863359               | 47                            |
+----------------------+-----------------------+--------------------------+-----------------------------+-------------------------------+
```

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0