### PR TITLE
[Tool] Support build icu thirdparty module

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1361,9 +1361,13 @@ build_icu() {
     unset CXXFLAGS
     unset CFLAGS
 
-    ./runConfigureICU Linux --prefix=$TP_INSTALL_DIR --enable-static --disable-shared
-    make -j$PARALLEL
-    make install
+    # Use a subshell to prevent LD_LIBRARY_PATH from affecting the external environment
+    (
+        export LD_LIBRARY_PATH=${STARROCKS_GCC_HOME}/lib:${STARROCKS_GCC_HOME}/lib64:${LD_LIBRARY_PATH:-}
+        ./runConfigureICU Linux --prefix=$TP_INSTALL_DIR --enable-static --disable-shared
+        make -j$PARALLEL
+        make install
+    )
     restore_compile_flags
 }
 


### PR DESCRIPTION
## Why I'm doing:
When execute build_thirdparty.sh. It report error:
```
Unpacking ./in/icudt76l.dat and generating out/tmp/icudata.lst (list of data files)
LD_LIBRARY_PATH=../lib:../stubdata:../tools/ctestfw:$LD_LIBRARY_PATH  ../bin/icupkg -d ./out/build/icudt76l --list -x \* ./in/icudt76l.dat -o out/tmp/icudata.lst
../bin/icupkg: /lib64/libstdc++.so.6: version CXXABI_1.3.9' not found (required by ../bin/icupkg)
```

## What I'm doing:
Reassign LD_LIBRARY_PATH to point to the lib directory under STARROCKS_GCC_HOME to avoid reading the local /lib64/libstdc++.so.6.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
