### PR TITLE
[BugFix] reset delta rows of the BasicStatsMeta when sync tablet meta in the background

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
@@ -243,7 +243,8 @@ public class TabletStatMgr extends FrontendDaemon {
     private void adjustStatUpdateRows(long tableId, long totalRowCount) {
         BasicStatsMeta meta = GlobalStateMgr.getCurrentState().getAnalyzeMgr().getTableBasicStatsMeta(tableId);
         if (meta != null) {
-            meta.setUpdateRows(totalRowCount);
+            meta.setTotalRows(totalRowCount);
+            meta.resetDeltaRows();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2015,7 +2015,7 @@ public class Config extends ConfigBase {
      * The collect thread work interval
      */
     @ConfField(mutable = true)
-    public static long statistic_collect_interval_sec = 5L * 60L; // 5m
+    public static long statistic_collect_interval_sec = 10L * 60L; // 10m
 
     @ConfField(mutable = true, comment = "The interval to persist predicate columns state")
     public static long statistic_predicate_columns_persist_interval_sec = 60L;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalcUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalcUtils.java
@@ -220,7 +220,7 @@ public class StatisticsCalcUtils {
         // For example, a large amount of data LOAD may cause the number of rows to change greatly.
         // This leads to very inaccurate row counts.
         LocalDateTime lastWorkTimestamp = GlobalStateMgr.getCurrentState().getTabletStatMgr().getLastWorkTimestamp();
-        long deltaRows = deltaRows(table, basicStatsMeta.getUpdateRows());
+        long deltaRows = deltaRows(table, basicStatsMeta.getTotalRows());
         Map<Long, Optional<Long>> tableStatisticMap = GlobalStateMgr.getCurrentState().getStatisticStorage()
                 .getTableStatistics(table.getId(), selectedPartitions);
         Map<Long, Long> result = Maps.newHashMap();
@@ -278,7 +278,7 @@ public class StatisticsCalcUtils {
             // attempt use updateRows from basicStatsMeta to adjust estimated row counts
             if (StatsConstants.AnalyzeType.SAMPLE == analyzeType
                     && basicStatsMeta.getUpdateTime().isAfter(lastWorkTimestamp)) {
-                long statsRowCount = Math.max(basicStatsMeta.getUpdateRows() / table.getPartitions().size(), 1)
+                long statsRowCount = Math.max(basicStatsMeta.getTotalRows() / table.getPartitions().size(), 1)
                         * selectedPartitions.size();
                 if (statsRowCount > rowCount) {
                     rowCount = statsRowCount;

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
@@ -338,7 +338,7 @@ public class AnalyzeMgr implements Writable {
 
     public long getExistUpdateRows(Long tableId) {
         BasicStatsMeta existInfo =  basicStatsMetaMap.get(tableId);
-        return existInfo == null ? 0 : existInfo.getUpdateRows();
+        return existInfo == null ? 0 : existInfo.getTotalRows();
     }
 
     public Map<StatsMetaKey, ExternalBasicStatsMeta> getExternalBasicStatsMetaMap() {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
@@ -65,9 +65,13 @@ public class BasicStatsMeta implements Writable {
     // The old semantics indicated the increment of ingestion tasks after last statistical collect job.
     // Since manually collecting sampled job would reset it to zero, affecting the incremental information,
     // it is now changed to record the total number of rows in the table.
+    // Every time data is imported, it will be appended.
+    // Every time tablet stats is synchronized, it is set to the total value of the latest snapshot.
     @SerializedName("updateRows")
-    private long updateRows;
+    private long totalRows;
 
+    // Every time data is imported, it will be appended.
+    // Every time tablet stats is synchronized, it will be reset to 0.
     @SerializedName("deltaRows")
     private long deltaRows;
 
@@ -91,17 +95,15 @@ public class BasicStatsMeta implements Writable {
                           StatsConstants.AnalyzeType type,
                           LocalDateTime updateTime,
                           Map<String, String> properties,
-                          long updateRows) {
+                          long totalRows) {
         this.dbId = dbId;
         this.tableId = tableId;
         this.columns = columns;
         this.type = type;
         this.updateTime = updateTime;
         this.properties = properties;
-        this.updateRows = updateRows;
+        this.totalRows = totalRows;
     }
-
-
 
     public static BasicStatsMeta read(DataInput in) throws IOException {
         String s = Text.readString(in);
@@ -168,7 +170,7 @@ public class BasicStatsMeta implements Writable {
                 updatePartitionCount++;
             }
         }
-        updatePartitionRowCount = Math.max(1, Math.max(tableRowCount + deltaRows, updateRows) - cachedTableRowCount);
+        updatePartitionRowCount = Math.max(1, Math.max(tableRowCount + deltaRows, totalRows) - cachedTableRowCount);
 
         double updateRatio;
         // 1. If none updated partitions, health is 1
@@ -186,16 +188,16 @@ public class BasicStatsMeta implements Writable {
         return 1 - Math.min(updateRatio, 1.0);
     }
 
-    public long getUpdateRows() {
-        return updateRows;
+    public long getTotalRows() {
+        return totalRows;
     }
 
-    public void setUpdateRows(Long updateRows) {
-        this.updateRows = updateRows;
+    public void setTotalRows(Long totalRows) {
+        this.totalRows = totalRows;
     }
 
     public void increaseDeltaRows(Long delta) {
-        updateRows += delta;
+        totalRows += delta;
         deltaRows += delta;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -551,7 +551,6 @@ public class StatisticExecutor {
                         basicStatsMeta.setUpdateTime(analyzeStatus.getEndTime());
                         basicStatsMeta.setProperties(statsJob.getProperties());
                         basicStatsMeta.setAnalyzeType(statsJob.getAnalyzeType());
-                        basicStatsMeta.resetDeltaRows();
                     }
 
                     for (String column : ListUtils.emptyIfNull(statsJob.getColumnNames())) {

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/BasicStatsMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/BasicStatsMetaTest.java
@@ -89,14 +89,14 @@ public class BasicStatsMetaTest extends PlanTestBase {
                     StatsConstants.AnalyzeType.FULL,
                     LocalDateTime.of(2024, 07, 22, 12, 20), Map.of(), 10000);
             basicStatsMeta.increaseDeltaRows(5000L);
-            basicStatsMeta.setUpdateRows(10000L);
+            basicStatsMeta.setTotalRows(10000L);
             Assert.assertEquals(1.0, basicStatsMeta.getHealthy(), 0.01);
             basicStatsMeta.resetDeltaRows();
             Assert.assertEquals(1.0, basicStatsMeta.getHealthy(), 0.01);
 
             basicStatsMeta.setProperties(ImmutableBiMap.of(INIT_SAMPLE_STATS_JOB, "true"));
             basicStatsMeta.increaseDeltaRows(5000L);
-            basicStatsMeta.setUpdateRows(10000L);
+            basicStatsMeta.setTotalRows(10000L);
             Assert.assertEquals(1.0, basicStatsMeta.getHealthy(), 0.01);
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -399,7 +399,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         BasicStatsMeta basicStatsMeta2 = new BasicStatsMeta(db.getId(), olapTable.getId(), null,
                 StatsConstants.AnalyzeType.SAMPLE,
                 LocalDateTime.of(2022, 1, 1, 1, 1, 1), Maps.newHashMap(),
-                basicStatsMeta.getUpdateRows());
+                basicStatsMeta.getTotalRows());
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().addBasicStatsMeta(basicStatsMeta2);
 
         List<StatisticsCollectJob> jobs2 = StatisticsCollectJobFactory.buildStatisticsCollectJob(


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
1. fix reset rows timing
the `totalRows` and `deltaRows` of BasicStatsMeta will increase immediately after loading data.

Synchronizing tabletStats in the background will update `totalRows`, which is the exact number of table rows.
so we need to reset the `deltaRows` of BasicStatsMeta according to the healthy formula. 
```
updatePartitionRowCount = Math.max(1, Math.max(tableRowCount + deltaRows, totalRows) - cachedTableRowCount)
```
The `tableRowCount` will be the exact value of the latest snapshot after tablet meta synchronization

2. extended auto collect interval to 10min
the interval of tablet stats sync in the background is 5min. It is best to exceed the interval for collecting statistics to ensure that a relatively accurate table stats healthy can be calculated each time. 

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0