### PR TITLE
[Enhancement] Support multiple audience and issuers in OIDC

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authentication/OIDCSecurityIntegration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/OIDCSecurityIntegration.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.authentication;
 
+import com.google.re2j.Pattern;
 import com.starrocks.sql.analyzer.SemanticException;
 
 import java.util.Arrays;
@@ -32,6 +33,8 @@ public class OIDCSecurityIntegration extends SecurityIntegration {
             OIDCSecurityIntegration.OIDC_JWKS_URL,
             OIDCSecurityIntegration.OIDC_PRINCIPAL_FIELD));
 
+    private static final Pattern COMMA_SPLIT = Pattern.compile("\\s*,\\s*");
+
     public OIDCSecurityIntegration(String name, Map<String, String> propertyMap) {
         super(name, propertyMap);
     }
@@ -40,9 +43,13 @@ public class OIDCSecurityIntegration extends SecurityIntegration {
     public AuthenticationProvider getAuthenticationProvider() throws AuthenticationException {
         String jwksUrl = propertyMap.get(OIDC_JWKS_URL);
         String principalFiled = propertyMap.get(OIDC_PRINCIPAL_FIELD);
-        String requireIssuer = propertyMap.get(OIDC_REQUIRED_ISSUER);
-        String requireAudience = propertyMap.get(OIDC_REQUIRED_AUDIENCE);
-        return new OpenIdConnectAuthenticationProvider(jwksUrl, principalFiled, requireIssuer, requireAudience);
+        String commaSeparatedIssuer = propertyMap.get(OIDC_REQUIRED_ISSUER);
+        String[] requireIssuer = commaSeparatedIssuer == null ?
+                new String[0] : COMMA_SPLIT.split(commaSeparatedIssuer);
+        String commaSeperatedRequireAudiences = propertyMap.get(OIDC_REQUIRED_AUDIENCE);
+        String[] requireAudiences = commaSeperatedRequireAudiences == null ?
+                new String[0] : COMMA_SPLIT.split(commaSeperatedRequireAudiences.trim());
+        return new OpenIdConnectAuthenticationProvider(jwksUrl, principalFiled, requireIssuer, requireAudiences);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/OpenIdConnectAuthenticationProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/OpenIdConnectAuthenticationProvider.java
@@ -28,11 +28,11 @@ import java.nio.ByteBuffer;
 public class OpenIdConnectAuthenticationProvider implements AuthenticationProvider {
     private final String jwksUrl;
     private final String principalFiled;
-    private final String requiredIssuer;
-    private final String requiredAudience;
+    private final String[] requiredIssuer;
+    private final String[] requiredAudience;
 
     public OpenIdConnectAuthenticationProvider(String jwksUrl, String principalFiled,
-                                               String requiredIssuer, String requiredAudience) {
+                                               String[] requiredIssuer, String[] requiredAudience) {
         this.jwksUrl = jwksUrl;
         this.principalFiled = principalFiled;
         this.requiredIssuer = requiredIssuer;

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/OpenIdConnectVerifier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/OpenIdConnectVerifier.java
@@ -24,6 +24,7 @@ import com.nimbusds.jwt.SignedJWT;
 
 import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
+import java.util.Arrays;
 
 public class OpenIdConnectVerifier {
 
@@ -31,8 +32,8 @@ public class OpenIdConnectVerifier {
                               String userName,
                               JWKSet jwkSet,
                               String principalFiled,
-                              String requiredIssuer,
-                              String requiredAudience) throws AuthenticationException {
+                              String[] requiredIssuer,
+                              String[] requiredAudience) throws AuthenticationException {
         try {
             OpenIdConnectVerifier.verifyJWT(idToken, jwkSet);
             SignedJWT signedJWT = SignedJWT.parse(idToken);
@@ -47,11 +48,13 @@ public class OpenIdConnectVerifier {
                 throw new AuthenticationException("Login name " + userName + " is not matched to user " + jwtUserName);
             }
 
-            if (requiredIssuer != null && !requiredIssuer.isEmpty() && !requiredIssuer.equals(claims.getIssuer())) {
+            if (requiredIssuer != null && requiredIssuer.length != 0 &&
+                    !Arrays.asList(requiredIssuer).contains(claims.getIssuer())) {
                 throw new AuthenticationException("Issuer (iss) field " + claims.getIssuer() + " is invalid");
             }
 
-            if (requiredAudience != null && !requiredAudience.isEmpty() && !claims.getAudience().contains(requiredAudience)) {
+            if (requiredAudience != null && requiredAudience.length != 0 &&
+                    !Arrays.stream(requiredAudience).anyMatch(claims.getAudience()::contains)) {
                 throw new AuthenticationException("Audience (aud) field " + claims.getAudience() + " is invalid");
             }
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3518,18 +3518,18 @@ public class Config extends ConfigBase {
     public static String oidc_principal_field = "sub";
 
     /**
-     * Specifies a string that must match the value of the JWT’s issuer (iss) field in order to consider this JWT valid.
-     * The iss field in the JWT identifies the principal that issued the JWT.
+     * Specifies a list of string. One of that must match the value of the JWT’s issuer (iss) field in order to consider
+     * this JWT valid. The iss field in the JWT identifies the principal that issued the JWT.
      */
     @ConfField(mutable = false)
-    public static String oidc_required_issuer = "";
+    public static String[] oidc_required_issuer = {};
 
     /**
-     * Specifies a string that must match the value of the JWT’s Audience (aud) field in order to consider this JWT valid.
-     * The aud field in the JWT identifies the recipients that the JWT is intended for.
+     * Specifies a list of strings. For a JWT to be considered valid, the value of its 'aud' (Audience) field must match
+     * at least one of these strings.
      */
     @ConfField(mutable = false)
-    public static String oidc_required_audience = "";
+    public static String[] oidc_required_audience = {};
 
     /**
      * The name of the group provider. If there are multiple, separate them with commas.

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/OpenIdConnectAuthenticationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/OpenIdConnectAuthenticationTest.java
@@ -34,6 +34,9 @@ import java.text.ParseException;
 
 public class OpenIdConnectAuthenticationTest {
 
+    private final String[] emptyAudience = {};
+    private final String[] emptyIssuer = {};
+
     static class MockJwkMgr extends JwkMgr {
         @Override
         public JWKSet getJwkSet(String jwksUrl) throws IOException, ParseException {
@@ -62,7 +65,7 @@ public class OpenIdConnectAuthenticationTest {
         GlobalStateMgr.getCurrentState().setJwkMgr(new MockJwkMgr());
 
         OpenIdConnectAuthenticationProvider provider =
-                new OpenIdConnectAuthenticationProvider("jwks.json", "preferred_username", "", "");
+                new OpenIdConnectAuthenticationProvider("jwks.json", "preferred_username", emptyIssuer, emptyAudience);
         provider.analyzeAuthOption(new UserIdentity("harbor", "%"),
                 new UserAuthOption("", null, null, true, NodePosition.ZERO));
         String openIdConnectJson = getOpenIdConnect("oidc.json");
@@ -84,7 +87,7 @@ public class OpenIdConnectAuthenticationTest {
         JWKSet jwkSet = mockJwkMgr.getJwkSet("jwks.json");
 
         try {
-            OpenIdConnectVerifier.verify(openIdConnectJson, "harbor", jwkSet, "preferred_username", "", "");
+            OpenIdConnectVerifier.verify(openIdConnectJson, "harbor", jwkSet, "preferred_username", emptyIssuer, emptyAudience);
             Assert.fail();
         } catch (AuthenticationException e) {
             Assert.assertTrue(e.getMessage().contains("JWT with kid JKA9Gjuzv--loolRTY_pBN19sUF1Mf8naxOwvb0mgKQ is invalid"));
@@ -98,7 +101,7 @@ public class OpenIdConnectAuthenticationTest {
 
         try {
             JWKSet jwkSet = mockJwkMgr.getJwkSet("error-jwks.json");
-            OpenIdConnectVerifier.verify(openIdConnectJson, "harbor", jwkSet, "preferred_username", "", "");
+            OpenIdConnectVerifier.verify(openIdConnectJson, "harbor", jwkSet, "preferred_username", emptyIssuer, emptyAudience);
             Assert.fail();
         } catch (AuthenticationException e) {
             Assert.assertTrue(e.getMessage().contains("Cannot find public key for kid"));
@@ -113,14 +116,15 @@ public class OpenIdConnectAuthenticationTest {
 
         try {
             OpenIdConnectVerifier.verify(openIdConnectJson, "harbor",
-                    jwkSet, "preferred_username", "http://localhost:38080/realms/master", "12345");
+                    jwkSet, "preferred_username", new String[] {"http://localhost:38080/realms/master",
+                            "foo"}, new String[] {"12345", "56789"});
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
 
         try {
             OpenIdConnectVerifier.verify(openIdConnectJson, "harbor",
-                    jwkSet, "xxx", "http://localhost:38080/realms/master", "12345");
+                    jwkSet, "xxx", new String[] {"http://localhost:38080/realms/master"}, new String[] {"12345"});
             Assert.fail();
         } catch (AuthenticationException e) {
             Assert.assertTrue(e.getMessage().contains("Can not get specified principal xxx"));
@@ -128,7 +132,7 @@ public class OpenIdConnectAuthenticationTest {
 
         try {
             OpenIdConnectVerifier.verify(openIdConnectJson, "harbor",
-                    jwkSet, "sub", "http://localhost:38080/realms/master", "12345");
+                    jwkSet, "sub", new String[] {"http://localhost:38080/realms/master"}, new String[] {"12345"});
             Assert.fail();
         } catch (AuthenticationException e) {
             Assert.assertTrue(
@@ -137,7 +141,7 @@ public class OpenIdConnectAuthenticationTest {
 
         try {
             OpenIdConnectVerifier.verify(openIdConnectJson, "harbor",
-                    jwkSet, "preferred_username", "foo", "12345");
+                    jwkSet, "preferred_username", new String[] {"foo", "foo1"}, new String[] {"12345"});
             Assert.fail();
         } catch (AuthenticationException e) {
             Assert.assertTrue(e.getMessage().contains("Issuer (iss) field http://localhost:38080/realms/master is invalid"));
@@ -145,7 +149,7 @@ public class OpenIdConnectAuthenticationTest {
 
         try {
             OpenIdConnectVerifier.verify(openIdConnectJson, "harbor",
-                    jwkSet, "preferred_username", "http://localhost:38080/realms/master", "foo");
+                    jwkSet, "preferred_username", new String[] {"http://localhost:38080/realms/master"}, new String[] {"foo", "56789"});
             Assert.fail();
         } catch (AuthenticationException e) {
             Assert.assertTrue(e.getMessage().contains("Audience (aud) field [12345] is invalid"));


### PR DESCRIPTION
## Why I'm doing:
Currently only one accepted issuer and audience is accepted for OIDC. We need to support multiple issuers and audience and even if one of them is present in OIDC token that should be accepted.

## What I'm doing:

Adding support for users to specify multiple audience and issuers.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
