### PR TITLE
[BugFix] Fix FE node crash caused by LoadStatistic serialization

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/EtlStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/EtlStatus.java
@@ -590,7 +590,7 @@ public class EtlStatus implements Writable {
             return details;
         }
 
-        public String toJson() throws IOException {
+        public synchronized String toJson() throws IOException {
             return GsonUtils.GSON.toJson(this);
         }
 


### PR DESCRIPTION
## Why I'm doing:

starrocks version: 2.1.13
fe node crashes by chance, which is a very small probability event


```
2025-03-15 18:35:32,897 ERROR (loading_load_task_scheduler_pool-9|425422) [EditLog.logEdit():870] Fatal Error : write stream Exception
java.util.ConcurrentModificationException: null
	at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:911) ~[?:1.8.0_261]
	at java.util.ArrayList$Itr.next(ArrayList.java:861) ~[?:1.8.0_261]
	at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.write(CollectionTypeAdapterFactory.java:96) ~[spark-dpp-1.0.0.jar:?]
	at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.write(CollectionTypeAdapterFactory.java:61) ~[spark-dpp-1.0.0.jar:?]
	at com.starrocks.persist.gson.GsonUtils$PostProcessTypeAdapterFactory$1.write(GsonUtils.java:385) ~[starrocks-fe.jar:?]
	at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.write(TypeAdapterRuntimeTypeWrapper.java:69) ~[spark-dpp-1.0.0.jar:?]
	at com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.write(MapTypeAdapterFactory.java:239) ~[spark-dpp-1.0.0.jar:?]
	at com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.write(MapTypeAdapterFactory.java:145) ~[spark-dpp-1.0.0.jar:?]
	at com.starrocks.persist.gson.GsonUtils$PostProcessTypeAdapterFactory$1.write(GsonUtils.java:385) ~[starrocks-fe.jar:?]
	at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.write(TypeAdapterRuntimeTypeWrapper.java:69) ~[spark-dpp-1.0.0.jar:?]
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.write(ReflectiveTypeAdapterFactory.java:127) ~[spark-dpp-1.0.0.jar:?]
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.write(ReflectiveTypeAdapterFactory.java:245) ~[spark-dpp-1.0.0.jar:?]
	at com.starrocks.persist.gson.GsonUtils$PostProcessTypeAdapterFactory$1.write(GsonUtils.java:385) ~[starrocks-fe.jar:?]
	at com.google.gson.Gson.toJson(Gson.java:704) ~[spark-dpp-1.0.0.jar:?]
	at com.google.gson.Gson.toJson(Gson.java:683) ~[spark-dpp-1.0.0.jar:?]
	at com.google.gson.Gson.toJson(Gson.java:638) ~[spark-dpp-1.0.0.jar:?]
	at com.google.gson.Gson.toJson(Gson.java:618) ~[spark-dpp-1.0.0.jar:?]
	at com.starrocks.load.EtlStatus$LoadStatistic.toJson(EtlStatus.java:375) ~[starrocks-fe.jar:?]
	at com.starrocks.load.EtlStatus.write(EtlStatus.java:203) ~[starrocks-fe.jar:?]
	at com.starrocks.load.loadv2.LoadJobFinalOperation.write(LoadJobFinalOperation.java:97) ~[starrocks-fe.jar:?]
	at com.starrocks.journal.JournalEntity.write(JournalEntity.java:133) ~[starrocks-fe.jar:?]
	at com.starrocks.journal.bdbje.BDBJEJournal.write(BDBJEJournal.java:140) ~[starrocks-fe.jar:?]
	at com.starrocks.persist.EditLog.logEdit(EditLog.java:868) [starrocks-fe.jar:?]
	at com.starrocks.persist.EditLog.logEndLoadJob(EditLog.java:1300) [starrocks-fe.jar:?]
	at com.starrocks.load.loadv2.LoadJob.logFinalOperation(LoadJob.java:636) [starrocks-fe.jar:?]
	at com.starrocks.load.loadv2.BulkLoadJob.onTaskFailed(BulkLoadJob.java:222) [starrocks-fe.jar:?]
	at com.starrocks.load.loadv2.LoadTask.exec(LoadTask.java:74) [starrocks-fe.jar:?]
	at com.starrocks.task.MasterTask.run(MasterTask.java:35) [starrocks-fe.jar:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_261]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_261]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_261]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_261]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_261]
2025-03-15 18:35:32,901 INFO (Thread-39|95) [StarRocksFE.lambda$addShutdownHook$1():310] start to execute shutdown hook
```

## What I'm doing:
Fixed serialization issue of LoadStatistics

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1