### PR TITLE
[BugFix] Avoid ScalarOperatorsReuse stack overflow

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1949,7 +1949,7 @@ public class Config extends ConfigBase {
     public static long max_planner_scalar_rewrite_num = 100000;
 
     @ConfField(mutable = true, comment = "The max depth that scalar operator optimization can be applied")
-    public static int max_scalar_operator_optimize_depth = 100;
+    public static int max_scalar_operator_optimize_depth = 256;
 
     /**
      * statistic collect flag

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1948,6 +1948,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static long max_planner_scalar_rewrite_num = 100000;
 
+    @ConfField(mutable = true, comment = "The max depth that scalar operator optimization can be applied")
+    public static int max_scalar_operator_optimize_depth = 100;
+
     /**
      * statistic collect flag
      */

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ArrayOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ArrayOperator.java
@@ -37,6 +37,7 @@ public class ArrayOperator extends ScalarOperator {
         super(ARRAY, type);
         this.nullable = nullable;
         this.arguments = arguments;
+        this.incrDepth(arguments);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ArraySliceOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ArraySliceOperator.java
@@ -30,6 +30,7 @@ public class ArraySliceOperator extends ScalarOperator {
     public ArraySliceOperator(Type type, List<ScalarOperator> arguments) {
         super(ARRAY_SLICE, type);
         this.arguments = arguments;
+        this.incrDepth(arguments);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BetweenPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BetweenPredicateOperator.java
@@ -28,12 +28,14 @@ public class BetweenPredicateOperator extends PredicateOperator {
         super(OperatorType.BETWEEN, arguments);
         this.notBetween = notBetween;
         Preconditions.checkState(arguments.length == 3);
+        this.incrDepth(arguments);
     }
 
     public BetweenPredicateOperator(boolean notBetween, List<ScalarOperator> arguments) {
         super(OperatorType.BETWEEN, arguments);
         this.notBetween = notBetween;
         Preconditions.checkState(arguments != null && arguments.size() == 3);
+        this.incrDepth(arguments);
     }
 
     public boolean isNotBetween() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
@@ -51,12 +51,14 @@ public class BinaryPredicateOperator extends PredicateOperator {
         super(OperatorType.BINARY, arguments);
         this.type = type;
         Preconditions.checkState(arguments.length == 2);
+        this.incrDepth(arguments);
     }
 
     public BinaryPredicateOperator(BinaryType type, List<ScalarOperator> arguments) {
         super(OperatorType.BINARY, arguments);
         this.type = type;
         Preconditions.checkState(arguments.size() == 2);
+        this.incrDepth(arguments);
     }
 
     public void setBinaryType(BinaryType type) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CallOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CallOperator.java
@@ -78,6 +78,7 @@ public class CallOperator extends ScalarOperator {
         this.fn = fn;
         this.isDistinct = isDistinct;
         this.removedDistinct = removedDistinct;
+        this.incrDepth(arguments);
     }
 
     public void setIgnoreNulls(boolean ignoreNulls) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CloneOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CloneOperator.java
@@ -29,6 +29,7 @@ public class CloneOperator extends ScalarOperator {
         super(OperatorType.CLONE, argument.getType());
         arguments = Lists.newArrayList(argument);
         setType(argument.getType());
+        this.incrDepth(argument);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CollectionElementOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CollectionElementOperator.java
@@ -35,6 +35,7 @@ public class CollectionElementOperator extends ScalarOperator {
         this.arguments.add(arrayOperator);
         this.arguments.add(subscriptOperator);
         this.isCheckOutOfBounds = isCheckOutOfBounds;
+        this.incrDepth(arguments);
     }
 
     public boolean isCheckOutOfBounds() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/MapOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/MapOperator.java
@@ -34,6 +34,7 @@ public class MapOperator extends ScalarOperator {
     public MapOperator(Type type, List<ScalarOperator> arguments) {
         super(MAP, type);
         this.arguments = arguments;
+        this.incrDepth(arguments);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/MatchExprOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/MatchExprOperator.java
@@ -34,6 +34,7 @@ public class MatchExprOperator extends ScalarOperator {
         super(OperatorType.MATCH_EXPR, Type.BOOLEAN);
         Preconditions.checkState(arguments.size() == 2);
         this.arguments = arguments;
+        this.incrDepth(arguments);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/PredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/PredicateOperator.java
@@ -35,6 +35,7 @@ public abstract class PredicateOperator extends ScalarOperator {
     public PredicateOperator(OperatorType operatorType, List<ScalarOperator> arguments) {
         super(operatorType, Type.BOOLEAN);
         this.arguments = requireNonNull(arguments, "arguments is null");
+        this.incrDepth(arguments);
     }
 
     public List<ScalarOperator> getChildren() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
@@ -49,6 +49,11 @@ public abstract class ScalarOperator implements Cloneable {
 
     private boolean isIndexOnlyFilter = false;
 
+    // 1. depth is scalar operator's nested depth, it starts from 0(eg: ColumnRefOperator/ConstantOperator), incr +1 for each
+    // child nested; if it contains multi children, the max depth of children will be added to this operator's depth.
+    // 2. depth is marked to avoid infinite loop in some cases.
+    protected int depth = 0;
+
     public ScalarOperator(OperatorType opType, Type type) {
         this.opType = requireNonNull(opType, "opType is null");
         this.type = requireNonNull(type, "type is null");
@@ -143,6 +148,39 @@ public abstract class ScalarOperator implements Cloneable {
 
     @Override
     public abstract boolean equals(Object other);
+
+    public int getDepth() {
+        return depth;
+    }
+
+    /**
+     * Incr depth for this operator: this.depth = 1 + max(depth of children)
+     */
+    public void incrDepth(List<ScalarOperator> args) {
+        // always add 1 for self
+        this.depth += 1;
+        if (args == null) {
+            return;
+        }
+        this.depth += args.stream().map(arg -> arg.getDepth()).max(Integer::compareTo).orElse(0);
+    }
+
+    /**
+     * Incr depth for this operator: this.depth = 1 + max(depth of children)
+     */
+    public void incrDepth(ScalarOperator... args) {
+        // always add 1 for self
+        this.depth += 1;
+
+        if (args == null) {
+            return;
+        }
+        int ans = 0;
+        for (ScalarOperator arg : args) {
+            ans = Math.max(ans, arg.getDepth());
+        }
+        this.depth += ans;
+    }
 
     /**
      * equivalent means logical equals, but may physical different, such as with different id

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/SubfieldOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/SubfieldOperator.java
@@ -59,6 +59,7 @@ public class SubfieldOperator extends ScalarOperator {
         this.children.add(child);
         this.fieldNames = ImmutableList.copyOf(fieldNames);
         this.copyFlag = copyFlag;
+        this.incrDepth(child);
     }
 
     public List<String> getFieldNames() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
@@ -331,9 +331,6 @@ public class ScalarOperatorsReuse {
 
         private int collectCommonOperatorsByDepth(int depth, ScalarOperator operator,
                                                   CommonSubScalarOperatorCollectorContext context) {
-            if (depth > 100) {
-                return depth;
-            }
             Set<ScalarOperator> operators = getOperatorsByDepth(depth, operatorsByDepth);
 
             boolean isDependentOnOuterLambda = isDependentOnOuterLambdaArguments(operator, context);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
@@ -384,11 +384,10 @@ public class ScalarOperatorsReuse {
 
         @Override
         public Integer visit(ScalarOperator scalarOperator, CommonSubScalarOperatorCollectorContext context) {
-            if (Config.max_scalar_operator_optimize_depth > 0 &&
-                    scalarOperator.getDepth() > Config.max_scalar_operator_optimize_depth) {
-                return 0;
-            }
-            if (scalarOperator.isConstant() || scalarOperator.getChildren().isEmpty()) {
+            // To avoid stack overflow if the operator tree is too deep(eg: contains too many `or` functions), set a limit
+            // to the depth of the operator tree.
+            if (scalarOperator.getDepth() > Config.max_scalar_operator_optimize_depth ||
+                    scalarOperator.isConstant() || scalarOperator.getChildren().isEmpty()) {
                 return 0;
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
+import com.starrocks.common.Config;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
@@ -266,7 +267,76 @@ public class ScalarOperatorsReuseTest {
     }
 
     @Test
-    public void testCaseWhenWithOr() {
+    public void testScalarOperatorDepth() {
+        ColumnRefOperator column1 = columnRefFactory.create("t1", ScalarType.INT, true);
+        ColumnRefOperator column2 = columnRefFactory.create("t2", ScalarType.INT, true);
+        ScalarOperator or1 = generateCompoundPredicateOperator(column1, Config.max_scalar_operator_optimize_depth - 1);
+        ScalarOperator or2 = generateCompoundPredicateOperator(column2, Config.max_scalar_operator_optimize_depth - 1);
+        Assert.assertEquals(0, column1.getDepth());
+        Assert.assertEquals(0, column2.getDepth());
+        Assert.assertEquals(Config.max_scalar_operator_optimize_depth - 1, or1.getDepth());
+        Assert.assertEquals(Config.max_scalar_operator_optimize_depth - 1, or2.getDepth());
+
+        ColumnRefOperator arg = columnRefFactory.create("x", ScalarType.INT, true, true);
+        Assert.assertEquals(0, arg.getDepth());
+        CallOperator multi = new CallOperator("multi", Type.INT,
+                Lists.newArrayList(arg, ConstantOperator.createInt(2)));
+        Assert.assertEquals(1, multi.getDepth());
+
+        CallOperator multi1 = new CallOperator("multi", Type.INT,
+                Lists.newArrayList(arg, ConstantOperator.createInt(2)));
+        Assert.assertEquals(1, multi1.getDepth());
+        CallOperator add1 = new CallOperator("add", Type.INT,
+                Lists.newArrayList(multi, multi1));
+        Assert.assertEquals(2, add1.getDepth());
+
+        CallOperator add3 = new CallOperator("add", Type.INT,
+                Lists.newArrayList(multi, or1));
+        Assert.assertEquals(Config.max_scalar_operator_optimize_depth, add3.getDepth());
+    }
+
+    @Test
+    public void testScalarOperatorIncrDepth() {
+        ColumnRefOperator column1 = columnRefFactory.create("t1", ScalarType.INT, true);
+        Assert.assertEquals(0, column1.getDepth());
+
+        ColumnRefOperator column2 = columnRefFactory.create("t2", ScalarType.INT, true);
+        Assert.assertEquals(0, column1.getDepth());
+
+        // mock construct
+        column1.incrDepth(column2);
+        Assert.assertEquals(1, column1.getDepth());
+
+        column1.incrDepth(column2, column2);
+        Assert.assertEquals(2, column1.getDepth());
+
+        column1.incrDepth(ImmutableList.of(column2, column2));
+        Assert.assertEquals(3, column1.getDepth());
+    }
+
+    @Test
+    public void testCaseWhenWithTooManyChildren1() {
+        ColumnRefOperator column1 = columnRefFactory.create("t1", ScalarType.INT, true);
+        ColumnRefOperator column2 = columnRefFactory.create("t2", ScalarType.INT, true);
+        ScalarOperator or1 = generateCompoundPredicateOperator(column1, Config.max_scalar_operator_optimize_depth - 1);
+        ScalarOperator or2 = generateCompoundPredicateOperator(column2, Config.max_scalar_operator_optimize_depth - 1);
+
+        CaseWhenOperator cwo1 = new CaseWhenOperator(Type.INT, or1, ConstantOperator.createInt(0),
+                Lists.newArrayList(or1, ConstantOperator.createInt(0), or2, ConstantOperator.createInt(1)));
+        CaseWhenOperator cwo2 = new CaseWhenOperator(Type.INT, or1, ConstantOperator.createInt(0),
+                Lists.newArrayList(or1, ConstantOperator.createInt(2), or2, ConstantOperator.createInt(3)));
+
+        List<ScalarOperator> oldOperators = Lists.newArrayList(cwo1, cwo2);
+        List<ScalarOperator> newOperators = ScalarOperatorsReuse.rewriteOperators(oldOperators, columnRefFactory);
+        Assert.assertEquals(newOperators.size(), 2);
+
+        Map<Integer, Map<ScalarOperator, ColumnRefOperator>> commonSubScalarOperators =
+                ScalarOperatorsReuse.collectCommonSubScalarOperators(null, oldOperators, columnRefFactory);
+        Assert.assertTrue(commonSubScalarOperators.size() == Config.max_scalar_operator_optimize_depth - 1);
+    }
+
+    @Test
+    public void testCaseWhenWithTooManyChildren2() {
         ColumnRefOperator column1 = columnRefFactory.create("t1", ScalarType.INT, true);
         ColumnRefOperator column2 = columnRefFactory.create("t2", ScalarType.INT, true);
         ScalarOperator or1 = generateCompoundPredicateOperator(column1, 2000);
@@ -278,10 +348,12 @@ public class ScalarOperatorsReuseTest {
                 Lists.newArrayList(or1, ConstantOperator.createInt(2), or2, ConstantOperator.createInt(3)));
 
         List<ScalarOperator> oldOperators = Lists.newArrayList(cwo1, cwo2);
-
-
         try {
             List<ScalarOperator> newOperators = ScalarOperatorsReuse.rewriteOperators(oldOperators, columnRefFactory);
+            Assert.assertEquals(newOperators.size(), 2);
+            for (int i = 0; i < newOperators.size(); i++) {
+                Assert.assertTrue(newOperators.get(i).equals(oldOperators.get(i)));
+            }
         } catch (Exception e) {
             Assert.fail();
         }


### PR DESCRIPTION
## Why I'm doing:

```
java.lang.StackOverflowError: null
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperator.isConstant(ScalarOperator.java:58) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperator.isConstant(ScalarOperator.java:59) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperator.isConstant(ScalarOperator.java:59) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperator.isConstant(ScalarOperator.java:59) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperator.isConstant(ScalarOperator.java:59) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperator.isConstant(ScalarOperator.java:59) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperator.isConstant(ScalarOperator.java:59) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperator.isConstant(ScalarOperator.java:59) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperator.isConstant(ScalarOperator.java:59) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperator.isConstant(ScalarOperator.java:59) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperator.isConstant(ScalarOperator.java:59) ~[starrocks-fe.jar:?]
	....
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperator.isConstant(ScalarOperator.java:59) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:362) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor.visitCompoundPredicate(ScalarOperatorVisitor.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.accept(CompoundPredicateOperator.java:80) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.lambda$visit$0(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_322]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_322]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_322]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_322]
	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:546) ~[?:1.8.0_322]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:372) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse$CommonSubScalarOperatorCollector.visit(ScalarOperatorsReuse.java:285) ~[starrocks-fe.jar:?]
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
