### PR TITLE
[BugFix] Fix clone for semi-structure cast expr

### DIFF
--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -1556,6 +1556,7 @@ StatusOr<ColumnPtr> MustNullExpr::evaluate_checked(ExprContext* context, Chunk* 
     return only_null;
 }
 
+// Need add result to pool by caller.
 Expr* VectorizedCastExprFactory::create_primitive_cast(ObjectPool* pool, const TExprNode& node, LogicalType from_type,
                                                        LogicalType to_type, bool allow_throw_exception) {
     if (to_type == TYPE_CHAR) {
@@ -1584,12 +1585,12 @@ Expr* VectorizedCastExprFactory::create_primitive_cast(ObjectPool* pool, const T
         if (cast_element_expr == nullptr) {
             return nullptr;
         }
+        DCHECK(pool != nullptr);
+        pool->add(cast_element_expr);
+
         auto* child = new ColumnRef(cast);
+        pool->add(child);
         cast_element_expr->add_child(child);
-        if (pool) {
-            pool->add(cast_element_expr);
-            pool->add(child);
-        }
 
         if (from_type == TYPE_VARCHAR) {
             return new CastStringToArray(node, cast_element_expr, cast_to, allow_throw_exception);
@@ -1601,7 +1602,7 @@ Expr* VectorizedCastExprFactory::create_primitive_cast(ObjectPool* pool, const T
     if (from_type == TYPE_JSON && to_type == TYPE_STRUCT) {
         TypeDescriptor cast_to = TypeDescriptor::from_thrift(node.type);
 
-        std::vector<std::unique_ptr<Expr>> field_casts(cast_to.children.size());
+        std::vector<Expr*> field_casts(cast_to.children.size());
         for (int i = 0; i < cast_to.children.size(); ++i) {
             TypeDescriptor json_type = TypeDescriptor::create_json_type();
             auto ret = create_cast_expr(pool, json_type, cast_to.children[i], allow_throw_exception);
@@ -1609,7 +1610,8 @@ Expr* VectorizedCastExprFactory::create_primitive_cast(ObjectPool* pool, const T
                 LOG(WARNING) << "Not support cast from type: " << json_type << ", to type: " << cast_to.children[i];
                 return nullptr;
             }
-            field_casts[i] = std::move(ret.value());
+            pool->add(ret.value());
+            field_casts[i] = ret.value();
             auto cast_input = create_slot_ref(json_type);
             field_casts[i]->add_child(cast_input.get());
             pool->add(cast_input.release());
@@ -1724,32 +1726,35 @@ Expr* VectorizedCastExprFactory::create_primitive_cast(ObjectPool* pool, const T
 }
 
 // NOTE: should return error status to avoid null in ASSIGN_OR_RETURN, otherwise causing crash
-StatusOr<std::unique_ptr<Expr>> VectorizedCastExprFactory::create_cast_expr(ObjectPool* pool, const TExprNode& node,
-                                                                            const TypeDescriptor& from_type,
-                                                                            const TypeDescriptor& to_type,
-                                                                            bool allow_throw_exception) {
+StatusOr<Expr*> VectorizedCastExprFactory::create_cast_expr(ObjectPool* pool, const TExprNode& node,
+                                                            const TypeDescriptor& from_type,
+                                                            const TypeDescriptor& to_type, bool allow_throw_exception) {
     if (from_type.is_array_type() && to_type.is_array_type()) {
-        ASSIGN_OR_RETURN(auto child_cast,
+        ASSIGN_OR_RETURN(auto* child_cast,
                          create_cast_expr(pool, from_type.children[0], to_type.children[0], allow_throw_exception));
+        pool->add(child_cast);
         auto child_input = create_slot_ref(from_type.children[0]);
         child_cast->add_child(child_input.get());
         pool->add(child_input.release());
-        return std::make_unique<CastArrayExpr>(node, std::move(child_cast));
+
+        return new CastArrayExpr(node, child_cast);
     }
     if (from_type.is_map_type() && to_type.is_map_type()) {
-        ASSIGN_OR_RETURN(auto key_cast,
+        ASSIGN_OR_RETURN(auto* key_cast,
                          create_cast_expr(pool, from_type.children[0], to_type.children[0], allow_throw_exception));
+        pool->add(key_cast);
         auto key_input = create_slot_ref(from_type.children[0]);
         key_cast->add_child(key_input.get());
         pool->add(key_input.release());
 
-        ASSIGN_OR_RETURN(auto value_cast,
+        ASSIGN_OR_RETURN(auto* value_cast,
                          create_cast_expr(pool, from_type.children[1], to_type.children[1], allow_throw_exception));
+        pool->add(value_cast);
         auto value_input = create_slot_ref(from_type.children[1]);
         value_cast->add_child(value_input.get());
         pool->add(value_input.release());
 
-        return std::make_unique<CastMapExpr>(node, std::move(key_cast), std::move(value_cast));
+        return new CastMapExpr(node, key_cast, value_cast);
     }
     if (from_type.is_struct_type() && to_type.is_struct_type()) {
         if (from_type.children.size() != to_type.children.size()) {
@@ -1758,28 +1763,30 @@ StatusOr<std::unique_ptr<Expr>> VectorizedCastExprFactory::create_cast_expr(Obje
         if (to_type.field_names.empty() || from_type.field_names.size() != to_type.field_names.size()) {
             return Status::NotSupported("Not support cast struct with different field of children.");
         }
-        std::vector<std::unique_ptr<Expr>> field_casts{from_type.children.size()};
+        std::vector<Expr*> field_casts{from_type.children.size()};
         for (int i = 0; i < from_type.children.size(); ++i) {
             ASSIGN_OR_RETURN(field_casts[i],
                              create_cast_expr(pool, from_type.children[i], to_type.children[i], allow_throw_exception));
+            pool->add(field_casts[i]);
             auto cast_input = create_slot_ref(from_type.children[i]);
             field_casts[i]->add_child(cast_input.get());
             pool->add(cast_input.release());
         }
-        return std::make_unique<CastStructExpr>(node, std::move(field_casts));
+        return new CastStructExpr(node, std::move(field_casts));
     }
     if ((from_type.type == TYPE_NULL || from_type.type == TYPE_BOOLEAN) && to_type.is_complex_type()) {
-        return std::make_unique<MustNullExpr>(node);
+        return new MustNullExpr(node);
     }
+
     auto res = create_primitive_cast(pool, node, from_type.type, to_type.type, allow_throw_exception);
     if (res == nullptr) {
         return Status::NotSupported(
                 fmt::format("Not support cast {} to {}.", from_type.debug_string(), to_type.debug_string()));
     }
-    std::unique_ptr<Expr> result(res);
-    return std::move(result);
+    return res;
 }
 
+// Need add result to pool by caller.
 Expr* VectorizedCastExprFactory::from_thrift(ObjectPool* pool, const TExprNode& node, bool allow_throw_exception) {
     TypeDescriptor to_type = TypeDescriptor::from_thrift(node.type);
     TypeDescriptor from_type(thrift_to_type(node.child_type));
@@ -1791,13 +1798,12 @@ Expr* VectorizedCastExprFactory::from_thrift(ObjectPool* pool, const TExprNode& 
         LOG(WARNING) << "Not support cast " << from_type << " to " << to_type;
         return nullptr;
     }
-    return std::move(ret).value().release();
+    return ret.value();
 }
 
-StatusOr<std::unique_ptr<Expr>> VectorizedCastExprFactory::create_cast_expr(ObjectPool* pool,
-                                                                            const TypeDescriptor& from_type,
-                                                                            const TypeDescriptor& to_type,
-                                                                            bool allow_throw_exception) {
+// Need add result to pool by caller.
+StatusOr<Expr*> VectorizedCastExprFactory::create_cast_expr(ObjectPool* pool, const TypeDescriptor& from_type,
+                                                            const TypeDescriptor& to_type, bool allow_throw_exception) {
     TExprNode cast_node;
     cast_node.node_type = TExprNodeType::CAST_EXPR;
     cast_node.type = to_type.to_thrift();
@@ -1806,6 +1812,7 @@ StatusOr<std::unique_ptr<Expr>> VectorizedCastExprFactory::create_cast_expr(Obje
     return create_cast_expr(pool, cast_node, from_type, to_type, allow_throw_exception);
 }
 
+// Need add result to pool by callee.
 Expr* VectorizedCastExprFactory::from_type(const TypeDescriptor& from, const TypeDescriptor& to, Expr* child,
                                            ObjectPool* pool, bool allow_throw_exception) {
     auto ret = create_cast_expr(pool, from, to, allow_throw_exception);
@@ -1813,7 +1820,8 @@ Expr* VectorizedCastExprFactory::from_type(const TypeDescriptor& from, const Typ
         LOG(WARNING) << "Not support cast " << from << " to " << to;
         return nullptr;
     }
-    auto cast_expr = std::move(ret).value().release();
+
+    auto* cast_expr = ret.value();
     pool->add(cast_expr);
     cast_expr->add_child(child);
     return cast_expr;

--- a/be/src/exprs/cast_expr.h
+++ b/be/src/exprs/cast_expr.h
@@ -43,12 +43,10 @@ public:
                            bool exception_if_failed = false);
 
 private:
-    static StatusOr<std::unique_ptr<Expr>> create_cast_expr(ObjectPool* pool, const TypeDescriptor& from_type,
-                                                            const TypeDescriptor& cast_type,
-                                                            bool allow_throw_exception);
-    static StatusOr<std::unique_ptr<Expr>> create_cast_expr(ObjectPool* pool, const TExprNode& node,
-                                                            const TypeDescriptor& from_type,
-                                                            const TypeDescriptor& to_type, bool allow_throw_exception);
+    static StatusOr<Expr*> create_cast_expr(ObjectPool* pool, const TypeDescriptor& from_type,
+                                            const TypeDescriptor& cast_type, bool allow_throw_exception);
+    static StatusOr<Expr*> create_cast_expr(ObjectPool* pool, const TExprNode& node, const TypeDescriptor& from_type,
+                                            const TypeDescriptor& to_type, bool allow_throw_exception);
     static Expr* create_primitive_cast(ObjectPool* pool, const TExprNode& node, LogicalType from_type,
                                        LogicalType to_type, bool allow_throw_exception);
 };
@@ -62,18 +60,34 @@ public:
               _cast_to_type_desc(std::move(type_desc)),
               _throw_exception_if_err(throw_exception_if_err) {}
     ~CastStringToArray() override = default;
+
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* input_chunk) override;
-    Expr* clone(ObjectPool* pool) const override { return pool->add(new CastStringToArray(*this)); }
+
+    Expr* clone(ObjectPool* pool) const override {
+        auto cloned = std::unique_ptr<CastStringToArray>(new CastStringToArray(*this));
+        if (_cast_elements_expr != nullptr) {
+            cloned->_cast_elements_expr = Expr::copy(pool, _cast_elements_expr);
+        }
+        return pool->add(cloned.release());
+    }
+
     Status open(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) override;
 
 private:
+    // Invoked only by clone.
+    CastStringToArray(const CastStringToArray& rhs)
+            : Expr(rhs),
+              _cast_to_type_desc(rhs._cast_to_type_desc),
+              _throw_exception_if_err(rhs._throw_exception_if_err),
+              _constant_res(rhs._constant_res != nullptr ? rhs._constant_res->clone() : nullptr) {}
+
     Slice _unquote(Slice slice) const;
     Slice _trim(Slice slice) const;
 
-    Expr* _cast_elements_expr;
+    Expr* _cast_elements_expr = nullptr;
     TypeDescriptor _cast_to_type_desc;
     bool _throw_exception_if_err;
-    ColumnPtr _constant_res;
+    ColumnPtr _constant_res = nullptr;
 };
 
 // Cast JsonArray to array<ANY>
@@ -84,17 +98,27 @@ public:
     ~CastJsonToArray() override = default;
 
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* input_chunk) override;
-    Expr* clone(ObjectPool* pool) const override { return pool->add(new CastJsonToArray(*this)); }
+
+    Expr* clone(ObjectPool* pool) const override {
+        auto cloned = std::unique_ptr<CastJsonToArray>(new CastJsonToArray(*this));
+        if (_cast_elements_expr != nullptr) {
+            cloned->_cast_elements_expr = Expr::copy(pool, _cast_elements_expr);
+        }
+        return pool->add(cloned.release());
+    }
 
 private:
-    Expr* _cast_elements_expr;
+    // Invoked only by clone.
+    CastJsonToArray(const CastJsonToArray& rhs) : Expr(rhs), _cast_to_type_desc(rhs._cast_to_type_desc) {}
+
+    Expr* _cast_elements_expr = nullptr;
     TypeDescriptor _cast_to_type_desc;
 };
 
 // Cast Json to struct<ANY>
 class CastJsonToStruct final : public Expr {
 public:
-    CastJsonToStruct(const TExprNode& node, std::vector<std::unique_ptr<Expr>> field_casts)
+    CastJsonToStruct(const TExprNode& node, std::vector<Expr*> field_casts)
             : Expr(node), _field_casts(std::move(field_casts)) {
         _json_paths.reserve(_type.field_names.size());
         for (int j = 0; j < _type.field_names.size(); j++) {
@@ -107,15 +131,25 @@ public:
         }
     }
 
-    CastJsonToStruct(const CastJsonToStruct& rhs) : Expr(rhs) {}
-
     ~CastJsonToStruct() override = default;
 
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* input_chunk) override;
-    Expr* clone(ObjectPool* pool) const override { return pool->add(new CastJsonToStruct(*this)); }
+    Expr* clone(ObjectPool* pool) const override {
+        auto cloned = std::unique_ptr<CastJsonToStruct>(new CastJsonToStruct(*this));
+        cloned->_field_casts.reserve(_field_casts.size());
+        for (int i = 0; i < _field_casts.size(); ++i) {
+            if (_field_casts[i] != nullptr) {
+                cloned->_field_casts.emplace_back(Expr::copy(pool, _field_casts[i]));
+            }
+        }
+        return pool->add(cloned.release());
+    }
 
 private:
-    std::vector<std::unique_ptr<Expr>> _field_casts;
+    // Invoked only by clone.
+    CastJsonToStruct(const CastJsonToStruct& rhs) : Expr(rhs), _json_paths(rhs._json_paths) {}
+
+    std::vector<Expr*> _field_casts;
     std::vector<JsonPath> _json_paths;
 };
 
@@ -124,19 +158,25 @@ private:
 //   cast ARRAY<tinyint> to ARRAY<int>
 class CastArrayExpr final : public Expr {
 public:
-    CastArrayExpr(const TExprNode& node, std::unique_ptr<Expr> element_cast)
-            : Expr(node), _element_cast(std::move(element_cast)) {}
-
-    CastArrayExpr(const CastArrayExpr& rhs) : Expr(rhs) {}
+    CastArrayExpr(const TExprNode& node, Expr* element_cast) : Expr(node), _element_cast(element_cast) {}
 
     ~CastArrayExpr() override = default;
 
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override;
 
-    Expr* clone(ObjectPool* pool) const override { return pool->add(new CastArrayExpr(*this)); }
+    Expr* clone(ObjectPool* pool) const override {
+        auto cloned = std::unique_ptr<CastArrayExpr>(new CastArrayExpr(*this));
+        if (_element_cast != nullptr) {
+            cloned->_element_cast = Expr::copy(pool, _element_cast);
+        }
+        return pool->add(cloned.release());
+    }
 
 private:
-    std::unique_ptr<Expr> _element_cast;
+    // Invoked only by clone.
+    CastArrayExpr(const CastArrayExpr& rhs) : Expr(rhs) {}
+
+    Expr* _element_cast = nullptr;
 };
 
 // cast one MAP to another MAP.
@@ -146,20 +186,30 @@ private:
 //  Need to refactor these Expressions as Functions
 class CastMapExpr final : public Expr {
 public:
-    CastMapExpr(const TExprNode& node, std::unique_ptr<Expr> key_cast, std::unique_ptr<Expr> value_cast)
-            : Expr(node), _key_cast(std::move(key_cast)), _value_cast(std::move(value_cast)) {}
-
-    CastMapExpr(const CastMapExpr& rhs) : Expr(rhs) {}
+    CastMapExpr(const TExprNode& node, Expr* key_cast, Expr* value_cast)
+            : Expr(node), _key_cast(key_cast), _value_cast(value_cast) {}
 
     ~CastMapExpr() override = default;
 
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override;
 
-    Expr* clone(ObjectPool* pool) const override { return pool->add(new CastMapExpr(*this)); }
+    Expr* clone(ObjectPool* pool) const override {
+        auto cloned = std::unique_ptr<CastMapExpr>(new CastMapExpr(*this));
+        if (_key_cast != nullptr) {
+            cloned->_key_cast = Expr::copy(pool, _key_cast);
+        }
+        if (_value_cast != nullptr) {
+            cloned->_value_cast = Expr::copy(pool, _value_cast);
+        }
+        return pool->add(cloned.release());
+    }
 
 private:
-    std::unique_ptr<Expr> _key_cast;
-    std::unique_ptr<Expr> _value_cast;
+    // Invoked only by clone.
+    CastMapExpr(const CastMapExpr& rhs) : Expr(rhs) {}
+
+    Expr* _key_cast = nullptr;
+    Expr* _value_cast = nullptr;
 };
 
 // cast one STRUCT to another STRUCT.
@@ -167,19 +217,29 @@ private:
 //   cast STRUCT<tinyint, tinyint> to STRUCT<int, int>
 class CastStructExpr final : public Expr {
 public:
-    CastStructExpr(const TExprNode& node, std::vector<std::unique_ptr<Expr>> field_casts)
+    CastStructExpr(const TExprNode& node, std::vector<Expr*> field_casts)
             : Expr(node), _field_casts(std::move(field_casts)) {}
-
-    CastStructExpr(const CastStructExpr& rhs) : Expr(rhs) {}
 
     ~CastStructExpr() override = default;
 
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override;
 
-    Expr* clone(ObjectPool* pool) const override { return pool->add(new CastStructExpr(*this)); }
+    Expr* clone(ObjectPool* pool) const override {
+        auto cloned = std::unique_ptr<CastStructExpr>(new CastStructExpr(*this));
+        cloned->_field_casts.reserve(_field_casts.size());
+        for (int i = 0; i < _field_casts.size(); ++i) {
+            if (_field_casts[i] != nullptr) {
+                cloned->_field_casts.emplace_back(Expr::copy(pool, _field_casts[i]));
+            }
+        }
+        return pool->add(cloned.release());
+    }
 
 private:
-    std::vector<std::unique_ptr<Expr>> _field_casts;
+    // Invoked only by clone.
+    CastStructExpr(const CastStructExpr& rhs) : Expr(rhs) {}
+
+    std::vector<Expr*> _field_casts;
 };
 
 // cast NULL OR Boolean to ComplexType

--- a/test/sql/test_semi/R/test_semi_cast
+++ b/test/sql/test_semi/R/test_semi_cast
@@ -1,0 +1,115 @@
+-- name: test_semi_cast
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) DISTRIBUTED BY HASH(`k1`) BUCKETS 64
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+-- result:
+-- !result
+insert into __row_util_base select * from __row_util_base; -- 20000
+insert into __row_util_base select * from __row_util_base; -- 40000
+insert into __row_util_base select * from __row_util_base; -- 80000
+insert into __row_util_base select * from __row_util_base; -- 160000
+insert into __row_util_base select * from __row_util_base; -- 320000
+insert into __row_util_base select * from __row_util_base; -- 640000
+insert into __row_util_base select * from __row_util_base; -- 1280000
+
+CREATE TABLE __row_util (
+  idx bigint NULL
+) DISTRIBUTED BY HASH(`idx`) BUCKETS 64
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into __row_util select row_number() over() as idx from __row_util_base;
+-- result:
+-- !result
+CREATE TABLE t1 (
+    k1 bigint NULL,
+
+    c_int bigint NULL,
+
+    c_json JSON NULL,
+    c_array_int ARRAY<INT> NULL,
+    c_map MAP<INT, INT> NULL,
+    c_struct STRUCT<k1 INT, k2 INT> NULL
+) DISTRIBUTED BY HASH(`k1`) BUCKETS 64
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t1
+SELECT
+    idx,
+
+    idx,
+
+    json_object('k1', idx, 'k2', idx + 1),
+    [idx, idx + 1, idx + 2, idx + 3],
+    map{0: idx, 1: idx + 1, 2: idx + 2},
+    struct(idx, idx + 1)
+FROM __row_util;
+-- result:
+-- !result
+INSERT INTO t1 (k1) SELECT idx from __row_util order by idx limit 10000;
+-- result:
+-- !result
+select count(1) from t1 where c_int > 0 AND (
+    c_array_int in (cast("[10, 11,12,13]" as array<INT>)) 
+    OR c_array_int in (cast("[20, 21,22,23]" as array<INT>))
+);
+-- result:
+2
+-- !result
+select count(1) from t1 where 
+    c_array_int in (cast(parse_json("[10, 11,12,13]") as array<INT>)) 
+    OR c_array_int in (cast(parse_json("[20, 21,22,23]") as array<INT>));
+-- result:
+2
+-- !result
+select count(1) from t1 where 
+    c_struct in (cast(parse_json("[10, 11]") as struct<k1 INT, k2 INT>)) 
+    OR c_struct not in (cast(parse_json("[20, 21]") as struct<k1 INT, k2 INT>));
+-- result:
+1279999
+-- !result
+select count(1) from t1 where (
+    c_array_int in ([10, 11, 12, 13]) 
+    OR c_array_int not in ([11, 12, 12, 14]) 
+);
+-- result:
+1280000
+-- !result
+select count(1) from t1 where (
+    c_array_int in (cast(['1', 11, 12, 13] as array<int>)) 
+    OR c_array_int not in ([11, 12, 12, 14]) 
+);
+-- result:
+1280000
+-- !result
+select count(1) from t1 where (
+    c_map in (map{0: 10, 1: 10 + 1, 2: 10 + 2}, map{0: 100000, 1: 100000 + 1, 2: 100000 + 2}, map{0: 1000000, 1: 1000000 + 1, 2: 1000000 + 2}) 
+    OR c_map not in (map{0: 10, 1: 10 + 1, 2: 10 + 2}, map{0: 100000, 1: 100000 + 1, 2: 100000 + 2}, map{0: 1000000, 1: 1000000 + 1, 2: 1000000 + 2})
+);
+-- result:
+1280000
+-- !result
+select count(1) from t1 where (
+    c_map in (cast (map{0: '10', 1: 11, 2: 12} as map<int, int>)) 
+    OR c_map in (cast (map{0: '20', 1: 21, 2: 22} as map<int, int>)) 
+);
+-- result:
+2
+-- !result
+select count(1) from t1 where 
+    c_struct in (struct(10, 11)) 
+    OR c_struct not in (struct(20, 21)) ;
+-- result:
+1279999
+-- !result

--- a/test/sql/test_semi/R/test_semi_cast
+++ b/test/sql/test_semi/R/test_semi_cast
@@ -74,6 +74,12 @@ select count(1) from t1 where
 2
 -- !result
 select count(1) from t1 where 
+    c_int in (cast(parse_json("[10, 11,12,13]") as array<INT>)[1]) 
+    OR c_int in (cast(parse_json("[20, 21,22,23]") as array<INT>)[1]);
+-- result:
+2
+-- !result
+select count(1) from t1 where 
     c_struct in (cast(parse_json("[10, 11]") as struct<k1 INT, k2 INT>)) 
     OR c_struct not in (cast(parse_json("[20, 21]") as struct<k1 INT, k2 INT>));
 -- result:
@@ -93,6 +99,12 @@ select count(1) from t1 where (
 -- result:
 1280000
 -- !result
+select count(1) from t1 where 
+    c_int =cast(['1', 11, 12, 13] as array<int>)[1]
+    OR c_int = [11, 12, 12, 14][1];
+-- result:
+2
+-- !result
 select count(1) from t1 where (
     c_map in (map{0: 10, 1: 10 + 1, 2: 10 + 2}, map{0: 100000, 1: 100000 + 1, 2: 100000 + 2}, map{0: 1000000, 1: 1000000 + 1, 2: 1000000 + 2}) 
     OR c_map not in (map{0: 10, 1: 10 + 1, 2: 10 + 2}, map{0: 100000, 1: 100000 + 1, 2: 100000 + 2}, map{0: 1000000, 1: 1000000 + 1, 2: 1000000 + 2})
@@ -100,10 +112,17 @@ select count(1) from t1 where (
 -- result:
 1280000
 -- !result
-select count(1) from t1 where (
+select count(1) from t1 where 
+    c_int > 0 and (
     c_map in (cast (map{0: '10', 1: 11, 2: 12} as map<int, int>)) 
     OR c_map in (cast (map{0: '20', 1: 21, 2: 22} as map<int, int>)) 
 );
+-- result:
+2
+-- !result
+select count(1) from t1 where 
+    c_int = cast (map{0: '10', 1: 11, 2: 12} as map<int, int>)[0]
+    OR c_int = cast (map{0: '20', 1: 21, 2: 22} as map<int, int>)[0];
 -- result:
 2
 -- !result

--- a/test/sql/test_semi/T/test_semi_cast
+++ b/test/sql/test_semi/T/test_semi_cast
@@ -67,6 +67,11 @@ select count(1) from t1 where
     OR c_array_int in (cast(parse_json("[20, 21,22,23]") as array<INT>));
 
 
+select count(1) from t1 where 
+    c_int in (cast(parse_json("[10, 11,12,13]") as array<INT>)[1]) 
+    OR c_int in (cast(parse_json("[20, 21,22,23]") as array<INT>)[1]);
+
+
 -- CastJsonToStruct
 select count(1) from t1 where 
     c_struct in (cast(parse_json("[10, 11]") as struct<k1 INT, k2 INT>)) 
@@ -84,17 +89,25 @@ select count(1) from t1 where (
     OR c_array_int not in ([11, 12, 12, 14]) 
 );
 
+select count(1) from t1 where 
+    c_int =cast(['1', 11, 12, 13] as array<int>)[1]
+    OR c_int = [11, 12, 12, 14][1];
+
 -- CastMapExpr
 select count(1) from t1 where (
     c_map in (map{0: 10, 1: 10 + 1, 2: 10 + 2}, map{0: 100000, 1: 100000 + 1, 2: 100000 + 2}, map{0: 1000000, 1: 1000000 + 1, 2: 1000000 + 2}) 
     OR c_map not in (map{0: 10, 1: 10 + 1, 2: 10 + 2}, map{0: 100000, 1: 100000 + 1, 2: 100000 + 2}, map{0: 1000000, 1: 1000000 + 1, 2: 1000000 + 2})
 );
 
-
-select count(1) from t1 where (
+select count(1) from t1 where 
+    c_int > 0 and (
     c_map in (cast (map{0: '10', 1: 11, 2: 12} as map<int, int>)) 
     OR c_map in (cast (map{0: '20', 1: 21, 2: 22} as map<int, int>)) 
 );
+
+select count(1) from t1 where 
+    c_int = cast (map{0: '10', 1: 11, 2: 12} as map<int, int>)[0]
+    OR c_int = cast (map{0: '20', 1: 21, 2: 22} as map<int, int>)[0];
 
 -- CastStructExpr
 select count(1) from t1 where 

--- a/test/sql/test_semi/T/test_semi_cast
+++ b/test/sql/test_semi/T/test_semi_cast
@@ -1,0 +1,102 @@
+-- name: test_semi_cast
+
+
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) DISTRIBUTED BY HASH(`k1`) BUCKETS 64
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+insert into __row_util_base select * from __row_util_base; -- 20000
+insert into __row_util_base select * from __row_util_base; -- 40000
+insert into __row_util_base select * from __row_util_base; -- 80000
+insert into __row_util_base select * from __row_util_base; -- 160000
+insert into __row_util_base select * from __row_util_base; -- 320000
+insert into __row_util_base select * from __row_util_base; -- 640000
+insert into __row_util_base select * from __row_util_base; -- 1280000
+
+CREATE TABLE __row_util (
+  idx bigint NULL
+) DISTRIBUTED BY HASH(`idx`) BUCKETS 64
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util select row_number() over() as idx from __row_util_base;
+
+
+CREATE TABLE t1 (
+    k1 bigint NULL,
+
+    c_int bigint NULL,
+
+    c_json JSON NULL,
+    c_array_int ARRAY<INT> NULL,
+    c_map MAP<INT, INT> NULL,
+    c_struct STRUCT<k1 INT, k2 INT> NULL
+) DISTRIBUTED BY HASH(`k1`) BUCKETS 64
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t1
+SELECT
+    idx,
+
+    idx,
+
+    json_object('k1', idx, 'k2', idx + 1),
+    [idx, idx + 1, idx + 2, idx + 3],
+    map{0: idx, 1: idx + 1, 2: idx + 2},
+    struct(idx, idx + 1)
+FROM __row_util;
+
+INSERT INTO t1 (k1) SELECT idx from __row_util order by idx limit 10000;
+
+
+-- CastStringToArray
+select count(1) from t1 where c_int > 0 AND (
+    c_array_int in (cast("[10, 11,12,13]" as array<INT>)) 
+    OR c_array_int in (cast("[20, 21,22,23]" as array<INT>))
+);
+
+
+-- CastJsonToArray 
+select count(1) from t1 where 
+    c_array_int in (cast(parse_json("[10, 11,12,13]") as array<INT>)) 
+    OR c_array_int in (cast(parse_json("[20, 21,22,23]") as array<INT>));
+
+
+-- CastJsonToStruct
+select count(1) from t1 where 
+    c_struct in (cast(parse_json("[10, 11]") as struct<k1 INT, k2 INT>)) 
+    OR c_struct not in (cast(parse_json("[20, 21]") as struct<k1 INT, k2 INT>));
+
+
+-- CastArrayExpr
+select count(1) from t1 where (
+    c_array_int in ([10, 11, 12, 13]) 
+    OR c_array_int not in ([11, 12, 12, 14]) 
+);
+
+select count(1) from t1 where (
+    c_array_int in (cast(['1', 11, 12, 13] as array<int>)) 
+    OR c_array_int not in ([11, 12, 12, 14]) 
+);
+
+-- CastMapExpr
+select count(1) from t1 where (
+    c_map in (map{0: 10, 1: 10 + 1, 2: 10 + 2}, map{0: 100000, 1: 100000 + 1, 2: 100000 + 2}, map{0: 1000000, 1: 1000000 + 1, 2: 1000000 + 2}) 
+    OR c_map not in (map{0: 10, 1: 10 + 1, 2: 10 + 2}, map{0: 100000, 1: 100000 + 1, 2: 100000 + 2}, map{0: 1000000, 1: 1000000 + 1, 2: 1000000 + 2})
+);
+
+
+select count(1) from t1 where (
+    c_map in (cast (map{0: '10', 1: 11, 2: 12} as map<int, int>)) 
+    OR c_map in (cast (map{0: '20', 1: 21, 2: 22} as map<int, int>)) 
+);
+
+-- CastStructExpr
+select count(1) from t1 where 
+    c_struct in (struct(10, 11)) 
+    OR c_struct not in (struct(20, 21)) ;


### PR DESCRIPTION
## Why I'm doing:

Some semi-struct `cast` expressions' copy constructors only invoke the base class `Expr`' copy constructor, failing to handle their own member variables—particularly those of type `Expr*` and `std::unique_ptr<Expr>`.  


## What I'm doing:

### `std::unique_ptr<Expr>` -> `Expr*`
Convert all `std::unique_ptr<Expr>` member variables to `Expr*`, managed via ​**`ObjectPool`**.  

​**Reasons**:  
- Expr instances are managed by `ObjectPool` elsewhere; mixing `ObjectPool` with `std::unique_ptr` is inconsistent.  
- The `Expr` class provides only `Expr* clone(ObjectPool*)`, not `std::unique_ptr<Expr> clone()`.  

### ​Fix copy constructor and clone
1. ​**Copy constructor**:  
    - Copies all member variables ​**except**​ `Expr*`-typed ones.  
    - Make copy constructor private to ensure it is only invoked by `clone()`.
2. ​**clone() method**:  
    - Handles the copy of `Expr*`-typed member variables.  


```
#0  0x00002b779db4ca2a in pthread_sigmask () from /lib64/libpthread.so.0
#1  0x00002b779eae790e in PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0] () from /usr/lib/jvm/jdk-17.0.13_centos7_x86_64/lib/server/libjvm.so
#2  0x00002b779eae83ee in JVM_handle_linux_signal () from /usr/lib/jvm/jdk-17.0.13_centos7_x86_64/lib/server/libjvm.so
#3  <signal handler called>
#4  0x00000000047725c8 in starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>::operator-> (this=0x0) at be/src/column/struct_column.cpp:534
#5  starrocks::StructColumn::unfold_const_children (this=0x2b77dd9b6a00, type=...) at be/src/column/struct_column.cpp:534
#6  0x0000000006b02f1f in starrocks::CastStructExpr::evaluate_checked (this=0x2b77ddc3f200, context=0x2b77dd9b6380, ptr=<optimized out>) at be/src/exprs/cast_nested.cpp:89
#7  0x0000000006bf237b in starrocks::VectorizedInConstPredicateGeneric::open (this=0x2b77ddbfd000, state=<optimized out>, context=0x2b77dd9b6380, scope=<optimized out>) at be/src/exprs/in_const_predicate.hpp:451
#8  0x0000000005dac361 in starrocks::ExprContext::open (this=<optimized out>, state=state@entry=0x2b7899cb6000) at be/src/exprs/expr_context.cpp:87
#9  0x000000000481a96d in starrocks::BoxedExpr::expr_context (this=0x2b77dd8f0d60, obj_pool=<optimized out>, state=0x2b7899cb6000) at be/src/exec/olap_scan_prepare.cpp:243
#10 0x00000000048434d7 in starrocks::ChunkPredicateBuilder<starrocks::BoxedExpr, (starrocks::CompoundNodeType)1>::build_column_expr_predicates (this=this@entry=0x2b77d05335a0) at be/src/exec/olap_scan_prepare.cpp:1200
#11 0x000000000488469e in starrocks::ChunkPredicateBuilder<starrocks::BoxedExpr, (starrocks::CompoundNodeType)1>::parse_conjuncts (this=this@entry=0x2b77d05335a0) at be/src/exec/olap_scan_prepare.cpp:273
#12 0x00000000048863f4 in _ZZN9starrocks21ChunkPredicateBuilderINS_16BoxedExprContextELNS_16CompoundNodeTypeE0EE29_normalize_compound_predicateEPKNS_4ExprEENKUlTnS2_vE_clILS2_1EEENS_8StatusOrIbEEv (
    __closure=__closure@entry=0x2b77d0533770) at be/src/exec/olap_scan_prepare.cpp:307
#13 0x00000000048bf651 in starrocks::ChunkPredicateBuilder<starrocks::BoxedExprContext, (starrocks::CompoundNodeType)0>::_normalize_compound_predicate (this=0x2b77a9432d00, root_expr=<optimized out>)
    at be/src/exec/olap_scan_prepare.cpp:318
#14 starrocks::ChunkPredicateBuilder<starrocks::BoxedExprContext, (starrocks::CompoundNodeType)0>::_normalize_compound_predicates (this=this@entry=0x2b77a9432d00) at be/src/exec/olap_scan_prepare.cpp:292
#15 0x00000000048bf8db in starrocks::ChunkPredicateBuilder<starrocks::BoxedExprContext, (starrocks::CompoundNodeType)0>::parse_conjuncts (this=this@entry=0x2b77a9432d00) at be/src/exec/olap_scan_prepare.cpp:273
#16 0x000000000481f739 in starrocks::ScanConjunctsManager::parse_conjuncts (this=this@entry=0x2b77a9432cc0) at be/src/exec/olap_scan_prepare.cpp:1289
#17 0x0000000007faf976 in starrocks::HdfsScanner::_build_scanner_context (this=0x2b77dd8f7800) at be/src/exec/hdfs_scanner.cpp:190
#18 0x0000000007fb0682 in starrocks::HdfsScanner::open (this=this@entry=0x2b77dd8f7800, runtime_state=runtime_state@entry=0x2b7899cb6000) at be/src/exec/hdfs_scanner.cpp:225
#19 0x0000000007f22005 in starrocks::connector::HiveDataSource::_init_scanner (this=0x2b77da35e800, state=<optimized out>) at be/src/connector/hive_connector.cpp:799
#20 0x0000000007f231d1 in starrocks::connector::HiveDataSource::open (this=0x2b77da35e800, state=0x2b7899cb6000) at be/src/connector/hive_connector.cpp:185
#21 0x0000000004c360cc in starrocks::pipeline::ConnectorChunkSource::_open_data_source (this=0x2b7802100c50, state=<optimized out>, mem_alloc_failed=<optimized out>) at be/src/exec/pipeline/scan/connector_scan_operator.cpp:730
#22 0x0000000004c3630d in starrocks::pipeline::ConnectorChunkSource::_read_chunk (this=0x2b7802100c50, state=0x2b7899cb6000, chunk=0x2b77d0534380) at be/src/exec/pipeline/scan/connector_scan_operator.cpp:757
#23 0x000000000501ae70 in starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking (this=0x2b7802100c50, state=0x2b7899cb6000, batch_size=batch_size@entry=64, running_wg=0x2b77f0e1c810)
    at be/src/exec/pipeline/scan/chunk_source.cpp:70
#24 0x0000000004c235bb in operator()<starrocks::workgroup::YieldContext> (__closure=0x2b780231cec0, ctx=...) at be/src/exec/pipeline/scan/scan_operator.cpp:479
#25 0x0000000004d503c9 in std::function<void (starrocks::workgroup::YieldContext&)>::operator()(starrocks::workgroup::YieldContext&) const (this=0x2b77d05348c0, __args#0=...)
    at /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/std_function.h:591
#26 starrocks::workgroup::ScanTask::run (this=0x2b77d0534878) at be/src/exec/workgroup/scan_task_queue.h:97
#27 starrocks::workgroup::ScanExecutor::worker_thread (this=0x2b77aa641ba0) at be/src/exec/workgroup/scan_executor.cpp:76
#28 0x0000000003f5b51f in starrocks::ThreadPool::dispatch_thread (this=0x2b77aa7b7b00) at be/src/util/threadpool.cpp:632
#29 0x0000000003f52af0 in std::function<void ()>::operator()() const (this=0x2b77aa7e3118) at /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/std_function.h:591
#30 starrocks::Thread::supervise_thread (arg=0x2b77aa7e3100) at be/src/util/thread.cpp:366
#31 0x00002b779db47ea5 in start_thread () from /lib64/libpthread.so.0
#32 0x00002b779fceab0d in clone () from /lib64/libc.so.6
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
