### PR TITLE
[Enhancement] add try acquire size for load spill

### DIFF
--- a/be/src/exec/spill/block_manager.h
+++ b/be/src/exec/spill/block_manager.h
@@ -48,6 +48,8 @@ public:
 
     virtual std::string debug_string() const = 0;
 
+    virtual bool try_acquire_sizes(size_t size) = 0;
+
     size_t size() const { return _size; }
     size_t num_rows() const { return _num_rows; }
     bool is_remote() const { return _is_remote; }

--- a/be/src/exec/spill/file_block_manager.cpp
+++ b/be/src/exec/spill/file_block_manager.cpp
@@ -193,6 +193,8 @@ public:
 #endif
     }
 
+    bool try_acquire_sizes(size_t size) override { return _container->try_acquire_sizes(size); }
+
 private:
     FileBlockContainerPtr _container;
 };

--- a/be/src/exec/spill/log_block_manager.cpp
+++ b/be/src/exec/spill/log_block_manager.cpp
@@ -237,6 +237,8 @@ public:
 #endif
     }
 
+    bool try_acquire_sizes(size_t size) override { return _container->try_acquire_sizes(size); }
+
 private:
     LogBlockContainerPtr _container;
     size_t _offset{};

--- a/be/src/storage/lake/spill_mem_table_sink.cpp
+++ b/be/src/storage/lake/spill_mem_table_sink.cpp
@@ -63,7 +63,7 @@ Status LoadSpillOutputDataStream::_freeze_current_block() {
 
 Status LoadSpillOutputDataStream::_preallocate(size_t block_size) {
     // Try to preallocate from current block first.
-    if (_block == nullptr) {
+    if (_block == nullptr || !_block->try_acquire_sizes(block_size)) {
         // Freeze current block firstly.
         RETURN_IF_ERROR(_freeze_current_block());
         // Acquire new block.

--- a/be/test/io/spill_block_manager_test.cpp
+++ b/be/test/io/spill_block_manager_test.cpp
@@ -178,6 +178,7 @@ TEST_F(SpillBlockManagerTest, log_block_allocation_test) {
         auto res = log_block_mgr->acquire_block(opts);
         ASSERT_TRUE(res.ok());
         auto block = res.value();
+        ASSERT_TRUE(block->try_acquire_sizes(10));
         std::string expected = fmt::format("LogBlock[container={}/{}/{}-{}]", local_path, print_id(dummy_query_id),
                                            print_id(dummy_query_id), "node1-1-0");
         ASSERT_EQ(block->debug_string(), expected);
@@ -231,6 +232,7 @@ TEST_F(SpillBlockManagerTest, file_block_allocation_test) {
         auto res = file_block_mgr->acquire_block(opts);
         ASSERT_TRUE(res.ok());
         auto block = res.value();
+        ASSERT_TRUE(block->try_acquire_sizes(10));
         std::string expected = fmt::format("FileBlock[container={}/{}/{}-{}]", local_path, print_id(dummy_query_id),
                                            print_id(dummy_query_id), "node1-1-0");
         ASSERT_EQ(block->debug_string(), expected);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
After this PR #57736, we need to add `try_acquire_sizes` before append data to block.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
