### PR TITLE
[BugFix] mutate null_column when construct NullableColumn from data_column and null_column

### DIFF
--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -29,7 +29,7 @@ NullableColumn::NullableColumn(MutableColumnPtr&& data_column, MutableColumnPtr&
             << "nullable column's data must be single column";
     DCHECK(!null_column->is_constant() && !null_column->is_nullable())
             << "nullable column's data must be single column";
-    _null_column = NullColumn::static_pointer_cast(std::move(null_column));
+    _null_column = NullColumn::static_pointer_cast(Column::mutate(std::move(null_column)));
     _has_null = SIMD::contain_nonzero(_null_column->get_data(), 0);
 }
 


### PR DESCRIPTION
## Why I'm doing:

https://github.com/StarRocks/StarRocksTest/issues/9461

Two nullable column share the same  null_column, so when Chunk::filter processing these columns, the null_column is truncated in the first nullable column, before processing the second column, sizes of  the data_column and the null_column are not equal, DCHECK fails.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0