### PR TITLE
[BugFix]Fix unclear error messages when an unsupported regex type is …

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -20,6 +20,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.re2j.Pattern;
+import com.google.re2j.PatternSyntaxException;
 import com.starrocks.analysis.AnalyticExpr;
 import com.starrocks.analysis.ArithmeticExpr;
 import com.starrocks.analysis.ArraySliceExpr;
@@ -114,7 +115,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
 import static com.starrocks.sql.analyzer.AnalyticAnalyzer.verifyAnalyticExpression;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/ExpressionAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/ExpressionAnalyzerTest.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.analyzer;
 import com.starrocks.analysis.CollectionElementExpr;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.IntLiteral;
+import com.starrocks.analysis.LikePredicate;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.UserVariableExpr;
@@ -225,5 +226,17 @@ public class ExpressionAnalyzerTest extends PlanTestBase {
         userVariableExpr.setValue(expr);
         UserVariableExpr copy = (UserVariableExpr) userVariableExpr.clone();
         Assert.assertEquals(userVariableExpr, copy);
+    }
+
+    @Test
+    public void testLikePatternSyntaxException() {
+        StringLiteral e1 = new StringLiteral("a");
+        e1.setType(Type.VARCHAR);
+        StringLiteral e2 = new StringLiteral("([A-Za-z0-9]+[\\u4e00-\\u9fa5]{2}[A-Za-z0-9]+)");
+        e2.setType(Type.VARCHAR);
+        LikePredicate likePredicate = new LikePredicate(LikePredicate.Operator.REGEXP, e1, e2);
+        ExpressionAnalyzer.Visitor visitor = new ExpressionAnalyzer.Visitor(new AnalyzeState(), new ConnectContext());
+        Assert.assertThrows(SemanticException.class, () -> visitor.visitLikePredicate(likePredicate,
+                new Scope(RelationId.anonymous(), new RelationFields())));
     }
 }


### PR DESCRIPTION
…used.

## Why I'm doing:
select 'a' RLIKE '([A-Za-z0-9]+[\\\u4e00-\\\u9fa5]{2}[A-Za-z0-9]+)';
before:
ERROR 1064 (HY000): error parsing regexp: invalid escape sequence: \u
after fix:
ERROR 1064 (HY000): Getting analyzing error from line 1, column 11 to line 1, column 17. Detail message: Invalid regular expression in ''a' REGEXP '([A-Za-z0-9]+[\\u4e00-\\u9fa5]{2}[A-Za-z0-9]+)''.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
