### PR TITLE
[BugFix] fix wrong sort key index generated by partial update

### DIFF
--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -370,14 +370,22 @@ std::shared_ptr<TabletSchema> TabletSchema::create(const TabletSchemaCSPtr& src_
         partial_tablet_schema_pb.set_bf_fpp(src_tablet_schema->bf_fpp());
     }
     std::vector<ColumnId> sort_key_idxes;
+    // from referenced column name to index, used for build sort key idxes later.
+    std::map<std::string, uint32_t> col_name_to_idx;
     uint32_t cid = 0;
     for (const auto referenced_column_id : referenced_column_ids) {
         auto* tablet_column = partial_tablet_schema_pb.add_column();
         src_tablet_schema->column(referenced_column_id).to_schema_pb(tablet_column);
-        if (src_tablet_schema->column(referenced_column_id).is_sort_key()) {
-            sort_key_idxes.emplace_back(cid);
+        col_name_to_idx[tablet_column->name()] = cid++;
+    }
+    // build sort key idxes
+    for (const auto& sort_key_idx : src_tablet_schema->sort_key_idxes()) {
+        std::string col_name = std::string(src_tablet_schema->column(sort_key_idx).name());
+        if (col_name_to_idx.count(col_name) <= 0) {
+            // sort key column is not in referenced column, skip it.
+            continue;
         }
-        cid++;
+        sort_key_idxes.emplace_back(col_name_to_idx[col_name]);
     }
     const auto* indexes = src_tablet_schema->indexes();
     for (const auto& index : *indexes) {

--- a/test/sql/test_insert_empty/R/test_insert_partial_update_sortkey
+++ b/test/sql/test_insert_empty/R/test_insert_partial_update_sortkey
@@ -1,0 +1,42 @@
+-- name: test_insert_partial_update_sortkey
+create table test_bug
+(
+    group_id    INT    NOT NULL,
+    customer_id BIGINT NOT NULL,
+    product_id LARGEINT NOT NULL,
+    num_items   INT,
+    code        VARCHAR(255)
+) PRIMARY KEY (group_id, customer_id, product_id)
+PARTITION BY (group_id)
+DISTRIBUTED BY HASH (customer_id)
+ORDER BY (group_id, product_id, customer_id)
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO test_bug VALUES (1,1,1,10, "AAA");
+-- result:
+-- !result
+INSERT INTO test_bug VALUES (1,2,1,20, "AAA");
+-- result:
+-- !result
+SELECT * FROM test_bug WHERE group_id=1 and product_id=1;
+-- result:
+1	2	1	20	AAA
+1	1	1	10	AAA
+-- !result
+INSERT INTO test_bug (group_id, customer_id, product_id, num_items, code) VALUES (1,1,1,30,"BBB");
+-- result:
+-- !result
+SELECT * FROM test_bug WHERE group_id=1 and product_id=1;
+-- result:
+1	2	1	20	AAA
+1	1	1	30	BBB
+-- !result
+INSERT INTO test_bug (group_id, customer_id, product_id, num_items) VALUES (1,1,1,40);
+-- result:
+-- !result
+SELECT * FROM test_bug WHERE group_id=1 and product_id=1;
+-- result:
+1	2	1	20	AAA
+1	1	1	40	BBB
+-- !result

--- a/test/sql/test_insert_empty/T/test_insert_partial_update_sortkey
+++ b/test/sql/test_insert_empty/T/test_insert_partial_update_sortkey
@@ -1,0 +1,23 @@
+-- name: test_insert_partial_update_sortkey
+create table test_bug
+(
+    group_id    INT    NOT NULL,
+    customer_id BIGINT NOT NULL,
+    product_id LARGEINT NOT NULL,
+    num_items   INT,
+    code        VARCHAR(255)
+) PRIMARY KEY (group_id, customer_id, product_id)
+PARTITION BY (group_id)
+DISTRIBUTED BY HASH (customer_id)
+ORDER BY (group_id, product_id, customer_id)
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO test_bug VALUES (1,1,1,10, "AAA");
+INSERT INTO test_bug VALUES (1,2,1,20, "AAA");
+SELECT * FROM test_bug WHERE group_id=1 and product_id=1;
+
+INSERT INTO test_bug (group_id, customer_id, product_id, num_items, code) VALUES (1,1,1,30,"BBB");
+SELECT * FROM test_bug WHERE group_id=1 and product_id=1;
+
+INSERT INTO test_bug (group_id, customer_id, product_id, num_items) VALUES (1,1,1,40);
+SELECT * FROM test_bug WHERE group_id=1 and product_id=1;


### PR DESCRIPTION
## Why I'm doing:
Fix #57233, currently we will generate a wrong sortkey idx when handle partial update.

## What I'm doing:
Generate a correct sortkey idx when handle partial update.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
