### PR TITLE
[BugFix] fix jersey conflict behind ranger integration 

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -1345,6 +1345,10 @@ under the License.
                         <groupId>com.nimbusds</groupId>
                         <artifactId>nimbus-jose-jwt</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>com.sun.jersey</groupId>
+                        <artifactId>jersey-bundle</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -755,6 +755,10 @@ under the License.
                         <groupId>ch.qos.reload4j</groupId>
                         <artifactId>reload4j</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>javax.ws.rs</groupId>
+                        <artifactId>jsr311-api</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 


### PR DESCRIPTION
## Why I'm doing:
![Screenshot 2025-03-26 at 17 04 30](https://github.com/user-attachments/assets/9551daf2-8ebe-4473-8a72-2dbc69150489)
When I tried to integrate StarRocks with Ranger, I faced a problem shown as the screenshot.  The issue is caused that ​StarRocks and Ranger rely on incompatible versions of the Jersey library, which leads to classpath conflicts during runtime.

## What I'm doing:
as title
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
