### PR TITLE
[BugFix] downgrade jetty to 9.x for hadoop-azure

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -72,7 +72,9 @@ under the License.
         <delta-kernel.version>4.0.0rc1</delta-kernel.version>
         <iceberg.version>1.7.1</iceberg.version>
         <staros.version>3.4-rc6</staros.version>
-        <jetty.version>10.0.24</jetty.version>
+        <!-- hadoop-azure requires no more than jetty10+ -->
+        <!-- https://stackoverflow.com/questions/66713254/spark-wasb-and-jetty-11 -->
+        <jetty.version>9.4.57.v20241219</jetty.version>
     </properties>
 
     <profiles>

--- a/java-extensions/pom.xml
+++ b/java-extensions/pom.xml
@@ -47,7 +47,9 @@
         <commons-io.version>2.14.0</commons-io.version>
         <gcs.connector.version>hadoop3-2.2.26</gcs.connector.version>
         <guava.version>32.0.1-jre</guava.version>
-        <jetty.version>10.0.24</jetty.version>
+        <!-- hadoop-azure requires no more than jetty10+ -->
+        <!-- https://stackoverflow.com/questions/66713254/spark-wasb-and-jetty-11 -->
+        <jetty.version>9.4.57.v20241219</jetty.version>
         <parquet.version>1.15.1</parquet.version>
         <airlift.version>0.27</airlift.version>
         <avro.version>1.11.4</avro.version>


### PR DESCRIPTION
## Why I'm doing:

I access azure native filesystem and got following error

```
java.lang.NoSuchMethodError: 'java.util.Properties org.eclipse.jetty.util.log.Log.getProperties()'
        at org.apache.hadoop.fs.azure.AzureNativeFileSystemStore.createPermissionJsonSerializer(AzureNativeFileSystemStore.java:429) ~[hadoop-azure-3.4.1.jar:?]
        at org.apache.hadoop.fs.azure.AzureNativeFileSystemStore.<clinit>(AzureNativeFileSystemStore.java:331) ~[hadoop-azure-3.4.1.jar:?]
        at org.apache.hadoop.fs.azure.NativeAzureFileSystem.createDefaultStore(NativeAzureFileSystem.java:1485) ~[hadoop-azure-3.4.1.jar:?]
        at org.apache.hadoop.fs.azure.NativeAzureFileSystem.initialize(NativeAzureFileSystem.java:1410) ~[hadoop-azure-3.4.1.jar:?]
        at org.apache.hadoop.fs.FileSystem.createFileSystemInternal(FileSystem.java:3740) ~[starrocks-hadoop-ext.jar:?]
        at org.apache.hadoop.fs.FileSystem.lambda$createFileSystem$0(FileSystem.java:3760) ~[starrocks-hadoop-ext.jar:?]
        at com.starrocks.connector.hadoop.HadoopExtEPack.doAs(HadoopExtEPack.java:168) ~[starrocks-hadoop-ext.jar:?]
        at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:3760) ~[starrocks-hadoop-ext.jar:?]
        at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:599) ~[starrocks-hadoop-ext.jar:?]
        at com.starrocks.fs.hdfs.HdfsFsManager.getFileSystemByCloudConfiguration(HdfsFsManager.java
```

[[azure - Spark, wasb and Jetty 11 - Stack Overflow](https://stackoverflow.com/questions/66713254/spark-wasb-and-jetty-11)](https://stackoverflow.com/questions/66713254/spark-wasb-and-jetty-11)

## What I'm doing:

Downgrade jetty version to 9.4.x

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
