### PR TITLE
[BugFix] Fix the bug in StarCacheModule where "charge_size" is wrongly used as "value_size"

### DIFF
--- a/be/src/cache/object_cache/starcache_module.cpp
+++ b/be/src/cache/object_cache/starcache_module.cpp
@@ -35,14 +35,14 @@ Status StarCacheModule::insert(const std::string& key, void* value, size_t size,
     };
     Status st;
     if (!options) {
-        st = to_status(_cache->set_object(key, value, charge, obj_deleter, obj_hdl, nullptr));
+        st = to_status(_cache->set_object(key, value, size, obj_deleter, obj_hdl, nullptr));
     } else {
         starcache::WriteOptions opts;
         opts.priority = options->priority;
         opts.ttl_seconds = options->ttl_seconds;
         opts.overwrite = options->overwrite;
         opts.evict_probability = options->evict_probability;
-        st = to_status(_cache->set_object(key, value, charge, obj_deleter, obj_hdl, &opts));
+        st = to_status(_cache->set_object(key, value, size, obj_deleter, obj_hdl, &opts));
     }
     if (!st.ok()) {
         delete obj_hdl;

--- a/be/test/cache/object_cache/starcache_module_test.cpp
+++ b/be/test/cache/object_cache/starcache_module_test.cpp
@@ -105,7 +105,7 @@ TEST_F(StarCacheModuleTest, test_charge_size) {
     size_t mem_size = 4096;
     size_t value_size = sizeof(int);
     void* ptr = malloc(mem_size);
-    int* value = new(ptr) int;
+    int* value = new (ptr) int;
     *value = 10;
     ObjectCacheHandlePtr handle = nullptr;
     ASSERT_OK(_cache->insert("1", (void*)ptr, value_size, mem_size, &Deleter, &handle, nullptr));
@@ -123,7 +123,7 @@ TEST_F(StarCacheModuleTest, test_charge_size_with_write_option) {
     size_t mem_size = 4096;
     size_t value_size = sizeof(int);
     void* ptr = malloc(mem_size);
-    int* value = new(ptr) int;
+    int* value = new (ptr) int;
     *value = 10;
     ObjectCacheHandlePtr handle = nullptr;
     ASSERT_OK(_cache->insert("1", (void*)ptr, value_size, mem_size, &Deleter, &handle, &_write_opt));

--- a/be/test/cache/object_cache/starcache_module_test.cpp
+++ b/be/test/cache/object_cache/starcache_module_test.cpp
@@ -101,6 +101,42 @@ TEST_F(StarCacheModuleTest, insert_success) {
     ASSERT_EQ(_cache->usage(), kv_size * 20);
 }
 
+TEST_F(StarCacheModuleTest, test_charge_size) {
+    size_t mem_size = 4096;
+    size_t value_size = sizeof(int);
+    void* ptr = malloc(mem_size);
+    int* value = new(ptr) int;
+    *value = 10;
+    ObjectCacheHandlePtr handle = nullptr;
+    ASSERT_OK(_cache->insert("1", (void*)ptr, value_size, mem_size, &Deleter, &handle, nullptr));
+    _cache->release(handle);
+
+    ObjectCacheHandlePtr lookup_handle = nullptr;
+    ASSERT_OK(_cache->lookup("1", &lookup_handle, nullptr));
+    auto value_slice = _cache->value_slice(lookup_handle);
+    ASSERT_EQ(value_slice.size, value_size);
+    ASSERT_EQ(*(int*)(value_slice.data + value_slice.size - value_size), 10);
+    _cache->release(lookup_handle);
+}
+
+TEST_F(StarCacheModuleTest, test_charge_size_with_write_option) {
+    size_t mem_size = 4096;
+    size_t value_size = sizeof(int);
+    void* ptr = malloc(mem_size);
+    int* value = new(ptr) int;
+    *value = 10;
+    ObjectCacheHandlePtr handle = nullptr;
+    ASSERT_OK(_cache->insert("1", (void*)ptr, value_size, mem_size, &Deleter, &handle, &_write_opt));
+    _cache->release(handle);
+
+    ObjectCacheHandlePtr lookup_handle = nullptr;
+    ASSERT_OK(_cache->lookup("1", &lookup_handle, nullptr));
+    auto value_slice = _cache->value_slice(lookup_handle);
+    ASSERT_EQ(value_slice.size, value_size);
+    ASSERT_EQ(*(int*)(value_slice.data + value_slice.size - value_size), 10);
+    _cache->release(lookup_handle);
+}
+
 TEST_F(StarCacheModuleTest, insert_with_null_options) {
     std::string key = int_to_string(6, 0);
     int* ptr = (int*)malloc(_value_size);


### PR DESCRIPTION
## Why I'm doing:

Currently interface `StarCache::set_object` only support `value_size` as param, `charge_size` is not supported now.

```
    Status StarCache::set_object(const CacheKey& cache_key, const void* ptr, size_t size, DeleterFunc deleter,
                      ObjectHandle* handle, WriteOptions* options = nullptr);
```

If we wrong pass `charge_size` as `value_size`, later we use `value_slice` to get the data and then decode with `page_slice.size - 4 - footer_size`, the result will be wrong.

```
Slice StarCacheModule::value_slice(ObjectCacheHandlePtr handle) {
    auto obj_hdl = reinterpret_cast<starcache::ObjectHandle*>(handle);
    Slice slice((char*)obj_hdl->ptr(), obj_hdl->size());
    return slice;
}
```

```
        Slice page_slice = handle->data();
        uint32_t footer_size = decode_fixed32_le((uint8_t*)page_slice.data + page_slice.size - 4);
        std::string_view footer_buf{page_slice.data + page_slice.size - 4 - footer_size, footer_size};
```

This modification will lead to errors in cache memory statistics.

This is one template fix, later all interface of cache will only support charge size, the value passed to cache should be self-parsing, then the code can be changed back again.

## What I'm doing:

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
