### PR TITLE
[BugFix] Fix a bug that when read HDFS text file array type the last empty string will be missed

### DIFF
--- a/be/src/formats/csv/array_reader.cpp
+++ b/be/src/formats/csv/array_reader.cpp
@@ -95,6 +95,9 @@ bool HiveTextArrayReader::split_array_elements(const Slice& s, std::vector<Slice
     }
     if (right >= left) {
         elements.emplace_back(s.data + left, right - left);
+    } else {
+        // for the case right = left will add an empty string into the elements
+        elements.emplace_back("");
     }
 
     return true;

--- a/be/test/formats/csv/array_converter_test.cpp
+++ b/be/test/formats/csv/array_converter_test.cpp
@@ -222,8 +222,9 @@ TEST(ArrayConverterTest, test_hive_read_string02) {
 
     EXPECT_TRUE(conv->read_string(col.get(), "", options));
     EXPECT_TRUE(conv->read_string(col.get(), "apple_banana_\\N", options));
+    EXPECT_TRUE(conv->read_string(col.get(), "__", options));
 
-    EXPECT_EQ(2, col->size());
+    EXPECT_EQ(3, col->size());
     // []
     EXPECT_EQ(0, col->get(0).get_array().size());
     // ["apple","banana",null]
@@ -231,6 +232,11 @@ TEST(ArrayConverterTest, test_hive_read_string02) {
     EXPECT_EQ("apple", col->get(1).get_array()[0].get_slice());
     EXPECT_EQ("banana", col->get(1).get_array()[1].get_slice());
     EXPECT_TRUE(col->get(1).get_array()[2].is_null());
+    // ["","",""]
+    EXPECT_EQ(3, col->get(2).get_array().size());
+    EXPECT_EQ("", col->get(2).get_array()[0].get_slice());
+    EXPECT_EQ("", col->get(2).get_array()[1].get_slice());
+    EXPECT_EQ("", col->get(2).get_array()[2].get_slice());
 }
 
 // NOLINTNEXTLINE


### PR DESCRIPTION
[BugFix] Fix a bug that when read HDFS text file array type the last empty string will be missed

## Why I'm doing:
When I doing some test for read text file and I got wrong result for the array type.
I found if the last array is an empty string, the result will always be wrong.
Here I provide this commit to fix it.
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
