### PR TITLE
[Enhancement] Support rebuild pk persistent index in clone

### DIFF
--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -369,7 +369,9 @@ void run_clone_task(const std::shared_ptr<CloneAgentTaskRequest>& agent_task_req
             LOG(WARNING) << "fail to get dest store. path_hash:" << clone_req.dest_path_hash;
             status_code = TStatusCode::RUNTIME_ERROR;
         } else {
-            EngineStorageMigrationTask engine_task(clone_req.tablet_id, clone_req.schema_hash, dest_store);
+            bool need_rebuild_pk_index = clone_req.__isset.need_rebuild_pk_index && clone_req.need_rebuild_pk_index;
+            EngineStorageMigrationTask engine_task(clone_req.tablet_id, clone_req.schema_hash, dest_store,
+                                                   need_rebuild_pk_index);
             Status res = StorageEngine::instance()->execute_task(&engine_task);
             if (!res.ok()) {
                 status_code = TStatusCode::RUNTIME_ERROR;
@@ -473,7 +475,10 @@ void run_storage_medium_migrate_task(const std::shared_ptr<StorageMediumMigrateT
             break;
         }
 
-        EngineStorageMigrationTask engine_task(tablet_id, schema_hash, stores[0]);
+        bool need_rebuild_pk_index = storage_medium_migrate_req.__isset.need_rebuild_pk_index &&
+                                     storage_medium_migrate_req.need_rebuild_pk_index;
+
+        EngineStorageMigrationTask engine_task(tablet_id, schema_hash, stores[0], need_rebuild_pk_index);
         Status res = StorageEngine::instance()->execute_task(&engine_task);
         if (!res.ok()) {
             LOG(WARNING) << "storage media migrate failed. status: " << res

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1336,6 +1336,14 @@ CONF_mBool(enable_pindex_read_by_page, "true");
 
 // check need to rebuild pindex or not
 CONF_mBool(enable_rebuild_pindex_check, "true");
+
+// Number of max persistent index load threads
+CONF_mInt32(pindex_load_thread_pool_num_max, "8");
+// Max wait time to rebuild persistent index in full clone
+CONF_mInt32(pindex_rebuild_clone_wait_seconds, "120");
+// Max wait time to rebuild persistent index in load (preload update state)
+CONF_mInt32(pindex_rebuild_load_wait_seconds, "20");
+
 // Used by query cache, cache entries are evicted when it exceeds its capacity(500MB in default)
 CONF_Int64(query_cache_capacity, "536870912");
 

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -63,6 +63,7 @@
 #include "storage/memtable_flush_executor.h"
 #include "storage/page_cache.h"
 #include "storage/persistent_index_compaction_manager.h"
+#include "storage/persistent_index_load_executor.h"
 #include "storage/segment_flush_executor.h"
 #include "storage/segment_replicate_executor.h"
 #include "storage/storage_engine.h"
@@ -345,6 +346,10 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
                 batch_write_mgr->txn_state_cache()->set_capacity(config::merge_commit_txn_state_cache_capacity);
             }
             return Status::OK();
+        });
+        _config_callback.emplace("pindex_load_thread_pool_num_max", [&]() -> Status {
+            LOG(INFO) << "set pindex_load_thread_pool_num_max: " << config::pindex_load_thread_pool_num_max;
+            return StorageEngine::instance()->update_manager()->get_pindex_load_executor()->refresh_max_thread_num();
         });
 
 #ifdef USE_STAROS

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -172,6 +172,10 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             }
             return Status::OK();
         });
+        _config_callback.emplace("pindex_load_thread_pool_num_max", [&]() -> Status {
+            LOG(INFO) << "Set pindex_load_thread_pool_num_max: " << config::pindex_load_thread_pool_num_max;
+            return StorageEngine::instance()->update_manager()->get_pindex_load_executor()->refresh_max_thread_num();
+        });
         _config_callback.emplace("update_memory_limit_percent", [&]() -> Status {
             Status st = StorageEngine::instance()->update_manager()->update_primary_index_memory_limit(
                     config::update_memory_limit_percent);
@@ -346,10 +350,6 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
                 batch_write_mgr->txn_state_cache()->set_capacity(config::merge_commit_txn_state_cache_capacity);
             }
             return Status::OK();
-        });
-        _config_callback.emplace("pindex_load_thread_pool_num_max", [&]() -> Status {
-            LOG(INFO) << "set pindex_load_thread_pool_num_max: " << config::pindex_load_thread_pool_num_max;
-            return StorageEngine::instance()->update_manager()->get_pindex_load_executor()->refresh_max_thread_num();
         });
 
 #ifdef USE_STAROS

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -240,6 +240,7 @@ set(STORAGE_FILES
     lake/txn_log_applier.cpp
     lake/lake_local_persistent_index.cpp
     persistent_index_compaction_manager.cpp
+    persistent_index_load_executor.cpp
     lake/local_pk_index_manager.cpp
     persistent_index_tablet_loader.cpp
     lake/lake_local_persistent_index_tablet_loader.cpp

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -751,7 +751,7 @@ Status DeltaWriter::commit() {
         !_storage_engine->update_manager()->mem_tracker()->limit_exceeded_by_ratio(config::memory_high_level) &&
         !_storage_engine->update_manager()->update_state_mem_tracker()->any_limit_exceeded()) {
         auto st = _storage_engine->update_manager()->on_rowset_finished(_tablet.get(), _cur_rowset.get());
-        if (!st.ok()) {
+        if (!st.ok() && !st.is_uninitialized()) {
             _set_state(kAborted, st);
             return st;
         }

--- a/be/src/storage/persistent_index_load_executor.cpp
+++ b/be/src/storage/persistent_index_load_executor.cpp
@@ -1,0 +1,102 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/persistent_index_load_executor.h"
+
+#include "storage/storage_engine.h"
+#include "storage/update_manager.h"
+#include "util/starrocks_metrics.h"
+
+namespace starrocks {
+
+class PersistentIndexLoadTask final : public Runnable {
+public:
+    PersistentIndexLoadTask(TabletSharedPtr tablet, std::function<void()> cb)
+            : _tablet(std::move(tablet)), _cb(std::move(cb)) {}
+
+    ~PersistentIndexLoadTask() override {
+        if (_cb) {
+            _cb();
+        }
+    }
+
+    void run() override {
+        auto tablet_id = _tablet->tablet_id();
+        auto manager = StorageEngine::instance()->update_manager();
+        auto& index_cache = manager->index_cache();
+        auto index_entry = index_cache.get_or_create(tablet_id);
+        auto st = index_entry->value().load(_tablet.get());
+        index_entry->update_expire_time(MonotonicMillis() + manager->get_index_cache_expire_ms(*_tablet));
+        index_cache.update_object_size(index_entry, index_entry->value().memory_usage());
+        if (st.ok()) {
+            VLOG(2) << "load primary index success. tablet: " << tablet_id;
+            index_cache.release(index_entry);
+        } else {
+            LOG(WARNING) << "load primary index error: " << st << ", tablet: " << tablet_id;
+            index_cache.remove(index_entry);
+        }
+    }
+
+private:
+    TabletSharedPtr _tablet;
+    std::function<void()> _cb;
+};
+
+Status PersistentIndexLoadExecutor::init() {
+    int max_threads = std::max<int>(1, config::pindex_load_thread_pool_num_max);
+    RETURN_IF_ERROR(
+            ThreadPoolBuilder("pindex_load").set_min_threads(0).set_max_threads(max_threads).build(&_load_pool));
+    REGISTER_THREAD_POOL_METRICS(pindex_load, _load_pool);
+    return Status::OK();
+}
+
+void PersistentIndexLoadExecutor::shutdown() {
+    if (_load_pool != nullptr) {
+        _load_pool->shutdown();
+    }
+}
+
+Status PersistentIndexLoadExecutor::refresh_max_thread_num() {
+    if (_load_pool != nullptr) {
+        int max_threads = std::max<int>(1, config::pindex_load_thread_pool_num_max);
+        return _load_pool->update_max_threads(max_threads);
+    } else {
+        return Status::InternalError("Thread pool not exist");
+    }
+}
+
+StatusOr<std::shared_ptr<CountDownLatch>> PersistentIndexLoadExecutor::submit_task(const TabletSharedPtr& tablet) {
+    auto tablet_id = tablet->tablet_id();
+    if (tablet->updates() == nullptr) {
+        return Status::InvalidArgument(fmt::format("tablet {} is not primary key", tablet_id));
+    }
+
+    std::lock_guard<std::mutex> lock(_lock);
+    auto it = _running_tablets.find(tablet_id);
+    if (it != _running_tablets.end()) {
+        return std::move(it->second);
+    }
+
+    auto latch = std::make_shared<CountDownLatch>(1);
+    auto task = std::make_shared<PersistentIndexLoadTask>(tablet, [this, latch, tablet]() {
+        latch->count_down();
+        std::lock_guard<std::mutex> lock(_lock);
+        _running_tablets.erase(tablet->tablet_id());
+    });
+    RETURN_IF_ERROR(_load_pool->submit(std::move(task)));
+    _running_tablets.emplace(tablet_id, latch);
+    return std::move(latch);
+}
+
+} // namespace starrocks

--- a/be/src/storage/persistent_index_load_executor.h
+++ b/be/src/storage/persistent_index_load_executor.h
@@ -39,10 +39,13 @@ public:
     void shutdown();
 
     Status refresh_max_thread_num();
+    ThreadPool* TEST_get_load_pool() { return _load_pool.get(); }
 
-    StatusOr<std::shared_ptr<CountDownLatch>> submit_task(const TabletSharedPtr& tablet);
+    Status submit_task_and_wait(const TabletSharedPtr& tablet, int32_t wait_seconds);
 
 private:
+    StatusOr<std::shared_ptr<CountDownLatch>> submit_task(const TabletSharedPtr& tablet);
+
     std::unique_ptr<ThreadPool> _load_pool;
     std::mutex _lock;
     std::unordered_map<int64_t, std::shared_ptr<CountDownLatch>> _running_tablets;

--- a/be/src/storage/persistent_index_load_executor.h
+++ b/be/src/storage/persistent_index_load_executor.h
@@ -1,0 +1,51 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "util/countdown_latch.h"
+#include "util/threadpool.h"
+
+namespace starrocks {
+
+class Tablet;
+using TabletSharedPtr = std::shared_ptr<Tablet>;
+
+// PersistentIndexLoadExecutor is responsible for loading the persistent index
+// for primary key tablet.
+//
+// The submit_task function returns CountDownLatch.
+// The caller can wait until the persistent index load is finished
+// or wait for a certain period if the persistent index is still loading.
+//
+// If the persistent index does not exist, it will be rebuilt.
+class PersistentIndexLoadExecutor {
+public:
+    PersistentIndexLoadExecutor() = default;
+    ~PersistentIndexLoadExecutor() = default;
+
+    Status init();
+    void shutdown();
+
+    Status refresh_max_thread_num();
+
+    StatusOr<std::shared_ptr<CountDownLatch>> submit_task(const TabletSharedPtr& tablet);
+
+private:
+    std::unique_ptr<ThreadPool> _load_pool;
+    std::mutex _lock;
+    std::unordered_map<int64_t, std::shared_ptr<CountDownLatch>> _running_tablets;
+};
+
+} // namespace starrocks

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1106,6 +1106,11 @@ void PrimaryIndex::unload() {
     _calc_memory_usage();
 }
 
+bool PrimaryIndex::is_loaded() {
+    std::lock_guard<std::mutex> lg(_lock);
+    return _loaded && _status.ok();
+}
+
 static string int_list_to_string(const vector<uint32_t>& l) {
     string ret;
     for (size_t i = 0; i < l.size(); i++) {

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -54,6 +54,9 @@ public:
     // [thread-safe]
     void unload();
 
+    // Whether index is normally loaded
+    bool is_loaded();
+
     // insert new primary keys into this index. caller need to make sure key doesn't exists
     // in index
     // [not thread-safe]

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -372,6 +372,16 @@ public:
         std::for_each(rowsets.begin(), rowsets.end(), [](const RowsetSharedPtr& rowset) { rowset->close(); });
     }
 
+    bool is_partial_update() const {
+        if (!rowset_meta()->get_meta_pb_without_schema().has_txn_meta()) {
+            return false;
+        }
+        // Merge condition and auto-increment-column-only partial update will also set txn_meta
+        // but will not set partial_update_column_ids
+        const auto& txn_meta = rowset_meta()->get_meta_pb_without_schema().txn_meta();
+        return !txn_meta.partial_update_column_ids().empty();
+    }
+
     bool is_column_mode_partial_update() const { return _rowset_meta->is_column_mode_partial_update(); }
 
     // only used in unit test

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -562,13 +562,10 @@ Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(Tablet* 
 }
 
 bool RowsetUpdateState::_check_partial_update(Rowset* rowset) {
-    if (!rowset->rowset_meta()->get_meta_pb_without_schema().has_txn_meta() || rowset->num_segments() == 0) {
+    if (rowset->num_segments() == 0) {
         return false;
     }
-    // Merge condition and auto-increment-column-only partial update will also set txn_meta
-    // but will not set partial_update_column_ids
-    const auto& txn_meta = rowset->rowset_meta()->get_meta_pb_without_schema().txn_meta();
-    return !txn_meta.partial_update_column_ids().empty();
+    return rowset->is_partial_update();
 }
 
 Status RowsetUpdateState::_rebuild_partial_update_states(Tablet* tablet, Rowset* rowset, uint32_t rowset_id,

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1788,7 +1788,7 @@ Status TabletManager::create_tablet_from_meta_snapshot(DataDir* store, TTabletId
     if (add_tablet_st.ok() && need_rebuild_pk_index && tablet->updates() != nullptr) {
         // rebuild primary index
         auto* pindex_load_executor = StorageEngine::instance()->update_manager()->get_pindex_load_executor();
-        (void)pindex_load_executor->submit_task_and_wait(tablet, rebuild_pk_index_wait_seconds);
+        (void)pindex_load_executor->submit_task_and_wait_for(tablet, rebuild_pk_index_wait_seconds);
     }
     return add_tablet_st;
 }

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -50,6 +50,7 @@
 #include "storage/compaction_manager.h"
 #include "storage/data_dir.h"
 #include "storage/olap_common.h"
+#include "storage/persistent_index_load_executor.h"
 #include "storage/rowset/rowset_factory.h"
 #include "storage/rowset/rowset_writer.h"
 #include "storage/rowset/rowset_writer_context.h"
@@ -1671,7 +1672,9 @@ std::vector<TabletSharedPtr> TabletManager::_get_all_tablets_from_shard(const Ta
 }
 
 Status TabletManager::create_tablet_from_meta_snapshot(DataDir* store, TTabletId tablet_id, SchemaHash schema_hash,
-                                                       const string& schema_hash_path, bool restore) {
+                                                       const string& schema_hash_path, bool restore,
+                                                       bool need_rebuild_pk_index,
+                                                       int32_t rebuild_pk_index_wait_seconds) {
     auto meta_path = strings::Substitute("$0/meta", schema_hash_path);
     auto shard_path = path_util::dir_name(path_util::dir_name(path_util::dir_name(meta_path)));
     auto shard_str = shard_path.substr(shard_path.find_last_of('/') + 1);
@@ -1761,24 +1764,44 @@ Status TabletManager::create_tablet_from_meta_snapshot(DataDir* store, TTabletId
         return Status::NotFound("tablet path not exists");
     }
 
-    std::unique_lock l(_get_tablets_shard_lock(tablet_id));
-    RETURN_IF_ERROR(meta_store->write_batch(&wb));
+    Status add_tablet_st;
+    {
+        std::unique_lock l(_get_tablets_shard_lock(tablet_id));
+        RETURN_IF_ERROR(meta_store->write_batch(&wb));
 
-    if (!tablet->init().ok()) {
-        LOG(WARNING) << "Fail to init cloned tablet " << tablet_id << ", try to clear meta store";
-        wb.Clear();
-        RETURN_IF_ERROR(TabletMetaManager::clear_del_vector(store, &wb, tablet_id));
-        RETURN_IF_ERROR(TabletMetaManager::clear_delta_column_group(store, &wb, tablet_id));
-        RETURN_IF_ERROR(TabletMetaManager::clear_rowset(store, &wb, tablet_id));
-        RETURN_IF_ERROR(TabletMetaManager::clear_log(store, &wb, tablet_id));
-        RETURN_IF_ERROR(TabletMetaManager::remove_tablet_meta(store, &wb, tablet_id, schema_hash));
-        auto st = meta_store->write_batch(&wb);
-        LOG_IF(WARNING, !st.ok()) << "Fail to clear meta store: " << st;
-        return Status::InternalError("tablet init failed");
+        if (!tablet->init().ok()) {
+            LOG(WARNING) << "Fail to init cloned tablet " << tablet_id << ", try to clear meta store";
+            wb.Clear();
+            RETURN_IF_ERROR(TabletMetaManager::clear_del_vector(store, &wb, tablet_id));
+            RETURN_IF_ERROR(TabletMetaManager::clear_delta_column_group(store, &wb, tablet_id));
+            RETURN_IF_ERROR(TabletMetaManager::clear_rowset(store, &wb, tablet_id));
+            RETURN_IF_ERROR(TabletMetaManager::clear_log(store, &wb, tablet_id));
+            RETURN_IF_ERROR(TabletMetaManager::remove_tablet_meta(store, &wb, tablet_id, schema_hash));
+            auto st = meta_store->write_batch(&wb);
+            LOG_IF(WARNING, !st.ok()) << "Fail to clear meta store: " << st;
+            return Status::InternalError("tablet init failed");
+        }
+        add_tablet_st = _add_tablet_unlocked(tablet, true, false);
+        LOG_IF(WARNING, !add_tablet_st.ok()) << "Fail to add cloned tablet " << tablet_id << ": " << add_tablet_st;
     }
-    auto st = _add_tablet_unlocked(tablet, true, false);
-    LOG_IF(WARNING, !st.ok()) << "Fail to add cloned tablet " << tablet_id << ": " << st;
-    return st;
+
+    if (add_tablet_st.ok() && need_rebuild_pk_index && tablet->updates() != nullptr) {
+        // rebuild primary index
+        auto manager = StorageEngine::instance()->update_manager();
+        auto* pindex_load_executor = manager->get_pindex_load_executor();
+        auto latch_or = pindex_load_executor->submit_task(tablet);
+        if (latch_or.ok()) {
+            auto finished = latch_or.value()->wait_for(std::chrono::seconds(rebuild_pk_index_wait_seconds));
+            if (!finished) {
+                LOG(INFO) << "persistent index is still loading, already wait " << rebuild_pk_index_wait_seconds
+                          << " seconds. tablet: " << tablet_id;
+            }
+        } else {
+            LOG(WARNING) << "fail to submit persistent index load task. tablet: " << tablet_id
+                         << ", error: " << latch_or.status().to_string();
+        }
+    }
+    return add_tablet_st;
 }
 
 Status TabletManager::_remove_tablet_meta(const TabletSharedPtr& tablet) {

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -155,7 +155,9 @@ public:
                                 const std::string& schema_hash_path, bool force = false, bool restore = false);
 
     Status create_tablet_from_meta_snapshot(DataDir* data_dir, TTabletId tablet_id, SchemaHash schema_hash,
-                                            const std::string& schema_hash_path, bool restore = false);
+                                            const std::string& schema_hash_path, bool restore = false,
+                                            bool need_rebuild_pk_index = false,
+                                            int32_t rebuild_pk_index_wait_seconds = 0);
 
     void release_schema_change_lock(TTabletId tablet_id);
 

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -5165,7 +5165,7 @@ Status TabletUpdates::load_snapshot(const SnapshotMeta& snapshot_meta, bool rest
         if (need_rebuild_pk_index) {
             // rebuild primary index
             auto* pindex_load_executor = manager->get_pindex_load_executor();
-            (void)pindex_load_executor->submit_task_and_wait(
+            (void)pindex_load_executor->submit_task_and_wait_for(
                     std::static_pointer_cast<Tablet>(_tablet.shared_from_this()), rebuild_pk_index_wait_seconds);
         }
 

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -44,6 +44,7 @@
 #include "storage/local_primary_key_recover.h"
 #include "storage/merge_iterator.h"
 #include "storage/persistent_index.h"
+#include "storage/persistent_index_load_executor.h"
 #include "storage/primary_key_dump.h"
 #include "storage/rows_mapper.h"
 #include "storage/rowset/base_rowset.h"
@@ -4907,7 +4908,8 @@ void TabletUpdates::_to_updates_pb_unlocked(TabletUpdatesPB* updates_pb) const {
 }
 
 Status TabletUpdates::load_snapshot(const SnapshotMeta& snapshot_meta, bool restore_from_backup,
-                                    bool save_source_schema) {
+                                    bool save_source_schema, bool need_rebuild_pk_index,
+                                    int32_t rebuild_pk_index_wait_seconds) {
 #define CHECK_FAIL(status)                                                                       \
     do {                                                                                         \
         Status st = (status);                                                                    \
@@ -5159,6 +5161,23 @@ Status TabletUpdates::load_snapshot(const SnapshotMeta& snapshot_meta, bool rest
         index_entry->update_expire_time(MonotonicMillis() + manager->get_index_cache_expire_ms(_tablet));
         index_entry->value().unload();
         index_cache.release(index_entry);
+
+        // rebuild primary index
+        if (need_rebuild_pk_index) {
+            auto* pindex_load_executor = manager->get_pindex_load_executor();
+            auto latch_or =
+                    pindex_load_executor->submit_task(std::static_pointer_cast<Tablet>(_tablet.shared_from_this()));
+            if (latch_or.ok()) {
+                auto finished = latch_or.value()->wait_for(std::chrono::seconds(rebuild_pk_index_wait_seconds));
+                if (!finished) {
+                    LOG(INFO) << "persistent index is still loading, already wait " << rebuild_pk_index_wait_seconds
+                              << " seconds. tablet: " << tablet_id;
+                }
+            } else {
+                LOG(WARNING) << "fail to submit persistent index load task. tablet: " << tablet_id
+                             << ", error: " << latch_or.status().to_string();
+            }
+        }
 
         LOG(INFO) << "load full snapshot done " << _debug_string(false) << ss.str();
 

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -246,7 +246,8 @@ public:
                         const std::string& err_msg_header = "");
 
     Status load_snapshot(const SnapshotMeta& snapshot_meta, bool restore_from_backup = false,
-                         bool save_source_schema = false);
+                         bool save_source_schema = false, bool need_rebuild_pk_index = false,
+                         int32_t rebuild_pk_index_wait_seconds = 0);
 
     Status get_latest_applied_version(EditVersion* latest_applied_version);
 

--- a/be/src/storage/task/engine_storage_migration_task.cpp
+++ b/be/src/storage/task/engine_storage_migration_task.cpp
@@ -46,8 +46,11 @@
 namespace starrocks {
 
 EngineStorageMigrationTask::EngineStorageMigrationTask(TTabletId tablet_id, TSchemaHash schema_hash,
-                                                       DataDir* dest_store)
-        : _tablet_id(tablet_id), _schema_hash(schema_hash), _dest_store(dest_store) {}
+                                                       DataDir* dest_store, bool need_rebuild_pk_index)
+        : _tablet_id(tablet_id),
+          _schema_hash(schema_hash),
+          _dest_store(dest_store),
+          _need_rebuild_pk_index(need_rebuild_pk_index) {}
 
 Status EngineStorageMigrationTask::execute() {
     StarRocksMetrics::instance()->storage_migrate_requests_total.increment(1);
@@ -537,8 +540,9 @@ Status EngineStorageMigrationTask::_finish_primary_key_migration(const TabletSha
         }
 
         auto tablet_manager = StorageEngine::instance()->tablet_manager();
+        // don't wait rebuild pk index finished because migration task will block the ingestion
         res = tablet_manager->create_tablet_from_meta_snapshot(_dest_store, _tablet_id, tablet->schema_hash(),
-                                                               schema_hash_path, false);
+                                                               schema_hash_path, false, _need_rebuild_pk_index, 0);
         if (!res.ok()) {
             LOG(WARNING) << "Fail to create tablet from meta snapshot. tablet_id: " << _tablet_id;
             WriteBatch wb;

--- a/be/src/storage/task/engine_storage_migration_task.cpp
+++ b/be/src/storage/task/engine_storage_migration_task.cpp
@@ -540,7 +540,8 @@ Status EngineStorageMigrationTask::_finish_primary_key_migration(const TabletSha
         }
 
         auto tablet_manager = StorageEngine::instance()->tablet_manager();
-        // don't wait rebuild pk index finished because migration task will block the ingestion
+        // don't wait rebuild pk index to finish because migration task does not support increment migration
+        // and needs to be completed as soon as possible
         res = tablet_manager->create_tablet_from_meta_snapshot(_dest_store, _tablet_id, tablet->schema_hash(),
                                                                schema_hash_path, false, _need_rebuild_pk_index, 0);
         if (!res.ok()) {

--- a/be/src/storage/task/engine_storage_migration_task.h
+++ b/be/src/storage/task/engine_storage_migration_task.h
@@ -50,7 +50,8 @@ public:
     Status execute() override;
 
 public:
-    EngineStorageMigrationTask(TTabletId tablet_id, TSchemaHash schema_hash, DataDir* dest_store);
+    EngineStorageMigrationTask(TTabletId tablet_id, TSchemaHash schema_hash, DataDir* dest_store,
+                               bool need_rebuild_pk_index);
     ~EngineStorageMigrationTask() override = default;
 
 private:
@@ -77,5 +78,6 @@ private:
     TTabletId _tablet_id;
     TSchemaHash _schema_hash;
     DataDir* _dest_store;
+    bool _need_rebuild_pk_index{false};
 }; // EngineTask
 } // namespace starrocks

--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -529,7 +529,7 @@ Status UpdateManager::on_rowset_finished(Tablet* tablet, Rowset* rowset) {
     // process.
 
     if (rowset->is_partial_update()) {
-        auto task_st = _pindex_load_executor->submit_task_and_wait(
+        auto task_st = _pindex_load_executor->submit_task_and_wait_for(
                 std::static_pointer_cast<Tablet>(tablet->shared_from_this()), config::pindex_rebuild_load_wait_seconds);
         if (!task_st.ok()) {
             return Status::Uninitialized(task_st.message());

--- a/be/src/storage/update_manager.h
+++ b/be/src/storage/update_manager.h
@@ -38,6 +38,7 @@ class RowsetUpdateState;
 class RowsetColumnUpdateState;
 class Tablet;
 class PersistentIndexCompactionManager;
+class PersistentIndexLoadExecutor;
 
 class LocalDelvecLoader : public DelvecLoader {
 public:
@@ -96,6 +97,7 @@ public:
     ThreadPool* apply_thread_pool() { return _apply_thread_pool.get(); }
     ThreadPool* get_pindex_thread_pool() { return _get_pindex_thread_pool.get(); }
     PersistentIndexCompactionManager* get_pindex_compaction_mgr() { return _persistent_index_compaction_mgr.get(); }
+    PersistentIndexLoadExecutor* get_pindex_load_executor() { return _pindex_load_executor.get(); }
 
     DynamicCache<uint64_t, PrimaryIndex>& index_cache() { return _index_cache; }
 
@@ -184,6 +186,7 @@ private:
     std::unique_ptr<ThreadPool> _apply_thread_pool;
     std::unique_ptr<ThreadPool> _get_pindex_thread_pool;
     std::unique_ptr<PersistentIndexCompactionManager> _persistent_index_compaction_mgr;
+    std::unique_ptr<PersistentIndexLoadExecutor> _pindex_load_executor;
 
     bool _keep_pindex_bf = true;
 

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -366,6 +366,7 @@ public:
     METRICS_DEFINE_THREAD_POOL(update_apply);
     METRICS_DEFINE_THREAD_POOL(pk_index_compaction);
     METRICS_DEFINE_THREAD_POOL(compact_pool);
+    METRICS_DEFINE_THREAD_POOL(pindex_load);
 
     METRIC_DEFINE_UINT_GAUGE(load_rpc_threadpool_size, MetricUnit::NOUNIT);
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -253,6 +253,7 @@ set(EXEC_FILES
         ./storage/protobuf_file_test.cpp
         ./storage/page_cache_test.cpp
         ./storage/persistent_index_test.cpp
+        ./storage/persistent_index_load_executor_test.cpp
         ./storage/primary_index_test.cpp
         ./storage/primary_key_encoder_test.cpp
         ./storage/roaring2range_test.cpp

--- a/be/test/http/action/update_config_action_test.cpp
+++ b/be/test/http/action/update_config_action_test.cpp
@@ -19,6 +19,10 @@
 #include "cache/block_cache/block_cache.h"
 #include "fs/fs_util.h"
 #include "runtime/exec_env.h"
+#include "storage/persistent_index_load_executor.h"
+#include "storage/storage_engine.h"
+#include "storage/update_manager.h"
+#include "testutil/assert.h"
 #include "testutil/scoped_updater.h"
 
 namespace starrocks {
@@ -64,6 +68,16 @@ TEST_F(UpdateConfigActionTest, update_datacache_disk_size) {
     ASSERT_EQ(spaces[0].size, 100000000);
 
     fs::remove_all(cache_dir).ok();
+}
+
+TEST_F(UpdateConfigActionTest, test_update_pindex_load_thread_pool_num_max) {
+    UpdateConfigAction action(ExecEnv::GetInstance());
+
+    auto st = action.update_config("pindex_load_thread_pool_num_max", "16");
+    CHECK_OK(st);
+
+    auto* load_pool = StorageEngine::instance()->update_manager()->get_pindex_load_executor()->TEST_get_load_pool();
+    ASSERT_EQ(16, load_pool->max_threads());
 }
 
 } // namespace starrocks

--- a/be/test/storage/persistent_index_load_executor_test.cpp
+++ b/be/test/storage/persistent_index_load_executor_test.cpp
@@ -1,0 +1,192 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/persistent_index_load_executor.h"
+
+#include <gtest/gtest.h>
+
+#include <utility>
+
+#include "column/datum.h"
+#include "storage/chunk_helper.h"
+#include "storage/rowset/rowset_factory.h"
+#include "storage/rowset/rowset_options.h"
+#include "storage/rowset/rowset_writer.h"
+#include "storage/rowset/rowset_writer_context.h"
+#include "storage/rowset/segment_options.h"
+#include "storage/storage_engine.h"
+#include "storage/tablet.h"
+#include "storage/tablet_manager.h"
+#include "storage/tablet_updates.h"
+#include "storage/update_manager.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+class PersistentIndexLoadExecutorTest : public ::testing::Test {
+public:
+    using Row = std::vector<Datum>;
+
+    void SetUp() override {
+        srand(GetCurrentTimeMicros());
+        _partition_id = 1;
+        _index_id = 1;
+        _tablet = create_tablet(rand(), rand());
+    }
+
+    void TearDown() override {
+        if (_tablet) {
+            auto st = StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet->tablet_id());
+            CHECK(st.ok()) << st.to_string();
+            _tablet.reset();
+        }
+    }
+
+    TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash) {
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(1);
+        request.__set_version_hash(0);
+        request.tablet_schema.schema_hash = schema_hash;
+        request.tablet_schema.short_key_column_count = 1;
+        request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        TColumn k1;
+        k1.column_name = "pk";
+        k1.__set_is_key(true);
+        k1.column_type.type = TPrimitiveType::BIGINT;
+        request.tablet_schema.columns.push_back(k1);
+
+        TColumn k2;
+        k2.column_name = "v1";
+        k2.__set_is_key(false);
+        k2.column_type.type = TPrimitiveType::BIGINT;
+        request.tablet_schema.columns.push_back(k2);
+
+        auto st = StorageEngine::instance()->create_tablet(request);
+        CHECK(st.ok()) << st.to_string();
+        return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    }
+
+    void generate_data(int64_t key_start, size_t num_row, size_t num_segment, std::vector<std::vector<Row>>& segments) {
+        size_t num_row_per_segment = (num_row + num_segment - 1) / num_segment;
+        std::vector<int64_t> keys(num_row, 0);
+        for (size_t i = 0; i < num_row; i++) {
+            keys[i] = key_start + i;
+        }
+        std::random_shuffle(keys.begin(), keys.end());
+        for (size_t i = 0; i < num_segment; i++) {
+            auto& segment = segments.emplace_back();
+            size_t start = i * num_row_per_segment;
+            size_t end = std::min((i + 1) * num_row_per_segment, num_row);
+            std::sort(keys.begin() + start, keys.begin() + end);
+            for (size_t j = start; j < end; j++) {
+                auto& row = segment.emplace_back();
+                auto key = keys[j];
+                row.push_back(Datum(key));
+                row.push_back(Datum(static_cast<int64_t>((key * 7919) % 7883)));
+            }
+        }
+    }
+
+    RowsetSharedPtr create_rowset(const TabletSharedPtr& tablet, const std::vector<std::vector<Row>>& segments,
+                                  SegmentsOverlapPB overlap) {
+        RowsetWriterContext writer_context;
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.rowset_id = rowset_id;
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = 0;
+        writer_context.rowset_path_prefix = tablet->schema_hash_path();
+        writer_context.rowset_state = COMMITTED;
+        writer_context.tablet_schema = tablet->tablet_schema();
+        writer_context.version.first = 0;
+        writer_context.version.second = 0;
+        writer_context.segments_overlap = overlap;
+        std::unique_ptr<RowsetWriter> writer;
+        EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+        auto schema = ChunkHelper::convert_schema(tablet->tablet_schema());
+        for (size_t i = 0; i < segments.size(); i++) {
+            auto& segment = segments[i];
+            auto chunk = ChunkHelper::new_chunk(schema, segment.size());
+            auto& cols = chunk->columns();
+            for (auto& row : segment) {
+                CHECK(cols.size() == row.size());
+                for (size_t j = 0; j < row.size(); j++) {
+                    cols[j]->append_datum(row[j]);
+                }
+            }
+            CHECK_OK(writer->flush_chunk(*chunk));
+        }
+        return *writer->build();
+    }
+
+    void wait_for_version(int64_t version, int64_t timeout_ms = 10000) {
+        while (true) {
+            timeout_ms -= 200;
+            if (timeout_ms <= 0) {
+                ASSERT_TRUE(false) << "timeout";
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+            std::vector<RowsetSharedPtr> rowsets;
+            EditVersion full_version;
+            ASSERT_TRUE(_tablet->updates()->get_applied_rowsets(version, &rowsets, &full_version).ok());
+            if (full_version.major_number() >= version) {
+                break;
+            }
+            std::cerr << "waiting for version " << version << std::endl;
+        }
+    }
+
+protected:
+    int64_t _partition_id;
+    int64_t _index_id;
+    TabletSharedPtr _tablet;
+};
+
+TEST_F(PersistentIndexLoadExecutorTest, test_submit_task) {
+    const int64_t key_start = 0;
+    const int num_row = 10000;
+    const size_t num_segment = 1;
+    LOG(INFO) << "rowset=1, segment=" << num_segment << ", num_row=" << num_row;
+    srand(GetCurrentTimeMicros());
+    _tablet = create_tablet(rand(), rand());
+    std::vector<std::vector<Row>> segments;
+    std::srand(0);
+    generate_data(key_start, num_row, num_segment, segments);
+    auto rs = create_rowset(_tablet, segments, SegmentsOverlapPB::OVERLAPPING);
+    ASSERT_TRUE(_tablet->rowset_commit(2, rs).ok());
+    wait_for_version(2);
+    ASSERT_EQ(2, _tablet->updates()->max_version());
+
+    auto tablet_id = _tablet->tablet_id();
+    auto manager = StorageEngine::instance()->update_manager();
+    auto& index_cache = manager->index_cache();
+
+    auto index_entry = index_cache.get_or_create(tablet_id);
+    ASSERT_TRUE(index_entry->value().is_loaded());
+    index_entry->value().unload();
+    ASSERT_FALSE(index_entry->value().is_loaded());
+    index_cache.remove(index_entry);
+
+    auto* pindex_load_executor = manager->get_pindex_load_executor();
+    auto latch_or = pindex_load_executor->submit_task(_tablet);
+    ASSERT_TRUE(latch_or.ok());
+    latch_or.value()->wait();
+    index_entry = index_cache.get_or_create(tablet_id);
+    ASSERT_TRUE(index_entry->value().is_loaded());
+}
+
+} // namespace starrocks

--- a/be/test/storage/persistent_index_load_executor_test.cpp
+++ b/be/test/storage/persistent_index_load_executor_test.cpp
@@ -182,9 +182,8 @@ TEST_F(PersistentIndexLoadExecutorTest, test_submit_task) {
     index_cache.remove(index_entry);
 
     auto* pindex_load_executor = manager->get_pindex_load_executor();
-    auto latch_or = pindex_load_executor->submit_task(_tablet);
-    ASSERT_TRUE(latch_or.ok());
-    latch_or.value()->wait();
+    auto st = pindex_load_executor->submit_task_and_wait(_tablet, 60);
+    CHECK_OK(st);
     index_entry = index_cache.get_or_create(tablet_id);
     ASSERT_TRUE(index_entry->value().is_loaded());
 }

--- a/be/test/storage/task/engine_storage_migration_task_test.cpp
+++ b/be/test/storage/task/engine_storage_migration_task_test.cpp
@@ -345,11 +345,11 @@ public:
         } else {
             dest_path = data_dir_1;
         }
-        EngineStorageMigrationTask migration_task(tablet_id, schema_hash, dest_path);
+        EngineStorageMigrationTask migration_task(tablet_id, schema_hash, dest_path, false);
         ASSERT_OK(migration_task.execute());
         // sleep 2 second for add latency for load
         sleep(2);
-        EngineStorageMigrationTask migration_task_2(tablet_id, schema_hash, source_path);
+        EngineStorageMigrationTask migration_task_2(tablet_id, schema_hash, source_path, false);
         ASSERT_OK(migration_task_2.execute());
     }
 
@@ -368,17 +368,17 @@ public:
             }
         }
 
-        EngineStorageMigrationTask migration_task_1(tablet_id, schema_hash, dest_dir[0]);
+        EngineStorageMigrationTask migration_task_1(tablet_id, schema_hash, dest_dir[0], false);
         ASSERT_OK(migration_task_1.execute());
 
         // sleep 2 second for add latency for load
         sleep(2);
-        EngineStorageMigrationTask migration_task_2(tablet_id, schema_hash, dest_dir[1]);
+        EngineStorageMigrationTask migration_task_2(tablet_id, schema_hash, dest_dir[1], false);
         ASSERT_OK(migration_task_2.execute());
 
         // sleep 2 second for add latency for load
         sleep(2);
-        EngineStorageMigrationTask migration_task_3(tablet_id, schema_hash, dest_dir[0]);
+        EngineStorageMigrationTask migration_task_3(tablet_id, schema_hash, dest_dir[0], false);
         ASSERT_OK(migration_task_3.execute());
     }
 
@@ -397,7 +397,7 @@ public:
         } else {
             dest_path = data_dir_1;
         }
-        EngineStorageMigrationTask migration_task(tablet_id, schema_hash, dest_path);
+        EngineStorageMigrationTask migration_task(tablet_id, schema_hash, dest_path, false);
         auto st = migration_task.execute();
         ASSERT_FALSE(st.ok());
     }
@@ -598,11 +598,11 @@ TEST_F(EngineStorageMigrationTaskTest, test_migrate_empty_pk_tablet) {
         dest_path = data_dir_1;
     }
     tablet->set_tablet_state(TabletState::TABLET_NOTREADY);
-    EngineStorageMigrationTask migration_task_not_ready(empty_tablet_id, empty_schema_hash, dest_path);
+    EngineStorageMigrationTask migration_task_not_ready(empty_tablet_id, empty_schema_hash, dest_path, false);
     ASSERT_ERROR(migration_task_not_ready.execute());
     tablet->set_tablet_state(TabletState::TABLET_RUNNING);
     tablet.reset();
-    EngineStorageMigrationTask migration_task(empty_tablet_id, empty_schema_hash, dest_path);
+    EngineStorageMigrationTask migration_task(empty_tablet_id, empty_schema_hash, dest_path, false);
     ASSERT_OK(migration_task.execute());
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -43,6 +43,7 @@ import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.authorization.PrivilegeType;
 import com.starrocks.catalog.ColocateTableIndex.GroupId;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.LocalTablet.TabletHealthStatus;
 import com.starrocks.catalog.MaterializedIndex;
@@ -190,7 +191,9 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
     private long finishedTime = -1;
 
     private LocalTablet tablet = null;
+    private KeysType tabletKeysType = null;
     private long visibleVersion = -1;
+    private long visibleVersionTime = -1;
     private long visibleTxnId = -1;
     private long committedVersion = -1;
 
@@ -376,11 +379,15 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         return tablet.getImmutableReplicas();
     }
 
-    public void setVersionInfo(long visibleVersion,
-                               long committedVersion, long visibleTxnId) {
+    public void setTabletKeysType(KeysType tabletKeysType) {
+        this.tabletKeysType = tabletKeysType;
+    }
+
+    public void setVersionInfo(long visibleVersion, long committedVersion, long visibleTxnId, long visibleVersionTime) {
         this.visibleVersion = visibleVersion;
         this.committedVersion = committedVersion;
         this.visibleTxnId = visibleTxnId;
+        this.visibleVersionTime = visibleVersionTime;
     }
 
     public long getVisibleTxnId() {
@@ -833,6 +840,8 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                 visibleVersion, (int) (taskTimeoutMs / 1000));
         cloneTask.setPathHash(srcPathHash, destPathHash);
         cloneTask.setIsLocal(srcReplica.getBackendId() == destBackendId);
+        cloneTask.setNeedRebuildPkIndex(tabletKeysType == KeysType.PRIMARY_KEYS &&
+                System.currentTimeMillis() - visibleVersionTime < Config.tablet_sched_pk_index_rebuild_threshold_seconds * 1000);
 
         // if this is a balance task, or this is a repair task with REPLICA_MISSING/REPLICA_RELOCATING,
         // we create a new replica with state CLONE

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -819,8 +819,9 @@ public class TabletScheduler extends FrontendDaemon {
             // we do not concern priority here.
             // once we take the tablet out of priority queue, priority is meaningless.
             tabletCtx.setTablet(tablet);
-            tabletCtx.setVersionInfo(physicalPartition.getVisibleVersion(),
-                    physicalPartition.getCommittedVersion(), physicalPartition.getVisibleTxnId());
+            tabletCtx.setTabletKeysType(tbl.getKeysType());
+            tabletCtx.setVersionInfo(physicalPartition.getVisibleVersion(), physicalPartition.getCommittedVersion(),
+                    physicalPartition.getVisibleTxnId(), physicalPartition.getVisibleVersionTime());
             tabletCtx.setSchemaHash(tbl.getSchemaHashByIndexId(idx.getId()));
             tabletCtx.setStorageMedium(dataProperty.getStorageMedium());
             if (!Objects.equals(oldStatus, statusPair.first)) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1725,6 +1725,15 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static double tablet_sched_num_based_balance_threshold_ratio = 0.5;
 
+    /**
+     * Persistent index rebuild is triggered only when the partition has new ingestion recently after clone finish.
+     * currentTime - partition VisibleVersionTime < tablet_sched_pk_index_rebuild_threshold_seconds
+     *
+     * the default value is 2 days for T+1 ingestion.
+     */
+    @ConfField(mutable = true)
+    public static int tablet_sched_pk_index_rebuild_threshold_seconds = 172800;
+
     @ConfField(mutable = true, comment = "How much time we should wait before dropping the tablet from BE on tablet report")
     public static long tablet_report_drop_tablet_delay_sec = 120;
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/CloneTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/CloneTask.java
@@ -63,6 +63,9 @@ public class CloneTask extends AgentTask {
     // Migration between different disks on the same backend
     private boolean isLocal = false;
 
+    // Rebuild persistent index at the end of clone task
+    private boolean needRebuildPkIndex = false;
+
     public CloneTask(long backendId, String destBackendHost, long dbId, long tableId, long partitionId, long indexId,
                      long tabletId, int schemaHash, List<TBackend> srcBackends, TStorageMedium storageMedium,
                      long visibleVersion, int timeoutS) {
@@ -105,6 +108,10 @@ public class CloneTask extends AgentTask {
         this.isLocal = isLocal;
     }
 
+    public void setNeedRebuildPkIndex(boolean needRebuildPkIndex) {
+        this.needRebuildPkIndex = needRebuildPkIndex;
+    }
+
     public TCloneReq toThrift() {
         TCloneReq request = new TCloneReq(tabletId, schemaHash, srcBackends);
         request.setStorage_medium(storageMedium);
@@ -116,7 +123,7 @@ public class CloneTask extends AgentTask {
         }
         request.setTimeout_s(timeoutS);
         request.setIs_local(isLocal);
-
+        request.setNeed_rebuild_pk_index(needRebuildPkIndex);
         return request;
     }
 
@@ -129,7 +136,7 @@ public class CloneTask extends AgentTask {
         sb.append(", src backend: ").append(srcBackends.get(0).getHost()).append(", src path hash: ")
                 .append(srcPathHash);
         sb.append(", dest backend: ").append(destBackendHost).append(", dest path hash: ").append(destPathHash);
-        sb.append(", is local: ").append(isLocal);
+        sb.append(", is local: ").append(isLocal).append(", need rebuild pk index: ").append(needRebuildPkIndex);
         return sb.toString();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/task/StorageMediaMigrationTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/StorageMediaMigrationTask.java
@@ -26,16 +26,21 @@ public class StorageMediaMigrationTask extends AgentTask {
     private int schemaHash;
     private TStorageMedium toStorageMedium;
 
+    // Rebuild persistent index at the end of clone task
+    private boolean needRebuildPkIndex = false;
+
     public StorageMediaMigrationTask(long backendId, long tabletId, int schemaHash,
-                                     TStorageMedium toStorageMedium) {
+                                     TStorageMedium toStorageMedium, boolean needRebuildPkIndex) {
         super(null, backendId, TTaskType.STORAGE_MEDIUM_MIGRATE, -1L, -1L, -1L, -1L, tabletId);
 
         this.schemaHash = schemaHash;
         this.toStorageMedium = toStorageMedium;
+        this.needRebuildPkIndex = needRebuildPkIndex;
     }
 
     public TStorageMediumMigrateReq toThrift() {
         TStorageMediumMigrateReq request = new TStorageMediumMigrateReq(tabletId, schemaHash, toStorageMedium);
+        request.setNeed_rebuild_pk_index(needRebuildPkIndex);
         return request;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedCtxTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedCtxTest.java
@@ -257,7 +257,7 @@ public class TabletSchedCtxTest {
                         TABLET_ID_2, System.currentTimeMillis(), GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
         ctx.setTablet(repairTablet);
         ctx.setStorageMedium(TStorageMedium.HDD);
-        ctx.setVersionInfo(101, 108, 12332);
+        ctx.setVersionInfo(101, 108, 12332, 12333);
 
         Map<Long, PathSlot> backendsWorkingSlots = Maps.newConcurrentMap();
         List<Long> pathHashes = new ArrayList<>();

--- a/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskTest.java
@@ -157,6 +157,7 @@ public class AgentTaskTest {
         cloneTask =
                 new CloneTask(backendId1, "127.0.0.1", dbId, tableId, partitionId, indexId1, tabletId1, 0,
                         Arrays.asList(new TBackend("host1", 8290, 8390)), TStorageMedium.HDD, -1, 3600);
+        ((CloneTask) cloneTask).setNeedRebuildPkIndex(true);
 
         // modify tablet meta
         // <tablet id, tablet in memory/ tablet enable persistent index>
@@ -235,6 +236,7 @@ public class AgentTaskTest {
         Assert.assertEquals(TTaskType.CLONE, request4.getTask_type());
         Assert.assertEquals(cloneTask.getSignature(), request4.getSignature());
         Assert.assertNotNull(request4.getClone_req());
+        Assert.assertEquals(true, request4.getClone_req().isNeed_rebuild_pk_index());
 
         // modify enable_persistent_index
         TAgentTaskRequest request7 =

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -234,12 +234,14 @@ struct TCloneReq {
     10: optional i32 timeout_s
 
     30: optional bool is_local
+    31: optional bool need_rebuild_pk_index
 }
 
 struct TStorageMediumMigrateReq {
     1: required Types.TTabletId tablet_id
     2: required Types.TSchemaHash schema_hash
     3: required Types.TStorageMedium storage_medium
+    4: optional bool need_rebuild_pk_index
 }
 
 struct TCancelDeleteDataReq {


### PR DESCRIPTION
## Why I'm doing:
1. Clone only copies segment files.
2. After full clone is completed, the first ingestion will trigger persistent index rebuild of primary key tablet. If the data of  tablet is very large, the rebuild time may be long, which will cause `add_chunk` rpc timeout.

## What I'm doing:
1. Rebuild the persistent index of the tablet which has ingestion recently after full clone.
2. Only wait for a specific time to rebuild persistent index in `delta writer commit` to prevent rpc timeout.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
