### PR TITLE
[BugFix] CREATE DICTIONARY should support USING catalog.db.tbl pattern

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/TableName.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/TableName.java
@@ -61,6 +61,7 @@ import java.util.Objects;
 public class TableName implements Writable, GsonPreProcessable, GsonPostProcessable {
     public static final String LAMBDA_FUNC_TABLE = "__LAMBDA_TABLE";
 
+    @SerializedName(value = "catalog")
     private String catalog;
     @SerializedName(value = "tbl")
     private String tbl;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Dictionary.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Dictionary.java
@@ -17,6 +17,7 @@ package com.starrocks.catalog;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.analysis.TableName;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
@@ -55,7 +56,7 @@ public class Dictionary implements Writable {
     @SerializedName(value = "dbName")
     private String dbName;
     @SerializedName(value = "queryableObject")
-    private String queryableObject;
+    private TableName queryableObject;
 
     @SerializedName(value = "dictionaryKeys")
     private List<String> dictionaryKeys = Lists.newArrayList();
@@ -85,7 +86,7 @@ public class Dictionary implements Writable {
     private long lastSuccessVersion = 0;
     // =============== Runtime parameter ===========================
 
-    public Dictionary(long dictionaryId, String dictionaryName, String queryableObject,
+    public Dictionary(long dictionaryId, String dictionaryName, TableName queryableObject,
                       String catalogName, String dbName, List<String> dictionaryKeys,
                       List<String> dictionaryValues, Map<String, String> properties) {
         this.dictionaryId = dictionaryId;
@@ -128,7 +129,7 @@ public class Dictionary implements Writable {
         return dbName;
     }
 
-    public String getQueryableObject() {
+    public TableName getQueryableObject() {
         return queryableObject;
     }
 
@@ -380,7 +381,7 @@ public class Dictionary implements Writable {
         info.add(dictionaryName);
         info.add(catalogName);
         info.add(dbName);
-        info.add(queryableObject);
+        info.add(queryableObject.toString());
 
         String keys = "";
         String values = "";

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DictionaryCacheSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DictionaryCacheSink.java
@@ -18,6 +18,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.SlotDescriptor;
 import com.starrocks.analysis.SlotId;
+import com.starrocks.analysis.TableName;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.analysis.TupleId;
 import com.starrocks.catalog.Column;
@@ -131,9 +132,9 @@ public class DictionaryCacheSink extends DataSink {
     private TOlapTableSchemaParam buildTSchema() {
         Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(new ConnectContext(),
                                         dictionary.getCatalogName(), dictionary.getDbName());
-        String queryableObject = dictionary.getQueryableObject();
+        TableName queryableObject = dictionary.getQueryableObject();
         Table tbl = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(new ConnectContext(),
-                                        dictionary.getCatalogName(), dictionary.getDbName(), queryableObject);
+                                        queryableObject.getCatalog(), queryableObject.getDb(), queryableObject.getTbl());
         Preconditions.checkNotNull(tbl);
 
         TupleDescriptor tupleDescriptor = new TupleDescriptor(TupleId.createGenerator().getNextId());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DictionaryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DictionaryAnalyzer.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.analyzer;
 
+import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
@@ -47,14 +48,16 @@ public class DictionaryAnalyzer {
                 throw new SemanticException("invalid catalog");
             }
 
-            String queryableObject = statement.getQueryableObject();
+            TableName queryableObject = statement.getQueryableObject();
+            queryableObject.normalization(context);
             Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(context, catalogName, context.getDatabase());
             if (db == null) {
                 throw new SemanticException("USE a Database before CREATE DICTIONARY");
             }
             
             Table tbl = GlobalStateMgr.getCurrentState().getMetadataMgr().
-                                getTable(context, catalogName, context.getDatabase(), queryableObject);
+                                getTable(context, queryableObject.getCatalog(), queryableObject.getDb(),
+                                        queryableObject.getTbl());
             if (tbl == null) {
                 throw new SemanticException(queryableObject + " does not exist");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -1749,8 +1749,9 @@ public class ExpressionAnalyzer {
                         + "invalid parameter: " + params.get(params.size() - 1).toString());
             }
 
+            TableName queryableObject = dictionary.getQueryableObject();
             Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(
-                    session, dictionary.getCatalogName(), dictionary.getDbName(), dictionary.getQueryableObject());
+                    session, queryableObject.getCatalog(), queryableObject.getDb(), queryableObject.getTbl());
             if (table == null) {
                 throw new SemanticException("dict table %s is not found", table.getName());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateDictionaryStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateDictionaryStmt.java
@@ -14,18 +14,19 @@
 
 package com.starrocks.sql.ast;
 
+import com.starrocks.analysis.TableName;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
 import java.util.Map;
 public class CreateDictionaryStmt extends DdlStmt {
     private final String dictionaryName;
-    private final String queryableObject;
+    private final TableName queryableObject;
     private final List<String> dictionaryKeys;
     private final List<String> dictionaryValues;
     private final Map<String, String> properties;
 
-    public CreateDictionaryStmt(String dictionaryName, String queryableObject, List<String> dictionaryKeys,
+    public CreateDictionaryStmt(String dictionaryName, TableName queryableObject, List<String> dictionaryKeys,
                                 List<String> dictionaryValues, Map<String, String> properties, NodePosition pos) {
         super(pos);
         this.dictionaryName = dictionaryName;
@@ -39,7 +40,7 @@ public class CreateDictionaryStmt extends DdlStmt {
         return dictionaryName;
     }
 
-    public String getQueryableObject() {
+    public TableName getQueryableObject() {
         return queryableObject;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -4415,7 +4415,8 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     @Override
     public ParseNode visitCreateDictionaryStatement(StarRocksParser.CreateDictionaryStatementContext context) {
         String dictionaryName = getQualifiedName(context.dictionaryName().qualifiedName()).toString();
-        String queryableObject = getQualifiedName(context.qualifiedName()).toString();
+        QualifiedName qualifiedSrcName = getQualifiedName(context.qualifiedName());
+        TableName queryableObject = qualifiedNameToTableName(qualifiedSrcName);
 
         List<StarRocksParser.DictionaryColumnDescContext> dictionaryColumnDescs = context.dictionaryColumnDesc();
         List<String> dictionaryKeys = new ArrayList<>();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DictionaryMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DictionaryMgrTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.catalog;
 
 import com.google.common.collect.Lists;
+import com.starrocks.analysis.TableName;
 import com.starrocks.persist.DictionaryMgrInfo;
 import com.starrocks.proto.PProcessDictionaryCacheResult;
 import com.starrocks.server.GlobalStateMgr;
@@ -56,7 +57,8 @@ public class DictionaryMgrTest {
         dictionaryKeys.add("key");
         dictionaryValues.add("value");
         Dictionary dictionary =
-                    new Dictionary(1, "dict", "t", "default_catalog", "testDb", dictionaryKeys, dictionaryValues, null);
+                    new Dictionary(1, "dict", new TableName("testDb", "t"), "default_catalog", "testDb",
+                            dictionaryKeys, dictionaryValues, null);
         Map<Long, Dictionary> dictionariesMapById = new HashMap<>();
         dictionariesMapById.put(1L, dictionary);
 

--- a/test/sql/test_dictionary/R/test_dictionary_catalog
+++ b/test/sql/test_dictionary/R/test_dictionary_catalog
@@ -1,0 +1,50 @@
+-- name: test_dict_catalog_operation
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `t_basic_operation` (
+  `id1` BIGINT NOT NULL COMMENT "",
+  `id2` BIGINT NOT NULL COMMENT "",
+  `id3` BIGINT NOT NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "true",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+INSERT INTO t_basic_operation VALUES (1, 2, 3);
+-- result:
+-- !result
+DROP DICTIONARY test_dict_basic_operation;
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: dictionary: test_dict_basic_operation does not exist.')
+-- !result
+CREATE DICTIONARY test_dict_basic_operation USING default_catalog.db_${uuid0}.t_basic_operation (id1 KEY, id2 VALUE);
+-- result:
+-- !result
+function: wait_refresh_dictionary_finish("test_dict_basic_operation", "FINISHED")
+-- result:
+None
+-- !result
+SELECT dictionary_get("test_dict_basic_operation", id1) FROM default_catalog.db_${uuid0}.t_basic_operation;
+-- result:
+{"id2":2}
+-- !result
+SELECT dictionary_get("test_dict_basic_operation", 1);
+-- result:
+{"id2":2}
+-- !result
+DROP DICTIONARY test_dict_basic_operation;
+-- result:
+-- !result
+DROP TABLE t_basic_operation;
+-- result:
+-- !result

--- a/test/sql/test_dictionary/T/test_dictionary_catalog
+++ b/test/sql/test_dictionary/T/test_dictionary_catalog
@@ -1,0 +1,27 @@
+-- name: test_dict_catalog_operation
+create database db_${uuid0};
+use db_${uuid0};
+CREATE TABLE `t_basic_operation` (
+  `id1` BIGINT NOT NULL COMMENT "",
+  `id2` BIGINT NOT NULL COMMENT "",
+  `id3` BIGINT NOT NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "true",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+INSERT INTO t_basic_operation VALUES (1, 2, 3);
+
+DROP DICTIONARY test_dict_basic_operation;
+CREATE DICTIONARY test_dict_basic_operation USING default_catalog.db_${uuid0}.t_basic_operation (id1 KEY, id2 VALUE);
+function: wait_refresh_dictionary_finish("test_dict_basic_operation", "FINISHED")
+
+SELECT dictionary_get("test_dict_basic_operation", id1) FROM default_catalog.db_${uuid0}.t_basic_operation;
+SELECT dictionary_get("test_dict_basic_operation", 1);
+
+DROP DICTIONARY test_dict_basic_operation;
+DROP TABLE t_basic_operation;


### PR DESCRIPTION
## Why I'm doing:

`CREATE DICTIONARY` will fail If you want to use mysql catalog datasoure or other catalog in the DICTIONARY:

`CREATE DICTIONARY dict_obj_mysql USING mysql_jdbc.testdb.testmysql (order_uuid KEY,  order_id_int VALUE);`

simliar issue: https://github.com/StarRocks/starrocks/issues/57659

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1