### PR TITLE
[Enhancement] add profile metric: output chunk bytes of every operator

### DIFF
--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -84,6 +84,7 @@ Status Operator::prepare(RuntimeState* state) {
     _push_row_num_counter = ADD_COUNTER(_common_metrics, "PushRowNum", TUnit::UNIT);
     _pull_chunk_num_counter = ADD_COUNTER(_common_metrics, "PullChunkNum", TUnit::UNIT);
     _pull_row_num_counter = ADD_COUNTER(_common_metrics, "PullRowNum", TUnit::UNIT);
+    _pull_chunk_bytes_counter = ADD_COUNTER(_common_metrics, "OutputChunkBytes", TUnit::UNIT);
     if (state->query_ctx() && state->query_ctx()->spill_manager()) {
         _mem_resource_manager.prepare(this, state->query_ctx()->spill_manager());
     }

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -319,6 +319,7 @@ protected:
     RuntimeProfile::Counter* _push_row_num_counter = nullptr;
     RuntimeProfile::Counter* _pull_chunk_num_counter = nullptr;
     RuntimeProfile::Counter* _pull_row_num_counter = nullptr;
+    RuntimeProfile::Counter* _pull_chunk_bytes_counter = nullptr;
     RuntimeProfile::Counter* _runtime_in_filter_num_counter = nullptr;
     RuntimeProfile::Counter* _runtime_bloom_filter_num_counter = nullptr;
     RuntimeProfile::Counter* _conjuncts_timer = nullptr;

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -339,6 +339,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state, int w
                         (maybe_chunk.value()->num_rows() > 0 ||
                          (maybe_chunk.value()->owner_info().is_last_chunk() && !next_op->ignore_empty_eos()))) {
                         size_t row_num = maybe_chunk.value()->num_rows();
+                        size_t chunk_bytes = maybe_chunk.value()->bytes_usage();
                         if (UNLIKELY(row_num > runtime_state->chunk_size())) {
                             return Status::InternalError(
                                     fmt::format("Intermediate chunk size must not be greater than {}, actually {} "
@@ -361,6 +362,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state, int w
                         if (row_num > 0L) {
                             COUNTER_UPDATE(curr_op->_pull_row_num_counter, row_num);
                             COUNTER_UPDATE(curr_op->_pull_chunk_num_counter, 1);
+                            COUNTER_UPDATE(curr_op->_pull_chunk_bytes_counter, chunk_bytes);
                             COUNTER_UPDATE(next_op->_push_chunk_num_counter, 1);
                             COUNTER_UPDATE(next_op->_push_row_num_counter, row_num);
                         }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Introduce a metric named `OutputChunkBytes` for every operator to represent the output size generated by each operator. 

For extensive data types such as strings/json/bitmaps, the variability in output size can significantly impact performance.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0