### PR TITLE
[BugFix] check aggregator errors in sorted_aggregate_streaming_sink_operator

### DIFF
--- a/be/src/exec/pipeline/aggregate/sorted_aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/sorted_aggregate_streaming_sink_operator.cpp
@@ -91,6 +91,7 @@ Status SortedAggregateStreamingSinkOperator::push_chunk(RuntimeState* state, con
         _aggregator->offer_chunk_to_buffer(accumulated);
     }
     DCHECK(_accumulator.need_input());
+    RETURN_IF_ERROR(_aggregator->check_has_error());
 
     return Status::OK();
 }


### PR DESCRIPTION
## Why I'm doing:
Aggregation errors that are set on context are not checked in aggregate_streaming_sink_operator and will be ignored.
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0