### PR TITLE
[Enhancement] reduce flat json path memory use

### DIFF
--- a/be/src/util/json_flattener.h
+++ b/be/src/util/json_flattener.h
@@ -139,6 +139,9 @@ private:
 
     void _visit_json_paths(const vpack::Slice& value, JsonFlatPath* root, size_t mark_row);
 
+    // clean sparsity path, to save memory
+    void _clean_sparsity_path(JsonFlatPath* root, size_t check_hits_min);
+
 private:
     struct JsonFlatDesc {
         // json compatible type


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Check the hit rate of flat JSON in advance and release the memory usage of JSON paths early.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
