### PR TITLE
[Enhancement] Improve efficiency of ARRAY_GENERATE (~4.75x speed up)

### DIFF
--- a/be/src/exprs/array_functions.tpp
+++ b/be/src/exprs/array_functions.tpp
@@ -1631,7 +1631,6 @@ private:
     }
 };
 
-// Todo:support datetime/date
 template <LogicalType Type>
 class ArrayGenerate {
 public:
@@ -1647,9 +1646,9 @@ public:
         NullColumnPtr nulls;
         for (auto& column : columns) {
             if (column->has_null()) {
-                const auto* nullable_column = down_cast<const NullableColumn*>(column.get());
+                auto nullable_column = down_cast<NullableColumn*>(column.get());
                 if (nulls == nullptr) {
-                    nulls = NullColumn::static_pointer_cast(nullable_column->null_column()->clone());
+                    nulls = std::static_pointer_cast<NullColumn>(nullable_column->null_column()->clone_shared());
                 } else {
                     ColumnHelper::or_two_filters(num_rows, nulls->get_data().data(),
                                                  nullable_column->null_column()->get_data().data());
@@ -1670,6 +1669,30 @@ public:
 
         auto num_rows_to_process = all_const_cols ? 1 : num_rows;
 
+        size_t total_elements = 0;
+        auto* data_column = elements->mutable_data_column();
+        auto* null_column = elements->mutable_null_column();
+        ColumnViewer start_viewer = ColumnViewer<Type>(columns[0]);
+        ColumnViewer stop_viewer = ColumnViewer<Type>(columns[1]);
+        ColumnViewer step_viewer = ColumnViewer<Type>(columns[2]);
+        for (size_t cur_row = 0; cur_row < num_rows_to_process; cur_row++) {
+            if (nulls && nulls->get_data()[cur_row]) {
+                continue;
+            }
+            auto step = step_viewer.value(cur_row);
+            if (step == 0) {
+                continue;
+            }
+            auto start = start_viewer.value(cur_row);
+            auto stop = stop_viewer.value(cur_row);
+            if (step > 0 && start <= stop) {
+                total_elements += (stop - start) / step + 1;
+            } else if (step < 0 && start >= stop) {
+                total_elements += (start - stop) / (-step) + 1;
+            }
+        }
+        TRY_CATCH_BAD_ALLOC(data_column->reserve(total_elements));
+
         size_t total_elements_num = 0;
         for (size_t cur_row = 0; cur_row < num_rows_to_process; cur_row++) {
             if (nulls && nulls->get_data()[cur_row]) {
@@ -1677,26 +1700,27 @@ public:
                 continue;
             }
 
-            auto start = columns[0]->get(cur_row).get<InputCppType>();
-            auto stop = columns[1]->get(cur_row).get<InputCppType>();
-            auto step = columns[2]->get(cur_row).get<InputCppType>();
+            auto step = step_viewer.value(cur_row);
 
             // just return empty array
             if (step == 0) {
                 offsets->append(offsets->get_data().back());
                 continue;
             }
+            auto start = start_viewer.value(cur_row);
+            auto stop = stop_viewer.value(cur_row);
 
             InputCppType temp;
             for (InputCppType cur_element = start; step > 0 ? cur_element <= stop : cur_element >= stop;
                  cur_element += step) {
-                TRY_CATCH_BAD_ALLOC(elements->append_numbers(&cur_element, sizeof(InputCppType)));
+                data_column->append_datum(cur_element);
                 total_elements_num++;
                 if (__builtin_add_overflow(cur_element, step, &temp)) break;
             }
             offsets->append(total_elements_num);
         }
 
+        null_column->get_data().resize(total_elements_num, 0);
         CHECK_EQ(offsets->get_data().back(), elements->size());
 
         auto dst = ArrayColumn::create(std::move(array_elements), std::move(array_offsets));

--- a/be/src/exprs/array_functions.tpp
+++ b/be/src/exprs/array_functions.tpp
@@ -1647,9 +1647,9 @@ public:
         NullColumnPtr nulls;
         for (auto& column : columns) {
             if (column->has_null()) {
-                auto nullable_column = down_cast<NullableColumn*>(column.get());
+                const auto* nullable_column = down_cast<const NullableColumn*>(column.get());
                 if (nulls == nullptr) {
-                    nulls = std::static_pointer_cast<NullColumn>(nullable_column->null_column()->clone_shared());
+                    nulls = NullColumn::static_pointer_cast(nullable_column->null_column()->clone());
                 } else {
                     ColumnHelper::or_two_filters(num_rows, nulls->get_data().data(),
                                                  nullable_column->null_column()->get_data().data());

--- a/be/src/exprs/array_functions.tpp
+++ b/be/src/exprs/array_functions.tpp
@@ -1631,6 +1631,7 @@ private:
     }
 };
 
+// Todo:support datetime/date
 template <LogicalType Type>
 class ArrayGenerate {
 public:


### PR DESCRIPTION
## Why I'm doing:

The performance of ARRAY_GENERATE is not ideal. However it is widely used in our project.

## What I'm doing:

This PR improves the efficiency of ARRAY_GENERATE, achieving approximately 4.75x speed up.

Benchmark of the original implementation
```
2025-03-19T22:48:12+00:00
Running ./be/build_Release/src/bench/celonis/output/array_generate_bench
Run on (32 X 2445.43 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x16)
  L1 Instruction 32 KiB (x16)
  L2 Unified 512 KiB (x16)
  L3 Unified 32768 KiB (x2)
Load Average: 11.59, 12.27, 10.16
// Number of rows / Output row length
---------------------------------------------------------------------------------------
Benchmark                             Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------
BM_ArrayGenerate/1000/100       2175607 ns      2175738 ns          324 RowInvRate=2.17574us
BM_ArrayGenerate/10000/100     21767753 ns     21767199 ns           32 RowInvRate=2.17672us
BM_ArrayGenerate/100000/100   231008231 ns    231003656 ns            3 RowInvRate=2.31004us
BM_ArrayGenerate/1000/1000     21236103 ns     21235991 ns           33 RowInvRate=21.236us
BM_ArrayGenerate/10000/1000   229587532 ns    229575371 ns            3 RowInvRate=22.9575us
BM_ArrayGenerate/100000/1000 2245083260 ns   2245005027 ns            1 RowInvRate=22.4501us
```

Benchmark of the new implementation
```
2025-03-24T20:09:43+00:00
Running ./be/build_Release/src/bench/celonis/output/array_generate_bench
Run on (32 X 3240.91 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x16)
  L1 Instruction 32 KiB (x16)
  L2 Unified 512 KiB (x16)
  L3 Unified 32768 KiB (x2)
Load Average: 6.72, 3.67, 3.19
// Number of rows / Output row length
---------------------------------------------------------------------------------------
Benchmark                             Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------
BM_ArrayGenerate/1000/100        422183 ns       422298 ns         1663 RowInvRate=422.298ns
BM_ArrayGenerate/10000/100      4647866 ns      4647761 ns          151 RowInvRate=464.776ns
BM_ArrayGenerate/100000/100    50428518 ns     50426918 ns           10 RowInvRate=504.269ns
BM_ArrayGenerate/1000/1000      4503198 ns      4503254 ns          155 RowInvRate=4.50325us
BM_ArrayGenerate/10000/1000    48847768 ns     48846313 ns           14 RowInvRate=4.88463us
BM_ArrayGenerate/100000/1000  483559655 ns    483526311 ns            2 RowInvRate=4.83526us
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0