### PR TITLE
[BugFix] Fix ExchangeSink check localhost failed

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -264,7 +264,8 @@ StatusOr<HeartbeatServer::CmpResult> HeartbeatServer::compare_master_info(const 
                 return Status::InternalError("Unmatched backend ip");
             }
 
-            LOG(INFO) << "update localhost done, the new localhost is " << BackendOptions::get_localhost();
+            LOG(INFO) << "update localhost done, the new localhost is " << BackendOptions::get_localhost()
+                      << ", new local_ip is " << BackendOptions::get_local_ip();
         }
     }
 

--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -254,7 +254,7 @@ StatusOr<HeartbeatServer::CmpResult> HeartbeatServer::compare_master_info(const 
 
             for (auto& host : hosts) {
                 if (host.get_host_address() == ip) {
-                    BackendOptions::set_localhost(master_info.backend_ip);
+                    BackendOptions::set_localhost(master_info.backend_ip, ip);
                     set_new_localhost = true;
                     break;
                 }

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -137,7 +137,7 @@ private:
 };
 
 bool ExchangeSinkOperator::Channel::is_local() {
-    if (BackendOptions::get_localhost() != _brpc_dest_addr.hostname) {
+    if (BackendOptions::get_local_ip() != _brpc_dest_addr.hostname) {
         return false;
     }
     if (config::brpc_port != _brpc_dest_addr.port) {

--- a/be/src/service/backend_options.cpp
+++ b/be/src/service/backend_options.cpp
@@ -32,6 +32,7 @@ namespace starrocks {
 static const std::string PRIORITY_CIDR_SEPARATOR = ";";
 
 std::string BackendOptions::_s_localhost;
+std::string BackendOptions::_s_local_ip;
 std::vector<CIDR> BackendOptions::_s_priority_cidrs;
 TBackend BackendOptions::_backend;
 bool BackendOptions::_bind_ipv6 = false;
@@ -71,7 +72,7 @@ bool BackendOptions::init(bool is_cn) {
             // Whether to use IPv4 or IPv6, it's configured by CIDR format.
             // If both IPv4 and IPv6 are configured, the config order decides priority.
             if (is_in_prior_network(addr_it->get_host_address())) {
-                _s_localhost = addr_it->get_host_address();
+                set_localhost(addr_it->get_host_address());
                 _bind_ipv6 = addr_it->is_ipv6();
                 break;
             }
@@ -94,10 +95,10 @@ bool BackendOptions::init(bool is_cn) {
                 _bind_ipv6 = is_ipv6;
                 if (config::net_use_ipv6_when_priority_networks_empty) {
                     if (is_ipv6) {
-                        _s_localhost = addr_it->get_host_address();
+                        set_localhost(addr_it->get_host_address());
                     }
                 } else if (!is_ipv6) {
-                    _s_localhost = addr_it->get_host_address();
+                    set_localhost(addr_it->get_host_address());
                 }
                 if (!_s_localhost.empty()) {
                     // Use the first found one.
@@ -113,14 +114,19 @@ bool BackendOptions::init(bool is_cn) {
 
     if (_s_localhost.empty()) {
         LOG(WARNING) << "failed to find one valid non-loopback address, use loopback address.";
-        _s_localhost = loopback;
+        set_localhost(loopback);
     }
     LOG(INFO) << "localhost " << _s_localhost;
+    LOG(INFO) << "local_ip " << _s_local_ip;
     return true;
 }
 
 std::string BackendOptions::get_localhost() {
     return _s_localhost;
+}
+
+std::string BackendOptions::get_local_ip() {
+    return _s_local_ip;
 }
 
 bool BackendOptions::is_bind_ipv6() {
@@ -147,6 +153,12 @@ TBackend BackendOptions::get_localBackend() {
 
 void BackendOptions::set_localhost(const std::string& host) {
     _s_localhost = host;
+    _s_local_ip = host;
+}
+
+void BackendOptions::set_localhost(const std::string& host, const std::string& ip) {
+    _s_localhost = host;
+    _s_local_ip = ip;
 }
 
 bool BackendOptions::analyze_priority_cidrs() {

--- a/be/src/service/backend_options.h
+++ b/be/src/service/backend_options.h
@@ -32,10 +32,12 @@ class BackendOptions {
 public:
     static bool init(bool is_cn);
     static std::string get_localhost();
+    static std::string get_local_ip();
     static TBackend get_localBackend();
     static const char* get_service_bind_address();
     static const char* get_service_bind_address_without_bracket();
     static void set_localhost(const std::string& host);
+    static void set_localhost(const std::string& host, const std::string& ip);
     static bool is_bind_ipv6();
     static bool is_cn();
 
@@ -44,6 +46,7 @@ private:
     static bool is_in_prior_network(const std::string& ip);
 
     static std::string _s_localhost;
+    static std::string _s_local_ip;
     static std::vector<CIDR> _s_priority_cidrs;
     static TBackend _backend;
     static bool _bind_ipv6;


### PR DESCRIPTION
## Why I'm doing:

Random ExchangeSink will send to the same BE, which can be benefit from passthrough exchange, if there is a destination address is the same as local address.

```cpp
bool ExchangeSinkOperator::Channel::is_local() {
    if (BackendOptions::get_localhost() != _brpc_dest_addr.hostname) {
        return false;
    }
    if (config::brpc_port != _brpc_dest_addr.port) {
        return false;
    }
    return true;
}
```

However, 
- the destination address in the fragment always be in **IP format** after #32062.
- `BackendOptions::get_localhost()` may be in **IP format** or **DOMAIN name** format.
    - BE stores `_s_localhost`, which is passed from FE heartbeat. If this backend is added by the **DOMAIN name**, then BE will also set `_s_localhost` as **DOMAIN name**.

```cpp
StatusOr<HeartbeatServer::CmpResult> HeartbeatServer::compare_master_info(const TMasterInfo& master_info) {
     if (master_info.__isset.backend_ip) {
            for (auto& host : hosts) {
                if (host.get_host_address() == ip) {
                    // ==================================
                    // Update _s_localhost to `master_info.backend_ip`, which may be a DOMAIN name.
                    // ==================================
                    BackendOptions::set_localhost(master_info.backend_ip);
                    set_new_localhost = true;
                    break;
                }
            }

            LOG(INFO) << "update localhost done, the new localhost is " << BackendOptions::get_localhost();
    }
}
```


## What I'm doing:
`BackendOptions::set_localhost` also stores a `_s_local_ip` besides `_s_localhost`.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0