### PR TITLE
[Enhancement] GetTableMeta handles list partition tables.

### DIFF
--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1283,10 +1283,17 @@ struct TRangePartitionDesc {
     2: optional map<i64, TRange> ranges
 }
 
+struct TListPartitionDesc {
+    // partition keys
+    1: optional list<TColumnMeta> columns
+    2: optional list<string> partition_values
+}
+
 struct TPartitionInfo {
     1: optional Partitions.TPartitionType type
     2: optional TSinglePartitionDesc single_partition_desc
     3: optional TRangePartitionDesc  range_partition_desc
+    4: optional TListPartitionDesc list_partition_desc
 }
 
 struct TPartitionMeta {

--- a/gensrc/thrift/Partitions.thrift
+++ b/gensrc/thrift/Partitions.thrift
@@ -57,7 +57,9 @@ enum TPartitionType {
   BUCKET_SHUFFLE_HASH_PARTITIONED,
 
   // Part of the data is hashed, and the other part is broadcast or randomly sent
-  HYBRID_HASH_PARTITIONED
+  HYBRID_HASH_PARTITIONED,
+
+  LIST
 }
 
 enum TDistributionType {


### PR DESCRIPTION
## Why I'm doing:
We are using Starrocks connector to query some other Starrocks clusters, during which we used to using LeaderImpl#GetTableMeta to get table metadata. But it throws exception while handling tables with list partitions.

## What I'm doing:
Return correct information for list-partition tables.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1