### PR TITLE
[BugFix] Exclude all join on-predicate columns in  lowcardinality optimization

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -2484,7 +2484,12 @@ public class MaterializedViewRewriter implements IMaterializedViewRewriter {
                 newProjection =
                         projection.getColumnRefMap().entrySet()
                                 .stream()
-                                .map(e -> Pair.create(e.getKey(), columnMapping.get(e.getKey())))
+                                .map(e -> {
+                                    Preconditions.checkArgument(columnMapping.containsKey(e.getKey()),
+                                            "columnMapping not contains key: %s, %s",
+                                            e.getKey(), columnMapping);
+                                    return Pair.create(e.getKey(), columnMapping.get(e.getKey()));
+                                })
                                 .collect(Collectors.toMap(p -> p.first, p -> p.second));
 
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
@@ -391,6 +391,7 @@ public class OptExpressionDuplicator {
                 LogicalFilterOperator.Builder filterBuilder = (LogicalFilterOperator.Builder) opBuilder;
                 filterBuilder.setPredicate(newPredicate);
             }
+            processCommon(opBuilder);
             return OptExpression.create(opBuilder.build(), inputs);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/PartitionRetentionTableCompensation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/PartitionRetentionTableCompensation.java
@@ -81,7 +81,7 @@ public final class PartitionRetentionTableCompensation extends TableCompensation
     @Override
     public String toString() {
         ScalarOperator compensate =  NegateFilterShuttle.getInstance().negateFilter(compensateOperator);
-        return String.format("%)", compensate.debugString());
+        return String.format("%s", compensate.debugString());
     }
 
     public static TableCompensation build(Table refBaseTable,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -418,11 +418,10 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         if (!result.inputStringColumns.containsAny(onColumns)) {
             return result;
         }
+        onColumns.getStream().forEach(c -> disableRewriteStringColumns.union(c));
         result.outputStringColumns.clear();
         result.inputStringColumns.getStream().forEach(c -> {
-            if (onColumns.contains(c)) {
-                disableRewriteStringColumns.union(c);
-            } else {
+            if (!onColumns.contains(c)) {
                 result.outputStringColumns.union(c);
             }
         });


### PR DESCRIPTION
## Why I'm doing:

- I found a wrong plan in tpcds which will cause wrong result.
![image](https://github.com/user-attachments/assets/ec127996-7dfd-434c-83e0-563177848a14)

## What I'm doing:

- Exclude all join on-predicate columns in lowcardinality optimization even it is not in the output columns.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
