### PR TITLE
[BugFix] Any user should have usage permission to create mv in default_warehouse

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
@@ -2330,7 +2330,9 @@ public class AuthorizerStmtVisitor implements AstVisitor<Void, ConnectContext> {
             Map<String, String> properties = statement.getProperties();
             if (properties != null && properties.containsKey(PropertyAnalyzer.PROPERTIES_WAREHOUSE)) {
                 String warehouseName = properties.get(PropertyAnalyzer.PROPERTIES_WAREHOUSE);
-                checkWarehouseUsagePrivilege(warehouseName, context);
+                if (!warehouseName.equalsIgnoreCase(WarehouseManager.DEFAULT_WAREHOUSE_NAME)) {
+                    checkWarehouseUsagePrivilege(warehouseName, context);
+                }
             }
 
         } catch (AccessDeniedException e) {


### PR DESCRIPTION

## Why I'm doing:
If you create mv with `PROPERTIES ("warehouse" = "default_warehouse")` with a **non-root user**, you will encounter the error:

`CREATE MATERIALIZED VIEW default_catalog.testsrdb.test_mv1 DISTRIBUTED BY HASH(`order_uuid`) REFRESH ASYNC START('2025-04-08 10:00:00') EVERY (interval 1 day) PROPERTIES ("warehouse" = "default_warehouse") as select * from mysql_jdbc.testdb.testmysql;`


`Access denied; you need (at least one of) the USAGE privilege(s) on WAREHOUSE default_warehouse for this operation. Please ask the admin to grant permission(s) or try activating existing roles using <set [default] role>. Current role(s): NONE. Inactivated role(s): NONE.`


But if you remove the  `PROPERTIES ("warehouse" = "default_warehouse")` and create the mv in the default_warehouse, you will successfully  create the mv.
`CREATE MATERIALIZED VIEW default_catalog.testsrdb.test_mv1 DISTRIBUTED BY HASH(`order_uuid`) REFRESH ASYNC START('2025-04-08 10:00:00') EVERY (interval 1 day)  as select * from mysql_jdbc.testdb.testmysql;`

IMO, Whether user have specified this parameter `PROPERTIES ("warehouse" = "default_warehouse")` or not , 
 user should be have the usage permission to create mv in the `default_warehouse`, no matter 

## What I'm doing:
Skip to check the usage permission in case of `default_warehouse` when creating mv.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1