### PR TITLE
[Feature] Implement user identity impersonation for the Iceberg REST catalog using the OIDC token + Iceberg token exchange flow

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -220,19 +220,15 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public void createDb(String dbName) throws DdlException, AlreadyExistsException {
-        normal.createDb(dbName);
-    }
-
-    @Override
     public boolean dbExists(ConnectContext context, String dbName) {
         ConnectorMetadata metadata = metadataOfDb(dbName);
         return metadata.dbExists(context, dbName);
     }
 
     @Override
-    public void createDb(String dbName, Map<String, String> properties) throws DdlException, AlreadyExistsException {
-        normal.createDb(dbName, properties);
+    public void createDb(ConnectContext context, String dbName, Map<String, String> properties)
+            throws DdlException, AlreadyExistsException {
+        normal.createDb(context, dbName, properties);
     }
 
     @Override
@@ -247,13 +243,13 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public boolean createTable(CreateTableStmt stmt) throws DdlException {
-        return normal.createTable(stmt);
+    public boolean createTable(ConnectContext context, CreateTableStmt stmt) throws DdlException {
+        return normal.createTable(context, stmt);
     }
 
     @Override
-    public void dropTable(DropTableStmt stmt) throws DdlException {
-        normal.dropTable(stmt);
+    public void dropTable(ConnectContext context, DropTableStmt stmt) throws DdlException {
+        normal.dropTable(context, stmt);
     }
 
     @Override
@@ -341,13 +337,13 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public void createView(CreateViewStmt stmt) throws DdlException {
-        normal.createView(stmt);
+    public void createView(ConnectContext context, CreateViewStmt stmt) throws DdlException {
+        normal.createView(context, stmt);
     }
 
     @Override
-    public void alterView(AlterViewStmt stmt) throws StarRocksException {
-        normal.alterView(stmt);
+    public void alterView(ConnectContext context, AlterViewStmt stmt) throws StarRocksException {
+        normal.alterView(context, stmt);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -56,7 +56,6 @@ import com.starrocks.thrift.TSinkCommitInfo;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileContent;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -220,15 +219,12 @@ public interface ConnectorMetadata {
     default void refreshTable(String srDbName, Table table, List<String> partitionNames, boolean onlyCachedPartitions) {
     }
 
-    default void createDb(String dbName) throws DdlException, AlreadyExistsException {
-        createDb(dbName, new HashMap<>());
-    }
-
     default boolean dbExists(ConnectContext context, String dbName) {
         return listDbNames(context).contains(dbName.toLowerCase(Locale.ROOT));
     }
 
-    default void createDb(String dbName, Map<String, String> properties) throws DdlException, AlreadyExistsException {
+    default void createDb(ConnectContext context, String dbName, Map<String, String> properties)
+            throws DdlException, AlreadyExistsException {
         throw new StarRocksConnectorException("This connector doesn't support creating databases");
     }
 
@@ -248,11 +244,11 @@ public interface ConnectorMetadata {
         return Lists.newArrayList();
     }
 
-    default boolean createTable(CreateTableStmt stmt) throws DdlException {
+    default boolean createTable(ConnectContext context, CreateTableStmt stmt) throws DdlException {
         throw new StarRocksConnectorException("This connector doesn't support creating tables");
     }
 
-    default void dropTable(DropTableStmt stmt) throws DdlException {
+    default void dropTable(ConnectContext context, DropTableStmt stmt) throws DdlException {
         throw new StarRocksConnectorException("This connector doesn't support dropping tables");
     }
 
@@ -317,11 +313,11 @@ public interface ConnectorMetadata {
             throws DdlException, MetaNotFoundException {
     }
 
-    default void createView(CreateViewStmt stmt) throws DdlException {
+    default void createView(ConnectContext context, CreateViewStmt stmt) throws DdlException {
         throw new StarRocksConnectorException("This connector doesn't support create view");
     }
 
-    default void alterView(AlterViewStmt stmt) throws StarRocksException {
+    default void alterView(ConnectContext context, AlterViewStmt stmt) throws StarRocksException {
         throw new StarRocksConnectorException("This connector doesn't support alter view");
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -122,7 +122,7 @@ public class HiveMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public void createDb(String dbName, Map<String, String> properties) throws AlreadyExistsException {
+    public void createDb(ConnectContext context, String dbName, Map<String, String> properties) throws AlreadyExistsException {
         if (dbExists(new ConnectContext(), dbName)) {
             throw new AlreadyExistsException("Database Already Exists");
         }
@@ -157,7 +157,7 @@ public class HiveMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public boolean createTable(CreateTableStmt stmt) throws DdlException {
+    public boolean createTable(ConnectContext context, CreateTableStmt stmt) throws DdlException {
         return hmsOps.createTable(stmt);
     }
 
@@ -167,7 +167,7 @@ public class HiveMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public void dropTable(DropTableStmt stmt) throws DdlException {
+    public void dropTable(ConnectContext context, DropTableStmt stmt) throws DdlException {
         String dbName = stmt.getDbName();
         String tableName = stmt.getTableName();
         if (isResourceMappingCatalog(catalogName)) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
@@ -235,7 +235,7 @@ public class HudiMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public void dropTable(DropTableStmt stmt) throws DdlException {
+    public void dropTable(ConnectContext context, DropTableStmt stmt) throws DdlException {
         String dbName = stmt.getDbName();
         String tableName = stmt.getTableName();
         if (isResourceMappingCatalog(catalogName)) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAlterTableExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAlterTableExecutor.java
@@ -322,7 +322,7 @@ public class IcebergAlterTableExecutor extends ConnectorAlterTableExecutor {
 
     @Override
     public Void visitTableRenameClause(TableRenameClause clause, ConnectContext context) {
-        icebergCatalog.renameTable(tableName.getDb(), tableName.getTbl(), clause.getNewTableName());
+        icebergCatalog.renameTable(context, tableName.getDb(), tableName.getTbl(), clause.getNewTableName());
         return null;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -220,16 +220,16 @@ public class IcebergMetadata implements ConnectorMetadata {
 
     @Override
     public List<String> listDbNames(ConnectContext context) {
-        return icebergCatalog.listAllDatabases();
+        return icebergCatalog.listAllDatabases(context);
     }
 
     @Override
-    public void createDb(String dbName, Map<String, String> properties) throws AlreadyExistsException {
+    public void createDb(ConnectContext context, String dbName, Map<String, String> properties) throws AlreadyExistsException {
         if (dbExists(new ConnectContext(), dbName)) {
             throw new AlreadyExistsException("Database Already Exists");
         }
 
-        icebergCatalog.createDB(dbName, properties);
+        icebergCatalog.createDB(context, dbName, properties);
     }
 
     @Override
@@ -240,7 +240,7 @@ public class IcebergMetadata implements ConnectorMetadata {
             throw new StarRocksConnectorException("Database %s not empty", dbName);
         }
 
-        icebergCatalog.dropDB(dbName);
+        icebergCatalog.dropDB(context, dbName);
         databases.remove(dbName);
     }
 
@@ -251,7 +251,7 @@ public class IcebergMetadata implements ConnectorMetadata {
         }
         Database db;
         try {
-            db = icebergCatalog.getDB(dbName);
+            db = icebergCatalog.getDB(context, dbName);
         } catch (NoSuchNamespaceException e) {
             LOG.error("Database {} not found", dbName, e);
             return null;
@@ -263,11 +263,11 @@ public class IcebergMetadata implements ConnectorMetadata {
 
     @Override
     public List<String> listTableNames(ConnectContext context, String dbName) {
-        return icebergCatalog.listTables(dbName);
+        return icebergCatalog.listTables(context, dbName);
     }
 
     @Override
-    public boolean createTable(CreateTableStmt stmt) throws DdlException {
+    public boolean createTable(ConnectContext context, CreateTableStmt stmt) throws DdlException {
         String dbName = stmt.getDbName();
         String tableName = stmt.getTableName();
 
@@ -284,11 +284,12 @@ public class IcebergMetadata implements ConnectorMetadata {
         }
         Map<String, String> createTableProperties = IcebergApiConverter.rebuildCreateTableProperties(properties);
 
-        return icebergCatalog.createTable(dbName, tableName, schema, partitionSpec, tableLocation, createTableProperties);
+        return icebergCatalog.createTable(context, dbName, tableName, schema, partitionSpec, tableLocation,
+                createTableProperties);
     }
 
     @Override
-    public void createView(CreateViewStmt stmt) throws DdlException {
+    public void createView(ConnectContext context, CreateViewStmt stmt) throws DdlException {
         String dbName = stmt.getDbName();
         String viewName = stmt.getTable();
 
@@ -297,7 +298,7 @@ public class IcebergMetadata implements ConnectorMetadata {
             ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
         }
 
-        if (getView(dbName, viewName) != null) {
+        if (getView(context, dbName, viewName) != null) {
             if (stmt.isSetIfNotExists()) {
                 LOG.info("create view[{}] which already exists", viewName);
                 return;
@@ -309,11 +310,11 @@ public class IcebergMetadata implements ConnectorMetadata {
         }
 
         ConnectorViewDefinition viewDefinition = ConnectorViewDefinition.fromCreateViewStmt(stmt);
-        icebergCatalog.createView(catalogName, viewDefinition, stmt.isReplace());
+        icebergCatalog.createView(context, catalogName, viewDefinition, stmt.isReplace());
     }
 
     @Override
-    public void alterView(AlterViewStmt stmt) throws StarRocksException {
+    public void alterView(ConnectContext context, AlterViewStmt stmt) throws StarRocksException {
         String dbName = stmt.getDbName();
         String viewName = stmt.getTable();
 
@@ -321,14 +322,14 @@ public class IcebergMetadata implements ConnectorMetadata {
         if (db == null) {
             ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
         }
-        if (getView(dbName, viewName) == null) {
+        if (getView(context, dbName, viewName) == null) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_TABLE_ERROR, dbName + "." + viewName);
         }
 
         ConnectorViewDefinition viewDefinition = ConnectorViewDefinition.fromAlterViewStmt(stmt);
-        View currentView = icebergCatalog.getView(dbName, viewName);
+        View currentView = icebergCatalog.getView(context, dbName, viewName);
         if (!stmt.getProperties().isEmpty() || stmt.isAlterDialect()) {
-            icebergCatalog.alterView(currentView, viewDefinition);
+            icebergCatalog.alterView(context, currentView, viewDefinition);
         } else {
             throw new DdlException("ALTER VIEW <viewName> AS is not supported. Use CREATE OR REPLACE VIEW instead");
         }
@@ -338,7 +339,7 @@ public class IcebergMetadata implements ConnectorMetadata {
     public void alterTable(ConnectContext context, AlterTableStmt stmt) throws StarRocksException {
         String dbName = stmt.getDbName();
         String tableName = stmt.getTableName();
-        org.apache.iceberg.Table table = icebergCatalog.getTable(dbName, tableName);
+        org.apache.iceberg.Table table = icebergCatalog.getTable(context, dbName, tableName);
 
         if (table == null) {
             throw new StarRocksConnectorException(
@@ -361,11 +362,11 @@ public class IcebergMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public void dropTable(DropTableStmt stmt) {
+    public void dropTable(ConnectContext context, DropTableStmt stmt) {
         Table icebergTable = getTable(new ConnectContext(), stmt.getDbName(), stmt.getTableName());
 
         if (icebergTable != null && icebergTable.isIcebergView()) {
-            icebergCatalog.dropView(stmt.getDbName(), stmt.getTableName());
+            icebergCatalog.dropView(context, stmt.getDbName(), stmt.getTableName());
             return;
         }
 
@@ -373,7 +374,7 @@ public class IcebergMetadata implements ConnectorMetadata {
             return;
         }
 
-        icebergCatalog.dropTable(stmt.getDbName(), stmt.getTableName(), stmt.isForceDrop());
+        icebergCatalog.dropTable(context, stmt.getDbName(), stmt.getTableName(), stmt.isForceDrop());
         tables.remove(TableIdentifier.of(stmt.getDbName(), stmt.getTableName()));
         StatisticUtils.dropStatisticsAfterDropTable(icebergTable);
         asyncRefreshOthersFeMetadataCache(stmt.getDbName(), stmt.getTableName());
@@ -397,7 +398,7 @@ public class IcebergMetadata implements ConnectorMetadata {
             if (tables.containsKey(identifier)) {
                 icebergTable = tables.get(identifier);
             } else {
-                icebergTable = icebergCatalog.getTable(dbName, tblName);
+                icebergTable = icebergCatalog.getTable(context, dbName, tblName);
             }
 
             IcebergCatalogType catalogType = icebergCatalog.getIcebergCatalogType();
@@ -417,7 +418,7 @@ public class IcebergMetadata implements ConnectorMetadata {
             LOG.error("Failed to get iceberg table {}", identifier, e);
             return null;
         } catch (NoSuchTableException e) {
-            return getView(dbName, tblName);
+            return getView(context, dbName, tblName);
         }
     }
 
@@ -485,9 +486,9 @@ public class IcebergMetadata implements ConnectorMetadata {
                 .snapshotId();
     }
 
-    public Table getView(String dbName, String viewName) {
+    public Table getView(ConnectContext context, String dbName, String viewName) {
         try {
-            View icebergView = icebergCatalog.getView(dbName, viewName);
+            View icebergView = icebergCatalog.getView(context, dbName, viewName);
             return IcebergApiConverter.toView(catalogName, dbName, icebergView);
         } catch (Exception e) {
             LOG.error("Failed to get iceberg view {}.{}", dbName, viewName, e);
@@ -516,7 +517,7 @@ public class IcebergMetadata implements ConnectorMetadata {
 
     @Override
     public boolean tableExists(ConnectContext context, String dbName, String tblName) {
-        return icebergCatalog.tableExists(dbName, tblName);
+        return icebergCatalog.tableExists(context, dbName, tblName);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -225,7 +225,7 @@ public class IcebergMetadata implements ConnectorMetadata {
 
     @Override
     public void createDb(ConnectContext context, String dbName, Map<String, String> properties) throws AlreadyExistsException {
-        if (dbExists(new ConnectContext(), dbName)) {
+        if (dbExists(context, dbName)) {
             throw new AlreadyExistsException("Database Already Exists");
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hadoop/IcebergHadoopCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hadoop/IcebergHadoopCatalog.java
@@ -25,6 +25,7 @@ import com.starrocks.connector.iceberg.IcebergCatalogType;
 import com.starrocks.connector.iceberg.cost.IcebergMetricsReporter;
 import com.starrocks.connector.iceberg.io.IcebergCachingFileIO;
 import com.starrocks.connector.share.iceberg.IcebergAwsClientFactory;
+import com.starrocks.qe.ConnectContext;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -88,24 +89,24 @@ public class IcebergHadoopCatalog implements IcebergCatalog {
     }
 
     @Override
-    public Table getTable(String dbName, String tableName) throws StarRocksConnectorException {
+    public Table getTable(ConnectContext context, String dbName, String tableName) throws StarRocksConnectorException {
         return delegate.loadTable(TableIdentifier.of(dbName, tableName));
     }
 
     @Override
-    public boolean tableExists(String dbName, String tableName) throws StarRocksConnectorException {
+    public boolean tableExists(ConnectContext context, String dbName, String tableName) throws StarRocksConnectorException {
         return delegate.tableExists(TableIdentifier.of(dbName, tableName));
     }
 
     @Override
-    public List<String> listAllDatabases() {
+    public List<String> listAllDatabases(ConnectContext context) {
         return delegate.listNamespaces().stream()
                 .map(ns -> ns.level(0))
                 .collect(Collectors.toList());
     }
 
     @Override
-    public void createDB(String dbName, Map<String, String> properties) {
+    public void createDB(ConnectContext context, String dbName, Map<String, String> properties) {
         properties = properties == null ? new HashMap<>() : properties;
         for (Map.Entry<String, String> entry : properties.entrySet()) {
             String key = entry.getKey();
@@ -128,10 +129,10 @@ public class IcebergHadoopCatalog implements IcebergCatalog {
     }
 
     @Override
-    public void dropDB(String dbName) throws MetaNotFoundException {
+    public void dropDB(ConnectContext context, String dbName) throws MetaNotFoundException {
         Database database;
         try {
-            database = getDB(dbName);
+            database = getDB(context, dbName);
         } catch (Exception e) {
             LOG.error("Failed to access database {}", dbName, e);
             throw new MetaNotFoundException("Failed to access database " + dbName);
@@ -150,20 +151,21 @@ public class IcebergHadoopCatalog implements IcebergCatalog {
     }
 
     @Override
-    public Database getDB(String dbName) {
+    public Database getDB(ConnectContext context, String dbName) {
         Map<String, String> dbMeta = delegate.loadNamespaceMetadata(Namespace.of(dbName));
         Preconditions.checkNotNull(dbMeta.get(LOCATION_PROPERTY), "Database " + dbName + " doesn't exist location");
         return new Database(CONNECTOR_ID_GENERATOR.getNextId().asInt(), dbName, dbMeta.get(LOCATION_PROPERTY));
     }
 
     @Override
-    public List<String> listTables(String dbName) {
+    public List<String> listTables(ConnectContext context, String dbName) {
         List<TableIdentifier> tableIdentifiers = delegate.listTables(Namespace.of(dbName));
         return tableIdentifiers.stream().map(TableIdentifier::name).collect(Collectors.toCollection(ArrayList::new));
     }
 
     @Override
     public boolean createTable(
+            ConnectContext context,
             String dbName,
             String tableName,
             Schema schema,
@@ -180,12 +182,13 @@ public class IcebergHadoopCatalog implements IcebergCatalog {
     }
 
     @Override
-    public boolean dropTable(String dbName, String tableName, boolean purge) {
+    public boolean dropTable(ConnectContext context, String dbName, String tableName, boolean purge) {
         return delegate.dropTable(TableIdentifier.of(dbName, tableName), purge);
     }
 
     @Override
-    public void renameTable(String dbName, String tblName, String newTblName) throws StarRocksConnectorException {
+    public void renameTable(ConnectContext context, String dbName, String tblName, String newTblName)
+            throws StarRocksConnectorException {
         delegate.renameTable(TableIdentifier.of(dbName, tblName), TableIdentifier.of(dbName, newTblName));
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalog.java
@@ -29,6 +29,7 @@ import com.starrocks.connector.iceberg.IcebergCatalogType;
 import com.starrocks.connector.iceberg.cost.IcebergMetricsReporter;
 import com.starrocks.connector.iceberg.io.IcebergCachingFileIO;
 import com.starrocks.connector.share.iceberg.IcebergAwsClientFactory;
+import com.starrocks.qe.ConnectContext;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -109,24 +110,24 @@ public class IcebergHiveCatalog implements IcebergCatalog {
     }
 
     @Override
-    public Table getTable(String dbName, String tableName) throws StarRocksConnectorException {
+    public Table getTable(ConnectContext context, String dbName, String tableName) throws StarRocksConnectorException {
         return delegate.loadTable(TableIdentifier.of(dbName, tableName));
     }
 
     @Override
-    public boolean tableExists(String dbName, String tableName) throws StarRocksConnectorException {
+    public boolean tableExists(ConnectContext context, String dbName, String tableName) throws StarRocksConnectorException {
         return delegate.tableExists(TableIdentifier.of(dbName, tableName));
     }
 
     @Override
-    public List<String> listAllDatabases() {
+    public List<String> listAllDatabases(ConnectContext context) {
         return delegate.listNamespaces().stream()
                 .map(ns -> ns.level(0))
                 .collect(Collectors.toList());
     }
 
     @Override
-    public void createDB(String dbName, Map<String, String> properties) {
+    public void createDB(ConnectContext context, String dbName, Map<String, String> properties) {
         properties = properties == null ? new HashMap<>() : properties;
         for (Map.Entry<String, String> entry : properties.entrySet()) {
             String key = entry.getKey();
@@ -150,10 +151,10 @@ public class IcebergHiveCatalog implements IcebergCatalog {
     }
 
     @Override
-    public void dropDB(String dbName) throws MetaNotFoundException {
+    public void dropDB(ConnectContext context, String dbName) throws MetaNotFoundException {
         Database database;
         try {
-            database = getDB(dbName);
+            database = getDB(context, dbName);
         } catch (Exception e) {
             LOG.error("Failed to access database {}", dbName, e);
             throw new MetaNotFoundException("Failed to access database " + dbName);
@@ -172,20 +173,21 @@ public class IcebergHiveCatalog implements IcebergCatalog {
     }
 
     @Override
-    public Database getDB(String dbName) {
+    public Database getDB(ConnectContext context, String dbName) {
         Map<String, String> dbMeta = delegate.loadNamespaceMetadata(Namespace.of(dbName));
         Preconditions.checkNotNull(dbMeta.get(LOCATION_PROPERTY), "Database " + dbName + " doesn't exist location");
         return new Database(CONNECTOR_ID_GENERATOR.getNextId().asInt(), dbName, dbMeta.get(LOCATION_PROPERTY));
     }
 
     @Override
-    public List<String> listTables(String dbName) {
+    public List<String> listTables(ConnectContext context, String dbName) {
         List<TableIdentifier> tableIdentifiers = delegate.listTables(Namespace.of(dbName));
         return tableIdentifiers.stream().map(TableIdentifier::name).collect(Collectors.toCollection(ArrayList::new));
     }
 
     @Override
     public boolean createTable(
+            ConnectContext context,
             String dbName,
             String tableName,
             Schema schema,
@@ -202,32 +204,33 @@ public class IcebergHiveCatalog implements IcebergCatalog {
     }
 
     @Override
-    public boolean dropTable(String dbName, String tableName, boolean purge) {
+    public boolean dropTable(ConnectContext context, String dbName, String tableName, boolean purge) {
         return delegate.dropTable(TableIdentifier.of(dbName, tableName), purge);
     }
 
     @Override
-    public void renameTable(String dbName, String tblName, String newTblName) throws StarRocksConnectorException {
+    public void renameTable(ConnectContext context, String dbName, String tblName, String newTblName)
+            throws StarRocksConnectorException {
         delegate.renameTable(TableIdentifier.of(dbName, tblName), TableIdentifier.of(dbName, newTblName));
     }
 
     @Override
-    public ViewBuilder getViewBuilder(TableIdentifier identifier) {
+    public ViewBuilder getViewBuilder(ConnectContext context, TableIdentifier identifier) {
         return delegate.buildView(identifier);
     }
 
     @Override
-    public boolean dropView(String dbName, String viewName) {
+    public boolean dropView(ConnectContext context, String dbName, String viewName) {
         return delegate.dropView(TableIdentifier.of(convertDbNameToNamespace(dbName), viewName));
     }
 
     @Override
-    public View getView(String dbName, String viewName) {
+    public View getView(ConnectContext context, String dbName, String viewName) {
         return delegate.loadView(TableIdentifier.of(convertDbNameToNamespace(dbName), viewName));
     }
 
     @Override
-    public Map<String, String> loadNamespaceMetadata(Namespace ns) {
+    public Map<String, String> loadNamespaceMetadata(ConnectContext context, Namespace ns) {
         return ImmutableMap.copyOf(delegate.loadNamespaceMetadata(ns));
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/jdbc/IcebergJdbcCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/jdbc/IcebergJdbcCatalog.java
@@ -25,6 +25,7 @@ import com.starrocks.connector.iceberg.IcebergCatalog;
 import com.starrocks.connector.iceberg.IcebergCatalogType;
 import com.starrocks.connector.iceberg.cost.IcebergMetricsReporter;
 import com.starrocks.connector.iceberg.io.IcebergCachingFileIO;
+import com.starrocks.qe.ConnectContext;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -99,24 +100,24 @@ public class IcebergJdbcCatalog implements IcebergCatalog {
     }
 
     @Override
-    public Table getTable(String dbName, String tableName) throws StarRocksConnectorException {
+    public Table getTable(ConnectContext context, String dbName, String tableName) throws StarRocksConnectorException {
         return delegate.loadTable(TableIdentifier.of(dbName, tableName));
     }
 
     @Override
-    public boolean tableExists(String dbName, String tableName) throws StarRocksConnectorException {
+    public boolean tableExists(ConnectContext context, String dbName, String tableName) throws StarRocksConnectorException {
         return delegate.tableExists(TableIdentifier.of(dbName, tableName));
     }
 
     @Override
-    public List<String> listAllDatabases() {
+    public List<String> listAllDatabases(ConnectContext context) {
         return delegate.listNamespaces().stream()
                 .map(ns -> ns.level(0))
                 .collect(Collectors.toList());
     }
 
     @Override
-    public void createDB(String dbName, Map<String, String> properties) {
+    public void createDB(ConnectContext context, String dbName, Map<String, String> properties) {
         properties = properties == null ? new HashMap<>() : properties;
         for (Map.Entry<String, String> entry : properties.entrySet()) {
             String key = entry.getKey();
@@ -139,10 +140,10 @@ public class IcebergJdbcCatalog implements IcebergCatalog {
     }
 
     @Override
-    public void dropDB(String dbName) throws MetaNotFoundException {
+    public void dropDB(ConnectContext context, String dbName) throws MetaNotFoundException {
         Database database;
         try {
-            database = getDB(dbName);
+            database = getDB(context, dbName);
         } catch (Exception e) {
             LOG.error("Failed to access database {}", dbName, e);
             throw new MetaNotFoundException("Failed to access database " + dbName);
@@ -161,20 +162,21 @@ public class IcebergJdbcCatalog implements IcebergCatalog {
     }
 
     @Override
-    public Database getDB(String dbName) {
+    public Database getDB(ConnectContext context, String dbName) {
         Map<String, String> dbMeta = delegate.loadNamespaceMetadata(Namespace.of(dbName));
         Preconditions.checkNotNull(dbMeta.get(LOCATION_PROPERTY), "Database " + dbName + " doesn't exist location");
         return new Database(CONNECTOR_ID_GENERATOR.getNextId().asInt(), dbName, dbMeta.get(LOCATION_PROPERTY));
     }
 
     @Override
-    public List<String> listTables(String dbName) {
+    public List<String> listTables(ConnectContext context, String dbName) {
         List<TableIdentifier> tableIdentifiers = delegate.listTables(Namespace.of(dbName));
         return tableIdentifiers.stream().map(TableIdentifier::name).collect(Collectors.toCollection(ArrayList::new));
     }
 
     @Override
     public boolean createTable(
+            ConnectContext context,
             String dbName,
             String tableName,
             Schema schema,
@@ -191,12 +193,13 @@ public class IcebergJdbcCatalog implements IcebergCatalog {
     }
 
     @Override
-    public boolean dropTable(String dbName, String tableName, boolean purge) {
+    public boolean dropTable(ConnectContext context, String dbName, String tableName, boolean purge) {
         return delegate.dropTable(TableIdentifier.of(dbName, tableName), purge);
     }
 
     @Override
-    public void renameTable(String dbName, String tblName, String newTblName) throws StarRocksConnectorException {
+    public void renameTable(ConnectContext context, String dbName, String tblName, String newTblName)
+            throws StarRocksConnectorException {
         delegate.renameTable(TableIdentifier.of(dbName, tblName), TableIdentifier.of(dbName, newTblName));
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -312,10 +312,6 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     private SessionCatalog.SessionContext convertContext(ConnectContext context) {
         String sessionId = format("%s-%s", context.getQualifiedUser(), context.getSessionId());
 
-        Map<String, String> properties = ImmutableMap.of(
-                "user", context.getQualifiedUser(),
-                "catalogName", this.catalogName);
-
         Map<String, String> credentials;
         if (Strings.isNullOrEmpty(context.getAuthToken())) {
             credentials = Maps.filterKeys(securityProperties.get(), key -> Set.of(TOKEN, CREDENTIAL).contains(key));
@@ -325,7 +321,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
                     .buildOrThrow();
         }
 
-        return new SessionCatalog.SessionContext(sessionId, context.getQualifiedUser(), credentials, properties,
+        return new SessionCatalog.SessionContext(sessionId, context.getQualifiedUser(), credentials, ImmutableMap.of(),
                 context.getCurrentUserIdentity());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -52,7 +52,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.starrocks.connector.ConnectorTableId.CONNECTOR_ID_GENERATOR;
@@ -62,8 +61,6 @@ import static com.starrocks.connector.iceberg.IcebergMetadata.COMMENT;
 import static com.starrocks.connector.iceberg.IcebergMetadata.LOCATION_PROPERTY;
 import static java.lang.String.format;
 import static org.apache.iceberg.CatalogUtil.configureHadoopConf;
-import static org.apache.iceberg.rest.auth.OAuth2Properties.CREDENTIAL;
-import static org.apache.iceberg.rest.auth.OAuth2Properties.TOKEN;
 
 public class IcebergRESTCatalog implements IcebergCatalog {
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -314,7 +314,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
         Map<String, String> credentials;
         if (Strings.isNullOrEmpty(context.getAuthToken())) {
-            credentials = Maps.filterKeys(securityProperties.get(), key -> Set.of(TOKEN, CREDENTIAL).contains(key));
+            return SessionCatalog.SessionContext.createEmpty();
         } else {
             credentials = ImmutableMap.<String, String>builder()
                     .put(OAuth2Properties.ACCESS_TOKEN_TYPE, context.getAuthToken())

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityConfig.java
@@ -24,6 +24,7 @@ public class OAuth2SecurityConfig {
     private String scope;
     private String token;
     private URI serverUri;
+    private String audience;
 
     // The type of security to use (default: NONE). OAUTH2 requires either a token or credential. Example: OAUTH2
     public static String SECURITY = "security";
@@ -36,6 +37,8 @@ public class OAuth2SecurityConfig {
     public static String OAUTH2_TOKEN = "oauth2.token";
     // The endpoint to retrieve access token from OAuth2 Server
     public static String SERVER_URI = "oauth2.server-uri";
+
+    public static String OAUTH2_AUDIENCE = "oauth2.audience";
 
     public SecurityEnum getSecurity() {
         return security;
@@ -82,6 +85,15 @@ public class OAuth2SecurityConfig {
         return this;
     }
 
+    public Optional<String> getAudience() {
+        return Optional.ofNullable(audience);
+    }
+
+    public OAuth2SecurityConfig setAudience(String audience) {
+        this.audience = audience;
+        return this;
+    }
+
     // OAuth2 requires a credential or token
     public boolean credentialOrTokenPresent() {
         return credential != null || token != null;
@@ -109,7 +121,9 @@ class OAuth2SecurityConfigBuilder {
         config = config.setSecurity(SecurityEnum.OAUTH2)
                 .setCredential(properties.get(OAuth2SecurityConfig.OAUTH2_CREDENTIAL))
                 .setScope(properties.get(OAuth2SecurityConfig.OAUTH2_SCOPE))
-                .setToken(properties.get(OAuth2SecurityConfig.OAUTH2_TOKEN));
+                .setToken(properties.get(OAuth2SecurityConfig.OAUTH2_TOKEN))
+                .setAudience(properties.get(OAuth2SecurityConfig.OAUTH2_AUDIENCE));
+
         String serverUri = properties.get(OAuth2SecurityConfig.SERVER_URI);
         if (serverUri != null) {
             config = config.setServerUri(URI.create(serverUri));

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityProperties.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityProperties.java
@@ -39,6 +39,8 @@ public class OAuth2SecurityProperties {
                     value -> propertiesBuilder.put(OAuth2Properties.TOKEN, value));
             securityConfig.getServerUri().ifPresent(
                     value -> propertiesBuilder.put(OAuth2Properties.OAUTH2_SERVER_URI, value.toString()));
+            securityConfig.getAudience().ifPresent(
+                    value -> propertiesBuilder.put(OAuth2Properties.AUDIENCE, value));
         }
 
         this.securityProperties = propertiesBuilder.buildOrThrow();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
@@ -225,18 +225,14 @@ public class UnifiedMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public void createDb(String dbName) throws DdlException, AlreadyExistsException {
-        hiveMetadata.createDb(dbName);
-    }
-
-    @Override
     public boolean dbExists(ConnectContext context, String dbName) {
         return hiveMetadata.dbExists(context, dbName);
     }
 
     @Override
-    public void createDb(String dbName, Map<String, String> properties) throws DdlException, AlreadyExistsException {
-        hiveMetadata.createDb(dbName, properties);
+    public void createDb(ConnectContext context, String dbName, Map<String, String> properties)
+            throws DdlException, AlreadyExistsException {
+        hiveMetadata.createDb(context, dbName, properties);
     }
 
     @Override
@@ -250,16 +246,16 @@ public class UnifiedMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public boolean createTable(CreateTableStmt stmt) throws DdlException {
+    public boolean createTable(ConnectContext context, CreateTableStmt stmt) throws DdlException {
         requireNonNull(stmt.getEngineName(), "engine name is null");
         Table.TableType type = Table.TableType.deserialize(stmt.getEngineName().toUpperCase());
-        return metadataMap.get(type).createTable(stmt);
+        return metadataMap.get(type).createTable(context, stmt);
     }
 
     @Override
-    public void dropTable(DropTableStmt stmt) throws DdlException {
+    public void dropTable(ConnectContext context, DropTableStmt stmt) throws DdlException {
         ConnectorMetadata metadata = metadataOfTable(stmt.getDbName(), stmt.getTableName());
-        metadata.dropTable(stmt);
+        metadata.dropTable(context, stmt);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -221,7 +221,7 @@ public class DDLStmtExecutor {
             boolean isSetIfNotExists = stmt.isSetIfNotExists();
             ErrorReport.wrapWithRuntimeException(() -> {
                 try {
-                    context.getGlobalStateMgr().getMetadataMgr().createDb(catalogName, fullDbName, properties);
+                    context.getGlobalStateMgr().getMetadataMgr().createDb(context, catalogName, fullDbName, properties);
                 } catch (AlreadyExistsException e) {
                     if (isSetIfNotExists) {
                         LOG.info("create database[{}] which already exists", fullDbName);
@@ -300,7 +300,7 @@ public class DDLStmtExecutor {
         @Override
         public ShowResultSet visitCreateTemporaryTableStatement(CreateTemporaryTableStmt stmt, ConnectContext context) {
             ErrorReport.wrapWithRuntimeException(() -> {
-                context.getGlobalStateMgr().getMetadataMgr().createTemporaryTable(stmt);
+                context.getGlobalStateMgr().getMetadataMgr().createTemporaryTable(context, stmt);
             });
             return null;
         }
@@ -318,7 +318,7 @@ public class DDLStmtExecutor {
                 CreateTemporaryTableLikeStmt stmt, ConnectContext context) {
             ErrorReport.wrapWithRuntimeException(() -> {
                 context.getGlobalStateMgr().getMetadataMgr()
-                        .createTemporaryTable((CreateTemporaryTableStmt) stmt.getCreateTableStmt());
+                        .createTemporaryTable(context, (CreateTemporaryTableStmt) stmt.getCreateTableStmt());
             });
             return null;
         }
@@ -332,7 +332,7 @@ public class DDLStmtExecutor {
                     dropTemporaryTableStmt.setSessionId(context.getSessionId());
                     context.getGlobalStateMgr().getMetadataMgr().dropTemporaryTable(dropTemporaryTableStmt);
                 } else {
-                    context.getGlobalStateMgr().getMetadataMgr().dropTable(stmt);
+                    context.getGlobalStateMgr().getMetadataMgr().dropTable(context, stmt);
                 }
             });
             return null;
@@ -421,7 +421,7 @@ public class DDLStmtExecutor {
         @Override
         public ShowResultSet visitAlterViewStatement(AlterViewStmt stmt, ConnectContext context) {
             ErrorReport.wrapWithRuntimeException(() -> {
-                context.getGlobalStateMgr().getMetadataMgr().alterView(stmt);
+                context.getGlobalStateMgr().getMetadataMgr().alterView(context, stmt);
             });
             return null;
         }
@@ -712,7 +712,7 @@ public class DDLStmtExecutor {
         @Override
         public ShowResultSet visitCreateViewStatement(CreateViewStmt stmt, ConnectContext context) {
             ErrorReport.wrapWithRuntimeException(() -> {
-                GlobalStateMgr.getCurrentState().getMetadataMgr().createView(stmt);
+                GlobalStateMgr.getCurrentState().getMetadataMgr().createView(context, stmt);
             });
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -970,7 +970,7 @@ public class StmtExecutor {
                 CreateTemporaryTableStmt createTemporaryTableStmt =
                         (CreateTemporaryTableStmt) stmt.getCreateTableStmt();
                 createTemporaryTableStmt.setSessionId(context.getSessionId());
-                return context.getGlobalStateMgr().getMetadataMgr().createTemporaryTable(createTemporaryTableStmt);
+                return context.getGlobalStateMgr().getMetadataMgr().createTemporaryTable(context, createTemporaryTableStmt);
             } else {
                 return context.getGlobalStateMgr().getMetadataMgr().createTable(context, stmt.getCreateTableStmt());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -364,7 +364,16 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         } // end for dbs
     }
 
+    public void createDb(String dbName) throws DdlException, AlreadyExistsException {
+        createDb(dbName, new HashMap<>());
+    }
+
     @Override
+    public void createDb(ConnectContext context, String dbName, Map<String, String> properties)
+            throws DdlException, AlreadyExistsException {
+        createDb(dbName, properties);
+    }
+
     public void createDb(String dbName, Map<String, String> properties) throws DdlException, AlreadyExistsException {
         long id = 0L;
         if (!tryLock(false)) {
@@ -758,6 +767,11 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         }
     }
 
+    @Override
+    public boolean createTable(ConnectContext context, CreateTableStmt stmt) throws DdlException {
+        return createTable(stmt);
+    }
+
     /**
      * Following is the step to create an olap table:
      * 1. create columns
@@ -777,7 +791,6 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
      *
      * @return whether the table is created
      */
-    @Override
     public boolean createTable(CreateTableStmt stmt) throws DdlException {
         // check if db exists
         Database db = getDb(stmt.getDbName());
@@ -2204,6 +2217,11 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         return chosenBackendIds;
     }
 
+    @Override
+    public void dropTable(ConnectContext context, DropTableStmt stmt) throws DdlException {
+        dropTable(stmt);
+    }
+
     // Drop table
     public void dropTable(DropTableStmt stmt) throws DdlException {
         String dbName = stmt.getDbName();
@@ -2750,8 +2768,8 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
      * used for handling AlterViewStmt (the ALTER VIEW command).
      */
     @Override
-    public void alterView(AlterViewStmt stmt) throws StarRocksException {
-        new AlterJobExecutor().process(stmt, ConnectContext.get());
+    public void alterView(ConnectContext context, AlterViewStmt stmt) throws StarRocksException {
+        new AlterJobExecutor().process(stmt, context);
     }
 
     @Override
@@ -4207,6 +4225,10 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
     }
 
     @Override
+    public void createView(ConnectContext context, CreateViewStmt stmt) throws DdlException {
+        createView(stmt);
+    }
+
     public void createView(CreateViewStmt stmt) throws DdlException {
         String dbName = stmt.getDbName();
         String tableName = stmt.getTable();

--- a/fe/fe-core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -111,6 +111,11 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+// copy from iceberg 1.7.1, do some changes:
+// 1. use basic auth (base64 encode credential) as Authorization header instead of bearer token
+// 2. do not add actor_token/actor_token_type in token exchange request if enable_actor_token is false
+// 3. do not refresh Authorization header when refresh token
+
 public class RESTSessionCatalog extends BaseViewSessionCatalog
         implements Configurable<Object>, Closeable {
     private static final Logger LOG = LoggerFactory.getLogger(RESTSessionCatalog.class);

--- a/fe/fe-core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -309,6 +309,8 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
             headersBuilder.putAll(this.catalogAuth.headers()).putAll(OAuth2Util.basicAuthHeaders(credential));
             this.catalogAuth.setHeaders(headersBuilder.buildKeepingLast());
         }
+        this.catalogAuth.setEnableActorToken(
+                PropertyUtil.propertyAsBoolean(mergedProps, "enable_actor_token", false));
 
         this.pageSize = PropertyUtil.propertyAsNullableInt(mergedProps, REST_PAGE_SIZE);
         if (pageSize != null) {

--- a/fe/fe-core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -1,0 +1,1458 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalListener;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.EnvironmentContext;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.MetadataTableUtils;
+import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.Transaction;
+import org.apache.iceberg.Transactions;
+import org.apache.iceberg.catalog.BaseViewSessionCatalog;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableCommit;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.NoSuchNamespaceException;
+import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.exceptions.NoSuchViewException;
+import org.apache.iceberg.hadoop.Configurable;
+import org.apache.iceberg.io.CloseableGroup;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.FileIOTracker;
+import org.apache.iceberg.metrics.MetricsReporter;
+import org.apache.iceberg.metrics.MetricsReporters;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.rest.auth.AuthConfig;
+import org.apache.iceberg.rest.auth.OAuth2Properties;
+import org.apache.iceberg.rest.auth.OAuth2Util;
+import org.apache.iceberg.rest.auth.OAuth2Util.AuthSession;
+import org.apache.iceberg.rest.requests.CommitTransactionRequest;
+import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
+import org.apache.iceberg.rest.requests.CreateTableRequest;
+import org.apache.iceberg.rest.requests.CreateViewRequest;
+import org.apache.iceberg.rest.requests.ImmutableCreateViewRequest;
+import org.apache.iceberg.rest.requests.ImmutableRegisterTableRequest;
+import org.apache.iceberg.rest.requests.RegisterTableRequest;
+import org.apache.iceberg.rest.requests.RenameTableRequest;
+import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
+import org.apache.iceberg.rest.requests.UpdateTableRequest;
+import org.apache.iceberg.rest.responses.ConfigResponse;
+import org.apache.iceberg.rest.responses.CreateNamespaceResponse;
+import org.apache.iceberg.rest.responses.GetNamespaceResponse;
+import org.apache.iceberg.rest.responses.ListNamespacesResponse;
+import org.apache.iceberg.rest.responses.ListTablesResponse;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.apache.iceberg.rest.responses.LoadViewResponse;
+import org.apache.iceberg.rest.responses.OAuthTokenResponse;
+import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
+import org.apache.iceberg.util.EnvironmentUtil;
+import org.apache.iceberg.util.Pair;
+import org.apache.iceberg.util.PropertyUtil;
+import org.apache.iceberg.util.ThreadPools;
+import org.apache.iceberg.view.BaseView;
+import org.apache.iceberg.view.ImmutableSQLViewRepresentation;
+import org.apache.iceberg.view.ImmutableViewVersion;
+import org.apache.iceberg.view.View;
+import org.apache.iceberg.view.ViewBuilder;
+import org.apache.iceberg.view.ViewMetadata;
+import org.apache.iceberg.view.ViewRepresentation;
+import org.apache.iceberg.view.ViewUtil;
+import org.apache.iceberg.view.ViewVersion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class RESTSessionCatalog extends BaseViewSessionCatalog
+        implements Configurable<Object>, Closeable {
+    private static final Logger LOG = LoggerFactory.getLogger(RESTSessionCatalog.class);
+    private static final String DEFAULT_FILE_IO_IMPL = "org.apache.iceberg.io.ResolvingFileIO";
+    private static final String REST_METRICS_REPORTING_ENABLED = "rest-metrics-reporting-enabled";
+    private static final String REST_SNAPSHOT_LOADING_MODE = "snapshot-loading-mode";
+    // for backwards compatibility with older REST servers where it can be assumed that a particular
+    // server supports view endpoints but doesn't send the "endpoints" field in the ConfigResponse
+    static final String VIEW_ENDPOINTS_SUPPORTED = "view-endpoints-supported";
+    public static final String REST_PAGE_SIZE = "rest-page-size";
+    private static final List<String> TOKEN_PREFERENCE_ORDER =
+            ImmutableList.of(
+                    OAuth2Properties.ID_TOKEN_TYPE,
+                    OAuth2Properties.ACCESS_TOKEN_TYPE,
+                    OAuth2Properties.JWT_TOKEN_TYPE,
+                    OAuth2Properties.SAML2_TOKEN_TYPE,
+                    OAuth2Properties.SAML1_TOKEN_TYPE);
+
+    // Auth-related properties that are allowed to be passed to the table session
+    private static final Set<String> TABLE_SESSION_ALLOW_LIST =
+            ImmutableSet.<String>builder()
+                    .add(OAuth2Properties.TOKEN)
+                    .addAll(TOKEN_PREFERENCE_ORDER)
+                    .build();
+
+    private static final Set<Endpoint> DEFAULT_ENDPOINTS =
+            ImmutableSet.<Endpoint>builder()
+                    .add(Endpoint.V1_LIST_NAMESPACES)
+                    .add(Endpoint.V1_LOAD_NAMESPACE)
+                    .add(Endpoint.V1_CREATE_NAMESPACE)
+                    .add(Endpoint.V1_UPDATE_NAMESPACE)
+                    .add(Endpoint.V1_DELETE_NAMESPACE)
+                    .add(Endpoint.V1_LIST_TABLES)
+                    .add(Endpoint.V1_LOAD_TABLE)
+                    .add(Endpoint.V1_CREATE_TABLE)
+                    .add(Endpoint.V1_UPDATE_TABLE)
+                    .add(Endpoint.V1_DELETE_TABLE)
+                    .add(Endpoint.V1_RENAME_TABLE)
+                    .add(Endpoint.V1_REGISTER_TABLE)
+                    .add(Endpoint.V1_REPORT_METRICS)
+                    .build();
+
+    private static final Set<Endpoint> VIEW_ENDPOINTS =
+            ImmutableSet.<Endpoint>builder()
+                    .add(Endpoint.V1_LIST_VIEWS)
+                    .add(Endpoint.V1_LOAD_VIEW)
+                    .add(Endpoint.V1_CREATE_VIEW)
+                    .add(Endpoint.V1_UPDATE_VIEW)
+                    .add(Endpoint.V1_DELETE_VIEW)
+                    .add(Endpoint.V1_RENAME_VIEW)
+                    .build();
+
+    private final Function<Map<String, String>, RESTClient> clientBuilder;
+    private final BiFunction<SessionContext, Map<String, String>, FileIO> ioBuilder;
+    private Cache<String, AuthSession> sessions = null;
+    private Cache<String, AuthSession> tableSessions = null;
+    private FileIOTracker fileIOTracker = null;
+    private AuthSession catalogAuth = null;
+    private boolean keepTokenRefreshed = true;
+    private RESTClient client = null;
+    private ResourcePaths paths = null;
+    private SnapshotMode snapshotMode = null;
+    private Object conf = null;
+    private FileIO io = null;
+    private MetricsReporter reporter = null;
+    private boolean reportingViaRestEnabled;
+    private Integer pageSize = null;
+    private CloseableGroup closeables = null;
+    private Set<Endpoint> endpoints;
+
+    // a lazy thread pool for token refresh
+    private volatile ScheduledExecutorService refreshExecutor = null;
+
+    enum SnapshotMode {
+        ALL,
+        REFS;
+
+        Map<String, String> params() {
+            return ImmutableMap.of("snapshots", this.name().toLowerCase(Locale.US));
+        }
+    }
+
+    public RESTSessionCatalog() {
+        this(config -> HTTPClient.builder(config).uri(config.get(CatalogProperties.URI)).build(), null);
+    }
+
+    public RESTSessionCatalog(
+            Function<Map<String, String>, RESTClient> clientBuilder,
+            BiFunction<SessionContext, Map<String, String>, FileIO> ioBuilder) {
+        Preconditions.checkNotNull(clientBuilder, "Invalid client builder: null");
+        this.clientBuilder = clientBuilder;
+        this.ioBuilder = ioBuilder;
+    }
+
+    @SuppressWarnings("checkstyle:CyclomaticComplexity")
+    @Override
+    public void initialize(String name, Map<String, String> unresolved) {
+        Preconditions.checkArgument(unresolved != null, "Invalid configuration: null");
+        // resolve any configuration that is supplied by environment variables
+        // note that this is only done for local config properties and not for properties from the
+        // catalog service
+        Map<String, String> props = EnvironmentUtil.resolveAll(unresolved);
+
+        long startTimeMillis =
+                System.currentTimeMillis(); // keep track of the init start time for token refresh
+        String initToken = props.get(OAuth2Properties.TOKEN);
+        boolean hasInitToken = initToken != null;
+
+        // fetch auth and config to complete initialization
+        ConfigResponse config;
+        OAuthTokenResponse authResponse;
+        String credential = props.get(OAuth2Properties.CREDENTIAL);
+        boolean hasCredential = credential != null && !credential.isEmpty();
+        String scope = props.getOrDefault(OAuth2Properties.SCOPE, OAuth2Properties.CATALOG_SCOPE);
+        Map<String, String> optionalOAuthParams = OAuth2Util.buildOptionalParam(props);
+        if (!props.containsKey(OAuth2Properties.OAUTH2_SERVER_URI)
+                && (hasInitToken || hasCredential)
+                && !PropertyUtil.propertyAsBoolean(props, "rest.sigv4-enabled", false)) {
+            LOG.warn(
+                    "Iceberg REST client is missing the OAuth2 server URI configuration and defaults to {}{}. "
+                            + "This automatic fallback will be removed in a future Iceberg release."
+                            + "It is recommended to configure the OAuth2 endpoint using the '{}' property to be prepared. "
+                            + "This warning will disappear if the OAuth2 endpoint is explicitly configured. "
+                            + "See https://github.com/apache/iceberg/issues/10537",
+                    props.get(CatalogProperties.URI),
+                    ResourcePaths.tokens(),
+                    OAuth2Properties.OAUTH2_SERVER_URI);
+        }
+        String oauth2ServerUri =
+                props.getOrDefault(OAuth2Properties.OAUTH2_SERVER_URI, ResourcePaths.tokens());
+        try (RESTClient initClient = clientBuilder.apply(props)) {
+            Map<String, String> initHeaders =
+                    RESTUtil.merge(configHeaders(props), OAuth2Util.authHeaders(initToken));
+            if (hasCredential) {
+                authResponse =
+                        OAuth2Util.fetchToken(
+                                initClient, initHeaders, credential, scope, oauth2ServerUri, optionalOAuthParams);
+                Map<String, String> authHeaders =
+                        RESTUtil.merge(initHeaders, OAuth2Util.authHeaders(authResponse.token()));
+                config = fetchConfig(initClient, authHeaders, props);
+            } else {
+                authResponse = null;
+                config = fetchConfig(initClient, initHeaders, props);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to close HTTP client", e);
+        }
+
+        // build the final configuration and set up the catalog's auth
+        Map<String, String> mergedProps = config.merge(props);
+        Map<String, String> baseHeaders = configHeaders(mergedProps);
+
+        if (config.endpoints().isEmpty()) {
+            this.endpoints =
+                    PropertyUtil.propertyAsBoolean(mergedProps, VIEW_ENDPOINTS_SUPPORTED, false)
+                            ? ImmutableSet.<Endpoint>builder()
+                            .addAll(DEFAULT_ENDPOINTS)
+                            .addAll(VIEW_ENDPOINTS)
+                            .build()
+                            : DEFAULT_ENDPOINTS;
+        } else {
+            this.endpoints = ImmutableSet.copyOf(config.endpoints());
+        }
+
+        this.sessions = newSessionCache(mergedProps);
+        this.tableSessions = newSessionCache(mergedProps);
+        this.keepTokenRefreshed =
+                PropertyUtil.propertyAsBoolean(
+                        mergedProps,
+                        OAuth2Properties.TOKEN_REFRESH_ENABLED,
+                        OAuth2Properties.TOKEN_REFRESH_ENABLED_DEFAULT);
+        this.client = clientBuilder.apply(mergedProps);
+        this.paths = ResourcePaths.forCatalogProperties(mergedProps);
+
+        String token = mergedProps.get(OAuth2Properties.TOKEN);
+        this.catalogAuth =
+                new AuthSession(
+                        baseHeaders,
+                        AuthConfig.builder()
+                                .credential(credential)
+                                .scope(scope)
+                                .oauth2ServerUri(oauth2ServerUri)
+                                .optionalOAuthParams(optionalOAuthParams)
+                                .build());
+        if (authResponse != null) {
+            this.catalogAuth =
+                    AuthSession.fromTokenResponse(
+                            client, tokenRefreshExecutor(name), authResponse, startTimeMillis, catalogAuth);
+        } else if (token != null) {
+            this.catalogAuth =
+                    AuthSession.fromAccessToken(
+                            client, tokenRefreshExecutor(name), token, expiresAtMillis(mergedProps), catalogAuth);
+        }
+        if (hasCredential) {
+            ImmutableMap.Builder<String, String> headersBuilder = ImmutableMap.builder();
+            headersBuilder.putAll(this.catalogAuth.headers()).putAll(OAuth2Util.basicAuthHeaders(credential));
+            this.catalogAuth.setHeaders(headersBuilder.buildKeepingLast());
+        }
+
+        this.pageSize = PropertyUtil.propertyAsNullableInt(mergedProps, REST_PAGE_SIZE);
+        if (pageSize != null) {
+            Preconditions.checkArgument(
+                    pageSize > 0, "Invalid value for %s, must be a positive integer", REST_PAGE_SIZE);
+        }
+
+        this.io = newFileIO(SessionContext.createEmpty(), mergedProps);
+
+        this.fileIOTracker = new FileIOTracker();
+        this.closeables = new CloseableGroup();
+        this.closeables.addCloseable(this.io);
+        this.closeables.addCloseable(this.client);
+        this.closeables.addCloseable(fileIOTracker);
+        this.closeables.setSuppressCloseFailure(true);
+
+        this.snapshotMode =
+                SnapshotMode.valueOf(
+                        PropertyUtil.propertyAsString(
+                                        mergedProps, REST_SNAPSHOT_LOADING_MODE, SnapshotMode.ALL.name())
+                                .toUpperCase(Locale.US));
+
+        this.reporter = CatalogUtil.loadMetricsReporter(mergedProps);
+
+        this.reportingViaRestEnabled =
+                PropertyUtil.propertyAsBoolean(mergedProps, REST_METRICS_REPORTING_ENABLED, true);
+        super.initialize(name, mergedProps);
+    }
+
+    private AuthSession session(SessionContext context) {
+        AuthSession session =
+                sessions.get(
+                        context.sessionId(),
+                        id -> {
+                            Pair<String, Supplier<AuthSession>> newSession =
+                                    newSession(context.credentials(), context.properties(), catalogAuth);
+                            if (null != newSession) {
+                                return newSession.second().get();
+                            }
+
+                            return null;
+                        });
+
+        return session != null ? session : catalogAuth;
+    }
+
+    private Supplier<Map<String, String>> headers(SessionContext context) {
+        return session(context)::headers;
+    }
+
+    @Override
+    public void setConf(Object newConf) {
+        this.conf = newConf;
+    }
+
+    @Override
+    public List<TableIdentifier> listTables(SessionContext context, Namespace ns) {
+        if (!endpoints.contains(Endpoint.V1_LIST_TABLES)) {
+            return ImmutableList.of();
+        }
+
+        checkNamespaceIsValid(ns);
+        Map<String, String> queryParams = Maps.newHashMap();
+        ImmutableList.Builder<TableIdentifier> tables = ImmutableList.builder();
+        String pageToken = "";
+        if (pageSize != null) {
+            queryParams.put("pageSize", String.valueOf(pageSize));
+        }
+
+        do {
+            queryParams.put("pageToken", pageToken);
+            ListTablesResponse response =
+                    client.get(
+                            paths.tables(ns),
+                            queryParams,
+                            ListTablesResponse.class,
+                            headers(context),
+                            ErrorHandlers.namespaceErrorHandler());
+            pageToken = response.nextPageToken();
+            tables.addAll(response.identifiers());
+        } while (pageToken != null);
+
+        return tables.build();
+    }
+
+    @Override
+    public boolean dropTable(SessionContext context, TableIdentifier identifier) {
+        Endpoint.check(endpoints, Endpoint.V1_DELETE_TABLE);
+        checkIdentifierIsValid(identifier);
+
+        try {
+            client.delete(
+                    paths.table(identifier), null, headers(context), ErrorHandlers.tableErrorHandler());
+            return true;
+        } catch (NoSuchTableException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean purgeTable(SessionContext context, TableIdentifier identifier) {
+        Endpoint.check(endpoints, Endpoint.V1_DELETE_TABLE);
+        checkIdentifierIsValid(identifier);
+
+        try {
+            client.delete(
+                    paths.table(identifier),
+                    ImmutableMap.of("purgeRequested", "true"),
+                    null,
+                    headers(context),
+                    ErrorHandlers.tableErrorHandler());
+            return true;
+        } catch (NoSuchTableException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public void renameTable(SessionContext context, TableIdentifier from, TableIdentifier to) {
+        Endpoint.check(endpoints, Endpoint.V1_RENAME_TABLE);
+        checkIdentifierIsValid(from);
+        checkIdentifierIsValid(to);
+
+        RenameTableRequest request =
+                RenameTableRequest.builder().withSource(from).withDestination(to).build();
+
+        // for now, ignore the response because there is no way to return it
+        client.post(paths.rename(), request, null, headers(context), ErrorHandlers.tableErrorHandler());
+    }
+
+    private LoadTableResponse loadInternal(
+            SessionContext context, TableIdentifier identifier, SnapshotMode mode) {
+        Endpoint.check(endpoints, Endpoint.V1_LOAD_TABLE);
+        return client.get(
+                paths.table(identifier),
+                mode.params(),
+                LoadTableResponse.class,
+                headers(context),
+                ErrorHandlers.tableErrorHandler());
+    }
+
+    @Override
+    public Table loadTable(SessionContext context, TableIdentifier identifier) {
+        Endpoint.check(
+                endpoints,
+                Endpoint.V1_LOAD_TABLE,
+                () ->
+                        new NoSuchTableException(
+                                "Unable to load table %s.%s: Server does not support endpoint %s",
+                                name(), identifier, Endpoint.V1_LOAD_TABLE));
+
+        checkIdentifierIsValid(identifier);
+
+        MetadataTableType metadataType;
+        LoadTableResponse response;
+        TableIdentifier loadedIdent;
+        try {
+            response = loadInternal(context, identifier, snapshotMode);
+            loadedIdent = identifier;
+            metadataType = null;
+
+        } catch (NoSuchTableException original) {
+            metadataType = MetadataTableType.from(identifier.name());
+            if (metadataType != null) {
+                // attempt to load a metadata table using the identifier's namespace as the base table
+                TableIdentifier baseIdent = TableIdentifier.of(identifier.namespace().levels());
+                try {
+                    response = loadInternal(context, baseIdent, snapshotMode);
+                    loadedIdent = baseIdent;
+                } catch (NoSuchTableException ignored) {
+                    // the base table does not exist
+                    throw original;
+                }
+            } else {
+                // name is not a metadata table
+                throw original;
+            }
+        }
+
+        TableIdentifier finalIdentifier = loadedIdent;
+        AuthSession session = tableSession(response.config(), session(context));
+        TableMetadata tableMetadata;
+
+        if (snapshotMode == SnapshotMode.REFS) {
+            tableMetadata =
+                    TableMetadata.buildFrom(response.tableMetadata())
+                            .withMetadataLocation(response.metadataLocation())
+                            .setPreviousFileLocation(null)
+                            .setSnapshotsSupplier(
+                                    () ->
+                                            loadInternal(context, finalIdentifier, SnapshotMode.ALL)
+                                                    .tableMetadata()
+                                                    .snapshots())
+                            .discardChanges()
+                            .build();
+        } else {
+            tableMetadata = response.tableMetadata();
+        }
+
+        RESTTableOperations ops =
+                new RESTTableOperations(
+                        client,
+                        paths.table(finalIdentifier),
+                        session::headers,
+                        tableFileIO(context, response.config()),
+                        tableMetadata,
+                        endpoints);
+
+        trackFileIO(ops);
+
+        BaseTable table =
+                new BaseTable(
+                        ops,
+                        fullTableName(finalIdentifier),
+                        metricsReporter(paths.metrics(finalIdentifier), session::headers));
+        if (metadataType != null) {
+            return MetadataTableUtils.createMetadataTableInstance(table, metadataType);
+        }
+
+        return table;
+    }
+
+    private void trackFileIO(RESTTableOperations ops) {
+        if (io != ops.io()) {
+            fileIOTracker.track(ops);
+        }
+    }
+
+    private MetricsReporter metricsReporter(
+            String metricsEndpoint, Supplier<Map<String, String>> headers) {
+        if (reportingViaRestEnabled && endpoints.contains(Endpoint.V1_REPORT_METRICS)) {
+            RESTMetricsReporter restMetricsReporter =
+                    new RESTMetricsReporter(client, metricsEndpoint, headers);
+            return MetricsReporters.combine(reporter, restMetricsReporter);
+        } else {
+            return this.reporter;
+        }
+    }
+
+    @Override
+    public Catalog.TableBuilder buildTable(
+            SessionContext context, TableIdentifier identifier, Schema schema) {
+        return new Builder(identifier, schema, context);
+    }
+
+    @Override
+    public void invalidateTable(SessionContext context, TableIdentifier ident) {
+    }
+
+    @Override
+    public Table registerTable(
+            SessionContext context, TableIdentifier ident, String metadataFileLocation) {
+        Endpoint.check(endpoints, Endpoint.V1_REGISTER_TABLE);
+        checkIdentifierIsValid(ident);
+
+        Preconditions.checkArgument(
+                metadataFileLocation != null && !metadataFileLocation.isEmpty(),
+                "Invalid metadata file location: %s",
+                metadataFileLocation);
+
+        RegisterTableRequest request =
+                ImmutableRegisterTableRequest.builder()
+                        .name(ident.name())
+                        .metadataLocation(metadataFileLocation)
+                        .build();
+
+        LoadTableResponse response =
+                client.post(
+                        paths.register(ident.namespace()),
+                        request,
+                        LoadTableResponse.class,
+                        headers(context),
+                        ErrorHandlers.tableErrorHandler());
+
+        AuthSession session = tableSession(response.config(), session(context));
+        RESTTableOperations ops =
+                new RESTTableOperations(
+                        client,
+                        paths.table(ident),
+                        session::headers,
+                        tableFileIO(context, response.config()),
+                        response.tableMetadata(),
+                        endpoints);
+
+        trackFileIO(ops);
+
+        return new BaseTable(
+                ops, fullTableName(ident), metricsReporter(paths.metrics(ident), session::headers));
+    }
+
+    @Override
+    public void createNamespace(
+            SessionContext context, Namespace namespace, Map<String, String> metadata) {
+        Endpoint.check(endpoints, Endpoint.V1_CREATE_NAMESPACE);
+        CreateNamespaceRequest request =
+                CreateNamespaceRequest.builder().withNamespace(namespace).setProperties(metadata).build();
+
+        // for now, ignore the response because there is no way to return it
+        client.post(
+                paths.namespaces(),
+                request,
+                CreateNamespaceResponse.class,
+                headers(context),
+                ErrorHandlers.namespaceErrorHandler());
+    }
+
+    @Override
+    public List<Namespace> listNamespaces(SessionContext context, Namespace namespace) {
+        if (!endpoints.contains(Endpoint.V1_LIST_NAMESPACES)) {
+            return ImmutableList.of();
+        }
+
+        Map<String, String> queryParams = Maps.newHashMap();
+        if (!namespace.isEmpty()) {
+            queryParams.put("parent", RESTUtil.NAMESPACE_JOINER.join(namespace.levels()));
+        }
+
+        ImmutableList.Builder<Namespace> namespaces = ImmutableList.builder();
+        String pageToken = "";
+        if (pageSize != null) {
+            queryParams.put("pageSize", String.valueOf(pageSize));
+        }
+
+        do {
+            queryParams.put("pageToken", pageToken);
+            ListNamespacesResponse response =
+                    client.get(
+                            paths.namespaces(),
+                            queryParams,
+                            ListNamespacesResponse.class,
+                            headers(context),
+                            ErrorHandlers.namespaceErrorHandler());
+            pageToken = response.nextPageToken();
+            namespaces.addAll(response.namespaces());
+        } while (pageToken != null);
+
+        return namespaces.build();
+    }
+
+    @Override
+    public Map<String, String> loadNamespaceMetadata(SessionContext context, Namespace ns) {
+        Endpoint.check(endpoints, Endpoint.V1_LOAD_NAMESPACE);
+        checkNamespaceIsValid(ns);
+
+        // TODO: rename to LoadNamespaceResponse?
+        GetNamespaceResponse response =
+                client.get(
+                        paths.namespace(ns),
+                        GetNamespaceResponse.class,
+                        headers(context),
+                        ErrorHandlers.namespaceErrorHandler());
+        return response.properties();
+    }
+
+    @Override
+    public boolean dropNamespace(SessionContext context, Namespace ns) {
+        Endpoint.check(endpoints, Endpoint.V1_DELETE_NAMESPACE);
+        checkNamespaceIsValid(ns);
+
+        try {
+            client.delete(
+                    paths.namespace(ns), null, headers(context), ErrorHandlers.namespaceErrorHandler());
+            return true;
+        } catch (NoSuchNamespaceException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean updateNamespaceMetadata(
+            SessionContext context, Namespace ns, Map<String, String> updates, Set<String> removals) {
+        Endpoint.check(endpoints, Endpoint.V1_UPDATE_NAMESPACE);
+        checkNamespaceIsValid(ns);
+
+        UpdateNamespacePropertiesRequest request =
+                UpdateNamespacePropertiesRequest.builder().updateAll(updates).removeAll(removals).build();
+
+        UpdateNamespacePropertiesResponse response =
+                client.post(
+                        paths.namespaceProperties(ns),
+                        request,
+                        UpdateNamespacePropertiesResponse.class,
+                        headers(context),
+                        ErrorHandlers.namespaceErrorHandler());
+
+        return !response.updated().isEmpty();
+    }
+
+    private ScheduledExecutorService tokenRefreshExecutor(String catalogName) {
+        if (!keepTokenRefreshed) {
+            return null;
+        }
+
+        if (refreshExecutor == null) {
+            synchronized (this) {
+                if (refreshExecutor == null) {
+                    this.refreshExecutor = ThreadPools.newScheduledPool(catalogName + "-token-refresh", 1);
+                }
+            }
+        }
+
+        return refreshExecutor;
+    }
+
+    @Override
+    public void close() throws IOException {
+        shutdownRefreshExecutor();
+
+        if (closeables != null) {
+            closeables.close();
+        }
+    }
+
+    private void shutdownRefreshExecutor() {
+        if (refreshExecutor != null) {
+            ScheduledExecutorService service = refreshExecutor;
+            this.refreshExecutor = null;
+
+            List<Runnable> tasks = service.shutdownNow();
+            tasks.forEach(
+                    task -> {
+                        if (task instanceof Future) {
+                            ((Future<?>) task).cancel(true);
+                        }
+                    });
+
+            try {
+                if (!service.awaitTermination(1, TimeUnit.MINUTES)) {
+                    LOG.warn("Timed out waiting for refresh executor to terminate");
+                }
+            } catch (InterruptedException e) {
+                LOG.warn("Interrupted while waiting for refresh executor to terminate", e);
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private class Builder implements Catalog.TableBuilder {
+        private final TableIdentifier ident;
+        private final Schema schema;
+        private final SessionContext context;
+        private final ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.builder();
+        private PartitionSpec spec = null;
+        private SortOrder writeOrder = null;
+        private String location = null;
+
+        private Builder(TableIdentifier ident, Schema schema, SessionContext context) {
+            checkIdentifierIsValid(ident);
+
+            this.ident = ident;
+            this.schema = schema;
+            this.context = context;
+        }
+
+        @Override
+        public Builder withPartitionSpec(PartitionSpec tableSpec) {
+            this.spec = tableSpec;
+            return this;
+        }
+
+        @Override
+        public Builder withSortOrder(SortOrder tableWriteOrder) {
+            this.writeOrder = tableWriteOrder;
+            return this;
+        }
+
+        @Override
+        public Builder withLocation(String tableLocation) {
+            this.location = tableLocation;
+            return this;
+        }
+
+        @Override
+        public Builder withProperties(Map<String, String> props) {
+            if (props != null) {
+                this.propertiesBuilder.putAll(props);
+            }
+            return this;
+        }
+
+        @Override
+        public Builder withProperty(String key, String value) {
+            this.propertiesBuilder.put(key, value);
+            return this;
+        }
+
+        @Override
+        public Table create() {
+            Endpoint.check(endpoints, Endpoint.V1_CREATE_TABLE);
+            CreateTableRequest request =
+                    CreateTableRequest.builder()
+                            .withName(ident.name())
+                            .withSchema(schema)
+                            .withPartitionSpec(spec)
+                            .withWriteOrder(writeOrder)
+                            .withLocation(location)
+                            .setProperties(propertiesBuilder.build())
+                            .build();
+
+            LoadTableResponse response =
+                    client.post(
+                            paths.tables(ident.namespace()),
+                            request,
+                            LoadTableResponse.class,
+                            headers(context),
+                            ErrorHandlers.tableErrorHandler());
+
+            AuthSession session = tableSession(response.config(), session(context));
+            RESTTableOperations ops =
+                    new RESTTableOperations(
+                            client,
+                            paths.table(ident),
+                            session::headers,
+                            tableFileIO(context, response.config()),
+                            response.tableMetadata(),
+                            endpoints);
+
+            trackFileIO(ops);
+
+            return new BaseTable(
+                    ops, fullTableName(ident), metricsReporter(paths.metrics(ident), session::headers));
+        }
+
+        @Override
+        public Transaction createTransaction() {
+            Endpoint.check(endpoints, Endpoint.V1_CREATE_TABLE);
+            LoadTableResponse response = stageCreate();
+            String fullName = fullTableName(ident);
+
+            AuthSession session = tableSession(response.config(), session(context));
+            TableMetadata meta = response.tableMetadata();
+
+            RESTTableOperations ops =
+                    new RESTTableOperations(
+                            client,
+                            paths.table(ident),
+                            session::headers,
+                            tableFileIO(context, response.config()),
+                            RESTTableOperations.UpdateType.CREATE,
+                            createChanges(meta),
+                            meta,
+                            endpoints);
+
+            trackFileIO(ops);
+
+            return Transactions.createTableTransaction(
+                    fullName, ops, meta, metricsReporter(paths.metrics(ident), session::headers));
+        }
+
+        @Override
+        public Transaction replaceTransaction() {
+            Endpoint.check(endpoints, Endpoint.V1_UPDATE_TABLE);
+            if (viewExists(context, ident)) {
+                throw new AlreadyExistsException("View with same name already exists: %s", ident);
+            }
+
+            LoadTableResponse response = loadInternal(context, ident, snapshotMode);
+            String fullName = fullTableName(ident);
+
+            AuthSession session = tableSession(response.config(), session(context));
+            TableMetadata base = response.tableMetadata();
+
+            Map<String, String> tableProperties = propertiesBuilder.build();
+            TableMetadata replacement =
+                    base.buildReplacement(
+                            schema,
+                            spec != null ? spec : PartitionSpec.unpartitioned(),
+                            writeOrder != null ? writeOrder : SortOrder.unsorted(),
+                            location != null ? location : base.location(),
+                            tableProperties);
+
+            ImmutableList.Builder<MetadataUpdate> changes = ImmutableList.builder();
+
+            if (replacement.changes().stream()
+                    .noneMatch(MetadataUpdate.SetCurrentSchema.class::isInstance)) {
+                // ensure there is a change to set the current schema
+                changes.add(new MetadataUpdate.SetCurrentSchema(replacement.currentSchemaId()));
+            }
+
+            if (replacement.changes().stream()
+                    .noneMatch(MetadataUpdate.SetDefaultPartitionSpec.class::isInstance)) {
+                // ensure there is a change to set the default spec
+                changes.add(new MetadataUpdate.SetDefaultPartitionSpec(replacement.defaultSpecId()));
+            }
+
+            if (replacement.changes().stream()
+                    .noneMatch(MetadataUpdate.SetDefaultSortOrder.class::isInstance)) {
+                // ensure there is a change to set the default sort order
+                changes.add(new MetadataUpdate.SetDefaultSortOrder(replacement.defaultSortOrderId()));
+            }
+
+            RESTTableOperations ops =
+                    new RESTTableOperations(
+                            client,
+                            paths.table(ident),
+                            session::headers,
+                            tableFileIO(context, response.config()),
+                            RESTTableOperations.UpdateType.REPLACE,
+                            changes.build(),
+                            base,
+                            endpoints);
+
+            trackFileIO(ops);
+
+            return Transactions.replaceTableTransaction(
+                    fullName, ops, replacement, metricsReporter(paths.metrics(ident), session::headers));
+        }
+
+        @Override
+        public Transaction createOrReplaceTransaction() {
+            // return a create or a replace transaction, depending on whether the table exists
+            // deciding whether to create or replace can't be determined on the service because schema
+            // field IDs are assigned
+            // at this point and then used in data and metadata files. because create and replace will
+            // assign different
+            // field IDs, they must be determined before any writes occur
+            try {
+                return replaceTransaction();
+            } catch (NoSuchTableException e) {
+                return createTransaction();
+            }
+        }
+
+        private LoadTableResponse stageCreate() {
+            Map<String, String> tableProperties = propertiesBuilder.build();
+
+            CreateTableRequest request =
+                    CreateTableRequest.builder()
+                            .stageCreate()
+                            .withName(ident.name())
+                            .withSchema(schema)
+                            .withPartitionSpec(spec)
+                            .withWriteOrder(writeOrder)
+                            .withLocation(location)
+                            .setProperties(tableProperties)
+                            .build();
+
+            return client.post(
+                    paths.tables(ident.namespace()),
+                    request,
+                    LoadTableResponse.class,
+                    headers(context),
+                    ErrorHandlers.tableErrorHandler());
+        }
+    }
+
+    private static List<MetadataUpdate> createChanges(TableMetadata meta) {
+        ImmutableList.Builder<MetadataUpdate> changes = ImmutableList.builder();
+
+        changes.add(new MetadataUpdate.AssignUUID(meta.uuid()));
+        changes.add(new MetadataUpdate.UpgradeFormatVersion(meta.formatVersion()));
+
+        Schema schema = meta.schema();
+        changes.add(new MetadataUpdate.AddSchema(schema, schema.highestFieldId()));
+        changes.add(new MetadataUpdate.SetCurrentSchema(-1));
+
+        PartitionSpec spec = meta.spec();
+        if (spec != null && spec.isPartitioned()) {
+            changes.add(new MetadataUpdate.AddPartitionSpec(spec));
+        } else {
+            changes.add(new MetadataUpdate.AddPartitionSpec(PartitionSpec.unpartitioned()));
+        }
+        changes.add(new MetadataUpdate.SetDefaultPartitionSpec(-1));
+
+        SortOrder order = meta.sortOrder();
+        if (order != null && order.isSorted()) {
+            changes.add(new MetadataUpdate.AddSortOrder(order));
+        } else {
+            changes.add(new MetadataUpdate.AddSortOrder(SortOrder.unsorted()));
+        }
+        changes.add(new MetadataUpdate.SetDefaultSortOrder(-1));
+
+        String location = meta.location();
+        if (location != null) {
+            changes.add(new MetadataUpdate.SetLocation(location));
+        }
+
+        Map<String, String> properties = meta.properties();
+        if (properties != null && !properties.isEmpty()) {
+            changes.add(new MetadataUpdate.SetProperties(properties));
+        }
+
+        return changes.build();
+    }
+
+    private String fullTableName(TableIdentifier ident) {
+        return String.format("%s.%s", name(), ident);
+    }
+
+    private FileIO newFileIO(SessionContext context, Map<String, String> properties) {
+        if (null != ioBuilder) {
+            return ioBuilder.apply(context, properties);
+        } else {
+            String ioImpl = properties.getOrDefault(CatalogProperties.FILE_IO_IMPL, DEFAULT_FILE_IO_IMPL);
+            return CatalogUtil.loadFileIO(ioImpl, properties, conf);
+        }
+    }
+
+    private FileIO tableFileIO(SessionContext context, Map<String, String> config) {
+        if (config.isEmpty() && ioBuilder == null) {
+            return io; // reuse client and io since config is the same
+        }
+
+        Map<String, String> fullConf = RESTUtil.merge(properties(), config);
+
+        return newFileIO(context, fullConf);
+    }
+
+    private AuthSession tableSession(Map<String, String> tableConf, AuthSession parent) {
+        Map<String, String> credentials = Maps.newHashMapWithExpectedSize(tableConf.size());
+        for (String prop : tableConf.keySet()) {
+            if (TABLE_SESSION_ALLOW_LIST.contains(prop)) {
+                credentials.put(prop, tableConf.get(prop));
+            }
+        }
+
+        Pair<String, Supplier<AuthSession>> newSession = newSession(credentials, tableConf, parent);
+        if (null == newSession) {
+            return parent;
+        }
+
+        AuthSession session = tableSessions.get(newSession.first(), id -> newSession.second().get());
+
+        return session != null ? session : parent;
+    }
+
+    private static ConfigResponse fetchConfig(
+            RESTClient client, Map<String, String> headers, Map<String, String> properties) {
+        // send the client's warehouse location to the service to keep in sync
+        // this is needed for cases where the warehouse is configured client side, but may be used on
+        // the server side,
+        // like the Hive Metastore, where both client and service hive-site.xml may have a warehouse
+        // location.
+        ImmutableMap.Builder<String, String> queryParams = ImmutableMap.builder();
+        if (properties.containsKey(CatalogProperties.WAREHOUSE_LOCATION)) {
+            queryParams.put(
+                    CatalogProperties.WAREHOUSE_LOCATION,
+                    properties.get(CatalogProperties.WAREHOUSE_LOCATION));
+        }
+
+        ConfigResponse configResponse =
+                client.get(
+                        ResourcePaths.config(),
+                        queryParams.build(),
+                        ConfigResponse.class,
+                        headers,
+                        ErrorHandlers.defaultErrorHandler());
+        configResponse.validate();
+        return configResponse;
+    }
+
+    private Pair<String, Supplier<AuthSession>> newSession(
+            Map<String, String> credentials, Map<String, String> properties, AuthSession parent) {
+        if (credentials != null) {
+            // use the bearer token without exchanging
+            if (credentials.containsKey(OAuth2Properties.TOKEN)) {
+                return Pair.of(
+                        credentials.get(OAuth2Properties.TOKEN),
+                        () ->
+                                AuthSession.fromAccessToken(
+                                        client,
+                                        tokenRefreshExecutor(name()),
+                                        credentials.get(OAuth2Properties.TOKEN),
+                                        expiresAtMillis(properties),
+                                        parent));
+            }
+
+            if (credentials.containsKey(OAuth2Properties.CREDENTIAL)) {
+                // fetch a token using the client credentials flow
+                return Pair.of(
+                        credentials.get(OAuth2Properties.CREDENTIAL),
+                        () ->
+                                AuthSession.fromCredential(
+                                        client,
+                                        tokenRefreshExecutor(name()),
+                                        credentials.get(OAuth2Properties.CREDENTIAL),
+                                        parent));
+            }
+
+            for (String tokenType : TOKEN_PREFERENCE_ORDER) {
+                if (credentials.containsKey(tokenType)) {
+                    // exchange the token for an access token using the token exchange flow
+                    return Pair.of(
+                            credentials.get(tokenType),
+                            () ->
+                                    AuthSession.fromTokenExchange(
+                                            client,
+                                            tokenRefreshExecutor(name()),
+                                            credentials.get(tokenType),
+                                            tokenType,
+                                            parent));
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private Long expiresAtMillis(Map<String, String> properties) {
+        if (properties.containsKey(OAuth2Properties.TOKEN_EXPIRES_IN_MS)) {
+            long expiresInMillis =
+                    PropertyUtil.propertyAsLong(
+                            properties,
+                            OAuth2Properties.TOKEN_EXPIRES_IN_MS,
+                            OAuth2Properties.TOKEN_EXPIRES_IN_MS_DEFAULT);
+            return System.currentTimeMillis() + expiresInMillis;
+        } else {
+            return null;
+        }
+    }
+
+    private void checkIdentifierIsValid(TableIdentifier tableIdentifier) {
+        if (tableIdentifier.namespace().isEmpty()) {
+            throw new NoSuchTableException("Invalid table identifier: %s", tableIdentifier);
+        }
+    }
+
+    private void checkViewIdentifierIsValid(TableIdentifier identifier) {
+        if (identifier.namespace().isEmpty()) {
+            throw new NoSuchViewException("Invalid view identifier: %s", identifier);
+        }
+    }
+
+    private void checkNamespaceIsValid(Namespace namespace) {
+        if (namespace.isEmpty()) {
+            throw new NoSuchNamespaceException("Invalid namespace: %s", namespace);
+        }
+    }
+
+    private static Map<String, String> configHeaders(Map<String, String> properties) {
+        return RESTUtil.extractPrefixMap(properties, "header.");
+    }
+
+    private static Cache<String, AuthSession> newSessionCache(Map<String, String> properties) {
+        long expirationIntervalMs =
+                PropertyUtil.propertyAsLong(
+                        properties,
+                        CatalogProperties.AUTH_SESSION_TIMEOUT_MS,
+                        CatalogProperties.AUTH_SESSION_TIMEOUT_MS_DEFAULT);
+
+        return Caffeine.newBuilder()
+                .expireAfterAccess(Duration.ofMillis(expirationIntervalMs))
+                .removalListener(
+                        (RemovalListener<String, AuthSession>)
+                                (id, auth, cause) -> {
+                                    if (auth != null) {
+                                        auth.stopRefreshing();
+                                    }
+                                })
+                .build();
+    }
+
+    public void commitTransaction(SessionContext context, List<TableCommit> commits) {
+        Endpoint.check(endpoints, Endpoint.V1_COMMIT_TRANSACTION);
+        List<UpdateTableRequest> tableChanges = Lists.newArrayListWithCapacity(commits.size());
+
+        for (TableCommit commit : commits) {
+            tableChanges.add(
+                    UpdateTableRequest.create(commit.identifier(), commit.requirements(), commit.updates()));
+        }
+
+        client.post(
+                paths.commitTransaction(),
+                new CommitTransactionRequest(tableChanges),
+                null,
+                headers(context),
+                ErrorHandlers.tableCommitHandler());
+    }
+
+    @Override
+    public List<TableIdentifier> listViews(SessionContext context, Namespace namespace) {
+        if (!endpoints.contains(Endpoint.V1_LIST_VIEWS)) {
+            return ImmutableList.of();
+        }
+
+        checkNamespaceIsValid(namespace);
+        Map<String, String> queryParams = Maps.newHashMap();
+        ImmutableList.Builder<TableIdentifier> views = ImmutableList.builder();
+        String pageToken = "";
+        if (pageSize != null) {
+            queryParams.put("pageSize", String.valueOf(pageSize));
+        }
+
+        do {
+            queryParams.put("pageToken", pageToken);
+            ListTablesResponse response =
+                    client.get(
+                            paths.views(namespace),
+                            queryParams,
+                            ListTablesResponse.class,
+                            headers(context),
+                            ErrorHandlers.namespaceErrorHandler());
+            pageToken = response.nextPageToken();
+            views.addAll(response.identifiers());
+        } while (pageToken != null);
+
+        return views.build();
+    }
+
+    @Override
+    public View loadView(SessionContext context, TableIdentifier identifier) {
+        Endpoint.check(
+                endpoints,
+                Endpoint.V1_LOAD_VIEW,
+                () ->
+                        new NoSuchViewException(
+                                "Unable to load view %s.%s: Server does not support endpoint %s",
+                                name(), identifier, Endpoint.V1_LOAD_VIEW));
+
+        checkViewIdentifierIsValid(identifier);
+
+        LoadViewResponse response =
+                client.get(
+                        paths.view(identifier),
+                        LoadViewResponse.class,
+                        headers(context),
+                        ErrorHandlers.viewErrorHandler());
+
+        AuthSession session = tableSession(response.config(), session(context));
+        ViewMetadata metadata = response.metadata();
+
+        RESTViewOperations ops =
+                new RESTViewOperations(
+                        client, paths.view(identifier), session::headers, metadata, endpoints);
+
+        return new BaseView(ops, ViewUtil.fullViewName(name(), identifier));
+    }
+
+    @Override
+    public RESTViewBuilder buildView(SessionContext context, TableIdentifier identifier) {
+        return new RESTViewBuilder(context, identifier);
+    }
+
+    @Override
+    public boolean dropView(SessionContext context, TableIdentifier identifier) {
+        Endpoint.check(endpoints, Endpoint.V1_DELETE_VIEW);
+        checkViewIdentifierIsValid(identifier);
+
+        try {
+            client.delete(
+                    paths.view(identifier), null, headers(context), ErrorHandlers.viewErrorHandler());
+            return true;
+        } catch (NoSuchViewException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public void renameView(SessionContext context, TableIdentifier from, TableIdentifier to) {
+        Endpoint.check(endpoints, Endpoint.V1_RENAME_VIEW);
+        checkViewIdentifierIsValid(from);
+        checkViewIdentifierIsValid(to);
+
+        RenameTableRequest request =
+                RenameTableRequest.builder().withSource(from).withDestination(to).build();
+
+        client.post(
+                paths.renameView(), request, null, headers(context), ErrorHandlers.viewErrorHandler());
+    }
+
+    private class RESTViewBuilder implements ViewBuilder {
+        private final SessionContext context;
+        private final TableIdentifier identifier;
+        private final Map<String, String> properties = Maps.newHashMap();
+        private final List<ViewRepresentation> representations = Lists.newArrayList();
+        private Namespace defaultNamespace = null;
+        private String defaultCatalog = null;
+        private Schema schema = null;
+        private String location = null;
+
+        private RESTViewBuilder(SessionContext context, TableIdentifier identifier) {
+            checkViewIdentifierIsValid(identifier);
+            this.identifier = identifier;
+            this.context = context;
+        }
+
+        @Override
+        public ViewBuilder withSchema(Schema newSchema) {
+            this.schema = newSchema;
+            return this;
+        }
+
+        @Override
+        public ViewBuilder withQuery(String dialect, String sql) {
+            representations.add(
+                    ImmutableSQLViewRepresentation.builder().dialect(dialect).sql(sql).build());
+            return this;
+        }
+
+        @Override
+        public ViewBuilder withDefaultCatalog(String catalog) {
+            this.defaultCatalog = catalog;
+            return this;
+        }
+
+        @Override
+        public ViewBuilder withDefaultNamespace(Namespace namespace) {
+            this.defaultNamespace = namespace;
+            return this;
+        }
+
+        @Override
+        public ViewBuilder withProperties(Map<String, String> newProperties) {
+            this.properties.putAll(newProperties);
+            return this;
+        }
+
+        @Override
+        public ViewBuilder withProperty(String key, String value) {
+            this.properties.put(key, value);
+            return this;
+        }
+
+        @Override
+        public ViewBuilder withLocation(String newLocation) {
+            this.location = newLocation;
+            return this;
+        }
+
+        @Override
+        public View create() {
+            Endpoint.check(endpoints, Endpoint.V1_CREATE_VIEW);
+            Preconditions.checkState(
+                    !representations.isEmpty(), "Cannot create view without specifying a query");
+            Preconditions.checkState(null != schema, "Cannot create view without specifying schema");
+            Preconditions.checkState(
+                    null != defaultNamespace, "Cannot create view without specifying a default namespace");
+
+            ViewVersion viewVersion =
+                    ImmutableViewVersion.builder()
+                            .versionId(1)
+                            .schemaId(schema.schemaId())
+                            .addAllRepresentations(representations)
+                            .defaultNamespace(defaultNamespace)
+                            .defaultCatalog(defaultCatalog)
+                            .timestampMillis(System.currentTimeMillis())
+                            .putAllSummary(EnvironmentContext.get())
+                            .build();
+
+            CreateViewRequest request =
+                    ImmutableCreateViewRequest.builder()
+                            .name(identifier.name())
+                            .location(location)
+                            .schema(schema)
+                            .viewVersion(viewVersion)
+                            .properties(properties)
+                            .build();
+
+            LoadViewResponse response =
+                    client.post(
+                            paths.views(identifier.namespace()),
+                            request,
+                            LoadViewResponse.class,
+                            headers(context),
+                            ErrorHandlers.viewErrorHandler());
+
+            AuthSession session = tableSession(response.config(), session(context));
+            RESTViewOperations ops =
+                    new RESTViewOperations(
+                            client, paths.view(identifier), session::headers, response.metadata(), endpoints);
+
+            return new BaseView(ops, ViewUtil.fullViewName(name(), identifier));
+        }
+
+        @Override
+        public View createOrReplace() {
+            try {
+                return replace(loadView());
+            } catch (NoSuchViewException e) {
+                return create();
+            }
+        }
+
+        @Override
+        public View replace() {
+            if (tableExists(context, identifier)) {
+                throw new AlreadyExistsException("Table with same name already exists: %s", identifier);
+            }
+
+            return replace(loadView());
+        }
+
+        private LoadViewResponse loadView() {
+            Endpoint.check(
+                    endpoints,
+                    Endpoint.V1_LOAD_VIEW,
+                    () ->
+                            new NoSuchViewException(
+                                    "Unable to load view %s.%s: Server does not support endpoint %s",
+                                    name(), identifier, Endpoint.V1_LOAD_VIEW));
+
+            return client.get(
+                    paths.view(identifier),
+                    LoadViewResponse.class,
+                    headers(context),
+                    ErrorHandlers.viewErrorHandler());
+        }
+
+        private View replace(LoadViewResponse response) {
+            Endpoint.check(endpoints, Endpoint.V1_UPDATE_VIEW);
+            Preconditions.checkState(
+                    !representations.isEmpty(), "Cannot replace view without specifying a query");
+            Preconditions.checkState(null != schema, "Cannot replace view without specifying schema");
+            Preconditions.checkState(
+                    null != defaultNamespace, "Cannot replace view without specifying a default namespace");
+
+            ViewMetadata metadata = response.metadata();
+
+            int maxVersionId =
+                    metadata.versions().stream()
+                            .map(ViewVersion::versionId)
+                            .max(Integer::compareTo)
+                            .orElseGet(metadata::currentVersionId);
+
+            ViewVersion viewVersion =
+                    ImmutableViewVersion.builder()
+                            .versionId(maxVersionId + 1)
+                            .schemaId(schema.schemaId())
+                            .addAllRepresentations(representations)
+                            .defaultNamespace(defaultNamespace)
+                            .defaultCatalog(defaultCatalog)
+                            .timestampMillis(System.currentTimeMillis())
+                            .putAllSummary(EnvironmentContext.get())
+                            .build();
+
+            ViewMetadata.Builder builder =
+                    ViewMetadata.buildFrom(metadata)
+                            .setProperties(properties)
+                            .setCurrentVersion(viewVersion, schema);
+
+            if (null != location) {
+                builder.setLocation(location);
+            }
+
+            ViewMetadata replacement = builder.build();
+
+            AuthSession session = tableSession(response.config(), session(context));
+            RESTViewOperations ops =
+                    new RESTViewOperations(
+                            client, paths.view(identifier), session::headers, metadata, endpoints);
+
+            ops.commit(metadata, replacement);
+
+            return new BaseView(ops, ViewUtil.fullViewName(name(), identifier));
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -55,6 +55,11 @@ import static org.apache.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS_DEFAUL
 import static org.apache.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS_DEFAULT;
 import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT;
 
+// copy from iceberg 1.7.1, do some changes:
+// 1. use basic auth (base64 encode credential) as Authorization header instead of bearer token
+// 2. do not add actor_token/actor_token_type in token exchange request if enable_actor_token is false
+// 3. do not refresh Authorization header when refresh token
+
 public class OAuth2Util {
     private OAuth2Util() {
     }

--- a/fe/fe-core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -1,0 +1,780 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.auth;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.relocated.com.google.common.base.Joiner;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Splitter;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.rest.ErrorHandlers;
+import org.apache.iceberg.rest.RESTClient;
+import org.apache.iceberg.rest.RESTUtil;
+import org.apache.iceberg.rest.ResourcePaths;
+import org.apache.iceberg.rest.responses.OAuthTokenResponse;
+import org.apache.iceberg.util.JsonUtil;
+import org.apache.iceberg.util.Pair;
+import org.apache.iceberg.util.Tasks;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+
+import static org.apache.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS_DEFAULT;
+import static org.apache.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS_DEFAULT;
+import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT;
+
+public class OAuth2Util {
+    private OAuth2Util() {
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(OAuth2Util.class);
+
+    // valid scope tokens are from ascii 0x21 to 0x7E, excluding 0x22 (") and 0x5C (\)
+    private static final Pattern VALID_SCOPE_TOKEN = Pattern.compile("^[!-~&&[^\"\\\\]]+$");
+    private static final Splitter SCOPE_DELIMITER = Splitter.on(" ");
+    private static final Joiner SCOPE_JOINER = Joiner.on(" ");
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String BASIC_PREFIX = "Basic ";
+
+    private static final Splitter CREDENTIAL_SPLITTER = Splitter.on(":").limit(2).trimResults();
+    private static final String GRANT_TYPE = "grant_type";
+    private static final String CLIENT_CREDENTIALS = "client_credentials";
+    private static final String TOKEN_EXCHANGE = "urn:ietf:params:oauth:grant-type:token-exchange";
+    private static final String SCOPE = "scope";
+
+    // Client credentials flow
+    private static final String CLIENT_ID = "client_id";
+    private static final String CLIENT_SECRET = "client_secret";
+
+    // Token exchange flow
+    private static final String SUBJECT_TOKEN = "subject_token";
+    private static final String SUBJECT_TOKEN_TYPE = "subject_token_type";
+    private static final String ACTOR_TOKEN = "actor_token";
+    private static final String ACTOR_TOKEN_TYPE = "actor_token_type";
+    private static final Set<String> VALID_TOKEN_TYPES =
+            Sets.newHashSet(
+                    OAuth2Properties.ACCESS_TOKEN_TYPE,
+                    OAuth2Properties.REFRESH_TOKEN_TYPE,
+                    OAuth2Properties.ID_TOKEN_TYPE,
+                    OAuth2Properties.SAML1_TOKEN_TYPE,
+                    OAuth2Properties.SAML2_TOKEN_TYPE,
+                    OAuth2Properties.JWT_TOKEN_TYPE);
+
+    // response serialization
+    private static final String ACCESS_TOKEN = "access_token";
+    private static final String TOKEN_TYPE = "token_type";
+    private static final String EXPIRES_IN = "expires_in";
+    private static final String ISSUED_TOKEN_TYPE = "issued_token_type";
+
+    public static Map<String, String> authHeaders(String token) {
+        if (token != null) {
+            return ImmutableMap.of(AUTHORIZATION_HEADER, BEARER_PREFIX + token);
+        } else {
+            return ImmutableMap.of();
+        }
+    }
+
+    public static Map<String, String> basicAuthHeaders(String credential) {
+        if (credential != null) {
+            return ImmutableMap.of(
+                    AUTHORIZATION_HEADER,
+                    BASIC_PREFIX
+                            + Base64.getEncoder().encodeToString(credential.getBytes(StandardCharsets.UTF_8)));
+        } else {
+            return ImmutableMap.of();
+        }
+    }
+
+    public static boolean isValidScopeToken(String scopeToken) {
+        return VALID_SCOPE_TOKEN.matcher(scopeToken).matches();
+    }
+
+    public static List<String> parseScope(String scope) {
+        return SCOPE_DELIMITER.splitToList(scope);
+    }
+
+    public static String toScope(Iterable<String> scopes) {
+        return SCOPE_JOINER.join(scopes);
+    }
+
+    public static Map<String, String> buildOptionalParam(Map<String, String> properties) {
+        // these are some options oauth params based on specification
+        // for any new optional oauth param, define the constant and add the constant to this list
+        Set<String> optionalParamKeys =
+                ImmutableSet.of(OAuth2Properties.AUDIENCE, OAuth2Properties.RESOURCE);
+        ImmutableMap.Builder<String, String> optionalParamBuilder = ImmutableMap.builder();
+        // add scope too,
+        optionalParamBuilder.put(
+                OAuth2Properties.SCOPE,
+                properties.getOrDefault(OAuth2Properties.SCOPE, OAuth2Properties.CATALOG_SCOPE));
+        // add all other parameters
+        for (String key : optionalParamKeys) {
+            String value = properties.get(key);
+            if (value != null) {
+                optionalParamBuilder.put(key, value);
+            }
+        }
+        return optionalParamBuilder.buildKeepingLast();
+    }
+
+    private static OAuthTokenResponse refreshToken(
+            RESTClient client,
+            Map<String, String> headers,
+            String subjectToken,
+            String subjectTokenType,
+            String scope,
+            String oauth2ServerUri,
+            Map<String, String> optionalOAuthParams) {
+        Map<String, String> request =
+                tokenExchangeRequest(
+                        subjectToken,
+                        subjectTokenType,
+                        scope != null ? ImmutableList.of(scope) : ImmutableList.of(),
+                        optionalOAuthParams);
+
+        OAuthTokenResponse response =
+                client.postForm(
+                        oauth2ServerUri,
+                        request,
+                        OAuthTokenResponse.class,
+                        headers,
+                        ErrorHandlers.oauthErrorHandler());
+        response.validate();
+
+        return response;
+    }
+
+    public static OAuthTokenResponse exchangeToken(
+            RESTClient client,
+            Map<String, String> headers,
+            String subjectToken,
+            String subjectTokenType,
+            String actorToken,
+            String actorTokenType,
+            String scope,
+            String oauth2ServerUri,
+            Map<String, String> optionalParams) {
+        Map<String, String> request =
+                tokenExchangeRequest(
+                        subjectToken,
+                        subjectTokenType,
+                        actorToken,
+                        actorTokenType,
+                        scope != null ? ImmutableList.of(scope) : ImmutableList.of(),
+                        optionalParams);
+
+        OAuthTokenResponse response =
+                client.postForm(
+                        oauth2ServerUri,
+                        request,
+                        OAuthTokenResponse.class,
+                        headers,
+                        ErrorHandlers.oauthErrorHandler());
+        response.validate();
+
+        return response;
+    }
+
+    public static OAuthTokenResponse exchangeToken(
+            RESTClient client,
+            Map<String, String> headers,
+            String subjectToken,
+            String subjectTokenType,
+            String actorToken,
+            String actorTokenType,
+            String scope) {
+        return exchangeToken(
+                client,
+                headers,
+                subjectToken,
+                subjectTokenType,
+                actorToken,
+                actorTokenType,
+                scope,
+                ResourcePaths.tokens(),
+                ImmutableMap.of());
+    }
+
+    public static OAuthTokenResponse exchangeToken(
+            RESTClient client,
+            Map<String, String> headers,
+            String subjectToken,
+            String subjectTokenType,
+            String actorToken,
+            String actorTokenType,
+            String scope,
+            String oauth2ServerUri) {
+        return exchangeToken(
+                client,
+                headers,
+                subjectToken,
+                subjectTokenType,
+                actorToken,
+                actorTokenType,
+                scope,
+                oauth2ServerUri,
+                ImmutableMap.of());
+    }
+
+    public static OAuthTokenResponse fetchToken(
+            RESTClient client,
+            Map<String, String> headers,
+            String credential,
+            String scope,
+            String oauth2ServerUri,
+            Map<String, String> optionalParams) {
+        Map<String, String> request =
+                clientCredentialsRequest(
+                        credential,
+                        scope != null ? ImmutableList.of(scope) : ImmutableList.of(),
+                        optionalParams);
+
+        OAuthTokenResponse response =
+                client.postForm(
+                        oauth2ServerUri,
+                        request,
+                        OAuthTokenResponse.class,
+                        headers,
+                        ErrorHandlers.oauthErrorHandler());
+        response.validate();
+
+        return response;
+    }
+
+    public static OAuthTokenResponse fetchToken(
+            RESTClient client, Map<String, String> headers, String credential, String scope) {
+
+        return fetchToken(
+                client, headers, credential, scope, ResourcePaths.tokens(), ImmutableMap.of());
+    }
+
+    public static OAuthTokenResponse fetchToken(
+            RESTClient client,
+            Map<String, String> headers,
+            String credential,
+            String scope,
+            String oauth2ServerUri) {
+
+        return fetchToken(client, headers, credential, scope, oauth2ServerUri, ImmutableMap.of());
+    }
+
+    private static Map<String, String> tokenExchangeRequest(
+            String subjectToken,
+            String subjectTokenType,
+            List<String> scopes,
+            Map<String, String> optionalOAuthParams) {
+        return tokenExchangeRequest(
+                subjectToken, subjectTokenType, null, null, scopes, optionalOAuthParams);
+    }
+
+    private static Map<String, String> tokenExchangeRequest(
+            String subjectToken,
+            String subjectTokenType,
+            String actorToken,
+            String actorTokenType,
+            List<String> scopes,
+            Map<String, String> optionalParams) {
+        Preconditions.checkArgument(
+                VALID_TOKEN_TYPES.contains(subjectTokenType), "Invalid token type: %s", subjectTokenType);
+        Preconditions.checkArgument(
+                actorToken == null || VALID_TOKEN_TYPES.contains(actorTokenType),
+                "Invalid token type: %s",
+                actorTokenType);
+
+        ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();
+        formData.put(GRANT_TYPE, TOKEN_EXCHANGE);
+        formData.put(SCOPE, toScope(scopes));
+        formData.put(SUBJECT_TOKEN, subjectToken);
+        formData.put(SUBJECT_TOKEN_TYPE, subjectTokenType);
+        if (actorToken != null) {
+            formData.put(ACTOR_TOKEN, actorToken);
+            formData.put(ACTOR_TOKEN_TYPE, actorTokenType);
+        }
+        formData.putAll(optionalParams);
+
+        return formData.buildKeepingLast();
+    }
+
+    private static Pair<String, String> parseCredential(String credential) {
+        Preconditions.checkNotNull(credential, "Invalid credential: null");
+        List<String> parts = CREDENTIAL_SPLITTER.splitToList(credential);
+        switch (parts.size()) {
+            case 2:
+                // client ID and client secret
+                return Pair.of(parts.get(0), parts.get(1));
+            case 1:
+                // client secret
+                return Pair.of(null, parts.get(0));
+            default:
+                // this should never happen because the credential splitter is limited to 2
+                throw new IllegalArgumentException("Invalid credential: " + credential);
+        }
+    }
+
+    private static Map<String, String> clientCredentialsRequest(
+            String credential, List<String> scopes, Map<String, String> optionalOAuthParams) {
+        Pair<String, String> credentialPair = parseCredential(credential);
+        return clientCredentialsRequest(
+                credentialPair.first(), credentialPair.second(), scopes, optionalOAuthParams);
+    }
+
+    private static Map<String, String> clientCredentialsRequest(
+            String clientId,
+            String clientSecret,
+            List<String> scopes,
+            Map<String, String> optionalOAuthParams) {
+        ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();
+        formData.put(GRANT_TYPE, CLIENT_CREDENTIALS);
+        if (clientId != null) {
+            formData.put(CLIENT_ID, clientId);
+        }
+        formData.put(CLIENT_SECRET, clientSecret);
+        formData.put(SCOPE, toScope(scopes));
+        formData.putAll(optionalOAuthParams);
+
+        return formData.buildKeepingLast();
+    }
+
+    public static String tokenResponseToJson(OAuthTokenResponse response) {
+        return JsonUtil.generate(gen -> tokenResponseToJson(response, gen), false);
+    }
+
+    public static void tokenResponseToJson(OAuthTokenResponse response, JsonGenerator gen)
+            throws IOException {
+        response.validate();
+
+        gen.writeStartObject();
+
+        gen.writeStringField(ACCESS_TOKEN, response.token());
+        gen.writeStringField(TOKEN_TYPE, response.tokenType());
+
+        if (response.issuedTokenType() != null) {
+            gen.writeStringField(ISSUED_TOKEN_TYPE, response.issuedTokenType());
+        }
+
+        if (response.expiresInSeconds() != null) {
+            gen.writeNumberField(EXPIRES_IN, response.expiresInSeconds());
+        }
+
+        if (response.scopes() != null && !response.scopes().isEmpty()) {
+            gen.writeStringField(SCOPE, toScope(response.scopes()));
+        }
+
+        gen.writeEndObject();
+    }
+
+    public static OAuthTokenResponse tokenResponseFromJson(String json) {
+        return JsonUtil.parse(json, OAuth2Util::tokenResponseFromJson);
+    }
+
+    public static OAuthTokenResponse tokenResponseFromJson(JsonNode json) {
+        Preconditions.checkArgument(
+                json.isObject(), "Cannot parse token response from non-object: %s", json);
+
+        OAuthTokenResponse.Builder builder =
+                OAuthTokenResponse.builder()
+                        .withToken(JsonUtil.getString(ACCESS_TOKEN, json))
+                        .withTokenType(JsonUtil.getString(TOKEN_TYPE, json))
+                        .withIssuedTokenType(JsonUtil.getStringOrNull(ISSUED_TOKEN_TYPE, json));
+
+        if (json.has(EXPIRES_IN)) {
+            builder.setExpirationInSeconds(JsonUtil.getInt(EXPIRES_IN, json));
+        }
+
+        if (json.has(SCOPE)) {
+            builder.addScopes(parseScope(JsonUtil.getString(SCOPE, json)));
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * If the token is a JWT, extracts the expiration timestamp from the ext claim or null.
+     *
+     * @param token a token String
+     * @return The epoch millisecond the token expires at or null if it's not a valid JWT.
+     */
+    static Long expiresAtMillis(String token) {
+        if (null == token) {
+            return null;
+        }
+
+        List<String> parts = Splitter.on('.').splitToList(token);
+        if (parts.size() != 3) {
+            return null;
+        }
+
+        JsonNode node;
+        try {
+            node = JsonUtil.mapper().readTree(Base64.getUrlDecoder().decode(parts.get(1)));
+        } catch (IOException e) {
+            return null;
+        }
+
+        Long expiresAtSeconds = JsonUtil.getLongOrNull("exp", node);
+        if (expiresAtSeconds != null) {
+            return TimeUnit.SECONDS.toMillis(expiresAtSeconds);
+        }
+
+        return null;
+    }
+
+    /**
+     * Class to handle authorization headers and token refresh.
+     */
+    public static class AuthSession {
+        private static int tokenRefreshNumRetries = 5;
+        private static final long MAX_REFRESH_WINDOW_MILLIS = 300_000; // 5 minutes
+        private static final long MIN_REFRESH_WAIT_MILLIS = 10;
+        private volatile Map<String, String> headers;
+        private volatile AuthConfig config;
+
+        public AuthSession(Map<String, String> baseHeaders, AuthConfig config) {
+            this.headers = RESTUtil.merge(baseHeaders, authHeaders(config.token()));
+            this.config = config;
+        }
+
+        public void setHeaders(Map<String, String> headers) {
+            this.headers = headers;
+        }
+
+        public Map<String, String> headers() {
+            return headers;
+        }
+
+        public String token() {
+            return config.token();
+        }
+
+        public String tokenType() {
+            return config.tokenType();
+        }
+
+        public Long expiresAtMillis() {
+            return config.expiresAtMillis();
+        }
+
+        public String scope() {
+            return config.scope();
+        }
+
+        public synchronized void stopRefreshing() {
+            this.config = ImmutableAuthConfig.copyOf(config).withKeepRefreshed(false);
+        }
+
+        public String credential() {
+            return config.credential();
+        }
+
+        public String oauth2ServerUri() {
+            return config.oauth2ServerUri();
+        }
+
+        public Map<String, String> optionalOAuthParams() {
+            return config.optionalOAuthParams();
+        }
+
+        public AuthConfig config() {
+            return config;
+        }
+
+        @VisibleForTesting
+        static void setTokenRefreshNumRetries(int retries) {
+            tokenRefreshNumRetries = retries;
+        }
+
+        /**
+         * A new {@link AuthSession} with empty headers.
+         *
+         * @return A new {@link AuthSession} with empty headers.
+         */
+        public static AuthSession empty() {
+            return new AuthSession(ImmutableMap.of(), AuthConfig.builder().build());
+        }
+
+        /**
+         * Attempt to refresh the session token using the token exchange flow.
+         *
+         * @param client a RESTClient
+         * @return interval to wait before calling refresh again, or null if no refresh is needed
+         */
+        public Pair<Integer, TimeUnit> refresh(RESTClient client) {
+            if (token() != null && config.keepRefreshed()) {
+                AtomicReference<OAuthTokenResponse> ref = new AtomicReference<>(null);
+                boolean isSuccessful =
+                        Tasks.foreach(ref)
+                                .suppressFailureWhenFinished()
+                                .retry(tokenRefreshNumRetries)
+                                .onFailure(
+                                        (holder, err) -> {
+                                            // attempt to refresh using the client credential instead of the parent token
+                                            holder.set(refreshExpiredToken(client));
+                                            if (holder.get() == null) {
+                                                LOG.warn("Failed to refresh token", err);
+                                            }
+                                        })
+                                .exponentialBackoff(
+                                        COMMIT_MIN_RETRY_WAIT_MS_DEFAULT,
+                                        COMMIT_MAX_RETRY_WAIT_MS_DEFAULT,
+                                        COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT,
+                                        2.0 /* exponential */)
+                                .run(holder -> holder.set(refreshCurrentToken(client)));
+
+                if (!isSuccessful || ref.get() == null) {
+                    return null;
+                }
+
+                OAuthTokenResponse response = ref.get();
+                this.config =
+                        AuthConfig.builder()
+                                .from(config())
+                                .token(response.token())
+                                .tokenType(response.issuedTokenType())
+                                .build();
+                Map<String, String> currentHeaders = this.headers;
+                this.headers = RESTUtil.merge(currentHeaders, authHeaders(config.token()));
+
+                if (response.expiresInSeconds() != null) {
+                    return Pair.of(response.expiresInSeconds(), TimeUnit.SECONDS);
+                }
+            }
+
+            return null;
+        }
+
+        private OAuthTokenResponse refreshCurrentToken(RESTClient client) {
+            if (null != expiresAtMillis() && expiresAtMillis() <= System.currentTimeMillis()) {
+                // the token has already expired, attempt to refresh using the credential
+                return refreshExpiredToken(client);
+            } else {
+                // attempt a normal refresh
+                return refreshToken(
+                        client,
+                        headers(),
+                        token(),
+                        tokenType(),
+                        scope(),
+                        oauth2ServerUri(),
+                        optionalOAuthParams());
+            }
+        }
+
+        private OAuthTokenResponse refreshExpiredToken(RESTClient client) {
+            if (credential() != null) {
+                Map<String, String> basicHeaders =
+                        RESTUtil.merge(headers(), basicAuthHeaders(credential()));
+                return refreshToken(
+                        client,
+                        basicHeaders,
+                        token(),
+                        tokenType(),
+                        scope(),
+                        oauth2ServerUri(),
+                        optionalOAuthParams());
+            }
+
+            return null;
+        }
+
+        /**
+         * Schedule refresh for a token using an expiration interval.
+         *
+         * @param client          a RESTClient
+         * @param executor        a ScheduledExecutorService in which to run the refresh
+         * @param session         AuthSession to refresh
+         * @param expiresAtMillis The epoch millis at which the token expires at
+         */
+        @SuppressWarnings("FutureReturnValueIgnored")
+        private static void scheduleTokenRefresh(
+                RESTClient client,
+                ScheduledExecutorService executor,
+                AuthSession session,
+                long expiresAtMillis) {
+            long expiresInMillis = expiresAtMillis - System.currentTimeMillis();
+            // how much ahead of time to start the request to allow it to complete
+            long refreshWindowMillis = Math.min(expiresInMillis / 10, MAX_REFRESH_WINDOW_MILLIS);
+            // how much time to wait before expiration
+            long waitIntervalMillis = expiresInMillis - refreshWindowMillis;
+            // how much time to actually wait
+            long timeToWait = Math.max(waitIntervalMillis, MIN_REFRESH_WAIT_MILLIS);
+
+            executor.schedule(
+                    () -> {
+                        long refreshStartTime = System.currentTimeMillis();
+                        Pair<Integer, TimeUnit> expiration = session.refresh(client);
+                        if (expiration != null) {
+                            scheduleTokenRefresh(
+                                    client,
+                                    executor,
+                                    session,
+                                    refreshStartTime + expiration.second().toMillis(expiration.first()));
+                        }
+                    },
+                    timeToWait,
+                    TimeUnit.MILLISECONDS);
+        }
+
+        public static AuthSession fromAccessToken(
+                RESTClient client,
+                ScheduledExecutorService executor,
+                String token,
+                Long defaultExpiresAtMillis,
+                AuthSession parent) {
+            AuthSession session =
+                    new AuthSession(
+                            parent.headers(),
+                            AuthConfig.builder()
+                                    .from(parent.config())
+                                    .token(token)
+                                    .tokenType(OAuth2Properties.ACCESS_TOKEN_TYPE)
+                                    .build());
+
+            long startTimeMillis = System.currentTimeMillis();
+            Long expiresAtMillis = session.expiresAtMillis();
+
+            if (null != expiresAtMillis && expiresAtMillis <= startTimeMillis) {
+                Pair<Integer, TimeUnit> expiration = session.refresh(client);
+                // if expiration is non-null, then token refresh was successful
+                if (expiration != null) {
+                    if (null != session.expiresAtMillis()) {
+                        // use the new expiration time from the refreshed token
+                        expiresAtMillis = session.expiresAtMillis();
+                    } else {
+                        // otherwise use the expiration time from the token response
+                        expiresAtMillis = startTimeMillis + expiration.second().toMillis(expiration.first());
+                    }
+                } else {
+                    // token refresh failed, don't reattempt with the original expiration
+                    expiresAtMillis = null;
+                }
+            } else if (null == expiresAtMillis && defaultExpiresAtMillis != null) {
+                expiresAtMillis = defaultExpiresAtMillis;
+            }
+
+            if (null != executor && null != expiresAtMillis) {
+                scheduleTokenRefresh(client, executor, session, expiresAtMillis);
+            }
+
+            return session;
+        }
+
+        public static AuthSession fromCredential(
+                RESTClient client,
+                ScheduledExecutorService executor,
+                String credential,
+                AuthSession parent) {
+            long startTimeMillis = System.currentTimeMillis();
+            OAuthTokenResponse response =
+                    fetchToken(
+                            client,
+                            parent.headers(),
+                            credential,
+                            parent.scope(),
+                            parent.oauth2ServerUri(),
+                            parent.optionalOAuthParams());
+            return fromTokenResponse(client, executor, response, startTimeMillis, parent, credential);
+        }
+
+        public static AuthSession fromTokenResponse(
+                RESTClient client,
+                ScheduledExecutorService executor,
+                OAuthTokenResponse response,
+                long startTimeMillis,
+                AuthSession parent) {
+            return fromTokenResponse(
+                    client, executor, response, startTimeMillis, parent, parent.credential());
+        }
+
+        private static AuthSession fromTokenResponse(
+                RESTClient client,
+                ScheduledExecutorService executor,
+                OAuthTokenResponse response,
+                long startTimeMillis,
+                AuthSession parent,
+                String credential) {
+            // issued_token_type is required in RFC 8693 but not in RFC 6749,
+            // thus assume type is access_token for compatibility with RFC 6749.
+            // See https://datatracker.ietf.org/doc/html/rfc6749#section-4.4.3
+            // for an example of a response that does not include the issued token type.
+            String issuedTokenType = response.issuedTokenType();
+            if (issuedTokenType == null) {
+                issuedTokenType = OAuth2Properties.ACCESS_TOKEN_TYPE;
+            }
+            AuthSession session =
+                    new AuthSession(
+                            parent.headers(),
+                            AuthConfig.builder()
+                                    .from(parent.config())
+                                    .token(response.token())
+                                    .tokenType(issuedTokenType)
+                                    .credential(credential)
+                                    .build());
+
+            Long expiresAtMillis = session.expiresAtMillis();
+            if (null == expiresAtMillis && response.expiresInSeconds() != null) {
+                expiresAtMillis = startTimeMillis + TimeUnit.SECONDS.toMillis(response.expiresInSeconds());
+            }
+
+            if (null != executor && null != expiresAtMillis) {
+                scheduleTokenRefresh(client, executor, session, expiresAtMillis);
+            }
+
+            return session;
+        }
+
+        public static AuthSession fromTokenExchange(
+                RESTClient client,
+                ScheduledExecutorService executor,
+                String token,
+                String tokenType,
+                AuthSession parent) {
+            long startTimeMillis = System.currentTimeMillis();
+            OAuthTokenResponse response =
+                    exchangeToken(
+                            client,
+                            parent.headers(),
+                            token,
+                            tokenType,
+                            parent.token(),
+                            parent.tokenType(),
+                            parent.scope(),
+                            parent.oauth2ServerUri(),
+                            parent.optionalOAuthParams());
+            return fromTokenResponse(client, executor, response, startTimeMillis, parent);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -570,8 +570,9 @@ public class OAuth2Util {
                                 .token(response.token())
                                 .tokenType(response.issuedTokenType())
                                 .build();
-                Map<String, String> currentHeaders = this.headers;
-                this.headers = RESTUtil.merge(currentHeaders, authHeaders(config.token()));
+                // Do not merge the headers, as we use basic auth for the token exchange flow
+                // Map<String, String> currentHeaders = this.headers;
+                // this.headers = RESTUtil.merge(currentHeaders, authHeaders(config.token()));
 
                 if (response.expiresInSeconds() != null) {
                     return Pair.of(response.expiresInSeconds(), TimeUnit.SECONDS);

--- a/fe/fe-core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -462,6 +462,7 @@ public class OAuth2Util {
         private static final long MIN_REFRESH_WAIT_MILLIS = 10;
         private volatile Map<String, String> headers;
         private volatile AuthConfig config;
+        private volatile boolean enableActorToken = false;
 
         public AuthSession(Map<String, String> baseHeaders, AuthConfig config) {
             this.headers = RESTUtil.merge(baseHeaders, authHeaders(config.token()));
@@ -474,6 +475,10 @@ public class OAuth2Util {
 
         public Map<String, String> headers() {
             return headers;
+        }
+
+        public void setEnableActorToken(boolean enableActorToken) {
+            this.enableActorToken = enableActorToken;
         }
 
         public String token() {
@@ -769,8 +774,8 @@ public class OAuth2Util {
                             parent.headers(),
                             token,
                             tokenType,
-                            parent.token(),
-                            parent.tokenType(),
+                            parent.enableActorToken ? parent.token() : null,
+                            parent.enableActorToken ? parent.tokenType() : null,
                             parent.scope(),
                             parent.oauth2ServerUri(),
                             parent.optionalOAuthParams());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/AlterTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/AlterTableTest.java
@@ -54,17 +54,17 @@ public class AlterTableTest extends TableTestBase {
     public void testCreateBranch() throws Exception {
         new MockUp<IcebergHiveCatalog>() {
             @Mock
-            Database getDB(String dbName) {
+            Database getDB(ConnectContext context, String dbName) {
                 return new Database(1, "db");
             }
 
             @Mock
-            org.apache.iceberg.Table getTable(String dbName, String tblName) {
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tblName) {
                 return mockedNativeTableB;
             }
 
             @Mock
-            boolean tableExists(String dbName, String tblName) {
+            boolean tableExists(ConnectContext context, String dbName, String tblName) {
                 return true;
             }
         };
@@ -136,17 +136,17 @@ public class AlterTableTest extends TableTestBase {
     public void testCreateTag() throws Exception {
         new MockUp<IcebergHiveCatalog>() {
             @Mock
-            Database getDB(String dbName) {
+            Database getDB(ConnectContext context, String dbName) {
                 return new Database(1, "db");
             }
 
             @Mock
-            org.apache.iceberg.Table getTable(String dbName, String tblName) {
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tblName) {
                 return mockedNativeTableB;
             }
 
             @Mock
-            boolean tableExists(String dbName, String tblName) {
+            boolean tableExists(ConnectContext context, String dbName, String tblName) {
                 return true;
             }
         };
@@ -204,17 +204,17 @@ public class AlterTableTest extends TableTestBase {
     public void testDropBranch() throws Exception {
         new MockUp<IcebergHiveCatalog>() {
             @Mock
-            Database getDB(String dbName) {
+            Database getDB(ConnectContext context, String dbName) {
                 return new Database(1, "db");
             }
 
             @Mock
-            org.apache.iceberg.Table getTable(String dbName, String tblName) {
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tblName) {
                 return mockedNativeTableB;
             }
 
             @Mock
-            boolean tableExists(String dbName, String tblName) {
+            boolean tableExists(ConnectContext context, String dbName, String tblName) {
                 return true;
             }
         };
@@ -246,17 +246,17 @@ public class AlterTableTest extends TableTestBase {
     public void testDropTag() throws Exception {
         new MockUp<IcebergHiveCatalog>() {
             @Mock
-            Database getDB(String dbName) {
+            Database getDB(ConnectContext context, String dbName) {
                 return new Database(1, "db");
             }
 
             @Mock
-            org.apache.iceberg.Table getTable(String dbName, String tblName) {
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tblName) {
                 return mockedNativeTableB;
             }
 
             @Mock
-            boolean tableExists(String dbName, String tblName) {
+            boolean tableExists(ConnectContext context, String dbName, String tblName) {
                 return true;
             }
         };
@@ -288,17 +288,17 @@ public class AlterTableTest extends TableTestBase {
     public void testAlterView() throws Exception {
         new MockUp<IcebergHiveCatalog>() {
             @Mock
-            Database getDB(String dbName) {
+            Database getDB(ConnectContext context, String dbName) {
                 return new Database(1, "db");
             }
 
             @Mock
-            org.apache.iceberg.Table getTable(String dbName, String tblName) {
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tblName) {
                 return mockedNativeTableB;
             }
 
             @Mock
-            boolean tableExists(String dbName, String tblName) {
+            boolean tableExists(ConnectContext context, String dbName, String tblName) {
                 return true;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
@@ -175,7 +175,7 @@ public class CatalogConnectorMetadataTest {
 
                 connectorMetadata.clear();
                 connectorMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadatRequestContext.DEFAULT);
-                connectorMetadata.dropTable(null);
+                connectorMetadata.dropTable(ctx, null);
                 connectorMetadata.refreshTable("test_db", null, null, false);
                 connectorMetadata.alterMaterializedView(null);
                 connectorMetadata.addPartitions(ctx, null, null, null);
@@ -187,15 +187,15 @@ public class CatalogConnectorMetadataTest {
                 connectorMetadata.alterMaterializedView(null);
                 connectorMetadata.refreshMaterializedView(null);
                 connectorMetadata.cancelRefreshMaterializedView(null);
-                connectorMetadata.createView(null);
-                connectorMetadata.alterView(null);
+                connectorMetadata.createView(ctx, null);
+                connectorMetadata.alterView(ctx, null);
                 connectorMetadata.truncateTable(null, null);
                 connectorMetadata.alterTableComment(null, null, null);
                 connectorMetadata.finishSink("test_db", "test_tbl", null, null);
                 connectorMetadata.abortSink("test_db", "test_tbl", null);
                 connectorMetadata.createTableLike(null);
-                connectorMetadata.createTable(null);
-                connectorMetadata.createDb("test_db");
+                connectorMetadata.createTable(ctx, null);
+                connectorMetadata.createDb(ctx, "test_db", new HashMap<>());
                 connectorMetadata.dropDb((ConnectContext) any, "test_db", false);
                 connectorMetadata.getRemoteFiles(null, getRemoteFilesParams);
                 connectorMetadata.getPartitions(null, null);
@@ -211,7 +211,7 @@ public class CatalogConnectorMetadataTest {
 
         catalogConnectorMetadata.clear();
         catalogConnectorMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadatRequestContext.DEFAULT);
-        catalogConnectorMetadata.dropTable(null);
+        catalogConnectorMetadata.dropTable(ctx, null);
         catalogConnectorMetadata.refreshTable("test_db", null, null, false);
         catalogConnectorMetadata.alterMaterializedView(null);
         catalogConnectorMetadata.addPartitions(com.starrocks.common.util.Util.getOrCreateInnerContext(), null, null, null);
@@ -223,15 +223,15 @@ public class CatalogConnectorMetadataTest {
         catalogConnectorMetadata.alterMaterializedView(null);
         catalogConnectorMetadata.refreshMaterializedView(null);
         catalogConnectorMetadata.cancelRefreshMaterializedView(null);
-        catalogConnectorMetadata.createView(null);
-        catalogConnectorMetadata.alterView(null);
+        catalogConnectorMetadata.createView(ctx, null);
+        catalogConnectorMetadata.alterView(ctx, null);
         catalogConnectorMetadata.truncateTable(null, null);
         catalogConnectorMetadata.alterTableComment(null, null, null);
         catalogConnectorMetadata.finishSink("test_db", "test_tbl", null, null);
         catalogConnectorMetadata.abortSink("test_db", "test_tbl", null);
         catalogConnectorMetadata.createTableLike(null);
-        catalogConnectorMetadata.createTable(null);
-        catalogConnectorMetadata.createDb("test_db");
+        catalogConnectorMetadata.createTable(ctx, null);
+        catalogConnectorMetadata.createDb(ctx, "test_db", new HashMap<>());
         catalogConnectorMetadata.dropDb(new ConnectContext(), "test_db", false);
         connectorMetadata.getRemoteFiles(null, getRemoteFilesParams);
         catalogConnectorMetadata.getPartitions(null, null);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
@@ -343,22 +343,22 @@ public class HiveMetadataTest {
     public void createDbTest() throws AlreadyExistsException {
         ExceptionChecker.expectThrowsWithMsg(AlreadyExistsException.class,
                 "Database Already Exists",
-                () -> hiveMetadata.createDb("db1", new HashMap<>()));
+                () -> hiveMetadata.createDb(connectContext, "db1", new HashMap<>()));
 
         Map<String, String> conf = new HashMap<>();
         conf.put("location", "abs://xxx/zzz");
         ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class,
                 "Invalid location URI: abs://xxx/zzz",
-                () -> hiveMetadata.createDb("db3", conf));
+                () -> hiveMetadata.createDb(connectContext, "db3", conf));
 
         conf.clear();
         conf.put("not_support_prop", "xxx");
         ExceptionChecker.expectThrowsWithMsg(IllegalArgumentException.class,
                 "Unrecognized property: not_support_prop",
-                () -> hiveMetadata.createDb("db3", conf));
+                () -> hiveMetadata.createDb(connectContext, "db3", conf));
 
         conf.clear();
-        hiveMetadata.createDb("db4", conf);
+        hiveMetadata.createDb(connectContext, "db4", conf);
     }
 
     @Test
@@ -385,9 +385,9 @@ public class HiveMetadataTest {
         ExceptionChecker.expectThrowsWithMsg(DdlException.class,
                 "Table location will be cleared. 'Force' must be set when dropping a hive table." +
                         " Please execute 'drop table hive_catalog.hive_db.hive_table force",
-                () -> hiveMetadata.dropTable(new DropTableStmt(false, tableName, false)));
+                () -> hiveMetadata.dropTable(connectContext, new DropTableStmt(false, tableName, false)));
 
-        hiveMetadata.dropTable(new DropTableStmt(false, tableName, true));
+        hiveMetadata.dropTable(connectContext, new DropTableStmt(false, tableName, true));
 
         new MockUp<HiveMetadata>() {
             @Mock
@@ -396,7 +396,7 @@ public class HiveMetadataTest {
             }
         };
 
-        hiveMetadata.dropTable(new DropTableStmt(true, tableName, true));
+        hiveMetadata.dropTable(connectContext, new DropTableStmt(true, tableName, true));
     }
 
     @Test(expected = StarRocksConnectorException.class)
@@ -774,7 +774,7 @@ public class HiveMetadataTest {
                 return true;
             }
         };
-        Assert.assertTrue(hiveMetadata.createTable(createTableStmt));
+        Assert.assertTrue(hiveMetadata.createTable(connectContext, createTableStmt));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergGlueCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergGlueCatalogTest.java
@@ -17,6 +17,8 @@ package com.starrocks.connector.iceberg;
 
 import com.google.common.collect.ImmutableList;
 import com.starrocks.connector.iceberg.glue.IcebergGlueCatalog;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.apache.hadoop.conf.Configuration;
@@ -24,6 +26,7 @@ import org.apache.iceberg.aws.glue.GlueCatalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -32,6 +35,12 @@ import java.util.List;
 import java.util.Map;
 
 public class IcebergGlueCatalogTest {
+    public static ConnectContext connectContext;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        connectContext = UtFrameUtils.createDefaultCtx();
+    }
 
     @Test
     public void testListAllDatabases(@Mocked GlueCatalog glueCatalog) {
@@ -46,7 +55,7 @@ public class IcebergGlueCatalogTest {
         Map<String, String> icebergProperties = new HashMap<>();
         IcebergGlueCatalog icebergGlueCatalog = new IcebergGlueCatalog(
                 "glue_native_catalog", new Configuration(), icebergProperties);
-        List<String> dbs = icebergGlueCatalog.listAllDatabases();
+        List<String> dbs = icebergGlueCatalog.listAllDatabases(connectContext);
         Assert.assertEquals(Arrays.asList("db1", "db2"), dbs);
     }
 
@@ -61,7 +70,7 @@ public class IcebergGlueCatalogTest {
         Map<String, String> icebergProperties = new HashMap<>();
         IcebergGlueCatalog icebergGlueCatalog = new IcebergGlueCatalog(
                 "glue_native_catalog", new Configuration(), icebergProperties);
-        Assert.assertTrue(icebergGlueCatalog.tableExists("db1", "tbl1"));
+        Assert.assertTrue(icebergGlueCatalog.tableExists(connectContext, "db1", "tbl1"));
     }
 
     @Test
@@ -75,8 +84,8 @@ public class IcebergGlueCatalogTest {
         Map<String, String> icebergProperties = new HashMap<>();
         IcebergGlueCatalog icebergGlueCatalog = new IcebergGlueCatalog(
                 "glue_native_catalog", new Configuration(), icebergProperties);
-        icebergGlueCatalog.renameTable("db", "tb1", "tb2");
-        boolean exists = icebergGlueCatalog.tableExists("db", "tbl2");
+        icebergGlueCatalog.renameTable(connectContext, "db", "tb1", "tb2");
+        boolean exists = icebergGlueCatalog.tableExists(connectContext, "db", "tbl2");
         Assert.assertTrue(exists);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergHadoopCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergHadoopCatalogTest.java
@@ -18,6 +18,8 @@ package com.starrocks.connector.iceberg;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.starrocks.connector.iceberg.hadoop.IcebergHadoopCatalog;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.apache.hadoop.conf.Configuration;
@@ -25,6 +27,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.hadoop.HadoopCatalog;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -36,6 +39,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class IcebergHadoopCatalogTest {
+    public static ConnectContext connectContext;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        connectContext = UtFrameUtils.createDefaultCtx();
+    }
+
     @Test
     public void testNewIcebergHadoopCatalog(@Mocked HadoopCatalog hadoopCatalog) {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new IcebergHadoopCatalog("catalog",
@@ -59,7 +69,7 @@ public class IcebergHadoopCatalogTest {
 
         IcebergHadoopCatalog icebergHadoopCatalog = new IcebergHadoopCatalog(
                 "catalog", new Configuration(), ImmutableMap.of("iceberg.catalog.warehouse", "s3://path/to/warehouse"));
-        List<String> dbs = icebergHadoopCatalog.listAllDatabases();
+        List<String> dbs = icebergHadoopCatalog.listAllDatabases(connectContext);
         assertEquals(Arrays.asList("db1", "db2"), dbs);
     }
 
@@ -73,7 +83,7 @@ public class IcebergHadoopCatalogTest {
         };
         IcebergHadoopCatalog icebergHadoopCatalog = new IcebergHadoopCatalog(
                 "catalog", new Configuration(), ImmutableMap.of("iceberg.catalog.warehouse", "s3://path/to/warehouse"));
-        assertTrue(icebergHadoopCatalog.tableExists("db1", "tbl1"));
+        assertTrue(icebergHadoopCatalog.tableExists(connectContext, "db1", "tbl1"));
     }
 
     @Test
@@ -86,8 +96,8 @@ public class IcebergHadoopCatalogTest {
         };
         IcebergHadoopCatalog icebergHadoopCatalog = new IcebergHadoopCatalog(
                 "catalog", new Configuration(), ImmutableMap.of("iceberg.catalog.warehouse", "s3://path/to/warehouse"));
-        icebergHadoopCatalog.renameTable("db", "tb1", "tb2");
-        boolean exists = icebergHadoopCatalog.tableExists("db", "tbl2");
+        icebergHadoopCatalog.renameTable(connectContext, "db", "tb1", "tb2");
+        boolean exists = icebergHadoopCatalog.tableExists(connectContext, "db", "tbl2");
         Assert.assertTrue(exists);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -180,7 +180,7 @@ public class IcebergMetadataTest extends TableTestBase {
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergCatalog,
                 Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
         List<String> expectResult = Lists.newArrayList("db1", "db2");
-        Assert.assertEquals(expectResult, metadata.listDbNames(new ConnectContext()));
+        Assert.assertEquals(expectResult, metadata.listDbNames(connectContext));
     }
 
     @Test
@@ -198,7 +198,7 @@ public class IcebergMetadataTest extends TableTestBase {
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
                 Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
         Database expectResult = new Database(0, db);
-        Assert.assertEquals(expectResult, metadata.getDb(new ConnectContext(), db));
+        Assert.assertEquals(expectResult, metadata.getDb(connectContext, db));
     }
 
     @Test
@@ -215,7 +215,7 @@ public class IcebergMetadataTest extends TableTestBase {
 
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
                 Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
-        Assert.assertNull(metadata.getDb(new ConnectContext(), db));
+        Assert.assertNull(metadata.getDb(connectContext, db));
     }
 
     @Test
@@ -235,7 +235,7 @@ public class IcebergMetadataTest extends TableTestBase {
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
                 Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
         List<String> expectResult = Lists.newArrayList("tbl1", "tbl2");
-        Assert.assertEquals(expectResult, metadata.listTableNames(new ConnectContext(), db1));
+        Assert.assertEquals(expectResult, metadata.listTableNames(connectContext, db1));
     }
 
     @Test
@@ -293,7 +293,7 @@ public class IcebergMetadataTest extends TableTestBase {
         };
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
                 Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
-        Assert.assertTrue(metadata.tableExists(new ConnectContext(), "db", "tbl"));
+        Assert.assertTrue(metadata.tableExists(connectContext, "db", "tbl"));
     }
 
     @Test
@@ -325,7 +325,7 @@ public class IcebergMetadataTest extends TableTestBase {
 
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
                 Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
-        Assert.assertNull(metadata.getTable(new ConnectContext(), "db", "tbl2"));
+        Assert.assertNull(metadata.getTable(connectContext, "db", "tbl2"));
     }
 
     @Test(expected = AlreadyExistsException.class)
@@ -404,7 +404,7 @@ public class IcebergMetadataTest extends TableTestBase {
             }
         };
 
-        metadata.createDb(new ConnectContext(), "iceberg_db", new HashMap<>());
+        metadata.createDb(connectContext, "iceberg_db", new HashMap<>());
     }
 
     @Test
@@ -425,7 +425,7 @@ public class IcebergMetadataTest extends TableTestBase {
         };
 
         try {
-            metadata.dropDb(new ConnectContext(), "iceberg_db", true);
+            metadata.dropDb(connectContext, "iceberg_db", true);
             Assert.fail();
         } catch (Exception e) {
             Assert.assertTrue(e instanceof StarRocksConnectorException);
@@ -528,7 +528,7 @@ public class IcebergMetadataTest extends TableTestBase {
         };
 
         try {
-            metadata.dropDb(new ConnectContext(), "iceberg_db", true);
+            metadata.dropDb(connectContext, "iceberg_db", true);
             Assert.fail();
         } catch (Exception e) {
             Assert.assertTrue(e instanceof MetaNotFoundException);
@@ -544,7 +544,7 @@ public class IcebergMetadataTest extends TableTestBase {
         };
 
         try {
-            metadata.dropDb(new ConnectContext(), "iceberg_db", true);
+            metadata.dropDb(connectContext, "iceberg_db", true);
             Assert.fail();
         } catch (Exception e) {
             Assert.assertTrue(e instanceof MetaNotFoundException);
@@ -560,7 +560,7 @@ public class IcebergMetadataTest extends TableTestBase {
         };
 
         try {
-            metadata.dropDb(new ConnectContext(), "iceberg_db", true);
+            metadata.dropDb(connectContext, "iceberg_db", true);
             Assert.fail();
         } catch (Exception e) {
             Assert.assertTrue(e instanceof MetaNotFoundException);
@@ -593,7 +593,7 @@ public class IcebergMetadataTest extends TableTestBase {
             }
         };
 
-        metadata.dropDb(new ConnectContext(), "iceberg_db", true);
+        metadata.dropDb(connectContext, "iceberg_db", true);
     }
 
     @Test
@@ -1053,12 +1053,13 @@ public class IcebergMetadataTest extends TableTestBase {
         mockedNativeTableB.newAppend().appendFile(FILE_B_1).appendFile(FILE_B_2).appendFile(FILE_B_3).commit();
         new MockUp<IcebergHiveCatalog>() {
             @Mock
-            org.apache.iceberg.Table getTable(String dbName, String tableName) throws StarRocksConnectorException {
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tableName)
+                    throws StarRocksConnectorException {
                 return mockedNativeTableB;
             }
 
             @Mock
-            Database getDB(String dbName) {
+            Database getDB(ConnectContext context, String dbName) {
                 return new Database(0, dbName);
             }
         };
@@ -1082,7 +1083,8 @@ public class IcebergMetadataTest extends TableTestBase {
         mockedNativeTableB.newAppend().appendFile(FILE_B_1).appendFile(FILE_B_2).commit();
         new MockUp<IcebergHiveCatalog>() {
             @Mock
-            org.apache.iceberg.Table getTable(String dbName, String tableName) throws StarRocksConnectorException {
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tableName)
+                    throws StarRocksConnectorException {
                 return mockedNativeTableB;
             }
         };
@@ -1107,7 +1109,8 @@ public class IcebergMetadataTest extends TableTestBase {
 
         new MockUp<IcebergHiveCatalog>() {
             @Mock
-            org.apache.iceberg.Table getTable(String dbName, String tableName) throws StarRocksConnectorException {
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tableName)
+                    throws StarRocksConnectorException {
                 return mockedNativeTableG;
             }
         };
@@ -1137,7 +1140,7 @@ public class IcebergMetadataTest extends TableTestBase {
 
         new MockUp<IcebergHiveCatalog>() {
             @Mock
-            org.apache.iceberg.Table getTable(String dbName, String tableName) throws StarRocksConnectorException {
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tableName) throws StarRocksConnectorException {
                 return mockedNativeTableB;
             }
         };
@@ -1300,12 +1303,13 @@ public class IcebergMetadataTest extends TableTestBase {
         mockedNativeTableG.newAppend().appendFile(FILE_B_5).commit();
         new MockUp<IcebergHiveCatalog>() {
             @Mock
-            org.apache.iceberg.Table getTable(String dbName, String tableName) throws StarRocksConnectorException {
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tableName)
+                    throws StarRocksConnectorException {
                 return mockedNativeTableG;
             }
 
             @Mock
-            Database getDB(String dbName) {
+            Database getDB(ConnectContext context, String dbName) {
                 return new Database(0, dbName);
             }
         };
@@ -1344,12 +1348,12 @@ public class IcebergMetadataTest extends TableTestBase {
 
         new MockUp<IcebergHiveCatalog>() {
             @Mock
-            org.apache.iceberg.Table getTable(String dbName, String tableName) throws StarRocksConnectorException {
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tableName) throws StarRocksConnectorException {
                 return mockedNativeTableA;
             }
 
             @Mock
-            Database getDB(String dbName) {
+            Database getDB(ConnectContext context, String dbName) {
                 return new Database(0, dbName);
             }
         };
@@ -1398,12 +1402,13 @@ public class IcebergMetadataTest extends TableTestBase {
 
         new MockUp<IcebergHiveCatalog>() {
             @Mock
-            org.apache.iceberg.Table getTable(String dbName, String tableName) throws StarRocksConnectorException {
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tableName)
+                    throws StarRocksConnectorException {
                 return mockedNativeTableC;
             }
 
             @Mock
-            boolean tableExists(String dbName, String tableName) {
+            boolean tableExists(ConnectContext context, String dbName, String tableName) {
                 return true;
             }
         };
@@ -1535,19 +1540,20 @@ public class IcebergMetadataTest extends TableTestBase {
                                                        @Mocked Snapshot snapshot) throws Exception {
         new MockUp<IcebergMetadata>() {
             @Mock
-            public Database getDb(String dbName) {
+            public Database getDb(ConnectContext context, String dbName) {
                 return new Database(1, "db");
             }
         };
 
         new MockUp<IcebergHiveCatalog>() {
             @Mock
-            org.apache.iceberg.Table getTable(String dbName, String tableName) throws StarRocksConnectorException {
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tableName)
+                    throws StarRocksConnectorException {
                 return mockedNativeTableA;
             }
 
             @Mock
-            boolean tableExists(String dbName, String tableName) {
+            boolean tableExists(ConnectContext context, String dbName, String tableName) {
                 return true;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -1140,7 +1140,8 @@ public class IcebergMetadataTest extends TableTestBase {
 
         new MockUp<IcebergHiveCatalog>() {
             @Mock
-            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tableName) throws StarRocksConnectorException {
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tableName)
+                    throws StarRocksConnectorException {
                 return mockedNativeTableB;
             }
         };
@@ -1348,7 +1349,8 @@ public class IcebergMetadataTest extends TableTestBase {
 
         new MockUp<IcebergHiveCatalog>() {
             @Mock
-            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tableName) throws StarRocksConnectorException {
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tableName)
+                    throws StarRocksConnectorException {
                 return mockedNativeTableA;
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -119,6 +119,7 @@ import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.HiveTableOperations;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
@@ -153,6 +154,7 @@ public class IcebergMetadataTest extends TableTestBase {
 
     public static final IcebergCatalogProperties DEFAULT_CATALOG_PROPERTIES;
     public static final Map<String, String> DEFAULT_CONFIG = new HashMap<>();
+    public static ConnectContext connectContext;
 
     static {
         DEFAULT_CONFIG.put(HIVE_METASTORE_URIS, "thrift://188.122.12.1:8732"); // non-exist ip, prevent to connect local service
@@ -160,11 +162,16 @@ public class IcebergMetadataTest extends TableTestBase {
         DEFAULT_CATALOG_PROPERTIES = new IcebergCatalogProperties(DEFAULT_CONFIG);
     }
 
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        connectContext = UtFrameUtils.createDefaultCtx();
+    }
+
     @Test
     public void testListDatabaseNames(@Mocked IcebergCatalog icebergCatalog) {
         new Expectations() {
             {
-                icebergCatalog.listAllDatabases();
+                icebergCatalog.listAllDatabases(connectContext);
                 result = Lists.newArrayList("db1", "db2");
                 minTimes = 0;
             }
@@ -182,7 +189,7 @@ public class IcebergMetadataTest extends TableTestBase {
 
         new Expectations() {
             {
-                icebergHiveCatalog.getDB(db);
+                icebergHiveCatalog.getDB(connectContext, db);
                 result = new Database(0, db);
                 minTimes = 0;
             }
@@ -200,7 +207,7 @@ public class IcebergMetadataTest extends TableTestBase {
 
         new Expectations() {
             {
-                icebergHiveCatalog.getDB(db);
+                icebergHiveCatalog.getDB(connectContext, db);
                 result = new NoSuchNamespaceException("database not found");
                 minTimes = 0;
             }
@@ -219,7 +226,7 @@ public class IcebergMetadataTest extends TableTestBase {
 
         new Expectations() {
             {
-                icebergHiveCatalog.listTables(db1);
+                icebergHiveCatalog.listTables(connectContext, db1);
                 result = Lists.newArrayList(tbl1, tbl2);
                 minTimes = 0;
             }
@@ -237,7 +244,7 @@ public class IcebergMetadataTest extends TableTestBase {
 
         new Expectations() {
             {
-                icebergHiveCatalog.getTable("db", "tbl");
+                icebergHiveCatalog.getTable(connectContext, "db", "tbl");
                 result = new BaseTable(hiveTableOperations, "tbl");
                 minTimes = 0;
             }
@@ -259,7 +266,7 @@ public class IcebergMetadataTest extends TableTestBase {
                 result = IcebergCatalogType.HIVE_CATALOG;
                 minTimes = 0;
 
-                icebergHiveCatalog.getTable("DB", "TBL");
+                icebergHiveCatalog.getTable(connectContext, "DB", "TBL");
                 result = new BaseTable(hiveTableOperations, "tbl");
                 minTimes = 0;
             }
@@ -279,7 +286,7 @@ public class IcebergMetadataTest extends TableTestBase {
     public void testIcebergHiveCatalogTableExists(@Mocked IcebergHiveCatalog icebergHiveCatalog) {
         new Expectations() {
             {
-                icebergHiveCatalog.tableExists("db", "tbl");
+                icebergHiveCatalog.tableExists(connectContext, "db", "tbl");
                 result = true;
                 minTimes = 0;
             }
@@ -293,13 +300,13 @@ public class IcebergMetadataTest extends TableTestBase {
     public void testIcebergCatalogTableExists(@Mocked IcebergCatalog icebergCatalog) {
         new Expectations() {
             {
-                icebergCatalog.getTable("db", "tbl");
+                icebergCatalog.getTable(connectContext, "db", "tbl");
                 result = null;
                 minTimes = 0;
             }
         };
         MockIcebergCatalog mockIcebergCatalog = new MockIcebergCatalog();
-        Assert.assertTrue(mockIcebergCatalog.tableExists("db", "tbl"));
+        Assert.assertTrue(mockIcebergCatalog.tableExists(connectContext, "db", "tbl"));
     }
 
     @Test
@@ -307,11 +314,11 @@ public class IcebergMetadataTest extends TableTestBase {
                                   @Mocked HiveTableOperations hiveTableOperations) {
         new Expectations() {
             {
-                icebergHiveCatalog.getTable("db", "tbl");
+                icebergHiveCatalog.getTable(connectContext, "db", "tbl");
                 result = new BaseTable(hiveTableOperations, "tbl");
                 minTimes = 0;
 
-                icebergHiveCatalog.getTable("db", "tbl2");
+                icebergHiveCatalog.getTable(connectContext, "db", "tbl2");
                 result = new StarRocksConnectorException("not found");
             }
         };
@@ -327,13 +334,13 @@ public class IcebergMetadataTest extends TableTestBase {
                 Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
         new Expectations() {
             {
-                icebergHiveCatalog.listAllDatabases();
+                icebergHiveCatalog.listAllDatabases(connectContext);
                 result = Lists.newArrayList("iceberg_db");
                 minTimes = 0;
             }
         };
 
-        metadata.createDb("iceberg_db", new HashMap<>());
+        metadata.createDb(connectContext, "iceberg_db", new HashMap<>());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -344,13 +351,13 @@ public class IcebergMetadataTest extends TableTestBase {
 
         new Expectations(hiveCatalog) {
             {
-                hiveCatalog.listAllDatabases();
+                hiveCatalog.listAllDatabases(connectContext);
                 result = Lists.newArrayList();
                 minTimes = 0;
             }
         };
 
-        metadata.createDb("iceberg_db", ImmutableMap.of("error_key", "error_value"));
+        metadata.createDb(connectContext, "iceberg_db", ImmutableMap.of("error_key", "error_value"));
     }
 
     @Test
@@ -361,14 +368,14 @@ public class IcebergMetadataTest extends TableTestBase {
 
         new Expectations(icebergHiveCatalog) {
             {
-                icebergHiveCatalog.listAllDatabases();
+                icebergHiveCatalog.listAllDatabases(connectContext);
                 result = Lists.newArrayList();
                 minTimes = 0;
             }
         };
 
         try {
-            metadata.createDb("iceberg_db", ImmutableMap.of("location", "hdfs:xx/aaaxx"));
+            metadata.createDb(connectContext, "iceberg_db", ImmutableMap.of("location", "hdfs:xx/aaaxx"));
             Assert.fail();
         } catch (Exception e) {
             Assert.assertTrue(e instanceof StarRocksConnectorException);
@@ -384,7 +391,7 @@ public class IcebergMetadataTest extends TableTestBase {
 
         new Expectations(icebergHiveCatalog) {
             {
-                icebergHiveCatalog.listAllDatabases();
+                icebergHiveCatalog.listAllDatabases(connectContext);
                 result = Lists.newArrayList();
                 minTimes = 0;
             }
@@ -397,7 +404,7 @@ public class IcebergMetadataTest extends TableTestBase {
             }
         };
 
-        metadata.createDb("iceberg_db");
+        metadata.createDb(new ConnectContext(), "iceberg_db", new HashMap<>());
     }
 
     @Test
@@ -411,7 +418,7 @@ public class IcebergMetadataTest extends TableTestBase {
 
         new Expectations(icebergHiveCatalog) {
             {
-                icebergHiveCatalog.listTables("iceberg_db");
+                icebergHiveCatalog.listTables(connectContext, "iceberg_db");
                 result = mockTables;
                 minTimes = 0;
             }
@@ -476,14 +483,14 @@ public class IcebergMetadataTest extends TableTestBase {
 
         new Expectations(icebergHiveCatalog) {
             {
-                icebergHiveCatalog.dropTable("iceberg_db", "table1", true);
+                icebergHiveCatalog.dropTable(connectContext, "iceberg_db", "table1", true);
                 result = true;
                 minTimes = 0;
             }
         };
 
         try {
-            metadata.dropTable(new DropTableStmt(false, new TableName(CATALOG_NAME,
+            metadata.dropTable(connectContext, new DropTableStmt(false, new TableName(CATALOG_NAME,
                     "iceberg_db", "table1"), true));
         } catch (Exception e) {
             Assert.fail();
@@ -498,7 +505,7 @@ public class IcebergMetadataTest extends TableTestBase {
             }
         };
         try {
-            metadata.dropTable(new DropTableStmt(false, new TableName(CATALOG_NAME,
+            metadata.dropTable(connectContext, new DropTableStmt(false, new TableName(CATALOG_NAME,
                     "iceberg_db", "table1"), true));
         } catch (Exception e) {
             Assert.fail();
@@ -514,7 +521,7 @@ public class IcebergMetadataTest extends TableTestBase {
 
         new Expectations(icebergHiveCatalog) {
             {
-                icebergHiveCatalog.listTables("iceberg_db");
+                icebergHiveCatalog.listTables(connectContext, "iceberg_db");
                 result = Lists.newArrayList();
                 minTimes = 0;
             }
@@ -530,7 +537,7 @@ public class IcebergMetadataTest extends TableTestBase {
 
         new Expectations(icebergHiveCatalog) {
             {
-                icebergHiveCatalog.getDB("iceberg_db");
+                icebergHiveCatalog.getDB(connectContext, "iceberg_db");
                 result = null;
                 minTimes = 0;
             }
@@ -546,7 +553,7 @@ public class IcebergMetadataTest extends TableTestBase {
 
         new Expectations(icebergHiveCatalog) {
             {
-                icebergHiveCatalog.getDB("iceberg_db");
+                icebergHiveCatalog.getDB(connectContext, "iceberg_db");
                 result = new Database();
                 minTimes = 0;
             }
@@ -569,11 +576,11 @@ public class IcebergMetadataTest extends TableTestBase {
 
         new Expectations(icebergHiveCatalog) {
             {
-                icebergHiveCatalog.listTables("iceberg_db");
+                icebergHiveCatalog.listTables(connectContext, "iceberg_db");
                 result = Lists.newArrayList();
                 minTimes = 0;
 
-                icebergHiveCatalog.getDB("iceberg_db");
+                icebergHiveCatalog.getDB(connectContext, "iceberg_db");
                 result = new Database(1, "db", "hdfs:namenode:9000/user/hive/iceberg_location");
                 minTimes = 0;
             }
@@ -1555,7 +1562,8 @@ public class IcebergMetadataTest extends TableTestBase {
         IcebergAlterTableExecutor executor = new IcebergAlterTableExecutor(new AlterTableStmt(
                 tableName,
                 List.of(clause)),
-                icebergHiveCatalog.getTable(tableName.getDb(), tableName.getTbl()), icebergHiveCatalog, HDFS_ENVIRONMENT);
+                icebergHiveCatalog.getTable(connectContext, tableName.getDb(), tableName.getTbl()), icebergHiveCatalog,
+                HDFS_ENVIRONMENT);
         executor.execute();
 
         // Illegal date
@@ -1566,7 +1574,8 @@ public class IcebergMetadataTest extends TableTestBase {
         executor = new IcebergAlterTableExecutor(new AlterTableStmt(
                 tableName,
                 List.of(clause)),
-                icebergHiveCatalog.getTable(tableName.getDb(), tableName.getTbl()), icebergHiveCatalog, HDFS_ENVIRONMENT);
+                icebergHiveCatalog.getTable(connectContext, tableName.getDb(), tableName.getTbl()), icebergHiveCatalog,
+                HDFS_ENVIRONMENT);
         IcebergAlterTableExecutor finalExecutor = executor;
         Assert.assertThrows(DdlException.class, finalExecutor::execute);
 
@@ -1578,7 +1587,8 @@ public class IcebergMetadataTest extends TableTestBase {
         executor = new IcebergAlterTableExecutor(new AlterTableStmt(
                 tableName,
                 List.of(clause)),
-                icebergHiveCatalog.getTable(tableName.getDb(), tableName.getTbl()), icebergHiveCatalog, HDFS_ENVIRONMENT);
+                icebergHiveCatalog.getTable(connectContext, tableName.getDb(), tableName.getTbl()), icebergHiveCatalog,
+                HDFS_ENVIRONMENT);
         finalExecutor = executor;
         Assert.assertThrows(DdlException.class, finalExecutor::execute);
 
@@ -1617,7 +1627,8 @@ public class IcebergMetadataTest extends TableTestBase {
         executor = new IcebergAlterTableExecutor(new AlterTableStmt(
                 tableName,
                 List.of(clause)),
-                icebergHiveCatalog.getTable(tableName.getDb(), tableName.getTbl()), icebergHiveCatalog, HDFS_ENVIRONMENT);
+                icebergHiveCatalog.getTable(connectContext, tableName.getDb(), tableName.getTbl()), icebergHiveCatalog,
+                HDFS_ENVIRONMENT);
         executor.execute();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
@@ -40,7 +40,6 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.rest.RESTCatalog;
 import org.apache.iceberg.rest.RESTSessionCatalog;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.view.BaseView;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
@@ -38,8 +38,10 @@ import mockit.Mocked;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.rest.RESTCatalog;
+import org.apache.iceberg.rest.RESTSessionCatalog;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.view.BaseView;
 import org.apache.iceberg.view.ImmutableSQLViewRepresentation;
@@ -63,6 +65,7 @@ public class IcebergRESTCatalogTest {
     public static final IcebergCatalogProperties DEFAULT_CATALOG_PROPERTIES;
 
     public static final HdfsEnvironment HDFS_ENVIRONMENT = new HdfsEnvironment();
+    public static ConnectContext connectContext;
 
     static {
         DEFAULT_CONFIG.put(ICEBERG_CATALOG_TYPE, "rest");
@@ -72,10 +75,11 @@ public class IcebergRESTCatalogTest {
     @BeforeClass
     public static void beforeClass() throws Exception {
         UtFrameUtils.createMinStarRocksCluster();
+        connectContext = UtFrameUtils.createDefaultCtx();
         AnalyzeTestUtil.init();
     }
 
-    public IcebergMetadata buildIcebergMetadata(RESTCatalog restCatalog) {
+    public IcebergMetadata buildIcebergMetadata(RESTSessionCatalog restCatalog) {
         IcebergRESTCatalog icebergRESTCatalog = new IcebergRESTCatalog(restCatalog, new Configuration());
         CachingIcebergCatalog cachingIcebergCatalog = new CachingIcebergCatalog(
                 CATALOG_NAME, icebergRESTCatalog, DEFAULT_CATALOG_PROPERTIES, Executors.newSingleThreadExecutor());
@@ -98,7 +102,7 @@ public class IcebergRESTCatalogTest {
         Map<String, String> icebergProperties = new HashMap<>();
         IcebergRESTCatalog icebergRESTCatalog = new IcebergRESTCatalog(
                 "rest_native_catalog", new Configuration(), icebergProperties);
-        List<String> dbs = icebergRESTCatalog.listAllDatabases();
+        List<String> dbs = icebergRESTCatalog.listAllDatabases(connectContext);
         Assert.assertEquals(Arrays.asList("db1", "db2"), dbs);
     }
 
@@ -112,7 +116,7 @@ public class IcebergRESTCatalogTest {
         };
         IcebergRESTCatalog icebergRESTCatalog = new IcebergRESTCatalog(
                 "rest_native_catalog", new Configuration(), new HashMap<>());
-        boolean exists = icebergRESTCatalog.tableExists("db1", "tbl1");
+        boolean exists = icebergRESTCatalog.tableExists(connectContext, "db1", "tbl1");
         Assert.assertTrue(exists);
     }
 
@@ -126,22 +130,22 @@ public class IcebergRESTCatalogTest {
         };
         IcebergRESTCatalog icebergRESTCatalog = new IcebergRESTCatalog(
                 "rest_native_catalog", new Configuration(), new HashMap<>());
-        icebergRESTCatalog.renameTable("db", "tb1", "tb2");
-        boolean exists = icebergRESTCatalog.tableExists("db", "tbl2");
+        icebergRESTCatalog.renameTable(connectContext, "db", "tb1", "tb2");
+        boolean exists = icebergRESTCatalog.tableExists(connectContext, "db", "tbl2");
         Assert.assertTrue(exists);
     }
 
     @Test
-    public void testShowTableVies(@Mocked RESTCatalog restCatalog) {
+    public void testShowTableVies(@Mocked RESTSessionCatalog restCatalog) {
         IcebergMetadata metadata = buildIcebergMetadata(restCatalog);
 
         new Expectations() {
             {
-                restCatalog.listTables((Namespace) any);
+                restCatalog.listTables((SessionCatalog.SessionContext) any, (Namespace) any);
                 result = ImmutableList.of(TableIdentifier.of("db", "tbl1"));
                 minTimes = 1;
 
-                restCatalog.listViews((Namespace) any);
+                restCatalog.listViews((SessionCatalog.SessionContext) any, (Namespace) any);
                 result = ImmutableList.of(TableIdentifier.of("db", "view1"));
                 minTimes = 1;
             }
@@ -153,7 +157,7 @@ public class IcebergRESTCatalogTest {
     }
 
     @Test
-    public void testDropView(@Mocked RESTCatalog restCatalog) {
+    public void testDropView(@Mocked RESTSessionCatalog restCatalog) {
         IcebergMetadata metadata = buildIcebergMetadata(restCatalog);
         new MockUp<IcebergMetadata>() {
             @Mock
@@ -166,24 +170,25 @@ public class IcebergRESTCatalogTest {
 
         new Expectations() {
             {
-                restCatalog.dropView((TableIdentifier) any);
+                restCatalog.dropView((SessionCatalog.SessionContext) any, (TableIdentifier) any);
                 result = true;
                 minTimes = 1;
             }
         };
 
-        metadata.dropTable(new DropTableStmt(false, new TableName("catalog", "db", "view"), false));
+        metadata.dropTable(connectContext, new DropTableStmt(false, new TableName("catalog", "db", "view"),
+                false));
     }
 
     @Test
-    public void testCreateView(@Mocked RESTCatalog restCatalog, @Mocked BaseView baseView,
+    public void testCreateView(@Mocked RESTSessionCatalog restCatalog, @Mocked BaseView baseView,
                                @Mocked ImmutableSQLViewRepresentation representation) throws Exception {
         IcebergMetadata metadata = buildIcebergMetadata(restCatalog);
 
         CreateViewStmt stmt = new CreateViewStmt(false, false, new TableName("catalog", "db", "table"),
                 Lists.newArrayList(new ColWithComment("k1", "", NodePosition.ZERO)), "", false, null, NodePosition.ZERO);
         stmt.setColumns(Lists.newArrayList(new Column("k1", INT)));
-        metadata.createView(stmt);
+        metadata.createView(connectContext, stmt);
 
         new Expectations() {
             {
@@ -211,13 +216,13 @@ public class IcebergRESTCatalogTest {
                 result = null;
                 minTimes = 1;
 
-                restCatalog.loadView(TableIdentifier.of("db", "view"));
+                restCatalog.loadView((SessionCatalog.SessionContext) any, TableIdentifier.of("db", "view"));
                 result = baseView;
                 minTimes = 1;
             }
         };
 
-        Table table = metadata.getView("db", "view");
+        Table table = metadata.getView(connectContext, "db", "view");
         Assert.assertEquals(ICEBERG_VIEW, table.getType());
         Assert.assertNull(table.getTableLocation());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
@@ -90,10 +90,10 @@ public class IcebergRESTCatalogTest {
     }
 
     @Test
-    public void testListAllDatabases(@Mocked RESTCatalog restCatalog) {
+    public void testListAllDatabases(@Mocked RESTSessionCatalog restCatalog) {
         new Expectations() {
             {
-                restCatalog.listNamespaces();
+                restCatalog.listNamespaces((SessionCatalog.SessionContext) any);
                 result = ImmutableList.of(Namespace.of("db1"), Namespace.of("db2"));
                 times = 1;
             }
@@ -107,10 +107,10 @@ public class IcebergRESTCatalogTest {
     }
 
     @Test
-    public void testTableExists(@Mocked RESTCatalog restCatalog) {
+    public void testTableExists(@Mocked RESTSessionCatalog restCatalog) {
         new Expectations() {
             {
-                restCatalog.tableExists((TableIdentifier) any);
+                restCatalog.tableExists((SessionCatalog.SessionContext) any, (TableIdentifier) any);
                 result = true;
             }
         };
@@ -121,10 +121,10 @@ public class IcebergRESTCatalogTest {
     }
 
     @Test
-    public void testRenameTable(@Mocked RESTCatalog restCatalog) {
+    public void testRenameTable(@Mocked RESTSessionCatalog restCatalog) {
         new Expectations() {
             {
-                restCatalog.tableExists((TableIdentifier) any);
+                restCatalog.tableExists((SessionCatalog.SessionContext) any, (TableIdentifier) any);
                 result = true;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergCatalog.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergCatalog.java
@@ -16,6 +16,7 @@ package com.starrocks.connector.iceberg;
 
 import com.starrocks.catalog.Database;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.qe.ConnectContext;
 import org.apache.iceberg.Table;
 
 import java.util.List;
@@ -29,26 +30,27 @@ public class MockIcebergCatalog implements IcebergCatalog {
     }
 
     @Override
-    public List<String> listAllDatabases() {
+    public List<String> listAllDatabases(ConnectContext context) {
         return null;
     }
 
     @Override
-    public Database getDB(String dbName) {
+    public Database getDB(ConnectContext context, String dbName) {
         return null;
     }
 
     @Override
-    public List<String> listTables(String dbName) {
+    public List<String> listTables(ConnectContext context, String dbName) {
         return null;
     }
 
     @Override
-    public void renameTable(String dbName, String tblName, String newTblName) throws StarRocksConnectorException {
+    public void renameTable(ConnectContext context, String dbName, String tblName, String newTblName)
+            throws StarRocksConnectorException {
     }
 
     @Override
-    public Table getTable(String dbName, String tableName) throws StarRocksConnectorException {
+    public Table getTable(ConnectContext context, String dbName, String tableName) throws StarRocksConnectorException {
         return null;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -688,8 +688,10 @@ public class PaimonMetadataTest {
     @Test
     public void testCreatePaimonView() {
         Assert.assertThrows(StarRocksConnectorException.class,
-                () -> metadata.createView(new CreateViewStmt(false, false, new TableName("catalog", "db", "table"),
-                    Lists.newArrayList(new ColWithComment("k1", "", NodePosition.ZERO)), "", false, null, NodePosition.ZERO)));
+                () -> metadata.createView(connectContext, new CreateViewStmt(false, false,
+                        new TableName("catalog", "db", "table"),
+                    Lists.newArrayList(new ColWithComment("k1", "", NodePosition.ZERO)),
+                        "", false, null, NodePosition.ZERO)));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
@@ -43,13 +43,17 @@ import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudType;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
 import mockit.Mocked;
+import org.junit.BeforeClass;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.wildfly.common.Assert;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.starrocks.catalog.Table.TableType.DELTALAKE;
 import static com.starrocks.catalog.Table.TableType.HIVE;
@@ -85,6 +89,13 @@ public class UnifiedMetadataTest {
 
     private GetRemoteFilesParams getRemoteFilesParams;
 
+    public static ConnectContext connectContext;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        connectContext = UtFrameUtils.createDefaultCtx();
+    }
+
     @BeforeEach
     public void setUp() {
         this.unifiedMetadata = new UnifiedMetadata(ImmutableMap.of(
@@ -115,12 +126,12 @@ public class UnifiedMetadataTest {
             }
 
             {
-                hiveMetadata.createDb("test_db");
+                hiveMetadata.createDb((ConnectContext) any, "test_db", (Map) any);
                 times = 1;
             }
 
             {
-                hiveMetadata.createDb("test_db", ImmutableMap.of("key", "value"));
+                hiveMetadata.createDb((ConnectContext) any, "test_db", ImmutableMap.of("key", "value"));
                 times = 1;
             }
 
@@ -146,8 +157,8 @@ public class UnifiedMetadataTest {
         assertEquals(ImmutableList.of("test_db1", "test_db2"), dbNames);
         List<String> tblNames = unifiedMetadata.listTableNames(new ConnectContext(), "test_db");
         assertEquals(ImmutableList.of("test_tbl1", "test_tbl2"), tblNames);
-        unifiedMetadata.createDb("test_db");
-        unifiedMetadata.createDb("test_db", ImmutableMap.of("key", "value"));
+        unifiedMetadata.createDb(connectContext, "test_db", new HashMap<>());
+        unifiedMetadata.createDb(connectContext, "test_db", ImmutableMap.of("key", "value"));
         assertTrue(unifiedMetadata.dbExists(new ConnectContext(), "test_db"));
         unifiedMetadata.dropDb(new ConnectContext(), "test_db", false);
         CloudConfiguration cloudConfiguration = unifiedMetadata.getCloudConfiguration();
@@ -200,7 +211,7 @@ public class UnifiedMetadataTest {
             }
 
             {
-                hiveMetadata.createTable(createTableStmt);
+                hiveMetadata.createTable((ConnectContext) any, createTableStmt);
                 result = true;
                 times = 1;
             }
@@ -221,7 +232,7 @@ public class UnifiedMetadataTest {
         unifiedMetadata.refreshTable("test_db", hiveTable, ImmutableList.of(), false);
         unifiedMetadata.finishSink("test_db", "test_tbl", ImmutableList.of(), null);
         createTableStmt.setEngineName("hive");
-        assertTrue(unifiedMetadata.createTable(createTableStmt));
+        assertTrue(unifiedMetadata.createTable(connectContext, createTableStmt));
     }
 
     @Test
@@ -288,7 +299,7 @@ public class UnifiedMetadataTest {
             }
 
             {
-                icebergMetadata.createTable(createTableStmt);
+                icebergMetadata.createTable((ConnectContext) any, createTableStmt);
                 result = true;
                 times = 1;
             }
@@ -314,7 +325,7 @@ public class UnifiedMetadataTest {
         unifiedMetadata.refreshTable("test_db", icebergTable, ImmutableList.of(), false);
         unifiedMetadata.finishSink("test_db", "test_tbl", ImmutableList.of(), null);
         createTableStmt.setEngineName("iceberg");
-        assertTrue(unifiedMetadata.createTable(createTableStmt));
+        assertTrue(unifiedMetadata.createTable(connectContext, createTableStmt));
         Assert.assertTrue(unifiedMetadata.prepareMetadata(new MetaPreparationItem(icebergTable, null,
                 -1, TableVersionRange.empty()), null, null));
         Assert.assertNotNull(unifiedMetadata.getSerializedMetaSpec("test_db", "test_tbl", -1, null, null));
@@ -372,7 +383,7 @@ public class UnifiedMetadataTest {
             }
 
             {
-                hudiMetadata.createTable(createTableStmt);
+                hudiMetadata.createTable((ConnectContext) any, createTableStmt);
                 result = true;
                 times = 1;
             }
@@ -392,7 +403,7 @@ public class UnifiedMetadataTest {
         unifiedMetadata.refreshTable("test_db", hudiTable, ImmutableList.of(), false);
         unifiedMetadata.finishSink("test_db", "test_tbl", ImmutableList.of(), null);
         createTableStmt.setEngineName("hudi");
-        assertTrue(unifiedMetadata.createTable(createTableStmt));
+        assertTrue(unifiedMetadata.createTable(connectContext, createTableStmt));
     }
 
     @Test
@@ -453,7 +464,7 @@ public class UnifiedMetadataTest {
             }
 
             {
-                deltaLakeMetadata.createTable(createTableStmt);
+                deltaLakeMetadata.createTable((ConnectContext) any, createTableStmt);
                 result = true;
                 times = 1;
             }
@@ -473,7 +484,7 @@ public class UnifiedMetadataTest {
         unifiedMetadata.refreshTable("test_db", deltaLakeTable, ImmutableList.of(), false);
         unifiedMetadata.finishSink("test_db", "test_tbl", ImmutableList.of(), null);
         createTableStmt.setEngineName("deltalake");
-        assertTrue(unifiedMetadata.createTable(createTableStmt));
+        assertTrue(unifiedMetadata.createTable(connectContext, createTableStmt));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
@@ -126,7 +126,7 @@ public class UnifiedMetadataTest {
             }
 
             {
-                hiveMetadata.createDb((ConnectContext) any, "test_db", (Map) any);
+                hiveMetadata.createDb((ConnectContext) any, "test_db", new HashMap<>());
                 times = 1;
             }
 
@@ -153,14 +153,14 @@ public class UnifiedMetadataTest {
             }
         };
 
-        List<String> dbNames = unifiedMetadata.listDbNames(new ConnectContext());
+        List<String> dbNames = unifiedMetadata.listDbNames(connectContext);
         assertEquals(ImmutableList.of("test_db1", "test_db2"), dbNames);
-        List<String> tblNames = unifiedMetadata.listTableNames(new ConnectContext(), "test_db");
+        List<String> tblNames = unifiedMetadata.listTableNames(connectContext, "test_db");
         assertEquals(ImmutableList.of("test_tbl1", "test_tbl2"), tblNames);
         unifiedMetadata.createDb(connectContext, "test_db", new HashMap<>());
         unifiedMetadata.createDb(connectContext, "test_db", ImmutableMap.of("key", "value"));
-        assertTrue(unifiedMetadata.dbExists(new ConnectContext(), "test_db"));
-        unifiedMetadata.dropDb(new ConnectContext(), "test_db", false);
+        assertTrue(unifiedMetadata.dbExists(connectContext, "test_db"));
+        unifiedMetadata.dropDb(connectContext, "test_db", false);
         CloudConfiguration cloudConfiguration = unifiedMetadata.getCloudConfiguration();
         assertEquals(CloudType.DEFAULT, cloudConfiguration.getCloudType());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
@@ -53,7 +53,6 @@ import org.wildfly.common.Assert;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static com.starrocks.catalog.Table.TableType.DELTALAKE;
 import static com.starrocks.catalog.Table.TableType.HIVE;

--- a/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
@@ -433,7 +433,7 @@ public class MetadataMgrTest {
     public void testGetMetadataTable() throws Exception {
         new MockUp<IcebergHiveCatalog>() {
             @Mock
-            boolean tableExists(String dbName, String tableName) {
+            boolean tableExists(ConnectContext context, String dbName, String tableName) {
                 return true;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergEqualityDeletePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergEqualityDeletePlanTest.java
@@ -107,7 +107,8 @@ public class IcebergEqualityDeletePlanTest extends TableTestBase {
         mockedNativeTableA.refresh();
         new MockUp<IcebergHiveCatalog>() {
             @Mock
-            org.apache.iceberg.Table getTable(String dbName, String tableName) throws StarRocksConnectorException {
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tableName)
+                    throws StarRocksConnectorException {
                 return mockedNativeTableA;
             }
         };
@@ -216,7 +217,8 @@ public class IcebergEqualityDeletePlanTest extends TableTestBase {
         mockedNativeTableC.refresh();
         new MockUp<IcebergHiveCatalog>() {
             @Mock
-            org.apache.iceberg.Table getTable(String dbName, String tableName) throws StarRocksConnectorException {
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tableName)
+                    throws StarRocksConnectorException {
                 return mockedNativeTableC;
             }
         };
@@ -379,7 +381,8 @@ public class IcebergEqualityDeletePlanTest extends TableTestBase {
 
         new MockUp<IcebergHiveCatalog>() {
             @Mock
-            org.apache.iceberg.Table getTable(String dbName, String tableName) throws StarRocksConnectorException {
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tableName)
+                    throws StarRocksConnectorException {
                 return mockedNativeTableC;
             }
         };
@@ -551,7 +554,8 @@ public class IcebergEqualityDeletePlanTest extends TableTestBase {
         mockedNativeTableC.refresh();
         new MockUp<IcebergHiveCatalog>() {
             @Mock
-            org.apache.iceberg.Table getTable(String dbName, String tableName) throws StarRocksConnectorException {
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tableName)
+                    throws StarRocksConnectorException {
                 return mockedNativeTableC;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ViewPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ViewPlanTest.java
@@ -1722,7 +1722,7 @@ public class ViewPlanTest extends PlanTestBase {
 
         AlterViewStmt alterViewStmt =
                 (AlterViewStmt) UtFrameUtils.parseStmtWithNewParser(alterView, starRocksAssert.getCtx());
-        GlobalStateMgr.getCurrentState().getLocalMetastore().alterView(alterViewStmt);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().alterView(connectContext, alterViewStmt);
 
         sqlPlan = getFragmentPlan(alterStmt);
         viewPlan = getFragmentPlan("select * from " + viewName);


### PR DESCRIPTION
## Why I'm doing:
#https://github.com/StarRocks/starrocks/issues/57024
Implement user identity impersonation for the Iceberg REST catalog using the OIDC token + Iceberg token exchange flow.
I have already conducted tests using OKTA + Nessie.

example:
```
CREATE EXTERNAL CATALOG `nessie`
PROPERTIES ("aws.s3.access_key"  =  "AK******CY",
"aws.s3.secret_key"  =  "Gf******hK",
"iceberg.catalog.oauth2.audience"  =  "localhost:19120/iceberg",
"aws.s3.enable_path_style_access"  =  "true",
"iceberg.catalog.client.region"  =  "us-west-2",
"iceberg.catalog.uri"  =  "http://127.0.0.1:19120/iceberg/main",
"iceberg.catalog.security"  =  "oauth2",
"iceberg.catalog.vended-credentials-enabled"  =  "false",
"type"  =  "iceberg",
"iceberg.catalog.oauth2.credential"  =  "xxx:xxxxx",
"client.factory"  =  "com.starrocks.connector.share.iceberg.IcebergAwsClientFactory",
"iceberg.catalog.oauth2.scope"  =  "catalog_read catalog_write",
"iceberg.catalog.oauth2.server-uri"  =  "https://xxxx.okta.com/oauth2/default/v1/token",
"aws.s3.region"  =  "us-west-2",
"iceberg.catalog.warehouse"  =  "warehouse",
"iceberg.catalog.type"  =  "rest"
)
```

## What I'm doing:
1. refactor connnector metadata, add paramter **ConnectContext**
2. copy **RESTSessionCatalog** from iceberg 1.7.1 and made some modifications to be compatible with the OKTA token exchange flow.
```
   // 1. use basic auth (base64 encode credential) as Authorization header instead of bearer token
   // 2. do not add actor_token/actor_token_type in token exchange request if enable_actor_token is false
   // 3. do not refresh Authorization header when refresh token
```
3. add **oauth2.audience** properties

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1