### PR TITLE
[BugFix] Fix percentile_disc crash with empty input

### DIFF
--- a/be/src/exprs/agg/percentile_cont.h
+++ b/be/src/exprs/agg/percentile_cont.h
@@ -490,7 +490,10 @@ class PercentileDiscAggregateFunction final : public PercentileContDiscAggregate
         const double& rate = this->data(state).rate;
 
         ResultColumnType* column = down_cast<ResultColumnType*>(to);
-        DCHECK(!new_vector.empty());
+        if (new_vector.empty()) {
+            column->append_default();
+            return;
+        }
         if (new_vector.size() == 1 || rate == 1) {
             column->append(new_vector.back());
             return;

--- a/test/sql/test_agg/R/test_empty_input
+++ b/test/sql/test_agg/R/test_empty_input
@@ -1,0 +1,49 @@
+-- name: test_empty_input
+CREATE TABLE `t0` (
+  `v1` bigint(20) COMMENT "",
+  `v2` bigint(20) COMMENT "",
+  `v3` bigint(20) COMMENT "",
+  `v4` varchar COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`, `v2`, `v3`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "true",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+select percentile_disc(v1,0.5) from t0;
+-- result:
+None
+-- !result
+select percentile_cont(v1,0.5) from t0;
+-- result:
+None
+-- !result
+select percentile_disc_lc(v1,0.5) from t0;
+-- result:
+None
+-- !result
+select max(v1),min(v1) from t0;
+-- result:
+None	None
+-- !result
+select max(v1),count(*) from t0;
+-- result:
+None	0
+-- !result
+select count(v1) from t0;
+-- result:
+0
+-- !result
+select count(*) from t0;
+-- result:
+0
+-- !result
+select count(distinct v1) from t0;
+-- result:
+0
+-- !result

--- a/test/sql/test_agg/T/test_empty_input
+++ b/test/sql/test_agg/T/test_empty_input
@@ -1,0 +1,25 @@
+-- name: test_empty_input
+
+CREATE TABLE `t0` (
+  `v1` bigint(20) COMMENT "",
+  `v2` bigint(20) COMMENT "",
+  `v3` bigint(20) COMMENT "",
+  `v4` varchar COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`, `v2`, `v3`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "true",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+select percentile_disc(v1,0.5) from t0;
+select percentile_cont(v1,0.5) from t0;
+select percentile_disc_lc(v1,0.5) from t0;
+select max(v1),min(v1) from t0;
+select max(v1),count(*) from t0;
+select count(v1) from t0;
+select count(*) from t0;
+select count(distinct v1) from t0;


### PR DESCRIPTION
## Why I'm doing:

reproduce case in test_empty_input

```
    @         0x13f5e217 starrocks::failure_function()
    @         0x2341ad4e google::LogMessage::Fail()
    @         0x2341bfc9 google::LogMessageFatal::~LogMessageFatal()
    @         0x191b055f starrocks::PercentileDiscAggregateFunction<(starrocks::LogicalType)5>::finalize_to_column(starrocks::FunctionContext*, unsigned char const*, starrocks::Column*) const
    @         0x14a86a2a starrocks::Aggregator::_finalize_to_chunk(unsigned char const*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > >&)
    @         0x14a7f7e1 starrocks::Aggregator::convert_to_chunk_no_groupby(std::shared_ptr<starrocks::Chunk>*)
    @         0x1700b57f starrocks::pipeline::AggregateBlockingSourceOperator::pull_chunk(starrocks::RuntimeState*)
    @         0x16f26396 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @         0x16ed7ae4 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @         0x16ed5e74 starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}::operator()() const
    @         0x16ee229c void std::__invoke_impl<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(std::__invoke_other, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&)
    @         0x16ee1675 std::enable_if<is_invocable_r_v<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>, void>::type std::__invoke_r<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(starrocks::pipeline::GlobalDriverU^A
    @         0x16ee0ff7 std::_Function_handler<void (), starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}>::_M_invoke(std::_Any_data const&)
    @         0x13f2bd9e std::function<void ()>::operator()() const
    @         0x21047a52 starrocks::FunctionRunnable::run()
    @         0x21041584 starrocks::ThreadPool::dispatch_thread()
    @         0x2106616c void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
    @         0x21065c0d std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
    @         0x21064aca void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>)
    @         0x2106382d void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>()
    @         0x21060fe2 void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&)
    @         0x2105cb04 std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::_Bind<void (starrocks::ThreadPool:U^A
    @         0x21057f6d std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()> >::_M_invoke(std::_Any_data const&)
    @         0x13f2bd9e std::function<void ()>::operator()() const
    @         0x21024a3c starrocks::Thread::supervise_thread(void*)
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
