### PR TITLE
[BugFix] Fix the issue of MV refresh failure

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
@@ -343,9 +343,10 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
         if (partitionTTLNumber > 0 && toRefreshPartitionNum > partitionTTLNumber) {
             // remove the oldest partitions
             int toRemoveNum = toRefreshPartitionNum - partitionTTLNumber;
-            toRefreshPartitions.entrySet().stream()
+            List<String> keysToRemove = toRefreshPartitions.keySet().stream()
                     .limit(toRemoveNum)
-                    .forEach(e -> toRefreshPartitions.remove(e.getKey()));
+                    .collect(Collectors.toList());
+            keysToRemove.forEach(toRefreshPartitions::remove);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitionerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitionerTest.java
@@ -1,0 +1,40 @@
+package com.starrocks.scheduler.mv;
+
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.TableProperty;
+import com.starrocks.scheduler.MvTaskRunContext;
+import com.starrocks.sql.common.PCell;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MVPCTRefreshRangePartitionerTest {
+
+    @Test
+    public void testFilterPartitionsByTTL() {
+        MvTaskRunContext mvContext = mock(MvTaskRunContext.class);
+        when(mvContext.getPartitionTTLNumber()).thenReturn(2);
+
+        MaterializedView mv = mock(MaterializedView.class);
+        when(mv.getTableProperty()).thenReturn(mock(TableProperty.class));
+        when(mv.getPartitionInfo()).thenReturn(mock(PartitionInfo.class));
+        when(mv.getTableProperty().getPartitionTTLNumber()).thenReturn(2);
+
+        MVPCTRefreshRangePartitioner partitioner = new MVPCTRefreshRangePartitioner(mvContext, null, null, mv);
+
+        Map<String, PCell> toRefreshPartitions = Maps.newHashMap();
+        toRefreshPartitions.put("partition1", mock(PCell.class));
+        toRefreshPartitions.put("partition2", mock(PCell.class));
+        toRefreshPartitions.put("partition3", mock(PCell.class));
+
+        partitioner.filterPartitionsByTTL(toRefreshPartitions, true);
+
+        Assert.assertEquals(2, toRefreshPartitions.size());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitionerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitionerTest.java
@@ -1,3 +1,17 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.starrocks.scheduler.mv;
 
 import com.google.common.collect.Maps;


### PR DESCRIPTION
## Why I'm doing:
I encountered a ConcurrentModificationException during materialized view (MV) refresh. The code attempts to ​​remove entries from a Map while iterating over it using Stream.forEach()​​, which leads to a ​​ConcurrentModificationException.
```
java.util.ConcurrentModificationException
	at java.base/java.util.HashMap$EntrySpliterator.tryAdvance(HashMap.java:1787)
	at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:127)
	at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:502)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:488)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497)
	at com.starrocks.scheduler.mv.MVPCTRefreshRangePartitioner.filterPartitionsByTTL(MVPCTRefreshRangePartitioner.java:364)
	at com.starrocks.scheduler.mv.MVPCTRefreshRangePartitioner.syncAddOrDropPartitions(MVPCTRefreshRangePartitioner.java:122)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.syncPartitions(PartitionBasedMvRefreshProcessor.java:959)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedView(PartitionBasedMvRefreshProcessor.java:422)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedViewWithRetry(PartitionBasedMvRefreshProcessor.java:377)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doMvRefresh(PartitionBasedMvRefreshProcessor.java:336)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.processTaskRun(PartitionBasedMvRefreshProcessor.java:205)
	at com.starrocks.scheduler.TaskRun.executeTaskRun(TaskRun.java:272)
	at com.starrocks.scheduler.TaskRunExecutor.lambda$executeTaskRun$0(TaskRunExecutor.java:59)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)

```
## What I'm doing:
as title

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
