### PR TITLE
[BugFix] Prevent LDAP Injection in authentication

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/security/LdapSecurity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/security/LdapSecurity.java
@@ -97,7 +97,9 @@ public class LdapSecurity {
             ctx = new InitialDirContext(env);
             SearchControls sc = new SearchControls();
             sc.setSearchScope(SearchControls.SUBTREE_SCOPE);
-            String searchFilter = "(" + Config.authentication_ldap_simple_user_search_attr + "=" + user + ")";
+            // Escapes special characters in user input to prevent LDAP injection
+            String safeUser = escapeLdapValue(user);
+            String searchFilter = "(" + Config.authentication_ldap_simple_user_search_attr + "=" + safeUser + ")";
             NamingEnumeration<SearchResult> results = ctx.search(baseDN, searchFilter, sc);
 
             String userDN = null;
@@ -148,5 +150,19 @@ public class LdapSecurity {
             }
         }
         return src;
+    }
+
+    public static String escapeLdapValue(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        value = value.replace("\\", "\\5c");
+        value = value.replace("*", "\\2a");
+        value = value.replace("(", "\\28");
+        value = value.replace(")", "\\29");
+        value = value.replace("|", "\\7c");
+        value = value.replace("\\u0000", "\\00");
+        return value;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/LdapSecurityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/LdapSecurityTest.java
@@ -1,0 +1,57 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.mysql.privilege;
+
+import com.starrocks.mysql.security.LdapSecurity;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class LdapSecurityTest {
+
+    public LdapSecurity ldapSecurity;
+
+    @Test
+    public void testEscapeJava() {
+        String input = "admin)(|(uid=*";
+        String escaped = ldapSecurity.escapeLdapValue(input);
+        Assert.assertFalse(escaped.contains(")"));
+        Assert.assertFalse(escaped.contains("("));
+        Assert.assertFalse(escaped.contains("|"));
+        Assert.assertFalse(escaped.contains("*"));
+        Assert.assertFalse(escaped.contains("."));
+    }
+
+    @Test
+    public void testEscapeJava_NullInput() {
+        String input = null;
+        String escaped = ldapSecurity.escapeLdapValue(input);
+        Assert.assertNull(escaped);
+    }
+
+    @Test
+    public void testEscapeJava_EmptyString() {
+        String input = "";
+        String escaped = ldapSecurity.escapeLdapValue(input);
+        Assert.assertEquals("", escaped);
+    }
+
+    @Test
+    public void testEscapeJava_SpecialCharacters() {
+        String input = "cn=admin,dc=example,dc=com";
+        String escaped = ldapSecurity.escapeLdapValue(input);
+        Assert.assertEquals(input, escaped);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
This PR enhances security by escaping special characters in user input before constructing the LDAP search filter. Without proper sanitization, an attacker could manipulate the input to modify the LDAP query structure, potentially leading to unauthorized access or data leakage.

## What I'm doing:


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0