### PR TITLE
[BugFix] fix list partition duplicate cardinality estimation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -424,6 +424,10 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
             return;
         }
         long tableRows = 0;
+
+        // This block is reentrant. This is the first cardinality estimation of the scan node.
+        // we need to ensure that the state of each predicate is reset before each entry.
+        Utils.extractConjuncts(predicate).forEach(op -> op.setNotEvalEstimate(false));
         predicate = removePartitionPredicate(predicate, node, optimizerContext);
         for (var entry : partitionStatistics.entrySet()) {
             Statistics partitionStat = estimateStatistics(ImmutableList.of(predicate), entry.getValue());
@@ -433,8 +437,9 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
             }
             tableRows += partitionSelectedRows;
         }
+        // For scan node, there is no need to evaluate the predicate later.
+        Utils.extractConjuncts(predicate).forEach(op -> op.setNotEvalEstimate(true));
         // adjust output rows
-        predicate.setNotEvalEstimate(true);
         statistics.setOutputRowCount(tableRows);
 
         // adjust output column statistics if possible

--- a/test/sql/test_list_partition/R/test_list_partition_cardinality
+++ b/test/sql/test_list_partition/R/test_list_partition_cardinality
@@ -13,7 +13,7 @@ CREATE TABLE partitions_multi_column_1 (
     c2 int NOT NULL,
     c3 int
 )
-PARTITION BY (c1, c2);
+PARTITION BY (c1, c2) properties("replication_num" = "1");
 -- result:
 -- !result
 INSERT INTO partitions_multi_column_1 VALUES
@@ -76,6 +76,38 @@ function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi
 None
 -- !result
 function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c2=7', 'cardinality: 1000')
+-- result:
+None
+-- !result
+CREATE TABLE partitions_multi_column_2 (
+    c1 int,
+    c2 int,
+    c3 int,
+    p1 int
+)
+PARTITION BY (p1) properties("replication_num" = "1");
+-- result:
+-- !result
+insert into partitions_multi_column_2 select generate_series % 10, generate_series % 10, generate_series % 10, 1 from table(generate_series(1, 1000000));
+-- result:
+-- !result
+insert into partitions_multi_column_2 select generate_series % 10, generate_series % 10, generate_series % 10, 2 from table(generate_series(1, 1000000));
+-- result:
+-- !result
+insert into partitions_multi_column_2 select generate_series % 10, generate_series % 10, generate_series % 10, 3 from table(generate_series(1, 1000000));
+-- result:
+-- !result
+insert into partitions_multi_column_2 select generate_series % 10, generate_series % 10, generate_series % 10, 4 from table(generate_series(1, 1000000));
+-- result:
+-- !result
+insert into partitions_multi_column_2 select generate_series % 10, generate_series % 10, generate_series % 10, 5 from table(generate_series(1, 1000000));
+-- result:
+-- !result
+ANALYZE FULL TABLE partitions_multi_column_2 WITH SYNC MODE;
+-- result:
+test_list_partition_cardinality.partitions_multi_column_2	analyze	status	OK
+-- !result
+function: assert_explain_costs_contains('SELECT * FROM partitions_multi_column_2 WHERE c1=1 AND c2=1 AND c3=1 AND p1=1', 'cardinality: 1000')
 -- result:
 None
 -- !result

--- a/test/sql/test_list_partition/T/test_list_partition_cardinality
+++ b/test/sql/test_list_partition/T/test_list_partition_cardinality
@@ -9,7 +9,7 @@ CREATE TABLE partitions_multi_column_1 (
     c2 int NOT NULL,
     c3 int
 )
-PARTITION BY (c1, c2);
+PARTITION BY (c1, c2) properties("replication_num" = "1");
 
 INSERT INTO partitions_multi_column_1 VALUES
     (1,1,1),
@@ -39,3 +39,20 @@ function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi
 function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c2=2', 'cardinality: 3')
 function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c2=3', 'cardinality: 1')
 function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c2=7', 'cardinality: 1000')
+
+CREATE TABLE partitions_multi_column_2 (
+    c1 int,
+    c2 int,
+    c3 int,
+    p1 int
+)
+PARTITION BY (p1) properties("replication_num" = "1");
+
+insert into partitions_multi_column_2 select generate_series % 10, generate_series % 10, generate_series % 10, 1 from table(generate_series(1, 1000000));
+insert into partitions_multi_column_2 select generate_series % 10, generate_series % 10, generate_series % 10, 2 from table(generate_series(1, 1000000));
+insert into partitions_multi_column_2 select generate_series % 10, generate_series % 10, generate_series % 10, 3 from table(generate_series(1, 1000000));
+insert into partitions_multi_column_2 select generate_series % 10, generate_series % 10, generate_series % 10, 4 from table(generate_series(1, 1000000));
+insert into partitions_multi_column_2 select generate_series % 10, generate_series % 10, generate_series % 10, 5 from table(generate_series(1, 1000000));
+
+ANALYZE FULL TABLE partitions_multi_column_2 WITH SYNC MODE;
+function: assert_explain_costs_contains('SELECT * FROM partitions_multi_column_2 WHERE c1=1 AND c2=1 AND c3=1 AND p1=1', 'cardinality: 1000')

--- a/test/sql/test_list_partition/T/test_list_partition_selectivity
+++ b/test/sql/test_list_partition/T/test_list_partition_selectivity
@@ -43,3 +43,20 @@ function: assert_explain_costs_contains('SELECT c2, c3 FROM partitions_multi_col
 function: assert_explain_costs_contains('SELECT c2, c3 FROM partitions_multi_column_1 WHERE c1 IN (3,4) AND c2=0 ', 'cardinality: 200', 'c3-->[1.0, 1000.0, 0.0, 4.0, 100.0]')
 function: assert_explain_costs_contains('SELECT c2, c3 FROM partitions_multi_column_1 WHERE c1 IN (2,4) AND c2=0 ', 'cardinality: 200', 'c3-->[1.0, 1000.0, 0.0, 4.0, 100.0]')
 function: assert_explain_costs_contains('SELECT c2, c3 FROM partitions_multi_column_1 WHERE c1 IN (2,4) ', 'cardinality: 200', 'c3-->[1.0, 1000.0, 0.0, 4.0, 100.0]')
+
+CREATE TABLE partitions_multi_column_2 (
+    c1 int,
+    c2 int,
+    c3 int,
+    p1 int
+)
+PARTITION BY (p1);
+
+insert into partitions_multi_column_2 select generate_series % 10, generate_series % 10, generate_series % 10, 1 from table(generate_series(1, 1000000));
+insert into partitions_multi_column_2 select generate_series % 10, generate_series % 10, generate_series % 10, 1 from table(generate_series(2, 1000000));
+insert into partitions_multi_column_2 select generate_series % 10, generate_series % 10, generate_series % 10, 1 from table(generate_series(3, 1000000));
+insert into partitions_multi_column_2 select generate_series % 10, generate_series % 10, generate_series % 10, 1 from table(generate_series(4, 1000000));
+insert into partitions_multi_column_2 select generate_series % 10, generate_series % 10, generate_series % 10, 1 from table(generate_series(5, 1000000));
+
+ANALYZE FULL TABLE partitions_multi_column_2 WITH SYNC MODE;
+function: assert_explain_costs_contains('SELECT * FROM partitions_multi_column_2 WHERE c1=1 AND c2=1 AND c3=1 AND p1=1', 'cardinality: 1000')


### PR DESCRIPTION
## Why I'm doing:
currently, we will use partition statistics to estimate scan node cardinality for list partition, and follow-up use of flag to prevent re-evaluation of predicate. but if the child size of compound predicate exceed two, we will duplicate evaluate the predicates.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0