### PR TITLE
[BugFix] Add behavioral test for statistics collection and fix some bugs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
@@ -97,6 +97,16 @@ public class TabletStatMgr extends FrontendDaemon {
 
     @Override
     protected void runAfterCatalogReady() {
+        // update interval
+        if (getInterval() != Config.tablet_stat_update_interval_second * 1000) {
+            setInterval(Config.tablet_stat_update_interval_second * 1000);
+        }
+
+        // for testing statistic behavior
+        if (!Config.enable_sync_tablet_stats) {
+            return;
+        }
+
         updateLocalTabletStat();
         updateLakeTabletStat();
 
@@ -245,6 +255,7 @@ public class TabletStatMgr extends FrontendDaemon {
         if (meta != null) {
             meta.setTotalRows(totalRowCount);
             meta.resetDeltaRows();
+            meta.updateTabletStatsReportTime();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1499,8 +1499,11 @@ public class Config extends ConfigBase {
      * update interval of tablet stat
      * All frontends will get tablet stat from all backends at each interval
      */
-    @ConfField
-    public static int tablet_stat_update_interval_second = 300;  // 5 min
+    @ConfField(mutable = true)
+    public static long tablet_stat_update_interval_second = 300;  // 5 min
+
+    @ConfField(mutable = true, comment = "for testing statistics behavior")
+    public static boolean enable_sync_tablet_stats = false;
 
     @ConfField(mutable = true, comment = "time interval to collect tablet info from backend")
     public static long tablet_collect_interval_seconds = 60;
@@ -1948,8 +1951,15 @@ public class Config extends ConfigBase {
     /**
      * statistic collect flag
      */
-    @ConfField(mutable = true)
+    @ConfField(mutable = true, comment = "Whether to enable periodic analyze job, " +
+            "including auto analyze job and analyze jobs created by user")
     public static boolean enable_statistic_collect = true;
+
+    @ConfField(mutable = true, comment = "enable auto collect internal statistics in the background")
+    public static boolean enable_auto_collect_statistics = true;
+
+    @ConfField(mutable = true, comment = "trigger task immediately after creating analyze job")
+    public static boolean enable_trigger_analyze_job_immediate = true;
 
     /**
      * whether to automatically collect statistics on temporary tables
@@ -2127,12 +2137,6 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true, comment = "max columns size of full analyze predicate columns instead of sample all columns")
     public static int statistic_auto_collect_max_predicate_column_size_on_sample_strategy = 16;
-
-    /**
-     * Max row count in statistics collect per query
-     */
-    @ConfField(mutable = true)
-    public static long statistic_collect_max_row_count_per_query = 5000000000L; //5 billion
 
     /**
      * The row number of sample collect, default 20w rows

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -928,16 +928,18 @@ public class DDLStmtExecutor {
                 }
                 context.getGlobalStateMgr().getAnalyzeMgr().addAnalyzeJob(analyzeJob);
 
-                ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext();
-                // from current session, may execute analyze stmt
-                statsConnectCtx.getSessionVariable().setStatisticCollectParallelism(
-                        context.getSessionVariable().getStatisticCollectParallelism());
-                Thread thread = new Thread(() -> {
-                    statsConnectCtx.setThreadLocalInfo();
-                    StatisticExecutor statisticExecutor = new StatisticExecutor();
-                    analyzeJob.run(statsConnectCtx, statisticExecutor);
-                });
-                thread.start();
+                if (Config.enable_trigger_analyze_job_immediate) {
+                    ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext();
+                    // from current session, may execute analyze stmt
+                    statsConnectCtx.getSessionVariable().setStatisticCollectParallelism(
+                            context.getSessionVariable().getStatisticCollectParallelism());
+                    Thread thread = new Thread(() -> {
+                        statsConnectCtx.setThreadLocalInfo();
+                        StatisticExecutor statisticExecutor = new StatisticExecutor();
+                        analyzeJob.run(statsConnectCtx, statisticExecutor);
+                    });
+                    thread.start();
+                }
             });
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropAnalyzeJobStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropAnalyzeJobStmt.java
@@ -18,6 +18,7 @@ package com.starrocks.sql.ast;
 import com.starrocks.sql.parser.NodePosition;
 
 public class DropAnalyzeJobStmt extends DdlStmt {
+    // -1 mean all jobs
     private final long id;
 
     public DropAnalyzeJobStmt(long id) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowBasicStatsMetaStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowBasicStatsMetaStmt.java
@@ -58,11 +58,14 @@ public class ShowBasicStatsMetaStmt extends ShowStmt {
                     .addColumn(new Column("Properties", ScalarType.createVarchar(200)))
                     .addColumn(new Column("Healthy", ScalarType.createVarchar(5)))
                     .addColumn(new Column("ColumnStats", ScalarType.createVarcharType(128)))
+                    .addColumn(new Column("TabletStatsReportTime", ScalarType.createVarcharType(60)))
+                    .addColumn(new Column("TableHealthyMetrics", ScalarType.createVarcharType(128)))
+                    .addColumn(new Column("TableUpdateTime", ScalarType.createVarcharType(60)))
                     .build();
 
     public static List<String> showBasicStatsMeta(ConnectContext context,
                                                   BasicStatsMeta basicStatsMeta) throws MetaNotFoundException {
-        List<String> row = Lists.newArrayList("", "", "ALL", "", "", "", "", "");
+        List<String> row = Lists.newArrayList("", "", "ALL", "", "", "", "", "", "", "", "");
         long dbId = basicStatsMeta.getDbId();
         long tableId = basicStatsMeta.getTableId();
         List<String> columns = basicStatsMeta.getColumns();
@@ -95,13 +98,16 @@ public class ShowBasicStatsMetaStmt extends ShowStmt {
         row.set(5, basicStatsMeta.getProperties() == null ? "{}" : basicStatsMeta.getProperties().toString());
         row.set(6, (int) (basicStatsMeta.getHealthy() * 100) + "%");
         row.set(7, basicStatsMeta.getColumnStatsString());
+        row.set(8, basicStatsMeta.getTabletStatsReportTime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+        row.set(9, basicStatsMeta.getTableHealthyMetrics(table).toString());
+        row.set(10, StatisticUtils.getTableLastUpdateTime(table).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
 
         return row;
     }
 
     public static List<String> showExternalBasicStatsMeta(ConnectContext context,
                                                           ExternalBasicStatsMeta basicStatsMeta) throws MetaNotFoundException {
-        List<String> row = Lists.newArrayList("", "", "ALL", "", "", "", "", "", "");
+        List<String> row = Lists.newArrayList("", "", "ALL", "", "", "", "", "", "", "", "", "");
         String catalogName = basicStatsMeta.getCatalogName();
         String dbName = basicStatsMeta.getDbName();
         String tableName = basicStatsMeta.getTableName();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -946,6 +946,7 @@ public class QueryOptimizer extends Optimizer {
             result = new SkewShuffleJoinEliminationRule().rewrite(result, rootTaskContext);
         }
 
+
         result = new ApplyTuningGuideRule(connectContext).rewrite(result, rootTaskContext);
 
         OperatorTuningGuides.OptimizedRecord optimizedRecord = PlanTuningAdvisor.getInstance()

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -2842,7 +2842,8 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     @Override
     public ParseNode visitDropAnalyzeJobStatement(StarRocksParser.DropAnalyzeJobStatementContext context) {
-        return new DropAnalyzeJobStmt(Long.parseLong(context.INTEGER_VALUE().getText()), createPos(context));
+        long id = context.ALL() != null ? -1 : Long.parseLong(context.INTEGER_VALUE().getText());
+        return new DropAnalyzeJobStmt(id, createPos(context));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1366,6 +1366,7 @@ createAnalyzeStatement
 
 dropAnalyzeJobStatement
     : DROP ANALYZE INTEGER_VALUE
+    | DROP ALL ANALYZE JOB
     ;
 
 showAnalyzeStatement

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
@@ -124,6 +124,13 @@ public class AnalyzeMgr implements Writable {
     }
 
     public void removeAnalyzeJob(long id) {
+        if (id == -1) {
+            List<Long> keysToRemove = new ArrayList<>(analyzeJobMap.keySet());
+            for (Long key : keysToRemove) {
+                AnalyzeJob job = analyzeJobMap.remove(key);
+                GlobalStateMgr.getCurrentState().getEditLog().logRemoveAnalyzeJob(job);
+            }
+        }
         if (analyzeJobMap.containsKey(id)) {
             GlobalStateMgr.getCurrentState().getEditLog().logRemoveAnalyzeJob(analyzeJobMap.remove(id));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
@@ -20,8 +20,10 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
+import com.starrocks.monitor.unit.ByteSizeValue;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
 import org.apache.commons.collections4.ListUtils;
@@ -35,11 +37,21 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.StringJoiner;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import static com.starrocks.catalog.ExpressionRangePartitionInfo.SHADOW_PARTITION_PREFIX;
+import static com.starrocks.statistic.StatsConstants.FULL_ONCE_TIMES;
+import static com.starrocks.statistic.StatsConstants.FULL_SCHEDULE_TIMES;
+import static com.starrocks.statistic.StatsConstants.SAMPLE_ONCE_TIMES;
+import static com.starrocks.statistic.StatsConstants.SAMPLE_SCHEDULE_TIMES;
 
 public class BasicStatsMeta implements Writable {
+    private static final List<String> STATS_COUNTER_KEYS = List.of(
+            SAMPLE_ONCE_TIMES, SAMPLE_SCHEDULE_TIMES, FULL_ONCE_TIMES, FULL_SCHEDULE_TIMES
+    );
+
     @SerializedName("dbId")
     private long dbId;
 
@@ -78,6 +90,9 @@ public class BasicStatsMeta implements Writable {
     // TODO: use ColumnId
     @SerializedName("columnStats")
     private Map<String, ColumnStatsMeta> columnStatsMetaMap = Maps.newConcurrentMap();
+
+    @SerializedName("tabletStatsReportTime")
+    private LocalDateTime tabletStatsReportTime = LocalDateTime.MIN;
 
     // Used for deserialization
     public BasicStatsMeta() {
@@ -148,11 +163,30 @@ public class BasicStatsMeta implements Writable {
     public double getHealthy() {
         Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getId(), tableId);
+        TableHealthyMetrics metrics = getTableHealthyMetrics(table);
+        LocalDateTime tableUpdateTime = StatisticUtils.getTableLastUpdateTime(table);
+        double updateRatio;
+        // 1. If none updated partitions, health is 1
+        // 2. If there are few updated partitions, the health only to calculated on rows
+        // 3. If there are many updated partitions, the health needs to be calculated based on partitions
+        if (tableUpdateTime.isBefore(tabletStatsReportTime) && metrics.unhealthyPartitionCount == 0) {
+            return 1;
+        } else if (metrics.unhealthyPartitionCount < StatsConstants.STATISTICS_PARTITION_UPDATED_THRESHOLD) {
+            updateRatio = (metrics.updatePartitionRowCountForCalc * 1.0) / metrics.tableRowCount;
+        } else {
+            double rowUpdateRatio = (metrics.unhealthyPartitionCount * 1.0) / metrics.tableRowCount;
+            double partitionUpdateRatio = (metrics.unhealthyPartitionCount * 1.0) / metrics.totalPartitionCount;
+            updateRatio = Math.min(rowUpdateRatio, partitionUpdateRatio);
+        }
+        return 1 - Math.min(updateRatio, 1.0);
+    }
 
+    public TableHealthyMetrics getTableHealthyMetrics(Table table) {
         long tableRowCount = 1L;
-        long cachedTableRowCount = 1L;
+        long cachedTableRowCount = isInitJobMeta() ? 0L : 1L;
         long updatePartitionRowCount = 0L;
-        long updatePartitionCount = 0L;
+        long unhealthyPartitionCount = 0L;
+        long unhealthyPartitionRowCount = 0L;
 
         Map<Long, Optional<Long>> tableStatistics = GlobalStateMgr.getCurrentState().getStatisticStorage()
                 .getTableStatistics(table.getId(), table.getPartitions());
@@ -161,31 +195,23 @@ public class BasicStatsMeta implements Writable {
                 .filter(p -> !(p.getName().startsWith(SHADOW_PARTITION_PREFIX)))
                 .collect(Collectors.toSet());
         long totalPartitionCount = allPartitions.size();
+        long unhealthyPartitionDataSize = 0L;
         for (Partition partition : allPartitions) {
             tableRowCount += partition.getRowCount();
             Optional<Long> statistic = tableStatistics.getOrDefault(partition.getId(), Optional.empty());
             cachedTableRowCount += statistic.orElse(0L);
 
             if (!StatisticUtils.isPartitionStatsHealthy(partition, this, statistic.orElse(0L))) {
-                updatePartitionCount++;
+                unhealthyPartitionCount++;
+                unhealthyPartitionRowCount += partition.getRowCount();
+                unhealthyPartitionDataSize += partition.getDataSize();
             }
         }
-        updatePartitionRowCount = Math.max(1, Math.max(tableRowCount + deltaRows, totalRows) - cachedTableRowCount);
+        updatePartitionRowCount = Math.max(isInitJobMeta() ? 0L : 1L,
+                Math.max(tableRowCount + deltaRows, totalRows) - cachedTableRowCount);
 
-        double updateRatio;
-        // 1. If none updated partitions, health is 1
-        // 2. If there are few updated partitions, the health only to calculated on rows
-        // 3. If there are many updated partitions, the health needs to be calculated based on partitions
-        if (updatePartitionCount == 0) {
-            return 1;
-        } else if (updatePartitionCount < StatsConstants.STATISTICS_PARTITION_UPDATED_THRESHOLD) {
-            updateRatio = (updatePartitionRowCount * 1.0) / tableRowCount;
-        } else {
-            double rowUpdateRatio = (updatePartitionRowCount * 1.0) / tableRowCount;
-            double partitionUpdateRatio = (updatePartitionCount * 1.0) / totalPartitionCount;
-            updateRatio = Math.min(rowUpdateRatio, partitionUpdateRatio);
-        }
-        return 1 - Math.min(updateRatio, 1.0);
+        return new TableHealthyMetrics(tableRowCount, cachedTableRowCount, totalPartitionCount, unhealthyPartitionCount,
+                unhealthyPartitionRowCount, unhealthyPartitionDataSize, updatePartitionRowCount, deltaRows);
     }
 
     public long getTotalRows() {
@@ -199,6 +225,18 @@ public class BasicStatsMeta implements Writable {
     public void increaseDeltaRows(Long delta) {
         totalRows += delta;
         deltaRows += delta;
+    }
+
+    public void increaseStatsCollectionCount(AnalyzeStatus status) {
+        StatsConstants.AnalyzeType analyzeType = status.getType();
+        StatsConstants.ScheduleType scheduleType = status.getScheduleType();
+        String key = analyzeType == StatsConstants.AnalyzeType.SAMPLE
+                ? (scheduleType == StatsConstants.ScheduleType.ONCE ? SAMPLE_ONCE_TIMES : SAMPLE_SCHEDULE_TIMES)
+                : (scheduleType == StatsConstants.ScheduleType.ONCE ? FULL_ONCE_TIMES : FULL_SCHEDULE_TIMES);
+
+        properties.compute(key, (k, v) ->
+                ((v == null ? 0 : Integer.parseInt(v)) + 1) % Integer.MAX_VALUE + ""
+        );
     }
 
     public boolean isInitJobMeta() {
@@ -217,11 +255,27 @@ public class BasicStatsMeta implements Writable {
     }
 
     public void setProperties(Map<String, String> properties) {
-        this.properties = properties;
+        Map<String, String> mergedProperties = new ConcurrentHashMap<>(properties);
+
+        if (this.properties != null) {
+            STATS_COUNTER_KEYS.stream()
+                    .filter(this.properties::containsKey)
+                    .forEach(key -> mergedProperties.put(key, this.properties.get(key)));
+        }
+
+        this.properties = mergedProperties;
     }
 
     public void setUpdateTime(LocalDateTime updateTime) {
         this.updateTime = updateTime;
+    }
+
+    public void updateTabletStatsReportTime() {
+        this.tabletStatsReportTime = LocalDateTime.now();
+    }
+
+    public LocalDateTime getTabletStatsReportTime() {
+        return tabletStatsReportTime;
     }
 
     public void setAnalyzeType(StatsConstants.AnalyzeType analyzeType) {
@@ -242,8 +296,10 @@ public class BasicStatsMeta implements Writable {
         if (MapUtils.isEmpty(columnStatsMetaMap)) {
             return "";
         }
+
         return columnStatsMetaMap.values().stream()
-                .map(ColumnStatsMeta::simpleString).collect(Collectors.joining(","));
+                .map(c -> c.simpleString(false))
+                .collect(Collectors.joining(","));
     }
 
     public void addColumnStatsMeta(ColumnStatsMeta columnStatsMeta) {
@@ -257,5 +313,45 @@ public class BasicStatsMeta implements Writable {
     public BasicStatsMeta clone() {
         String json = GsonUtils.GSON.toJson(this);
         return GsonUtils.GSON.fromJson(json, BasicStatsMeta.class);
+    }
+
+    public static class TableHealthyMetrics {
+        public long tableRowCount;
+        public long tableRowCountInStatistics;
+        public long totalPartitionCount;
+        public long unhealthyPartitionCount;
+        public long unhealthyPartitionRowCount;
+        public long unhealthyPartitionDataSize;
+        public long updatePartitionRowCountForCalc;
+        public long deltaRowCount;
+
+        public TableHealthyMetrics(long tableRowCount, long tableRowCountInStatistics,
+                                   long totalPartitionCount, long unhealthyPartitionCount,
+                                   long unhealthyPartitionRowCount, long unhealthyPartitionDataSize,
+                                   long updatePartitionRowCountForCalc, long deltaRowCount) {
+            this.tableRowCount = tableRowCount;
+            this.tableRowCountInStatistics = tableRowCountInStatistics;
+            this.totalPartitionCount = totalPartitionCount;
+            this.unhealthyPartitionCount = unhealthyPartitionCount;
+            this.unhealthyPartitionRowCount = unhealthyPartitionRowCount;
+            this.unhealthyPartitionDataSize = unhealthyPartitionDataSize;
+            this.updatePartitionRowCountForCalc = updatePartitionRowCountForCalc;
+            this.deltaRowCount = deltaRowCount;
+
+        }
+
+        @Override
+        public String toString() {
+            return new StringJoiner(", ", "[", "]")
+                    .add("tableRowCount=" + tableRowCount)
+                    .add("tableRowCountInStatistics=" + tableRowCountInStatistics)
+                    .add("totalPartitionCount=" + totalPartitionCount)
+                    .add("unhealthyPartitionCount=" + unhealthyPartitionCount)
+                    .add("unhealthyPartitionRowCount=" + unhealthyPartitionRowCount)
+                    .add("unhealthyPartitionDataSize=" + new ByteSizeValue(unhealthyPartitionDataSize).getKb() + "KB")
+                    .add("updatePartitionRowCountForCalc=" + updatePartitionRowCountForCalc)
+                    .add("deltaRowCount=" + deltaRowCount)
+                    .toString();
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ColumnStatsMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ColumnStatsMeta.java
@@ -86,8 +86,8 @@ public class ColumnStatsMeta {
         return allPartitionSize;
     }
 
-    public String simpleString() {
-        if (type == StatsConstants.AnalyzeType.SAMPLE && sampledPartitionsHashValue != null) {
+    public String simpleString(boolean isExternalTable) {
+        if (isExternalTable && type == StatsConstants.AnalyzeType.SAMPLE && sampledPartitionsHashValue != null) {
             return String.format("(%s,%s,sampled_partition_size=%d,all_partition_size=%d)", columnName, type,
                     sampledPartitionsHashValue.size(), allPartitionSize);
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalBasicStatsMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalBasicStatsMeta.java
@@ -136,8 +136,10 @@ public class ExternalBasicStatsMeta implements Writable {
         if (MapUtils.isEmpty(columnStatsMetaMap)) {
             return "";
         }
+
         return columnStatsMetaMap.values().stream()
-                .map(ColumnStatsMeta::simpleString).collect(Collectors.joining(","));
+                .map(c -> c.simpleString(true))
+                .collect(Collectors.joining(","));
     }
 
     public ExternalBasicStatsMeta clone() {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/NativeAnalyzeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/NativeAnalyzeJob.java
@@ -37,6 +37,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
+import static com.starrocks.statistic.StatisticAutoCollector.DEFAULT_JOB_FLAG;
+
 public class NativeAnalyzeJob implements AnalyzeJob, Writable {
 
     @SerializedName("id")
@@ -208,7 +210,8 @@ public class NativeAnalyzeJob implements AnalyzeJob, Writable {
     }
 
     public boolean isDefaultJob() {
-        return isAnalyzeAllDb() && isAnalyzeAllTable() && getScheduleType() == ScheduleType.SCHEDULE;
+        return isAnalyzeAllDb() && isAnalyzeAllTable() && getScheduleType() == ScheduleType.SCHEDULE &&
+                getProperties() != null && getProperties().containsKey(DEFAULT_JOB_FLAG);
     }
 
     @Override
@@ -249,6 +252,7 @@ public class NativeAnalyzeJob implements AnalyzeJob, Writable {
 
         if (!hasFailedCollectJob) {
             setStatus(ScheduleStatus.FINISH);
+            setReason("");
             setWorkTime(LocalDateTime.now());
             GlobalStateMgr.getCurrentState().getAnalyzeMgr().updateAnalyzeJobWithLog(this);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -547,11 +547,13 @@ public class StatisticExecutor {
                         basicStatsMeta = new BasicStatsMeta(db.getId(), table.getId(),
                                 statsJob.getColumnNames(), statsJob.getAnalyzeType(), analyzeStatus.getEndTime(),
                                 statsJob.getProperties(), existUpdateRows);
+                        basicStatsMeta.increaseStatsCollectionCount(analyzeStatus);
                     } else {
                         basicStatsMeta = basicStatsMeta.clone();
                         basicStatsMeta.setUpdateTime(analyzeStatus.getEndTime());
                         basicStatsMeta.setProperties(statsJob.getProperties());
                         basicStatsMeta.setAnalyzeType(statsJob.getAnalyzeType());
+                        basicStatsMeta.increaseStatsCollectionCount(analyzeStatus);
                     }
 
                     for (String column : ListUtils.emptyIfNull(statsJob.getColumnNames())) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
@@ -292,7 +292,7 @@ public class StatisticsCollectionTrigger {
         Preconditions.checkNotNull(overwriteJobStats, "must have overwrite stats");
         long sourceRows = overwriteJobStats.getSourceRows();
         long targetRows = overwriteJobStats.getTargetRows();
-        double deltaRatio = 1.0 * (targetRows - sourceRows) / (sourceRows + 1);
+        double deltaRatio = 1.0 * Math.abs(targetRows - sourceRows) / (sourceRows + 1);
         if (deltaRatio < Config.statistic_sample_collect_ratio_threshold_of_first_load) {
             return null;
         } else if (targetRows > Config.statistic_sample_collect_rows) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
@@ -114,6 +114,11 @@ public class StatsConstants {
     public static final String TABLE_PROPERTY_SEPARATOR = ",\n\"";
     public static final String COLUMN_ID_SEPARATOR = "#";
 
+    public static final String FULL_ONCE_TIMES = "full_once_times";
+    public static final String FULL_SCHEDULE_TIMES = "full_schedule_times";
+    public static final String SAMPLE_ONCE_TIMES = "sample_once_times";
+    public static final String SAMPLE_SCHEDULE_TIMES = "sample_schedule_times";
+
     public enum AnalyzeType {
         SAMPLE,
         FULL,

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/sample/SampleInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/sample/SampleInfo.java
@@ -105,7 +105,7 @@ public class SampleInfo {
     public int getMaxSampleTabletNum() {
         int max = getHighWeightTablets().size();
         max = Math.max(max, getMediumHighWeightTablets().size());
-        max = Math.max(max, getMediumHighWeightTablets().size());
+        max = Math.max(max, getMediumLowWeightTablets().size());
         max = Math.max(max, getLowWeightTablets().size());
         return max;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
@@ -301,20 +301,6 @@ public class AnalyzeStmtTest {
                 StatsConstants.ScheduleType.ONCE, Maps.newHashMap(), LocalDateTime.MIN);
         Assert.assertNull(ShowAnalyzeStatusStmt.showAnalyzeStatus(getConnectContext(), extenalAnalyzeStatus));
 
-        BasicStatsMeta basicStatsMeta = new BasicStatsMeta(testDb.getId(), table.getId(), null,
-                StatsConstants.AnalyzeType.FULL,
-                LocalDateTime.of(2020, 1, 1, 1, 1), Maps.newHashMap());
-        Assert.assertEquals("[test, t0, ALL, FULL, 2020-01-01 01:01:00, {}, 100%, ]",
-                ShowBasicStatsMetaStmt.showBasicStatsMeta(getConnectContext(), basicStatsMeta).toString());
-
-        sql = "show stats meta where `database` like '%te%'";
-        ShowBasicStatsMetaStmt showAnalyzeMetaStmt = (ShowBasicStatsMetaStmt) analyzeSuccess(sql);
-        getConnectContext().getGlobalStateMgr().getAnalyzeMgr().addBasicStatsMeta(basicStatsMeta);
-        res = ShowExecutor.execute(showAnalyzeMetaStmt, getConnectContext()).getResultRows().toString();
-        Assert.assertEquals("[[test, t0, ALL, FULL, 2020-01-01 01:01:00, {}, 100%, ]]", res);
-        getConnectContext().getGlobalStateMgr().getAnalyzeMgr().dropBasicStatsMetaAndData(
-                getConnectContext(), Set.of(table.getId()));
-
         sql = "show histogram meta where updateTime = '2020-01-01 01:01:00'";
         ShowHistogramStatsMetaStmt showHistogramStatsMetaStmt = (ShowHistogramStatsMetaStmt) analyzeSuccess(sql);
         HistogramStatsMeta histogramStatsMeta = new HistogramStatsMeta(testDb.getId(), table.getId(), "v1",

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/BasicStatsMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/BasicStatsMetaTest.java
@@ -90,14 +90,14 @@ public class BasicStatsMetaTest extends PlanTestBase {
                     LocalDateTime.of(2024, 07, 22, 12, 20), Map.of(), 10000);
             basicStatsMeta.increaseDeltaRows(5000L);
             basicStatsMeta.setTotalRows(10000L);
-            Assert.assertEquals(1.0, basicStatsMeta.getHealthy(), 0.01);
+            Assert.assertEquals(0.5, basicStatsMeta.getHealthy(), 0.01);
             basicStatsMeta.resetDeltaRows();
             Assert.assertEquals(1.0, basicStatsMeta.getHealthy(), 0.01);
 
             basicStatsMeta.setProperties(ImmutableBiMap.of(INIT_SAMPLE_STATS_JOB, "true"));
             basicStatsMeta.increaseDeltaRows(5000L);
             basicStatsMeta.setTotalRows(10000L);
-            Assert.assertEquals(1.0, basicStatsMeta.getHealthy(), 0.01);
+            Assert.assertEquals(0.5, basicStatsMeta.getHealthy(), 0.01);
         }
     }
 

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -2434,6 +2434,7 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
         tools.assert_equal(200, res.status_code, f"failed to post http request [res={res}] [url={exec_url}]")
         return res.content.decode("utf-8")
 
+
     def manual_compact(self, database_name, table_name):
         sql = "show tablet from " + database_name + "." + table_name
         res = self.execute_sql(sql, True)
@@ -2788,6 +2789,32 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
         write_cache_size = int(result[1].replace("B", "").replace("KB", ""))
         tools.assert_true(read_cache_size + write_cache_size > 0,
                           "cache select is failed, read_cache_size + write_cache_size must larger than 0 bytes")
+
+    def show_stats_meta(self, sql=None):
+        if sql is None:
+            sql = "show stats meta"
+
+        res = self.execute_sql(sql, ori=True)
+        if not res["status"]:
+            return {"status": False, "msg": res["msg"]}
+
+        column_names = [desc[0] for desc in res["desc"]]
+
+        skip_columns = ["UpdateTime", "TabletStatsReportTime", "TableUpdateTime"]
+        time_related_columns = []
+        for i, col_name in enumerate(column_names):
+            if col_name in skip_columns:
+                time_related_columns.append(i)
+
+        processed_results = []
+        for row in res["result"]:
+            processed_row = []
+            for i, value in enumerate(row):
+                if i not in time_related_columns:
+                    processed_row.append(value)
+            processed_results.append(processed_row)
+
+        return processed_results
 
     @staticmethod
     def regex_match(check_str: str, pattern: str):

--- a/test/sql/test_aa_statistic_behavior/R/test_aa_statistic_behavior
+++ b/test/sql/test_aa_statistic_behavior/R/test_aa_statistic_behavior
@@ -1,0 +1,297 @@
+-- name: test_aa_statistic_behavior @sequential
+DROP DATABASE IF EXISTS test_statistic_behavior;
+-- result:
+-- !result
+CREATE DATABASE test_statistic_behavior;
+-- result:
+-- !result
+USE test_statistic_behavior;
+-- result:
+-- !result
+CREATE TABLE `source` (
+  `k1` int(11) NULL COMMENT "",
+  `event_day` datetime NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`, `event_day`)
+PARTITION BY date_trunc('day', event_day)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into source select generate_series, '2020-01-01' from table(generate_series(1, 250000));
+-- result:
+-- !result
+insert into source select generate_series, '2021-01-01' from table(generate_series(1, 250000));
+-- result:
+-- !result
+insert into source select generate_series, '2022-01-01' from table(generate_series(1, 250000));
+-- result:
+-- !result
+insert into source select generate_series, '2023-01-01' from table(generate_series(1, 250000));
+-- result:
+-- !result
+insert into source select generate_series, '2024-01-01' from table(generate_series(1, 150000));
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("enable_sync_tablet_stats" = "false");
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("loads_history_sync_interval_second" = "1000000");
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("enable_trigger_analyze_job_immediate" = "false");
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("enable_auto_collect_statistics" = "false");
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("enable_statistic_collect" = "false");
+-- result:
+-- !result
+drop all analyze job;
+-- result:
+-- !result
+shell: sleep 7
+-- result:
+0
+
+-- !result
+update default_catalog.information_schema.be_configs set `value` = "3" where name= "tablet_stat_cache_update_interval_second";
+-- result:
+-- !result
+CREATE TABLE `target_table` (
+  `k1` int(11) NULL COMMENT "",
+  `event_day` datetime NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`, `event_day`)
+PARTITION BY date_trunc('day', event_day)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into target_table select * from source where event_day = '2020-01-01';
+-- result:
+-- !result
+function: show_stats_meta("show stats meta where `Database` = 'test_statistic_behavior' and `table` = 'target_table'")
+-- result:
+[['test_statistic_behavior', 'target_table', 'ALL', 'SAMPLE', '{sample_once_times=1, init_stats_sample_job=true}', '100%', '(k1,SAMPLE),(event_day,SAMPLE)', '[tableRowCount=1, tableRowCountInStatistics=250000, totalPartitionCount=1, unhealthyPartitionCount=1, unhealthyPartitionRowCount=0, unhealthyPartitionDataSize=0KB, updatePartitionRowCountForCalc=0, deltaRowCount=0]']]
+-- !result
+insert into target_table select * from source where event_day >= '2022-01-01';
+-- result:
+-- !result
+function: show_stats_meta("show stats meta where `Database` = 'test_statistic_behavior' and `table` = 'target_table'")
+-- result:
+[['test_statistic_behavior', 'target_table', 'ALL', 'SAMPLE', '{sample_once_times=2, init_stats_sample_job=true}', '100%', '(k1,SAMPLE),(event_day,SAMPLE)', '[tableRowCount=1, tableRowCountInStatistics=900000, totalPartitionCount=4, unhealthyPartitionCount=4, unhealthyPartitionRowCount=0, unhealthyPartitionDataSize=0KB, updatePartitionRowCountForCalc=0, deltaRowCount=650000]']]
+-- !result
+insert into target_table select * from source;
+-- result:
+-- !result
+function: show_stats_meta("show stats meta where `Database` = 'test_statistic_behavior' and `table` = 'target_table'")
+-- result:
+[['test_statistic_behavior', 'target_table', 'ALL', 'SAMPLE', '{sample_once_times=3, init_stats_sample_job=true}', '0%', '(k1,SAMPLE),(event_day,SAMPLE)', '[tableRowCount=1, tableRowCountInStatistics=1150000, totalPartitionCount=5, unhealthyPartitionCount=5, unhealthyPartitionRowCount=0, unhealthyPartitionDataSize=0KB, updatePartitionRowCountForCalc=900000, deltaRowCount=1800000]']]
+-- !result
+ADMIN SET FRONTEND CONFIG ("enable_sync_tablet_stats" = "true");
+-- result:
+-- !result
+shell: sleep 5
+-- result:
+0
+
+-- !result
+function: show_stats_meta("show stats meta where `Database` = 'test_statistic_behavior' and `table` = 'target_table'")
+-- result:
+[['test_statistic_behavior', 'target_table', 'ALL', 'SAMPLE', '{sample_once_times=3, init_stats_sample_job=true}', '56%', '(k1,SAMPLE),(event_day,SAMPLE)', '[tableRowCount=2050001, tableRowCountInStatistics=1150000, totalPartitionCount=5, unhealthyPartitionCount=4, unhealthyPartitionRowCount=1800000, unhealthyPartitionDataSize=181KB, updatePartitionRowCountForCalc=900001, deltaRowCount=0]']]
+-- !result
+ADMIN SET FRONTEND CONFIG ("enable_statistic_collect" = "true");
+-- result:
+-- !result
+create analyze full all properties  ("statistic_exclude_pattern"="^(?!.*test_statistic_behavior).*$");
+-- result:
+-- !result
+shell: sleep 7
+-- result:
+0
+
+-- !result
+function: show_stats_meta("show stats meta where `Database` = 'test_statistic_behavior' and `table` = 'target_table'")
+-- result:
+[['test_statistic_behavior', 'target_table', 'ALL', 'SAMPLE', '{sample_once_times=3, statistic_exclude_pattern=^(?!.*test_statistic_behavior).*$, sample_schedule_times=1}', '100%', '(k1,SAMPLE),(event_day,SAMPLE)', '[tableRowCount=2050001, tableRowCountInStatistics=2050001, totalPartitionCount=5, unhealthyPartitionCount=0, unhealthyPartitionRowCount=0, unhealthyPartitionDataSize=0KB, updatePartitionRowCountForCalc=1, deltaRowCount=0]']]
+-- !result
+drop all analyze job;
+-- result:
+-- !result
+shell: sleep 7
+-- result:
+0
+
+-- !result
+insert into target_table select * from target_table;
+-- result:
+-- !result
+shell: sleep 5
+-- result:
+0
+
+-- !result
+create analyze full all properties  ("statistic_exclude_pattern"="^(?!.*test_statistic_behavior).*$");
+-- result:
+-- !result
+shell: sleep 7
+-- result:
+0
+
+-- !result
+function: show_stats_meta("show stats meta where `Database` = 'test_statistic_behavior' and `table` = 'target_table'")
+-- result:
+[['test_statistic_behavior', 'target_table', 'ALL', 'SAMPLE', '{sample_once_times=3, statistic_exclude_pattern=^(?!.*test_statistic_behavior).*$, sample_schedule_times=2}', '100%', '(k1,SAMPLE),(event_day,SAMPLE)', '[tableRowCount=4100001, tableRowCountInStatistics=4100001, totalPartitionCount=5, unhealthyPartitionCount=0, unhealthyPartitionRowCount=0, unhealthyPartitionDataSize=0KB, updatePartitionRowCountForCalc=1, deltaRowCount=0]']]
+-- !result
+drop all analyze job;
+-- result:
+-- !result
+shell: sleep 7
+-- result:
+0
+
+-- !result
+insert into target_table select * from source where event_day = '2020-01-01' limit 100000;
+-- result:
+-- !result
+shell: sleep 5
+-- result:
+0
+
+-- !result
+create analyze full all properties  ("statistic_exclude_pattern"="^(?!.*test_statistic_behavior).*$");
+-- result:
+-- !result
+shell: sleep 7
+-- result:
+0
+
+-- !result
+function: show_stats_meta("show stats meta where `Database` = 'test_statistic_behavior' and `table` = 'target_table'")
+-- result:
+[['test_statistic_behavior', 'target_table', 'ALL', 'SAMPLE', '{sample_once_times=3, statistic_exclude_pattern=^(?!.*test_statistic_behavior).*$, sample_schedule_times=2}', '97%', '(k1,SAMPLE),(event_day,SAMPLE)', '[tableRowCount=4200001, tableRowCountInStatistics=4100001, totalPartitionCount=5, unhealthyPartitionCount=1, unhealthyPartitionRowCount=1100000, unhealthyPartitionDataSize=123KB, updatePartitionRowCountForCalc=100000, deltaRowCount=0]']]
+-- !result
+drop all analyze job;
+-- result:
+-- !result
+shell: sleep 13
+-- result:
+0
+
+-- !result
+insert into target_table select k1, '2026-01-01' from source where event_day = '2021-01-01';
+-- result:
+-- !result
+shell: sleep 5
+-- result:
+0
+
+-- !result
+function: show_stats_meta("show stats meta where `Database` = 'test_statistic_behavior' and `table` = 'target_table'")
+-- result:
+[['test_statistic_behavior', 'target_table', 'ALL', 'SAMPLE', '{sample_once_times=4, init_stats_sample_job=true, sample_schedule_times=2}', '97%', '(k1,SAMPLE),(event_day,SAMPLE)', '[tableRowCount=4450001, tableRowCountInStatistics=4350000, totalPartitionCount=6, unhealthyPartitionCount=1, unhealthyPartitionRowCount=1100000, unhealthyPartitionDataSize=123KB, updatePartitionRowCountForCalc=100001, deltaRowCount=0]']]
+-- !result
+insert into target_table select * from source;
+-- result:
+-- !result
+shell: sleep 5
+-- result:
+0
+
+-- !result
+create analyze all properties  ("statistic_exclude_pattern"="^(?!.*test_statistic_behavior).*$");
+-- result:
+-- !result
+shell: sleep 7
+-- result:
+0
+
+-- !result
+function: show_stats_meta("show stats meta where `Database` = 'test_statistic_behavior' and `table` = 'target_table'")
+-- result:
+[['test_statistic_behavior', 'target_table', 'ALL', 'SAMPLE', '{sample_once_times=4, statistic_exclude_pattern=^(?!.*test_statistic_behavior).*$, sample_schedule_times=3}', '100%', '(k1,SAMPLE),(event_day,SAMPLE)', '[tableRowCount=5600001, tableRowCountInStatistics=5600001, totalPartitionCount=6, unhealthyPartitionCount=0, unhealthyPartitionRowCount=0, unhealthyPartitionDataSize=0KB, updatePartitionRowCountForCalc=1, deltaRowCount=0]']]
+-- !result
+drop all analyze job;
+-- result:
+-- !result
+shell: sleep 7
+-- result:
+0
+
+-- !result
+ADMIN SET FRONTEND CONFIG ("statistic_auto_collect_small_table_size" = "1");
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("statistic_auto_collect_large_table_interval" = "0");
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("statistic_auto_collect_sample_threshold" = "0.6");
+-- result:
+-- !result
+select count(*) from target_table where k1 = -1 and event_day = '2021-01-01';
+-- result:
+0
+-- !result
+admin execute on frontend 'import com.starrocks.statistic.columns.PredicateColumnsMgr; PredicateColumnsMgr.getInstance().persist();';
+-- result:
+-- !result
+insert into target_table select * from target_table;
+-- result:
+-- !result
+shell: sleep 5
+-- result:
+0
+
+-- !result
+create analyze all properties  ("statistic_exclude_pattern"="^(?!.*test_statistic_behavior).*$");
+-- result:
+-- !result
+shell: sleep 7
+-- result:
+0
+
+-- !result
+function: show_stats_meta("show stats meta where `Database` = 'test_statistic_behavior' and `table` = 'target_table'")
+-- result:
+[['test_statistic_behavior', 'target_table', 'ALL', 'FULL', '{sample_once_times=4, full_schedule_times=1, sample_schedule_times=3}', '100%', '(k1,FULL),(event_day,FULL)', '[tableRowCount=11200001, tableRowCountInStatistics=11200001, totalPartitionCount=6, unhealthyPartitionCount=0, unhealthyPartitionRowCount=0, unhealthyPartitionDataSize=0KB, updatePartitionRowCountForCalc=1, deltaRowCount=0]']]
+-- !result
+drop stats target_table;
+-- result:
+-- !result
+drop table target_table;
+-- result:
+-- !result
+drop all analyze job;
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("enable_sync_tablet_stats" = "true");
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("enable_statistic_collect" = "true");
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("enable_auto_collect_statistics" = "true");
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("enable_trigger_analyze_job_immediate" = "true");
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("statistic_auto_collect_small_table_size" = "5368709120");
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("statistic_auto_collect_large_table_interval" = "43200");
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("statistic_auto_collect_sample_threshold" = "0.3");
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("statistic_collect_interval_sec" = "600");
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("tablet_stat_update_interval_second" = "180");
+-- result:
+-- !result

--- a/test/sql/test_aa_statistic_behavior/T/test_aa_statistic_behavior
+++ b/test/sql/test_aa_statistic_behavior/T/test_aa_statistic_behavior
@@ -1,0 +1,137 @@
+-- name: test_aa_statistic_behavior @sequential
+
+-- This case is used to test statistics collection behavior.
+-- Include auto collection/partition first load
+-- The order of this case is carefully adjusted. If the case is failed, do not delete it easily, there must be a bug.
+-- Since async tablet stats report and auto collect statistics in the background will affect the behavior of statistics collection.
+-- The inconsistency of the triggering timing order of the two will lead to inconsistent case results.
+-- So we need to use SLEEP command in the case.
+-- tablet stats report interval: 3s
+-- auto collect statistics interval: 6s
+-- sleep 5 means wait for tablet stats report
+-- sleep 7 means wait for statistics auto collect
+-- Since the default analyze job of collecting statistic will collect all databases and tables.
+-- This time is uncontrollable in the testing environment. So we use an analyze job with `statistic_exclude_pattern` to replace it.
+
+DROP DATABASE IF EXISTS test_statistic_behavior;
+CREATE DATABASE test_statistic_behavior;
+USE test_statistic_behavior;
+
+CREATE TABLE `source` (
+  `k1` int(11) NULL COMMENT "",
+  `event_day` datetime NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`, `event_day`)
+PARTITION BY date_trunc('day', event_day)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into source select generate_series, '2020-01-01' from table(generate_series(1, 250000));
+insert into source select generate_series, '2021-01-01' from table(generate_series(1, 250000));
+insert into source select generate_series, '2022-01-01' from table(generate_series(1, 250000));
+insert into source select generate_series, '2023-01-01' from table(generate_series(1, 250000));
+insert into source select generate_series, '2024-01-01' from table(generate_series(1, 150000));
+
+ADMIN SET FRONTEND CONFIG ("enable_sync_tablet_stats" = "false");
+ADMIN SET FRONTEND CONFIG ("loads_history_sync_interval_second" = "1000000");
+ADMIN SET FRONTEND CONFIG ("enable_trigger_analyze_job_immediate" = "false");
+ADMIN SET FRONTEND CONFIG ("enable_auto_collect_statistics" = "false");
+ADMIN SET FRONTEND CONFIG ("enable_statistic_collect" = "false");
+drop all analyze job;
+shell: sleep 7
+update default_catalog.information_schema.be_configs set `value` = "3" where name= "tablet_stat_cache_update_interval_second";
+
+CREATE TABLE `target_table` (
+  `k1` int(11) NULL COMMENT "",
+  `event_day` datetime NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`, `event_day`)
+PARTITION BY date_trunc('day', event_day)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+-- insert one new partition. sample collect
+insert into target_table select * from source where event_day = '2020-01-01';
+function: show_stats_meta("show stats meta where `Database` = 'test_statistic_behavior' and `table` = 'target_table'")
+
+-- insert three new partitions. sample collect
+insert into target_table select * from source where event_day >= '2022-01-01';
+function: show_stats_meta("show stats meta where `Database` = 'test_statistic_behavior' and `table` = 'target_table'")
+
+-- insert all partitions. only one is a new partition.
+insert into target_table select * from source;
+function: show_stats_meta("show stats meta where `Database` = 'test_statistic_behavior' and `table` = 'target_table'")
+ADMIN SET FRONTEND CONFIG ("enable_sync_tablet_stats" = "true");
+-- report tablet stats and check table stats healthy
+shell: sleep 5
+function: show_stats_meta("show stats meta where `Database` = 'test_statistic_behavior' and `table` = 'target_table'")
+
+-- wait for auto collect statistics. this should be full collected.
+ADMIN SET FRONTEND CONFIG ("enable_statistic_collect" = "true");
+-- simulate default auto job. only collect case db
+create analyze full all properties  ("statistic_exclude_pattern"="^(?!.*test_statistic_behavior).*$");
+shell: sleep 7
+function: show_stats_meta("show stats meta where `Database` = 'test_statistic_behavior' and `table` = 'target_table'")
+
+-- no new partitions, wait for auto collect statistics. full_schedule_times increase once.
+drop all analyze job;
+shell: sleep 7
+insert into target_table select * from target_table;
+shell: sleep 5
+create analyze full all properties  ("statistic_exclude_pattern"="^(?!.*test_statistic_behavior).*$");
+shell: sleep 7
+function: show_stats_meta("show stats meta where `Database` = 'test_statistic_behavior' and `table` = 'target_table'")
+
+-- no new partitions, wait for auto collect statistics. table stats is healthy and no new stats collect job.
+drop all analyze job;
+shell: sleep 7
+insert into target_table select * from source where event_day = '2020-01-01' limit 100000;
+shell: sleep 5
+create analyze full all properties  ("statistic_exclude_pattern"="^(?!.*test_statistic_behavior).*$");
+shell: sleep 7
+function: show_stats_meta("show stats meta where `Database` = 'test_statistic_behavior' and `table` = 'target_table'")
+
+-- add a new partition, sample_once_times increase once.
+drop all analyze job;
+shell: sleep 13
+insert into target_table select k1, '2026-01-01' from source where event_day = '2021-01-01';
+shell: sleep 5
+function: show_stats_meta("show stats meta where `Database` = 'test_statistic_behavior' and `table` = 'target_table'")
+
+-- create sample analyze job. eliminate init_job flag.
+insert into target_table select * from source;
+shell: sleep 5
+create analyze all properties  ("statistic_exclude_pattern"="^(?!.*test_statistic_behavior).*$");
+shell: sleep 7
+function: show_stats_meta("show stats meta where `Database` = 'test_statistic_behavior' and `table` = 'target_table'")
+
+-- test auto sample strategy to full analyze predicate column
+drop all analyze job;
+shell: sleep 7
+ADMIN SET FRONTEND CONFIG ("statistic_auto_collect_small_table_size" = "1");
+ADMIN SET FRONTEND CONFIG ("statistic_auto_collect_large_table_interval" = "0");
+ADMIN SET FRONTEND CONFIG ("statistic_auto_collect_sample_threshold" = "0.6");
+select count(*) from target_table where k1 = -1 and event_day = '2021-01-01';
+admin execute on frontend 'import com.starrocks.statistic.columns.PredicateColumnsMgr; PredicateColumnsMgr.getInstance().persist();';
+insert into target_table select * from target_table;
+shell: sleep 5
+create analyze all properties  ("statistic_exclude_pattern"="^(?!.*test_statistic_behavior).*$");
+shell: sleep 7
+function: show_stats_meta("show stats meta where `Database` = 'test_statistic_behavior' and `table` = 'target_table'")
+
+drop stats target_table;
+drop table target_table;
+drop all analyze job;
+
+-- reset fe config
+ADMIN SET FRONTEND CONFIG ("enable_sync_tablet_stats" = "true");
+ADMIN SET FRONTEND CONFIG ("enable_statistic_collect" = "true");
+ADMIN SET FRONTEND CONFIG ("enable_auto_collect_statistics" = "true");
+ADMIN SET FRONTEND CONFIG ("enable_trigger_analyze_job_immediate" = "true");
+ADMIN SET FRONTEND CONFIG ("statistic_auto_collect_small_table_size" = "5368709120");
+ADMIN SET FRONTEND CONFIG ("statistic_auto_collect_large_table_interval" = "43200");
+ADMIN SET FRONTEND CONFIG ("statistic_auto_collect_sample_threshold" = "0.3");
+ADMIN SET FRONTEND CONFIG ("statistic_collect_interval_sec" = "600");
+ADMIN SET FRONTEND CONFIG ("tablet_stat_update_interval_second" = "180");


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
1. Add more metrics to `show stats meta`
```
mysql> show stats meta where `table`='t5'\G
*************************** 1. row ***************************
             Database: test_stats
                Table: t5
              Columns: ALL
                 Type: FULL
           UpdateTime: 2025-03-31 17:36:45
           Properties: {sample_once_times=1, full_schedule_times=2}
              Healthy: 100%
          ColumnStats: (k1,FULL),(event_day,FULL)
TabletStatsReportTime: 2025-04-01 16:30:10
  TableHealthyMetrics: [tableRowCount=10000001, tableRowCountInStatistics=10000001, totalPartitionCount=5, unhealthyPartitionCount=0, unhealthyPartitionRowCount=0, unhealthyPartitionDataSize=0KB, updatePartitionRowCountForCalc=1, deltaRowCount=0]
      TableUpdateTime: 2025-03-31 17:26:51
```

2. support `drop all analyze job` syntax
3. fix table stats healthy calculation when partition is first imported
4. fix `getMaxSampleTabletNum()` on SampleInfo
5. clear `reason` field after collection statistics
6. fix default_job check on StatisticsAutoCollector
7. fix the auto collection strategy that converting sample analyze job to full analyze predicate column in the background
8. Add some fe config for easy testing
9. add statistics behavior test

TODO:
- I will mark sql test as @slow when pr is merged.
- add insert overwrite and refresh mv case to behavior test


Fixes #57363 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
