### PR TITLE
[BugFix] support boolean type predicate cardinality estimation

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
@@ -265,5 +265,21 @@ public class HistogramStatisticsTest {
                 Optional.of(columnRefOperator),
                 columnStatistic, eq10, Optional.of(ConstantOperator.createBoolean(false)), statistics);
         Assert.assertEquals(500L, estimated.getOutputRowCount(), 0.001);
+
+
+        mcv = Maps.newHashMap();
+        mcv.put("0", 500L);
+        mcv.put("1", 500L);
+        histogram = new Histogram(new ArrayList<>(), mcv);
+        columnRefOperator = new ColumnRefOperator(0, Type.BOOLEAN, "b1", true);
+        columnStatistic = new ColumnStatistic(0, 1, 0, 4, 2, histogram, ColumnStatistic.StatisticType.ESTIMATE);
+        builder = Statistics.builder();
+        builder.setOutputRowCount(100000);
+        builder.addColumnStatistic(columnRefOperator, columnStatistic);
+        statistics = builder.build();
+
+        estimated = PredicateStatisticsCalculator.statisticsCalculate(columnRefOperator, statistics);
+        Assert.assertEquals(500L, estimated.getOutputRowCount(), 0.001);
     }
+
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
currently, if a predicate with boolean column is `bool_col = true`, we will convert it to `bool_col`.  and we will use a default  coefficient to calculate it in the statistics calculator.  we need to convert it original predicate for more accurate cardinality.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0