### PR TITLE
[Enhancement] Secondary replica supports to poll state from primary replica 

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -487,6 +487,10 @@ CONF_Int32(make_snapshot_rpc_timeout_ms, "20000");
 // OlapTableSink sender's send interval, should be less than the real response time of a tablet writer rpc.
 CONF_mInt32(olap_table_sink_send_interval_ms, "10");
 
+// The interval that the secondary replica checks it's status on the primary replica after receiving eos
+CONF_mInt32(load_replica_status_check_interval_ms_on_success, "20000");
+// The interval that the secondary replica checks it's status on the primary replica after receiving eos
+CONF_mInt32(load_replica_status_check_interval_ms_on_failure, "2000");
 // If load rpc timeout is larger than this value, slow log will be printed every time,
 // if smaller than this value, will reduce slow log print frequency.
 // 0 is print slow log every time.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -487,9 +487,9 @@ CONF_Int32(make_snapshot_rpc_timeout_ms, "20000");
 // OlapTableSink sender's send interval, should be less than the real response time of a tablet writer rpc.
 CONF_mInt32(olap_table_sink_send_interval_ms, "10");
 
-// The interval that the secondary replica checks it's status on the primary replica after receiving eos
-CONF_mInt32(load_replica_status_check_interval_ms_on_success, "20000");
-// The interval that the secondary replica checks it's status on the primary replica after receiving eos
+// The interval that the secondary replica checks it's status on the primary replica if the last check rpc successes.
+CONF_mInt32(load_replica_status_check_interval_ms_on_success, "15000");
+// The interval that the secondary replica checks it's status on the primary replica if the last check rpc fails.
 CONF_mInt32(load_replica_status_check_interval_ms_on_failure, "2000");
 // If load rpc timeout is larger than this value, slow log will be printed every time,
 // if smaller than this value, will reduce slow log print frequency.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -511,8 +511,6 @@ CONF_mInt32(load_diagnose_rpc_timeout_stack_trace_threshold_ms, "600000");
 CONF_mInt32(load_fp_brpc_timeout_ms, "-1");
 // Used in load fail point. The block time to simulate TabletsChannel::add_chunk spends much time
 CONF_mInt32(load_fp_tablets_channel_add_chunk_block_ms, "-1");
-// Used in load fail point. The block time to simulate waiting secondary replica spends much time
-CONF_mInt32(load_fp_tablets_channel_wait_secondary_replica_block_ms, "-1");
 
 // The interval for performing stack trace to control the frequency.
 CONF_mInt64(diagnose_stack_trace_interval_ms, "1800000");

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -462,23 +462,13 @@ void LoadChannel::diagnose(const std::string& remote_ip, const PLoadDiagnoseRequ
 void LoadChannel::get_load_replica_status(const std::string& remote_ip, const PLoadReplicaStatusRequest* request,
                                           PLoadReplicaStatusResult* response) {
     TabletsChannelKey key(request->load_id(), request->sink_id(), request->index_id());
-    auto channel = get_tablets_channel(key);
-    if (channel == nullptr) {
-        for (int64_t tablet_id : request->tablet_ids()) {
-            auto replica_status = response->add_replica_statuses();
-            replica_status->set_tablet_id(tablet_id);
-            replica_status->set_state(LoadReplicaStatePB::NOT_PRESENT);
-            replica_status->set_message("can't find the tablets channel");
-        }
-        return;
-    }
-    auto local_tablets_channel = dynamic_cast<LocalTabletsChannel*>(channel.get());
+    auto local_tablets_channel = dynamic_cast<LocalTabletsChannel*>(get_tablets_channel(key).get());
     if (local_tablets_channel == nullptr) {
         for (int64_t tablet_id : request->tablet_ids()) {
             auto replica_status = response->add_replica_statuses();
             replica_status->set_tablet_id(tablet_id);
             replica_status->set_state(LoadReplicaStatePB::NOT_PRESENT);
-            replica_status->set_message("only local tablets channel supports get load replica status");
+            replica_status->set_message("can't find local tablets channel");
         }
         return;
     }

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -459,6 +459,32 @@ void LoadChannel::diagnose(const std::string& remote_ip, const PLoadDiagnoseRequ
     }
 }
 
+void LoadChannel::get_load_replica_status(const std::string& remote_ip, const PLoadReplicaStatusRequest* request,
+                                          PLoadReplicaStatusResult* response) {
+    TabletsChannelKey key(request->load_id(), request->sink_id(), request->index_id());
+    auto channel = get_tablets_channel(key);
+    if (channel == nullptr) {
+        for (int64_t tablet_id : request->tablet_ids()) {
+            auto replica_status = response->add_replica_statuses();
+            replica_status->set_tablet_id(tablet_id);
+            replica_status->set_state(LoadReplicaStatePB::NOT_PRESENT);
+            replica_status->set_message("can't find the tablets channel");
+        }
+        return;
+    }
+    auto local_tablets_channel = dynamic_cast<LocalTabletsChannel*>(channel.get());
+    if (local_tablets_channel == nullptr) {
+        for (int64_t tablet_id : request->tablet_ids()) {
+            auto replica_status = response->add_replica_statuses();
+            replica_status->set_tablet_id(tablet_id);
+            replica_status->set_state(LoadReplicaStatePB::NOT_PRESENT);
+            replica_status->set_message("only local tablets channel supports get load replica status");
+        }
+        return;
+    }
+    local_tablets_channel->get_load_replica_status(remote_ip, request, response);
+}
+
 Status LoadChannel::_update_and_serialize_profile(std::string* result, bool print_profile) {
     COUNTER_UPDATE(_profile_report_count, 1);
     SCOPED_TIMER(_profile_report_timer);

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -130,6 +130,8 @@ public:
     void report_profile(PTabletWriterAddBatchResult* result, bool print_profile);
 
     void diagnose(const std::string& remote_ip, const PLoadDiagnoseRequest* request, PLoadDiagnoseResult* response);
+    void get_load_replica_status(const std::string& remote_ip, const PLoadReplicaStatusRequest* request,
+                                 PLoadReplicaStatusResult* response);
 
 private:
     void _add_chunk(Chunk* chunk, const MonotonicStopWatch* watch, const PTabletWriterAddChunkRequest& request,

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -283,6 +283,24 @@ void LoadChannelMgr::cancel(brpc::Controller* cntl, const PTabletWriterCancelReq
     }
 }
 
+void LoadChannelMgr::get_load_replica_status(brpc::Controller* cntl, const PLoadReplicaStatusRequest* request,
+                                             PLoadReplicaStatusResult* response, google::protobuf::Closure* done) {
+    ClosureGuard done_guard(done);
+    UniqueId load_id(request->load_id());
+    auto channel = _find_load_channel(load_id);
+    if (channel == nullptr) {
+        for (int64_t tablet_id : request->tablet_ids()) {
+            auto replica_status = response->add_replica_statuses();
+            replica_status->set_tablet_id(tablet_id);
+            replica_status->set_state(LoadReplicaStatePB::NOT_PRESENT);
+            replica_status->set_message("can't find the load channel");
+        }
+    } else {
+        std::string remote_ip = butil::ip2str(cntl->remote_side().ip).c_str();
+        channel->get_load_replica_status(remote_ip, request, response);
+    }
+}
+
 void LoadChannelMgr::load_diagnose(brpc::Controller* cntl, const PLoadDiagnoseRequest* request,
                                    PLoadDiagnoseResult* response, google::protobuf::Closure* done) {
     ClosureGuard done_guard(done);

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -293,7 +293,7 @@ void LoadChannelMgr::get_load_replica_status(brpc::Controller* cntl, const PLoad
             auto replica_status = response->add_replica_statuses();
             replica_status->set_tablet_id(tablet_id);
             replica_status->set_state(LoadReplicaStatePB::NOT_PRESENT);
-            replica_status->set_message("can't find the load channel");
+            replica_status->set_message("can't find load channel");
         }
     } else {
         std::string remote_ip = butil::ip2str(cntl->remote_side().ip).c_str();

--- a/be/src/runtime/load_channel_mgr.h
+++ b/be/src/runtime/load_channel_mgr.h
@@ -84,6 +84,9 @@ public:
     void cancel(brpc::Controller* cntl, const PTabletWriterCancelRequest& request, PTabletWriterCancelResult* response,
                 google::protobuf::Closure* done);
 
+    void get_load_replica_status(brpc::Controller* cntl, const PLoadReplicaStatusRequest* request,
+                                 PLoadReplicaStatusResult* response, google::protobuf::Closure* done);
+
     void load_diagnose(brpc::Controller* cntl, const PLoadDiagnoseRequest* request, PLoadDiagnoseResult* response,
                        google::protobuf::Closure* done);
 

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -57,6 +57,7 @@ namespace starrocks {
 
 DEFINE_FAIL_POINT(tablets_channel_add_chunk_wait_write_block);
 DEFINE_FAIL_POINT(tablets_channel_wait_secondary_replica_block);
+DEFINE_FAIL_POINT(tablets_channel_abort_replica_failure);
 
 std::atomic<uint64_t> LocalTabletsChannel::_s_tablet_writer_count;
 
@@ -160,6 +161,11 @@ void LocalTabletsChannel::add_segment(brpc::Controller* cntl, const PTabletWrite
 
     delta_writer->write_segment(req);
     closure_guard.release();
+}
+
+static bool is_delta_writer_finished(AsyncDeltaWriter* delta_writer) {
+    auto state = delta_writer->get_state();
+    return state == kCommitted || state == kAborted || state == kUninitialized;
 }
 
 void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequest& request,
@@ -343,51 +349,20 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
 
     // We need wait all secondary replica commit before we close the channel
     if (_is_replicated_storage && close_channel && response->status().status_code() == TStatusCode::OK) {
-        bool timeout = false;
+        std::unordered_map<int64_t, std::vector<AsyncDeltaWriter*>> unfinished_replicas_grouped_by_primary_node;
         for (auto& [tablet_id, delta_writer] : _delta_writers) {
-            // Wait util seconary replica commit/abort by primary
-            if (delta_writer->replica_state() == Secondary) {
-                int i = 0;
-                int64_t start_wait_time_ms = MonotonicMillis();
-                bool trigger_diagnose = false;
-                do {
-                    auto state = delta_writer->get_state();
-                    if (state == kCommitted || state == kAborted || state == kUninitialized) {
-                        break;
-                    }
-                    i++;
-                    // only sleep in bthread
-                    bthread_usleep(10000); // 10ms
-                    FAIL_POINT_TRIGGER_EXECUTE(tablets_channel_wait_secondary_replica_block, {
-                        int32_t timeout_ms = config::load_fp_tablets_channel_wait_secondary_replica_block_ms;
-                        if (timeout_ms > 0) {
-                            bthread_usleep(timeout_ms * 1000);
-                        }
-                    });
-                    if (!trigger_diagnose && (MonotonicMillis() - start_wait_time_ms >
-                                              config::load_diagnose_rpc_timeout_stack_trace_threshold_ms)) {
-                        _diagnose_primary_replica_stack_trace(tablet_id, request.id(), delta_writer.get());
-                        trigger_diagnose = true;
-                    }
-                    auto elapse_time_ms = watch.elapsed_time() / 1000000;
-                    if (elapse_time_ms > request.timeout_ms()) {
-                        LOG(INFO) << "LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(request.id())
-                                  << " wait tablet " << tablet_id << " secondary replica finish timeout "
-                                  << request.timeout_ms() << "ms still in state " << state
-                                  << ", primary replica: " << delta_writer->replicas()[0].host();
-                        timeout = true;
-                        break;
-                    }
-
-                    if (i % 6000 == 0) {
-                        LOG(INFO) << "LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(request.id())
-                                  << " wait tablet " << tablet_id << " secondary replica finish already "
-                                  << elapse_time_ms << "ms still in state " << state
-                                  << ", primary replica: " << delta_writer->replicas()[0].host();
-                    }
-                } while (true);
+            if (delta_writer->replica_state() == Secondary && !is_delta_writer_finished(delta_writer.get())) {
+                int64_t node_id = delta_writer->writer()->replicas()[0].node_id();
+                unfinished_replicas_grouped_by_primary_node[node_id].push_back(delta_writer.get());
             }
-            if (timeout) {
+        }
+        int64_t start_wait_time = MonotonicMillis();
+        for (auto& [node_id, delta_writers] : unfinished_replicas_grouped_by_primary_node) {
+            int64_t left_timeout_ms = std::max((uint64_t)0, request.timeout_ms() - watch.elapsed_time() / 1000000);
+            SecondaryReplicasWaiter waiter(request.id(), _txn_id, request.sink_id(), left_timeout_ms, start_wait_time,
+                                           delta_writers);
+            Status status = waiter.wait();
+            if (status.is_time_out()) {
                 break;
             }
         }
@@ -573,6 +548,15 @@ void LocalTabletsChannel::_abort_replica_tablets(
         const std::unordered_map<int64_t, std::vector<int64_t>>& node_id_to_abort_tablets) {
     for (auto& [node_id, tablet_ids] : node_id_to_abort_tablets) {
         auto& endpoint = _node_id_to_endpoint[node_id];
+        FAIL_POINT_TRIGGER_EXECUTE(tablets_channel_abort_replica_failure, {
+            std::string tablets_str;
+            JoinInts(tablet_ids, ",", &tablets_str);
+            LOG(INFO) << "tablets_channel_abort_replica_failure, load_id: " << print_id(request.id())
+                      << ", txn_id: " << _txn_id << ", node: " << endpoint.host() << ":" << endpoint.port()
+                      << ", abort_reason: " << abort_reason << ", tablet_id: " << tablets_str;
+            continue;
+        });
+
         auto stub = ExecEnv::GetInstance()->brpc_stub_cache()->get_stub(endpoint.host(), endpoint.port());
         if (stub == nullptr) {
             auto msg =
@@ -1122,6 +1106,51 @@ void LocalTabletsChannel::update_profile() {
     }
 }
 
+void LocalTabletsChannel::get_load_replica_status(const std::string& remote_ip,
+                                                  const PLoadReplicaStatusRequest* request,
+                                                  PLoadReplicaStatusResult* response) {
+    std::shared_lock<bthreads::BThreadSharedMutex> lk(_rw_mtx);
+    for (int64_t tablet_id : request->tablet_ids()) {
+        LoadReplicaStatePB replica_state;
+        std::string message;
+        auto it = _delta_writers.find(tablet_id);
+        if (it == _delta_writers.end()) {
+            replica_state = LoadReplicaStatePB::NOT_PRESENT;
+            message = "can't find delta writer";
+        } else {
+            auto writer = it->second.get()->writer();
+            if (writer->replica_state() != Primary) {
+                // getting replica status from a none primary replica should not happen unless
+                // the secondary replica has some errors, so the secondary should fail
+                replica_state = LoadReplicaStatePB::FAILED;
+                message = fmt::format("not a primary replica, replica state is {}",
+                                      DeltaWriter::replica_state_name(writer->replica_state()));
+            } else {
+                auto writer_state = writer->get_state();
+                if (writer_state == kCommitted) {
+                    auto status = writer->replicate_token()->get_replica_status(request->node_id());
+                    if (status.ok()) {
+                        replica_state = LoadReplicaStatePB::SUCCESS;
+                    } else {
+                        replica_state = LoadReplicaStatePB::FAILED;
+                        message = "primary replica is committed, but replica failed, error: " + status.to_string();
+                    }
+                } else if (writer_state == kAborted) {
+                    replica_state = LoadReplicaStatePB::FAILED;
+                    message = "primary replica is aborted, error: " + writer->get_err_status().to_string();
+                } else {
+                    replica_state = LoadReplicaStatePB::IN_PROCESSING;
+                    message = fmt::format("primary replica state is {}", DeltaWriter::state_name(writer_state));
+                }
+            }
+        }
+        auto state = response->add_replica_statuses();
+        state->set_tablet_id(tablet_id);
+        state->set_state(replica_state);
+        state->set_message(message);
+    }
+}
+
 #define ADD_AND_SET_COUNTER(profile, name, type, val) (ADD_COUNTER(profile, name, type))->set(val)
 #define ADD_AND_UPDATE_COUNTER(profile, name, type, val) (ADD_COUNTER(profile, name, type))->update(val)
 #define ADD_AND_UPDATE_TIMER(profile, name, val) (ADD_TIMER(profile, name))->update(val)
@@ -1203,17 +1232,210 @@ void LocalTabletsChannel::_update_secondary_replica_profile(DeltaWriter* writer,
     ADD_AND_UPDATE_TIMER(profile, "FlushTaskExecuteTime", stat.execute_time_ns);
 }
 
-void LocalTabletsChannel::_diagnose_primary_replica_stack_trace(int64_t tablet_id, const PUniqueId& load_id,
-                                                                AsyncDeltaWriter* async_delta_writer) {
-    auto delta_writer = async_delta_writer->writer();
-    if (delta_writer->replica_state() != ReplicaState::Secondary || delta_writer->replicas().empty()) {
+std::shared_ptr<LocalTabletsChannel> new_local_tablets_channel(LoadChannel* load_channel, const TabletsChannelKey& key,
+                                                               MemTracker* mem_tracker,
+                                                               RuntimeProfile* parent_profile) {
+    return std::make_shared<LocalTabletsChannel>(load_channel, key, mem_tracker, parent_profile);
+}
+
+SecondaryReplicasWaiter::SecondaryReplicasWaiter(PUniqueId load_id, int64_t txn_id, int64_t sink_id, int64_t timeout_ms,
+                                                 int64_t eos_time_ms, std::vector<AsyncDeltaWriter*> delta_writers)
+        : _load_id(std::move(load_id)),
+          _txn_id(txn_id),
+          _sink_id(sink_id),
+          _timeout_ns(timeout_ms * NANOSECS_PER_MILLIS),
+          _delta_writers(std::move(delta_writers)),
+          _eos_time_ms(eos_time_ms),
+          _last_get_replica_status_time_ms(eos_time_ms) {}
+
+SecondaryReplicasWaiter::~SecondaryReplicasWaiter() {
+    _release_replica_status_closure();
+}
+
+Status SecondaryReplicasWaiter::wait() {
+    MonotonicStopWatch watch;
+    watch.start();
+    auto last_log_time = watch.elapsed_time();
+    for (int i = 0; i < _delta_writers.size(); i++) {
+        auto delta_writer = _delta_writers[i];
+        int64_t tablet_id = delta_writer->writer()->tablet()->tablet_id();
+        bool finished = false;
+        while (true) {
+            finished = is_delta_writer_finished(delta_writer);
+            if (finished) {
+                break;
+            }
+            bthread_usleep(10 * USECS_PER_MILLIS);
+            _try_check_replica_status_on_primary(i);
+            _try_diagnose_stack_strace_on_primary(i);
+            FAIL_POINT_TRIGGER_EXECUTE(tablets_channel_wait_secondary_replica_block, {
+                int32_t timeout_ms = config::load_fp_tablets_channel_wait_secondary_replica_block_ms;
+                if (timeout_ms > 0) {
+                    bthread_usleep(timeout_ms * USECS_PER_MILLIS);
+                }
+            });
+            if (watch.elapsed_time() > _timeout_ns) {
+                break;
+            }
+            if (watch.elapsed_time() - last_log_time > 60 * NANOSECS_PER_SEC) {
+                last_log_time = watch.elapsed_time();
+                LOG(WARNING) << "waiting secondary replicas too long, load_id: " << print_id(_load_id)
+                             << ", txn_id: " << _txn_id << ", timeout: " << _timeout_ns / NANOSECS_PER_MILLIS
+                             << " ms, elapsed time: " << watch.elapsed_time() / NANOSECS_PER_MILLIS
+                             << " ms, primary replica host: " << delta_writer->replicas()[0].host()
+                             << ", num finished tablets: " << i
+                             << ", num unfinished tablets: " << (_delta_writers.size() - i)
+                             << ", last unfinished tablet: [tablet_id: " << tablet_id << ", state "
+                             << delta_writer->get_state() << "]";
+            }
+        }
+        if (!finished) {
+            LOG(WARNING) << "wait secondary replicas timeout, load_id: " << print_id(_load_id)
+                         << ", txn_id: " << _txn_id << ", timeout: " << _timeout_ns / NANOSECS_PER_MILLIS
+                         << " ms, elapsed time: " << watch.elapsed_time() / NANOSECS_PER_MILLIS
+                         << " ms, primary replica host: " << delta_writer->replicas()[0].host()
+                         << ", num finished tablets: " << i
+                         << ", num unfinished tablets: " << (_delta_writers.size() - i)
+                         << ", last unfinished tablet: [tablet_id: " << tablet_id << ", state "
+                         << delta_writer->get_state() << "]";
+            return Status::TimedOut("wait secondary replicas timeout");
+        }
+    }
+    return Status::OK();
+}
+
+void SecondaryReplicasWaiter::_try_check_replica_status_on_primary(int unfinished_tablet_start_index) {
+    if (_replica_status_closure != nullptr) {
+        _process_replica_status_response(unfinished_tablet_start_index);
         return;
     }
+    int64_t check_interval_ms = _replica_status_fail_num > 0 ? config::load_replica_status_check_interval_ms_on_failure
+                                                             : config::load_replica_status_check_interval_ms_on_success;
+    if (MonotonicMillis() - _last_get_replica_status_time_ms <= check_interval_ms) {
+        return;
+    }
+    _send_replica_status_request(unfinished_tablet_start_index);
+}
+
+void SecondaryReplicasWaiter::_send_replica_status_request(int unfinished_tablet_start_index) {
+    auto delta_writer = _delta_writers[unfinished_tablet_start_index];
+    auto& primary_replica = delta_writer->writer()->replicas()[0];
+    auto stub = ExecEnv::GetInstance()->brpc_stub_cache()->get_stub(primary_replica.host(), primary_replica.port());
+    if (stub == nullptr) {
+        _replica_status_fail_num += 1;
+        _last_get_replica_status_time_ms = MonotonicMillis();
+        LOG(WARNING) << "failed to get stub for load replica status, txn_id: " << _txn_id
+                     << ", load_id: " << print_id(_load_id) << ", primary replica: [" << primary_replica.host() << ":"
+                     << primary_replica.port() << "]";
+        return;
+    }
+    _replica_status_closure = new ReusableClosure<PLoadReplicaStatusResult>();
+    _replica_status_closure->ref();
+    _replica_status_closure->cntl.set_timeout_ms(config::load_diagnose_send_rpc_timeout_ms);
+    SET_IGNORE_OVERCROWDED(_replica_status_closure->cntl, load);
+    PLoadReplicaStatusRequest request;
+    request.mutable_load_id()->set_hi(_load_id.hi());
+    request.mutable_load_id()->set_hi(_load_id.lo());
+    request.set_txn_id(_txn_id);
+    request.set_index_id(delta_writer->writer()->index_id());
+    request.set_sink_id(_sink_id);
+    int64_t node_id = delta_writer->writer()->node_id();
+    request.set_node_id(node_id);
+    for (int i = unfinished_tablet_start_index; i < _delta_writers.size(); i++) {
+        auto writer = _delta_writers[i];
+        if (!is_delta_writer_finished(writer)) {
+            request.add_tablet_ids(writer->writer()->tablet()->tablet_id());
+        }
+    }
+    int num_unfinished_tablets = request.tablet_ids_size();
+    _replica_status_closure->ref();
+#ifndef BE_TEST
+    stub->get_load_replica_status(&_replica_status_closure->cntl, &request, &_replica_status_closure->result,
+                                  _replica_status_closure);
+#else
+    std::pair<PLoadReplicaStatusRequest*, ReusableClosure<PLoadReplicaStatusResult>*> rpc_pair{&request,
+                                                                                               _replica_status_closure};
+    TEST_SYNC_POINT_CALLBACK("LocalTabletsChannel::rpc::get_load_replica_status", &rpc_pair);
+#endif
+    LOG(INFO) << "send request to get load replica status, txn_id: " << _txn_id << ", load_id: " << print_id(_load_id)
+              << ", primary replica: [" << primary_replica.host() << ":" << primary_replica.port()
+              << "], num unfinished tablets: " << num_unfinished_tablets;
+}
+
+void SecondaryReplicasWaiter::_process_replica_status_response(int unfinished_tablet_start_index) {
+    if (_replica_status_closure->count() != 1) {
+        return;
+    }
+    DeferOp defer([this]() {
+        _release_replica_status_closure();
+        _last_get_replica_status_time_ms = MonotonicMillis();
+    });
+    _replica_status_closure->join();
+    if (_replica_status_closure->cntl.Failed()) {
+        _replica_status_fail_num += 1;
+        auto writer = _delta_writers[unfinished_tablet_start_index];
+        auto& primary_replica = writer->writer()->replicas()[0];
+        if (_replica_status_fail_num >= 3) {
+            for (int i = unfinished_tablet_start_index; i < _delta_writers.size(); i++) {
+                auto delta_writer = _delta_writers[i];
+                if (!is_delta_writer_finished(delta_writer)) {
+                    delta_writer->cancel(Status::Cancelled("can't get status from primary, rpc error: " +
+                                                           _replica_status_closure->cntl.ErrorText()));
+                    delta_writer->abort(true);
+                }
+            }
+        }
+        LOG(WARNING) << "failed to get load replica status, txn_id: " << _txn_id << ", load_id: " << print_id(_load_id)
+                     << ", primary replica: [" << primary_replica.host() << ":" << primary_replica.port()
+                     << "], fail num: " << _replica_status_fail_num
+                     << ", error: " << _replica_status_closure->cntl.ErrorText();
+        return;
+    }
+
+    _replica_status_fail_num = 0;
+    std::map<int64_t, AsyncDeltaWriter*> writer_map;
+    for (int i = unfinished_tablet_start_index; i < _delta_writers.size(); i++) {
+        auto writer = _delta_writers[i];
+        writer_map.insert_or_assign(writer->writer()->tablet()->tablet_id(), writer);
+    }
+    PLoadReplicaStatusResult& result = _replica_status_closure->result;
+    for (auto& status : result.replica_statuses()) {
+        auto it = writer_map.find(status.tablet_id());
+        if (it == writer_map.end() || is_delta_writer_finished(it->second)) {
+            continue;
+        }
+        auto& writer = it->second;
+        if (status.state() == LoadReplicaStatePB::NOT_PRESENT || status.state() == LoadReplicaStatePB::FAILED) {
+            writer->cancel(Status::Cancelled(fmt::format("already failed on primary replica, status: {}, message: {}",
+                                                         LoadReplicaStatePB_Name(status.state()), status.message())));
+            writer->abort(true);
+        }
+    }
+}
+
+void SecondaryReplicasWaiter::_release_replica_status_closure() {
+    if (_replica_status_closure == nullptr) {
+        return;
+    }
+    _replica_status_closure->cancel();
+    if (_replica_status_closure->unref()) {
+        delete _replica_status_closure;
+    }
+    _replica_status_closure = nullptr;
+}
+
+void SecondaryReplicasWaiter::_try_diagnose_stack_strace_on_primary(int unfinished_tablet_start_index) {
+    if (_diagnose_triggered ||
+        (MonotonicMillis() - _eos_time_ms) < config::load_diagnose_rpc_timeout_stack_trace_threshold_ms) {
+        return;
+    }
+    _diagnose_triggered = true;
+    auto delta_writer = _delta_writers[unfinished_tablet_start_index];
     auto& primary_replica = delta_writer->replicas()[0];
     auto stub = ExecEnv::GetInstance()->brpc_stub_cache()->get_stub(primary_replica.host(), primary_replica.port());
     if (stub == nullptr) {
-        LOG(WARNING) << "failed to diagnose primary replica, txn_id: " << _txn_id << ", load_id: " << print_id(load_id)
-                     << ", tablet_id: " << tablet_id << ", primary_replica: [" << primary_replica.host() << ":"
+        LOG(WARNING) << "failed to get stub to diagnose primary replica, txn_id: " << _txn_id
+                     << ", load_id: " << print_id(_load_id) << ", primary_replica: [" << primary_replica.host() << ":"
                      << primary_replica.port() << "]";
         return;
     }
@@ -1221,8 +1443,8 @@ void LocalTabletsChannel::_diagnose_primary_replica_stack_trace(int64_t tablet_i
     closure->cntl.set_timeout_ms(config::load_diagnose_send_rpc_timeout_ms);
     SET_IGNORE_OVERCROWDED(closure->cntl, load);
     PLoadDiagnoseRequest request;
-    request.mutable_id()->set_hi(load_id.hi());
-    request.mutable_id()->set_hi(load_id.lo());
+    request.mutable_id()->set_hi(_load_id.hi());
+    request.mutable_id()->set_hi(_load_id.lo());
     request.set_txn_id(_txn_id);
     request.set_stack_trace(true);
     closure->ref();
@@ -1233,14 +1455,8 @@ void LocalTabletsChannel::_diagnose_primary_replica_stack_trace(int64_t tablet_i
     std::pair<PLoadDiagnoseRequest*, ReusableClosure<PLoadDiagnoseResult>*> rpc_pair{&request, closure};
     TEST_SYNC_POINT_CALLBACK("LocalTabletsChannel::rpc::load_diagnose_send", &rpc_pair);
 #endif
-    LOG(INFO) << "send request to diagnose primary replica, txn_id: " << _txn_id << ", load_id: " << print_id(load_id)
-              << ", tablet_id: " << tablet_id << ", primary_replica: [" << primary_replica.host() << ":"
-              << primary_replica.port() << "]";
-}
-
-std::shared_ptr<TabletsChannel> new_local_tablets_channel(LoadChannel* load_channel, const TabletsChannelKey& key,
-                                                          MemTracker* mem_tracker, RuntimeProfile* parent_profile) {
-    return std::make_shared<LocalTabletsChannel>(load_channel, key, mem_tracker, parent_profile);
+    LOG(INFO) << "send request to diagnose primary replica, txn_id: " << _txn_id << ", load_id: " << print_id(_load_id)
+              << ", primary_replica: [" << primary_replica.host() << ":" << primary_replica.port() << "]";
 }
 
 } // namespace starrocks

--- a/be/src/runtime/local_tablets_channel.h
+++ b/be/src/runtime/local_tablets_channel.h
@@ -72,12 +72,8 @@ public:
 
     MemTracker* mem_tracker() { return _mem_tracker; }
 
-    std::vector<AsyncDeltaWriter*> TEST_async_delta_writers() {
-        std::vector<AsyncDeltaWriter*> writers;
-        for (auto& [tablet_id, writer] : _delta_writers) {
-            writers.push_back(writer.get());
-        }
-        return writers;
+    const std::unordered_map<int64_t, std::unique_ptr<AsyncDeltaWriter>>& TEST_delta_writers() const {
+        return _delta_writers;
     }
 
 private:

--- a/be/src/runtime/local_tablets_channel.h
+++ b/be/src/runtime/local_tablets_channel.h
@@ -24,6 +24,7 @@
 #include "storage/async_delta_writer.h"
 #include "util/bthreads/bthread_shared_mutex.h"
 #include "util/countdown_latch.h"
+#include "util/reusable_closure.h"
 
 namespace brpc {
 class Controller;
@@ -66,7 +67,18 @@ public:
 
     void update_profile() override;
 
+    void get_load_replica_status(const std::string& remote_ip, const PLoadReplicaStatusRequest* request,
+                                 PLoadReplicaStatusResult* response);
+
     MemTracker* mem_tracker() { return _mem_tracker; }
+
+    std::vector<AsyncDeltaWriter*> TEST_async_delta_writers() {
+        std::vector<AsyncDeltaWriter*> writers;
+        for (auto& [tablet_id, writer] : _delta_writers) {
+            writers.push_back(writer.get());
+        }
+        return writers;
+    }
 
 private:
     using BThreadCountDownLatch = GenericCountDownLatch<bthread::Mutex, bthread::ConditionVariable>;
@@ -185,9 +197,6 @@ private:
     void _update_primary_replica_profile(DeltaWriter* writer, RuntimeProfile* profile);
     void _update_secondary_replica_profile(DeltaWriter* writer, RuntimeProfile* profile);
 
-    void _diagnose_primary_replica_stack_trace(int64_t tablet_id, const PUniqueId& load_id,
-                                               AsyncDeltaWriter* async_delta_writer);
-
     LoadChannel* _load_channel;
 
     TabletsChannelKey _key;
@@ -266,7 +275,33 @@ private:
     std::unique_ptr<RuntimeProfile> _tablets_profile;
 };
 
-std::shared_ptr<TabletsChannel> new_local_tablets_channel(LoadChannel* load_channel, const TabletsChannelKey& key,
-                                                          MemTracker* mem_tracker, RuntimeProfile* parent_profile);
+class SecondaryReplicasWaiter {
+public:
+    SecondaryReplicasWaiter(PUniqueId load_id, int64_t txn_id, int64_t sink_id, int64_t timeout_ms, int64_t eos_time_ms,
+                            std::vector<AsyncDeltaWriter*> delta_writers);
+    ~SecondaryReplicasWaiter();
+    Status wait();
+
+private:
+    void _try_check_replica_status_on_primary(int unfinished_tablet_start_index);
+    void _send_replica_status_request(int unfinished_tablet_start_index);
+    void _process_replica_status_response(int unfinished_tablet_start_index);
+    void _release_replica_status_closure();
+    void _try_diagnose_stack_strace_on_primary(int unfinished_tablet_start_index);
+
+    PUniqueId _load_id;
+    int64_t _txn_id;
+    int64_t _sink_id;
+    int64_t _timeout_ns;
+    std::vector<AsyncDeltaWriter*> _delta_writers;
+    int64_t _eos_time_ms;
+    int64_t _last_get_replica_status_time_ms;
+    int64_t _replica_status_fail_num{0};
+    ReusableClosure<PLoadReplicaStatusResult>* _replica_status_closure{nullptr};
+    bool _diagnose_triggered{false};
+};
+
+std::shared_ptr<LocalTabletsChannel> new_local_tablets_channel(LoadChannel* load_channel, const TabletsChannelKey& key,
+                                                               MemTracker* mem_tracker, RuntimeProfile* parent_profile);
 
 } // namespace starrocks

--- a/be/src/runtime/time_types.h
+++ b/be/src/runtime/time_types.h
@@ -80,6 +80,7 @@ static const int64_t USECS_PER_SEC = 1000000;
 static const int64_t USECS_PER_MILLIS = 1000;
 
 static const int64_t NANOSECS_PER_USEC = 1000;
+static const int64_t NANOSECS_PER_MILLIS = 1000000;
 static const int64_t NANOSECS_PER_SEC = 1000000000;
 
 // Corresponding to TimeUnit

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -422,6 +422,12 @@ void PInternalServiceImplBase<T>::tablet_writer_cancel(google::protobuf::RpcCont
                                                        google::protobuf::Closure* done) {}
 
 template <typename T>
+void PInternalServiceImplBase<T>::get_load_replica_status(google::protobuf::RpcController* controller,
+                                                          const PLoadReplicaStatusRequest* request,
+                                                          PLoadReplicaStatusResult* response,
+                                                          google::protobuf::Closure* done) {}
+
+template <typename T>
 void PInternalServiceImplBase<T>::load_diagnose(google::protobuf::RpcController* controller,
                                                 const PLoadDiagnoseRequest* request, PLoadDiagnoseResult* response,
                                                 google::protobuf::Closure* done) {}

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -124,6 +124,9 @@ public:
     void tablet_writer_cancel(google::protobuf::RpcController* controller, const PTabletWriterCancelRequest* request,
                               PTabletWriterCancelResult* response, google::protobuf::Closure* done) override;
 
+    void get_load_replica_status(google::protobuf::RpcController* controller, const PLoadReplicaStatusRequest* request,
+                                 PLoadReplicaStatusResult* response, google::protobuf::Closure* done) override;
+
     void load_diagnose(google::protobuf::RpcController* controller, const PLoadDiagnoseRequest* request,
                        PLoadDiagnoseResult* response, google::protobuf::Closure* done) override;
 

--- a/be/src/service/service_be/internal_service.cpp
+++ b/be/src/service/service_be/internal_service.cpp
@@ -202,6 +202,18 @@ void BackendInternalServiceImpl<T>::tablet_writer_cancel(google::protobuf::RpcCo
 }
 
 template <typename T>
+void BackendInternalServiceImpl<T>::get_load_replica_status(google::protobuf::RpcController* controller,
+                                                            const starrocks::PLoadReplicaStatusRequest* request,
+                                                            starrocks::PLoadReplicaStatusResult* response,
+                                                            google::protobuf::Closure* done) {
+    VLOG_RPC << "load replica status, load_id=" << print_id(request->load_id()) << ", txn_id=" << request->txn_id()
+             << ", index_id=" << request->index_id();
+    ;
+    PInternalServiceImplBase<T>::_exec_env->load_channel_mgr()->get_load_replica_status(
+            static_cast<brpc::Controller*>(controller), request, response, done);
+}
+
+template <typename T>
 void BackendInternalServiceImpl<T>::load_diagnose(google::protobuf::RpcController* controller,
                                                   const starrocks::PLoadDiagnoseRequest* request,
                                                   starrocks::PLoadDiagnoseResult* response,

--- a/be/src/service/service_be/internal_service.h
+++ b/be/src/service/service_be/internal_service.h
@@ -81,6 +81,9 @@ public:
     void tablet_writer_cancel(google::protobuf::RpcController* controller, const PTabletWriterCancelRequest* request,
                               PTabletWriterCancelResult* response, google::protobuf::Closure* done) override;
 
+    void get_load_replica_status(google::protobuf::RpcController* controller, const PLoadReplicaStatusRequest* request,
+                                 PLoadReplicaStatusResult* response, google::protobuf::Closure* done) override;
+
     void load_diagnose(google::protobuf::RpcController* controller, const PLoadDiagnoseRequest* request,
                        PLoadDiagnoseResult* response, google::protobuf::Closure* done) override;
 

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -369,7 +369,7 @@ Status DeltaWriter::_init() {
     _set_state(kWriting, Status::OK());
 
     VLOG(2) << "DeltaWriter [tablet_id=" << _opt.tablet_id << ", load_id=" << print_id(_opt.load_id)
-            << ", replica_state=" << _replica_state_name(_replica_state) << "] open success.";
+            << ", replica_state=" << replica_state_name(_replica_state) << "] open success.";
 
     // no need after initialization.
     _opt.ptable_schema_param = nullptr;
@@ -446,13 +446,13 @@ Status DeltaWriter::write(const Chunk& chunk, const uint32_t* indexes, uint32_t 
         // no error just in wrong state
         if (err_st.ok()) {
             err_st = Status::InternalError(
-                    fmt::format("Fail to prepare. tablet_id: {}, state: {}", _opt.tablet_id, _state_name(state)));
+                    fmt::format("Fail to prepare. tablet_id: {}, state: {}", _opt.tablet_id, state_name(state)));
         }
         return err_st;
     }
     if (_replica_state == Secondary) {
         return Status::InternalError(fmt::format("Fail to write chunk, tablet_id: {}, replica_state: {}",
-                                                 _opt.tablet_id, _replica_state_name(_replica_state)));
+                                                 _opt.tablet_id, replica_state_name(_replica_state)));
     }
 
     if (_tablet->keys_type() == KeysType::PRIMARY_KEYS && !_mem_table->check_supported_column_partial_update(chunk)) {
@@ -489,14 +489,14 @@ Status DeltaWriter::write_segment(const SegmentPB& segment_pb, butil::IOBuf& dat
         // no error just in wrong state
         if (err_st.ok()) {
             err_st = Status::InternalError(
-                    fmt::format("Fail to write segment. tablet_id: {}, state: {}", _opt.tablet_id, _state_name(state)));
+                    fmt::format("Fail to write segment. tablet_id: {}, state: {}", _opt.tablet_id, state_name(state)));
         }
         return err_st;
     }
     if (_replica_state != Secondary) {
         return Status::InternalError(fmt::format("Fail to write segment: {}, tablet_id: {}, replica_state: {}",
                                                  segment_pb.segment_id(), _opt.tablet_id,
-                                                 _replica_state_name(_replica_state)));
+                                                 replica_state_name(_replica_state)));
     }
 
     _tablet->add_in_writing_data_size(_opt.txn_id, segment_pb.data_size());
@@ -539,8 +539,8 @@ Status DeltaWriter::close() {
     }
         // no error just in wrong state
     case kCommitted:
-        return Status::InternalError(fmt::format("Fail to close delta writer. tablet_id: {}, state: {}", _opt.tablet_id,
-                                                 _state_name(state)));
+        return Status::InternalError(
+                fmt::format("Fail to close delta writer. tablet_id: {}, state: {}", _opt.tablet_id, state_name(state)));
     case kClosed:
         return Status::OK();
     case kWriting:
@@ -722,7 +722,7 @@ Status DeltaWriter::commit() {
         // no error just in wrong state
     case kWriting:
         return Status::InternalError(fmt::format("Fail to commit delta writer. tablet_id: {}, state: {}",
-                                                 _opt.tablet_id, _state_name(state)));
+                                                 _opt.tablet_id, state_name(state)));
     case kCommitted:
         return Status::OK();
     case kClosed:
@@ -785,7 +785,7 @@ Status DeltaWriter::commit() {
             _state = kCommitted;
         } else {
             return Status::InternalError(fmt::format("Delta writer has been aborted. tablet_id: {}, state: {}",
-                                                     _opt.tablet_id, _state_name(_state)));
+                                                     _opt.tablet_id, state_name(_state)));
         }
     }
     VLOG(2) << "Closed delta writer. tablet_id: " << _tablet->tablet_id() << ", stats: " << _flush_token->get_stats();
@@ -841,7 +841,7 @@ int64_t DeltaWriter::partition_id() const {
     return _opt.partition_id;
 }
 
-const char* DeltaWriter::_state_name(State state) const {
+const char* DeltaWriter::state_name(State state) {
     switch (state) {
     case kUninitialized:
         return "kUninitialized";
@@ -857,7 +857,7 @@ const char* DeltaWriter::_state_name(State state) const {
     return "";
 }
 
-const char* DeltaWriter::_replica_state_name(ReplicaState state) const {
+const char* DeltaWriter::replica_state_name(ReplicaState state) {
     switch (state) {
     case Primary:
         return "Primary Replica";

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -233,6 +233,9 @@ public:
                                                          const std::vector<ColumnId>& sort_key_idxes,
                                                          size_t num_key_columns);
 
+    static const char* state_name(State state);
+    static const char* replica_state_name(ReplicaState state);
+
 private:
     DeltaWriter(DeltaWriterOptions opt, MemTracker* parent, StorageEngine* storage_engine);
 
@@ -241,7 +244,6 @@ private:
     Status _build_current_tablet_schema(int64_t index_id, const POlapTableSchemaParam* table_schema_param,
                                         const TabletSchemaCSPtr& ori_tablet_schema);
 
-    const char* _state_name(State state) const;
     const char* _replica_state_name(ReplicaState state) const;
     Status _fill_auto_increment_id(const Chunk& chunk);
     Status _check_partial_update_with_sort_key(const Chunk& chunk);

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -244,7 +244,6 @@ private:
     Status _build_current_tablet_schema(int64_t index_id, const POlapTableSchemaParam* table_schema_param,
                                         const TabletSchemaCSPtr& ori_tablet_schema);
 
-    const char* _replica_state_name(ReplicaState state) const;
     Status _fill_auto_increment_id(const Chunk& chunk);
     Status _check_partial_update_with_sort_key(const Chunk& chunk);
 

--- a/be/src/storage/segment_replicate_executor.cpp
+++ b/be/src/storage/segment_replicate_executor.cpp
@@ -108,14 +108,17 @@ Status ReplicateChannel::_init() {
 Status ReplicateChannel::async_segment(SegmentPB* segment, butil::IOBuf& data, bool eos,
                                        std::vector<std::unique_ptr<PTabletInfo>>* replicate_tablet_infos,
                                        std::vector<std::unique_ptr<PTabletInfo>>* failed_tablet_infos) {
-    RETURN_IF_ERROR(_st);
+    RETURN_IF_ERROR(get_status());
 
     VLOG(2) << "Async tablet " << _opt->tablet_id << " segment id " << (segment == nullptr ? -1 : segment->segment_id())
             << " eos " << eos << " to [" << _host << ":" << _port;
 
     // 1. init sync channel
-    _st = _init();
-    RETURN_IF_ERROR(_st);
+    Status status = _init();
+    if (!status.ok()) {
+        _set_status(status);
+        return status;
+    }
 
     // 2. wait pre request's result
     RETURN_IF_ERROR(_wait_response(replicate_tablet_infos, failed_tablet_infos));
@@ -132,7 +135,7 @@ Status ReplicateChannel::async_segment(SegmentPB* segment, butil::IOBuf& data, b
             << (segment == nullptr ? -1 : segment->segment_id()) << " eos " << eos << " to [" << _host << ":" << _port
             << "] res " << _closure->result.DebugString();
 
-    return _st;
+    return get_status();
 }
 
 void ReplicateChannel::_send_request(SegmentPB* segment, butil::IOBuf& data, bool eos) {
@@ -173,16 +176,19 @@ void ReplicateChannel::_send_request(SegmentPB* segment, butil::IOBuf& data, boo
 Status ReplicateChannel::_wait_response(std::vector<std::unique_ptr<PTabletInfo>>* replicate_tablet_infos,
                                         std::vector<std::unique_ptr<PTabletInfo>>* failed_tablet_infos) {
     if (_closure->join()) {
+        Status status;
         _mem_tracker->release_without_root(_closure->request_size);
         if (_closure->cntl.Failed()) {
-            _st = Status::InternalError(_closure->cntl.ErrorText());
-            LOG(WARNING) << "Failed to send rpc to " << debug_string() << " err=" << _st;
-            return _st;
+            status = Status::InternalError(_closure->cntl.ErrorText());
+            LOG(WARNING) << "Failed to send rpc to " << debug_string() << " err=" << status;
+            _set_status(status);
+            return status;
         }
-        _st = _closure->result.status();
+        status = _closure->result.status();
         if (!_st.ok()) {
-            LOG(WARNING) << "Failed to send rpc to " << debug_string() << " err=" << _st;
-            return _st;
+            LOG(WARNING) << "Failed to send rpc to " << debug_string() << " err=" << status;
+            _set_status(status);
+            return status;
         }
 
         for (size_t i = 0; i < _closure->result.tablet_vec_size(); ++i) {
@@ -199,23 +205,21 @@ Status ReplicateChannel::_wait_response(std::vector<std::unique_ptr<PTabletInfo>
     return Status::OK();
 }
 
-void ReplicateChannel::cancel() {
-    if (!_init().ok()) {
-        return;
-    }
-
+void ReplicateChannel::cancel(const Status& status) {
     // cancel rpc request, accelerate the release of related resources
     // Cancel an already-cancelled call_id has no effect.
     _closure->cancel();
+    _set_status(status);
 }
 
 ReplicateToken::ReplicateToken(std::unique_ptr<ThreadPoolToken> replicate_pool_token, const DeltaWriterOptions* opt)
         : _replicate_token(std::move(replicate_pool_token)), _status(), _opt(opt), _fs(new_fs_posix()) {
     // first replica is primary replica, skip it
     for (size_t i = 1; i < opt->replicas.size(); ++i) {
-        _replicate_channels.emplace_back(std::make_unique<ReplicateChannel>(
-                opt, opt->replicas[i].host(), opt->replicas[i].port(), opt->replicas[i].node_id()));
-        _replica_node_ids.emplace_back(opt->replicas[i].node_id());
+        auto node_id = opt->replicas[i].node_id();
+        _replicate_channels.emplace(node_id, std::make_unique<ReplicateChannel>(opt, opt->replicas[i].host(),
+                                                                                opt->replicas[i].port(), node_id));
+        _replica_node_ids.emplace_back(node_id);
     }
     if (opt->write_quorum == WriteQuorumTypePB::ONE) {
         _max_fail_replica_num = opt->replicas.size();
@@ -253,6 +257,14 @@ Status ReplicateToken::wait() {
     return _status;
 }
 
+Status ReplicateToken::get_replica_status(int64_t node_id) const {
+    auto channel = _replicate_channels.find(node_id);
+    if (channel == _replicate_channels.end()) {
+        return Status::NotFound("replica node id not found");
+    }
+    return channel->second->get_status();
+}
+
 std::string ReplicateToken::debug_string() {
     return fmt::format("[ReplicateToken tablet_id: {}, txn_id: {}]", _opt->tablet_id, _opt->txn_id);
 }
@@ -274,7 +286,7 @@ void ReplicateToken::_sync_segment(std::unique_ptr<SegmentPB> segment, bool eos)
             }
             auto rfile = std::move(res.value());
             auto buf = new uint8[segment->data_size()];
-            data.append_user_data(buf, segment->data_size(), [](void* buf) { delete[](uint8*) buf; });
+            data.append_user_data(buf, segment->data_size(), [](void* buf) { delete[] (uint8*)buf; });
             auto st = rfile->read_fully(buf, segment->data_size());
             if (!st.ok()) {
                 LOG(WARNING) << "Failed to read segment " << segment->DebugString() << " by " << debug_string()
@@ -291,7 +303,7 @@ void ReplicateToken::_sync_segment(std::unique_ptr<SegmentPB> segment, bool eos)
             }
             auto rfile = std::move(res.value());
             auto buf = new uint8[segment->delete_data_size()];
-            data.append_user_data(buf, segment->delete_data_size(), [](void* buf) { delete[](uint8*) buf; });
+            data.append_user_data(buf, segment->delete_data_size(), [](void* buf) { delete[] (uint8*)buf; });
             auto st = rfile->read_fully(buf, segment->delete_data_size());
             if (!st.ok()) {
                 LOG(WARNING) << "Failed to read delete file " << segment->DebugString() << " by " << debug_string()
@@ -308,7 +320,7 @@ void ReplicateToken::_sync_segment(std::unique_ptr<SegmentPB> segment, bool eos)
             }
             auto rfile = std::move(res.value());
             auto buf = new uint8[segment->update_data_size()];
-            data.append_user_data(buf, segment->update_data_size(), [](void* buf) { delete[](uint8*) buf; });
+            data.append_user_data(buf, segment->update_data_size(), [](void* buf) { delete[] (uint8*)buf; });
             auto st = rfile->read_fully(buf, segment->update_data_size());
             if (!st.ok()) {
                 LOG(WARNING) << "Failed to read delete file " << segment->DebugString() << " by " << debug_string()
@@ -342,7 +354,7 @@ void ReplicateToken::_sync_segment(std::unique_ptr<SegmentPB> segment, bool eos)
 
                     auto rfile = std::move(res.value());
                     auto buf = new uint8[file_size];
-                    data.append_user_data(buf, file_size, [](void* buf) { delete[](uint8*) buf; });
+                    data.append_user_data(buf, file_size, [](void* buf) { delete[] (uint8*)buf; });
                     auto st = rfile->read_fully(buf, file_size);
                     if (!st.ok()) {
                         LOG(WARNING) << "Failed to read index file " << segment->DebugString() << " by "
@@ -356,13 +368,13 @@ void ReplicateToken::_sync_segment(std::unique_ptr<SegmentPB> segment, bool eos)
     }
 
     // 2. send segment to secondary replica
-    for (auto& channel : _replicate_channels) {
+    for (const auto& [_, channel] : _replicate_channels) {
         auto st = Status::OK();
         if (_failed_node_id.count(channel->node_id()) == 0) {
             st = channel->async_segment(segment.get(), data, eos, &_replicated_tablet_infos, &_failed_tablet_infos);
             if (!st.ok()) {
                 LOG(WARNING) << "Failed to sync segment " << channel->debug_string() << " err " << st;
-                channel->cancel();
+                channel->cancel(st);
                 _failed_node_id.insert(channel->node_id());
             }
         }
@@ -370,9 +382,9 @@ void ReplicateToken::_sync_segment(std::unique_ptr<SegmentPB> segment, bool eos)
         if (_failed_node_id.size() > _max_fail_replica_num) {
             LOG(WARNING) << "Failed to sync segment err " << st << " by " << debug_string() << " fail_num "
                          << _failed_node_id.size() << " max_fail_num " << _max_fail_replica_num;
-            for (auto& channel : _replicate_channels) {
+            for (const auto& [_, channel] : _replicate_channels) {
                 if (_failed_node_id.count(channel->node_id()) == 0) {
-                    channel->cancel();
+                    channel->cancel(Status::InternalError("failed replica num exceed max fail num"));
                 }
             }
             return set_status(st);

--- a/be/src/storage/segment_replicate_executor.cpp
+++ b/be/src/storage/segment_replicate_executor.cpp
@@ -286,7 +286,7 @@ void ReplicateToken::_sync_segment(std::unique_ptr<SegmentPB> segment, bool eos)
             }
             auto rfile = std::move(res.value());
             auto buf = new uint8[segment->data_size()];
-            data.append_user_data(buf, segment->data_size(), [](void* buf) { delete[] (uint8*)buf; });
+            data.append_user_data(buf, segment->data_size(), [](void* buf) { delete[](uint8*) buf; });
             auto st = rfile->read_fully(buf, segment->data_size());
             if (!st.ok()) {
                 LOG(WARNING) << "Failed to read segment " << segment->DebugString() << " by " << debug_string()
@@ -303,7 +303,7 @@ void ReplicateToken::_sync_segment(std::unique_ptr<SegmentPB> segment, bool eos)
             }
             auto rfile = std::move(res.value());
             auto buf = new uint8[segment->delete_data_size()];
-            data.append_user_data(buf, segment->delete_data_size(), [](void* buf) { delete[] (uint8*)buf; });
+            data.append_user_data(buf, segment->delete_data_size(), [](void* buf) { delete[](uint8*) buf; });
             auto st = rfile->read_fully(buf, segment->delete_data_size());
             if (!st.ok()) {
                 LOG(WARNING) << "Failed to read delete file " << segment->DebugString() << " by " << debug_string()
@@ -320,7 +320,7 @@ void ReplicateToken::_sync_segment(std::unique_ptr<SegmentPB> segment, bool eos)
             }
             auto rfile = std::move(res.value());
             auto buf = new uint8[segment->update_data_size()];
-            data.append_user_data(buf, segment->update_data_size(), [](void* buf) { delete[] (uint8*)buf; });
+            data.append_user_data(buf, segment->update_data_size(), [](void* buf) { delete[](uint8*) buf; });
             auto st = rfile->read_fully(buf, segment->update_data_size());
             if (!st.ok()) {
                 LOG(WARNING) << "Failed to read delete file " << segment->DebugString() << " by " << debug_string()
@@ -354,7 +354,7 @@ void ReplicateToken::_sync_segment(std::unique_ptr<SegmentPB> segment, bool eos)
 
                     auto rfile = std::move(res.value());
                     auto buf = new uint8[file_size];
-                    data.append_user_data(buf, file_size, [](void* buf) { delete[] (uint8*)buf; });
+                    data.append_user_data(buf, file_size, [](void* buf) { delete[](uint8*) buf; });
                     auto st = rfile->read_fully(buf, file_size);
                     if (!st.ok()) {
                         LOG(WARNING) << "Failed to read index file " << segment->DebugString() << " by "

--- a/be/src/storage/segment_replicate_executor.cpp
+++ b/be/src/storage/segment_replicate_executor.cpp
@@ -185,7 +185,7 @@ Status ReplicateChannel::_wait_response(std::vector<std::unique_ptr<PTabletInfo>
             return status;
         }
         status = _closure->result.status();
-        if (!_st.ok()) {
+        if (!status.ok()) {
             LOG(WARNING) << "Failed to send rpc to " << debug_string() << " err=" << status;
             _set_status(status);
             return status;

--- a/be/src/storage/segment_replicate_executor.h
+++ b/be/src/storage/segment_replicate_executor.h
@@ -45,17 +45,27 @@ public:
                          std::vector<std::unique_ptr<PTabletInfo>>* replicate_tablet_infos,
                          std::vector<std::unique_ptr<PTabletInfo>>* failed_tablet_infos);
 
-    void cancel();
+    void cancel(const Status& status);
 
     int64_t node_id() { return _node_id; }
 
     std::string debug_string();
+
+    Status get_status() {
+        std::lock_guard l(_status_lock);
+        return _st;
+    }
 
 private:
     Status _init();
     void _send_request(SegmentPB* segment, butil::IOBuf& data, bool eos);
     Status _wait_response(std::vector<std::unique_ptr<PTabletInfo>>* replicate_tablet_infos,
                           std::vector<std::unique_ptr<PTabletInfo>>* failed_tablet_infos);
+
+    void _set_status(const Status& status) {
+        std::lock_guard l(_status_lock);
+        if (_st.ok()) _st = status;
+    }
 
     std::unique_ptr<MemTracker> _mem_tracker;
 
@@ -68,6 +78,8 @@ private:
     std::shared_ptr<PInternalService_RecoverableStub> _stub;
 
     bool _inited = false;
+
+    mutable SpinLock _status_lock;
     Status _st = Status::OK();
 };
 
@@ -106,6 +118,8 @@ public:
         if (_status.ok()) _status = status;
     }
 
+    Status get_replica_status(int64_t node_id) const;
+
     std::string debug_string();
 
     const std::vector<std::unique_ptr<PTabletInfo>>* replicated_tablet_infos() const {
@@ -133,7 +147,8 @@ private:
 
     const DeltaWriterOptions* _opt;
 
-    std::vector<std::unique_ptr<ReplicateChannel>> _replicate_channels;
+    // node id -> channel
+    std::map<int64_t, std::unique_ptr<ReplicateChannel>> _replicate_channels;
 
     std::vector<std::unique_ptr<PTabletInfo>> _replicated_tablet_infos;
     std::vector<std::unique_ptr<PTabletInfo>> _failed_tablet_infos;

--- a/be/src/storage/segment_replicate_executor.h
+++ b/be/src/storage/segment_replicate_executor.h
@@ -148,7 +148,7 @@ private:
     const DeltaWriterOptions* _opt;
 
     // node id -> channel
-    std::map<int64_t, std::unique_ptr<ReplicateChannel>> _replicate_channels;
+    std::unordered_map<int64_t, std::unique_ptr<ReplicateChannel>> _replicate_channels;
 
     std::vector<std::unique_ptr<PTabletInfo>> _replicated_tablet_infos;
     std::vector<std::unique_ptr<PTabletInfo>> _failed_tablet_infos;

--- a/be/src/util/internal_service_recoverable_stub.cpp
+++ b/be/src/util/internal_service_recoverable_stub.cpp
@@ -138,6 +138,14 @@ void PInternalService_RecoverableStub::tablet_writer_add_segment(
     _stub->tablet_writer_add_segment(controller, request, response, closure);
 }
 
+void PInternalService_RecoverableStub::get_load_replica_status(google::protobuf::RpcController* controller,
+                                                               const PLoadReplicaStatusRequest* request,
+                                                               PLoadReplicaStatusResult* response,
+                                                               google::protobuf::Closure* done) {
+    auto closure = new RecoverableClosure(shared_from_this(), controller, done);
+    _stub->get_load_replica_status(controller, request, response, closure);
+}
+
 void PInternalService_RecoverableStub::load_diagnose(::google::protobuf::RpcController* controller,
                                                      const ::starrocks::PLoadDiagnoseRequest* request,
                                                      ::starrocks::PLoadDiagnoseResult* response,

--- a/be/src/util/internal_service_recoverable_stub.h
+++ b/be/src/util/internal_service_recoverable_stub.h
@@ -67,6 +67,8 @@ public:
                                    const ::starrocks::PTabletWriterAddSegmentRequest* request,
                                    ::starrocks::PTabletWriterAddSegmentResult* response,
                                    ::google::protobuf::Closure* done);
+    void get_load_replica_status(google::protobuf::RpcController* controller, const PLoadReplicaStatusRequest* request,
+                                 PLoadReplicaStatusResult* response, google::protobuf::Closure* done) override;
     void load_diagnose(::google::protobuf::RpcController* controller, const ::starrocks::PLoadDiagnoseRequest* request,
                        ::starrocks::PLoadDiagnoseResult* response, ::google::protobuf::Closure* done) override;
     void transmit_runtime_filter(::google::protobuf::RpcController* controller,

--- a/be/test/runtime/local_tablets_channel_test.cpp
+++ b/be/test/runtime/local_tablets_channel_test.cpp
@@ -76,9 +76,14 @@ protected:
         _tablets_channel.reset();
         _load_channel.reset();
         if (_tablet) {
-            _tablet.reset();
-            auto st = StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet_id);
+            auto st = StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet->tablet_id());
             ASSERT_OK(st);
+            _tablet.reset();
+        }
+        for (auto& tablet : _tablets) {
+            auto st = StorageEngine::instance()->tablet_manager()->drop_tablet(tablet->tablet_id());
+            ASSERT_OK(st);
+            tablet.reset();
         }
     }
 
@@ -171,6 +176,69 @@ protected:
         return request;
     }
 
+    struct TabletReplicas {
+        int64_t tablet_id;
+        ReplicaState replica_state;
+        std::vector<PNetworkAddress> nodes;
+    };
+
+    PTabletWriterOpenRequest _create_open_request(int64_t node_id, std::vector<TabletReplicas> tablet_vec) {
+        PTabletWriterOpenRequest request;
+        request.mutable_id()->CopyFrom(_load_id);
+        request.set_index_id(_index_id);
+        request.set_txn_id(_txn_id);
+        request.set_is_lake_tablet(false);
+        request.set_is_replicated_storage(true);
+        request.set_node_id(node_id);
+        request.set_sink_id(0);
+        request.set_write_quorum(WriteQuorumTypePB::ONE);
+        request.set_miss_auto_increment_column(false);
+        request.set_table_id(_table_id);
+        request.set_is_incremental(false);
+        request.set_num_senders(1);
+        request.set_sender_id(0);
+        request.set_need_gen_rollup(false);
+        request.set_load_channel_timeout_s(10);
+        request.set_is_vectorized(true);
+        request.set_timeout_ms(10000);
+        request.set_immutable_tablet_size(0);
+        for (auto& tablet_replicas : tablet_vec) {
+            auto tablet = request.add_tablets();
+            tablet->set_partition_id(_partition_id);
+            tablet->set_tablet_id(tablet_replicas.tablet_id);
+            for (auto& node : tablet_replicas.nodes) {
+                auto replica = tablet->add_replicas();
+                replica->CopyFrom(node);
+            }
+        }
+
+        auto schema = request.mutable_schema();
+        schema->set_db_id(_db_id);
+        schema->set_table_id(_table_id);
+        schema->set_version(1);
+        auto index = schema->add_indexes();
+        index->set_id(_index_id);
+        index->set_schema_hash(0);
+        for (int i = 0, sz = _tablet->tablet_schema()->num_columns(); i < sz; i++) {
+            auto slot = request.mutable_schema()->add_slot_descs();
+            auto& column = _tablet->tablet_schema()->column(i);
+            slot->set_id(i);
+            slot->set_byte_offset(i * sizeof(int) /*unused*/);
+            slot->set_col_name(std::string(column.name()));
+            slot->set_slot_idx(i);
+            slot->set_is_materialized(true);
+            slot->mutable_slot_type()->add_types()->mutable_scalar_type()->set_type(column.type());
+            index->add_columns(std::string(column.name()));
+        }
+        auto tuple_desc = schema->mutable_tuple_desc();
+        tuple_desc->set_id(1);
+        tuple_desc->set_byte_size(8 /*unused*/);
+        tuple_desc->set_num_null_bytes(0 /*unused*/);
+        tuple_desc->set_table_id(_table_id);
+
+        return request;
+    }
+
     Chunk generate_data(int64_t chunk_size) {
         std::vector<int> v0(chunk_size);
         std::vector<int> v1(chunk_size);
@@ -200,9 +268,10 @@ protected:
     std::unique_ptr<RuntimeProfile> _root_profile;
     std::unique_ptr<LoadChannelMgr> _load_channel_mgr;
     std::shared_ptr<LoadChannel> _load_channel;
-    std::shared_ptr<TabletsChannel> _tablets_channel;
+    std::shared_ptr<LocalTabletsChannel> _tablets_channel;
 
     TabletSharedPtr _tablet;
+    std::vector<TabletSharedPtr> _tablets;
     std::shared_ptr<Schema> _schema;
     std::shared_ptr<OlapTableSchemaParam> _schema_param;
 
@@ -421,6 +490,87 @@ TEST_F(LocalTabletsChannelTest, test_cancel_secondary_replica_rpc_fail) {
             << add_chunk_response.status().error_msgs(0);
     ASSERT_TRUE(close_channel);
     ASSERT_EQ(1, num_cancel);
+}
+
+using RpcReplicaStatusPair = std::pair<PLoadReplicaStatusRequest*, ReusableClosure<PLoadReplicaStatusResult>*>;
+
+TEST_F(LocalTabletsChannelTest, test_secondary_replicas_waiter) {
+    std::vector<TabletReplicas> tablet_vec;
+    for (int i = 0; i < 3; i++) {
+        TabletReplicas tablet_replicas;
+        tablet_replicas.tablet_id = rand();
+        for (int j = 0; j < 3; j++) {
+            PNetworkAddress node;
+            node.set_node_id(j);
+            node.set_host(fmt::format("127.0.0.{}", j));
+            tablet_replicas.nodes.push_back(node);
+        }
+        tablet_vec.push_back(tablet_replicas);
+    }
+
+    for (auto& tablet_replicas : tablet_vec) {
+        auto tablet = create_tablet(tablet_replicas.tablet_id, rand());
+        _tablets.push_back(tablet);
+    }
+
+    PTabletWriterOpenRequest open_request = _create_open_request(1, tablet_vec);
+    PTabletWriterOpenResult open_result;
+    ASSERT_OK(_tablets_channel->open(open_request, &open_result, _schema_param, false));
+
+    auto old_check_interval_on_success = config::load_replica_status_check_interval_ms_on_success;
+    auto old_check_interval_on_failure = config::load_replica_status_check_interval_ms_on_failure;
+    DeferOp defer([&] {
+        SyncPoint::GetInstance()->DisableProcessing();
+        SyncPoint::GetInstance()->ClearCallBack("LocalTabletsChannel::rpc::get_load_replica_status");
+        config::load_replica_status_check_interval_ms_on_success = old_check_interval_on_success;
+        config::load_replica_status_check_interval_ms_on_failure = old_check_interval_on_failure;
+    });
+
+    config::load_replica_status_check_interval_ms_on_success = 100;
+    config::load_replica_status_check_interval_ms_on_failure = 50;
+    int num_get_replica_status = 0;
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("LocalTabletsChannel::rpc::get_load_replica_status", [&](void* arg) {
+        RpcReplicaStatusPair* rpc_pair = (RpcReplicaStatusPair*)arg;
+        PLoadReplicaStatusRequest* request = (PLoadReplicaStatusRequest*)rpc_pair->first;
+        ReusableClosure<PLoadReplicaStatusResult>* result =
+                (ReusableClosure<PLoadReplicaStatusResult>*)rpc_pair->second;
+        EXPECT_EQ(print_id(_load_id), print_id(request->load_id()));
+        EXPECT_EQ(_txn_id, request->txn_id());
+        EXPECT_EQ(_index_id, request->index_id());
+        EXPECT_EQ(1, request->node_id());
+        EXPECT_EQ(0, request->sink_id());
+        if (num_get_replica_status < 2) {
+            EXPECT_EQ(3 - num_get_replica_status, request->tablet_ids().size());
+        }
+        num_get_replica_status += 1;
+    });
+
+    auto t = std::thread([&]() {
+        PTabletWriterAddChunkRequest add_chunk_request;
+        add_chunk_request.mutable_id()->CopyFrom(_load_id);
+        add_chunk_request.set_index_id(_index_id);
+        add_chunk_request.set_sender_id(0);
+        add_chunk_request.set_txn_id(_txn_id);
+        add_chunk_request.set_sink_id(0);
+        add_chunk_request.set_eos(true);
+        add_chunk_request.set_packet_seq(0);
+        add_chunk_request.set_wait_all_sender_close(true);
+        add_chunk_request.set_timeout_ms(3600000);
+
+        bool close_channel;
+        PTabletWriterAddBatchResult add_chunk_response;
+        _tablets_channel->add_chunk(nullptr, add_chunk_request, &add_chunk_response, &close_channel);
+        EXPECT_TRUE(close_channel);
+    });
+
+    std::vector<AsyncDeltaWriter*> writers = _tablets_channel->TEST_async_delta_writers();
+    ASSERT_EQ(3, writers.size());
+    for (auto& writer : writers) {
+        writer->cancel(Status::Cancelled("artificial failure"));
+    }
+
+    t.join();
 }
 
 } // namespace starrocks

--- a/be/test/runtime/local_tablets_channel_test.cpp
+++ b/be/test/runtime/local_tablets_channel_test.cpp
@@ -38,13 +38,20 @@
 
 namespace starrocks {
 
+class SecondaryReplicasWaiterTestCase;
+
 class LocalTabletsChannelTest : public testing::Test {
 protected:
     void SetUp() override {
         srand(GetCurrentTimeMicros());
 
-        _primary_node_id = 100;
-        _secondary_node_id = 101;
+        for (int i = 0; i < 3; i++) {
+            PNetworkAddress node;
+            node.set_node_id(i);
+            node.set_host(fmt::format("127.0.0.{}", i));
+            node.set_port(8060);
+            _nodes.push_back(node);
+        }
         _load_id.set_hi(456789);
         _load_id.set_lo(987654);
         _txn_id = 10000;
@@ -52,9 +59,7 @@ protected:
         _table_id = 101;
         _partition_id = 10;
         _index_id = 1;
-        _tablet_id = rand();
-        _tablet = create_tablet(_tablet_id, rand());
-        _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet->tablet_schema()));
+        _sink_id = 1;
 
         _mem_tracker = std::make_unique<MemTracker>(1024 * 1024);
         _root_profile = std::make_unique<RuntimeProfile>("LoadChannel");
@@ -62,24 +67,13 @@ protected:
         auto load_mem_tracker = std::make_unique<MemTracker>(-1, "", _mem_tracker.get());
         _load_channel = std::make_shared<LoadChannel>(_load_channel_mgr.get(), nullptr, _load_id, _txn_id, string(),
                                                       1000, std::move(load_mem_tracker));
-        _open_single_replica_request = _create_open_request(ReplicaState::Primary, true);
-        _open_primary_request = _create_open_request(ReplicaState::Primary, false);
-        _open_secondary_request = _create_open_request(ReplicaState::Secondary, false);
-        TabletsChannelKey key{_load_id, 0, _index_id};
-        _schema_param.reset(new OlapTableSchemaParam());
-        ASSERT_OK(_schema_param->init(_open_single_replica_request.schema()));
-        _tablets_channel =
-                new_local_tablets_channel(_load_channel.get(), key, _load_channel->mem_tracker(), _root_profile.get());
+        _tablets_channel = new_local_tablets_channel(_load_channel.get(), {_load_id, _sink_id, _index_id},
+                                                     _load_channel->mem_tracker(), _root_profile.get());
     }
 
     void TearDown() override {
         _tablets_channel.reset();
         _load_channel.reset();
-        if (_tablet) {
-            auto st = StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet->tablet_id());
-            ASSERT_OK(st);
-            _tablet.reset();
-        }
         for (auto& tablet : _tablets) {
             auto st = StorageEngine::instance()->tablet_manager()->drop_tablet(tablet->tablet_id());
             ASSERT_OK(st);
@@ -88,8 +82,39 @@ protected:
     }
 
     void test_cancel_secondary_replica_base(bool is_empty_tablet);
+    void test_secondary_replicas_waiter_base(SecondaryReplicasWaiterTestCase& test_case);
 
-    TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash) {
+    struct ReplicaInfo {
+        int64_t tablet_id;
+        std::vector<PNetworkAddress> nodes;
+    };
+
+    void _open_channel(int64_t node_id, std::vector<ReplicaInfo> replica_infos) {
+        PTabletWriterOpenRequest request;
+        _create_open_request(node_id, replica_infos, &request);
+        std::shared_ptr<OlapTableSchemaParam> schema_param(new OlapTableSchemaParam());
+        ASSERT_OK(schema_param->init(request.schema()));
+        PTabletWriterOpenResult response;
+        ASSERT_OK(_tablets_channel->open(request, &response, schema_param, false));
+    }
+
+    void _create_tablets(int num_tablets) {
+        std::unordered_set<int64_t> tablet_ids;
+        for (auto& tablet : _tablets) {
+            tablet_ids.emplace(tablet->tablet_id());
+        }
+        int size = _tablets.size() + num_tablets;
+        while (_tablets.size() < size) {
+            int64_t tablet_id = rand();
+            if (tablet_ids.find(tablet_id) != tablet_ids.end()) {
+                continue;
+            }
+            tablet_ids.emplace(tablet_id);
+            _tablets.push_back(_create_tablet(tablet_id, rand()));
+        }
+    }
+
+    TabletSharedPtr _create_tablet(int64_t tablet_id, int32_t schema_hash) {
         TCreateTabletReq request;
         request.tablet_id = tablet_id;
         request.__set_version(1);
@@ -115,95 +140,28 @@ protected:
         return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
     }
 
-    PTabletWriterOpenRequest _create_open_request(ReplicaState replica_state, bool single_replica) {
-        PTabletWriterOpenRequest request;
-        request.mutable_id()->CopyFrom(_load_id);
-        request.set_index_id(_index_id);
-        request.set_txn_id(_txn_id);
-        request.set_is_lake_tablet(false);
-        request.set_is_replicated_storage(true);
-        request.set_node_id(replica_state != ReplicaState::Secondary ? _primary_node_id : _secondary_node_id);
-        request.set_write_quorum(WriteQuorumTypePB::ONE);
-        request.set_miss_auto_increment_column(false);
-        request.set_table_id(_table_id);
-        request.set_is_incremental(false);
-        request.set_num_senders(1);
-        request.set_sender_id(0);
-        request.set_need_gen_rollup(false);
-        request.set_load_channel_timeout_s(10);
-        request.set_is_vectorized(true);
-        request.set_timeout_ms(10000);
-
-        request.set_immutable_tablet_size(0);
-        auto tablet = request.add_tablets();
-        tablet->set_partition_id(_partition_id);
-        tablet->set_tablet_id(_tablet_id);
-        auto primary_replica = tablet->add_replicas();
-        primary_replica->set_host("127.0.0.1");
-        primary_replica->set_port(8060);
-        primary_replica->set_node_id(_primary_node_id);
-        if (!single_replica) {
-            auto secondary_replica = tablet->add_replicas();
-            secondary_replica->set_host("127.0.0.2");
-            secondary_replica->set_port(8060);
-            secondary_replica->set_node_id(_secondary_node_id);
-        }
-
-        auto schema = request.mutable_schema();
-        schema->set_db_id(_db_id);
-        schema->set_table_id(_table_id);
-        schema->set_version(1);
-        auto index = schema->add_indexes();
-        index->set_id(_index_id);
-        index->set_schema_hash(0);
-        for (int i = 0, sz = _tablet->tablet_schema()->num_columns(); i < sz; i++) {
-            auto slot = request.mutable_schema()->add_slot_descs();
-            auto& column = _tablet->tablet_schema()->column(i);
-            slot->set_id(i);
-            slot->set_byte_offset(i * sizeof(int) /*unused*/);
-            slot->set_col_name(std::string(column.name()));
-            slot->set_slot_idx(i);
-            slot->set_is_materialized(true);
-            slot->mutable_slot_type()->add_types()->mutable_scalar_type()->set_type(column.type());
-            index->add_columns(std::string(column.name()));
-        }
-        auto tuple_desc = schema->mutable_tuple_desc();
-        tuple_desc->set_id(1);
-        tuple_desc->set_byte_size(8 /*unused*/);
-        tuple_desc->set_num_null_bytes(0 /*unused*/);
-        tuple_desc->set_table_id(_table_id);
-
-        return request;
-    }
-
-    struct TabletReplicas {
-        int64_t tablet_id;
-        ReplicaState replica_state;
-        std::vector<PNetworkAddress> nodes;
-    };
-
-    PTabletWriterOpenRequest _create_open_request(int64_t node_id, std::vector<TabletReplicas> tablet_vec) {
-        PTabletWriterOpenRequest request;
-        request.mutable_id()->CopyFrom(_load_id);
-        request.set_index_id(_index_id);
-        request.set_txn_id(_txn_id);
-        request.set_is_lake_tablet(false);
-        request.set_is_replicated_storage(true);
-        request.set_node_id(node_id);
-        request.set_sink_id(0);
-        request.set_write_quorum(WriteQuorumTypePB::ONE);
-        request.set_miss_auto_increment_column(false);
-        request.set_table_id(_table_id);
-        request.set_is_incremental(false);
-        request.set_num_senders(1);
-        request.set_sender_id(0);
-        request.set_need_gen_rollup(false);
-        request.set_load_channel_timeout_s(10);
-        request.set_is_vectorized(true);
-        request.set_timeout_ms(10000);
-        request.set_immutable_tablet_size(0);
+    void _create_open_request(int64_t node_id, std::vector<ReplicaInfo> tablet_vec, PTabletWriterOpenRequest* request) {
+        ASSERT_FALSE(tablet_vec.empty());
+        request->mutable_id()->CopyFrom(_load_id);
+        request->set_index_id(_index_id);
+        request->set_txn_id(_txn_id);
+        request->set_is_lake_tablet(false);
+        request->set_is_replicated_storage(true);
+        request->set_node_id(node_id);
+        request->set_sink_id(_sink_id);
+        request->set_write_quorum(WriteQuorumTypePB::ONE);
+        request->set_miss_auto_increment_column(false);
+        request->set_table_id(_table_id);
+        request->set_is_incremental(false);
+        request->set_num_senders(1);
+        request->set_sender_id(0);
+        request->set_need_gen_rollup(false);
+        request->set_load_channel_timeout_s(10);
+        request->set_is_vectorized(true);
+        request->set_timeout_ms(10000);
+        request->set_immutable_tablet_size(0);
         for (auto& tablet_replicas : tablet_vec) {
-            auto tablet = request.add_tablets();
+            auto tablet = request->add_tablets();
             tablet->set_partition_id(_partition_id);
             tablet->set_tablet_id(tablet_replicas.tablet_id);
             for (auto& node : tablet_replicas.nodes) {
@@ -212,16 +170,18 @@ protected:
             }
         }
 
-        auto schema = request.mutable_schema();
+        ASSERT_FALSE(_tablets.empty());
+        TabletSharedPtr tablet = _tablets[0];
+        auto schema = request->mutable_schema();
         schema->set_db_id(_db_id);
         schema->set_table_id(_table_id);
         schema->set_version(1);
         auto index = schema->add_indexes();
         index->set_id(_index_id);
         index->set_schema_hash(0);
-        for (int i = 0, sz = _tablet->tablet_schema()->num_columns(); i < sz; i++) {
-            auto slot = request.mutable_schema()->add_slot_descs();
-            auto& column = _tablet->tablet_schema()->column(i);
+        for (int i = 0, sz = tablet->tablet_schema()->num_columns(); i < sz; i++) {
+            auto slot = request->mutable_schema()->add_slot_descs();
+            auto& column = tablet->tablet_schema()->column(i);
             slot->set_id(i);
             slot->set_byte_offset(i * sizeof(int) /*unused*/);
             slot->set_col_name(std::string(column.name()));
@@ -235,11 +195,10 @@ protected:
         tuple_desc->set_byte_size(8 /*unused*/);
         tuple_desc->set_num_null_bytes(0 /*unused*/);
         tuple_desc->set_table_id(_table_id);
-
-        return request;
     }
 
-    Chunk generate_data(int64_t chunk_size) {
+    Chunk _generate_data(int64_t chunk_size, TabletSchemaCSPtr tablet_schema) {
+        auto schema = std::make_shared<Schema>(ChunkHelper::convert_schema(tablet_schema));
         std::vector<int> v0(chunk_size);
         std::vector<int> v1(chunk_size);
         for (int i = 0; i < chunk_size; i++) {
@@ -249,46 +208,40 @@ protected:
         auto c1 = Int32Column::create();
         c0->append_numbers(v0.data(), v0.size() * sizeof(int));
         c1->append_numbers(v1.data(), v1.size() * sizeof(int));
-        Chunk chunk({std::move(c0), std::move(c1)}, _schema);
+        Chunk chunk({std::move(c0), std::move(c1)}, schema);
         chunk.set_slot_id_to_index(0, 0);
         chunk.set_slot_id_to_index(1, 1);
         return chunk;
     }
 
-    int64_t _primary_node_id;
-    int64_t _secondary_node_id;
+    std::vector<PNetworkAddress> _nodes;
     PUniqueId _load_id;
     int64_t _txn_id;
     int64_t _db_id;
     int64_t _table_id;
     int64_t _partition_id;
     int32_t _index_id;
-    int64_t _tablet_id;
+    int32_t _sink_id;
     std::unique_ptr<MemTracker> _mem_tracker;
     std::unique_ptr<RuntimeProfile> _root_profile;
     std::unique_ptr<LoadChannelMgr> _load_channel_mgr;
     std::shared_ptr<LoadChannel> _load_channel;
     std::shared_ptr<LocalTabletsChannel> _tablets_channel;
-
-    TabletSharedPtr _tablet;
     std::vector<TabletSharedPtr> _tablets;
-    std::shared_ptr<Schema> _schema;
-    std::shared_ptr<OlapTableSchemaParam> _schema_param;
-
-    PTabletWriterOpenRequest _open_single_replica_request;
-    PTabletWriterOpenRequest _open_primary_request;
-    PTabletWriterOpenRequest _open_secondary_request;
-    PTabletWriterOpenResult _open_response;
 };
 
 using RpcLoadDisagnosePair = std::pair<PLoadDiagnoseRequest*, ReusableClosure<PLoadDiagnoseResult>*>;
 
 TEST_F(LocalTabletsChannelTest, diagnose_stack_trace) {
-    _open_secondary_request.set_timeout_ms(100);
-    ASSERT_OK(_tablets_channel->open(_open_secondary_request, &_open_response, _schema_param, false));
+    _create_tablets(1);
+    // open as a secondary replica of 3 replicas
+    ReplicaInfo replica_info{_tablets[0]->tablet_id(), _nodes};
+    _open_channel(_nodes[1].node_id(), {replica_info});
+
     PTabletWriterAddChunkRequest add_chunk_request;
     add_chunk_request.mutable_id()->CopyFrom(_load_id);
     add_chunk_request.set_index_id(_index_id);
+    add_chunk_request.set_sink_id(_sink_id);
     add_chunk_request.set_sender_id(0);
     add_chunk_request.set_eos(true);
     add_chunk_request.set_packet_seq(0);
@@ -297,21 +250,8 @@ TEST_F(LocalTabletsChannelTest, diagnose_stack_trace) {
     DeferOp defer([&]() {
         SyncPoint::GetInstance()->ClearCallBack("LocalTabletsChannel::rpc::load_diagnose_send");
         SyncPoint::GetInstance()->DisableProcessing();
-        PFailPointTriggerMode trigger_mode;
-        trigger_mode.set_mode(FailPointTriggerModeType::DISABLE);
-        auto fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get(
-                "tablets_channel_wait_secondary_replica_block");
-        fp->setMode(trigger_mode);
-        config::load_fp_tablets_channel_wait_secondary_replica_block_ms = -1;
         config::load_diagnose_rpc_timeout_stack_trace_threshold_ms = old_threshold;
     });
-
-    PFailPointTriggerMode trigger_mode;
-    trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);
-    auto fp =
-            starrocks::failpoint::FailPointRegistry::GetInstance()->get("tablets_channel_wait_secondary_replica_block");
-    fp->setMode(trigger_mode);
-    config::load_fp_tablets_channel_wait_secondary_replica_block_ms = 50;
     config::load_diagnose_rpc_timeout_stack_trace_threshold_ms = 0;
 
     int32_t num_diagnose = 0;
@@ -337,7 +277,11 @@ TEST_F(LocalTabletsChannelTest, diagnose_stack_trace) {
 }
 
 TEST_F(LocalTabletsChannelTest, test_primary_replica_profile) {
-    ASSERT_OK(_tablets_channel->open(_open_single_replica_request, &_open_response, _schema_param, false));
+    _create_tablets(1);
+    auto& tablet = _tablets[0];
+    // open as a primary replica of 1 replica
+    ReplicaInfo replica_info{tablet->tablet_id(), {_nodes[0]}};
+    _open_channel(_nodes[0].node_id(), {replica_info});
 
     PTabletWriterAddChunkRequest add_chunk_request;
     add_chunk_request.mutable_id()->CopyFrom(_load_id);
@@ -347,12 +291,12 @@ TEST_F(LocalTabletsChannelTest, test_primary_replica_profile) {
     add_chunk_request.set_packet_seq(0);
 
     int chunk_size = 16;
-    auto chunk = generate_data(chunk_size);
+    auto chunk = _generate_data(chunk_size, tablet->tablet_schema());
     ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
     add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
 
     for (int i = 0; i < chunk_size; i++) {
-        add_chunk_request.add_tablet_ids(_tablet_id);
+        add_chunk_request.add_tablet_ids(tablet->tablet_id());
         add_chunk_request.add_partition_ids(_partition_id);
     }
 
@@ -380,8 +324,10 @@ TEST_F(LocalTabletsChannelTest, test_primary_replica_profile) {
 }
 
 TEST_F(LocalTabletsChannelTest, test_secondary_replica_profile) {
-    _open_secondary_request.set_timeout_ms(100);
-    ASSERT_OK(_tablets_channel->open(_open_secondary_request, &_open_response, _schema_param, false));
+    _create_tablets(1);
+    // open as a secondary replica of 3 replicas
+    ReplicaInfo replica_info{_tablets[0]->tablet_id(), _nodes};
+    _open_channel(_nodes[1].node_id(), {replica_info});
     _tablets_channel->update_profile();
     auto* profile = _root_profile->get_child(fmt::format("Index (id={})", _index_id));
     ASSERT_NE(nullptr, profile);
@@ -396,22 +342,27 @@ using RpcTabletWriterCancelTuple =
         std::tuple<PTabletWriterCancelRequest*, google::protobuf::Closure*, brpc::Controller*>;
 
 void LocalTabletsChannelTest::test_cancel_secondary_replica_base(bool is_empty_tablet) {
-    ASSERT_OK(_tablets_channel->open(_open_primary_request, &_open_response, _schema_param, false));
+    _create_tablets(1);
+    auto& tablet = _tablets[0];
+    // open as a primary replica of 3 replicas
+    ReplicaInfo replica_info{_tablets[0]->tablet_id(), _nodes};
+    _open_channel(_nodes[0].node_id(), {replica_info});
 
     PTabletWriterAddChunkRequest add_chunk_request;
     add_chunk_request.mutable_id()->CopyFrom(_load_id);
     add_chunk_request.set_index_id(_index_id);
+    add_chunk_request.set_sink_id(_sink_id);
     add_chunk_request.set_sender_id(0);
     add_chunk_request.set_txn_id(_txn_id);
     add_chunk_request.set_eos(true);
     add_chunk_request.set_packet_seq(0);
     add_chunk_request.set_wait_all_sender_close(true);
 
-    auto chunk = generate_data(1);
+    auto chunk = _generate_data(1, tablet->tablet_schema());
     ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
     if (!is_empty_tablet) {
         add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
-        add_chunk_request.add_tablet_ids(_tablet_id);
+        add_chunk_request.add_tablet_ids(tablet->tablet_id());
         add_chunk_request.add_partition_ids(_partition_id);
     }
 
@@ -430,7 +381,7 @@ void LocalTabletsChannelTest::test_cancel_secondary_replica_base(bool is_empty_t
         EXPECT_EQ(request->sender_id(), 0);
         EXPECT_EQ(request->txn_id(), _txn_id);
         EXPECT_EQ(1, request->tablet_ids().size());
-        EXPECT_EQ(_tablet_id, request->tablet_ids().Get(0));
+        EXPECT_EQ(tablet->tablet_id(), request->tablet_ids().Get(0));
         EXPECT_EQ(request->reason(), is_empty_tablet ? "" : "primary replica failed to sync data");
         google::protobuf::Closure* closure = std::get<1>(*rpc_tuple);
         closure->Run();
@@ -444,7 +395,7 @@ void LocalTabletsChannelTest::test_cancel_secondary_replica_base(bool is_empty_t
     ASSERT_TRUE(add_chunk_response.status().status_code() == TStatusCode::OK)
             << add_chunk_response.status().error_msgs(0);
     ASSERT_TRUE(close_channel);
-    ASSERT_EQ(1, num_cancel);
+    ASSERT_EQ(2, num_cancel);
 }
 
 TEST_F(LocalTabletsChannelTest, test_cancel_empty_secondary_replica) {
@@ -456,11 +407,15 @@ TEST_F(LocalTabletsChannelTest, test_cancel_failed_secondary_replica) {
 }
 
 TEST_F(LocalTabletsChannelTest, test_cancel_secondary_replica_rpc_fail) {
-    ASSERT_OK(_tablets_channel->open(_open_primary_request, &_open_response, _schema_param, false));
+    _create_tablets(1);
+    // open as a primary replica of 3 replicas
+    ReplicaInfo replica_info{_tablets[0]->tablet_id(), _nodes};
+    _open_channel(_nodes[0].node_id(), {replica_info});
 
     PTabletWriterAddChunkRequest add_chunk_request;
     add_chunk_request.mutable_id()->CopyFrom(_load_id);
     add_chunk_request.set_index_id(_index_id);
+    add_chunk_request.set_sink_id(_sink_id);
     add_chunk_request.set_sender_id(0);
     add_chunk_request.set_txn_id(_txn_id);
     add_chunk_request.set_eos(true);
@@ -489,61 +444,102 @@ TEST_F(LocalTabletsChannelTest, test_cancel_secondary_replica_rpc_fail) {
     ASSERT_TRUE(add_chunk_response.status().status_code() == TStatusCode::OK)
             << add_chunk_response.status().error_msgs(0);
     ASSERT_TRUE(close_channel);
-    ASSERT_EQ(1, num_cancel);
+    ASSERT_EQ(2, num_cancel);
 }
 
 using RpcReplicaStatusPair = std::pair<PLoadReplicaStatusRequest*, ReusableClosure<PLoadReplicaStatusResult>*>;
 
-TEST_F(LocalTabletsChannelTest, test_secondary_replicas_waiter) {
-    std::vector<TabletReplicas> tablet_vec;
-    for (int i = 0; i < 3; i++) {
-        TabletReplicas tablet_replicas;
-        tablet_replicas.tablet_id = rand();
-        for (int j = 0; j < 3; j++) {
-            PNetworkAddress node;
-            node.set_node_id(j);
-            node.set_host(fmt::format("127.0.0.{}", j));
-            tablet_replicas.nodes.push_back(node);
-        }
-        tablet_vec.push_back(tablet_replicas);
-    }
+struct RpcStep {
+    // expected number of tablets in the request
+    int num_tablets;
+    // mock the response of the request
+    bool mock_response{true};
+    bool rpc_fail{false};
+    std::string rpc_fail_msg;
+    std::vector<LoadReplicaStatePB> replica_states;
+    std::vector<std::string> messages;
+};
 
-    for (auto& tablet_replicas : tablet_vec) {
-        auto tablet = create_tablet(tablet_replicas.tablet_id, rand());
-        _tablets.push_back(tablet);
-    }
+struct TabletExpectedState {
+    State writer_state;
+    Status error_status;
+};
 
-    PTabletWriterOpenRequest open_request = _create_open_request(1, tablet_vec);
-    PTabletWriterOpenResult open_result;
-    ASSERT_OK(_tablets_channel->open(open_request, &open_result, _schema_param, false));
+struct SecondaryReplicasWaiterTestCase {
+    int64_t timeout_ms{60000};
+    std::vector<RpcStep> steps;
+    std::vector<TabletExpectedState> final_states;
+};
+
+void LocalTabletsChannelTest::test_secondary_replicas_waiter_base(SecondaryReplicasWaiterTestCase& test_case) {
+    _create_tablets(3);
+    // open as the secondary replica of 3 replicas
+    std::vector<ReplicaInfo> replica_infos;
+    for (auto& tablet : _tablets) {
+        replica_infos.push_back(ReplicaInfo{tablet->tablet_id(), _nodes});
+    }
+    _open_channel(_nodes[1].node_id(), replica_infos);
+    std::unordered_map<int64_t, AsyncDeltaWriter*> writer_map;
+    for (auto& [tablet_id, writer] : _tablets_channel->TEST_delta_writers()) {
+        writer_map[tablet_id] = writer.get();
+    }
+    ASSERT_EQ(replica_infos.size(), writer_map.size());
+    for (auto& replica : replica_infos) {
+        auto writer = writer_map.find(replica.tablet_id);
+        ASSERT_NE(writer, writer_map.end());
+    }
 
     auto old_check_interval_on_success = config::load_replica_status_check_interval_ms_on_success;
     auto old_check_interval_on_failure = config::load_replica_status_check_interval_ms_on_failure;
+    std::vector<ReusableClosure<PLoadReplicaStatusResult>*> closures_to_release;
     DeferOp defer([&] {
         SyncPoint::GetInstance()->DisableProcessing();
         SyncPoint::GetInstance()->ClearCallBack("LocalTabletsChannel::rpc::get_load_replica_status");
         config::load_replica_status_check_interval_ms_on_success = old_check_interval_on_success;
         config::load_replica_status_check_interval_ms_on_failure = old_check_interval_on_failure;
+        for (auto closure : closures_to_release) {
+            closure->Run();
+        }
     });
 
-    config::load_replica_status_check_interval_ms_on_success = 100;
-    config::load_replica_status_check_interval_ms_on_failure = 50;
-    int num_get_replica_status = 0;
+    config::load_replica_status_check_interval_ms_on_success = 50;
+    config::load_replica_status_check_interval_ms_on_failure = 20;
+    int num_rpc_request = 0;
+    std::vector<int64_t> tablet_ids;
     SyncPoint::GetInstance()->EnableProcessing();
     SyncPoint::GetInstance()->SetCallBack("LocalTabletsChannel::rpc::get_load_replica_status", [&](void* arg) {
         RpcReplicaStatusPair* rpc_pair = (RpcReplicaStatusPair*)arg;
         PLoadReplicaStatusRequest* request = (PLoadReplicaStatusRequest*)rpc_pair->first;
-        ReusableClosure<PLoadReplicaStatusResult>* result =
-                (ReusableClosure<PLoadReplicaStatusResult>*)rpc_pair->second;
         EXPECT_EQ(print_id(_load_id), print_id(request->load_id()));
         EXPECT_EQ(_txn_id, request->txn_id());
         EXPECT_EQ(_index_id, request->index_id());
         EXPECT_EQ(1, request->node_id());
-        EXPECT_EQ(0, request->sink_id());
-        if (num_get_replica_status < 2) {
-            EXPECT_EQ(3 - num_get_replica_status, request->tablet_ids().size());
+        EXPECT_EQ(_sink_id, request->sink_id());
+        EXPECT_TRUE(num_rpc_request < test_case.steps.size());
+        auto& step = test_case.steps[num_rpc_request];
+        EXPECT_EQ(step.num_tablets, request->tablet_ids().size());
+        if (num_rpc_request == 0) {
+            tablet_ids.insert(tablet_ids.end(), request->tablet_ids().begin(), request->tablet_ids().end());
         }
-        num_get_replica_status += 1;
+        num_rpc_request += 1;
+        ReusableClosure<PLoadReplicaStatusResult>* response =
+                (ReusableClosure<PLoadReplicaStatusResult>*)rpc_pair->second;
+        if (!step.mock_response) {
+            closures_to_release.push_back(response);
+            return;
+        }
+        if (step.rpc_fail) {
+            response->cntl.SetFailed(step.rpc_fail_msg);
+        } else {
+            EXPECT_EQ(step.replica_states.size(), request->tablet_ids().size());
+            for (int i = 0; i < step.replica_states.size(); i++) {
+                auto replica_state = response->result.add_replica_statuses();
+                replica_state->set_tablet_id(request->tablet_ids(i));
+                replica_state->set_state(step.replica_states[i]);
+                replica_state->set_message(step.messages[i]);
+            }
+        }
+        response->Run();
     });
 
     auto t = std::thread([&]() {
@@ -552,25 +548,215 @@ TEST_F(LocalTabletsChannelTest, test_secondary_replicas_waiter) {
         add_chunk_request.set_index_id(_index_id);
         add_chunk_request.set_sender_id(0);
         add_chunk_request.set_txn_id(_txn_id);
-        add_chunk_request.set_sink_id(0);
+        add_chunk_request.set_sink_id(_sink_id);
         add_chunk_request.set_eos(true);
         add_chunk_request.set_packet_seq(0);
         add_chunk_request.set_wait_all_sender_close(true);
-        add_chunk_request.set_timeout_ms(3600000);
+        add_chunk_request.set_timeout_ms(test_case.timeout_ms);
 
         bool close_channel;
         PTabletWriterAddBatchResult add_chunk_response;
         _tablets_channel->add_chunk(nullptr, add_chunk_request, &add_chunk_response, &close_channel);
         EXPECT_TRUE(close_channel);
+        EXPECT_EQ(add_chunk_response.status().status_code(), TStatusCode::OK)
+                << add_chunk_response.status().error_msgs(0);
     });
+    t.join();
+    ASSERT_EQ(test_case.final_states.size(), tablet_ids.size());
+    for (int i = 0; i < tablet_ids.size(); i++) {
+        auto tablet_id = tablet_ids[i];
+        auto iter = writer_map.find(tablet_id);
+        ASSERT_NE(iter, writer_map.end());
+        auto writer = iter->second;
+        ASSERT_NE(nullptr, writer);
+        ASSERT_EQ(test_case.final_states[i].writer_state, writer->writer()->get_state());
+        ASSERT_EQ(test_case.final_states[i].error_status.to_string(false),
+                  writer->writer()->get_err_status().to_string(false));
+    }
+}
 
-    std::vector<AsyncDeltaWriter*> writers = _tablets_channel->TEST_async_delta_writers();
-    ASSERT_EQ(3, writers.size());
-    for (auto& writer : writers) {
-        writer->cancel(Status::Cancelled("artificial failure"));
+TEST_F(LocalTabletsChannelTest, test_secondary_replicas_waiter) {
+    SecondaryReplicasWaiterTestCase test_case;
+
+    RpcStep step1;
+    step1.num_tablets = 3;
+    step1.rpc_fail = false;
+    step1.replica_states = {LoadReplicaStatePB::NOT_PRESENT, LoadReplicaStatePB::IN_PROCESSING,
+                            LoadReplicaStatePB::IN_PROCESSING};
+    step1.messages = {"not found", "", ""};
+    test_case.steps.push_back(step1);
+
+    RpcStep step2;
+    step2.num_tablets = 2;
+    step2.rpc_fail = true;
+    step2.rpc_fail_msg = "rpc artificial failure 1";
+    test_case.steps.push_back(step2);
+
+    RpcStep step3;
+    step3.num_tablets = 2;
+    step3.rpc_fail = true;
+    step3.rpc_fail_msg = "rpc artificial failure 2";
+    test_case.steps.push_back(step3);
+
+    RpcStep step4;
+    step4.num_tablets = 2;
+    step4.rpc_fail = false;
+    step4.replica_states = {LoadReplicaStatePB::FAILED, LoadReplicaStatePB::FAILED};
+    step4.messages = {"artificial failure 1", "artificial failure 2"};
+    test_case.steps.push_back(step4);
+
+    test_case.final_states = {
+            TabletExpectedState{
+                    kAborted,
+                    Status::Cancelled("already failed on primary replica, status: NOT_PRESENT, message: not found")},
+            TabletExpectedState{
+                    kAborted,
+                    Status::Cancelled(
+                            "already failed on primary replica, status: FAILED, message: artificial failure 1")},
+            TabletExpectedState{
+                    kAborted,
+                    Status::Cancelled(
+                            "already failed on primary replica, status: FAILED, message: artificial failure 2")}};
+    test_secondary_replicas_waiter_base(test_case);
+}
+
+TEST_F(LocalTabletsChannelTest, test_secondary_repclias_waiter_rpc_fail) {
+    SecondaryReplicasWaiterTestCase test_case;
+    for (int i = 0; i < 3; i++) {
+        RpcStep step;
+        step.num_tablets = 3;
+        step.rpc_fail = true;
+        step.rpc_fail_msg = "rpc artificial failure";
+        test_case.steps.push_back(step);
+    }
+    test_case.final_states = {
+            TabletExpectedState{kAborted,
+                                Status::Cancelled("can't get status from primary, rpc error: rpc artificial failure")},
+            TabletExpectedState{kAborted,
+                                Status::Cancelled("can't get status from primary, rpc error: rpc artificial failure")},
+            TabletExpectedState{kAborted,
+                                Status::Cancelled("can't get status from primary, rpc error: rpc artificial failure")}};
+    test_secondary_replicas_waiter_base(test_case);
+}
+
+TEST_F(LocalTabletsChannelTest, test_secondary_repclias_waiter_timeout) {
+    SecondaryReplicasWaiterTestCase test_case;
+    test_case.timeout_ms = 300;
+    RpcStep step;
+    step.num_tablets = 3;
+    step.mock_response = false;
+    test_case.steps.push_back(step);
+    test_case.final_states = {TabletExpectedState{kWriting, Status::OK()}, TabletExpectedState{kWriting, Status::OK()},
+                              TabletExpectedState{kWriting, Status::OK()}};
+    test_secondary_replicas_waiter_base(test_case);
+}
+
+TEST_F(LocalTabletsChannelTest, test_get_replica_status) {
+    _create_tablets(4);
+    // open as a primary replica of 3 replicas
+    std::vector<ReplicaInfo> replica_infos;
+    for (int i = 0; i < 3; i++) {
+        auto& tablet = _tablets[i];
+        replica_infos.push_back(ReplicaInfo{tablet->tablet_id(), _nodes});
+    }
+    _open_channel(_nodes[0].node_id(), replica_infos);
+
+    PLoadReplicaStatusRequest request;
+    request.mutable_load_id()->CopyFrom(_load_id);
+    request.set_txn_id(_txn_id);
+    request.set_index_id(_index_id);
+    request.set_sink_id(_sink_id);
+    request.set_node_id(_nodes[1].node_id());
+    for (auto& tablet : _tablets) {
+        request.add_tablet_ids(tablet->tablet_id());
     }
 
-    t.join();
+    // LoadChannelMgr does not have the load channel
+    PLoadReplicaStatusResult result1;
+    _load_channel_mgr->get_load_replica_status(nullptr, &request, &result1, nullptr);
+    ASSERT_EQ(4, result1.replica_statuses_size());
+    for (int i = 0; i < 4; i++) {
+        auto& replica_status = result1.replica_statuses().at(i);
+        ASSERT_EQ(_tablets[i]->tablet_id(), replica_status.tablet_id());
+        ASSERT_EQ(LoadReplicaStatePB::NOT_PRESENT, replica_status.state());
+        ASSERT_EQ("can't find load channel", replica_status.message());
+    }
+
+    // LoadChannel does not have the tablets channel
+    PLoadReplicaStatusResult result2;
+    _load_channel->get_load_replica_status(_nodes[1].host(), &request, &result2);
+    ASSERT_EQ(4, result2.replica_statuses_size());
+    for (int i = 0; i < 4; i++) {
+        auto& replica_status = result2.replica_statuses().at(i);
+        ASSERT_EQ(_tablets[i]->tablet_id(), replica_status.tablet_id());
+        ASSERT_EQ(LoadReplicaStatePB::NOT_PRESENT, replica_status.state());
+        ASSERT_EQ("can't find local tablets channel", replica_status.message());
+    }
+
+    // 3 IN_PROCESSING, 1 NOT_PRESENT
+    PLoadReplicaStatusResult result3;
+    _tablets_channel->get_load_replica_status(_nodes[1].host(), &request, &result3);
+    ASSERT_EQ(4, result3.replica_statuses_size());
+    for (int i = 0; i < 3; i++) {
+        auto& replica_status = result3.replica_statuses(i);
+        ASSERT_EQ(_tablets[i]->tablet_id(), replica_status.tablet_id());
+        ASSERT_EQ(LoadReplicaStatePB::IN_PROCESSING, replica_status.state());
+        ASSERT_EQ("primary replica state is kWriting", replica_status.message());
+    }
+    ASSERT_EQ(_tablets[3]->tablet_id(), result3.replica_statuses(3).tablet_id());
+    ASSERT_EQ(LoadReplicaStatePB::NOT_PRESENT, result3.replica_statuses(3).state());
+    ASSERT_EQ("can't find delta writer", result3.replica_statuses(3).message());
+
+    // 3 FAILED, 1 NOT_PRESENT
+    _tablets_channel->abort({_tablets[0]->tablet_id()}, "artificial failure");
+    PTabletWriterAddChunkRequest add_chunk_request;
+    add_chunk_request.mutable_id()->CopyFrom(_load_id);
+    add_chunk_request.set_index_id(_index_id);
+    add_chunk_request.set_sink_id(_sink_id);
+    add_chunk_request.set_sender_id(0);
+    add_chunk_request.set_txn_id(_txn_id);
+    add_chunk_request.set_eos(true);
+    add_chunk_request.set_packet_seq(0);
+    add_chunk_request.set_wait_all_sender_close(true);
+    auto chunk = _generate_data(2, _tablets[0]->tablet_schema());
+    ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
+    add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
+    for (int i = 1; i < 3; i++) {
+        add_chunk_request.add_tablet_ids(_tablets[i]->tablet_id());
+        add_chunk_request.add_partition_ids(_partition_id);
+    }
+    bool close_channel;
+    PTabletWriterAddBatchResult add_chunk_response;
+    DeferOp defer([&]() {
+        SyncPoint::GetInstance()->ClearCallBack("LocalTabletsChannel::rpc::tablet_writer_cancel");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("LocalTabletsChannel::rpc::tablet_writer_cancel", [&](void* arg) {
+        RpcTabletWriterCancelTuple* rpc_tuple = (RpcTabletWriterCancelTuple*)arg;
+        google::protobuf::Closure* closure = std::get<1>(*rpc_tuple);
+        closure->Run();
+    });
+    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response, &close_channel);
+    ASSERT_TRUE(add_chunk_response.status().status_code() != TStatusCode::OK);
+    ASSERT_TRUE(close_channel);
+
+    PLoadReplicaStatusResult result4;
+    _tablets_channel->get_load_replica_status(_nodes[1].host(), &request, &result4);
+    ASSERT_EQ(4, result4.replica_statuses_size());
+    ASSERT_EQ(_tablets[0]->tablet_id(), result4.replica_statuses(0).tablet_id());
+    ASSERT_EQ(LoadReplicaStatePB::FAILED, result4.replica_statuses(0).state());
+    ASSERT_EQ("primary replica is aborted, Cancelled: artificial failure", result4.replica_statuses(0).message());
+    for (int i = 1; i < 3; i++) {
+        auto& replica_status = result4.replica_statuses(i);
+        ASSERT_EQ(_tablets[i]->tablet_id(), replica_status.tablet_id());
+        ASSERT_EQ(LoadReplicaStatePB::FAILED, replica_status.state());
+        ASSERT_TRUE(replica_status.message().find("primary replica is committed, but replica failed") !=
+                    std::string::npos);
+    }
+    ASSERT_EQ(_tablets[3]->tablet_id(), result4.replica_statuses(3).tablet_id());
+    ASSERT_EQ(LoadReplicaStatePB::NOT_PRESENT, result4.replica_statuses(3).state());
+    ASSERT_EQ("can't find delta writer", result4.replica_statuses(3).message());
 }
 
 } // namespace starrocks

--- a/be/test/service/service_be/internal_service_test.cpp
+++ b/be/test/service/service_be/internal_service_test.cpp
@@ -219,4 +219,20 @@ TEST_F(InternalServiceTest, test_fetch_datacache_via_brpc) {
     }
 }
 
+TEST_F(InternalServiceTest, test_get_load_replica_status) {
+    BackendInternalServiceImpl<PInternalService> service(ExecEnv::GetInstance());
+    PLoadReplicaStatusRequest request;
+    request.mutable_load_id()->set_hi(0);
+    request.mutable_load_id()->set_lo(0);
+    request.set_txn_id(1);
+    request.set_sink_id(1);
+    request.set_node_id(1);
+    request.add_tablet_ids(1);
+    PLoadReplicaStatusResult response;
+    brpc::Controller cntl;
+    MockClosure closure;
+    service.get_load_replica_status(&cntl, &request, &response, &closure);
+    ASSERT_EQ(1, response.replica_statuses_size());
+}
+
 } // namespace starrocks

--- a/be/test/util/internal_service_recoverable_stub_test.cpp
+++ b/be/test/util/internal_service_recoverable_stub_test.cpp
@@ -81,3 +81,20 @@ TEST_F(PInternalService_RecoverableStubTest, test_load_diagnose) {
     auto* closure = new starrocks::RefCountClosure<starrocks::PLoadDiagnoseResult>();
     stub->load_diagnose(&closure->cntl, &request, &closure->result, closure);
 }
+
+TEST_F(PInternalService_RecoverableStubTest, test_get_load_replica_status) {
+    std::shared_ptr<starrocks::PInternalService_RecoverableStub> stub;
+
+    butil::EndPoint point;
+    auto res = butil::str2endpoint("127.0.0.1", 8000, &point);
+    ASSERT_EQ(res, 0);
+
+    stub = std::make_shared<starrocks::PInternalService_RecoverableStub>(point);
+
+    auto st = stub->reset_channel();
+    ASSERT_TRUE(st.ok());
+
+    PLoadReplicaStatusRequest request;
+    auto* closure = new starrocks::RefCountClosure<starrocks::PLoadReplicaStatusResult>();
+    stub->get_load_replica_status(&closure->cntl, &request, &closure->result, closure);
+}

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -5286,3 +5286,21 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Is mutable: Yes
 - Description: The retry times of rpc request to report exec rpc request to FE. The default value is 10, which means that the rpc request will be retried 10 times if it fails only if it's fragment instatnce finish rpc. Report exec rpc request is important for load job, if one fragment instance finish report failed, the load job will be hang until timeout.
 - Introduced in: -
+
+##### load_replica_status_check_interval_ms_on_success
+
+- Default: 15000
+- Type: Int
+- Unit: Milliseconds
+- Is mutable: Yes
+- Description: The interval that the secondary replica checks it's status on the primary replica if the last check rpc successes.
+- Introduced in: 3.5.1
+
+##### load_replica_status_check_interval_ms_on_failure
+
+- Default: 2000
+- Type: Int
+- Unit: Milliseconds
+- Is mutable: Yes
+- Description: The interval that the secondary replica checks it's status on the primary replica if the last check rpc fails.
+- Introduced in: 3.5.1

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -312,6 +312,33 @@ message PTabletWriterCancelRequest {
 message PTabletWriterCancelResult {
 };
 
+// Sent from secondary replica to primary replica
+message PLoadReplicaStatusRequest {
+    optional PUniqueId load_id = 1;
+    optional int64 txn_id = 2;
+    optional int64 index_id = 3;
+    optional int64 sink_id = 4;
+    optional int32 node_id = 5;
+    repeated int64 tablet_ids = 6;
+}
+
+enum LoadReplicaStatePB {
+    NOT_PRESENT = 0;
+    IN_PROCESSING = 1;
+    SUCCESS = 2;
+    FAILED = 3;
+}
+
+message PLoadReplicaStatus {
+    optional int64 tablet_id = 1;
+    optional LoadReplicaStatePB state = 2;
+    optional string message = 3;
+}
+
+message PLoadReplicaStatusResult {
+    repeated PLoadReplicaStatus replica_statuses = 2;
+}
+
 message PLoadDiagnoseRequest {
     optional PUniqueId id = 1;
     optional int64 txn_id = 2;
@@ -730,6 +757,7 @@ service PInternalService {
     rpc tablet_writer_add_chunks_via_http(PHttpRequest) returns (starrocks.PTabletWriterAddBatchResult);
     rpc tablet_writer_add_segment(starrocks.PTabletWriterAddSegmentRequest) returns (starrocks.PTabletWriterAddSegmentResult);
     rpc load_diagnose(PLoadDiagnoseRequest) returns (PLoadDiagnoseResult);
+    rpc get_load_replica_status(PLoadReplicaStatusRequest) returns (PLoadReplicaStatusResult);
     rpc transmit_runtime_filter(PTransmitRuntimeFilterParams) returns (PTransmitRuntimeFilterResult);
 
     rpc submit_mv_maintenance_task(PMVMaintenanceTaskRequest) returns (PMVMaintenanceTaskResult);

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -336,7 +336,7 @@ message PLoadReplicaStatus {
 }
 
 message PLoadReplicaStatusResult {
-    repeated PLoadReplicaStatus replica_statuses = 2;
+    repeated PLoadReplicaStatus replica_statuses = 1;
 }
 
 message PLoadDiagnoseRequest {


### PR DESCRIPTION
## Why I'm doing:
When using replicated storage for load, the data is synchronized from primary replica to secondary replica. At the end of load, secondary replica needs to wait for the final sync from primary replica which can be an EOS(success) or an abort(fail), then secondary replica responses to Coordinator BE. Sometimes secondary replica can't receive brpc from primary replica because of various reasons, leading to brpc `Reached timeout` between Coordinator BE and secondary replica
* network is unreachable between primary and secondary replica even after retry
* primary replica forgets to send brpc to secondary replca #58854
* brpc client has bug #40229 

We want to design a mechanism to ensure the secondary replica can get the state from primary replica before the brpc timeout no matter what's the reason to break the meaningless wait.

## What I'm doing:
The idea is secondary replica polls the primary replica for its status if wait for some time before the brpc timeout. 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1