### PR TITLE
[Enhancement] Avoid useless get object api call in get tablet medata for shared-data cluster

### DIFF
--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -315,17 +315,22 @@ TabletMetadataPtr TabletManager::get_latest_cached_tablet_metadata(int64_t table
 StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(int64_t tablet_id, int64_t version, bool fill_cache,
                                                                int64_t expected_gtid,
                                                                const std::shared_ptr<FileSystem>& fs) {
-    if (version <= kInitialVersion) {
-        // Handle tablet initial metadata
-        auto initial_metadata =
-                get_tablet_metadata(tablet_initial_metadata_location(tablet_id), fill_cache, expected_gtid, fs);
-        if (initial_metadata.ok()) {
-            auto tablet_metadata = std::make_shared<TabletMetadata>(*initial_metadata.value());
-            tablet_metadata->set_id(tablet_id);
-            return tablet_metadata;
-        }
+    auto tablet_metadata_or =
+            get_tablet_metadata(tablet_metadata_location(tablet_id, version), fill_cache, expected_gtid, fs);
+    if (!tablet_metadata_or.status().is_not_found() || version > kInitialVersion) {
+        return tablet_metadata_or;
     }
-    return get_tablet_metadata(tablet_metadata_location(tablet_id, version), fill_cache, expected_gtid, fs);
+
+    // Handle tablet initial metadata
+    auto initial_metadata_or =
+            get_tablet_metadata(tablet_initial_metadata_location(tablet_id), fill_cache, expected_gtid, fs);
+    if (!initial_metadata_or.ok()) {
+        return tablet_metadata_or;
+    }
+
+    auto tablet_metadata = std::make_shared<TabletMetadata>(*initial_metadata_or.value());
+    tablet_metadata->set_id(tablet_id);
+    return tablet_metadata;
 }
 
 StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(const string& path, bool fill_cache,


### PR DESCRIPTION
## Why I'm doing:
There may useless get object api call in get tablet medata for shared-data cluster.

## What I'm doing:
Avoid useless get object api call in get tablet medata for shared-data cluster.
We wll update the code again when the optimize feature turned on by default.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
