### PR TITLE
[Enhancement] support retry apply for primary key table

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -613,7 +613,7 @@ CONF_Int32(update_memory_limit_percent, "60");
 // Disable metadata cache when metadata_cache_memory_limit_percent <= 0.
 CONF_mInt32(metadata_cache_memory_limit_percent, "30"); // 30%
 
-// If enable_retry_apply is set to true, the system will attempt retries when apply fails. 
+// If enable_retry_apply is set to true, the system will attempt retries when apply fails.
 // Retry scenarios for apply operations include the following cases:
 //   1. ​Retry indefinitely for explicitly retryable errors (e.g., memory limits)
 // ​  2. No retry for explicitly non-retryable errors (e.g., Corruption) → Directly enter error state

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -617,7 +617,7 @@ CONF_mInt32(metadata_cache_memory_limit_percent, "30"); // 30%
 // the failed apply task will retry after `retry_apply_interval_second`
 CONF_mBool(enable_retry_apply, "true");
 CONF_mInt32(retry_apply_interval_second, "30");
-CONF_mInt32(max_apply_retry_times, "30");
+CONF_mInt32(retry_apply_timeout, "7200");
 
 // Update interval of tablet stat cache.
 CONF_mInt32(tablet_stat_cache_update_interval_second, "300");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -617,7 +617,7 @@ CONF_mInt32(metadata_cache_memory_limit_percent, "30"); // 30%
 // the failed apply task will retry after `retry_apply_interval_second`
 CONF_mBool(enable_retry_apply, "true");
 CONF_mInt32(retry_apply_interval_second, "30");
-CONF_mInt32(retry_apply_timeout, "7200");
+CONF_mInt32(retry_apply_timeout_second, "7200");
 
 // Update interval of tablet stat cache.
 CONF_mInt32(tablet_stat_cache_update_interval_second, "300");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -613,8 +613,11 @@ CONF_Int32(update_memory_limit_percent, "60");
 // Disable metadata cache when metadata_cache_memory_limit_percent <= 0.
 CONF_mInt32(metadata_cache_memory_limit_percent, "30"); // 30%
 
-// if `enable_retry_apply`, it apply failed due to some tolerable error(e.g. memory exceed limit)
-// the failed apply task will retry after `retry_apply_interval_second`
+// If enable_retry_apply is set to true, the system will attempt retries when apply fails. 
+// Retry scenarios for apply operations include the following cases:
+//   1. ​Retry indefinitely for explicitly retryable errors (e.g., memory limits)
+// ​  2. No retry for explicitly non-retryable errors (e.g., Corruption) → Directly enter error state
+// ​  3. Retry until timeout: If still failing after timeout duration → Enter error state
 CONF_mBool(enable_retry_apply, "true");
 CONF_mInt32(retry_apply_interval_second, "30");
 CONF_mInt32(retry_apply_timeout_second, "7200");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -617,6 +617,7 @@ CONF_mInt32(metadata_cache_memory_limit_percent, "30"); // 30%
 // the failed apply task will retry after `retry_apply_interval_second`
 CONF_mBool(enable_retry_apply, "true");
 CONF_mInt32(retry_apply_interval_second, "30");
+CONF_mInt32(max_apply_retry_times, "30");
 
 // Update interval of tablet stat cache.
 CONF_mInt32(tablet_stat_cache_update_interval_second, "300");

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1225,7 +1225,8 @@ Status TabletUpdates::_apply_column_partial_update_commit(const EditVersionInfo&
         _apply_version_changed.notify_all();
     }
 
-    WARN_IF_ERROR(index.on_commited(), "primary index on commited failed, tablet: " + _tablet.tablet_id());
+    WARN_IF_ERROR(index.on_commited(),
+                  fmt::format("primary index on commited failed, tablet: {}", _tablet.tablet_id()));
     _pk_index_write_amp_score.store(PersistentIndex::major_compaction_score(index_meta));
 
     _update_total_stats(version_info.rowsets, nullptr, nullptr);
@@ -1800,7 +1801,7 @@ Status TabletUpdates::_apply_normal_rowset_commit(const EditVersionInfo& version
         }
     }
     new_deletes.clear();
-    WARN_IF_ERROR(index.on_commited(), "primary index on_commit failed, tablet: " + _tablet.tablet_id());
+    WARN_IF_ERROR(index.on_commited(), fmt::format("primary index on_commit failed, tablet: {}", _tablet.tablet_id()));
     _pk_index_write_amp_score.store(PersistentIndex::major_compaction_score(*index_meta));
 
     // if `enable_persistent_index` of tablet is change(maybe changed by alter table)
@@ -2529,7 +2530,8 @@ Status TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_in
         _apply_version_changed.notify_all();
     }
 
-    WARN_IF_ERROR(index.on_commited(), "primary index on commited failed, tablet: " + _tablet.tablet_id());
+    WARN_IF_ERROR(index.on_commited(),
+                  fmt::format("primary index on commited failed, tablet: {}", _tablet.tablet_id()));
     _pk_index_write_amp_score.store(PersistentIndex::major_compaction_score(*index_meta));
 
     {

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -880,7 +880,7 @@ bool TabletUpdates::_check_status_msg(std::string_view msg) {
 
 bool TabletUpdates::_retry_times_limit() {
     const size_t base_interval = config::retry_apply_interval_second;
-    const size_t max_interval = 1800;
+    const size_t max_interval = 600;
     const size_t max_retries = max_interval / base_interval;
     const size_t failed_retries = _apply_failed_time;
 
@@ -1034,7 +1034,7 @@ void TabletUpdates::do_apply() {
         if (config::enable_retry_apply && _is_retryable(apply_st) && !apply_st.ok()) {
             //reset pk index, reset rowset_update_states, reset compaction_state
             _reset_apply_status(*version_info_apply);
-            size_t interval_seconds = std::min((size_t)1800, config::retry_apply_interval_second * _apply_failed_time);
+            size_t interval_seconds = std::min((size_t)600, config::retry_apply_interval_second * _apply_failed_time);
             auto time_point = std::chrono::steady_clock::now() + std::chrono::seconds(interval_seconds);
             StorageEngine::instance()->add_schedule_apply_task(_tablet.tablet_id(), time_point);
             std::string msg = strings::Substitute("apply tablet: $0 failed and retry later, status: $1",

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -893,7 +893,7 @@ bool TabletUpdates::_retry_times_limit() {
         total_duration = sum_base + (failed_retries - max_retries) * max_interval;
     }
 
-    return total_duration < config::retry_apply_timeout;
+    return total_duration < config::retry_apply_timeout_second;
 }
 
 bool TabletUpdates::_is_retryable(Status& status) {

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -526,6 +526,7 @@ private:
                                           vector<std::pair<uint32_t, DelVectorPtr>>* delvecs);
 
     bool _check_status_msg(std::string_view msg);
+    bool _retry_times_limit();
     bool _is_retryable(Status& status);
     bool _is_breakpoint(Status& status);
 

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -593,6 +593,7 @@ private:
     std::atomic<double> _pk_index_write_amp_score{0.0};
 
     std::atomic<bool> _apply_schedule{false};
+    size_t _apply_failed_time = 0;
 };
 
 } // namespace starrocks

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -3406,7 +3406,7 @@ TEST_F(TabletUpdatesTest, test_load_primary_index_failed) {
     ASSERT_EQ(N * 2, read_tablet(_tablet, rowsets.size() + 1));
 
     {
-        config::max_apply_retry_times = 0;
+        config::retry_apply_timeout = 0;
         _tablet->updates()->set_error("ut_test");
         ASSERT_TRUE(_tablet->updates()->is_error());
         config::enable_pindex_rebuild_in_compaction = false;
@@ -3422,7 +3422,7 @@ TEST_F(TabletUpdatesTest, test_load_primary_index_failed) {
     }
 
     {
-        config::max_apply_retry_times = 1;
+        config::retry_apply_timeout = 3600;
         config::retry_apply_interval_second = 1;
         _tablet->updates()->reset_error();
         _tablet->updates()->check_for_apply();
@@ -3557,7 +3557,7 @@ TEST_F(TabletUpdatesTest, test_alter_state_not_correct) {
 
 TEST_F(TabletUpdatesTest, test_normal_apply_retry) {
     config::retry_apply_interval_second = 1;
-    config::max_apply_retry_times = 0;
+    config::retry_apply_timeout = 0;
     _tablet = create_tablet(rand(), rand());
     _tablet->updates()->stop_compaction(true);
     _tablet->set_enable_persistent_index(true);
@@ -3662,7 +3662,7 @@ TEST_F(TabletUpdatesTest, test_normal_apply_retry) {
         fp->setMode(trigger_mode);
 
         auto old_val = config::retry_apply_interval_second;
-        config::retry_apply_interval_second = 2;
+        config::retry_apply_timeout = 3600;
         // Create and commit rowset
         auto rs = create_rowset(_tablet, keys, &deletes);
         ASSERT_TRUE(_tablet->rowset_commit(16, rs).ok());
@@ -3681,6 +3681,7 @@ TEST_F(TabletUpdatesTest, test_normal_apply_retry) {
         config::retry_apply_interval_second = old_val;
     }
 
+    config::retry_apply_timeout = 0;
     // 16. write tablet meta failed
     test_fail_point("tablet_meta_manager_apply_rowset_manager_internal_error", 17, N / 2);
 
@@ -3720,7 +3721,7 @@ TEST_F(TabletUpdatesTest, test_normal_apply_retry) {
     // 20. delvec inconsistent
     {
         // Enable fail point
-        config::max_apply_retry_times = 30;
+        config::retry_apply_timeout = 3600;
         trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);
         auto fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get("tablet_apply_cache_del_vec_failed");
         fp->setMode(trigger_mode);
@@ -3741,7 +3742,7 @@ TEST_F(TabletUpdatesTest, test_normal_apply_retry) {
 
 TEST_F(TabletUpdatesTest, test_compaction_apply_retry) {
     config::retry_apply_interval_second = 1;
-    config::max_apply_retry_times = 1;
+    config::retry_apply_timeout = 0;
     _tablet = create_tablet(rand(), rand());
     _tablet->set_enable_persistent_index(true);
     _tablet->updates()->stop_compaction(true);
@@ -3757,7 +3758,6 @@ TEST_F(TabletUpdatesTest, test_compaction_apply_retry) {
     ASSERT_EQ(N, read_tablet(_tablet, 3));
 
     // 1. load index failed
-    config::max_apply_retry_times = 0;
     PFailPointTriggerMode trigger_mode;
     trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);
     std::string fp_name = "tablet_apply_load_index_failed";
@@ -3823,7 +3823,7 @@ TEST_F(TabletUpdatesTest, test_compaction_apply_retry) {
     // 10. write meta failed
     test_fail_point("tablet_apply_index_commit_failed", "tablet_meta_manager_apply_rowset_manager_internal_error");
 
-    config::max_apply_retry_times = 1;
+    config::retry_apply_timeout = 0;
     // 11. cache del vec failed
     trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);
     fp_name = "tablet_meta_manager_apply_rowset_manager_fake_ok";

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -3406,7 +3406,7 @@ TEST_F(TabletUpdatesTest, test_load_primary_index_failed) {
     ASSERT_EQ(N * 2, read_tablet(_tablet, rowsets.size() + 1));
 
     {
-        config::retry_apply_timeout = 0;
+        config::retry_apply_timeout_second = 0;
         _tablet->updates()->set_error("ut_test");
         ASSERT_TRUE(_tablet->updates()->is_error());
         config::enable_pindex_rebuild_in_compaction = false;
@@ -3422,7 +3422,7 @@ TEST_F(TabletUpdatesTest, test_load_primary_index_failed) {
     }
 
     {
-        config::retry_apply_timeout = 3600;
+        config::retry_apply_timeout_second = 3600;
         config::retry_apply_interval_second = 1;
         _tablet->updates()->reset_error();
         _tablet->updates()->check_for_apply();
@@ -3557,7 +3557,7 @@ TEST_F(TabletUpdatesTest, test_alter_state_not_correct) {
 
 TEST_F(TabletUpdatesTest, test_normal_apply_retry) {
     config::retry_apply_interval_second = 1;
-    config::retry_apply_timeout = 0;
+    config::retry_apply_timeout_second = 0;
     _tablet = create_tablet(rand(), rand());
     _tablet->updates()->stop_compaction(true);
     _tablet->set_enable_persistent_index(true);
@@ -3662,7 +3662,7 @@ TEST_F(TabletUpdatesTest, test_normal_apply_retry) {
         fp->setMode(trigger_mode);
 
         auto old_val = config::retry_apply_interval_second;
-        config::retry_apply_timeout = 3600;
+        config::retry_apply_timeout_second = 3600;
         // Create and commit rowset
         auto rs = create_rowset(_tablet, keys, &deletes);
         ASSERT_TRUE(_tablet->rowset_commit(16, rs).ok());
@@ -3681,7 +3681,7 @@ TEST_F(TabletUpdatesTest, test_normal_apply_retry) {
         config::retry_apply_interval_second = old_val;
     }
 
-    config::retry_apply_timeout = 0;
+    config::retry_apply_timeout_second = 0;
     // 16. write tablet meta failed
     test_fail_point("tablet_meta_manager_apply_rowset_manager_internal_error", 17, N / 2);
 
@@ -3721,7 +3721,7 @@ TEST_F(TabletUpdatesTest, test_normal_apply_retry) {
     // 20. delvec inconsistent
     {
         // Enable fail point
-        config::retry_apply_timeout = 3600;
+        config::retry_apply_timeout_second = 3600;
         trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);
         auto fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get("tablet_apply_cache_del_vec_failed");
         fp->setMode(trigger_mode);
@@ -3742,7 +3742,7 @@ TEST_F(TabletUpdatesTest, test_normal_apply_retry) {
 
 TEST_F(TabletUpdatesTest, test_compaction_apply_retry) {
     config::retry_apply_interval_second = 1;
-    config::retry_apply_timeout = 0;
+    config::retry_apply_timeout_second = 0;
     _tablet = create_tablet(rand(), rand());
     _tablet->set_enable_persistent_index(true);
     _tablet->updates()->stop_compaction(true);
@@ -3823,7 +3823,7 @@ TEST_F(TabletUpdatesTest, test_compaction_apply_retry) {
     // 10. write meta failed
     test_fail_point("tablet_apply_index_commit_failed", "tablet_meta_manager_apply_rowset_manager_internal_error");
 
-    config::retry_apply_timeout = 0;
+    config::retry_apply_timeout_second = 0;
     // 11. cache del vec failed
     trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);
     fp_name = "tablet_meta_manager_apply_rowset_manager_fake_ok";


### PR DESCRIPTION
## Why I'm doing:
The PK table apply retry feature was previously supported only for memory shortage cases(https://github.com/StarRocks/starrocks/pull/47144).  But the tablet will enter error state if meets other exceptions(e.g. the disk is full) and can't recover automatic.


## What I'm doing:
This pr support retry apply for more exceptions and the tablet will enter error state in the following two scenarios:
1. The corruption exception is thrown.
2. Retry too many times but still failed.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
