### PR TITLE
[Enhancement] support current_timestamp(6)

### DIFF
--- a/docs/en/sql-reference/sql-functions/date-time-functions/current_timestamp.md
+++ b/docs/en/sql-reference/sql-functions/date-time-functions/current_timestamp.md
@@ -19,7 +19,7 @@ DATETIME CURRENT_TIMESTAMP(INT p)
 
 ## Parameters
 
-`p`: optional, the specified precision, that is, the number of digits to retain after seconds. It must be an INT value within the range of [1,6]. `select now(0)` is equivalent to `select now()`.
+`p`: optional, the specified precision, that is, the number of digits to retain after seconds. It must be an INT value within the range of [1,6]. `select current_timestamp(0)` is equivalent to `select current_timestamp()`.
 
 ## Return value
 

--- a/docs/en/sql-reference/sql-functions/date-time-functions/current_timestamp.md
+++ b/docs/en/sql-reference/sql-functions/date-time-functions/current_timestamp.md
@@ -14,7 +14,17 @@ This function is a synonym of the [now()](./now.md) function.
 
 ```Haskell
 DATETIME CURRENT_TIMESTAMP()
+DATETIME CURRENT_TIMESTAMP(INT p)
 ```
+
+## Parameters
+
+`p`: optional, the specified precision, that is, the number of digits to retain after seconds. It must be an INT value within the range of [1,6]. `select now(0)` is equivalent to `select now()`.
+
+## Return value
+
+- If `p` is not specified, this function returns a DATETIME value accurate to the second.
+- If `p` is specified, this function returns a date and time value of the specified precision.
 
 ## Examples
 

--- a/docs/ja/sql-reference/sql-functions/date-time-functions/current_timestamp.md
+++ b/docs/ja/sql-reference/sql-functions/date-time-functions/current_timestamp.md
@@ -12,7 +12,17 @@ displayed_sidebar: docs
 
 ```Haskell
 DATETIME CURRENT_TIMESTAMP()
+DATETIME CURRENT_TIMESTAMP(INT p)
 ```
+
+## パラメータ
+
+`p`: 任意指定で、秒の後に保持する桁数を指定します。範囲は [1,6] の INT 値でなければなりません。`select now(0)` は `select now()` と同等です。
+
+## 戻り値
+
+- `p` が指定されていない場合、この関数は秒単位の精度で DATETIME 値を返します。
+- `p` が指定されている場合、この関数は指定された精度の日付と時刻の値を返します。
 
 ## Examples
 

--- a/docs/ja/sql-reference/sql-functions/date-time-functions/current_timestamp.md
+++ b/docs/ja/sql-reference/sql-functions/date-time-functions/current_timestamp.md
@@ -17,7 +17,7 @@ DATETIME CURRENT_TIMESTAMP(INT p)
 
 ## パラメータ
 
-`p`: 任意指定で、秒の後に保持する桁数を指定します。範囲は [1,6] の INT 値でなければなりません。`select now(0)` は `select now()` と同等です。
+`p`: 任意指定で、秒の後に保持する桁数を指定します。範囲は [1,6] の INT 値でなければなりません。`select current_timestamp(0)` は `select current_timestamp()` と同等です。
 
 ## 戻り値
 

--- a/docs/zh/sql-reference/sql-functions/date-time-functions/current_timestamp.md
+++ b/docs/zh/sql-reference/sql-functions/date-time-functions/current_timestamp.md
@@ -14,7 +14,17 @@ displayed_sidebar: docs
 
 ```Haskell
 DATETIME CURRENT_TIMESTAMP()
+DATETIME CURRENT_TIMESTAMP(INT p)
 ```
+
+## 参数说明
+
+`p`：可选，指定的时间精度位数，支持的数据类型为 INT。最大支持返回微秒级时间（最多 6 位）。`select now(0)` 等同于 `select now()`。
+
+## 返回值说明
+
+- 如果不指定 `p`，则返回秒级精度的时间。
+- 如果指定了 `p`，则返回指定精度的时间。
 
 ## 示例
 

--- a/docs/zh/sql-reference/sql-functions/date-time-functions/current_timestamp.md
+++ b/docs/zh/sql-reference/sql-functions/date-time-functions/current_timestamp.md
@@ -19,7 +19,7 @@ DATETIME CURRENT_TIMESTAMP(INT p)
 
 ## 参数说明
 
-`p`：可选，指定的时间精度位数，支持的数据类型为 INT。最大支持返回微秒级时间（最多 6 位）。`select now(0)` 等同于 `select now()`。
+`p`：可选，指定的时间精度位数，支持的数据类型为 INT。最大支持返回微秒级时间（最多 6 位）。`select current_timestamp(0)` 等同于 `select current_timestamp()`。
 
 ## 返回值说明
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -729,7 +729,10 @@ public class ScalarOperatorFunctions {
         return ConstantOperator.createDatetimeOrNull(startTime);
     }
 
-    @ConstantFunction(name = "now", argTypes = {INT}, returnType = DATETIME)
+    @ConstantFunction.List(list = {
+            @ConstantFunction(name = "now", argTypes = {INT}, returnType = DATETIME),
+            @ConstantFunction(name = "current_timestamp", argTypes = {INT}, returnType = DATETIME)
+    })
     public static ConstantOperator now(ConstantOperator fsp) throws AnalysisException {
         int fspVal = fsp.getInt();
         if (fspVal == 0) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -7470,7 +7470,11 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     @Override
     public ParseNode visitSpecialDateTimeExpression(StarRocksParser.SpecialDateTimeExpressionContext context) {
-        return new FunctionCallExpr(context.name.getText().toUpperCase(), Lists.newArrayList());
+        List<Expr> expr = Lists.newArrayList();
+        if (context.INTEGER_VALUE() != null) {
+            expr.add(new IntLiteral(Long.parseLong(context.INTEGER_VALUE().getText()), Type.INT));
+        }
+        return new FunctionCallExpr(context.name.getText().toUpperCase(), new FunctionParams(false, expr));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -2612,7 +2612,7 @@ informationFunctionExpression
 specialDateTimeExpression
     : name = CURRENT_DATE ('(' ')')?
     | name = CURRENT_TIME ('(' ')')?
-    | name = CURRENT_TIMESTAMP ('(' ')')?
+    | name = CURRENT_TIMESTAMP ('(' (INTEGER_VALUE)? ')')?
     | name = LOCALTIME ('(' ')')?
     | name = LOCALTIMESTAMP ('(' ')')?
     ;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -245,6 +245,8 @@ public class SelectStmtTest {
         starRocksAssert.query(sql).explainQuery();
         sql = "select current_timestamp";
         starRocksAssert.query(sql).explainQuery();
+        sql = "select current_timestamp(6)";
+        starRocksAssert.query(sql).explainQuery();
         sql = "select current_time()";
         starRocksAssert.query(sql).explainQuery();
         sql = "select current_time";

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -503,6 +503,7 @@ vectorized_functions = [
     [50202, 'localtime', True, False, 'DATETIME', [], 'TimeFunctions::now'],
     [50203, 'localtimestamp', True, False, 'DATETIME', [], 'TimeFunctions::now'],
     [50204, 'now', True, False, 'DATETIME', ['INT'], 'TimeFunctions::now'],
+    [50205, 'current_timestamp', True, False, 'DATETIME', ['INT'], 'TimeFunctions::now'],
     [50210, 'curtime', True, False, 'TIME', [], 'TimeFunctions::curtime'],
     [50211, 'current_time', True, False, 'TIME', [], 'TimeFunctions::curtime'],
     [50220, 'curdate', True, False, 'DATE', [], 'TimeFunctions::curdate'],


### PR DESCRIPTION
Fixes #57676 

mysql> select current_timestamp(0), current_timestamp(1), current_timestamp(2), current_timestamp(3), current_timestamp(4), current_timestamp(5), current_timestamp(6)\G;
*************************** 1. row ***************************
current_timestamp(0): 2025-04-08 21:08:30
current_timestamp(1): 2025-04-08 21:08:30.700000
current_timestamp(2): 2025-04-08 21:08:30.780000
current_timestamp(3): 2025-04-08 21:08:30.788000
current_timestamp(4): 2025-04-08 21:08:30.788900
current_timestamp(5): 2025-04-08 21:08:30.788960
current_timestamp(6): 2025-04-08 21:08:30.788960

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1