### PR TITLE
[BugFix] Fix UAF when spill yield

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -181,6 +181,7 @@ void GlobalDriverExecutor::_worker_thread() {
                              << ", status=" << status;
                 driver->runtime_profile()->add_info_string("ErrorMsg", std::string(status.message()));
                 query_ctx->cancel(status, false);
+                runtime_state->set_is_cancelled(true);
                 driver->cancel_operators(runtime_state);
                 if (driver->is_still_pending_finish()) {
                     driver->set_driver_state(DriverState::PENDING_FINISH);

--- a/be/src/exec/spill/spill_components.h
+++ b/be/src/exec/spill/spill_components.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <functional>
+#include <memory>
 #include <queue>
 
 #include "column/vectorized_fwd.h"
@@ -178,6 +179,8 @@ public:
 
 public:
     struct FlushContext : public SpillIOTaskContext {
+        FlushContext(std::shared_ptr<Spiller> spiller_) : spiller(std::move(spiller_)) {}
+        std::shared_ptr<Spiller> spiller;
         std::shared_ptr<SpillOutputDataStream> output;
         std::shared_ptr<BlockGroup> block_group;
         InputStreamPtr input_stream;
@@ -303,6 +306,7 @@ public:
 
 public:
     struct PartitionedFlushContext : public SpillIOTaskContext {
+        PartitionedFlushContext(std::shared_ptr<Spiller> spiller_) : spiller(std::move(spiller_)) {}
         // used in spill stage
         struct SpillStageContext {
             size_t processing_idx{};
@@ -327,6 +331,7 @@ public:
         PartitionedFlushContext(PartitionedFlushContext&&) = default;
         PartitionedFlushContext& operator=(PartitionedFlushContext&&) = default;
 
+        std::shared_ptr<Spiller> spiller;
         SpillStageContext spill_stage_ctx;
         SplitStageContext split_stage_ctx;
     };

--- a/be/src/exec/spill/spiller.hpp
+++ b/be/src/exec/spill/spiller.hpp
@@ -160,7 +160,8 @@ Status RawSpillerWriter::flush(RuntimeState* state, MemGuard&& guard) {
         DCHECK(has_pending_data());
         //
         if (!yield_ctx.task_context_data.has_value()) {
-            yield_ctx.task_context_data = SpillIOTaskContextPtr(std::make_shared<FlushContext>());
+            yield_ctx.task_context_data =
+                    SpillIOTaskContextPtr(std::make_shared<FlushContext>(_spiller->shared_from_this()));
         }
         auto defer = CancelableDefer([&]() {
             {
@@ -332,7 +333,8 @@ Status PartitionedSpillerWriter::flush(RuntimeState* state, bool is_final_flush,
         yield_ctx.time_spent_ns = 0;
         yield_ctx.need_yield = false;
         if (!yield_ctx.task_context_data.has_value()) {
-            yield_ctx.task_context_data = SpillIOTaskContextPtr(std::make_shared<PartitionedFlushContext>());
+            yield_ctx.task_context_data =
+                    SpillIOTaskContextPtr(std::make_shared<PartitionedFlushContext>(_spiller->shared_from_this()));
         }
         _spiller->update_spilled_task_status(
                 yieldable_flush_task(yield_ctx, splitting_partitions, spilling_partitions));

--- a/test/sql/test_exception/R/test_pipeline_operator_failed
+++ b/test/sql/test_exception/R/test_pipeline_operator_failed
@@ -1,4 +1,4 @@
--- name: test_pipeline_operator_failed 
+-- name: test_pipeline_operator_failed @sequential
 create table t0 (
     c0 INT,
     c1 BIGINT

--- a/test/sql/test_exception/R/test_pipeline_operator_failed
+++ b/test/sql/test_exception/R/test_pipeline_operator_failed
@@ -1,0 +1,28 @@
+-- name: test_pipeline_operator_failed 
+create table t0 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t0 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  4096));
+-- result:
+-- !result
+set enable_spill=true;
+-- result:
+-- !result
+set spill_mode="force";
+-- result:
+-- !result
+admin enable failpoint 'operator_return_failed_status';
+-- result:
+-- !result
+[UC] select count(*) from t0;
+-- result:
+-- !result
+[UC] select count(*) from t0 group by c0;
+-- result:
+-- !result
+admin disable failpoint 'operator_return_failed_status';
+-- result:
+-- !result

--- a/test/sql/test_exception/T/test_pipeline_operator_failed
+++ b/test/sql/test_exception/T/test_pipeline_operator_failed
@@ -1,0 +1,14 @@
+-- name: test_pipeline_operator_failed 
+
+create table t0 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+insert into t0 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  4096));
+
+set enable_spill=true;
+set spill_mode="force";
+admin enable failpoint 'operator_return_failed_status';
+[UC] select count(*) from t0;
+[UC] select count(*) from t0 group by c0;
+admin disable failpoint 'operator_return_failed_status';

--- a/test/sql/test_exception/T/test_pipeline_operator_failed
+++ b/test/sql/test_exception/T/test_pipeline_operator_failed
@@ -1,4 +1,4 @@
--- name: test_pipeline_operator_failed 
+-- name: test_pipeline_operator_failed @sequential
 
 create table t0 (
     c0 INT,


### PR DESCRIPTION
## Why I'm doing:
this bug introduced in https://github.com/StarRocks/starrocks/pull/56490

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/9419
Fixes https://github.com/StarRocks/StarRocksTest/issues/9495

```
(gdb) bt
#0  0x0000000000000000 in ?? ()
#1  0x0000000005905ed9 in starrocks::MemTracker::release (bytes=42087560, this=<optimized out>) at be/src/runtime/mem_tracker.h:265
#2  starrocks::MemTracker::release (bytes=42087560, this=<optimized out>) at be/src/runtime/mem_tracker.h:260
#3  starrocks::spill::SpillableMemTable::~SpillableMemTable (this=0x79746a8b7740, __in_chrg=<optimized out>) at be/src/exec/spill/mem_table.h:56
#4  0x0000000005905f40 in starrocks::spill::UnorderedMemTable::~UnorderedMemTable (this=0x79746a8b7740, __in_chrg=<optimized out>) at /usr/include/c++/11/bits/allocator.h:174
#5  starrocks::spill::UnorderedMemTable::~UnorderedMemTable (this=0x79746a8b7740, __in_chrg=<optimized out>) at be/src/exec/spill/mem_table.h:109
#6  std::default_delete<starrocks::spill::UnorderedMemTable>::operator() (__ptr=0x79746a8b7740, this=<optimized out>) at /usr/include/c++/11/bits/unique_ptr.h:85
#7  std::_Sp_counted_deleter<starrocks::spill::UnorderedMemTable*, std::default_delete<starrocks::spill::UnorderedMemTable>, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose (this=<optimized out>) at /usr/include/c++/11/bits/shared_ptr_base.h:442
#8  0x00000000052d1a5a in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release (this=0x7974c2af1160) at /usr/include/c++/11/bits/shared_ptr_base.h:168
#9  std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release (this=0x7974c2af1160) at /usr/include/c++/11/bits/shared_ptr_base.h:161
#10 0x00000000058780ae in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count (this=0x7977aef2b008, __in_chrg=<optimized out>) at /usr/include/c++/11/bits/shared_ptr_base.h:705
#11 std::__shared_ptr<starrocks::spill::SpillableMemTable, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr (this=0x7977aef2b000, __in_chrg=<optimized out>) at /usr/include/c++/11/bits/shared_ptr_base.h:1154
#12 std::shared_ptr<starrocks::spill::SpillableMemTable>::~shared_ptr (this=0x7977aef2b000, __in_chrg=<optimized out>) at /usr/include/c++/11/bits/shared_ptr.h:122
#13 starrocks::spill::RawSpillerWriter::~RawSpillerWriter (this=<optimized out>, __in_chrg=<optimized out>) at be/src/exec/spill/spill_components.h:135
#14 starrocks::spill::RawSpillerWriter::~RawSpillerWriter (this=<optimized out>, __in_chrg=<optimized out>) at be/src/exec/spill/spill_components.h:135
#15 std::default_delete<starrocks::spill::RawSpillerWriter>::operator() (__ptr=<optimized out>, this=<optimized out>) at /usr/include/c++/11/bits/unique_ptr.h:85
#16 std::unique_ptr<starrocks::spill::RawSpillerWriter, std::default_delete<starrocks::spill::RawSpillerWriter> >::~unique_ptr (this=0x797778bf90e8, __in_chrg=<optimized out>) at /usr/include/c++/11/bits/unique_ptr.h:361
#17 starrocks::spill::SpilledPartition::~SpilledPartition (this=0x797778bf90c0, __in_chrg=<optimized out>) at be/src/exec/spill/spill_components.h:207
#18 std::default_delete<starrocks::spill::SpilledPartition>::operator() (__ptr=0x797778bf90c0, this=<optimized out>) at /usr/include/c++/11/bits/unique_ptr.h:85
#19 std::unique_ptr<starrocks::spill::SpilledPartition, std::default_delete<starrocks::spill::SpilledPartition> >::~unique_ptr (this=0x7974af2868b0, __in_chrg=<optimized out>) at /usr/include/c++/11/bits/unique_ptr.h:361
#20 starrocks::spill::PartitionedSpillerWriter::PartitionedFlushContext::SplitStageContext::~SplitStageContext (this=0x7974af2868a0, __in_chrg=<optimized out>) at be/src/exec/spill/spill_components.h:311
#21 starrocks::spill::PartitionedSpillerWriter::PartitionedFlushContext::~PartitionedFlushContext (this=0x7974af286890, __in_chrg=<optimized out>) at be/src/exec/spill/spill_components.h:305
#22 std::destroy_at<starrocks::spill::PartitionedSpillerWriter::PartitionedFlushContext> (__location=0x7974af286890) at /usr/include/c++/11/bits/stl_construct.h:88
#23 std::allocator_traits<std::allocator<starrocks::spill::PartitionedSpillerWriter::PartitionedFlushContext> >::destroy<starrocks::spill::PartitionedSpillerWriter::PartitionedFlushContext> (__p=0x7974af286890, __a=...) at /usr/include/c++/11/bits/alloc_traits.h:537
#24 std::_Sp_counted_ptr_inplace<starrocks::spill::PartitionedSpillerWriter::PartitionedFlushContext, std::allocator<starrocks::spill::PartitionedSpillerWriter::PartitionedFlushContext>, (__gnu_cxx::_Lock_policy)2>::_M_dispose (this=0x7974af286880) at /usr/include/c++/11/bits/shared_ptr_base.h:528
#25 0x00000000052d1a5a in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release (this=0x7974af286880) at /usr/include/c++/11/bits/shared_ptr_base.h:168
#26 std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release (this=0x7974af286880) at /usr/include/c++/11/bits/shared_ptr_base.h:161
#27 0x000000000587715b in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count (this=<optimized out>, __in_chrg=<optimized out>) at /usr/include/c++/11/bits/shared_ptr_base.h:705
#28 std::__shared_ptr<starrocks::spill::SpillIOTaskContext, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr (this=<optimized out>, __in_chrg=<optimized out>) at /usr/include/c++/11/bits/shared_ptr_base.h:1154
#29 std::shared_ptr<starrocks::spill::SpillIOTaskContext>::~shared_ptr (this=<optimized out>, __in_chrg=<optimized out>) at /usr/include/c++/11/bits/shared_ptr.h:122
#30 std::any::_Manager_external<std::shared_ptr<starrocks::spill::SpillIOTaskContext> >::_S_manage (__which=<optimized out>, __any=<optimized out>, __arg=0x0) at /usr/include/c++/11/any:627
#31 0x00000000058d2f65 in std::any::reset (this=0x79762f99cb38) at /usr/include/c++/11/any:289
#32 starrocks::workgroup::YieldContext::set_finished (this=<optimized out>) at be/src/exec/workgroup/scan_task_queue.h:55
#33 starrocks::workgroup::YieldContext::defer_finished()::{lambda()#1}::operator()() const (__closure=0x79762f99c948) at be/src/exec/workgroup/scan_task_queue.h:58
#34 starrocks::CancelableDefer<starrocks::workgroup::YieldContext::defer_finished()::{lambda()#1}>::~CancelableDefer() (this=0x79762f99c940, __in_chrg=<optimized out>) at be/src/util/defer_op.h:60
#35 starrocks::CancelableDefer<starrocks::workgroup::YieldContext::defer_finished()::{lambda()#1}>::~CancelableDefer() (this=0x79762f99c940, __in_chrg=<optimized out>) at be/src/util/defer_op.h:58
#36 starrocks::spill::PartitionedSpillerWriter::flush<starrocks::spill::IOTaskExecutor, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller> >&>(starrocks::RuntimeState*, bool, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller> >&)::{lambda(auto:1&)#1}::operator()<starrocks::workgroup::YieldContext>(starrocks::workgroup::YieldContext&) const (__closure=0x7974c2ad1640, yield_ctx=...) at be/src/exec/spill/spiller.hpp:346
#37 0x00000000058d370d in std::__invoke_impl<starrocks::Status, starrocks::spill::PartitionedSpillerWriter::flush<starrocks::spill::IOTaskExecutor, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller> >&>(starrocks::RuntimeState*, bool, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller> >&)::{lambda(auto:1&)#1}&, starrocks::workgroup::YieldContext&>(std::__invoke_other, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller> >&, starrocks::workgroup::YieldContext&) (__f=...) at /usr/include/c++/11/bits/invoke.h:61
#38 std::__invoke_r<void, starrocks::spill::PartitionedSpillerWriter::flush<starrocks::spill::IOTaskExecutor, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller> >&>(starrocks::RuntimeState*, bool, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller> >&)::{lambda(auto:1&)#1}&, starrocks::workgroup::YieldContext&>(starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller> >&, starrocks::workgroup::YieldContext&) (__fn=...) at /usr/include/c++/11/bits/invoke.h:111
#39 std::_Function_handler<void (starrocks::workgroup::YieldContext&), starrocks::spill::PartitionedSpillerWriter::flush<starrocks::spill::IOTaskExecutor, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller> >&>(starrocks::RuntimeState*, bool, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller> >&)::{lambda(auto:1&)#1}>::_M_invoke(std::_Any_data const&, starrocks::workgroup::YieldContext&) (__functor=..., __args#0=...) at /usr/include/c++/11/bits/std_function.h:290
#40 0x00000000053d858e in std::function<void (starrocks::workgroup::YieldContext&)>::operator()(starrocks::workgroup::YieldContext&) const (__args#0=..., this=0x79762f99cb70) at /usr/include/c++/11/bits/std_function.h:590
#41 starrocks::workgroup::ScanTask::run (this=0x79762f99cb28) at be/src/exec/workgroup/scan_task_queue.h:97
#42 starrocks::workgroup::ScanExecutor::worker_thread (this=0x7977ec340c40) at be/src/exec/workgroup/scan_executor.cpp:71
#43 0x0000000008b17c72 in std::function<void ()>::operator()() const (this=<optimized out>) at /usr/include/c++/11/bits/std_function.h:590
#44 starrocks::FunctionRunnable::run (this=<optimized out>) at be/src/util/threadpool.cpp:60
#45 starrocks::ThreadPool::dispatch_thread (this=0x7977ed597d00) at be/src/util/threadpool.cpp:636
#46 0x0000000008b0ff39 in std::function<void ()>::operator()() const (this=0x7977ec421618) at /usr/include/c++/11/bits/std_function.h:590
#47 starrocks::Thread::supervise_thread (arg=0x7977ec421600) at be/src/util/thread.cpp:366
#48 0x00007977ef494ac3 in start_thread (arg=<optimized out>) at ./nptl/pthread_create.c:442
#49 0x00007977ef526850 in clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0