### PR TITLE
[BugFix] Constant group-by column in grouping-sets should not propagate upwards (backport #57471)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
@@ -590,6 +590,13 @@ public class QueryTransformer {
 
             LogicalRepeatOperator repeatOperator =
                     new LogicalRepeatOperator(repeatOutput, repeatColumnRefList, groupingIds);
+
+            // constant group-by column in grouping-set should not propagate upwards, since repeat operator
+            // would output NULL values for this constant group-by column and projection operator upon
+            // aggregate operator would substitute this values with constant values mistakenly, so NULL values
+            // is eliminated.
+            groupByColumnRefs.forEach(groupByCol ->
+                    groupingTranslations.getColumnRefToConstOperators().remove(groupByCol));
             subOpt = new OptExprBuilder(repeatOperator, Lists.newArrayList(subOpt), groupingTranslations);
         }
 


### PR DESCRIPTION
cp #57471 
## Why I'm doing:
https://github.com/StarRocks/starrocks/issues/56028

constant group-by column in grouping-set should not propagate upwards, since repeat operator would output NULL values for this constant group-by column and projection operator upon aggregate operator would substitute this values with constant values mistakenly, so NULL values is eliminated.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1

