### PR TITLE
[BugFix] Fix FE may get incorrect version when enable batch publish in shared data

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1904,7 +1904,12 @@ public class DatabaseTransactionMgr {
     }
 
     public void replayUpsertTransactionStateBatch(TransactionStateBatch transactionStateBatch) {
+        Locker locker = new Locker();
+        locker.lockTablesWithIntensiveDbLock(transactionStateBatch.getDbId(),
+                List.of(transactionStateBatch.getTableId()),
+                LockType.WRITE);
         writeLock();
+
         try {
             LOG.debug("replay a transaction state batch{}", transactionStateBatch);
             transactionStateBatch.replaySetTransactionStatus();
@@ -1914,6 +1919,8 @@ public class DatabaseTransactionMgr {
             unprotectSetTransactionStateBatch(transactionStateBatch);
         } finally {
             writeUnlock();
+            locker.unLockTablesWithIntensiveDbLock(transactionStateBatch.getDbId(),
+                    List.of(transactionStateBatch.getTableId()), LockType.WRITE);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1904,6 +1904,8 @@ public class DatabaseTransactionMgr {
     }
 
     public void replayUpsertTransactionStateBatch(TransactionStateBatch transactionStateBatch) {
+        // Locks are held to ensure that updates of visible version in the same batch are atomic,
+        // so that intermediate versions cannot be seen.
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(transactionStateBatch.getDbId(),
                 List.of(transactionStateBatch.getTableId()),


### PR DESCRIPTION
## Why I'm doing:
When batch publish is enabled, a series of transactions are published in one RPC, and only the final version of the tablet meta is generated. The corresponding meta of the intermediate version does not exist, so the version should not be visible to Fe. However, there is no lock when replay, so it is possible to read the intermediate version in the follower node, resulting in query errors.
```
Scan tasks error: Not found: starlet err [RequestID=67E73C4AF007D23235A104B3][StatusCode=404]Get object oss://sr-c-7e8d69b019375556-1737528149080/7856aece-634f-4433-938e-69949da142f1/db10124/2063748/22375150/meta/0000000001556AF5_00000000002C52B5.meta error: The specified key does not exist.
```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
