### PR TITLE
[BugFix] Fix the temporary partition residue caused by optimize duplicate partitions (backport #57005) (backport #57583)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseVisitor.java
@@ -435,7 +435,7 @@ public class AlterTableClauseVisitor extends AstVisitor<Void, ConnectContext> {
                 }
             }
 
-            List<Long> partitionIds = Lists.newArrayList();
+            Set<Long> partitionIds = Sets.newHashSet();
             for (String partitionName : partitionNameList) {
                 Partition partition = olapTable.getPartition(partitionName);
                 if (partition == null) {
@@ -443,7 +443,7 @@ public class AlterTableClauseVisitor extends AstVisitor<Void, ConnectContext> {
                 }
                 partitionIds.add(partition.getId());
             }
-            clause.setSourcePartitionIds(partitionIds);
+            clause.setSourcePartitionIds(Lists.newArrayList(partitionIds));
         } else {
             clause.setSourcePartitionIds(olapTable.getPartitions().stream().map(Partition::getId).collect(Collectors.toList()));
             clause.setTableOptimize(true);

--- a/test/sql/test_optimize_table/R/test_optimize_table
+++ b/test/sql/test_optimize_table/R/test_optimize_table
@@ -455,50 +455,6 @@ PROPERTIES (
 "replication_num" = "3"
 );
 -- !result
-<<<<<<< HEAD
-=======
-admin set frontend config ('enable_online_optimize_table'='false');
--- result:
--- !result
-alter table `t#t` distributed by hash(k) buckets 30;
--- result:
--- !result
-function: wait_optimize_table_finish()
--- result:
-None
--- !result
-show create table `t#t`;
--- result:
-t#t	CREATE TABLE `t#t` (
-  `k` int(11) NULL COMMENT ""
-) ENGINE=OLAP 
-DUPLICATE KEY(`k`)
-DISTRIBUTED BY HASH(`k`) BUCKETS 30 
-PROPERTIES (
-"compression" = "LZ4",
-"fast_schema_evolution" = "true",
-"replicated_storage" = "true",
-"replication_num" = "3"
-);
--- !result
-admin set frontend config ('enable_online_optimize_table'='true');
--- result:
--- !result
-
--- name: test_cancel_optimize
-create table t(k int) distributed by hash(k) buckets 10;
--- result:
--- !result
-alter table t distributed by hash(k);
--- result:
--- !result
-cancel alter table optimize from t;
--- result:
--- !result
-function: wait_optimize_table_finish(expect_status="CANCELLED")
--- result:
-None
--- !result
 
 -- name: test_optimize_duplicate_partitions
 CREATE TABLE `duplicate_table_with_null_partition` (
@@ -542,4 +498,3 @@ show partitions from duplicate_table_with_null_partition;
 .*p202007.*k1, k2, k3, k4, k5	4.*
 .*p202008.*k1, k2, k3, k4, k5	3.*
 -- !result
->>>>>>> 056a4fe487 ([BugFix] Fix the temporary partition residue caused by optimize duplicate partitions (backport #57005) (#57583))

--- a/test/sql/test_optimize_table/R/test_optimize_table
+++ b/test/sql/test_optimize_table/R/test_optimize_table
@@ -81,6 +81,7 @@ alter table t distributed by random buckets 10;
 E: (5064, 'Getting analyzing error. Detail message: Random distribution table already supports automatic scaling and does not require optimization.')
 -- !result
 
+<<<<<<< HEAD
 
 
 
@@ -299,6 +300,8 @@ select * from t;
 3	2020-08-01
 2	2020-07-01
 -- !result
+=======
+>>>>>>> 056a4fe487 ([BugFix] Fix the temporary partition residue caused by optimize duplicate partitions (backport #57005) (#57583))
 -- name: test_change_partial_partition_distribution
 create table t(k int, k1 date) PARTITION BY RANGE(`k1`)
 (
@@ -452,3 +455,91 @@ PROPERTIES (
 "replication_num" = "3"
 );
 -- !result
+<<<<<<< HEAD
+=======
+admin set frontend config ('enable_online_optimize_table'='false');
+-- result:
+-- !result
+alter table `t#t` distributed by hash(k) buckets 30;
+-- result:
+-- !result
+function: wait_optimize_table_finish()
+-- result:
+None
+-- !result
+show create table `t#t`;
+-- result:
+t#t	CREATE TABLE `t#t` (
+  `k` int(11) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 30 
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "3"
+);
+-- !result
+admin set frontend config ('enable_online_optimize_table'='true');
+-- result:
+-- !result
+
+-- name: test_cancel_optimize
+create table t(k int) distributed by hash(k) buckets 10;
+-- result:
+-- !result
+alter table t distributed by hash(k);
+-- result:
+-- !result
+cancel alter table optimize from t;
+-- result:
+-- !result
+function: wait_optimize_table_finish(expect_status="CANCELLED")
+-- result:
+None
+-- !result
+
+-- name: test_optimize_duplicate_partitions
+CREATE TABLE `duplicate_table_with_null_partition` (
+    `k1` date,
+    `k2` datetime,
+    `k3` char(20),
+    `k4` varchar(20),
+    `k5` boolean,
+    `k6` tinyint,
+    `k7` smallint,
+    `k8` int,
+    `k9` bigint,
+    `k10` largeint,
+    `k11` float,
+    `k12` double,
+    `k13` decimal(27,9)
+)
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`)
+PARTITION BY RANGE(`k1`)
+(
+    PARTITION `p202006` VALUES LESS THAN ("2020-07-01"),
+    PARTITION `p202007` VALUES LESS THAN ("2020-08-01"),
+    PARTITION `p202008` VALUES LESS THAN ("2020-09-01")
+)
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`, `k4`, `k5`) BUCKETS 3;
+-- result:
+-- !result
+alter table duplicate_table_with_null_partition PARTITIONS(p202006,p202006,p202007) DISTRIBUTED BY HASH(`k1`, `k2`, `k3`, `k4`, `k5`) BUCKETS 4;
+-- result:
+-- !result
+function: wait_optimize_table_finish()
+-- result:
+None
+-- !result
+show temporary partitions from duplicate_table_with_null_partition;
+-- result:
+-- !result
+show partitions from duplicate_table_with_null_partition;
+-- result:
+[REGEX].*p202006.*k1, k2, k3, k4, k5	4.*
+.*p202007.*k1, k2, k3, k4, k5	4.*
+.*p202008.*k1, k2, k3, k4, k5	3.*
+-- !result
+>>>>>>> 056a4fe487 ([BugFix] Fix the temporary partition residue caused by optimize duplicate partitions (backport #57005) (#57583))

--- a/test/sql/test_optimize_table/R/test_optimize_table
+++ b/test/sql/test_optimize_table/R/test_optimize_table
@@ -81,7 +81,6 @@ alter table t distributed by random buckets 10;
 E: (5064, 'Getting analyzing error. Detail message: Random distribution table already supports automatic scaling and does not require optimization.')
 -- !result
 
-<<<<<<< HEAD
 
 
 
@@ -300,8 +299,7 @@ select * from t;
 3	2020-08-01
 2	2020-07-01
 -- !result
-=======
->>>>>>> 056a4fe487 ([BugFix] Fix the temporary partition residue caused by optimize duplicate partitions (backport #57005) (#57583))
+
 -- name: test_change_partial_partition_distribution
 create table t(k int, k1 date) PARTITION BY RANGE(`k1`)
 (

--- a/test/sql/test_optimize_table/T/test_optimize_table
+++ b/test/sql/test_optimize_table/T/test_optimize_table
@@ -129,3 +129,46 @@ show create table `t#t`;
 alter table `t#t` distributed by hash(k) buckets 20;
 function: wait_optimize_table_finish()
 show create table `t#t`;
+<<<<<<< HEAD
+=======
+admin set frontend config ('enable_online_optimize_table'='false');
+alter table `t#t` distributed by hash(k) buckets 30;
+function: wait_optimize_table_finish()
+show create table `t#t`;
+admin set frontend config ('enable_online_optimize_table'='true');
+
+-- name: test_cancel_optimize
+create table t(k int) distributed by hash(k) buckets 10;
+alter table t distributed by hash(k);
+cancel alter table optimize from t;
+function: wait_optimize_table_finish(expect_status="CANCELLED")
+
+-- name: test_optimize_duplicate_partitions
+CREATE TABLE `duplicate_table_with_null_partition` (
+    `k1` date,
+    `k2` datetime,
+    `k3` char(20),
+    `k4` varchar(20),
+    `k5` boolean,
+    `k6` tinyint,
+    `k7` smallint,
+    `k8` int,
+    `k9` bigint,
+    `k10` largeint,
+    `k11` float,
+    `k12` double,
+    `k13` decimal(27,9)
+)
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`)
+PARTITION BY RANGE(`k1`)
+(
+    PARTITION `p202006` VALUES LESS THAN ("2020-07-01"),
+    PARTITION `p202007` VALUES LESS THAN ("2020-08-01"),
+    PARTITION `p202008` VALUES LESS THAN ("2020-09-01")
+)
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`, `k4`, `k5`) BUCKETS 3;
+alter table duplicate_table_with_null_partition PARTITIONS(p202006,p202006,p202007) DISTRIBUTED BY HASH(`k1`, `k2`, `k3`, `k4`, `k5`) BUCKETS 4;
+function: wait_optimize_table_finish()
+show temporary partitions from duplicate_table_with_null_partition;
+show partitions from duplicate_table_with_null_partition;
+>>>>>>> 056a4fe487 ([BugFix] Fix the temporary partition residue caused by optimize duplicate partitions (backport #57005) (#57583))

--- a/test/sql/test_optimize_table/T/test_optimize_table
+++ b/test/sql/test_optimize_table/T/test_optimize_table
@@ -129,19 +129,6 @@ show create table `t#t`;
 alter table `t#t` distributed by hash(k) buckets 20;
 function: wait_optimize_table_finish()
 show create table `t#t`;
-<<<<<<< HEAD
-=======
-admin set frontend config ('enable_online_optimize_table'='false');
-alter table `t#t` distributed by hash(k) buckets 30;
-function: wait_optimize_table_finish()
-show create table `t#t`;
-admin set frontend config ('enable_online_optimize_table'='true');
-
--- name: test_cancel_optimize
-create table t(k int) distributed by hash(k) buckets 10;
-alter table t distributed by hash(k);
-cancel alter table optimize from t;
-function: wait_optimize_table_finish(expect_status="CANCELLED")
 
 -- name: test_optimize_duplicate_partitions
 CREATE TABLE `duplicate_table_with_null_partition` (
@@ -171,4 +158,3 @@ alter table duplicate_table_with_null_partition PARTITIONS(p202006,p202006,p2020
 function: wait_optimize_table_finish()
 show temporary partitions from duplicate_table_with_null_partition;
 show partitions from duplicate_table_with_null_partition;
->>>>>>> 056a4fe487 ([BugFix] Fix the temporary partition residue caused by optimize duplicate partitions (backport #57005) (#57583))


### PR DESCRIPTION
## Why I'm doing:
When running OPTIMIZE TABLE with duplicate partitions specified, the operation will fail and leave behind temporary partition remnants.

## What I'm doing:
Use SET for deduplication, and add a SQL interface in the ALTER operation to drop all temporary partitions

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0<hr>This is an automatic backport of pull request #57005 done by [Mergify](https://mergify.com).

<hr>This is an automatic backport of pull request #57583 done by [Mergify](https://mergify.com).



