### PR TITLE
[BugFix] Fix Intersect not process has_outer_join_child

### DIFF
--- a/be/src/exec/intersect_node.cpp
+++ b/be/src/exec/intersect_node.cpp
@@ -37,6 +37,8 @@ Status IntersectNode::init(const TPlanNode& tnode, RuntimeState* state) {
     DCHECK_EQ(_conjunct_ctxs.size(), 0);
     DCHECK_GE(_children.size(), 2);
     _intersect_times = _children.size() - 1;
+    _has_outer_join_child =
+            tnode.intersect_node.__isset.has_outer_join_child && tnode.intersect_node.has_outer_join_child;
 
     // Create result_expr_ctx_lists_ from thrift exprs.
     const auto& result_texpr_lists = tnode.intersect_node.result_expr_lists;
@@ -253,8 +255,10 @@ pipeline::OpFactories IntersectNode::decompose_to_pipeline(pipeline::PipelineBui
     OpFactories ops_with_intersect_build_sink = child(0)->decompose_to_pipeline(context);
     ops_with_intersect_build_sink = context->maybe_interpolate_local_shuffle_exchange(
             runtime_state(), id(), ops_with_intersect_build_sink, _child_expr_lists[0]);
+
     ops_with_intersect_build_sink.emplace_back(std::make_shared<IntersectBuildSinkOperatorFactory>(
-            context->next_operator_id(), id(), intersect_partition_ctx_factory, _child_expr_lists[0]));
+            context->next_operator_id(), id(), intersect_partition_ctx_factory, _child_expr_lists[0],
+            _has_outer_join_child));
     // Initialize OperatorFactory's fields involving runtime filters.
     this->init_runtime_filter_for_operator(ops_with_intersect_build_sink.back().get(), context, rc_rf_probe_collector);
     context->add_pipeline(ops_with_intersect_build_sink);

--- a/be/src/exec/intersect_node.h
+++ b/be/src/exec/intersect_node.h
@@ -68,6 +68,7 @@ private:
     const int _tuple_id;
     // Descriptor for tuples this union node constructs.
     const TupleDescriptor* _tuple_desc;
+    bool _has_outer_join_child = false;
     // Exprs materialized by this node. The i-th result expr list refers to the i-th child.
     std::vector<std::vector<ExprContext*>> _child_expr_lists;
 

--- a/be/src/exec/pipeline/set/intersect_build_sink_operator.cpp
+++ b/be/src/exec/pipeline/set/intersect_build_sink_operator.cpp
@@ -27,7 +27,7 @@ Status IntersectBuildSinkOperator::push_chunk(RuntimeState* state, const ChunkPt
 Status IntersectBuildSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
     _intersect_ctx->observable().attach_sink_observer(state, observer());
-    return _intersect_ctx->prepare(state, _dst_exprs);
+    return _intersect_ctx->prepare(state, _dst_exprs, _has_outer_join_child);
 }
 
 void IntersectBuildSinkOperator::close(RuntimeState* state) {

--- a/be/src/exec/pipeline/set/intersect_build_sink_operator.h
+++ b/be/src/exec/pipeline/set/intersect_build_sink_operator.h
@@ -42,10 +42,11 @@ class IntersectBuildSinkOperator final : public Operator {
 public:
     IntersectBuildSinkOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
                                std::shared_ptr<IntersectContext> intersect_ctx,
-                               const std::vector<ExprContext*>& dst_exprs)
+                               const std::vector<ExprContext*>& dst_exprs, bool has_outer_join_child)
             : Operator(factory, id, "intersect_build_sink", plan_node_id, false, driver_sequence),
               _intersect_ctx(std::move(intersect_ctx)),
-              _dst_exprs(dst_exprs) {
+              _dst_exprs(dst_exprs),
+              _has_outer_join_child(has_outer_join_child) {
         _intersect_ctx->ref();
     }
 
@@ -74,6 +75,7 @@ private:
     std::shared_ptr<IntersectContext> _intersect_ctx;
 
     const std::vector<ExprContext*>& _dst_exprs;
+    const bool _has_outer_join_child;
 
     bool _is_finished = false;
 };
@@ -82,15 +84,16 @@ class IntersectBuildSinkOperatorFactory final : public OperatorFactory {
 public:
     IntersectBuildSinkOperatorFactory(int32_t id, int32_t plan_node_id,
                                       IntersectPartitionContextFactoryPtr intersect_partition_ctx_factory,
-                                      const std::vector<ExprContext*>& dst_exprs)
+                                      const std::vector<ExprContext*>& dst_exprs, bool has_outer_join_child)
             : OperatorFactory(id, "intersect_build_sink", plan_node_id),
               _intersect_partition_ctx_factory(std::move(intersect_partition_ctx_factory)),
-              _dst_exprs(dst_exprs) {}
+              _dst_exprs(dst_exprs),
+              _has_outer_join_child(has_outer_join_child) {}
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
         return std::make_shared<IntersectBuildSinkOperator>(
                 this, _id, _plan_node_id, driver_sequence,
-                _intersect_partition_ctx_factory->get_or_create(driver_sequence), _dst_exprs);
+                _intersect_partition_ctx_factory->get_or_create(driver_sequence), _dst_exprs, _has_outer_join_child);
     }
 
     Status prepare(RuntimeState* state) override;
@@ -100,6 +103,7 @@ public:
 private:
     IntersectPartitionContextFactoryPtr _intersect_partition_ctx_factory;
     const std::vector<ExprContext*>& _dst_exprs;
+    const bool _has_outer_join_child;
 };
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/set/intersect_context.cpp
+++ b/be/src/exec/pipeline/set/intersect_context.cpp
@@ -18,14 +18,15 @@
 
 namespace starrocks::pipeline {
 
-Status IntersectContext::prepare(RuntimeState* state, const std::vector<ExprContext*>& build_exprs) {
+Status IntersectContext::prepare(RuntimeState* state, const std::vector<ExprContext*>& build_exprs,
+                                 bool has_outer_join_child) {
     RETURN_IF_ERROR(_hash_set->init(state));
     _build_pool = std::make_unique<MemPool>();
 
     _dst_tuple_desc = state->desc_tbl().get_tuple_descriptor(_dst_tuple_id);
     _dst_nullables.reserve(build_exprs.size());
     for (auto build_expr : build_exprs) {
-        _dst_nullables.emplace_back(build_expr->root()->is_nullable());
+        _dst_nullables.emplace_back(build_expr->root()->is_nullable() || has_outer_join_child);
     }
 
     return Status::OK();

--- a/be/src/exec/pipeline/set/intersect_context.h
+++ b/be/src/exec/pipeline/set/intersect_context.h
@@ -65,7 +65,7 @@ public:
     bool is_output_finished() const { return _next_processed_iter == _hash_set_end_iter; }
 
     // Called in the preparation phase of IntersectBuildSinkOperator.
-    Status prepare(RuntimeState* state, const std::vector<ExprContext*>& build_exprs);
+    Status prepare(RuntimeState* state, const std::vector<ExprContext*>& build_exprs, bool has_outer_join_child);
 
     void close(RuntimeState* state) override;
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IntersectNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IntersectNode.java
@@ -54,5 +54,6 @@ public class IntersectNode extends SetOperationNode {
     @Override
     protected void toThrift(TPlanNode msg) {
         toThrift(msg, TPlanNodeType.INTERSECT_NODE);
+        msg.intersect_node.setHas_outer_join_child(hasNullableGenerateChild);
     }
 }

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -1075,6 +1075,8 @@ struct TIntersectNode {
     3: required list<list<Exprs.TExpr>> const_expr_lists
     // Index of the first child that needs to be materialized.
     4: required i64 first_materialized_child_idx
+    
+    5: optional bool has_outer_join_child
 }
 
 struct TExceptNode {

--- a/test/sql/test_union/R/test_intersect
+++ b/test/sql/test_union/R/test_intersect
@@ -1,0 +1,26 @@
+-- name: test_intersect_with_null_child
+create table t0 (
+    c0 INT NOT NULL,
+    c1 BIGINT NOT NULL
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t0 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  4096));
+-- result:
+-- !result
+create table t1 (
+    c0 INT NOT NULL,
+    c1 BIGINT NOT NULL
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t1 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  1024));
+-- result:
+-- !result
+insert into t1 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(4096,  8192));
+-- result:
+-- !result
+SELECT SUM(LC0), sum(LC1), sum(rc0), sum(rc1) FROM ( SELECT l.c0 lc0, l.c1 lc1, r.c0 rc0, r.c1 rc1 FROM t0 l FULL JOIN ( SELECT c0, c1 FROM t1 GROUP BY 1, 2 ORDER BY 1 desc ) r ON l.c0 = r.c0 INTERSECT SELECT l.c0 lc0, l.c1 lc1, r.c0 rc0, r.c1 rc1 FROM t0 l FULL JOIN t1 r ON l.c0 = r.c0 GROUP BY 1, 2, 3, 4 ) t;
+-- result:
+8390656	8386560	25696768	-4721152
+-- !result

--- a/test/sql/test_union/T/test_intersect
+++ b/test/sql/test_union/T/test_intersect
@@ -1,0 +1,15 @@
+-- name: test_intersect_with_null_child
+
+create table t0 (
+    c0 INT NOT NULL,
+    c1 BIGINT NOT NULL
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+insert into t0 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  4096));
+create table t1 (
+    c0 INT NOT NULL,
+    c1 BIGINT NOT NULL
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+insert into t1 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  1024));
+insert into t1 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(4096,  8192));
+
+SELECT SUM(LC0), sum(LC1), sum(rc0), sum(rc1) FROM ( SELECT l.c0 lc0, l.c1 lc1, r.c0 rc0, r.c1 rc1 FROM t0 l FULL JOIN ( SELECT c0, c1 FROM t1 GROUP BY 1, 2 ORDER BY 1 desc ) r ON l.c0 = r.c0 INTERSECT SELECT l.c0 lc0, l.c1 lc1, r.c0 rc0, r.c1 rc1 FROM t0 l FULL JOIN t1 r ON l.c0 = r.c0 GROUP BY 1, 2, 3, 4 ) t;


### PR DESCRIPTION
## Why I'm doing:

see reproduce case in test_intersect_with_null_child. Except also has the same problem, will fixed in next PR

```
==3774492==ERROR: AddressSanitizer: unknown-crash on address 0x62d000a672ef at pc 0x00001425c94a bp 0x7f8a4188ebe0 sp 0x7f8a4188ebd0
READ of size 4 at 0x62d000a672ef thread T640
    #0 0x1425c949 in starrocks::FixedLengthColumnBase<int>::deserialize_and_append_batch(std::vector<starrocks::Slice, starrocks::ColumnAllocator<starrocks::Slice> >&, unsigned long) be/src/column/fixed_length_column_base.cpp:213
    #1 0x15e78067 in starrocks::IntersectHashSet<phmap::flat_hash_set<starrocks::IntersectSliceFlag, starrocks::IntersectSliceFlagHash, starrocks::IntersectSliceFlagEqual, std::allocator<starrocks::IntersectSliceFlag> > >::deserialize_to_columns(std::vector<starrocks::Slice, starrocks::ColumnAllocator<starrocks::Slice> >&, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > >&, unsigned long) be/src/exec/intersect_hash_set.cpp:98
    #2 0x1717aa41 in starrocks::pipeline::IntersectContext::pull_chunk(starrocks::RuntimeState*) be/src/exec/pipeline/set/intersect_context.cpp:74
    #3 0x171902e6 in starrocks::pipeline::IntersectOutputSourceOperator::pull_chunk(starrocks::RuntimeState*) be/src/exec/pipeline/set/intersect_output_source_operator.cpp:26
    #4 0x16f26395 in starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int) be/src/exec/pipeline/pipeline_driver.cpp:324
    #5 0x16ed7ae3 in starrocks::pipeline::GlobalDriverExecutor::_worker_thread() be/src/exec/pipeline/pipeline_driver_executor.cpp:160
    #6 0x16ed5e73 in operator() be/src/exec/pipeline/pipeline_driver_executor.cpp:60
    #7 0x16ee229b in __invoke_impl<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::<lambda()>&> /usr/include/c++/11/bits/invoke.h:61
    #8 0x16ee1674 in __invoke_r<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::<lambda()>&> /usr/include/c++/11/bits/invoke.h:111
    #9 0x16ee0ff6 in _M_invoke /usr/include/c++/11/bits/std_function.h:290
```

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/9420

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
