### PR TITLE
[Enhancement] support storage query history on be

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
@@ -78,6 +78,12 @@ public final class GlobalVariable {
     public static final String ACTIVATE_ALL_ROLES_ON_LOGIN_V2 = "activate_all_roles_on_login_v2";
     public static final String ENABLE_TDE = "enable_tde";
 
+    public static final String ENABLE_QUERY_HISTORY = "enable_query_history";
+
+    public static final String QUERY_HISTORY_KEEP_SECONDS = "query_history_keep_seconds";
+
+    public static final String QUERY_HISTORY_LOAD_INTERVAL_SECONDS = "query_history_load_interval_seconds";
+
     @VariableMgr.VarAttr(name = VERSION_COMMENT, flag = VariableMgr.READ_ONLY)
     public static String versionComment = Version.STARROCKS_VERSION + "-" + Version.STARROCKS_COMMIT_HASH;
 
@@ -177,6 +183,19 @@ public final class GlobalVariable {
 
     @VariableMgr.VarAttr(name = ENABLE_TDE, flag = VariableMgr.GLOBAL | VariableMgr.READ_ONLY)
     public static boolean enableTde = KeyMgr.isEncrypted();
+
+    @VariableMgr.VarAttr(name = ENABLE_QUERY_HISTORY, flag = VariableMgr.GLOBAL)
+    public static boolean enableQueryHistory = false;
+
+    @VariableMgr.VarAttr(name = QUERY_HISTORY_KEEP_SECONDS, flag = VariableMgr.GLOBAL)
+    public static long queryHistoryKeepSeconds = 86400 * 3; // 3 days
+
+    @VariableMgr.VarAttr(name = QUERY_HISTORY_LOAD_INTERVAL_SECONDS, flag = VariableMgr.GLOBAL)
+    public static long queryHistoryLoadIntervalSeconds = 60 * 15; // 15min
+
+    public static boolean isEnableQueryHistory() {
+        return enableQueryHistory;
+    }
 
     public static boolean isEnableQueryQueueSelect() {
         return enableQueryQueueSelect;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
@@ -84,6 +84,12 @@ public final class GlobalVariable {
 
     public static final String QUERY_HISTORY_LOAD_INTERVAL_SECONDS = "query_history_load_interval_seconds";
 
+    public static final String ENABLE_SPM_CAPTURE = "enable_plan_capture";
+
+    public static final String SPM_CAPTURE_INTERVAL_SECONDS = "plan_capture_interval_seconds";
+
+    public static final String SPM_CAPTURE_INCLUDE_TABLE_PATTERN = "plan_capture_include_pattern";
+
     @VariableMgr.VarAttr(name = VERSION_COMMENT, flag = VariableMgr.READ_ONLY)
     public static String versionComment = Version.STARROCKS_VERSION + "-" + Version.STARROCKS_COMMIT_HASH;
 
@@ -192,6 +198,27 @@ public final class GlobalVariable {
 
     @VariableMgr.VarAttr(name = QUERY_HISTORY_LOAD_INTERVAL_SECONDS, flag = VariableMgr.GLOBAL)
     public static long queryHistoryLoadIntervalSeconds = 60 * 15; // 15min
+
+    @VariableMgr.VarAttr(name = ENABLE_SPM_CAPTURE, flag = VariableMgr.GLOBAL)
+    public static boolean enableSPMCapture = false;
+
+    @VariableMgr.VarAttr(name = SPM_CAPTURE_INTERVAL_SECONDS, flag = VariableMgr.GLOBAL)
+    public static long spmCaptureIntervalSeconds = 60 * 60 * 3; // 3 hour
+
+    @VariableMgr.VarAttr(name = SPM_CAPTURE_INCLUDE_TABLE_PATTERN, flag = VariableMgr.GLOBAL)
+    public static String spmCaptureIncludeTablePattern = ".*";
+
+    public static boolean isEnableSPMCapture() {
+        return enableSPMCapture;
+    }
+
+    public static long getSpmCaptureIntervalSeconds() {
+        return spmCaptureIntervalSeconds;
+    }
+
+    public static String getSpmCaptureIncludeTablePattern() {
+        return spmCaptureIncludeTablePattern;
+    }
 
     public static boolean isEnableQueryHistory() {
         return enableQueryHistory;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1409,6 +1409,7 @@ public class StmtExecutor {
         }
 
         processQueryStatisticsFromResult(batch, execPlan, isOutfileQuery);
+        GlobalStateMgr.getCurrentState().getQueryHistoryMgr().addQueryHistory(context, execPlan);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -218,6 +218,7 @@ import com.starrocks.sql.optimizer.statistics.CachedStatisticStorage;
 import com.starrocks.sql.optimizer.statistics.StatisticStorage;
 import com.starrocks.sql.parser.AstBuilder;
 import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.sql.spm.SPMAutoCapturer;
 import com.starrocks.sql.spm.SQLPlanStorage;
 import com.starrocks.staros.StarMgrServer;
 import com.starrocks.statistic.AnalyzeMgr;
@@ -534,6 +535,7 @@ public class GlobalStateMgr {
     private final TabletCollector tabletCollector;
     private final SQLPlanStorage sqlPlanStorage;
     private final QueryHistoryMgr queryHistoryMgr;
+    private final SPMAutoCapturer spmAutoCapturer;
 
     private JwkMgr jwkMgr;
 
@@ -686,6 +688,7 @@ public class GlobalStateMgr {
         this.statisticStorage = new CachedStatisticStorage();
         this.sqlPlanStorage = SQLPlanStorage.create(true);
         this.queryHistoryMgr = new QueryHistoryMgr();
+        this.spmAutoCapturer = new SPMAutoCapturer();
 
         this.replayedJournalId = new AtomicLong(0L);
         this.synchronizedTimeMs = 0;
@@ -1442,6 +1445,7 @@ public class GlobalStateMgr {
         pipeListener.start();
         pipeScheduler.start();
         mvActiveChecker.start();
+        spmAutoCapturer.start();
 
         // start daemon thread to report the progress of RunningTaskRun to the follower by editlog
         taskRunStateSynchronizer = new TaskRunStateSynchronizer();

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -224,6 +224,7 @@ import com.starrocks.statistic.AnalyzeMgr;
 import com.starrocks.statistic.StatisticAutoCollector;
 import com.starrocks.statistic.StatisticsMetaManager;
 import com.starrocks.statistic.columns.PredicateColumnsMgr;
+import com.starrocks.summary.QueryHistoryMgr;
 import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.Frontend;
@@ -532,6 +533,7 @@ public class GlobalStateMgr {
     private final ReportHandler reportHandler;
     private final TabletCollector tabletCollector;
     private final SQLPlanStorage sqlPlanStorage;
+    private final QueryHistoryMgr queryHistoryMgr;
 
     private JwkMgr jwkMgr;
 
@@ -683,6 +685,7 @@ public class GlobalStateMgr {
         this.safeModeChecker = new SafeModeChecker();
         this.statisticStorage = new CachedStatisticStorage();
         this.sqlPlanStorage = SQLPlanStorage.create(true);
+        this.queryHistoryMgr = new QueryHistoryMgr();
 
         this.replayedJournalId = new AtomicLong(0L);
         this.synchronizedTimeMs = 0;
@@ -917,6 +920,10 @@ public class GlobalStateMgr {
 
     public AnalyzeMgr getAnalyzeMgr() {
         return analyzeMgr;
+    }
+
+    public QueryHistoryMgr getQueryHistoryMgr() {
+        return queryHistoryMgr;
     }
 
     public AuthenticationMgr getAuthenticationMgr() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
@@ -55,7 +55,7 @@ import java.util.stream.Collectors;
  * it will be consistent with the original db-lock logic
  * and obtain the db-read-lock of all dbs involved in the query.
  */
-public class PlannerMetaLocker {
+public class PlannerMetaLocker implements AutoCloseable {
     // Map database id -> database
     private Map<Long, Database> dbs = Maps.newTreeMap(Long::compareTo);
 
@@ -121,6 +121,10 @@ public class PlannerMetaLocker {
         }
     }
 
+    @Override
+    public void close() {
+        unlock();
+    }
     /**
      * Collect tables that need to be protected by the PlannerMetaLock
      */

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/spm/DropBaselinePlanStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/spm/DropBaselinePlanStmt.java
@@ -18,15 +18,17 @@ import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.DdlStmt;
 import com.starrocks.sql.parser.NodePosition;
 
-public class DropBaselinePlanStmt extends DdlStmt {
-    private final long baseLineId;
+import java.util.List;
 
-    public DropBaselinePlanStmt(long baseLineId, NodePosition pos) {
+public class DropBaselinePlanStmt extends DdlStmt {
+    private final List<Long> baseLineId;
+
+    public DropBaselinePlanStmt(List<Long> baseLineId, NodePosition pos) {
         super(pos);
         this.baseLineId = baseLineId;
     }
 
-    public long getBaseLineId() {
+    public List<Long> getBaseLineId() {
         return baseLineId;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/spm/ShowBaselinePlanStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/spm/ShowBaselinePlanStmt.java
@@ -26,11 +26,14 @@ public class ShowBaselinePlanStmt extends ShowStmt {
     private static final ShowResultSetMetaData META_DATA = ShowResultSetMetaData.builder()
             .addColumn(new Column("Id", ScalarType.createVarchar(60)))
             .addColumn(new Column("global", ScalarType.createVarchar(10)))
+            .addColumn(new Column("enable", ScalarType.createVarchar(10)))
             .addColumn(new Column("bindSQLDigest", ScalarType.createVarchar(65535)))
             .addColumn(new Column("bindSQLHash", ScalarType.createVarchar(60)))
             .addColumn(new Column("bindSQL", ScalarType.createVarchar(65535)))
             .addColumn(new Column("planSQL", ScalarType.createVarchar(65535)))
             .addColumn(new Column("costs", ScalarType.createVarchar(60)))
+            .addColumn(new Column("queryMs", ScalarType.createVarchar(60)))
+            .addColumn(new Column("source", ScalarType.createVarchar(60)))
             .addColumn(new Column("updateTime", ScalarType.createVarchar(60)))
             .build();
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -8544,8 +8544,12 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         if (ctx.INTEGER_VALUE() == null) {
             throw new ParsingException("Invalid number of statement arguments");
         }
-        long id = Long.parseLong(ctx.INTEGER_VALUE().getText());
-        return new DropBaselinePlanStmt(id, createPos(ctx));
+        List<Long> ids = ctx.INTEGER_VALUE().stream()
+                .map(ParseTree::getText)
+                .map(Integer::parseInt)
+                .collect(toList());
+
+        return new DropBaselinePlanStmt(ids, createPos(ctx));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -8546,8 +8546,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         }
         List<Long> ids = ctx.INTEGER_VALUE().stream()
                 .map(ParseTree::getText)
-                .map(Integer::parseInt)
-                .collect(toList());
+                .map(Long::parseLong).toList();
 
         return new DropBaselinePlanStmt(ids, createPos(ctx));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1412,7 +1412,7 @@ createBaselinePlanStatement
     ;
 
 dropBaselinePlanStatement
-    : DROP BASELINE INTEGER_VALUE
+    : DROP BASELINE INTEGER_VALUE (',' INTEGER_VALUE)*
     ;
 
 showBaselinePlanStatement

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/BaselinePlan.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/BaselinePlan.java
@@ -17,19 +17,24 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.io.Writable;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Objects;
 
 public class BaselinePlan implements Writable {
-    @SerializedName("id")
+    public static final String SOURCE_USER = "USER";
+
+    public static final String SOURCE_CAPTURE = "CAPTURE";
+
     private long id;
 
-    private final boolean isGlobal;
+    private boolean isGlobal = false;
+
+    private boolean isEnable = false;
 
     // bind sql with spm function, for extract placeholder
     private final String bindSql;
     // bind sql without spm function, for bind query
     private final String bindSqlDigest;
-    @SerializedName("bindSqlHash")
     // bind sql hash, for fast search
     private final long bindSqlHash;
     // plan sql with hints
@@ -37,12 +42,23 @@ public class BaselinePlan implements Writable {
 
     private final double costs;
 
-    private final LocalDateTime updateTime;
+    private String source = SOURCE_USER;
+
+    private double queryMs = -1;
+
+    private LocalDateTime updateTime;
+
+    // for transform replay log
+    @SerializedName("replayIds")
+    private List<Long> replayIds;
+    @SerializedName("replayBindSqlHash")
+    private List<Long> replayBindSQLHash;
 
     public BaselinePlan(long id, long bindSqlHash) {
         this.id = id;
         this.bindSqlHash = bindSqlHash;
         this.isGlobal = false;
+        this.isEnable = false;
         this.bindSql = "";
         this.bindSqlDigest = "";
         this.planSql = "";
@@ -50,15 +66,13 @@ public class BaselinePlan implements Writable {
         this.updateTime = null;
     }
 
-    public BaselinePlan(boolean isGlobal, String bindSql, String bindSqlDigest,
-                        long bindSqlHash, String planSql, double costs, LocalDateTime updateTime) {
-        this.isGlobal = isGlobal;
+    public BaselinePlan(String bindSql, String bindSqlDigest, long bindSqlHash, String planSql, double costs) {
         this.bindSql = bindSql;
         this.bindSqlDigest = bindSqlDigest;
         this.bindSqlHash = bindSqlHash;
         this.planSql = planSql;
         this.costs = costs;
-        this.updateTime = updateTime;
+        this.updateTime = LocalDateTime.now();
     }
 
     public long getId() {
@@ -71,6 +85,22 @@ public class BaselinePlan implements Writable {
 
     public boolean isGlobal() {
         return isGlobal;
+    }
+
+    public void setGlobal(boolean global) {
+        isGlobal = global;
+    }
+
+    public boolean isEnable() {
+        return isEnable;
+    }
+
+    public void setEnable(boolean enable) {
+        isEnable = enable;
+    }
+
+    public String getSource() {
+        return source;
     }
 
     public String getBindSql() {
@@ -93,8 +123,40 @@ public class BaselinePlan implements Writable {
         return costs;
     }
 
+    public double getQueryMs() {
+        return queryMs;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    public void setQueryMs(double queryMs) {
+        this.queryMs = queryMs;
+    }
+
+    public void setUpdateTime(LocalDateTime updateTime) {
+        this.updateTime = updateTime;
+    }
+
     public LocalDateTime getUpdateTime() {
         return updateTime;
+    }
+
+    public List<Long> getReplayIds() {
+        return replayIds;
+    }
+
+    public void setReplayIds(List<Long> replayIds) {
+        this.replayIds = replayIds;
+    }
+
+    public List<Long> getReplayBindSQLHash() {
+        return replayBindSQLHash;
+    }
+
+    public void setReplayBindSQLHash(List<Long> replayBindSQLHash) {
+        this.replayBindSQLHash = replayBindSQLHash;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMAutoCapturer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMAutoCapturer.java
@@ -19,7 +19,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Table;
-import com.starrocks.common.AuditLog;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.GlobalVariable;
@@ -31,6 +30,8 @@ import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.summary.QueryHistory;
 import com.starrocks.summary.QueryHistoryMgr;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -38,6 +39,8 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 public class SPMAutoCapturer extends FrontendDaemon {
+    private static final Logger LOG = LogManager.getLogger(SPMAutoCapturer.class);
+
     private LocalDateTime lastWorkTime = LocalDateTime.now();
 
     private ConnectContext connect;
@@ -113,7 +116,7 @@ public class SPMAutoCapturer extends FrontendDaemon {
                 base.setUpdateTime(queryHistory.getDatetime());
                 plans.put(queryHistory.getSqlDigest(), base);
             } catch (Exception e) {
-                AuditLog.getStatisticAudit().warn("sql plan capture failed. sql: {}", queryHistory.getOriginSQL(), e);
+                LOG.warn("sql plan capture failed. sql: " + queryHistory.getOriginSQL(), e);
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMAutoCapturer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMAutoCapturer.java
@@ -51,16 +51,16 @@ public class SPMAutoCapturer extends FrontendDaemon {
 
     @Override
     public long getInterval() {
-        return GlobalVariable.getSpmCaptureIntervalSeconds() * 1000;
+        return GlobalVariable.getSpmCaptureIntervalSeconds() * 100;
     }
 
     @Override
     protected void runAfterCatalogReady() {
-        if (getInterval() != GlobalVariable.getSpmCaptureIntervalSeconds() * 1000) {
-            setInterval(GlobalVariable.getSpmCaptureIntervalSeconds() * 1000);
-        }
-
         if (!GlobalVariable.isEnableSPMCapture()) {
+            return;
+        }
+        
+        if (lastWorkTime.plusSeconds(GlobalVariable.getSpmCaptureIntervalSeconds()).isAfter(LocalDateTime.now())) {
             return;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMAutoCapturer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMAutoCapturer.java
@@ -1,0 +1,139 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.spm;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.analysis.TableName;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.AuditLog;
+import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.GlobalVariable;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.statistic.StatisticUtils;
+import com.starrocks.summary.QueryHistory;
+import com.starrocks.summary.QueryHistoryMgr;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public class SPMAutoCapturer extends FrontendDaemon {
+    private LocalDateTime lastWorkTime = LocalDateTime.now();
+
+    private ConnectContext connect;
+
+    public SPMAutoCapturer() {
+        super("SPMAutoCapturer");
+    }
+
+    @Override
+    public long getInterval() {
+        return GlobalVariable.getSpmCaptureIntervalSeconds() * 1000;
+    }
+
+    @Override
+    protected void runAfterCatalogReady() {
+        if (getInterval() != GlobalVariable.getSpmCaptureIntervalSeconds() * 1000) {
+            setInterval(GlobalVariable.getSpmCaptureIntervalSeconds() * 1000);
+        }
+
+        if (!GlobalVariable.isEnableSPMCapture()) {
+            return;
+        }
+
+        // non query history data, skip
+        QueryHistoryMgr historyMgr = GlobalStateMgr.getCurrentState().getQueryHistoryMgr();
+        if (historyMgr.getLastLoadTime().isBefore(lastWorkTime)) {
+            return;
+        }
+
+        List<QueryHistory> qhs = historyMgr.queryLastHistory(lastWorkTime);
+        if (qhs.isEmpty()) {
+            return;
+        }
+
+        connect = StatisticUtils.buildConnectContext();
+        // sqlDigest -> plan
+        List<BaselinePlan> baselines = generateBaseline(qhs);
+
+        SQLPlanStorage sqlPlanStorage = GlobalStateMgr.getCurrentState().getSqlPlanStorage();
+        sqlPlanStorage.storeBaselinePlan(baselines);
+        lastWorkTime = LocalDateTime.now();
+    }
+
+    private List<BaselinePlan> generateBaseline(List<QueryHistory> histories) {
+        Pattern checkPattern = Pattern.compile(GlobalVariable.getSpmCaptureIncludeTablePattern());
+
+        // 1.generate plan & check pattern
+        Map<String, BaselinePlan> plans = Maps.newHashMap();
+        for (QueryHistory queryHistory : histories) {
+            try {
+                List<StatementBase> stmt = SqlParser.parse(queryHistory.getOriginSQL(), connect.getSessionVariable());
+                Preconditions.checkState(stmt.size() == 1);
+                Preconditions.checkState(stmt.get(0) instanceof QueryStatement);
+
+                Map<TableName, Table> tables = AnalyzerUtils.collectAllTable(stmt.get(0));
+                if (tables.size() < 2) {
+                    continue;
+                }
+                if (!tables.keySet().stream().allMatch(t -> {
+                    String s = t.getDb() + "." + t.getTbl();
+                    return checkPattern.matcher(s).find();
+                })) {
+                    continue;
+                }
+
+                SPMPlanBuilder builder = new SPMPlanBuilder(connect, ((QueryStatement) stmt.get(0)));
+                BaselinePlan base = builder.execute();
+
+                base.setSource(BaselinePlan.SOURCE_CAPTURE);
+                base.setGlobal(true);
+                base.setEnable(false);
+                base.setQueryMs(queryHistory.getQueryMs());
+                base.setUpdateTime(queryHistory.getDatetime());
+                plans.put(queryHistory.getSqlDigest(), base);
+            } catch (Exception e) {
+                AuditLog.getStatisticAudit().warn("sql plan capture failed. sql: {}", queryHistory.getOriginSQL(), e);
+            }
+        }
+
+        // 2. get exists baselines
+        SQLPlanStorage sqlPlanStorage = GlobalStateMgr.getCurrentState().getSqlPlanStorage();
+        List<String> queryDigests = histories.stream().map(QueryHistory::getSqlDigest).toList();
+        List<BaselinePlan> allBaselines = sqlPlanStorage.queryBaselinePlan(queryDigests, BaselinePlan.SOURCE_CAPTURE);
+
+        // 3. remove duplicate baseline
+        List<BaselinePlan> result = Lists.newArrayList();
+        for (var entry : plans.entrySet()) {
+            String digest = entry.getKey();
+            BaselinePlan plan = entry.getValue();
+
+            if (allBaselines.stream().anyMatch(b -> b.getBindSqlDigest().equalsIgnoreCase(digest) &&
+                    b.getPlanSql().equalsIgnoreCase(plan.getPlanSql()))) {
+                continue;
+            }
+            result.add(plan);
+        }
+        return result;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlanBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlanBuilder.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.sql.spm;
 
-import com.google.common.collect.Lists;
 import com.starrocks.analysis.HintNode;
 import com.starrocks.analysis.SetVarHint;
 import com.starrocks.analysis.StringLiteral;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlanBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlanBuilder.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.spm;
 
+import com.google.common.collect.Lists;
 import com.starrocks.analysis.HintNode;
 import com.starrocks.analysis.SetVarHint;
 import com.starrocks.analysis.StringLiteral;
@@ -40,13 +41,14 @@ import com.starrocks.sql.optimizer.transformer.LogicalPlan;
 import com.starrocks.sql.optimizer.transformer.RelationTransformer;
 import com.starrocks.sql.optimizer.transformer.TransformerContext;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 // to build plan for bind sql
 public class SPMPlanBuilder {
     private final ConnectContext session;
-    private final CreateBaselinePlanStmt stmt;
+    private final QueryRelation bindStmt;
+    private final QueryRelation planStmt;
+    private final List<HintNode> planHints;
 
     private String bindSqlDigest;
     private long bindSqlHash;
@@ -68,25 +70,32 @@ public class SPMPlanBuilder {
 
     public SPMPlanBuilder(ConnectContext session, CreateBaselinePlanStmt stmt) {
         this.session = session;
-        this.stmt = stmt;
+        this.bindStmt = stmt.getBindStmt();
+        this.planStmt = stmt.getPlanStmt();
+        this.planHints = stmt.getAllQueryScopeHints();
+    }
+
+    public SPMPlanBuilder(ConnectContext session, QueryStatement planStmt) {
+        this.session = session;
+        this.planHints = planStmt.getAllQueryScopeHints();
+        this.planStmt = planStmt.getQueryRelation();
+        this.bindStmt = null;
     }
 
     public BaselinePlan execute() {
         analyze();
         parameterizedStmt();
         generatePlan();
-        return new BaselinePlan(stmt.isGlobal(), bindSql, bindSqlDigest, bindSqlHash,
-                planStmtSQL, costs, LocalDateTime.now());
+        return new BaselinePlan(bindSql, bindSqlDigest, bindSqlHash, planStmtSQL, costs);
     }
 
     // don't need lock, because we don't need to modify table stats
     public void generatePlan() {
-        List<HintNode> hints = this.stmt.getAllQueryScopeHints();
         SessionVariable backupVariable = session.getSessionVariable();
         SessionVariable cloneVariable = null;
-        if (hints != null && !hints.isEmpty()) {
+        if (planHints != null && !planHints.isEmpty()) {
             cloneVariable = (SessionVariable) backupVariable.clone();
-            for (HintNode hint : hints) {
+            for (HintNode hint : planHints) {
                 if (!(hint instanceof SetVarHint)) {
                     UnsupportedException.unsupportedException(
                             "sql pLan manager only supported session variables: " + hint.toSql());
@@ -105,11 +114,11 @@ public class SPMPlanBuilder {
             session.setSessionVariable(cloneVariable);
         }
 
-        QueryRelation query = this.stmt.getPlanStmt();
         try {
             ColumnRefFactory columnRefFactory = new ColumnRefFactory();
             TransformerContext transformerContext = new TransformerContext(columnRefFactory, session, null);
-            LogicalPlan logicalPlan = new RelationTransformer(transformerContext).transformWithSelectLimit(query);
+            LogicalPlan logicalPlan =
+                    new RelationTransformer(transformerContext).transformWithSelectLimit(this.planStmt);
 
             OptimizerContext optimizerContext = OptimizerFactory.initContext(session, columnRefFactory);
             optimizerContext.setOptimizerOptions(
@@ -121,7 +130,7 @@ public class SPMPlanBuilder {
                     new ColumnRefSet(logicalPlan.getOutputColumn()));
 
             SPMPlan2SQLBuilder sqlBuilder = new SPMPlan2SQLBuilder();
-            planStmtSQL = sqlBuilder.toSQL(hints, optimizedPlan, logicalPlan.getOutputColumn());
+            planStmtSQL = sqlBuilder.toSQL(planHints, optimizedPlan, logicalPlan.getOutputColumn());
             costs = optimizedPlan.getCost();
         } finally {
             if (cloneVariable != null) {
@@ -133,14 +142,14 @@ public class SPMPlanBuilder {
     protected void parameterizedStmt() {
         QueryRelation bind;
         SPMPlaceholderBuilder builder = new SPMPlaceholderBuilder(false);
-        if (this.stmt.getBindStmt() != null) {
+        if (this.bindStmt != null) {
             // has bind and plan
-            builder.findPlaceholder(this.stmt.getBindStmt());
-            bind = builder.insertPlaceholder(this.stmt.getBindStmt());
-            builder.bindPlaceholder(this.stmt.getPlanStmt());
+            builder.findPlaceholder(this.bindStmt);
+            bind = builder.insertPlaceholder(this.bindStmt);
+            builder.bindPlaceholder(this.bindStmt);
         } else {
             // only plan
-            bind = builder.insertPlaceholder(this.stmt.getPlanStmt());
+            bind = builder.insertPlaceholder(this.planStmt);
         }
         SPMAst2SQLBuilder digestBuilder = new SPMAst2SQLBuilder(false, true);
         SPMAst2SQLBuilder sqlBuilder = new SPMAst2SQLBuilder(false, false);
@@ -150,15 +159,13 @@ public class SPMPlanBuilder {
     }
 
     protected void analyze() {
-        PlannerMetaLocker locker = new PlannerMetaLocker(session, stmt);
-        try {
+        QueryStatement p = new QueryStatement(this.planStmt);
+        try (PlannerMetaLocker locker = new PlannerMetaLocker(session, p)) {
             locker.lock();
-            Analyzer.analyze(new QueryStatement(stmt.getPlanStmt()), session);
-            if (stmt.getBindStmt() != null) {
-                Analyzer.analyze(new QueryStatement(stmt.getBindStmt()), session);
+            Analyzer.analyze(p, session);
+            if (this.bindStmt != null) {
+                Analyzer.analyze(new QueryStatement(this.bindStmt), session);
             }
-        } finally {
-            locker.unlock();
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlanner.java
@@ -103,12 +103,9 @@ public class SPMPlanner {
     }
 
     private void analyze(StatementBase query) {
-        PlannerMetaLocker locker = new PlannerMetaLocker(session, query);
-        try {
+        try (PlannerMetaLocker locker = new PlannerMetaLocker(session, query)) {
             locker.lock();
             Analyzer.analyze(query, session);
-        } finally {
-            locker.unlock();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMStmtExecutor.java
@@ -29,10 +29,13 @@ public class SPMStmtExecutor {
     public static void execute(ConnectContext context, CreateBaselinePlanStmt stmt) {
         SPMPlanBuilder builder = new SPMPlanBuilder(context, stmt);
         BaselinePlan plan = builder.execute();
+        plan.setEnable(true);
+        plan.setGlobal(stmt.isGlobal());
+        plan.setSource(BaselinePlan.SOURCE_USER);
         if (stmt.isGlobal()) {
-            context.getGlobalStateMgr().getSqlPlanStorage().storeBaselinePlan(plan);
+            context.getGlobalStateMgr().getSqlPlanStorage().storeBaselinePlan(List.of(plan));
         } else {
-            context.getSqlPlanStorage().storeBaselinePlan(plan);
+            context.getSqlPlanStorage().storeBaselinePlan(List.of(plan));
         }
     }
 
@@ -49,11 +52,14 @@ public class SPMStmtExecutor {
             List<String> row = Lists.newArrayList();
             row.add(String.valueOf(baseline.getId()));
             row.add(baseline.isGlobal() ? "Y" : "N");
+            row.add(baseline.isEnable() ? "Y" : "N");
             row.add(baseline.getBindSqlDigest());
             row.add(String.valueOf(baseline.getBindSqlHash()));
             row.add(baseline.getBindSql());
             row.add(baseline.getPlanSql());
             row.add(String.valueOf(baseline.getCosts()));
+            row.add(String.valueOf(baseline.getQueryMs()));
+            row.add(baseline.getSource());
             row.add(baseline.getUpdateTime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
             rows.add(row);
         });

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SQLPlanSessionStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SQLPlanSessionStorage.java
@@ -26,9 +26,12 @@ class SQLPlanSessionStorage implements SQLPlanStorage {
         return baselinePlans;
     }
 
-    public void storeBaselinePlan(BaselinePlan plan) {
-        plan.setId(GlobalStateMgr.getCurrentState().getNextId());
-        baselinePlans.add(plan);
+    @Override
+    public void storeBaselinePlan(List<BaselinePlan> plans) {
+        for (BaselinePlan plan : plans) {
+            plan.setId(GlobalStateMgr.getCurrentState().getNextId());
+            baselinePlans.add(plan);
+        }
     }
 
     public List<BaselinePlan> findBaselinePlan(String sqlDigest, long hash) {
@@ -36,8 +39,8 @@ class SQLPlanSessionStorage implements SQLPlanStorage {
                 .collect(Collectors.toList());
     }
 
-    public void dropBaselinePlan(long baseLineId) {
-        baselinePlans.removeIf(p -> p.getId() == baseLineId);
+    public void dropBaselinePlan(List<Long> baseLineIds) {
+        baselinePlans.removeIf(p -> baseLineIds.contains(p.getId()));
     }
 
     public void dropAllBaselinePlans() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SQLPlanStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SQLPlanStorage.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.starrocks.sql.spm;
 
+import java.util.Collections;
 import java.util.List;
 
 public interface SQLPlanStorage {
@@ -22,14 +23,18 @@ public interface SQLPlanStorage {
 
     List<BaselinePlan> getAllBaselines();
 
-    void storeBaselinePlan(BaselinePlan plan);
+    void storeBaselinePlan(List<BaselinePlan> plan);
 
     List<BaselinePlan> findBaselinePlan(String sqlDigest, long hash);
 
-    void dropBaselinePlan(long baseLineId);
+    void dropBaselinePlan(List<Long> baseLineIds);
 
     // for ut test use
     void dropAllBaselinePlans();
 
     default void replayBaselinePlan(BaselinePlan plan, boolean isCreate) {}
+
+    default List<BaselinePlan> queryBaselinePlan(List<String> sqlDigest, String source) {
+        return Collections.emptyList();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -62,6 +62,7 @@ import static com.starrocks.statistic.StatsConstants.EXTERNAL_HISTOGRAM_STATISTI
 import static com.starrocks.statistic.StatsConstants.FULL_STATISTICS_TABLE_NAME;
 import static com.starrocks.statistic.StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME;
 import static com.starrocks.statistic.StatsConstants.MULTI_COLUMN_STATISTICS_TABLE_NAME;
+import static com.starrocks.statistic.StatsConstants.QUERY_HISTORY_TABLE_NAME;
 import static com.starrocks.statistic.StatsConstants.SAMPLE_STATISTICS_TABLE_NAME;
 import static com.starrocks.statistic.StatsConstants.SPM_BASELINE_TABLE_NAME;
 import static com.starrocks.statistic.StatsConstants.STATISTICS_DB_NAME;
@@ -373,6 +374,41 @@ public class StatisticsMetaManager extends FrontendDaemon {
         return checkTableExist(SPM_BASELINE_TABLE_NAME);
     }
 
+    private boolean createQueryHistoryTable(ConnectContext context) {
+        LOG.info("create query_history table start");
+        TableName tableName = new TableName(STATISTICS_DB_NAME, QUERY_HISTORY_TABLE_NAME);
+        KeysType keysType = KeysType.DUP_KEYS;
+        Map<String, String> properties = Maps.newHashMap();
+        try {
+            List<ColumnDef> columns = ImmutableList.of(
+                    new ColumnDef("dt", new TypeDef(ScalarType.createType(PrimitiveType.DATETIME))),
+                    new ColumnDef("frontend", new TypeDef(ScalarType.createVarcharType(65530))),
+                    new ColumnDef("sql_digest", new TypeDef(ScalarType.createVarcharType(65530))),
+                    new ColumnDef("sql", new TypeDef(ScalarType.createVarcharType(65530))),
+                    new ColumnDef("plan", new TypeDef(ScalarType.createVarcharType(65530))),
+                    new ColumnDef("plan_costs", new TypeDef(ScalarType.createType(PrimitiveType.DOUBLE))),
+                    new ColumnDef("query_ms", new TypeDef(ScalarType.createType(PrimitiveType.DOUBLE))),
+                    new ColumnDef("other", new TypeDef(ScalarType.createType(PrimitiveType.JSON)))
+            );
+
+            int defaultReplicationNum = AutoInferUtil.calDefaultReplicationNum();
+            properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Integer.toString(defaultReplicationNum));
+            CreateTableStmt stmt = new CreateTableStmt(false, false,
+                    tableName, columns, EngineType.defaultEngine().name(),
+                    new KeysDesc(keysType, List.of("dt", "frontend")), null,
+                    new HashDistributionDesc(10, List.of("dt")),
+                    properties, null, "");
+
+            Analyzer.analyze(stmt, context);
+            GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(stmt);
+        } catch (StarRocksException e) {
+            LOG.warn("Failed to create query_history table", e);
+            return false;
+        }
+        LOG.info("create query_history table done");
+        return checkTableExist(QUERY_HISTORY_TABLE_NAME);
+    }
+
     private void refreshAnalyzeJob() {
         for (Map.Entry<Long, BasicStatsMeta> entry :
                 GlobalStateMgr.getCurrentState().getAnalyzeMgr().getBasicStatsMetaMap().entrySet()) {
@@ -412,6 +448,8 @@ public class StatisticsMetaManager extends FrontendDaemon {
                 return createMultiColumnStatisticsTable(context);
             } else if (SPM_BASELINE_TABLE_NAME.equals(tableName)) {
                 return createSPMBaselinesTable(context);
+            } else if (QUERY_HISTORY_TABLE_NAME.equals(tableName)) {
+                return createQueryHistoryTable(context);
             } else {
                 throw new StarRocksPlannerException("Error table name " + tableName, ErrorType.INTERNAL_ERROR);
             }
@@ -518,10 +556,12 @@ public class StatisticsMetaManager extends FrontendDaemon {
         refreshStatisticsTable(EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME);
         refreshStatisticsTable(MULTI_COLUMN_STATISTICS_TABLE_NAME);
         refreshStatisticsTable(SPM_BASELINE_TABLE_NAME);
+        refreshStatisticsTable(QUERY_HISTORY_TABLE_NAME);
 
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().clearStatisticFromDroppedPartition();
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().clearStatisticFromDroppedTable();
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().clearExpiredAnalyzeStatus();
+        GlobalStateMgr.getCurrentState().getQueryHistoryMgr().clearExpiredQueryHistory();
 
         RepoCreator.getInstance().run();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -348,11 +348,14 @@ public class StatisticsMetaManager extends FrontendDaemon {
         try {
             List<ColumnDef> columns = ImmutableList.of(
                     new ColumnDef("id", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
+                    new ColumnDef("is_enable", new TypeDef(ScalarType.createType(PrimitiveType.BOOLEAN))),
                     new ColumnDef("bind_sql", new TypeDef(ScalarType.createVarcharType(65530))),
                     new ColumnDef("bind_sql_digest", new TypeDef(ScalarType.createVarcharType(65530))),
                     new ColumnDef("bind_sql_hash", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
                     new ColumnDef("plan_sql", new TypeDef(ScalarType.createVarcharType(65530))),
                     new ColumnDef("costs", new TypeDef(ScalarType.createType(PrimitiveType.DOUBLE))),
+                    new ColumnDef("query_ms", new TypeDef(ScalarType.createType(PrimitiveType.DOUBLE))),
+                    new ColumnDef("source", new TypeDef(ScalarType.createVarcharType(100))),
                     new ColumnDef("update_time", new TypeDef(ScalarType.createType(PrimitiveType.DATETIME)))
             );
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
@@ -61,6 +61,7 @@ public class StatsConstants {
                     .build();
 
     public static final int STATISTICS_PARTITION_UPDATED_THRESHOLD = 10;
+
     public static final String STATISTICS_DB_NAME = "_statistics_";
     public static final String SAMPLE_STATISTICS_TABLE_NAME = "table_statistic_v1";
     public static final String FULL_STATISTICS_TABLE_NAME = "column_statistics";
@@ -98,6 +99,7 @@ public class StatsConstants {
 
     // SQL plan manager table
     public static final String SPM_BASELINE_TABLE_NAME = "spm_baselines";
+    public static final String QUERY_HISTORY_TABLE_NAME = "query_history";
 
     /**
      * Deprecated stats properties

--- a/fe/fe-core/src/main/java/com/starrocks/summary/QueryHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/summary/QueryHistory.java
@@ -1,0 +1,114 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.summary;
+
+import com.google.common.collect.Maps;
+import com.google.gson.Gson;
+import com.starrocks.common.util.DateUtils;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.sql.spm.SPMAst2SQLBuilder;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+public class QueryHistory {
+    private String originSQL;
+    private final StatementBase statement;
+    private final ExecPlan plan;
+    private double queryMs;
+    private LocalDateTime datetime;
+    private final Map<String, String> other = Map.of();
+
+    private double costs;
+    private String sqlDigest;
+
+    QueryHistory() {
+        statement = null;
+        plan = null;
+    }
+
+    QueryHistory(ConnectContext ctx, ExecPlan plan) {
+        originSQL = ctx.getExecutor().getOriginStmtInString();
+        statement = ctx.getExecutor().getParsedStmt();
+        datetime = LocalDateTime.now();
+        queryMs = System.currentTimeMillis() - ctx.getStartTime();
+
+        this.plan = plan;
+        this.costs = plan.getPhysicalPlan().getCost();
+    }
+
+    public void setOriginSQL(String originSQL) {
+        this.originSQL = originSQL;
+    }
+
+    public void setQueryMs(double queryMs) {
+        this.queryMs = queryMs;
+    }
+
+    public void setDatetime(LocalDateTime datetime) {
+        this.datetime = datetime;
+    }
+
+    public void setCosts(double costs) {
+        this.costs = costs;
+    }
+
+    public void setSqlDigest(String sqlDigest) {
+        this.sqlDigest = sqlDigest;
+    }
+
+    public String getOriginSQL() {
+        return originSQL;
+    }
+
+    public String getSqlDigest() {
+        return sqlDigest;
+    }
+
+    public double getCosts() {
+        return costs;
+    }
+
+    public double getQueryMs() {
+        return queryMs;
+    }
+
+    public LocalDateTime getDatetime() {
+        return datetime;
+    }
+
+    String toJSON() {
+        Map<String, Object> jsonMaps = Maps.newHashMap();
+        jsonMaps.put("dt", DateUtils.formatDateTimeUnix(datetime));
+        jsonMaps.put("frontend", GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf().getHost() + ":" +
+                GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf().getQueryPort());
+        jsonMaps.put("sql", originSQL);
+        jsonMaps.put("plan_costs", costs);
+        jsonMaps.put("query_ms", queryMs);
+        jsonMaps.put("other", other);
+
+        SPMAst2SQLBuilder builder = new SPMAst2SQLBuilder(false, true);
+        sqlDigest = builder.build((QueryStatement) statement);
+
+        String planStr = this.plan.getExplainString(StatementBase.ExplainLevel.LOGICAL);
+        jsonMaps.put("sql_digest", sqlDigest);
+        jsonMaps.put("plan", planStr);
+        return new Gson().toJson(jsonMaps);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/summary/QueryHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/summary/QueryHistory.java
@@ -16,6 +16,7 @@ package com.starrocks.summary;
 
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -109,6 +110,8 @@ public class QueryHistory {
         String planStr = this.plan.getExplainString(StatementBase.ExplainLevel.LOGICAL);
         jsonMaps.put("sql_digest", sqlDigest);
         jsonMaps.put("plan", planStr);
-        return new Gson().toJson(jsonMaps);
+
+        Gson gson = new GsonBuilder().disableHtmlEscaping().create();
+        return gson.toJson(jsonMaps);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/summary/QueryHistoryMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/summary/QueryHistoryMgr.java
@@ -1,0 +1,171 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.summary;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.gson.Gson;
+import com.starrocks.common.ThreadPoolManager;
+import com.starrocks.common.util.DateUtils;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.GlobalVariable;
+import com.starrocks.qe.SimpleExecutor;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.sql.spm.SPMAst2SQLBuilder;
+import com.starrocks.sql.spm.SPMPlan2SQLBuilder;
+import com.starrocks.statistic.StatsConstants;
+import com.starrocks.thrift.TResultSinkType;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpStatus;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+
+public class QueryHistoryMgr {
+    private static final Logger LOG = LogManager.getLogger(QueryHistoryMgr.class);
+
+    private static final int CONVERT_BATCH_SIZE = 100;
+
+    private static final int MAX_MEMORY_SIZE = 200 * 1024 * 1024; // 200 MB
+
+    private static final ExecutorService EXECUTOR = ThreadPoolManager.newDaemonFixedThreadPool(
+            1, Integer.MAX_VALUE,
+            "query-history-executor", true);
+
+    private final List<QueryHistory> histories = Lists.newArrayListWithCapacity(CONVERT_BATCH_SIZE + 1);
+
+    private StringBuffer buffer = new StringBuffer();
+
+    private int batchSize = 0;
+
+    private LocalDateTime lastLoadTime = LocalDateTime.now();
+
+    public synchronized void addQueryHistory(ConnectContext ctx, ExecPlan plan) {
+        if (!GlobalVariable.isEnableQueryHistory()) {
+            return;
+        }
+        if (ctx.isStatisticsConnection() || ctx.isStatisticsJob() || plan.getScanNodes().isEmpty()
+                || StringUtils.containsIgnoreCase(ctx.getExecutor().getOriginStmtInString(),
+                StatsConstants.INFORMATION_SCHEMA)) {
+            return;
+        }
+
+        histories.add(new QueryHistory(ctx, plan));
+        if (histories.size() > CONVERT_BATCH_SIZE || lastLoadTime.plusSeconds(
+                GlobalVariable.queryHistoryLoadIntervalSeconds).isBefore(LocalDateTime.now())) {
+            loadQueryHistory(Lists.newArrayList(histories));
+            histories.clear();
+        }
+    }
+
+    private void loadQueryHistory(List<QueryHistory> list) {
+        EXECUTOR.submit(() -> {
+            try {
+                for (QueryHistory query : list) {
+                    buffer.append(query.toJSON()).append(",");
+                }
+                batchSize += list.size();
+
+                if (buffer.isEmpty()) {
+                    return;
+                }
+                if (buffer.length() < MAX_MEMORY_SIZE && lastLoadTime.plusSeconds(
+                        GlobalVariable.queryHistoryLoadIntervalSeconds).isAfter(LocalDateTime.now())) {
+                    return;
+                }
+                buffer.setLength(buffer.length() - 1);
+                StreamLoader loader = new StreamLoader(StatsConstants.STATISTICS_DB_NAME,
+                        StatsConstants.QUERY_HISTORY_TABLE_NAME,
+                        List.of("dt", "frontend", "sql_digest", "sql", "plan", "plan_costs", "query_ms", "other"));
+                StreamLoader.Response response = loader.loadBatch("query_history", buffer.toString());
+
+                if (response != null && response.status() == HttpStatus.SC_OK) {
+                    LOG.debug("load query history success, batch size[{}], response[{}]", batchSize, response);
+                } else {
+                    LOG.warn("load query history failed, batch size[{}], response[{}]", batchSize, response);
+                }
+
+                buffer = new StringBuffer();
+                lastLoadTime = LocalDateTime.now();
+                batchSize = 0;
+            } catch (Exception e) {
+                LOG.warn("Failed to load query history.", e);
+            }
+        });
+    }
+
+    public void clearExpiredQueryHistory() {
+        if (!GlobalVariable.isEnableQueryHistory()) {
+            return;
+        }
+
+        String date =
+                DateUtils.formatDateTimeUnix(LocalDateTime.now().minusSeconds(GlobalVariable.queryHistoryKeepSeconds));
+        SimpleExecutor executor = new SimpleExecutor("QueryHistoryDrop", TResultSinkType.MYSQL_PROTOCAL);
+        executor.executeDML(
+                "DELETE FROM " + StatsConstants.STATISTICS_DB_NAME + "." + StatsConstants.QUERY_HISTORY_TABLE_NAME
+                        + " WHERE dt <= '" + date + "'");
+    }
+
+    private static class QueryHistory {
+        private final String originSQL;
+        private final StatementBase statement;
+        private final OptExpression physicalPlan;
+        private final List<ColumnRefOperator> outputs;
+        private final long queryMs;
+        private final String datetime;
+        private final Map<String, String> other = Map.of();
+
+        private QueryHistory(ConnectContext ctx, ExecPlan plan) {
+            originSQL = ctx.getExecutor().getOriginStmtInString();
+            statement = ctx.getExecutor().getParsedStmt();
+            physicalPlan = plan.getPhysicalPlan();
+            outputs = plan.getOutputColumns();
+
+            datetime = DateUtils.formatDateTimeUnix(LocalDateTime.now());
+            queryMs = System.currentTimeMillis() - ctx.getStartTime();
+        }
+
+        private String toJSON() {
+            Map<String, Object> jsonMaps = Maps.newHashMap();
+            jsonMaps.put("dt", datetime);
+            jsonMaps.put("frontend", GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf().getHost() + ":" +
+                    GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf().getQueryPort());
+            jsonMaps.put("sql", originSQL);
+            jsonMaps.put("plan_costs", physicalPlan.getCost());
+            jsonMaps.put("query_ms", queryMs);
+            jsonMaps.put("other", other);
+
+            SPMAst2SQLBuilder builder = new SPMAst2SQLBuilder(false, true);
+            String sqlDigest = builder.build((QueryStatement) statement);
+            SPMPlan2SQLBuilder planBuilder = new SPMPlan2SQLBuilder();
+            String planSQL = planBuilder.toSQL(List.of(), physicalPlan, outputs);
+
+            jsonMaps.put("sql_digest", sqlDigest);
+            jsonMaps.put("plan", planSQL);
+
+            return new Gson().toJson(jsonMaps);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/summary/QueryHistoryMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/summary/QueryHistoryMgr.java
@@ -24,6 +24,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.GlobalVariable;
 import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.statistic.StatsConstants;
 import com.starrocks.thrift.TResultBatch;
 import com.starrocks.thrift.TResultSinkType;
@@ -126,7 +127,9 @@ public class QueryHistoryMgr {
     }
 
     private void loadQueryHistory(List<QueryHistory> list) {
+        ConnectContext ctx = StatisticUtils.buildConnectContext();
         EXECUTOR.submit(() -> {
+            ctx.setThreadLocalInfo();
             for (QueryHistory query : list) {
                 try {
                     buffer.append(query.toJSON()).append(",");

--- a/fe/fe-core/src/main/java/com/starrocks/summary/StreamLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/summary/StreamLoader.java
@@ -1,0 +1,110 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.summary;
+
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.system.Frontend;
+import com.starrocks.system.SystemInfoService;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.http.HttpStatus;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+class StreamLoader {
+    private static final String LOAD_URL_PATTERN = "/api/%s/%s/_stream_load";
+    private final String loadUrlStr;
+
+    private final List<String> columns;
+
+    public StreamLoader(String db, String tbl, List<String> columns) {
+        this.columns = columns;
+        this.loadUrlStr = String.format(LOAD_URL_PATTERN, db, tbl);
+    }
+
+    public record Response(int status, String msg) {}
+
+    public Response loadBatch(String label, String sb) throws URISyntaxException, IOException,
+            InterruptedException {
+        Frontend fe = GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf();
+        label += fe.getHost().replace(".", "_");
+        label += fe.getEditLogPort();
+        label += "_" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
+
+        String authString = fe.getHost() + ":" + fe.getNodeName();
+        String authEncoding = Base64.getEncoder().encodeToString(authString.getBytes());
+
+        Optional<ComputeNode> be = chooseBENode();
+        if (be.isEmpty()) {
+            return new Response(HttpStatus.SC_PRECONDITION_FAILED, "doesn't found available be node");
+        }
+        URI uri = new URI("http", null, be.get().getHost(), be.get().getHttpPort(), loadUrlStr, null, null);
+        HttpRequest request = HttpRequest.newBuilder(uri)
+                .header("Authorization", "Basic " + authEncoding)
+                .header("Content-Type", "text/plain; charset=UTF-8")
+                .header("format", "json")
+                .header("label", label)
+                .header("columns", String.join(",", columns))
+                .PUT(HttpRequest.BodyPublishers.ofString(sb))
+                .build();
+
+        HttpClient client = HttpClient.newHttpClient();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        return new Response(response.statusCode(), response.body());
+    }
+
+    private static Optional<ComputeNode> chooseBENode() {
+        // Choose a backend sequentially, or choose a cn in shared_data mode
+        List<Long> nodeIds = new ArrayList<>();
+        if (RunMode.isSharedDataMode()) {
+            List<Long> computeIds = GlobalStateMgr.getCurrentState().getWarehouseMgr()
+                    .getAllComputeNodeIds(WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+            for (long nodeId : computeIds) {
+                ComputeNode node =
+                        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendOrComputeNode(nodeId);
+                if (node != null && node.isAvailable()) {
+                    nodeIds.add(nodeId);
+                }
+            }
+            Collections.shuffle(nodeIds);
+        } else {
+            SystemInfoService systemInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+            nodeIds = systemInfoService.getNodeSelector().seqChooseBackendIds(1, true, false, null);
+        }
+        if (CollectionUtils.isEmpty(nodeIds)) {
+            return Optional.empty();
+        }
+        ComputeNode node =
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendOrComputeNode(nodeIds.get(0));
+        if (node == null) {
+            return Optional.empty();
+        }
+        return Optional.of(node);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/summary/StreamLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/summary/StreamLoader.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.summary;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
@@ -76,6 +78,18 @@ class StreamLoader {
 
         HttpClient client = HttpClient.newHttpClient();
         HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() == HttpStatus.SC_OK) {
+            JsonElement obj = JsonParser.parseString(response.body());
+            String status = obj.getAsJsonObject().get("Status").getAsString();
+            String message = obj.getAsJsonObject().get("Message").getAsString();
+
+            if (!status.equalsIgnoreCase("success")) {
+                return new Response(HttpStatus.SC_INTERNAL_SERVER_ERROR, message);
+            } else {
+                return new Response(HttpStatus.SC_OK, message);
+            }
+        }
         return new Response(response.statusCode(), response.body());
     }
 

--- a/test/sql/test_query_history/R/test_query_history
+++ b/test/sql/test_query_history/R/test_query_history
@@ -1,0 +1,45 @@
+-- name: test_query_history
+create table t1 (
+    k1 int,
+    k2 int,
+    k3 string
+)
+duplicate key(k1)
+distributed by hash(k1) buckets 1
+properties("replication_num" = "1");
+-- result:
+-- !result
+insert into t1 
+select s1, s1 % 1000, repeat('a', 128) FROM TABLE(generate_series(1, 100)) s(s1);
+-- result:
+-- !result
+truncate table _statistics_.query_history;
+-- result:
+-- !result
+select count(1) from _statistics_.query_history;
+-- result:
+0
+-- !result
+set global enable_query_history=true;
+-- result:
+-- !result
+set global query_history_load_interval_seconds=0;
+-- result:
+-- !result
+select count(1) from t1;
+-- result:
+100
+-- !result
+select sleep(2);
+-- result:
+1
+-- !result
+select count(1) from _statistics_.query_history where sql_digest like "%count%"; 
+
+set global enable_query_history=false;
+-- result:
+1
+-- !result
+set global query_history_load_interval_seconds=900;
+-- result:
+-- !result

--- a/test/sql/test_query_history/T/test_query_history
+++ b/test/sql/test_query_history/T/test_query_history
@@ -1,0 +1,28 @@
+-- name: test_query_history
+
+create table t1 (
+    k1 int,
+    k2 int,
+    k3 string
+)
+duplicate key(k1)
+distributed by hash(k1) buckets 1
+properties("replication_num" = "1");
+
+insert into t1 
+select s1, s1 % 1000, repeat('a', 128) FROM TABLE(generate_series(1, 100)) s(s1);
+
+truncate table _statistics_.query_history;
+select count(1) from _statistics_.query_history;
+
+set global enable_query_history=true;
+set global query_history_load_interval_seconds=0;
+
+select count(1) from t1;
+
+select sleep(2);
+
+select count(1) from _statistics_.query_history where sql_digest like "%count%"; 
+
+set global enable_query_history=false;
+set global query_history_load_interval_seconds=900;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

stream load QueryPlan into be. e.g.
```
MySQL _statistics_> select * from query_history
+---------------------+--------------------+------------------------------------------------------+--------------------------+--------------------------------------------------------------------------------+------------+----------+-------+
| dt                  | frontend           | sql_digest                                           | sql                      | plan                                                                           | plan_costs | query_ms | other |
+---------------------+--------------------+------------------------------------------------------+--------------------------+--------------------------------------------------------------------------------+------------+----------+-------+
| 2025-04-03 16:04:32 | 172.26.92.227:8112 | SELECT count(?) AS `count(1)`                        | select count(1) from t1; | SELECT c_4 FROM (SELECT count(1) AS c_4 FROM (SELECT 1 AS c_6 FROM t1) t_0) t2 | 516.0      | 5.0      | {}    |
|                     |                    | FROM `test_db_5232800e372d4766af3374d701bfa5b9`.`t1` |                          |                                                                                |            |          |       |
+---------------------+--------------------+------------------------------------------------------+--------------------------+--------------------------------------------------------------------------------+------------+----------+-------+
1 row in set
Time: 0.050s
MySQL _statistics_>
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
