### PR TITLE
[Refactor] Remove param mor_reader_mode from join param

### DIFF
--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -481,7 +481,7 @@ pipeline::OpFactories HashJoinNode::_decompose_to_pipeline(pipeline::PipelineBui
     HashJoinerParam param(pool, _hash_join_node, _is_null_safes, _build_expr_ctxs, _probe_expr_ctxs,
                           _other_join_conjunct_ctxs, _conjunct_ctxs, child(1)->row_desc(), child(0)->row_desc(),
                           child(1)->type(), child(0)->type(), child(1)->conjunct_ctxs().empty(), _build_runtime_filters,
-                          _output_slots, _output_slots, _distribution_mode, false, _enable_late_materialization,
+                          _output_slots, _output_slots, _distribution_mode, _enable_late_materialization,
                           _enable_partition_hash_join, _is_skew_join);
     auto hash_joiner_factory = std::make_shared<starrocks::pipeline::HashJoinerFactory>(param);
 

--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -79,7 +79,6 @@ HashJoiner::HashJoiner(const HashJoinerParam& param)
           _build_output_slots(param._build_output_slots),
           _probe_output_slots(param._probe_output_slots),
           _build_runtime_filters(param._build_runtime_filters.begin(), param._build_runtime_filters.end()),
-          _mor_reader_mode(param._mor_reader_mode),
           _enable_late_materialization(param._enable_late_materialization),
           _is_skew_join(param._is_skew_join) {
     _is_push_down = param._hash_join_node.is_push_down;
@@ -152,7 +151,6 @@ void HashJoiner::_init_hash_table_param(HashTableParam* param) {
     param->probe_row_desc = &_probe_row_descriptor;
     param->build_output_slots = _build_output_slots;
     param->probe_output_slots = _probe_output_slots;
-    param->mor_reader_mode = _mor_reader_mode;
     param->enable_late_materialization = _enable_late_materialization;
 
     std::set<SlotId> predicate_slots;

--- a/be/src/exec/hash_joiner.h
+++ b/be/src/exec/hash_joiner.h
@@ -71,8 +71,8 @@ struct HashJoinerParam {
                     TPlanNodeType::type build_node_type, TPlanNodeType::type probe_node_type,
                     bool build_conjunct_ctxs_is_empty, std::list<RuntimeFilterBuildDescriptor*> build_runtime_filters,
                     std::set<SlotId> build_output_slots, std::set<SlotId> probe_output_slots,
-                    const TJoinDistributionMode::type distribution_mode, bool mor_reader_mode,
-                    bool enable_late_materialization, bool enable_partition_hash_join, bool is_skew_join)
+                    const TJoinDistributionMode::type distribution_mode, bool enable_late_materialization,
+                    bool enable_partition_hash_join, bool is_skew_join)
             : _pool(pool),
               _hash_join_node(hash_join_node),
               _is_null_safes(std::move(is_null_safes)),
@@ -89,7 +89,6 @@ struct HashJoinerParam {
               _build_output_slots(std::move(build_output_slots)),
               _probe_output_slots(std::move(probe_output_slots)),
               _distribution_mode(distribution_mode),
-              _mor_reader_mode(mor_reader_mode),
               _enable_late_materialization(enable_late_materialization),
               _enable_partition_hash_join(enable_partition_hash_join),
               _is_skew_join(is_skew_join) {}
@@ -115,7 +114,6 @@ struct HashJoinerParam {
     std::set<SlotId> _probe_output_slots;
 
     const TJoinDistributionMode::type _distribution_mode;
-    const bool _mor_reader_mode;
     const bool _enable_late_materialization;
     const bool _enable_partition_hash_join;
     const bool _is_skew_join;
@@ -479,7 +477,6 @@ private:
     HashJoinBuildMetrics* _build_metrics;
     HashJoinProbeMetrics* _probe_metrics;
     size_t _hash_table_build_rows{};
-    bool _mor_reader_mode = false;
     bool _enable_late_materialization = false;
     // probe side notify build observe
     pipeline::Observable _builder_observable;

--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -131,7 +131,6 @@ struct JoinHashTableItems {
     float keys_per_bucket = 0;
     size_t used_buckets = 0;
     bool cache_miss_serious = false;
-    bool mor_reader_mode = false;
     bool enable_late_materialization = false;
     bool is_collision_free_and_unique = false;
 
@@ -299,7 +298,6 @@ struct HashTableParam {
     RuntimeProfile::Counter* output_build_column_timer = nullptr;
     RuntimeProfile::Counter* output_probe_column_timer = nullptr;
     RuntimeProfile::Counter* probe_counter = nullptr;
-    bool mor_reader_mode = false;
 };
 
 template <class T, size_t Size = sizeof(T)>
@@ -644,10 +642,6 @@ private:
     void _build_output(ChunkPtr* chunk) {
         SCOPED_TIMER(_probe_state->output_build_column_timer);
 
-        if (_table_items->mor_reader_mode) {
-            return;
-        }
-
         for (size_t i = 0; i < _table_items->build_column_count; i++) {
             HashTableSlotDescriptor hash_table_slot = _table_items->build_slots[i];
             SlotDescriptor* slot = hash_table_slot.slot;
@@ -874,7 +868,6 @@ public:
 private:
     void _init_probe_column(const HashTableParam& param);
     void _init_build_column(const HashTableParam& param);
-    void _init_mor_reader();
     void _init_join_keys();
 
     JoinHashMapType _choose_join_hash_map();

--- a/be/src/exec/join_hash_map.tpp
+++ b/be/src/exec/join_hash_map.tpp
@@ -478,10 +478,6 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const Col
         {
             // output default values for build-columns as placeholder.
             SCOPED_TIMER(_probe_state->output_build_column_timer);
-            if (_table_items->mor_reader_mode) {
-                return;
-            }
-
             if (!_table_items->with_other_conjunct) {
                 // When the project doesn't require any cols from join, FE will select the first col in the build table
                 // of join as the output col for simple, wo we also need output build column here

--- a/be/test/exec/join_hash_map_test.cpp
+++ b/be/test/exec/join_hash_map_test.cpp
@@ -229,7 +229,6 @@ HashTableParam JoinHashMapTest::create_table_param_int(TJoinOp::type join_type, 
 
     HashTableParam param;
     param.with_other_conjunct = false;
-    param.mor_reader_mode = false;
     param.join_type = join_type;
     param.search_ht_timer = ADD_TIMER(_runtime_profile, "SearchHashTableTime");
     param.output_build_column_timer = ADD_TIMER(_runtime_profile, "OutputBuildColumnTime");
@@ -2400,7 +2399,6 @@ TEST_F(JoinHashMapTest, EmptyHashMapTestLazyFilter) {
     JoinHashTable ht;
 
     HashTableParam param;
-    param.mor_reader_mode = false;
     param.enable_late_materialization = true;
     param.probe_row_desc = probe_row_desc.get();
     param.build_row_desc = build_row_desc.get();
@@ -2456,7 +2454,6 @@ TEST_F(JoinHashMapTest, EmptyHashMapTestLazyOutputAll) {
     JoinHashTable ht;
 
     HashTableParam param;
-    param.mor_reader_mode = false;
     param.enable_late_materialization = true;
     param.probe_row_desc = probe_row_desc.get();
     param.build_row_desc = build_row_desc.get();
@@ -2801,7 +2798,6 @@ TEST_F(JoinHashMapTest, TestOutputSlotsEmpty) {
     JoinHashTable ht;
 
     HashTableParam param;
-    param.mor_reader_mode = false;
     param.enable_late_materialization = false;
     param.probe_row_desc = probe_row_desc.get();
     param.build_row_desc = build_row_desc.get();
@@ -2829,7 +2825,6 @@ TEST_F(JoinHashMapTest, TestOutputSlotsNormal) {
     JoinHashTable ht;
 
     HashTableParam param;
-    param.mor_reader_mode = false;
     param.enable_late_materialization = false;
     param.probe_row_desc = probe_row_desc.get();
     param.build_row_desc = build_row_desc.get();
@@ -2860,7 +2855,6 @@ TEST_F(JoinHashMapTest, TestLazyOutputSlotsEmpty) {
     JoinHashTable ht;
 
     HashTableParam param;
-    param.mor_reader_mode = false;
     param.enable_late_materialization = true;
     param.probe_row_desc = probe_row_desc.get();
     param.build_row_desc = build_row_desc.get();
@@ -2888,7 +2882,6 @@ TEST_F(JoinHashMapTest, TestLazyPredicateSlotsEmpty) {
     JoinHashTable ht;
 
     HashTableParam param;
-    param.mor_reader_mode = false;
     param.enable_late_materialization = true;
     param.probe_row_desc = probe_row_desc.get();
     param.build_row_desc = build_row_desc.get();
@@ -2919,7 +2912,6 @@ TEST_F(JoinHashMapTest, TestLazyPredicateSlotsNormal) {
     JoinHashTable ht;
 
     HashTableParam param;
-    param.mor_reader_mode = false;
     param.enable_late_materialization = true;
     param.probe_row_desc = probe_row_desc.get();
     param.build_row_desc = build_row_desc.get();
@@ -2937,33 +2929,4 @@ TEST_F(JoinHashMapTest, TestLazyPredicateSlotsNormal) {
     check_lazy_build_output_slot_ids(*ht.table_items(), {4});
     check_not_output_slot_ids(*ht.table_items(), {0, 3});
 }
-
-// NOLINTNEXTLINE
-TEST_F(JoinHashMapTest, TestMorRead) {
-    TDescriptorTableBuilder row_desc_builder;
-    add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false, 3);
-    add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false, 3);
-
-    auto probe_row_desc = create_probe_desc(&row_desc_builder);
-    auto build_row_desc = create_build_desc(&row_desc_builder);
-
-    JoinHashTable ht;
-
-    HashTableParam param;
-    param.mor_reader_mode = true;
-    param.enable_late_materialization = false;
-    param.probe_row_desc = probe_row_desc.get();
-    param.build_row_desc = build_row_desc.get();
-    param.probe_output_slots = {1};
-    param.build_output_slots = {4};
-    param.predicate_slots = {2, 5};
-
-    ht.create(param);
-
-    ASSERT_EQ(ht.get_probe_column_count(), 6);
-    ASSERT_EQ(ht.get_build_column_count(), 3);
-    check_lazy_probe_output_slot_ids(*ht.table_items(), {});
-    check_lazy_build_output_slot_ids(*ht.table_items(), {});
-}
-
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

`mor_reader_mode` is used for old implement of iceberg equility delete, current is useless now, so remove it.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
