### PR TITLE
[Enhancement] use histogram to evaluate list partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -388,6 +388,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CBO_PRUNE_JSON_SUBFIELD = "cbo_prune_json_subfield";
     public static final String CBO_PRUNE_JSON_SUBFIELD_DEPTH = "cbo_prune_json_subfield_depth";
     public static final String CBO_PUSH_DOWN_AGG_WITH_MULTI_COLUMN_STATS = "cbo_push_down_aggregate_with_multi_column_stats";
+    public static final String CBO_USE_HISTOGRAM_EVALUDATE_LIST_PARTITION =  "cbo_use_histogram_evaluate_list_partition";
     public static final String ENABLE_OPTIMIZER_REWRITE_GROUPINGSETS_TO_UNION_ALL =
             "enable_rewrite_groupingsets_to_union_all";
     public static final String ENABLE_PARTITION_LEVEL_CARDINALITY_ESTIMATION =
@@ -1172,6 +1173,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = CBO_PRUNE_JSON_SUBFIELD_DEPTH, flag = VariableMgr.INVISIBLE)
     private int cboPruneJsonSubfieldDepth = 20;
 
+    @VarAttr(name = CBO_USE_HISTOGRAM_EVALUDATE_LIST_PARTITION, flag = VariableMgr.INVISIBLE)
+    private boolean cboUseHistogramEvaluateListPartition = false;
+
     @VarAttr(name = ENABLE_SQL_DIGEST, flag = VariableMgr.INVISIBLE)
     private boolean enableSQLDigest = false;
 
@@ -1757,6 +1761,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setCboPruneJsonSubfieldDepth(int cboPruneJsonSubfieldDepth) {
         this.cboPruneJsonSubfieldDepth = cboPruneJsonSubfieldDepth;
+    }
+
+    public boolean isCboUseHistogramEvaluateListPartition() {
+        return cboUseHistogramEvaluateListPartition;
+    }
+
+    public void setCboUseHistogramEvaluateListPartition(boolean cboUseHistogramEvaluateListPartition) {
+        this.cboUseHistogramEvaluateListPartition = cboUseHistogramEvaluateListPartition;
     }
 
     public boolean isEnableExecutionOnly() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticStorage.java
@@ -41,6 +41,9 @@ public interface StatisticStorage {
     default void refreshMultiColumnStatistics(Long tableId) {
     }
 
+    default void refreshHistogramStatistics(Table table, List<String> columns, boolean isSync) {
+    }
+
     /**
      * Overwrite the statistics of `targetPartition` with `sourcePartition`
      */
@@ -74,11 +77,7 @@ public interface StatisticStorage {
     default Map<String, Histogram> getHistogramStatistics(Table table, List<String> columns) {
         return Maps.newHashMap();
     }
-
-    default Map<String, Histogram> getHistogramStatisticsSync(Table table, List<String> columns) {
-        return getHistogramStatistics(table, columns);
-    }
-
+    
     default Map<String, Histogram> getConnectorHistogramStatistics(Table table, List<String> columns) {
         return Maps.newHashMap();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -419,7 +419,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
 
         ScalarOperator predicate = node.getPredicate();
         Map<Long, Statistics> partitionStatistics =
-                StatisticsCalcUtils.getPartitionStatistics(node, table, columnMap);
+                StatisticsCalcUtils.getPartitionStatistics(node, table, columnMap, statistics);
         if (MapUtils.isEmpty(partitionStatistics)) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
@@ -381,12 +381,7 @@ public class AnalyzeMgr implements Writable {
             return;
         }
 
-        GlobalStateMgr.getCurrentState().getStatisticStorage().expireHistogramStatistics(table.getId(), columns);
-        if (async) {
-            GlobalStateMgr.getCurrentState().getStatisticStorage().getHistogramStatistics(table, columns);
-        } else {
-            GlobalStateMgr.getCurrentState().getStatisticStorage().getHistogramStatisticsSync(table, columns);
-        }
+        GlobalStateMgr.getCurrentState().getStatisticStorage().refreshHistogramStatistics(table, columns, !async);
     }
 
     public void replayRemoveHistogramStatsMeta(HistogramStatsMeta histogramStatsMeta) {

--- a/test/sql/test_list_partition/R/test_list_partition_cardinality
+++ b/test/sql/test_list_partition/R/test_list_partition_cardinality
@@ -111,3 +111,46 @@ function: assert_explain_costs_contains('SELECT * FROM partitions_multi_column_2
 -- result:
 None
 -- !result
+set cbo_use_histogram_evaluate_list_partition=true;
+-- result:
+-- !result
+CREATE TABLE partitions_multi_column_3 (
+    c1 int NOT NULL,
+    p1 int
+)
+PARTITION BY (p1) properties("replication_num"="1");
+-- result:
+-- !result
+insert into partitions_multi_column_3 select 1, 1 from table(generate_series(1, 90));
+-- result:
+-- !result
+insert into partitions_multi_column_3 select 2, 1 from table(generate_series(1, 10));
+-- result:
+-- !result
+insert into partitions_multi_column_3 select 3, 2 from table(generate_series(1, 100));
+-- result:
+-- !result
+insert into partitions_multi_column_3 select 3, 3 from table(generate_series(1, 100));
+-- result:
+-- !result
+insert into partitions_multi_column_3 select 3, 4 from table(generate_series(1, 100));
+-- result:
+-- !result
+insert into partitions_multi_column_3 select 3, 5 from table(generate_series(1, 100));
+-- result:
+-- !result
+drop stats partitions_multi_column_3;
+-- result:
+-- !result
+ANALYZE FULL TABLE partitions_multi_column_3 WITH SYNC MODE;
+-- result:
+test_list_partition_cardinality.partitions_multi_column_3	analyze	status	OK
+-- !result
+ANALYZE TABLE partitions_multi_column_3 UPDATE HISTOGRAM ON c1;
+-- result:
+test_list_partition_cardinality.partitions_multi_column_3	histogram	status	OK
+-- !result
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_3 WHERE c1=2 and p1 =1 ', 'cardinality: 2')
+-- result:
+None
+-- !result

--- a/test/sql/test_list_partition/T/test_list_partition_cardinality
+++ b/test/sql/test_list_partition/T/test_list_partition_cardinality
@@ -56,3 +56,21 @@ insert into partitions_multi_column_2 select generate_series % 10, generate_seri
 
 ANALYZE FULL TABLE partitions_multi_column_2 WITH SYNC MODE;
 function: assert_explain_costs_contains('SELECT * FROM partitions_multi_column_2 WHERE c1=1 AND c2=1 AND c3=1 AND p1=1', 'cardinality: 1000')
+
+-- with histogram
+set cbo_use_histogram_evaluate_list_partition=true;
+CREATE TABLE partitions_multi_column_3 (
+    c1 int NOT NULL,
+    p1 int
+)
+PARTITION BY (p1) properties("replication_num"="1");
+insert into partitions_multi_column_3 select 1, 1 from table(generate_series(1, 90));
+insert into partitions_multi_column_3 select 2, 1 from table(generate_series(1, 10));
+insert into partitions_multi_column_3 select 3, 2 from table(generate_series(1, 100));
+insert into partitions_multi_column_3 select 3, 3 from table(generate_series(1, 100));
+insert into partitions_multi_column_3 select 3, 4 from table(generate_series(1, 100));
+insert into partitions_multi_column_3 select 3, 5 from table(generate_series(1, 100));
+drop stats partitions_multi_column_3;
+ANALYZE FULL TABLE partitions_multi_column_3 WITH SYNC MODE;
+ANALYZE TABLE partitions_multi_column_3 UPDATE HISTOGRAM ON c1;
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_3 WHERE c1=2 and p1 =1 ', 'cardinality: 2')


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
currently, we use partition level statistics without histogram to estimate node output rows and histogram is table level. However, based on the premise that partition is independent， we could use histogram or mcv to estimate cardinality. 

added session variable:
cbo_use_histogram_evaluate_list_partition.
default value is false.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0