### PR TITLE
[Enhancement] use histogram to estimate in_predicate cardinality

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsUtils.java
@@ -1,0 +1,207 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.statistics;
+
+import com.starrocks.catalog.Type;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.statistic.StatisticUtils;
+import org.apache.commons.math3.util.Precision;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class HistogramStatisticsUtils {
+
+    public static Statistics estimateInPredicateWithHistogram(
+            ColumnRefOperator columnRefOperator,
+            ColumnStatistic columnStatistic,
+            List<ConstantOperator> constants,
+            boolean isNotIn,
+            Statistics statistics) {
+
+        Histogram histogram = columnStatistic.getHistogram();
+        Map<String, Long> mcv = histogram.getMCV();
+        long histogramTotalRows = histogram.getTotalRows();
+
+        long totalMatchedRows = 0;
+        int matchedConstantsCount = 0;
+        List<Double> validMatchedConstants = new ArrayList<>();
+        boolean isCharFamily = columnRefOperator.getType().getPrimitiveType().isCharFamily();
+
+        for (ConstantOperator constant : constants) {
+            String constantStr = constant.toString();
+            if (constant.getType() == Type.BOOLEAN) {
+                constantStr = constant.getBoolean() ? "1" : "0";
+            }
+
+            if (mcv.containsKey(constantStr)) {
+                totalMatchedRows += mcv.get(constantStr);
+                matchedConstantsCount++;
+            } else {
+                Optional<Long> rowCountInBucket = histogram.getRowCountInBucket(
+                        constant, columnStatistic.getDistinctValuesCount());
+
+                if (rowCountInBucket.isPresent()) {
+                    totalMatchedRows += rowCountInBucket.get();
+                    matchedConstantsCount++;
+                } else {
+                    long estimatedRows = estimateOutOfRangeConstant(columnRefOperator, columnStatistic, constant, histogram);
+                    totalMatchedRows += estimatedRows;
+
+                    if (estimatedRows > 0) {
+                        matchedConstantsCount++;
+                    }
+                }
+            }
+
+            if (!isCharFamily) {
+                Optional<Double> constantValueOpt = StatisticUtils.convertStatisticsToDouble(
+                        constant.getType(), constantStr);
+                constantValueOpt.ifPresent(validMatchedConstants::add);
+            }
+        }
+
+        double selectivity = (double) totalMatchedRows / histogramTotalRows;
+        selectivity = Math.min(1.0, Math.max(0.0, selectivity));
+
+        if (isNotIn) {
+            selectivity = 1.0 - selectivity;
+
+            double nullsFraction = columnStatistic.getNullsFraction();
+            double rowCount = statistics.getOutputRowCount() * (1 - nullsFraction) * selectivity;
+
+            if (Precision.equals(selectivity, 0.0, 0.000001d)) {
+                selectivity = 1 - StatisticsEstimateCoefficient.IN_PREDICATE_DEFAULT_FILTER_COEFFICIENT;
+                rowCount = statistics.getOutputRowCount() * (1 - nullsFraction) * selectivity;
+            }
+
+            double overlapFactor = Math.min(1.0, matchedConstantsCount / columnStatistic.getDistinctValuesCount());
+            double estimatedDistinctValues = columnStatistic.getDistinctValuesCount() * (1 - overlapFactor);
+
+            ColumnStatistic estimatedColumnStatistic = ColumnStatistic.buildFrom(columnStatistic)
+                    .setNullsFraction(0)
+                    .setDistinctValuesCount(Math.max(1, estimatedDistinctValues))
+                    .build();
+
+            Statistics result = Statistics.buildFrom(statistics)
+                    .setOutputRowCount(rowCount)
+                    .addColumnStatistic(columnRefOperator, estimatedColumnStatistic)
+                    .build();
+
+            return StatisticsEstimateUtils.adjustStatisticsByRowCount(result, rowCount);
+        } else {
+            double nullsFraction = columnStatistic.getNullsFraction();
+            double rowCount = statistics.getOutputRowCount() * (1 - nullsFraction) * selectivity;
+
+            if (isCharFamily) {
+                ColumnStatistic estimatedColumnStatistic = ColumnStatistic.buildFrom(columnStatistic)
+                        .setNullsFraction(0)
+                        .setDistinctValuesCount(Math.min(matchedConstantsCount, columnStatistic.getDistinctValuesCount()))
+                        .build();
+
+                Statistics result = Statistics.buildFrom(statistics)
+                        .setOutputRowCount(rowCount)
+                        .addColumnStatistic(columnRefOperator, estimatedColumnStatistic)
+                        .build();
+
+                return StatisticsEstimateUtils.adjustStatisticsByRowCount(result, rowCount);
+            } else {
+                if (validMatchedConstants.isEmpty()) {
+                    ColumnStatistic estimatedColumnStatistic = ColumnStatistic.buildFrom(columnStatistic)
+                            .setNullsFraction(0)
+                            .setDistinctValuesCount(Math.min(matchedConstantsCount, columnStatistic.getDistinctValuesCount()))
+                            .build();
+
+                    Statistics result = Statistics.buildFrom(statistics)
+                            .setOutputRowCount(rowCount)
+                            .addColumnStatistic(columnRefOperator, estimatedColumnStatistic)
+                            .build();
+
+                    return StatisticsEstimateUtils.adjustStatisticsByRowCount(result, rowCount);
+                }
+
+                double constantsMin = Collections.min(validMatchedConstants);
+                double constantsMax = Collections.max(validMatchedConstants);
+
+                double columnMin = columnStatistic.getMinValue();
+                double columnMax = columnStatistic.getMaxValue();
+
+                double newMin = Math.max(columnMin, constantsMin);
+                double newMax = Math.min(columnMax, constantsMax);
+
+                if (newMin > newMax) {
+                    newMin = constantsMin;
+                    newMax = constantsMax;
+                }
+
+                ColumnStatistic estimatedColumnStatistic = ColumnStatistic.buildFrom(columnStatistic)
+                        .setNullsFraction(0)
+                        .setMinValue(newMin)
+                        .setMaxValue(newMax)
+                        .setDistinctValuesCount(Math.min(matchedConstantsCount, columnStatistic.getDistinctValuesCount()))
+                        .build();
+
+                Statistics result = Statistics.buildFrom(statistics)
+                        .setOutputRowCount(rowCount)
+                        .addColumnStatistic(columnRefOperator, estimatedColumnStatistic)
+                        .build();
+
+                return StatisticsEstimateUtils.adjustStatisticsByRowCount(result, rowCount);
+            }
+        }
+    }
+
+    private static long estimateOutOfRangeConstant(
+            ColumnRefOperator columnRefOperator, ColumnStatistic columnStatistic,
+            ConstantOperator constant, Histogram histogram) {
+
+        long mcvRowCount = histogram.getMCV().values().stream().mapToLong(Long::longValue).sum();
+        long totalRows = histogram.getTotalRows();
+        double ndv = columnStatistic.getDistinctValuesCount();
+        double mcvCount = histogram.getMCV().size();
+
+        if (columnRefOperator.getType().getPrimitiveType().isCharFamily()) {
+            double avgRowsPerValue = totalRows / ndv;
+            double sparsityFactor = 0.1;
+            return Math.max(1, Math.round(avgRowsPerValue * sparsityFactor));
+        } else {
+            Optional<Double> constantValueOpt = StatisticUtils.convertStatisticsToDouble(
+                    constant.getType(), constant.toString());
+
+            if (constantValueOpt.isPresent()) {
+                double constantValue = constantValueOpt.get();
+                double minValue = columnStatistic.getMinValue();
+                double maxValue = columnStatistic.getMaxValue();
+
+                if (constantValue < minValue || constantValue > maxValue) {
+                    return 0;
+                }
+            }
+
+            long nonMcvRows = totalRows - mcvRowCount;
+
+            double nonMcvNdv = Math.max(1.0, ndv - mcvCount);
+            double avgRowsPerNonMcvValue = nonMcvRows / nonMcvNdv;
+            double outOfRangeFactor = 0.1;
+
+            return Math.max(1, Math.round(avgRowsPerNonMcvValue * outOfRangeFactor));
+        }
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
@@ -72,4 +72,7 @@ public class StatisticsEstimateCoefficient {
     public static final double MAXIMUM_ROW_COUNT = Double.MAX_VALUE / Math.pow(10, 100);
 
     public static final double MAXIMUM_OUTPUT_SIZE = Double.MAX_VALUE / Math.pow(10, 80);
+
+    // used to estimate the cardinality of values not explicitly represented in the histogram.
+    public static final double HISTOGRAM_UNREPRESENTED_VALUE_COEFFICIENT = 0.1;
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculatorTest.java
@@ -28,10 +28,12 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
 
 public class PredicateStatisticsCalculatorTest {
     @Test
-    public void testDateBinaryPredicate() throws Exception {
+    public void testDateBinaryPredicate() {
         Statistics.Builder builder = Statistics.builder();
         builder.setOutputRowCount(1000);
         double min = Utils.getLongFromDateTime(LocalDateTime.of(2020, 1, 1, 0, 0, 0));
@@ -126,5 +128,215 @@ public class PredicateStatisticsCalculatorTest {
                 .setOutputRowCount(10000).build();
         ColumnStatistic estimatedStatistics = ExpressionStatisticCalculator.calculate(concat, statistics);
         Assert.assertEquals(0.52, estimatedStatistics.getNullsFraction(), 0.001);
+    }
+
+    @Test
+    public void testEstimateInPredicateWithHistogramNumeric() {
+        ColumnRefOperator columnRef = new ColumnRefOperator(1, Type.INT, "c1", true);
+
+        List<Bucket> buckets = Lists.newArrayList(
+                new Bucket(1, 9, 100L, 20L),
+                new Bucket(11, 19, 200L, 30L),
+                new Bucket(21, 29, 300L, 40L)
+        );
+
+        Map<String, Long> mcv = new java.util.HashMap<>();
+        mcv.put("10", 50L);
+        mcv.put("20", 60L);
+        mcv.put("30", 70L);
+        mcv.put("35", 80L);
+
+        Histogram histogram = new Histogram(buckets, mcv);
+
+        ColumnStatistic columnStatistic = ColumnStatistic.builder()
+                .setMinValue(1)
+                .setMaxValue(40)
+                .setDistinctValuesCount(30)
+                .setNullsFraction(0.1)
+                .setHistogram(histogram)
+                .build();
+
+        Statistics statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(columnRef, columnStatistic)
+                .build();
+
+        List<ConstantOperator> constants = Lists.newArrayList(
+                ConstantOperator.createInt(10),
+                ConstantOperator.createInt(15),
+                ConstantOperator.createInt(30),
+                ConstantOperator.createInt(50)
+        );
+
+        Statistics result = HistogramStatisticsUtils.estimateInPredicateWithHistogram(
+                columnRef, columnStatistic, constants, false, statistics);
+
+        Assert.assertEquals(207, (int) result.getOutputRowCount());
+        Assert.assertEquals(3, result.getColumnStatistic(columnRef).getDistinctValuesCount(), 0.001);
+        Assert.assertEquals(0, result.getColumnStatistic(columnRef).getNullsFraction(), 0.001);
+        Assert.assertEquals(10, result.getColumnStatistic(columnRef).getMinValue(), 0.001);
+        Assert.assertEquals(30, result.getColumnStatistic(columnRef).getMaxValue(), 0.001);
+    }
+
+    @Test
+    public void testEstimateNotInPredicateWithHistogram() {
+        ColumnRefOperator columnRef = new ColumnRefOperator(3, Type.BIGINT, "c3", true);
+
+        List<Bucket> buckets = List.of(
+                new Bucket(101, 149, 150L, 25L),
+                new Bucket(151, 199, 200L, 30L),
+                new Bucket(201, 249, 250L, 35L),
+                new Bucket(251, 299, 300L, 40L)
+        );
+
+        Map<String, Long> mcv = Map.of(
+                "100", 100L,
+                "150", 120L,
+                "200", 140L,
+                "250", 160L,
+                "300", 180L
+        );
+
+        Histogram histogram = new Histogram(buckets, mcv);
+
+        ColumnStatistic columnStatistic = ColumnStatistic.builder()
+                .setMinValue(100)
+                .setMaxValue(300)
+                .setDistinctValuesCount(50)
+                .setNullsFraction(0.05)
+                .setHistogram(histogram)
+                .build();
+
+        Statistics statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(columnRef, columnStatistic)
+                .build();
+
+        List<ConstantOperator> constants = List.of(
+                ConstantOperator.createBigint(100),
+                ConstantOperator.createBigint(150),
+                ConstantOperator.createBigint(225)
+        );
+
+        Statistics result = HistogramStatisticsUtils.estimateInPredicateWithHistogram(
+                columnRef, columnStatistic, constants, true, statistics);
+
+        Assert.assertEquals(740, (int) result.getOutputRowCount());
+        Assert.assertEquals(47, (int) result.getColumnStatistic(columnRef).getDistinctValuesCount());
+        Assert.assertEquals(0, result.getColumnStatistic(columnRef).getNullsFraction(), 0.001);
+    }
+
+    @Test
+    public void testEstimateInPredicateWithStringType() {
+        ColumnRefOperator columnRef = new ColumnRefOperator(2, Type.VARCHAR, "c2", true);
+
+        Map<String, Long> mcv = Map.of(
+                "apple", 50L,
+                "banana", 60L,
+                "orange", 70L,
+                "peach", 80L,
+                "grape", 90L
+        );
+
+        Histogram histogram = new Histogram(List.of(), mcv);
+
+        ColumnStatistic columnStatistic = ColumnStatistic.builder()
+                .setDistinctValuesCount(40)
+                .setNullsFraction(0.08)
+                .setHistogram(histogram)
+                .build();
+
+        Statistics statistics = Statistics.builder()
+                .setOutputRowCount(1200)
+                .addColumnStatistic(columnRef, columnStatistic)
+                .build();
+
+        List<ConstantOperator> constants = List.of(
+                ConstantOperator.createVarchar("apple"),
+                ConstantOperator.createVarchar("banana"),
+                ConstantOperator.createVarchar("cherry")
+        );
+
+        Statistics result = HistogramStatisticsUtils.estimateInPredicateWithHistogram(
+                columnRef, columnStatistic, constants, false, statistics);
+
+        Assert.assertEquals(350, (int) result.getOutputRowCount());
+        Assert.assertEquals(3, result.getColumnStatistic(columnRef).getDistinctValuesCount(), 0.001);
+        Assert.assertEquals(0, result.getColumnStatistic(columnRef).getNullsFraction(), 0.001);
+    }
+
+    @Test
+    public void testEstimateInPredicateWithBooleanType() {
+        ColumnRefOperator columnRef = new ColumnRefOperator(6, Type.BOOLEAN, "c6", true);
+
+        Map<String, Long> mcv = Map.of(
+                "1", 600L,
+                "0", 300L
+        );
+
+        Histogram histogram = new Histogram(List.of(), mcv);
+
+        ColumnStatistic columnStatistic = ColumnStatistic.builder()
+                .setDistinctValuesCount(2)
+                .setNullsFraction(0.1)
+                .setHistogram(histogram)
+                .build();
+
+        Statistics statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(columnRef, columnStatistic)
+                .build();
+
+        List<ConstantOperator> constants = List.of(
+                ConstantOperator.createBoolean(true)
+        );
+
+        Statistics result = HistogramStatisticsUtils.estimateInPredicateWithHistogram(
+                columnRef, columnStatistic, constants, false, statistics);
+
+        Assert.assertEquals(600, (int) result.getOutputRowCount());
+        Assert.assertEquals(1, result.getColumnStatistic(columnRef).getDistinctValuesCount(), 0.001);
+        Assert.assertEquals(0, result.getColumnStatistic(columnRef).getNullsFraction(), 0.001);
+    }
+
+    @Test
+    public void testEstimateInPredicateWithOutOfRangeConstants() {
+        ColumnRefOperator columnRef = new ColumnRefOperator(7, Type.INT, "c7", true);
+
+        List<Bucket> buckets = Lists.newArrayList(
+                new Bucket(10, 19, 100L, 10L),
+                new Bucket(21, 29, 200L, 20L)
+        );
+
+        Map<String, Long> mcv = Map.of(
+                "20", 50L,
+                "30", 60L
+        );
+
+        Histogram histogram = new Histogram(buckets, mcv);
+
+        ColumnStatistic columnStatistic = ColumnStatistic.builder()
+                .setMinValue(10)
+                .setMaxValue(30)
+                .setDistinctValuesCount(20)
+                .setNullsFraction(0.1)
+                .setHistogram(histogram)
+                .build();
+
+        Statistics statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(columnRef, columnStatistic)
+                .build();
+
+        List<ConstantOperator> constants = Lists.newArrayList(
+                ConstantOperator.createInt(5),
+                ConstantOperator.createInt(35)
+        );
+
+        Statistics result = HistogramStatisticsUtils.estimateInPredicateWithHistogram(
+                columnRef, columnStatistic, constants, false, statistics);
+
+        Assert.assertEquals(1, (int) result.getOutputRowCount());
+        Assert.assertEquals(0, result.getColumnStatistic(columnRef).getNullsFraction(), 0.001);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculatorTest.java
@@ -52,7 +52,7 @@ public class PredicateStatisticsCalculatorTest {
     }
 
     @Test
-    public void testDateCompoundPredicate() throws Exception {
+    public void testDateCompoundPredicate() {
         Statistics.Builder builder = Statistics.builder();
         builder.setOutputRowCount(1000);
         double min = Utils.getLongFromDateTime(LocalDateTime.of(2020, 1, 1, 0, 0, 0));

--- a/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q16.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q16.sql
@@ -11,7 +11,7 @@ column statistics:
 * P_BRAND-->[-Infinity, Infinity, 0.0, 10.0, 25.0] ESTIMATE
 * P_TYPE-->[-Infinity, Infinity, 0.0, 25.0, 150.0] ESTIMATE
 * P_SIZE-->[1.0, 43.0, 0.0, 4.0, 8.0] ESTIMATE
-* count-->[0.0, 6914952.0, 0.0, 8.0, 7119.140625] ESTIMATE
+* count-->[0.0, 6853797.89325, 0.0, 8.0, 7119.140625] ESTIMATE
 
 PLAN FRAGMENT 1(F05)
 
@@ -27,7 +27,7 @@ OutPut Exchange Id: 15
 |  * P_BRAND-->[-Infinity, Infinity, 0.0, 10.0, 25.0] ESTIMATE
 |  * P_TYPE-->[-Infinity, Infinity, 0.0, 25.0, 150.0] ESTIMATE
 |  * P_SIZE-->[1.0, 43.0, 0.0, 4.0, 8.0] ESTIMATE
-|  * count-->[0.0, 6914952.0, 0.0, 8.0, 7119.140625] ESTIMATE
+|  * count-->[0.0, 6853797.89325, 0.0, 8.0, 7119.140625] ESTIMATE
 |
 13:AGGREGATE (update finalize)
 |  aggregate: count[([2: PS_SUPPKEY, INT, false]); args: INT; result: BIGINT; args nullable: false; result nullable: false]
@@ -37,11 +37,11 @@ OutPut Exchange Id: 15
 |  * P_BRAND-->[-Infinity, Infinity, 0.0, 10.0, 25.0] ESTIMATE
 |  * P_TYPE-->[-Infinity, Infinity, 0.0, 25.0, 150.0] ESTIMATE
 |  * P_SIZE-->[1.0, 43.0, 0.0, 4.0, 8.0] ESTIMATE
-|  * count-->[0.0, 6914952.0, 0.0, 8.0, 7119.140625] ESTIMATE
+|  * count-->[0.0, 6853797.89325, 0.0, 8.0, 7119.140625] ESTIMATE
 |
 12:AGGREGATE (merge serialize)
 |  group by: [2: PS_SUPPKEY, INT, false], [10: P_BRAND, VARCHAR, false], [11: P_TYPE, VARCHAR, false], [12: P_SIZE, INT, false]
-|  cardinality: 6914952
+|  cardinality: 6853798
 |  column statistics:
 |  * PS_SUPPKEY-->[1.0, 1000000.0, 0.0, 8.0, 250000.0] ESTIMATE
 |  * P_BRAND-->[-Infinity, Infinity, 0.0, 10.0, 25.0] ESTIMATE
@@ -51,7 +51,7 @@ OutPut Exchange Id: 15
 11:EXCHANGE
 distribution type: SHUFFLE
 partition exprs: [10: P_BRAND, VARCHAR, false], [11: P_TYPE, VARCHAR, false], [12: P_SIZE, INT, false]
-cardinality: 6914952
+cardinality: 6853798
 
 PLAN FRAGMENT 2(F00)
 
@@ -62,7 +62,7 @@ OutPut Exchange Id: 11
 10:AGGREGATE (update serialize)
 |  STREAMING
 |  group by: [2: PS_SUPPKEY, INT, false], [10: P_BRAND, VARCHAR, false], [11: P_TYPE, VARCHAR, false], [12: P_SIZE, INT, false]
-|  cardinality: 6914952
+|  cardinality: 6853798
 |  column statistics:
 |  * PS_SUPPKEY-->[1.0, 1000000.0, 0.0, 8.0, 250000.0] ESTIMATE
 |  * P_BRAND-->[-Infinity, Infinity, 0.0, 10.0, 25.0] ESTIMATE
@@ -75,7 +75,7 @@ OutPut Exchange Id: 11
 |  10 <-> [10: P_BRAND, VARCHAR, false]
 |  11 <-> [11: P_TYPE, VARCHAR, false]
 |  12 <-> [12: P_SIZE, INT, false]
-|  cardinality: 6914952
+|  cardinality: 6853798
 |  column statistics:
 |  * PS_SUPPKEY-->[1.0, 1000000.0, 0.0, 8.0, 250000.0] ESTIMATE
 |  * P_BRAND-->[-Infinity, Infinity, 0.0, 10.0, 25.0] ESTIMATE
@@ -86,7 +86,7 @@ OutPut Exchange Id: 11
 |  join op: NULL AWARE LEFT ANTI JOIN (BROADCAST)
 |  equal join conjunct: [2: PS_SUPPKEY, INT, false] = [17: S_SUPPKEY, INT, false]
 |  output columns: 2, 10, 11, 12
-|  cardinality: 6914952
+|  cardinality: 6853798
 |  column statistics:
 |  * PS_SUPPKEY-->[1.0, 1000000.0, 0.0, 8.0, 250000.0] ESTIMATE
 |  * P_BRAND-->[-Infinity, Infinity, 0.0, 10.0, 25.0] ESTIMATE
@@ -104,7 +104,7 @@ OutPut Exchange Id: 11
 |  10 <-> [10: P_BRAND, CHAR, false]
 |  11 <-> [11: P_TYPE, VARCHAR, false]
 |  12 <-> [12: P_SIZE, INT, false]
-|  cardinality: 9219936
+|  cardinality: 9138397
 |  column statistics:
 |  * PS_SUPPKEY-->[1.0, 1000000.0, 0.0, 8.0, 1000000.0] ESTIMATE
 |  * P_BRAND-->[-Infinity, Infinity, 0.0, 10.0, 25.0] ESTIMATE
@@ -117,11 +117,11 @@ OutPut Exchange Id: 11
 |  build runtime filters:
 |  - filter_id = 0, build_expr = (7: P_PARTKEY), remote = false
 |  output columns: 2, 10, 11, 12
-|  cardinality: 9219936
+|  cardinality: 9138397
 |  column statistics:
-|  * PS_PARTKEY-->[1.0, 2.0E7, 0.0, 8.0, 2304984.0] ESTIMATE
+|  * PS_PARTKEY-->[1.0, 2.0E7, 0.0, 8.0, 2284599.29775] ESTIMATE
 |  * PS_SUPPKEY-->[1.0, 1000000.0, 0.0, 8.0, 1000000.0] ESTIMATE
-|  * P_PARTKEY-->[1.0, 2.0E7, 0.0, 8.0, 2304984.0] ESTIMATE
+|  * P_PARTKEY-->[1.0, 2.0E7, 0.0, 8.0, 2284599.29775] ESTIMATE
 |  * P_BRAND-->[-Infinity, Infinity, 0.0, 10.0, 25.0] ESTIMATE
 |  * P_TYPE-->[-Infinity, Infinity, 0.0, 25.0, 150.0] ESTIMATE
 |  * P_SIZE-->[1.0, 43.0, 0.0, 4.0, 8.0] ESTIMATE
@@ -129,7 +129,7 @@ OutPut Exchange Id: 11
 |----2:EXCHANGE
 |       distribution type: SHUFFLE
 |       partition exprs: [7: P_PARTKEY, INT, false]
-|       cardinality: 2304984
+|       cardinality: 2284599
 |
 0:OlapScanNode
 table: partsupp, rollup: partsupp
@@ -179,9 +179,9 @@ preAggregation: on
 Predicates: [10: P_BRAND, CHAR, false] != 'Brand#43', NOT (11: P_TYPE LIKE 'PROMO BURNISHED%'), 12: P_SIZE IN (31, 43, 9, 6, 18, 11, 25, 1)
 partitionsRatio=1/1, tabletsRatio=10/10
 actualRows=0, avgRowSize=47.0
-cardinality: 2304984
+cardinality: 2284599
 column statistics:
-* P_PARTKEY-->[1.0, 2.0E7, 0.0, 8.0, 2304984.0] ESTIMATE
+* P_PARTKEY-->[1.0, 2.0E7, 0.0, 8.0, 2284599.29775] ESTIMATE
 * P_BRAND-->[-Infinity, Infinity, 0.0, 10.0, 25.0] MCV: [[Brand#35:823300][Brand#12:816700][Brand#52:815800][Brand#33:814100][Brand#53:808800]] ESTIMATE
 * P_TYPE-->[-Infinity, Infinity, 0.0, 25.0, 150.0] MCV: [[ECONOMY ANODIZED STEEL:145100][LARGE PLATED STEEL:143400][PROMO BRUSHED BRASS:142000][LARGE PLATED BRASS:141500][MEDIUM BURNISHED COPPER:141500]] ESTIMATE
 * P_SIZE-->[1.0, 43.0, 0.0, 4.0, 8.0] MCV: [[10:417700][14:415300][30:412700][3:412300][16:410300]] ESTIMATE


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
using histogram to estimate in_predicate cardinality. Only support `in values (constants)`

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
