### PR TITLE
[Enhancement] Remove meaningless global locks in show database

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -430,47 +430,42 @@ public class ShowExecutor {
 
         @Override
         public ShowResultSet visitShowDatabasesStatement(ShowDbStmt statement, ConnectContext context) {
-            GlobalStateMgr.getCurrentState().tryLock(true);
-            try {
-                List<List<String>> rows = Lists.newArrayList();
-                List<String> dbNames;
-                String catalogName;
-                if (statement.getCatalogName() == null) {
-                    catalogName = context.getCurrentCatalog();
-                } else {
-                    catalogName = statement.getCatalogName();
-                }
-                dbNames = GlobalStateMgr.getCurrentState().getMetadataMgr().listDbNames(context, catalogName);
-
-                PatternMatcher matcher = null;
-                if (statement.getPattern() != null) {
-                    matcher = PatternMatcher.createMysqlPattern(statement.getPattern(),
-                            CaseSensibility.DATABASE.getCaseSensibility());
-                }
-                Set<String> dbNameSet = Sets.newTreeSet();
-                for (String dbName : dbNames) {
-                    // Filter dbname
-                    if (matcher != null && !matcher.match(dbName)) {
-                        continue;
-                    }
-
-                    try {
-                        Authorizer.checkAnyActionOnOrInDb(context, catalogName, dbName);
-                    } catch (AccessDeniedException e) {
-                        continue;
-                    }
-
-                    dbNameSet.add(dbName);
-                }
-
-                for (String dbName : dbNameSet) {
-                    rows.add(Lists.newArrayList(dbName));
-                }
-
-                return new ShowResultSet(((ShowDbStmt) statement).getMetaData(), rows);
-            } finally {
-                GlobalStateMgr.getCurrentState().unlock();
+            List<List<String>> rows = Lists.newArrayList();
+            List<String> dbNames;
+            String catalogName;
+            if (statement.getCatalogName() == null) {
+                catalogName = context.getCurrentCatalog();
+            } else {
+                catalogName = statement.getCatalogName();
             }
+            dbNames = GlobalStateMgr.getCurrentState().getMetadataMgr().listDbNames(context, catalogName);
+
+            PatternMatcher matcher = null;
+            if (statement.getPattern() != null) {
+                matcher = PatternMatcher.createMysqlPattern(statement.getPattern(),
+                        CaseSensibility.DATABASE.getCaseSensibility());
+            }
+            Set<String> dbNameSet = Sets.newTreeSet();
+            for (String dbName : dbNames) {
+                // Filter dbname
+                if (matcher != null && !matcher.match(dbName)) {
+                    continue;
+                }
+
+                try {
+                    Authorizer.checkAnyActionOnOrInDb(context, catalogName, dbName);
+                } catch (AccessDeniedException e) {
+                    continue;
+                }
+
+                dbNameSet.add(dbName);
+            }
+
+            for (String dbName : dbNameSet) {
+                rows.add(Lists.newArrayList(dbName));
+            }
+
+            return new ShowResultSet(((ShowDbStmt) statement).getMetaData(), rows);
         }
 
         public ShowResultSet visitShowTableStatement(ShowTableStmt statement, ConnectContext context) {


### PR DESCRIPTION
## Why I'm doing:
The global lock in show database has no practical significance, because the db list in Localmetastore is ConcurrentHashMap, and show only displays information.
However, this may cause the global lock to be occupied for a long time because an external catalog responds too slowly.
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
