### PR TITLE
[Enhancement] Optimize details for HashJoin

### DIFF
--- a/be/src/exec/join_hash_map.cpp
+++ b/be/src/exec/join_hash_map.cpp
@@ -137,8 +137,8 @@ void SerializedJoinBuildFunc::_build_columns(JoinHashTableItems* table_items, Ha
                                              uint8_t** ptr) {
     for (size_t i = 0; i < count; i++) {
         table_items->build_slice[start + i] = JoinHashMapHelper::get_hash_key(data_columns, start + i, *ptr);
-        probe_state->buckets[i] = JoinHashMapHelper::calc_bucket_num<Slice>(table_items->build_slice[start + i],
-                                                                            table_items->bucket_size);
+        probe_state->buckets[i] = JoinHashMapHelper::calc_bucket_num<Slice>(
+                table_items->build_slice[start + i], table_items->bucket_size, table_items->log_bucket_size);
         *ptr += table_items->build_slice[start + i].size;
     }
 
@@ -163,8 +163,8 @@ void SerializedJoinBuildFunc::_build_nullable_columns(JoinHashTableItems* table_
     for (size_t i = 0; i < count; i++) {
         if (probe_state->is_nulls[i] == 0) {
             table_items->build_slice[start + i] = JoinHashMapHelper::get_hash_key(data_columns, start + i, *ptr);
-            probe_state->buckets[i] = JoinHashMapHelper::calc_bucket_num<Slice>(table_items->build_slice[start + i],
-                                                                                table_items->bucket_size);
+            probe_state->buckets[i] = JoinHashMapHelper::calc_bucket_num<Slice>(
+                    table_items->build_slice[start + i], table_items->bucket_size, table_items->log_bucket_size);
             *ptr += table_items->build_slice[start + i].size;
         }
     }
@@ -223,8 +223,8 @@ void SerializedJoinProbeFunc::_probe_column(const JoinHashTableItems& table_item
 
     for (uint32_t i = 0; i < row_count; i++) {
         probe_state->probe_slice[i] = JoinHashMapHelper::get_hash_key(data_columns, i, ptr);
-        probe_state->buckets[i] =
-                JoinHashMapHelper::calc_bucket_num<Slice>(probe_state->probe_slice[i], table_items.bucket_size);
+        probe_state->buckets[i] = JoinHashMapHelper::calc_bucket_num<Slice>(
+                probe_state->probe_slice[i], table_items.bucket_size, table_items.log_bucket_size);
         ptr += probe_state->probe_slice[i].size;
     }
 
@@ -259,8 +259,8 @@ void SerializedJoinProbeFunc::_probe_nullable_column(const JoinHashTableItems& t
 
     for (uint32_t i = 0; i < row_count; i++) {
         if (probe_state->is_nulls[i] == 0) {
-            probe_state->buckets[i] =
-                    JoinHashMapHelper::calc_bucket_num<Slice>(probe_state->probe_slice[i], table_items.bucket_size);
+            probe_state->buckets[i] = JoinHashMapHelper::calc_bucket_num<Slice>(
+                    probe_state->probe_slice[i], table_items.bucket_size, table_items.log_bucket_size);
             probe_state->next[i] = table_items.first[probe_state->buckets[i]];
         } else {
             probe_state->next[i] = 0;

--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -116,6 +116,7 @@ struct JoinHashTableItems {
     Buffer<Slice> build_slice;
     ColumnPtr build_key_column = nullptr;
     uint32_t bucket_size = 0;
+    uint32_t log_bucket_size = 0;
     uint32_t row_count = 0; // real row count
     size_t build_column_count = 0;
     size_t output_build_column_count = 0;
@@ -301,38 +302,44 @@ struct HashTableParam {
     bool mor_reader_mode = false;
 };
 
-template <class T>
+template <class T, size_t Size = sizeof(T)>
 struct JoinKeyHash {
-    static const uint32_t CRC_SEED = 0x811C9DC5;
-    std::size_t operator()(const T& value) const { return crc_hash_32(&value, sizeof(T), CRC_SEED); }
+    static constexpr uint32_t CRC_SEED = 0x811C9DC5;
+    uint32_t operator()(const T& value, uint32_t num_buckets, uint32_t num_log_buckets) const {
+        const size_t hash = crc_hash_32(&value, sizeof(T), CRC_SEED);
+        return hash & (num_buckets - 1);
+    }
 };
 
-// The hash func used by the bucketing of the colocate table is crc,
-// and the hash func used by HashJoin is also crc,
-// which leads to a high conflict rate of HashJoin and affects performance.
-// Therefore, there is no theoretical basis for adding an integer to the source value.
-// The current test shows that the +2, +4 pair does not change the conflict rate,
-// which may be related to the implementation of CRC or mod.
-template <>
-struct JoinKeyHash<int32_t> {
-    static const uint32_t CRC_SEED = 0x811C9DC5;
-    std::size_t operator()(const int32_t& value) const {
-#if defined(__x86_64__) && defined(__SSE4_2__)
-        size_t hash = _mm_crc32_u32(CRC_SEED, value + 2);
-#elif defined(__x86_64__)
-        size_t hash = crc_hash_32(&value, sizeof(value), CRC_SEED);
-#else
-        size_t hash = __crc32cw(CRC_SEED, value + 2);
-#endif
-        hash = (hash << 16u) | (hash >> 16u);
-        return hash;
+template <typename T>
+struct JoinKeyHash<T, 4> {
+    uint32_t operator()(T value, uint32_t num_buckets, uint32_t num_log_buckets) const {
+        static constexpr uint32_t a = 2654435761u;
+        uint32_t v = *reinterpret_cast<uint32_t*>(&value);
+        v ^= v >> (32 - num_log_buckets);
+        const uint32_t fraction = v * a;
+        return fraction >> (32 - num_log_buckets);
+    }
+};
+
+template <typename T>
+struct JoinKeyHash<T, 8> {
+    uint32_t operator()(T value, uint32_t num_buckets, uint32_t num_log_buckets) const {
+        static constexpr uint64_t a = 11400714819323198485ull;
+        uint64_t v = *reinterpret_cast<uint64_t*>(&value);
+        v ^= v >> (64 - num_log_buckets);
+        const uint64_t fraction = v * a;
+        return fraction >> (64 - num_log_buckets);
     }
 };
 
 template <>
 struct JoinKeyHash<Slice> {
     static const uint32_t CRC_SEED = 0x811C9DC5;
-    std::size_t operator()(const Slice& slice) const { return crc_hash_32(slice.data, slice.size, CRC_SEED); }
+    uint32_t operator()(const Slice& slice, uint32_t num_buckets, uint32_t num_log_buckets) const {
+        const size_t hash = crc_hash_32(slice.data, slice.size, CRC_SEED);
+        return hash & (num_buckets - 1);
+    }
 };
 
 class JoinHashMapHelper {
@@ -350,18 +357,18 @@ public:
     }
 
     template <typename CppType>
-    static uint32_t calc_bucket_num(const CppType& value, uint32_t bucket_size) {
+    static uint32_t calc_bucket_num(const CppType& value, uint32_t bucket_size, uint32_t num_log_buckets) {
         using HashFunc = JoinKeyHash<CppType>;
 
-        return HashFunc()(value) & (bucket_size - 1);
+        return HashFunc()(value, bucket_size, num_log_buckets);
     }
 
     template <typename CppType>
-    static void calc_bucket_nums(const Buffer<CppType>& data, uint32_t bucket_size, Buffer<uint32_t>* buckets,
-                                 uint32_t start, uint32_t count) {
+    static void calc_bucket_nums(const Buffer<CppType>& data, uint32_t bucket_size, uint32_t num_log_buckets,
+                                 Buffer<uint32_t>* buckets, uint32_t start, uint32_t count) {
         DCHECK(count <= buckets->size());
         for (size_t i = 0; i < count; i++) {
-            (*buckets)[i] = calc_bucket_num<CppType>(data[start + i], bucket_size);
+            (*buckets)[i] = calc_bucket_num<CppType>(data[start + i], bucket_size, num_log_buckets);
         }
     }
 

--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -133,7 +133,7 @@ struct JoinHashTableItems {
     bool cache_miss_serious = false;
     bool mor_reader_mode = false;
     bool enable_late_materialization = false;
-    bool is_collision_free = false;
+    bool is_collision_free_and_unique = false;
 
     float get_keys_per_bucket() const { return keys_per_bucket; }
     bool ht_cache_miss_serious() const { return cache_miss_serious; }
@@ -152,7 +152,7 @@ struct JoinHashTableItems {
             VLOG_QUERY << "ht cache miss serious = " << cache_miss_serious << " row# = " << row_count
                        << " , bytes = " << probe_bytes << " , depth = " << keys_per_bucket;
 
-            is_collision_free = used_buckets == row_count;
+            is_collision_free_and_unique = used_buckets == row_count;
         }
     }
 
@@ -720,7 +720,7 @@ private:
     // for one key inner join
     template <bool first_probe>
     void _probe_from_ht(RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data);
-    template <bool first_probe, bool is_collision_free>
+    template <bool first_probe, bool is_collision_free_and_unique>
     void _do_probe_from_ht(RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data);
 
     HashTableProbeState::ProbeCoroutine _probe_from_ht(RuntimeState* state, const Buffer<CppType>& build_data,

--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -132,6 +132,7 @@ struct JoinHashTableItems {
     bool cache_miss_serious = false;
     bool mor_reader_mode = false;
     bool enable_late_materialization = false;
+    bool no_conflicts = false;
 
     float get_keys_per_bucket() const { return keys_per_bucket; }
     bool ht_cache_miss_serious() const { return cache_miss_serious; }
@@ -149,6 +150,8 @@ struct JoinHashTableItems {
                                   (probe_bytes > (1UL << 26) && keys_per_bucket > 1.5) || probe_bytes > (1UL << 27));
             VLOG_QUERY << "ht cache miss serious = " << cache_miss_serious << " row# = " << row_count
                        << " , bytes = " << probe_bytes << " , depth = " << keys_per_bucket;
+
+            no_conflicts = used_buckets == row_count;
         }
     }
 
@@ -708,6 +711,8 @@ private:
     // for one key inner join
     template <bool first_probe>
     void _probe_from_ht(RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data);
+    template <bool first_probe, bool no_conflicts>
+    void _do_probe_from_ht(RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data);
 
     HashTableProbeState::ProbeCoroutine _probe_from_ht(RuntimeState* state, const Buffer<CppType>& build_data,
                                                        const Buffer<CppType>& probe_data);

--- a/be/src/exec/join_hash_map.tpp
+++ b/be/src/exec/join_hash_map.tpp
@@ -299,12 +299,13 @@ void JoinProbeFunc<LT>::lookup_init(const JoinHashTableItems& table_items, HashT
             probe_state->null_array = &nullable_column->null_column()->get_data();
             probe_state->consider_probe_time_locality();
         }
-    } else {
-        SIMDGather::gather(nexts, firsts, buckets, probe_row_count);
-
-        probe_state->null_array = nullptr;
-        probe_state->consider_probe_time_locality();
+        return;
     }
+
+    SIMDGather::gather(nexts, firsts, buckets, probe_row_count);
+
+    probe_state->null_array = nullptr;
+    probe_state->consider_probe_time_locality();
 }
 
 template <LogicalType LT>

--- a/be/src/exec/join_hash_map.tpp
+++ b/be/src/exec/join_hash_map.tpp
@@ -275,22 +275,22 @@ void JoinProbeFunc<LT>::lookup_init(const JoinHashTableItems& table_items, HashT
         if (nullable_column->has_null()) {
             const auto& null_array = nullable_column->null_column()->get_data();
 
-            // static constexpr uint32_t W = 8;
-            // uint32_t buffer[W];
+            static constexpr uint32_t W = 8;
+            uint32_t buffer[W];
             size_t i = 0;
-            // for (; i + W <= probe_row_count; i += W) {
-            //     for (uint32_t j = 0; j < W; j++) {
-            //         if (null_array[i + j] == 0) {
-            //             buffer[j] = firsts[buckets[i + j]];
-            //         } else {
-            //             buffer[j] = 0;
-            //         }
-            //     }
+            for (; i + W <= probe_row_count; i += W) {
+                for (uint32_t j = 0; j < W; j++) {
+                    if (null_array[i + j] == 0) {
+                        buffer[j] = firsts[buckets[i + j]];
+                    } else {
+                        buffer[j] = 0;
+                    }
+                }
 
-            //     for (uint32_t j = 0; j < W; j++) {
-            //         nexts[i + j] = buffer[j];
-            //     }
-            // }
+                for (uint32_t j = 0; j < W; j++) {
+                    nexts[i + j] = buffer[j];
+                }
+            }
 
             for (; i < probe_row_count; i++) {
                 if (null_array[i] == 0) {
@@ -306,18 +306,18 @@ void JoinProbeFunc<LT>::lookup_init(const JoinHashTableItems& table_items, HashT
         }
     }
 
-    // static constexpr uint32_t W = 8;
-    // uint32_t buffer[W];
+    static constexpr uint32_t W = 8;
+    uint32_t buffer[W];
     size_t i = 0;
-    // for (; i + W <= probe_row_count; i += W) {
-    //     for (uint32_t j = 0; j < W; j++) {
-    //         buffer[j] = firsts[buckets[i + j]];
-    //     }
+    for (; i + W <= probe_row_count; i += W) {
+        for (uint32_t j = 0; j < W; j++) {
+            buffer[j] = firsts[buckets[i + j]];
+        }
 
-    //     for (uint32_t j = 0; j < W; j++) {
-    //         nexts[i + j] = buffer[j];
-    //     }
-    // }
+        for (uint32_t j = 0; j < W; j++) {
+            nexts[i + j] = buffer[j];
+        }
+    }
     for (; i < probe_row_count; i++) {
         nexts[i] = firsts[buckets[i]];
     }

--- a/be/src/exec/join_hash_map.tpp
+++ b/be/src/exec/join_hash_map.tpp
@@ -298,8 +298,8 @@ void JoinProbeFunc<LT>::lookup_init(const JoinHashTableItems& table_items, HashT
 
             probe_state->null_array = &nullable_column->null_column()->get_data();
             probe_state->consider_probe_time_locality();
+            return;
         }
-        return;
     }
 
     SIMDGather::gather(nexts, firsts, buckets, probe_row_count);

--- a/be/src/exec/join_hash_map.tpp
+++ b/be/src/exec/join_hash_map.tpp
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "simd/gather.h"
+#pragma once
 
+#include "simd/gather.h"
 #include "simd/simd.h"
 #include "util/runtime_profile.h"
 

--- a/be/src/simd/gather.h
+++ b/be/src/simd/gather.h
@@ -65,5 +65,76 @@ struct SIMDGather {
             c++;
         }
     }
+
+    static uint32_t simd_register_bitwidth() {
+#ifdef __AVX2__
+        return 256;
+#elif defined(__ARM_NEON) && defined(__aarch64__)
+        return 128;
+#else
+        return 128;
+#endif
+    }
+
+    /// dest[i] = src[indexes[i]]
+    template <typename DataType, typename IndexType>
+    static void gather(DataType* dest, const DataType* src, const IndexType* indexes, size_t num_rows) {
+        static_assert(std::is_integral_v<DataType>);
+        static_assert(std::is_integral_v<IndexType>);
+
+        static constexpr uint32_t SIMD_WIDTH = simd_register_bitwidth();
+        static constexpr uint32_t NUM_BATCH_VALUES = SIMD_WIDTH / (8 * sizeof(DataType));
+        DataType buffer[NUM_BATCH_VALUES];
+
+        size_t i = 0;
+        for (; i + NUM_BATCH_VALUES <= num_rows; i += NUM_BATCH_VALUES) {
+            for (int j = 0; j < NUM_BATCH_VALUES; j++) {
+                buffer[j] = src[indexes[i + j]];
+            }
+
+            for (int j = 0; j < NUM_BATCH_VALUES; j++) {
+                dest[i + j] = buffer[j];
+            }
+        }
+
+        for (; i < num_rows; i++) {
+            dest[i] = src[indexes[i]];
+        }
+    }
+
+    /// dest[i] = is_filtered[i] == 0 ? src[indexes[i]] : 0
+    template <typename DataType, typename IndexType, typename CondType>
+    static void gather(DataType* dest, const DataType* src, const IndexType* indexes, const CondType* is_filtered,
+                       size_t num_rows) {
+        static_assert(std::is_integral_v<DataType>);
+        static_assert(std::is_integral_v<IndexType>);
+
+        static constexpr uint32_t SIMD_WIDTH = simd_register_bitwidth();
+        static constexpr uint32_t NUM_BATCH_VALUES = SIMD_WIDTH / (8 * sizeof(DataType));
+        DataType buffer[NUM_BATCH_VALUES];
+
+        size_t i = 0;
+        for (; i + NUM_BATCH_VALUES <= num_rows; i += NUM_BATCH_VALUES) {
+            for (int j = 0; j < NUM_BATCH_VALUES; j++) {
+                if (is_filtered[i + j] == 0) {
+                    buffer[j] = src[indexes[i + j]];
+                } else {
+                    buffer[j] = 0;
+                }
+            }
+
+            for (int j = 0; j < NUM_BATCH_VALUES; j++) {
+                dest[i + j] = buffer[j];
+            }
+        }
+
+        for (; i < num_rows; i++) {
+            if (is_filtered[i] == 0) {
+                dest[i] = src[indexes[i]];
+            } else {
+                dest[i] = 0;
+            }
+        }
+    }
 };
 } // namespace starrocks

--- a/be/src/simd/gather.h
+++ b/be/src/simd/gather.h
@@ -79,7 +79,6 @@ struct SIMDGather {
     /// dest[i] = src[indexes[i]]
     template <typename DataType, typename IndexType>
     static void gather(DataType* dest, const DataType* src, const IndexType* indexes, size_t num_rows) {
-        static_assert(std::is_integral_v<DataType>);
         static_assert(std::is_integral_v<IndexType>);
 
         static constexpr uint32_t SIMD_WIDTH = simd_register_bitwidth();
@@ -106,7 +105,6 @@ struct SIMDGather {
     template <typename DataType, typename IndexType, typename CondType>
     static void gather(DataType* dest, const DataType* src, const IndexType* indexes, const CondType* is_filtered,
                        size_t num_rows) {
-        static_assert(std::is_integral_v<DataType>);
         static_assert(std::is_integral_v<IndexType>);
 
         static constexpr uint32_t SIMD_WIDTH = simd_register_bitwidth();

--- a/be/src/simd/gather.h
+++ b/be/src/simd/gather.h
@@ -66,7 +66,7 @@ struct SIMDGather {
         }
     }
 
-    static uint32_t simd_register_bitwidth() {
+    static constexpr uint32_t simd_register_bitwidth() {
 #ifdef __AVX2__
         return 256;
 #elif defined(__ARM_NEON) && defined(__aarch64__)

--- a/be/test/exec/join_hash_map_test.cpp
+++ b/be/test/exec/join_hash_map_test.cpp
@@ -913,12 +913,89 @@ std::shared_ptr<RuntimeState> JoinHashMapTest::create_runtime_state() {
 
 // NOLINTNEXTLINE
 TEST_F(JoinHashMapTest, JoinKeyHash) {
-    auto v1 = JoinKeyHash<int64_t>()(1);
-    auto v2 = JoinKeyHash<int32_t>()(1);
-    auto v3 = JoinKeyHash<Slice>()(Slice{"abcd", 4});
+    const uint32_t num_buckets = 1 << 16;
+    const uint32_t log_num_buckets = 16;
 
-    ASSERT_EQ(v1, 2592448939l);
-    ASSERT_EQ(v2, 98743132903886l);
+    auto get_hash_statistics = [&](const std::vector<uint32_t>& count_per_bucket) {
+        uint32_t min_count = *std::ranges::min_element(count_per_bucket);
+        uint32_t max_count = *std::ranges::max_element(count_per_bucket);
+
+        return std::make_tuple(min_count, max_count);
+    };
+
+    {
+        std::vector<uint32_t> count_per_bucket(num_buckets);
+        for (int32_t i = 0; i < num_buckets * 3 * 5; i += 3) {
+            auto bucket = JoinKeyHash<int32_t>()(i, num_buckets, log_num_buckets);
+            count_per_bucket[bucket]++;
+        }
+        auto [min_count, max_count] = get_hash_statistics(count_per_bucket);
+        // crc32: 0, 11
+        ASSERT_EQ(0, min_count);
+        ASSERT_EQ(11, max_count);
+    }
+
+    {
+        std::vector<uint32_t> count_per_bucket(num_buckets);
+        for (int32_t i = 0; i < num_buckets * 7 * 5; i += 7) {
+            auto bucket = JoinKeyHash<int32_t>()(i, num_buckets, log_num_buckets);
+            count_per_bucket[bucket]++;
+        }
+        auto [min_count, max_count] = get_hash_statistics(count_per_bucket);
+        // crc32: 0, 14
+        ASSERT_EQ(0, min_count);
+        ASSERT_EQ(14, max_count);
+    }
+
+    {
+        std::vector<uint32_t> count_per_bucket(num_buckets);
+        for (int32_t i = 0; i < num_buckets * 5; i++) {
+            auto bucket = JoinKeyHash<int32_t>()(i, num_buckets, log_num_buckets);
+            count_per_bucket[bucket]++;
+        }
+        auto [min_count, max_count] = get_hash_statistics(count_per_bucket);
+        // crc32: 4, 6
+        ASSERT_EQ(4, min_count);
+        ASSERT_EQ(6, max_count);
+    }
+
+    {
+        std::vector<uint32_t> count_per_bucket(num_buckets);
+        for (int32_t i = 0; i < num_buckets * 3 * 5; i += 3) {
+            auto bucket = JoinKeyHash<int64_t>()(i, num_buckets, log_num_buckets);
+            count_per_bucket[bucket]++;
+        }
+        auto [min_count, max_count] = get_hash_statistics(count_per_bucket);
+        // crc32: 0, 12
+        ASSERT_EQ(3, min_count);
+        ASSERT_EQ(7, max_count);
+    }
+
+    {
+        std::vector<uint32_t> count_per_bucket(num_buckets);
+        for (int32_t i = 0; i < num_buckets * 7 * 5; i += 7) {
+            auto bucket = JoinKeyHash<int64_t>()(i, num_buckets, log_num_buckets);
+            count_per_bucket[bucket]++;
+        }
+        auto [min_count, max_count] = get_hash_statistics(count_per_bucket);
+        // crc32: 0, 15
+        ASSERT_EQ(4, min_count);
+        ASSERT_EQ(7, max_count);
+    }
+
+    {
+        std::vector<uint32_t> count_per_bucket(num_buckets);
+        for (int32_t i = 0; i < num_buckets * 5; i++) {
+            auto bucket = JoinKeyHash<int64_t>()(i, num_buckets, log_num_buckets);
+            count_per_bucket[bucket]++;
+        }
+        auto [min_count, max_count] = get_hash_statistics(count_per_bucket);
+        // crc32: 5, 5
+        ASSERT_EQ(4, min_count);
+        ASSERT_EQ(6, max_count);
+    }
+
+    auto v3 = JoinKeyHash<Slice>()(Slice{"abcd", 4}, num_buckets, log_num_buckets);
     ASSERT_EQ(v3, 2777932099l);
 }
 

--- a/be/test/exec/join_hash_map_test.cpp
+++ b/be/test/exec/join_hash_map_test.cpp
@@ -996,7 +996,7 @@ TEST_F(JoinHashMapTest, JoinKeyHash) {
     }
 
     auto v3 = JoinKeyHash<Slice>()(Slice{"abcd", 4}, num_buckets, log_num_buckets);
-    ASSERT_EQ(v3, 2777932099l);
+    ASSERT_EQ(v3, 2777932099l % num_buckets);
 }
 
 // NOLINTNEXTLINE

--- a/be/test/exec/join_hash_map_test.cpp
+++ b/be/test/exec/join_hash_map_test.cpp
@@ -1001,17 +1001,22 @@ TEST_F(JoinHashMapTest, JoinKeyHash) {
 
 // NOLINTNEXTLINE
 TEST_F(JoinHashMapTest, CalcBucketNum) {
-    uint32_t bucket_num = JoinHashMapHelper::calc_bucket_num(1, 4);
+    const uint32_t num_buckets = 1 << 2;
+    const uint32_t log_num_buckets = 2;
+    uint32_t bucket_num = JoinHashMapHelper::calc_bucket_num(1, num_buckets, log_num_buckets);
     ASSERT_EQ(2, bucket_num);
 }
 
 // NOLINTNEXTLINE
 TEST_F(JoinHashMapTest, CalcBucketNums) {
+    const uint32_t num_buckets = 1 << 2;
+    const uint32_t log_num_buckets = 2;
+
     Buffer<int32_t> data{1, 2, 3, 4};
     Buffer<uint32_t> buckets{0, 0, 0, 0};
-    Buffer<uint32_t> check_buckets{2, 2, 3, 1};
+    Buffer<uint32_t> check_buckets{2, 0, 3, 1};
 
-    JoinHashMapHelper::calc_bucket_nums<int32_t>(data, 4, &buckets, 0, 4);
+    JoinHashMapHelper::calc_bucket_nums<int32_t>(data, num_buckets, log_num_buckets, &buckets, 0, 4);
     for (size_t i = 0; i < buckets.size(); i++) {
         ASSERT_EQ(buckets[i], check_buckets[i]);
     }


### PR DESCRIPTION
## Why I'm doing:

**Detailed optimizations applied to HashJoin:**  
1. Optimize `_copy_build_column`.
2. **Cache certain variables in registers for `lookup_init` and `_probe_from_ht` (INNER JOIN).**  
   - The logic of `_probe_from_ht` is highly complex, preventing the compiler from performing optimizations. This results in:  
     - Reloading some member variables of `probe_state` from memory during each loop iteration, which becomes especially noticeable with large hash tables.  
     - Repeatedly checking `used_buckets == row_count` (`is_collision_free_and_unique`) in every loop iteration.  

3. **Manual loop unrolling for `lookup_init`.**  

4. **Manual loop unrolling for `FixedLengthColumnBase<T>::append_selective`.**  

5. **Multiplicative hashing for 4-byte or 8-byte keys.**  
   - It only needs to perform arithmetic operations on the key as a whole, so the compiler can automatically vectorize it.

### Hash Test
Generate `<num_values>` values by `<mode>` (sequence or random) mode and insert into `<num_buckets>` buckets.
- ​**Min**: Indicates the number of values contained in the bucket with the fewest values.
- ​**Max**: Indicates the number of values contained in the bucket with the most values.
- ​**Variance**: Represents the variance of the number of values across all buckets.

**num_values=1<<26, num_buckets=1<<25, mode=sequence**
  | Min | Max | Variance
-- | -- | -- | --
fnv_hash | 0 | 6 | 1.88
crc32 | 2 | 2 | 0.00
std::hash | 2 | 2 | 0.00
knuth_multiplicative_hash | 1 | 4 | 0.68

**num_values=1<<25, num_buckets=1<<24, mode=sequence**
  | Min | Max | Variance
-- | -- | -- | --
fnv_hash | 0 | 5 | 1.27
crc32 | 2 | 2 | 0
std::hash | 2 | 2 | 0
knuth_multiplicative_hash | 0 | 3 | 1.47


**num_values=1<<26, num_buckets=1<<25, mode=random**
  | Min | Max | Variance
-- | -- | -- | --
fnv_hash | 0 | 8 | 2
crc32 | 0 | 7| 2
std::hash | 0 | 7 | 2
knuth_multiplicative_hash | 0 | 9 | 2

**num_values=1<<25, num_buckets=1<<24, mode=random**
  | Min | Max | Variance
-- | -- | -- | --
fnv_hash | 0 | 7 | 2
crc32 | 0 | 9 | 2
std::hash | 0 | 7 | 2
knuth_multiplicative_hash | 0 | 8 | 2





### Test

Environment Information
- TPC-DS 1T iceberg
- BE: 4 * m7gd.4xlarge

Q14-1
- base: 6.264s
- OPT-1~2: 6.008s
- OPT-1~3: 5.878s
- OPT-1~4: 5.789s
- OPT-1~5: 5.668s


CPU perf before patch

![QQ_1742808086086](https://github.com/user-attachments/assets/3a47174b-47c2-4acd-bcc9-376d2e717b59)



CPU perf after patch
![QQ_1742808045600](https://github.com/user-attachments/assets/7176b0b9-cbe6-4853-9036-787dd2ca46c1)

### Better cases

SUM | 212045 | 206979 | 1.02
-- | -- | -- | --
Q10 | 492 | 460 | 1.07
Q14-1 | 6259 | 5668 | 1.10
Q14-2 | 5784 | 5234 | 1.11
Q17 | 1730 | 1557 | 1.11
Q26 | 655 | 616 | 1.06
Q36 | 1022 | 927 | 1.10
Q47 | 2847 | 2664 | 1.07
Q57 | 1803 | 1597 | 1.13
Q62 | 853 | 764 | 1.12
Q67 | 14151 | 13260 | 1.07
Q87 | 3084 | 2864 | 1.08
Q97 | 3845 | 3216 | 1.20
Q99 | 1756 | 1382 | 1.27

### All the cases


Query | Before | After | Before/After
-- | -- | -- | --
SUM | 212045 | 206979 | 1.02
Q01 | 512 | 490 | 1.04
Q02 | 1223 | 1231 | 0.99
Q03 | 273 | 272 | 1.00
Q04 | 8134 | 8241 | 0.99
Q05 | 1376 | 1404 | 0.98
Q06 | 322 | 329 | 0.98
Q07 | 1303 | 1287 | 1.01
Q08 | 269 | 258 | 1.04
Q09 | 4774 | 4853 | 0.98
Q10 | 492 | 460 | 1.07
Q11 | 4929 | 4720 | 1.04
Q12 | 206 | 196 | 1.05
Q13 | 1448 | 1469 | 0.99
Q14-1 | 6259 | 5668 | 1.10
Q14-2 | 5784 | 5234 | 1.11
Q15 | 401 | 383 | 1.05
Q16 | 883 | 866 | 1.02
Q17 | 1730 | 1557 | 1.11
Q18 | 1001 | 988 | 1.01
Q19 | 483 | 482 | 1.00
Q20 | 237 | 247 | 0.96
Q21 | 155 | 150 | 1.03
Q22 | 1818 | 1763 | 1.03
Q23-1 | 11803 | 11428 | 1.03
Q23-2 | 12088 | 11761 | 1.03
Q24-1 | 4157 | 4229 | 0.98
Q24-2 | 4200 | 4223 | 0.99
Q25 | 1235 | 1247 | 0.99
Q26 | 655 | 616 | 1.06
Q27 | 1024 | 1039 | 0.99
Q28 | 4114 | 4287 | 0.96
Q29 | 1945 | 1844 | 1.05
Q30 | 427 | 414 | 1.03
Q31 | 1544 | 1588 | 0.97
Q32 | 256 | 255 | 1.00
Q33 | 552 | 531 | 1.04
Q34 | 770 | 759 | 1.01
Q35 | 1193 | 1162 | 1.03
Q36 | 1022 | 927 | 1.10
Q37 | 182 | 177 | 1.03
Q38 | 3090 | 2957 | 1.04
Q39-1 | 434 | 432 | 1.00
Q39-2 | 283 | 269 | 1.05
Q40 | 489 | 496 | 0.99
Q41 | 63 | 62 | 1.02
Q42 | 180 | 192 | 0.94
Q43 | 482 | 480 | 1.00
Q44 | 2719 | 2737 | 0.99
Q45 | 439 | 434 | 1.01
Q46 | 1116 | 1126 | 0.99
Q47 | 2847 | 2664 | 1.07
Q48 | 1057 | 1057 | 1.00
Q49 | 1210 | 1214 | 1.00
Q50 | 3582 | 3662 | 0.98
Q51 | 2093 | 2009 | 1.04
Q52 | 218 | 215 | 1.01
Q53 | 568 | 555 | 1.02
Q54 | 650 | 634 | 1.03
Q55 | 201 | 208 | 0.97
Q56 | 504 | 488 | 1.03
Q57 | 1803 | 1597 | 1.13
Q58 | 468 | 463 | 1.01
Q59 | 1912 | 1904 | 1.00
Q60 | 583 | 577 | 1.01
Q61 | 810 | 813 | 1.00
Q62 | 853 | 764 | 1.12
Q63 | 561 | 557 | 1.01
Q64 | 7674 | 7471 | 1.03
Q65 | 2042 | 2002 | 1.02
Q66 | 971 | 966 | 1.01
Q67 | 14151 | 13260 | 1.07
Q68 | 695 | 689 | 1.01
Q69 | 446 | 448 | 1.00
Q70 | 3047 | 3156 | 0.97
Q71 | 1961 | 1906 | 1.03
Q72 | 3533 | 3442 | 1.03
Q73 | 386 | 394 | 0.98
Q74 | 4483 | 4261 | 1.05
Q75 | 6420 | 6453 | 0.99
Q76 | 3140 | 3342 | 0.94
Q77 | 547 | 538 | 1.02
Q78 | 12282 | 12285 | 1.00
Q79 | 1314 | 1302 | 1.01
Q80 | 1762 | 1790 | 0.98
Q81 | 564 | 558 | 1.01
Q82 | 750 | 755 | 0.99
Q83 | 379 | 381 | 0.99
Q84 | 287 | 281 | 1.02
Q85 | 907 | 910 | 1.00
Q86 | 868 | 836 | 1.04
Q87 | 3084 | 2864 | 1.08
Q88 | 2354 | 2398 | 0.98
Q89 | 805 | 781 | 1.03
Q90 | 582 | 596 | 0.98
Q91 | 236 | 230 | 1.03
Q92 | 218 | 210 | 1.04
Q93 | 4009 | 4066 | 0.99
Q94 | 918 | 951 | 0.97
Q95 | 2260 | 2228 | 1.01
Q96 | 2246 | 2299 | 0.98
Q97 | 3845 | 3216 | 1.20
Q98 | 729 | 731 | 1.00
Q99 | 1756 | 1382 | 1.27
  |   |   |  



## What I'm doing:



## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0