### PR TITLE
[BugFix] fix cache select crash for struct/json/map/array column

### DIFF
--- a/be/src/storage/rowset/array_column_iterator.h
+++ b/be/src/storage/rowset/array_column_iterator.h
@@ -64,6 +64,9 @@ public:
 
     ColumnReader* get_column_reader() override { return _reader; }
 
+    StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range,
+                                                                        Column* dst) override;
+
 private:
     Status next_batch_null_offsets(size_t* n, UInt32Column* offsets, UInt8Column* nulls, size_t* element_rows);
     Status next_batch_null_offsets(const SparseRange<>& range, UInt32Column* offsets, UInt8Column* nulls,

--- a/be/src/storage/rowset/column_iterator.h
+++ b/be/src/storage/rowset/column_iterator.h
@@ -108,45 +108,9 @@ public:
 
     virtual Status next_batch(const SparseRange<>& range, Column* dst);
 
-    StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range) {
-        std::vector<std::pair<int64_t, int64_t>> res;
-        auto reader = get_column_reader();
-        if (reader == nullptr) {
-            // should't happen
-            return Status::InvalidArgument(fmt::format("column reader for {} is nullptr", _opts.read_file->filename()));
-        }
-
-        std::vector<std::pair<int, int>> page_index;
-        int prev_page_index = -1;
-        for (auto index = 0; index < range.size(); index++) {
-            auto row_start = range[index].begin();
-            auto row_end = range[index].end() - 1;
-            OrdinalPageIndexIterator iter_start;
-            OrdinalPageIndexIterator iter_end;
-            RETURN_IF_ERROR(reader->seek_at_or_before(row_start, &iter_start));
-            RETURN_IF_ERROR(reader->seek_at_or_before(row_end, &iter_end));
-
-            if (prev_page_index == iter_start.page_index()) {
-                // merge page index
-                page_index.back().second = iter_end.page_index();
-            } else {
-                page_index.emplace_back(std::make_pair(iter_start.page_index(), iter_end.page_index()));
-            }
-
-            prev_page_index = iter_end.page_index();
-        }
-
-        for (auto pair : page_index) {
-            OrdinalPageIndexIterator iter_start;
-            OrdinalPageIndexIterator iter_end;
-            RETURN_IF_ERROR(reader->seek_by_page_index(pair.first, &iter_start));
-            RETURN_IF_ERROR(reader->seek_by_page_index(pair.second, &iter_end));
-            auto offset = iter_start.page().offset;
-            auto size = iter_end.page().offset - offset + iter_end.page().size;
-            res.push_back({offset, size});
-        }
-
-        return res;
+    virtual StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range,
+                                                                                Column* dst) {
+        return Status::NotSupported("Not Implemented");
     }
 
     Status convert_sparse_range_to_io_range(const SparseRange<>& range) {
@@ -156,7 +120,7 @@ public:
         }
 
         std::vector<io::SharedBufferedInputStream::IORange> result;
-        ASSIGN_OR_RETURN(auto vec, get_io_range_vec(range));
+        ASSIGN_OR_RETURN(auto vec, get_io_range_vec(range, nullptr));
         for (auto e : vec) {
             io::SharedBufferedInputStream::IORange io_range(e.first, e.second);
             result.emplace_back(io_range);

--- a/be/src/storage/rowset/json_column_iterator.cpp
+++ b/be/src/storage/rowset/json_column_iterator.cpp
@@ -454,6 +454,9 @@ public:
 
     [[nodiscard]] Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) override;
 
+    StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range,
+                                                                        Column* dst) override;
+
 private:
     template <typename FUNC>
     Status _merge(JsonColumn* dst, FUNC func);
@@ -613,6 +616,21 @@ Status JsonMergeIterator::get_row_ranges_by_zone_map(const std::vector<const Col
                                                      CompoundNodeType pred_relation) {
     row_ranges->add({0, static_cast<rowid_t>(_reader->num_rows())});
     return Status::OK();
+}
+
+StatusOr<std::vector<std::pair<int64_t, int64_t>>> JsonMergeIterator::get_io_range_vec(const SparseRange<>& range,
+                                                                                       Column* dst) {
+    std::vector<std::pair<int64_t, int64_t>> res;
+    if (_null_iter != nullptr) {
+        ASSIGN_OR_RETURN(auto vec, _null_iter->get_io_range_vec(range, dst));
+        res.insert(res.end(), vec.begin(), vec.end());
+    }
+
+    for (size_t i = 0; i < _all_iter.size(); i++) {
+        ASSIGN_OR_RETURN(auto vec, _all_iter[i]->get_io_range_vec(range, dst));
+        res.insert(res.end(), vec.begin(), vec.end());
+    }
+    return res;
 }
 
 StatusOr<std::unique_ptr<ColumnIterator>> create_json_flat_iterator(

--- a/be/src/storage/rowset/map_column_iterator.cpp
+++ b/be/src/storage/rowset/map_column_iterator.cpp
@@ -149,47 +149,9 @@ Status MapColumnIterator::next_batch(const SparseRange<>& range, Column* dst) {
         down_cast<NullableColumn*>(dst)->update_has_null();
     }
 
-    SparseRangeIterator<> iter = range.new_iterator();
-    size_t to_read = range.span_size();
-
-    // array column can be nested, range may be empty
-    DCHECK(range.empty() || (range.begin() == _offsets->get_current_ordinal()));
     SparseRange element_read_range;
     size_t read_rows = 0;
-    while (iter.has_more()) {
-        Range<> r = iter.next(to_read);
-
-        RETURN_IF_ERROR(_offsets->seek_to_ordinal_and_calc_element_ordinal(r.begin()));
-        size_t element_ordinal = _offsets->element_ordinal();
-        // if array column in nullable or element of array is empty, element_read_range may be empty.
-        // so we should reseek the element_ordinal
-        if (element_read_range.span_size() == 0) {
-            RETURN_IF_ERROR(_keys->seek_to_ordinal(element_ordinal));
-            RETURN_IF_ERROR(_values->seek_to_ordinal(element_ordinal));
-        }
-        // 2. Read offset column
-        // [1, 2, 3], [4, 5, 6]
-        // In memory, it will be transformed to actual offset(0, 3, 6)
-        // On disk, offset is stored as length array(3, 3)
-        auto* offsets = map_column->offsets_column().get();
-        auto& data = offsets->get_data();
-        size_t end_offset = data.back();
-
-        size_t prev_array_size = offsets->size();
-        SparseRange<> size_read_range(r);
-        RETURN_IF_ERROR(_offsets->next_batch(size_read_range, offsets));
-        size_t curr_array_size = offsets->size();
-
-        size_t num_to_read = end_offset;
-        for (size_t i = prev_array_size; i < curr_array_size; ++i) {
-            end_offset += data[i];
-            data[i] = end_offset;
-        }
-        num_to_read = end_offset - num_to_read;
-        read_rows += num_to_read;
-
-        element_read_range.add(Range<>(element_ordinal, element_ordinal + num_to_read));
-    }
+    RETURN_IF_ERROR(get_element_range_vec(range, map_column, true /* seek */, element_read_range, read_rows));
 
     // if array column is nullable, element_read_range may be empty
     DCHECK(element_read_range.empty() || (element_read_range.begin() == _keys->get_current_ordinal()));
@@ -306,6 +268,83 @@ Status MapColumnIterator::seek_to_ordinal(ordinal_t ord) {
     RETURN_IF_ERROR(_keys->seek_to_ordinal(element_ordinal));
     RETURN_IF_ERROR(_values->seek_to_ordinal(element_ordinal));
     return Status::OK();
+}
+
+Status MapColumnIterator::get_element_range_vec(const SparseRange<>& range, MapColumn* map_column, bool seek,
+                                                SparseRange<>& element_read_range, size_t& read_rows) {
+    SparseRangeIterator<> iter = range.new_iterator();
+    size_t to_read = range.span_size();
+
+    // array column can be nested, range may be empty
+    DCHECK(range.empty() || (range.begin() == _offsets->get_current_ordinal()));
+    element_read_range.clear();
+    read_rows = 0;
+    while (iter.has_more()) {
+        Range<> r = iter.next(to_read);
+
+        RETURN_IF_ERROR(_offsets->seek_to_ordinal_and_calc_element_ordinal(r.begin()));
+        size_t element_ordinal = _offsets->element_ordinal();
+        // if array column in nullable or element of array is empty, element_read_range may be empty.
+        // so we should reseek the element_ordinal
+        if (seek && element_read_range.span_size() == 0) {
+            RETURN_IF_ERROR(_keys->seek_to_ordinal(element_ordinal));
+            RETURN_IF_ERROR(_values->seek_to_ordinal(element_ordinal));
+        }
+        // 2. Read offset column
+        // [1, 2, 3], [4, 5, 6]
+        // In memory, it will be transformed to actual offset(0, 3, 6)
+        // On disk, offset is stored as length array(3, 3)
+        auto* offsets = map_column->offsets_column().get();
+        auto& data = offsets->get_data();
+        size_t end_offset = data.back();
+
+        size_t prev_array_size = offsets->size();
+        SparseRange<> size_read_range(r);
+        RETURN_IF_ERROR(_offsets->next_batch(size_read_range, offsets));
+        size_t curr_array_size = offsets->size();
+
+        size_t num_to_read = end_offset;
+        for (size_t i = prev_array_size; i < curr_array_size; ++i) {
+            end_offset += data[i];
+            data[i] = end_offset;
+        }
+        num_to_read = end_offset - num_to_read;
+        read_rows += num_to_read;
+
+        element_read_range.add(Range<>(element_ordinal, element_ordinal + num_to_read));
+    }
+
+    return Status::OK();
+}
+
+StatusOr<std::vector<std::pair<int64_t, int64_t>>> MapColumnIterator::get_io_range_vec(const SparseRange<>& range,
+                                                                                       Column* dst) {
+    MapColumn* map_column = nullptr;
+    if (dst->is_nullable()) {
+        auto* nullable_column = down_cast<NullableColumn*>(dst);
+        map_column = down_cast<MapColumn*>(nullable_column->data_column().get());
+    } else {
+        map_column = down_cast<MapColumn*>(dst);
+    }
+
+    std::vector<std::pair<int64_t, int64_t>> res;
+    if (_nulls != nullptr) {
+        ASSIGN_OR_RETURN(auto vec, _nulls->get_io_range_vec(range, dst));
+        res.insert(res.end(), vec.begin(), vec.end());
+    }
+
+    SparseRange element_read_range;
+    size_t read_rows = 0;
+    RETURN_IF_ERROR(get_element_range_vec(range, map_column, false /* seek */, element_read_range, read_rows));
+    if (_access_keys) {
+        ASSIGN_OR_RETURN(auto vec, _keys->get_io_range_vec(element_read_range, dst));
+        res.insert(res.end(), vec.begin(), vec.end());
+    }
+    if (_access_values) {
+        ASSIGN_OR_RETURN(auto vec, _values->get_io_range_vec(element_read_range, dst));
+        res.insert(res.end(), vec.begin(), vec.end());
+    }
+    return res;
 }
 
 } // namespace starrocks

--- a/be/src/storage/rowset/map_column_iterator.h
+++ b/be/src/storage/rowset/map_column_iterator.h
@@ -46,7 +46,13 @@ public:
 
     ColumnReader* get_column_reader() override { return _reader; }
 
+    StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range,
+                                                                        Column* dst) override;
+
 private:
+    Status get_element_range_vec(const SparseRange<>& range, MapColumn* map_column, bool seek,
+                                 SparseRange<>& element_read_range, size_t& read_rows);
+
     ColumnReader* _reader;
 
     std::unique_ptr<ColumnIterator> _nulls;

--- a/be/src/storage/rowset/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/scalar_column_iterator.cpp
@@ -676,4 +676,47 @@ bool ScalarColumnIterator::_contains_deleted_row(uint32_t page_index) const {
     return true;
 }
 
+StatusOr<std::vector<std::pair<int64_t, int64_t>>> ScalarColumnIterator::get_io_range_vec(const SparseRange<>& range,
+                                                                                          Column* dst) {
+    (void)dst;
+    std::vector<std::pair<int64_t, int64_t>> res;
+    auto reader = get_column_reader();
+    if (reader == nullptr) {
+        // should't happen
+        return Status::InvalidArgument(fmt::format("column reader for {} is nullptr", _opts.read_file->filename()));
+    }
+
+    std::vector<std::pair<int, int>> page_index;
+    int prev_page_index = -1;
+    for (auto index = 0; index < range.size(); index++) {
+        auto row_start = range[index].begin();
+        auto row_end = range[index].end() - 1;
+        OrdinalPageIndexIterator iter_start;
+        OrdinalPageIndexIterator iter_end;
+        RETURN_IF_ERROR(reader->seek_at_or_before(row_start, &iter_start));
+        RETURN_IF_ERROR(reader->seek_at_or_before(row_end, &iter_end));
+
+        if (prev_page_index == iter_start.page_index()) {
+            // merge page index
+            page_index.back().second = iter_end.page_index();
+        } else {
+            page_index.emplace_back(std::make_pair(iter_start.page_index(), iter_end.page_index()));
+        }
+
+        prev_page_index = iter_end.page_index();
+    }
+
+    for (auto pair : page_index) {
+        OrdinalPageIndexIterator iter_start;
+        OrdinalPageIndexIterator iter_end;
+        RETURN_IF_ERROR(reader->seek_by_page_index(pair.first, &iter_start));
+        RETURN_IF_ERROR(reader->seek_by_page_index(pair.second, &iter_end));
+        auto offset = iter_start.page().offset;
+        auto size = iter_end.page().offset - offset + iter_end.page().size;
+        res.emplace_back(offset, size);
+    }
+
+    return res;
+}
+
 } // namespace starrocks

--- a/be/src/storage/rowset/scalar_column_iterator.h
+++ b/be/src/storage/rowset/scalar_column_iterator.h
@@ -106,6 +106,9 @@ public:
     // used to acquire load local dict
     int dict_size() override;
 
+    StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range,
+                                                                        Column* dst) override;
+
 private:
     static Status _seek_to_pos_in_page(ParsedPage* page, ordinal_t offset_in_page);
     Status _load_next_page(bool* eos);

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1421,8 +1421,15 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
         if (buf_size <= 0) {
             buf_size = 1048576; // 1MB
         }
-        for (auto& [cid, stream] : _column_files) {
-            ASSIGN_OR_RETURN(auto vec, _column_iterators[cid]->get_io_range_vec(_scan_range));
+        _context->_read_chunk->reset();
+        Chunk* chunk = _context->_read_chunk.get();
+        size_t column_index = 0;
+        for (size_t cid = 0; cid < _column_iterators.size(); ++cid) {
+            if (_column_iterators[cid] == nullptr) {
+                continue;
+            }
+            ColumnPtr& col = chunk->get_column_by_index(column_index++);
+            ASSIGN_OR_RETURN(auto vec, _column_iterators[cid]->get_io_range_vec(_scan_range, col.get()));
             for (auto e : vec) {
                 // if buf_size is 1MB, offset is 123, and size is 2MB
                 // after calculation, offset will be 0, and size will be 2MB+123
@@ -1430,7 +1437,7 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
                 size_t size = e.second + (e.first % buf_size);
                 while (size > 0) {
                     size_t cur_size = std::min(buf_size, size);
-                    RETURN_IF_ERROR(stream->touch_cache(offset, cur_size));
+                    RETURN_IF_ERROR(_column_files[cid]->touch_cache(offset, cur_size));
                     offset += cur_size;
                     size -= cur_size;
                 }
@@ -1903,6 +1910,10 @@ Status SegmentIterator::_init_context() {
             }
         }
 
+        if (_opts.lake_io_opts.cache_file_only) {
+            // CACHE SELECT disable late materialization
+            _late_materialization_ratio = 0;
+        }
         if (_late_materialization_ratio <= 0) {
             // late materialization been disabled.
             RETURN_IF_ERROR(_build_context<false>(&_context_list[0]));

--- a/be/src/storage/rowset/struct_column_iterator.cpp
+++ b/be/src/storage/rowset/struct_column_iterator.cpp
@@ -58,6 +58,9 @@ public:
 
     ColumnReader* get_column_reader() override { return _reader; }
 
+    StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range,
+                                                                        Column* dst) override;
+
 private:
     ColumnReader* _reader;
 
@@ -170,6 +173,21 @@ Status StructColumnIterator::next_batch(const SparseRange<>& range, Column* dst)
 
     _current_ordinal = _access_iters[0]->get_current_ordinal();
     return Status::OK();
+}
+
+StatusOr<std::vector<std::pair<int64_t, int64_t>>> StructColumnIterator::get_io_range_vec(const SparseRange<>& range,
+                                                                                          Column* dst) {
+    std::vector<std::pair<int64_t, int64_t>> res;
+    if (_null_iter != nullptr) {
+        ASSIGN_OR_RETURN(auto vec, _null_iter->get_io_range_vec(range, dst));
+        res.insert(res.end(), vec.begin(), vec.end());
+    }
+
+    for (size_t i = 0; i < _access_iters.size(); i++) {
+        ASSIGN_OR_RETURN(auto vec, _access_iters[i]->get_io_range_vec(range, dst));
+        res.insert(res.end(), vec.begin(), vec.end());
+    }
+    return res;
 }
 
 Status StructColumnIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
crash at `get_io_range_vec `
NOTE: disable late materialization for CACHE SELECT for now, it needs more work to support.

```
*** Aborted at 1743023408 (unix time) try "date -d @1743023408" if you are using GNU date ***
PC: @          0x6233474 starrocks::OrdinalIndexReader::seek_at_or_before(unsigned long)
*** SIGSEGV (@0x4) received by PID 74291 (TID 0x73b5207e3640) from PID 4; stack trace: ***
    @     0x73b5e2c99ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @          0xd5cc309 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x73b5e2c42520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @          0x6233474 starrocks::OrdinalIndexReader::seek_at_or_before(unsigned long)
    @          0x62149e5 starrocks::ColumnReader::seek_at_or_before(unsigned long, starrocks::OrdinalPageIndexIterator*)
    @          0x7af938c starrocks::ColumnIterator::get_io_range_vec(starrocks::SparseRange const&)
    @          0x7ae6b9b starrocks::SegmentIterator::_do_get_next(starrocks::Chunk*, std::vector >*)
    @          0x7af0442 starrocks::SegmentIterator::do_get_next(starrocks::Chunk*)
    @          0x63f20a6 starrocks::ProjectionIterator::do_get_next(starrocks::Chunk*)
    @          0x7995d63 starrocks::TimedChunkIterator::do_get_next(starrocks::Chunk*)
    @          0x7aac55f starrocks::lake::TabletReader::do_get_next(starrocks::Chunk*)
    @          0x8e057ac starrocks::connector::LakeDataSource::get_next(starrocks::RuntimeState*, std::shared_ptr*)
    @          0x8e263bf starrocks::pipeline::ConnectorChunkSource::_read_chunk(starrocks::RuntimeState*, std::shared_ptr*)
    @          0x87bf41f starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking(starrocks::RuntimeState*, unsigned long, starrocks::workgroup::WorkGroup const*)
    @          0x5aeecbf auto starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}::operator()(starrocks::workgroup::YieldContext&) const [clone .constprop.0]
    @          0x5abb096 starrocks::workgroup::ScanExecutor::worker_thread()
    @          0x94a67d3 starrocks::ThreadPool::dispatch_thread()
```
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
