### PR TITLE
[Enhancement] enable shared scan when doing insert

### DIFF
--- a/be/src/connector/file_connector.cpp
+++ b/be/src/connector/file_connector.cpp
@@ -155,7 +155,8 @@ Status FileDataSource::get_next(RuntimeState* state, ChunkPtr* chunk) {
 }
 
 const std::string FileDataSource::get_custom_coredump_msg() const {
-    return strings::Substitute("Load file path: $0", _scan_range.ranges[0].path);
+    return strings::Substitute("Load file path: $0",
+                               _scan_range.ranges.empty() ? "<null>" : _scan_range.ranges[0].path);
 }
 
 int64_t FileDataSource::raw_rows_read() const {

--- a/be/src/exec/scan_node.cpp
+++ b/be/src/exec/scan_node.cpp
@@ -129,7 +129,7 @@ StatusOr<pipeline::MorselQueueFactoryPtr> ScanNode::convert_scan_range_to_morsel
         const std::map<int32_t, std::vector<TScanRangeParams>>& scan_ranges_per_driver_seq, int node_id,
         int pipeline_dop, bool in_colocate_exec_group, bool enable_tablet_internal_parallel,
         TTabletInternalParallelMode::type tablet_internal_parallel_mode, bool enable_shared_scan) {
-    if (scan_ranges_per_driver_seq.empty() && !in_colocate_exec_group) {
+    if ((scan_ranges_per_driver_seq.empty() && !in_colocate_exec_group) || always_shared_scan()) {
         ASSIGN_OR_RETURN(auto morsel_queue,
                          convert_scan_range_to_morsel_queue(global_scan_ranges, node_id, pipeline_dop,
                                                             enable_tablet_internal_parallel,


### PR DESCRIPTION
## Why I'm doing:

https://github.com/StarRocks/starrocks/pull/12070

In this pr, for insert SQL stmt, it forces to use "scan rangers per driver seq"

```
                if (targetTable instanceof OlapTable) {
                    sinkFragment.setHasOlapTableSink();
                    sinkFragment.setForceAssignScanRangesPerDriverSeq();
```

And in backend code, if set "scan ranges per drive seq", then backend can not use shared scan any more.

But for external table, there is no sense of "scan ranges per drive seq" at all.  So for scan node which has property of "always shared scan",  we still use shared scan.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
