### PR TITLE
[UT] fix random failure in UpdateManagerTest.test_on_rowset_finished test case

### DIFF
--- a/be/test/storage/update_manager_test.cpp
+++ b/be/test/storage/update_manager_test.cpp
@@ -162,7 +162,7 @@ TEST_F(UpdateManagerTest, testDelVec) {
 }
 
 TEST_F(UpdateManagerTest, testExpireEntry) {
-    srand(time(nullptr));
+    srand(GetCurrentTimeMicros());
     create_tablet(rand(), rand());
     // write
     const int N = 8000;
@@ -198,7 +198,7 @@ TEST_F(UpdateManagerTest, testExpireEntry) {
 }
 
 TEST_F(UpdateManagerTest, testSetEmptyCachedDeltaColumnGroup) {
-    srand(time(nullptr));
+    srand(GetCurrentTimeMicros());
     create_tablet(rand(), rand());
     TabletSegmentId tsid;
     tsid.tablet_id = _tablet->tablet_id();
@@ -214,7 +214,7 @@ TEST_F(UpdateManagerTest, testSetEmptyCachedDeltaColumnGroup) {
 }
 
 TEST_F(UpdateManagerTest, test_on_rowset_finished) {
-    srand(time(nullptr));
+    srand(GetCurrentTimeMicros());
     create_tablet(rand(), rand());
     const int N = 10;
     std::vector<int64_t> keys;


### PR DESCRIPTION
[ RUN      ] UpdateManagerTest.testSetEmptyCachedDeltaColumnGroup
I20250328 07:25:31.431420 131786630815424 tablet_manager.cpp:169] **Creating tablet 793588412**
I20250328 07:25:31.431452 131786630815424 tablet_manager.cpp:1443] creating tablet meta. next_unique_id:3
I20250328 07:25:31.431925 131786630815424 tablet_manager.cpp:238] Created tablet 793588412
I20250328 07:25:31.432236 131786630815424 tablet_manager.cpp:395] Start to drop tablet 793588412
I20250328 07:25:31.432320 131786630815424 tablet_manager.cpp:469] Succeed to drop tablet 793588412
[       OK ] UpdateManagerTest.testSetEmptyCachedDeltaColumnGroup (45 ms)
[ RUN      ] UpdateManagerTest.test_on_rowset_finished
I20250328 07:25:31.451808 131786630815424 tablet_manager.cpp:169] **Creating tablet 793588412**
/root/starrocks/be/test/storage/update_manager_test.cpp:112: Failure
Value of: st.ok()
  Actual: false
Expected: true
Internal error: tablet still resident in shutdown queue

## Why I'm doing:
test_on_rowset_finished randomly fails because the same tablet id is generated as the previous test case.
time() api is used as seed to generate random number. if the time is same between subsequent test case execution, the same random number will be generated.

## What I'm doing:
after fix:
[----------] 4 tests from UpdateManagerTest (2122 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (2122 ms total)
[  PASSED  ] 4 tests.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [X] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
