### PR TITLE
[Enhancement] Support for dynamic linking to support switching jemalloc with debug option

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -163,10 +163,6 @@ message(STATUS ${Boost_LIBRARIES})
 set(GPERFTOOLS_HOME "${THIRDPARTY_DIR}/gperftools")
 set(JEMALLOC_HOME "${THIRDPARTY_DIR}/jemalloc")
 
-if (${JEMALLOC_DEBUG})
-    set(JEMALLOC_HOME "${THIRDPARTY_DIR}/jemalloc-debug")
-endif()
-
 # Set all libraries
 
 add_library(clucene-core STATIC IMPORTED)
@@ -272,8 +268,13 @@ set_target_properties(openssl PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib
 add_library(leveldb STATIC IMPORTED GLOBAL)
 set_target_properties(leveldb PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libleveldb.a)
 
-add_library(jemalloc STATIC IMPORTED)
-set_target_properties(jemalloc PROPERTIES IMPORTED_LOCATION ${JEMALLOC_HOME}/lib/libjemalloc_pic.a)
+if ("${CMAKE_BUILD_TYPE}" STREQUAL "DEBUG" OR "${CMAKE_BUILD_TYPE}" STREQUAL "RELEASE")
+    add_library(jemalloc SHARED IMPORTED)
+    set_target_properties(jemalloc PROPERTIES IMPORTED_LOCATION ${JEMALLOC_HOME}/lib-shared/libjemalloc.so)
+else()
+    add_library(jemalloc STATIC IMPORTED)
+    set_target_properties(jemalloc PROPERTIES IMPORTED_LOCATION ${JEMALLOC_HOME}/lib-static/libjemalloc.a)
+endif()
 
 add_library(brotlicommon STATIC IMPORTED)
 set_target_properties(brotlicommon PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib64/libbrotlicommon.a)

--- a/bin/start_backend.sh
+++ b/bin/start_backend.sh
@@ -95,7 +95,6 @@ if [[ -z "$JEMALLOC_CONF" ]]; then
         ln -s -f $STARROCKS_HOME/lib/libjemalloc-dbg.so.2 $JEMALLOC_LIB
         export JEMALLOC_CONF="junk:true,tcache:false,prof:true"
     elif [ ${RUN_CHECK_MEM_LEAK} -eq 1 ] ; then
-        ln -s $STARROCKS_HOME/lib/libjemalloc.so.2 $JEMALLOC_LIB
         export JEMALLOC_CONF="percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true,prof:true,prof_active:true,prof_leak:true,lg_prof_sample:0,prof_final:true"
     else
         export JEMALLOC_CONF="percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true,prof:true,prof_active:false"

--- a/build.sh
+++ b/build.sh
@@ -206,9 +206,6 @@ fi
 if [[ -z ${USE_BMI_2} ]]; then
     USE_BMI_2=ON
 fi
-if [[ -z ${JEMALLOC_DEBUG} ]]; then
-    JEMALLOC_DEBUG=OFF
-fi
 if [[ -z ${ENABLE_JIT} ]]; then
     ENABLE_JIT=ON
 fi
@@ -338,7 +335,6 @@ echo "Get params:
     USE_AVX512                  -- $USE_AVX512
     USE_SSE4_2                  -- $USE_SSE4_2
     USE_BMI_2                   -- $USE_BMI_2
-    JEMALLOC_DEBUG              -- $JEMALLOC_DEBUG
     PARALLEL                    -- $PARALLEL
     ENABLE_QUERY_DEBUG_TRACE    -- $ENABLE_QUERY_DEBUG_TRACE
     ENABLE_FAULT_INJECTION      -- $ENABLE_FAULT_INJECTION
@@ -461,7 +457,6 @@ if [ ${BUILD_BE} -eq 1 ] || [ ${BUILD_FORMAT_LIB} -eq 1 ] ; then
                   -DMAKE_TEST=OFF -DWITH_GCOV=${WITH_GCOV}              \
                   -DUSE_AVX2=$USE_AVX2 -DUSE_AVX512=$USE_AVX512         \
                   -DUSE_SSE4_2=$USE_SSE4_2 -DUSE_BMI_2=$USE_BMI_2       \
-                  -DJEMALLOC_DEBUG=$JEMALLOC_DEBUG                      \
                   -DENABLE_QUERY_DEBUG_TRACE=$ENABLE_QUERY_DEBUG_TRACE  \
                   -DWITH_BENCH=${WITH_BENCH}                            \
                   -DWITH_CLANG_TIDY=${WITH_CLANG_TIDY}                  \
@@ -613,6 +608,10 @@ if [ ${BUILD_BE} -eq 1 ]; then
     cp -r -p ${STARROCKS_HOME}/be/output/lib/starrocks_be ${STARROCKS_OUTPUT}/be/lib/
     cp -r -p ${STARROCKS_HOME}/be/output/lib/libmockjvm.so ${STARROCKS_OUTPUT}/be/lib/libjvm.so
     cp -r -p ${STARROCKS_THIRDPARTY}/installed/jemalloc/bin/jeprof ${STARROCKS_OUTPUT}/be/bin
+    cp -r -p ${STARROCKS_THIRDPARTY}/installed/jemalloc/lib-shared/libjemalloc.so.2 ${STARROCKS_OUTPUT}/be/lib/libjemalloc.so.2
+    cp -r -p ${STARROCKS_THIRDPARTY}/installed/jemalloc-debug/lib/libjemalloc.so.2 ${STARROCKS_OUTPUT}/be/lib/libjemalloc-dbg.so.2
+    ln -s ./libjemalloc.so.2 ${STARROCKS_OUTPUT}/be/lib/libjemalloc.so
+
     # format $BUILD_TYPE to lower case
     ibuildtype=`echo ${BUILD_TYPE} | tr 'A-Z' 'a-z'`
     if [ "${ibuildtype}" == "release" ] ; then

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -246,6 +246,8 @@ mkdir -p $LOG_DIR
 mkdir -p ${UDF_RUNTIME_DIR}
 rm -f ${UDF_RUNTIME_DIR}/*
 
+export LD_LIBRARY_PATH=${STARROCKS_THIRDPARTY}/installed/jemalloc/lib-shared/:$LD_LIBRARY_PATH
+
 # ====================== configure JAVA/JVM ====================
 # NOTE: JAVA_HOME must be configed if using hdfs scan, like hive external table
 # this is only for starting be

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1083,12 +1083,16 @@ build_jemalloc() {
     fi
     # build jemalloc with release
     CFLAGS="-O3 -fno-omit-frame-pointer -fPIC -g" \
-    ./configure --prefix=${TP_INSTALL_DIR}/jemalloc --with-jemalloc-prefix=je --enable-prof --disable-cxx --disable-libdl --disable-shared $addition_opts
+    ./configure --prefix=${TP_INSTALL_DIR}/jemalloc --with-jemalloc-prefix=je --enable-prof --disable-cxx --disable-libdl $addition_opts
     make -j$PARALLEL
     make install
+    mkdir -p ${TP_INSTALL_DIR}/jemalloc/lib-shared/
+    mkdir -p ${TP_INSTALL_DIR}/jemalloc/lib-static/
+    mv ${TP_INSTALL_DIR}/jemalloc/lib/*.so* ${TP_INSTALL_DIR}/jemalloc/lib-shared/
+    mv ${TP_INSTALL_DIR}/jemalloc/lib/*.a ${TP_INSTALL_DIR}/jemalloc/lib-static/
     # build jemalloc with debug options
     CFLAGS="-O3 -fno-omit-frame-pointer -fPIC -g" \
-    ./configure --prefix=${TP_INSTALL_DIR}/jemalloc-debug --with-jemalloc-prefix=je --enable-prof --enable-debug --enable-fill --enable-prof --disable-cxx --disable-libdl --disable-shared $addition_opts
+    ./configure --prefix=${TP_INSTALL_DIR}/jemalloc-debug --with-jemalloc-prefix=je --enable-prof --disable-static --enable-debug --enable-fill --enable-prof --disable-cxx --disable-libdl $addition_opts
     make -j$PARALLEL
     make install
 }

--- a/thirdparty/patches/jemalloc_nallocx.patch
+++ b/thirdparty/patches/jemalloc_nallocx.patch
@@ -1,11 +1,13 @@
---- src/jemalloc.c  2022-05-07 02:29:14.000000000 +0800
-+++ src/jemalloc.c  2024-01-17 16:13:16.063123457 +0800
-@@ -3960,8 +3960,6 @@ je_nallocx(size_t size, int flags) {
-    size_t usize;
-    tsdn_t *tsdn;
-
--   assert(size != 0);
--
-    if (unlikely(malloc_init())) {
-        LOG("core.nallocx.exit", "result: %zu", ZU(0));
-        return 0;
+diff --git src/jemalloc.c src/jemalloc.c
+index 7655de4..51acaa0 100644
+--- src/jemalloc.c
++++ src/jemalloc.c
+@@ -3960,7 +3960,7 @@ je_nallocx(size_t size, int flags) {
+ 	size_t usize;
+ 	tsdn_t *tsdn;
+ 
+-	assert(size != 0);
++	// assert(size != 0);
+ 
+ 	if (unlikely(malloc_init())) {
+ 		LOG("core.nallocx.exit", "result: %zu", ZU(0));


### PR DESCRIPTION
## Why I'm doing:

Provide more troubleshooting tools for online UAF issues.

## What I'm doing:

For sanitize we still use static links.
For debug/release we use dynamic links.
Enable jemalloc debug.
```
. /start_be.sh --daemon --jemalloc_debug
```

Comparison of dynamic and static link performance

bench empty function 
```
------------------------------------------------------
Benchmark            Time             CPU   Iterations
------------------------------------------------------
StaticLink        1.10 ns         1.10 ns    639139454
DynamicLink       2.04 ns         2.04 ns    343695155
```

bench function with atomic variable
```
void* static_call() {
    static std::atomic_int v{};
    v++;
    return nullptr;
}
```

```
------------------------------------------------------
Benchmark            Time             CPU   Iterations
------------------------------------------------------
StaticLink        7.82 ns         7.82 ns     89483989
DynamicLink       7.83 ns         7.82 ns     89371612
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
