### PR TITLE
[Doc]A spelling mistake for value in the bit_shift_left function

### DIFF
--- a/docs/zh/sql-reference/sql-functions/bit-functions/bit_shift_left.md
+++ b/docs/zh/sql-reference/sql-functions/bit-functions/bit_shift_left.md
@@ -30,7 +30,7 @@ bit_shift_left(value, shift)
 
 - 如果任何一个输入参数为 NULL，则返回 NULL。
 - 如果 `shift` 小于 0，则返回 0。
-- 对于任意 `valu``e` 值，如果 `shift` 等于 0，则返回原本的 `value` 值。
+- 对于任意 `value` 值，如果 `shift` 等于 0，则返回原本的 `value` 值。
 - 如果 `value` 等于 0，则固定返回 0。
 - 如果 `value` 为非整型的数值，会转换为整数进行运算。参见[示例](#示例)。
 - 如果 `value` 为 STRING 类型，会转换为整数进行运算。如果 STRING 无法转换为整数，则作为 NULL 处理。参见[示例](#示例)。


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Correct the spelling mistake of 'value' in the bit_shift_left function

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
