### PR TITLE
[Enhancement] use partition level null fraction to estimate list partition cardinality

### DIFF
--- a/be/src/runtime/statistic_result_writer.h
+++ b/be/src/runtime/statistic_result_writer.h
@@ -54,6 +54,9 @@ private:
     Status _fill_partition_statistic_data(int version, const Columns& columns, const Chunk* chunk,
                                           TFetchDataResult* result);
 
+    Status _fill_partition_statistic_data_v2(int version, const Columns& columns, const Chunk* chunk,
+                                             TFetchDataResult* result);
+
     Status _fill_full_statistic_data_v4(int version, const Columns& columns, const Chunk* chunk,
                                         TFetchDataResult* result);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
@@ -371,8 +371,7 @@ public class CachedStatisticStorage implements StatisticStorage, MemoryTrackable
     /**
      *
      */
-    private Map<String, PartitionStats> getColumnNDVForPartitions(Table table, List<Long> partitions,
-                                                                  List<String> columns) {
+    private Map<String, PartitionStats> getColumnNDVForPartitions(Table table, List<String> columns) {
 
         List<ColumnStatsCacheKey> cacheKeys = new ArrayList<>();
         long tableId = table.getId();
@@ -414,12 +413,8 @@ public class CachedStatisticStorage implements StatisticStorage, MemoryTrackable
             return null;
         }
 
-        long tableId = table.getId();
-        List<ColumnStatsCacheKey> cacheKeys = columns.stream()
-                .map(x -> new ColumnStatsCacheKey(tableId, x))
-                .collect(Collectors.toList());
         List<ColumnStatistic> columnStatistics = getColumnStatistics(table, columns);
-        Map<String, PartitionStats> columnNDVForPartitions = getColumnNDVForPartitions(table, partitions, columns);
+        Map<String, PartitionStats> columnNDVForPartitions = getColumnNDVForPartitions(table, columns);
         if (MapUtils.isEmpty(columnNDVForPartitions)) {
             return null;
         }
@@ -439,8 +434,10 @@ public class CachedStatisticStorage implements StatisticStorage, MemoryTrackable
                     return null;
                 }
                 double distinctCount = partitionStats.getDistinctCount().get(partition);
+                double nullFraction = partitionStats.getNullFraction().get(partition);
                 ColumnStatistic newStats = ColumnStatistic.buildFrom(columnStatistic)
-                                .setDistinctValuesCount(distinctCount).build();
+                        .setDistinctValuesCount(distinctCount)
+                        .setNullsFraction(nullFraction).build();
                 newStatistics.add(newStats);
             }
             result.put(partition, newStatistics);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PartitionStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PartitionStats.java
@@ -23,16 +23,18 @@ import java.util.Map;
  */
 public class PartitionStats {
     public final Map<Long, Double> distinctCount;
+    public final Map<Long, Double> nullFraction;
 
     public PartitionStats() {
         this.distinctCount = Maps.newHashMap();
-    }
-
-    public PartitionStats(Map<Long, Double> distinctCount) {
-        this.distinctCount = distinctCount;
+        this.nullFraction = Maps.newHashMap();
     }
 
     public Map<Long, Double> getDistinctCount() {
         return distinctCount;
+    }
+
+    public Map<Long, Double> getNullFraction() {
+        return nullFraction;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PartitionStatsCacheLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PartitionStatsCacheLoader.java
@@ -61,8 +61,9 @@ public class PartitionStatsCacheLoader implements AsyncCacheLoader<ColumnStatsCa
                         tableId, Lists.newArrayList(), columns);
                 for (TStatisticData data : statisticData) {
                     ColumnStatsCacheKey key = new ColumnStatsCacheKey(tableId, data.columnName);
-                    result.computeIfAbsent(key, (x) -> Optional.of(new PartitionStats()))
-                            .get().getDistinctCount().put(data.partitionId, (double) data.countDistinct);
+                    Optional<PartitionStats> stats = result.computeIfAbsent(key, (x) -> Optional.of(new PartitionStats()));
+                    stats.get().getDistinctCount().put(data.partitionId, (double) data.countDistinct);
+                    stats.get().getNullFraction().put(data.partitionId, data.nullCount * 1.0 / Math.max(data.rowCount, 1));
                 }
                 for (ColumnStatsCacheKey key : cacheKey) {
                     if (!result.containsKey(key)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -464,6 +464,12 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
                 statistics.addColumnStatistic(column, newStats);
             }
         }
+
+        if (partitionStatistics.size() == 1) {
+            Statistics partitionStats =  partitionStatistics.values().iterator().next();
+            columnMap.keySet().forEach(column ->
+                    statistics.addColumnStatistic(column, partitionStats.getColumnStatistic(column)));
+        }
     }
 
     private boolean withinDelta(double a, double b, double ratio) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
@@ -39,7 +39,7 @@ import static com.starrocks.statistic.StatsConstants.STATISTIC_DATA_VERSION_V2;
 import static com.starrocks.statistic.StatsConstants.STATISTIC_EXTERNAL_HISTOGRAM_VERSION;
 import static com.starrocks.statistic.StatsConstants.STATISTIC_EXTERNAL_QUERY_V2_VERSION;
 import static com.starrocks.statistic.StatsConstants.STATISTIC_HISTOGRAM_VERSION;
-import static com.starrocks.statistic.StatsConstants.STATISTIC_PARTITION_VERSION;
+import static com.starrocks.statistic.StatsConstants.STATISTIC_PARTITION_VERSION_V2;
 import static com.starrocks.statistic.StatsConstants.STATISTIC_QUERY_MULTI_COLUMN_VERSION;
 import static com.starrocks.statistic.StatsConstants.STATISTIC_TABLE_VERSION;
 
@@ -51,8 +51,9 @@ public class StatisticSQLBuilder {
                     + " GROUP BY partition_id";
 
     private static final String QUERY_PARTITION_STATISTIC_TEMPLATE =
-            "SELECT cast(" + STATISTIC_PARTITION_VERSION + " as INT), " +
-                    " `partition_id`, `column_name`, hll_cardinality(hll_union(`ndv`)) as distinct_count"
+            "SELECT cast(" + STATISTIC_PARTITION_VERSION_V2 + " as INT), " +
+                    " `partition_id`, `column_name`, hll_cardinality(hll_union(`ndv`)) as distinct_count,"
+                    + " any_value(null_count), any_value(row_count)"
                     + " FROM " + FULL_STATISTICS_TABLE_NAME
                     + " WHERE $predicate"
                     + " GROUP BY `partition_id`, `column_name`";

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
@@ -37,6 +37,7 @@ public class StatsConstants {
     public static final int STATISTIC_DATA_VERSION_V2 = 10;
     public static final int STATISTIC_MULTI_COLUMN_VERSION = 12;
     public static final int STATISTIC_QUERY_MULTI_COLUMN_VERSION = 13;
+    public static final int STATISTIC_PARTITION_VERSION_V2 = 20;
 
 
 
@@ -56,6 +57,7 @@ public class StatsConstants {
                     .add(STATISTIC_DATA_VERSION_V2)
                     .add(STATISTIC_MULTI_COLUMN_VERSION)
                     .add(STATISTIC_QUERY_MULTI_COLUMN_VERSION)
+                    .add(STATISTIC_PARTITION_VERSION_V2)
                     .build();
 
     public static final int STATISTICS_PARTITION_UPDATED_THRESHOLD = 10;

--- a/test/sql/test_list_partition/R/test_list_partition_selectivity
+++ b/test/sql/test_list_partition/R/test_list_partition_selectivity
@@ -13,7 +13,7 @@ CREATE TABLE partitions_multi_column_1 (
     c2 int NOT NULL,
     c3 int
 )
-PARTITION BY (c1, c2);
+PARTITION BY (c1, c2) properties("replication_num"="1");
 -- result:
 -- !result
 INSERT INTO partitions_multi_column_1 SELECT 0, 0, generate_series FROM TABLE(generate_series(1, 1000));
@@ -101,6 +101,40 @@ function: assert_explain_costs_contains('SELECT c2, c3 FROM partitions_multi_col
 None
 -- !result
 function: assert_explain_costs_contains('SELECT c2, c3 FROM partitions_multi_column_1 WHERE c1 IN (2,4) ', 'cardinality: 200', 'c3-->[1.0, 1000.0, 0.0, 4.0, 100.0]')
+-- result:
+None
+-- !result
+CREATE TABLE partitions_multi_column_2 (
+    c1 int,
+    p1 int
+)
+PARTITION BY (p1) properties("replication_num"="1");
+-- result:
+-- !result
+insert into partitions_multi_column_2 select 1,1;
+-- result:
+-- !result
+insert into partitions_multi_column_2 select 2,1;
+-- result:
+-- !result
+insert into partitions_multi_column_2 select 1,2;
+-- result:
+-- !result
+insert into partitions_multi_column_2 select null,2;
+-- result:
+-- !result
+insert into partitions_multi_column_2 select null, generate_series from table(generate_series(3,10));
+-- result:
+-- !result
+ANALYZE FULL TABLE partitions_multi_column_2 WITH SYNC MODE;
+-- result:
+test_list_partition_selectivity.partitions_multi_column_2	analyze	status	OK
+-- !result
+function: assert_explain_costs_contains('SELECT * FROM partitions_multi_column_2 WHERE c1=1 and p1=1 ', 'c1-->[1.0, 2.0, 0.0, 1.0, 2.0]')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('SELECT * FROM partitions_multi_column_2 WHERE c1=1 and p1<3 ', 'c1-->[1.0, 2.0, 0.75, 1.0, 2.0]')
 -- result:
 None
 -- !result

--- a/test/sql/test_list_partition/T/test_list_partition_selectivity
+++ b/test/sql/test_list_partition/T/test_list_partition_selectivity
@@ -9,7 +9,7 @@ CREATE TABLE partitions_multi_column_1 (
     c2 int NOT NULL,
     c3 int
 )
-PARTITION BY (c1, c2);
+PARTITION BY (c1, c2) properties("replication_num"="1");
 
 INSERT INTO partitions_multi_column_1 SELECT 0, 0, generate_series FROM TABLE(generate_series(1, 1000));
 INSERT INTO partitions_multi_column_1 SELECT 0, 1, generate_series FROM TABLE(generate_series(1, 100));
@@ -46,17 +46,15 @@ function: assert_explain_costs_contains('SELECT c2, c3 FROM partitions_multi_col
 
 CREATE TABLE partitions_multi_column_2 (
     c1 int,
-    c2 int,
-    c3 int,
     p1 int
 )
-PARTITION BY (p1);
+PARTITION BY (p1) properties("replication_num"="1");
 
-insert into partitions_multi_column_2 select generate_series % 10, generate_series % 10, generate_series % 10, 1 from table(generate_series(1, 1000000));
-insert into partitions_multi_column_2 select generate_series % 10, generate_series % 10, generate_series % 10, 1 from table(generate_series(2, 1000000));
-insert into partitions_multi_column_2 select generate_series % 10, generate_series % 10, generate_series % 10, 1 from table(generate_series(3, 1000000));
-insert into partitions_multi_column_2 select generate_series % 10, generate_series % 10, generate_series % 10, 1 from table(generate_series(4, 1000000));
-insert into partitions_multi_column_2 select generate_series % 10, generate_series % 10, generate_series % 10, 1 from table(generate_series(5, 1000000));
-
+insert into partitions_multi_column_2 select 1,1;
+insert into partitions_multi_column_2 select 2,1;
+insert into partitions_multi_column_2 select 1,2;
+insert into partitions_multi_column_2 select null,2;
+insert into partitions_multi_column_2 select null, generate_series from table(generate_series(3,10));
 ANALYZE FULL TABLE partitions_multi_column_2 WITH SYNC MODE;
-function: assert_explain_costs_contains('SELECT * FROM partitions_multi_column_2 WHERE c1=1 AND c2=1 AND c3=1 AND p1=1', 'cardinality: 1000')
+function: assert_explain_costs_contains('SELECT * FROM partitions_multi_column_2 WHERE c1=1 and p1=1 ', 'c1-->[1.0, 2.0, 0.0, 1.0, 2.0]')
+function: assert_explain_costs_contains('SELECT * FROM partitions_multi_column_2 WHERE c1=1 and p1<3 ', 'c1-->[1.0, 2.0, 0.75, 1.0, 2.0]')


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
1. add null fraction to partition level stats
2. If the query hits only one partition, we use the exact stats of that partition for evaluation
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0