### PR TITLE
[BugFix][ISSUE-57393]Fix the errors when user use unified catalog and MetadataMgr try to getDeleteFIles

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
@@ -43,10 +43,13 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.thrift.TSinkCommitInfo;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.starrocks.catalog.Table.TableType.DELTALAKE;
@@ -271,5 +274,12 @@ public class UnifiedMetadata implements ConnectorMetadata {
     @Override
     public CloudConfiguration getCloudConfiguration() {
         return hiveMetadata.getCloudConfiguration();
+    }
+
+    @Override
+    public Set<DeleteFile> getDeleteFiles(IcebergTable icebergTable, Long snapshotId,
+                                          ScalarOperator predicate, FileContent content) {
+        ConnectorMetadata metadata = metadataOfTable(icebergTable.getCatalogDBName(), icebergTable.getCatalogTableName());
+        return metadata.getDeleteFiles(icebergTable, snapshotId, predicate, content);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
@@ -16,6 +16,7 @@ package com.starrocks.connector.unified;
 
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AlreadyExistsException;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
@@ -49,6 +49,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.wildfly.common.Assert;
 
+import java.util.HashSet;
 import java.util.List;
 
 import static com.starrocks.catalog.Table.TableType.DELTALAKE;
@@ -298,6 +299,12 @@ public class UnifiedMetadataTest {
                 result = true;
                 times = 1;
             }
+
+            {
+                icebergMetadata.getDeleteFiles((IcebergTable) any, -1L, null, null);
+                result = new HashSet<>();
+                times = 1;
+            }
         };
 
         Table table = unifiedMetadata.getTable(new ConnectContext(), "test_db", "test_tbl");
@@ -318,6 +325,7 @@ public class UnifiedMetadataTest {
         Assert.assertTrue(unifiedMetadata.prepareMetadata(new MetaPreparationItem(icebergTable, null,
                 -1, TableVersionRange.empty()), null, null));
         Assert.assertNotNull(unifiedMetadata.getSerializedMetaSpec("test_db", "test_tbl", -1, null, null));
+        Assert.assertNotNull(unifiedMetadata.getDeleteFiles(new IcebergTable(), -1L, null, null));
     }
 
     @Test


### PR DESCRIPTION
Implement the getDeleteFiles method within the UnifiedMetadata module to handle file deletion logic.

## Why I'm doing:

fix #57393 

## What I'm doing:

Implement the getDeleteFiles method within the UnifiedMetadata module to handle file deletion logic.

Fixes #57393 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1