### PR TITLE
[Feature] Make Flat Json parameters table-level configs

### DIFF
--- a/be/src/storage/base_tablet.h
+++ b/be/src/storage/base_tablet.h
@@ -97,6 +97,7 @@ public:
     int32_t schema_hash() const;
     int16_t shard_id();
     const int64_t creation_time() const;
+    const std::shared_ptr<FlatJsonConfig> flat_json_config() const;
     void set_creation_time(int64_t creation_time);
     bool equal(int64_t tablet_id, int32_t schema_hash);
 
@@ -189,6 +190,10 @@ inline const int64_t BaseTablet::creation_time() const {
 
 inline void BaseTablet::set_creation_time(int64_t creation_time) {
     _tablet_meta->set_creation_time(creation_time);
+}
+
+inline const std::shared_ptr<FlatJsonConfig> BaseTablet::flat_json_config() const {
+    return _tablet_meta->get_flat_json_config();
 }
 
 inline bool BaseTablet::equal(int64_t id, int32_t hash) {

--- a/be/src/storage/compaction_utils.cpp
+++ b/be/src/storage/compaction_utils.cpp
@@ -62,6 +62,7 @@ Status CompactionUtils::construct_output_rowset_writer(Tablet* tablet, uint32_t 
     context.tablet_schema_hash = tablet->schema_hash();
     context.rowset_path_prefix = tablet->schema_hash_path();
     context.tablet_schema = (tablet_schema == nullptr) ? tablet->tablet_schema() : tablet_schema;
+    context.flat_json_config = tablet->flat_json_config();
     context.rowset_state = VISIBLE;
     context.version = version;
     context.segments_overlap = NONOVERLAPPING;

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -347,6 +347,8 @@ Status DeltaWriter::_init() {
     writer_context.segments_overlap = OVERLAPPING;
     writer_context.global_dicts = _opt.global_dicts;
     writer_context.miss_auto_increment_column = _opt.miss_auto_increment_column;
+    writer_context.flat_json_config = _tablet->flat_json_config();
+
     Status st = RowsetFactory::create_rowset_writer(writer_context, &_rowset_writer);
     if (!st.ok()) {
         auto msg = strings::Substitute("Fail to create rowset writer. tablet_id: $0, error: $1", _opt.tablet_id,

--- a/be/src/storage/flat_json_config.h
+++ b/be/src/storage/flat_json_config.h
@@ -1,0 +1,95 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <gen_cpp/olap_file.pb.h>
+
+#include "gen_cpp/AgentService_types.h"
+
+namespace starrocks {
+class FlatJsonConfig {
+public:
+    // Constructor
+    FlatJsonConfig() = default;
+
+    // Constructor with parameters
+    FlatJsonConfig(bool enable, double nullFactor, double sparsityFactor, int maxColumnMax)
+            : _flat_json_enable(enable),
+              _flat_json_null_factor(nullFactor),
+              _flat_json_sparsity_factor(sparsityFactor),
+              _flat_json_max_column_max(maxColumnMax) {}
+
+    // Getters and Setters
+    bool is_flat_json_enabled() const { return _flat_json_enable; }
+    void set_flat_json_enabled(bool enable) { _flat_json_enable = enable; }
+
+    double get_flat_json_null_factor() const { return _flat_json_null_factor; }
+    void set_flat_json_null_factor(double factor) { _flat_json_null_factor = factor; }
+
+    double get_flat_json_sparsity_factor() const { return _flat_json_sparsity_factor; }
+    void set_flat_json_sparsity_factor(double factor) { _flat_json_sparsity_factor = factor; }
+
+    int get_flat_json_max_column_max() const { return _flat_json_max_column_max; }
+    void set_flat_json_max_column_max(int max) { _flat_json_max_column_max = max; }
+
+    void to_pb(FlatJsonConfigPB* binlog_config_pb) {
+        binlog_config_pb->set_flat_json_enable(_flat_json_enable);
+        binlog_config_pb->set_flat_json_null_factor(_flat_json_null_factor);
+        binlog_config_pb->set_flat_json_sparsity_factor(_flat_json_sparsity_factor);
+        binlog_config_pb->set_flat_json_max_column_max(_flat_json_max_column_max);
+    }
+
+    // Update function using another FlatJsonConfig
+    void update(const FlatJsonConfig& config) {
+        update(config.is_flat_json_enabled(), config.get_flat_json_null_factor(),
+               config.get_flat_json_sparsity_factor(), config.get_flat_json_max_column_max());
+    }
+
+    void update(const TFlatJsonConfig& config) {
+        update(config.flat_json_enable, config.flat_json_null_factor, config.flat_json_sparsity_factor,
+               config.flat_json_column_max);
+    }
+
+    void update(const FlatJsonConfigPB& flat_json_config_pb) {
+        update(flat_json_config_pb.flat_json_enable(), flat_json_config_pb.flat_json_null_factor(),
+               flat_json_config_pb.flat_json_sparsity_factor(), flat_json_config_pb.flat_json_max_column_max());
+    }
+
+    // Copy Assignment
+    FlatJsonConfig& operator=(const FlatJsonConfig& other) {
+        if (this != &other) {
+            _flat_json_enable = other._flat_json_enable;
+            _flat_json_null_factor = other._flat_json_null_factor;
+            _flat_json_sparsity_factor = other._flat_json_sparsity_factor;
+            _flat_json_max_column_max = other._flat_json_max_column_max;
+        }
+        return *this;
+    }
+
+    // Update function using four parameters
+    void update(bool enable, double nullFactor, double sparsityFactor, int maxColumnMax) {
+        _flat_json_enable = enable;
+        _flat_json_null_factor = nullFactor;
+        _flat_json_sparsity_factor = sparsityFactor;
+        _flat_json_max_column_max = maxColumnMax;
+    }
+
+private:
+    bool _flat_json_enable = false;
+    double _flat_json_null_factor = 0.3;
+    double _flat_json_sparsity_factor = 0.9;
+    int _flat_json_max_column_max = 100;
+};
+} // namespace starrocks

--- a/be/src/storage/rowset/column_writer.h
+++ b/be/src/storage/rowset/column_writer.h
@@ -34,6 +34,8 @@
 
 #pragma once
 
+#include <storage/flat_json_config.h>
+
 #include <memory> // for unique_ptr
 
 #include "column/vectorized_fwd.h"
@@ -74,6 +76,7 @@ struct ColumnWriterOptions {
     bool need_bloom_filter = false;
     bool need_vector_index = false;
     bool need_inverted_index = false;
+
     std::unordered_map<IndexType, std::string> standalone_index_file_paths;
     std::unordered_map<IndexType, TabletIndex> tablet_index;
 
@@ -85,10 +88,11 @@ struct ColumnWriterOptions {
     // if global_dict is not nullptr, will checkout whether global_dict can cover all data
     GlobalDictMap* global_dict = nullptr;
 
-    bool need_flat = false;
     bool is_compaction = false;
+    bool need_flat = false;
 
     std::string field_name;
+    const FlatJsonConfig* flat_json_config = nullptr;
 };
 
 class BitmapIndexWriter;

--- a/be/src/storage/rowset/json_column_compactor.cpp
+++ b/be/src/storage/rowset/json_column_compactor.cpp
@@ -48,6 +48,8 @@ Status FlatJsonColumnCompactor::_compact_columns(Columns& json_datas) {
         vc.emplace_back(js.get());
     }
     deriver.set_generate_filter(true);
+    deriver.init_flat_json_config(_flat_json_config);
+
     deriver.derived(vc);
 
     _flat_paths = deriver.flat_paths();

--- a/be/src/storage/rowset/json_column_writer.cpp
+++ b/be/src/storage/rowset/json_column_writer.cpp
@@ -51,7 +51,8 @@ FlatJsonColumnWriter::FlatJsonColumnWriter(const ColumnWriterOptions& opts, Type
         : ColumnWriter(std::move(type_info), opts.meta->length(), opts.meta->is_nullable()),
           _json_meta(opts.meta),
           _wfile(wfile),
-          _json_writer(std::move(json_writer)) {}
+          _json_writer(std::move(json_writer)),
+          _flat_json_config(opts.flat_json_config) {}
 
 Status FlatJsonColumnWriter::init() {
     _json_meta->mutable_json_meta()->set_format_version(kJsonMetaDefaultFormatVersion);
@@ -82,6 +83,8 @@ Status FlatJsonColumnWriter::append(const Column& column) {
 Status FlatJsonColumnWriter::_flat_column(Columns& json_datas) {
     // all json datas must full json
     JsonPathDeriver deriver;
+    deriver.init_flat_json_config(_flat_json_config);
+
     std::vector<const Column*> vc;
     for (const auto& js : json_datas) {
         vc.emplace_back(js.get());

--- a/be/src/storage/rowset/json_column_writer.h
+++ b/be/src/storage/rowset/json_column_writer.h
@@ -72,5 +72,6 @@ protected:
     bool _has_remain;
     std::shared_ptr<BloomFilter> _remain_filter;
     bool _is_flat = false;
+    const FlatJsonConfig* _flat_json_config = nullptr;
 };
 } // namespace starrocks

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -124,7 +124,7 @@ Status RowsetWriter::init() {
     _writer_options.global_dicts = _context.global_dicts != nullptr ? _context.global_dicts : nullptr;
     _writer_options.referenced_column_ids = _context.referenced_column_ids;
     _writer_options.is_compaction = _context.is_compaction;
-
+    _writer_options.flat_json_config = _context.flat_json_config;
     if (_context.tablet_schema->keys_type() == KeysType::PRIMARY_KEYS &&
         (_context.is_partial_update || !_context.merge_condition.empty() || _context.miss_auto_increment_column)) {
         _rowset_txn_meta_pb = std::make_unique<RowsetTxnMetaPB>();

--- a/be/src/storage/rowset/rowset_writer_context.h
+++ b/be/src/storage/rowset/rowset_writer_context.h
@@ -34,6 +34,8 @@
 
 #pragma once
 
+#include <storage/flat_json_config.h>
+
 #include "fs/fs.h"
 #include "gen_cpp/olap_file.pb.h"
 #include "runtime/global_dict/types_fwd_decl.h"
@@ -99,6 +101,8 @@ public:
     bool is_compaction = false;
 
     std::map<string, string>* column_to_expr_value = nullptr;
+
+    std::shared_ptr<FlatJsonConfig> flat_json_config = nullptr;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -94,8 +94,8 @@ void SegmentWriter::_init_column_meta(ColumnMetaPB* meta, uint32_t column_id, co
     if (column.type() == TYPE_JSON) {
         JsonMetaPB* json_meta = meta->mutable_json_meta();
         json_meta->set_format_version(kJsonMetaDefaultFormatVersion);
-        json_meta->set_is_flat(false);
         json_meta->set_has_remain(false);
+        json_meta->set_is_flat(false);
     }
 
     for (uint32_t i = 0; i < column.subcolumn_count(); ++i) {
@@ -209,6 +209,12 @@ Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has
 
         opts.need_flat = config::enable_json_flat;
         opts.is_compaction = _opts.is_compaction;
+
+        if (column.type() == LogicalType::TYPE_JSON && _opts.flat_json_config != nullptr) {
+            opts.need_flat = _opts.flat_json_config->is_flat_json_enabled();
+            opts.flat_json_config = _opts.flat_json_config.get();
+        }
+
         ASSIGN_OR_RETURN(auto writer, ColumnWriter::create(opts, &column, _wfile.get()));
         RETURN_IF_ERROR(writer->init());
         _column_writers.push_back(std::move(writer));

--- a/be/src/storage/rowset/segment_writer.h
+++ b/be/src/storage/rowset/segment_writer.h
@@ -34,6 +34,8 @@
 
 #pragma once
 
+#include <storage/flat_json_config.h>
+
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -78,6 +80,7 @@ struct SegmentWriterOptions {
     SegmentFileMark segment_file_mark;
     std::string encryption_meta;
     bool is_compaction = false;
+    std::shared_ptr<FlatJsonConfig> flat_json_config = nullptr;
 };
 
 // SegmentWriter is responsible for writing data into single segment by all or partital columns.

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1382,7 +1382,7 @@ Status TabletManager::_create_inital_rowset_unlocked(const TCreateTabletReq& req
             context.version = version;
             // there is no data in init rowset, so overlapping info is unknown.
             context.segments_overlap = OVERLAP_UNKNOWN;
-
+            context.flat_json_config = tablet->flat_json_config();
             std::unique_ptr<RowsetWriter> rowset_writer;
             st = RowsetFactory::create_rowset_writer(context, &rowset_writer);
             if (!st.ok()) {

--- a/be/src/storage/tablet_meta.cpp
+++ b/be/src/storage/tablet_meta.cpp
@@ -69,6 +69,12 @@ Status TabletMeta::create(const TCreateTabletReq& request, const TabletUid& tabl
         (*tablet_meta)->set_binlog_config(binlog_config);
     }
 
+    if (request.__isset.flat_json_config) {
+        FlatJsonConfig flat_json_config;
+        flat_json_config.update(request.flat_json_config);
+        (*tablet_meta)->set_flat_json_config(flat_json_config);
+    }
+
     return Status::OK();
 }
 
@@ -368,6 +374,12 @@ void TabletMeta::init_from_pb(TabletMetaPB* ptablet_meta_pb, bool use_tablet_sch
     if (tablet_meta_pb.has_source_schema()) {
         _source_schema = std::make_shared<const TabletSchema>(tablet_meta_pb.source_schema());
     }
+
+    if (tablet_meta_pb.has_flat_json_config()) {
+        FlatJsonConfig flat_json_config;
+        flat_json_config.update(tablet_meta_pb.flat_json_config());
+        set_flat_json_config(flat_json_config);
+    }
 }
 
 void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb, bool skip_tablet_schema) {
@@ -440,6 +452,10 @@ void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb, bool skip_tablet_schem
 
     if (_source_schema != nullptr) {
         _source_schema->to_schema_pb(tablet_meta_pb->mutable_source_schema());
+    }
+
+    if (_flat_json_config != nullptr) {
+        _flat_json_config->to_pb(tablet_meta_pb->mutable_flat_json_config());
     }
 }
 

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -45,6 +45,7 @@
 #include "gen_cpp/olap_file.pb.h"
 #include "storage/binlog_manager.h"
 #include "storage/delete_handler.h"
+#include "storage/flat_json_config.h"
 #include "storage/olap_common.h"
 #include "storage/olap_define.h"
 #include "storage/rowset/rowset.h"
@@ -218,9 +219,15 @@ public:
 
     std::shared_ptr<BinlogConfig> get_binlog_config() { return _binlog_config; }
 
+    std::shared_ptr<FlatJsonConfig> get_flat_json_config() { return _flat_json_config; }
+
     void set_binlog_config(const BinlogConfig& new_config) {
         _binlog_config = std::make_shared<BinlogConfig>();
         _binlog_config->update(new_config);
+    }
+
+    void set_flat_json_config(const FlatJsonConfig& new_config) {
+        _flat_json_config = std::make_shared<FlatJsonConfig>(new_config);
     }
 
     BinlogLsn get_binlog_min_lsn() { return _binlog_min_lsn; }
@@ -285,6 +292,7 @@ private:
     TabletUpdates* _updates = nullptr;
 
     std::shared_ptr<BinlogConfig> _binlog_config;
+    std::shared_ptr<FlatJsonConfig> _flat_json_config;
 
     // The minimum lsn of binlog that is valid. It will be updated when deleting expired
     // or overcapacity binlog in Tablet#delete_expired_inc_rowsets, and used to skip those

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -183,6 +183,8 @@ Status TabletReader::_init_compaction_column_paths(const TabletReaderParams& rea
         if (readers.size() == num_readers) {
             // must all be flat json type
             JsonPathDeriver deriver;
+            auto flat_json_config = _tablet->flat_json_config();
+            deriver.init_flat_json_config(flat_json_config.get());
             deriver.derived(readers);
             auto paths = deriver.flat_paths();
             auto types = deriver.flat_types();

--- a/be/src/util/json_flattener.h
+++ b/be/src/util/json_flattener.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <storage/flat_json_config.h>
+
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -106,11 +108,14 @@ class JsonPathDeriver {
 public:
     JsonPathDeriver() = default;
     JsonPathDeriver(const std::vector<std::string>& paths, const std::vector<LogicalType>& types, bool has_remain);
+    void init_flat_json_config(const FlatJsonConfig* flat_json_config);
 
     ~JsonPathDeriver() = default;
 
     // dervie paths
     void derived(const std::vector<const Column*>& json_datas);
+
+    StatusOr<size_t> check_null_factor(const std::vector<const Column*>& json_datas);
 
     void derived(const std::vector<const ColumnReader*>& json_readers);
 
@@ -163,6 +168,9 @@ private:
     std::vector<LogicalType> _types;
 
     double _min_json_sparsity_factory = config::json_flat_sparsity_factor;
+    double _max_json_null_factor = config::json_flat_null_factor;
+    int _max_column = config::json_flat_column_max;
+
     size_t _total_rows;
     FlatJsonHashMap<JsonFlatPath*, JsonFlatDesc> _derived_maps;
     std::shared_ptr<JsonFlatPath> _path_root;

--- a/be/test/storage/rowset/flat_json_column_rw_test.cpp
+++ b/be/test/storage/rowset/flat_json_column_rw_test.cpp
@@ -433,6 +433,46 @@ TEST_F(FlatJsonColumnRWTest, testMergeRemainFlatJson) {
     EXPECT_EQ(R"({"a": 5, "b": 25})", read_col->debug_item(4));
 }
 
+TEST_F(FlatJsonColumnRWTest, testMergeRemainFlatJsonWithConfig) {
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+
+    ASSIGN_OR_ABORT(auto jv1, JsonValue::parse(R"({"a": 1, "b": 21, "c": 31})"));
+    ASSIGN_OR_ABORT(auto jv2, JsonValue::parse(R"({"a": 2, "b": 22, "d": 32})"));
+    ASSIGN_OR_ABORT(auto jv3, JsonValue::parse(R"({"a": 3, "b": 23, "e": [1,2,3]})"));
+    ASSIGN_OR_ABORT(auto jv4, JsonValue::parse(R"({"a": 4, "b": 24, "g": {"x": 1}})"));
+    ASSIGN_OR_ABORT(auto jv5, JsonValue::parse(R"({"a": 5, "b": 25})"));
+
+    json_col->append(&jv1);
+    json_col->append(&jv2);
+    json_col->append(&jv3);
+    json_col->append(&jv4);
+    json_col->append(&jv5);
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    FlatJsonConfig config;
+    writer_opts.need_flat = true;
+    writer_opts.flat_json_config = &config;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, nullptr);
+
+    EXPECT_EQ(3, writer_opts.meta->children_columns_size());
+    EXPECT_TRUE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_TRUE(writer_opts.meta->json_meta().has_remain());
+    EXPECT_EQ("a", writer_opts.meta->children_columns(0).name());
+    EXPECT_EQ("b", writer_opts.meta->children_columns(1).name());
+    EXPECT_EQ("remain", writer_opts.meta->children_columns(2).name());
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({"a": 1, "b": 21, "c": 31})", read_col->debug_item(0));
+    EXPECT_EQ(R"({"a": 2, "b": 22, "d": 32})", read_col->debug_item(1));
+    EXPECT_EQ(R"({"a": 3, "b": 23, "e": [1, 2, 3]})", read_col->debug_item(2));
+    EXPECT_EQ(R"({"a": 4, "b": 24, "g": {"x": 1}})", read_col->debug_item(3));
+    EXPECT_EQ(R"({"a": 5, "b": 25})", read_col->debug_item(4));
+}
+
 TEST_F(FlatJsonColumnRWTest, testMergeRemainFlatJson2) {
     ColumnPtr write_col = JsonColumn::create();
     auto* json_col = down_cast<JsonColumn*>(write_col.get());
@@ -554,6 +594,46 @@ TEST_F(FlatJsonColumnRWTest, testMergeMiddleRemainFlatJson2) {
     }
 }
 
+TEST_F(FlatJsonColumnRWTest, testMergeMiddleRemainFlatJson2WithConfig) {
+    FlatJsonConfig config;
+    config.set_flat_json_null_factor(0.4);
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+    std::vector<std::string> json = {
+            R"({"a": 1, "b": {"b1": 22, "b2": {"b3": "abc"}, "b4": 1}, "c": 31})",
+            R"({"a": 2, "b": {"b1": 23, "b2": {"b3": "efg"}, "b4": [1, 2, 3]}, "d": 32})",
+            R"({"a": 3, "b": {"b1": 24, "b2": {"b3": "xyz"}, "b4": {"b5": 1}}, "e": [1, 2, 3]})",
+            R"({"a": 4, "b": {"b1": 25, "b2": {"b3": "qwe"}, "b4": {"b7": 2}}, "g": {"x": 1}})",
+            R"({"a": 5, "b": {"b1": 26, "b2": {"b3": "sdf"}, "b4": 23}})"};
+
+    for (auto& x : json) {
+        ASSIGN_OR_ABORT(auto jv, JsonValue::parse(x));
+        json_col->append(jv);
+    }
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    writer_opts.flat_json_config = &config;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, nullptr);
+
+    EXPECT_EQ(5, writer_opts.meta->children_columns_size());
+    EXPECT_TRUE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_TRUE(writer_opts.meta->json_meta().has_remain());
+    EXPECT_EQ("a", writer_opts.meta->children_columns(0).name());
+    EXPECT_EQ("b.b1", writer_opts.meta->children_columns(1).name());
+    EXPECT_EQ("b.b2.b3", writer_opts.meta->children_columns(2).name());
+    EXPECT_EQ("b.b4", writer_opts.meta->children_columns(3).name());
+    EXPECT_EQ("remain", writer_opts.meta->children_columns(4).name());
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_FALSE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    for (size_t i = 0; i < json.size(); i++) {
+        EXPECT_EQ(json[i], read_col->debug_item(i));
+    }
+}
+
 TEST_F(FlatJsonColumnRWTest, testMergeMiddleRemainFlatJson3) {
     config::json_flat_null_factor = 0.4;
     ColumnPtr write_col = JsonColumn::create();
@@ -580,6 +660,56 @@ TEST_F(FlatJsonColumnRWTest, testMergeMiddleRemainFlatJson3) {
     ColumnPtr read_col = JsonColumn::create();
     ColumnWriterOptions writer_opts;
     writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root_path.get());
+
+    EXPECT_EQ(6, writer_opts.meta->children_columns_size());
+    EXPECT_TRUE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_TRUE(writer_opts.meta->json_meta().has_remain());
+    EXPECT_EQ("a", writer_opts.meta->children_columns(0).name());
+    EXPECT_EQ("b.b1", writer_opts.meta->children_columns(1).name());
+    EXPECT_EQ("b.b2.b3", writer_opts.meta->children_columns(2).name());
+    EXPECT_EQ("b.b2.c1.c2", writer_opts.meta->children_columns(3).name());
+    EXPECT_EQ("b.b4", writer_opts.meta->children_columns(4).name());
+    EXPECT_EQ("remain", writer_opts.meta->children_columns(5).name());
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({b.b2: {"b3": "abc", "bc": 1, "c1": {"c2": "a", "ce": 1}}})", read_col->debug_item(0));
+    EXPECT_EQ(R"({b.b2: {"b3": "efg", "bd": 2, "c1": {"c2": "b", "cd": 2}}})", read_col->debug_item(1));
+    EXPECT_EQ(R"({b.b2: {"b3": "xyz", "be": 3, "c1": {"c2": "c", "cf": 3}}})", read_col->debug_item(2));
+    EXPECT_EQ(R"({b.b2: {"b3": "qwe", "bf": 4, "c1": {"c2": "d", "cg": 4}}})", read_col->debug_item(3));
+    EXPECT_EQ(R"({b.b2: {"b3": "sdf", "bg": 5, "c1": {"c2": "e", "ch": 5}}})", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testMergeMiddleRemainFlatJson3WithConfig) {
+    FlatJsonConfig config;
+    config.set_flat_json_null_factor(0.4);
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+    std::vector<std::string> json = {
+            R"({"a": 1, "b": {"b1": 22, "b2": {"b3": "abc", "c1": {"c2": "a", "ce": 1},"bc": 1}, "b4": 1}})",
+            R"({"a": 2, "b": {"b1": 23, "b2": {"b3": "efg", "c1": {"c2": "b", "cd": 2},"bd": 2}, "b4": [1, 2, 3]}})",
+            R"({"a": 3, "b": {"b1": 24, "b2": {"b3": "xyz", "c1": {"c2": "c", "cf": 3},"be": 3}, "b4": {"b5": 1}}})",
+            R"({"a": 4, "b": {"b1": 25, "b2": {"b3": "qwe", "c1": {"c2": "d", "cg": 4},"bf": 4}, "b4": {"b7": 2}}})",
+            R"({"a": 5, "b": {"b1": 26, "b2": {"b3": "sdf", "c1": {"c2": "e", "ch": 5},"bg": 5}, "b4": 23}})"};
+
+    for (auto& x : json) {
+        ASSIGN_OR_ABORT(auto jv, JsonValue::parse(x));
+        json_col->append(jv);
+    }
+
+    ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ASSIGN_OR_ABORT(auto b_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.b", 0));
+    ASSIGN_OR_ABORT(auto b2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.b.b2", 0));
+
+    b_path->children().emplace_back(std::move(b2_path));
+    root_path->children().emplace_back(std::move(b_path));
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    writer_opts.flat_json_config = &config;
     test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root_path.get());
 
     EXPECT_EQ(6, writer_opts.meta->children_columns_size());
@@ -673,6 +803,60 @@ TEST_F(FlatJsonColumnRWTest, testHyperFlatJson) {
     ColumnPtr read_col = JsonColumn::create();
     ColumnWriterOptions writer_opts;
     writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root.get());
+
+    int index = 0;
+    EXPECT_EQ(8, writer_opts.meta->children_columns_size());
+    EXPECT_TRUE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_TRUE(writer_opts.meta->json_meta().has_remain());
+    EXPECT_EQ("a", writer_opts.meta->children_columns(index++).name());
+    EXPECT_EQ("b.b1", writer_opts.meta->children_columns(index++).name());
+    EXPECT_EQ("b.b2.b3", writer_opts.meta->children_columns(index++).name());
+    EXPECT_EQ("b.b2.c1.c2", writer_opts.meta->children_columns(index++).name());
+    EXPECT_EQ("b.b4", writer_opts.meta->children_columns(index++).name());
+    EXPECT_EQ("ff.f1", writer_opts.meta->children_columns(index++).name());
+    EXPECT_EQ("gg", writer_opts.meta->children_columns(index++).name());
+    EXPECT_EQ("remain", writer_opts.meta->children_columns(index++).name());
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "abc", a: 1, ff.f1: "985", gg.g1: NULL})", read_col->debug_item(0));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "efg", a: 2, ff.f1: "984", gg.g1: NULL})", read_col->debug_item(1));
+    EXPECT_EQ(R"({b.b4.b5: 1, b.b2.b3: "xyz", a: 3, ff.f1: "983", gg.g1: NULL})", read_col->debug_item(2));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "qwe", a: 4, ff.f1: NULL, gg.g1: NULL})", read_col->debug_item(3));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "sdf", a: 5, ff.f1: NULL, gg.g1: NULL})", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testHyperFlatJsonWithConfig) {
+    FlatJsonConfig config;
+    config.set_flat_json_null_factor(0.4);
+    config.set_flat_json_sparsity_factor(0.5);
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+    std::vector<std::string> json = {
+            R"({"a": 1, "gg": "te1", "ff": {"f1": "985"}, "b": {"b1": 22, "b2": {"b3": "abc", "c1": {"c2": "a", "ce": 1},"bc": 1}, "b4": 1}})",
+            R"({"a": 2, "gg": "te2", "ff": {"f1": "984"}, "b": {"b1": 23, "b2": {"b3": "efg", "c1": {"c2": "b", "cd": 2},"bd": 2}, "b4": [1, 2, 3]}})",
+            R"({"a": 3, "gg": "te3", "ff": {"f1": "983"}, "b": {"b1": 24, "b2": {"b3": "xyz", "c1": {"c2": "c", "cf": 3},"be": 3}, "b4": {"b5": 1}}})",
+            R"({"a": 4, "gg": "te4", "ff": 781, "b": {"b1": 25, "b2": {"b3": "qwe", "c1": {"c2": "d", "cg": 4},"bf": 4}, "b4": {"b7": 2}}})",
+            R"({"a": 5, "gg": "te5", "ff": 782, "b": {"b1": 26, "b2": {"b3": "sdf", "c1": {"c2": "e", "ch": 5},"bg": 5}, "b4": 23}})"};
+
+    for (auto& x : json) {
+        ASSIGN_OR_ABORT(auto jv, JsonValue::parse(x));
+        json_col->append(jv);
+    }
+
+    ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "b.b2.b3");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "ff.f1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "gg.g1");
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    writer_opts.flat_json_config = &config;
     test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root.get());
 
     int index = 0;
@@ -817,6 +1001,49 @@ TEST_F(FlatJsonColumnRWTest, testMergeMiddleRemainJson2) {
     EXPECT_EQ(R"({b.b2: {"b3": "sdf", "bg": 5, "c1": {"c2": "e", "ch": 5}}})", read_col->debug_item(4));
 }
 
+TEST_F(FlatJsonColumnRWTest, testMergeMiddleRemainJson2WithConfig) {
+    FlatJsonConfig config;
+    config.set_flat_json_null_factor(0.4);
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+    std::vector<std::string> json = {
+            R"({"a": 1, "b": {"b1": 22, "b2": {"b3": "abc", "c1": {"c2": "a", "ce": 1},"bc": 1}, "b4": 1}})",
+            R"({"a": 2, "b": {"b1": 23, "b2": {"b3": "efg", "c1": {"c2": "b", "cd": 2},"bd": 2}, "b4": [1, 2, 3]}})",
+            R"({"a": 3, "b": {"b1": 24, "b2": {"b3": "xyz", "c1": {"c2": "c", "cf": 3},"be": 3}, "b4": {"b5": 1}}})",
+            R"({"a": 4, "b": {"b1": 25, "b2": {"b3": "qwe", "c1": {"c2": "d", "cg": 4},"bf": 4}, "b4": {"b7": 2}}})",
+            R"({"a": 5, "b": {"b1": 26, "b2": {"b3": "sdf", "c1": {"c2": "e", "ch": 5},"bg": 5}, "b4": 23}})"};
+
+    for (auto& x : json) {
+        ASSIGN_OR_ABORT(auto jv, JsonValue::parse(x));
+        json_col->append(jv);
+    }
+
+    ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ASSIGN_OR_ABORT(auto b_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.b", 0));
+    ASSIGN_OR_ABORT(auto b2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.b.b2", 0));
+
+    b_path->children().emplace_back(std::move(b2_path));
+    root_path->children().emplace_back(std::move(b_path));
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = false;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root_path.get());
+
+    EXPECT_EQ(0, writer_opts.meta->children_columns_size());
+    EXPECT_FALSE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_FALSE(writer_opts.meta->json_meta().has_remain());
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({b.b2: {"b3": "abc", "bc": 1, "c1": {"c2": "a", "ce": 1}}})", read_col->debug_item(0));
+    EXPECT_EQ(R"({b.b2: {"b3": "efg", "bd": 2, "c1": {"c2": "b", "cd": 2}}})", read_col->debug_item(1));
+    EXPECT_EQ(R"({b.b2: {"b3": "xyz", "be": 3, "c1": {"c2": "c", "cf": 3}}})", read_col->debug_item(2));
+    EXPECT_EQ(R"({b.b2: {"b3": "qwe", "bf": 4, "c1": {"c2": "d", "cg": 4}}})", read_col->debug_item(3));
+    EXPECT_EQ(R"({b.b2: {"b3": "sdf", "bg": 5, "c1": {"c2": "e", "ch": 5}}})", read_col->debug_item(4));
+}
+
 TEST_F(FlatJsonColumnRWTest, testDeepJson) {
     ColumnPtr write_col = JsonColumn::create();
     auto* json_col = down_cast<JsonColumn*>(write_col.get());
@@ -899,6 +1126,52 @@ TEST_F(FlatJsonColumnRWTest, testHyperJson) {
     EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "sdf", a: 5, ff.f1: NULL, gg.g1: NULL})", read_col->debug_item(4));
 }
 
+TEST_F(FlatJsonColumnRWTest, testHyperJsonWithConfig) {
+    FlatJsonConfig config;
+    config.set_flat_json_null_factor(0.4);
+    config.set_flat_json_sparsity_factor(0.5);
+
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+    std::vector<std::string> json = {
+            R"({"a": 1, "gg": "te1", "ff": {"f1": "985"}, "b": {"b1": 22, "b2": {"b3": "abc", "c1": {"c2": "a", "ce": 1},"bc": 1}, "b4": 1}})",
+            R"({"a": 2, "gg": "te2", "ff": {"f1": "984"}, "b": {"b1": 23, "b2": {"b3": "efg", "c1": {"c2": "b", "cd": 2},"bd": 2}, "b4": [1, 2, 3]}})",
+            R"({"a": 3, "gg": "te3", "ff": {"f1": "983"}, "b": {"b1": 24, "b2": {"b3": "xyz", "c1": {"c2": "c", "cf": 3},"be": 3}, "b4": {"b5": 1}}})",
+            R"({"a": 4, "gg": "te4", "ff": 781, "b": {"b1": 25, "b2": {"b3": "qwe", "c1": {"c2": "d", "cg": 4},"bf": 4}, "b4": {"b7": 2}}})",
+            R"({"a": 5, "gg": "te5", "ff": 782, "b": {"b1": 26, "b2": {"b3": "sdf", "c1": {"c2": "e", "ch": 5},"bg": 5}, "b4": 23}})"};
+
+    for (auto& x : json) {
+        ASSIGN_OR_ABORT(auto jv, JsonValue::parse(x));
+        json_col->append(jv);
+    }
+
+    ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "b.b2.b3");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "ff.f1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "gg.g1");
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = false;
+    writer_opts.flat_json_config = &config;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root.get());
+
+    EXPECT_EQ(0, writer_opts.meta->children_columns_size());
+    EXPECT_FALSE(writer_opts.meta->json_meta().is_flat());
+    EXPECT_FALSE(writer_opts.meta->json_meta().has_remain());
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "abc", a: 1, ff.f1: "985", gg.g1: NULL})", read_col->debug_item(0));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "efg", a: 2, ff.f1: "984", gg.g1: NULL})", read_col->debug_item(1));
+    EXPECT_EQ(R"({b.b4.b5: 1, b.b2.b3: "xyz", a: 3, ff.f1: "983", gg.g1: NULL})", read_col->debug_item(2));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "qwe", a: 4, ff.f1: NULL, gg.g1: NULL})", read_col->debug_item(3));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: "sdf", a: 5, ff.f1: NULL, gg.g1: NULL})", read_col->debug_item(4));
+}
+
 TEST_F(FlatJsonColumnRWTest, testHyperNoCastTypeJson) {
     config::json_flat_null_factor = 0.4;
     config::json_flat_sparsity_factor = 0.5;
@@ -939,6 +1212,48 @@ TEST_F(FlatJsonColumnRWTest, testHyperNoCastTypeJson) {
     EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: 'sdf', a: 5, ff.f1: NULL, gg.g1: NULL})", read_col->debug_item(4));
 }
 
+TEST_F(FlatJsonColumnRWTest, testHyperNoCastTypeJsonWithConfig) {
+    FlatJsonConfig config;
+    config.set_flat_json_null_factor(0.4);
+    config.set_flat_json_sparsity_factor(0.5);
+
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+    std::vector<std::string> json = {
+            R"({"a": 1, "gg": "te1", "ff": {"f1": "985"}, "b": {"b1": 22, "b2": {"b3": "abc", "c1": {"c2": "a", "ce": 1},"bc": 1}, "b4": 1}})",
+            R"({"a": 2, "gg": "te2", "ff": {"f1": "984"}, "b": {"b1": 23, "b2": {"b3": "efg", "c1": {"c2": "b", "cd": 2},"bd": 2}, "b4": [1, 2, 3]}})",
+            R"({"a": 3, "gg": "te3", "ff": {"f1": "983"}, "b": {"b1": 24, "b2": {"b3": "xyz", "c1": {"c2": "c", "cf": 3},"be": 3}, "b4": {"b5": 1}}})",
+            R"({"a": 4, "gg": "te4", "ff": 781, "b": {"b1": 25, "b2": {"b3": "qwe", "c1": {"c2": "d", "cg": 4},"bf": 4}, "b4": {"b7": 2}}})",
+            R"({"a": 5, "gg": "te5", "ff": 782, "b": {"b1": 26, "b2": {"b3": "sdf", "c1": {"c2": "e", "ch": 5},"bg": 5}, "b4": 23}})"};
+
+    for (auto& x : json) {
+        ASSIGN_OR_ABORT(auto jv, JsonValue::parse(x));
+        json_col->append(jv);
+    }
+
+    ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "b.b2.b3");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "ff.f1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "gg.g1");
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    writer_opts.flat_json_config = &config;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root.get());
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: 'abc', a: 1, ff.f1: "985", gg.g1: NULL})", read_col->debug_item(0));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: 'efg', a: 2, ff.f1: "984", gg.g1: NULL})", read_col->debug_item(1));
+    EXPECT_EQ(R"({b.b4.b5: 1, b.b2.b3: 'xyz', a: 3, ff.f1: "983", gg.g1: NULL})", read_col->debug_item(2));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: 'qwe', a: 4, ff.f1: NULL, gg.g1: NULL})", read_col->debug_item(3));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2.b3: 'sdf', a: 5, ff.f1: NULL, gg.g1: NULL})", read_col->debug_item(4));
+}
+
 TEST_F(FlatJsonColumnRWTest, testHyperCastTypeJson) {
     config::json_flat_null_factor = 0.4;
     config::json_flat_sparsity_factor = 0.5;
@@ -967,6 +1282,48 @@ TEST_F(FlatJsonColumnRWTest, testHyperCastTypeJson) {
     ColumnPtr read_col = JsonColumn::create();
     ColumnWriterOptions writer_opts;
     writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root.get());
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2: NULL, a: '1', ff.f1: 985, gg.g1: NULL})", read_col->debug_item(0));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2: NULL, a: '2', ff.f1: 984, gg.g1: NULL})", read_col->debug_item(1));
+    EXPECT_EQ(R"({b.b4.b5: 1, b.b2: NULL, a: '3', ff.f1: 983, gg.g1: NULL})", read_col->debug_item(2));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2: NULL, a: '4', ff.f1: NULL, gg.g1: NULL})", read_col->debug_item(3));
+    EXPECT_EQ(R"({b.b4.b5: NULL, b.b2: NULL, a: '5', ff.f1: NULL, gg.g1: NULL})", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testHyperCastTypeJsonWithConfig) {
+    FlatJsonConfig config;
+    config.set_flat_json_null_factor(0.4);
+    config.set_flat_json_sparsity_factor(0.5);
+
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+    std::vector<std::string> json = {
+            R"({"a": 1, "gg": "te1", "ff": {"f1": "985"}, "b": {"b1": 22, "b2": {"b3": "abc", "c1": {"c2": "a", "ce": 1},"bc": 1}, "b4": 1}})",
+            R"({"a": 2, "gg": "te2", "ff": {"f1": "984"}, "b": {"b1": 23, "b2": {"b3": "efg", "c1": {"c2": "b", "cd": 2},"bd": 2}, "b4": [1, 2, 3]}})",
+            R"({"a": 3, "gg": "te3", "ff": {"f1": "983"}, "b": {"b1": 24, "b2": {"b3": "xyz", "c1": {"c2": "c", "cf": 3},"be": 3}, "b4": {"b5": 1}}})",
+            R"({"a": 4, "gg": "te4", "ff": 781, "b": {"b1": 25, "b2": {"b3": "qwe", "c1": {"c2": "d", "cg": 4},"bf": 4}, "b4": {"b7": 2}}})",
+            R"({"a": 5, "gg": "te5", "ff": 782, "b": {"b1": 26, "b2": {"b3": "sdf", "c1": {"c2": "e", "ch": 5},"bg": 5}, "b4": 23}})"};
+
+    for (auto& x : json) {
+        ASSIGN_OR_ABORT(auto jv, JsonValue::parse(x));
+        json_col->append(jv);
+    }
+
+    ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_DOUBLE, "b.b4.b5");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "b.b2");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_VARCHAR, "a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_BIGINT, "ff.f1");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "gg.g1");
+
+    ColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    writer_opts.flat_json_config = &config;
     test_json(writer_opts, "/test_flat_json_rw2.data", write_col, read_col, root.get());
 
     auto* read_json = down_cast<JsonColumn*>(read_col.get());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -483,6 +483,16 @@ public class AlterJobExecutor implements AstVisitor<Void, ConnectContext> {
                 if (!isSuccess) {
                     throw new DdlException("modify binlog config of FEMeta failed or table has been droped");
                 }
+            } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE) ||
+                    properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR) ||
+                    properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR) ||
+                    properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX)) {
+                boolean isSuccess = schemaChangeHandler.updateFlatJsonConfigMeta(db, table.getId(),
+                        properties, TTabletMetaType.FLAT_JSON_CONFIG);
+                if (!isSuccess) {
+                    throw new DdlException("modify flat json config of FEMeta failed");
+
+                }
             } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FOREIGN_KEY_CONSTRAINT)
                     || properties.containsKey(PropertyAnalyzer.PROPERTIES_UNIQUE_CONSTRAINT)) {
                 schemaChangeHandler.updateTableConstraint(db, tableName.getTbl(), properties);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FlatJsonConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FlatJsonConfig.java
@@ -1,0 +1,150 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.Config;
+import com.starrocks.common.io.Text;
+import com.starrocks.common.io.Writable;
+import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.thrift.TFlatJsonConfig;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class FlatJsonConfig implements Writable {
+    @SerializedName("flatJsonEnable")
+    private boolean flatJsonEnable;
+
+    @SerializedName("flatJsonNullFactor")
+    private double flatJsonNullFactor;
+
+    @SerializedName("flatJsonSparsityFactor")
+    private double flatJsonSparsityFactor;
+
+    @SerializedName("flatJsonColumnMax")
+    private int flatJsonColumnMax;
+
+    public FlatJsonConfig(boolean enabled, double nullFactor, double sparsityFactor, int columnMax) {
+        this.flatJsonEnable = enabled;
+        this.flatJsonNullFactor = nullFactor;
+        this.flatJsonSparsityFactor = sparsityFactor;
+        this.flatJsonColumnMax = columnMax;
+    }
+
+    public FlatJsonConfig(FlatJsonConfig config) {
+        this.flatJsonEnable = config.getFlatJsonEnable();
+        this.flatJsonNullFactor = config.getFlatJsonNullFactor();
+        this.flatJsonSparsityFactor = config.getFlatJsonSparsityFactor();
+        this.flatJsonColumnMax = config.getFlatJsonColumnMax();
+    }
+
+    public FlatJsonConfig() {
+        this(false, Config.flat_json_null_factor, Config.flat_json_sparsity_factory,
+                Config.flat_json_column_max);
+    }
+
+    public void buildFromProperties(Map<String, String> properties) {
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE)) {
+            flatJsonEnable = Boolean.parseBoolean(properties.get(
+                    PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE));
+        }
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR)) {
+            flatJsonNullFactor = Double.parseDouble(properties.get(
+                    PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR));
+        }
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR)) {
+            flatJsonSparsityFactor = Double.parseDouble(properties.get(
+                    PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR));
+        }
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX)) {
+            flatJsonColumnMax = Integer.parseInt(properties.get(
+                    PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX));
+        }
+    }
+
+    public boolean getFlatJsonEnable() {
+        return flatJsonEnable;
+    }
+
+    public void setFlatJsonEnable(boolean flatJsonEnable) {
+        this.flatJsonEnable = flatJsonEnable;
+    }
+
+    public double getFlatJsonNullFactor() {
+        return flatJsonNullFactor;
+    }
+
+    public void setFlatJsonNullFactor(double flatJsonNullFactor) {
+        this.flatJsonNullFactor = flatJsonNullFactor;
+    }
+
+    public double getFlatJsonSparsityFactor() {
+        return flatJsonSparsityFactor;
+    }
+
+    public void setFlatJsonSparsityFactor(double flatJsonSparsityFactor) {
+        this.flatJsonSparsityFactor = flatJsonSparsityFactor;
+    }
+
+    public int getFlatJsonColumnMax() {
+        return flatJsonColumnMax;
+    }
+
+    public void setFlatJsonColumnMax(int flatJsonColumnMax) {
+        this.flatJsonColumnMax = flatJsonColumnMax;
+    }
+
+
+    public Map<String, String> toProperties() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE, String.valueOf(flatJsonEnable));
+        properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR, String.valueOf(flatJsonNullFactor));
+        properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR, String.valueOf(flatJsonSparsityFactor));
+        properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX, String.valueOf(flatJsonColumnMax));
+        return properties;
+    }
+
+    public TFlatJsonConfig toTFlatJsonConfig() {
+        TFlatJsonConfig tFlatJsonConfig = new TFlatJsonConfig();
+        tFlatJsonConfig.setFlat_json_enable(flatJsonEnable);
+        tFlatJsonConfig.setFlat_json_null_factor(flatJsonNullFactor);
+        tFlatJsonConfig.setFlat_json_sparsity_factor(flatJsonSparsityFactor);
+        tFlatJsonConfig.setFlat_json_column_max(flatJsonColumnMax);
+        return tFlatJsonConfig;
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        Text.writeString(out, GsonUtils.GSON.toJson(this));
+    }
+
+    public static FlatJsonConfig read(DataInput in) throws IOException {
+        return GsonUtils.GSON.fromJson(Text.readString(in), FlatJsonConfig.class);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("{ flat_json_enable : %b,\n " +
+                "flat_json_null_factor : %f,\n " +
+                "flat_json_sparsity_factor : %f,\n" +
+                "flat_json_column_max : %d }", flatJsonEnable, flatJsonNullFactor, flatJsonSparsityFactor,
+                flatJsonColumnMax);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -491,10 +491,33 @@ public class OlapTable extends Table {
         tableProperty.setBinlogConfig(curBinlogConfig);
     }
 
+    public void setFlatJsonConfig(FlatJsonConfig flatJsonConfig) {
+        if (tableProperty == null) {
+            tableProperty = new TableProperty(Maps.newHashMap());
+        }
+        tableProperty.modifyTableProperties(flatJsonConfig.toProperties());
+        tableProperty.setFlatJsonConfig(flatJsonConfig);
+    }
+
+    public FlatJsonConfig getFlatJsonConfig() {
+        if (tableProperty != null) {
+            return tableProperty.getFlatJsonConfig();
+        }
+        return null;
+    }
+
     public boolean containsBinlogConfig() {
         if (tableProperty == null ||
                 tableProperty.getBinlogConfig() == null ||
                 tableProperty.getBinlogConfig().getVersion() == BinlogConfig.INVALID) {
+            return false;
+        }
+        return true;
+    }
+
+    public boolean containsFlatJsonConfig() {
+        if (tableProperty == null ||
+                tableProperty.getFlatJsonConfig() == null) {
             return false;
         }
         return true;
@@ -3518,6 +3541,30 @@ public class OlapTable extends Table {
         // storage type
         if (storageType() != null && !PropertyAnalyzer.PROPERTIES_STORAGE_TYPE_COLUMN.equalsIgnoreCase(storageType())) {
             properties.put(PropertyAnalyzer.PROPERTIES_STORAGE_TYPE, storageType());
+        }
+
+        // flat json enable
+        String flatJsonEnable = tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE);
+        if (!Strings.isNullOrEmpty(flatJsonEnable)) {
+            properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE, flatJsonEnable);
+        }
+
+        // flat json null factor
+        String flatJsonNullFactor = tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR);
+        if (!Strings.isNullOrEmpty(flatJsonNullFactor)) {
+            properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR, flatJsonNullFactor);
+        }
+
+        // flat json sparsity factor
+        String flatJsonSparsityFactor = tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR);
+        if (!Strings.isNullOrEmpty(flatJsonSparsityFactor)) {
+            properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR, flatJsonSparsityFactor);
+        }
+
+        // flat json column max
+        String flatJsonColumnMax = tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX);
+        if (!Strings.isNullOrEmpty(flatJsonColumnMax)) {
+            properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX, flatJsonColumnMax);
         }
 
         return properties;

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3088,6 +3088,15 @@ public class Config extends ConfigBase {
     @ConfField
     public static long binlog_max_size = Long.MAX_VALUE; // no limit
 
+    @ConfField
+    public static double flat_json_null_factor = 0.3;
+
+    @ConfField
+    public static double flat_json_sparsity_factory = 0.9;
+
+    @ConfField
+    public static int flat_json_column_max = 100;
+
     /**
      * Enable check if the cluster is under safe mode or not
      **/

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -141,7 +141,6 @@ public class PropertyAnalyzer {
     public static final String PROPERTIES_COLOCATE_WITH = "colocate_with";
 
     public static final String PROPERTIES_TIMEOUT = "timeout";
-
     public static final String PROPERTIES_DISTRIBUTION_TYPE = "distribution_type";
     public static final String PROPERTIES_SEND_CLEAR_ALTER_TASK = "send_clear_alter_tasks";
 
@@ -164,6 +163,13 @@ public class PropertyAnalyzer {
     public static final String PROPERTIES_BINLOG_TTL = "binlog_ttl_second";
 
     public static final String PROPERTIES_BINLOG_MAX_SIZE = "binlog_max_size";
+    public static final String PROPERTIES_FLAT_JSON_ENABLE = "flat_json.enable";
+
+    public static final String PROPERTIES_FLAT_JSON_NULL_FACTOR = "flat_json.null.factor";
+
+    public static final String PROPERTIES_FLAT_JSON_SPARSITY_FACTOR = "flat_json.sparsity.factor";
+
+    public static final String PROPERTIES_FLAT_JSON_COLUMN_MAX = "flat_json.column.max";
 
     public static final String PROPERTIES_STORAGE_TYPE_COLUMN = "column";
     public static final String PROPERTIES_STORAGE_TYPE_COLUMN_WITH_ROW = "column_with_row";
@@ -495,6 +501,65 @@ public class PropertyAnalyzer {
         } else {
             throw new SemanticException("Mutable bucket num is not set");
         }
+    }
+
+    public static double analyzeFlatJsonNullFactor(Map<String, String> properties) {
+        double flatJsonNullFactor = 0;
+        if (properties != null && properties.containsKey(PROPERTIES_FLAT_JSON_NULL_FACTOR)) {
+            try {
+                flatJsonNullFactor = Double.parseDouble(properties.get(PROPERTIES_FLAT_JSON_NULL_FACTOR));
+            } catch (NumberFormatException e) {
+                throw new SemanticException("Flat json null factor: " + e.getMessage());
+            }
+            if (flatJsonNullFactor < 0 || flatJsonNullFactor > 1) {
+                throw new SemanticException("Illegal flat json null factor: " + flatJsonNullFactor);
+            }
+            return flatJsonNullFactor;
+        } else {
+            throw new SemanticException("Flat json null factor is not set");
+        }
+    }
+
+    public static double analyzeFlatJsonSparsityFactor(Map<String, String> properties) {
+        double flatJsonSparsityFactor = 0;
+        if (properties != null && properties.containsKey(PROPERTIES_FLAT_JSON_SPARSITY_FACTOR)) {
+            try {
+                flatJsonSparsityFactor = Double.parseDouble(properties.get(PROPERTIES_FLAT_JSON_SPARSITY_FACTOR));
+            } catch (NumberFormatException e) {
+                throw new SemanticException("Flat json sparsity factor: " + e.getMessage());
+            }
+            if (flatJsonSparsityFactor < 0 || flatJsonSparsityFactor > 1) {
+                throw new SemanticException("Illegal flat json sparsity factor: " + flatJsonSparsityFactor);
+            }
+            return flatJsonSparsityFactor;
+        } else {
+            throw new SemanticException("Flat json sparsity factor is not set");
+        }
+    }
+
+    public static int analyzeFlatJsonColumnMax(Map<String, String> properties) {
+        int columnMax = 0;
+        if (properties != null && properties.containsKey(PROPERTIES_FLAT_JSON_COLUMN_MAX)) {
+            try {
+                columnMax = Integer.parseInt(properties.get(PROPERTIES_FLAT_JSON_COLUMN_MAX));
+            } catch (NumberFormatException e) {
+                throw new SemanticException("Flat json column max: " + e.getMessage());
+            }
+            if (columnMax < 0) {
+                throw new SemanticException("Illegal flat json column max: " + columnMax);
+            }
+            return columnMax;
+        } else {
+            throw new SemanticException("Flat json column max is not set");
+        }
+    }
+
+    public static boolean analyzeFlatJsonEnabled(Map<String, String> properties) {
+        boolean flatJsonEnabled = false;
+        if (properties != null && properties.containsKey(PROPERTIES_FLAT_JSON_ENABLE)) {
+            flatJsonEnabled = Boolean.parseBoolean(properties.get(PROPERTIES_FLAT_JSON_ENABLE));
+        }
+        return flatJsonEnabled;
     }
 
     public static boolean analyzeEnableLoadProfile(Map<String, String> properties) {
@@ -1128,17 +1193,48 @@ public class PropertyAnalyzer {
         return type;
     }
 
+    public static int analyzeIntProp(Map<String, String> properties, String propKey, int defaultVal)
+            throws AnalysisException {
+        int val = defaultVal;
+        if (properties != null && properties.containsKey(propKey)) {
+            String valStr = properties.get(propKey);
+            try {
+                val = Integer.parseInt(valStr);
+            } catch (NumberFormatException e) {
+                throw new AnalysisException("Invalid " + propKey + " format: " + valStr);
+            }
+            properties.remove(propKey);
+        }
+        return val;
+    }
+
     public static long analyzeLongProp(Map<String, String> properties, String propKey, long defaultVal)
             throws AnalysisException {
         long val = defaultVal;
         if (properties != null && properties.containsKey(propKey)) {
             String valStr = properties.get(propKey);
+            properties.remove(propKey);
             try {
                 val = Long.parseLong(valStr);
             } catch (NumberFormatException e) {
                 throw new AnalysisException("Invalid " + propKey + " format: " + valStr);
             }
             properties.remove(propKey);
+        }
+        return val;
+    }
+
+    public static double analyzerDoubleProp(Map<String, String> properties, String propKey, double defaultVal)
+        throws AnalysisException {
+        double val = defaultVal;
+        if (properties != null && properties.containsKey(propKey)) {
+            String valStr = properties.get(propKey);
+            properties.remove(propKey);
+            try {
+                val = Double.parseDouble(valStr);
+            } catch (NumberFormatException e) {
+                throw new AnalysisException("Invalid " + propKey + " format: " + valStr);
+            }
         }
         return val;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -1993,6 +1993,10 @@ public class EditLog {
         logEdit(OperationType.OP_MODIFY_BINLOG_CONFIG, log);
     }
 
+    public void logModifyFlatJsonConfig(ModifyTablePropertyOperationLog log) {
+        logEdit(OperationType.OP_MODIFY_FLAT_JSON_CONFIG, log);
+    }
+
     public void logModifyBinlogAvailableVersion(ModifyTablePropertyOperationLog log) {
         logEdit(OperationType.OP_MODIFY_BINLOG_AVAILABLE_VERSION, log);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -202,6 +202,9 @@ public class OperationType {
     @IgnorableOnReplayFailed
     public static final short OP_REMOVE_MULTI_COLUMN_STATS_META = 10019;
 
+    @IgnorableOnReplayFailed
+    public static final short OP_MODIFY_FLAT_JSON_CONFIG = 10020;
+
 
     // workgroup 10021 ~ 10030
     @IgnorableOnReplayFailed

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -70,6 +70,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.FlatJsonConfig;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.HiveTable;
@@ -3898,6 +3899,19 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                 new ModifyTablePropertyOperationLog(db.getId(), table.getId(), properties);
         GlobalStateMgr.getCurrentState().getEditLog().logModifyEnablePersistentIndex(info);
 
+    }
+
+    public void modifyFlatJsonMeta(Database db, OlapTable table, FlatJsonConfig flatJsonConfig) {
+        Locker locker = new Locker();
+        Preconditions.checkArgument(locker.isDbWriteLockHeldByCurrentThread(db));
+        table.setFlatJsonConfig(flatJsonConfig);
+
+        ModifyTablePropertyOperationLog info = new ModifyTablePropertyOperationLog(
+                db.getId(),
+                table.getId(),
+                flatJsonConfig.toProperties()
+        );
+        GlobalStateMgr.getCurrentState().getEditLog().logModifyFlatJsonConfig(info);
     }
 
     public void modifyBinlogMeta(Database db, OlapTable table, BinlogConfig binlogConfig) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -353,6 +353,27 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
             } catch (Throwable e) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, e.getMessage());
             }
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_ENABLE)) {
+            PropertyAnalyzer.analyzeFlatJsonEnabled(properties);
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR) ||
+                    properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR) ||
+                    properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX)) {
+            if (table instanceof OlapTable) {
+                OlapTable olapTable = (OlapTable) table;
+                if (olapTable.getFlatJsonConfig() != null && olapTable.getFlatJsonConfig().getFlatJsonEnable()) {
+                    if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_NULL_FACTOR)) {
+                        PropertyAnalyzer.analyzeFlatJsonNullFactor(properties);
+                    } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_SPARSITY_FACTOR)) {
+                        PropertyAnalyzer.analyzeFlatJsonSparsityFactor(properties);
+                    } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX)) {
+                        PropertyAnalyzer.analyzeFlatJsonColumnMax(properties);
+                    }
+                } else {
+                    ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                            "Property " + PropertyAnalyzer.PROPERTIES_BINLOG_ENABLE +
+                                    " haven't been enabled");
+                }
+            }
         } else {
             ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "Unknown properties: " + properties);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
@@ -36,11 +36,13 @@ package com.starrocks.task;
 
 import com.google.common.base.Preconditions;
 import com.starrocks.binlog.BinlogConfig;
+import com.starrocks.catalog.FlatJsonConfig;
 import com.starrocks.common.Status;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.thrift.TBinlogConfig;
 import com.starrocks.thrift.TCompressionType;
 import com.starrocks.thrift.TCreateTabletReq;
+import com.starrocks.thrift.TFlatJsonConfig;
 import com.starrocks.thrift.TPersistentIndexType;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TStorageMedium;
@@ -66,6 +68,7 @@ public class CreateReplicaTask extends AgentTask {
     private TPersistentIndexType persistentIndexType;
 
     private BinlogConfig binlogConfig;
+    private FlatJsonConfig flatJsonConfig;
 
     private final TTabletType tabletType;
 
@@ -101,6 +104,7 @@ public class CreateReplicaTask extends AgentTask {
         this.compressionLevel = builder.getCompressionLevel();
         this.tabletSchema = builder.getTabletSchema();
         this.binlogConfig = builder.getBinlogConfig();
+        this.flatJsonConfig = builder.getFlatJsonConfig();
         this.createSchemaFile = builder.isCreateSchemaFile();
         this.enableTabletCreationOptimization = builder.isEnableTabletCreationOptimization();
         this.baseTabletId = builder.getBaseTabletId();
@@ -171,6 +175,10 @@ public class CreateReplicaTask extends AgentTask {
             TBinlogConfig tBinlogConfig = binlogConfig.toTBinlogConfig();
             createTabletReq.setBinlog_config(tBinlogConfig);
         }
+        if (flatJsonConfig != null) {
+            TFlatJsonConfig tFlatJsonConfig = flatJsonConfig.toTFlatJsonConfig();
+            createTabletReq.setFlat_json_config(tFlatJsonConfig);
+        }
         if (inRestoreMode) {
             createTabletReq.setIn_restore_mode(true);
         }
@@ -206,6 +214,7 @@ public class CreateReplicaTask extends AgentTask {
         private boolean enablePersistentIndex;
         private TPersistentIndexType persistentIndexType;
         private BinlogConfig binlogConfig;
+        private FlatJsonConfig flatJsonConfig;
         private TTabletType tabletType = TTabletType.TABLET_TYPE_DISK;
         private MarkedCountDownLatch<Long, Long> latch;
         private boolean inRestoreMode = false;
@@ -326,6 +335,15 @@ public class CreateReplicaTask extends AgentTask {
 
         public Builder setPersistentIndexType(TPersistentIndexType persistentIndexType) {
             this.persistentIndexType = persistentIndexType;
+            return this;
+        }
+
+        public FlatJsonConfig getFlatJsonConfig() {
+            return flatJsonConfig;
+        }
+
+        public Builder setFlatJsonConfig(FlatJsonConfig flatJsonConfig) {
+            this.flatJsonConfig = flatJsonConfig;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
@@ -273,6 +273,7 @@ public class TabletTaskExecutor {
                         .setPersistentIndexType(table.getPersistentIndexType())
                         .setPrimaryIndexCacheExpireSec(table.primaryIndexCacheExpireSec())
                         .setBinlogConfig(table.getCurBinlogConfig())
+                        .setFlatJsonConfig(table.getFlatJsonConfig())
                         .setTabletType(tabletType)
                         .setCompressionType(table.getCompressionType())
                         .setCompressionLevel(table.getCompressionLevel())

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -274,6 +274,13 @@ message BinlogConfigPB {
     optional int64 binlog_max_size = 4;
 }
 
+message FlatJsonConfigPB {
+    optional bool flat_json_enable = 1;
+    optional double flat_json_null_factor = 2;
+    optional double flat_json_sparsity_factor = 3;
+    optional int64 flat_json_max_column_max = 4;
+}
+
 message TabletMetaPB {
     optional int64 table_id = 1;               // ?
     optional int64 partition_id = 2;           // ?
@@ -305,6 +312,7 @@ message TabletMetaPB {
     optional int32 primary_index_cache_expire_sec = 61 [default = 0];
     // If the tablet is replicated from another cluster, the source_schema saved the schema in the cluster
     optional TabletSchemaPB source_schema = 70;
+    optional FlatJsonConfigPB flat_json_config = 80;
 }
 
 message OLAPIndexHeaderMessage {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -82,6 +82,13 @@ struct TBinlogConfig {
     4: optional i64 binlog_max_size;
 }
 
+struct TFlatJsonConfig {
+    1: optional bool flat_json_enable;
+    2: optional double flat_json_null_factor;
+    3: optional double flat_json_sparsity_factor;
+    4: optional i64 flat_json_column_max;
+}
+
 // If you want to add types,
 // don't forget to also add type to PersistentIndexTypePB
 enum TPersistentIndexType {
@@ -122,6 +129,7 @@ struct TCreateTabletReq {
     23: optional i64 timeout_ms = -1;
     // Global transaction id
     24: optional i64 gtid = 0;
+    25: optional TFlatJsonConfig flat_json_config;
 }
 
 struct TDropTabletReq {
@@ -426,7 +434,8 @@ enum TTabletMetaType {
     STORAGE_TYPE,
     MUTABLE_BUCKET_NUM,
     ENABLE_LOAD_PROFILE,
-    BASE_COMPACTION_FORBIDDEN_TIME_RANGES
+    BASE_COMPACTION_FORBIDDEN_TIME_RANGES,
+    FLAT_JSON_CONFIG
 }
 
 struct TTabletMetaInfo {
@@ -442,6 +451,7 @@ struct TTabletMetaInfo {
     // |create_schema_file| only used when |tablet_schema| exists
     10: optional bool create_schema_file;
     11: optional TPersistentIndexType persistent_index_type;
+    12: optional TFlatJsonConfig flat_json_config;
 }
 
 struct TUpdateTabletMetaInfoReq {

--- a/test/sql/test_semi/R/test_flat_json_with_properties
+++ b/test/sql/test_semi/R/test_flat_json_with_properties
@@ -1,19 +1,23 @@
--- name: test_normal_flat_json @system
+-- name: test_normal_flat_json_with_properties @system
 CREATE TABLE `js1` (
   `v1` bigint(20) NULL COMMENT "",
   `v2` int(11) NULL COMMENT "",
   `j1` json NULL COMMENT "",
   `j2` json NULL COMMENT ""
-) ENGINE=OLAP 
+) ENGINE=OLAP
 DUPLICATE KEY(`v1`)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`v1`) BUCKETS 10 
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
 PROPERTIES (
 "replication_num" = "1",
-"enable_persistent_index" = "true",
+"enable_persistent_index" = "false",
 "replicated_storage" = "false",
 "fast_schema_evolution" = "true",
-"compression" = "LZ4"
+"compression" = "LZ4",
+"flat_json.enable" = "true",
+"flat_json.null.factor" = "0.2",
+"flat_json.sparsity.factor" = "0.2",
+"flat_json.column.max" = "120"
 );
 -- result:
 -- !result

--- a/test/sql/test_semi/T/test_flat_json_with_properties
+++ b/test/sql/test_semi/T/test_flat_json_with_properties
@@ -1,22 +1,26 @@
--- name: test_normal_flat_json @system
+-- name: test_normal_flat_json_with_properties @system
+
 CREATE TABLE `js1` (
   `v1` bigint(20) NULL COMMENT "",
   `v2` int(11) NULL COMMENT "",
   `j1` json NULL COMMENT "",
   `j2` json NULL COMMENT ""
-) ENGINE=OLAP 
+) ENGINE=OLAP
 DUPLICATE KEY(`v1`)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`v1`) BUCKETS 10 
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
 PROPERTIES (
 "replication_num" = "1",
-"enable_persistent_index" = "true",
+"enable_persistent_index" = "false",
 "replicated_storage" = "false",
 "fast_schema_evolution" = "true",
-"compression" = "LZ4"
+"compression" = "LZ4",
+"flat_json.enable" = "true",
+"flat_json.null.factor" = "0.2",
+"flat_json.sparsity.factor" = "0.2",
+"flat_json.column.max" = "120"
 );
--- result:
--- !result
+
 INSERT INTO `js1` (`v1`, `v2`, `j1`, `j2`) VALUES
 (1, 28, parse_json('{"key1": "value11", "key2": "value12", "key3": "value13", "key4": "value14", "key5": "value15", "key6": "value16", "key7": "value17", "key8": "value18"}'), parse_json('{"key1": "value11", "key2": "value12", "key3": "value13", "key4": "value14", "key5": "value15", "key6": "value16"}')),
 (2, 29, parse_json('{"key1": "value21", "key2": "value22", "key3": "value23", "key4": "value24", "key5": "value25", "key6": "value26", "key7": "value27"}'), parse_json('{"key1": "value21", "key2": "value22", "key3": "value23", "key4": "value24", "key5": "value25", "key6": "value26", "key7": "value27", "key8": "value28"}')),
@@ -68,260 +72,77 @@ INSERT INTO `js1` (`v1`, `v2`, `j1`, `j2`) VALUES
 (48, 44, parse_json('{"key1": "value481", "key2": "value482", "key3": "value483", "key4": "value484", "key5": "value485", "key6": "value486", "key7": "value487", "key8": "value488", "key9": "value489"}'), parse_json('{"key1": "value481", "key2": "value482", "key3": "value483", "key4": "value484", "key5": "value485", "key6": "value486", "key7": "value487"}')),
 (49, 5, parse_json('{"key1": "value491", "key2": "value492", "key3": "value493", "key4": "value494", "key5": "value495", "key6": "value496", "key7": "value497"}'), parse_json('{"key1": "value491", "key2": "value492", "key3": "value493", "key4": "value494", "key5": "value495", "key6": "value496", "key7": "value497"}')),
 (50, 76, parse_json('{"key1": "value501", "key2": "value502", "key3": "value503", "key4": "value504", "key5": "value505", "key6": "value506", "key7": "value507", "key8": "value508"}'), parse_json('{"key1": "value501", "key2": "value502", "key3": "value503", "key4": "value504", "key5": "value505", "key6": "value506", "key7": "value507"}'));
--- result:
--- !result
+
 insert into js1 select * from js1;
--- result:
--- !result
 insert into js1 select * from js1;
--- result:
--- !result
 insert into js1 select * from js1;
--- result:
--- !result
+
 select get_json_string(j1, "$.key2"), get_json_double(j2, "$.key3"), get_json_string(j2, "$.key4") from js1 order by v1 limit 2;
--- result:
-value12	None	value14
-value12	None	value14
--- !result
 select get_json_string(j1, "$.key8"), get_json_double(j2, "$.key9"), get_json_string(j2, "$.key10") from js1 order by v1 limit 2;
--- result:
-value18	None	None
-value18	None	None
--- !result
 select get_json_string(j1, "$.key12"), get_json_double(j2, "$.key13"), get_json_string(j2, "$") from js1 order by v1 limit 2;
--- result:
-None	None	{"key1": "value11", "key2": "value12", "key3": "value13", "key4": "value14", "key5": "value15", "key6": "value16"}
-None	None	{"key1": "value11", "key2": "value12", "key3": "value13", "key4": "value14", "key5": "value15", "key6": "value16"}
--- !result
 select get_json_string(j1, "asdf"), get_json_double(j2, "$13"), get_json_string(j2, "$.key3") from js1 order by v1 limit 2;
--- result:
-None	None	value13
-None	None	value13
--- !result
 select get_json_string(j1, "$.key2"), get_json_double(j2, "$.key2.key3") from js1 order by v1 limit 2;
--- result:
-value12	None
-value12	None
--- !result
+
 select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j2, "$.key2.key3") from js1 order by v1 limit 2;
--- result:
-1	0
-1	0
--- !result
 select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j2, "$.key3"), JSON_EXISTS(j2, "$.key4") from js1 order by v1 limit 2;
--- result:
-1	1	1
-1	1	1
--- !result
 select JSON_EXISTS(j1, "$.key8"), JSON_EXISTS(j2, "$.key9"), JSON_EXISTS(j2, "$.key10") from js1 order by v1 limit 2;
--- result:
-1	0	0
-1	0	0
--- !result
 select JSON_EXISTS(j1, "$.key12"), JSON_EXISTS(j2, "$.key13"), JSON_EXISTS(j2, "$") from js1 order by v1 limit 2;
--- result:
-0	0	1
-0	0	1
--- !result
 select JSON_EXISTS(j1, "asdf"), JSON_EXISTS(j2, "$13"), JSON_EXISTS(j2, "$.key3") from js1 order by v1 limit 2;
--- result:
-0	0	1
-0	0	1
--- !result
 select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j2, "$.key2.key3") from js1 order by v1 limit 2;
--- result:
-1	0
-1	0
--- !result
+
 select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j2, "$.key2.key3") from js1 order by v1 limit 2;
--- result:
-1	0
-1	0
--- !result
 select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j2, "$.key3"), JSON_LENGTH(j2, "$.key4") from js1 order by v1 limit 2;
--- result:
-1	1	1
-1	1	1
--- !result
 select JSON_LENGTH(j1, "$.key8"), JSON_LENGTH(j2, "$.key9"), JSON_LENGTH(j2, "$.key10") from js1 order by v1 limit 2;
--- result:
-1	0	0
-1	0	0
--- !result
 select JSON_LENGTH(j1, "$.key12"), JSON_LENGTH(j2, "$.key13"), JSON_LENGTH(j2, "$") from js1 order by v1 limit 2;
--- result:
-0	0	6
-0	0	6
--- !result
 select JSON_LENGTH(j1, "asdf"), JSON_LENGTH(j2, "$13"), JSON_LENGTH(j2, "$.key3") from js1 order by v1 limit 2;
--- result:
-0	0	1
-0	0	1
--- !result
+
 select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j2, "$.key2.key3") from js1 where v2 = 2 order by v1 limit 2;
--- result:
-1	0
-1	0
--- !result
 select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j2, "$.key3"), JSON_LENGTH(j2, "$.key4") from js1 where v2 > 1 order by v1 limit 2;
--- result:
-1	1	1
-1	1	1
--- !result
 select JSON_LENGTH(j1, "$.key8"), JSON_LENGTH(j2, "$.key9"), JSON_LENGTH(j2, "$.key10") from js1 where v1 < 1 order by v1 limit 2;
--- result:
--- !result
 select JSON_LENGTH(j1, "$.key12"), JSON_LENGTH(j2, "$.key13"), JSON_LENGTH(j2, "$") from js1 where v1 = -1 order by v1 limit 2;
--- result:
--- !result
 select JSON_LENGTH(j1, "asdf"), JSON_LENGTH(j2, "$13"), JSON_LENGTH(j2, "$.key3") from js1 where v1 = 10 order by v1 limit 2;
--- result:
-0	0	1
-0	0	1
--- !result
+
+-- delete data
 delete from js1 where v1 = 1;
--- result:
--- !result
 delete from js1 where v1 = 2;
--- result:
--- !result
 delete from js1 where v1 = 3;
--- result:
--- !result
+
 select JSON_EXISTS(j1, "$.key12"), JSON_EXISTS(j2, "$.key13"), JSON_EXISTS(j2, "$") from js1 order by v1 limit 2;
--- result:
-0	0	1
-0	0	1
--- !result
 select JSON_LENGTH(j1, "$.key8"), JSON_LENGTH(j2, "$.key9"), JSON_LENGTH(j2, "$.key10") from js1 order by v1 limit 2;
--- result:
-0	0	0
-0	0	0
--- !result
 select get_json_string(j1, "asdf"), get_json_double(j2, "$13"), get_json_string(j2, "$.key3") from js1 order by v1 limit 2;
--- result:
-None	None	value43
-None	None	value43
--- !result
 select JSON_LENGTH(j1, "$.key12"), JSON_LENGTH(j2, "$.key13"), JSON_LENGTH(j2, "$") from js1 where v1 = -1 order by v1 limit 2;
--- result:
--- !result
+
+-- schema change
 ALTER TABLE js1 ADD COLUMN j3 JSON DEFAULT NULL AFTER j2;
--- result:
--- !result
 ALTER TABLE js1 ADD COLUMN j4 JSON DEFAULT NULL AFTER j1;
--- result:
--- !result
+
 select get_json_string(j1, "$.key2"), get_json_double(j3, "$.key3"), get_json_string(j3, "$.key4") from js1 order by v1 limit 2;
--- result:
-value42	None	None
-value42	None	None
--- !result
 select get_json_string(j1, "$.key2"), get_json_double(j3, "$.key2.key3") from js1 order by v1 limit 2;
--- result:
-value42	None
-value42	None
--- !result
 select JSON_EXISTS(j1, "$.key12"), JSON_EXISTS(j3, "$.key13"), JSON_EXISTS(j3, "$") from js1 order by v1 limit 2;
--- result:
-0	None	None
-0	None	None
--- !result
 select JSON_EXISTS(j1, "asdf"), JSON_EXISTS(j3, "$13"), JSON_EXISTS(j3, "$.key3") from js1 order by v1 limit 2;
--- result:
-0	None	None
-0	None	None
--- !result
 select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j3, "$.key2.key3") from js1 order by v1 limit 2;
--- result:
-1	None
-1	None
--- !result
 select JSON_LENGTH(j1, "asdf"), JSON_LENGTH(j3, "$13"), JSON_LENGTH(j3, "$.key3") from js1 order by v1 limit 2;
--- result:
-0	None	None
-0	None	None
--- !result
 select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j3, "$.key2.key3") from js1 where v2 = 2 order by v1 limit 2;
--- result:
-1	None
-1	None
--- !result
 select JSON_LENGTH(j1, "$.key12"), JSON_LENGTH(j3, "$.key13"), JSON_LENGTH(j3, "$") from js1 where v1 = -1 order by v1 limit 2;
--- result:
--- !result
 select JSON_LENGTH(j1, "$.key12"), JSON_LENGTH(j3, "$.key13"), JSON_LENGTH(j3, "$") from js1 where v1 = -1 order by v1 limit 2;
--- result:
--- !result
 select JSON_LENGTH(j1, "$.key12"), JSON_LENGTH(j3, "$.key13"), JSON_LENGTH(j3, "$") from js1 where v1 = -1 order by v1 limit 2;
--- result:
--- !result
+
 select get_json_string(j4, "$.key2"), get_json_double(j3, "$.key3"), get_json_string(j3, "$.key4") from js1 order by v1 limit 2;
--- result:
-None	None	None
-None	None	None
--- !result
 select get_json_string(j4, "$.key2"), get_json_double(j3, "$.key2.key3") from js1 order by v1 limit 2;
--- result:
-None	None
-None	None
--- !result
 select JSON_EXISTS(j4, "$.key12"), JSON_EXISTS(j3, "$.key13"), JSON_EXISTS(j3, "$") from js1 order by v1 limit 2;
--- result:
-None	None	None
-None	None	None
--- !result
 select JSON_EXISTS(j4, "asdf"), JSON_EXISTS(j3, "$13"), JSON_EXISTS(j2, "$.key3") from js1 order by v1 limit 2;
--- result:
-None	None	1
-None	None	1
--- !result
 select JSON_LENGTH(j4, "$.key2"), JSON_LENGTH(j2, "$.key2.key3") from js1 order by v1 limit 2;
--- result:
-None	0
-None	0
--- !result
 select JSON_LENGTH(j4, "asdf"), JSON_LENGTH(j2, "$13"), JSON_LENGTH(j2, "$.key3") from js1 order by v1 limit 2;
--- result:
-None	0	1
-None	0	1
--- !result
 select JSON_LENGTH(j4, "$.key2"), JSON_LENGTH(j2, "$.key2.key3") from js1 where v2 = 2 order by v1 limit 2;
--- result:
-None	0
-None	0
--- !result
 select JSON_LENGTH(j4, "$.key12"), JSON_LENGTH(j2, "$.key13"), JSON_LENGTH(j3, "$") from js1 where v1 = -1 order by v1 limit 2;
--- result:
--- !result
 select JSON_LENGTH(j4, "$.key12"), JSON_LENGTH(j3, "$.key13"), JSON_LENGTH(j3, "$") from js1 where v1 = -1 order by v1 limit 2;
--- result:
--- !result
 select JSON_LENGTH(j4, "$.key12"), JSON_LENGTH(j3, "$.key13"), JSON_LENGTH(j2, "$") from js1 where v1 = -1 order by v1 limit 2;
--- result:
--- !result
+
+
 ALTER TABLE js1 DROP COLUMN j1;
--- result:
--- !result
 ALTER TABLE js1 DROP COLUMN j4;
--- result:
--- !result
+
 select JSON_EXISTS(j2, "$.key12"), JSON_EXISTS(j2, "$.key13"), JSON_EXISTS(j2, "$") from js1 order by v1 limit 2;
--- result:
-0	0	1
-0	0	1
--- !result
 select JSON_LENGTH(j2, "$.key8"), JSON_LENGTH(j2, "$.key9"), JSON_LENGTH(j2, "$.key10") from js1 order by v1 limit 2;
--- result:
-0	0	0
-0	0	0
--- !result
 select get_json_string(j2, "asdf"), get_json_double(j2, "$13"), get_json_string(j2, "$.key3") from js1 order by v1 limit 2;
--- result:
-None	None	value43
-None	None	value43
--- !result
 select JSON_LENGTH(j2, "$.key12"), JSON_LENGTH(j2, "$.key13"), JSON_LENGTH(j2, "$") from js1 where v1 = -1 order by v1 limit 2;
--- result:
--- !result


### PR DESCRIPTION
## Why I'm doing:
Currently, the configuration for flat JSON is primarily based on global settings, and the variables are dynamic rather than persistent. This approach does not fully align with actual business requirements. In different business scenarios and tables, factors such as data sparsity and NULL value handling vary significantly. As a result, a unified global configuration fails to meet all cases, potentially leading to inefficient data processing for some tables or suboptimal performance in certain scenarios. Moreover, the global configuration approach limits the flexibility of the cluster, preventing tailored adjustments based on specific needs.

## What I'm doing:
The flat JSON configuration needs to be changed from a global setting to a table-level configuration. This way, each table can be independently configured based on its data characteristics and actual requirements, improving flexibility and performance.

Fixes #57380

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
