### PR TITLE
[Enhancement] Support to specify warehouse for query_plan rest query

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
@@ -150,6 +150,9 @@ public class RestBaseAction extends BaseAction {
         ctx.setCurrentUserIdentity(currentUser);
         ctx.setCurrentRoleIds(currentUser);
         ctx.setThreadLocalInfo();
+        if (request.getRequest().headers().contains(WAREHOUSE_KEY)) {
+            ctx.setCurrentWarehouse(request.getRequest().headers().get(WAREHOUSE_KEY));
+        }
         executeWithoutPassword(request, response);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
@@ -150,9 +150,6 @@ public class RestBaseAction extends BaseAction {
         ctx.setCurrentUserIdentity(currentUser);
         ctx.setCurrentRoleIds(currentUser);
         ctx.setThreadLocalInfo();
-        if (request.getRequest().headers().contains(WAREHOUSE_KEY)) {
-            ctx.setCurrentWarehouse(request.getRequest().headers().get(WAREHOUSE_KEY));
-        }
         executeWithoutPassword(request, response);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/http/TableQueryPlanActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TableQueryPlanActionTest.java
@@ -198,11 +198,11 @@ public class TableQueryPlanActionTest extends StarRocksHttpTestCase {
             String respStr = Objects.requireNonNull(response.body()).string();
             JSONObject jsonObject = new JSONObject(respStr);
             System.out.println(respStr);
-            Assert.assertEquals(500, jsonObject.getInt("status"));
+            Assert.assertEquals(404, jsonObject.getInt("status"));
             String exception = jsonObject.getString("exception");
             Assert.assertNotNull(exception);
             Assert.assertTrue(
-                    exception.startsWith("Invalid SQL:  select k1 from testDb.testTbl "));
+                    exception.startsWith("Warehouse [invalid_warehouse] does not exist"));
         }
     }
 }


### PR DESCRIPTION
## Why I'm doing:
Refert to the doc: https://github.com/StarRocks/starrocks-connector-for-apache-flink/blob/main/docs/content/connector-source.md
At present, we can not specify a warehouse when using flink to query the sr table. I propose to pass the warehouse info through  http header.
This PR can be worked after https://github.com/StarRocks/starrocks-connector-for-apache-flink/pull/423

## What I'm doing:
Support to specify warehouse for rest query, like flink sr connector.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
