### PR TITLE
[Enhancement] Remove unused function from LogUtils

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/LogUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/LogUtil.java
@@ -101,12 +101,6 @@ public class LogUtil {
         return strListToJsonArray(getStackTraceToList(threadInfo.getStackTrace(), trimHeadLevels, reserveLevels));
     }
 
-    public static JsonArray getStackTraceToJsonArray(Thread thread, int reserveLevels) {
-        StackTraceElement[] stackTraceElements = thread.getStackTrace();
-        return strListToJsonArray(getStackTraceToList(stackTraceElements,
-                stackTraceElements.length - reserveLevels, reserveLevels));
-    }
-
     public static String getCurrentStackTrace() {
         return Arrays.stream(Thread.currentThread().getStackTrace())
                 .map(stack -> "        " + stack.toString())


### PR DESCRIPTION
## Why I'm doing:
There is a overflow bug in `getStackTraceToJsonArray`, but it's unused in 3.5 and 3.4, remove it.
```
2025-03-21 16:21:33.303+05:00 ERROR (PUBLISH_VERSION|56) [PublishVersionDaemon.runAfterCatalogReady():148] errors while publish version to all backends
java.lang.IllegalStateException: null
        at com.google.common.base.Preconditions.checkState(Preconditions.java:496) ~[spark-dpp-1.0.0.jar:?]
        at com.starrocks.common.util.LogUtil.getStackTraceToList(LogUtil.java:119) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.LogUtil.getStackTraceToJsonArray(LogUtil.java:106) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.concurrent.lock.LockManager.logSlowLockTrace(LockManager.java:413) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.concurrent.lock.LockManager.lock(LockManager.java:136) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.concurrent.lock.Locker.lock(Locker.java:90) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.concurrent.lock.Locker.lockTablesWithIntensiveDbLock(Locker.java:339) ~[starrocks-fe.jar:?]
        at com.starrocks.transaction.DatabaseTransactionMgr.finishTransaction(DatabaseTransactionMgr.java:1047) ~[starrocks-fe.jar:?]
        at com.starrocks.transaction.GlobalTransactionMgr.finishTransaction(GlobalTransactionMgr.java:586) ~[starrocks-fe.jar:?]
        at com.starrocks.transaction.PublishVersionDaemon.publishVersionForOlapTable(PublishVersionDaemon.java:331) ~[starrocks-fe.jar:?]
        at com.starrocks.transaction.PublishVersionDaemon.runAfterCatalogReady(PublishVersionDaemon.java:143) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.FrontendDaemon.runOneCycle(FrontendDaemon.java:72) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.Daemon.run(Daemon.java:109) ~[starrocks-fe.jar:?]
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
