### PR TITLE
[BugFix] fix BE crash because of runtime profile missing when do load spill

### DIFF
--- a/be/src/storage/lake/spill_mem_table_sink.cpp
+++ b/be/src/storage/lake/spill_mem_table_sink.cpp
@@ -77,6 +77,11 @@ SpillMemTableSink::SpillMemTableSink(LoadSpillBlockManager* block_manager, Table
     _block_manager = block_manager;
     _writer = writer;
     _profile = profile;
+    if (_profile == nullptr) {
+        // use dummy profile
+        _dummy_profile = std::make_unique<RuntimeProfile>("dummy");
+        _profile = _dummy_profile.get();
+    }
     _runtime_state = std::make_shared<RuntimeState>();
     _spiller_factory = spill::make_spilled_factory();
     std::string tracker_label = "LoadSpillMerge-" + std::to_string(_block_manager->tablet_id()) + "-" +

--- a/be/src/storage/lake/spill_mem_table_sink.h
+++ b/be/src/storage/lake/spill_mem_table_sink.h
@@ -85,6 +85,8 @@ private:
     SchemaPtr _schema;
     // used for spill merge, parent trakcer is compaction tracker
     std::unique_ptr<MemTracker> _merge_mem_tracker = nullptr;
+    // used when input profile is nullptr
+    std::unique_ptr<RuntimeProfile> _dummy_profile;
 };
 
 } // namespace lake

--- a/be/src/storage/lake/spill_mem_table_sink.h
+++ b/be/src/storage/lake/spill_mem_table_sink.h
@@ -79,14 +79,14 @@ private:
     TabletWriter* _writer;
     // destroy spiller before runtime_state
     std::shared_ptr<RuntimeState> _runtime_state;
+    // used when input profile is nullptr
+    std::unique_ptr<RuntimeProfile> _dummy_profile;
     RuntimeProfile* _profile = nullptr;
     spill::SpillerFactoryPtr _spiller_factory;
     std::shared_ptr<spill::Spiller> _spiller;
     SchemaPtr _schema;
     // used for spill merge, parent trakcer is compaction tracker
     std::unique_ptr<MemTracker> _merge_mem_tracker = nullptr;
-    // used when input profile is nullptr
-    std::unique_ptr<RuntimeProfile> _dummy_profile;
 };
 
 } // namespace lake


### PR DESCRIPTION
## Why I'm doing:
In some case, load runtime profile could be nullptr, it could lead to BE crash:
```
SIGSEGV (@0xe0) received by PID 68608 (TID 0x7859c4e00640) from PID 224; stack trace: ***
    @     0x786002c99ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @          0xd5cc309 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x786002c42520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @     0x786002c97ef4 pthread_mutex_lock
    @          0x9443944 starrocks::RuntimeProfile::add_child_counter(std::__cxx11::basic_string, std::allocator > const&, starrocks::TUnit::type, starrocks::TCounterStrategy const&, std::__cxx11::basic_string, std::a
    @          0x86fa838 starrocks::spill::SpillProcessMetrics::SpillProcessMetrics(starrocks::RuntimeProfile*, std::atomic*)
    @          0x9078214 starrocks::lake::SpillMemTableSink::_prepare(std::shared_ptr const&)
    @          0x9078604 starrocks::lake::SpillMemTableSink::_do_spill(starrocks::Chunk const&, std::shared_ptr const&)
    @          0x90789fd starrocks::lake::SpillMemTableSink::flush_chunk(starrocks::Chunk const&, starrocks::SegmentPB*, bool, long*)
    @          0x7a3bd1f starrocks::MemTable::flush(starrocks::SegmentPB*, bool, long*)
    @          0x7bcd1c2 starrocks::FlushToken::_flush_memtable(starrocks::MemTable*, starrocks::SegmentPB*, bool, long*)
    @          0x7bcf013 starrocks::MemtableFlushTask::run()
    @          0x94a67d3 starrocks::ThreadPool::dispatch_thread()
    @          0x949dda9 starrocks::Thread::supervise_thread(void*)
    @     0x786002c94ac3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
    @     0x786002d26850 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x12684f)
```

## What I'm doing:
If load runtime profile is nullptr, we will create a dummy profile.

Fix #53954

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
