### PR TITLE
[UT] speed up test_runtime_bitset_filter

### DIFF
--- a/test/sql/test_runtime_filter/R/test_runtime_bitset_filter
+++ b/test/sql/test_runtime_filter/R/test_runtime_bitset_filter
@@ -391,22 +391,28 @@ from t1 join [broadcast] w1 using(c_bool_1_null);
 6400000
 -- !result
 with w1 as (
-   select * from t2 order by k1 limit 10
+    select * from t2 order by k1 limit 10
 )
 select count(1)
 from t1 join [broadcast] w1 using(c_bool_2_notnull);
 -- result:
 6450000
 -- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [broadcast] t2 using(c_tinyint_1_null);
+from t1 join [broadcast] w1 using(c_tinyint_1_null);
 -- result:
-1000000000
+100000
 -- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [broadcast] t2 using(c_tinyint_2_notnull);
+from t1 join [broadcast] w1 using(c_tinyint_2_notnull);
 -- result:
-1108593760
+100780
 -- !result
 select count(1)
 from t1 join [broadcast] t2 using(c_smallint_1_null);
@@ -468,15 +474,21 @@ from t1 join [broadcast] t2 using(c_str_2_notnull);
 -- result:
 120000
 -- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [broadcast] t2 using(c_str_3_low_null);
+from t1 join [broadcast] w1 using(c_str_3_low_null);
 -- result:
-500000000
+50000
 -- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [broadcast] t2 using(c_str_4_low_notnull);
+from t1 join [broadcast] w1 using(c_str_4_low_notnull);
 -- result:
-554296880
+50390
 -- !result
 select count(1)
 from t1 join [broadcast] t2 using(c_datetime_1_seq);
@@ -497,22 +509,28 @@ from t1 join [broadcast] w1 on t1.c_bool_1_null <=> w1.c_bool_1_null;
 6400000
 -- !result
 with w1 as (
-   select * from t2 order by k1 limit 10
+    select * from t2 order by k1 limit 10
 )
 select count(1)
 from t1 join [broadcast] w1 on t1.c_bool_2_notnull <=> w1.c_bool_2_notnull;
 -- result:
 6450000
 -- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [broadcast] t2 on t1.c_tinyint_1_null <=> t2.c_tinyint_1_null;
+from t1 join [broadcast] w1 on t1.c_tinyint_1_null <=> w1.c_tinyint_1_null;
 -- result:
-1100000000
+100000
 -- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [broadcast] t2 on t1.c_tinyint_2_notnull <=> t2.c_tinyint_2_notnull;
+from t1 join [broadcast] w1 on t1.c_tinyint_2_notnull <=> w1.c_tinyint_2_notnull;
 -- result:
-1108593760
+100780
 -- !result
 select count(1)
 from t1 join [broadcast] t2 on t1.c_smallint_1_null <=> t2.c_smallint_1_null;
@@ -574,15 +592,21 @@ from t1 join [broadcast] t2 on t1.c_str_2_notnull <=> t2.c_str_2_notnull;
 -- result:
 120000
 -- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [broadcast] t2 on t1.c_str_3_low_null <=> t2.c_str_3_low_null;
+from t1 join [broadcast] w1 on t1.c_str_3_low_null <=> w1.c_str_3_low_null;
 -- result:
-600000000
+50000
 -- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [broadcast] t2 on t1.c_str_4_low_notnull <=> t2.c_str_4_low_notnull;
+from t1 join [broadcast] w1 on t1.c_str_4_low_notnull <=> w1.c_str_4_low_notnull;
 -- result:
-554296880
+50390
 -- !result
 select count(1)
 from t1 join [broadcast] t2 on t1.c_datetime_1_seq <=> t2.c_datetime_1_seq;
@@ -603,22 +627,28 @@ from (select distinct c_bool_1_null from t1)t join [broadcast] w1 using(c_bool_1
 10
 -- !result
 with w1 as (
-   select * from t2 order by k1 limit 10
+    select * from t2 order by k1 limit 10
 )
 select count(1)
 from (select distinct c_bool_2_notnull from t1)t join [broadcast] w1 using(c_bool_2_notnull);
 -- result:
 10
 -- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from (select distinct c_tinyint_1_null from t1)t join [broadcast] t2 using(c_tinyint_1_null);
+from (select distinct c_tinyint_1_null from t1)t join [broadcast] w1 using(c_tinyint_1_null);
 -- result:
-100000
+10
 -- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from (select distinct c_tinyint_2_notnull from t1)t join [broadcast] t2 using(c_tinyint_2_notnull);
+from (select distinct c_tinyint_2_notnull from t1)t join [broadcast] w1 using(c_tinyint_2_notnull);
 -- result:
-110000
+10
 -- !result
 select count(1)
 from (select distinct c_smallint_1_null from t1)t join [broadcast] t2 using(c_smallint_1_null);
@@ -680,15 +710,21 @@ from (select distinct c_str_2_notnull from t1)t join [broadcast] t2 using(c_str_
 -- result:
 110000
 -- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+) 
 select count(1)
-from (select distinct c_str_3_low_null from t1)t join [broadcast] t2 using(c_str_3_low_null);
+from (select distinct c_str_3_low_null from t1)t join [broadcast] w1 using(c_str_3_low_null);
 -- result:
-100000
+10
 -- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from (select distinct c_str_4_low_notnull from t1)t join [broadcast] t2 using(c_str_4_low_notnull);
+from (select distinct c_str_4_low_notnull from t1)t join [broadcast] w1 using(c_str_4_low_notnull);
 -- result:
-110000
+10
 -- !result
 select count(1)
 from (select distinct c_datetime_1_seq from t1)t join [broadcast] t2 using(c_datetime_1_seq);
@@ -716,15 +752,21 @@ from t1 join [shuffle] w1 using(c_bool_2_notnull);
 -- result:
 6450000
 -- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [shuffle] t2 using(c_tinyint_1_null);
+from t1 join [shuffle] w1 using(c_tinyint_1_null);
 -- result:
-1000000000
+100000
 -- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [shuffle] t2 using(c_tinyint_2_notnull);
+from t1 join [shuffle] w1 using(c_tinyint_2_notnull);
 -- result:
-1108593760
+100780
 -- !result
 select count(1)
 from t1 join [shuffle] t2 using(c_smallint_1_null);
@@ -786,15 +828,21 @@ from t1 join [shuffle] t2 using(c_str_2_notnull);
 -- result:
 120000
 -- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [shuffle] t2 using(c_str_3_low_null);
+from t1 join [shuffle] w1 using(c_str_3_low_null);
 -- result:
-500000000
+50000
 -- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [shuffle] t2 using(c_str_4_low_notnull);
+from t1 join [shuffle] w1 using(c_str_4_low_notnull);
 -- result:
-554296880
+50390
 -- !result
 select count(1)
 from t1 join [shuffle] t2 using(c_datetime_1_seq);
@@ -822,15 +870,21 @@ from t1 join [broadcast] w1 using(c_bool_2_notnull);
 -- result:
 6450000
 -- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
-from t1 join [broadcast] t2 using(c_tinyint_1_null);
+from t1 join [broadcast] w1 using(c_tinyint_1_null);
 -- result:
-1000000000
+100000
 -- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
-from t1 join [broadcast] t2 using(c_tinyint_2_notnull);
+from t1 join [broadcast] w1 using(c_tinyint_2_notnull);
 -- result:
-1108593760
+100780
 -- !result
 select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
 from t1 join [broadcast] t2 using(c_smallint_1_null);
@@ -892,15 +946,21 @@ from t1 join [broadcast] t2 using(c_str_2_notnull);
 -- result:
 120000
 -- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
-from t1 join [broadcast] t2 using(c_str_3_low_null);
+from t1 join [broadcast] w1 using(c_str_3_low_null);
 -- result:
-500000000
+50000
 -- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
-from t1 join [broadcast] t2 using(c_str_4_low_notnull);
+from t1 join [broadcast] w1 using(c_str_4_low_notnull);
 -- result:
-554296880
+50390
 -- !result
 select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
 from t1 join [broadcast] t2 using(c_datetime_1_seq);
@@ -921,22 +981,28 @@ from t1 join [broadcast] w1 using(c_bool_1_null);
 6400000
 -- !result
 with w1 as (
-   select * from t3 order by k1 limit 10
+    select * from t3 order by k1 limit 10
 )
 select count(1)
 from t1 join [broadcast] w1 using(c_bool_2_notnull);
 -- result:
 6450000
 -- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [broadcast] t3 using(c_tinyint_1_null);
+from t1 join [broadcast] w1 using(c_tinyint_1_null);
 -- result:
-1000000000
+100000
 -- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [broadcast] t3 using(c_tinyint_2_notnull);
+from t1 join [broadcast] w1 using(c_tinyint_2_notnull);
 -- result:
-1108593760
+100780
 -- !result
 select count(1)
 from t1 join [broadcast] t3 using(c_smallint_1_null);
@@ -998,15 +1064,21 @@ from t1 join [broadcast] t3 using(c_str_2_notnull);
 -- result:
 120000
 -- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+) 
 select count(1)
-from t1 join [broadcast] t3 using(c_str_3_low_null);
+from t1 join [broadcast] w1 using(c_str_3_low_null);
 -- result:
-500000000
+50000
 -- !result
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [broadcast] t3 using(c_str_4_low_notnull);
+from t1 join [broadcast] w1 using(c_str_4_low_notnull);
 -- result:
-554296880
+50390
 -- !result
 select count(1)
 from t1 join [broadcast] t3 using(c_datetime_1_seq);

--- a/test/sql/test_runtime_filter/T/test_runtime_bitset_filter
+++ b/test/sql/test_runtime_filter/T/test_runtime_bitset_filter
@@ -392,20 +392,24 @@ with w1 as (
 select count(1)
 from t1 join [broadcast] w1 using(c_bool_1_null);
 
- with w1 as (
+with w1 as (
     select * from t2 order by k1 limit 10
 )
 select count(1)
 from t1 join [broadcast] w1 using(c_bool_2_notnull);
 
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [broadcast] t2 using(c_tinyint_1_null);
+from t1 join [broadcast] w1 using(c_tinyint_1_null);
 
- 
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [broadcast] t2 using(c_tinyint_2_notnull);
+from t1 join [broadcast] w1 using(c_tinyint_2_notnull);
 
- 
 select count(1)
 from t1 join [broadcast] t2 using(c_smallint_1_null);
 
@@ -453,13 +457,17 @@ from t1 join [broadcast] t2 using(c_str_1_null);
 select count(1)
 from t1 join [broadcast] t2 using(c_str_2_notnull);
 
- 
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [broadcast] t2 using(c_str_3_low_null);
+from t1 join [broadcast] w1 using(c_str_3_low_null);
 
- 
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [broadcast] t2 using(c_str_4_low_notnull);
+from t1 join [broadcast] w1 using(c_str_4_low_notnull);
 
  
 select count(1)
@@ -477,18 +485,23 @@ with w1 as (
 select count(1)
 from t1 join [broadcast] w1 on t1.c_bool_1_null <=> w1.c_bool_1_null;
 
- with w1 as (
+with w1 as (
     select * from t2 order by k1 limit 10
 )
 select count(1)
 from t1 join [broadcast] w1 on t1.c_bool_2_notnull <=> w1.c_bool_2_notnull;
 
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [broadcast] t2 on t1.c_tinyint_1_null <=> t2.c_tinyint_1_null;
+from t1 join [broadcast] w1 on t1.c_tinyint_1_null <=> w1.c_tinyint_1_null;
 
- 
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [broadcast] t2 on t1.c_tinyint_2_notnull <=> t2.c_tinyint_2_notnull;
+from t1 join [broadcast] w1 on t1.c_tinyint_2_notnull <=> w1.c_tinyint_2_notnull;
 
  
 select count(1)
@@ -538,13 +551,17 @@ from t1 join [broadcast] t2 on t1.c_str_1_null <=> t2.c_str_1_null;
 select count(1)
 from t1 join [broadcast] t2 on t1.c_str_2_notnull <=> t2.c_str_2_notnull;
 
- 
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [broadcast] t2 on t1.c_str_3_low_null <=> t2.c_str_3_low_null;
+from t1 join [broadcast] w1 on t1.c_str_3_low_null <=> w1.c_str_3_low_null;
 
- 
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [broadcast] t2 on t1.c_str_4_low_notnull <=> t2.c_str_4_low_notnull;
+from t1 join [broadcast] w1 on t1.c_str_4_low_notnull <=> w1.c_str_4_low_notnull;
 
  
 select count(1)
@@ -562,18 +579,23 @@ with w1 as (
 select count(1)
 from (select distinct c_bool_1_null from t1)t join [broadcast] w1 using(c_bool_1_null);
 
- with w1 as (
+with w1 as (
     select * from t2 order by k1 limit 10
 )
 select count(1)
 from (select distinct c_bool_2_notnull from t1)t join [broadcast] w1 using(c_bool_2_notnull);
 
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from (select distinct c_tinyint_1_null from t1)t join [broadcast] t2 using(c_tinyint_1_null);
+from (select distinct c_tinyint_1_null from t1)t join [broadcast] w1 using(c_tinyint_1_null);
 
- 
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from (select distinct c_tinyint_2_notnull from t1)t join [broadcast] t2 using(c_tinyint_2_notnull);
+from (select distinct c_tinyint_2_notnull from t1)t join [broadcast] w1 using(c_tinyint_2_notnull);
 
  
 select count(1)
@@ -623,13 +645,17 @@ from (select distinct c_str_1_null from t1)t join [broadcast] t2 using(c_str_1_n
 select count(1)
 from (select distinct c_str_2_notnull from t1)t join [broadcast] t2 using(c_str_2_notnull);
 
- 
+with w1 as (
+    select * from t2 order by k1 limit 10
+) 
 select count(1)
-from (select distinct c_str_3_low_null from t1)t join [broadcast] t2 using(c_str_3_low_null);
+from (select distinct c_str_3_low_null from t1)t join [broadcast] w1 using(c_str_3_low_null);
 
- 
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from (select distinct c_str_4_low_notnull from t1)t join [broadcast] t2 using(c_str_4_low_notnull);
+from (select distinct c_str_4_low_notnull from t1)t join [broadcast] w1 using(c_str_4_low_notnull);
 
  
 select count(1)
@@ -653,12 +679,17 @@ from t1 join [shuffle] w1 using(c_bool_1_null);
 select count(1)
 from t1 join [shuffle] w1 using(c_bool_2_notnull);
 
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [shuffle] t2 using(c_tinyint_1_null);
+from t1 join [shuffle] w1 using(c_tinyint_1_null);
 
- 
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [shuffle] t2 using(c_tinyint_2_notnull);
+from t1 join [shuffle] w1 using(c_tinyint_2_notnull);
 
  
 select count(1)
@@ -708,13 +739,17 @@ from t1 join [shuffle] t2 using(c_str_1_null);
 select count(1)
 from t1 join [shuffle] t2 using(c_str_2_notnull);
 
- 
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [shuffle] t2 using(c_str_3_low_null);
+from t1 join [shuffle] w1 using(c_str_3_low_null);
 
- 
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [shuffle] t2 using(c_str_4_low_notnull);
+from t1 join [shuffle] w1 using(c_str_4_low_notnull);
 
  
 select count(1)
@@ -737,12 +772,17 @@ from t1 join [broadcast] w1 using(c_bool_1_null);
 select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
 from t1 join [broadcast] w1 using(c_bool_2_notnull);
 
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
-from t1 join [broadcast] t2 using(c_tinyint_1_null);
+from t1 join [broadcast] w1 using(c_tinyint_1_null);
 
- 
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
-from t1 join [broadcast] t2 using(c_tinyint_2_notnull);
+from t1 join [broadcast] w1 using(c_tinyint_2_notnull);
 
  
 select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
@@ -792,13 +832,17 @@ from t1 join [broadcast] t2 using(c_str_1_null);
 select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
 from t1 join [broadcast] t2 using(c_str_2_notnull);
 
- 
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
-from t1 join [broadcast] t2 using(c_str_3_low_null);
+from t1 join [broadcast] w1 using(c_str_3_low_null);
 
- 
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
-from t1 join [broadcast] t2 using(c_str_4_low_notnull);
+from t1 join [broadcast] w1 using(c_str_4_low_notnull);
 
  
 select /*+SET_VAR(enable_join_runtime_bitset_filter=false)*/ count(1)
@@ -816,18 +860,23 @@ with w1 as (
 select count(1)
 from t1 join [broadcast] w1 using(c_bool_1_null);
 
- with w1 as (
+with w1 as (
     select * from t3 order by k1 limit 10
 )
 select count(1)
 from t1 join [broadcast] w1 using(c_bool_2_notnull);
 
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [broadcast] t3 using(c_tinyint_1_null);
+from t1 join [broadcast] w1 using(c_tinyint_1_null);
 
- 
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [broadcast] t3 using(c_tinyint_2_notnull);
+from t1 join [broadcast] w1 using(c_tinyint_2_notnull);
 
  
 select count(1)
@@ -877,13 +926,17 @@ from t1 join [broadcast] t3 using(c_str_1_null);
 select count(1)
 from t1 join [broadcast] t3 using(c_str_2_notnull);
 
- 
+with w1 as (
+    select * from t2 order by k1 limit 10
+) 
 select count(1)
-from t1 join [broadcast] t3 using(c_str_3_low_null);
+from t1 join [broadcast] w1 using(c_str_3_low_null);
 
- 
+with w1 as (
+    select * from t2 order by k1 limit 10
+)
 select count(1)
-from t1 join [broadcast] t3 using(c_str_4_low_notnull);
+from t1 join [broadcast] w1 using(c_str_4_low_notnull);
 
  
 select count(1)


### PR DESCRIPTION
## Why I'm doing:

Joining on small types, which only contains few distinct values, will generate lots of results, which will make the test too slow.

## What I'm doing:

Add a limit to the right table for the small types.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0