### PR TITLE
[Enhancement] support collect partition level stats for partition first load

### DIFF
--- a/be/src/agent/publish_version.cpp
+++ b/be/src/agent/publish_version.cpp
@@ -272,7 +272,7 @@ void run_publish_version_task(ThreadPoolToken* token, const TPublishVersionReque
                     auto& finish_tablet_info = finish_tablet_infos.back();
                     finish_tablet_info.__set_row_count(tablet->num_rows());
                     finish_tablet_info.__set_partition_id(tablet->partition_id());
-                    finish_tablet_infos.push_back(finish_tablet_info);
+                    finish_tablet_info.__set_tablet_id(tablet->tablet_id());
                 }
             }
         }

--- a/be/src/agent/publish_version.cpp
+++ b/be/src/agent/publish_version.cpp
@@ -243,6 +243,7 @@ void run_publish_version_task(ThreadPoolToken* token, const TPublishVersionReque
     }
     // return tablet and its version which has already finished.
     int total_tablet_cnt = 0;
+    std::vector<TTabletInfo> finish_tablet_infos;
     for (const auto& partition_version : publish_version_req.partition_version_infos) {
         std::vector<TabletInfo> tablet_infos;
         StorageEngine::instance()->tablet_manager()->get_tablets_by_partition(partition_version.partition_id,
@@ -265,9 +266,20 @@ void run_publish_version_task(ThreadPoolToken* token, const TPublishVersionReque
 
                 if (enable_sync_publish && tablet_tasks.empty() && max_continuous_version < partition_version.version) {
                     error_tablet_ids.push_back(tablet_info.tablet_id);
+                } else if (partition_version.version == 2) {
+                    // Used to collect statistics when the partition is first imported
+                    finish_tablet_infos.emplace_back();
+                    auto& finish_tablet_info = finish_tablet_infos.back();
+                    finish_tablet_info.__set_row_count(tablet->num_rows());
+                    finish_tablet_info.__set_partition_id(tablet->partition_id());
+                    finish_tablet_infos.push_back(finish_tablet_info);
                 }
             }
         }
+    }
+
+    if (!finish_tablet_infos.empty()) {
+        finish_task.__set_finish_tablet_infos(finish_tablet_infos);
     }
 
     // TODO: add more information to status, rather than just first error tablet

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -228,8 +228,13 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
                     if (res.ok()) {
                         auto metadata = std::move(res).value();
                         auto score = compaction_score(_tablet_mgr, metadata);
+                        auto tablet = _tablet_mgr->get_tablet(tablet_id);
                         std::lock_guard l(response_mtx);
                         response->mutable_compaction_scores()->insert({tablet_id, score});
+                        if (request->base_version() == 1) {
+                            // Used to collect statistics when the partition is first imported
+                            response->mutable_tablet_row_nums()->insert({tablet_id, tablet->num_rows()});
+                        }
                     } else {
                         g_publish_version_failed_tasks << 1;
                         if (res.status().is_resource_busy()) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
@@ -101,14 +101,15 @@ public class Utils {
     public static void publishVersion(@NotNull List<Tablet> tablets, TxnInfoPB txnInfo, long baseVersion,
                                       long newVersion, long warehouseId)
             throws NoAliveBackendException, RpcException {
-        publishVersion(tablets, txnInfo, baseVersion, newVersion, null, warehouseId);
+        publishVersion(tablets, txnInfo, baseVersion, newVersion, null, warehouseId, null);
     }
 
     public static void publishVersionBatch(@NotNull List<Tablet> tablets, List<TxnInfoPB> txnInfos,
                                            long baseVersion, long newVersion,
                                            Map<Long, Double> compactionScores,
                                            Map<ComputeNode, List<Long>> nodeToTablets,
-                                           long warehouseId)
+                                           long warehouseId,
+                                           Map<Long, Long> tabletRowNum)
             throws NoAliveBackendException, RpcException {
         if (nodeToTablets == null) {
             nodeToTablets = new HashMap<>();
@@ -169,6 +170,9 @@ public class Utils {
                 if (compactionScores != null && response != null && response.compactionScores != null) {
                     compactionScores.putAll(response.compactionScores);
                 }
+                if (baseVersion == 1 && tabletRowNum != null && response != null && response.tabletRowNums != null) {
+                    tabletRowNum.putAll(response.tabletRowNums);
+                }
             } catch (Exception e) {
                 throw new RpcException(nodeList.get(i).getHost(), e.getMessage());
             }
@@ -177,10 +181,10 @@ public class Utils {
 
     public static void publishVersion(@NotNull List<Tablet> tablets, TxnInfoPB txnInfo, long baseVersion,
                                       long newVersion, Map<Long, Double> compactionScores,
-                                      long warehouseId)
+                                      long warehouseId, Map<Long, Long> tabletRowNums)
             throws NoAliveBackendException, RpcException {
         List<TxnInfoPB> txnInfos = Lists.newArrayList(txnInfo);
-        publishVersionBatch(tablets, txnInfos, baseVersion, newVersion, compactionScores, null, warehouseId);
+        publishVersionBatch(tablets, txnInfos, baseVersion, newVersion, compactionScores, null, warehouseId, tabletRowNums);
     }
 
     public static void publishLogVersion(@NotNull List<Tablet> tablets, TxnInfoPB txnInfo, long version, long warehouseId)

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -149,6 +149,7 @@ import com.starrocks.thrift.TTabletInfo;
 import com.starrocks.thrift.TTabletMeta;
 import com.starrocks.thrift.TTaskType;
 import com.starrocks.transaction.GlobalTransactionMgr;
+import com.starrocks.transaction.PartitionCommitInfo;
 import com.starrocks.transaction.TabletCommitInfo;
 import com.starrocks.transaction.TabletFailInfo;
 import com.starrocks.transaction.TransactionState;
@@ -728,6 +729,27 @@ public class LeaderImpl {
         TransactionState txnState = publishVersionTask.getTxnState();
         if (txnState != null) {
             txnState.updatePublishTaskFinishTime();
+
+            // Used to collect statistics when the partition is first imported
+            // TODO(stephen): support insert into multiple tables in a transaction
+            if (txnState.getSourceType() == LoadJobSourceType.INSERT_STREAMING &&
+                    txnState.getIdToTableCommitInfos().size() == 1 &&
+                    request.isSetFinish_tablet_infos() &&
+                    !request.getFinish_tablet_infos().isEmpty()) {
+                Map<Long, PartitionCommitInfo> idToPartitionCommitInfo = txnState.getIdToTableCommitInfos().values()
+                        .iterator().next().getIdToPartitionCommitInfo();
+                List<TTabletInfo> tabletInfos = request.getFinish_tablet_infos();
+                for (TTabletInfo tabletInfo : tabletInfos) {
+                    long partitionId = tabletInfo.getPartition_id();
+                    PartitionCommitInfo commitInfo = idToPartitionCommitInfo.get(partitionId);
+                    if (commitInfo != null && commitInfo.getVersion() == Partition.PARTITION_INIT_VERSION + 1) {
+                        long rowCount = tabletInfo.getRow_count();
+                        long tabletId = tabletInfo.getTablet_id();
+                        Map<Long, Long> tableIdToRowCount = commitInfo.getTabletIdToRowCountForPartitionFirstLoad();
+                        tableIdToRowCount.put(tabletId, rowCount);
+                    }
+                }
+            }
         }
 
         if (request.getTask_status().getStatus_code() != TStatusCode.OK) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/HyperStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/HyperStatisticsCollectJob.java
@@ -86,7 +86,7 @@ public class HyperStatisticsCollectJob extends StatisticsCollectJob {
                 queryJobs = HyperQueryJob.createFullQueryJobs(context, db, table, columnNames, columnTypes,
                             partitionIdList, splitSize);
             } else {
-                PartitionSampler sampler = PartitionSampler.create(table, partitionIdList, properties, ptRowNums);
+                PartitionSampler sampler = PartitionSampler.create(table, partitionIdList, properties, partitionTabletRowCounts);
                 queryJobs = HyperQueryJob.createSampleQueryJobs(context, db, table, columnNames, columnTypes,
                         partitionIdList, splitSize, sampler);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/HyperStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/HyperStatisticsCollectJob.java
@@ -86,7 +86,7 @@ public class HyperStatisticsCollectJob extends StatisticsCollectJob {
                 queryJobs = HyperQueryJob.createFullQueryJobs(context, db, table, columnNames, columnTypes,
                             partitionIdList, splitSize);
             } else {
-                PartitionSampler sampler = PartitionSampler.create(table, partitionIdList, properties);
+                PartitionSampler sampler = PartitionSampler.create(table, partitionIdList, properties, ptRowNums);
                 queryJobs = HyperQueryJob.createSampleQueryJobs(context, db, table, columnNames, columnTypes,
                         partitionIdList, splitSize, sampler);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.statistic;
 
+import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
@@ -72,6 +73,12 @@ public abstract class StatisticsCollectJob {
     // for multi-column combined statistics job.
     // Using group is to support automatic collection of all predicate columns of a table in the future.
     protected final List<List<String>> columnGroups;
+
+    // for partition first load to collect statistics with sample strategy.
+    // After the partition is first imported, we cannot immediately get the tablet row count.
+    // we need to wait the tabletStatMgr to sync in the background. so we collect row num for each tablet.
+    // partition_id -> tablet_id -> row_count
+    protected com.google.common.collect.Table<Long, Long, Long> ptRowNums = HashBasedTable.create();
 
     protected StatisticsCollectJob(Database db, Table table, List<String> columnNames,
                                    StatsConstants.AnalyzeType analyzeType, StatsConstants.ScheduleType scheduleType,
@@ -179,6 +186,10 @@ public abstract class StatisticsCollectJob {
         // set the max task num of connector io tasks per scan operator to 4, default is 16,
         // to avoid generate too many chunk source for collect stats in BE
         sessionVariable.setConnectorIoTasksPerScanOperator(4);
+    }
+
+    public void setPtRowNums(com.google.common.collect.Table<Long, Long, Long> ptRowNums) {
+        this.ptRowNums = ptRowNums;
     }
 
     protected void collectStatisticSync(String sql, ConnectContext context) throws Exception {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
@@ -78,7 +78,7 @@ public abstract class StatisticsCollectJob {
     // After the partition is first imported, we cannot immediately get the tablet row count.
     // we need to wait the tabletStatMgr to sync in the background. so we collect row num for each tablet.
     // partition_id -> tablet_id -> row_count
-    protected com.google.common.collect.Table<Long, Long, Long> ptRowNums = HashBasedTable.create();
+    protected com.google.common.collect.Table<Long, Long, Long> partitionTabletRowCounts = HashBasedTable.create();
 
     protected StatisticsCollectJob(Database db, Table table, List<String> columnNames,
                                    StatsConstants.AnalyzeType analyzeType, StatsConstants.ScheduleType scheduleType,
@@ -188,8 +188,8 @@ public abstract class StatisticsCollectJob {
         sessionVariable.setConnectorIoTasksPerScanOperator(4);
     }
 
-    public void setPtRowNums(com.google.common.collect.Table<Long, Long, Long> ptRowNums) {
-        this.ptRowNums = ptRowNums;
+    public void setPartitionTabletRowCounts(com.google.common.collect.Table<Long, Long, Long> partitionTabletRowCounts) {
+        this.partitionTabletRowCounts = partitionTabletRowCounts;
     }
 
     protected void collectStatisticSync(String sql, ConnectContext context) throws Exception {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
@@ -88,7 +88,7 @@ public class StatisticsCollectionTrigger {
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
 
     // partition_id -> tablet_id -> row_count
-    protected com.google.common.collect.Table<Long, Long, Long> ptRowNums = HashBasedTable.create();
+    protected com.google.common.collect.Table<Long, Long, Long> partitionTabletRowCounts = HashBasedTable.create();
 
     public static StatisticsCollectionTrigger triggerOnInsertOverwrite(InsertOverwriteJobStats stats,
                                                 Database db,
@@ -202,8 +202,8 @@ public class StatisticsCollectionTrigger {
                                 new ArrayList<>(partitionIds), null, null,
                                 analyzeType, StatsConstants.ScheduleType.ONCE,
                                 analyzeStatus.getProperties(), List.of(), List.of());
-                        if (!ptRowNums.isEmpty()) {
-                            job.setPtRowNums(ptRowNums);
+                        if (!partitionTabletRowCounts.isEmpty()) {
+                            job.setPartitionTabletRowCounts(partitionTabletRowCounts);
                         }
 
                         statisticExecutor.collectStatistics(statsConnectCtx, job, analyzeStatus, false);
@@ -264,7 +264,7 @@ public class StatisticsCollectionTrigger {
                     PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
                     Long partitionId = table.getPartition(physicalPartition.getParentId()).getId();
                     partitionIds.add(partitionId);
-                    tabletRows.forEach((tabletId, rowCount) -> ptRowNums.put(partitionId, tabletId, rowCount));
+                    tabletRows.forEach((tabletId, rowCount) -> partitionTabletRowCounts.put(partitionId, tabletId, rowCount));
                 }
             }
         } finally {
@@ -279,7 +279,7 @@ public class StatisticsCollectionTrigger {
         analyzeType = decideAnalyzeTypeForLoad(txnState, (OlapTable) table);
 
         if (analyzeType != SAMPLE) {
-            ptRowNums.clear();
+            partitionTabletRowCounts.clear();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
@@ -15,6 +15,7 @@
 package com.starrocks.statistic;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.Database;
@@ -85,6 +86,9 @@ public class StatisticsCollectionTrigger {
     // execution stats
     private Future<?> future;
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
+
+    // partition_id -> tablet_id -> row_count
+    protected com.google.common.collect.Table<Long, Long, Long> ptRowNums = HashBasedTable.create();
 
     public static StatisticsCollectionTrigger triggerOnInsertOverwrite(InsertOverwriteJobStats stats,
                                                 Database db,
@@ -194,12 +198,15 @@ public class StatisticsCollectionTrigger {
                             statsConnectCtx.setSessionId(((OlapTable) table).getSessionId());
                         }
                         statsConnectCtx.setThreadLocalInfo();
+                        StatisticsCollectJob job = StatisticsCollectJobFactory.buildStatisticsCollectJob(db, table,
+                                new ArrayList<>(partitionIds), null, null,
+                                analyzeType, StatsConstants.ScheduleType.ONCE,
+                                analyzeStatus.getProperties(), List.of(), List.of());
+                        if (!ptRowNums.isEmpty()) {
+                            job.setPtRowNums(ptRowNums);
+                        }
 
-                        statisticExecutor.collectStatistics(statsConnectCtx,
-                                StatisticsCollectJobFactory.buildStatisticsCollectJob(db, table,
-                                        new ArrayList<>(partitionIds), null, null,
-                                        analyzeType, StatsConstants.ScheduleType.ONCE,
-                                        analyzeStatus.getProperties(), List.of(), List.of()), analyzeStatus, false);
+                        statisticExecutor.collectStatistics(statsConnectCtx, job, analyzeStatus, false);
                     });
         } catch (Throwable e) {
             LOG.error("failed to submit statistic collect job", e);
@@ -248,13 +255,16 @@ public class StatisticsCollectionTrigger {
         try {
             for (var entry : tableCommitInfo.getIdToPartitionCommitInfo().entrySet()) {
                 // partition commit info id is physical partition id.
-                // statistic collect granularity is logic partition.
+                // statistic collect granularity is logical partition.
                 long physicalPartitionId = entry.getKey();
                 PartitionCommitInfo partitionCommitInfo = entry.getValue();
+                Map<Long, Long> tabletRows = partitionCommitInfo.getTabletIdToRowCountForPartitionFirstLoad();
+
                 if (partitionCommitInfo.getVersion() == Partition.PARTITION_INIT_VERSION + 1) {
                     PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
-                    Partition partition = table.getPartition(physicalPartition.getParentId());
-                    partitionIds.add(partition.getId());
+                    Long partitionId = table.getPartition(physicalPartition.getParentId()).getId();
+                    partitionIds.add(partitionId);
+                    tabletRows.forEach((tabletId, rowCount) -> ptRowNums.put(partitionId, tabletId, rowCount));
                 }
             }
         } finally {
@@ -267,6 +277,10 @@ public class StatisticsCollectionTrigger {
         }
 
         analyzeType = decideAnalyzeTypeForLoad(txnState, (OlapTable) table);
+
+        if (analyzeType != SAMPLE) {
+            ptRowNums.clear();
+        }
     }
 
     private void prepareAnalyzeForOverwrite() {
@@ -282,7 +296,7 @@ public class StatisticsCollectionTrigger {
         if (deltaRatio < Config.statistic_sample_collect_ratio_threshold_of_first_load) {
             return null;
         } else if (targetRows > Config.statistic_sample_collect_rows) {
-            return StatsConstants.AnalyzeType.SAMPLE;
+            return SAMPLE;
         } else {
             return StatsConstants.AnalyzeType.FULL;
         }
@@ -310,7 +324,7 @@ public class StatisticsCollectionTrigger {
         if (deltaRatio < Config.statistic_sample_collect_ratio_threshold_of_first_load) {
             return null;
         } else if (loadRows > Config.statistic_sample_collect_rows) {
-            return StatsConstants.AnalyzeType.SAMPLE;
+            return SAMPLE;
         } else {
             return StatsConstants.AnalyzeType.FULL;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/base/PartitionSampler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/base/PartitionSampler.java
@@ -57,7 +57,7 @@ public class PartitionSampler {
     }
 
     public void classifyPartitions(Table table, List<Long> partitions,
-                                   com.google.common.collect.Table<Long, Long, Long> ptRowNums) {
+                                   com.google.common.collect.Table<Long, Long, Long> partitionTabletRowCounts) {
         for (Long partitionId : partitions) {
             Partition p = table.getPartition(partitionId);
             if (p == null || !p.hasData()) {
@@ -71,8 +71,8 @@ public class PartitionSampler {
 
             for (Tablet tablet : p.getDefaultPhysicalPartition().getBaseIndex().getTablets()) {
                 Long rowCount = tablet.getFuzzyRowCount();
-                if (rowCount <= 0 && ptRowNums != null && !ptRowNums.isEmpty()) {
-                    rowCount = ptRowNums.get(partitionId, tablet.getId());
+                if (rowCount <= 0 && partitionTabletRowCounts != null && !partitionTabletRowCounts.isEmpty()) {
+                    rowCount = partitionTabletRowCounts.get(partitionId, tablet.getId());
                 }
 
                 if (rowCount == null || rowCount <= 0) {
@@ -140,7 +140,7 @@ public class PartitionSampler {
     }
 
     public static PartitionSampler create(Table table, List<Long> partitions, Map<String, String> properties,
-                                          com.google.common.collect.Table<Long, Long, Long> ptRowNums) {
+                                          com.google.common.collect.Table<Long, Long, Long> partitionTabletRowCounts) {
         double highSampleRatio = Double.parseDouble(properties.getOrDefault(StatsConstants.HIGH_WEIGHT_SAMPLE_RATIO, "0.5"));
         double mediumHighRatio =
                 Double.parseDouble(properties.getOrDefault(StatsConstants.MEDIUM_HIGH_WEIGHT_SAMPLE_RATIO, "0.5"));
@@ -150,7 +150,7 @@ public class PartitionSampler {
         int maxSize = Integer.parseInt(properties.getOrDefault(StatsConstants.MAX_SAMPLE_TABLET_NUM, "5000"));
 
         PartitionSampler sampler = new PartitionSampler(highSampleRatio, mediumHighRatio, mediumLowRatio, lowRatio, maxSize);
-        sampler.classifyPartitions(table, partitions, ptRowNums);
+        sampler.classifyPartitions(table, partitions, partitionTabletRowCounts);
         return sampler;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/base/PartitionSampler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/base/PartitionSampler.java
@@ -56,7 +56,8 @@ public class PartitionSampler {
         return partitionSampleMaps.get(pid);
     }
 
-    public void classifyPartitions(Table table, List<Long> partitions) {
+    public void classifyPartitions(Table table, List<Long> partitions,
+                                   com.google.common.collect.Table<Long, Long, Long> ptRowNums) {
         for (Long partitionId : partitions) {
             Partition p = table.getPartition(partitionId);
             if (p == null || !p.hasData()) {
@@ -69,8 +70,12 @@ public class PartitionSampler {
             TabletSampler low = new TabletSampler(lowRatio, maxSize);
 
             for (Tablet tablet : p.getDefaultPhysicalPartition().getBaseIndex().getTablets()) {
-                long rowCount = tablet.getFuzzyRowCount();
-                if (rowCount <= 0) {
+                Long rowCount = tablet.getFuzzyRowCount();
+                if (rowCount <= 0 && ptRowNums != null && !ptRowNums.isEmpty()) {
+                    rowCount = ptRowNums.get(partitionId, tablet.getId());
+                }
+
+                if (rowCount == null || rowCount <= 0) {
                     continue;
                 }
                 if (rowCount >= HIGH_WEIGHT_ROWS_THRESHOLD) {
@@ -134,7 +139,8 @@ public class PartitionSampler {
         return sampleRows;
     }
 
-    public static PartitionSampler create(Table table, List<Long> partitions, Map<String, String> properties) {
+    public static PartitionSampler create(Table table, List<Long> partitions, Map<String, String> properties,
+                                          com.google.common.collect.Table<Long, Long, Long> ptRowNums) {
         double highSampleRatio = Double.parseDouble(properties.getOrDefault(StatsConstants.HIGH_WEIGHT_SAMPLE_RATIO, "0.5"));
         double mediumHighRatio =
                 Double.parseDouble(properties.getOrDefault(StatsConstants.MEDIUM_HIGH_WEIGHT_SAMPLE_RATIO, "0.5"));
@@ -144,7 +150,7 @@ public class PartitionSampler {
         int maxSize = Integer.parseInt(properties.getOrDefault(StatsConstants.MAX_SAMPLE_TABLET_NUM, "5000"));
 
         PartitionSampler sampler = new PartitionSampler(highSampleRatio, mediumHighRatio, mediumLowRatio, lowRatio, maxSize);
-        sampler.classifyPartitions(table, partitions);
+        sampler.classifyPartitions(table, partitions, ptRowNums);
         return sampler;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PartitionCommitInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PartitionCommitInfo.java
@@ -44,7 +44,9 @@ import com.starrocks.persist.gson.GsonUtils;
 
 import java.io.DataInput;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 public class PartitionCommitInfo implements Writable {
@@ -84,6 +86,8 @@ public class PartitionCommitInfo implements Writable {
     // compaction score quantiles of lake table
     @SerializedName(value = "compactionScore")
     private Quantiles compactionScore;
+
+    private final Map<Long, Long> tabletIdToRowCountForPartitionFirstLoad = new HashMap<>();
 
     private boolean isDoubleWrite = false;
 
@@ -176,6 +180,10 @@ public class PartitionCommitInfo implements Writable {
 
     public void setCompactionScore(Quantiles compactionScore) {
         this.compactionScore = compactionScore;
+    }
+
+    public Map<Long, Long> getTabletIdToRowCountForPartitionFirstLoad() {
+        return tabletIdToRowCountForPartitionFirstLoad;
     }
 
     @Nullable

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/hyper/HyperJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/hyper/HyperJobTest.java
@@ -86,7 +86,7 @@ public class HyperJobTest extends DistributedEnvPlanTestBase {
         db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable("test", "t_struct");
         pid = table.getPartition("t_struct").getId();
-        sampler = PartitionSampler.create(table, List.of(pid), Maps.newHashMap());
+        sampler = PartitionSampler.create(table, List.of(pid), Maps.newHashMap(), null);
 
         for (Partition partition : ((OlapTable) table).getAllPartitions()) {
             partition.getDefaultPhysicalPartition().getBaseIndex().setRowCount(10000);
@@ -259,7 +259,7 @@ public class HyperJobTest extends DistributedEnvPlanTestBase {
             }
 
         };
-        PartitionSampler sampler = PartitionSampler.create(table, List.of(pid), Maps.newHashMap());
+        PartitionSampler sampler = PartitionSampler.create(table, List.of(pid), Maps.newHashMap(), null);
         Assert.assertEquals(5550000, sampler.getSampleInfo(pid).getSampleRowCount());
     }
 

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -45,6 +45,8 @@ message PublishVersionResponse {
     // Mapping from tablet id to compaction score.
     map<int64, double> compaction_scores = 2;
     optional StatusPB status = 3;
+    // Mapping from tablet id to row_nums when the partition is first imported
+    map<int64, uint64> tablet_row_nums = 4;
 }
 
 message AbortTxnRequest {

--- a/test/sql/test_analyze_statistics/R/test_partition_first_load_collect_stats
+++ b/test/sql/test_analyze_statistics/R/test_partition_first_load_collect_stats
@@ -1,4 +1,7 @@
--- name: test_partition_first_load_collect_stats
+-- name: test_partition_first_load_collect_stat @sequential
+admin set frontend config('enable_statistic_collect_on_first_load'='true');
+-- result:
+-- !result
 DROP DATABASE IF EXISTS test_partition_first_load_collect_stats;
 -- result:
 -- !result

--- a/test/sql/test_analyze_statistics/R/test_partition_first_load_collect_stats
+++ b/test/sql/test_analyze_statistics/R/test_partition_first_load_collect_stats
@@ -1,0 +1,30 @@
+-- name: test_partition_first_load_collect_stats
+DROP DATABASE IF EXISTS test_partition_first_load_collect_stats;
+-- result:
+-- !result
+CREATE DATABASE test_partition_first_load_collect_stats;
+-- result:
+-- !result
+USE test_partition_first_load_collect_stats;
+-- result:
+-- !result
+CREATE TABLE test_first_load (
+    event_day datetime,
+    k1 int
+) PARTITION BY date_trunc('day', event_day)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into test_first_load select '2020-01-01', generate_series from table(generate_series(1,3000000));
+-- result:
+-- !result
+select column_name, partition_name, row_count, max, min from _statistics_.column_statistics where table_name = "test_partition_first_load_collect_stats.test_first_load" order by column_name;
+-- result:
+event_day	p20200101	3000000	2020-01-01 00:00:00	2020-01-01 00:00:00
+k1	p20200101	3000000	3000000	1
+-- !result
+drop stats test_first_load;
+-- result:
+-- !result

--- a/test/sql/test_analyze_statistics/T/test_partition_first_load_collect_stats
+++ b/test/sql/test_analyze_statistics/T/test_partition_first_load_collect_stats
@@ -1,0 +1,17 @@
+-- name: test_partition_first_load_collect_stats
+
+DROP DATABASE IF EXISTS test_partition_first_load_collect_stats;
+CREATE DATABASE test_partition_first_load_collect_stats;
+USE test_partition_first_load_collect_stats;
+
+CREATE TABLE test_first_load (
+    event_day datetime,
+    k1 int
+) PARTITION BY date_trunc('day', event_day)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into test_first_load select '2020-01-01', generate_series from table(generate_series(1,3000000));
+select column_name, partition_name, row_count, max, min from _statistics_.column_statistics where table_name = "test_partition_first_load_collect_stats.test_first_load" order by column_name;
+drop stats test_first_load;

--- a/test/sql/test_analyze_statistics/T/test_partition_first_load_collect_stats
+++ b/test/sql/test_analyze_statistics/T/test_partition_first_load_collect_stats
@@ -1,5 +1,6 @@
--- name: test_partition_first_load_collect_stats
+-- name: test_partition_first_load_collect_stat @sequential
 
+admin set frontend config('enable_statistic_collect_on_first_load'='true');
 DROP DATABASE IF EXISTS test_partition_first_load_collect_stats;
 CREATE DATABASE test_partition_first_load_collect_stats;
 USE test_partition_first_load_collect_stats;
@@ -15,3 +16,4 @@ PROPERTIES (
 insert into test_first_load select '2020-01-01', generate_series from table(generate_series(1,3000000));
 select column_name, partition_name, row_count, max, min from _statistics_.column_statistics where table_name = "test_partition_first_load_collect_stats.test_first_load" order by column_name;
 drop stats test_first_load;
+


### PR DESCRIPTION
## Why I'm doing:
we have collected table statistics after the partitions are first imported. if there are too many loaded rows in an `INSERT INTO` dml, we will use sample strategy to collect statistics.  Sample partitions are grouped according to partition rows num, and different read ratios are selected according to tablet row count. but we can't immediately get the new added partition or tablet row nums in fe. Currently, we sync tablet or partition info by TabletStatMgr in the background for each 5 min.  So we don't collect statistics when partition is first imported in current main. 
we need to return the tablet row nums of the partition which is first imported to sample partition when the dml is finished.

## What I'm doing:
supporting return tablet row num and collect partition level stats when partition is first imported. including shared-nothing and shared-data. 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0