### PR TITLE
[BugFix] Fix delta lake un-partitioned mv can not query rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DeltaLakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DeltaLakeTable.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.base.Joiner;
+import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -180,5 +182,28 @@ public class DeltaLakeTable extends Table {
                 fullSchema.size(), 0, tableName, dbName);
         tTableDescriptor.setDeltaLakeTable(tDeltaLakeTable);
         return tTableDescriptor;
+    }
+
+    public String getTableIdentifier() {
+        String uuid = this.deltaSnapshot.getMetadata().getId();
+        return Joiner.on(":").join(tableName, uuid == null ? "" : uuid);
+    }
+
+    @Override
+    public int hashCode() {
+        return com.google.common.base.Objects.hashCode(getCatalogName(), dbName, getTableIdentifier());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof DeltaLakeTable otherTable)) {
+            return false;
+        }
+
+        String catalogName = getCatalogName();
+        String tableIdentifier = getTableIdentifier();
+        return Objects.equal(catalogName, otherTable.getCatalogName()) &&
+                Objects.equal(dbName, otherTable.dbName) &&
+                Objects.equal(tableIdentifier, otherTable.getTableIdentifier());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/pattern/MultiOpPattern.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/pattern/MultiOpPattern.java
@@ -24,6 +24,7 @@ public class MultiOpPattern extends Pattern {
             .add(OperatorType.LOGICAL_OLAP_SCAN)
             .add(OperatorType.LOGICAL_HIVE_SCAN)
             .add(OperatorType.LOGICAL_ICEBERG_SCAN)
+            .add(OperatorType.LOGICAL_DELTALAKE_SCAN)
             .add(OperatorType.LOGICAL_HUDI_SCAN)
             .add(OperatorType.LOGICAL_FILE_SCAN)
             .add(OperatorType.LOGICAL_SCHEMA_SCAN)

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -14,12 +14,14 @@
 
 package com.starrocks.analysis;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DeltaLakeTable;
 import com.starrocks.catalog.ExpressionRangePartitionInfo;
 import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.KeysType;
@@ -95,6 +97,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.starrocks.sql.optimizer.MVTestUtils.waitingRollupJobV2Finish;
@@ -4175,6 +4178,13 @@ public class CreateMaterializedViewTest extends MVTestBase {
 
     @Test
     public void createDeltaLakeMV() throws Exception {
+        new MockUp<DeltaLakeTable>() {
+            @Mock
+            public String getTableIdentifier() {
+                String uuid = UUID.randomUUID().toString();
+                return Joiner.on(":").join("tbl", uuid);
+            }
+        };
         starRocksAssert.withMaterializedView("create materialized view mv_deltalake " +
                 " refresh manual" +
                 " as select * from deltalake_catalog.deltalake_db.tbl");

--- a/test/sql/test_materialized_view/R/test_mv_deltalake_rewrite
+++ b/test/sql/test_materialized_view/R/test_mv_deltalake_rewrite
@@ -1,0 +1,35 @@
+-- name: test_mv_deltalake_rewrite
+create external catalog delta_test_${uuid0} PROPERTIES (
+    "type"="deltalake",
+    "hive.metastore.uris"="${deltalake_catalog_hive_metastore_uris}",
+    "aws.s3.access_key"="${oss_ak}",
+    "aws.s3.secret_key"="${oss_sk}",
+    "aws.s3.endpoint"="${oss_endpoint}"
+);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database delta_mv_${uuid0};
+-- result:
+-- !result
+use delta_mv_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1
+REFRESH DEFERRED MANUAL AS SELECT col_tinyint, col_smallint, col_int
+FROM delta_test_${uuid0}.delta_oss_db.delta_lake_data_type;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT col_tinyint, col_smallint, col_int FROM delta_test_${uuid0}.delta_oss_db.delta_lake_data_type", "test_mv1")
+-- result:
+None
+-- !result
+drop database delta_mv_${uuid0};
+-- result:
+-- !result
+drop catalog delta_test_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/T/test_mv_deltalake_rewrite
+++ b/test/sql/test_materialized_view/T/test_mv_deltalake_rewrite
@@ -1,0 +1,28 @@
+-- name: test_mv_deltalake_rewrite
+
+-- create catalog
+create external catalog delta_test_${uuid0} PROPERTIES (
+    "type"="deltalake",
+    "hive.metastore.uris"="${deltalake_catalog_hive_metastore_uris}",
+    "aws.s3.access_key"="${oss_ak}",
+    "aws.s3.secret_key"="${oss_sk}",
+    "aws.s3.endpoint"="${oss_endpoint}"
+);
+
+
+-- create database
+set catalog default_catalog;
+create database delta_mv_${uuid0};
+use delta_mv_${uuid0};
+
+-- create mv
+CREATE MATERIALIZED VIEW test_mv1
+REFRESH DEFERRED MANUAL AS SELECT col_tinyint, col_smallint, col_int
+FROM delta_test_${uuid0}.delta_oss_db.delta_lake_data_type;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT col_tinyint, col_smallint, col_int FROM delta_test_${uuid0}.delta_oss_db.delta_lake_data_type", "test_mv1")
+
+drop database delta_mv_${uuid0};
+drop catalog delta_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
can not query rewrite for delta lake un-partitioned mv 
## What I'm doing:

Fixes #57654
1. add hashCode and equals method for DeltaLakeTable
2. add LOGICAL_DELTALAKE_SCAN to ALL_SCAN_TYPES, so it can used by mv rewrite rule

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
