### PR TITLE
[BugFix] Fix prune group_concat plan error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -3412,6 +3412,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return broadcastRowCountLimit;
     }
 
+    public void setBroadcastRowCountLimit(long broadcastRowCountLimit) {
+        this.broadcastRowCountLimit = broadcastRowCountLimit;
+    }
+
     public double getBroadcastRightTableScaleFactor() {
         return broadcastRightTableScaleFactor;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer.cost;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.starrocks.catalog.FunctionSet;
 import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
@@ -55,6 +56,8 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.sql.optimizer.statistics.StatisticsEstimateCoefficient;
@@ -529,6 +532,23 @@ public class CostModel {
                 Group group = context.getGroupExpression().getGroup();
                 boolean existBestPlan = CollectionUtils.isNotEmpty(group.getAllBestExpressionWithCost());
                 if (existBestPlan && desc.getSourceType() != HashDistributionDesc.SourceType.SHUFFLE_AGG) {
+                    // check multi-stage agg, split aggregate node lose distinct flag, check the group's origin
+                    // aggregate
+                    LogicalAggregationOperator originAgg = group.getFirstLogicalExpression().getOp().cast();
+                    for (CallOperator callOperator : originAgg.getAggregations().values()) {
+                        if (callOperator.isDistinct()) {
+                            String fnName = callOperator.getFnName();
+                            List<ScalarOperator> children = callOperator.getChildren();
+                            if (children.size() > 1 || children.stream().anyMatch(c -> c.getType().isComplexType())
+                                    || FunctionSet.GROUP_CONCAT.equalsIgnoreCase(fnName)
+                                    || FunctionSet.AVG.equalsIgnoreCase(fnName)) {
+                                return Optional.empty();
+                            } else if (FunctionSet.ARRAY_AGG.equalsIgnoreCase(fnName) && (children.size() > 1
+                                    || children.get(0).getType().isDecimalOfAnyVersion())) {
+                                return Optional.empty();
+                            }
+                        }
+                    }
                     return Optional.of(CostEstimate.infinite());
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -532,7 +532,8 @@ public class CostModel {
                 Group group = context.getGroupExpression().getGroup();
                 boolean existBestPlan = CollectionUtils.isNotEmpty(group.getAllBestExpressionWithCost());
                 if (existBestPlan && desc.getSourceType() != HashDistributionDesc.SourceType.SHUFFLE_AGG) {
-                    // check multi-stage agg, split aggregate node lose distinct flag, check the group's origin
+                    // Don't limited to multi-stage aggregate node, refs: invalidOneStageAggCost
+                    // split aggregate node lose distinct flag, check the group's origin
                     // aggregate
                     LogicalAggregationOperator originAgg = group.getFirstLogicalExpression().getOp().cast();
                     for (CallOperator callOperator : originAgg.getAggregations().values()) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -1607,16 +1607,16 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
     public void testOneTabletDistinctAgg() throws Exception {
         String sql = "select sum(id), group_concat(distinct name) from skew_table where id = 1 group by id";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "2:AGGREGATE (update finalize)\n" +
-                "  |  output: sum(3: sum), group_concat(2: name, ',')\n" +
-                "  |  group by: 1: id\n" +
-                "  |  \n" +
-                "  1:AGGREGATE (update serialize)\n" +
-                "  |  output: sum(1: id)\n" +
-                "  |  group by: 1: id, 2: name\n" +
-                "  |  \n" +
-                "  0:OlapScanNode\n" +
-                "     TABLE: skew_table");
+        assertContains(plan, "2:AGGREGATE (update serialize)\n"
+                + "  |  STREAMING\n"
+                + "  |  output: sum(3: sum), group_concat(2: name, ',')\n"
+                + "  |  group by: 1: id\n"
+                + "  |  \n"
+                + "  1:AGGREGATE (update serialize)\n"
+                + "  |  output: sum(1: id)\n"
+                + "  |  group by: 1: id, 2: name\n"
+                + "  |  \n"
+                + "  0:OlapScanNode");
 
         sql = "select n_name,count(distinct n_regionkey,n_name) from nation group by n_name";
         plan = getFragmentPlan(sql);
@@ -1657,5 +1657,22 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
                 "  |  group by: 2: N_NAME, 3: N_REGIONKEY\n" +
                 "  |  \n" +
                 "  0:OlapScanNode");
+    }
+
+    @Test
+    public void testLocalGroupConcatDistinct() throws Exception {
+        String sql = "select * from ("
+                + "select v1, count(distinct v2) c1, group_concat(distinct v2 SEPARATOR ',') "
+                + "from colocate_t0 group by v1 ) t left join colocate_t1 on v1 = v4 ";
+        connectContext.getSessionVariable().setOptimizerExecuteTimeout(-1);
+        connectContext.getSessionVariable().disableJoinReorder();
+        connectContext.getSessionVariable().setBroadcastRowCountLimit(0);
+        String plan = getFragmentPlan(sql);
+        connectContext.getSessionVariable().setOptimizerExecuteTimeout(-1);
+        connectContext.getSessionVariable().enableJoinReorder();
+        connectContext.getSessionVariable().setBroadcastRowCountLimit(15000000);
+        assertContains(plan, "2:AGGREGATE (update finalize)\n"
+                + "  |  output: count(2: v2), group_concat(CAST(2: v2 AS VARCHAR), ',')\n"
+                + "  |  group by: 1: v1");
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

for SQL pattern: SELECT * FROM (SELECT GROUP_CONCAT(DISTINCT ....)/COUNT(DISTINCT ...) FROM x) t1 join y;

1. `group_concat(distinct)`/`count(distinct)` must use multi-stage agg, so will prune one-stage plan
2. `t1 join y` will enforce broadcast and shuffle property
3. broadcast maybe can't statisfy the rows limit of right table, so will prune broadcast plan in join node, but was generate best plan for aggregate.
4. aggregate prune the redundant local plan(the delete code), for save cost compute or avoid choose bad plan (firstly, I think this is impossible. secondly, the condition that this method checks is incorrect; it should check for the best plan that meets the required property, rather than all best plans )

5. so, the aggregate can't support any plan when the join node enforce shuffle property


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
