### PR TITLE
[BugFix] concat(col) should return cloned column instead of original column to avoid abusing sharing column (backport #57522)

### DIFF
--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -2818,7 +2818,7 @@ static inline ColumnPtr concat_not_const(Columns const& columns) {
  */
 StatusOr<ColumnPtr> StringFunctions::concat(FunctionContext* context, const Columns& columns) {
     if (columns.size() == 1) {
-        return columns[0];
+        return columns[0]->clone_shared();
     }
 
     RETURN_IF_COLUMNS_ONLY_NULL(columns);


### PR DESCRIPTION
cp #57522 
## Why I'm doing:

Chunk::check_or_die fails since columns in chunk has different sizes.

```
F20250401 18:53:38.763079 22825814390336 chunk.cpp:367] Check failed: num_rows() == c->size() (988 vs. 506) F20250401 18:53:38.885509 22825883203136 chunk.cpp:367] Check failed: num_rows() == c->size() (964 vs. 494) F20250401 18:53:38.939654 22825759340096 chunk.cpp:367] Check failed: num_rows() == c->size() (989 vs. 501) F20250401 18:53:39.071995 22825745577536 chunk.cpp:367] Check failed: num_rows() == c->size() (1025 vs. 517)
    @         0x1ef8d39d std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()> >::_M_invoke(std::_Any_data const&)
    @         0x12595a6e std::function<void ()>::operator()() const
    @         0x1ef59346 starrocks::Thread::supervise_thread(void*)
    @     0x14c355b84ac3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
    @     0x14c355c16850 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x12684f)
start time: Tue Apr  1 18:53:42 CST 2025, server uptime:  18:53:41 up 139 days,  3:01,  3 users,  load average: 9.24, 4.64, 3.73
```

The root cause is:

In the plan, project operator output both column dept_nbr and concat(dept_nbr), when concat is applied to only one argument, the column is return directly, so dept_nbr appears twice in output chunk of project operator,  accumulator operator is descendant of the project operator, it try to merge small chunks into big one via column::append method, so twice-appearing column is appended twice, its size is large than other columns.

![img_v3_02ku_11209bd8-fcff-4c76-be92-3ad0a9c0d95g](https://github.com/user-attachments/assets/ec0bbd7e-b842-425c-925e-080baa673874)

![img_v3_02ku_8f6259ec-5886-4aed-9703-56348ef88cag](https://github.com/user-attachments/assets/2f2a1d25-9be7-40a5-a6ce-e8aa30d9f3ff)


## What I'm doing:


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
