### PR TITLE
[BugFix] Fix bug switch to mysql_native_password authPlugin fail

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationProvider.java
@@ -43,4 +43,14 @@ public interface AuthenticationProvider {
     default byte[] authMoreDataPacket(String user, String host) throws AuthenticationException {
         return null;
     }
+
+    /**
+     * Authentication method Switch Request Packet
+     * If both server and the client support CLIENT_PLUGIN_AUTH capability,
+     * server can send this packet tp ask client to use another authentication method.
+     * <a href="https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_auth_switch_request.html">...</a>
+     */
+    default byte[] authSwitchRequestPacket(String user, String host, byte[] randomString) throws AuthenticationException {
+        return null;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlAuthPacket.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlAuthPacket.java
@@ -49,7 +49,6 @@ public class MysqlAuthPacket extends MysqlPacket {
     private String pluginName;
     private MysqlCapability capability;
     private Map<String, String> connectAttributes;
-    private byte[] randomString;
 
     public String getUser() {
         return userName;
@@ -65,10 +64,6 @@ public class MysqlAuthPacket extends MysqlPacket {
 
     public String getDb() {
         return database;
-    }
-
-    public byte[] getRandomString() {
-        return randomString;
     }
 
     public MysqlCapability getCapability() {

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlHandshakePacket.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlHandshakePacket.java
@@ -36,14 +36,10 @@ package com.starrocks.mysql;
 
 import com.starrocks.common.Config;
 import com.starrocks.mysql.privilege.AuthPlugin;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 // MySQL protocol handshake packet.
 public class MysqlHandshakePacket extends MysqlPacket {
-    private static final Logger LOG = LogManager.getLogger(MysqlHandshakePacket.class);
 
-    private static final int SCRAMBLE_LENGTH = 20;
     // Version of handshake packet, since MySQL 3.21.0, Handshake of protocol 10 is used
     private static final int PROTOCOL_VERSION = 10;
 
@@ -59,14 +55,10 @@ public class MysqlHandshakePacket extends MysqlPacket {
     private final byte[] authPluginData;
     private final boolean supportSSL;
 
-    public MysqlHandshakePacket(int connectionId, boolean supportSSL) {
+    public MysqlHandshakePacket(int connectionId, boolean supportSSL, byte[] authPluginData) {
         this.connectionId = connectionId;
-        this.authPluginData = MysqlPassword.createRandomString(SCRAMBLE_LENGTH);
+        this.authPluginData = authPluginData;
         this.supportSSL = supportSSL;
-    }
-
-    public byte[] getAuthPluginData() {
-        return authPluginData;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlPassword.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlPassword.java
@@ -73,7 +73,6 @@ import java.util.Arrays;
 //          this three steps are done in check_scramble()
 public class MysqlPassword {
     private static final Logger LOG = LogManager.getLogger(MysqlPassword.class);
-    // TODO(zhaochun): this is duplicated with handshake packet.
     public static final byte[] EMPTY_PASSWORD = new byte[0];
     public static final int SCRAMBLE_LENGTH = 20;
     public static final int SCRAMBLE_LENGTH_HEX_LENGTH = 2 * SCRAMBLE_LENGTH + 1;
@@ -81,12 +80,12 @@ public class MysqlPassword {
     private static final byte[] DIG_VEC_UPPER = {'0', '1', '2', '3', '4', '5', '6', '7',
             '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
 
-    public static byte[] createRandomString(int len) {
+    public static byte[] createRandomString() {
         SecureRandom random = new SecureRandom();
-        byte[] bytes = new byte[len];
+        byte[] bytes = new byte[SCRAMBLE_LENGTH];
         random.nextBytes(bytes);
         // NOTE: MySQL challenge string can't contain 0.
-        for (int i = 0; i < len; ++i) {
+        for (int i = 0; i < SCRAMBLE_LENGTH; ++i) {
             if ((bytes[i] >= 'a' && bytes[i] <= 'z') || (bytes[i] >= 'A' && bytes[i] <= 'Z')) {
                 // pass
             } else {

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlAuthPacketTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlAuthPacketTest.java
@@ -149,7 +149,8 @@ public class MysqlAuthPacketTest {
 
         MysqlAuthPacket authPacket = buildPacket("harbor");
         ConnectContext context = new ConnectContext();
-        MysqlProto.switchAuthPlugin(authPacket, context);
+        byte[] randomString = MysqlPassword.createRandomString();
+        MysqlProto.switchAuthPlugin(authPacket, context, randomString);
         Assert.assertEquals("authentication_openid_connect_client", authPacket.getPluginName());
 
         //test security integration
@@ -163,7 +164,7 @@ public class MysqlAuthPacketTest {
 
         Config.authentication_chain = new String[] {"native", "oidc"};
         authPacket = buildPacket("tina");
-        MysqlProto.switchAuthPlugin(authPacket, context);
+        MysqlProto.switchAuthPlugin(authPacket, context, randomString);
         Assert.assertEquals("authentication_openid_connect_client", authPacket.getPluginName());
     }
 
@@ -190,10 +191,11 @@ public class MysqlAuthPacketTest {
 
         MysqlAuthPacket authPacket = buildPacket("harbor");
         ConnectContext context = new ConnectContext();
-        Assert.assertThrows(AuthenticationException.class, () -> MysqlProto.switchAuthPlugin(authPacket, context));
+        byte[] randomString = MysqlPassword.createRandomString();
+        Assert.assertThrows(AuthenticationException.class, () -> MysqlProto.switchAuthPlugin(authPacket, context, randomString));
 
         authPacket.setPluginName(null);
-        MysqlProto.switchAuthPlugin(authPacket, context);
+        MysqlProto.switchAuthPlugin(authPacket, context, randomString);
         Assert.assertNull(authPacket.getPluginName());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlHandshakePacketTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlHandshakePacketTest.java
@@ -42,7 +42,7 @@ public class MysqlHandshakePacketTest {
 
         new Expectations() {
             {
-                MysqlPassword.createRandomString(20);
+                MysqlPassword.createRandomString();
                 minTimes = 0;
                 result = buf;
             }
@@ -53,7 +53,7 @@ public class MysqlHandshakePacketTest {
 
     @Test
     public void testWrite() {
-        MysqlHandshakePacket packet = new MysqlHandshakePacket(1090, false);
+        MysqlHandshakePacket packet = new MysqlHandshakePacket(1090, false, MysqlPassword.createRandomString());
         MysqlSerializer serializer = MysqlSerializer.newInstance(capability);
 
         packet.writeTo(serializer);

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlPasswordTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlPasswordTest.java
@@ -45,7 +45,7 @@ public class MysqlPasswordTest {
     @Test
     public void testCheckPass() {
         // client
-        byte[] publicSeed = MysqlPassword.createRandomString(20);
+        byte[] publicSeed = MysqlPassword.createRandomString();
         byte[] codePass = MysqlPassword.scramble(publicSeed, "mypass");
 
         Assert.assertTrue(MysqlPassword.checkScramble(codePass,


### PR DESCRIPTION
## Why I'm doing:
introduced by #56992
When switch to mysql_native_password, should send random string to client. the string missed by refactoring
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0