### PR TITLE
[BugFix] Fix the problem of inconsistent that the same Java enumeration class may have different hash values in different JVM instance

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
@@ -913,7 +913,7 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         // may be null.
         // NOTE that all the types of the related member variables must implement hashCode() and equals().
         if (id == null) {
-            int result = 31 * Objects.hashCode(type) + Objects.hashCode(opcode);
+            int result = 31 * Objects.hashCode(type) + Objects.hashCode(opcode.getValue());
             for (Expr child : children) {
                 result = 31 * result + Objects.hashCode(child);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionKey.java
@@ -557,6 +557,13 @@ public class PartitionKey implements Comparable<PartitionKey>, Writable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(keys, types);
+        int code = 1;
+        for (LiteralExpr expr : keys) {
+            code += code * 31 + Objects.hash(expr);
+        }
+        for (PrimitiveType type : types) {
+            code += code * 31 + Objects.hash(type.toString());
+        }
+        return code;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionKey.java
@@ -557,12 +557,9 @@ public class PartitionKey implements Comparable<PartitionKey>, Writable {
 
     @Override
     public int hashCode() {
-        int code = 1;
-        for (LiteralExpr expr : keys) {
-            code += code * 31 + Objects.hash(expr);
-        }
+        int code = Objects.hash(keys);
         for (PrimitiveType type : types) {
-            code += code * 31 + Objects.hash(type.toString());
+            code += code * 31 + Objects.hash(type.getDescription());
         }
         return code;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PrimitiveType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PrimitiveType.java
@@ -383,6 +383,10 @@ public enum PrimitiveType {
         return slotSize;
     }
 
+    public String getDescription() {
+        return description;
+    }
+
     public int getTypeSize() {
         int typeSize = 0;
         switch (this) {


### PR DESCRIPTION
## Why I'm doing:

According to my verification, the same Java enumeration class may have different hash values in different JVMs.

This will cause some problems.

For example,  when using catalog to query hive with datacache, 
some FEs could not hit datacache while others could hit,  this will result in inconsistent between SQL query and datacache warm up, and degrade query performance.

So we should keep consistent of the same Java enumeration class's hash value in different JVMs.


## What I'm doing:
The hashCode method of Java enum class is final, we should not use it directly. 

We should use the enum class's properties to calculate the hash value.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
