### PR TITLE
[BugFix] fix query profile min/max correctness for long-running queries

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -297,24 +297,28 @@ public class RuntimeProfile {
                     Pair<Counter, String> pair = counterMap.get(topName);
                     TCounter tcounter = tCounterMap.get(topName);
                     String parentName = child2ParentMap.get(topName);
+                    Counter counter = null;
                     if (pair == null && tcounter != null && parentName != null) {
-                        Counter counter =
-                                addCounter(topName, tcounter.type, tcounter.strategy, parentName);
+                        counter = addCounter(topName, tcounter.type, tcounter.strategy, parentName);
                         counter.setValue(tcounter.value);
                         counter.setStrategy(tcounter.strategy);
-                        if (tcounter.isSetMin_value()) {
-                            counter.setMinValue(tcounter.getMin_value());
-                        }
-                        if (tcounter.isSetMax_value()) {
-                            counter.setMaxValue(tcounter.getMax_value());
-                        }
-                        tCounterMap.remove(topName);
                     } else if (pair != null && tcounter != null) {
+                        counter = pair.first;
                         if (pair.first.getType() != tcounter.type) {
                             LOG.error("Cannot update counters with the same name but different types"
                                     + " type=" + tcounter.type);
                         } else {
                             pair.first.setValue(tcounter.value);
+                        }
+                    }
+
+                    if (counter != null) {
+                        // Running profile will report multiple times, we only need the last time value
+                        if (tcounter.isSetMin_value()) {
+                            counter.setMinValue(tcounter.getMin_value());
+                        }
+                        if (tcounter.isSetMax_value()) {
+                            counter.setMaxValue(tcounter.getMax_value());
                         }
                         tCounterMap.remove(topName);
                     }
@@ -332,23 +336,27 @@ public class RuntimeProfile {
             // Second, processing the remaining counters, set ROOT_COUNTER as it's parent
             for (TCounter tcounter : tCounterMap.values()) {
                 Pair<Counter, String> pair = counterMap.get(tcounter.name);
+                Counter counter = null;
                 if (pair == null) {
-                    Counter counter = addCounter(tcounter.name, tcounter.type, tcounter.strategy);
+                    counter = addCounter(tcounter.name, tcounter.type, tcounter.strategy);
                     counter.setValue(tcounter.value);
                     counter.setStrategy(tcounter.strategy);
-                    if (tcounter.isSetMin_value()) {
-                        counter.setMinValue(tcounter.getMin_value());
-                    }
-                    if (tcounter.isSetMax_value()) {
-                        counter.setMaxValue(tcounter.getMax_value());
-                    }
                 } else {
+                    counter = pair.first;
                     if (pair.first.getType() != tcounter.type) {
                         LOG.error("Cannot update counters with the same name but different types"
                                 + " type=" + tcounter.type);
                     } else {
                         pair.first.setValue(tcounter.value);
                     }
+                }
+
+                // Running profile will report multiple times, we only need the last time value
+                if (tcounter.isSetMin_value()) {
+                    counter.setMinValue(tcounter.getMin_value());
+                }
+                if (tcounter.isSetMax_value()) {
+                    counter.setMaxValue(tcounter.getMax_value());
                 }
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryRuntimeProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryRuntimeProfileTest.java
@@ -71,7 +71,7 @@ public class QueryRuntimeProfileTest {
 
         QueryRuntimeProfile profile = new QueryRuntimeProfile(connectContext, jobSpec, false);
         profile.initFragmentProfiles(1);
-        TReportExecStatusParams reportExecStatusParams = buildReportStatus();
+        TReportExecStatusParams reportExecStatusParams = buildReportStatus(1L);
         profile.updateLoadChannelProfile(reportExecStatusParams);
         Optional<RuntimeProfile> optional = profile.mergeLoadChannelProfile();
         Assert.assertTrue(optional.isPresent());
@@ -93,7 +93,7 @@ public class QueryRuntimeProfileTest {
 
         QueryRuntimeProfile profile = new QueryRuntimeProfile(connectContext, jobSpec, false);
         profile.initFragmentProfiles(1);
-        TReportExecStatusParams reportExecStatusParams = buildReportStatus();
+        TReportExecStatusParams reportExecStatusParams = buildReportStatus(1L);
         profile.updateLoadChannelProfile(reportExecStatusParams);
         RuntimeProfile runtimeProfile = profile.buildQueryProfile(true);
         Assert.assertNotNull(runtimeProfile);
@@ -102,6 +102,58 @@ public class QueryRuntimeProfileTest {
         RuntimeProfile loadChannelProfile = runtimeProfile.getChild("LoadChannel");
         Assert.assertNotNull(loadChannelProfile);
         verifyMergedLoadChannelProfile(loadChannelProfile);
+    }
+
+    @Test
+    public void testMultipleUpdateLoadChannelProfile() {
+        new Expectations() {
+            {
+                jobSpec.hasOlapTableSink();
+                result = true;
+                minTimes = 0;
+            }
+        };
+
+        QueryRuntimeProfile profile = new QueryRuntimeProfile(connectContext, jobSpec, false);
+        profile.initFragmentProfiles(1);
+
+        // Generate and update with multiple reportStatus
+        for (long i = 1; i <= 3; i++) {
+            TReportExecStatusParams reportExecStatusParams = buildReportStatus(i);
+            profile.updateLoadChannelProfile(reportExecStatusParams);
+
+            Optional<RuntimeProfile> optional = profile.mergeLoadChannelProfile();
+            Assert.assertTrue(optional.isPresent());
+            RuntimeProfile mergedProfile = optional.get();
+
+            // Verify the correctness of the final profile
+            Assert.assertEquals("LoadChannel", mergedProfile.getName());
+            Assert.assertEquals("288fb1df-f955-472f-a377-cb1e10e4d993", mergedProfile.getInfoString("LoadId"));
+            Assert.assertEquals("40", mergedProfile.getInfoString("TxnId"));
+            Assert.assertEquals("127.0.0.1,127.0.0.2", mergedProfile.getInfoString("BackendAddresses"));
+            Assert.assertEquals(2, mergedProfile.getCounter("ChannelNum").getValue());
+            Assert.assertEquals(537395200 * i, mergedProfile.getCounter("PeakMemoryUsage").getValue());
+            Assert.assertEquals(1073741824 * i, mergedProfile.getCounter("__MAX_OF_PeakMemoryUsage").getValue());
+            Assert.assertEquals(1048576 * i, mergedProfile.getCounter("__MIN_OF_PeakMemoryUsage").getValue());
+            Assert.assertEquals(2, mergedProfile.getChildMap().size());
+
+            RuntimeProfile indexProfile1 = mergedProfile.getChild("Index (id=10176)");
+            Assert.assertEquals(162 * i, indexProfile1.getCounter("AddChunkCount").getValue());
+            Assert.assertEquals(82 * i, indexProfile1.getCounter("__MAX_OF_AddChunkCount").getValue());
+            Assert.assertEquals(80 * i, indexProfile1.getCounter("__MIN_OF_AddChunkCount").getValue());
+            Assert.assertEquals(15000000000L * i, indexProfile1.getCounter("AddChunkTime").getValue());
+            Assert.assertEquals(20000000000L * i, indexProfile1.getCounter("__MAX_OF_AddChunkTime").getValue());
+            Assert.assertEquals(10000000000L * i, indexProfile1.getCounter("__MIN_OF_AddChunkTime").getValue());
+
+            RuntimeProfile indexProfile2 = mergedProfile.getChild("Index (id=10298)");
+            Assert.assertEquals(162 * i, indexProfile2.getCounter("AddChunkCount").getValue());
+            Assert.assertEquals(82 * i, indexProfile2.getCounter("__MAX_OF_AddChunkCount").getValue());
+            Assert.assertEquals(80 * i, indexProfile2.getCounter("__MIN_OF_AddChunkCount").getValue());
+            Assert.assertEquals(1500000000L * i, indexProfile2.getCounter("AddChunkTime").getValue());
+            Assert.assertEquals(2000000000L * i, indexProfile2.getCounter("__MAX_OF_AddChunkTime").getValue());
+            Assert.assertEquals(1000000000L * i, indexProfile2.getCounter("__MIN_OF_AddChunkTime").getValue());
+        }
+
     }
 
     private void verifyMergedLoadChannelProfile(RuntimeProfile mergedProfile) {
@@ -132,7 +184,7 @@ public class QueryRuntimeProfileTest {
         Assert.assertEquals(1000000000L, indexProfile2.getCounter("__MIN_OF_AddChunkTime").getValue());
     }
 
-    private TReportExecStatusParams buildReportStatus() {
+    private TReportExecStatusParams buildReportStatus(long valueBase) {
         RuntimeProfile profile = new RuntimeProfile("LoadChannel");
         profile.addInfoString("LoadId", "288fb1df-f955-472f-a377-cb1e10e4d993");
         profile.addInfoString("TxnId", "40");
@@ -141,49 +193,49 @@ public class QueryRuntimeProfileTest {
         profile.addChild(channelProfile1);
         Counter peakMemoryCounter1 = channelProfile1.addCounter("PeakMemoryUsage", TUnit.BYTES,
                 Counter.createStrategy(TCounterAggregateType.AVG));
-        peakMemoryCounter1.setValue(1024 * 1024 * 1024);
+        peakMemoryCounter1.setValue(1024 * 1024 * 1024 * valueBase);
 
         RuntimeProfile indexProfile1 = new RuntimeProfile("Index (id=10176)");
         channelProfile1.addChild(indexProfile1);
         Counter addChunkCounter1 = indexProfile1.addCounter("AddChunkCount", TUnit.UNIT,
                 Counter.createStrategy(TUnit.UNIT));
-        addChunkCounter1.setValue(82);
+        addChunkCounter1.setValue(82 * valueBase);
         Counter addChunkTime1 = indexProfile1.addCounter("AddChunkTime", TUnit.TIME_NS,
                 Counter.createStrategy(TCounterAggregateType.AVG));
-        addChunkTime1.setValue(20000000000L);
+        addChunkTime1.setValue(20000000000L * valueBase);
 
         RuntimeProfile indexProfile2 = new RuntimeProfile("Index (id=10298)");
         channelProfile1.addChild(indexProfile2);
         Counter addChunkCounter2 = indexProfile2.addCounter("AddChunkCount", TUnit.UNIT,
                 Counter.createStrategy(TUnit.UNIT));
-        addChunkCounter2.setValue(82);
+        addChunkCounter2.setValue(82 * valueBase);
         Counter addChunkTime2 = indexProfile2.addCounter("AddChunkTime", TUnit.TIME_NS,
                 Counter.createStrategy(TCounterAggregateType.AVG));
-        addChunkTime2.setValue(1000000000L);
+        addChunkTime2.setValue(1000000000L * valueBase);
 
         RuntimeProfile channelProfile2 = new RuntimeProfile("Channel (host=127.0.0.2)");
         profile.addChild(channelProfile2);
         Counter peakMemoryCounter2 = channelProfile2.addCounter("PeakMemoryUsage", TUnit.BYTES,
                 Counter.createStrategy(TCounterAggregateType.AVG));
-        peakMemoryCounter2.setValue(1024 * 1024);
+        peakMemoryCounter2.setValue(1024 * 1024 * valueBase);
 
         RuntimeProfile indexProfile3 = new RuntimeProfile("Index (id=10176)");
         channelProfile2.addChild(indexProfile3);
         Counter addChunkCounter3 = indexProfile3.addCounter("AddChunkCount", TUnit.UNIT,
                 Counter.createStrategy(TUnit.UNIT));
-        addChunkCounter3.setValue(80);
+        addChunkCounter3.setValue(80 * valueBase);
         Counter addChunkTime3 = indexProfile3.addCounter("AddChunkTime", TUnit.TIME_NS,
                 Counter.createStrategy(TCounterAggregateType.AVG));
-        addChunkTime3.setValue(10000000000L);
+        addChunkTime3.setValue(10000000000L * valueBase);
 
         RuntimeProfile indexProfile4 = new RuntimeProfile("Index (id=10298)");
         channelProfile2.addChild(indexProfile4);
         Counter addChunkCounter4 = indexProfile4.addCounter("AddChunkCount", TUnit.UNIT,
                 Counter.createStrategy(TUnit.UNIT));
-        addChunkCounter4.setValue(80);
+        addChunkCounter4.setValue(80 * valueBase);
         Counter addChunkTime4 = indexProfile4.addCounter("AddChunkTime", TUnit.TIME_NS,
                 Counter.createStrategy(TCounterAggregateType.AVG));
-        addChunkTime4.setValue(2000000000L);
+        addChunkTime4.setValue(2000000000L * valueBase);
 
         TReportExecStatusParams params = new TReportExecStatusParams(FrontendServiceVersion.V1);
         TRuntimeProfileTree profileTree = profile.toThrift();


### PR DESCRIPTION
## Why I'm doing:

The minimum and maximum values may be inaccurate for long-running queries.

## What I'm doing:

Issue:
1. With running profile function, the profile will be reported periodically according to `runtime_profile_report_interval`
2. The minimum and maximum counters are not being updated accurately in this scenario.
3. Consequently, the minimum counter may underestimate the actual value, while the maximum counter might overestimate it.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
