### PR TITLE
[BugFix] Fix `insert into files` statement not support delimiter convert

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -840,10 +840,21 @@ public class TableFunctionTable extends Table {
 
         // csv options
         if (properties.containsKey(PROPERTY_CSV_COLUMN_SEPARATOR)) {
-            this.csvColumnSeparator = properties.get(PROPERTY_CSV_COLUMN_SEPARATOR);
+            csvColumnSeparator = Delimiter.convertDelimiter(properties.get(PROPERTY_CSV_COLUMN_SEPARATOR));
+            int len = csvColumnSeparator.getBytes(StandardCharsets.UTF_8).length;
+            if (len > CsvFormat.MAX_COLUMN_SEPARATOR_LENGTH || len == 0) {
+                throw new SemanticException("The valid bytes length for '%s' is [%d, %d]",
+                        PROPERTY_CSV_COLUMN_SEPARATOR, 1, CsvFormat.MAX_COLUMN_SEPARATOR_LENGTH);
+            }
         }
+
         if (properties.containsKey(PROPERTY_CSV_ROW_DELIMITER)) {
-            this.csvRowDelimiter = properties.get(PROPERTY_CSV_ROW_DELIMITER);
+            csvRowDelimiter = Delimiter.convertDelimiter(properties.get(PROPERTY_CSV_ROW_DELIMITER));
+            int len = csvRowDelimiter.getBytes(StandardCharsets.UTF_8).length;
+            if (len > CsvFormat.MAX_ROW_DELIMITER_LENGTH || len == 0) {
+                throw new SemanticException("The valid bytes length for '%s' is [%d, %d]", PROPERTY_CSV_ROW_DELIMITER,
+                        1, CsvFormat.MAX_ROW_DELIMITER_LENGTH);
+            }
         }
 
         // parquet options

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
@@ -20,6 +20,7 @@ import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.fs.HdfsUtil;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
@@ -44,7 +45,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 public class TableFunctionTableTest {
 
     Map<String, String> newProperties() {
@@ -271,5 +271,52 @@ public class TableFunctionTableTest {
                 "\"aws.s3.secret_key\" = \"***\", \"format\" = \"parquet\", \"path\" = \"s3://xxx/yyy\") SELECT *\n" +
                 "FROM FILES(\"aws.s3.access_key\" = \"***\", \"aws.s3.region\" = \"us-west-1\", " +
                 "\"aws.s3.secret_key\" = \"***\", \"format\" = \"parquet\", \"path\" = \"s3://xxx/zzz\")", desensitizationSql);
+    }
+
+    @Test
+    public void testCSVDelimiterConverterForUnload() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("path", "file://test_dir");
+        properties.put("format", "csv");
+
+
+        {
+            // normal case: default
+            Assertions.assertDoesNotThrow(() -> {
+                TableFunctionTable table = new TableFunctionTable(new ArrayList<>(), properties, new SessionVariable());
+                Assert.assertEquals("\t", table.getCsvColumnSeparator());
+                Assert.assertEquals("\n", table.getCsvRowDelimiter());
+            });
+        }
+
+        {
+            // normal case: support hexadecimal representations of ASCII control character
+            properties.put("csv.column_separator", "\\x01");
+            properties.put("csv.row_delimiter", "0x02");
+            Assertions.assertDoesNotThrow(() -> {
+                TableFunctionTable table = new TableFunctionTable(new ArrayList<>(), properties, new SessionVariable());
+                Assert.assertEquals("\1", table.getCsvColumnSeparator());
+                Assert.assertEquals("\2", table.getCsvRowDelimiter());
+            });
+        }
+
+        // abnormal case 1
+        properties.put("csv.column_separator", "0123456789012345678901234567890123456789012345678901234567890");
+        ExceptionChecker.expectThrowsWithMsg(SemanticException.class,
+                "The valid bytes length for 'csv.column_separator' is [1, 50]",
+                () -> new TableFunctionTable(new ArrayList<>(), properties, new SessionVariable()));
+
+        // abnormal case 2
+        properties.put("csv.column_separator", "0x11");
+        properties.put("csv.row_delimiter", "0123456789012345678901234567890123456789012345678901234567890");
+        ExceptionChecker.expectThrowsWithMsg(SemanticException.class,
+                "The valid bytes length for 'csv.row_delimiter' is [1, 50]",
+                () -> new TableFunctionTable(new ArrayList<>(), properties, new SessionVariable()));
+
+        // abnormal case 3
+        properties.put("csv.column_separator", "");
+        ExceptionChecker.expectThrowsWithMsg(SemanticException.class,
+                "Delimiter cannot be empty or null",
+                () -> new TableFunctionTable(new ArrayList<>(), properties, new SessionVariable()));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
@@ -279,7 +279,6 @@ public class TableFunctionTableTest {
         properties.put("path", "file://test_dir");
         properties.put("format", "csv");
 
-
         {
             // normal case: default
             Assertions.assertDoesNotThrow(() -> {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #57125

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0