### PR TITLE
[Enhancement] optimize decode_string for DecodeNode

### DIFF
--- a/be/src/runtime/global_dict/decoder.cpp
+++ b/be/src/runtime/global_dict/decoder.cpp
@@ -151,7 +151,7 @@ Status GlobalDictDecoderBase<Dict>::decode_string(const Column* in, Column* out)
             }
             res_slices[i] = iter->second;
         } else {
-            // res_slices[i] is empty slice which is done by constructor, so do nohting here.
+            // res_slices[i] is an empty slice which is done by constructor, so do nothing here.
         }
     }
     res_data_column->append_strings(res_slices.data(), num_rows);

--- a/be/src/runtime/global_dict/decoder.cpp
+++ b/be/src/runtime/global_dict/decoder.cpp
@@ -157,6 +157,7 @@ Status GlobalDictDecoderBase<Dict>::decode_string(const Column* in, Column* out)
     res_data_column->append_strings(res_slices.data(), num_rows);
     strings::memcpy_inlined(res_column->null_column_data().data(), column->null_column_data().data(),
                             num_rows * sizeof(NullColumn::ValueType));
+    res_column->set_has_null(column->has_null());
 
     return Status::OK();
 }


### PR DESCRIPTION
## Why I'm doing:

Recently, we support `low_cardinality_optimize_on_lake`.

However, when enabling it by default, some queries for TPC-DS 1T have performance regressions. 

For example, the latency of Q70 increases from 2.5s to 3.0s. The reason is that `s_state` is a very small VARCAHR field and doesn't belong to grouping-by columns for aggregation or ON columns for hash join, but the `DecodeNode` costs 500ms.

![image](https://github.com/user-attachments/assets/21c0c4c5-6dd9-41e7-8294-6e76d422772d)


## What I'm doing:

Because `low_cardinality_optimize_on_lake` is better for most cases, we cannot disable it by default. Therefore, this PR try to optimize `decode_string` for `DecodeNode`.

Q70:
- disable `low_cardinality_optimize_on_lake`: 2.5s
- enable `low_cardinality_optimize_on_lake`: 3.0s
- enable `low_cardinality_optimize_on_lake` and with this PR: 2.7s.

CPU perf Before

![image](https://github.com/user-attachments/assets/aa6f743d-77b7-482d-b433-e474424e5bdd)


CPU perf After
![image](https://github.com/user-attachments/assets/d807d8ee-5885-4cce-8116-a3371509849d)


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
