### PR TITLE
[Enhancement] safe guard to jni string

### DIFF
--- a/be/src/udf/java/java_udf.cpp
+++ b/be/src/udf/java/java_udf.cpp
@@ -298,6 +298,9 @@ std::string JVMFunctionHelper::to_string(jobject obj) {
 }
 
 std::string JVMFunctionHelper::to_cxx_string(jstring str) {
+    if (str == nullptr) {
+        return "<null>";
+    }
     std::string res;
     const char* charflow = _env->GetStringUTFChars((jstring)str, nullptr);
     res = charflow;


### PR DESCRIPTION
## Why I'm doing:

if JNI exception happens because of OOM, stack trace could be nullptr. 

I observed some crash case

```
java.lang.OutOfMemoryError: Java heap space
java.lang.OutOfMemoryError: Java heap space
[509.936s][warning][gc,alloc] Thread-9: Retried waiting for GCLocker too often allocating 2367 words
[509.937s][warning][gc,alloc] Thread-105: Retried waiting for GCLocker too often allocating 3 words
[509.937s][warning][gc,alloc] Thread-55: Retried waiting for GCLocker too often allocating 1299 words
[509.937s][warning][gc,alloc] Thread-76: Retried waiting for GCLocker too often allocating 2316 words
[509.937s][warning][gc,alloc] Thread-73: Retried waiting for GCLocker too often allocating 52 words
[509.937s][warning][gc,alloc] Thread-50: Retried waiting for GCLocker too often allocating 3034 words
[509.937s][warning][gc,alloc] Thread-98: Retried waiting for GCLocker too often allocating 1939 words
Exception in thread "Thread-74" java.lang.OutOfMemoryError: Java heap space
Exception in thread "Thread-73" java.lang.OutOfMemoryError: Java heap space
Exception in thread "Thread-13" java.lang.OutOfMemoryError: Java heap space
Exception in thread "Thread-105" [510.349s][warning][gc,alloc] Thread-33: Retried waiting for GCLocker too often allocating 3 words
java.lang.OutOfMemoryError: Java heap space
[510.349s][warning][gc,alloc] Thread-60: Retried waiting for GCLocker too often allocating 1539 words
main RELEASE (build 759619b)
query_id:ff7cf4e2-0b4a-11f0-912e-00163e02362f, fragment_instance:ff7cf4e2-0b4a-11f0-912e-00163e023643
Hive file path: part-00008-2fbb6ac2-a3b7-4243-bf07-9817c8e46dad-c000, partition id: 0, length: 1941965, offset: 0
tracker:process consumption: 839311096
tracker:query_pool consumption: 76986040
tracker:load consumption: 0
tracker:consistency consumption: 0
tracker:compaction consumption: 0
tracker:schema_change consumption: 0
tracker:jemalloc_metadata consumption: 86826912
tracker:passthrough consumption: 0
tracker:connector_scan consumption: 763314339
tracker:metadata consumption: 77834575
tracker:tablet_metadata consumption: 35205079
tracker:rowset_metadata consumption: 16272835
tracker:segment_metadata consumption: 3003392
tracker:column_metadata consumption: 21849721
tracker:tablet_schema consumption: 506911
tracker:short_key_index consumption: 490654
tracker:column_zonemap_index consumption: 5653001
tracker:ordinal_index consumption: 4499184
tracker:bitmap_index consumption: 209216
tracker:bloom_filter_index consumption: 226976
tracker:page_cache consumption: 2098674
tracker:jit_cache consumption: 31912
tracker:update consumption: 70443599
tracker:chunk_allocator consumption: 0
tracker:clone consumption: 0
tracker:datacache consumption: 7881338
tracker:poco_connection_pool consumption: 755600
tracker:replication consumption: 0
*** Aborted at 1743107724 (unix time) try "date -d @1743107724" if you are using GNU date ***
PC: @     0x2ba08c9c8d70 (/usr/lib/jvm/jdk-17.0.13_centos7_x86_64/lib/server/libjvm.so+0x28cd6f)
*** SIGSEGV (@0x0) received by PID 2849 (TID 0x2ba0bdb84700) LWP(3232) from PID 0; stack trace: ***
    @     0x2ba08c52620b __pthread_once_slow
    @          0xb5b09d4 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x2ba08d4c7999 PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0]
    @     0x2ba08d4c83ee JVM_handle_linux_signal
    @     0x2ba08c52f630 (/usr/lib64/libpthread-2.17.so+0xf62f)
    @     0x2ba08c9c8d70 (/usr/lib/jvm/jdk-17.0.13_centos7_x86_64/lib/server/libjvm.so+0x28cd6f)
    @     0x2ba08cff5aa9 jni_GetStringUTFChars
    @          0x7b9ea3b starrocks::JVMFunctionHelper::to_cxx_string[abi:cxx11](_jstring*)
    @          0x7ba5de9 starrocks::JVMFunctionHelper::dumpExceptionString[abi:cxx11](_jthrowable*)
```

and gdb session is like

```
(gdb) p _env
$3 = (JNIEnv *) 0x2ba08fe29cb0
(gdb) p *_env
$4 = {functions = 0x2ba08da04500 <jni_NativeInterface>}

(gdb) f 7
#7  starrocks::JVMFunctionHelper::to_cxx_string[abi:cxx11](_jstring*) (this=<optimized out>, str=0x0) at be/src/udf/java/java_udf.cpp:302
302     in be/src/udf/java/java_udf.cpp
(gdb) p str
$7 = (jstring) 0x0

(gdb) f 8
#8  0x0000000007ba5de9 in starrocks::JVMFunctionHelper::dumpExceptionString[abi:cxx11](_jthrowable*) (this=0x13f2fb40 <starrocks::JVMFunctionHelper::getInstance()::helper>, throwable=throwable@entry=0x2ba163017c38)
    at be/src/udf/java/java_udf.cpp:315
315     in be/src/udf/java/java_udf.cpp
(gdb) p jstack_traces
No symbol "jstack_traces" in current context.
(gdb) info local
get_stack_trace = <optimized out>
stack_traces = 0x0
guard_L314 = <optimized out>
```


## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/9475

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
