### PR TITLE
[Enhancement] Optimize aggregation group by one high cardinality string

### DIFF
--- a/be/src/exec/aggregate/agg_hash_variant.cpp
+++ b/be/src/exec/aggregate/agg_hash_variant.cpp
@@ -58,6 +58,8 @@ DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase1_null_string, NullOneStringAggHas
 DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase1_slice, SerializedKeyAggHashMap<PhmapSeed1>);
 DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase1_slice_two_level, SerializedKeyTwoLevelAggHashMap<PhmapSeed1>);
 DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase1_int32_two_level, Int32TwoLevelAggHashMapWithOneNumberKey<PhmapSeed1>);
+DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase1_null_string_two_level, NullOneStringTwoLevelAggHashMap<PhmapSeed1>);
+DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase1_string_two_level, OneStringTwoLevelAggHashMap<PhmapSeed1>);
 DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase1_slice_fx4, SerializedKeyFixedSize4AggHashMap<PhmapSeed1>);
 DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase1_slice_fx8, SerializedKeyFixedSize8AggHashMap<PhmapSeed1>);
 DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase1_slice_fx16, SerializedKeyFixedSize16AggHashMap<PhmapSeed1>);
@@ -88,6 +90,8 @@ DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase2_null_string, NullOneStringAggHas
 DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase2_slice, SerializedKeyAggHashMap<PhmapSeed2>);
 DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase2_slice_two_level, SerializedKeyTwoLevelAggHashMap<PhmapSeed2>);
 DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase2_int32_two_level, Int32TwoLevelAggHashMapWithOneNumberKey<PhmapSeed2>);
+DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase2_null_string_two_level, NullOneStringTwoLevelAggHashMap<PhmapSeed2>);
+DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase2_string_two_level, OneStringTwoLevelAggHashMap<PhmapSeed2>);
 DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase2_slice_fx4, SerializedKeyFixedSize4AggHashMap<PhmapSeed2>);
 DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase2_slice_fx8, SerializedKeyFixedSize8AggHashMap<PhmapSeed2>);
 DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase2_slice_fx16, SerializedKeyFixedSize16AggHashMap<PhmapSeed2>);
@@ -128,6 +132,9 @@ DEFINE_SET_TYPE(AggHashSetVariant::Type::phase1_null_string, NullOneStringAggHas
 DEFINE_SET_TYPE(AggHashSetVariant::Type::phase1_slice, SerializedKeyAggHashSet<PhmapSeed1>);
 DEFINE_SET_TYPE(AggHashSetVariant::Type::phase1_slice_two_level, SerializedTwoLevelKeyAggHashSet<PhmapSeed1>);
 DEFINE_SET_TYPE(AggHashSetVariant::Type::phase1_int32_two_level, Int32TwoLevelAggHashSetOfOneNumberKey<PhmapSeed1>);
+DEFINE_SET_TYPE(AggHashSetVariant::Type::phase1_string_two_level, OneStringTwoLevelAggHashSet<PhmapSeed1>);
+DEFINE_SET_TYPE(AggHashSetVariant::Type::phase1_null_string_two_level, NullOneStringTwoLevelAggHashSet<PhmapSeed1>);
+
 DEFINE_SET_TYPE(AggHashSetVariant::Type::phase2_uint8, UInt8AggHashSetOfOneNumberKey<PhmapSeed2>);
 DEFINE_SET_TYPE(AggHashSetVariant::Type::phase2_int8, Int8AggHashSetOfOneNumberKey<PhmapSeed2>);
 DEFINE_SET_TYPE(AggHashSetVariant::Type::phase2_int16, Int16AggHashSetOfOneNumberKey<PhmapSeed2>);
@@ -155,6 +162,9 @@ DEFINE_SET_TYPE(AggHashSetVariant::Type::phase2_null_string, NullOneStringAggHas
 DEFINE_SET_TYPE(AggHashSetVariant::Type::phase2_slice, SerializedKeyAggHashSet<PhmapSeed2>);
 DEFINE_SET_TYPE(AggHashSetVariant::Type::phase2_slice_two_level, SerializedTwoLevelKeyAggHashSet<PhmapSeed2>);
 DEFINE_SET_TYPE(AggHashSetVariant::Type::phase2_int32_two_level, Int32TwoLevelAggHashSetOfOneNumberKey<PhmapSeed2>);
+DEFINE_SET_TYPE(AggHashSetVariant::Type::phase2_string_two_level, OneStringTwoLevelAggHashSet<PhmapSeed2>);
+DEFINE_SET_TYPE(AggHashSetVariant::Type::phase2_null_string_two_level, NullOneStringTwoLevelAggHashSet<PhmapSeed2>);
+
 DEFINE_SET_TYPE(AggHashSetVariant::Type::phase1_slice_fx4, SerializedKeyAggHashSetFixedSize4<PhmapSeed1>);
 DEFINE_SET_TYPE(AggHashSetVariant::Type::phase1_slice_fx8, SerializedKeyAggHashSetFixedSize8<PhmapSeed1>);
 DEFINE_SET_TYPE(AggHashSetVariant::Type::phase1_slice_fx16, SerializedKeyAggHashSetFixedSize16<PhmapSeed1>);
@@ -199,6 +209,12 @@ void AggHashMapVariant::init(RuntimeState* state, Type type, AggStatistics* agg_
 void AggHashMapVariant::convert_to_two_level(RuntimeState* state) {
     CONVERT_TO_TWO_LEVEL_MAP(phase1_slice_two_level, phase1_slice);
     CONVERT_TO_TWO_LEVEL_MAP(phase2_slice_two_level, phase2_slice);
+
+    CONVERT_TO_TWO_LEVEL_MAP(phase1_string_two_level, phase1_string);
+    CONVERT_TO_TWO_LEVEL_MAP(phase2_string_two_level, phase2_string);
+
+    CONVERT_TO_TWO_LEVEL_MAP(phase1_null_string_two_level, phase1_null_string);
+    CONVERT_TO_TWO_LEVEL_MAP(phase2_null_string_two_level, phase2_null_string);
 }
 
 void AggHashMapVariant::reset() {
@@ -274,6 +290,12 @@ void AggHashSetVariant::init(RuntimeState* state, Type type, AggStatistics* agg_
 void AggHashSetVariant::convert_to_two_level(RuntimeState* state) {
     CONVERT_TO_TWO_LEVEL_SET(phase1_slice_two_level, phase1_slice);
     CONVERT_TO_TWO_LEVEL_SET(phase2_slice_two_level, phase2_slice);
+
+    CONVERT_TO_TWO_LEVEL_SET(phase1_string_two_level, phase1_string);
+    CONVERT_TO_TWO_LEVEL_SET(phase2_string_two_level, phase2_string);
+
+    CONVERT_TO_TWO_LEVEL_SET(phase1_null_string_two_level, phase1_null_string);
+    CONVERT_TO_TWO_LEVEL_SET(phase2_null_string_two_level, phase2_null_string);
 }
 
 void AggHashSetVariant::reset() {

--- a/be/src/exec/aggregate/agg_hash_variant.h
+++ b/be/src/exec/aggregate/agg_hash_variant.h
@@ -57,6 +57,9 @@ namespace starrocks {
     M(phase1_null_string)            \
     M(phase1_slice_two_level)        \
     M(phase1_int32_two_level)        \
+    M(phase1_null_string_two_level)  \
+    M(phase1_string_two_level)       \
+                                     \
     M(phase2_uint8)                  \
     M(phase2_int8)                   \
     M(phase2_int16)                  \
@@ -84,6 +87,9 @@ namespace starrocks {
     M(phase2_null_string)            \
     M(phase2_slice_two_level)        \
     M(phase2_int32_two_level)        \
+    M(phase2_null_string_two_level)  \
+    M(phase2_string_two_level)       \
+                                     \
     M(phase1_slice_fx4)              \
     M(phase1_slice_fx8)              \
     M(phase1_slice_fx16)             \
@@ -150,6 +156,10 @@ template <PhmapSeed seed>
 using OneStringAggHashMap = AggHashMapWithOneStringKey<SliceAggHashMap<seed>>;
 template <PhmapSeed seed>
 using NullOneStringAggHashMap = AggHashMapWithOneNullableStringKey<SliceAggHashMap<seed>>;
+template <PhmapSeed seed>
+using OneStringTwoLevelAggHashMap = AggHashMapWithOneStringKey<SliceAggTwoLevelHashMap<seed>>;
+template <PhmapSeed seed>
+using NullOneStringTwoLevelAggHashMap = AggHashMapWithOneNullableStringKey<SliceAggTwoLevelHashMap<seed>>;
 template <PhmapSeed seed>
 using SerializedKeyAggHashMap = AggHashMapWithSerializedKey<SliceAggHashMap<seed>>;
 template <PhmapSeed seed>
@@ -222,6 +232,10 @@ template <PhmapSeed seed>
 using OneStringAggHashSet = AggHashSetOfOneStringKey<SliceAggHashSet<seed>>;
 template <PhmapSeed seed>
 using NullOneStringAggHashSet = AggHashSetOfOneNullableStringKey<SliceAggHashSet<seed>>;
+template <PhmapSeed seed>
+using NullOneStringTwoLevelAggHashSet = AggHashSetOfOneNullableStringKey<SliceAggTwoLevelHashSet<seed>>;
+template <PhmapSeed seed>
+using OneStringTwoLevelAggHashSet = AggHashSetOfOneStringKey<SliceAggTwoLevelHashSet<seed>>;
 template <PhmapSeed seed>
 using SerializedKeyAggHashSet = AggHashSetOfSerializedKey<SliceAggHashSet<seed>>;
 template <PhmapSeed seed>
@@ -303,6 +317,8 @@ using AggHashMapWithKeyPtr = std::variant<
         std::unique_ptr<NullOneStringAggHashMap<PhmapSeed1>>, std::unique_ptr<SerializedKeyAggHashMap<PhmapSeed1>>,
         std::unique_ptr<SerializedKeyTwoLevelAggHashMap<PhmapSeed1>>,
         std::unique_ptr<Int32TwoLevelAggHashMapWithOneNumberKey<PhmapSeed1>>,
+        std::unique_ptr<OneStringTwoLevelAggHashMap<PhmapSeed1>>,
+        std::unique_ptr<NullOneStringTwoLevelAggHashMap<PhmapSeed1>>,
         std::unique_ptr<SerializedKeyFixedSize4AggHashMap<PhmapSeed1>>,
         std::unique_ptr<SerializedKeyFixedSize8AggHashMap<PhmapSeed1>>,
         std::unique_ptr<SerializedKeyFixedSize16AggHashMap<PhmapSeed1>>,
@@ -332,6 +348,8 @@ using AggHashMapWithKeyPtr = std::variant<
         std::unique_ptr<NullOneStringAggHashMap<PhmapSeed2>>, std::unique_ptr<SerializedKeyAggHashMap<PhmapSeed2>>,
         std::unique_ptr<SerializedKeyTwoLevelAggHashMap<PhmapSeed2>>,
         std::unique_ptr<Int32TwoLevelAggHashMapWithOneNumberKey<PhmapSeed2>>,
+        std::unique_ptr<OneStringTwoLevelAggHashMap<PhmapSeed2>>,
+        std::unique_ptr<NullOneStringTwoLevelAggHashMap<PhmapSeed2>>,
         std::unique_ptr<SerializedKeyFixedSize4AggHashMap<PhmapSeed2>>,
         std::unique_ptr<SerializedKeyFixedSize8AggHashMap<PhmapSeed2>>,
         std::unique_ptr<SerializedKeyFixedSize16AggHashMap<PhmapSeed2>>>;
@@ -362,6 +380,8 @@ using AggHashSetWithKeyPtr = std::variant<
         std::unique_ptr<NullTimeStampAggHashSetOfOneNumberKey<PhmapSeed1>>,
         std::unique_ptr<NullOneStringAggHashSet<PhmapSeed1>>, std::unique_ptr<SerializedKeyAggHashSet<PhmapSeed1>>,
         std::unique_ptr<SerializedTwoLevelKeyAggHashSet<PhmapSeed1>>,
+        std::unique_ptr<OneStringTwoLevelAggHashSet<PhmapSeed1>>,
+        std::unique_ptr<NullOneStringTwoLevelAggHashSet<PhmapSeed1>>,
         std::unique_ptr<Int32TwoLevelAggHashSetOfOneNumberKey<PhmapSeed1>>,
         std::unique_ptr<UInt8AggHashSetOfOneNumberKey<PhmapSeed2>>,
         std::unique_ptr<Int8AggHashSetOfOneNumberKey<PhmapSeed2>>,
@@ -389,6 +409,8 @@ using AggHashSetWithKeyPtr = std::variant<
         std::unique_ptr<NullOneStringAggHashSet<PhmapSeed2>>, std::unique_ptr<SerializedKeyAggHashSet<PhmapSeed2>>,
         std::unique_ptr<SerializedTwoLevelKeyAggHashSet<PhmapSeed2>>,
         std::unique_ptr<Int32TwoLevelAggHashSetOfOneNumberKey<PhmapSeed2>>,
+        std::unique_ptr<OneStringTwoLevelAggHashSet<PhmapSeed2>>,
+        std::unique_ptr<NullOneStringTwoLevelAggHashSet<PhmapSeed2>>,
         std::unique_ptr<SerializedKeyAggHashSetFixedSize4<PhmapSeed1>>,
         std::unique_ptr<SerializedKeyAggHashSetFixedSize8<PhmapSeed1>>,
         std::unique_ptr<SerializedKeyAggHashSetFixedSize16<PhmapSeed1>>,
@@ -425,6 +447,8 @@ struct AggHashMapVariant {
         phase1_slice,
         phase1_slice_two_level,
         phase1_int32_two_level,
+        phase1_null_string_two_level,
+        phase1_string_two_level,
 
         phase1_slice_fx4,
         phase1_slice_fx8,
@@ -457,6 +481,8 @@ struct AggHashMapVariant {
         phase2_slice,
         phase2_slice_two_level,
         phase2_int32_two_level,
+        phase2_null_string_two_level,
+        phase2_string_two_level,
 
         phase2_slice_fx4,
         phase2_slice_fx8,
@@ -530,6 +556,9 @@ struct AggHashSetVariant {
         phase1_slice,
         phase1_slice_two_level,
         phase1_int32_two_level,
+        phase1_null_string_two_level,
+        phase1_string_two_level,
+
         phase2_uint8,
         phase2_int8,
         phase2_int16,
@@ -557,6 +586,8 @@ struct AggHashSetVariant {
         phase2_slice,
         phase2_slice_two_level,
         phase2_int32_two_level,
+        phase2_null_string_two_level,
+        phase2_string_two_level,
 
         phase1_slice_fx4,
         phase1_slice_fx8,

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -159,6 +159,16 @@ PARALLEL_TEST(BinaryColumnTest, test_append_strings) {
         ASSERT_EQ(values[i], c1->get_data()[i]);
     }
 
+    std::vector<Slice> values2{{"abcd"}, {"123456"}};
+    ASSERT_TRUE(c1->append_strings(values2.data(), values2.size()));
+    ASSERT_EQ(values.size() + values2.size(), c1->size());
+    for (size_t i = 0; i < values.size(); i++) {
+        ASSERT_EQ(values[i], c1->get_data()[i]);
+    }
+    for (size_t i = 0; i < values2.size(); i++) {
+        ASSERT_EQ(values2[i], c1->get_data()[i + 2]);
+    }
+
     // Nullable BinaryColumn
     NullableColumn::Ptr c2 = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
     ASSERT_TRUE(c2->append_strings(values.data(), values.size()));


### PR DESCRIPTION
## Why I'm doing:

**1. Use two level hash map for grouping by one high cardinality string** 
When a aggregation hash map with high cardinality string grouping keys, the performance is bad. Therefore, we convert it to two level hash map.

However, we only do this for the hash map type `phase1_slice` and `phase2_slice`, but grouping by one string uses `phase1/2_string` or `phase1/2_null_string` not `phase1/2_slice`.

**2. Optimize BinaryColumn::append_strings**

### Test
Environment Information
- BE: 4 * m7gd.4xlarge
- Table `t1`
    - contains 26,2144,0000 rows
    - `c1` is varchar, length is 12, and each value is distinct.

```sql
select count(distinct c1) from t1;
```

Latency
- Before: > 5min timeout
- OPT1: 28s
- OPT1~2: 24s


## What I'm doing:


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0