### PR TITLE
[BugFix] fix slot conflicts in array_map

### DIFF
--- a/be/src/exprs/array_map_expr.cpp
+++ b/be/src/exprs/array_map_expr.cpp
@@ -16,6 +16,7 @@
 
 #include <fmt/format.h>
 
+#include <algorithm>
 #include <memory>
 #include <sstream>
 
@@ -48,8 +49,12 @@ Status ArrayMapExpr::prepare(RuntimeState* state, ExprContext* context) {
 
     auto lambda_expr = down_cast<LambdaFunction*>(_children[0]);
     LambdaFunction::ExtractContext extract_ctx;
-    // assign slot ids to outer common exprs starting with max_used_slot_id + 1
     extract_ctx.next_slot_id = context->root()->max_used_slot_id() + 1;
+    std::vector<SlotId> tmp_slots;
+    lambda_expr->get_slot_ids(&tmp_slots);
+    for (const auto id : tmp_slots) {
+        _initial_required_slots.insert(id);
+    }
 
     RETURN_IF_ERROR(lambda_expr->extract_outer_common_exprs(state, context, &extract_ctx));
     _outer_common_exprs.swap(extract_ctx.outer_common_exprs);
@@ -57,6 +62,15 @@ Status ArrayMapExpr::prepare(RuntimeState* state, ExprContext* context) {
         RETURN_IF_ERROR(expr->prepare(state, context));
     }
     RETURN_IF_ERROR(lambda_expr->prepare(state, context));
+    {
+        // remove lambda arguments and common sub exprs from _initial_required_slots
+        for (auto id: extract_ctx.all_lambda_arguments) {
+            _initial_required_slots.erase(id);
+        }
+        for (auto id: extract_ctx.all_common_sub_expr_ids) {
+            _initial_required_slots.erase(id);
+        }
+    }
 
     return Status::OK();
 }
@@ -82,9 +96,10 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_lambda_expr(ExprContext* context, Chu
     // create a new chunk to evaluate the lambda expression
     auto cur_chunk = std::make_shared<Chunk>();
     auto tmp_chunk = std::make_shared<Chunk>();
+
     {
-        // see more details: https://github.com/StarRocks/starrocks/pull/52692
-        for (const auto& [slot_id, _] : chunk->get_slot_id_to_index_map()) {
+        // We put the slots needed for lambda function evaluation into a separate chunk to avoid conflicts between outer_common_expr and other slots.
+        for (const auto& slot_id : _initial_required_slots) {
             tmp_chunk->append_column(chunk->get_column_by_slot_id(slot_id), slot_id);
         }
     }
@@ -94,7 +109,6 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_lambda_expr(ExprContext* context, Chu
         ASSIGN_OR_RETURN(auto col, context->evaluate(expr, tmp_chunk.get()));
         tmp_chunk->append_column(col, slot_id);
     }
-
     auto lambda_func = dynamic_cast<LambdaFunction*>(_children[0]);
     std::vector<SlotId> capture_slot_ids;
     lambda_func->get_captured_slot_ids(&capture_slot_ids);

--- a/be/src/exprs/array_map_expr.cpp
+++ b/be/src/exprs/array_map_expr.cpp
@@ -16,7 +16,6 @@
 
 #include <fmt/format.h>
 
-#include <algorithm>
 #include <memory>
 #include <sstream>
 

--- a/be/src/exprs/array_map_expr.cpp
+++ b/be/src/exprs/array_map_expr.cpp
@@ -64,10 +64,10 @@ Status ArrayMapExpr::prepare(RuntimeState* state, ExprContext* context) {
     RETURN_IF_ERROR(lambda_expr->prepare(state, context));
     {
         // remove lambda arguments and common sub exprs from _initial_required_slots
-        for (auto id: extract_ctx.all_lambda_arguments) {
+        for (auto id : extract_ctx.all_lambda_arguments) {
             _initial_required_slots.erase(id);
         }
-        for (auto id: extract_ctx.all_common_sub_expr_ids) {
+        for (auto id : extract_ctx.all_common_sub_expr_ids) {
             _initial_required_slots.erase(id);
         }
     }

--- a/be/src/exprs/array_map_expr.h
+++ b/be/src/exprs/array_map_expr.h
@@ -52,5 +52,8 @@ private:
 
     // use map to make sure the order of execution
     std::map<SlotId, Expr*> _outer_common_exprs;
+    // the slots initially required for lambda function evaluation, excluding lambda arguments,
+    // other common expressions can be evaluated based on these slots.
+    std::unordered_set<SlotId> _initial_required_slots;
 };
 } // namespace starrocks

--- a/be/src/exprs/lambda_function.h
+++ b/be/src/exprs/lambda_function.h
@@ -17,7 +17,6 @@
 #include <memory>
 #include <mutex>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 #include "common/global_types.h"

--- a/be/src/exprs/lambda_function.h
+++ b/be/src/exprs/lambda_function.h
@@ -17,6 +17,7 @@
 #include <memory>
 #include <mutex>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "common/global_types.h"
@@ -69,9 +70,14 @@ public:
     std::string debug_string() const override;
 
     struct ExtractContext {
-        std::unordered_set<SlotId> lambda_arguments;
-        // slot id of common sub expr inside lambda expr
-        std::unordered_set<SlotId> common_sub_expr_ids;
+        // lambda arguments id in the current scope
+        std::unordered_set<SlotId> current_lambda_arguments;
+        // lambda arguments id all seen
+        std::unordered_set<SlotId> all_lambda_arguments;
+        // slot ids of common sub expr inside lambda expr
+        std::unordered_set<SlotId> current_common_sub_expr_ids;
+        // slot ids of common sub exprs all seen
+        std::unordered_set<SlotId> all_common_sub_expr_ids;
         SlotId next_slot_id;
         std::map<SlotId, Expr*> outer_common_exprs;
     };

--- a/test/sql/test_array/R/test_array_map
+++ b/test/sql/test_array/R/test_array_map
@@ -116,3 +116,12 @@ AND array_length(array_map(x -> x + array_length(t2.arr_str), t1.arr_largeint)) 
 2	2	[3,4,5]
 3	None	[6]
 -- !result
+WITH `CTE` AS (
+    SELECT TRUE AS bool_1, TRUE AS bool_2, TRUE AS bool_3, ["a"] AS arr
+    UNION ALL
+    SELECT TRUE AS bool_1, TRUE AS bool_2, TRUE AS bool_3, ["a"] AS arr
+) SELECT ARRAY_MAP((arg)->`bool_1` AND `bool_2` AND `bool_3`, arr), ARRAY_MAP((arg)->`bool_1` AND `bool_3` AND `bool_2`, arr) FROM `CTE`;
+-- result:
+[1]	[1]
+[1]	[1]
+-- !result

--- a/test/sql/test_array/T/test_array_map
+++ b/test/sql/test_array/T/test_array_map
@@ -106,3 +106,9 @@ FROM table1 t1
 LEFT JOIN[broadcast] table2 t2
 ON t1.id = t2.id
 AND array_length(array_map(x -> x + array_length(t2.arr_str), t1.arr_largeint)) >= 2;
+
+WITH `CTE` AS (
+    SELECT TRUE AS bool_1, TRUE AS bool_2, TRUE AS bool_3, ["a"] AS arr
+    UNION ALL
+    SELECT TRUE AS bool_1, TRUE AS bool_2, TRUE AS bool_3, ["a"] AS arr
+) SELECT ARRAY_MAP((arg)->`bool_1` AND `bool_2` AND `bool_3`, arr), ARRAY_MAP((arg)->`bool_1` AND `bool_3` AND `bool_2`, arr) FROM `CTE`;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

`array_map` can appear in the expressions of multiple operators, but only the scan predicate and project operator support common expression reuse in the plan stage.

Before this, in order to avoid repeated calculation of expressions in lambda function, we implemented the logic of extracting common expressions on BE and assigned new slot ids to them. This will bring a problem. Since BE does not know the global slot information, the allocated slots may conflict. We have fixed several related bugs before, e.g. #52692 #52911

**To completely solve this problem, the best way is to support expression reuse anywhere in the plan stage.** We can consider implementing it in the future which will take some time.

In fact, only a part of the slots are used in the calculation of `array_map`. We only need to ensure that there is no conflict in the slots during the calculation. A tricky but simple solution is to create a temporary chunk and put only the slots required for the array_map calculation, so as to avoid this problem.



Fixes #57762 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
