### PR TITLE
[BugFix] Fix log block container causing disk space statistics issues

### DIFF
--- a/be/src/exec/spill/block_manager.h
+++ b/be/src/exec/spill/block_manager.h
@@ -53,8 +53,6 @@ public:
     bool is_remote() const { return _is_remote; }
     void set_is_remote(bool is_remote) { _is_remote = is_remote; }
 
-    virtual bool preallocate(size_t write_size) = 0;
-
     void inc_num_rows(size_t num_rows) { _num_rows += num_rows; }
 
     void set_affinity_group(BlockAffinityGroup affinity_group) { _affinity_group = affinity_group; }

--- a/be/src/exec/spill/data_stream.cpp
+++ b/be/src/exec/spill/data_stream.cpp
@@ -53,7 +53,7 @@ private:
 };
 
 Status BlockSpillOutputDataStream::_prepare_block(RuntimeState* state, size_t write_size) {
-    if (_cur_block == nullptr || !_cur_block->preallocate(write_size)) {
+    if (_cur_block == nullptr) {
         // flush current block firstly
         RETURN_IF_ERROR(flush());
         // TODO: add profile for acquire block

--- a/be/src/exec/spill/dir_manager.h
+++ b/be/src/exec/spill/dir_manager.h
@@ -113,4 +113,8 @@ private:
 #endif
 };
 
+#define DISK_ACQUIRE_ERROR(acquire_size, dir)                                                                      \
+    Status::RuntimeError(fmt::format("acquire size error: dir {} try acquire:{} usage:{} capacity:{}", dir->dir(), \
+                                     acquire_size, dir->get_current_size(), dir->get_max_size()))
+
 } // namespace starrocks::spill

--- a/be/src/exec/spill/log_block_manager.cpp
+++ b/be/src/exec/spill/log_block_manager.cpp
@@ -82,7 +82,14 @@ public:
     std::string parent_path() const { return fmt::format("{}/{}", _dir->dir(), print_id(_query_id)); }
     uint64_t id() const { return _id; }
 
-    bool pre_allocate(size_t allocate_size) {
+    // Count acquired_size, then return the remaing size to dir to avoid too much error in counting.
+    void add_acquired_size(size_t acquired_size) {
+        size_t remaing_size = _acquired_data_size - _data_size;
+        _acquired_data_size += acquired_size - remaing_size;
+        _dir->dec_size(remaing_size);
+    }
+
+    bool try_acquire_sizes(size_t allocate_size) {
         if (_data_size + allocate_size <= _acquired_data_size) {
             return true;
         }
@@ -144,6 +151,8 @@ Status LogBlockContainer::close() {
 }
 
 Status LogBlockContainer::append_data(const std::vector<Slice>& data, size_t total_size) {
+    auto* dir = _dir.get();
+    RETURN_IF(!try_acquire_sizes(total_size), DISK_ACQUIRE_ERROR(total_size, dir));
     RETURN_IF_ERROR(_writable_file->pre_allocate(total_size));
     auto scope = IOProfiler::scope(IOProfiler::TAG::TAG_SPILL, 0);
     RETURN_IF_ERROR(_writable_file->appendv(data.data(), data.size()));
@@ -228,8 +237,6 @@ public:
 #endif
     }
 
-    bool preallocate(size_t write_size) override { return _container->pre_allocate(write_size); }
-
 private:
     LogBlockContainerPtr _container;
     size_t _offset{};
@@ -262,11 +269,7 @@ StatusOr<BlockPtr> LogBlockManager::acquire_block(const AcquireBlockOptions& opt
     DCHECK(opts.block_size > 0) << "block size should be larger than 0";
     AcquireDirOptions acquire_dir_opts;
     acquire_dir_opts.data_size = opts.block_size;
-#ifdef BE_TEST
     ASSIGN_OR_RETURN(auto dir, _dir_mgr->acquire_writable_dir(acquire_dir_opts));
-#else
-    ASSIGN_OR_RETURN(auto dir, ExecEnv::GetInstance()->spill_dir_mgr()->acquire_writable_dir(acquire_dir_opts));
-#endif
 
     ASSIGN_OR_RETURN(auto block_container,
                      get_or_create_container(dir, opts.fragment_instance_id, opts.plan_node_id, opts.name,
@@ -327,6 +330,7 @@ StatusOr<LogBlockContainerPtr> LogBlockManager::get_or_create_container(
         auto container = q->front();
         TRACE_SPILL_LOG << "return an existed container: " << container->path();
         q->pop();
+        container->add_acquired_size(block_size);
         return container;
     }
     uint64_t id = _next_container_id++;

--- a/be/src/storage/lake/spill_mem_table_sink.cpp
+++ b/be/src/storage/lake/spill_mem_table_sink.cpp
@@ -63,7 +63,7 @@ Status LoadSpillOutputDataStream::_freeze_current_block() {
 
 Status LoadSpillOutputDataStream::_preallocate(size_t block_size) {
     // Try to preallocate from current block first.
-    if (_block == nullptr || !_block->preallocate(block_size)) {
+    if (_block == nullptr) {
         // Freeze current block firstly.
         RETURN_IF_ERROR(_freeze_current_block());
         // Acquire new block.

--- a/be/test/io/spill_block_manager_test.cpp
+++ b/be/test/io/spill_block_manager_test.cpp
@@ -344,51 +344,38 @@ TEST_F(SpillBlockManagerTest, dir_allocate_test) {
 }
 
 TEST_F(SpillBlockManagerTest, block_capacity_test) {
-    auto test_func = [&](std::shared_ptr<spill::BlockManager>& block_mgr, spill::DirPtr dir) {
-        ASSERT_OK(block_mgr->open());
-        {
-            spill::AcquireBlockOptions opts{.query_id = dummy_query_id,
-                                            .fragment_instance_id = dummy_query_id,
-                                            .plan_node_id = 1,
-                                            .name = "node1",
-                                            .block_size = 10};
-            auto res = block_mgr->acquire_block(opts);
-            ASSERT_TRUE(res.ok());
-            ASSERT_EQ(dir->get_current_size(), 10);
-            auto block = res.value();
+    {
+        auto log_block_mgr = std::make_shared<spill::LogBlockManager>(dummy_query_id, local_dir_mgr.get());
+        ASSERT_OK(log_block_mgr->open());
+        char vals[4096];
+        // 1. allocate the first block but not release it
+        spill::AcquireBlockOptions opts{.query_id = dummy_query_id,
+                                        .fragment_instance_id = dummy_query_id,
+                                        .plan_node_id = 1,
+                                        .name = "node1",
+                                        .block_size = 10};
+        opts.affinity_group = log_block_mgr->acquire_affinity_group();
+        auto res = log_block_mgr->acquire_block(opts);
+        ASSERT_TRUE(res.ok());
+        ASSERT_EQ(local_dir->get_current_size(), 10);
+        ASSERT_OK(res.value()->append(std::vector<Slice>{Slice(vals, 5)}));
+        ASSERT_EQ(local_dir->get_current_size(), 10);
+        ASSERT_OK(res.value()->append(std::vector<Slice>{Slice(vals, 5)}));
+        ASSERT_EQ(local_dir->get_current_size(), 10);
+        ASSERT_OK(res.value()->append(std::vector<Slice>{Slice(vals, 5)}));
+        ASSERT_EQ(local_dir->get_current_size(), 15);
+        ASSERT_OK(log_block_mgr->release_block(res.value()));
 
-            ASSERT_TRUE(block->preallocate(5));
-            // there are 10 bytes left unused, preallocate will not actually apply for space at this time
-            ASSERT_EQ(dir->get_current_size(), 10);
-            ASSERT_EQ(block->size(), 0);
-            char tmp[5];
-            ASSERT_OK(block->append({Slice(tmp, 5)}));
-            ASSERT_EQ(block->size(), 5);
+        res = log_block_mgr->acquire_block(opts);
+        ASSERT_TRUE(res.ok());
+        ASSERT_EQ(local_dir->get_current_size(), 25);
+        ASSERT_OK(log_block_mgr->release_block(res.value()));
 
-            // there are 5 bytes left unused, preallocate will not actually apply for space at this time
-            ASSERT_TRUE(block->preallocate(5));
-            ASSERT_EQ(dir->get_current_size(), 10);
-            ASSERT_OK(block->append({Slice(tmp, 5)}));
-            ASSERT_EQ(block->size(), 10);
-            ASSERT_EQ(dir->get_current_size(), 10);
-
-            // there is no remaining space, preallocate needs to actually apply for space
-            ASSERT_TRUE(block->preallocate(20));
-            ASSERT_EQ(block->size(), 10);
-            ASSERT_EQ(dir->get_current_size(), 30);
-        }
-
-        block_mgr.reset();
-        // after block_mgr is destroyed, all space should be released
-        ASSERT_EQ(dir->get_current_size(), 0);
-    };
-    std::shared_ptr<spill::BlockManager> log_block_mgr =
-            std::make_shared<spill::LogBlockManager>(dummy_query_id, local_dir_mgr.get());
-    test_func(log_block_mgr, local_dir);
-
-    std::shared_ptr<spill::BlockManager> file_block_mgr =
-            std::make_shared<spill::FileBlockManager>(dummy_query_id, remote_dir_mgr.get());
-    test_func(file_block_mgr, remote_dir);
+        res = log_block_mgr->acquire_block(opts);
+        ASSERT_TRUE(res.ok());
+        ASSERT_EQ(local_dir->get_current_size(), 25);
+    }
+    ASSERT_EQ(local_dir->get_current_size(), 0);
 }
 
 } // namespace starrocks::vectorized


### PR DESCRIPTION
## Why I'm doing:

This commit contains two parts
1. removes the block pre_allocate interface.
2. Fix the dir disk usage statistics error caused by #52020. Container reuse can result in consumed dir not being counted in the container, causing a leak.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
