### PR TITLE
Fixing delete propagation during incremental snapshot

### DIFF
--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -229,6 +229,10 @@ public:
 
     uint32_t get_num_update_files() const { return _rowset_meta_pb->num_update_files(); }
 
+    void set_num_delete_files(uint32_t num_del_files) const { _rowset_meta_pb->set_num_delete_files(num_del_files); }
+
+    void add_delfile_idxes(uint32_t idx) { _rowset_meta_pb->add_delfile_idxes(idx); }
+
     // rowset_meta_pb keep `tablet_schema_pb` right now and it will use more memory.
     // But it is not necessary always hold tablet schema pb in memory. The access frequency of
     // tablet_schema_pb is very low and it could be generated from `_schema` temporarily.

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -35,6 +35,7 @@
 #include "rowset_merger.h"
 #include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
+#include "serde/column_array_serde.h"
 #include "storage/chunk_helper.h"
 #include "storage/chunk_iterator.h"
 #include "storage/compaction_utils.h"
@@ -72,6 +73,46 @@
 #include "util/starrocks_metrics.h"
 
 namespace starrocks {
+
+namespace {
+
+Status _update_delete_pks(MutableColumnPtr& total_delete_pks, MutableColumnPtr& delete_pks, PrimaryIndex& index,
+                          PrimaryIndex::DeletesMap& new_deletes) {
+    RETURN_IF_ERROR(index.erase(*delete_pks, &new_deletes));
+    if (total_delete_pks == nullptr) {
+        total_delete_pks = std::move(delete_pks);
+        return Status::OK();
+    }
+
+    total_delete_pks->append(*delete_pks);
+    return Status::OK();
+}
+
+Status _verify_delete_file(const std::string& del_file_path, const Column& deletes, FileSystem& fs) {
+    ASSIGN_OR_RETURN(auto read_file, fs.new_random_access_file(del_file_path));
+    ASSIGN_OR_RETURN(auto file_size, read_file->get_size());
+    std::vector<uint8_t> read_buffer;
+    TRY_CATCH_BAD_ALLOC(read_buffer.resize(file_size));
+    RETURN_IF_ERROR(read_file->read_at_fully(0, read_buffer.data(), read_buffer.size()));
+    auto col = deletes.clone_empty();
+    if (serde::ColumnArraySerde::deserialize(read_buffer.data(), col.get()) == nullptr) {
+        return Status::InternalError("column deserialization failed");
+    }
+    if (col->size() != deletes.size()) {
+        return Status::InternalError(
+                fmt::format("The delete files sizes are different col:{} dels:{}", col->size(), deletes.size()));
+    }
+    for (auto i = 0; i < col->size(); ++i) {
+        if (col->equals(i, deletes, i) == Column::EQUALS_FALSE) {
+            return Status::InternalError(
+                    fmt::format("The delete files values are different size:{} i:{} col:{} dels:{}", deletes.size(), i,
+                                col->debug_item(i), deletes.debug_item(i)));
+        }
+    }
+    return Status::OK();
+}
+
+} // namespace
 
 const std::string kBreakpointMsg = "primary key apply stopped";
 
@@ -1295,6 +1336,28 @@ bool TabletUpdates::check_delta_column_generate_from_version(EditVersion begin_v
     return false;
 }
 
+Status TabletUpdates::_create_delete_file_for_segment(const RowsetSharedPtr& rowset, const Column& deletes,
+                                                      FileSystem& fs) {
+    auto num_delfiles = rowset->num_delete_files();
+    auto rowset_path = Rowset::segment_del_file_path(rowset->rowset_path(), rowset->rowset_id(), num_delfiles);
+    if (fs.path_exists(rowset_path).ok()) {
+        RETURN_IF_ERROR(_verify_delete_file(rowset_path, deletes, fs));
+        return Status::OK();
+    }
+    ASSIGN_OR_RETURN(auto wfile, fs.new_writable_file(rowset_path));
+    size_t sz = serde::ColumnArraySerde::max_serialized_size(deletes);
+    std::vector<uint8_t> content(sz);
+    if (serde::ColumnArraySerde::serialize(deletes, content.data()) == nullptr) {
+        return Status::InternalError("deletes column serialize failed");
+    }
+    RETURN_IF_ERROR(wfile->append(Slice(content.data(), content.size())));
+    if (config::sync_tablet_meta) {
+        RETURN_IF_ERROR(wfile->sync());
+    }
+    RETURN_IF_ERROR(wfile->close());
+    return Status::OK();
+}
+
 Status TabletUpdates::_apply_normal_rowset_commit(const EditVersionInfo& version_info, const RowsetSharedPtr& rowset) {
     CHECK_MEM_LIMIT("TabletUpdates::_apply_normal_rowset_commit");
     auto span = Tracer::Instance().start_trace_tablet("apply_rowset_commit", _tablet.tablet_id());
@@ -1420,6 +1483,7 @@ Status TabletUpdates::_apply_normal_rowset_commit(const EditVersionInfo& version
 
     int64_t full_row_size = 0;
     int64_t full_rowset_size = 0;
+    MutableColumnPtr total_delete_pks = nullptr;
     if (rowset->rowset_meta()->get_meta_pb_without_schema().delfile_idxes_size() == 0) {
         for (uint32_t i = 0; i < rowset->num_segments(); i++) {
             st = state.load_upserts(rowset.get(), i);
@@ -1454,7 +1518,7 @@ Status TabletUpdates::_apply_normal_rowset_commit(const EditVersionInfo& version
                 }
                 manager->index_cache().update_object_size(index_entry, index.memory_usage());
                 if (delete_pks != nullptr) {
-                    st = index.erase(*delete_pks, &new_deletes);
+                    st = _update_delete_pks(total_delete_pks, delete_pks, index, new_deletes);
                     if (!st.ok()) {
                         std::string msg = strings::Substitute("_apply_rowset_commit error: index erase failed: $0 $1",
                                                               st.to_string(), debug_string());
@@ -1542,7 +1606,7 @@ Status TabletUpdates::_apply_normal_rowset_commit(const EditVersionInfo& version
                     }
                     manager->index_cache().update_object_size(index_entry, index.memory_usage());
                     if (delete_pks != nullptr) {
-                        st = index.erase(*delete_pks, &new_deletes);
+                        st = _update_delete_pks(total_delete_pks, delete_pks, index, new_deletes);
                         if (!st.ok()) {
                             std::string msg =
                                     strings::Substitute("_apply_rowset_commit error: index erase failed: $0 $1",
@@ -1724,6 +1788,19 @@ Status TabletUpdates::_apply_normal_rowset_commit(const EditVersionInfo& version
     StarRocksMetrics::instance()->update_del_vector_deletes_new.increment(new_del);
     int64_t t_delvec = MonotonicMillis();
 
+    if (total_delete_pks != nullptr) {
+        std::shared_ptr<FileSystem> fs;
+        ASSIGN_OR_RETURN(fs, FileSystem::CreateSharedFromString(rowset->rowset_path()));
+
+        st = _create_delete_file_for_segment(rowset, *total_delete_pks, *fs);
+        if (!st.ok() && !st.is_not_found()) {
+            std::string msg = strings::Substitute("_apply_rowset_commit error: Failed to write delete file $0 $1",
+                                                  st.to_string(), _debug_string(false, true));
+            failure_handler(msg, st.code(), true);
+            return apply_st;
+        }
+    }
+
     {
         std::lock_guard wl(_lock);
         FAIL_POINT_TRIGGER_EXECUTE(tablet_apply_tablet_drop, { _edit_version_infos.clear(); });
@@ -1734,6 +1811,12 @@ Status TabletUpdates::_apply_normal_rowset_commit(const EditVersionInfo& version
         }
         // 4. write meta
         const auto& rowset_meta_pb = rowset->rowset_meta()->get_meta_pb_without_schema();
+        if (total_delete_pks != nullptr) {
+            // _delfile_idxes keep the idx for every delete file, so we need to add the idx to _delfile_idxes if we create a
+            // new delete file
+            rowset->rowset_meta()->add_delfile_idxes(rowset_meta_pb.num_segments() + rowset_meta_pb.num_delete_files());
+            rowset->rowset_meta()->set_num_delete_files(rowset_meta_pb.num_delete_files() + 1);
+        }
         // TODO reset tablet schema in rowset
         if (rowset_meta_pb.has_txn_meta()) {
             auto r = rowset->total_segment_data_size();

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -531,6 +531,8 @@ private:
 
     void _reset_apply_status(const EditVersionInfo& version_info_apply);
 
+    Status _create_delete_file_for_segment(const RowsetSharedPtr& rowset, const Column& delete_pks, FileSystem& fs);
+
 private:
     Tablet& _tablet;
 

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -4014,4 +4014,93 @@ TEST_F(TabletUpdatesTest, test_apply_breakpoint_check_pindex) {
     test_apply_breakpoint_check(true);
 }
 
+TEST_F(TabletUpdatesTest, test_updates_deletes_and_snapshot) {
+    srand(GetCurrentTimeMicros());
+    auto tablet0 = create_tablet_with_auto_increment(rand(), rand());
+    auto tablet1 = create_tablet_with_auto_increment(rand(), rand());
+    tablet0->set_enable_persistent_index(false);
+    tablet1->set_enable_persistent_index(false);
+
+    DeferOp defer([&]() {
+        auto tablet_mgr = StorageEngine::instance()->tablet_manager();
+        (void)tablet_mgr->drop_tablet(tablet0->tablet_id());
+        (void)tablet_mgr->drop_tablet(tablet1->tablet_id());
+        (void)fs::remove_all(tablet0->schema_hash_path());
+        (void)fs::remove_all(tablet1->schema_hash_path());
+    });
+
+    std::vector<int32_t> column_indexes = {0, 1};
+    std::shared_ptr<TabletSchema> partial_schema = TabletSchema::create(tablet1->tablet_schema(), column_indexes);
+    std::vector<int64_t> keys0 = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    for (int i = 0; i < 4; i++) {
+        ASSERT_TRUE(tablet0->rowset_commit(i + 2 /*version*/, create_rowset_auto_increment(tablet0, keys0)).ok());
+    }
+
+    {
+        EditVersion version;
+        std::vector<RowsetSharedPtr> applied_rowsets;
+        ASSERT_TRUE(tablet0->updates()->get_applied_rowsets(5, &applied_rowsets, &version).ok());
+    }
+
+    // create a partial rowset, commit but not apply
+    tablet0->updates()->stop_apply(true);
+    std::vector<int64_t> partial_keys = {1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009};
+    RowsetSharedPtr partial_rowset = create_partial_rowset_auto_increment(tablet0, partial_keys, column_indexes, partial_schema);
+    ASSERT_TRUE(tablet0->rowset_commit(6, partial_rowset).ok());
+    ASSERT_EQ(tablet0->updates()->max_version(), 6);
+    EditVersion latest_applied_verison;
+    tablet0->updates()->get_latest_applied_version(&latest_applied_verison);
+    ASSERT_EQ(latest_applied_verison.major_number(), 5);
+    LOG(INFO) << "commit partial rowset success";
+
+    // create rowsets for tablet1
+    std::vector<int64_t> keys1 = {0, 1, 2, 3};
+    for (int i = 0; i < 2; i++) {
+        ASSERT_TRUE(tablet1->rowset_commit(i + 2 /*version*/, create_rowset_auto_increment(tablet1, keys1)).ok());
+    }
+    tablet0->updates()->stop_apply(false);
+    tablet0->updates()->check_for_apply();
+    {
+        EditVersion version;
+        std::vector<RowsetSharedPtr> applied_rowsets;
+        Status status = tablet0->updates()->get_applied_rowsets(6, &applied_rowsets, &version);
+        EditVersion latest_applied_verison;
+        tablet0->updates()->get_latest_applied_version(&latest_applied_verison);
+        ASSERT_EQ(latest_applied_verison.major_number(), 6);
+    }
+
+    // try to do snapshot
+    std::vector<int64_t> delta_versions = {4, 5, 6};
+    TabletMetaSharedPtr snapshot_tablet_meta = std::make_shared<TabletMeta>();
+    std::vector<RowsetSharedPtr> snapshot_rowsets;
+    std::vector<RowsetMetaSharedPtr> snapshot_rowset_metas;
+    std::string snapshot_id_path;
+    std::string snapshot_dir;
+    DeferOp remove([&]() {
+        (void)fs::remove_all(snapshot_dir);
+        (void)fs::remove_all(snapshot_id_path);
+    });
+
+    snapshot_prepare(tablet0, delta_versions, &snapshot_id_path, &snapshot_dir, &snapshot_rowsets,
+                     &snapshot_rowset_metas, snapshot_tablet_meta);
+
+    ASSERT_TRUE(SnapshotManager::instance()
+                        ->make_snapshot_on_tablet_meta(SNAPSHOT_TYPE_INCREMENTAL, snapshot_dir, tablet0,
+                                                       snapshot_rowset_metas, 0, 4 /*TSNAPSHOT_REQ_VERSION2*/)
+                        .ok());
+
+    // rowset status is applied in meta, rowset file is full rowset
+    // rowsets applied success, link files directly
+    for (const auto& rowset : snapshot_rowsets) {
+        ASSERT_TRUE(rowset->link_files_to(tablet0->data_dir()->get_meta(), snapshot_dir, rowset->rowset_id()).ok());
+    }
+
+    auto meta_dir = SnapshotManager::instance()->get_schema_hash_full_path(tablet0, snapshot_id_path);
+    SegmentFooterPB footer;
+    load_snapshot(meta_dir, tablet1, &footer);
+    ASSERT_EQ(footer.columns_size(), 3);
+    ASSERT_EQ(10, read_tablet(tablet0, tablet0->updates()->max_version()));
+    ASSERT_EQ(10, read_tablet(tablet1, tablet1->updates()->max_version()));
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
This is fix for the issue described in https://github.com/StarRocks/starrocks/issues/57362
## What I'm doing:
Added an extra delete file to handle the deletes done by auto increment in the remote replica after a snapshot. Since the files can be linked after the snapshot of the meta we just verify in remote if the contents are as expected instead of creating the new delete file if it exists
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1