### PR TITLE
[Enhancement] Only clear mv's metadata in schema changing

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -223,7 +223,6 @@ public class AlterJobMgr {
             List<BaseTableInfo> baseTableInfos =
                     Lists.newArrayList(MaterializedViewAnalyzer.getBaseTableInfos(mvQueryStatement, !isReplay));
             materializedView.setBaseTableInfos(baseTableInfos);
-            materializedView.getRefreshScheme().getAsyncRefreshContext().clearVisibleVersionMap();
             materializedView.onReload();
             materializedView.setActive();
         } else if (AlterMaterializedViewStatusClause.INACTIVE.equalsIgnoreCase(status)) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -457,7 +457,7 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
                 // for manual refresh type, do not refresh
                 if (materializedView.getRefreshScheme().getType() != MaterializedView.RefreshType.MANUAL) {
                     GlobalStateMgr.getCurrentState().getLocalMetastore()
-                            .refreshMaterializedView(dbName, materializedView.getName(), true, null,
+                            .refreshMaterializedView(dbName, materializedView.getName(), false, null,
                                     Constants.TaskRunPriority.NORMAL.value(), true, false);
                 }
             } else if (AlterMaterializedViewStatusClause.INACTIVE.equalsIgnoreCase(status)) {
@@ -611,6 +611,9 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
                 if (mv.getColumns().stream().anyMatch(x -> modifiedColumns.contains(x.getName()))) {
                     doInactiveMaterializedView(mv, reason);
                 }
+            } finally {
+                // clear version map to make sure the MV will be refreshed
+                mv.getRefreshScheme().getAsyncRefreshContext().clearVisibleVersionMap();
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -832,6 +832,8 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
                             mvColumn.getName(), tbl.getName());
                     mv.setInactiveAndReason(
                             MaterializedViewExceptions.inactiveReasonForColumnChanged(modifiedColumns));
+                    // clear version map to make sure the MV will be refreshed
+                    mv.getRefreshScheme().getAsyncRefreshContext().clearVisibleVersionMap();
                     return;
                 }
             }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
@@ -17,8 +17,12 @@ package com.starrocks.analysis;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.starrocks.alter.AlterJobMgr;
+import com.starrocks.alter.AlterMVJobExecutor;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.qe.ConnectContext;
@@ -39,7 +43,10 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
+
+import static com.starrocks.analysis.CreateSyncMaterializedViewTest.executeInsertSql;
 
 public class AlterMaterializedViewTest {
     private static ConnectContext connectContext;
@@ -181,6 +188,110 @@ public class AlterMaterializedViewTest {
                     (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(alterMvSql, connectContext);
             Assert.assertThrows(SemanticException.class, () -> currentState.getLocalMetastore().alterMaterializedView(stmt));
         }
+    }
+
+
+    @Test
+    public void testInactiveMV() throws Exception {
+
+        starRocksAssert
+                .withTable("CREATE TABLE IF NOT EXISTS par_tbl1\n" +
+                        "(\n" +
+                        "    datekey DATETIME,\n" +
+                        "    item_id STRING,\n" +
+                        "    v1      INT\n" +
+                        ")PRIMARY KEY (`datekey`,`item_id`)\n" +
+                        "    PARTITION BY date_trunc('day', `datekey`);");
+        executeInsertSql(connectContext, "INSERT INTO par_tbl1 values ('2025-01-01', '1', 1);");
+        executeInsertSql(connectContext, "INSERT INTO par_tbl1 values ('2025-01-02', '1', 1);");
+
+        starRocksAssert
+                .withTable("CREATE TABLE IF NOT EXISTS par_tbl2\n" +
+                        "(\n" +
+                        "    datekey DATETIME,\n" +
+                        "    item_id STRING,\n" +
+                        "    v1      INT\n" +
+                        ")PRIMARY KEY (`datekey`,`item_id`)\n" +
+                        "    PARTITION BY date_trunc('day', `datekey`);");
+        executeInsertSql(connectContext, "INSERT INTO par_tbl2 values ('2025-01-01', '1', 2);");
+        executeInsertSql(connectContext, "INSERT INTO par_tbl2 values ('2025-01-02', '1', 1);");
+
+        starRocksAssert
+                .withTable("CREATE TABLE IF NOT EXISTS dim_data\n" +
+                        "(\n" +
+                        "    item_id STRING,\n" +
+                        "    v1 INT\n" +
+                        ")PRIMARY KEY (`item_id`);");
+        executeInsertSql(connectContext, "INSERT INTO dim_data values ('1', 4);");
+
+        starRocksAssert
+                .withMaterializedView("CREATE\n" +
+                        "MATERIALIZED VIEW mv_dim_data1\n" +
+                        "REFRESH ASYNC EVERY(INTERVAL 60 MINUTE)\n" +
+                        "AS\n" +
+                        "select *\n" +
+                        "from dim_data;");
+
+        starRocksAssert
+                .withMaterializedView("CREATE\n" +
+                        "MATERIALIZED VIEW mv_test1\n" +
+                        "REFRESH ASYNC EVERY(INTERVAL 60 MINUTE)\n" +
+                        "PARTITION BY p_time\n" +
+                        "PROPERTIES (\n" +
+                        "\"excluded_trigger_tables\" = \"mv_dim_data1\",\n" +
+                        "\"excluded_refresh_tables\" = \"mv_dim_data1\",\n" +
+                        "\"partition_refresh_number\" = \"1\"\n" +
+                        ")\n" +
+                        "AS\n" +
+                        "select date_trunc(\"day\", a.datekey) as p_time, sum(a.v1) + sum(b.v1) as v1\n" +
+                        "from par_tbl1 a\n" +
+                        "         left join par_tbl2 b on a.datekey = b.datekey and a.item_id = b.item_id\n" +
+                        "         left join mv_dim_data1 d on a.item_id = d.item_id\n" +
+                        "group by date_trunc(\"day\", a.datekey), a.item_id;");
+
+        starRocksAssert.refreshMV("refresh materialized view mv_test1");
+        MaterializedView mv = (MaterializedView) starRocksAssert.getTable(connectContext.getDatabase(), "mv_test1");
+        Assert.assertTrue(starRocksAssert.waitRefreshFinished(mv.getId()));
+
+        Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap =
+                mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
+        Assert.assertTrue(!baseTableVisibleVersionMap.isEmpty());
+
+        String alterMvSql = "alter materialized view mv_test1 INACTIVE";
+        AlterMaterializedViewStmt stmt =
+                (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(alterMvSql, connectContext);
+        currentState.getLocalMetastore().alterMaterializedView(stmt);
+        Assert.assertFalse(mv.isActive());
+
+        alterMvSql = "alter materialized view mv_test1 ACTIVE";
+        stmt = (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(alterMvSql, connectContext);
+        currentState.getLocalMetastore().alterMaterializedView(stmt);
+        Assert.assertTrue(starRocksAssert.waitRefreshFinished(mv.getId()));
+        Assert.assertTrue(mv.isActive());
+        baseTableVisibleVersionMap =
+                mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
+        Assert.assertTrue(!baseTableVisibleVersionMap.isEmpty());
+
+        alterMvSql = "alter materialized view mv_test1 INACTIVE";
+        stmt = (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(alterMvSql, connectContext);
+        currentState.getLocalMetastore().alterMaterializedView(stmt);
+        Assert.assertFalse(mv.isActive());
+
+        alterMvSql = "alter materialized view mv_test1 ACTIVE";
+        stmt = (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(alterMvSql, connectContext);
+        currentState.getLocalMetastore().alterMaterializedView(stmt);
+        Assert.assertTrue(starRocksAssert.waitRefreshFinished(mv.getId()));
+        Assert.assertTrue(mv.isActive());
+        // Don't refresh base table version map
+        baseTableVisibleVersionMap = mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
+        Assert.assertTrue(!baseTableVisibleVersionMap.isEmpty());
+
+        // inactive mv when base table's schema changed
+        Database db = starRocksAssert.getDb(connectContext.getDatabase());
+        Table parTbl1 = starRocksAssert.getTable(connectContext.getDatabase(), "par_tbl1");
+        AlterMVJobExecutor.inactiveRelatedMaterializedViews(db, (OlapTable) parTbl1, Set.of("item_id"));
+        baseTableVisibleVersionMap = mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
+        Assert.assertTrue(baseTableVisibleVersionMap.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

When an `MV` is changed from `inactive` to `active`, it triggers a refresh of all partitions, which is a resource-intensive process. Therefore, we would like to add an option to control whether all partitions need to be refreshed.


## What I'm doing:

- Clear the version map only during schema changes.
- When the MV is set to `ACTIVE` manually, it will not be `forced` to refresh.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0