### PR TITLE
[Enhancement] bump jdk to jdk17 for main branch in dockerfile

### DIFF
--- a/docker/dockerfiles/allin1/allin1-ubuntu.Dockerfile
+++ b/docker/dockerfiles/allin1/allin1-ubuntu.Dockerfile
@@ -34,13 +34,14 @@ ARG DEPLOYDIR=/data/deploy
 ENV SR_HOME=${DEPLOYDIR}/starrocks
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
-        binutils-dev default-jdk python2 mysql-client curl vim tree net-tools less tzdata linux-tools-common linux-tools-generic supervisor nginx netcat locales && \
+        binutils-dev openjdk-17-jdk python2 mysql-client curl vim tree net-tools less tzdata linux-tools-common linux-tools-generic supervisor nginx netcat locales && \
         ln -fs /usr/share/zoneinfo/UTC /etc/localtime && \
         dpkg-reconfigure -f noninteractive tzdata && \
         locale-gen en_US.UTF-8 && \
         rm -rf /var/lib/apt/lists/*
-RUN echo "export PATH=/usr/lib/linux-tools/5.15.0-60-generic:$PATH" >> /etc/bash.bashrc
-ENV JAVA_HOME=/lib/jvm/default-java
+RUN echo "export PATH=/usr/lib/linux-tools/5.15.0-60-generic:$PATH" >> /etc/bash.bashrc ; ARCH=`uname -m` && cd /lib/jvm && \
+    if [ "$ARCH" = "aarch64" ] ; then ln -s java-17-openjdk-arm64 java-17-openjdk ; else ln -s java-17-openjdk-amd64 java-17-openjdk  ; fi ;
+ENV JAVA_HOME=/lib/jvm/java-17-openjdk
 
 WORKDIR $DEPLOYDIR
 

--- a/docker/dockerfiles/be/be-ubuntu.Dockerfile
+++ b/docker/dockerfiles/be/be-ubuntu.Dockerfile
@@ -36,14 +36,14 @@ ARG RUN_AS_USER
 ARG GROUP=starrocks
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
-        binutils-dev default-jdk mysql-client curl vim tree net-tools less tzdata locales pigz inotify-tools rclone gdb && \
+        binutils-dev openjdk-17-jdk mysql-client curl vim tree net-tools less tzdata locales pigz inotify-tools rclone gdb && \
         ln -fs /usr/share/zoneinfo/UTC /etc/localtime && \
         dpkg-reconfigure -f noninteractive tzdata && \
         locale-gen en_US.UTF-8 && \
         rm -rf /var/lib/apt/lists/*
-ENV JAVA_HOME=/lib/jvm/default-java
-
-RUN touch /.dockerenv
+RUN touch /.dockerenv ; ARCH=`uname -m` && cd /lib/jvm && \
+    if [ "$ARCH" = "aarch64" ] ; then ln -s java-17-openjdk-arm64 java-17-openjdk ; else ln -s java-17-openjdk-amd64 java-17-openjdk  ; fi ;
+ENV JAVA_HOME=/lib/jvm/java-17-openjdk
 
 WORKDIR $STARROCKS_ROOT
 

--- a/docker/dockerfiles/fe/fe-ubuntu.Dockerfile
+++ b/docker/dockerfiles/fe/fe-ubuntu.Dockerfile
@@ -33,13 +33,14 @@ ARG RUN_AS_USER
 ARG GROUP=starrocks
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
-        default-jdk mysql-client curl vim tree net-tools less tzdata locales netcat && \
+        openjdk-17-jdk mysql-client curl vim tree net-tools less tzdata locales netcat && \
         ln -fs /usr/share/zoneinfo/UTC /etc/localtime && \
         dpkg-reconfigure -f noninteractive tzdata && \
         locale-gen en_US.UTF-8 && \
         rm -rf /var/lib/apt/lists/*
-RUN touch /.dockerenv
-ENV JAVA_HOME=/lib/jvm/default-java
+RUN touch /.dockerenv ; ARCH=`uname -m` && cd /lib/jvm && \
+    if [ "$ARCH" = "aarch64" ] ; then ln -s java-17-openjdk-arm64 java-17-openjdk ; else ln -s java-17-openjdk-amd64 java-17-openjdk  ; fi ;
+ENV JAVA_HOME=/lib/jvm/java-17-openjdk
 
 WORKDIR $STARROCKS_ROOT
 


### PR DESCRIPTION
## Why I'm doing:

The following PRs bump the JDK version to JDK17 in build env and fe maven build target, this PR is a subsequent change to bump JDK version in fe/be/allin1 image.

https://github.com/StarRocks/starrocks/pull/53560
https://github.com/StarRocks/starrocks/pull/53617

## What I'm doing:

* main and v3.5+ will set to jdk17 as the default java sdk version

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0