### PR TITLE
[BugFix] Remove zero-width space in method call

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -360,7 +360,7 @@ public class OlapTable extends Table {
 
         for (Index index : indexes) {
             Set<ColumnId> columnIdsSetForIndex = index.getColumns().stream().collect(Collectors.toSet());
-            if (columnIdsSetForSchema.containsAll​(columnIdsSetForIndex)) {
+            if (columnIdsSetForSchema.containsAll(columnIdsSetForIndex)) {
                 hitIndexes.add(index);
             }
         }


### PR DESCRIPTION
## Why I'm doing:
<img width="496" alt="image" src="https://github.com/user-attachments/assets/b200c8e5-a43f-4435-8ea0-9466d1dde7be" />

## What I'm doing:

Removed an invisible zero-width space character (U+200B) after 
containsAll method call that could cause compilation issues.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
