### PR TITLE
[BugFix]ban low-card optimization for array column with predicate on lake

### DIFF
--- a/test/sql/test_global_dict/R/global_dict_on_lake
+++ b/test/sql/test_global_dict/R/global_dict_on_lake
@@ -10,26 +10,27 @@ drop table if exists low_card_test_${uuid0} force;
 -- !result
 create table low_card_test_${uuid0} (
 c1 int,
-c2 string
+c2 string,
+c3 array<string>
 );
 -- result:
 -- !result
-insert into low_card_test_${uuid0} values (1, '1');
+insert into low_card_test_${uuid0} values (1, '1', ['1', '2', '3']);
 -- result:
 -- !result
-insert into low_card_test_${uuid0} values (2, '2');
+insert into low_card_test_${uuid0} values (2, '2', ['1', '2', '3']);
 -- result:
 -- !result
-insert into low_card_test_${uuid0} values (3, '3');
+insert into low_card_test_${uuid0} values (3, '3', ['1', '2', '3']);
 -- result:
 -- !result
-insert into low_card_test_${uuid0} values (4, '4');
+insert into low_card_test_${uuid0} values (4, '4', ['4', '5', '6']);
 -- result:
 -- !result
-insert into low_card_test_${uuid0} values (5, '5');
+insert into low_card_test_${uuid0} values (5, '5', ['4', '5', '6']);
 -- result:
 -- !result
-insert into low_card_test_${uuid0} values (6, '6');
+insert into low_card_test_${uuid0} values (6, '6', ['4', '5', '6']);
 -- result:
 -- !result
 select count(c2) from low_card_test_${uuid0};
@@ -52,7 +53,7 @@ select count(c2) from low_card_test_${uuid0};
 -- result:
 6
 -- !result
-insert into low_card_test_${uuid0} values (7, '7');
+insert into low_card_test_${uuid0} values (7, '7', []);
 -- result:
 -- !result
 select count(c2) from low_card_test_${uuid0};
@@ -75,7 +76,7 @@ select count(c1) from low_card_test_${uuid0} where c2 = '1';
 -- result:
 1
 -- !result
-insert into low_card_test_${uuid0} values (8, '');
+insert into low_card_test_${uuid0} values (8, '', null);
 -- result:
 -- !result
 select count(c2) from low_card_test_${uuid0};
@@ -89,6 +90,14 @@ function: wait_global_dict_ready('c2', 'low_card_test_${uuid0}')
 select count(c2) from low_card_test_${uuid0};
 -- result:
 8
+-- !result
+function: wait_global_dict_ready('c3', 'low_card_test_${uuid0}')
+-- result:
+
+-- !result
+select count(*) from low_card_test_${uuid0} where c3[1] = '2';
+-- result:
+0
 -- !result
 drop table low_card_test_${uuid0} force;
 -- result:

--- a/test/sql/test_global_dict/T/global_dict_on_lake
+++ b/test/sql/test_global_dict/T/global_dict_on_lake
@@ -6,15 +6,16 @@ use hive_sql_test_${uuid0}.hive_oss_db;
 drop table if exists low_card_test_${uuid0} force;
 create table low_card_test_${uuid0} (
 c1 int,
-c2 string
+c2 string,
+c3 array<string>
 );
 
-insert into low_card_test_${uuid0} values (1, '1');
-insert into low_card_test_${uuid0} values (2, '2');
-insert into low_card_test_${uuid0} values (3, '3');
-insert into low_card_test_${uuid0} values (4, '4');
-insert into low_card_test_${uuid0} values (5, '5');
-insert into low_card_test_${uuid0} values (6, '6');
+insert into low_card_test_${uuid0} values (1, '1', ['1', '2', '3']);
+insert into low_card_test_${uuid0} values (2, '2', ['1', '2', '3']);
+insert into low_card_test_${uuid0} values (3, '3', ['1', '2', '3']);
+insert into low_card_test_${uuid0} values (4, '4', ['4', '5', '6']);
+insert into low_card_test_${uuid0} values (5, '5', ['4', '5', '6']);
+insert into low_card_test_${uuid0} values (6, '6', ['4', '5', '6']);
 
 select count(c2) from low_card_test_${uuid0};
 function: wait_global_dict_ready('c2', 'low_card_test_${uuid0}')
@@ -22,16 +23,19 @@ select count(c2) from low_card_test_${uuid0};
 function: wait_global_dict_ready('c2', 'low_card_test_${uuid0}')
 select count(c2) from low_card_test_${uuid0};
 
-insert into low_card_test_${uuid0} values (7, '7');
+insert into low_card_test_${uuid0} values (7, '7', []);
 select count(c2) from low_card_test_${uuid0};
 function: wait_global_dict_ready('c2', 'low_card_test_${uuid0}')
 select count(c2) from low_card_test_${uuid0};
 select count(c2) from low_card_test_${uuid0} where c2 = '7';
 select count(c1) from low_card_test_${uuid0} where c2 = '1';
-insert into low_card_test_${uuid0} values (8, '');
+insert into low_card_test_${uuid0} values (8, '', null);
 select count(c2) from low_card_test_${uuid0};
 function: wait_global_dict_ready('c2', 'low_card_test_${uuid0}')
 select count(c2) from low_card_test_${uuid0};
+
+function: wait_global_dict_ready('c3', 'low_card_test_${uuid0}')
+select count(*) from low_card_test_${uuid0} where c3[1] = '2';
 
 drop table low_card_test_${uuid0} force;
 


### PR DESCRIPTION
## Why I'm doing:
OLAP table and table on lake have different implements on predicates of low-card columns,
OLAP table, local dict code -> global dict code -> rewritten  predicates (string, array<string>)
table on lake, local dict code -> rewritten predicates -> global dict code (string, subfield of multi-layer struct)
supporting array<string> on lake needs more design, so ban it first.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
