### PR TITLE
[Enhancement] Support multiple backup/restore jobs running parallel

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeBackupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeBackupJob.java
@@ -72,9 +72,9 @@ public class LakeBackupJob extends BackupJob {
     public LakeBackupJob() {
     }
 
-    public LakeBackupJob(String label, long dbId, String dbName, List<TableRef> tableRefs, long timeoutMs,
+    public LakeBackupJob(String label, long dbId, String dbName, List<Long> tableIds, List<TableRef> tableRefs, long timeoutMs,
                          GlobalStateMgr globalStateMgr, long repoId) {
-        super(label, dbId, dbName, tableRefs, timeoutMs, globalStateMgr, repoId);
+        super(label, dbId, dbName, tableIds, tableRefs, timeoutMs, globalStateMgr, repoId);
         this.type = JobType.LAKE_BACKUP;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
@@ -82,11 +82,11 @@ public class LakeRestoreJob extends RestoreJob {
     public LakeRestoreJob() {
     }
 
-    public LakeRestoreJob(String label, String backupTs, long dbId, String dbName, BackupJobInfo jobInfo,
+    public LakeRestoreJob(String label, String backupTs, long dbId, String dbName, List<Long> tableIds, BackupJobInfo jobInfo,
                           boolean allowLoad, int restoreReplicationNum, long timeoutMs,
                           GlobalStateMgr globalStateMgr, long repoId, BackupMeta backupMeta,
                           MvRestoreContext mvRestoreContext) {
-        super(label, backupTs, dbId, dbName, jobInfo, allowLoad, restoreReplicationNum, timeoutMs,
+        super(label, backupTs, dbId, dbName, tableIds, jobInfo, allowLoad, restoreReplicationNum, timeoutMs,
                 globalStateMgr, repoId, backupMeta, mvRestoreContext);
         this.type = JobType.LAKE_RESTORE;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -580,13 +580,16 @@ public final class MetricRepo {
             }
 
             for (Database db : dbs) {
-                AbstractJob jobI = GlobalStateMgr.getCurrentState().getBackupHandler().getJob(db.getId());
-                if (jobI instanceof BackupJob && !((BackupJob) jobI).isDone()) {
-                    COUNTER_UNFINISHED_BACKUP_JOB.increase(1L);
-                } else if (jobI instanceof RestoreJob && !((RestoreJob) jobI).isDone()) {
-                    COUNTER_UNFINISHED_RESTORE_JOB.increase(1L);
+                List<AbstractJob> jobIs = GlobalStateMgr.getCurrentState().getBackupHandler().getJob(db.getId());
+                if (jobIs != null) {
+                    for (AbstractJob jobI : jobIs) {
+                        if (jobI instanceof BackupJob && !((BackupJob) jobI).isDone()) {
+                            COUNTER_UNFINISHED_BACKUP_JOB.increase(1L);
+                        } else if (jobI instanceof RestoreJob && !((RestoreJob) jobI).isDone()) {
+                            COUNTER_UNFINISHED_RESTORE_JOB.increase(1L);
+                        }
+                    }
                 }
-
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/DownloadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/DownloadTask.java
@@ -35,19 +35,19 @@ public class DownloadTask extends AgentTask {
     private Map<String, String> brokerProperties;
     private THdfsProperties hdfsProperties;
 
-    public DownloadTask(TResourceInfo resourceInfo, long backendId, long signature, long jobId, long dbId,
+    public DownloadTask(TResourceInfo resourceInfo, long backendId, long signature, long jobId, long dbId, long tableId,
                         Map<String, String> srcToDestPath, FsBroker brokerAddr, Map<String, String> brokerProperties) {
-        super(resourceInfo, backendId, TTaskType.DOWNLOAD, dbId, -1, -1, -1, -1, signature);
+        super(resourceInfo, backendId, TTaskType.DOWNLOAD, dbId, tableId, -1, -1, signature);
         this.jobId = jobId;
         this.srcToDestPath = srcToDestPath;
         this.brokerAddr = brokerAddr;
         this.brokerProperties = brokerProperties;
     }
 
-    public DownloadTask(TResourceInfo resourceInfo, long backendId, long signature, long jobId, long dbId,
+    public DownloadTask(TResourceInfo resourceInfo, long backendId, long signature, long jobId, long dbId, long tableId,
                         Map<String, String> srcToDestPath, FsBroker brokerAddr, Map<String, String> brokerProperties,
                         THdfsProperties hdfsProperties) {
-        super(resourceInfo, backendId, TTaskType.DOWNLOAD, dbId, -1, -1, -1, -1, signature);
+        super(resourceInfo, backendId, TTaskType.DOWNLOAD, dbId, tableId, -1, -1, signature);
         this.jobId = jobId;
         this.srcToDestPath = srcToDestPath;
         this.brokerAddr = brokerAddr;

--- a/fe/fe-core/src/main/java/com/starrocks/task/UploadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/UploadTask.java
@@ -36,19 +36,19 @@ public class UploadTask extends AgentTask {
     private Map<String, String> brokerProperties;
     private THdfsProperties hdfsProperties;
 
-    public UploadTask(TResourceInfo resourceInfo, long backendId, long signature, long jobId, Long dbId,
+    public UploadTask(TResourceInfo resourceInfo, long backendId, long signature, long jobId, Long dbId, Long tableId,
                       Map<String, String> srcToDestPath, FsBroker broker, Map<String, String> brokerProperties) {
-        super(resourceInfo, backendId, TTaskType.UPLOAD, dbId, -1, -1, -1, -1, signature);
+        super(resourceInfo, backendId, TTaskType.UPLOAD, dbId, tableId, -1, -1, signature);
         this.jobId = jobId;
         this.srcToDestPath = srcToDestPath;
         this.broker = broker;
         this.brokerProperties = brokerProperties;
     }
 
-    public UploadTask(TResourceInfo resourceInfo, long backendId, long signature, long jobId, Long dbId,
+    public UploadTask(TResourceInfo resourceInfo, long backendId, long signature, long jobId, Long dbId, Long tableId,
                       Map<String, String> srcToDestPath, FsBroker broker, Map<String, String> brokerProperties, 
                       THdfsProperties hdfsProperties) {
-        super(resourceInfo, backendId, TTaskType.UPLOAD, dbId, -1, -1, -1, -1, signature);
+        super(resourceInfo, backendId, TTaskType.UPLOAD, dbId, tableId, -1, -1, signature);
         this.jobId = jobId;
         this.srcToDestPath = srcToDestPath;
         this.broker = broker;

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
@@ -104,7 +104,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -323,9 +325,9 @@ public class BackupHandlerTest {
         }
 
         // handleFinishedSnapshotTask
-        BackupJob backupJob = (BackupJob) handler.getJob(CatalogMocker.TEST_DB_ID);
+        BackupJob backupJob = (BackupJob) handler.getJob(Collections.singletonList(CatalogMocker.TEST_TBL_ID));
         SnapshotTask snapshotTask = new SnapshotTask(null, 0, 0, backupJob.getJobId(), CatalogMocker.TEST_DB_ID,
-                0, 0, 0, 0, 0, 0, 1, false);
+                CatalogMocker.TEST_TBL_ID, 0, 0, 0, 0, 0, 1, false);
         TFinishTaskRequest request = new TFinishTaskRequest();
         List<String> snapshotFiles = Lists.newArrayList();
         request.setSnapshot_files(snapshotFiles);
@@ -336,7 +338,7 @@ public class BackupHandlerTest {
         // handleFinishedSnapshotUploadTask
         Map<String, String> srcToDestPath = Maps.newHashMap();
         UploadTask uploadTask = new UploadTask(null, 0, 0, backupJob.getJobId(), CatalogMocker.TEST_DB_ID,
-                srcToDestPath, null, null);
+                CatalogMocker.TEST_TBL_ID, srcToDestPath, null, null);
         request = new TFinishTaskRequest();
         Map<Long, List<String>> tabletFiles = Maps.newHashMap();
         request.setTablet_files(tabletFiles);
@@ -382,9 +384,9 @@ public class BackupHandlerTest {
         }
 
         // handleFinishedSnapshotTask
-        BackupJob backupJob1 = (BackupJob) handler.getJob(CatalogMocker.TEST_DB_ID);
+        BackupJob backupJob1 = (BackupJob) handler.getJob(Collections.singletonList(CatalogMocker.TEST_TBL3_ID));
         SnapshotTask snapshotTask1 = new SnapshotTask(null, 0, 0, backupJob1.getJobId(), CatalogMocker.TEST_DB_ID,
-                0, 0, 0, 0, 0, 0, 1, false);
+                CatalogMocker.TEST_TBL3_ID, 0, 0, 0, 0, 0, 1, false);
         TFinishTaskRequest request1 = new TFinishTaskRequest();
         List<String> snapshotFiles1 = Lists.newArrayList();
         request1.setSnapshot_files(snapshotFiles1);
@@ -395,7 +397,7 @@ public class BackupHandlerTest {
         // handleFinishedSnapshotUploadTask
         Map<String, String> srcToDestPath1 = Maps.newHashMap();
         UploadTask uploadTask1 = new UploadTask(null, 0, 0, backupJob1.getJobId(), CatalogMocker.TEST_DB_ID,
-                srcToDestPath1, null, null);
+                CatalogMocker.TEST_TBL3_ID, srcToDestPath1, null, null);
         request1 = new TFinishTaskRequest();
         Map<Long, List<String>> tabletFiles1 = Maps.newHashMap();
         request1.setTablet_files(tabletFiles1);
@@ -449,9 +451,9 @@ public class BackupHandlerTest {
         }
 
         // handleFinishedSnapshotTask
-        RestoreJob restoreJob = (RestoreJob) handler.getJob(CatalogMocker.TEST_DB_ID);
+        RestoreJob restoreJob = (RestoreJob) handler.getJob(Collections.singletonList(CatalogMocker.TEST_TBL_ID));
         snapshotTask = new SnapshotTask(null, 0, 0, restoreJob.getJobId(), CatalogMocker.TEST_DB_ID,
-                0, 0, 0, 0, 0, 0, 1, true);
+                CatalogMocker.TEST_TBL_ID, 0, 0, 0, 0, 0, 1, true);
         request = new TFinishTaskRequest();
         request.setSnapshot_path("./snapshot/path");
         request.setTask_status(new TStatus(TStatusCode.OK));
@@ -459,7 +461,7 @@ public class BackupHandlerTest {
 
         // handleDownloadSnapshotTask
         DownloadTask downloadTask = new DownloadTask(null, 0, 0, restoreJob.getJobId(), CatalogMocker.TEST_DB_ID,
-                srcToDestPath, null, null);
+                CatalogMocker.TEST_TBL_ID, srcToDestPath, null, null);
         request = new TFinishTaskRequest();
         List<Long> downloadedTabletIds = Lists.newArrayList();
         request.setDownloaded_tablet_ids(downloadedTabletIds);
@@ -467,8 +469,8 @@ public class BackupHandlerTest {
         handler.handleDownloadSnapshotTask(downloadTask, request);
 
         // handleDirMoveTask
-        DirMoveTask dirMoveTask = new DirMoveTask(null, 0, 0, restoreJob.getJobId(), CatalogMocker.TEST_DB_ID, 0, 0, 0,
-                0, "", 0, true);
+        DirMoveTask dirMoveTask = new DirMoveTask(null, 0, 0, restoreJob.getJobId(),
+                CatalogMocker.TEST_DB_ID, CatalogMocker.TEST_TBL_ID, 0, 0, 0, "", 0, true);
         request = new TFinishTaskRequest();
         request.setTask_status(new TStatus(TStatusCode.OK));
         handler.handleDirMoveTask(dirMoveTask, request);
@@ -527,9 +529,9 @@ public class BackupHandlerTest {
         }
 
         // handleFinishedSnapshotTask
-        RestoreJob restoreJob1 = (RestoreJob) handler.getJob(CatalogMocker.TEST_DB_ID);
+        RestoreJob restoreJob1 = (RestoreJob) handler.getJob(Collections.singletonList(CatalogMocker.TEST_TBL_ID));
         snapshotTask1 = new SnapshotTask(null, 0, 0, restoreJob1.getJobId(), CatalogMocker.TEST_DB_ID,
-                0, 0, 0, 0, 0, 0, 1, true);
+                CatalogMocker.TEST_TBL_ID, 0, 0, 0, 0, 0, 1, true);
         request1 = new TFinishTaskRequest();
         request1.setSnapshot_path("./snapshot/path1");
         request1.setTask_status(new TStatus(TStatusCode.OK));
@@ -537,7 +539,7 @@ public class BackupHandlerTest {
 
         // handleDownloadSnapshotTask
         DownloadTask downloadTask1 = new DownloadTask(null, 0, 0, restoreJob1.getJobId(), CatalogMocker.TEST_DB_ID,
-                srcToDestPath1, null, null);
+                CatalogMocker.TEST_TBL_ID, srcToDestPath1, null, null);
         request1 = new TFinishTaskRequest();
         List<Long> downloadedTabletIds1 = Lists.newArrayList();
         request1.setDownloaded_tablet_ids(downloadedTabletIds1);
@@ -631,41 +633,53 @@ public class BackupHandlerTest {
 
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
         handler = new BackupHandler(globalStateMgr);
-        Assert.assertEquals(0, handler.dbIdToBackupOrRestoreJob.size());
+        Assert.assertEquals(0, handler.tableIdToBackupOrRestoreJob.size());
         long now = System.currentTimeMillis();
 
         // 1. create 3 jobs
         // running jobs, won't expire
-        BackupJob runningJob = new BackupJob("running_job", 1, "test_db", new ArrayList<>(), 10000, globalStateMgr, 1);
-        handler.dbIdToBackupOrRestoreJob.put(runningJob.getDbId(), runningJob);
+        BackupJob runningJob = new BackupJob("running_job", 1, "test_db", new ArrayList<>() {{
+                add(1L);
+            }}, new ArrayList<>(), 10000, globalStateMgr, 1);
+        handler.tableIdToBackupOrRestoreJob.put(new HashSet<>() {{
+                add(1L);
+            }}, runningJob);
         // just finished job, won't expire
-        BackupJob goodJob = new BackupJob("good_job", 2, "test_db", new ArrayList<>(), 10000, globalStateMgr, 1);
+        BackupJob goodJob = new BackupJob("good_job", 2, "test_db", new ArrayList<>() {{
+                add(2L);
+            }}, new ArrayList<>(), 10000, globalStateMgr, 1);
         goodJob.finishedTime = now;
         goodJob.state = BackupJob.BackupJobState.FINISHED;
-        handler.dbIdToBackupOrRestoreJob.put(goodJob.getDbId(), goodJob);
+        handler.tableIdToBackupOrRestoreJob.put(new HashSet<>() {{
+                add(2L);
+            }}, goodJob);
         // expired job
-        BackupJob badJob = new BackupJob("bad_job", 3, "test_db", new ArrayList<>(), 10000, globalStateMgr, 1);
+        BackupJob badJob = new BackupJob("bad_job", 3, "test_db", new ArrayList<>() {{
+                add(3L);
+            }}, new ArrayList<>(), 10000, globalStateMgr, 1);
         badJob.finishedTime = now - (Config.history_job_keep_max_second + 10) * 1000;
         badJob.state = BackupJob.BackupJobState.FINISHED;
-        handler.dbIdToBackupOrRestoreJob.put(badJob.getDbId(), badJob);
-        Assert.assertEquals(3, handler.dbIdToBackupOrRestoreJob.size());
+        handler.tableIdToBackupOrRestoreJob.put(new HashSet<>() {{
+                add(3L);
+            }}, badJob);
+        Assert.assertEquals(3, handler.tableIdToBackupOrRestoreJob.size());
 
         // 2. save image & reload
         UtFrameUtils.PseudoImage pseudoImage = new UtFrameUtils.PseudoImage();
         handler.write(pseudoImage.getDataOutputStream());
         BackupHandler reloadHandler = BackupHandler.read(pseudoImage.getDataInputStream());
         // discard expired job
-        Assert.assertEquals(2, reloadHandler.dbIdToBackupOrRestoreJob.size());
-        Assert.assertNotNull(reloadHandler.getJob(1));
-        Assert.assertNotNull(reloadHandler.getJob(2));
-        Assert.assertNull(reloadHandler.getJob(3));
+        Assert.assertEquals(2, reloadHandler.tableIdToBackupOrRestoreJob.size());
+        Assert.assertNotNull(reloadHandler.getJob(Collections.singletonList(1L)));
+        Assert.assertNotNull(reloadHandler.getJob(Collections.singletonList(2L)));
+        Assert.assertNull(reloadHandler.getJob(Collections.singletonList(3L)));
 
         // 3. clean expire
         handler.removeOldJobs();
-        Assert.assertEquals(2, handler.dbIdToBackupOrRestoreJob.size());
-        Assert.assertNotNull(handler.getJob(1));
-        Assert.assertNotNull(handler.getJob(2));
-        Assert.assertNull(handler.getJob(3));
+        Assert.assertEquals(2, handler.tableIdToBackupOrRestoreJob.size());
+        Assert.assertNotNull(reloadHandler.getJob(Collections.singletonList(1L)));
+        Assert.assertNotNull(reloadHandler.getJob(Collections.singletonList(2L)));
+        Assert.assertNull(reloadHandler.getJob(Collections.singletonList(3L)));
 
         UtFrameUtils.tearDownForPersisTest();
     }
@@ -675,8 +689,12 @@ public class BackupHandlerTest {
         UtFrameUtils.setUpForPersistTest();
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
         handler = new BackupHandler(globalStateMgr);
-        BackupJob runningJob = new BackupJob("running_job", 1, "test_db", new ArrayList<>(), 10000, globalStateMgr, 1);
-        handler.dbIdToBackupOrRestoreJob.put(runningJob.getDbId(), runningJob);
+        BackupJob runningJob = new BackupJob("running_job", 1, "test_db", new ArrayList<>() {{
+                add(1L);
+            }}, new ArrayList<>(), 10000, globalStateMgr, 1);
+        handler.tableIdToBackupOrRestoreJob.put(new HashSet<>() {{
+                add(1L);
+            }}, runningJob);
 
         UtFrameUtils.PseudoImage pseudoImage = new UtFrameUtils.PseudoImage();
         handler.saveBackupHandlerV2(pseudoImage.getImageWriter());
@@ -685,7 +703,7 @@ public class BackupHandlerTest {
         followerHandler.loadBackupHandlerV2(reader);
         reader.close();
 
-        Assert.assertEquals(1, followerHandler.dbIdToBackupOrRestoreJob.size());
+        Assert.assertEquals(1, followerHandler.tableIdToBackupOrRestoreJob.size());
 
         UtFrameUtils.tearDownForPersisTest();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobMaterializedViewTest.java
@@ -63,6 +63,7 @@ import java.io.IOException;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -219,7 +220,10 @@ public class BackupJobMaterializedViewTest {
         tableRefs.add(new TableRef(new TableName(UnitTestUtil.DB_NAME, UnitTestUtil.MATERIALIZED_VIEW_NAME), null));
         tableRefs.add(new TableRef(new TableName(UnitTestUtil.DB_NAME, UnitTestUtil.TABLE_NAME), null));
 
-        job = new BackupJob(MV_LABEL, dbId, UnitTestUtil.DB_NAME, tableRefs, 13600 * 1000, globalStateMgr, repo.getId());
+        job = new BackupJob(MV_LABEL, dbId, UnitTestUtil.DB_NAME, new ArrayList<>() {{
+                add(tblId);
+                add(tblId + 1);
+            }}, tableRefs, 13600 * 1000, globalStateMgr, repo.getId());
         new Expectations(job) {
             {
                 job.validateLocalFile(anyString);
@@ -429,8 +433,8 @@ public class BackupJobMaterializedViewTest {
         tableRefs.add(new TableRef(new TableName(UnitTestUtil.DB_NAME, "unknown_tbl"), null));
         tableRefs.add(new TableRef(new TableName(UnitTestUtil.DB_NAME, "unknown_mv"), null));
 
-        job = new BackupJob("mv_label_abnormal", dbId, UnitTestUtil.DB_NAME, tableRefs, 13600 * 1000,
-                    globalStateMgr, repo.getId());
+        job = new BackupJob("mv_label_abnormal", dbId, UnitTestUtil.DB_NAME, new ArrayList<>(),
+                    tableRefs, 13600 * 1000, globalStateMgr, repo.getId());
         job.run();
         Assert.assertEquals(Status.ErrCode.NOT_FOUND, job.getStatus().getErrCode());
         Assert.assertEquals(BackupJobState.CANCELLED, job.getState());

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobPrimaryKeyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobPrimaryKeyTest.java
@@ -79,6 +79,7 @@ import java.io.IOException;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -244,7 +245,9 @@ public class BackupJobPrimaryKeyTest {
 
         List<TableRef> tableRefs = Lists.newArrayList();
         tableRefs.add(new TableRef(new TableName(testDbName, testTableName), null));
-        job = new BackupJob("label_pk", dbId, testDbName, tableRefs, 13600 * 1000, globalStateMgr, repo.getId());
+        job = new BackupJob("label_pk", dbId, testDbName, new ArrayList<>() {{
+                add(tblId);
+            }}, tableRefs, 13600 * 1000, globalStateMgr, repo.getId());
         job.setTestPrimaryKey();
     }
 
@@ -379,7 +382,8 @@ public class BackupJobPrimaryKeyTest {
 
         List<TableRef> tableRefs = Lists.newArrayList();
         tableRefs.add(new TableRef(new TableName(testDbName, "unknown_tbl"), null));
-        job = new BackupJob("label", dbId, testDbName, tableRefs, 13600 * 1000, globalStateMgr, repo.getId());
+        job = new BackupJob("label", dbId, testDbName, new ArrayList<>(),
+                tableRefs, 13600 * 1000, globalStateMgr, repo.getId());
         job.run();
         Assert.assertEquals(Status.ErrCode.NOT_FOUND, job.getStatus().getErrCode());
         Assert.assertEquals(BackupJobState.CANCELLED, job.getState());

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobTest.java
@@ -80,6 +80,7 @@ import java.io.IOException;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -247,11 +248,15 @@ public class BackupJobTest {
 
         List<TableRef> tableRefs = Lists.newArrayList();
         tableRefs.add(new TableRef(new TableName(UnitTestUtil.DB_NAME, UnitTestUtil.TABLE_NAME), null));
-        job = new BackupJob("label", dbId, UnitTestUtil.DB_NAME, tableRefs, 13600 * 1000, globalStateMgr, repo.getId());
+        job = new BackupJob("label", dbId, UnitTestUtil.DB_NAME, new ArrayList<>() {{
+                add(tblId);
+            }}, tableRefs, 13600 * 1000, globalStateMgr, repo.getId());
 
         List<TableRef> viewRefs = Lists.newArrayList();
         viewRefs.add(new TableRef(new TableName(UnitTestUtil.DB_NAME, UnitTestUtil.VIEW_NAME), null));
-        jobView = new BackupJob("label-view", dbId, UnitTestUtil.DB_NAME, viewRefs, 13600 * 1000, globalStateMgr, repo.getId());
+        jobView = new BackupJob("label-view", dbId, UnitTestUtil.DB_NAME, new ArrayList<>() {{
+                add(viewId);
+            }}, viewRefs, 13600 * 1000, globalStateMgr, repo.getId());
     }
 
     @Test
@@ -391,7 +396,8 @@ public class BackupJobTest {
 
         List<TableRef> tableRefs = Lists.newArrayList();
         tableRefs.add(new TableRef(new TableName(UnitTestUtil.DB_NAME, "unknown_tbl"), null));
-        job = new BackupJob("label", dbId, UnitTestUtil.DB_NAME, tableRefs, 13600 * 1000, globalStateMgr, repo.getId());
+        job = new BackupJob("label", dbId, UnitTestUtil.DB_NAME, new ArrayList<>(),
+                tableRefs, 13600 * 1000, globalStateMgr, repo.getId());
         job.run();
         Assert.assertEquals(Status.ErrCode.NOT_FOUND, job.getStatus().getErrCode());
         Assert.assertEquals(BackupJobState.CANCELLED, job.getState());

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobMaterializedViewTest.java
@@ -88,6 +88,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static com.starrocks.common.util.UnitTestUtil.DB_NAME;
@@ -374,6 +375,7 @@ public class RestoreJobMaterializedViewTest {
         }
 
         RestoreJob job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(),
+                tbls.stream().map(Table::getId).collect(Collectors.toList()),
                 jobInfo, false, 3, 100000,
                 globalStateMgr, repo.getId(), backupMeta, mvRestoreContext);
         job.setRepo(repo);

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobPrimaryKeyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobPrimaryKeyTest.java
@@ -77,6 +77,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -260,9 +261,10 @@ public class RestoreJobPrimaryKeyTest {
         List<Table> tbls = Lists.newArrayList();
         tbls.add(expectedRestoreTbl);
         backupMeta = new BackupMeta(tbls);
-        job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(),
-                jobInfo, false, 3, 100000,
-                globalStateMgr, repo.getId(), backupMeta, new MvRestoreContext());
+        job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(), new ArrayList<>() {{
+                add(expectedRestoreTbl.getId());
+            }}, jobInfo, false, 3, 100000, globalStateMgr, repo.getId(), backupMeta,
+                new MvRestoreContext());
     }
 
     @Ignore

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
@@ -89,6 +89,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -182,9 +183,10 @@ public class RestoreJobTest {
                 expectedRestoreTbl.getBaseSchema(), KeysType.DUP_KEYS, expectedRestoreTbl.getPartitionInfo(),
                 expectedRestoreTbl.getDefaultDistributionInfo());
 
-        job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(),
-                jobInfo, false, 3, 100000,
-                globalStateMgr, repo.getId(), backupMeta, new MvRestoreContext());
+        job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(), new ArrayList<>() {{
+                add(expectedRestoreTbl.getId());
+            }}, jobInfo, false, 3, 100000, globalStateMgr, repo.getId(), backupMeta,
+                new MvRestoreContext());
 
         new MockUp<OlapTable>() {
             @Mock
@@ -368,9 +370,10 @@ public class RestoreJobTest {
         List<Table> tbls = Lists.newArrayList();
         tbls.add(expectedRestoreTbl);
         backupMeta = new BackupMeta(tbls);
-        job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(),
-                jobInfo, false, 3, 100000,
-                globalStateMgr, repo.getId(), backupMeta, new MvRestoreContext());
+        job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(), new ArrayList<>() {{
+                add(expectedRestoreTbl.getId());
+            }}, jobInfo, false, 3, 100000, globalStateMgr, repo.getId(), backupMeta,
+                new MvRestoreContext());
         job.setRepo(repo);
         // pending
         job.run();
@@ -545,8 +548,9 @@ public class RestoreJobTest {
         List<Table> tbls = Lists.newArrayList();
         tbls.add(expectedRestoreTbl);
         backupMeta = new BackupMeta(tbls);
-        job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(),
-                jobInfo, false, 3, 100000,
+        job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(), new ArrayList<>() {{
+                add(expectedRestoreTbl.getId());
+            }}, jobInfo, false, 3, 100000,
                 globalStateMgr, repo.getId(), backupMeta, new MvRestoreContext());
         job.setRepo(repo);
         // pending
@@ -716,9 +720,10 @@ public class RestoreJobTest {
         List<Table> tbls = Lists.newArrayList();
         tbls.add(expectedRestoreTbl);
         backupMeta = new BackupMeta(tbls);
-        job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(),
-                jobInfo, false, 3, 100000,
-                globalStateMgr, repo.getId(), backupMeta, new MvRestoreContext());
+        job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(), new ArrayList<>() {{
+                add(expectedRestoreTbl.getId());
+            }}, jobInfo, false, 3, 100000, globalStateMgr, repo.getId(),
+                backupMeta, new MvRestoreContext());
         job.setRepo(repo);
         // pending
         job.run();
@@ -903,9 +908,10 @@ public class RestoreJobTest {
         backupMeta = new BackupMeta(tbls);
 
         db.dropTable(restoredView.getName());
-        job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(),
-                jobInfo, false, 3, 100000,
-                globalStateMgr, repo.getId(), backupMeta, new MvRestoreContext());
+        job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(), new ArrayList<>() {{
+                add(restoredView.getId());
+            }}, jobInfo, false, 3, 100000, globalStateMgr, repo.getId(),
+                backupMeta, new MvRestoreContext());
         job.setRepo(repo);
         Assert.assertEquals(RestoreJobState.PENDING, job.getState());
         {
@@ -941,9 +947,10 @@ public class RestoreJobTest {
         Assert.assertEquals(RestoreJobState.FINISHED, job.getState());
 
         // restore when the view already existed
-        job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(),
-                jobInfo, false, 3, 100000,
-                globalStateMgr, repo.getId(), backupMeta, new MvRestoreContext());
+        job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(), new ArrayList<>() {{
+                add(1L);
+            }}, jobInfo, false, 3, 100000, globalStateMgr, repo.getId(),
+                backupMeta, new MvRestoreContext());
         job.setRepo(repo);
         Assert.assertEquals(RestoreJobState.PENDING, job.getState());
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Currently, backup/restore job can only run in series. Backup/restore jobs between different tables does not affect each other. So it can be parallelized, yet backup/restore job running on the same table is still forbidden.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
