### PR TITLE
[Enhancement] Add fe query memory Statistics in Audit log and QueryDetail

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
+++ b/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
@@ -526,29 +526,27 @@ public class StarRocksFE {
     // Currently, only one log is printed to distinguish whether it is a normal exit or killed by the operating system.
     private static void addShutdownHook() {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-                    LOG.info("start to execute shutdown hook");
+            LOG.info("start to execute shutdown hook");
+            try {
+                Thread t = new Thread(() -> {
                     try {
-                        Thread t = new Thread(() -> {
-                            try {
-                                ConnectScheduler connectScheduler = ExecuteEnv.getInstance().getScheduler();
-                                connectScheduler.printAllRunningQuery();
-
-                            } catch (Throwable e) {
-                                LOG.warn("printing running query failed when fe shut down", e);
-                            }
-                        });
-
-                        t.start();
-
-                        // it is necessary to set shutdown timeout,
-                        // because in addition to kill by user, System.exit(-1) will trigger the shutdown hook too,
-                        // if no timeout and shutdown hook blocked indefinitely, Fe will fall into a catastrophic state.
-                        t.join(30000);
+                        ConnectScheduler connectScheduler = ExecuteEnv.getInstance().getScheduler();
+                        connectScheduler.printAllRunningQuery();
                     } catch (Throwable e) {
-                        LOG.warn("shut down hook failed", e);
+                        LOG.warn("printing running query failed when fe shut down", e);
                     }
-                    LOG.info("shutdown hook end");
-                })
-        );
+                });
+
+                t.start();
+
+                // it is necessary to set shutdown timeout,
+                // because in addition to kill by user, System.exit(-1) will trigger the shutdown hook too,
+                // if no timeout and shutdown hook blocked indefinitely, Fe will fall into a catastrophic state.
+                t.join(30000);
+            } catch (Throwable e) {
+                LOG.warn("shut down hook failed", e);
+            }
+            LOG.info("shutdown hook end");
+        }));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
+++ b/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
@@ -526,7 +526,29 @@ public class StarRocksFE {
     // Currently, only one log is printed to distinguish whether it is a normal exit or killed by the operating system.
     private static void addShutdownHook() {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            LOG.info("FE shutdown");
-        }));
+                    LOG.info("start to execute shutdown hook");
+                    try {
+                        Thread t = new Thread(() -> {
+                            try {
+                                ConnectScheduler connectScheduler = ExecuteEnv.getInstance().getScheduler();
+                                connectScheduler.printAllRunningQuery();
+
+                            } catch (Throwable e) {
+                                LOG.warn("printing running query failed when fe shut down", e);
+                            }
+                        });
+
+                        t.start();
+
+                        // it is necessary to set shutdown timeout,
+                        // because in addition to kill by user, System.exit(-1) will trigger the shutdown hook too,
+                        // if no timeout and shutdown hook blocked indefinitely, Fe will fall into a catastrophic state.
+                        t.join(30000);
+                    } catch (Throwable e) {
+                        LOG.warn("shut down hook failed", e);
+                    }
+                    LOG.info("shutdown hook end");
+                })
+        );
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
@@ -148,6 +148,9 @@ public class AuditEvent {
     @AuditField(value = "IsForwardToLeader")
     public boolean isForwardToLeader = false;
 
+    @AuditField(value = "queryFeMemory")
+    public long queryFeMemory = 0;
+
     public static class AuditEventBuilder {
 
         private AuditEvent auditEvent = new AuditEvent();
@@ -378,6 +381,11 @@ public class AuditEvent {
 
         public AuditEventBuilder setIsForwardToLeader(boolean isForwardToLeader) {
             auditEvent.isForwardToLeader = isForwardToLeader;
+            return this;
+        }
+
+        public AuditEventBuilder setQueryFeMemory(long queryFeMemory) {
+            auditEvent.queryFeMemory = queryFeMemory;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
@@ -148,7 +148,7 @@ public class AuditEvent {
     @AuditField(value = "IsForwardToLeader")
     public boolean isForwardToLeader = false;
 
-    @AuditField(value = "queryFeMemory")
+    @AuditField(value = "QueryFEAllocatedMemory")
     public long queryFeMemory = 0;
 
     public static class AuditEventBuilder {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -285,6 +285,8 @@ public class ConnectContext {
     // Whether leader is transferred during executing stmt
     private boolean isLeaderTransferred = false;
 
+    private long currentThreadAllocatedMemory;
+
     public void setExplicitTxnState(ExplicitTxnState explicitTxnState) {
         this.explicitTxnState = explicitTxnState;
     }
@@ -1458,5 +1460,13 @@ public class ConnectContext {
 
         return endTime.isAfter(startTime)
                 && endTime.plusMillis(milliSeconds).isBefore(Instant.now());
+    }
+
+    public long getCurrentThreadAllocatedMemory() {
+        return currentThreadAllocatedMemory;
+    }
+
+    public void setCurrentThreadAllocatedMemory(long currentThreadAllocatedMemory) {
+        this.currentThreadAllocatedMemory = currentThreadAllocatedMemory;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -1482,6 +1482,6 @@ public class ConnectContext {
     }
 
     public void setCurrentThreadId(long currentThreadId) {
-        this.currentThreadId.set(currentThreadId);
+        this.currentThreadId = new AtomicLong(currentThreadId);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -109,6 +109,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 // When one client connect in, we create a connection context for it.
 // We store session information here. Meanwhile, ConnectScheduler all
@@ -285,7 +286,10 @@ public class ConnectContext {
     // Whether leader is transferred during executing stmt
     private boolean isLeaderTransferred = false;
 
-    private long currentThreadAllocatedMemory;
+    private AtomicLong currentThreadAllocatedMemory = new AtomicLong(0);
+
+    // thread id is the thread who created this ConnectContext's id
+    private AtomicLong currentThreadId = null;
 
     public void setExplicitTxnState(ExplicitTxnState explicitTxnState) {
         this.explicitTxnState = explicitTxnState;
@@ -1463,10 +1467,21 @@ public class ConnectContext {
     }
 
     public long getCurrentThreadAllocatedMemory() {
-        return currentThreadAllocatedMemory;
+        return currentThreadAllocatedMemory.get();
     }
 
     public void setCurrentThreadAllocatedMemory(long currentThreadAllocatedMemory) {
-        this.currentThreadAllocatedMemory = currentThreadAllocatedMemory;
+        this.currentThreadAllocatedMemory.set(currentThreadAllocatedMemory);
+    }
+
+    public long getCurrentThreadId() {
+        if (currentThreadId == null) {
+            return 0;
+        }
+        return currentThreadId.get();
+    }
+
+    public void setCurrentThreadId(long currentThreadId) {
+        this.currentThreadId.set(currentThreadId);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -187,7 +187,7 @@ public class ConnectProcessor {
         ctx.resetSessionVariable();
     }
 
-    private static long initAllocatedMemoryProvider() {
+    public static long getThreadAllocatedBytes(long threadId) {
         ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
         if (threadMXBean instanceof com.sun.management.ThreadMXBean) {
             com.sun.management.ThreadMXBean casted = (com.sun.management.ThreadMXBean) threadMXBean;
@@ -260,7 +260,7 @@ public class ConnectProcessor {
             if (Config.enable_sql_digest || ctx.getSessionVariable().isEnableSQLDigest()) {
                 ctx.getAuditEventBuilder().setDigest(computeStatementDigest(parsedStmt));
             }
-            long threadAllocatedMemory = initAllocatedMemoryProvider() - ctx.getCurrentThreadAllocatedMemory();
+            long threadAllocatedMemory = getThreadAllocatedBytes(Thread.currentThread().getId()) - ctx.getCurrentThreadAllocatedMemory();
             ctx.getAuditEventBuilder().setQueryFeMemory(threadAllocatedMemory);
         }
 
@@ -299,7 +299,7 @@ public class ConnectProcessor {
     // process COM_QUERY statement,
     protected void handleQuery() {
         MetricRepo.COUNTER_REQUEST_ALL.increase(1L);
-        long beginMemory = initAllocatedMemoryProvider();
+        long beginMemory = getThreadAllocatedBytes(Thread.currentThread().getId());
         ctx.setCurrentThreadAllocatedMemory(beginMemory);
 
         // convert statement to Java string

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -192,7 +192,7 @@ public class ConnectProcessor {
             ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
             if (threadMXBean instanceof com.sun.management.ThreadMXBean) {
                 com.sun.management.ThreadMXBean casted = (com.sun.management.ThreadMXBean) threadMXBean;
-                if (casted.isThreadAllocatedMemoryEnabled() && casted.isThreadAllocatedMemorySupported()) {
+                if (casted.isThreadAllocatedMemorySupported() && casted.isThreadAllocatedMemoryEnabled()) {
                     long allocatedBytes = casted.getThreadAllocatedBytes(threadId);
                     if (allocatedBytes != -1) {
                         return allocatedBytes;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -188,13 +188,21 @@ public class ConnectProcessor {
     }
 
     public static long getThreadAllocatedBytes(long threadId) {
-        ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
-        if (threadMXBean instanceof com.sun.management.ThreadMXBean) {
-            com.sun.management.ThreadMXBean casted = (com.sun.management.ThreadMXBean) threadMXBean;
-
-            return casted.getThreadAllocatedBytes(threadId);
+        try {
+            ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+            if (threadMXBean instanceof com.sun.management.ThreadMXBean) {
+                com.sun.management.ThreadMXBean casted = (com.sun.management.ThreadMXBean) threadMXBean;
+                if (casted.isThreadAllocatedMemoryEnabled() && casted.isThreadAllocatedMemorySupported()) {
+                    long allocatedBytes = casted.getThreadAllocatedBytes(threadId);
+                    if (allocatedBytes != -1) {
+                        return allocatedBytes;
+                    }
+                }
+            }
+            return 0;
+        } catch (Exception e) {
+            return 0;
         }
-        return 0;
     }
 
     public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -201,7 +201,6 @@ public class ConnectProcessor {
         // slow query
         long endTime = System.currentTimeMillis();
         long elapseMs = endTime - ctx.getStartTime();
-        long threadAllocatedMemory = initAllocatedMemoryProvider() - ctx.getCurrentThreadAllocatedMemory();
 
         boolean isForwardToLeader = (executor != null) ? executor.getIsForwardToLeaderOrInit(false) : false;
 
@@ -252,16 +251,17 @@ public class ConnectProcessor {
                 ctx.getAuditEventBuilder().setBigQueryLogScanRowsThreshold(
                         ctx.getSessionVariable().getBigQueryLogScanRowsThreshold());
             }
-            ctx.getAuditEventBuilder().setQueryFeMemory(threadAllocatedMemory);
         } else {
             ctx.getAuditEventBuilder().setIsQuery(false);
         }
 
-        // Build Digest for SELECT/INSERT/UPDATE/DELETE
+        // Build Digest and queryFeMemory for SELECT/INSERT/UPDATE/DELETE
         if (ctx.getState().isQuery() || parsedStmt instanceof DmlStmt) {
             if (Config.enable_sql_digest || ctx.getSessionVariable().isEnableSQLDigest()) {
                 ctx.getAuditEventBuilder().setDigest(computeStatementDigest(parsedStmt));
             }
+            long threadAllocatedMemory = initAllocatedMemoryProvider() - ctx.getCurrentThreadAllocatedMemory();
+            ctx.getAuditEventBuilder().setQueryFeMemory(threadAllocatedMemory);
         }
 
         ctx.getAuditEventBuilder().setFeIp(FrontendOptions.getLocalHostAddress());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -192,7 +192,7 @@ public class ConnectProcessor {
         if (threadMXBean instanceof com.sun.management.ThreadMXBean) {
             com.sun.management.ThreadMXBean casted = (com.sun.management.ThreadMXBean) threadMXBean;
 
-            return casted.getThreadAllocatedBytes(Thread.currentThread().getId());
+            return casted.getThreadAllocatedBytes(threadId);
         }
         return 0;
     }
@@ -260,7 +260,8 @@ public class ConnectProcessor {
             if (Config.enable_sql_digest || ctx.getSessionVariable().isEnableSQLDigest()) {
                 ctx.getAuditEventBuilder().setDigest(computeStatementDigest(parsedStmt));
             }
-            long threadAllocatedMemory = getThreadAllocatedBytes(Thread.currentThread().getId()) - ctx.getCurrentThreadAllocatedMemory();
+            long threadAllocatedMemory =
+                    getThreadAllocatedBytes(Thread.currentThread().getId()) - ctx.getCurrentThreadAllocatedMemory();
             ctx.getAuditEventBuilder().setQueryFeMemory(threadAllocatedMemory);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
@@ -293,7 +293,6 @@ public class ConnectScheduler {
                 }
             }
         });
-
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
@@ -42,6 +42,7 @@ import com.starrocks.authorization.PrivilegeType;
 import com.starrocks.common.CloseableLock;
 import com.starrocks.common.Pair;
 import com.starrocks.common.ThreadPoolManager;
+import com.starrocks.mysql.MysqlCommand;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.arrow.flight.sql.ArrowFlightSqlConnectContext;
 import com.starrocks.sql.analyzer.Authorizer;
@@ -269,6 +270,22 @@ public class ConnectScheduler {
                 }
             });
         }
+    }
+
+    public void printAllRunningQuery() {
+        connectionMap.values().stream().forEach(ctx -> {
+            if (ctx.getCommand() == MysqlCommand.COM_QUERY || ctx.getCommand() == MysqlCommand.COM_STMT_EXECUTE ||
+                    ctx.getCommand() == MysqlCommand.COM_STMT_PREPARE) {
+                if (ctx.getExecutor() != null) {
+                    if (ctx.getExecutor().getParsedStmt() != null) {
+                        if (ctx.getExecutor().getParsedStmt().getOrigStmt() != null) {
+                            LOG.warn("FE ShutDown! Running Query: " +
+                                    ctx.getExecutor().getParsedStmt().getOrigStmt().getOrigStmt());
+                        }
+                    }
+                }
+            }
+        });
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
@@ -277,19 +277,16 @@ public class ConnectScheduler {
         connectionMap.values().stream().forEach(ctx -> {
             if (ctx.getCommand() == MysqlCommand.COM_QUERY || ctx.getCommand() == MysqlCommand.COM_STMT_EXECUTE ||
                     ctx.getCommand() == MysqlCommand.COM_STMT_PREPARE) {
-                if (ctx.getExecutor() != null) {
-                    if (ctx.getExecutor().getParsedStmt() != null) {
-                        if (ctx.getExecutor().getParsedStmt().getOrigStmt() != null) {
-                            long threadId = ctx.getCurrentThreadId();
-                            long theadAllocatedBytes = 0;
-                            if (threadId != 0) {
-                                theadAllocatedBytes = ConnectProcessor.getThreadAllocatedBytes(threadId) -
-                                        ctx.getCurrentThreadAllocatedMemory();
-                            }
-                            LOG.warn("FE ShutDown! Running Query:{},  QueryFEAllocatedMemory: {}",
-                                    ctx.getExecutor().getParsedStmt().getOrigStmt().getOrigStmt(), theadAllocatedBytes);
-                        }
+                if (ctx.getExecutor() != null && ctx.getExecutor().getParsedStmt() != null &&
+                        ctx.getExecutor().getParsedStmt().getOrigStmt() != null) {
+                    long threadId = ctx.getCurrentThreadId();
+                    long theadAllocatedBytes = 0;
+                    if (threadId != 0) {
+                        theadAllocatedBytes = ConnectProcessor.getThreadAllocatedBytes(threadId) -
+                                ctx.getCurrentThreadAllocatedMemory();
                     }
+                    LOG.warn("FE ShutDown! Running Query:{},  QueryFEAllocatedMemory: {}",
+                            ctx.getExecutor().getParsedStmt().getOrigStmt().getOrigStmt(), theadAllocatedBytes);
                 }
             }
         });

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetail.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetail.java
@@ -87,6 +87,8 @@ public class QueryDetail implements Serializable {
     private String digest;
     private String catalog;
 
+    private long queryFeMemory;
+
     public QueryDetail() {
     }
 
@@ -152,6 +154,7 @@ public class QueryDetail implements Serializable {
         queryDetail.digest = this.digest;
         queryDetail.resourceGroupName = this.resourceGroupName;
         queryDetail.catalog = this.catalog;
+        queryDetail.queryFeMemory = this.queryFeMemory;
         return queryDetail;
     }
 
@@ -365,5 +368,9 @@ public class QueryDetail implements Serializable {
 
     public void setCatalog(String catalog) {
         this.catalog = catalog;
+    }
+
+    public void setQueryFeMemory(long queryFeMemory) {
+        this.queryFeMemory = queryFeMemory;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetail.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetail.java
@@ -87,7 +87,7 @@ public class QueryDetail implements Serializable {
     private String digest;
     private String catalog;
 
-    private long queryFeMemory;
+    private long queryFeMemory = 0;
 
     public QueryDetail() {
     }
@@ -372,5 +372,9 @@ public class QueryDetail implements Serializable {
 
     public void setQueryFeMemory(long queryFeMemory) {
         this.queryFeMemory = queryFeMemory;
+    }
+
+    public long getQueryFeMemory() {
+        return queryFeMemory;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -524,6 +524,7 @@ public class StmtExecutor {
         context.setStmtId(STMT_ID_GENERATOR.incrementAndGet());
         context.setIsForward(false);
         context.setIsLeaderTransferred(false);
+        context.setCurrentThreadId(Thread.currentThread().getId());
 
         // set execution id.
         // Try to use query id as execution id when execute first time.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -2982,6 +2982,9 @@ public class StmtExecutor {
 
         long endTime = System.currentTimeMillis();
         long elapseMs = endTime - ctx.getStartTime();
+        long queryFeMemory =
+                ConnectProcessor.getThreadAllocatedBytes(Thread.currentThread().getId()) -
+                        ctx.getCurrentThreadAllocatedMemory();
 
         if (ctx.getState().getStateType() == QueryState.MysqlStateType.ERR) {
             queryDetail.setState(QueryDetail.QueryMemState.FAILED);
@@ -2991,6 +2994,7 @@ public class StmtExecutor {
         }
         queryDetail.setEndTime(endTime);
         queryDetail.setLatency(elapseMs);
+        queryDetail.setQueryFeMemory(queryFeMemory);
         long pendingTime = ctx.getAuditEventBuilder().build().pendingTimeMs;
         pendingTime = pendingTime < 0 ? 0 : pendingTime;
         queryDetail.setPendingTime(pendingTime);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailQueueTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailQueueTest.java
@@ -85,7 +85,8 @@ public class QueryDetailQueueTest extends PlanTestBase {
                 "\"memCostBytes\":100003," +
                 "\"spillBytes\":-1," +
                 "\"warehouse\":\"default_warehouse\"," +
-                "\"catalog\":\"default_catalog\"}]";
+                "\"catalog\":\"default_catalog\"," +
+                "\"queryFeMemory\":0}]";
         Assert.assertEquals(jsonString, queryDetailString);
 
         queryDetails = QueryDetailQueue.getQueryDetailsAfterTime(startQueryDetail.getEventTime());

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailQueueTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailQueueTest.java
@@ -126,6 +126,7 @@ public class QueryDetailQueueTest extends PlanTestBase {
         QueryDetail finishedDetail = queryDetails.get(1);
         Assert.assertEquals(QueryDetail.QueryMemState.FINISHED, finishedDetail.getState());
         Assert.assertEquals(sql, finishedDetail.getSql());
+        Assert.assertTrue(finishedDetail.getQueryFeMemory() > 0);
 
         Config.enable_collect_query_detail_info = old;
     }


### PR DESCRIPTION
## Why I'm doing:
right now if some query allocates lots of memory in FE, we have no method to find them. 

## What I'm doing:
1. for query, parser/analyze/optimize/plan fragment builder phases are all in one thread, so if calculated thread's current heap usage between parser and after /plan fragment builder, we can know how much memory does this query allocate. So I add it in audit log and query detail 
2. when fe shut down, print current running query and current memory allocation stattistics in fe.warning.log, so we can know if there are some bad query cause FE crash

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
