### PR TITLE
[Enhancement] Introduce runtime bitset filter

### DIFF
--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -499,9 +499,9 @@ pipeline::OpFactories HashJoinNode::_decompose_to_pipeline(pipeline::PipelineBui
         runtime_join_filter_pushdown_limit = _runtime_join_filter_pushdown_limit * num_right_partitions;
     }
 
-    auto partial_rf_merger = std::make_unique<PartialRuntimeFilterMerger>(pool, runtime_join_filter_pushdown_limit,
-                                                                          global_runtime_filter_build_max_size,
-                                                                          runtime_state()->func_version());
+    auto partial_rf_merger = std::make_unique<PartialRuntimeFilterMerger>(
+            pool, runtime_join_filter_pushdown_limit, global_runtime_filter_build_max_size,
+            runtime_state()->func_version(), runtime_state()->enable_join_runtime_bitset_filter());
 
     auto build_op = std::make_shared<HashJoinBuilderFactory>(context->next_operator_id(), id(), hash_joiner_factory,
                                                              std::move(partial_rf_merger), _distribution_mode,

--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -57,7 +57,8 @@ void HashJoinBuildMetrics::prepare(RuntimeProfile* runtime_profile) {
     runtime_filter_num = ADD_COUNTER(runtime_profile, "RuntimeFilterNum", TUnit::UNIT);
     build_keys_per_bucket = ADD_COUNTER(runtime_profile, "BuildKeysPerBucket%", TUnit::UNIT);
     hash_table_memory_usage = ADD_COUNTER(runtime_profile, "HashTableMemoryUsage", TUnit::BYTES);
-    partial_runtime_bloom_filter_bytes = ADD_COUNTER(runtime_profile, "PartialRuntimeBloomFilterBytes", TUnit::BYTES);
+    partial_runtime_bloom_filter_bytes =
+            ADD_COUNTER(runtime_profile, "PartialRuntimeMembershipFilterBytes", TUnit::BYTES);
     partition_nums = ADD_COUNTER(runtime_profile, "PartitionNums", TUnit::UNIT);
 }
 

--- a/be/src/exec/olap_scan_prepare.h
+++ b/be/src/exec/olap_scan_prepare.h
@@ -123,6 +123,9 @@ private:
 
     Status _get_column_predicates(PredicateParser* parser, ColumnPredicatePtrs& col_preds_owner);
 
+    Status _build_bitset_in_predicates(PredicateCompoundNode<Type>& tree_root, PredicateParser* parser,
+                                       ColumnPredicatePtrs& col_preds_owner);
+
     friend struct ColumnRangeBuilder;
     friend class ConjunctiveTestFixture;
 

--- a/be/src/exec/pipeline/runtime_filter_types.h
+++ b/be/src/exec/pipeline/runtime_filter_types.h
@@ -276,11 +276,13 @@ private:
 // not take effects on operators in front of LocalExchangeSourceOperators before they are merged into a total one.
 class PartialRuntimeFilterMerger {
 public:
-    PartialRuntimeFilterMerger(ObjectPool* pool, size_t local_rf_limit, size_t global_rf_limit, int func_version)
+    PartialRuntimeFilterMerger(ObjectPool* pool, size_t local_rf_limit, size_t global_rf_limit, int func_version,
+                               bool enable_join_runtime_bitset_filter)
             : _pool(pool),
               _local_rf_limit(local_rf_limit),
               _global_rf_limit(global_rf_limit),
-              _func_version(func_version) {}
+              _func_version(func_version),
+              _enable_join_runtime_bitset_filter(enable_join_runtime_bitset_filter) {}
 
     void incr_builder() {
         _ht_row_counts.emplace_back(0);
@@ -325,6 +327,7 @@ private:
     const size_t _local_rf_limit;
     const size_t _global_rf_limit;
     const int _func_version;
+    const bool _enable_join_runtime_bitset_filter;
 
     std::atomic<bool> _always_true{false};
     std::atomic<size_t> _num_active_builders{0};

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -280,6 +280,314 @@ size_t RuntimeEmptyFilter<LT>::deserialize(int serialize_version, const uint8_t*
 }
 
 // ------------------------------------------------------------------------------------
+// Bitset
+// ------------------------------------------------------------------------------------
+
+template <LogicalType LT>
+void Bitset<LT>::insert(const CppType& value) {
+    const uint64_t bucket = _value_interval(value);
+    const uint64_t group = bucket / 8;
+    const uint64_t index_in_group = bucket % 8;
+    _bitset[group] |= (1 << index_in_group);
+}
+
+template <LogicalType LT>
+bool Bitset<LT>::contains_range(const CppType& min_value, const CppType& max_value) const {
+    if (min_value > _max_value || max_value < _min_value || min_value > max_value) {
+        return false;
+    }
+
+    // `min_value < _min_value <= max_value` always contains _min_value.
+    // `min_value <= _max_value < max_value` always contains _max_value.
+    if (min_value < _min_value || max_value > _max_value) {
+        return true;
+    }
+
+    // _min_value <= min_value <= max_value <= _max_value
+    //
+    // 1. Check [min_index_in_group, 7] in min_group.
+    // 2. Check [0, max_index_in_group] in max_group.
+    // 3. Check [min_group + 1, max_group - 1] group.
+    //
+    // min_group  max_group
+    // |              |
+    // ┌──┬──┬──┬──┬──┐
+    // └┬─┴──┴──┴──┴─┬┘
+    //  └────────────┘
+    //  |            |
+    // min_index  max_index
+    // _in_group  _in_group
+
+    const size_t min_bucket = _value_interval(min_value);
+    const uint64_t min_group = min_bucket / 8;
+    const uint64_t min_index_in_group = min_bucket % 8;
+    // Clear low `min_index_in_group` bits.
+    const uint8_t min_group_mask = _bitset[min_group] & (0xFFull << min_index_in_group);
+
+    const size_t max_bucket = _value_interval(max_value);
+    const uint64_t max_group = max_bucket / 8;
+    const uint64_t max_index_in_group = max_bucket % 8;
+    // Clear high `max_index_in_group` bits.
+    const uint8_t max_group_mask = _bitset[max_group] & (0xFFull >> (7 - max_index_in_group));
+
+    if (min_group == max_group) {
+        if (min_group_mask & max_group_mask) {
+            return true;
+        }
+    } else {
+        if (min_group_mask | max_group_mask) {
+            return true;
+        }
+    }
+
+    if (min_group + 1 <= max_group - 1) {
+        return SIMD::count_nonzero(_bitset.data() + min_group + 1, max_group - min_group - 1);
+    }
+    return false;
+}
+
+template <LogicalType LT>
+void Bitset<LT>::init() {
+    const size_t key_interval = value_interval() + 1;
+    const size_t num_buckets = (key_interval + 7) / 8;
+    _bitset.resize(num_buckets);
+}
+
+template <LogicalType LT>
+template <bool CheckRange>
+void Bitset<LT>::contains_batch(uint8_t* __restrict selection, const CppType* __restrict values, size_t from,
+                                size_t to) const {
+    for (size_t i = from; i < to; i++) {
+        selection[i] = contains<CheckRange>(values[i], selection[i]);
+    }
+}
+
+template <LogicalType LT>
+template <bool CheckRange, bool NullIsTrue>
+void Bitset<LT>::contains_batch(uint8_t* __restrict selection, const CppType* __restrict values,
+                                const uint8_t* __restrict is_nulls, size_t from, size_t to) const {
+    // `contains<false/*CheckRange*/>` considers the values[i] with true `selection[i]` is in the range, which is set
+    // by the min-max-filter, and doesn't check range again.
+    // However, min-max-filter will also set `selection[i]` to true, if NullIsTrue and `is_nulls[i]` is true regardless
+    // of the value of `values[i]`.
+    // Therefore, we need to temporarily set `selection[i]` to false and re-consider `is_nulls[i]` later, if NullIsTrue
+    // and `is_nulls[i]` is true.
+    for (int i = from; i < to; i++) {
+        selection[i] &= is_nulls[i] == 0;
+    }
+    for (int i = from; i < to; i++) {
+        selection[i] = contains<CheckRange>(values[i], selection[i]);
+    }
+
+    if constexpr (NullIsTrue) {
+        for (int i = from; i < to; i++) {
+            selection[i] |= is_nulls[i] != 0;
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------
+// RuntimeBitsetFilter
+// ------------------------------------------------------------------------------------
+
+template <LogicalType LT>
+void RuntimeBitsetFilter<LT>::init(size_t num_elements) {
+    RuntimeMembershipFilter::init(num_elements);
+    _bitset.init();
+}
+
+template <LogicalType LT>
+void RuntimeBitsetFilter<LT>::evaluate(const Column* input_column, RunningContext* ctx) const {
+    const size_t num_rows = input_column->size();
+
+    Filter& selection_filter = ctx->use_merged_selection ? ctx->merged_selection : ctx->selection;
+    selection_filter.resize(num_rows);
+    uint8_t* selection = selection_filter.data();
+
+    if (_has_null) {
+        _evaluate_vectorized<true>(input_column, selection, 0, num_rows);
+    } else {
+        _evaluate_vectorized<false>(input_column, selection, 0, num_rows);
+    }
+}
+
+template <LogicalType LT>
+void RuntimeBitsetFilter<LT>::evaluate(const Column* input_column, const std::vector<uint32_t>& hash_values,
+                                       uint8_t* selection, uint16_t from, uint16_t to) const {
+    if (_has_null) {
+        _evaluate_vectorized<true>(input_column, selection, from, to);
+    } else {
+        _evaluate_vectorized<false>(input_column, selection, from, to);
+    }
+}
+
+template <LogicalType LT>
+uint16_t RuntimeBitsetFilter<LT>::evaluate(const Column* input_column, const std::vector<uint32_t>& hash_values,
+                                           uint16_t* sel, uint16_t sel_size, uint16_t* dst_sel) const {
+    if (_has_null) {
+        return _evaluate_branchless<true>(input_column, hash_values, sel, sel_size, dst_sel);
+    } else {
+        return _evaluate_branchless<false>(input_column, hash_values, sel, sel_size, dst_sel);
+    }
+}
+
+template <LogicalType LT>
+template <bool null_is_true>
+void RuntimeBitsetFilter<LT>::_evaluate_vectorized(const Column* __restrict input_column, uint8_t* __restrict selection,
+                                                   size_t from, size_t to) const {
+    if (input_column->is_constant()) {
+        const auto* const_column = down_cast<const ConstColumn*>(input_column);
+        if (const_column->only_null()) {
+            memset(selection + from, _has_null, to - from);
+        } else {
+            const auto& values = GetContainer<LT>::get_data(const_column->data_column());
+            const bool selected = _test_data(values[0], selection[0]);
+            memset(selection + from, selected, to - from);
+        }
+    } else if (input_column->is_nullable()) {
+        const auto* nullable_column = down_cast<const NullableColumn*>(input_column);
+        const auto* values = GetContainer<LT>::get_data(nullable_column->data_column()).data();
+        if (nullable_column->has_null()) {
+            const uint8_t* null_data = nullable_column->immutable_null_column_data().data();
+            _bitset.template contains_batch<false /*CheckRange*/, null_is_true>(selection, values, null_data, from, to);
+        } else {
+            _bitset.template contains_batch<false /*CheckRange*/>(selection, values, from, to);
+        }
+    } else {
+        const auto* values = GetContainer<LT>::get_data(input_column).data();
+        _bitset.template contains_batch<false /*CheckRange*/>(selection, values, from, to);
+    }
+}
+
+template <LogicalType LT>
+template <bool null_is_true>
+uint16_t RuntimeBitsetFilter<LT>::_evaluate_branchless(const Column* __restrict input_column,
+                                                       const std::vector<uint32_t>& hash_values,
+                                                       uint16_t* __restrict sel, uint16_t sel_size,
+                                                       uint16_t* dst_sel) const {
+    uint16_t num_dst_rows = 0;
+    if (input_column->is_nullable()) {
+        const auto* nullable_column = down_cast<const NullableColumn*>(input_column);
+        const auto& values = GetContainer<LT>::get_data(nullable_column->data_column());
+        if (nullable_column->has_null()) {
+            const uint8_t* null_data = nullable_column->immutable_null_column_data().data();
+            for (int i = 0; i < sel_size; i++) {
+                const auto idx = sel[i];
+                dst_sel[num_dst_rows] = idx;
+                if constexpr (!null_is_true) {
+                    num_dst_rows += _test_data(values[idx], null_data[idx] == 0);
+                } else {
+                    num_dst_rows += (null_data[idx] != 0) | _test_data(values[idx], null_data[idx] == 0);
+                }
+            }
+        } else {
+            for (int i = 0; i < sel_size; i++) {
+                const auto idx = sel[i];
+                dst_sel[num_dst_rows] = idx;
+                num_dst_rows += _test_data(values[idx], true);
+            }
+        }
+    } else {
+        const auto& values = GetContainer<LT>::get_data(input_column);
+        for (int i = 0; i < sel_size; i++) {
+            const auto idx = sel[i];
+            dst_sel[num_dst_rows] = idx;
+            num_dst_rows += _test_data(values[idx], true);
+        }
+    }
+
+    return num_dst_rows;
+}
+
+template <LogicalType LT>
+std::string RuntimeBitsetFilter<LT>::debug_string() const {
+    std::stringstream ss;
+    ss << "RuntimeBitsetFilter("
+       << "has_null=" << _has_null                        //
+       << ", join_mode=" << _join_mode                    //
+       << ", num_elements=" << _size                      //
+       << ", min_value=" << _bitset.min_value()           //
+       << ", max_value=" << _bitset.max_value()           //
+       << ", value_interval=" << _bitset.value_interval() //
+       << ", bitset_bytes=" << _bitset.size()             //
+       << ")";
+    return ss.str();
+}
+
+template <LogicalType LT>
+size_t RuntimeBitsetFilter<LT>::max_serialized_size() const {
+    return sizeof(_has_null) +              // 1. has_null
+           sizeof(_size) +                  // 2. num_elements
+           sizeof(_join_mode) +             // 3. join_mode
+           sizeof(_bitset.min_value()) +    // 4. min_value
+           sizeof(_bitset.max_value()) +    // 5. max_value
+           sizeof(size_t) + _bitset.size(); // 6. bitset
+}
+
+template <LogicalType LT>
+size_t RuntimeBitsetFilter<LT>::serialize(int serialize_version, uint8_t* data) const {
+    DCHECK(serialize_version >= RF_VERSION_V3);
+
+    size_t offset = 0;
+
+#define JRF_COPY_FIELD(field)                     \
+    memcpy(data + offset, &field, sizeof(field)); \
+    offset += sizeof(field);
+
+    JRF_COPY_FIELD(_has_null);  // 1. has_null
+    JRF_COPY_FIELD(_size);      // 2. num_elements
+    JRF_COPY_FIELD(_join_mode); // 3. join_mode
+
+    const auto min_value = _bitset.min_value();
+    const auto max_value = _bitset.max_value();
+    JRF_COPY_FIELD(min_value); // 4. min_value
+    JRF_COPY_FIELD(max_value); // 5. max_value
+
+    // 6. bitset
+    const size_t bitset_size = _bitset.size();
+    JRF_COPY_FIELD(bitset_size);
+    memcpy(data + offset, _bitset.data(), bitset_size);
+    offset += bitset_size;
+
+#undef JRF_COPY_FIELD
+
+    return offset;
+}
+
+template <LogicalType LT>
+size_t RuntimeBitsetFilter<LT>::deserialize(int serialize_version, const uint8_t* data) {
+    DCHECK(serialize_version >= RF_VERSION_V3);
+
+    size_t offset = 0;
+
+#define JRF_COPY_FIELD(field)                     \
+    memcpy(&field, data + offset, sizeof(field)); \
+    offset += sizeof(field);
+
+    JRF_COPY_FIELD(_has_null);  // 1. has_null
+    JRF_COPY_FIELD(_size);      // 2. num_elements
+    JRF_COPY_FIELD(_join_mode); // 3. join_mode
+
+    CppType min_value;
+    CppType max_value;
+    JRF_COPY_FIELD(min_value); // 4. min_value
+    JRF_COPY_FIELD(max_value); // 5. max_value
+    _bitset.set_min_max(min_value, max_value);
+    _bitset.init();
+
+    // 6. bitset
+    size_t bitset_size = 0;
+    JRF_COPY_FIELD(bitset_size);
+    DCHECK_EQ(_bitset.size(), bitset_size);
+    memcpy(_bitset.data(), data + offset, bitset_size);
+    offset += bitset_size;
+
+#undef JRF_COPY_FIELD
+
+    return offset;
+}
+
+// ------------------------------------------------------------------------------------
 // Instantiate runtime filters.
 // ------------------------------------------------------------------------------------
 
@@ -291,5 +599,13 @@ size_t RuntimeEmptyFilter<LT>::deserialize(int serialize_version, const uint8_t*
 
 APPLY_FOR_ALL_SCALAR_TYPE(InstantiateRuntimeFilter)
 #undef InstantiateRuntimeFilter
+
+#define InstantiateRuntimeBitsetFilter(LT)  \
+    template class Bitset<LT>;              \
+    template class RuntimeBitsetFilter<LT>; \
+    template class ComposedRuntimeFilter<LT, RuntimeBitsetFilter<LT>>;
+
+APPLY_FOR_BITSET_FILTER_SUPPORTED_TYPE(InstantiateRuntimeBitsetFilter)
+#undef InstantiateRuntimeBitsetFilter
 
 } // namespace starrocks

--- a/be/src/exprs/runtime_filter_bank.h
+++ b/be/src/exprs/runtime_filter_bank.h
@@ -60,9 +60,13 @@ public:
 
     static RuntimeFilter* create_runtime_empty_filter(ObjectPool* pool, LogicalType type, int8_t join_mode);
     static RuntimeFilter* create_runtime_bloom_filter(ObjectPool* pool, LogicalType type, int8_t join_mode);
+    static RuntimeFilter* create_runtime_bitset_filter(ObjectPool* pool, LogicalType type, int8_t join_mode);
     static RuntimeFilter* transmit_to_runtime_empty_filter(ObjectPool* pool, RuntimeFilter* rf);
     static RuntimeFilter* create_join_runtime_filter(ObjectPool* pool, RuntimeFilterSerializeType rf_type,
                                                      LogicalType ltype, int8_t join_mode);
+    static RuntimeFilter* create_join_runtime_filter(ObjectPool* pool, LogicalType type, int8_t join_mode,
+                                                     const pipeline::RuntimeMembershipFilterBuildParam& param,
+                                                     size_t column_offset, size_t row_count);
 
     // ====================================
     static Status fill_runtime_filter(const ColumnPtr& column, LogicalType type, RuntimeFilter* filter,

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -517,6 +517,11 @@ public:
                _query_options.enable_join_runtime_filter_pushdown;
     }
 
+    bool enable_join_runtime_bitset_filter() const {
+        return _query_options.__isset.enable_join_runtime_bitset_filter &&
+               _query_options.enable_join_runtime_bitset_filter;
+    }
+
     bool lower_upper_support_utf8() const {
         return _query_options.__isset.lower_upper_support_utf8 && _query_options.lower_upper_support_utf8;
     }

--- a/be/src/storage/column_predicate.h
+++ b/be/src/storage/column_predicate.h
@@ -260,4 +260,9 @@ ColumnPredicate* new_column_dict_conjuct_predicate(const TypeInfoPtr& type_info,
 
 ColumnPredicate* new_column_placeholder_predicate(const TypeInfoPtr& type_info, ColumnId id);
 
+template <LogicalType LT>
+class Bitset;
+template <LogicalType LT>
+ColumnPredicate* new_bitset_in_predicate(const TypeInfoPtr& type_info, ColumnId id, const Bitset<LT>& bitset);
+
 } //namespace starrocks

--- a/be/src/types/date_value.h
+++ b/be/src/types/date_value.h
@@ -103,6 +103,8 @@ public:
 
     inline operator TimestampValue() const;
 
+    explicit operator int32_t() const { return _julian; }
+
 public:
     static const DateValue MAX_DATE_VALUE;
     static const DateValue MIN_DATE_VALUE;
@@ -156,5 +158,17 @@ namespace std {
 template <>
 struct hash<starrocks::DateValue> {
     size_t operator()(const starrocks::DateValue& v) const { return std::hash<int32_t>()(v._julian); }
+};
+
+template <>
+struct numeric_limits<starrocks::DateValue> {
+public:
+    static starrocks::DateValue min() { return starrocks::DateValue::MIN_DATE_VALUE; }
+    static starrocks::DateValue max() { return starrocks::DateValue::MAX_DATE_VALUE; }
+
+    // Must define the following static constants.
+    static constexpr bool is_specialized = true;
+    static constexpr bool is_integer = false;
+    static constexpr bool is_signed = false;
 };
 } // namespace std

--- a/be/src/types/logical_type_infra.h
+++ b/be/src/types/logical_type_infra.h
@@ -101,6 +101,16 @@ namespace starrocks {
     M(VARBINARY)                        \
     M(JSON)
 
+#define APPLY_FOR_BITSET_FILTER_SUPPORTED_TYPE(M) \
+    M(TYPE_BOOLEAN)                               \
+    M(TYPE_TINYINT)                               \
+    M(TYPE_SMALLINT)                              \
+    M(TYPE_INT)                                   \
+    M(TYPE_BIGINT)                                \
+    M(TYPE_DECIMAL32)                             \
+    M(TYPE_DECIMAL64)                             \
+    M(TYPE_DATE)
+
 #define _TYPE_DISPATCH_CASE(type) \
     case type:                    \
         return fun.template operator()<type>(args...);
@@ -203,6 +213,15 @@ template <class Functor, class Ret, class... Args>
 auto type_dispatch_filter(LogicalType ltype, Ret default_value, Functor fun, Args... args) {
     switch (ltype) {
         APPLY_FOR_ALL_SCALAR_TYPE(_TYPE_DISPATCH_CASE)
+    default:
+        return default_value;
+    }
+}
+
+template <class Functor, class Ret, class... Args>
+auto type_dispatch_bitset_filter(LogicalType ltype, Ret default_value, Functor fun, Args... args) {
+    switch (ltype) {
+        APPLY_FOR_BITSET_FILTER_SUPPORTED_TYPE(_TYPE_DISPATCH_CASE)
     default:
         return default_value;
     }

--- a/be/test/storage/column_predicate_test.cpp
+++ b/be/test/storage/column_predicate_test.cpp
@@ -1686,13 +1686,13 @@ TEST(ColumnPredicateTest, test_in_bitset) {
     ASSERT_EQ("0,1,0,1,0,0,0", to_string(buff));
 
     bitset_pred->evaluate(nullable_col.get(), buff.data(), 1, 6);
-    ASSERT_EQ("1,0,1,0,0", to_string(buff));
+    ASSERT_EQ("0,1,0,1,0,0,0", to_string(buff));
 
     bitset_pred->evaluate(col.get(), buff.data(), 0, 5);
-    ASSERT_EQ("0,1,0,1,0", to_string(buff));
+    ASSERT_EQ("0,1,0,1,0,0,0", to_string(buff));
 
     bitset_pred->evaluate(nullable_col.get(), buff.data(), 1, 4);
-    ASSERT_EQ("1,0,1", to_string(buff));
+    ASSERT_EQ("0,1,0,1,0,0,0", to_string(buff));
 
     // ---------------------------------------------
     // evaluate_and()

--- a/be/test/storage/column_predicate_test.cpp
+++ b/be/test/storage/column_predicate_test.cpp
@@ -37,7 +37,7 @@ static inline std::string to_string(const std::vector<uint8_t>& v) {
 }
 static inline std::string to_string(const std::vector<uint16_t>& values) {
     std::stringstream ss;
-    for (uint8_t value : values) {
+    for (uint16_t value : values) {
         ss << value << ",";
     }
     std::string s = ss.str();

--- a/be/test/storage/column_predicate_test.cpp
+++ b/be/test/storage/column_predicate_test.cpp
@@ -1703,13 +1703,13 @@ TEST(ColumnPredicateTest, test_in_bitset) {
     ASSERT_EQ("0,1,0,1,0,0,0", to_string(buff));
 
     bitset_pred->evaluate_and(nullable_col.get(), buff.data(), 1, 6);
-    ASSERT_EQ("1,0,1,0,0", to_string(buff));
+    ASSERT_EQ("0,1,0,1,0,0,0", to_string(buff));
 
     bitset_pred->evaluate_and(col.get(), buff.data(), 0, 5);
-    ASSERT_EQ("0,1,0,1,0", to_string(buff));
+    ASSERT_EQ("0,1,0,1,0,0,0", to_string(buff));
 
     bitset_pred->evaluate_and(nullable_col.get(), buff.data(), 1, 4);
-    ASSERT_EQ("1,0,1", to_string(buff));
+    ASSERT_EQ("0,1,0,1,0,0,0", to_string(buff));
 
     buff.assign(7, 0);
     bitset_pred->evaluate_and(nullable_col.get(), buff.data(), 0, 7);
@@ -1728,13 +1728,13 @@ TEST(ColumnPredicateTest, test_in_bitset) {
     ASSERT_EQ("0,1,0,1,0,0,0", to_string(buff));
 
     bitset_pred->evaluate_and(nullable_col.get(), buff.data(), 1, 6);
-    ASSERT_EQ("1,0,1,0,0", to_string(buff));
+    ASSERT_EQ("0,1,0,1,0,0,0", to_string(buff));
 
     bitset_pred->evaluate_and(col.get(), buff.data(), 0, 5);
-    ASSERT_EQ("0,1,0,1,0", to_string(buff));
+    ASSERT_EQ("0,1,0,1,0,0,0", to_string(buff));
 
     bitset_pred->evaluate_and(nullable_col.get(), buff.data(), 1, 4);
-    ASSERT_EQ("1,0,1", to_string(buff));
+    ASSERT_EQ("0,1,0,1,0,0,0", to_string(buff));
 
     buff.assign(7, 1);
     bitset_pred->evaluate_and(nullable_col.get(), buff.data(), 0, 7);
@@ -1749,13 +1749,15 @@ TEST(ColumnPredicateTest, test_in_bitset) {
         auto status_sel_size = bitset_pred->evaluate_branchless(nullable_col.get(), sel.data(), 7);
         ASSERT_TRUE(status_sel_size.ok());
         ASSERT_EQ(2, status_sel_size.value());
+        sel.resize(2);
         ASSERT_EQ("1,3", to_string(buff));
     }
     {
         std::vector<uint16_t> sel{0, 2, 3, 5, 6, 7};
         auto status_sel_size = bitset_pred->evaluate_branchless(nullable_col.get(), sel.data(), 6);
         ASSERT_TRUE(status_sel_size.ok());
-        ASSERT_EQ(2, status_sel_size.value());
+        ASSERT_EQ(1, status_sel_size.value());
+        sel.resize(1);
         ASSERT_EQ("3", to_string(buff));
     }
     {
@@ -1763,13 +1765,15 @@ TEST(ColumnPredicateTest, test_in_bitset) {
         auto status_sel_size = bitset_pred->evaluate_branchless(col.get(), sel.data(), 5);
         ASSERT_TRUE(status_sel_size.ok());
         ASSERT_EQ(2, status_sel_size.value());
+        sel.resize(2);
         ASSERT_EQ("1,3", to_string(buff));
     }
     {
         std::vector<uint16_t> sel{0, 2, 3, 5, 6, 7};
         auto status_sel_size = bitset_pred->evaluate_branchless(col.get(), sel.data(), 4);
         ASSERT_TRUE(status_sel_size.ok());
-        ASSERT_EQ(2, status_sel_size.value());
+        ASSERT_EQ(1, status_sel_size.value());
+        sel.resize(1);
         ASSERT_EQ("3", to_string(buff));
     }
 }

--- a/be/test/storage/column_predicate_test.cpp
+++ b/be/test/storage/column_predicate_test.cpp
@@ -1750,7 +1750,7 @@ TEST(ColumnPredicateTest, test_in_bitset) {
         ASSERT_TRUE(status_sel_size.ok());
         ASSERT_EQ(2, status_sel_size.value());
         sel.resize(2);
-        ASSERT_EQ("1,3", to_string(buff));
+        ASSERT_EQ("1,3", to_string(sel));
     }
     {
         std::vector<uint16_t> sel{0, 2, 3, 5, 6, 7};
@@ -1758,7 +1758,7 @@ TEST(ColumnPredicateTest, test_in_bitset) {
         ASSERT_TRUE(status_sel_size.ok());
         ASSERT_EQ(1, status_sel_size.value());
         sel.resize(1);
-        ASSERT_EQ("3", to_string(buff));
+        ASSERT_EQ("3", to_string(sel));
     }
     {
         std::vector<uint16_t> sel{0, 1, 2, 3, 5, 6, 7};
@@ -1766,7 +1766,7 @@ TEST(ColumnPredicateTest, test_in_bitset) {
         ASSERT_TRUE(status_sel_size.ok());
         ASSERT_EQ(2, status_sel_size.value());
         sel.resize(2);
-        ASSERT_EQ("1,3", to_string(buff));
+        ASSERT_EQ("1,3", to_string(sel));
     }
     {
         std::vector<uint16_t> sel{0, 2, 3, 5, 6, 7};
@@ -1774,7 +1774,7 @@ TEST(ColumnPredicateTest, test_in_bitset) {
         ASSERT_TRUE(status_sel_size.ok());
         ASSERT_EQ(1, status_sel_size.value());
         sel.resize(1);
-        ASSERT_EQ("3", to_string(buff));
+        ASSERT_EQ("3", to_string(sel));
     }
 }
 

--- a/be/test/storage/column_predicate_test.cpp
+++ b/be/test/storage/column_predicate_test.cpp
@@ -16,6 +16,7 @@
 
 #include <vector>
 
+#include "exprs/runtime_filter.h"
 #include "gtest/gtest.h"
 #include "storage/chunk_helper.h"
 #include "testutil/assert.h"
@@ -29,6 +30,15 @@ static inline std::string to_string(const std::vector<uint8_t>& v) {
     std::stringstream ss;
     for (uint8_t n : v) {
         ss << (n != 0) << ",";
+    }
+    std::string s = ss.str();
+    s.pop_back();
+    return s;
+}
+static inline std::string to_string(const std::vector<uint16_t>& values) {
+    std::stringstream ss;
+    for (uint8_t value : values) {
+        ss << value << ",";
     }
     std::string s = ss.str();
     s.pop_back();
@@ -1636,6 +1646,131 @@ TEST(ColumnPredicateTest, test_in) {
 
         p->evaluate_or(c.get(), buff.data(), 2, 4);
         ASSERT_EQ("1,1,1,1,1", to_string(buff));
+    }
+}
+
+TEST(ColumnPredicateTest, test_in_bitset) {
+    Bitset<TYPE_INT> bitset;
+    bitset.set_min_max(10, 100);
+    bitset.init();
+    for (int i = 10; i < 100; i += 2) {
+        bitset.insert(i);
+    }
+    std::unique_ptr<ColumnPredicate> bitset_pred(new_bitset_in_predicate(get_type_info(TYPE_INT), 0, bitset));
+
+    ASSERT_EQ(PredicateType::kInList, bitset_pred->type());
+    ASSERT_TRUE(bitset_pred->can_vectorized());
+
+    auto nullable_col = ChunkHelper::column_from_field_type(TYPE_INT, true);
+    nullable_col->append_datum(Datum(1));   // 0
+    nullable_col->append_datum(Datum(12));  // 1
+    nullable_col->append_datum(Datum(13));  // 0
+    nullable_col->append_datum(Datum(14));  // 1
+    nullable_col->append_datum(Datum(105)); // 0
+    (void)nullable_col->append_nulls(1);    // 0
+    (void)nullable_col->append_nulls(1);    // 0
+
+    auto col = ChunkHelper::column_from_field_type(TYPE_INT, true);
+    col->append_datum(Datum(1));   // 0
+    col->append_datum(Datum(12));  // 1
+    col->append_datum(Datum(13));  // 0
+    col->append_datum(Datum(14));  // 1
+    col->append_datum(Datum(105)); // 0
+
+    std::vector<uint8_t> buff(7);
+
+    // ---------------------------------------------
+    // evaluate()
+    // ---------------------------------------------
+    bitset_pred->evaluate(nullable_col.get(), buff.data(), 0, 7);
+    ASSERT_EQ("0,1,0,1,0,0,0", to_string(buff));
+
+    bitset_pred->evaluate(nullable_col.get(), buff.data(), 1, 6);
+    ASSERT_EQ("1,0,1,0,0", to_string(buff));
+
+    bitset_pred->evaluate(col.get(), buff.data(), 0, 5);
+    ASSERT_EQ("0,1,0,1,0", to_string(buff));
+
+    bitset_pred->evaluate(nullable_col.get(), buff.data(), 1, 4);
+    ASSERT_EQ("1,0,1", to_string(buff));
+
+    // ---------------------------------------------
+    // evaluate_and()
+    // ---------------------------------------------
+    buff.assign(7, 1);
+
+    bitset_pred->evaluate_and(nullable_col.get(), buff.data(), 0, 7);
+    ASSERT_EQ("0,1,0,1,0,0,0", to_string(buff));
+
+    bitset_pred->evaluate_and(nullable_col.get(), buff.data(), 1, 6);
+    ASSERT_EQ("1,0,1,0,0", to_string(buff));
+
+    bitset_pred->evaluate_and(col.get(), buff.data(), 0, 5);
+    ASSERT_EQ("0,1,0,1,0", to_string(buff));
+
+    bitset_pred->evaluate_and(nullable_col.get(), buff.data(), 1, 4);
+    ASSERT_EQ("1,0,1", to_string(buff));
+
+    buff.assign(7, 0);
+    bitset_pred->evaluate_and(nullable_col.get(), buff.data(), 0, 7);
+    ASSERT_EQ("0,0,0,0,0,0,0", to_string(buff));
+
+    buff[1] = 1;
+    bitset_pred->evaluate_and(nullable_col.get(), buff.data(), 0, 7);
+    ASSERT_EQ("0,1,0,0,0,0,0", to_string(buff));
+
+    // ---------------------------------------------
+    // evaluate_or()
+    // ---------------------------------------------
+    buff.assign(7, 0);
+
+    bitset_pred->evaluate_and(nullable_col.get(), buff.data(), 0, 7);
+    ASSERT_EQ("0,1,0,1,0,0,0", to_string(buff));
+
+    bitset_pred->evaluate_and(nullable_col.get(), buff.data(), 1, 6);
+    ASSERT_EQ("1,0,1,0,0", to_string(buff));
+
+    bitset_pred->evaluate_and(col.get(), buff.data(), 0, 5);
+    ASSERT_EQ("0,1,0,1,0", to_string(buff));
+
+    bitset_pred->evaluate_and(nullable_col.get(), buff.data(), 1, 4);
+    ASSERT_EQ("1,0,1", to_string(buff));
+
+    buff.assign(7, 1);
+    bitset_pred->evaluate_and(nullable_col.get(), buff.data(), 0, 7);
+    ASSERT_EQ("1,1,1,1,1,1,1", to_string(buff));
+
+    // ---------------------------------------------
+    // evaluate_branchless()
+    // ---------------------------------------------
+
+    {
+        std::vector<uint16_t> sel{0, 1, 2, 3, 5, 6, 7};
+        auto status_sel_size = bitset_pred->evaluate_branchless(nullable_col.get(), sel.data(), 7);
+        ASSERT_TRUE(status_sel_size.ok());
+        ASSERT_EQ(2, status_sel_size.value());
+        ASSERT_EQ("1,3", to_string(buff));
+    }
+    {
+        std::vector<uint16_t> sel{0, 2, 3, 5, 6, 7};
+        auto status_sel_size = bitset_pred->evaluate_branchless(nullable_col.get(), sel.data(), 6);
+        ASSERT_TRUE(status_sel_size.ok());
+        ASSERT_EQ(2, status_sel_size.value());
+        ASSERT_EQ("3", to_string(buff));
+    }
+    {
+        std::vector<uint16_t> sel{0, 1, 2, 3, 5, 6, 7};
+        auto status_sel_size = bitset_pred->evaluate_branchless(col.get(), sel.data(), 5);
+        ASSERT_TRUE(status_sel_size.ok());
+        ASSERT_EQ(2, status_sel_size.value());
+        ASSERT_EQ("1,3", to_string(buff));
+    }
+    {
+        std::vector<uint16_t> sel{0, 2, 3, 5, 6, 7};
+        auto status_sel_size = bitset_pred->evaluate_branchless(col.get(), sel.data(), 4);
+        ASSERT_TRUE(status_sel_size.ok());
+        ASSERT_EQ(2, status_sel_size.value());
+        ASSERT_EQ("3", to_string(buff));
     }
 }
 

--- a/be/test/storage/column_predicate_test.cpp
+++ b/be/test/storage/column_predicate_test.cpp
@@ -1724,20 +1724,20 @@ TEST(ColumnPredicateTest, test_in_bitset) {
     // ---------------------------------------------
     buff.assign(7, 0);
 
-    bitset_pred->evaluate_and(nullable_col.get(), buff.data(), 0, 7);
+    bitset_pred->evaluate_or(nullable_col.get(), buff.data(), 0, 7);
     ASSERT_EQ("0,1,0,1,0,0,0", to_string(buff));
 
-    bitset_pred->evaluate_and(nullable_col.get(), buff.data(), 1, 6);
+    bitset_pred->evaluate_or(nullable_col.get(), buff.data(), 1, 6);
     ASSERT_EQ("0,1,0,1,0,0,0", to_string(buff));
 
-    bitset_pred->evaluate_and(col.get(), buff.data(), 0, 5);
+    bitset_pred->evaluate_or(col.get(), buff.data(), 0, 5);
     ASSERT_EQ("0,1,0,1,0,0,0", to_string(buff));
 
-    bitset_pred->evaluate_and(nullable_col.get(), buff.data(), 1, 4);
+    bitset_pred->evaluate_or(nullable_col.get(), buff.data(), 1, 4);
     ASSERT_EQ("0,1,0,1,0,0,0", to_string(buff));
 
     buff.assign(7, 1);
-    bitset_pred->evaluate_and(nullable_col.get(), buff.data(), 0, 7);
+    bitset_pred->evaluate_or(nullable_col.get(), buff.data(), 0, 7);
     ASSERT_EQ("1,1,1,1,1,1,1", to_string(buff));
 
     // ---------------------------------------------

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -432,6 +432,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_TOPN_RUNTIME_FILTER = "enable_topn_runtime_filter";
     public static final String GLOBAL_RUNTIME_FILTER_RPC_HTTP_MIN_SIZE = "global_runtime_filter_rpc_http_min_size";
     public static final String ENABLE_JOIN_RUNTIME_FILTER_PUSH_DOWN = "enable_join_runtime_filter_push_down";
+    public static final String ENABLE_JOIN_RUNTIME_BITSET_FILTER = "enable_join_runtime_bitset_filter";
 
     public static final String ENABLE_PIPELINE_LEVEL_MULTI_PARTITIONED_RF =
             "enable_pipeline_level_multi_partitioned_rf";
@@ -1525,6 +1526,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private long globalRuntimeFilterRpcHttpMinSize = 64L * 1024 * 1024;
     @VariableMgr.VarAttr(name = ENABLE_JOIN_RUNTIME_FILTER_PUSH_DOWN, flag = VariableMgr.INVISIBLE)
     private boolean enableJoinRuntimeFilterPushDown = true;
+    @VariableMgr.VarAttr(name = ENABLE_JOIN_RUNTIME_BITSET_FILTER, flag = VariableMgr.INVISIBLE)
+    private boolean enableJoinRuntimeBitsetFilter = true;
 
     @VarAttr(name = ENABLE_PIPELINE_LEVEL_MULTI_PARTITIONED_RF)
     private boolean enablePipelineLevelMultiPartitionedRf = false;
@@ -4842,6 +4845,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setRuntime_filter_scan_wait_time_ms(runtimeFilterScanWaitTime);
         tResult.setRuntime_filter_rpc_http_min_size(globalRuntimeFilterRpcHttpMinSize);
         tResult.setEnable_join_runtime_filter_pushdown(enableJoinRuntimeFilterPushDown);
+        tResult.setEnable_join_runtime_bitset_filter(enableJoinRuntimeBitsetFilter);
         tResult.setLower_upper_support_utf8(lowerUpperSupportUTF8);
         tResult.setPipeline_dop(pipelineDop);
         if (pipelineProfileLevel == 2) {

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -330,6 +330,7 @@ struct TQueryOptions {
   152: optional double k_factor;
 
   160: optional bool enable_join_runtime_filter_pushdown;
+  161: optional bool enable_join_runtime_bitset_filter;
 
   170: optional bool enable_parquet_reader_bloom_filter;
   171: optional bool enable_parquet_reader_page_index;

--- a/test/sql/test_runtime_filter/R/test_runtime_bitset_filter
+++ b/test/sql/test_runtime_filter/R/test_runtime_bitset_filter
@@ -1,0 +1,1052 @@
+-- name: test_runtime_bitset_filter
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+-- result:
+-- !result
+insert into __row_util_base select * from __row_util_base; -- 20000
+insert into __row_util_base select * from __row_util_base; -- 40000
+insert into __row_util_base select * from __row_util_base; -- 80000
+insert into __row_util_base select * from __row_util_base; -- 160000
+insert into __row_util_base select * from __row_util_base; -- 320000
+insert into __row_util_base select * from __row_util_base; -- 640000
+insert into __row_util_base select * from __row_util_base; -- 1280000
+
+CREATE TABLE __row_util (
+  idx bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into __row_util select row_number() over() as idx from __row_util_base;
+-- result:
+-- !result
+CREATE TABLE t1 (
+  k1 bigint NULL,
+
+  c_bool_1_null BOOLEAN NULL,
+  c_bool_2_notnull BOOLEAN NOT NULL,
+
+  c_tinyint_1_null TINYINT NULL,
+  c_tinyint_2_notnull TINYINT NOT NULL,
+
+  c_smallint_1_null SMALLINT NULL,
+  c_smallint_2_notnull SMALLINT NOT NULL,
+
+  c_int_1_null INT NULL,
+  c_int_2_notnull INT NOT NULL,
+
+  c_bigint_1_null BIGINT NULL,
+  c_bigint_2_notnull BIGINT NOT NULL,
+
+  c_date_1_null date NULL,
+  c_date_2_notnull date NULL,
+
+  c_decimal64_1_null DECIMAL(18) NULL,
+  c_decimal64_2_notnull DECIMAL(18) NOT NULL,
+
+  c_str_1_null STRING NULL,
+  c_str_2_notnull STRING NOT NULL,
+
+  c_str_3_low_null STRING NULL,
+  c_str_4_low_notnull STRING NOT NULL,
+
+  c_datetime_1_seq datetime NULL,
+  c_datetime_2_seq datetime NOT NULL
+
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE t2 (
+  k1 bigint NULL,
+
+  c_bool_1_null BOOLEAN NULL,
+  c_bool_2_notnull BOOLEAN NOT NULL,
+
+  c_tinyint_1_null TINYINT NULL,
+  c_tinyint_2_notnull TINYINT NOT NULL,
+
+  c_smallint_1_null SMALLINT NULL,
+  c_smallint_2_notnull SMALLINT NOT NULL,
+
+  c_int_1_null INT NULL,
+  c_int_2_notnull INT NOT NULL,
+
+  c_bigint_1_null BIGINT NULL,
+  c_bigint_2_notnull BIGINT NOT NULL,
+
+  c_date_1_null date NULL,
+  c_date_2_notnull date NULL,
+
+  c_decimal64_1_null DECIMAL(18) NULL,
+  c_decimal64_2_notnull DECIMAL(18) NOT NULL,
+
+  c_str_1_null STRING NULL,
+  c_str_2_notnull STRING NOT NULL,
+
+  c_str_3_low_null STRING NULL,
+  c_str_4_low_notnull STRING NOT NULL,
+
+  c_datetime_1_seq datetime NULL,
+  c_datetime_2_seq datetime NOT NULL
+
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE t3 (
+  k1 bigint NULL,
+
+  c_bool_1_null BOOLEAN NULL,
+  c_bool_2_notnull BOOLEAN NOT NULL,
+
+  c_tinyint_1_null TINYINT NULL,
+  c_tinyint_2_notnull TINYINT NOT NULL,
+
+  c_smallint_1_null SMALLINT NULL,
+  c_smallint_2_notnull SMALLINT NOT NULL,
+
+  c_int_1_null INT NULL,
+  c_int_2_notnull INT NOT NULL,
+
+  c_bigint_1_null BIGINT NULL,
+  c_bigint_2_notnull BIGINT NOT NULL,
+
+  c_date_1_null date NULL,
+  c_date_2_notnull date NULL,
+
+  c_decimal64_1_null DECIMAL(18) NULL,
+  c_decimal64_2_notnull DECIMAL(18) NOT NULL,
+
+  c_str_1_null STRING NULL,
+  c_str_2_notnull STRING NOT NULL,
+
+  c_str_3_low_null STRING NULL,
+  c_str_4_low_notnull STRING NOT NULL,
+
+  c_datetime_1_seq datetime NULL,
+  c_datetime_2_seq datetime NOT NULL
+
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t2 
+SELECT 
+    idx,
+
+    idx % 2 = 0,
+    idx % 2 = 0,
+
+    idx % 128,
+    idx % 128,
+
+    idx % 32768,
+    idx % 32768,
+
+    idx % 2147483648,
+    idx % 2147483648,
+
+    idx,
+    idx,
+
+    cast(date_add('2023-01-01', interval idx day) as date),
+    cast(date_add('2023-01-01', interval idx day) as date),
+
+    idx,
+    idx,
+
+    concat('str-abc-', idx),
+    concat('str-abc-', idx),
+
+    concat('str-abc-', idx % 256),
+    concat('str-abc-', idx % 256),
+
+    cast(date_add('2023-01-01', interval idx second) as datetime),
+    cast(date_add('2023-01-01', interval idx second) as datetime)
+FROM __row_util
+order by idx
+limit 100000;
+-- result:
+-- !result
+INSERT INTO t2 
+SELECT 
+    idx,
+
+    NULL,
+    idx % 2 = 0,
+
+    NULL,
+    idx % 128,
+
+    NULL,
+    idx % 32768,
+
+    NULL,
+    idx % 2147483648,
+
+    NULL,
+    idx,
+
+    NULL,
+    cast(date_add('2023-01-01', interval idx day) as date),
+
+    NULL,
+    idx,
+
+    NULL,
+    concat('str-abc-', idx),
+
+    NULL,
+    concat('str-abc-', idx % 256),
+
+    NULL,
+    cast(date_add('2023-01-01', interval idx second) as datetime)
+FROM __row_util
+order by idx
+limit 100000, 10000;
+-- result:
+-- !result
+INSERT INTO t3 
+SELECT 
+    idx,
+
+    idx % 2 = 0,
+    idx % 2 = 0,
+
+    idx % 128,
+    idx % 128,
+
+    idx % 32768,
+    idx % 32768,
+
+    idx * 37 % 2147483648 ,
+    idx * 37 % 2147483648,
+
+    idx * 37,
+    idx * 37,
+
+    cast(date_add('2023-01-01', interval idx * 37 day) as date),
+    cast(date_add('2023-01-01', interval idx * 37 day) as date),
+
+    idx * 37,
+    idx * 37,
+
+    concat('str-abc-', idx),
+    concat('str-abc-', idx),
+
+    concat('str-abc-', idx % 256),
+    concat('str-abc-', idx % 256),
+
+    cast(date_add('2023-01-01', interval idx second) as datetime),
+    cast(date_add('2023-01-01', interval idx second) as datetime)
+FROM __row_util
+order by idx
+limit 100000;
+-- result:
+-- !result
+INSERT INTO t3 
+SELECT 
+    idx,
+
+    NULL,
+    idx % 2 = 0,
+
+    NULL,
+    idx % 128,
+
+    NULL,
+    idx % 32768,
+
+    NULL,
+    idx * 37 % 2147483648,
+
+    NULL,
+    idx * 37,
+
+    NULL,
+    cast(date_add('2023-01-01', interval idx * 37 day) as date),
+
+    NULL,
+    idx * 37,
+
+    NULL,
+    concat('str-abc-', idx),
+
+    NULL,
+    concat('str-abc-', idx % 256),
+
+    NULL,
+    cast(date_add('2023-01-01', interval idx second) as datetime)
+FROM __row_util
+order by idx
+limit 100000, 10000;
+-- result:
+-- !result
+INSERT INTO t1
+SELECT 
+    idx,
+
+    idx % 2 = 0,
+    idx % 2 = 0,
+
+    idx % 128,
+    idx % 128,
+
+    idx % 32768,
+    idx % 32768,
+
+    idx % 2147483648,
+    idx % 2147483648,
+
+    idx,
+    idx,
+
+    cast(date_add('2023-01-01', interval idx day) as date),
+    cast(date_add('2023-01-01', interval idx day) as date),
+
+    idx,
+    idx,
+
+    concat('str-abc-', idx),
+    concat('str-abc-', idx),
+
+    concat('str-abc-', idx % 256),
+    concat('str-abc-', idx % 256),
+
+    cast(date_add('2023-01-01', interval idx second) as datetime),
+    cast(date_add('2023-01-01', interval idx second) as datetime)
+FROM __row_util;
+-- result:
+-- !result
+INSERT INTO t1
+SELECT 
+    idx,
+
+    NULL,
+    idx % 2 = 0,
+
+    NULL,
+    idx % 128,
+
+    NULL,
+    idx % 32768,
+
+    NULL,
+    idx % 2147483648,
+
+    NULL,
+    idx,
+
+    NULL,
+    cast(date_add('2023-01-01', interval idx day) as date),
+
+    NULL,
+    idx,
+
+    NULL,
+    concat('str-abc-', idx),
+
+    NULL,
+    concat('str-abc-', idx % 256),
+
+    NULL,
+    cast(date_add('2023-01-01', interval idx second) as datetime)
+FROM __row_util
+order by idx
+limit 100000, 10000;
+-- result:
+-- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
+select count(1)
+from t1 join [broadcast] w1 using(c_bool_1_null);
+-- result:
+6400000
+-- !result
+with w1 as (
+   select * from t2 order by k1 limit 10
+)
+select count(1)
+from t1 join [broadcast] w1 using(c_bool_2_notnull);
+-- result:
+6450000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 using(c_tinyint_1_null);
+-- result:
+1000000000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 using(c_tinyint_2_notnull);
+-- result:
+1108593760
+-- !result
+select count(1)
+from t1 join [broadcast] t2 using(c_smallint_1_null);
+-- result:
+3907840
+-- !result
+select count(1)
+from t1 join [broadcast] t2 using(c_smallint_2_notnull);
+-- result:
+4338192
+-- !result
+select count(1)
+from t1 join [broadcast] t2 using(c_int_1_null);
+-- result:
+100000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 using(c_int_2_notnull);
+-- result:
+120000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 using(c_bigint_1_null);
+-- result:
+100000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 using(c_bigint_2_notnull);
+-- result:
+120000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 using(c_date_1_null);
+-- result:
+100000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 using(c_date_2_notnull);
+-- result:
+120000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 using(c_decimal64_1_null);
+-- result:
+100000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 using(c_decimal64_2_notnull);
+-- result:
+120000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 using(c_str_1_null);
+-- result:
+100000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 using(c_str_2_notnull);
+-- result:
+120000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 using(c_str_3_low_null);
+-- result:
+500000000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 using(c_str_4_low_notnull);
+-- result:
+554296880
+-- !result
+select count(1)
+from t1 join [broadcast] t2 using(c_datetime_1_seq);
+-- result:
+100000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 using(c_datetime_2_seq);
+-- result:
+120000
+-- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
+select count(1)
+from t1 join [broadcast] w1 on t1.c_bool_1_null <=> w1.c_bool_1_null;
+-- result:
+6400000
+-- !result
+with w1 as (
+   select * from t2 order by k1 limit 10
+)
+select count(1)
+from t1 join [broadcast] w1 on t1.c_bool_2_notnull <=> w1.c_bool_2_notnull;
+-- result:
+6450000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 on t1.c_tinyint_1_null <=> t2.c_tinyint_1_null;
+-- result:
+1100000000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 on t1.c_tinyint_2_notnull <=> t2.c_tinyint_2_notnull;
+-- result:
+1108593760
+-- !result
+select count(1)
+from t1 join [broadcast] t2 on t1.c_smallint_1_null <=> t2.c_smallint_1_null;
+-- result:
+103907840
+-- !result
+select count(1)
+from t1 join [broadcast] t2 on t1.c_smallint_2_notnull <=> t2.c_smallint_2_notnull;
+-- result:
+4338192
+-- !result
+select count(1)
+from t1 join [broadcast] t2 on t1.c_int_1_null <=> t2.c_int_1_null;
+-- result:
+100100000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 on t1.c_int_2_notnull <=> t2.c_int_2_notnull;
+-- result:
+120000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 on t1.c_bigint_1_null <=> t2.c_bigint_1_null;
+-- result:
+100100000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 on t1.c_bigint_2_notnull <=> t2.c_bigint_2_notnull;
+-- result:
+120000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 on t1.c_date_1_null <=> t2.c_date_1_null;
+-- result:
+100100000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 on t1.c_date_2_notnull <=> t2.c_date_2_notnull;
+-- result:
+120000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 on t1.c_decimal64_1_null <=> t2.c_decimal64_1_null;
+-- result:
+100100000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 on t1.c_decimal64_2_notnull <=> t2.c_decimal64_2_notnull;
+-- result:
+120000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 on t1.c_str_1_null <=> t2.c_str_1_null;
+-- result:
+100100000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 on t1.c_str_2_notnull <=> t2.c_str_2_notnull;
+-- result:
+120000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 on t1.c_str_3_low_null <=> t2.c_str_3_low_null;
+-- result:
+600000000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 on t1.c_str_4_low_notnull <=> t2.c_str_4_low_notnull;
+-- result:
+554296880
+-- !result
+select count(1)
+from t1 join [broadcast] t2 on t1.c_datetime_1_seq <=> t2.c_datetime_1_seq;
+-- result:
+100100000
+-- !result
+select count(1)
+from t1 join [broadcast] t2 on t1.c_datetime_2_seq <=> t2.c_datetime_2_seq;
+-- result:
+120000
+-- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
+select count(1)
+from (select distinct c_bool_1_null from t1)t join [broadcast] w1 using(c_bool_1_null);
+-- result:
+10
+-- !result
+with w1 as (
+   select * from t2 order by k1 limit 10
+)
+select count(1)
+from (select distinct c_bool_2_notnull from t1)t join [broadcast] w1 using(c_bool_2_notnull);
+-- result:
+10
+-- !result
+select count(1)
+from (select distinct c_tinyint_1_null from t1)t join [broadcast] t2 using(c_tinyint_1_null);
+-- result:
+100000
+-- !result
+select count(1)
+from (select distinct c_tinyint_2_notnull from t1)t join [broadcast] t2 using(c_tinyint_2_notnull);
+-- result:
+110000
+-- !result
+select count(1)
+from (select distinct c_smallint_1_null from t1)t join [broadcast] t2 using(c_smallint_1_null);
+-- result:
+100000
+-- !result
+select count(1)
+from (select distinct c_smallint_2_notnull from t1)t join [broadcast] t2 using(c_smallint_2_notnull);
+-- result:
+110000
+-- !result
+select count(1)
+from (select distinct c_int_1_null from t1)t join [broadcast] t2 using(c_int_1_null);
+-- result:
+100000
+-- !result
+select count(1)
+from (select distinct c_int_2_notnull from t1)t join [broadcast] t2 using(c_int_2_notnull);
+-- result:
+110000
+-- !result
+select count(1)
+from (select distinct c_bigint_1_null from t1)t join [broadcast] t2 using(c_bigint_1_null);
+-- result:
+100000
+-- !result
+select count(1)
+from (select distinct c_bigint_2_notnull from t1)t join [broadcast] t2 using(c_bigint_2_notnull);
+-- result:
+110000
+-- !result
+select count(1)
+from (select distinct c_date_1_null from t1)t join [broadcast] t2 using(c_date_1_null);
+-- result:
+100000
+-- !result
+select count(1)
+from (select distinct c_date_2_notnull from t1)t join [broadcast] t2 using(c_date_2_notnull);
+-- result:
+110000
+-- !result
+select count(1)
+from (select distinct c_decimal64_1_null from t1)t join [broadcast] t2 using(c_decimal64_1_null);
+-- result:
+100000
+-- !result
+select count(1)
+from (select distinct c_decimal64_2_notnull from t1)t join [broadcast] t2 using(c_decimal64_2_notnull);
+-- result:
+110000
+-- !result
+select count(1)
+from (select distinct c_str_1_null from t1)t join [broadcast] t2 using(c_str_1_null);
+-- result:
+100000
+-- !result
+select count(1)
+from (select distinct c_str_2_notnull from t1)t join [broadcast] t2 using(c_str_2_notnull);
+-- result:
+110000
+-- !result
+select count(1)
+from (select distinct c_str_3_low_null from t1)t join [broadcast] t2 using(c_str_3_low_null);
+-- result:
+100000
+-- !result
+select count(1)
+from (select distinct c_str_4_low_notnull from t1)t join [broadcast] t2 using(c_str_4_low_notnull);
+-- result:
+110000
+-- !result
+select count(1)
+from (select distinct c_datetime_1_seq from t1)t join [broadcast] t2 using(c_datetime_1_seq);
+-- result:
+100000
+-- !result
+select count(1)
+from (select distinct c_datetime_2_seq from t1)t join [broadcast] t2 using(c_datetime_2_seq);
+-- result:
+110000
+-- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
+select count(1)
+from t1 join [shuffle] w1 using(c_bool_1_null);
+-- result:
+6400000
+-- !result
+with w1 as (
+   select * from t2 order by k1 limit 10
+)
+select count(1)
+from t1 join [shuffle] w1 using(c_bool_2_notnull);
+-- result:
+6450000
+-- !result
+select count(1)
+from t1 join [shuffle] t2 using(c_tinyint_1_null);
+-- result:
+1000000000
+-- !result
+select count(1)
+from t1 join [shuffle] t2 using(c_tinyint_2_notnull);
+-- result:
+1108593760
+-- !result
+select count(1)
+from t1 join [shuffle] t2 using(c_smallint_1_null);
+-- result:
+3907840
+-- !result
+select count(1)
+from t1 join [shuffle] t2 using(c_smallint_2_notnull);
+-- result:
+4338192
+-- !result
+select count(1)
+from t1 join [shuffle] t2 using(c_int_1_null);
+-- result:
+100000
+-- !result
+select count(1)
+from t1 join [shuffle] t2 using(c_int_2_notnull);
+-- result:
+120000
+-- !result
+select count(1)
+from t1 join [shuffle] t2 using(c_bigint_1_null);
+-- result:
+100000
+-- !result
+select count(1)
+from t1 join [shuffle] t2 using(c_bigint_2_notnull);
+-- result:
+120000
+-- !result
+select count(1)
+from t1 join [shuffle] t2 using(c_date_1_null);
+-- result:
+100000
+-- !result
+select count(1)
+from t1 join [shuffle] t2 using(c_date_2_notnull);
+-- result:
+120000
+-- !result
+select count(1)
+from t1 join [shuffle] t2 using(c_decimal64_1_null);
+-- result:
+100000
+-- !result
+select count(1)
+from t1 join [shuffle] t2 using(c_decimal64_2_notnull);
+-- result:
+120000
+-- !result
+select count(1)
+from t1 join [shuffle] t2 using(c_str_1_null);
+-- result:
+100000
+-- !result
+select count(1)
+from t1 join [shuffle] t2 using(c_str_2_notnull);
+-- result:
+120000
+-- !result
+select count(1)
+from t1 join [shuffle] t2 using(c_str_3_low_null);
+-- result:
+500000000
+-- !result
+select count(1)
+from t1 join [shuffle] t2 using(c_str_4_low_notnull);
+-- result:
+554296880
+-- !result
+select count(1)
+from t1 join [shuffle] t2 using(c_datetime_1_seq);
+-- result:
+100000
+-- !result
+select count(1)
+from t1 join [shuffle] t2 using(c_datetime_2_seq);
+-- result:
+120000
+-- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] w1 using(c_bool_1_null);
+-- result:
+6400000
+-- !result
+with w1 as (
+   select * from t2 order by k1 limit 10
+)
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] w1 using(c_bool_2_notnull);
+-- result:
+6450000
+-- !result
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_tinyint_1_null);
+-- result:
+1000000000
+-- !result
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_tinyint_2_notnull);
+-- result:
+1108593760
+-- !result
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_smallint_1_null);
+-- result:
+3907840
+-- !result
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_smallint_2_notnull);
+-- result:
+4338192
+-- !result
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_int_1_null);
+-- result:
+100000
+-- !result
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_int_2_notnull);
+-- result:
+120000
+-- !result
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_bigint_1_null);
+-- result:
+100000
+-- !result
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_bigint_2_notnull);
+-- result:
+120000
+-- !result
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_date_1_null);
+-- result:
+100000
+-- !result
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_date_2_notnull);
+-- result:
+120000
+-- !result
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_decimal64_1_null);
+-- result:
+100000
+-- !result
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_decimal64_2_notnull);
+-- result:
+120000
+-- !result
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_str_1_null);
+-- result:
+100000
+-- !result
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_str_2_notnull);
+-- result:
+120000
+-- !result
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_str_3_low_null);
+-- result:
+500000000
+-- !result
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_str_4_low_notnull);
+-- result:
+554296880
+-- !result
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_datetime_1_seq);
+-- result:
+100000
+-- !result
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_datetime_2_seq);
+-- result:
+120000
+-- !result
+with w1 as (
+    select * from t3 order by k1 limit 10
+)
+select count(1)
+from t1 join [broadcast] w1 using(c_bool_1_null);
+-- result:
+6400000
+-- !result
+with w1 as (
+   select * from t3 order by k1 limit 10
+)
+select count(1)
+from t1 join [broadcast] w1 using(c_bool_2_notnull);
+-- result:
+6450000
+-- !result
+select count(1)
+from t1 join [broadcast] t3 using(c_tinyint_1_null);
+-- result:
+1000000000
+-- !result
+select count(1)
+from t1 join [broadcast] t3 using(c_tinyint_2_notnull);
+-- result:
+1108593760
+-- !result
+select count(1)
+from t1 join [broadcast] t3 using(c_smallint_1_null);
+-- result:
+3907840
+-- !result
+select count(1)
+from t1 join [broadcast] t3 using(c_smallint_2_notnull);
+-- result:
+4338192
+-- !result
+select count(1)
+from t1 join [broadcast] t3 using(c_int_1_null);
+-- result:
+34594
+-- !result
+select count(1)
+from t1 join [broadcast] t3 using(c_int_2_notnull);
+-- result:
+34864
+-- !result
+select count(1)
+from t1 join [broadcast] t3 using(c_bigint_1_null);
+-- result:
+34594
+-- !result
+select count(1)
+from t1 join [broadcast] t3 using(c_bigint_2_notnull);
+-- result:
+34864
+-- !result
+select count(1)
+from t1 join [broadcast] t3 using(c_date_1_null);
+-- result:
+34594
+-- !result
+select count(1)
+from t1 join [broadcast] t3 using(c_date_2_notnull);
+-- result:
+34864
+-- !result
+select count(1)
+from t1 join [broadcast] t3 using(c_decimal64_1_null);
+-- result:
+34594
+-- !result
+select count(1)
+from t1 join [broadcast] t3 using(c_decimal64_2_notnull);
+-- result:
+34864
+-- !result
+select count(1)
+from t1 join [broadcast] t3 using(c_str_1_null);
+-- result:
+100000
+-- !result
+select count(1)
+from t1 join [broadcast] t3 using(c_str_2_notnull);
+-- result:
+120000
+-- !result
+select count(1)
+from t1 join [broadcast] t3 using(c_str_3_low_null);
+-- result:
+500000000
+-- !result
+select count(1)
+from t1 join [broadcast] t3 using(c_str_4_low_notnull);
+-- result:
+554296880
+-- !result
+select count(1)
+from t1 join [broadcast] t3 using(c_datetime_1_seq);
+-- result:
+100000
+-- !result
+select count(1)
+from t1 join [broadcast] t3 using(c_datetime_2_seq);
+-- result:
+120000
+-- !result
+select count(1)
+from 
+    t1 
+    join [broadcast] t2 on t1.c_int_1_null = t2.c_int_1_null
+    join [shuffle] t3 on t1.c_int_1_null = t3.c_int_1_null;
+-- result:
+2702
+-- !result
+select count(1)
+from 
+    t1 
+    join [broadcast] t2 on t1.c_int_1_null = t2.c_int_1_null
+    join [shuffle] t3 on t1.c_date_1_null = t3.c_date_1_null;
+-- result:
+2702
+-- !result
+select count(1)
+from 
+    (select distinct c_int_1_null from t1) t1
+    join [broadcast] t2 on t1.c_int_1_null = t2.c_int_1_null
+    join [shuffle] t3 on t1.c_int_1_null = t3.c_int_1_null;
+-- result:
+2702
+-- !result
+select count(1)
+from 
+    (select distinct c_int_1_null,c_date_1_null from t1) t1
+    join [broadcast] t2 on t1.c_int_1_null = t2.c_int_1_null
+    join [shuffle] t3 on t1.c_date_1_null = t3.c_date_1_null;
+-- result:
+2702
+-- !result

--- a/test/sql/test_runtime_filter/T/test_runtime_bitset_filter
+++ b/test/sql/test_runtime_filter/T/test_runtime_bitset_filter
@@ -1,0 +1,921 @@
+-- name: test_runtime_bitset_filter
+
+-- - type: 
+--      - supported: BOOLEAN, TINYINT, SMALLINT, INT, BIGINT, DECIMAL32, DECIMAL64, DATE
+--      - take care: low cardinality VARCHAR
+--      - not supported: VARCHAR, FLOAT, DOUBLE, DECIMAL128
+-- - trigger bitset filter or not
+--      - trigger: value interval is small
+--      - not trigger: value interval is large
+-- - filter effectivness
+--      - filter out all rows
+--      - filter the most rows
+--      - filter few rows
+--      - filter nothing
+-- - zonemap effectivness
+-- - multiple filters (BLOOM, BITSET, EMPTY)
+-- - enable or disable _enable_join_runtime_bitset_filter
+-- - nullable or not nullable for build and probe columns
+-- - only support boradcast join
+
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+insert into __row_util_base select * from __row_util_base; -- 20000
+insert into __row_util_base select * from __row_util_base; -- 40000
+insert into __row_util_base select * from __row_util_base; -- 80000
+insert into __row_util_base select * from __row_util_base; -- 160000
+insert into __row_util_base select * from __row_util_base; -- 320000
+insert into __row_util_base select * from __row_util_base; -- 640000
+insert into __row_util_base select * from __row_util_base; -- 1280000
+
+CREATE TABLE __row_util (
+  idx bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util select row_number() over() as idx from __row_util_base;
+
+CREATE TABLE t1 (
+  k1 bigint NULL,
+
+  c_bool_1_null BOOLEAN NULL,
+  c_bool_2_notnull BOOLEAN NOT NULL,
+
+  c_tinyint_1_null TINYINT NULL,
+  c_tinyint_2_notnull TINYINT NOT NULL,
+
+  c_smallint_1_null SMALLINT NULL,
+  c_smallint_2_notnull SMALLINT NOT NULL,
+
+  c_int_1_null INT NULL,
+  c_int_2_notnull INT NOT NULL,
+
+  c_bigint_1_null BIGINT NULL,
+  c_bigint_2_notnull BIGINT NOT NULL,
+
+  c_date_1_null date NULL,
+  c_date_2_notnull date NULL,
+
+  c_decimal64_1_null DECIMAL(18) NULL,
+  c_decimal64_2_notnull DECIMAL(18) NOT NULL,
+
+  c_str_1_null STRING NULL,
+  c_str_2_notnull STRING NOT NULL,
+
+  c_str_3_low_null STRING NULL,
+  c_str_4_low_notnull STRING NOT NULL,
+
+  c_datetime_1_seq datetime NULL,
+  c_datetime_2_seq datetime NOT NULL
+
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+CREATE TABLE t2 (
+  k1 bigint NULL,
+
+  c_bool_1_null BOOLEAN NULL,
+  c_bool_2_notnull BOOLEAN NOT NULL,
+
+  c_tinyint_1_null TINYINT NULL,
+  c_tinyint_2_notnull TINYINT NOT NULL,
+
+  c_smallint_1_null SMALLINT NULL,
+  c_smallint_2_notnull SMALLINT NOT NULL,
+
+  c_int_1_null INT NULL,
+  c_int_2_notnull INT NOT NULL,
+
+  c_bigint_1_null BIGINT NULL,
+  c_bigint_2_notnull BIGINT NOT NULL,
+
+  c_date_1_null date NULL,
+  c_date_2_notnull date NULL,
+
+  c_decimal64_1_null DECIMAL(18) NULL,
+  c_decimal64_2_notnull DECIMAL(18) NOT NULL,
+
+  c_str_1_null STRING NULL,
+  c_str_2_notnull STRING NOT NULL,
+
+  c_str_3_low_null STRING NULL,
+  c_str_4_low_notnull STRING NOT NULL,
+
+  c_datetime_1_seq datetime NULL,
+  c_datetime_2_seq datetime NOT NULL
+
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+CREATE TABLE t3 (
+  k1 bigint NULL,
+
+  c_bool_1_null BOOLEAN NULL,
+  c_bool_2_notnull BOOLEAN NOT NULL,
+
+  c_tinyint_1_null TINYINT NULL,
+  c_tinyint_2_notnull TINYINT NOT NULL,
+
+  c_smallint_1_null SMALLINT NULL,
+  c_smallint_2_notnull SMALLINT NOT NULL,
+
+  c_int_1_null INT NULL,
+  c_int_2_notnull INT NOT NULL,
+
+  c_bigint_1_null BIGINT NULL,
+  c_bigint_2_notnull BIGINT NOT NULL,
+
+  c_date_1_null date NULL,
+  c_date_2_notnull date NULL,
+
+  c_decimal64_1_null DECIMAL(18) NULL,
+  c_decimal64_2_notnull DECIMAL(18) NOT NULL,
+
+  c_str_1_null STRING NULL,
+  c_str_2_notnull STRING NOT NULL,
+
+  c_str_3_low_null STRING NULL,
+  c_str_4_low_notnull STRING NOT NULL,
+
+  c_datetime_1_seq datetime NULL,
+  c_datetime_2_seq datetime NOT NULL
+
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t2 
+SELECT 
+    idx,
+
+    idx % 2 = 0,
+    idx % 2 = 0,
+
+    idx % 128,
+    idx % 128,
+
+    idx % 32768,
+    idx % 32768,
+
+    idx % 2147483648,
+    idx % 2147483648,
+
+    idx,
+    idx,
+
+    cast(date_add('2023-01-01', interval idx day) as date),
+    cast(date_add('2023-01-01', interval idx day) as date),
+
+    idx,
+    idx,
+
+    concat('str-abc-', idx),
+    concat('str-abc-', idx),
+
+    concat('str-abc-', idx % 256),
+    concat('str-abc-', idx % 256),
+
+    cast(date_add('2023-01-01', interval idx second) as datetime),
+    cast(date_add('2023-01-01', interval idx second) as datetime)
+FROM __row_util
+order by idx
+limit 100000;
+
+INSERT INTO t2 
+SELECT 
+    idx,
+
+    NULL,
+    idx % 2 = 0,
+
+    NULL,
+    idx % 128,
+
+    NULL,
+    idx % 32768,
+
+    NULL,
+    idx % 2147483648,
+
+    NULL,
+    idx,
+
+    NULL,
+    cast(date_add('2023-01-01', interval idx day) as date),
+
+    NULL,
+    idx,
+
+    NULL,
+    concat('str-abc-', idx),
+
+    NULL,
+    concat('str-abc-', idx % 256),
+
+    NULL,
+    cast(date_add('2023-01-01', interval idx second) as datetime)
+FROM __row_util
+order by idx
+limit 100000, 10000;
+
+INSERT INTO t3 
+SELECT 
+    idx,
+
+    idx % 2 = 0,
+    idx % 2 = 0,
+
+    idx % 128,
+    idx % 128,
+
+    idx % 32768,
+    idx % 32768,
+
+    idx * 37 % 2147483648 ,
+    idx * 37 % 2147483648,
+
+    idx * 37,
+    idx * 37,
+
+    cast(date_add('2023-01-01', interval idx * 37 day) as date),
+    cast(date_add('2023-01-01', interval idx * 37 day) as date),
+
+    idx * 37,
+    idx * 37,
+
+    concat('str-abc-', idx),
+    concat('str-abc-', idx),
+
+    concat('str-abc-', idx % 256),
+    concat('str-abc-', idx % 256),
+
+    cast(date_add('2023-01-01', interval idx second) as datetime),
+    cast(date_add('2023-01-01', interval idx second) as datetime)
+FROM __row_util
+order by idx
+limit 100000;
+
+INSERT INTO t3 
+SELECT 
+    idx,
+
+    NULL,
+    idx % 2 = 0,
+
+    NULL,
+    idx % 128,
+
+    NULL,
+    idx % 32768,
+
+    NULL,
+    idx * 37 % 2147483648,
+
+    NULL,
+    idx * 37,
+
+    NULL,
+    cast(date_add('2023-01-01', interval idx * 37 day) as date),
+
+    NULL,
+    idx * 37,
+
+    NULL,
+    concat('str-abc-', idx),
+
+    NULL,
+    concat('str-abc-', idx % 256),
+
+    NULL,
+    cast(date_add('2023-01-01', interval idx second) as datetime)
+FROM __row_util
+order by idx
+limit 100000, 10000;
+
+INSERT INTO t1
+SELECT 
+    idx,
+
+    idx % 2 = 0,
+    idx % 2 = 0,
+
+    idx % 128,
+    idx % 128,
+
+    idx % 32768,
+    idx % 32768,
+
+    idx % 2147483648,
+    idx % 2147483648,
+
+    idx,
+    idx,
+
+    cast(date_add('2023-01-01', interval idx day) as date),
+    cast(date_add('2023-01-01', interval idx day) as date),
+
+    idx,
+    idx,
+
+    concat('str-abc-', idx),
+    concat('str-abc-', idx),
+
+    concat('str-abc-', idx % 256),
+    concat('str-abc-', idx % 256),
+
+    cast(date_add('2023-01-01', interval idx second) as datetime),
+    cast(date_add('2023-01-01', interval idx second) as datetime)
+FROM __row_util;
+
+INSERT INTO t1
+SELECT 
+    idx,
+
+    NULL,
+    idx % 2 = 0,
+
+    NULL,
+    idx % 128,
+
+    NULL,
+    idx % 32768,
+
+    NULL,
+    idx % 2147483648,
+
+    NULL,
+    idx,
+
+    NULL,
+    cast(date_add('2023-01-01', interval idx day) as date),
+
+    NULL,
+    idx,
+
+    NULL,
+    concat('str-abc-', idx),
+
+    NULL,
+    concat('str-abc-', idx % 256),
+
+    NULL,
+    cast(date_add('2023-01-01', interval idx second) as datetime)
+FROM __row_util
+order by idx
+limit 100000, 10000;
+
+-- type
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
+select count(1)
+from t1 join [broadcast] w1 using(c_bool_1_null);
+
+ with w1 as (
+    select * from t2 order by k1 limit 10
+)
+select count(1)
+from t1 join [broadcast] w1 using(c_bool_2_notnull);
+
+select count(1)
+from t1 join [broadcast] t2 using(c_tinyint_1_null);
+
+ 
+select count(1)
+from t1 join [broadcast] t2 using(c_tinyint_2_notnull);
+
+ 
+select count(1)
+from t1 join [broadcast] t2 using(c_smallint_1_null);
+
+ 
+select count(1)
+from t1 join [broadcast] t2 using(c_smallint_2_notnull);
+
+ 
+select count(1)
+from t1 join [broadcast] t2 using(c_int_1_null);
+
+ 
+select count(1)
+from t1 join [broadcast] t2 using(c_int_2_notnull);
+
+ 
+select count(1)
+from t1 join [broadcast] t2 using(c_bigint_1_null);
+
+ 
+select count(1)
+from t1 join [broadcast] t2 using(c_bigint_2_notnull);
+
+ 
+select count(1)
+from t1 join [broadcast] t2 using(c_date_1_null);
+
+ 
+select count(1)
+from t1 join [broadcast] t2 using(c_date_2_notnull);
+
+ 
+select count(1)
+from t1 join [broadcast] t2 using(c_decimal64_1_null);
+
+ 
+select count(1)
+from t1 join [broadcast] t2 using(c_decimal64_2_notnull);
+
+ 
+select count(1)
+from t1 join [broadcast] t2 using(c_str_1_null);
+
+ 
+select count(1)
+from t1 join [broadcast] t2 using(c_str_2_notnull);
+
+ 
+select count(1)
+from t1 join [broadcast] t2 using(c_str_3_low_null);
+
+ 
+select count(1)
+from t1 join [broadcast] t2 using(c_str_4_low_notnull);
+
+ 
+select count(1)
+from t1 join [broadcast] t2 using(c_datetime_1_seq);
+
+ 
+select count(1)
+from t1 join [broadcast] t2 using(c_datetime_2_seq);
+
+-- null safe
+
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
+select count(1)
+from t1 join [broadcast] w1 on t1.c_bool_1_null <=> w1.c_bool_1_null;
+
+ with w1 as (
+    select * from t2 order by k1 limit 10
+)
+select count(1)
+from t1 join [broadcast] w1 on t1.c_bool_2_notnull <=> w1.c_bool_2_notnull;
+
+select count(1)
+from t1 join [broadcast] t2 on t1.c_tinyint_1_null <=> t2.c_tinyint_1_null;
+
+ 
+select count(1)
+from t1 join [broadcast] t2 on t1.c_tinyint_2_notnull <=> t2.c_tinyint_2_notnull;
+
+ 
+select count(1)
+from t1 join [broadcast] t2 on t1.c_smallint_1_null <=> t2.c_smallint_1_null;
+
+ 
+select count(1)
+from t1 join [broadcast] t2 on t1.c_smallint_2_notnull <=> t2.c_smallint_2_notnull;
+
+ 
+select count(1)
+from t1 join [broadcast] t2 on t1.c_int_1_null <=> t2.c_int_1_null;
+
+ 
+select count(1)
+from t1 join [broadcast] t2 on t1.c_int_2_notnull <=> t2.c_int_2_notnull;
+
+ 
+select count(1)
+from t1 join [broadcast] t2 on t1.c_bigint_1_null <=> t2.c_bigint_1_null;
+
+ 
+select count(1)
+from t1 join [broadcast] t2 on t1.c_bigint_2_notnull <=> t2.c_bigint_2_notnull;
+
+ 
+select count(1)
+from t1 join [broadcast] t2 on t1.c_date_1_null <=> t2.c_date_1_null;
+
+ 
+select count(1)
+from t1 join [broadcast] t2 on t1.c_date_2_notnull <=> t2.c_date_2_notnull;
+
+ 
+select count(1)
+from t1 join [broadcast] t2 on t1.c_decimal64_1_null <=> t2.c_decimal64_1_null;
+
+ 
+select count(1)
+from t1 join [broadcast] t2 on t1.c_decimal64_2_notnull <=> t2.c_decimal64_2_notnull;
+
+ 
+select count(1)
+from t1 join [broadcast] t2 on t1.c_str_1_null <=> t2.c_str_1_null;
+
+ 
+select count(1)
+from t1 join [broadcast] t2 on t1.c_str_2_notnull <=> t2.c_str_2_notnull;
+
+ 
+select count(1)
+from t1 join [broadcast] t2 on t1.c_str_3_low_null <=> t2.c_str_3_low_null;
+
+ 
+select count(1)
+from t1 join [broadcast] t2 on t1.c_str_4_low_notnull <=> t2.c_str_4_low_notnull;
+
+ 
+select count(1)
+from t1 join [broadcast] t2 on t1.c_datetime_1_seq <=> t2.c_datetime_1_seq;
+
+ 
+select count(1)
+from t1 join [broadcast] t2 on t1.c_datetime_2_seq <=> t2.c_datetime_2_seq;
+
+-- left scan and broadcast join cross exchange
+
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
+select count(1)
+from (select distinct c_bool_1_null from t1)t join [broadcast] w1 using(c_bool_1_null);
+
+ with w1 as (
+    select * from t2 order by k1 limit 10
+)
+select count(1)
+from (select distinct c_bool_2_notnull from t1)t join [broadcast] w1 using(c_bool_2_notnull);
+
+select count(1)
+from (select distinct c_tinyint_1_null from t1)t join [broadcast] t2 using(c_tinyint_1_null);
+
+ 
+select count(1)
+from (select distinct c_tinyint_2_notnull from t1)t join [broadcast] t2 using(c_tinyint_2_notnull);
+
+ 
+select count(1)
+from (select distinct c_smallint_1_null from t1)t join [broadcast] t2 using(c_smallint_1_null);
+
+ 
+select count(1)
+from (select distinct c_smallint_2_notnull from t1)t join [broadcast] t2 using(c_smallint_2_notnull);
+
+ 
+select count(1)
+from (select distinct c_int_1_null from t1)t join [broadcast] t2 using(c_int_1_null);
+
+ 
+select count(1)
+from (select distinct c_int_2_notnull from t1)t join [broadcast] t2 using(c_int_2_notnull);
+
+ 
+select count(1)
+from (select distinct c_bigint_1_null from t1)t join [broadcast] t2 using(c_bigint_1_null);
+
+ 
+select count(1)
+from (select distinct c_bigint_2_notnull from t1)t join [broadcast] t2 using(c_bigint_2_notnull);
+
+ 
+select count(1)
+from (select distinct c_date_1_null from t1)t join [broadcast] t2 using(c_date_1_null);
+
+ 
+select count(1)
+from (select distinct c_date_2_notnull from t1)t join [broadcast] t2 using(c_date_2_notnull);
+
+ 
+select count(1)
+from (select distinct c_decimal64_1_null from t1)t join [broadcast] t2 using(c_decimal64_1_null);
+
+ 
+select count(1)
+from (select distinct c_decimal64_2_notnull from t1)t join [broadcast] t2 using(c_decimal64_2_notnull);
+
+ 
+select count(1)
+from (select distinct c_str_1_null from t1)t join [broadcast] t2 using(c_str_1_null);
+
+ 
+select count(1)
+from (select distinct c_str_2_notnull from t1)t join [broadcast] t2 using(c_str_2_notnull);
+
+ 
+select count(1)
+from (select distinct c_str_3_low_null from t1)t join [broadcast] t2 using(c_str_3_low_null);
+
+ 
+select count(1)
+from (select distinct c_str_4_low_notnull from t1)t join [broadcast] t2 using(c_str_4_low_notnull);
+
+ 
+select count(1)
+from (select distinct c_datetime_1_seq from t1)t join [broadcast] t2 using(c_datetime_1_seq);
+
+ 
+select count(1)
+from (select distinct c_datetime_2_seq from t1)t join [broadcast] t2 using(c_datetime_2_seq);
+
+-- shuffle join should not use bitset filter
+
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
+select count(1)
+from t1 join [shuffle] w1 using(c_bool_1_null);
+
+ with w1 as (
+    select * from t2 order by k1 limit 10
+)
+select count(1)
+from t1 join [shuffle] w1 using(c_bool_2_notnull);
+
+select count(1)
+from t1 join [shuffle] t2 using(c_tinyint_1_null);
+
+ 
+select count(1)
+from t1 join [shuffle] t2 using(c_tinyint_2_notnull);
+
+ 
+select count(1)
+from t1 join [shuffle] t2 using(c_smallint_1_null);
+
+ 
+select count(1)
+from t1 join [shuffle] t2 using(c_smallint_2_notnull);
+
+ 
+select count(1)
+from t1 join [shuffle] t2 using(c_int_1_null);
+
+ 
+select count(1)
+from t1 join [shuffle] t2 using(c_int_2_notnull);
+
+ 
+select count(1)
+from t1 join [shuffle] t2 using(c_bigint_1_null);
+
+ 
+select count(1)
+from t1 join [shuffle] t2 using(c_bigint_2_notnull);
+
+ 
+select count(1)
+from t1 join [shuffle] t2 using(c_date_1_null);
+
+ 
+select count(1)
+from t1 join [shuffle] t2 using(c_date_2_notnull);
+
+ 
+select count(1)
+from t1 join [shuffle] t2 using(c_decimal64_1_null);
+
+ 
+select count(1)
+from t1 join [shuffle] t2 using(c_decimal64_2_notnull);
+
+ 
+select count(1)
+from t1 join [shuffle] t2 using(c_str_1_null);
+
+ 
+select count(1)
+from t1 join [shuffle] t2 using(c_str_2_notnull);
+
+ 
+select count(1)
+from t1 join [shuffle] t2 using(c_str_3_low_null);
+
+ 
+select count(1)
+from t1 join [shuffle] t2 using(c_str_4_low_notnull);
+
+ 
+select count(1)
+from t1 join [shuffle] t2 using(c_datetime_1_seq);
+
+ 
+select count(1)
+from t1 join [shuffle] t2 using(c_datetime_2_seq);
+
+-- disable _enable_join_runtime_bitset_filter
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] w1 using(c_bool_1_null);
+
+ with w1 as (
+    select * from t2 order by k1 limit 10
+)
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] w1 using(c_bool_2_notnull);
+
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_tinyint_1_null);
+
+ 
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_tinyint_2_notnull);
+
+ 
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_smallint_1_null);
+
+ 
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_smallint_2_notnull);
+
+ 
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_int_1_null);
+
+ 
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_int_2_notnull);
+
+ 
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_bigint_1_null);
+
+ 
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_bigint_2_notnull);
+
+ 
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_date_1_null);
+
+ 
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_date_2_notnull);
+
+ 
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_decimal64_1_null);
+
+ 
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_decimal64_2_notnull);
+
+ 
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_str_1_null);
+
+ 
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_str_2_notnull);
+
+ 
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_str_3_low_null);
+
+ 
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_str_4_low_notnull);
+
+ 
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_datetime_1_seq);
+
+ 
+select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
+from t1 join [broadcast] t2 using(c_datetime_2_seq);
+
+-- join with t3 should not trigger bitset filter, because the value interval is large
+
+with w1 as (
+    select * from t3 order by k1 limit 10
+)
+select count(1)
+from t1 join [broadcast] w1 using(c_bool_1_null);
+
+ with w1 as (
+    select * from t3 order by k1 limit 10
+)
+select count(1)
+from t1 join [broadcast] w1 using(c_bool_2_notnull);
+
+select count(1)
+from t1 join [broadcast] t3 using(c_tinyint_1_null);
+
+ 
+select count(1)
+from t1 join [broadcast] t3 using(c_tinyint_2_notnull);
+
+ 
+select count(1)
+from t1 join [broadcast] t3 using(c_smallint_1_null);
+
+ 
+select count(1)
+from t1 join [broadcast] t3 using(c_smallint_2_notnull);
+
+ 
+select count(1)
+from t1 join [broadcast] t3 using(c_int_1_null);
+
+ 
+select count(1)
+from t1 join [broadcast] t3 using(c_int_2_notnull);
+
+ 
+select count(1)
+from t1 join [broadcast] t3 using(c_bigint_1_null);
+
+ 
+select count(1)
+from t1 join [broadcast] t3 using(c_bigint_2_notnull);
+
+ 
+select count(1)
+from t1 join [broadcast] t3 using(c_date_1_null);
+
+ 
+select count(1)
+from t1 join [broadcast] t3 using(c_date_2_notnull);
+
+ 
+select count(1)
+from t1 join [broadcast] t3 using(c_decimal64_1_null);
+
+ 
+select count(1)
+from t1 join [broadcast] t3 using(c_decimal64_2_notnull);
+
+ 
+select count(1)
+from t1 join [broadcast] t3 using(c_str_1_null);
+
+ 
+select count(1)
+from t1 join [broadcast] t3 using(c_str_2_notnull);
+
+ 
+select count(1)
+from t1 join [broadcast] t3 using(c_str_3_low_null);
+
+ 
+select count(1)
+from t1 join [broadcast] t3 using(c_str_4_low_notnull);
+
+ 
+select count(1)
+from t1 join [broadcast] t3 using(c_datetime_1_seq);
+
+ 
+select count(1)
+from t1 join [broadcast] t3 using(c_datetime_2_seq);
+
+-- multiple filters (BLOOM, BITSET, EMPTY)
+select count(1)
+from 
+    t1 
+    join [broadcast] t2 on t1.c_int_1_null = t2.c_int_1_null
+    join [shuffle] t3 on t1.c_int_1_null = t3.c_int_1_null;
+
+select count(1)
+from 
+    t1 
+    join [broadcast] t2 on t1.c_int_1_null = t2.c_int_1_null
+    join [shuffle] t3 on t1.c_date_1_null = t3.c_date_1_null;
+
+select count(1)
+from 
+    (select distinct c_int_1_null from t1) t1
+    join [broadcast] t2 on t1.c_int_1_null = t2.c_int_1_null
+    join [shuffle] t3 on t1.c_int_1_null = t3.c_int_1_null;
+
+select count(1)
+from 
+    (select distinct c_int_1_null,c_date_1_null from t1) t1
+    join [broadcast] t2 on t1.c_int_1_null = t2.c_int_1_null
+    join [shuffle] t3 on t1.c_date_1_null = t3.c_date_1_null;
+
+


### PR DESCRIPTION
## Why I'm doing:

Depends on #57101 first. 

When the right table's `value_interval` (defined as `max_value - min_value + 1`) is sufficiently small, a **bitset** may supersede a Bloom filter to optimize membership testing.  

### **Operational Logic**  
- **Initialization**:  
  Allocate a `vector<uint8_t>` with a size of `(value_interval + 7) / 8`.
- **Insertion**:  
  Set the bit at index `(value - min_value)` to `true`, encoding the presence of the value.  
- **Containment Check**:  
  1. Verify whether `value` resides within the interval `[min_value, max_value]`.  
  2. If valid, inspect the bit at index `(value - min_value)` to confirm membership.  

### **Usage Heuristics**  
Compare memory footprints:  
- **Bitset Memory**: `(value_interval + 7) / 8` bytes  
- **Bloom Filter Memory**: `num_rows` bytes

Adopt bitset when:  
1. `bitset_memory ≤ bloom_filter_memory`, **or**  
2. `bitset_memory ≤ bloom_filter_memory × 4` **and** `bitset_memory ≤ L2 cache size`, **or**  
3. `bitset_memory ≤ bloom_filter_memory × 2` **and** `bitset_memory ≤ L2 cache size`.  

### **Storage-Layer Pushdown**  
- **Zonemap Index**:  
  - For both local and external tables, inject a new `BitsetInPredicate` into the `PredicateTree` and set to `index_only`.  
- **Late Materialization**:  
  - The same as the other runtime filters by using `enable_join_runtime_filter_push_down`.

### **Advantages**  
- **Performance**:  
  Compared to Bloom filters, it reduces CPU instructions and memory access size.
- **Storage Efficiency**:  
  Since bitset contains all the existed values, it enhances zonemap index pruning accuracy  

## Test

### JOIN 3

BE: 4 * m6id.4xlarge
iceberg SSB 1T

Query  | Disable | Enable | Disable/Enable
-- | -- | -- | --
SUM(all queries) | 1,067,489 | 1,043,534 | 1.02
Q_10_1_1 | 3744 | 3400 | 1.10
Q_11_2_3 | 3388 | 3057 | 1.11
Q_11_4_2 | 3662 | 3262 | 1.12
Q_11_4_3 | 3607 | 3198 | 1.13
Q_3_2_2 | 3967 | 3477 | 1.14
Q_3_2_3 | 3880 | 3389 | 1.14
Q_3_4_2 | 4626 | 4037 | 1.15
Q_3_4_3 | 4458 | 3878 | 1.15

</byte-sheet-html-origin><!--EndFragment-->

### TPC-DS 1T iceberg

BE: 4 * m7gd.4xlarge

Query | Disable | Enable | Disable/Enable
-- | -- | -- | --
SUM | 205344 | 203240 | 1.01
Q01 | 490 | 498 | 0.98
Q02 | 1207 | 1218 | 0.99
Q03 | 1290 | 266 | **4.85**
Q04 | 7865 | 7777 | 1.01
Q05 | 1363 | 1379 | 0.99
Q06 | 323 | 320 | 1.01
Q07 | 1278 | 1282 | 1.00
Q08 | 271 | 263 | 1.03
Q09 | 4721 | 4725 | 1.00
Q10 | 481 | 458 | 1.05
Q11 | 4708 | 4686 | 1.00
Q12 | 184 | 179 | 1.03
Q13 | 1424 | 1433 | 0.99
Q14-1 | 5293 | 5269 | 1.00
Q14-2 | 4930 | 4834 | 1.02
Q15 | 397 | 387 | 1.03
Q16 | 874 | 883 | 0.99
Q17 | 1604 | 1662 | 0.97
Q18 | 1006 | 966 | 1.04
Q19 | 466 | 482 | 0.97
Q20 | 222 | 210 | 1.06
Q21 | 145 | 146 | 0.99
Q22 | 1621 | 1677 | 0.97
Q23-1 | 11343 | 11593 | 0.98
Q23-2 | 11571 | 11545 | 1.00
Q24-1 | 4292 | 4155 | 1.03
Q24-2 | 4296 | 4104 | 1.05
Q25 | 1286 | 1261 | 1.02
Q26 | 610 | 610 | 1.00
Q27 | 997 | 985 | 1.01
Q28 | 4119 | 4109 | 1.00
Q29 | 1864 | 1912 | 0.97
Q30 | 442 | 448 | 0.99
Q31 | 1525 | 1522 | 1.00
Q32 | 257 | 260 | 0.99
Q33 | 551 | 504 | 1.09
Q34 | 763 | 763 | 1.00
Q35 | 1137 | 1221 | 0.93
Q36 | 887 | 894 | 0.99
Q37 | 177 | 178 | 0.99
Q38 | 2940 | 3034 | 0.97
Q39-1 | 397 | 401 | 0.99
Q39-2 | 231 | 234 | 0.99
Q40 | 479 | 484 | 0.99
Q41 | 64 | 62 | 1.03
Q42 | 189 | 185 | 1.02
Q43 | 499 | 504 | 0.99
Q44 | 2664 | 2673 | 1.00
Q45 | 423 | 410 | 1.03
Q46 | 1097 | 1107 | 0.99
Q47 | 2501 | 2497 | 1.00
Q48 | 1058 | 1050 | 1.01
Q49 | 1227 | 1207 | 1.02
Q50 | 3595 | 3575 | 1.01
Q51 | 1980 | 2009 | 0.99
Q52 | 212 | 217 | 0.98
Q53 | 591 | 559 | 1.06
Q54 | 662 | 637 | 1.04
Q55 | 204 | 211 | 0.97
Q56 | 492 | 476 | 1.03
Q57 | 1519 | 1502 | 1.01
Q58 | 465 | 468 | 0.99
Q59 | 1888 | 1885 | 1.00
Q60 | 589 | 565 | 1.04
Q61 | 787 | 805 | 0.98
Q62 | 668 | 708 | 0.94
Q63 | 588 | 566 | 1.04
Q64 | 7485 | 7412 | 1.01
Q65 | 1948 | 1993 | 0.98
Q66 | 965 | 961 | 1.00
Q67 | 13286 | 13215 | 1.01
Q68 | 676 | 695 | 0.97
Q69 | 453 | 438 | 1.03
Q70 | 2927 | 2954 | 0.99
Q71 | 1954 | 1917 | 1.02
Q72 | 3774 | 3533 | 1.07
Q73 | 384 | 379 | 1.01
Q74 | 4235 | 4254 | 1.00
Q75 | 6559 | 6332 | 1.04
Q76 | 3080 | 3072 | 1.00
Q77 | 554 | 543 | 1.02
Q78 | 12228 | 12112 | 1.01
Q79 | 1286 | 1286 | 1.00
Q80 | 1798 | 1771 | 1.02
Q81 | 570 | 569 | 1.00
Q82 | 748 | 743 | 1.01
Q83 | 389 | 373 | 1.04
Q84 | 284 | 281 | 1.01
Q85 | 959 | 930 | 1.03
Q86 | 835 | 802 | 1.04
Q87 | 2892 | 2954 | 0.98
Q88 | 2304 | 2289 | 1.01
Q89 | 803 | 764 | 1.05
Q90 | 583 | 581 | 1.00
Q91 | 238 | 235 | 1.01
Q92 | 221 | 213 | 1.04
Q93 | 4036 | 3969 | 1.02
Q94 | 935 | 932 | 1.00
Q95 | 2327 | 2287 | 1.02
Q96 | 2200 | 2198 | 1.00
Q97 | 3153 | 3165 | 1.00
Q98 | 680 | 660 | 1.03
Q99 | 1306 | 1333 | 0.98

</byte-sheet-html-origin><!--EndFragment-->

### TPC-DS 1T OLAP Table


BE: 4 * m7gd.4xlarge

Query | Disable | Enable | Disable/Enable
-- | -- | -- | --
SUM | 366356 | 353679 | 1.04
Q01 | 807 | 755 | 1.07
Q02 | 1186 | 1192 | 0.99
Q03 | 886 | 245 | **3.62**
Q04 | 17313 | 16041 | 1.08
Q05 | 659 | 617 | 1.07
Q06 | 279 | 286 | 0.98
Q07 | 1169 | 1144 | 1.02
Q08 | 271 | 257 | 1.05
Q09 | 11577 | 11399 | 1.02
Q10 | 495 | 467 | 1.06
Q11 | 9658 | 8893 | 1.09
Q12 | 174 | 157 | 1.11
Q13 | 891 | 873 | 1.02
Q14-1 | 10272 | 9793 | 1.05
Q14-2 | 9657 | 9443 | 1.02
Q15 | 573 | 583 | 0.98
Q16 | 844 | 832 | 1.01
Q17 | 2277 | 2118 | 1.08
Q18 | 1113 | 1112 | 1.00
Q19 | 315 | 314 | 1.00
Q20 | 202 | 207 | 0.98
Q21 | 91 | 86 | 1.06
Q22 | 1681 | 1626 | 1.03
Q23-1 | 26552 | 26595 | 1.00
Q23-2 | 28726 | 27959 | 1.03
Q24-1 | 3422 | 3316 | 1.03
Q24-2 | 3445 | 3212 | 1.07
Q25 | 1742 | 1509 | 1.15
Q26 | 709 | 686 | 1.03
Q27 | 1049 | 1086 | 0.97
Q28 | 10606 | 10699 | 0.99
Q29 | 3732 | 3345 | 1.12
Q30 | 464 | 482 | 0.96
Q31 | 2923 | 2715 | 1.08
Q32 | 168 | 178 | 0.94
Q33 | 399 | 332 | 1.20
Q34 | 909 | 895 | 1.02
Q35 | 1719 | 1709 | 1.01
Q36 | 1001 | 957 | 1.05
Q37 | 307 | 312 | 0.98
Q38 | 6385 | 5993 | 1.07
Q39-1 | 421 | 398 | 1.06
Q39-2 | 207 | 190 | 1.09
Q40 | 172 | 164 | 1.05
Q41 | 48 | 43 | 1.12
Q42 | 126 | 121 | 1.04
Q43 | 700 | 642 | 1.09
Q44 | 3226 | 3356 | 0.96
Q45 | 713 | 742 | 0.96
Q46 | 1699 | 1641 | 1.04
Q47 | 5433 | 5089 | 1.07
Q48 | 819 | 835 | 0.98
Q49 | 1044 | 920 | 1.13
Q50 | 3038 | 2896 | 1.05
Q51 | 6090 | 6212 | 0.98
Q52 | 135 | 128 | 1.05
Q53 | 706 | 678 | 1.04
Q54 | 308 | 297 | 1.04
Q55 | 123 | 124 | 0.99
Q56 | 289 | 246 | 1.17
Q57 | 3804 | 3320 | 1.15
Q58 | 390 | 386 | 1.01
Q59 | 4082 | 4133 | 0.99
Q60 | 445 | 366 | 1.22
Q61 | 508 | 494 | 1.03
Q62 | 958 | 951 | 1.01
Q63 | 705 | 662 | 1.06
Q64 | 10872 | 9795 | 1.11
Q65 | 7498 | 7357 | 1.02
Q66 | 712 | 690 | 1.03
Q67 | 40985 | 39476 | 1.04
Q68 | 518 | 507 | 1.02
Q69 | 402 | 405 | 0.99
Q70 | 4024 | 3952 | 1.02
Q71 | 2038 | 2028 | 1.00
Q72 | 2536 | 2490 | 1.02
Q73 | 349 | 345 | 1.01
Q74 | 8987 | 8376 | 1.07
Q75 | 10234 | 9955 | 1.03
Q76 | 2452 | 2392 | 1.03
Q77 | 402 | 366 | 1.10
Q78 | 22748 | 22135 | 1.03
Q79 | 2693 | 2493 | 1.08
Q80 | 936 | 922 | 1.02
Q81 | 741 | 716 | 1.03
Q82 | 763 | 787 | 0.97
Q83 | 211 | 203 | 1.04
Q84 | 227 | 225 | 1.01
Q85 | 624 | 621 | 1.00
Q86 | 1120 | 1039 | 1.08
Q87 | 6112 | 6172 | 0.99
Q88 | 14735 | 14807 | 1.00
Q89 | 884 | 899 | 0.98
Q90 | 943 | 944 | 1.00
Q91 | 145 | 148 | 0.98
Q92 | 112 | 121 | 0.93
Q93 | 2683 | 2643 | 1.02
Q94 | 1054 | 1087 | 0.97
Q95 | 2896 | 2793 | 1.04
Q96 | 2295 | 2257 | 1.02
Q97 | 6537 | 6148 | 1.06
Q98 | 783 | 753 | 1.04
Q99 | 2268 | 2178 | 1.04
  |   |   |  

</byte-sheet-html-origin><!--EndFragment-->

## What I'm doing:


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0