### PR TITLE
[BugFix] Use operator id not node id for feedback

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/feedback/OperatorTuningGuides.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/feedback/OperatorTuningGuides.java
@@ -30,27 +30,42 @@ public class OperatorTuningGuides {
 
     private final UUID originalQueryId;
 
-    private final Map<Integer, List<TuningGuide>> tuningGuides;
+    private final Map<Integer, OperatorGuideInfo> operatorIdToTuningGuideInfo;
 
     private final Cache<UUID, Long> optimizedRecords;
+
+    private static class OperatorGuideInfo {
+        private final List<TuningGuide> tuningGuides = Lists.newArrayList();
+        private final int nodeId;
+
+        public OperatorGuideInfo(int nodeId) {
+            this.nodeId = nodeId;
+        }
+    }
 
     public OperatorTuningGuides(UUID originalQueryId, long originalTimeCost) {
         this.originalQueryId = originalQueryId;
         this.originalTimeCost = originalTimeCost;
-        this.tuningGuides = Maps.newHashMap();
+        this.operatorIdToTuningGuideInfo = Maps.newHashMap();
         this.optimizedRecords = Caffeine.newBuilder().maximumSize(50).build();
     }
 
-    public void addTuningGuide(int nodeId, TuningGuide tuningGuide) {
-        tuningGuides.computeIfAbsent(nodeId, e -> Lists.newArrayList()).add(tuningGuide);
+    public void addTuningGuide(int nodeId, int operatorId, TuningGuide tuningGuide) {
+        OperatorGuideInfo operatorGuideInfo =
+                operatorIdToTuningGuideInfo.computeIfAbsent(operatorId, e -> new OperatorGuideInfo(nodeId));
+        operatorGuideInfo.tuningGuides.add(tuningGuide);
     }
 
-    public List<TuningGuide> getTuningGuides(int nodeId) {
-        return tuningGuides.get(nodeId);
+    public List<TuningGuide> getTuningGuides(int operatorId) {
+        OperatorGuideInfo guide = operatorIdToTuningGuideInfo.get(operatorId);
+        if (guide == null) {
+            return null;
+        }
+        return guide.tuningGuides;
     }
 
     public boolean isEmpty() {
-        return tuningGuides.isEmpty();
+        return operatorIdToTuningGuideInfo.isEmpty();
     }
 
     public long optimizedQueryCount() {
@@ -104,9 +119,9 @@ public class OperatorTuningGuides {
 
     public String getTuneGuidesInfo(boolean isFull) {
         StringBuilder sb = new StringBuilder();
-        for (Map.Entry<Integer, List<TuningGuide>> entry : tuningGuides.entrySet()) {
-            sb.append("PlanNode ").append(entry.getKey()).append(":").append("\n");
-            for (TuningGuide guide : entry.getValue()) {
+        for (Map.Entry<Integer, OperatorGuideInfo> entry : operatorIdToTuningGuideInfo.entrySet()) {
+            sb.append("PlanNode ").append(entry.getValue().nodeId).append(":").append("\n");
+            for (TuningGuide guide : entry.getValue().tuningGuides) {
                 sb.append(guide.getClass().getSimpleName()).append("\n");
                 if (isFull) {
                     sb.append(guide.getDescription()).append("\n");

--- a/fe/fe-core/src/main/java/com/starrocks/qe/feedback/analyzer/JoinTuningAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/feedback/analyzer/JoinTuningAnalyzer.java
@@ -90,14 +90,14 @@ public class JoinTuningAnalyzer implements PlanTuningAnalyzer.Analyzer {
 
             if (rightExecStats.getPullRows() > rightStats.getOutputRowCount() * UNDERESTIMATED_FACTOR
                     && rightExecStats.getPullRows() > LARGE_TABLE_ROWS_THRESHOLD) {
-                tuningGuides.addTuningGuide(joinNode.getNodeId(),
+                tuningGuides.addTuningGuide(joinNode.getNodeId(), skeletonNode.getOperatorId(),
                         new RightChildEstimationErrorTuningGuide(joinNode, RIGHT_INPUT_UNDERESTIMATED));
             } else if (rightStats.getOutputRowCount() > rightExecStats.getPullRows() * UNDERESTIMATED_FACTOR) {
-                tuningGuides.addTuningGuide(joinNode.getNodeId(),
+                tuningGuides.addTuningGuide(joinNode.getNodeId(), skeletonNode.getOperatorId(),
                         new RightChildEstimationErrorTuningGuide(joinNode, RIGHT_INPUT_OVERESTIMATED));
             } else if (rightExecStats.getPullRows() > LARGE_TABLE_ROWS_THRESHOLD &&
                     leftStats.getOutputRowCount() > leftExecStats.getPullRows() * UNDERESTIMATED_FACTOR) {
-                tuningGuides.addTuningGuide(joinNode.getNodeId(),
+                tuningGuides.addTuningGuide(joinNode.getNodeId(), skeletonNode.getOperatorId(),
                         new LeftChildEstimationErrorTuningGuide(joinNode, LEFT_INPUT_OVERESTIMATED));
             }
             visit(optExpression, context);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/feedback/analyzer/StreamingAggTuningAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/feedback/analyzer/StreamingAggTuningAnalyzer.java
@@ -81,9 +81,12 @@ public class StreamingAggTuningAnalyzer implements PlanTuningAnalyzer.Analyzer {
                 BlockingAggNode blockingAggNode = findBlockingAggNode(skeletonNode);
                 if (blockingAggNode != null) {
                     double blockingOutputRows = blockingAggNode.getNodeExecStats().getPullRows();
-                    if (blockingOutputRows < inputRows && (inputRows / streamingOutputRows) > STREAMING_AGGREGATION_THRESHOLD
+                    // If the streaming aggregation has poor aggregation effectiveness while the final blocking aggregation
+                    // performs exceptionally well, switch the streaming aggregation to `force_preaggregation` mode.
+                    if (blockingOutputRows < inputRows
+                            && (inputRows / streamingOutputRows) < STREAMING_AGGREGATION_THRESHOLD
                             && (inputRows / blockingOutputRows) > AGGREGATION_THRESHOLD) {
-                        tuningGuides.addTuningGuide(skeletonNode.getNodeId(),
+                        tuningGuides.addTuningGuide(skeletonNode.getNodeId(), skeletonNode.getOperatorId(),
                                 new StreamingAggTuningGuide((StreamingAggNode) skeletonNode));
                     }
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/feedback/skeleton/SkeletonNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/feedback/skeleton/SkeletonNode.java
@@ -26,7 +26,10 @@ import java.util.Objects;
 
 public class SkeletonNode extends TreeNode<SkeletonNode> {
 
-    protected int nodeId;
+    protected final int operatorId;
+
+    // nodeId is not used in `hashCode` and `equals`, because rewrite phase has not set nodeIds to physical operators.
+    protected final int nodeId;
 
     protected final OperatorType type;
 
@@ -41,9 +44,8 @@ public class SkeletonNode extends TreeNode<SkeletonNode> {
     protected final NodeExecStats nodeExecStats;
 
     public SkeletonNode(OptExpression optExpression, NodeExecStats nodeExecStats, SkeletonNode parent) {
-        if (optExpression.getOp().getPlanNodeId() != - 1) {
-            this.nodeId = optExpression.getOp().getPlanNodeId();
-        }
+        this.operatorId = optExpression.getOp().getOperatorId();
+        this.nodeId = optExpression.getOp().getPlanNodeId();
         this.type = optExpression.getOp().getOpType();
         this.limit = optExpression.getOp().getLimit();
         this.predicate = optExpression.getOp().getPredicate();
@@ -60,6 +62,10 @@ public class SkeletonNode extends TreeNode<SkeletonNode> {
         return nodeId;
     }
 
+    public int getOperatorId() {
+        return operatorId;
+    }
+
     public SkeletonNode getParent() {
         return parent;
     }
@@ -72,13 +78,9 @@ public class SkeletonNode extends TreeNode<SkeletonNode> {
         return statistics;
     }
 
-    public void setNodeId(int nodeId) {
-        this.nodeId = nodeId;
-    }
-
     @Override
     public int hashCode() {
-        return Objects.hash(nodeId, type, limit, predicate);
+        return Objects.hash(operatorId, type, limit, predicate);
     }
 
     @Override
@@ -90,7 +92,7 @@ public class SkeletonNode extends TreeNode<SkeletonNode> {
             return false;
         }
         SkeletonNode that = (SkeletonNode) o;
-        return nodeId == that.nodeId && limit == that.limit && type == that.type &&
+        return operatorId == that.operatorId && limit == that.limit && type == that.type &&
                 Objects.equals(predicate, that.predicate);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Operator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Operator.java
@@ -36,6 +36,7 @@ import java.util.Set;
 public abstract class Operator {
     public static final long DEFAULT_LIMIT = -1;
     public static final long DEFAULT_OFFSET = 0;
+    public static final int ABSENT_OPERATOR_ID = -1;
 
     protected final OperatorType opType;
     protected long limit = DEFAULT_LIMIT;
@@ -73,7 +74,13 @@ public abstract class Operator {
 
     protected DomainProperty domainProperty;
 
+    // `planNodeId` is set only after the `FragmentBuilder` decomposes the physical plan into fragments.
+    // It is the ID of the ExecNode after decompossion.
     protected int planNodeId = -1;
+
+    // `operatorId` is set only after the `FragmentBuilder` decomposes the physical plan into fragments.
+    // It is the ID of the physical operator, which is generated in postorder traversal from zero.
+    protected int operatorId = ABSENT_OPERATOR_ID;
 
     public Operator(OperatorType opType) {
         this.opType = opType;
@@ -226,6 +233,14 @@ public abstract class Operator {
 
     public void setPlanNodeId(int planNodeId) {
         this.planNodeId = planNodeId;
+    }
+
+    public int getOperatorId() {
+        return operatorId;
+    }
+
+    public void setOperatorId(int operatorId) {
+        this.operatorId = operatorId;
     }
 
     protected RowOutputInfo deriveRowOutputInfo(List<OptExpression> inputs) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ApplyTuningGuideRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ApplyTuningGuideRule.java
@@ -117,7 +117,7 @@ public class ApplyTuningGuideRule implements TreeRewriteRule {
                 OptExpression newChild = child.getOp().accept(this, child, context.getChild(i));
                 opt.setChild(i, newChild);
             }
-            List<TuningGuide> guideList = tuningGuides.getTuningGuides(context.getNodeId());
+            List<TuningGuide> guideList = tuningGuides.getTuningGuides(context.getOperatorId());
             OptExpression res = opt;
             if (guideList != null) {
                 for (TuningGuide guide : guideList) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
@@ -156,7 +156,7 @@ public class ExecPlan {
     public Map<Integer, PlanFragment> getCteProduceFragments() {
         return cteProduceFragments;
     }
-    
+
     public Map<Integer, PlanFragment> getSplitProduceFragments() {
         return splitProduceFragments;
     }
@@ -184,6 +184,18 @@ public class ExecPlan {
     public void recordPlanNodeId2OptExpression(int id, OptExpression optExpression) {
         optExpression.getOp().setPlanNodeId(id);
         optExpressions.put(id, optExpression);
+    }
+
+    public static void assignOperatorIds(OptExpression root) {
+        IdGenerator<PlanNodeId> operatorIdGenerator = PlanNodeId.createGenerator();
+        assignOperatorIds(root, operatorIdGenerator);
+    }
+
+    private static void assignOperatorIds(OptExpression root, IdGenerator<PlanNodeId> operatorIdGenerator) {
+        root.getOp().setOperatorId(operatorIdGenerator.getNextId().asInt());
+        for (OptExpression child : root.getInputs()) {
+            assignOperatorIds(child, operatorIdGenerator);
+        }
     }
 
     public OptExpression getOptExpression(int planNodeId) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -379,6 +379,8 @@ public class PlanFragmentBuilder {
     }
 
     private static ExecPlan finalizeFragments(ExecPlan execPlan, TResultSinkType resultSinkType) {
+        ExecPlan.assignOperatorIds(execPlan.getPhysicalPlan());
+
         List<PlanFragment> fragments = execPlan.getFragments();
         for (PlanFragment fragment : fragments) {
             fragment.createDataSink(resultSinkType);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/feedback/analyzer/PlanTuningAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/feedback/analyzer/PlanTuningAnalyzerTest.java
@@ -55,7 +55,7 @@ class PlanTuningAnalyzerTest extends DistributedEnvPlanTestBase {
         ExecPlan execPlan = getExecPlan(sql);
         OptExpression root = execPlan.getPhysicalPlan();
 
-        NodeExecStats localAgg = new NodeExecStats(1, 3000000000L, 2000000L, 0, 0, 0);
+        NodeExecStats localAgg = new NodeExecStats(1, 3000000000L, 2000000000L, 0, 0, 0);
         NodeExecStats globalAgg = new NodeExecStats(3, 500000, 7, 0, 0, 0);
         Map<Integer, NodeExecStats> map = Maps.newHashMap();
         map.put(1, localAgg);
@@ -64,7 +64,7 @@ class PlanTuningAnalyzerTest extends DistributedEnvPlanTestBase {
         Pair<SkeletonNode, Map<Integer, SkeletonNode>> pair = skeletonBuilder.buildSkeleton(root);
         OperatorTuningGuides tuningGuides = new OperatorTuningGuides(UUID.randomUUID(), 50);
         PlanTuningAnalyzer.getInstance().analyzePlan(execPlan.getPhysicalPlan(), pair.second, tuningGuides);
-        Assert.assertTrue(tuningGuides.getTuningGuides(1).get(0) instanceof StreamingAggTuningGuide);
+        Assert.assertTrue(tuningGuides.getTuningGuides(2).get(0) instanceof StreamingAggTuningGuide);
     }
 
     @Test
@@ -83,7 +83,7 @@ class PlanTuningAnalyzerTest extends DistributedEnvPlanTestBase {
             Pair<SkeletonNode, Map<Integer, SkeletonNode>> pair = skeletonBuilder.buildSkeleton(root);
             OperatorTuningGuides tuningGuides = new OperatorTuningGuides(UUID.randomUUID(), 50);
             PlanTuningAnalyzer.getInstance().analyzePlan(execPlan.getPhysicalPlan(), pair.second, tuningGuides);
-            Assert.assertTrue(tuningGuides.getTuningGuides(5).get(0) instanceof RightChildEstimationErrorTuningGuide);
+            Assert.assertTrue(tuningGuides.getTuningGuides(0).get(0) instanceof RightChildEstimationErrorTuningGuide);
         }
 
         {
@@ -100,7 +100,7 @@ class PlanTuningAnalyzerTest extends DistributedEnvPlanTestBase {
             Pair<SkeletonNode, Map<Integer, SkeletonNode>> pair = skeletonBuilder.buildSkeleton(root);
             OperatorTuningGuides tuningGuides = new OperatorTuningGuides(UUID.randomUUID(), 50);
             PlanTuningAnalyzer.getInstance().analyzePlan(execPlan.getPhysicalPlan(), pair.second, tuningGuides);
-            Assert.assertTrue(tuningGuides.getTuningGuides(5).get(0) instanceof RightChildEstimationErrorTuningGuide);
+            Assert.assertTrue(tuningGuides.getTuningGuides(0).get(0) instanceof RightChildEstimationErrorTuningGuide);
         }
 
         {
@@ -117,7 +117,7 @@ class PlanTuningAnalyzerTest extends DistributedEnvPlanTestBase {
             Pair<SkeletonNode, Map<Integer, SkeletonNode>> pair = skeletonBuilder.buildSkeleton(root);
             OperatorTuningGuides tuningGuides = new OperatorTuningGuides(UUID.randomUUID(), 50);
             PlanTuningAnalyzer.getInstance().analyzePlan(execPlan.getPhysicalPlan(), pair.second, tuningGuides);
-            Assert.assertTrue(tuningGuides.getTuningGuides(5).get(0) instanceof LeftChildEstimationErrorTuningGuide);
+            Assert.assertTrue(tuningGuides.getTuningGuides(0).get(0) instanceof LeftChildEstimationErrorTuningGuide);
             PlanTuningAdvisor.getInstance().putTuningGuides(sql, pair.first, tuningGuides);
             List<List<String>> showResult = PlanTuningAdvisor.getInstance().getShowResult();
             Assert.assertEquals(8, showResult.get(0).size());

--- a/test/sql/test_feedback/R/test_agg_feedback
+++ b/test/sql/test_feedback/R/test_agg_feedback
@@ -133,11 +133,104 @@ alter plan advisor add select count(*) from pre_agg_case group by c3;
 -- result:
 [REGEX]Add query into plan advisor in FE
 -- !result
-function: assert_explain_contains("select count(*) from pre_agg_case group by c3", "StreamingAggTuningGuide")
+function: assert_explain_not_contains("select count(*) from pre_agg_case group by c3", "StreamingAggTuningGuide")
 -- result:
 None
 -- !result
 truncate plan advisor;
 -- result:
 [REGEX]Clear all plan advisor in FE
+-- !result
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+-- result:
+-- !result
+insert into __row_util_base select * from __row_util_base; -- 20000
+insert into __row_util_base select * from __row_util_base; -- 40000
+insert into __row_util_base select * from __row_util_base; -- 80000
+insert into __row_util_base select * from __row_util_base; -- 160000
+insert into __row_util_base select * from __row_util_base; -- 320000
+insert into __row_util_base select * from __row_util_base; -- 640000
+insert into __row_util_base select * from __row_util_base; -- 1280000
+
+insert into __row_util_base select * from __row_util_base; 
+insert into __row_util_base select * from __row_util_base; 
+insert into __row_util_base select * from __row_util_base; 
+insert into __row_util_base select * from __row_util_base; 
+
+
+CREATE TABLE __row_util (
+  idx bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into __row_util select row_number() over() as idx from __row_util_base;
+-- result:
+-- !result
+CREATE TABLE t1 (
+  k1 bigint NULL,
+  c1 bigint NULL,
+  c2 int NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 16
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1 select idx, idx % (20480000 / 26), idx from __row_util;
+-- result:
+-- !result
+analyze full table t1 with sync mode;
+-- result:
+[REGEX].*t1	analyze	status	OK
+-- !result
+select count(1) as cnt from t1 group by c1 order by cnt limit 10;
+-- result:
+9
+25
+26
+26
+26
+26
+26
+26
+26
+26
+-- !result
+alter plan advisor add select count(1) as cnt from t1 group by c1 order by cnt limit 10;
+-- result:
+[REGEX]Add query into plan advisor in FE
+-- !result
+function: assert_explain_contains("select count(1) as cnt from t1 group by c1 order by cnt limit 10", "StreamingAggTuningGuide")
+-- result:
+None
+-- !result
+select count(1) as cnt from t1 group by c1 order by cnt limit 10;
+-- result:
+9
+25
+26
+26
+26
+26
+26
+26
+26
+26
 -- !result

--- a/test/sql/test_feedback/T/test_agg_feedback
+++ b/test/sql/test_feedback/T/test_agg_feedback
@@ -54,5 +54,59 @@ set enable_plan_analyzer=true;
 set enable_global_runtime_filter = false;
 function: assert_explain_not_contains("select count(*) from pre_agg_case group by c3", "StreamingAggTuningGuide")
 alter plan advisor add select count(*) from pre_agg_case group by c3;
-function: assert_explain_contains("select count(*) from pre_agg_case group by c3", "StreamingAggTuningGuide")
+function: assert_explain_not_contains("select count(*) from pre_agg_case group by c3", "StreamingAggTuningGuide")
 truncate plan advisor;
+
+
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+insert into __row_util_base select * from __row_util_base; -- 20000
+insert into __row_util_base select * from __row_util_base; -- 40000
+insert into __row_util_base select * from __row_util_base; -- 80000
+insert into __row_util_base select * from __row_util_base; -- 160000
+insert into __row_util_base select * from __row_util_base; -- 320000
+insert into __row_util_base select * from __row_util_base; -- 640000
+insert into __row_util_base select * from __row_util_base; -- 1280000
+
+insert into __row_util_base select * from __row_util_base; 
+insert into __row_util_base select * from __row_util_base; 
+insert into __row_util_base select * from __row_util_base; 
+insert into __row_util_base select * from __row_util_base; 
+
+
+CREATE TABLE __row_util (
+  idx bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util select row_number() over() as idx from __row_util_base;
+
+CREATE TABLE t1 (
+  k1 bigint NULL,
+  c1 bigint NULL,
+  c2 int NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 16
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into t1 select idx, idx % (20480000 / 26), idx from __row_util;
+
+analyze full table t1 with sync mode;
+
+select count(1) as cnt from t1 group by c1 order by cnt limit 10;
+
+alter plan advisor add select count(1) as cnt from t1 group by c1 order by cnt limit 10;
+function: assert_explain_contains("select count(1) as cnt from t1 group by c1 order by cnt limit 10", "StreamingAggTuningGuide")
+select count(1) as cnt from t1 group by c1 order by cnt limit 10;


### PR DESCRIPTION
## Why I'm doing:


### Use Operator ID Instead of Node ID to Identify SkeletonNode  

The feedback system generates SkeletonNode trees in two distinct phases and checks for consistency:  
- ​**Query execution completion phase**: Analyzes the query using actual execution information to produce tuning guides.  
- ​**Rewrite phase**: Rewrites the query based on the tuning guides.  

To compare SkeletonNode trees for consistency, the current approach collects all nodes via ​**pre-order traversal**​ into a list and compares each node's `nodeId` and predicates. This method has two flaws:  
1. ​**Pre-order traversal loses structural information**:  
   - Two trees may yield identical pre-order sequences while having different structures.  
2. ​**SkeletonNode's `nodeId` dependency**:  
   - `nodeId` is generated during the ​**FragmentBuilder**​ phase and assigned back to the corresponding physical operator. However, in the rewrite phase, physical operators do not yet have `nodeId`s.  

​**This PR addresses the second issue**: After generating the physical plan, it assigns a monotonically increasing `operator id` (starting from 0) to each physical operator via pre-order traversal. These `operator id`s (instead of `nodeId`s) are used to identify SkeletonNodes.  

​**Future work**: Implement a more robust method to compare SkeletonNode tree consistency.  

---

### ​**StreamingAggTuningAnalyzer**​  

The previous logic of `StreamingAggTuningAnalyzer` may be more proper than the current logic, so revert it back:  
- If the streaming aggregation has poor aggregation effectiveness while the final blocking aggregation performs exceptionally well, switch the streaming aggregation to `force_preaggregation` mode.


## What I'm doing:


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
