### PR TITLE
[BugFix] Fix the NPE bug of processing null as timestamptz partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
@@ -334,7 +334,7 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
             if (type.equals(Types.TimestampType.withZone())) {
                 Long value = PartitionUtil.getPartitionValue(partition, index, javaClass);
                 if (value == null) {
-                    partitionValue = null;
+                    partitionValue = "null";
                 } else {
                     partitionValue = ChronoUnit.MICROS.addTo(Instant.ofEpochSecond(0).atZone(
                             TimeUtils.getTimeZone().toZoneId()), value).toLocalDateTime().toString();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
@@ -329,14 +329,21 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
             Class<?> javaClass = type.typeId().javaClass();
 
             String partitionValue;
-            partitionValue = field.transform().toHumanString(type,
-                    PartitionUtil.getPartitionValue(partition, index, javaClass));
 
             // currently starrocks date literal only support local datetime
             if (type.equals(Types.TimestampType.withZone())) {
-                partitionValue = ChronoUnit.MICROS.addTo(Instant.ofEpochSecond(0).atZone(TimeUtils.getTimeZone().toZoneId()),
-                        PartitionUtil.getPartitionValue(partition, index, javaClass)).toLocalDateTime().toString();
+                Long value = PartitionUtil.getPartitionValue(partition, index, javaClass);
+                if (value == null) {
+                    partitionValue = null;
+                } else {
+                    partitionValue = ChronoUnit.MICROS.addTo(Instant.ofEpochSecond(0).atZone(
+                            TimeUtils.getTimeZone().toZoneId()), value).toLocalDateTime().toString();
+                }
+            } else {
+                partitionValue = field.transform().toHumanString(type, PartitionUtil.getPartitionValue(
+                        partition, index, javaClass));
             }
+
             partitionValues.add(partitionValue);
 
             cols.add(table.getColumn(field.name()));

--- a/test/sql/test_iceberg/R/test_timestamp_as_partition_col
+++ b/test/sql/test_iceberg/R/test_timestamp_as_partition_col
@@ -1,0 +1,25 @@
+-- name: test_timestamp_as_partition_col
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+-- !result
+set time_zone = 'Asia/Shanghai';
+-- result:
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_oss_db.t_timestamp_partition_null;
+-- result:
+1	None
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_oss_db.t_timestamp_partition_not_null;
+-- result:
+1	2024-01-02 00:00:00
+-- !result
+set time_zone = 'UTC';
+-- result:
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_oss_db.t_timestamp_partition_not_null;
+-- result:
+1	2024-01-01 16:00:00
+-- !result
+drop catalog iceberg_sql_test_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_timestamp_as_partition_col
+++ b/test/sql/test_iceberg/T/test_timestamp_as_partition_col
@@ -1,0 +1,15 @@
+-- name: test_timestamp_as_partition_col
+
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+
+set time_zone = 'Asia/Shanghai';
+
+-- null value as partition value
+select * from iceberg_sql_test_${uuid0}.iceberg_oss_db.t_timestamp_partition_null;
+
+-- not null value as partition value
+select * from iceberg_sql_test_${uuid0}.iceberg_oss_db.t_timestamp_partition_not_null;
+set time_zone = 'UTC';
+select * from iceberg_sql_test_${uuid0}.iceberg_oss_db.t_timestamp_partition_not_null;
+
+drop catalog iceberg_sql_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

If use timestamp column as partition column, and the value of timestamp column is null, the result of `PartitionUtil.getPartitionValue` is null, `ChronoUnit.MICROS.addTo` will cast null to long, so it will report npe.

```
 java.lang.NullPointerException: Cannot invoke "java.lang.Long.longValue()" because the return value of "com.starrocks.connector.PartitionUtil.getPartitionValue(org.apache.iceberg.StructLike, int, java.l
ang.Class)" is null
        at com.starrocks.connector.iceberg.IcebergConnectorScanRangeSource.lambda$getPartitionKey$5(IcebergConnectorScanRangeSource.java:338)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
        at com.starrocks.connector.iceberg.IcebergConnectorScanRangeSource.getPartitionKey(IcebergConnectorScanRangeSource.java:325)
        at com.starrocks.connector.iceberg.IcebergConnectorScanRangeSource.addPartition(IcebergConnectorScanRangeSource.java:273)
        at com.starrocks.connector.iceberg.IcebergConnectorScanRangeSource.toScanRanges(IcebergConnectorScanRangeSource.java:137)
        at com.starrocks.connector.iceberg.IcebergConnectorScanRangeSource.getSourceOutputs(IcebergConnectorScanRangeSource.java:128)
        at com.starrocks.connector.ConnectorScanRangeSource.getOutputs(ConnectorScanRangeSource.java:27)
        at com.starrocks.planner.IcebergScanNode.getScanRangeLocations(IcebergScanNode.java:100)
        at com.starrocks.qe.scheduler.assignment.BackendSelectorFactory.create(BackendSelectorFactory.java:56)
        at com.starrocks.qe.scheduler.assignment.LocalFragmentAssignmentStrategy.assignScanRangesToWorker(LocalFragmentAssignmentStrategy.java:90)
        at com.starrocks.qe.scheduler.assignment.LocalFragmentAssignmentStrategy.assignFragmentToWorker(LocalFragmentAssignmentStrategy.java:74)
        at com.starrocks.qe.CoordinatorPreprocessor.computeFragmentInstances(CoordinatorPreprocessor.java:249)
        at com.starrocks.qe.CoordinatorPreprocessor.prepareExec(CoordinatorPreprocessor.java:205)
        at com.starrocks.qe.DefaultCoordinator.prepareExec(DefaultCoordinator.java:517)
        at com.starrocks.qe.DefaultCoordinator.startScheduling(DefaultCoordinator.java:569)
        at com.starrocks.qe.scheduler.Coordinator.execWithQueryDeployExecutor(Coordinator.java:112)
        at com.starrocks.qe.StmtExecutor.handleQueryStmt(StmtExecutor.java:1337)
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:679)
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:366)
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:576)
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:914)
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:70)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:840)
```

## What I'm doing:

Fix the NPE bug of processing null as timestamptz partition

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0