### PR TITLE
[Enhancement] support specify the warehouse to execute statistics collect job

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2846,6 +2846,9 @@ public class Config extends ConfigBase {
     public static String lake_background_warehouse = "default_warehouse";
 
     @ConfField(mutable = true)
+    public static String statistics_collect_warehouse = "default_warehouse";
+
+    @ConfField(mutable = true)
     public static int lake_warehouse_max_compute_replica = 3;
 
     @ConfField(mutable = true, comment = "time interval to check whether warehouse is idle")

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -479,6 +479,7 @@ public class StatisticExecutor {
             GlobalStateMgr.getCurrentState().getAnalyzeMgr().replayAddAnalyzeStatus(analyzeStatus);
 
             statsConnectCtx.setStatisticsConnection(true);
+            statsConnectCtx.getSessionVariable().setWarehouseName(Config.statistics_collect_warehouse);
             statsJob.collect(statsConnectCtx, analyzeStatus);
             LOG.info("execute statistics job successfully, duration={}, job={}", watch.toString(), statsJob);
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/HyperQueryJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/HyperQueryJob.java
@@ -136,7 +136,7 @@ public abstract class HyperQueryJob {
             return executor.executeStatisticDQL(context, sql);
         } catch (Exception e) {
             failures++;
-            String message = "execute statistics query failed, sql: " + sql;
+            String message = "execute statistics query failed, sql: " + sql +  ", error: " + e.getMessage();
             LOG.error(message, e);
             lastFailure = new RuntimeException(message, e);
             return Collections.emptyList();


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
added fe config `statistics_collect_warehouse` to control which warehouse can execute statistics collect job. including manual and auto collection. 
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0