### PR TITLE
[Enhancement] Use uuid instead of table create time when selecting paimon (backport #57578)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PaimonTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PaimonTable.java
@@ -48,7 +48,7 @@ public class PaimonTable extends Table {
     }
 
     public PaimonTable(String catalogName, String dbName, String tblName, List<Column> schema,
-                       org.apache.paimon.table.Table paimonNativeTable, long createTime) {
+                       org.apache.paimon.table.Table paimonNativeTable) {
         super(CONNECTOR_ID_GENERATOR.getNextId().asInt(), tblName, TableType.PAIMON, schema);
         this.catalogName = catalogName;
         this.databaseName = dbName;
@@ -58,7 +58,6 @@ public class PaimonTable extends Table {
         this.paimonFieldNames = paimonNativeTable.rowType().getFields().stream()
                 .map(DataField::name)
                 .collect(Collectors.toList());
-        this.createTime = createTime;
     }
 
     @Override
@@ -87,7 +86,7 @@ public class PaimonTable extends Table {
 
     @Override
     public String getUUID() {
-        return String.join(".", catalogName, databaseName, tableName, Long.toString(createTime));
+        return String.join(".", catalogName, databaseName, tableName, paimonNativeTable.uuid());
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/PaimonTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/PaimonTableTest.java
@@ -62,8 +62,7 @@ public class PaimonTableTest {
                 result = partitions;
             }
         };
-        PaimonTable paimonTable = new PaimonTable("testCatalog", "testDB", "testTable", fullSchema,
-                paimonNativeTable, 100L);
+        PaimonTable paimonTable = new PaimonTable("testCatalog", "testDB", "testTable", fullSchema, paimonNativeTable);
         Map<String, String> properties = paimonTable.getProperties();
         Assert.assertEquals(0, properties.size());
         List<Column> partitionColumns = paimonTable.getPartitionColumns();
@@ -88,8 +87,7 @@ public class PaimonTableTest {
         };
         String dbName = "testDB";
         String tableName = "testTable";
-        PaimonTable paimonTable = new PaimonTable("testCatalog", dbName, tableName, fullSchema,
-                paimonNativeTable, 100L);
+        PaimonTable paimonTable = new PaimonTable("testCatalog", dbName, tableName, fullSchema, paimonNativeTable);
 
         TTableDescriptor tTableDescriptor = paimonTable.toThrift(null);
         Assert.assertEquals(tTableDescriptor.getDbName(), dbName);
@@ -100,10 +98,8 @@ public class PaimonTableTest {
     public void testEquals(@Mocked FileStoreTable paimonNativeTable) {
         String dbName = "testDB";
         String tableName = "testTable";
-        PaimonTable table = new PaimonTable("testCatalog", dbName, tableName, null,
-                paimonNativeTable, 100L);
-        PaimonTable table2 = new PaimonTable("testCatalog", dbName, tableName, null,
-                paimonNativeTable, 100L);
+        PaimonTable table = new PaimonTable("testCatalog", dbName, tableName, null, paimonNativeTable);
+        PaimonTable table2 = new PaimonTable("testCatalog", dbName, tableName, null, paimonNativeTable);
         Assert.assertEquals(table, table2);
         Assert.assertEquals(table, table);
         Assert.assertNotEquals(table, null);

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/PaimonPartitionsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/PaimonPartitionsProcDirTest.java
@@ -74,7 +74,7 @@ public class PaimonPartitionsProcDirTest {
 
             @Mock
             public Table getTable(String catalogName, String dbName, String tblName) {
-                return new PaimonTable("paimon_catalog", "db1", "tb1", null, nativeTable, 1L);
+                return new PaimonTable("paimon_catalog", "db1", "tb1", null, nativeTable);
             }
 
             @Mock

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -86,7 +86,6 @@ import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableScan;
 import org.apache.paimon.table.system.ManifestsTable;
-import org.apache.paimon.table.system.SchemasTable;
 import org.apache.paimon.table.system.SnapshotsTable;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.BooleanType;
@@ -174,12 +173,6 @@ public class PaimonMetadataTest {
         List<DataField> fields = new ArrayList<>();
         fields.add(new DataField(1, "col2", new IntType(true)));
         fields.add(new DataField(2, "col3", new DoubleType(false)));
-        new MockUp<PaimonMetadata>() {
-            @Mock
-            public long getTableCreateTime(String dbName, String tblName) {
-                return 0L;
-            }
-        };
         new Expectations() {
             {
                 paimonNativeCatalog.getTable((Identifier) any);
@@ -204,7 +197,7 @@ public class PaimonMetadataTest {
         Assert.assertEquals(ScalarType.DOUBLE, paimonTable.getBaseSchema().get(1).getType());
         Assert.assertTrue(paimonTable.getBaseSchema().get(1).isAllowNull());
         Assert.assertEquals("paimon_catalog", paimonTable.getCatalogName());
-        Assert.assertEquals("paimon_catalog.db1.tbl1.0", paimonTable.getUUID());
+        Assert.assertEquals("paimon_catalog.db1.tbl1.null", paimonTable.getUUID());
     }
 
     @Test
@@ -312,12 +305,6 @@ public class PaimonMetadataTest {
                                    @Mocked ReadBuilder readBuilder,
                                    @Mocked InnerTableScan scan)
             throws Catalog.TableNotExistException {
-        new MockUp<PaimonMetadata>() {
-            @Mock
-            public long getTableCreateTime(String dbName, String tblName) {
-                return 0L;
-            }
-        };
         new Expectations() {
             {
                 paimonNativeCatalog.getTable((Identifier) any);
@@ -520,63 +507,6 @@ public class PaimonMetadataTest {
     }
 
     @Test
-    public void testGetCreateTime(@Mocked SchemasTable schemasTable,
-                                  @Mocked RecordReader<InternalRow> recordReader) throws Exception {
-        RowType rowType = new RowType(Arrays.asList(
-                new DataField(0, "schema_id", new BigIntType(false)),
-                new DataField(1, "fields", SerializationUtils.newStringType(false)),
-                new DataField(2, "partition_keys", SerializationUtils.newStringType(false)),
-                new DataField(3, "primary_keys", SerializationUtils.newStringType(false)),
-                new DataField(4, "options", SerializationUtils.newStringType(false)),
-                new DataField(5, "comment", SerializationUtils.newStringType(true)),
-                new DataField(6, "update_time", new TimestampType(false, 3))));
-
-        GenericRow row1 = new GenericRow(2);
-        row1.setField(0, (long) 0);
-        row1.setField(1, Timestamp.fromLocalDateTime(LocalDateTime.of(2023, 1, 1, 0, 0, 0, 0)));
-
-        GenericRow row2 = new GenericRow(2);
-        row2.setField(1, (long) 1);
-        row2.setField(1, Timestamp.fromLocalDateTime(LocalDateTime.of(2023, 2, 1, 0, 0, 0, 0)));
-
-        new MockUp<RecordReaderIterator>() {
-            private int callCount;
-            private final GenericRow[] elements = {row1, row2};
-            private final boolean[] hasNextOutputs = {true, true, false};
-
-            @Mock
-            public boolean hasNext() {
-                if (callCount < hasNextOutputs.length) {
-                    return hasNextOutputs[callCount];
-                }
-                return false;
-            }
-
-            @Mock
-            public InternalRow next() {
-                if (callCount < elements.length) {
-                    return elements[callCount++];
-                }
-                return null;
-            }
-        };
-        new Expectations() {
-            {
-                paimonNativeCatalog.getTable((Identifier) any);
-                result = schemasTable;
-                schemasTable.rowType();
-                result = rowType;
-                schemasTable.newReadBuilder().withProjection((int[]) any)
-                        .withFilter((Predicate) any).newRead().createReader((TableScan.Plan) any);
-                result = recordReader;
-            }
-        };
-
-        long createTime = metadata.getTableCreateTime("db1", "tbl1");
-        Assert.assertEquals(1672531200000L, createTime);
-    }
-
-    @Test
     public void testGetUpdateTime(@Mocked SnapshotsTable snapshotsTable,
                                   @Mocked RecordReader<InternalRow> recordReader) throws Exception {
         RowType rowType = new RowType(Arrays.asList(
@@ -639,12 +569,6 @@ public class PaimonMetadataTest {
                         .setFiles(Lists.newArrayList(PaimonRemoteFileDesc.createPaimonRemoteFileDesc(
                                 new PaimonSplitsInfo(null, Lists.newArrayList((Split) splits.get(0))))))
                         .build());
-            }
-        };
-        new MockUp<PaimonMetadata>() {
-            @Mock
-            public long getTableCreateTime(String dbName, String tblName) {
-                return 0L;
             }
         };
 
@@ -759,7 +683,7 @@ public class PaimonMetadataTest {
             }
         };
         PaimonTable paimonTable =
-                new PaimonTable("paimon", "db1", "tbl1", Lists.newArrayList(), nativeTable, 1723081832L);
+                new PaimonTable("paimon", "db1", "tbl1", Lists.newArrayList(), nativeTable);
         new ConnectContext().setThreadLocalInfo();
         ConnectContext.get().getSessionVariable().setEnablePaimonColumnStatistics(true);
 
@@ -784,6 +708,5 @@ public class PaimonMetadataTest {
                 metadata.getTableStatistics(new OptimizerContext(null, null, ConnectContext.get()), paimonTable,
                         colRefToColumnMetaMap, null, null, -1, null);
         Assert.assertEquals(tableStatistics.getColumnStatistics().size(), colRefToColumnMetaMap.size());
-
     }
 }


### PR DESCRIPTION


## Why I'm doing:

## What I'm doing:

Backport #57578

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1

