### PR TITLE
[Enhancement] de-virtual for nullable multi_distinct_count aggregation

### DIFF
--- a/be/src/exprs/agg/distinct.h
+++ b/be/src/exprs/agg/distinct.h
@@ -357,9 +357,10 @@ struct DistinctAggregateStateV2<LT, SumLT, StringLTGuard<LT>> : public DistinctA
 template <LogicalType LT, LogicalType SumLT,
           template <LogicalType X, LogicalType Y, typename = guard::Guard> class TDistinctAggState,
           AggDistinctType DistinctType, typename T = RunTimeCppType<LT>>
-class TDistinctAggregateFunction : public AggregateFunctionBatchHelper<
-                                           TDistinctAggState<LT, SumLT>,
-                                           TDistinctAggregateFunction<LT, SumLT, TDistinctAggState, DistinctType, T>> {
+class TDistinctAggregateFunction final
+        : public AggregateFunctionBatchHelper<
+                  TDistinctAggState<LT, SumLT>,
+                  TDistinctAggregateFunction<LT, SumLT, TDistinctAggState, DistinctType, T>> {
 public:
     using ColumnType = RunTimeColumnType<LT>;
 
@@ -524,16 +525,16 @@ public:
 };
 
 template <LogicalType LT, AggDistinctType DistinctType, typename T = RunTimeCppType<LT>>
-class DistinctAggregateFunction final
-        : public TDistinctAggregateFunction<LT, SumResultLT<LT>, DistinctAggregateState, DistinctType, T> {};
+using DistinctAggregateFunction =
+        TDistinctAggregateFunction<LT, SumResultLT<LT>, DistinctAggregateState, DistinctType, T>;
 
 template <LogicalType LT, AggDistinctType DistinctType, typename T = RunTimeCppType<LT>>
-class DistinctAggregateFunctionV2 final
-        : public TDistinctAggregateFunction<LT, SumResultLT<LT>, DistinctAggregateStateV2, DistinctType, T> {};
+using DistinctAggregateFunctionV2 =
+        TDistinctAggregateFunction<LT, SumResultLT<LT>, DistinctAggregateStateV2, DistinctType, T>;
 
 template <LogicalType LT, AggDistinctType DistinctType, typename T = RunTimeCppType<LT>>
-class DecimalDistinctAggregateFunction final
-        : public TDistinctAggregateFunction<LT, TYPE_DECIMAL128, DistinctAggregateStateV2, DistinctType, T> {};
+using DecimalDistinctAggregateFunction =
+        TDistinctAggregateFunction<LT, TYPE_DECIMAL128, DistinctAggregateStateV2, DistinctType, T>;
 
 // now we only support String
 struct DictMergeState : DistinctAggregateStateV2<TYPE_VARCHAR, SumResultLT<TYPE_VARCHAR>> {

--- a/be/src/exprs/agg/factory/aggregate_factory.hpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.hpp
@@ -98,9 +98,9 @@ public:
     static AggregateFunctionPtr MakeCountAggregateFunction();
 
     template <LogicalType LT>
-    static AggregateFunctionPtr MakeCountDistinctAggregateFunction();
+    static auto MakeCountDistinctAggregateFunction();
     template <LogicalType LT>
-    static AggregateFunctionPtr MakeCountDistinctAggregateFunctionV2();
+    static auto MakeCountDistinctAggregateFunctionV2();
 
     template <LogicalType LT>
     static AggregateFunctionPtr MakeGroupConcatAggregateFunction();
@@ -286,12 +286,12 @@ AggregateFunctionPtr AggregateFactory::MakeWindowfunnelAggregateFunction() {
 }
 
 template <LogicalType LT>
-AggregateFunctionPtr AggregateFactory::MakeCountDistinctAggregateFunction() {
+auto AggregateFactory::MakeCountDistinctAggregateFunction() {
     return std::make_shared<DistinctAggregateFunction<LT, AggDistinctType::COUNT>>();
 }
 
 template <LogicalType LT>
-AggregateFunctionPtr AggregateFactory::MakeCountDistinctAggregateFunctionV2() {
+auto AggregateFactory::MakeCountDistinctAggregateFunctionV2() {
     return std::make_shared<DistinctAggregateFunctionV2<LT, AggDistinctType::COUNT>>();
 }
 


### PR DESCRIPTION
## Why I'm doing:



Recently, the `final` modifier was added to the class `DistinctAggregateFunctionV2`.

However, strangely, this caused TPC-DS 1T Q28 to regress from 4.3s to 4.5s.

The call chain for nullable multi_distinct_count is: 
- NullableAggregateFunctionUnary::update_batch 
- -> DistinctAggregateFunctionV2::update 
- -> DistinctAggregateStateV2::update 
- -> phmap::insert 
- -> phmap::EmplaceDecomposable

From the CPU perf results, the reason is that after adding `final`, `DistinctAggregateFunctionV2::update` did not fully inline `phmap::insert`.
- ​With `final`:
    - NullableAggregateFunctionUnary::update_batch -> DistinctAggregateFunctionV2::update -> **phmap::EmplaceDecomposable**
- ​Without final:
   - NullableAggregateFunctionUnary::update_batch -> DistinctAggregateFunctionV2::update


The root cause for the failure to inline has not been identified. I guess it might be that our code is too complex, triggering certain edge cases in the compiler.

To completely avoid this issue, make `NullableAggregateFunctionUnary` store `NestedFunctionPtr` as the actual `DistinctAggregateFunctionV2` instead of the base class `AggregateFunction`. ( by change `AggregateFunctionPtr MakeCountDistinctAggregateFunctionV2()` to `auto MakeCountDistinctAggregateFunctionV2()`)



CPU perf results with `final`:
```
   - 15.71% starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)                                                                                                                                                                                                                                                                                                                                                                                                  ▒
         - 9.95% starrocks::pipeline::AggregateBlockingSinkOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)                                                                                                                                                                                                                                                                                                                                         ▒
            - 9.84% starrocks::Aggregator::compute_single_agg_state(starrocks::Chunk*, unsigned long)                                                                                                                                                                                                                                                                                                                                                                                       ▒
               - 8.98% starrocks::NullableAggregateFunctionUnary<std::shared_ptr<starrocks::AggregateFunction>, starrocks::NullableAggregateFunctionState<starrocks::DistinctAggregateStateV2<(starrocks::LogicalType)11, (starrocks::LogicalType)11, int>, false>, false, true, starrocks::AggNonNullPred<starrocks::DistinctAggregateStateV2<(starrocks::LogicalType)11, (starrocks::LogicalType)11, int> > >::update_batch_single_state(starrocks::FunctionContext*, unsigned long, starr▒
                  - 8.31% starrocks::TDistinctAggregateFunction<(starrocks::LogicalType)11, (starrocks::LogicalType)11, starrocks::DistinctAggregateStateV2, (starrocks::AggDistinctType)0, double>::update(starrocks::FunctionContext*, starrocks::Column const**, unsigned char*, unsigned long) const                                                                                                                                                                                    ▒
                     - 5.66% std::pair<phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<double>, starrocks::StdHash<double>, phmap::EqualTo<double>, starrocks::AggregateStateAllocator<double> >::iterator, bool> phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<double>, starrocks::StdHash<double>, phmap::EqualTo<double>, starrocks::AggregateStateAllocator<double> >::EmplaceDecomposable::operator()<double, double const&>(double const&, double const&) const   ▒
                          5.24% std::pair<phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<double>, starrocks::StdHash<double>, phmap::EqualTo<double>, starrocks::AggregateStateAllocator<double> >::iterator, bool> phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<double>, starrocks::StdHash<double>, phmap::EqualTo<double>, starrocks::AggregateStateAllocator<double> >::EmplaceDecomposable::operator()<double, double const&>(double const&, double const&) const▒
                     - 2.54% starrocks::TDistinctAggregateFunction<(starrocks::LogicalType)11, (starrocks::LogicalType)11, starrocks::DistinctAggregateStateV2, (starrocks::AggDistinctType)0, double>::update(starrocks::FunctionContext*, starrocks::Column const**, unsigned char*, unsigned long) const                                                                                                                                                                                 ▒
                          std::pair<phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<double>, starrocks::StdHash<double>, phmap::EqualTo<double>, starrocks::AggregateStateAllocator<double> >::iterator, bool> phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<double>, starrocks::StdHash<double>, phmap::EqualTo<double>, starrocks::AggregateStateAllocator<double> >::EmplaceDecomposable::operator()<double, double const&>(double const&, double const&) const      ▒
                    0.66% starrocks::NullableAggregateFunctionUnary<std::shared_ptr<starrocks::AggregateFunction>, starrocks::NullableAggregateFunctionState<starrocks::DistinctAggregateStateV2<(starrocks::LogicalType)11, (starrocks::LogicalType)11, int>, false>, false, true, starrocks::AggNonNullPred<starrocks::DistinctAggregateStateV2<(starrocks::LogicalType)11, (starrocks::LogicalType)11, int> > >::update_batch_single_state(starrocks::FunctionContext*, unsigned long, st▒
         + 5.34% starrocks::pipeline::ProjectOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
```


CPU perf results without `final`:
```
      - 14.53% starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)                                                                                                                                                                                                                                                                                                                                                                                                  ▒
         - 8.57% starrocks::pipeline::AggregateBlockingSinkOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)                                                                                                                                                                                                                                                                                                                                         ▒
            - 8.45% starrocks::Aggregator::compute_single_agg_state(starrocks::Chunk*, unsigned long)                                                                                                                                                                                                                                                                                                                                                                                       ▒
               - 7.55% starrocks::NullableAggregateFunctionUnary<std::shared_ptr<starrocks::AggregateFunction>, starrocks::NullableAggregateFunctionState<starrocks::DistinctAggregateStateV2<(starrocks::LogicalType)11, (starrocks::LogicalType)11, int>, false>, false, true, starrocks::AggNonNullPred<starrocks::DistinctAggregateStateV2<(starrocks::LogicalType)11, (starrocks::LogicalType)11, int> > >::update_batch_single_state(starrocks::FunctionContext*, unsigned long, starr▒
                  - 5.69% starrocks::TDistinctAggregateFunction<(starrocks::LogicalType)11, (starrocks::LogicalType)11, starrocks::DistinctAggregateStateV2, (starrocks::AggDistinctType)0, double>::update(starrocks::FunctionContext*, starrocks::Column const**, unsigned char*, unsigned long) const                                                                                                                                                                                    ▒
                       5.34% starrocks::TDistinctAggregateFunction<(starrocks::LogicalType)11, (starrocks::LogicalType)11, starrocks::DistinctAggregateStateV2, (starrocks::AggDistinctType)0, double>::update(starrocks::FunctionContext*, starrocks::Column const**, unsigned char*, unsigned long) const                                                                                                                                                                                 ▒
                  - 1.86% starrocks::NullableAggregateFunctionUnary<std::shared_ptr<starrocks::AggregateFunction>, starrocks::NullableAggregateFunctionState<starrocks::DistinctAggregateStateV2<(starrocks::LogicalType)11, (starrocks::LogicalType)11, int>, false>, false, true, starrocks::AggNonNullPred<starrocks::DistinctAggregateStateV2<(starrocks::LogicalType)11, (starrocks::LogicalType)11, int> > >::update_batch_single_state(starrocks::FunctionContext*, unsigned long, st▒
                       starrocks::TDistinctAggregateFunction<(starrocks::LogicalType)11, (starrocks::LogicalType)11, starrocks::DistinctAggregateStateV2, (starrocks::AggDistinctType)0, double>::update(starrocks::FunctionContext*, starrocks::Column const**, unsigned char*, unsigned long) const                                                                                                                                                                                       ▒
               + 0.51% starrocks::NullableAggregateFunctionUnary<std::shared_ptr<starrocks::AvgAggregateFunction<(starrocks::LogicalType)11, double, (starrocks::LogicalType)11, double> >, starrocks::NullableAggregateFunctionState<starrocks::AvgAggregateState<double>, false>, false, true, starrocks::AggNonNullPred<starrocks::AvgAggregateState<double> > >::update_batch_single_state(starrocks::FunctionContext*, unsigned long, starrocks::Column const**, unsigned char*) const ▒
         + 5.55% starrocks::pipeline::ProjectOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
```



## What I'm doing:


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
