### PR TITLE
[Enhancement] Refactoring to extract authentication logical from Mysql negotiate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationHandler.java
@@ -120,8 +120,8 @@ public class AuthenticationHandler {
             context.setCurrentRoleIds(authenticatedUser);
             context.setAuthDataSalt(randomString);
 
-            UserProperty userProperty = context.getGlobalStateMgr().getAuthenticationMgr()
-                    .getUserProperty(authenticatedUser.getUser());
+            UserProperty userProperty =
+                    GlobalStateMgr.getCurrentState().getAuthenticationMgr().getUserProperty(authenticatedUser.getUser());
             context.updateByUserProperty(userProperty);
         }
         context.setQualifiedUser(user);

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationHandler.java
@@ -119,6 +119,10 @@ public class AuthenticationHandler {
         if (!authenticatedUser.isEphemeral()) {
             context.setCurrentRoleIds(authenticatedUser);
             context.setAuthDataSalt(randomString);
+
+            UserProperty userProperty = context.getGlobalStateMgr().getAuthenticationMgr()
+                    .getUserProperty(authenticatedUser.getUser());
+            context.updateByUserProperty(userProperty);
         }
         context.setQualifiedUser(user);
 

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationMgr.java
@@ -163,21 +163,6 @@ public class AuthenticationMgr {
     }
 
     /**
-     * Get max connection number of the user, if the user is ephemeral, i.e. the user is saved in SR,
-     * but some external system, like LDAP, return default max connection number
-     * @param currUserIdentity user identity of current connection
-     * @return max connection number of the user
-     */
-    public long getMaxConn(UserIdentity currUserIdentity) {
-        if (currUserIdentity.isEphemeral()) {
-            return DEFAULT_MAX_CONNECTION_FOR_EXTERNAL_USER;
-        } else {
-            String userName = currUserIdentity.getUser();
-            return getMaxConn(userName);
-        }
-    }
-
-    /**
      * Get max connection number based on plain username, the user should be an internal user,
      * if the user doesn't exist in SR, it will throw an exception.
      * @param userName plain username saved in SR
@@ -186,7 +171,7 @@ public class AuthenticationMgr {
     public long getMaxConn(String userName) {
         UserProperty userProperty = userNameToProperty.get(userName);
         if (userProperty == null) {
-            throw new SemanticException("Unknown user: " + userName);
+            return DEFAULT_MAX_CONNECTION_FOR_EXTERNAL_USER;
         } else {
             return userNameToProperty.get(userName).getMaxConn();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlAuthPacket.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlAuthPacket.java
@@ -49,6 +49,7 @@ public class MysqlAuthPacket extends MysqlPacket {
     private String pluginName;
     private MysqlCapability capability;
     private Map<String, String> connectAttributes;
+    private byte[] randomString;
 
     public String getUser() {
         return userName;
@@ -84,6 +85,14 @@ public class MysqlAuthPacket extends MysqlPacket {
 
     public Map<String, String> getConnectAttributes() {
         return connectAttributes;
+    }
+
+    public void setRandomString(byte[] randomString) {
+        this.randomString = randomString;
+    }
+
+    public byte[] getRandomString() {
+        return randomString;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlPassword.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlPassword.java
@@ -108,7 +108,7 @@ public class MysqlPassword {
     }
 
     // Check that scrambled message corresponds to the password; the function
-    // is used by server to check that recieved reply is authentic.
+    // is used by server to check that received reply is authentic.
     // This function does not check lengths of given strings: message must be
     // null-terminated, reply and hash_stage2 must be at least SHA1_HASH_SIZE
     // long (if not, something fishy is going on).

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
@@ -140,10 +140,9 @@ public class ConnectScheduler {
             AtomicInteger currentConnAtomic = connCountByUser.get(ctx.getQualifiedUser());
             int currentConn = currentConnAtomic.get();
             long currentUserMaxConn =
-                    ctx.getGlobalStateMgr().getAuthenticationMgr().getMaxConn(ctx.getCurrentUserIdentity());
+                    ctx.getGlobalStateMgr().getAuthenticationMgr().getMaxConn(ctx.getQualifiedUser());
             if (currentConn >= currentUserMaxConn) {
-                String userErrMsg = "Reach user-level(qualifiedUser: " + ctx.getQualifiedUser() +
-                        ", currUserIdentity: " + ctx.getCurrentUserIdentity() + ") connection limit, " +
+                String userErrMsg = "Reach user-level(qualifiedUser: " + ctx.getQualifiedUser() + ") connection limit, " +
                         "currentUserMaxConn=" + currentUserMaxConn + ", connectionMap.size=" + connectionMap.size() +
                         ", connByUser.totConn=" + connCountByUser.values().stream().mapToInt(AtomicInteger::get).sum() +
                         ", user.currConn=" + currentConn +

--- a/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
@@ -219,6 +219,9 @@ public class NodeMgr {
     }
 
     public Frontend getFrontend(Integer frontendId) {
+        if (frontendId == 0) {
+            return getMySelf();
+        }
         return frontendIds.get(frontendId);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SecurityIntegrationStatementAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SecurityIntegrationStatementAnalyzer.java
@@ -57,7 +57,7 @@ public class SecurityIntegrationStatementAnalyzer {
             Preconditions.checkNotNull(securityIntegration);
             securityIntegration.checkProperty();
 
-            AuthenticationMgr authenticationMgr = GlobalStateMgr.getServingState().getAuthenticationMgr();
+            AuthenticationMgr authenticationMgr = GlobalStateMgr.getCurrentState().getAuthenticationMgr();
             if (authenticationMgr.getSecurityIntegration(statement.getName()) != null) {
                 throw new SemanticException("security integration '" + statement.getName() + "' already exists");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/integration/ShowCreateSecurityIntegrationStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/integration/ShowCreateSecurityIntegrationStatement.java
@@ -28,7 +28,7 @@ public class ShowCreateSecurityIntegrationStatement extends ShowStmt {
                     .addColumn(new Column("Create Security Integration", ScalarType.createVarchar(500)))
                     .build();
 
-    private String name;
+    private final String name;
 
     public ShowCreateSecurityIntegrationStatement(String name, NodePosition pos) {
         super(pos);
@@ -37,10 +37,6 @@ public class ShowCreateSecurityIntegrationStatement extends ShowStmt {
 
     public String getName() {
         return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/AuthenticationManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/AuthenticationManagerTest.java
@@ -26,7 +26,6 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.qe.SetDefaultRoleExecutor;
 import com.starrocks.server.CatalogMgr;
-import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AlterUserStmt;
 import com.starrocks.sql.ast.CreateCatalogStmt;
 import com.starrocks.sql.ast.CreateRoleStmt;
@@ -380,8 +379,7 @@ public class AuthenticationManagerTest {
         DDLStmtExecutor.execute(dropStmt, ctx);
         Assert.assertFalse(manager.doesUserExist(testUserWithIp));
 
-        // can't get max connection after all test user are dropped
-        Assert.assertThrows(SemanticException.class, () -> manager.getMaxConn("test"));
+        Assert.assertEquals(AuthenticationMgr.DEFAULT_MAX_CONNECTION_FOR_EXTERNAL_USER, manager.getMaxConn("test"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlAuthPacketTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlAuthPacketTest.java
@@ -149,8 +149,7 @@ public class MysqlAuthPacketTest {
 
         MysqlAuthPacket authPacket = buildPacket("harbor");
         ConnectContext context = new ConnectContext();
-        byte[] randomString = MysqlPassword.createRandomString();
-        MysqlProto.switchAuthPlugin(authPacket, context, randomString);
+        MysqlProto.switchAuthPlugin(authPacket, context);
         Assert.assertEquals("authentication_openid_connect_client", authPacket.getPluginName());
 
         //test security integration
@@ -164,7 +163,7 @@ public class MysqlAuthPacketTest {
 
         Config.authentication_chain = new String[] {"native", "oidc"};
         authPacket = buildPacket("tina");
-        MysqlProto.switchAuthPlugin(authPacket, context, randomString);
+        MysqlProto.switchAuthPlugin(authPacket, context);
         Assert.assertEquals("authentication_openid_connect_client", authPacket.getPluginName());
     }
 
@@ -191,11 +190,10 @@ public class MysqlAuthPacketTest {
 
         MysqlAuthPacket authPacket = buildPacket("harbor");
         ConnectContext context = new ConnectContext();
-        byte[] randomString = MysqlPassword.createRandomString();
-        Assert.assertThrows(AuthenticationException.class, () -> MysqlProto.switchAuthPlugin(authPacket, context, randomString));
+        Assert.assertThrows(AuthenticationException.class, () -> MysqlProto.switchAuthPlugin(authPacket, context));
 
         authPacket.setPluginName(null);
-        MysqlProto.switchAuthPlugin(authPacket, context, randomString);
+        MysqlProto.switchAuthPlugin(authPacket, context);
         Assert.assertNull(authPacket.getPluginName());
     }
 


### PR DESCRIPTION
## Why I'm doing:
The current MySQL negotiate and authenticate logics are coupled together, which is not conducive to the expansion of subsequent PRs. Only after the user is authenticated can the connectContext be registered. However, some authentication modes require the use of connectContext, which makes development difficult. 
On the other hand, it is not make sense to authenticate first and then register. Because after the connection is established, the ConnectionContext should be fully established, regardless of whether the authentication is successful.
## What I'm doing:
extract authentication logical from Mysql negotiate
Modified process: 1. negotiate 2. register connection 3. authenticate

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
