### PR TITLE
[Enhancement] Optimize some performance regression for TPC-DS

### DIFF
--- a/be/src/exprs/min_max_predicate.h
+++ b/be/src/exprs/min_max_predicate.h
@@ -47,8 +47,8 @@ public:
     CppType get_max_value() const { return _max_value; }
 
     StatusOr<ColumnPtr> evaluate_with_filter(ExprContext* context, Chunk* ptr, uint8_t* filter) override {
-        const ColumnPtr col = ptr->get_column_by_slot_id(_slot_id);
-        size_t size = col->size();
+        const ColumnPtr& col = ptr->get_column_by_slot_id(_slot_id);
+        const size_t size = col->size();
 
         BooleanColumn::MutablePtr result = BooleanColumn::create(size, 1);
         uint8_t* res = result->get_data().data();
@@ -73,29 +73,37 @@ public:
         //   1. memcpy filter -> res
         //   2. res[i] = res[i] && (null_data[i] || (data[i] >= _min_value && data[i] <= _max_value));
         // but they can not be compiled into SIMD instructions.
-        if (col->is_nullable() && col->has_null()) {
-            auto tmp = ColumnHelper::as_raw_column<NullableColumn>(col);
-            uint8_t* __restrict__ null_data = tmp->null_column_data().data();
-            CppType* __restrict__ data = ColumnHelper::cast_to_raw<Type>(tmp->data_column())->get_data().data();
-            for (int i = 0; i < size; i++) {
-                res[i] = (data[i] >= _min_value && data[i] <= _max_value);
-            }
 
-            if (_has_null) {
-                for (int i = 0; i < size; i++) {
-                    res[i] = res[i] | null_data[i];
+        auto check_range = [](uint8_t* __restrict__ local_res, const CppType* __restrict__ local_values,
+                              const size_t local_size, const CppType min_value, const CppType max_value) {
+            for (int i = 0; i < local_size; i++) {
+                local_res[i] = (local_values[i] >= min_value) & (local_values[i] <= max_value);
+            }
+        };
+        auto merge_null = [](uint8_t* __restrict__ local_res, const uint8_t* __restrict__ local_null_data,
+                             const size_t local_size, const bool local_has_null) {
+            if (local_has_null) {
+                for (int i = 0; i < local_size; i++) {
+                    local_res[i] = local_res[i] | local_null_data[i];
                 }
             } else {
-                for (int i = 0; i < size; i++) {
-                    res[i] = res[i] & !null_data[i];
+                for (int i = 0; i < local_size; i++) {
+                    local_res[i] = local_res[i] & !local_null_data[i];
                 }
             }
+        };
+
+        if (col->is_nullable() && col->has_null()) {
+            const auto* tmp = ColumnHelper::as_raw_column<NullableColumn>(col);
+
+            const CppType* data = ColumnHelper::cast_to_raw<Type>(tmp->data_column())->get_data().data();
+            check_range(res, data, size, _min_value, _max_value);
+
+            const uint8_t* null_data = tmp->null_column_data().data();
+            merge_null(res, null_data, size, _has_null);
         } else {
-            const CppType* __restrict__ data =
-                    ColumnHelper::get_data_column_by_type<Type>(col.get())->get_data().data();
-            for (int i = 0; i < size; i++) {
-                res[i] = (data[i] >= _min_value && data[i] <= _max_value);
-            }
+            const CppType* data = ColumnHelper::get_data_column_by_type<Type>(col.get())->get_data().data();
+            check_range(res, data, size, _min_value, _max_value);
         }
 
         // NOTE(yan): filter can be used optionally.

--- a/be/src/exprs/min_max_predicate.h
+++ b/be/src/exprs/min_max_predicate.h
@@ -74,6 +74,7 @@ public:
         //   2. res[i] = res[i] && (null_data[i] || (data[i] >= _min_value && data[i] <= _max_value));
         // but they can not be compiled into SIMD instructions.
 
+        // Use lambdas to make the compiler to better analyze code within smaller scopes, thereby ensuring vectorization.
         auto check_range = [](uint8_t* __restrict__ local_res, const CppType* __restrict__ local_values,
                               const size_t local_size, const CppType min_value, const CppType max_value) {
             for (int i = 0; i < local_size; i++) {

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -291,32 +291,6 @@ void Bitset<LT>::insert(const CppType& value) {
     _bitset[group] |= (1 << index_in_group);
 }
 
-template <typename T>
-concept Integer8BitType = std::is_same_v<T, int8_t> || std::is_same_v<T, uint8_t>;
-
-template <Integer8BitType T>
-inline bool contains_nonzero_bit(const T* data, size_t size) {
-    const T* end = data + size;
-
-#if defined(__ARM_NEON) && defined(__aarch64__)
-    const T* end16 = data + (size / 16 * 16);
-    for (; data < end16; data += 16) {
-        uint8x16_t vdata = vld1q_u8(data);
-        if (vmaxvq_u8(vdata) != 0) {
-            return true;
-        }
-    }
-#endif
-
-    for (; data < end; ++data) {
-        if (*data != 0) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
 template <LogicalType LT>
 bool Bitset<LT>::contains_range(const CppType& min_value, const CppType& max_value) const {
     if (min_value > _max_value || max_value < _min_value || min_value > max_value) {
@@ -367,7 +341,7 @@ bool Bitset<LT>::contains_range(const CppType& min_value, const CppType& max_val
     }
 
     if (min_group + 1 <= max_group - 1) {
-        return contains_nonzero_bit(_bitset.data() + min_group + 1, max_group - min_group - 1);
+        return SIMD::contains_nonzero_bit(_bitset.data() + min_group + 1, max_group - min_group - 1);
     }
     return false;
 }

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -17,11 +17,6 @@
 #include "types/logical_type_infra.h"
 #include "util/compression/stream_compression.h"
 
-#if defined(__ARM_NEON) && defined(__aarch64__)
-#include <arm_acle.h>
-#include <arm_neon.h>
-#endif
-
 namespace starrocks {
 
 // ------------------------------------------------------------------------------------

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -17,6 +17,11 @@
 #include "types/logical_type_infra.h"
 #include "util/compression/stream_compression.h"
 
+#if defined(__ARM_NEON) && defined(__aarch64__)
+#include <arm_acle.h>
+#include <arm_neon.h>
+#endif
+
 namespace starrocks {
 
 // ------------------------------------------------------------------------------------
@@ -291,6 +296,32 @@ void Bitset<LT>::insert(const CppType& value) {
     _bitset[group] |= (1 << index_in_group);
 }
 
+template <typename T>
+concept Integer8BitType = std::is_same_v<T, int8_t> || std::is_same_v<T, uint8_t>;
+
+template <Integer8BitType T>
+inline bool contains_nonzero_bit(const T* data, size_t size) {
+    const T* end = data + size;
+
+#if defined(__ARM_NEON) && defined(__aarch64__)
+    const T* end16 = data + (size / 16 * 16);
+    for (; data < end16; data += 16) {
+        uint8x16_t vdata = vld1q_u8(data);
+        if (vmaxvq_u8(vdata) != 0) {
+            return true;
+        }
+    }
+#endif
+
+    for (; data < end; ++data) {
+        if (*data != 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 template <LogicalType LT>
 bool Bitset<LT>::contains_range(const CppType& min_value, const CppType& max_value) const {
     if (min_value > _max_value || max_value < _min_value || min_value > max_value) {
@@ -341,7 +372,7 @@ bool Bitset<LT>::contains_range(const CppType& min_value, const CppType& max_val
     }
 
     if (min_group + 1 <= max_group - 1) {
-        return SIMD::count_nonzero(_bitset.data() + min_group + 1, max_group - min_group - 1);
+        return contains_nonzero_bit(_bitset.data() + min_group + 1, max_group - min_group - 1);
     }
     return false;
 }

--- a/be/src/simd/simd.h
+++ b/be/src/simd/simd.h
@@ -26,6 +26,10 @@
 #include <arm_acle.h>
 #include <arm_neon.h>
 #endif
+#ifdef __AVX2__
+#include <emmintrin.h>
+#include <immintrin.h>
+#endif
 
 namespace SIMD {
 
@@ -243,7 +247,7 @@ template <Integer8BitType T>
 inline bool contains_nonzero_bit(const T* data, size_t size) {
     const T* end = data + size;
 
-#if defined(__SSE2__)
+#if defined(__AVX2__)
     constexpr size_t W = 32;
     const T* end32 = data + (size / W * W);
     for (; data < end32; data += W) {

--- a/be/src/simd/simd.h
+++ b/be/src/simd/simd.h
@@ -243,7 +243,7 @@ template <Integer8BitType T>
 inline bool contains_nonzero_bit(const T* data, size_t size) {
     const T* end = data + size;
 
-#if defined(__SSE2__) && defined(__POPCNT__)
+#if defined(__SSE2__)
     constexpr size_t W = 32;
     const T* end32 = data + (size / W * W);
     for (; data < end32; data += W) {

--- a/be/test/simd/simd_test.cpp
+++ b/be/test/simd/simd_test.cpp
@@ -134,4 +134,22 @@ TEST_F(SIMDTest, count_nonzero_int32) {
     EXPECT_EQ(30u, SIMD::count_nonzero(numbers));
 }
 
+TEST_F(SIMDTest, contains_nonzero_bit) {
+    std::vector<uint8_t> nums;
+    for (int i = 0; i < 1000; i++) {
+        nums.emplace_back(0);
+    }
+    EXPECT_FALSE(SIMD::contains_nonzero_bit(nums.data(), nums.size()));
+
+    // non-zero in non-SIMD check tail part.
+    nums.emplace_back(8);
+    EXPECT_TRUE(SIMD::contains_nonzero_bit(nums.data(), nums.size()));
+
+    // non-zero in SIMD check part.
+    for (int i = 0; i < 1000; i++) {
+        nums.emplace_back(0);
+    }
+    EXPECT_TRUE(SIMD::contains_nonzero_bit(nums.data(), nums.size()));
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:


### 1. ​**RuntimeBitsetFilter::contains_range**​  

Use `SIMD::contains_nonzero_bit` instead of `SIMD::count_non_zero` to terminate early upon encountering the first non-zero byte.  

​**TPC-DS 1T Q85 Execution Time**​  
- Before: 1055 ms  
- After: 910 ms  

​**CPU Perf**​  
- Before: `RuntimeFilter::contains_range` consumes 12%  
- After: `RuntimeFilter::contains_range` consumes <1%  

CPU Perf Before
![image](https://github.com/user-attachments/assets/35ea8762-e9d9-404a-a3ca-516634ee3b1f)


---

### 2. ​**Vectorization of MinMaxPredicate**​  

After recent logic additions to `MinMaxPredicate`, several for-loops were no longer vectorized, even if I use `__restrict__` to all the pointers.  

Therefore, use lambdas to allow the compiler to better analyze code within smaller scopes, thereby ensuring vectorization.  

​**TPC-DS 1T Q96 Execution Time**​  
- Before: 2.2 s  
- After: 2.0 s  

​**CPU Perf**​  
- Before: `MinMaxPredicate::evaluate` consumes 12%  
- After: `MinMaxPredicate::evaluate` consumes 2.55%  


CPU Profile Before
![image](https://github.com/user-attachments/assets/50904d21-6504-49c1-bfac-393d2be8b719)

<img src="https://github.com/user-attachments/assets/c0b00605-cf49-4090-927a-4fdc8416fa21" width=60%>

CPU Perf After
![image](https://github.com/user-attachments/assets/d89d5d68-cd96-49e5-91c9-2e01ec333fc0)


<img src="https://github.com/user-attachments/assets/44848abc-ac80-49dd-9e6d-71814949400d" width=60%>


---

### 3. ​**Inline ScanIterator::for_each**​  

Replace the `std::function` parameter of `for_each` with a template to eliminate virtual function calls from `std::function` and inline all row-wise invocations.  

​**TPC-DS 1T Q95 Execution Time**​  
- Before: 2.47 s  
- After: 2.14 s  

​**CPU Perf**​  
- Before:  
    - `RuntimeFilterProbeCollector::evaluate` consumes 23.65%  
    - `dispatch_layout` consumes 12.13% within it  
- After:  
    - `RuntimeFilterProbeCollector::evaluate` consumes 15.01%  
    - `dispatch_layout` consumes 2.89% within it  

CPU Perf Before
![image](https://github.com/user-attachments/assets/d162bf7f-8b0b-44bd-8f8d-91cdc7a46bac)



CPU Perf After
![image](https://github.com/user-attachments/assets/3ce0dd9d-2f59-4355-af3e-576282a0cc79)


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
