### PR TITLE
[Enhancement] turn on avro_ignore_union_type_tag by default

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1607,7 +1607,7 @@ CONF_mInt64(load_spill_merge_max_thread, "16");
 CONF_mInt64(pk_column_lazy_load_threshold_bytes, "314572800");
 
 // ignore union type tag in avro kafka routine load
-CONF_mBool(avro_ignore_union_type_tag, "false");
+CONF_mBool(avro_ignore_union_type_tag, "true");
 
 // default batch size for simdjson lib
 CONF_mInt32(json_parse_many_batch_size, "1000000");

--- a/be/test/formats/avro/binary_column_test.cpp
+++ b/be/test/formats/avro/binary_column_test.cpp
@@ -23,6 +23,7 @@
 
 #include "column/binary_column.h"
 #include "column/fixed_length_column.h"
+#include "common/config.h"
 #include "exec/avro_test.h"
 #include "runtime/types.h"
 #include "util/defer_op.h"
@@ -168,8 +169,12 @@ TEST_F(AvroAddBinaryColumnTest, test_add_object) {
 
     auto st = add_binary_column(column.get(), t, "f_object", avro_helper.avro_val);
     ASSERT_TRUE(st.ok());
-    ASSERT_EQ(R"(['{"boolean_type": true, "long_type": 4294967296, "double_type": 1.234567}'])",
-              column->debug_string());
+    if (config::avro_ignore_union_type_tag) {
+        ASSERT_EQ(R"(['{"boolean_type":true,"long_type":4294967296,"double_type":1.234567}'])", column->debug_string());
+    } else {
+        ASSERT_EQ(R"(['{"boolean_type": true, "long_type": 4294967296, "double_type": 1.234567}'])",
+                  column->debug_string());
+    }
 }
 
 TEST_F(AvroAddBinaryColumnTest, test_add_array) {
@@ -195,7 +200,11 @@ TEST_F(AvroAddBinaryColumnTest, test_add_array) {
 
     auto st = add_binary_column(column.get(), t, "f_array", avro_helper.avro_val);
     ASSERT_TRUE(st.ok());
-    ASSERT_EQ(R"(['[4294967297, 4294967298]'])", column->debug_string());
+    if (config::avro_ignore_union_type_tag) {
+        ASSERT_EQ(R"(['[4294967297,4294967298]'])", column->debug_string());
+    } else {
+        ASSERT_EQ(R"(['[4294967297, 4294967298]'])", column->debug_string());
+    }
 }
 
 TEST_F(AvroAddBinaryColumnTest, test_add_map) {
@@ -221,7 +230,11 @@ TEST_F(AvroAddBinaryColumnTest, test_add_map) {
 
     auto st = add_binary_column(column.get(), t, "f_map", avro_helper.avro_val);
     ASSERT_TRUE(st.ok());
-    ASSERT_EQ(R"(['{"ele1": 4294967297, "ele2": 4294967298}'])", column->debug_string());
+    if (config::avro_ignore_union_type_tag) {
+        ASSERT_EQ(R"(['{"ele1":4294967297,"ele2":4294967298}'])", column->debug_string());
+    } else {
+        ASSERT_EQ(R"(['{"ele1": 4294967297, "ele2": 4294967298}'])", column->debug_string());
+    }
 }
 
 } // namespace starrocks

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -531,6 +531,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - Description: The number of threads used for Schema Change.
 - Introduced in: -
 
+##### avro_ignore_union_type_tag
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether to strip the type tag from the JSON string serialized from the Avro Union data type.
+- Introduced in: v3.3.7, v3.4
+
 <!--
 ##### delete_worker_count_normal_priority
 

--- a/docs/ja/administration/management/BE_configuration.md
+++ b/docs/ja/administration/management/BE_configuration.md
@@ -343,6 +343,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 説明: スキーマ変更のために使用されるスレッドの数。
 - 導入バージョン: -
 
+##### avro_ignore_union_type_tag
+
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 可変: はい
+- 説明: Avro の Union データタイプからシリアライズされた JSON 文字列からタイプタグを取り除くかどうか。
+- 導入バージョン: v3.3.7, v3.4
+
 ##### clone_worker_count
 
 - デフォルト: 3

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -527,6 +527,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：进行 Schema Change 的线程数。自 2.5 版本起，该参数由静态变为动态。
 - 引入版本：-
 
+##### avro_ignore_union_type_tag
+
+- 默认值：true
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：是否在 Avro Union 数据结构序列化成 JSON 格式时，去除 Union 结构的类型标签信息。
+- 引入版本：v3.3.7, v3.4
+
 <!--
 ##### delete_worker_count_normal_priority
 


### PR DESCRIPTION
* strip avro union type tag from json string by default

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
