### PR TITLE
[BugFix] avoid list objects when reporting tablet row count after partition first load

### DIFF
--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -46,7 +46,7 @@ message PublishVersionResponse {
     map<int64, double> compaction_scores = 2;
     optional StatusPB status = 3;
     // Mapping from tablet id to row_nums when the partition is first imported
-    map<int64, uint64> tablet_row_nums = 4;
+    map<int64, int64> tablet_row_nums = 4;
 }
 
 message AbortTxnRequest {


### PR DESCRIPTION

## Why I'm doing:

## What I'm doing:
fix LakeServiceTest.test_publish_version_for_schema_change
![image](https://github.com/user-attachments/assets/f2d6d381-e6e4-420d-bfa0-4dbbdd3c46cf)

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
