### PR TITLE
[BugFix]fix deduplicate shared buffer when read from remote

### DIFF
--- a/be/src/io/cache_input_stream.cpp
+++ b/be/src/io/cache_input_stream.cpp
@@ -146,11 +146,6 @@ Status CacheInputStream::_read_block_from_local(const int64_t offset, const int6
         _stats.skip_read_cache_bytes += read_size;
     }
 
-    if (res.ok() && sb) {
-        // Duplicate the block ranges to avoid saving the same data both in cache and shared buffer.
-        _deduplicate_shared_buffer(sb);
-    }
-
     return res;
 }
 
@@ -189,6 +184,11 @@ Status CacheInputStream::_read_blocks_from_remote(const int64_t offset, const in
                 RETURN_IF_ERROR(_sb_stream->read_at_fully(read_offset_cursor, _buffer.data(), read_size));
                 src = _buffer.data();
             }
+        }
+
+        if (sb) {
+            // Duplicate the block ranges to avoid saving the same data both in block_map and shared buffer.
+            _deduplicate_shared_buffer(sb);
         }
 
         if (_enable_cache_io_adaptor) {


### PR DESCRIPTION
## Why I'm doing:
when read from remote, there will be data both in shared buffer and block_map,
we need deduplicate it to save memory.
when read from local, there is no chance that data both in shared buffer and block_map.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0