### PR TITLE
[BugFix] limit the state size of FlatJson to avoid excessive memory consumption

### DIFF
--- a/be/test/util/json_flattener_test.cpp
+++ b/be/test/util/json_flattener_test.cpp
@@ -261,6 +261,25 @@ TEST_F(JsonFlattenerTest, testDeepJson3) {
     EXPECT_EQ("NULL", result[2]->debug_item(1));
 }
 
+TEST_F(JsonFlattenerTest, testLargeJson) {
+    std::vector<std::string> json;
+    for (int k = 0; k < 10; k++) {
+        json.emplace_back(R"({"k1": 1)");
+        for (int i = 2; i <= 2000; i++) {
+            json[k] += fmt::format(", \"k{0}\": {1}", i, i);
+        }
+        json[k] += "}";
+    }
+
+    std::vector<std::string> paths = {"k1", "k2", "k1000"};
+    std::vector<LogicalType> types = {TYPE_BIGINT, TYPE_BIGINT, TYPE_BIGINT};
+    auto result = test_json(json, paths, types, false);
+    EXPECT_EQ(3, result.size());
+    EXPECT_EQ("1", result[0]->debug_item(0));
+    EXPECT_EQ("2", result[1]->debug_item(0));
+    EXPECT_EQ("1000", result[2]->debug_item(0));
+}
+
 TEST_F(JsonFlattenerTest, testMiddleJson) {
     std::vector<std::string> json = {R"( {"k1": {"c1": {"d1":  123 }}, "k2": {"j1": "def", "j2": {"g1": [1,2,3]}}} )",
                                      R"( {"k1": {"c1": {"d1": "abc"}}, "k2": {"j1": "abc", "j2": {"g1": 123}}} )"};


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

For complicate JSON structure, the `JsonFlattener` can consume excessive memory.

To solve this problem, here we add a hard limit on the state: `json_flat_column_max * 10`.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0