### PR TITLE
[BugFix] null_column must be cloned to avoid being abused by multiple nullable columns in FunctionHelper::union_nullable_column

### DIFF
--- a/be/src/exprs/function_helper.cpp
+++ b/be/src/exprs/function_helper.cpp
@@ -27,18 +27,16 @@ NullColumn::MutablePtr FunctionHelper::union_nullable_column(const ColumnPtr& v1
         const auto& n1 = ColumnHelper::as_raw_column<NullableColumn>(v1)->null_column();
         const auto& n2 = ColumnHelper::as_raw_column<NullableColumn>(v2)->null_column();
         if (!v1->has_null()) {
-            result = (std::move(*n2)).mutate();
+            result = n2->clone();
         }
         if (!v2->has_null()) {
-            result = (std::move(*n1)).mutate();
+            result = n1->clone();
         }
         return union_null_column(n1, n2);
     } else if (v1->is_nullable()) {
-        auto& v1_null = ColumnHelper::as_raw_column<NullableColumn>(v1)->null_column();
-        result = (std::move(*v1_null)).mutate();
+        result = ColumnHelper::as_raw_column<NullableColumn>(v1)->null_column()->clone();
     } else if (v2->is_nullable()) {
-        auto& v2_null = ColumnHelper::as_raw_column<NullableColumn>(v2)->null_column();
-        result = (std::move(*v2_null)).mutate();
+        result = ColumnHelper::as_raw_column<NullableColumn>(v2)->null_column()->clone();
     } else {
         return nullptr;
     }
@@ -152,7 +150,7 @@ ColumnPtr FunctionHelper::merge_column_and_null_column(ColumnPtr&& column, NullC
     } else if (column->is_constant()) {
         auto* const_column = down_cast<ConstColumn*>(column.get());
         const auto& data_column = const_column->data_column();
-        auto new_data_column = (std::move(*data_column)).mutate();
+        auto new_data_column = data_column->clone();
         new_data_column->assign(null_column->size(), 0);
         return NullableColumn::create(std::move(new_data_column), std::move(null_column));
     } else if (column->is_nullable()) {


### PR DESCRIPTION
## Why I'm doing:
Fix https://github.com/StarRocks/StarRocksTest/issues/9461, caused by #56662.  

FunctionHelper::union_nullable_column is changed wrongly, so revert it
```cpp
diff --git a/be/src/exprs/function_helper.cpp b/be/src/exprs/function_helper.cpp
index 14d1d7ca4d3..ab1dbd9e11b 100644
--- a/be/src/exprs/function_helper.cpp
+++ b/be/src/exprs/function_helper.cpp
@@ -34,9 +34,9 @@ NullColumn::MutablePtr FunctionHelper::union_nullable_column(const ColumnPtr& v1
         }
         return union_null_column(n1, n2);
     } else if (v1->is_nullable()) {
-        result = ColumnHelper::as_raw_column<NullableColumn>(v1)->null_column()->clone();
+        return ColumnHelper::as_raw_column<NullableColumn>(v1)->null_column()->clone();
     } else if (v2->is_nullable()) {
-        result = ColumnHelper::as_raw_column<NullableColumn>(v2)->null_column()->clone();
+        return ColumnHelper::as_raw_column<NullableColumn>(v2)->null_column()->clone();
     } else {
         return nullptr;
     }
@@ -150,7 +150,7 @@ ColumnPtr FunctionHelper::merge_column_and_null_column(ColumnPtr&& column, NullC
     } else if (column->is_constant()) {
         auto* const_column = down_cast<ConstColumn*>(column.get());
         const auto& data_column = const_column->data_column();
-        auto new_data_column = data_column->clone();
+        auto new_data_column = (std::move(*data_column)).mutate();
         new_data_column->assign(null_column->size(), 0);
         return NullableColumn::create(std::move(new_data_column), std::move(null_column));
     } else if (column->is_nullable()) {

```

when executing tpcds query47, the plan contains CSE in SelectOperator.

```
|   23:SELECT                                                                                                                                                                                                                                               |
|   |  predicates: (((435: expr) AND (105: rank() - 1 IS NOT NULL)) OR ((435: expr) AND (105: rank() + 1 IS NOT NULL))) OR (((52: d_year = 1999) AND (432: expr)) AND (if(432: expr, abs(103: sum - 104: avg(103: sum)) / 104: avg(103: sum), NULL) > 0.1)) |
|   |    common sub expr:                                                                                                                                                                                                                                   |
|   |    <slot 432> : 104: avg(103: sum) > 0                                                                                                                                                                                                                |
|   |    <slot 433> : (428: expr) AND (429: expr)                                                                                                                                                                                                           |
|   |    <slot 434> : (430: expr) AND (431: expr)                                                                                                                                                                                                           |
|   |    <slot 435> : (433: expr) AND (434: expr)                                                                                                                                                                                                           |
|   |    <slot 428> : 13: i_category IS NOT NULL                                                                                                                                                                                                            |
|   |    <slot 429> : 9: i_brand IS NOT NULL                                                                                                                                                                                                                |
|   |    <slot 430> : 79: s_store_name IS NOT NULL                                                                                                                                                                                                          |
|   |    <slot 431> : 91: s_company_name IS NOT NULL   
```

slot#104 and slot#432 both reside in the chunk and slot#432 is depend on slot#104, when evaluating BinaryPredicateExpr slot#104>0, it happens that the result column(i.e. slot#432) abuses the slot#104 column's null_column. later then Chunk::filter to compact the retaining rows, null column would be compacted twice,  sizes of data_column and null_column in the second nullable column are not equal, so DCHECK fails and be crashed in ASAN/DEBUG build.



## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
