### PR TITLE
[Enhancement] Use query blacklist for stream load BE/CN selection

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3656,8 +3656,8 @@ public class Config extends ConfigBase {
     public static boolean enable_trace_historical_node = false;
 
     /**
-     * Whether to enable black list to filter BE/CN for stream load
+     * Whether to enable block list to filter BE/CN for stream load
      */
     @ConfField(mutable = true)
-    public static boolean enable_black_list_for_stream_load = true;
+    public static boolean enable_block_list_for_stream_load = true;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3654,4 +3654,10 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static boolean enable_trace_historical_node = false;
+
+    /**
+     * Whether to enable black list to filter BE/CN for stream load
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_black_list_for_stream_load = true;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
@@ -98,11 +98,10 @@ public class LoadAction extends RestBaseAction {
             }
         } else {
             SystemInfoService systemInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
-            nodeIds = systemInfoService.getNodeSelector()
-                                       .seqChooseBackendIds(systemInfoService.getAvailableBackends().size(), true, false, null);
+            nodeIds = systemInfoService.getAvailableBackends().stream().map(be -> be.getId()).collect(Collectors.toList());
         }
 
-        if (Config.enable_black_list_for_stream_load) {
+        if (Config.enable_block_list_for_stream_load) {
             List<Long> filterNodeIds = nodeIds.stream()
                                               .filter(id -> !SimpleScheduler.isInBlocklist(id)).collect(Collectors.toList());
             if (filterNodeIds != null && !filterNodeIds.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
@@ -73,6 +73,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -224,7 +225,7 @@ public class TransactionLoadAction extends RestBaseAction {
         // redirect transaction op to BE
         TNetworkAddress redirectAddress = result.getRedirectAddress();
         if (null == redirectAddress) {
-            Long nodeId = getNodeId(txnOperation, label);
+            Long nodeId = getNodeId(txnOperation, label, txnOperationParams.getWarehouseName());
             ComputeNode node = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackend(nodeId);
             if (node == null) {
                 node = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getComputeNode(nodeId);
@@ -279,12 +280,12 @@ public class TransactionLoadAction extends RestBaseAction {
                 ? new BypassWriteTransactionHandler(params) : new TransactionWithoutChannelHandler(params);
     }
 
-    private Long getNodeId(TransactionOperation txnOperation, String label) throws StarRocksException {
+    private Long getNodeId(TransactionOperation txnOperation, String label, String warehouseName) throws StarRocksException {
         Long nodeId;
         // save label->be hashmap when begin transaction, so that subsequent operator can send to same BE
         if (TXN_BEGIN.equals(txnOperation)) {
-            Long chosenNodeId = GlobalStateMgr.getCurrentState().getNodeMgr()
-                    .getClusterInfo().getNodeSelector().seqChooseBackendOrComputeId();
+            List<Long> nodeIds = LoadAction.selectNodes(warehouseName);
+            Long chosenNodeId = nodeIds.get(0);
             nodeId = chosenNodeId;
             // txnNodeMap is LRU cache, it atomic remove unused entry
             accessTxnNodeMapWithWriteLock(txnNodeMap -> txnNodeMap.put(label, chosenNodeId));

--- a/fe/fe-core/src/test/java/com/starrocks/http/LoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/LoadActionTest.java
@@ -282,7 +282,7 @@ public class LoadActionTest extends StarRocksHttpTestCase {
             @Mock
             public List<Long> seqChooseBackendIds(int backendNum, boolean needAvailable,
                                                   boolean isCreate, Multimap<String, String> locReq) {
-                assertEquals(1, backendNum);
+                assertEquals(0, backendNum);
                 assertTrue(needAvailable);
                 assertFalse(isCreate);
                 return new ArrayList<>();

--- a/fe/fe-core/src/test/java/com/starrocks/http/LoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/LoadActionTest.java
@@ -15,7 +15,6 @@
 package com.starrocks.http;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.google.common.collect.Multimap;
 import com.starrocks.load.batchwrite.BatchWriteMgr;
 import com.starrocks.load.batchwrite.RequestCoordinatorBackendResult;
 import com.starrocks.load.batchwrite.TableId;
@@ -25,7 +24,6 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
-import com.starrocks.system.NodeSelector;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
@@ -62,7 +60,6 @@ import java.util.concurrent.TimeUnit;
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_ENABLE_BATCH_WRITE;
 import static com.starrocks.server.WarehouseManager.DEFAULT_WAREHOUSE_NAME;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class LoadActionTest extends StarRocksHttpTestCase {
@@ -156,13 +153,13 @@ public class LoadActionTest extends StarRocksHttpTestCase {
 
     @Test
     public void testLoadTest100ContinueRespondHTTP307() throws Exception {
-        new MockUp<NodeSelector>() {
+        new MockUp<SystemInfoService>() {
             @Mock
-            public List<Long> seqChooseBackendIds(int backendNum, boolean needAvailable,
-                                                  boolean isCreate, Multimap<String, String> locReq) {
-                List<Long> result = new ArrayList<>();
-                result.add(testBackendId1);
-                return result;
+            public List<Backend> getAvailableBackends() {
+                List<Backend> bes = new ArrayList<>();
+                bes.add(new Backend());
+                bes.get(0).setId(testBackendId1);
+                return bes;
             }
         };
 
@@ -202,13 +199,13 @@ public class LoadActionTest extends StarRocksHttpTestCase {
 
     @Test
     public void testLoad100ContinueBackwardsCompatible() throws Exception {
-        new MockUp<NodeSelector>() {
+        new MockUp<SystemInfoService>() {
             @Mock
-            public List<Long> seqChooseBackendIds(int backendNum, boolean needAvailable,
-                                                  boolean isCreate, Multimap<String, String> locReq) {
-                List<Long> result = new ArrayList<>();
-                result.add(testBackendId1);
-                return result;
+            public List<Backend> getAvailableBackends() {
+                List<Backend> bes = new ArrayList<>();
+                bes.add(new Backend());
+                bes.get(0).setId(testBackendId1);
+                return bes;
             }
         };
 
@@ -278,13 +275,9 @@ public class LoadActionTest extends StarRocksHttpTestCase {
 
     @Test
     public void testStreamLoadSkipNonAliveNodesForSharedNothing() throws Exception {
-        new MockUp<NodeSelector>() {
+        new MockUp<SystemInfoService>() {
             @Mock
-            public List<Long> seqChooseBackendIds(int backendNum, boolean needAvailable,
-                                                  boolean isCreate, Multimap<String, String> locReq) {
-                assertEquals(0, backendNum);
-                assertTrue(needAvailable);
-                assertFalse(isCreate);
+            public List<Backend> getAvailableBackends() {
                 return new ArrayList<>();
             }
         };
@@ -350,15 +343,17 @@ public class LoadActionTest extends StarRocksHttpTestCase {
         }
 
         {
-            new MockUp<NodeSelector>() {
+            new MockUp<SystemInfoService>() {
                 @Mock
-                public List<Long> seqChooseBackendIds(int backendNum, boolean needAvailable,
-                                                      boolean isCreate, Multimap<String, String> locReq) {
-                    List<Long> result = new ArrayList<>();
-                    result.add(1L);
-                    result.add(2L);
-                    result.add(3L);
-                    return result;
+                public List<Backend> getAvailableBackends() {
+                    List<Backend> bes = new ArrayList<>();
+                    bes.add(new Backend());
+                    bes.add(new Backend());
+                    bes.add(new Backend());
+                    bes.get(0).setId(1L);
+                    bes.get(1).setId(2L);
+                    bes.get(2).setId(3L);
+                    return bes;
                 }
             };
 

--- a/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionOnSharedDataClusterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionOnSharedDataClusterTest.java
@@ -19,6 +19,7 @@ import com.starrocks.http.rest.TransactionLoadAction;
 import com.starrocks.http.rest.TransactionResult;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.TNetworkAddress;
 import io.netty.handler.codec.http.HttpMethod;
@@ -27,6 +28,9 @@ import mockit.Mock;
 import mockit.MockUp;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.Assert.assertTrue;
 
@@ -53,6 +57,15 @@ public class TransactionLoadActionOnSharedDataClusterTest extends TransactionLoa
             @Mock
             boolean isLeader() {
                 return true;
+            }
+        };
+
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public List<Long> getAllComputeNodeIds(String warehouseName) {
+                List<Long> nodes = new ArrayList<>();
+                nodes.add(1234L);
+                return nodes;
             }
         };
 


### PR DESCRIPTION
## Why I'm doing:
If a BE/CN is still alive but it is in query blacklist for some reason. In this case, FE will still  try to redirect the stream load request into such BE/CN and maybe fail.

## What I'm doing:
Filter the nodes by query blacklist

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
