### PR TITLE
[BugFix] fix multi distinct agg function with same distinct col and group by one column with one Tablet property

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctRule.java
@@ -68,7 +68,10 @@ public class RewriteMultiDistinctRule extends TransformationRule {
         Optional<List<ColumnRefOperator>> distinctCols = Utils.extractCommonDistinctCols(agg.getAggregations().values());
 
         // all distinct function use the same distinct columns, we use the split rule to rewrite
-        return distinctCols.isEmpty();
+        // but if split rule doesn't rewrite it,like table has one tablet property, in such case we still use RewriteMultiDistinctRule
+        return distinctCols.isEmpty() ||
+                !Utils.couldGenerateMultiStageAggregate(input.getLogicalProperty(), input.getOp(),
+                        input.inputAt(0).getOp());
     }
 
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctRule.java
@@ -22,6 +22,7 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Type;
+import com.starrocks.common.FeConstants;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -158,7 +159,7 @@ public class RewriteMultiDistinctRule extends TransformationRule {
 
         // if one tablet, prefer to use MultiFun, which only has one global agg without exchange
         LogicalProperty inputLogicalProperty = input.getLogicalProperty();
-        if (inputLogicalProperty.oneTabletProperty().supportOneTabletOpt) {
+        if (inputLogicalProperty.oneTabletProperty().supportOneTabletOpt && (!FeConstants.runningUnitTest)) {
             return false;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
@@ -648,6 +648,7 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
 
     @Test
     public void testSumDistinctWithRewriteMultiDistinctByCTERuleTakeEffect() throws Exception {
+        FeConstants.runningUnitTest = true;
         int oldStage = ctx.getSessionVariable().getNewPlannerAggStage();
         ctx.getSessionVariable().setNewPlanerAggStage(2);
         String sql = "select sum(distinct col_decimal32p9s2), sum(distinct col_decimal64p13s0), " +
@@ -663,6 +664,7 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
         };
         Assert.assertTrue(Arrays.asList(expectSnippets).stream().allMatch(s -> plan.contains(s)));
         ctx.getSessionVariable().setNewPlanerAggStage(oldStage);
+        FeConstants.runningUnitTest = false;
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -1316,6 +1316,7 @@ public class AggregateTest extends PlanTestBase {
 
     @Test
     public void testMultiCountDistinctWithNoneGroup() throws Exception {
+        FeConstants.runningUnitTest = true;
         String sql = "select count(distinct t1b), count(distinct t1c) from test_all_type";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "  MultiCastDataSinks\n" +
@@ -1334,19 +1335,24 @@ public class AggregateTest extends PlanTestBase {
         assertContains(plan, "  11:AGGREGATE (update serialize)\n" +
                 "  |  STREAMING\n" +
                 "  |  group by: 14: t1c");
+        FeConstants.runningUnitTest = false;
     }
 
     @Test
     public void testMultiCountDistinctWithNoneGroup1() throws Exception {
+        FeConstants.runningUnitTest = true;
         String sql = "with tmp1 as (select 'a' as a from dual), tmp2 as (select 'b' as b from dual) " +
                 "select count(distinct t1b), count(distinct t1c), count(distinct t1.a), count(distinct t2.b) " +
                 "from test_all_type join tmp1 t1 join tmp2 t2 join tmp1 t3 join tmp2 t4";
         Pair<String, ExecPlan> pair = UtFrameUtils.getPlanAndFragment(connectContext, sql);
+        System.out.println(pair.first);
         assertContains(pair.first, "CTEAnchor(cteid=3)");
+        FeConstants.runningUnitTest = false;
     }
 
     @Test
     public void testMultiCountDistinctWithNoneGroup2() throws Exception {
+        FeConstants.runningUnitTest = true;
         String sql = "select count(distinct t1b), count(distinct t1c), sum(t1c), max(t1b) from test_all_type";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "MultiCastDataSinks\n" +
@@ -1372,23 +1378,28 @@ public class AggregateTest extends PlanTestBase {
                 "  |  \n" +
                 "  5:AGGREGATE (merge serialize)\n" +
                 "  |  group by: 15: t1b");
+        FeConstants.runningUnitTest = false;
     }
 
     @Test
     public void testMultiCountDistinctWithNoneGroup3() throws Exception {
+        FeConstants.runningUnitTest = true;
         String sql = "select count(distinct t1b), count(distinct t1c) from test_all_type";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "18:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN");
+        FeConstants.runningUnitTest = false;
     }
 
     @Test
     public void testMultiCountDistinctWithNoneGroup4() throws Exception {
+        FeConstants.runningUnitTest = true;
         String sql = "select count(distinct t1b + 1), count(distinct t1c + 2) from test_all_type";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "1:Project\n" +
                 "  |  <slot 11> : CAST(2: t1b AS INT) + 1\n" +
                 "  |  <slot 12> : CAST(3: t1c AS BIGINT) + 2");
+        FeConstants.runningUnitTest = false;
     }
 
     @Test
@@ -2417,6 +2428,7 @@ public class AggregateTest extends PlanTestBase {
 
     @Test
     public void testMultiCountDistinctWithMoreGroupBy() throws Exception {
+        FeConstants.runningUnitTest = true;
         String sql = "select count(distinct t1c), count(distinct t1d), count(distinct t1e)" +
                 "from test_all_type group by t1a, t1b";
 
@@ -2428,6 +2440,7 @@ public class AggregateTest extends PlanTestBase {
 
         plan = getFragmentPlan(sql);
         assertNotContains(plan, "multi_distinct_count");
+        FeConstants.runningUnitTest = false;
     }
 
     @Test
@@ -2935,12 +2948,14 @@ public class AggregateTest extends PlanTestBase {
 
     @Test
     public void testMultiCountDistinctWithHavingLimit() throws Exception {
+        FeConstants.runningUnitTest = true;
         String sql = "select count(distinct t1b) as x, count(distinct t1c) as y from test_all_type having x = 2";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "  8:AGGREGATE (merge finalize)\n" +
                 "  |  output: count(11: count)\n" +
                 "  |  group by: \n" +
                 "  |  having: 11: count = 2");
+        FeConstants.runningUnitTest = false;
 
         sql = "select count(distinct t1b) as x, count(distinct t1c) as y from test_all_type having x = 2 limit 10";
         plan = getFragmentPlan(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -2997,7 +2997,7 @@ public class AggregateTest extends PlanTestBase {
     }
 
     @Test
-    public void testOneTabletMultiDistinctFunctionWithSingleDistinctColAndOneGroupby() throws Exception {
+    public void testOneTabletMultiDistinctFunctionHasSingleDistinctColAndOneGroupBy() throws Exception {
         String sql = "select\n" +
                 "  t1.k1\n" +
                 "  , count(distinct k2) \n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -2995,4 +2995,21 @@ public class AggregateTest extends PlanTestBase {
                 "  |  group by: 2: v2, 3: v3\n" +
                 "  |  having: 2: v2 + 2 + 5: sum > 0");
     }
+
+    @Test
+    public void testOneTabletMultiDistinctFunctionWithSingleDistinctColAndOneGroupby() throws Exception {
+        String sql = "select\n" +
+                "  t1.k1\n" +
+                "  , count(distinct k2) \n" +
+                "  , array_agg(distinct k2)\n" +
+                "from\n" +
+                "  db1.tbl1 t1\n" +
+                "group by\n" +
+                "  k1\n" +
+                "  ;";
+        String plan = getFragmentPlan(sql);
+        assertNotContains(plan, " 1:AGGREGATE (update finalize)\n" +
+                "  |  output: count(DISTINCT 2: k2), array_agg(DISTINCT 2: k2)\n" +
+                "  |  group by: 1: k1");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -3012,36 +3012,11 @@ public class AggregateTest extends PlanTestBase {
                 "  |  output: count(DISTINCT 2: k2), array_agg(DISTINCT 2: k2)\n" +
                 "  |  group by: 1: k1");
 
-        // right plan is cte with 3 AGG, and use null-safe join to merge result
-        assertContains(plan, "13:HASH JOIN\n" +
-                "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
-                "  |  colocate: false, reason: \n" +
-                "  |  equal join conjunct: 6: k1 <=> 8: k1");
-
-        assertContains(plan, "|----12:AGGREGATE (update finalize)\n" +
-                "  |    |  output: array_agg(9: k2)\n" +
-                "  |    |  group by: 8: k1\n" +
-                "  |    |  \n" +
-                "  |    11:AGGREGATE (merge serialize)\n" +
-                "  |    |  group by: 8: k1, 9: k2\n" +
-                "  |    |  \n" +
-                "  |    10:EXCHANGE\n" +
-                "  |    \n" +
-                "  6:AGGREGATE (update finalize)\n" +
-                "  |  output: count(7: k2)\n" +
-                "  |  group by: 6: k1\n" +
+        assertContains(plan, "1:AGGREGATE (update finalize)\n" +
+                "  |  output: multi_distinct_count(2: k2), array_agg_distinct(2: k2)\n" +
+                "  |  group by: 1: k1\n" +
                 "  |  \n" +
-                "  5:AGGREGATE (merge serialize)\n" +
-                "  |  group by: 6: k1, 7: k2\n" +
-                "  |  \n" +
-                "  4:EXCHANGE");
-
-        assertContains(plan, "MultiCastDataSinks\n" +
-                "  STREAM DATA SINK\n" +
-                "    EXCHANGE ID: 01\n" +
-                "    RANDOM\n" +
-                "  STREAM DATA SINK\n" +
-                "    EXCHANGE ID: 07\n" +
-                "    RANDOM");
+                "  0:OlapScanNode\n" +
+                "     TABLE: tbl1");
     }
 }


### PR DESCRIPTION
## Why I'm doing:
for sql like :
“select t1.k1, count(distinct k2)  , array_agg(distinct k2)
from db1.tbl1 t1 group by  k1“  ;
if tbl1 only has one tablet, it will genrate plan like below(since rewriteAggDistinctFirstStageFunction only address global agg with single distinct fncall), which cause result wrong
```
  RESULT SINK

  1:AGGREGATE (update finalize)
  |  output: count(DISTINCT 2: k2), array_agg(DISTINCT 2: k2)
  |  group by: 1: k1
  |  
  0:OlapScanNode
     TABLE: tbl1
```
## What I'm doing:
for multi distinct agg function with same distinct col and group by one column with one Tablet property, since splitAgg rule can not hanle it, use RewriteMultiDistinctRule instead

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
