### PR TITLE
[Enhancement] modify histogram_statistic cache expire-update logical

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticStorage.java
@@ -41,6 +41,9 @@ public interface StatisticStorage {
     default void refreshMultiColumnStatistics(Long tableId) {
     }
 
+    default void refreshHistogramStatistics(Table table, List<String> columns, boolean isSync) {
+    }
+
     /**
      * Overwrite the statistics of `targetPartition` with `sourcePartition`
      */
@@ -74,11 +77,7 @@ public interface StatisticStorage {
     default Map<String, Histogram> getHistogramStatistics(Table table, List<String> columns) {
         return Maps.newHashMap();
     }
-
-    default Map<String, Histogram> getHistogramStatisticsSync(Table table, List<String> columns) {
-        return getHistogramStatistics(table, columns);
-    }
-
+    
     default Map<String, Histogram> getConnectorHistogramStatistics(Table table, List<String> columns) {
         return Maps.newHashMap();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
@@ -381,12 +381,7 @@ public class AnalyzeMgr implements Writable {
             return;
         }
 
-        GlobalStateMgr.getCurrentState().getStatisticStorage().expireHistogramStatistics(table.getId(), columns);
-        if (async) {
-            GlobalStateMgr.getCurrentState().getStatisticStorage().getHistogramStatistics(table, columns);
-        } else {
-            GlobalStateMgr.getCurrentState().getStatisticStorage().getHistogramStatisticsSync(table, columns);
-        }
+        GlobalStateMgr.getCurrentState().getStatisticStorage().refreshHistogramStatistics(table, columns, !async);
     }
 
     public void replayRemoveHistogramStatsMeta(HistogramStatsMeta histogramStatsMeta) {


### PR DESCRIPTION
## Why I'm doing:
histogram statistics cache can't be refreshed after collecting histogram in sync mode.

## What I'm doing:
Before this PR:

collect new histogram
drop old histogram cache
wait a moment and really update new histogram cache.

This PR:

collect new histogram
update new histogram statistics cache directly and replace old cache

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0