### PR TITLE
[Enhancement] Backend alive status taking its report tablets timestamp into consideration

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1521,6 +1521,12 @@ public class Config extends ConfigBase {
     public static int tablet_collect_timeout_seconds = 60;
 
     /**
+     * Usually the backend will report its tablets status every 10 seconds.
+     */
+    @ConfField(mutable = true, comment = "Max tolerant period for a Backend node not reporting its tablets status." +
+            "The Backend node will be put into non-alive status otherwise.")
+    public static long backend_report_tablets_max_tolerant_seconds = 3600 * 2;
+    /**
      * The tryLock timeout configuration of globalStateMgr lock.
      * Normally it does not need to change, unless you need to test something.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendsProcDir.java
@@ -39,7 +39,6 @@ import com.google.common.base.Stopwatch;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.gson.Gson;
 import com.starrocks.alter.DecommissionType;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Pair;
@@ -193,7 +192,7 @@ public class BackendsProcDir implements ProcDirInterface {
 
             backendInfo.add(backend.getHeartbeatErrMsg());
             backendInfo.add(backend.getVersion());
-            backendInfo.add(new Gson().toJson(backend.getBackendStatus()));
+            backendInfo.add(backend.getBackendStatusJson());
 
             // data total
             long dataTotalB = backend.getDataTotalCapacityB();

--- a/fe/fe-core/src/main/java/com/starrocks/consistency/MetaRecoveryDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/MetaRecoveryDaemon.java
@@ -290,10 +290,10 @@ public class MetaRecoveryDaemon extends FrontendDaemon {
 
     protected boolean checkTabletReportCacheUp(long timeMs) {
         for (Backend backend : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackends()) {
-            if (TimeUtils.timeStringToLong(backend.getBackendStatus().lastSuccessReportTabletsTime)
-                    < timeMs) {
+            if (backend.getLastSuccessReportTabletsTime() < timeMs) {
                 LOG.warn("last tablet report time of backend {}:{} is {}, should wait it to report tablets",
-                        backend.getHost(), backend.getHeartbeatPort(), backend.getBackendStatus().lastSuccessReportTabletsTime);
+                        backend.getHost(), backend.getHeartbeatPort(),
+                        TimeUtils.longToTimeString(backend.getLastSuccessReportTabletsTime()));
                 return false;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/http/action/BackendAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/action/BackendAction.java
@@ -97,7 +97,8 @@ public class BackendAction extends WebBaseAction {
                     + ", brpc_port: " + backend.getBrpcPort()
                     + ", state: " + backend.getBackendState()
                     + ", start_time: " + TimeUtils.longToTimeString(backend.getLastStartTime())
-                    + ", last_report_tablets_time: " + backend.getBackendStatus().lastSuccessReportTabletsTime
+                    + ", last_report_tablets_time: " +
+                    TimeUtils.longToTimeString(backend.getLastSuccessReportTabletsTime())
                     + ", version: " + backend.getVersion());
 
             backendInfos.add(backendInfo);

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -75,7 +75,6 @@ import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.Daemon;
 import com.starrocks.common.util.NetUtils;
-import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.datacache.DataCacheMetrics;
@@ -86,7 +85,6 @@ import com.starrocks.persist.ReplicaPersistInfo;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.system.Backend;
-import com.starrocks.system.Backend.BackendStatus;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.task.AgentBatchTask;
@@ -541,8 +539,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
         final SystemInfoService currentSystemInfo = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
         Backend reportBackend = currentSystemInfo.getBackend(backendId);
         if (reportBackend != null) {
-            BackendStatus backendStatus = reportBackend.getBackendStatus();
-            backendStatus.lastSuccessReportTabletsTime = TimeUtils.longToTimeString(start);
+            reportBackend.setLastSuccessReportTabletsTime(start);
         }
 
         long cost = System.currentTimeMillis() - start;
@@ -1449,7 +1446,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
         long maxLastSuccessReportTabletsTime = -1L;
 
         for (Backend be : backends) {
-            long lastSuccessReportTabletsTime = TimeUtils.timeStringToLong(be.getBackendStatus().lastSuccessReportTabletsTime);
+            long lastSuccessReportTabletsTime = be.getLastSuccessReportTabletsTime();
             maxLastSuccessReportTabletsTime = Math.max(maxLastSuccessReportTabletsTime, lastSuccessReportTabletsTime);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/HostBlacklist.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/HostBlacklist.java
@@ -198,6 +198,10 @@ public class HostBlacklist {
                 // Avoid the node enter and exit the blocklist too quick.
                 continue;
             }
+            if (!node.isReportTabletsSuccessfulRecently()) {
+                // still fail to report its tablets status
+                continue;
+            }
 
             // Check all the ports, determine if the BE node is recovered
             if (clusterInfoService.checkNodeAvailable(node) && entry.getValue().type == DisconnectEvent.TYPE_AUTO) {

--- a/fe/fe-core/src/main/java/com/starrocks/system/Backend.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/Backend.java
@@ -40,13 +40,17 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.DiskInfo;
 import com.starrocks.catalog.DiskInfo.DiskState;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.io.Text;
+import com.starrocks.common.util.TimeUtils;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.thrift.TDisk;
 import com.starrocks.thrift.TStorageMedium;
 import org.apache.logging.log4j.LogManager;
@@ -92,8 +96,7 @@ public class Backend extends ComputeNode {
     // this field is set by tablet report, and just for metric monitor, no need to persist.
     private volatile long tabletMaxCompactionScore = 0;
 
-    // additional backendStatus information for BE, display in JSON format
-    private final BackendStatus backendStatus = new BackendStatus();
+    private long lastSuccessReportTabletsTimeMs = -1;
 
     public Backend() {
         super();
@@ -390,8 +393,12 @@ public class Backend extends ComputeNode {
         }
     }
 
-    public BackendStatus getBackendStatus() {
-        return backendStatus;
+    public void setLastSuccessReportTabletsTime(long lastSuccessReportTabletsTimeMs) {
+        this.lastSuccessReportTabletsTimeMs = lastSuccessReportTabletsTimeMs;
+    }
+
+    public long getLastSuccessReportTabletsTime() {
+        return lastSuccessReportTabletsTimeMs;
     }
 
     @Override
@@ -541,6 +548,26 @@ public class Backend extends ComputeNode {
                 .stream()
                 .anyMatch(diskInfo -> (pathHash == diskInfo.getPathHash())
                         && diskInfo.getState() == DiskState.DECOMMISSIONED);
+    }
+
+    @Override
+    public boolean isReportTabletsSuccessfulRecently() {
+        if (RunMode.isSharedDataMode()) {
+            // skip the check in shared data mode
+            return true;
+        }
+        if (lastSuccessReportTabletsTimeMs == -1) {
+            // skip the check if never reported before.
+            return true;
+        }
+        return lastSuccessReportTabletsTimeMs + Config.backend_report_tablets_max_tolerant_seconds >=
+                System.currentTimeMillis();
+    }
+
+    public String getBackendStatusJson() {
+        BackendStatus status = new BackendStatus();
+        status.lastSuccessReportTabletsTime = TimeUtils.longToTimeString(this.lastSuccessReportTabletsTimeMs);
+        return new Gson().toJson(status);
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/consistency/MetaRecoveryDaemonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/consistency/MetaRecoveryDaemonTest.java
@@ -23,7 +23,6 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.proc.BaseProcResult;
-import com.starrocks.common.util.TimeUtils;
 import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
@@ -89,8 +88,7 @@ public class MetaRecoveryDaemonTest {
         partition.getDefaultPhysicalPartition().setNextVersion(2L);
 
         for (Backend backend : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackends()) {
-            backend.getBackendStatus().lastSuccessReportTabletsTime = TimeUtils
-                    .longToTimeString(System.currentTimeMillis());
+            backend.setLastSuccessReportTabletsTime(System.currentTimeMillis());
         }
 
         // add a committed txn
@@ -176,8 +174,7 @@ public class MetaRecoveryDaemonTest {
         long timeMs = System.currentTimeMillis();
         MetaRecoveryDaemon metaRecoveryDaemon = new MetaRecoveryDaemon();
         for (Backend backend : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackends()) {
-            backend.getBackendStatus().lastSuccessReportTabletsTime = TimeUtils
-                    .longToTimeString(timeMs);
+            backend.setLastSuccessReportTabletsTime(timeMs);
         }
         Assert.assertFalse(metaRecoveryDaemon.checkTabletReportCacheUp(timeMs + 1000L));
         Assert.assertTrue(metaRecoveryDaemon.checkTabletReportCacheUp(timeMs - 1000L));

--- a/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
@@ -30,7 +30,6 @@ import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
-import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
@@ -39,7 +38,6 @@ import com.starrocks.qe.scheduler.slot.ResourceUsageMonitor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.system.Backend;
-import com.starrocks.system.Backend.BackendStatus;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.task.AgentBatchTask;
@@ -368,8 +366,7 @@ public class ReportHandlerTest {
 
         final SystemInfoService currentSystemInfo = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
         Backend reportBackend = currentSystemInfo.getBackend(10001);
-        BackendStatus backendStatus = reportBackend.getBackendStatus();
-        backendStatus.lastSuccessReportTabletsTime = TimeUtils.longToTimeString(Long.MAX_VALUE);
+        reportBackend.setLastSuccessReportTabletsTime(Long.MAX_VALUE);
 
         ReportHandler.handleMigration(tabletMetaMigrationMap, 10001);
 


### PR DESCRIPTION
* set the Backend to non-alive status if fails to report its tablets status for a long time, defaults to 2 hours by config var Config.backend_report_tablets_max_tolerant_seconds

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1