### PR TITLE
[BugFix] Fix the bug of the runtime filter cannot be pushed down for iceberg table with equality delete

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/IcebergEqualityDeleteRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/IcebergEqualityDeleteRewriteRule.java
@@ -136,7 +136,7 @@ public class IcebergEqualityDeleteRewriteRule extends TransformationRule {
         List<List<Integer>> allIds = deleteSchemas.stream()
                 .map(IcebergDeleteSchema::equalityIds)
                 .distinct()
-                .collect(Collectors.toList());
+                .toList();
 
         List<IcebergMORParams> tableFullMorParams = Stream.concat(
                         Stream.of(IcebergMORParams.DATA_FILE_WITHOUT_EQ_DELETE, IcebergMORParams.DATA_FILE_WITH_EQ_DELETE),
@@ -147,7 +147,6 @@ public class IcebergEqualityDeleteRewriteRule extends TransformationRule {
         scanOperator.setMORParam(IcebergMORParams.DATA_FILE_WITHOUT_EQ_DELETE);
         scanOperator.setTableFullMORParams(icebergTableFullMorParams);
         scanOperator.setFromEqDeleteRewriteRule(true);
-        OptExpression dataFileWithoutDeleteScanOp = OptExpression.create(scanOperator);
 
         ImmutableMap.Builder<ColumnRefOperator, ScalarOperator> projectForUnion = ImmutableMap.builder();
         LogicalIcebergScanOperator icebergDataFileWithDeleteScanOp = buildNewScanOperatorWithUnselectedAndExtendedField(
@@ -162,7 +161,7 @@ public class IcebergEqualityDeleteRewriteRule extends TransformationRule {
             String equalityDeleteTableName = buildEqualityDeleteTableName(icebergTable, equalityIds);
             List<String> columnNames = equalityIds.stream()
                     .map(id -> table.schema().findColumnName(id))
-                    .collect(Collectors.toList());
+                    .toList();
             List<Column> deleteColumns = columnNames.stream().map(icebergTable::getColumn).collect(Collectors.toList());
             IcebergTable equalityDeleteTable = new IcebergTable(
                     ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(), equalityDeleteTableName,
@@ -206,9 +205,13 @@ public class IcebergEqualityDeleteRewriteRule extends TransformationRule {
         LogicalProjectOperator logicalProjectOperator = new LogicalProjectOperator(projectForUnion.build(), limit);
         optExpression = OptExpression.create(logicalProjectOperator, optExpression);
 
+        LogicalIcebergScanOperator withoutDeleteScanOperator = buildNewScanOperatorWithoutDelete(
+                scanOperator, columnRefFactory);
+        OptExpression optExpressionWithoutDelete = OptExpression.create(withoutDeleteScanOperator);
+
         // build union all
         List<List<ColumnRefOperator>> childOutputColumns = new ArrayList<>();
-        childOutputColumns.add(scanOperator.getOutputColumns());
+        childOutputColumns.add(withoutDeleteScanOperator.getOutputColumns());
         childOutputColumns.add(new ArrayList<>(logicalProjectOperator.getColumnRefMap().keySet()));
 
         LogicalUnionOperator unionOperator = LogicalUnionOperator.builder()
@@ -219,7 +222,7 @@ public class IcebergEqualityDeleteRewriteRule extends TransformationRule {
                 .setLimit(limit)
                 .build();
 
-        optExpression = OptExpression.create(unionOperator, dataFileWithoutDeleteScanOp, optExpression);
+        optExpression = OptExpression.create(unionOperator, optExpressionWithoutDelete, optExpression);
         return Collections.singletonList(optExpression);
     }
 
@@ -240,6 +243,50 @@ public class IcebergEqualityDeleteRewriteRule extends TransformationRule {
 
         List<ScalarOperator> onOps = onPredicates.stream().map(PredicateOperator::clone).collect(Collectors.toList());
         return Utils.createCompound(CompoundPredicateOperator.CompoundType.AND, onOps);
+    }
+
+    private LogicalIcebergScanOperator buildNewScanOperatorWithoutDelete(
+            LogicalIcebergScanOperator scanOperator,
+            ColumnRefFactory columnRefFactory) {
+        IcebergTable table = (IcebergTable) scanOperator.getTable();
+
+        Map<ColumnRefOperator, Column> colRefToColumnMetaMap = scanOperator.getColRefToColumnMetaMap();
+        Map<Column, ColumnRefOperator> columnMetaToColRefMap = scanOperator.getColumnMetaToColRefMap();
+
+        ImmutableMap.Builder<ColumnRefOperator, Column> newColRefToColBuilder =
+                ImmutableMap.builder();
+        ImmutableMap.Builder<Column, ColumnRefOperator> newColToColRefBuilder =
+                ImmutableMap.builder();
+
+        // fill ImmutableMap.Builder<Column, ColumnRefOperator> newColToColRefBuilder
+        Map<ColumnRefOperator, ColumnRefOperator> originToNewCols = new HashMap<>();
+        for (Map.Entry<Column, ColumnRefOperator> entry : columnMetaToColRefMap.entrySet()) {
+            Column originalCol = entry.getKey();
+            ColumnRefOperator originalColRef = entry.getValue();
+            ColumnRefOperator newColRef = buildNewColumnRef(originalCol, columnRefFactory, table);
+            newColToColRefBuilder.put(originalCol, newColRef);
+            originToNewCols.put(originalColRef, newColRef);
+        }
+
+        // fill newColRefToColBuilder and projectForUnion to guarantee column order.
+        for (Map.Entry<ColumnRefOperator, Column> entry : colRefToColumnMetaMap.entrySet()) {
+            ColumnRefOperator originRef = entry.getKey();
+            Column originCol = entry.getValue();
+            ColumnRefOperator newRef = originToNewCols.get(originRef);
+            newColRefToColBuilder.put(newRef, originCol);
+        }
+
+        // build new table's predicate
+        ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(originToNewCols);
+        ScalarOperator newPredicate = rewriter.rewrite(scanOperator.getPredicate());
+
+        LogicalIcebergScanOperator newOp =  new LogicalIcebergScanOperator(table, newColRefToColBuilder.build(),
+                newColToColRefBuilder.build(), scanOperator.getLimit(), newPredicate, scanOperator.getTableVersionRange());
+
+        newOp.setMORParam(scanOperator.getMORParam());
+        newOp.setTableFullMORParams(scanOperator.getTableFullMORParams());
+        newOp.setFromEqDeleteRewriteRule(true);
+        return newOp;
     }
 
     private LogicalIcebergScanOperator buildNewScanOperatorWithUnselectedAndExtendedField(

--- a/test/sql/test_iceberg/R/test_iceberg_v2
+++ b/test/sql/test_iceberg/R/test_iceberg_v2
@@ -110,7 +110,7 @@ with cte1 as (
     select l.k1, sum(length(l.k2)) l_k2, sum(length(r.k2)) r_k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table l
         left join iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table r on l.k1 = r.k1 group by 1
     )
-select cte1.k1, cte2.k1, cte1.l_k2, cte2.r_k2 from cte1 left join cte2 on cte1.k1 = cte2.k1;
+select cte1.k1, cte2.k1, cte1.l_k2, cte2.r_k2 from cte1 left join cte2 on cte1.k1 = cte2.k1 order by cte1.k1 desc;
 -- result:
 2	2	9	9
 1	1	8	8
@@ -149,6 +149,18 @@ select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_
 -- !result
 select k1,k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table group by k1,k3 having count(1) > 1;
 -- result:
+-- !result
+function: assert_explain_verbose_contains('select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table', '[1, INT, true] | [2, VARCHAR(1073741824), true] | [3, VARCHAR(1073741824), true]')
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains('select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table', '[11: k1, INT, true] | [12: k2, VARCHAR(1073741824), true] | [13: k3, VARCHAR(1073741824), true]')
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains('select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table', '[4: k1, INT, true] | [5: k2, VARCHAR(1073741824), true] | [6: k3, VARCHAR(1073741824), true]')
+-- result:
+None
 -- !result
 drop catalog iceberg_sql_test_${uuid0};
 -- result:

--- a/test/sql/test_iceberg/T/test_iceberg_v2
+++ b/test/sql/test_iceberg/T/test_iceberg_v2
@@ -81,7 +81,7 @@ with cte1 as (
     select l.k1, sum(length(l.k2)) l_k2, sum(length(r.k2)) r_k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table l
         left join iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table r on l.k1 = r.k1 group by 1
     )
-select cte1.k1, cte2.k1, cte1.l_k2, cte2.r_k2 from cte1 left join cte2 on cte1.k1 = cte2.k1;
+select cte1.k1, cte2.k1, cte1.l_k2, cte2.r_k2 from cte1 left join cte2 on cte1.k1 = cte2.k1 order by cte1.k1 desc;
 
 -- partitioned table with parquet (eq-delete && pos-delete)
 /*
@@ -106,5 +106,9 @@ select k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partit
 select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
 
 select k1,k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table group by k1,k3 having count(1) > 1;
+
+function: assert_explain_verbose_contains('select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table', '[1, INT, true] | [2, VARCHAR(1073741824), true] | [3, VARCHAR(1073741824), true]')
+function: assert_explain_verbose_contains('select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table', '[11: k1, INT, true] | [12: k2, VARCHAR(1073741824), true] | [13: k3, VARCHAR(1073741824), true]')
+function: assert_explain_verbose_contains('select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table', '[4: k1, INT, true] | [5: k2, VARCHAR(1073741824), true] | [6: k3, VARCHAR(1073741824), true]')
 
 drop catalog iceberg_sql_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

Fix: https://github.com/StarRocks/starrocks/issues/55770

After the pr: https://github.com/StarRocks/starrocks/pull/52248, `IcebergEqualityDeleteRewriteRule` will rewrite the `IcebergScan` with equality delete to this:

![image](https://github.com/user-attachments/assets/3331da32-6372-4d4d-827a-e1664c0f5a5f)

But this rewrite has some problem:

```
|   0:UNION                                                                                                                                        |
|   |  output exprs:                                                                                                                                       |
|   |      [1, INT, true] | [2, VARCHAR(1073741824), true]                                                                                                 |
|   |  child exprs:                                                                                                                                        |
|   |      [1: k1, INT, true] | [2: k2, VARCHAR(1073741824), true]                                                                                        |
|   |      [12: k1, INT, true] | [13: k2, VARCHAR(1073741824), true]                                                                                       |
|   |  pass-through-operands: all                                                                                                                          |
|   |  cardinality: 2                                                                                                                                      |
|   |  column statistics:                                                                                                                                  |
|   |  * k1-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN                                                                                                 |
|   |  * k2-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN                                                                                                 |
|   |                                                                                                                                                      |
|   |----8:EXCHANGE                                                                                                                                        |
|   |       cardinality: 1                                                                                                                                 |
|   |                                                                                                                                                      |
|   2:EXCHANGE                                                                                                                                             |
|      cardinality: 1 
```

The output columns of `Union` is same as the input child columns, so the `ColRefToExpr` for union will be overrided by `buildIcebergScanNode`.

```
        private PlanFragment buildSetOperation(OptExpression optExpr, ExecPlan context, OperatorType operatorType) {
            PhysicalSetOperation setOperation = (PhysicalSetOperation) optExpr.getOp();
            TupleDescriptor setOperationTuple = context.getDescTbl().createTupleDescriptor();

            for (ColumnRefOperator columnRefOperator : setOperation.getOutputColumnRefOp()) {
                SlotDescriptor slotDesc = context.getDescTbl()
                        .addSlotDescriptor(setOperationTuple, new SlotId(columnRefOperator.getId()));
                slotDesc.setType(columnRefOperator.getType());
                slotDesc.setIsMaterialized(true);
                slotDesc.setIsNullable(columnRefOperator.isNullable());

                context.getColRefToExpr().put(columnRefOperator, new SlotRef(columnRefOperator.toString(), slotDesc));
            }
```
```
        public PlanFragment buildIcebergScanNode(OptExpression expression, ExecPlan context) {
            PhysicalScanOperator node = expression.getOp().cast();
            Table referenceTable = node.getTable();
            context.getDescTbl().addReferencedTable(referenceTable);
            TupleDescriptor tupleDescriptor = context.getDescTbl().createTupleDescriptor();
            tupleDescriptor.setTable(referenceTable);

            // set slot
            prepareContextSlots(node, context, tupleDescriptor);


        private void prepareContextSlots(PhysicalScanOperator node, ExecPlan context, TupleDescriptor tupleDescriptor) {
            // set slot
            for (Map.Entry<ColumnRefOperator, Column> entry : node.getColRefToColumnMetaMap().entrySet()) {
                SlotDescriptor slotDescriptor =
                        context.getDescTbl().addSlotDescriptor(tupleDescriptor, new SlotId(entry.getKey().getId()));
                slotDescriptor.setColumn(entry.getValue());
                slotDescriptor.setIsNullable(entry.getValue().isAllowNull());
                slotDescriptor.setIsMaterialized(true);
                slotDescriptor.setIsOutputColumn(node.getOutputColumns().contains(entry.getKey()));
                if (slotDescriptor.getOriginType().isComplexType()) {
                    slotDescriptor.setOriginType(entry.getKey().getType());
                    slotDescriptor.setType(entry.getKey().getType());
                }
                context.getColRefToExpr().put(entry.getKey(), new SlotRef(entry.getKey().toString(), slotDescriptor));
            }
        }
```

If there is another `JoinNode` on top of the `UnionNode`, the equal join conjunct can't bind to the tuple id of left child node, so it will not push down.

```
|   11:HASH JOIN                                                                                                                                           |
|   |  join op: INNER JOIN (BROADCAST)                                                                                                                     |
|   |  equal join conjunct: [1: k1, INT, true] = [3: p_partkey, INT, false]                                                                                |
|   |  can local shuffle: false                                                                                                                            |
|   |  cardinality: 1000000                                                                                                                                |
|   |                                                                                                                                                      |
|   |----10:EXCHANGE                                                                                                                                       |
|   |       distribution type: BROADCAST                                                                                                                   |
|   |       cardinality: 1000000                                                                                                                           |
|   |                                                                                                                                                      |
|   0:UNION      
```

The right plan should be this:

```
|   0:UNION                                                                                                                                                |                                               
|   |  output exprs:                                                                                                                                       |                                               
|   |      [1, INT, true] | [2, VARCHAR(1073741824), true]                                                                                                 |                                               
|   |  child exprs:                                                                                                                                        |                                               
|   |      [17: k1, INT, true] | [18: k2, VARCHAR(1073741824), true]                                                                                       |                                               
|   |      [12: k1, INT, true] | [13: k2, VARCHAR(1073741824), true] 
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
