### PR TITLE
[Enhancement] Optimize parse predicate tree logic for external tables

### DIFF
--- a/be/src/exec/filter_condition.h
+++ b/be/src/exec/filter_condition.h
@@ -1,0 +1,67 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "column/datum.h"
+#include "gen_cpp/InternalService_types.h"
+#include "types/logical_type.h"
+
+namespace starrocks {
+
+class GeneralCondition {
+public:
+    std::string column_name;
+    std::string condition_op;
+    std::vector<Datum> condition_values;
+    bool is_index_filter_only;
+    // When `condition_op` is `IS`, _is_null indicates whether the column is `NULL` or `NOT NULL`.
+    bool _is_null = false;
+
+    void set_column_name(const std::string& column_name) { this->column_name = column_name; }
+    void set_condition_op(const std::string& condition_op) { this->condition_op = condition_op; }
+    void set_is_index_filter_only(bool is_index_filter_only) { this->is_index_filter_only = is_index_filter_only; }
+    void add_condition_value(Datum value, [[maybe_unused]] LogicalType lt, [[maybe_unused]] int precision,
+                             [[maybe_unused]] int scale) {
+        condition_values.emplace_back(std::move(value));
+    }
+    void set_is_null(bool is_null) { _is_null = is_null; }
+
+    bool is_null() const { return _is_null; }
+};
+
+class OlapCondition final : public TCondition {
+public:
+    void set_column_name(const std::string& column_name) { __set_column_name(column_name); }
+    void set_condition_op(const std::string& condition_op) { __set_condition_op(condition_op); }
+    void set_is_index_filter_only(bool is_index_filter_only) { __set_is_index_filter_only(is_index_filter_only); }
+    void add_condition_value(const auto& value, [[maybe_unused]] LogicalType lt, [[maybe_unused]] int precision,
+                             [[maybe_unused]] int scale) {
+        condition_values.push_back(cast_to_string(value, lt, precision, scale));
+    }
+    void set_is_null(bool is_null) {
+        if (is_null) {
+            condition_values.emplace_back("NULL");
+        } else {
+            condition_values.emplace_back("NOT NULL");
+        }
+    }
+
+    bool is_null() const { return strcasecmp(condition_values[0].c_str(), "null") == 0; }
+};
+
+} // namespace starrocks

--- a/be/src/exec/olap_scan_prepare.cpp
+++ b/be/src/exec/olap_scan_prepare.cpp
@@ -37,6 +37,7 @@
 #include "types/date_value.hpp"
 #include "types/logical_type.h"
 #include "types/logical_type_infra.h"
+#include "util/orlp/pdqsort.h"
 
 namespace starrocks {
 
@@ -460,7 +461,6 @@ requires(!lt_is_date<SlotType>) Status ChunkPredicateBuilder<E, Type>::normalize
                     continue;
                 }
 
-                std::set<RangeValueType> values;
                 if (pred->null_in_set()) {
                     if (pred->is_eq_null()) {
                         // TODO: equal null is also can be normalized, will be optimized later
@@ -475,6 +475,8 @@ requires(!lt_is_date<SlotType>) Status ChunkPredicateBuilder<E, Type>::normalize
                     }
                 }
 
+                boost::container::flat_set<RangeValueType> values;
+                values.reserve(pred->hash_set().size());
                 for (const auto& value : pred->hash_set()) {
                     values.insert(value);
                 }
@@ -494,7 +496,7 @@ requires(!lt_is_date<SlotType>) Status ChunkPredicateBuilder<E, Type>::normalize
             ASSIGN_OR_RETURN(auto* expr_context, _exprs[i].expr_context(_opts.obj_pool, _opts.runtime_state));
             bool ok = get_predicate_value<Negative>(_opts.obj_pool, slot, get_root_expr(expr_context), expr_context,
                                                     &value, &op, &status);
-            if (ok && range->add_fixed_values(FILTER_IN, std::set<RangeValueType>{value}).ok()) {
+            if (ok && range->add_fixed_values(FILTER_IN, boost::container::flat_set<RangeValueType>{value}).ok()) {
                 _normalized_exprs[i] = true;
             }
         }
@@ -537,7 +539,7 @@ requires lt_is_date<SlotType> Status ChunkPredicateBuilder<E, Type>::normalize_i
             }
             std::vector<SlotId> slot_ids;
             if (1 == l->get_slot_ids(&slot_ids) && slot_ids[0] == slot.id()) {
-                std::set<DateValue> values;
+                boost::container::flat_set<DateValue> values;
 
                 if (pred_type == starrocks::TYPE_DATETIME) {
                     const auto* pred =
@@ -561,6 +563,7 @@ requires lt_is_date<SlotType> Status ChunkPredicateBuilder<E, Type>::normalize_i
                         }
                     }
 
+                    values.reserve(pred->hash_set().size());
                     for (const TimestampValue& ts : pred->hash_set()) {
                         auto date = implicit_cast<DateValue>(ts);
                         if (implicit_cast<TimestampValue>(date) == ts) {
@@ -583,6 +586,8 @@ requires lt_is_date<SlotType> Status ChunkPredicateBuilder<E, Type>::normalize_i
                             continue;
                         }
                     }
+
+                    values.reserve(pred->hash_set().size());
                     for (const DateValue& date : pred->hash_set()) {
                         values.insert(date);
                     }
@@ -605,7 +610,7 @@ requires lt_is_date<SlotType> Status ChunkPredicateBuilder<E, Type>::normalize_i
             ASSIGN_OR_RETURN(auto* expr_context, _exprs[i].expr_context(_opts.obj_pool, _opts.runtime_state));
             bool ok = get_predicate_value<Negative>(_opts.obj_pool, slot, get_root_expr(expr_context), expr_context,
                                                     &value, &op, &status);
-            if (ok && range->add_fixed_values(FILTER_IN, std::set<DateValue>{value}).ok()) {
+            if (ok && range->add_fixed_values(FILTER_IN, boost::container::flat_set<DateValue>{value}).ok()) {
                 _normalized_exprs[i] = true;
             }
         }
@@ -745,11 +750,11 @@ Status ChunkPredicateBuilder<E, Type>::normalize_join_runtime_filter(const SlotD
                         _child_builders.emplace_back(child_builder);
                     }
                 } else {
-                    std::set<RangeValueType> values;
-                    for (const auto& value : pred->hash_set()) {
-                        values.insert(value);
-                    }
-                    (void)range->add_fixed_values(FILTER_IN, values);
+                    std::vector<RangeValueType> values(pred->hash_set().begin(), pred->hash_set().end());
+                    ::pdqsort(values.begin(), values.end());
+
+                    boost::container::flat_set<RangeValueType> value_set(values.begin(), values.end());
+                    (void)range->add_fixed_values(FILTER_IN, value_set);
                 }
             }
         }
@@ -843,7 +848,7 @@ Status ChunkPredicateBuilder<E, Type>::normalize_not_in_or_not_equal_predicate(
             ASSIGN_OR_RETURN(auto* expr_context, _exprs[i].expr_context(_opts.obj_pool, _opts.runtime_state));
             bool ok = get_predicate_value<Negative>(_opts.obj_pool, slot, get_root_expr(expr_context), expr_context,
                                                     &value, &op, &status);
-            if (ok && range->add_fixed_values(FILTER_NOT_IN, std::set<RangeValueType>{value}).ok()) {
+            if (ok && range->add_fixed_values(FILTER_NOT_IN, boost::container::flat_set<RangeValueType>{value}).ok()) {
                 _normalized_exprs[i] = true;
             }
         }
@@ -869,7 +874,6 @@ Status ChunkPredicateBuilder<E, Type>::normalize_not_in_or_not_equal_predicate(
                     continue;
                 }
 
-                std::set<RangeValueType> values;
                 if (pred->null_in_set()) {
                     if (pred->is_eq_null()) {
                         continue;
@@ -884,6 +888,8 @@ Status ChunkPredicateBuilder<E, Type>::normalize_not_in_or_not_equal_predicate(
                     }
                 }
 
+                boost::container::flat_set<RangeValueType> values;
+                values.reserve(pred->hash_set().size());
                 for (const auto& value : pred->hash_set()) {
                     values.insert(value);
                 }
@@ -1000,31 +1006,41 @@ Status ChunkPredicateBuilder<E, Type>::normalize_expressions() {
 template <BoxedExprType E, CompoundNodeType Type>
 Status ChunkPredicateBuilder<E, Type>::build_olap_filters() {
     constexpr bool Negative = Type == CompoundNodeType::OR;
-    olap_filters.clear();
 
-    // False alert from clang-tidy-14
-    // NOLINTNEXTLINE(performance-for-range-copy)
-    for (auto iter : column_value_ranges) {
-        std::vector<TCondition> filters;
-        std::visit([&](auto&& range) { range.template to_olap_filter<Negative>(filters); }, iter.second);
-        const bool empty_range = std::visit([](auto&& range) { return range.is_empty_value_range(); }, iter.second);
-        if (empty_range) {
-            if constexpr (!Negative) {
-                return Status::EndOfFile("EOF, Filter by always false condition");
-            } else {
-                auto not_null_filter =
-                        std::visit([&](auto&& range) { return range.to_olap_not_null_filter(); }, iter.second);
-                filters.clear();
-                filters.emplace_back(std::move(not_null_filter));
+    auto process = [&]<typename ConditionType>(std::vector<ConditionType>& result_filters) {
+        result_filters.clear();
+
+        // False alert from clang-tidy-14
+        // NOLINTNEXTLINE(performance-for-range-copy)
+        for (auto& iter : column_value_ranges) {
+            std::vector<ConditionType> filters;
+            std::visit([&](auto&& range) { range.template to_olap_filter<ConditionType, Negative>(filters); },
+                       iter.second);
+            const bool empty_range = std::visit([](auto&& range) { return range.is_empty_value_range(); }, iter.second);
+            if (empty_range) {
+                if constexpr (!Negative) {
+                    return Status::EndOfFile("EOF, Filter by always false condition");
+                } else {
+                    auto not_null_filter = std::visit(
+                            [&](auto&& range) { return range.template to_olap_not_null_filter<ConditionType>(); },
+                            iter.second);
+                    filters.clear();
+                    filters.emplace_back(std::move(not_null_filter));
+                }
+            }
+
+            for (auto& filter : filters) {
+                result_filters.emplace_back(std::move(filter));
             }
         }
+        return Status::OK();
+    };
 
-        for (auto& filter : filters) {
-            olap_filters.emplace_back(std::move(filter));
-        }
+    if (_opts.is_olap_scan) {
+        return process(olap_filters);
+    } else {
+        return process(external_filters);
     }
-
-    return Status::OK();
 }
 
 // Try to convert the ranges predicates applied on key columns to in predicates to increase
@@ -1083,12 +1099,20 @@ Status ChunkPredicateBuilder<E, Type>::build_scan_keys(bool unlimited, int32_t m
 template <BoxedExprType E, CompoundNodeType Type>
 Status ChunkPredicateBuilder<E, Type>::_get_column_predicates(PredicateParser* parser,
                                                               ColumnPredicatePtrs& col_preds_owner) {
-    for (auto& f : olap_filters) {
-        std::unique_ptr<ColumnPredicate> p(parser->parse_thrift_cond(f));
-        RETURN_IF(!p, Status::RuntimeError("invalid filter"));
-        p->set_index_filter_only(f.is_index_filter_only);
-        col_preds_owner.emplace_back(std::move(p));
+    auto process_filter_conditions = [&]<typename ConditionType>(const std::vector<ConditionType>& filters) {
+        for (const auto& filter : filters) {
+            std::unique_ptr<ColumnPredicate> p(parser->parse_thrift_cond(filter));
+            RETURN_IF(!p, Status::RuntimeError("invalid filter"));
+            col_preds_owner.emplace_back(std::move(p));
+        }
+        return Status::OK();
+    };
+    if (_opts.is_olap_scan) {
+        RETURN_IF_ERROR(process_filter_conditions(olap_filters));
+    } else {
+        RETURN_IF_ERROR(process_filter_conditions(external_filters));
     }
+
     for (auto& f : is_null_vector) {
         std::unique_ptr<ColumnPredicate> p(parser->parse_thrift_cond(f));
         RETURN_IF(!p, Status::RuntimeError("invalid filter"));
@@ -1115,7 +1139,7 @@ Status ChunkPredicateBuilder<E, Type>::_get_column_predicates(PredicateParser* p
         }
     }
 
-    if (_is_root_builder && _opts.runtime_state->enable_join_runtime_filter_pushdown()) {
+    if (_is_root_builder && _opts.runtime_state->enable_join_runtime_filter_pushdown() && _opts.is_olap_scan) {
         for (const auto& it : _opts.runtime_filters->descriptors()) {
             RuntimeFilterProbeDescriptor* desc = it.second;
             SlotId slot_id;

--- a/be/src/exec/olap_scan_prepare.h
+++ b/be/src/exec/olap_scan_prepare.h
@@ -18,6 +18,7 @@
 #include "exec/olap_common.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
+#include "filter_condition.h"
 #include "runtime/descriptors.h"
 #include "storage/predicate_tree/predicate_tree_fwd.h"
 #include "storage/predicate_tree_params.h"
@@ -109,7 +110,8 @@ private:
     std::vector<uint8_t> _normalized_exprs;
     std::map<std::string, ColumnValueRangeType> column_value_ranges; // from conjunct_ctxs
     OlapScanKeys scan_keys;                                          // from _column_value_ranges
-    std::vector<TCondition> olap_filters;                            // from _column_value_ranges
+    std::vector<OlapCondition> olap_filters;                         // from _column_value_ranges
+    std::vector<GeneralCondition> external_filters;                  // from _column_value_ranges
     std::vector<TCondition> is_null_vector;                          // from conjunct_ctxs
 
     std::map<int, std::vector<ExprContext*>> slot_index_to_expr_ctxs; // from conjunct_ctxs

--- a/be/src/storage/column_in_predicate.cpp
+++ b/be/src/storage/column_in_predicate.cpp
@@ -23,6 +23,7 @@
 #include "roaring/roaring.hh"
 #include "storage/column_predicate.h"
 #include "storage/in_predicate_utils.h"
+#include "storage/olap_type_infra.h"
 #include "storage/rowset/bitmap_index_reader.h"
 #include "types/logical_type.h"
 #include "util/bloom_filter.h"
@@ -722,6 +723,49 @@ ColumnPredicate* new_column_in_predicate(const TypeInfoPtr& type_info, ColumnId 
         return new_column_in_predicate_generic<ItemHashSet>(type_info, id, strs);
     } else {
         return new_column_in_predicate_small(type_info, id, strs);
+    }
+}
+
+template <template <typename, size_t...> typename Set, size_t... Args>
+ColumnPredicate* new_column_in_predicate_generic(const TypeInfoPtr& type_info, ColumnId id,
+                                                 const std::vector<Datum>& operands) {
+    const auto type = type_info->type();
+    return field_type_dispatch_column_predicate(
+            type, static_cast<ColumnPredicate*>(nullptr), [&]<LogicalType LT>() -> ColumnPredicate* {
+                if constexpr (lt_is_string<LT>) {
+                    std::vector<std::string> strings;
+                    strings.reserve(operands.size());
+                    for (const auto& v : operands) {
+                        strings.emplace_back(v.get_slice().to_string());
+                    }
+                    return new BinaryColumnInPredicate<LT>(type_info, id, std::move(strings));
+                } else {
+                    using SetType = Set<typename CppTypeTraits<LT>::CppType, (Args)...>;
+                    SetType value_set = predicate_internal::datums_to_set<LT>(operands);
+                    return new ColumnInPredicate<LT, SetType>(type_info, id, std::move(value_set));
+                }
+            });
+}
+
+ColumnPredicate* new_column_in_predicate_small(const TypeInfoPtr& type_info, ColumnId id,
+                                               const std::vector<Datum>& operands) {
+    if (operands.size() == 3) {
+        return new_column_in_predicate_generic<ArraySet, 3>(type_info, id, operands);
+    } else if (operands.size() == 2) {
+        return new_column_in_predicate_generic<ArraySet, 2>(type_info, id, operands);
+    } else if (operands.size() == 1) {
+        return new_column_in_predicate_generic<ArraySet, 1>(type_info, id, operands);
+    }
+    CHECK(false) << "unreachable path";
+    return nullptr;
+}
+
+ColumnPredicate* new_column_in_predicate_from_datum(const TypeInfoPtr& type_info, ColumnId id,
+                                                    const std::vector<Datum>& operands) {
+    if (operands.size() > 3) {
+        return new_column_in_predicate_generic<ItemHashSet>(type_info, id, operands);
+    } else {
+        return new_column_in_predicate_small(type_info, id, operands);
     }
 }
 

--- a/be/src/storage/column_predicate.h
+++ b/be/src/storage/column_predicate.h
@@ -260,6 +260,17 @@ ColumnPredicate* new_column_dict_conjuct_predicate(const TypeInfoPtr& type_info,
 
 ColumnPredicate* new_column_placeholder_predicate(const TypeInfoPtr& type_info, ColumnId id);
 
+ColumnPredicate* new_column_eq_predicate_from_datum(const TypeInfoPtr& type, ColumnId id, const Datum& operand);
+ColumnPredicate* new_column_ne_predicate_from_datum(const TypeInfoPtr& type, ColumnId id, const Datum& operand);
+ColumnPredicate* new_column_lt_predicate_from_datum(const TypeInfoPtr& type, ColumnId id, const Datum& operand);
+ColumnPredicate* new_column_le_predicate_from_datum(const TypeInfoPtr& type, ColumnId id, const Datum& operand);
+ColumnPredicate* new_column_gt_predicate_from_datum(const TypeInfoPtr& type, ColumnId id, const Datum& operand);
+ColumnPredicate* new_column_ge_predicate_from_datum(const TypeInfoPtr& type, ColumnId id, const Datum& operand);
+ColumnPredicate* new_column_in_predicate_from_datum(const TypeInfoPtr& type, ColumnId id,
+                                                    const std::vector<Datum>& operands);
+ColumnPredicate* new_column_not_in_predicate_from_datum(const TypeInfoPtr& type, ColumnId id,
+                                                        const std::vector<Datum>& operands);
+
 template <LogicalType LT>
 class Bitset;
 template <LogicalType LT>

--- a/be/src/storage/column_predicate_cmp.cpp
+++ b/be/src/storage/column_predicate_cmp.cpp
@@ -19,6 +19,7 @@
 #include "column/column.h" // Column
 #include "column/datum.h"
 #include "common/object_pool.h"
+#include "olap_type_infra.h"
 #include "storage/column_predicate.h"
 #include "storage/olap_common.h" // ColumnId
 #include "storage/range.h"
@@ -184,6 +185,25 @@ static ColumnPredicate* new_column_predicate(const TypeInfoPtr& type_info, Colum
         // No default to ensure newly added enumerator will be handled.
     }
     return nullptr;
+}
+
+template <template <LogicalType> typename Predicate, template <LogicalType> typename BinaryPredicate>
+static ColumnPredicate* new_column_predicate(const TypeInfoPtr& type_info, ColumnId id, const Datum& operand) {
+    const auto type = type_info->type();
+    return field_type_dispatch_column_predicate(
+            type, static_cast<ColumnPredicate*>(nullptr), [&]<LogicalType LT>() -> ColumnPredicate* {
+                using CppType = typename CppTypeTraits<LT>::CppType;
+                // ColumnRangeBuilder treats TINYINT and BOOLEAN as INT.
+                constexpr auto MappingLogicalType = LT == TYPE_TINYINT || LT == TYPE_BOOLEAN ? TYPE_INT : LT;
+                using MappingCppType = typename CppTypeTraits<MappingLogicalType>::CppType;
+
+                if constexpr (lt_is_string<LT>) {
+                    return new BinaryPredicate<LT>(type_info, id, operand.get_slice());
+                } else {
+                    const auto value = static_cast<CppType>(operand.get<MappingCppType>());
+                    return new Predicate<LT>(type_info, id, value);
+                }
+            });
 }
 
 // Base class for column predicate
@@ -943,6 +963,30 @@ ColumnPredicate* new_column_cmp_predicate(PredicateType predicate, const TypeInf
     default:
         CHECK(false) << "not a cmp predicate";
     }
+}
+
+ColumnPredicate* new_column_ne_predicate_from_datum(const TypeInfoPtr& type_info, ColumnId id, const Datum& operand) {
+    return new_column_predicate<ColumnNePredicate, BinaryColumnNePredicate>(type_info, id, operand);
+}
+
+ColumnPredicate* new_column_eq_predicate_from_datum(const TypeInfoPtr& type_info, ColumnId id, const Datum& operand) {
+    return new_column_predicate<ColumnEqPredicate, BinaryColumnEqPredicate>(type_info, id, operand);
+}
+
+ColumnPredicate* new_column_lt_predicate_from_datum(const TypeInfoPtr& type_info, ColumnId id, const Datum& operand) {
+    return new_column_predicate<ColumnLtPredicate, BinaryColumnLtPredicate>(type_info, id, operand);
+}
+
+ColumnPredicate* new_column_le_predicate_from_datum(const TypeInfoPtr& type_info, ColumnId id, const Datum& operand) {
+    return new_column_predicate<ColumnLePredicate, BinaryColumnLePredicate>(type_info, id, operand);
+}
+
+ColumnPredicate* new_column_gt_predicate_from_datum(const TypeInfoPtr& type_info, ColumnId id, const Datum& operand) {
+    return new_column_predicate<ColumnGtPredicate, BinaryColumnGtPredicate>(type_info, id, operand);
+}
+
+ColumnPredicate* new_column_ge_predicate_from_datum(const TypeInfoPtr& type_info, ColumnId id, const Datum& operand) {
+    return new_column_predicate<ColumnGePredicate, BinaryColumnGePredicate>(type_info, id, operand);
 }
 
 std::ostream& operator<<(std::ostream& os, PredicateType p) {

--- a/be/src/storage/in_predicate_utils.h
+++ b/be/src/storage/in_predicate_utils.h
@@ -145,6 +145,22 @@ inline Converter<typename CppTypeTraits<field_type>::CppType> strings_to_decimal
 }
 
 template <LogicalType field_type>
+inline Converter<typename CppTypeTraits<field_type>::CppType> datums_to_set(const std::vector<Datum>& values) {
+    using CppType = typename CppTypeTraits<field_type>::CppType;
+    // ColumnRangeBuilder treats TINYINT and BOOLEAN as INT.
+    constexpr auto MappingLogicalType =
+            field_type == TYPE_TINYINT || field_type == TYPE_BOOLEAN ? TYPE_INT : field_type;
+    using MappingCppType = typename CppTypeTraits<MappingLogicalType>::CppType;
+
+    Converter<CppType> result;
+    for (const auto& v : values) {
+        const auto value = static_cast<CppType>(v.get<MappingCppType>());
+        result.push_back(value);
+    }
+    return result;
+}
+
+template <LogicalType field_type>
 inline ItemHashSet<typename CppTypeTraits<field_type>::CppType> strings_to_hashset(
         const std::vector<std::string>& strings) {
     using CppType = typename CppTypeTraits<field_type>::CppType;

--- a/be/src/storage/olap_type_infra.h
+++ b/be/src/storage/olap_type_infra.h
@@ -121,6 +121,16 @@ namespace starrocks {
     M(TYPE_JSON)                             \
     M(TYPE_DOUBLE)
 
+#define APPLY_FOR_COLUMN_PREDICATE_TYPE(M) \
+    M(TYPE_BOOLEAN)                        \
+    APPLY_FOR_TYPE_INTEGER(M)              \
+    APPLY_FOR_TYPE_DECIMAL(M)              \
+    APPLY_FOR_TYPE_TIME(M)                 \
+    M(TYPE_FLOAT)                          \
+    M(TYPE_DOUBLE)                         \
+    M(TYPE_CHAR)                           \
+    M(TYPE_VARCHAR)
+
 #define _TYPE_DISPATCH_CASE(type) \
     case type:                    \
         return fun.template operator()<type>(std::forward<Args>(args)...);
@@ -208,6 +218,15 @@ auto field_type_dispatch_supported(LogicalType ftype, Functor fun, Args&&... arg
     default:
         CHECK(false) << "Unsupported type: " << ftype;
         __builtin_unreachable();
+    }
+}
+
+template <class Functor, class Ret, class... Args>
+auto field_type_dispatch_column_predicate(LogicalType ftype, Ret default_value, Functor fun, Args&&... args) {
+    switch (ftype) {
+        APPLY_FOR_COLUMN_PREDICATE_TYPE(_TYPE_DISPATCH_CASE)
+    default:
+        return default_value;
     }
 }
 

--- a/be/src/storage/predicate_parser.h
+++ b/be/src/storage/predicate_parser.h
@@ -18,6 +18,7 @@
 #include <utility>
 
 #include "common/statusor.h"
+#include "exec/filter_condition.h"
 #include "storage/predicate_tree/predicate_tree_fwd.h"
 #include "tablet_schema.h"
 
@@ -44,6 +45,7 @@ public:
     // Parse |condition| into a predicate that can be pushed down.
     // return nullptr if parse failed.
     virtual ColumnPredicate* parse_thrift_cond(const TCondition& condition) const = 0;
+    virtual ColumnPredicate* parse_thrift_cond(const GeneralCondition& condition) const = 0;
 
     virtual StatusOr<ColumnPredicate*> parse_expr_ctx(const SlotDescriptor& slot_desc, RuntimeState*,
                                                       ExprContext* expr_ctx) const = 0;
@@ -52,6 +54,8 @@ public:
 
 protected:
     static ColumnPredicate* create_column_predicate(const TCondition& condition, TypeInfoPtr& type_info,
+                                                    ColumnId index);
+    static ColumnPredicate* create_column_predicate(const GeneralCondition& condition, TypeInfoPtr& type_info,
                                                     ColumnId index);
 };
 
@@ -70,6 +74,7 @@ public:
     // Parse |condition| into a predicate that can be pushed down.
     // return nullptr if parse failed.
     ColumnPredicate* parse_thrift_cond(const TCondition& condition) const override;
+    ColumnPredicate* parse_thrift_cond(const GeneralCondition& condition) const override;
 
     StatusOr<ColumnPredicate*> parse_expr_ctx(const SlotDescriptor& slot_desc, RuntimeState*,
                                               ExprContext* expr_ctx) const override;
@@ -77,6 +82,9 @@ public:
     uint32_t column_id(const SlotDescriptor& slot_desc) const override;
 
 private:
+    template <typename ConditionType>
+    ColumnPredicate* t_parse_thrift_cond(const ConditionType& condition) const;
+
     const TabletSchemaCSPtr _schema = nullptr;
     // const std::vector<SlotDescriptor*>* _slot_desc = nullptr;
 };
@@ -93,6 +101,7 @@ public:
     bool can_pushdown(const SlotDescriptor* slot_desc) const override;
 
     ColumnPredicate* parse_thrift_cond(const TCondition& condition) const override;
+    ColumnPredicate* parse_thrift_cond(const GeneralCondition& condition) const override;
 
     StatusOr<ColumnPredicate*> parse_expr_ctx(const SlotDescriptor& slot_desc, RuntimeState*,
                                               ExprContext* expr_ctx) const override;
@@ -100,6 +109,9 @@ public:
     uint32_t column_id(const SlotDescriptor& slot_desc) const override;
 
 private:
+    template <typename ConditionType>
+    ColumnPredicate* t_parse_thrift_cond(const ConditionType& condition) const;
+
     const std::vector<SlotDescriptor*>* _slot_desc = nullptr;
 };
 

--- a/be/src/storage/runtime_range_pruner.hpp
+++ b/be/src/storage/runtime_range_pruner.hpp
@@ -81,7 +81,7 @@ struct RuntimeColumnPredicateBuilder {
                 build_minmax_range<RangeType, limit_type, mapping_type, DummyDecoder>(range, minmax, pool, nullptr);
             }
 
-            std::vector<TCondition> filters;
+            std::vector<OlapCondition> filters;
             range.to_olap_filter(filters);
 
             // if runtime filter generate an empty range we could return directly

--- a/be/test/exec/column_value_range_test.cpp
+++ b/be/test/exec/column_value_range_test.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <exec/filter_condition.h>
+
 #include "column/type_traits.h"
 #include "exec/olap_common.h"
 #include "gtest/gtest.h"
@@ -34,8 +36,8 @@ TEST_F(ColumnValueRangeTest, add_range_le_max) {
     ColumnValueRange<int32_t> range("c_int32", TYPE_INT, _int32_min_value, _int32_max_value, 5, _int32_max_value);
 
     ASSERT_OK(range.add_range(SQLFilterOp::FILTER_LESS_OR_EQUAL, _int32_max_value));
-    std::vector<TCondition> filters;
-    range.to_olap_filter<false>(filters);
+    std::vector<OlapCondition> filters;
+    range.to_olap_filter<OlapCondition, false>(filters);
 
     ASSERT_EQ(filters.size(), 1);
     _ss << filters[0];
@@ -47,8 +49,8 @@ TEST_F(ColumnValueRangeTest, add_range_ge_min) {
     ColumnValueRange<int32_t> range("c_int32", TYPE_INT, _int32_min_value, _int32_max_value, _int32_min_value, 100);
 
     ASSERT_OK(range.add_range(SQLFilterOp::FILTER_LARGER_OR_EQUAL, _int32_min_value));
-    std::vector<TCondition> filters;
-    range.to_olap_filter<false>(filters);
+    std::vector<OlapCondition> filters;
+    range.to_olap_filter<OlapCondition, false>(filters);
 
     ASSERT_EQ(filters.size(), 1);
     _ss << filters[0];
@@ -65,7 +67,7 @@ TEST(NormalizeRangeTest, RangeTest) {
                                         std::numeric_limits<CppType>::max());
         ASSERT_OK(range.add_fixed_values(SQLFilterOp::FILTER_IN, {1, 2, 3, 4}));
         ASSERT_OK(range.add_fixed_values(SQLFilterOp::FILTER_NOT_IN, {1, 2}));
-        std::set<CppType> values = {3, 4};
+        ColumnValueRange<CppType>::ValuesContainer values = {3, 4};
         ASSERT_EQ(range._fixed_values, values);
     }
     {

--- a/test/sql/test_iceberg/R/test_iceberg_parse_predicates
+++ b/test/sql/test_iceberg/R/test_iceberg_parse_predicates
@@ -1,0 +1,1226 @@
+-- name: test_iceberg_parse_predicates
+create external catalog ice_cat_${uuid0}
+properties (
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog ice_cat_${uuid0};
+-- result:
+-- !result
+create database ice_db_${uuid0};
+-- result:
+-- !result
+use ice_db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+);
+-- result:
+-- !result
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+-- result:
+-- !result
+insert into __row_util_base select * from __row_util_base; -- 20000
+insert into __row_util_base select * from __row_util_base; -- 40000
+insert into __row_util_base select * from __row_util_base; -- 80000
+insert into __row_util_base select * from __row_util_base; -- 160000
+insert into __row_util_base select * from __row_util_base; -- 320000
+insert into __row_util_base select * from __row_util_base; -- 640000
+insert into __row_util_base select * from __row_util_base; -- 1280000
+
+CREATE TABLE __row_util (
+  idx bigint NULL
+);
+-- result:
+-- !result
+insert into __row_util select row_number() over() as idx from __row_util_base;
+-- result:
+-- !result
+CREATE TABLE t1 (
+    k1 bigint NULL,
+
+    c_bool boolean NULL,
+    c_tinyint tinyint NULL,
+    c_smallint smallint NULL,
+    c_int int NULL,
+    c_bigint bigint NULL,
+    c_float float NULL,
+    c_double double NULL,
+    c_decimal64 DECIMAL(18, 0) NULL,
+    c_decimal128 DECIMAL(38, 0) NULL,
+
+    c_varchar STRING NULL,
+    c_char CHAR(32) NULL,
+
+    c_date DATE NULL,
+    c_datetime DATETIME NULL,
+
+    c_array_int ARRAY<INT> NULL,
+    c_map MAP<INT, INT> NULL,
+    c_struct STRUCT<k1 INT, k2 INT> NULL
+);
+-- result:
+-- !result
+INSERT INTO t1
+SELECT
+    idx,
+
+    idx % 2 = 0,
+    idx % 128,
+    idx % 32768,
+    idx % 2147483648,
+    idx,
+    idx,
+    idx,
+    idx,
+    idx,
+
+    concat('varchar-', idx),
+    concat('char-', idx),
+
+    cast(date_sub('2023-01-01', interval cast(idx % 10000 as int) day) as date),
+    date_sub('2023-01-01', interval cast(idx % 10000 as int) second),
+
+    [idx, idx + 1, idx + 2, idx + 3],
+    map{0: idx, 1: idx + 1, 2: idx + 2},
+    struct(idx, idx + 1)
+FROM __row_util;
+-- result:
+-- !result
+INSERT INTO t1 (k1) SELECT idx from __row_util order by idx limit 10000;
+-- result:
+-- !result
+select count(1) from t1 where c_bool = false;
+-- result:
+640000
+-- !result
+select count(1) from t1 where c_bool != false;
+-- result:
+640000
+-- !result
+select count(1) from t1 where c_bool > false;
+-- result:
+640000
+-- !result
+select count(1) from t1 where c_bool >= false;
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_bool < false;
+-- result:
+0
+-- !result
+select count(1) from t1 where c_bool <= false;
+-- result:
+640000
+-- !result
+select count(1) from t1 where c_bool <=> false;
+-- result:
+640000
+-- !result
+select count(1) from t1 where c_bool <=> null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_bool is null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_bool is not null;
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_bool = false AND c_bool != false;
+-- result:
+0
+-- !result
+select count(1) from t1 where c_bool > false AND c_bool < false;
+-- result:
+0
+-- !result
+select count(1) from t1 where c_bool >= false AND c_bool <= false;
+-- result:
+640000
+-- !result
+select count(1) from t1 where c_bool in (true, false);
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_bool not in (true, false);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_bool in (true, false) and c_bool in (true);
+-- result:
+640000
+-- !result
+select count(1) from t1 where c_bool in (true, false) and c_bool not in (true, false);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_bool in (true, false) and c_bool not in (true);
+-- result:
+640000
+-- !result
+select count(1) from t1 where c_bool >= 0 AND (c_bool in (true, false) OR c_bool not in (true, false));
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_tinyint = 10;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_tinyint != 10;
+-- result:
+1270000
+-- !result
+select count(1) from t1 where c_tinyint > 10;
+-- result:
+1170000
+-- !result
+select count(1) from t1 where c_tinyint >= 10;
+-- result:
+1180000
+-- !result
+select count(1) from t1 where c_tinyint < 10;
+-- result:
+100000
+-- !result
+select count(1) from t1 where c_tinyint <= 10;
+-- result:
+110000
+-- !result
+select count(1) from t1 where c_tinyint <=> 10;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_tinyint <=> null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_tinyint is null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_tinyint is not null;
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_tinyint = 10 AND c_tinyint != 10;
+-- result:
+0
+-- !result
+select count(1) from t1 where c_tinyint > 10 AND c_tinyint < 100;
+-- result:
+890000
+-- !result
+select count(1) from t1 where c_tinyint >= 10 AND c_tinyint <= 100;
+-- result:
+910000
+-- !result
+select count(1) from t1 where c_tinyint in (10, 10, 100);
+-- result:
+20000
+-- !result
+select count(1) from t1 where c_tinyint not in (10, 10, 100);
+-- result:
+1260000
+-- !result
+select count(1) from t1 where c_tinyint in (100, 10, 10) and c_tinyint in (10, 100, 10, 7, 8, 9, 1);
+-- result:
+20000
+-- !result
+select count(1) from t1 where c_tinyint in (10, 10, 100) and c_tinyint not in (10, 10, 100);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_tinyint in (10, 10, 100, 7) and c_tinyint not in (10, 10, 100);
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_tinyint > 0 AND (c_tinyint in (10, 10, 100) OR c_tinyint not in (10, 10, 100));
+-- result:
+1270000
+-- !result
+select count(1) from t1 where c_smallint = 10000;
+-- result:
+39
+-- !result
+select count(1) from t1 where c_smallint != 10000;
+-- result:
+1279961
+-- !result
+select count(1) from t1 where c_smallint > 10000;
+-- result:
+887913
+-- !result
+select count(1) from t1 where c_smallint >= 10000;
+-- result:
+887952
+-- !result
+select count(1) from t1 where c_smallint < 10000;
+-- result:
+392048
+-- !result
+select count(1) from t1 where c_smallint <= 10000;
+-- result:
+392087
+-- !result
+select count(1) from t1 where c_smallint <=> 10000;
+-- result:
+39
+-- !result
+select count(1) from t1 where c_smallint <=> null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_smallint is null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_smallint is not null;
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_smallint = 10000 AND c_smallint != 10000;
+-- result:
+0
+-- !result
+select count(1) from t1 where c_smallint > 10000 AND c_smallint < 100000;
+-- result:
+887913
+-- !result
+select count(1) from t1 where c_smallint >= 10000 AND c_smallint <= 100000;
+-- result:
+887952
+-- !result
+select count(1) from t1 where c_smallint in (10, 10000, 100000);
+-- result:
+79
+-- !result
+select count(1) from t1 where c_smallint not in (10, 10000, 100000);
+-- result:
+1279921
+-- !result
+select count(1) from t1 where c_smallint in (100000, 10000, 10) and c_smallint in (10, 100000, 10000, 7, 8, 9, 1);
+-- result:
+79
+-- !result
+select count(1) from t1 where c_smallint in (10, 10000, 100000) and c_smallint not in (10, 10000, 100000);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_smallint in (10, 10000, 100000, 7) and c_smallint not in (10, 10000, 100000);
+-- result:
+40
+-- !result
+select count(1) from t1 where c_smallint > 0 AND (c_smallint in (10, 10000, 100000) OR c_smallint not in (10, 10000, 100000));
+-- result:
+1279961
+-- !result
+select count(1) from t1 where c_int = 100000;
+-- result:
+1
+-- !result
+select count(1) from t1 where c_int != 100000;
+-- result:
+1279999
+-- !result
+select count(1) from t1 where c_int > 100000;
+-- result:
+1180000
+-- !result
+select count(1) from t1 where c_int >= 100000;
+-- result:
+1180001
+-- !result
+select count(1) from t1 where c_int < 100000;
+-- result:
+99999
+-- !result
+select count(1) from t1 where c_int <= 100000;
+-- result:
+100000
+-- !result
+select count(1) from t1 where c_int <=> 100000;
+-- result:
+1
+-- !result
+select count(1) from t1 where c_int <=> null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_int is null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_int is not null;
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_int = 100000 AND c_int != 100000;
+-- result:
+0
+-- !result
+select count(1) from t1 where c_int > 100000 AND c_int < 1000000;
+-- result:
+899999
+-- !result
+select count(1) from t1 where c_int >= 100000 AND c_int <= 1000000;
+-- result:
+900001
+-- !result
+select count(1) from t1 where c_int in (10, 100000, 1000000);
+-- result:
+3
+-- !result
+select count(1) from t1 where c_int not in (10, 100000, 1000000);
+-- result:
+1279997
+-- !result
+select count(1) from t1 where c_int in (1000000, 100000, 10) and c_int in (10, 1000000, 100000, 7, 8, 9, 1);
+-- result:
+3
+-- !result
+select count(1) from t1 where c_int in (10, 100000, 1000000) and c_int not in (10, 100000, 1000000);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_int in (10, 100000, 1000000, 7) and c_int not in (10, 100000, 1000000);
+-- result:
+1
+-- !result
+select count(1) from t1 where c_int > 0 AND (c_int in (10, 100000, 1000000) OR c_int not in (10, 100000, 1000000));
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_bigint = 100000;
+-- result:
+1
+-- !result
+select count(1) from t1 where c_bigint != 100000;
+-- result:
+1279999
+-- !result
+select count(1) from t1 where c_bigint > 100000;
+-- result:
+1180000
+-- !result
+select count(1) from t1 where c_bigint >= 100000;
+-- result:
+1180001
+-- !result
+select count(1) from t1 where c_bigint < 100000;
+-- result:
+99999
+-- !result
+select count(1) from t1 where c_bigint <= 100000;
+-- result:
+100000
+-- !result
+select count(1) from t1 where c_bigint <=> 100000;
+-- result:
+1
+-- !result
+select count(1) from t1 where c_bigint <=> null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_bigint is null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_bigint is not null;
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_bigint = 100000 AND c_bigint != 100000;
+-- result:
+0
+-- !result
+select count(1) from t1 where c_bigint > 100000 AND c_bigint < 1000000;
+-- result:
+899999
+-- !result
+select count(1) from t1 where c_bigint >= 100000 AND c_bigint <= 1000000;
+-- result:
+900001
+-- !result
+select count(1) from t1 where c_bigint in (10, 100000, 1000000);
+-- result:
+3
+-- !result
+select count(1) from t1 where c_bigint not in (10, 100000, 1000000);
+-- result:
+1279997
+-- !result
+select count(1) from t1 where c_bigint in (1000000, 100000, 10) and c_bigint in (10, 1000000, 100000, 7, 8, 9, 1);
+-- result:
+3
+-- !result
+select count(1) from t1 where c_bigint in (10, 100000, 1000000) and c_bigint not in (10, 100000, 1000000);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_bigint in (10, 100000, 1000000, 7) and c_bigint not in (10, 100000, 1000000);
+-- result:
+1
+-- !result
+select count(1) from t1 where c_bigint > 0 AND (c_bigint in (10, 100000, 1000000) OR c_bigint not in (10, 100000, 1000000));
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_float = 100000;
+-- result:
+1
+-- !result
+select count(1) from t1 where c_float != 100000;
+-- result:
+1279999
+-- !result
+select count(1) from t1 where c_float > 100000;
+-- result:
+1180000
+-- !result
+select count(1) from t1 where c_float >= 100000;
+-- result:
+1180001
+-- !result
+select count(1) from t1 where c_float < 100000;
+-- result:
+99999
+-- !result
+select count(1) from t1 where c_float <= 100000;
+-- result:
+100000
+-- !result
+select count(1) from t1 where c_float <=> 100000;
+-- result:
+1
+-- !result
+select count(1) from t1 where c_float <=> null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_float is null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_float is not null;
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_float = 100000 AND c_float != 100000;
+-- result:
+0
+-- !result
+select count(1) from t1 where c_float > 100000 AND c_float < 1000000;
+-- result:
+899999
+-- !result
+select count(1) from t1 where c_float >= 100000 AND c_float <= 1000000;
+-- result:
+900001
+-- !result
+select count(1) from t1 where c_float in (10, 100000, 1000000);
+-- result:
+3
+-- !result
+select count(1) from t1 where c_float not in (10, 100000, 1000000);
+-- result:
+1279997
+-- !result
+select count(1) from t1 where c_float in (1000000, 100000, 10) and c_float in (10, 1000000, 100000, 7, 8, 9, 1);
+-- result:
+3
+-- !result
+select count(1) from t1 where c_float in (10, 100000, 1000000) and c_float not in (10, 100000, 1000000);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_float in (10, 100000, 1000000, 7) and c_float not in (10, 100000, 1000000);
+-- result:
+1
+-- !result
+select count(1) from t1 where c_float > 0 AND (c_float in (10, 100000, 1000000) OR c_float not in (10, 100000, 1000000));
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_double = 100000;
+-- result:
+1
+-- !result
+select count(1) from t1 where c_double != 100000;
+-- result:
+1279999
+-- !result
+select count(1) from t1 where c_double > 100000;
+-- result:
+1180000
+-- !result
+select count(1) from t1 where c_double >= 100000;
+-- result:
+1180001
+-- !result
+select count(1) from t1 where c_double < 100000;
+-- result:
+99999
+-- !result
+select count(1) from t1 where c_double <= 100000;
+-- result:
+100000
+-- !result
+select count(1) from t1 where c_double <=> 100000;
+-- result:
+1
+-- !result
+select count(1) from t1 where c_double <=> null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_double is null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_double is not null;
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_double = 100000 AND c_double != 100000;
+-- result:
+0
+-- !result
+select count(1) from t1 where c_double > 100000 AND c_double < 1000000;
+-- result:
+899999
+-- !result
+select count(1) from t1 where c_double >= 100000 AND c_double <= 1000000;
+-- result:
+900001
+-- !result
+select count(1) from t1 where c_double in (10, 100000, 1000000);
+-- result:
+3
+-- !result
+select count(1) from t1 where c_double not in (10, 100000, 1000000);
+-- result:
+1279997
+-- !result
+select count(1) from t1 where c_double in (1000000, 100000, 10) and c_double in (10, 1000000, 100000, 7, 8, 9, 1);
+-- result:
+3
+-- !result
+select count(1) from t1 where c_double in (10, 100000, 1000000) and c_double not in (10, 100000, 1000000);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_double in (10, 100000, 1000000, 7) and c_double not in (10, 100000, 1000000);
+-- result:
+1
+-- !result
+select count(1) from t1 where c_double > 0 AND (c_double in (10, 100000, 1000000) OR c_double not in (10, 100000, 1000000));
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_decimal64 = 100000;
+-- result:
+1
+-- !result
+select count(1) from t1 where c_decimal64 != 100000;
+-- result:
+1279999
+-- !result
+select count(1) from t1 where c_decimal64 > 100000;
+-- result:
+1180000
+-- !result
+select count(1) from t1 where c_decimal64 >= 100000;
+-- result:
+1180001
+-- !result
+select count(1) from t1 where c_decimal64 < 100000;
+-- result:
+99999
+-- !result
+select count(1) from t1 where c_decimal64 <= 100000;
+-- result:
+100000
+-- !result
+select count(1) from t1 where c_decimal64 <=> 100000;
+-- result:
+1
+-- !result
+select count(1) from t1 where c_decimal64 <=> null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_decimal64 is null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_decimal64 is not null;
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_decimal64 = 100000 AND c_decimal64 != 100000;
+-- result:
+0
+-- !result
+select count(1) from t1 where c_decimal64 > 100000 AND c_decimal64 < 1000000;
+-- result:
+899999
+-- !result
+select count(1) from t1 where c_decimal64 >= 100000 AND c_decimal64 <= 1000000;
+-- result:
+900001
+-- !result
+select count(1) from t1 where c_decimal64 in (10, 100000, 1000000);
+-- result:
+3
+-- !result
+select count(1) from t1 where c_decimal64 not in (10, 100000, 1000000);
+-- result:
+1279997
+-- !result
+select count(1) from t1 where c_decimal64 in (1000000, 100000, 10) and c_decimal64 in (10, 1000000, 100000, 7, 8, 9, 1);
+-- result:
+3
+-- !result
+select count(1) from t1 where c_decimal64 in (10, 100000, 1000000) and c_decimal64 not in (10, 100000, 1000000);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_decimal64 in (10, 100000, 1000000, 7) and c_decimal64 not in (10, 100000, 1000000);
+-- result:
+1
+-- !result
+select count(1) from t1 where c_decimal64 > 0 AND (c_decimal64 in (10, 100000, 1000000) OR c_decimal64 not in (10, 100000, 1000000));
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_decimal128 = 100000;
+-- result:
+1
+-- !result
+select count(1) from t1 where c_decimal128 != 100000;
+-- result:
+1279999
+-- !result
+select count(1) from t1 where c_decimal128 > 100000;
+-- result:
+1180000
+-- !result
+select count(1) from t1 where c_decimal128 >= 100000;
+-- result:
+1180001
+-- !result
+select count(1) from t1 where c_decimal128 < 100000;
+-- result:
+99999
+-- !result
+select count(1) from t1 where c_decimal128 <= 100000;
+-- result:
+100000
+-- !result
+select count(1) from t1 where c_decimal128 <=> 100000;
+-- result:
+1
+-- !result
+select count(1) from t1 where c_decimal128 <=> null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_decimal128 is null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_decimal128 is not null;
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_decimal128 = 100000 AND c_decimal128 != 100000;
+-- result:
+0
+-- !result
+select count(1) from t1 where c_decimal128 > 100000 AND c_decimal128 < 1000000;
+-- result:
+899999
+-- !result
+select count(1) from t1 where c_decimal128 >= 100000 AND c_decimal128 <= 1000000;
+-- result:
+900001
+-- !result
+select count(1) from t1 where c_decimal128 in (10, 100000, 1000000);
+-- result:
+3
+-- !result
+select count(1) from t1 where c_decimal128 not in (10, 100000, 1000000);
+-- result:
+1279997
+-- !result
+select count(1) from t1 where c_decimal128 in (1000000, 100000, 10) and c_decimal128 in (10, 1000000, 100000, 7, 8, 9, 1);
+-- result:
+3
+-- !result
+select count(1) from t1 where c_decimal128 in (10, 100000, 1000000) and c_decimal128 not in (10, 100000, 1000000);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_decimal128 in (10, 100000, 1000000, 7) and c_decimal128 not in (10, 100000, 1000000);
+-- result:
+1
+-- !result
+select count(1) from t1 where c_decimal128 > 0 AND (c_decimal128 in (10, 100000, 1000000) OR c_decimal128 not in (10, 100000, 1000000));
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_varchar = concat('varchar-', 100000);
+-- result:
+1
+-- !result
+select count(1) from t1 where c_varchar != concat('varchar-', 100000);
+-- result:
+1279999
+-- !result
+select count(1) from t1 where c_varchar > concat('varchar-', 100000);
+-- result:
+1279994
+-- !result
+select count(1) from t1 where c_varchar >= concat('varchar-', 100000);
+-- result:
+1279995
+-- !result
+select count(1) from t1 where c_varchar < concat('varchar-', 100000);
+-- result:
+5
+-- !result
+select count(1) from t1 where c_varchar <= concat('varchar-', 100000);
+-- result:
+6
+-- !result
+select count(1) from t1 where c_varchar <=> concat('varchar-', 100000);
+-- result:
+1
+-- !result
+select count(1) from t1 where c_varchar <=> null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_varchar is null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_varchar is not null;
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_varchar = concat('varchar-', 100000) AND c_varchar != concat('varchar-', 100000);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_varchar > concat('varchar-', 100000) AND c_varchar < concat('varchar-', 1000000);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_varchar >= concat('varchar-', 100000) AND c_varchar <= concat('varchar-', 1000000);
+-- result:
+2
+-- !result
+select count(1) from t1 where c_varchar in (concat('varchar-', 10), concat('varchar-', 100000), concat('varchar-', 1000000));
+-- result:
+3
+-- !result
+select count(1) from t1 where c_varchar not in (concat('varchar-', 10), concat('varchar-', 100000), concat('varchar-', 1000000));
+-- result:
+1279997
+-- !result
+select count(1) from t1 where c_varchar in (concat('varchar-', 1000000), concat('varchar-', 100000), concat('varchar-', 10)) and c_varchar in (concat('varchar-', 10), concat('varchar-', 1000000), concat('varchar-', 100000), concat('varchar-', 7), concat('varchar-', 8), concat('varchar-', 9), 1);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_varchar in (concat('varchar-', 10), concat('varchar-', 100000), concat('varchar-', 1000000)) and c_varchar not in (concat('varchar-', 10), concat('varchar-', 100000), concat('varchar-', 1000000));
+-- result:
+0
+-- !result
+select count(1) from t1 where c_varchar in (concat('varchar-', 10), concat('varchar-', 100000), concat('varchar-', 1000000), concat('varchar-', 7)) and c_varchar not in (concat('varchar-', 10), concat('varchar-', 100000), concat('varchar-', 1000000));
+-- result:
+1
+-- !result
+select count(1) from t1 where c_varchar > 0 AND (c_varchar in (concat('varchar-', 10), concat('varchar-', 100000), concat('varchar-', 1000000)) OR c_varchar not in (concat('varchar-', 10), concat('varchar-', 100000), concat('varchar-', 1000000)));
+-- result:
+0
+-- !result
+select count(1) from t1 where c_char = concat('char-', 100000);
+-- result:
+1
+-- !result
+select count(1) from t1 where c_char != concat('char-', 100000);
+-- result:
+1279999
+-- !result
+select count(1) from t1 where c_char > concat('char-', 100000);
+-- result:
+1279994
+-- !result
+select count(1) from t1 where c_char >= concat('char-', 100000);
+-- result:
+1279995
+-- !result
+select count(1) from t1 where c_char < concat('char-', 100000);
+-- result:
+5
+-- !result
+select count(1) from t1 where c_char <= concat('char-', 100000);
+-- result:
+6
+-- !result
+select count(1) from t1 where c_char <=> concat('char-', 100000);
+-- result:
+1
+-- !result
+select count(1) from t1 where c_char <=> null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_char is null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_char is not null;
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_char = concat('char-', 100000) AND c_char != concat('char-', 100000);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_char > concat('char-', 100000) AND c_char < concat('char-', 1000000);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_char >= concat('char-', 100000) AND c_char <= concat('char-', 1000000);
+-- result:
+2
+-- !result
+select count(1) from t1 where c_char in (concat('char-', 10), concat('char-', 100000), concat('char-', 1000000));
+-- result:
+3
+-- !result
+select count(1) from t1 where c_char not in (concat('char-', 10), concat('char-', 100000), concat('char-', 1000000));
+-- result:
+1279997
+-- !result
+select count(1) from t1 where c_char in (concat('char-', 1000000), concat('char-', 100000), concat('char-', 10)) and c_char in (concat('char-', 10), concat('char-', 1000000), concat('char-', 100000), concat('char-', 7), concat('char-', 8), concat('char-', 9), 1);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_char in (concat('char-', 10), concat('char-', 100000), concat('char-', 1000000)) and c_char not in (concat('char-', 10), concat('char-', 100000), concat('char-', 1000000));
+-- result:
+0
+-- !result
+select count(1) from t1 where c_char in (concat('char-', 10), concat('char-', 100000), concat('char-', 1000000), concat('char-', 7)) and c_char not in (concat('char-', 10), concat('char-', 100000), concat('char-', 1000000));
+-- result:
+1
+-- !result
+select count(1) from t1 where c_char > 0 AND (c_char in (concat('char-', 10), concat('char-', 100000), concat('char-', 1000000)) OR c_char not in (concat('char-', 10), concat('char-', 100000), concat('char-', 1000000)));
+-- result:
+0
+-- !result
+select count(1) from t1 where c_date = cast(date_sub('2023-01-01', interval 100000 day) as date);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_date != cast(date_sub('2023-01-01', interval 100000 day) as date);
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_date > cast(date_sub('2023-01-01', interval 100000 day) as date);
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_date >= cast(date_sub('2023-01-01', interval 100000 day) as date);
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_date < cast(date_sub('2023-01-01', interval 100000 day) as date);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_date <= cast(date_sub('2023-01-01', interval 100000 day) as date);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_date <=> cast(date_sub('2023-01-01', interval 100000 day) as date);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_date <=> null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_date is null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_date is not null;
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_date = cast(date_sub('2023-01-01', interval 100000 day) as date) AND c_date != cast(date_sub('2023-01-01', interval 100000 day) as date);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_date > cast(date_sub('2023-01-01', interval 100000 day) as date) AND c_date < cast(date_sub('2023-01-01', interval 1000000 day) as date);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_date >= cast(date_sub('2023-01-01', interval 100000 day) as date) AND c_date <= cast(date_sub('2023-01-01', interval 1000000 day) as date);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_date in (cast(date_sub('2023-01-01', interval 10 day) as date), cast(date_sub('2023-01-01', interval 100000 day) as date), cast(date_sub('2023-01-01', interval 1000000 day) as date));
+-- result:
+128
+-- !result
+select count(1) from t1 where c_date not in (cast(date_sub('2023-01-01', interval 10 day) as date), cast(date_sub('2023-01-01', interval 100000 day) as date), cast(date_sub('2023-01-01', interval 1000000 day) as date));
+-- result:
+0
+-- !result
+select count(1) from t1 where c_date in (cast(date_sub('2023-01-01', interval 1000000 day) as date), cast(date_sub('2023-01-01', interval 100000 day) as date), cast(date_sub('2023-01-01', interval 10 day) as date)) and c_date in (cast(date_sub('2023-01-01', interval 10 day) as date), cast(date_sub('2023-01-01', interval 1000000 day) as date), cast(date_sub('2023-01-01', interval 100000 day) as date), cast(date_sub('2023-01-01', interval 7 day) as date), cast(date_sub('2023-01-01', interval 8 day) as date), cast(date_sub('2023-01-01', interval 9 day) as date), 1);
+-- result:
+128
+-- !result
+select count(1) from t1 where c_date in (cast(date_sub('2023-01-01', interval 10 day) as date), cast(date_sub('2023-01-01', interval 100000 day) as date), cast(date_sub('2023-01-01', interval 1000000 day) as date)) and c_date not in (cast(date_sub('2023-01-01', interval 10 day) as date), cast(date_sub('2023-01-01', interval 100000 day) as date), cast(date_sub('2023-01-01', interval 1000000 day) as date));
+-- result:
+0
+-- !result
+select count(1) from t1 where c_date in (cast(date_sub('2023-01-01', interval 10 day) as date), cast(date_sub('2023-01-01', interval 100000 day) as date), cast(date_sub('2023-01-01', interval 1000000 day) as date), cast(date_sub('2023-01-01', interval 7 day) as date)) and c_date not in (cast(date_sub('2023-01-01', interval 10 day) as date), cast(date_sub('2023-01-01', interval 100000 day) as date), cast(date_sub('2023-01-01', interval 1000000 day) as date));
+-- result:
+0
+-- !result
+select count(1) from t1 where c_date <= cast(date_sub('2023-01-01', interval 0 day) as date) AND (c_date in (cast(date_sub('2023-01-01', interval 10 day) as date), cast(date_sub('2023-01-01', interval 100000 day) as date), cast(date_sub('2023-01-01', interval 1000000 day) as date)) OR c_date not in (cast(date_sub('2023-01-01', interval 10 day) as date), cast(date_sub('2023-01-01', interval 100000 day) as date), cast(date_sub('2023-01-01', interval 1000000 day) as date)));
+-- result:
+128
+-- !result
+select count(1) from t1 where c_datetime = date_sub('2023-01-01', interval 100000 second);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_datetime != date_sub('2023-01-01', interval 100000 second);
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_datetime > date_sub('2023-01-01', interval 100000 second);
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_datetime >= date_sub('2023-01-01', interval 100000 second);
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_datetime < date_sub('2023-01-01', interval 100000 second);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_datetime <= date_sub('2023-01-01', interval 100000 second);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_datetime <=> date_sub('2023-01-01', interval 100000 second);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_datetime <=> null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_datetime is null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_datetime is not null;
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_datetime = date_sub('2023-01-01', interval 100000 second) AND c_datetime != date_sub('2023-01-01', interval 100000 second);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_datetime > date_sub('2023-01-01', interval 100000 second) AND c_datetime < date_sub('2023-01-01', interval 1000000 second);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_datetime >= date_sub('2023-01-01', interval 100000 second) AND c_datetime <= date_sub('2023-01-01', interval 1000000 second);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_datetime in (date_sub('2023-01-01', interval 10 second), date_sub('2023-01-01', interval 100000 second), date_sub('2023-01-01', interval 1000000 second));
+-- result:
+128
+-- !result
+select count(1) from t1 where c_datetime not in (date_sub('2023-01-01', interval 10 second), date_sub('2023-01-01', interval 100000 second), date_sub('2023-01-01', interval 1000000 second));
+-- result:
+1279872
+-- !result
+select count(1) from t1 where c_datetime in (date_sub('2023-01-01', interval 1000000 second), date_sub('2023-01-01', interval 100000 second), date_sub('2023-01-01', interval 10 second)) and c_datetime in (date_sub('2023-01-01', interval 10 second), date_sub('2023-01-01', interval 1000000 second), date_sub('2023-01-01', interval 100000 second), date_sub('2023-01-01', interval 7 second), date_sub('2023-01-01', interval 8 second), date_sub('2023-01-01', interval 9 second), 1);
+-- result:
+128
+-- !result
+select count(1) from t1 where c_datetime in (date_sub('2023-01-01', interval 10 second), date_sub('2023-01-01', interval 100000 second), date_sub('2023-01-01', interval 1000000 second)) and c_datetime not in (date_sub('2023-01-01', interval 10 second), date_sub('2023-01-01', interval 100000 second), date_sub('2023-01-01', interval 1000000 second));
+-- result:
+0
+-- !result
+select count(1) from t1 where c_datetime in (date_sub('2023-01-01', interval 10 second), date_sub('2023-01-01', interval 100000 second), date_sub('2023-01-01', interval 1000000 second), date_sub('2023-01-01', interval 7 second)) and c_datetime not in (date_sub('2023-01-01', interval 10 second), date_sub('2023-01-01', interval 100000 second), date_sub('2023-01-01', interval 1000000 second));
+-- result:
+128
+-- !result
+select count(1) from t1 where c_datetime <= date_sub('2023-01-01', interval 0 second) AND (c_datetime in (date_sub('2023-01-01', interval 10 second), date_sub('2023-01-01', interval 100000 second), date_sub('2023-01-01', interval 1000000 second)) OR c_datetime not in (date_sub('2023-01-01', interval 10 second), date_sub('2023-01-01', interval 100000 second), date_sub('2023-01-01', interval 1000000 second)));
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_array_int = [100000, 100000+1, 100000+2, 100000+3];
+-- result:
+1
+-- !result
+select count(1) from t1 where c_array_int != [100000, 100000+1, 100000+2, 100000+3];
+-- result:
+1279999
+-- !result
+select count(1) from t1 where c_array_int > [100000, 100000+1, 100000+2, 100000+3];
+-- result:
+1180000
+-- !result
+select count(1) from t1 where c_array_int >= [100000, 100000+1, 100000+2, 100000+3];
+-- result:
+1180001
+-- !result
+select count(1) from t1 where c_array_int < [100000, 100000+1, 100000+2, 100000+3];
+-- result:
+99999
+-- !result
+select count(1) from t1 where c_array_int <= [100000, 100000+1, 100000+2, 100000+3];
+-- result:
+100000
+-- !result
+select count(1) from t1 where c_array_int <=> [100000, 100000+1, 100000+2, 100000+3];
+-- result:
+1
+-- !result
+select count(1) from t1 where c_array_int <=> null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_array_int is null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_array_int is not null;
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_array_int = [100000, 100000+1, 100000+2, 100000+3] AND c_array_int != [100000, 100000+1, 100000+2, 100000+3];
+-- result:
+0
+-- !result
+select count(1) from t1 where c_array_int > [100000, 100000+1, 100000+2, 100000+3] AND c_array_int < [1000000, 1000000+1, 1000000+2, 1000000+3];
+-- result:
+899999
+-- !result
+select count(1) from t1 where c_array_int >= [100000, 100000+1, 100000+2, 100000+3] AND c_array_int <= [1000000, 1000000+1, 1000000+2, 1000000+3];
+-- result:
+900001
+-- !result
+select count(1) from t1 where c_array_int in ([10, 10+1, 10+2, 10+3], [100000, 100000+1, 100000+2, 100000+3], [1000000, 1000000+1, 1000000+2, 1000000+3]);
+-- result:
+3
+-- !result
+select count(1) from t1 where c_array_int not in ([10, 10+1, 10+2, 10+3], [100000, 100000+1, 100000+2, 100000+3], [1000000, 1000000+1, 1000000+2, 1000000+3]);
+-- result:
+1279997
+-- !result
+select count(1) from t1 where c_array_int in ([1000000, 1000000+1, 1000000+2, 1000000+3], [100000, 100000+1, 100000+2, 100000+3], [10, 10+1, 10+2, 10+3]) and c_array_int in ([10, 10+1, 10+2, 10+3], [1000000, 1000000+1, 1000000+2, 1000000+3], [100000, 100000+1, 100000+2, 100000+3], [7, 7+1, 7+2, 7+3], [8, 8+1, 8+2, 8+3], [9, 9+1, 9+2, 9+3]);
+-- result:
+3
+-- !result
+select count(1) from t1 where c_array_int in ([10, 10+1, 10+2, 10+3], [100000, 100000+1, 100000+2, 100000+3], [1000000, 1000000+1, 1000000+2, 1000000+3]) and c_array_int not in ([10, 10+1, 10+2, 10+3], [100000, 100000+1, 100000+2, 100000+3], [1000000, 1000000+1, 1000000+2, 1000000+3]);
+-- result:
+0
+-- !result
+select count(1) from t1 where c_array_int in ([10, 10+1, 10+2, 10+3], [100000, 100000+1, 100000+2, 100000+3], [1000000, 1000000+1, 1000000+2, 1000000+3], [7, 7+1, 7+2, 7+3]) and c_array_int not in ([10, 10+1, 10+2, 10+3], [100000, 100000+1, 100000+2, 100000+3], [1000000, 1000000+1, 1000000+2, 1000000+3]);
+-- result:
+1
+-- !result
+select count(1) from t1 where c_array_int > [0, 0+1, 0+2, 0+3] AND (c_array_int in ([10, 10+1, 10+2, 10+3], [100000, 100000+1, 100000+2, 100000+3], [1000000, 1000000+1, 1000000+2, 1000000+3]) OR c_array_int not in ([10, 10+1, 10+2, 10+3], [100000, 100000+1, 100000+2, 100000+3], [1000000, 1000000+1, 1000000+2, 1000000+3]));
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_map =  map{0: 100000, 1: 100000 + 1, 2: 100000 + 2};
+-- result:
+1
+-- !result
+select count(1) from t1 where c_map !=  map{0: 100000, 1: 100000 + 1, 2: 100000 + 2};
+-- result:
+1279999
+-- !result
+select count(1) from t1 where c_map <=>  map{0: 100000, 1: 100000 + 1, 2: 100000 + 2};
+-- result:
+1
+-- !result
+select count(1) from t1 where c_map <=> null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_map is null;
+-- result:
+10000
+-- !result
+select count(1) from t1 where c_map is not null;
+-- result:
+1280000
+-- !result
+select count(1) from t1 where c_map =  map{0: 100000, 1: 100000 + 1, 2: 100000 + 2} AND c_map !=  map{0: 100000, 1: 100000 + 1, 2: 100000 + 2};
+-- result:
+0
+-- !result
+select count(1) from t1 where c_map in ( map{0: 10, 1: 10 + 1, 2: 10 + 2},  map{0: 100000, 1: 100000 + 1, 2: 100000 + 2},  map{0: 1000000, 1: 1000000 + 1, 2: 1000000 + 2});
+-- result:
+3
+-- !result
+select count(1) from t1 where c_map not in ( map{0: 10, 1: 10 + 1, 2: 10 + 2},  map{0: 100000, 1: 100000 + 1, 2: 100000 + 2},  map{0: 1000000, 1: 1000000 + 1, 2: 1000000 + 2});
+-- result:
+1279997
+-- !result
+select count(1) from t1 where c_map in ( map{0: 1000000, 1: 1000000 + 1, 2: 1000000 + 2},  map{0: 100000, 1: 100000 + 1, 2: 100000 + 2},  map{0: 10, 1: 10 + 1, 2: 10 + 2}) and c_map in ( map{0: 10, 1: 10 + 1, 2: 10 + 2},  map{0: 1000000, 1: 1000000 + 1, 2: 1000000 + 2},  map{0: 100000, 1: 100000 + 1, 2: 100000 + 2},  map{0: 7, 1: 7 + 1, 2: 7 + 2},  map{0: 8, 1: 8 + 1, 2: 8 + 2},  map{0: 9, 1: 9 + 1, 2: 9 + 2});
+-- result:
+3
+-- !result
+select count(1) from t1 where c_map in ( map{0: 10, 1: 10 + 1, 2: 10 + 2},  map{0: 100000, 1: 100000 + 1, 2: 100000 + 2},  map{0: 1000000, 1: 1000000 + 1, 2: 1000000 + 2}) and c_map not in ( map{0: 10, 1: 10 + 1, 2: 10 + 2},  map{0: 100000, 1: 100000 + 1, 2: 100000 + 2},  map{0: 1000000, 1: 1000000 + 1, 2: 1000000 + 2});
+-- result:
+0
+-- !result
+select count(1) from t1 where c_map in ( map{0: 10, 1: 10 + 1, 2: 10 + 2},  map{0: 100000, 1: 100000 + 1, 2: 100000 + 2},  map{0: 1000000, 1: 1000000 + 1, 2: 1000000 + 2},  map{0: 7, 1: 7 + 1, 2: 7 + 2}) and c_map not in ( map{0: 10, 1: 10 + 1, 2: 10 + 2},  map{0: 100000, 1: 100000 + 1, 2: 100000 + 2},  map{0: 1000000, 1: 1000000 + 1, 2: 1000000 + 2});
+-- result:
+1
+-- !result
+drop table t1 force;
+-- result:
+-- !result
+drop table __row_util force;
+-- result:
+-- !result
+drop table __row_util_base force;
+-- result:
+-- !result
+drop database ice_db_${uuid0};
+-- result:
+-- !result
+drop catalog ice_cat_${uuid0};
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_parse_predicates
+++ b/test/sql/test_iceberg/T/test_iceberg_parse_predicates
@@ -1,0 +1,460 @@
+-- name: test_iceberg_parse_predicates
+
+create external catalog ice_cat_${uuid0}
+properties (
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog ice_cat_${uuid0};
+create database ice_db_${uuid0};
+use ice_db_${uuid0};
+
+
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+);
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+insert into __row_util_base select * from __row_util_base; -- 20000
+insert into __row_util_base select * from __row_util_base; -- 40000
+insert into __row_util_base select * from __row_util_base; -- 80000
+insert into __row_util_base select * from __row_util_base; -- 160000
+insert into __row_util_base select * from __row_util_base; -- 320000
+insert into __row_util_base select * from __row_util_base; -- 640000
+insert into __row_util_base select * from __row_util_base; -- 1280000
+
+CREATE TABLE __row_util (
+  idx bigint NULL
+);
+insert into __row_util select row_number() over() as idx from __row_util_base;
+
+
+CREATE TABLE t1 (
+    k1 bigint NULL,
+
+    c_bool boolean NULL,
+    c_tinyint tinyint NULL,
+    c_smallint smallint NULL,
+    c_int int NULL,
+    c_bigint bigint NULL,
+    c_float float NULL,
+    c_double double NULL,
+    c_decimal64 DECIMAL(18, 0) NULL,
+    c_decimal128 DECIMAL(38, 0) NULL,
+
+    c_varchar STRING NULL,
+    c_char CHAR(32) NULL,
+
+    c_date DATE NULL,
+    c_datetime DATETIME NULL,
+
+    c_array_int ARRAY<INT> NULL,
+    c_map MAP<INT, INT> NULL,
+    c_struct STRUCT<k1 INT, k2 INT> NULL
+);
+
+INSERT INTO t1
+SELECT
+    idx,
+
+    idx % 2 = 0,
+    idx % 128,
+    idx % 32768,
+    idx % 2147483648,
+    idx,
+    idx,
+    idx,
+    idx,
+    idx,
+
+    concat('varchar-', idx),
+    concat('char-', idx),
+
+    cast(date_sub('2023-01-01', interval cast(idx % 10000 as int) day) as date),
+    date_sub('2023-01-01', interval cast(idx % 10000 as int) second),
+
+    [idx, idx + 1, idx + 2, idx + 3],
+    map{0: idx, 1: idx + 1, 2: idx + 2},
+    struct(idx, idx + 1)
+FROM __row_util;
+
+INSERT INTO t1 (k1) SELECT idx from __row_util order by idx limit 10000;
+
+-- BOOL
+select count(1) from t1 where c_bool = false;
+select count(1) from t1 where c_bool != false;
+select count(1) from t1 where c_bool > false;
+select count(1) from t1 where c_bool >= false;
+select count(1) from t1 where c_bool < false;
+select count(1) from t1 where c_bool <= false;
+select count(1) from t1 where c_bool <=> false;
+select count(1) from t1 where c_bool <=> null;
+select count(1) from t1 where c_bool is null;
+select count(1) from t1 where c_bool is not null;
+
+select count(1) from t1 where c_bool = false AND c_bool != false;
+select count(1) from t1 where c_bool > false AND c_bool < false;
+select count(1) from t1 where c_bool >= false AND c_bool <= false;
+
+select count(1) from t1 where c_bool in (true, false);
+select count(1) from t1 where c_bool not in (true, false);
+select count(1) from t1 where c_bool in (true, false) and c_bool in (true);
+select count(1) from t1 where c_bool in (true, false) and c_bool not in (true, false);
+select count(1) from t1 where c_bool in (true, false) and c_bool not in (true);
+select count(1) from t1 where c_bool >= 0 AND (c_bool in (true, false) OR c_bool not in (true, false));
+
+
+-- TINYINT
+select count(1) from t1 where c_tinyint = 10;
+select count(1) from t1 where c_tinyint != 10;
+select count(1) from t1 where c_tinyint > 10;
+select count(1) from t1 where c_tinyint >= 10;
+select count(1) from t1 where c_tinyint < 10;
+select count(1) from t1 where c_tinyint <= 10;
+select count(1) from t1 where c_tinyint <=> 10;
+select count(1) from t1 where c_tinyint <=> null;
+select count(1) from t1 where c_tinyint is null;
+select count(1) from t1 where c_tinyint is not null;
+
+select count(1) from t1 where c_tinyint = 10 AND c_tinyint != 10;
+select count(1) from t1 where c_tinyint > 10 AND c_tinyint < 100;
+select count(1) from t1 where c_tinyint >= 10 AND c_tinyint <= 100;
+
+select count(1) from t1 where c_tinyint in (10, 10, 100);
+select count(1) from t1 where c_tinyint not in (10, 10, 100);
+select count(1) from t1 where c_tinyint in (100, 10, 10) and c_tinyint in (10, 100, 10, 7, 8, 9, 1);
+select count(1) from t1 where c_tinyint in (10, 10, 100) and c_tinyint not in (10, 10, 100);
+select count(1) from t1 where c_tinyint in (10, 10, 100, 7) and c_tinyint not in (10, 10, 100);
+-- parse to: c_tinyint > 0 and c_tinyint is not null
+select count(1) from t1 where c_tinyint > 0 AND (c_tinyint in (10, 10, 100) OR c_tinyint not in (10, 10, 100));
+
+
+
+-- SMALLINT
+select count(1) from t1 where c_smallint = 10000;
+select count(1) from t1 where c_smallint != 10000;
+select count(1) from t1 where c_smallint > 10000;
+select count(1) from t1 where c_smallint >= 10000;
+select count(1) from t1 where c_smallint < 10000;
+select count(1) from t1 where c_smallint <= 10000;
+select count(1) from t1 where c_smallint <=> 10000;
+select count(1) from t1 where c_smallint <=> null;
+select count(1) from t1 where c_smallint is null;
+select count(1) from t1 where c_smallint is not null;
+
+select count(1) from t1 where c_smallint = 10000 AND c_smallint != 10000;
+select count(1) from t1 where c_smallint > 10000 AND c_smallint < 100000;
+select count(1) from t1 where c_smallint >= 10000 AND c_smallint <= 100000;
+
+select count(1) from t1 where c_smallint in (10, 10000, 100000);
+select count(1) from t1 where c_smallint not in (10, 10000, 100000);
+select count(1) from t1 where c_smallint in (100000, 10000, 10) and c_smallint in (10, 100000, 10000, 7, 8, 9, 1);
+select count(1) from t1 where c_smallint in (10, 10000, 100000) and c_smallint not in (10, 10000, 100000);
+select count(1) from t1 where c_smallint in (10, 10000, 100000, 7) and c_smallint not in (10, 10000, 100000);
+-- parse to: c_smallint > 0 and c_smallint is not null
+select count(1) from t1 where c_smallint > 0 AND (c_smallint in (10, 10000, 100000) OR c_smallint not in (10, 10000, 100000));
+
+
+-- INT
+select count(1) from t1 where c_int = 100000;
+select count(1) from t1 where c_int != 100000;
+select count(1) from t1 where c_int > 100000;
+select count(1) from t1 where c_int >= 100000;
+select count(1) from t1 where c_int < 100000;
+select count(1) from t1 where c_int <= 100000;
+select count(1) from t1 where c_int <=> 100000;
+select count(1) from t1 where c_int <=> null;
+select count(1) from t1 where c_int is null;
+select count(1) from t1 where c_int is not null;
+
+select count(1) from t1 where c_int = 100000 AND c_int != 100000;
+select count(1) from t1 where c_int > 100000 AND c_int < 1000000;
+select count(1) from t1 where c_int >= 100000 AND c_int <= 1000000;
+
+select count(1) from t1 where c_int in (10, 100000, 1000000);
+select count(1) from t1 where c_int not in (10, 100000, 1000000);
+select count(1) from t1 where c_int in (1000000, 100000, 10) and c_int in (10, 1000000, 100000, 7, 8, 9, 1);
+select count(1) from t1 where c_int in (10, 100000, 1000000) and c_int not in (10, 100000, 1000000);
+select count(1) from t1 where c_int in (10, 100000, 1000000, 7) and c_int not in (10, 100000, 1000000);
+-- parse to: c_int > 0 and c_int is not null
+select count(1) from t1 where c_int > 0 AND (c_int in (10, 100000, 1000000) OR c_int not in (10, 100000, 1000000));
+
+
+
+-- BIGINT
+select count(1) from t1 where c_bigint = 100000;
+select count(1) from t1 where c_bigint != 100000;
+select count(1) from t1 where c_bigint > 100000;
+select count(1) from t1 where c_bigint >= 100000;
+select count(1) from t1 where c_bigint < 100000;
+select count(1) from t1 where c_bigint <= 100000;
+select count(1) from t1 where c_bigint <=> 100000;
+select count(1) from t1 where c_bigint <=> null;
+select count(1) from t1 where c_bigint is null;
+select count(1) from t1 where c_bigint is not null;
+
+select count(1) from t1 where c_bigint = 100000 AND c_bigint != 100000;
+select count(1) from t1 where c_bigint > 100000 AND c_bigint < 1000000;
+select count(1) from t1 where c_bigint >= 100000 AND c_bigint <= 1000000;
+
+select count(1) from t1 where c_bigint in (10, 100000, 1000000);
+select count(1) from t1 where c_bigint not in (10, 100000, 1000000);
+select count(1) from t1 where c_bigint in (1000000, 100000, 10) and c_bigint in (10, 1000000, 100000, 7, 8, 9, 1);
+select count(1) from t1 where c_bigint in (10, 100000, 1000000) and c_bigint not in (10, 100000, 1000000);
+select count(1) from t1 where c_bigint in (10, 100000, 1000000, 7) and c_bigint not in (10, 100000, 1000000);
+-- parse to: c_bigint > 0 and c_bigint is not null
+select count(1) from t1 where c_bigint > 0 AND (c_bigint in (10, 100000, 1000000) OR c_bigint not in (10, 100000, 1000000));
+
+
+
+-- FLOAT
+select count(1) from t1 where c_float = 100000;
+select count(1) from t1 where c_float != 100000;
+select count(1) from t1 where c_float > 100000;
+select count(1) from t1 where c_float >= 100000;
+select count(1) from t1 where c_float < 100000;
+select count(1) from t1 where c_float <= 100000;
+select count(1) from t1 where c_float <=> 100000;
+select count(1) from t1 where c_float <=> null;
+select count(1) from t1 where c_float is null;
+select count(1) from t1 where c_float is not null;
+
+select count(1) from t1 where c_float = 100000 AND c_float != 100000;
+select count(1) from t1 where c_float > 100000 AND c_float < 1000000;
+select count(1) from t1 where c_float >= 100000 AND c_float <= 1000000;
+
+select count(1) from t1 where c_float in (10, 100000, 1000000);
+select count(1) from t1 where c_float not in (10, 100000, 1000000);
+select count(1) from t1 where c_float in (1000000, 100000, 10) and c_float in (10, 1000000, 100000, 7, 8, 9, 1);
+select count(1) from t1 where c_float in (10, 100000, 1000000) and c_float not in (10, 100000, 1000000);
+select count(1) from t1 where c_float in (10, 100000, 1000000, 7) and c_float not in (10, 100000, 1000000);
+-- parse to: c_float > 0 and c_float is not null
+select count(1) from t1 where c_float > 0 AND (c_float in (10, 100000, 1000000) OR c_float not in (10, 100000, 1000000));
+
+
+
+-- DOUBLE
+select count(1) from t1 where c_double = 100000;
+select count(1) from t1 where c_double != 100000;
+select count(1) from t1 where c_double > 100000;
+select count(1) from t1 where c_double >= 100000;
+select count(1) from t1 where c_double < 100000;
+select count(1) from t1 where c_double <= 100000;
+select count(1) from t1 where c_double <=> 100000;
+select count(1) from t1 where c_double <=> null;
+select count(1) from t1 where c_double is null;
+select count(1) from t1 where c_double is not null;
+
+select count(1) from t1 where c_double = 100000 AND c_double != 100000;
+select count(1) from t1 where c_double > 100000 AND c_double < 1000000;
+select count(1) from t1 where c_double >= 100000 AND c_double <= 1000000;
+
+select count(1) from t1 where c_double in (10, 100000, 1000000);
+select count(1) from t1 where c_double not in (10, 100000, 1000000);
+select count(1) from t1 where c_double in (1000000, 100000, 10) and c_double in (10, 1000000, 100000, 7, 8, 9, 1);
+select count(1) from t1 where c_double in (10, 100000, 1000000) and c_double not in (10, 100000, 1000000);
+select count(1) from t1 where c_double in (10, 100000, 1000000, 7) and c_double not in (10, 100000, 1000000);
+-- parse to: c_double > 0 and c_double is not null
+select count(1) from t1 where c_double > 0 AND (c_double in (10, 100000, 1000000) OR c_double not in (10, 100000, 1000000));
+
+
+-- DECIMAL 64
+select count(1) from t1 where c_decimal64 = 100000;
+select count(1) from t1 where c_decimal64 != 100000;
+select count(1) from t1 where c_decimal64 > 100000;
+select count(1) from t1 where c_decimal64 >= 100000;
+select count(1) from t1 where c_decimal64 < 100000;
+select count(1) from t1 where c_decimal64 <= 100000;
+select count(1) from t1 where c_decimal64 <=> 100000;
+select count(1) from t1 where c_decimal64 <=> null;
+select count(1) from t1 where c_decimal64 is null;
+select count(1) from t1 where c_decimal64 is not null;
+
+select count(1) from t1 where c_decimal64 = 100000 AND c_decimal64 != 100000;
+select count(1) from t1 where c_decimal64 > 100000 AND c_decimal64 < 1000000;
+select count(1) from t1 where c_decimal64 >= 100000 AND c_decimal64 <= 1000000;
+
+select count(1) from t1 where c_decimal64 in (10, 100000, 1000000);
+select count(1) from t1 where c_decimal64 not in (10, 100000, 1000000);
+select count(1) from t1 where c_decimal64 in (1000000, 100000, 10) and c_decimal64 in (10, 1000000, 100000, 7, 8, 9, 1);
+select count(1) from t1 where c_decimal64 in (10, 100000, 1000000) and c_decimal64 not in (10, 100000, 1000000);
+select count(1) from t1 where c_decimal64 in (10, 100000, 1000000, 7) and c_decimal64 not in (10, 100000, 1000000);
+-- parse to: c_decimal64 > 0 and c_decimal64 is not null
+select count(1) from t1 where c_decimal64 > 0 AND (c_decimal64 in (10, 100000, 1000000) OR c_decimal64 not in (10, 100000, 1000000));
+
+
+-- DECIMAL 128
+select count(1) from t1 where c_decimal128 = 100000;
+select count(1) from t1 where c_decimal128 != 100000;
+select count(1) from t1 where c_decimal128 > 100000;
+select count(1) from t1 where c_decimal128 >= 100000;
+select count(1) from t1 where c_decimal128 < 100000;
+select count(1) from t1 where c_decimal128 <= 100000;
+select count(1) from t1 where c_decimal128 <=> 100000;
+select count(1) from t1 where c_decimal128 <=> null;
+select count(1) from t1 where c_decimal128 is null;
+select count(1) from t1 where c_decimal128 is not null;
+
+select count(1) from t1 where c_decimal128 = 100000 AND c_decimal128 != 100000;
+select count(1) from t1 where c_decimal128 > 100000 AND c_decimal128 < 1000000;
+select count(1) from t1 where c_decimal128 >= 100000 AND c_decimal128 <= 1000000;
+
+select count(1) from t1 where c_decimal128 in (10, 100000, 1000000);
+select count(1) from t1 where c_decimal128 not in (10, 100000, 1000000);
+select count(1) from t1 where c_decimal128 in (1000000, 100000, 10) and c_decimal128 in (10, 1000000, 100000, 7, 8, 9, 1);
+select count(1) from t1 where c_decimal128 in (10, 100000, 1000000) and c_decimal128 not in (10, 100000, 1000000);
+select count(1) from t1 where c_decimal128 in (10, 100000, 1000000, 7) and c_decimal128 not in (10, 100000, 1000000);
+-- parse to: c_decimal128 > 0 and c_decimal128 is not null
+select count(1) from t1 where c_decimal128 > 0 AND (c_decimal128 in (10, 100000, 1000000) OR c_decimal128 not in (10, 100000, 1000000));
+
+
+-- c_varchar
+select count(1) from t1 where c_varchar = concat('varchar-', 100000);
+select count(1) from t1 where c_varchar != concat('varchar-', 100000);
+select count(1) from t1 where c_varchar > concat('varchar-', 100000);
+select count(1) from t1 where c_varchar >= concat('varchar-', 100000);
+select count(1) from t1 where c_varchar < concat('varchar-', 100000);
+select count(1) from t1 where c_varchar <= concat('varchar-', 100000);
+select count(1) from t1 where c_varchar <=> concat('varchar-', 100000);
+select count(1) from t1 where c_varchar <=> null;
+select count(1) from t1 where c_varchar is null;
+select count(1) from t1 where c_varchar is not null;
+
+select count(1) from t1 where c_varchar = concat('varchar-', 100000) AND c_varchar != concat('varchar-', 100000);
+select count(1) from t1 where c_varchar > concat('varchar-', 100000) AND c_varchar < concat('varchar-', 1000000);
+select count(1) from t1 where c_varchar >= concat('varchar-', 100000) AND c_varchar <= concat('varchar-', 1000000);
+
+select count(1) from t1 where c_varchar in (concat('varchar-', 10), concat('varchar-', 100000), concat('varchar-', 1000000));
+select count(1) from t1 where c_varchar not in (concat('varchar-', 10), concat('varchar-', 100000), concat('varchar-', 1000000));
+select count(1) from t1 where c_varchar in (concat('varchar-', 1000000), concat('varchar-', 100000), concat('varchar-', 10)) and c_varchar in (concat('varchar-', 10), concat('varchar-', 1000000), concat('varchar-', 100000), concat('varchar-', 7), concat('varchar-', 8), concat('varchar-', 9), 1);
+select count(1) from t1 where c_varchar in (concat('varchar-', 10), concat('varchar-', 100000), concat('varchar-', 1000000)) and c_varchar not in (concat('varchar-', 10), concat('varchar-', 100000), concat('varchar-', 1000000));
+select count(1) from t1 where c_varchar in (concat('varchar-', 10), concat('varchar-', 100000), concat('varchar-', 1000000), concat('varchar-', 7)) and c_varchar not in (concat('varchar-', 10), concat('varchar-', 100000), concat('varchar-', 1000000));
+-- parse to: c_varchar > 0 and c_varchar is not null
+select count(1) from t1 where c_varchar > 0 AND (c_varchar in (concat('varchar-', 10), concat('varchar-', 100000), concat('varchar-', 1000000)) OR c_varchar not in (concat('varchar-', 10), concat('varchar-', 100000), concat('varchar-', 1000000)));
+
+
+
+-- c_char
+select count(1) from t1 where c_char = concat('char-', 100000);
+select count(1) from t1 where c_char != concat('char-', 100000);
+select count(1) from t1 where c_char > concat('char-', 100000);
+select count(1) from t1 where c_char >= concat('char-', 100000);
+select count(1) from t1 where c_char < concat('char-', 100000);
+select count(1) from t1 where c_char <= concat('char-', 100000);
+select count(1) from t1 where c_char <=> concat('char-', 100000);
+select count(1) from t1 where c_char <=> null;
+select count(1) from t1 where c_char is null;
+select count(1) from t1 where c_char is not null;
+
+select count(1) from t1 where c_char = concat('char-', 100000) AND c_char != concat('char-', 100000);
+select count(1) from t1 where c_char > concat('char-', 100000) AND c_char < concat('char-', 1000000);
+select count(1) from t1 where c_char >= concat('char-', 100000) AND c_char <= concat('char-', 1000000);
+
+select count(1) from t1 where c_char in (concat('char-', 10), concat('char-', 100000), concat('char-', 1000000));
+select count(1) from t1 where c_char not in (concat('char-', 10), concat('char-', 100000), concat('char-', 1000000));
+select count(1) from t1 where c_char in (concat('char-', 1000000), concat('char-', 100000), concat('char-', 10)) and c_char in (concat('char-', 10), concat('char-', 1000000), concat('char-', 100000), concat('char-', 7), concat('char-', 8), concat('char-', 9), 1);
+select count(1) from t1 where c_char in (concat('char-', 10), concat('char-', 100000), concat('char-', 1000000)) and c_char not in (concat('char-', 10), concat('char-', 100000), concat('char-', 1000000));
+select count(1) from t1 where c_char in (concat('char-', 10), concat('char-', 100000), concat('char-', 1000000), concat('char-', 7)) and c_char not in (concat('char-', 10), concat('char-', 100000), concat('char-', 1000000));
+-- parse to: c_char > 0 and c_char is not null
+select count(1) from t1 where c_char > 0 AND (c_char in (concat('char-', 10), concat('char-', 100000), concat('char-', 1000000)) OR c_char not in (concat('char-', 10), concat('char-', 100000), concat('char-', 1000000)));
+
+
+-- c_date
+select count(1) from t1 where c_date = cast(date_sub('2023-01-01', interval 100000 day) as date);
+select count(1) from t1 where c_date != cast(date_sub('2023-01-01', interval 100000 day) as date);
+select count(1) from t1 where c_date > cast(date_sub('2023-01-01', interval 100000 day) as date);
+select count(1) from t1 where c_date >= cast(date_sub('2023-01-01', interval 100000 day) as date);
+select count(1) from t1 where c_date < cast(date_sub('2023-01-01', interval 100000 day) as date);
+select count(1) from t1 where c_date <= cast(date_sub('2023-01-01', interval 100000 day) as date);
+select count(1) from t1 where c_date <=> cast(date_sub('2023-01-01', interval 100000 day) as date);
+select count(1) from t1 where c_date <=> null;
+select count(1) from t1 where c_date is null;
+select count(1) from t1 where c_date is not null;
+
+select count(1) from t1 where c_date = cast(date_sub('2023-01-01', interval 100000 day) as date) AND c_date != cast(date_sub('2023-01-01', interval 100000 day) as date);
+select count(1) from t1 where c_date > cast(date_sub('2023-01-01', interval 100000 day) as date) AND c_date < cast(date_sub('2023-01-01', interval 1000000 day) as date);
+select count(1) from t1 where c_date >= cast(date_sub('2023-01-01', interval 100000 day) as date) AND c_date <= cast(date_sub('2023-01-01', interval 1000000 day) as date);
+
+select count(1) from t1 where c_date in (cast(date_sub('2023-01-01', interval 10 day) as date), cast(date_sub('2023-01-01', interval 100000 day) as date), cast(date_sub('2023-01-01', interval 1000000 day) as date));
+select count(1) from t1 where c_date not in (cast(date_sub('2023-01-01', interval 10 day) as date), cast(date_sub('2023-01-01', interval 100000 day) as date), cast(date_sub('2023-01-01', interval 1000000 day) as date));
+select count(1) from t1 where c_date in (cast(date_sub('2023-01-01', interval 1000000 day) as date), cast(date_sub('2023-01-01', interval 100000 day) as date), cast(date_sub('2023-01-01', interval 10 day) as date)) and c_date in (cast(date_sub('2023-01-01', interval 10 day) as date), cast(date_sub('2023-01-01', interval 1000000 day) as date), cast(date_sub('2023-01-01', interval 100000 day) as date), cast(date_sub('2023-01-01', interval 7 day) as date), cast(date_sub('2023-01-01', interval 8 day) as date), cast(date_sub('2023-01-01', interval 9 day) as date), 1);
+select count(1) from t1 where c_date in (cast(date_sub('2023-01-01', interval 10 day) as date), cast(date_sub('2023-01-01', interval 100000 day) as date), cast(date_sub('2023-01-01', interval 1000000 day) as date)) and c_date not in (cast(date_sub('2023-01-01', interval 10 day) as date), cast(date_sub('2023-01-01', interval 100000 day) as date), cast(date_sub('2023-01-01', interval 1000000 day) as date));
+select count(1) from t1 where c_date in (cast(date_sub('2023-01-01', interval 10 day) as date), cast(date_sub('2023-01-01', interval 100000 day) as date), cast(date_sub('2023-01-01', interval 1000000 day) as date), cast(date_sub('2023-01-01', interval 7 day) as date)) and c_date not in (cast(date_sub('2023-01-01', interval 10 day) as date), cast(date_sub('2023-01-01', interval 100000 day) as date), cast(date_sub('2023-01-01', interval 1000000 day) as date));
+-- parse to: c_date <= cast(date_sub('2023-01-01', interval 0 day) as date) and c_date is not null
+select count(1) from t1 where c_date <= cast(date_sub('2023-01-01', interval 0 day) as date) AND (c_date in (cast(date_sub('2023-01-01', interval 10 day) as date), cast(date_sub('2023-01-01', interval 100000 day) as date), cast(date_sub('2023-01-01', interval 1000000 day) as date)) OR c_date not in (cast(date_sub('2023-01-01', interval 10 day) as date), cast(date_sub('2023-01-01', interval 100000 day) as date), cast(date_sub('2023-01-01', interval 1000000 day) as date)));
+
+
+-- c_datetime
+select count(1) from t1 where c_datetime = date_sub('2023-01-01', interval 100000 second);
+select count(1) from t1 where c_datetime != date_sub('2023-01-01', interval 100000 second);
+select count(1) from t1 where c_datetime > date_sub('2023-01-01', interval 100000 second);
+select count(1) from t1 where c_datetime >= date_sub('2023-01-01', interval 100000 second);
+select count(1) from t1 where c_datetime < date_sub('2023-01-01', interval 100000 second);
+select count(1) from t1 where c_datetime <= date_sub('2023-01-01', interval 100000 second);
+select count(1) from t1 where c_datetime <=> date_sub('2023-01-01', interval 100000 second);
+select count(1) from t1 where c_datetime <=> null;
+select count(1) from t1 where c_datetime is null;
+select count(1) from t1 where c_datetime is not null;
+
+select count(1) from t1 where c_datetime = date_sub('2023-01-01', interval 100000 second) AND c_datetime != date_sub('2023-01-01', interval 100000 second);
+select count(1) from t1 where c_datetime > date_sub('2023-01-01', interval 100000 second) AND c_datetime < date_sub('2023-01-01', interval 1000000 second);
+select count(1) from t1 where c_datetime >= date_sub('2023-01-01', interval 100000 second) AND c_datetime <= date_sub('2023-01-01', interval 1000000 second);
+
+select count(1) from t1 where c_datetime in (date_sub('2023-01-01', interval 10 second), date_sub('2023-01-01', interval 100000 second), date_sub('2023-01-01', interval 1000000 second));
+select count(1) from t1 where c_datetime not in (date_sub('2023-01-01', interval 10 second), date_sub('2023-01-01', interval 100000 second), date_sub('2023-01-01', interval 1000000 second));
+select count(1) from t1 where c_datetime in (date_sub('2023-01-01', interval 1000000 second), date_sub('2023-01-01', interval 100000 second), date_sub('2023-01-01', interval 10 second)) and c_datetime in (date_sub('2023-01-01', interval 10 second), date_sub('2023-01-01', interval 1000000 second), date_sub('2023-01-01', interval 100000 second), date_sub('2023-01-01', interval 7 second), date_sub('2023-01-01', interval 8 second), date_sub('2023-01-01', interval 9 second), 1);
+select count(1) from t1 where c_datetime in (date_sub('2023-01-01', interval 10 second), date_sub('2023-01-01', interval 100000 second), date_sub('2023-01-01', interval 1000000 second)) and c_datetime not in (date_sub('2023-01-01', interval 10 second), date_sub('2023-01-01', interval 100000 second), date_sub('2023-01-01', interval 1000000 second));
+select count(1) from t1 where c_datetime in (date_sub('2023-01-01', interval 10 second), date_sub('2023-01-01', interval 100000 second), date_sub('2023-01-01', interval 1000000 second), date_sub('2023-01-01', interval 7 second)) and c_datetime not in (date_sub('2023-01-01', interval 10 second), date_sub('2023-01-01', interval 100000 second), date_sub('2023-01-01', interval 1000000 second));
+-- parse to: c_datetime <= date_sub('2023-01-01', interval 0 second) and c_datetime is not null
+select count(1) from t1 where c_datetime <= date_sub('2023-01-01', interval 0 second) AND (c_datetime in (date_sub('2023-01-01', interval 10 second), date_sub('2023-01-01', interval 100000 second), date_sub('2023-01-01', interval 1000000 second)) OR c_datetime not in (date_sub('2023-01-01', interval 10 second), date_sub('2023-01-01', interval 100000 second), date_sub('2023-01-01', interval 1000000 second)));
+
+
+-- c_array_int
+select count(1) from t1 where c_array_int = [100000, 100000+1, 100000+2, 100000+3];
+select count(1) from t1 where c_array_int != [100000, 100000+1, 100000+2, 100000+3];
+select count(1) from t1 where c_array_int > [100000, 100000+1, 100000+2, 100000+3];
+select count(1) from t1 where c_array_int >= [100000, 100000+1, 100000+2, 100000+3];
+select count(1) from t1 where c_array_int < [100000, 100000+1, 100000+2, 100000+3];
+select count(1) from t1 where c_array_int <= [100000, 100000+1, 100000+2, 100000+3];
+select count(1) from t1 where c_array_int <=> [100000, 100000+1, 100000+2, 100000+3];
+select count(1) from t1 where c_array_int <=> null;
+select count(1) from t1 where c_array_int is null;
+select count(1) from t1 where c_array_int is not null;
+
+select count(1) from t1 where c_array_int = [100000, 100000+1, 100000+2, 100000+3] AND c_array_int != [100000, 100000+1, 100000+2, 100000+3];
+select count(1) from t1 where c_array_int > [100000, 100000+1, 100000+2, 100000+3] AND c_array_int < [1000000, 1000000+1, 1000000+2, 1000000+3];
+select count(1) from t1 where c_array_int >= [100000, 100000+1, 100000+2, 100000+3] AND c_array_int <= [1000000, 1000000+1, 1000000+2, 1000000+3];
+
+select count(1) from t1 where c_array_int in ([10, 10+1, 10+2, 10+3], [100000, 100000+1, 100000+2, 100000+3], [1000000, 1000000+1, 1000000+2, 1000000+3]);
+select count(1) from t1 where c_array_int not in ([10, 10+1, 10+2, 10+3], [100000, 100000+1, 100000+2, 100000+3], [1000000, 1000000+1, 1000000+2, 1000000+3]);
+select count(1) from t1 where c_array_int in ([1000000, 1000000+1, 1000000+2, 1000000+3], [100000, 100000+1, 100000+2, 100000+3], [10, 10+1, 10+2, 10+3]) and c_array_int in ([10, 10+1, 10+2, 10+3], [1000000, 1000000+1, 1000000+2, 1000000+3], [100000, 100000+1, 100000+2, 100000+3], [7, 7+1, 7+2, 7+3], [8, 8+1, 8+2, 8+3], [9, 9+1, 9+2, 9+3]);
+select count(1) from t1 where c_array_int in ([10, 10+1, 10+2, 10+3], [100000, 100000+1, 100000+2, 100000+3], [1000000, 1000000+1, 1000000+2, 1000000+3]) and c_array_int not in ([10, 10+1, 10+2, 10+3], [100000, 100000+1, 100000+2, 100000+3], [1000000, 1000000+1, 1000000+2, 1000000+3]);
+select count(1) from t1 where c_array_int in ([10, 10+1, 10+2, 10+3], [100000, 100000+1, 100000+2, 100000+3], [1000000, 1000000+1, 1000000+2, 1000000+3], [7, 7+1, 7+2, 7+3]) and c_array_int not in ([10, 10+1, 10+2, 10+3], [100000, 100000+1, 100000+2, 100000+3], [1000000, 1000000+1, 1000000+2, 1000000+3]);
+-- parse to: c_array_int > [0, 0+1, 0+2, 0+3] and c_array_int is not null
+select count(1) from t1 where c_array_int > [0, 0+1, 0+2, 0+3] AND (c_array_int in ([10, 10+1, 10+2, 10+3], [100000, 100000+1, 100000+2, 100000+3], [1000000, 1000000+1, 1000000+2, 1000000+3]) OR c_array_int not in ([10, 10+1, 10+2, 10+3], [100000, 100000+1, 100000+2, 100000+3], [1000000, 1000000+1, 1000000+2, 1000000+3]));
+
+
+-- c_map
+select count(1) from t1 where c_map =  map{0: 100000, 1: 100000 + 1, 2: 100000 + 2};
+select count(1) from t1 where c_map !=  map{0: 100000, 1: 100000 + 1, 2: 100000 + 2};
+select count(1) from t1 where c_map <=>  map{0: 100000, 1: 100000 + 1, 2: 100000 + 2};
+select count(1) from t1 where c_map <=> null;
+select count(1) from t1 where c_map is null;
+select count(1) from t1 where c_map is not null;
+
+select count(1) from t1 where c_map =  map{0: 100000, 1: 100000 + 1, 2: 100000 + 2} AND c_map !=  map{0: 100000, 1: 100000 + 1, 2: 100000 + 2};
+
+select count(1) from t1 where c_map in ( map{0: 10, 1: 10 + 1, 2: 10 + 2},  map{0: 100000, 1: 100000 + 1, 2: 100000 + 2},  map{0: 1000000, 1: 1000000 + 1, 2: 1000000 + 2});
+select count(1) from t1 where c_map not in ( map{0: 10, 1: 10 + 1, 2: 10 + 2},  map{0: 100000, 1: 100000 + 1, 2: 100000 + 2},  map{0: 1000000, 1: 1000000 + 1, 2: 1000000 + 2});
+select count(1) from t1 where c_map in ( map{0: 1000000, 1: 1000000 + 1, 2: 1000000 + 2},  map{0: 100000, 1: 100000 + 1, 2: 100000 + 2},  map{0: 10, 1: 10 + 1, 2: 10 + 2}) and c_map in ( map{0: 10, 1: 10 + 1, 2: 10 + 2},  map{0: 1000000, 1: 1000000 + 1, 2: 1000000 + 2},  map{0: 100000, 1: 100000 + 1, 2: 100000 + 2},  map{0: 7, 1: 7 + 1, 2: 7 + 2},  map{0: 8, 1: 8 + 1, 2: 8 + 2},  map{0: 9, 1: 9 + 1, 2: 9 + 2});
+select count(1) from t1 where c_map in ( map{0: 10, 1: 10 + 1, 2: 10 + 2},  map{0: 100000, 1: 100000 + 1, 2: 100000 + 2},  map{0: 1000000, 1: 1000000 + 1, 2: 1000000 + 2}) and c_map not in ( map{0: 10, 1: 10 + 1, 2: 10 + 2},  map{0: 100000, 1: 100000 + 1, 2: 100000 + 2},  map{0: 1000000, 1: 1000000 + 1, 2: 1000000 + 2});
+select count(1) from t1 where c_map in ( map{0: 10, 1: 10 + 1, 2: 10 + 2},  map{0: 100000, 1: 100000 + 1, 2: 100000 + 2},  map{0: 1000000, 1: 1000000 + 1, 2: 1000000 + 2},  map{0: 7, 1: 7 + 1, 2: 7 + 2}) and c_map not in ( map{0: 10, 1: 10 + 1, 2: 10 + 2},  map{0: 100000, 1: 100000 + 1, 2: 100000 + 2},  map{0: 1000000, 1: 1000000 + 1, 2: 1000000 + 2});
+
+drop table t1 force;
+drop table __row_util force;
+drop table __row_util_base force;
+drop database ice_db_${uuid0};
+drop catalog ice_cat_${uuid0};
+
+
+set catalog default_catalog;


### PR DESCRIPTION
## Why I'm doing:


External tables now also use `ScanConjunctsManager` to convert `ExprContext` into `PredicateTree`, which is then applied to various indexes.  
However, the difference between external tables and OLAP in using `ScanConjunctsManager` lies in:  
- OLAP table invokes `ScanConjunctsManager` ​**once for all the tablet files**​  
- External tables invoke `ScanConjunctsManager` ​**once per rowgroup file**​  

Since modifying external tables to invoke `ScanConjunctsManager` only once is challenging and poses stability risks, this PR focuses on optimizing bottlenecks within `ScanConjunctsManager`.  


## What I'm doing:



### ​**ColumnValueRange Modifications**​  
- Replace `std::set` with `boost/container/flat_set` for storing ordered values in `ColumnValueRange`.  
- In `normalize_join_runtime_filter`, values are first sorted with `pdqsort` before being inserted into the `flat_set`.  
  `pdqsort` is faster than `flat_set::insert`, despite both having O(n log n) time complexity.  


### ​**ColumnValueRange-to-ColumnPredicate Conversion Without TCondition**​  
Previously, converting `ColumnValueRange` to `ColumnPredicate` required an intermediate `TCondition` format, which introduced overhead—especially for large in-value lists, as `TCondition` stores each in-value as a string.  

This PR abstracts the intermediate format into ​**`ConditionType`**:  
- ​**Internal tables**​ retain the original `TCondition`  
- ​**External tables**​ use ​**`GeneralCondition`**, which stores in-values in `Datum` format.  

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
