### PR TITLE
[Enhancement] Use histograms for join selectivity estimation (backport #57639)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -374,6 +374,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CBO_PUSH_DOWN_AGGREGATE_ON_BROADCAST_JOIN_ROW_COUNT_LIMIT =
             "cbo_push_down_aggregate_on_broadcast_join_row_count_limit";
     public static final String CBO_ENABLE_INTERSECT_ADD_DISTINCT = "cbo_enable_intersect_add_distinct";
+    public static final String CBO_ENABLE_HISTOGRAM_JOIN_ESTIMATION = "cbo_enable_histogram_join_estimation";
 
     public static final String CBO_PUSH_DOWN_DISTINCT_BELOW_WINDOW = "cbo_push_down_distinct_below_window";
     public static final String CBO_PUSH_DOWN_AGGREGATE = "cbo_push_down_aggregate";
@@ -1579,6 +1580,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = CBO_PUSH_DOWN_GROUPINGSET_RESHUFFLE, flag = VariableMgr.INVISIBLE)
     private boolean cboPushDownGroupingSetReshuffle = true;
+
+    @VarAttr(name = CBO_ENABLE_HISTOGRAM_JOIN_ESTIMATION, flag = VariableMgr.INVISIBLE)
+    private boolean cboEnableHistogramJoinEstimation = false;
 
     @VariableMgr.VarAttr(name = PARSE_TOKENS_LIMIT)
     private int parseTokensLimit = 3500000;
@@ -3734,6 +3738,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setCboPushDownDistinctBelowWindow(boolean flag) {
         this.cboPushDownDistinctBelowWindow = flag;
+    }
+
+    public boolean isCboEnableHistogramJoinEstimation() {
+        return cboEnableHistogramJoinEstimation;
+    }
+
+    public void setCboEnableHistogramJoinEstimation(boolean cboEnableHistogramJoinEstimation) {
+        this.cboEnableHistogramJoinEstimation = cboEnableHistogramJoinEstimation;
     }
 
     public boolean isCboPushDownDistinctBelowWindow() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer.statistics;
 
 import com.starrocks.analysis.BinaryType;
 import com.starrocks.catalog.Type;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
@@ -32,6 +33,8 @@ import java.util.Optional;
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
 
 public class BinaryPredicateStatisticCalculator {
     public static Statistics estimateColumnToConstantComparison(Optional<ColumnRefOperator> columnRefOperator,
@@ -81,7 +84,7 @@ public class BinaryPredicateStatisticCalculator {
                                                             ColumnStatistic columnStatistic,
                                                             Optional<ConstantOperator> constant,
                                                             Statistics statistics) {
-        if (columnStatistic.getHistogram() == null || !constant.isPresent()) {
+        if (columnStatistic.getHistogram() == null || constant.isEmpty()) {
             StatisticRangeValues predicateRange;
 
             if (constant.isPresent()) {
@@ -102,53 +105,67 @@ public class BinaryPredicateStatisticCalculator {
             double max = StatisticUtils.convertStatisticsToDouble(constantOperator.getType(), constantOperator.toString())
                     .orElse(POSITIVE_INFINITY);
 
-            ColumnStatistic estimatedColumnStatistic = ColumnStatistic.buildFrom(columnStatistic)
+            ColumnStatistic.Builder estimatedColumnStatisticBuilder = ColumnStatistic.buildFrom(columnStatistic)
                     .setNullsFraction(0)
                     .setMinValue(min)
                     .setMaxValue(max)
-                    .setDistinctValuesCount(1)
-                    .build();
+                    .setDistinctValuesCount(1);
 
-            double predicateFactor;
             double rows;
-            Histogram hist = columnStatistic.getHistogram();
-            Map<String, Long> histogramTopN = columnStatistic.getHistogram().getMCV();
-
-            String constantStringValue = constantOperator.toString();
-            if (constantOperator.getType() == Type.BOOLEAN) {
-                constantStringValue = constantOperator.getBoolean() ? "1" : "0";
-            }
-            // If there is a constant key in MCV, we use the MCV count to estimate the row count.
-            // If it is not in MCV but in a bucket, we use the bucket info to estimate the row count.
-            // If it is not in MCV and not in any bucket, we combine hist row count, total row count and bucket number
-            // to estimate the row count.
-            if (histogramTopN.containsKey(constantStringValue)) {
-                double rowCountInHistogram = histogramTopN.get(constantStringValue);
-                predicateFactor = rowCountInHistogram / columnStatistic.getHistogram().getTotalRows();
-                double estimatedRows = statistics.getOutputRowCount() * (1 - columnStatistic.getNullsFraction())
-                        * predicateFactor;
-                rows = Math.min(rowCountInHistogram, estimatedRows);
+            Histogram columnHist = columnStatistic.getHistogram();
+            Optional<Histogram> hist = updateHistWithEqual(columnStatistic, constant);
+            if (hist.isPresent()) {
+                double rowCountInHistogram = hist.get().getTotalRows();
+                double predicateFactor = rowCountInHistogram / (double) columnHist.getTotalRows();
+                rows = Math.min(rowCountInHistogram, statistics.getOutputRowCount() * (1 - columnStatistic.getNullsFraction())
+                        * predicateFactor);
             } else {
-                Optional<Long> rowCounts = hist.getRowCountInBucket(constantOperator, columnStatistic.getDistinctValuesCount());
-                if (rowCounts.isPresent()) {
-                    predicateFactor = rowCounts.get() * 1.0 / columnStatistic.getHistogram().getTotalRows();
-                    double estimatedRows = statistics.getOutputRowCount() * (1 - columnStatistic.getNullsFraction())
-                            * predicateFactor;
-                    rows = Math.min(rowCounts.get(), estimatedRows);
-                } else {
-                    Long mostCommonValuesCount = histogramTopN.values().stream().reduce(Long::sum).orElse(0L);
-                    double f = 1 / Math.max(columnStatistic.getDistinctValuesCount() - histogramTopN.size(),
-                            hist.getBuckets().size());
-                    predicateFactor = (columnStatistic.getHistogram().getTotalRows() - mostCommonValuesCount)
-                            * f / columnStatistic.getHistogram().getTotalRows();
-                    rows = statistics.getOutputRowCount() * (1 - columnStatistic.getNullsFraction())
-                            * predicateFactor;
-                }
+                // The constant was not found in the column histogram.
+                Long mostCommonValuesCount = columnHist.getMCV().values().stream().reduce(Long::sum).orElse(0L);
+                double f = 1 / Math.max(columnStatistic.getDistinctValuesCount() - columnHist.getMCV().size(),
+                        columnHist.getBuckets().size());
+                double predicateFactor = (columnHist.getTotalRows() - mostCommonValuesCount) * f / columnHist.getTotalRows();
+                rows = statistics.getOutputRowCount() * (1 - columnStatistic.getNullsFraction()) * predicateFactor;
             }
-            return columnRefOperator.map(operator -> Statistics.buildFrom(statistics)
-                            .setOutputRowCount(rows).addColumnStatistic(operator, estimatedColumnStatistic).build())
+
+            return columnRefOperator.map(operator -> Statistics.buildFrom(statistics).setOutputRowCount(rows)
+                            .addColumnStatistic(operator, estimatedColumnStatisticBuilder.build()).build())
                     .orElseGet(() -> Statistics.buildFrom(statistics).setOutputRowCount(rows).build());
         }
+    }
+
+    public static Optional<Histogram> updateHistWithEqual(ColumnStatistic columnStatistic,
+                                                          Optional<ConstantOperator> constant) {
+        if (constant.isEmpty() || columnStatistic.getHistogram() == null) {
+            return Optional.empty();
+        }
+
+        Map<String, Long> estimatedMcv = new HashMap<>();
+        ConstantOperator constantOperator = constant.get();
+        Histogram hist = columnStatistic.getHistogram();
+        Map<String, Long> histogramTopN = columnStatistic.getHistogram().getMCV();
+
+        String constantStringValue = constantOperator.toString();
+        if (constantOperator.getType() == Type.BOOLEAN) {
+            constantStringValue = constantOperator.getBoolean() ? "1" : "0";
+        }
+        // If there is a constant key in MCV, we use the MCV count to estimate the row count.
+        // If it is not in MCV but in a bucket, we use the bucket info to estimate the row count.
+        // If it is not in MCV and not in any bucket, we combine hist row count, total row count and bucket number
+        // to estimate the row count.
+        if (histogramTopN.containsKey(constantStringValue)) {
+            Long rowCountInHistogram = histogramTopN.get(constantStringValue);
+            estimatedMcv.put(constantOperator.toString(), rowCountInHistogram);
+        } else {
+            Optional<Long> rowCountInHistogram =
+                    hist.getRowCountInBucket(constantOperator, columnStatistic.getDistinctValuesCount());
+            if (rowCountInHistogram.isEmpty()) {
+                return Optional.empty();
+            }
+
+            estimatedMcv.put(constantOperator.toString(), rowCountInHistogram.get());
+        }
+        return Optional.of(new Histogram(new ArrayList<>(), estimatedMcv));
     }
 
     private static Statistics estimateColumnNotEqualToConstant(Optional<ColumnRefOperator> columnRefOperator,
@@ -306,13 +323,6 @@ public class BinaryPredicateStatisticCalculator {
                                                          ColumnStatistic rightColumnStatistic,
                                                          Statistics statistics,
                                                          boolean isEqualForNull) {
-        double leftDistinctValuesCount = leftColumnStatistic.getDistinctValuesCount();
-        double rightDistinctValuesCount = rightColumnStatistic.getDistinctValuesCount();
-        double selectivity = 1.0 / Math.max(1, Math.max(leftDistinctValuesCount, rightDistinctValuesCount));
-        double rowCount = statistics.getOutputRowCount() * selectivity *
-                (isEqualForNull ? 1 :
-                        (1 - leftColumnStatistic.getNullsFraction()) * (1 - rightColumnStatistic.getNullsFraction()));
-
         StatisticRangeValues intersect = StatisticRangeValues.from(leftColumnStatistic)
                 .intersect(StatisticRangeValues.from(rightColumnStatistic));
         ColumnStatistic.Builder newEstimateColumnStatistics = ColumnStatistic.builder().
@@ -320,22 +330,49 @@ public class BinaryPredicateStatisticCalculator {
                 setMinValue(intersect.getLow()).
                 setDistinctValuesCount(intersect.getDistinctValues());
 
+        boolean enableJoinHistogram =
+                ConnectContext.get() != null &&
+                        ConnectContext.get().getSessionVariable() != null &&
+                        ConnectContext.get().getSessionVariable().isCboEnableHistogramJoinEstimation();
+
+        double rowCount;
+        Optional<Histogram> hist = enableJoinHistogram ?
+                updateHistWithJoin(leftColumnStatistic, leftColumn.getType(), rightColumnStatistic, rightColumn.getType()) :
+                Optional.empty();
+        if (hist.isEmpty()) {
+            double selectivity = 1.0 /
+                    max(1, max(leftColumnStatistic.getDistinctValuesCount(), rightColumnStatistic.getDistinctValuesCount()));
+            rowCount = statistics.getOutputRowCount() * selectivity *
+                    (isEqualForNull ? 1 :
+                            (1 - leftColumnStatistic.getNullsFraction()) * (1 - rightColumnStatistic.getNullsFraction()));
+        } else {
+            double selectivity = hist.get().getTotalRows() / (double)
+                    (leftColumnStatistic.getHistogram().getTotalRows() * rightColumnStatistic.getHistogram().getTotalRows());
+            rowCount = statistics.getOutputRowCount() * selectivity;
+        }
+
         ColumnStatistic newLeftStatistic;
         ColumnStatistic newRightStatistic;
         if (!isEqualForNull) {
             newEstimateColumnStatistics.setNullsFraction(0);
             newLeftStatistic = newEstimateColumnStatistics
-                    .setAverageRowSize(leftColumnStatistic.getAverageRowSize()).build();
+                    .setAverageRowSize(leftColumnStatistic.getAverageRowSize())
+                    .setHistogram(leftColumnStatistic.getHistogram())
+                    .build();
             newRightStatistic = newEstimateColumnStatistics
-                    .setAverageRowSize(rightColumnStatistic.getAverageRowSize()).build();
+                    .setAverageRowSize(rightColumnStatistic.getAverageRowSize())
+                    .setHistogram(rightColumnStatistic.getHistogram())
+                    .build();
         } else {
             newLeftStatistic = newEstimateColumnStatistics
                     .setAverageRowSize(leftColumnStatistic.getAverageRowSize())
                     .setNullsFraction(leftColumnStatistic.getNullsFraction())
+                    .setHistogram(leftColumnStatistic.getHistogram())
                     .build();
             newRightStatistic = newEstimateColumnStatistics
                     .setAverageRowSize(rightColumnStatistic.getAverageRowSize())
                     .setNullsFraction(rightColumnStatistic.getNullsFraction())
+                    .setHistogram(rightColumnStatistic.getHistogram())
                     .build();
         }
 
@@ -350,13 +387,171 @@ public class BinaryPredicateStatisticCalculator {
         return builder.build();
     }
 
+    public static Optional<Histogram> updateHistWithJoin(ColumnStatistic leftColumnStatistic, Type leftColumnType,
+                                                         ColumnStatistic rightColumnStatistic, Type rightColumnType) {
+        if (leftColumnStatistic.getHistogram() == null || rightColumnStatistic.getHistogram() == null) {
+            return Optional.empty();
+        }
+
+        Histogram leftHistogram = leftColumnStatistic.getHistogram();
+        Histogram rightHistogram = rightColumnStatistic.getHistogram();
+        double leftColumnDistinctCount = min(leftHistogram.getTotalRows(), leftColumnStatistic.getDistinctValuesCount());
+        double rightColumnDistinctCount = min(rightHistogram.getTotalRows(), rightColumnStatistic.getDistinctValuesCount());
+
+        Map<String, Long> estimatedMcv = estimateMcvToMcv(leftHistogram.getMCV(), rightHistogram.getMCV());
+        estimateMcvToBucket(leftHistogram.getMCV(), estimatedMcv, rightHistogram, rightColumnDistinctCount, leftColumnType);
+        estimateMcvToBucket(rightHistogram.getMCV(), estimatedMcv, leftHistogram, leftColumnDistinctCount, rightColumnType);
+        List<Bucket> estimatedBuckets =
+                estimateBucketToBucket(leftHistogram, leftColumnDistinctCount, leftColumnType, rightHistogram,
+                        rightColumnDistinctCount, rightColumnType);
+
+        if (estimatedMcv.isEmpty() && estimatedBuckets.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new Histogram(estimatedBuckets, estimatedMcv));
+    }
+
+    private static Map<String, Long> estimateMcvToMcv(Map<String, Long> leftMcv, Map<String, Long> rightMcv) {
+        Map<String, Long> mcvIntersection = new HashMap<>();
+        leftMcv.forEach((value, leftFreq) -> {
+            if (rightMcv.containsKey(value)) {
+                mcvIntersection.put(value, leftFreq * rightMcv.get(value));
+            }
+        });
+        return mcvIntersection;
+    }
+
+    private static void estimateMcvToBucket(Map<String, Long> leftMcv, Map<String, Long> estimatedMcv,
+                                            Histogram rightHistogram, double distinctValuesCount, Type dataType) {
+        if (rightHistogram.getBuckets() == null) {
+            return;
+        }
+
+        for (Map.Entry<String, Long> entry : leftMcv.entrySet()) {
+            if (estimatedMcv.containsKey(entry.getKey())) {
+                continue;
+            }
+
+            Optional<Double> value = StatisticUtils.convertStatisticsToDouble(dataType, entry.getKey());
+            if (value.isEmpty()) {
+                continue;
+            }
+
+            Long leftFreq = entry.getValue();
+            Optional<Long> rowCountInBucketOpt = rightHistogram.getRowCountInBucket(value.get(), distinctValuesCount,
+                    dataType.isFixedPointType());
+            rowCountInBucketOpt.ifPresent(rowCountInBucket -> estimatedMcv.put(entry.getKey(), leftFreq * rowCountInBucket));
+        }
+    }
+
+    private static List<Bucket> estimateBucketToBucket(Histogram leftHistogram, double leftColumnDistinctValue, Type dataTypeLeft,
+                                                       Histogram rightHistogram, double rightColumnDistinctValue,
+                                                       Type dataTypeRight) {
+        if (leftHistogram == null || rightHistogram == null) {
+            return null;
+        }
+
+        List<Bucket> leftBuckets = leftHistogram.getBuckets();
+        List<Bucket> rightBuckets = rightHistogram.getBuckets();
+        if (leftBuckets == null || leftBuckets.isEmpty() || rightBuckets == null || rightBuckets.isEmpty()) {
+            return null;
+        }
+
+        // Assume the distinct values are uniformly distributed.
+        long leftBucketDistinctRowCount = (long) (leftColumnDistinctValue / leftBuckets.size());
+        long rightBucketDistinctRowCount = (long) (rightColumnDistinctValue / rightBuckets.size());
+
+        List<Bucket> mergedBuckets = new ArrayList<>();
+
+        long rowCount = 0;
+        Long prevLeftBucketRowCount = 0L;
+        Long prevRightBucketRowCount = 0L;
+        int leftBucketIndex = 0;
+        int rightBucketIndex = 0;
+        while (leftBucketIndex < leftBuckets.size() && rightBucketIndex < rightBuckets.size()) {
+            Bucket leftBucket = leftBuckets.get(leftBucketIndex);
+            Bucket rightBucket = rightBuckets.get(rightBucketIndex);
+
+            Optional<StatisticRangeValues> bucketIntersectionRangeOpt = computeBucketIntersection(leftBucket, rightBucket);
+            if (bucketIntersectionRangeOpt.isPresent()) {
+                StatisticRangeValues bucketIntersectionRange = bucketIntersectionRangeOpt.get();
+                long leftBucketRowCount = leftBucket.getCount() - prevLeftBucketRowCount;
+                long rightBucketRowCount = rightBucket.getCount() - prevRightBucketRowCount;
+                if (dataTypeLeft.isFixedPointType()) {
+                    leftBucketDistinctRowCount = (long) (leftBucket.getUpper() - leftBucket.getLower());
+                }
+                if (dataTypeRight.isFixedPointType()) {
+                    rightBucketDistinctRowCount = (long) (rightBucket.getUpper() - rightBucket.getLower());
+                }
+
+                // merge the upper repeats.
+                long upperRepeats = 0L;
+                if (bucketIntersectionRange.getHigh() == leftBucket.getUpper()) {
+                    Optional<Long> countInRightBucket = rightBucket.getRowCountInBucket(leftBucket.getUpper(),
+                            prevRightBucketRowCount, rightBucketDistinctRowCount, dataTypeRight.isFixedPointType());
+                    if (countInRightBucket.isPresent()) {
+                        upperRepeats = leftBucket.getUpperRepeats() * countInRightBucket.get();
+                    }
+                } else {
+                    Optional<Long> countInLeftBucket = leftBucket.getRowCountInBucket(rightBucket.getUpper(),
+                            prevLeftBucketRowCount, leftBucketDistinctRowCount, dataTypeLeft.isFixedPointType());
+                    if (countInLeftBucket.isPresent()) {
+                        upperRepeats = countInLeftBucket.get() * rightBucket.getUpperRepeats();
+                    }
+                }
+
+                // merge the row count.
+                long rowCountInBucket = upperRepeats;
+                if (bucketIntersectionRange.getLow() < bucketIntersectionRange.getHigh()) {
+                    double leftIntersectionFraction = computeBucketIntersectionFraction(leftBucket, bucketIntersectionRange);
+                    double rightIntersectionFraction = computeBucketIntersectionFraction(rightBucket, bucketIntersectionRange);
+
+                    // compute the number of matches in the buckets intersection assuming uniform distribution.
+                    rowCountInBucket = max(rowCountInBucket, (long) (
+                            leftBucketRowCount * leftIntersectionFraction * rightBucketRowCount * rightIntersectionFraction /
+                                    max(leftBucketDistinctRowCount * leftIntersectionFraction,
+                                            rightBucketDistinctRowCount * rightIntersectionFraction)));
+                }
+
+                rowCount += rowCountInBucket;
+                mergedBuckets.add(
+                        new Bucket(bucketIntersectionRange.getLow(), bucketIntersectionRange.getHigh(), rowCount, upperRepeats));
+            }
+
+            if (leftBucket.getUpper() <= rightBucket.getUpper()) {
+                ++leftBucketIndex;
+                prevLeftBucketRowCount = leftBucket.getCount();
+            }
+            if (rightBucket.getUpper() <= leftBucket.getUpper()) {
+                ++rightBucketIndex;
+                prevRightBucketRowCount = rightBucket.getCount();
+            }
+        }
+
+        return mergedBuckets;
+    }
+
+    private static Optional<StatisticRangeValues> computeBucketIntersection(Bucket leftBucket, Bucket rightBucket) {
+        if (leftBucket.getUpper() < rightBucket.getLower() || rightBucket.getUpper() < leftBucket.getLower()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new StatisticRangeValues(max(leftBucket.getLower(), rightBucket.getLower()),
+                min(leftBucket.getUpper(), rightBucket.getUpper()), 0.0));
+    }
+
+    private static double computeBucketIntersectionFraction(Bucket bucket, StatisticRangeValues intersectionRange) {
+        return (intersectionRange.getHigh() - intersectionRange.getLow()) / (bucket.getUpper() - bucket.getLower());
+    }
+
     public static Statistics estimateColumnNotEqualToColumn(
             ColumnStatistic leftColumn,
             ColumnStatistic rightColumn,
             Statistics statistics) {
         double leftDistinctValuesCount = leftColumn.getDistinctValuesCount();
         double rightDistinctValuesCount = rightColumn.getDistinctValuesCount();
-        double selectivity = 1.0 / Math.max(1, Math.max(leftDistinctValuesCount, rightDistinctValuesCount));
+        double selectivity = 1.0 / max(1, max(leftDistinctValuesCount, rightDistinctValuesCount));
 
         double rowCount = statistics.getOutputRowCount();
         // If any ColumnStatistic is default, give a default selectivity

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Bucket.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Bucket.java
@@ -15,6 +15,8 @@
 
 package com.starrocks.sql.optimizer.statistics;
 
+import java.util.Optional;
+
 public class Bucket {
     private final double lower;
     private final double upper;
@@ -42,5 +44,24 @@ public class Bucket {
 
     public Long getUpperRepeats() {
         return upperRepeats;
+    }
+
+    public Optional<Long> getRowCountInBucket(double value, Long previousBucketCount, double distinctValuesCount,
+                                              boolean useFixedPointEstimation) {
+        if (lower <= value && value < upper) {
+            long rowCount = count - previousBucketCount - upperRepeats;
+
+            if (useFixedPointEstimation) {
+                rowCount = (long) Math.ceil(Math.max(1, rowCount / Math.max(1, (upper - lower))));
+            } else {
+                rowCount = (long) Math.ceil(Math.max(1, rowCount / Math.max(1, distinctValuesCount)));
+            }
+
+            return Optional.of(rowCount);
+        } else if (upper == value) {
+            return Optional.of(upperRepeats);
+        }
+
+        return Optional.empty();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -1081,13 +1081,17 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
     private Void computeJoinNode(ExpressionContext context, JoinOperator joinType, ScalarOperator joinOnPredicate) {
         Preconditions.checkState(context.arity() == 2);
 
+        boolean preserveJoinHistogram = ConnectContext.get().getSessionVariable().isCboEnableHistogramJoinEstimation();
+
         List<ScalarOperator> allJoinPredicate = Utils.extractConjuncts(joinOnPredicate);
         Statistics leftStatistics = context.getChildStatistics(0);
         Statistics rightStatistics = context.getChildStatistics(1);
         // construct cross join statistics
         Statistics.Builder crossBuilder = Statistics.builder();
-        crossBuilder.addColumnStatisticsFromOtherStatistic(leftStatistics, context.getChildOutputColumns(0), false);
-        crossBuilder.addColumnStatisticsFromOtherStatistic(rightStatistics, context.getChildOutputColumns(1), false);
+        crossBuilder.addColumnStatisticsFromOtherStatistic(leftStatistics, context.getChildOutputColumns(0),
+                preserveJoinHistogram);
+        crossBuilder.addColumnStatisticsFromOtherStatistic(rightStatistics, context.getChildOutputColumns(1),
+                preserveJoinHistogram);
         double leftRowCount = leftStatistics.getOutputRowCount();
         double rightRowCount = rightStatistics.getOutputRowCount();
         double crossRowCount = StatisticUtils.multiplyRowCount(leftRowCount, rightRowCount);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
@@ -17,20 +17,23 @@ package com.starrocks.sql.optimizer.statistics;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.BinaryType;
 import com.starrocks.catalog.Type;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 public class HistogramStatisticsTest {
     @Test
-    public void test() {
+    public void testColumnToConstant() {
         ColumnRefOperator columnRefOperator = new ColumnRefOperator(0, Type.BIGINT, "v1", true);
 
         List<Bucket> bucketList = new ArrayList<>();
@@ -162,6 +165,79 @@ public class HistogramStatisticsTest {
     }
 
     @Test
+    public void testColumnToColumn() {
+        ColumnRefOperator leftColumnRefOperator = new ColumnRefOperator(0, Type.BIGINT, "v1", true);
+        List<Bucket> leftBucketList = new ArrayList<>();
+        leftBucketList.add(new Bucket(1D, 10D, 100L, 20L));
+        leftBucketList.add(new Bucket(15D, 20D, 200L, 20L));
+        leftBucketList.add(new Bucket(21D, 36D, 300L, 20L));
+        leftBucketList.add(new Bucket(40D, 45D, 400L, 20L));
+        leftBucketList.add(new Bucket(46D, 46D, 500L, 100L));
+        leftBucketList.add(new Bucket(47D, 47D, 600L, 100L));
+        leftBucketList.add(new Bucket(48D, 58D, 700L, 20L));
+        leftBucketList.add(new Bucket(61D, 65D, 800L, 20L));
+        leftBucketList.add(new Bucket(66D, 99D, 900L, 20L));
+        leftBucketList.add(new Bucket(100D, 100D, 1000L, 100L));
+        HashMap<String, Long> leftMcv = new HashMap<>();
+        leftMcv.put("59", 500L);
+        leftMcv.put("38", 300L);
+        leftMcv.put("17", 200L);
+        Histogram leftHistogram = new Histogram(leftBucketList, leftMcv);
+
+        ColumnRefOperator rightColumnRefOperator = new ColumnRefOperator(1, Type.BIGINT, "v2", true);
+        List<Bucket> rightBucketList = new ArrayList<>();
+        rightBucketList.add(new Bucket(1D, 15D, 200L, 20L));
+        rightBucketList.add(new Bucket(18D, 38D, 300L, 20L));
+        rightBucketList.add(new Bucket(41D, 55D, 400L, 20L));
+        rightBucketList.add(new Bucket(56D, 56D, 500L, 100L));
+        rightBucketList.add(new Bucket(57D, 57D, 600L, 100L));
+        rightBucketList.add(new Bucket(58D, 67D, 700L, 20L));
+        rightBucketList.add(new Bucket(70D, 98D, 900L, 20L));
+        rightBucketList.add(new Bucket(100D, 100D, 1000L, 100L));
+        HashMap<String, Long> rightMcv = new HashMap<>();
+        rightMcv.put("99", 500L);
+        rightMcv.put("16", 300L);
+        rightMcv.put("17", 200L);
+        Histogram rightHistogram = new Histogram(rightBucketList, rightMcv);
+
+        Statistics.Builder builder = Statistics.builder();
+        builder.setOutputRowCount(2000 * 2000);
+        builder.addColumnStatistic(leftColumnRefOperator, ColumnStatistic.builder()
+                .setMinValue(1)
+                .setMaxValue(100)
+                .setNullsFraction(0)
+                .setAverageRowSize(20)
+                .setDistinctValuesCount(20)
+                .setHistogram(leftHistogram)
+                .build());
+        builder.addColumnStatistic(rightColumnRefOperator, ColumnStatistic.builder()
+                .setMinValue(1)
+                .setMaxValue(100)
+                .setNullsFraction(0)
+                .setAverageRowSize(20)
+                .setDistinctValuesCount(20)
+                .setHistogram(rightHistogram)
+                .build());
+        Statistics statistics = builder.build();
+        BinaryPredicateOperator binaryPredicateOperator = new BinaryPredicateOperator(BinaryType.EQ,
+                leftColumnRefOperator, rightColumnRefOperator);
+
+        ConnectContext connectContext = UtFrameUtils.createDefaultCtx();
+        Statistics estimated = PredicateStatisticsCalculator.statisticsCalculate(binaryPredicateOperator, statistics);
+        Assert.assertEquals(estimated.getColumnStatistics().size(), 2);
+        Assert.assertEquals(estimated.getColumnStatistic(leftColumnRefOperator).getHistogram(), leftHistogram);
+        Assert.assertEquals(estimated.getColumnStatistic(rightColumnRefOperator).getHistogram(), rightHistogram);
+        Assert.assertEquals(200000, estimated.getOutputRowCount(), 0.1);
+
+        connectContext.getSessionVariable().setCboEnableHistogramJoinEstimation(true);
+        estimated = PredicateStatisticsCalculator.statisticsCalculate(binaryPredicateOperator, statistics);
+        Assert.assertEquals(estimated.getColumnStatistics().size(), 2);
+        Assert.assertEquals(estimated.getColumnStatistic(leftColumnRefOperator).getHistogram(), leftHistogram);
+        Assert.assertEquals(estimated.getColumnStatistic(rightColumnRefOperator).getHistogram(), rightHistogram);
+        Assert.assertEquals(83576, estimated.getOutputRowCount(), 0.1);
+    }
+
+    @Test
     public void testNotHitBucketInHist() {
         List<Bucket> bucketList = new ArrayList<>();
         bucketList.add(new Bucket(1D, 10D, 100L, 20L));
@@ -179,7 +255,6 @@ public class HistogramStatisticsTest {
                 Optional.of(new ConstantOperator(-1, Type.BIGINT)), true);
         Assert.assertFalse(notExist.isPresent());
 
-
         // only one bucket in histogram can cover the predicate range
         Optional<Histogram> exist = BinaryPredicateStatisticCalculator.updateHistWithGreaterThan(columnStatistic,
                 Optional.of(new ConstantOperator(18, Type.BIGINT)), true);
@@ -195,6 +270,37 @@ public class HistogramStatisticsTest {
         exist = BinaryPredicateStatisticCalculator.updateHistWithLessThan(columnStatistic,
                 Optional.of(new ConstantOperator(18, Type.BIGINT)), true);
         Assert.assertEquals(exist.get().getBuckets().size(), 2);
+    }
+
+    @Test
+    public void testUpdateHistWithEqual() {
+        List<Bucket> bucketList = new ArrayList<>();
+        bucketList.add(new Bucket(1D, 10D, 100L, 20L));
+        bucketList.add(new Bucket(15D, 20D, 200L, 20L));
+        Map<String, Long> mcv = new HashMap<>();
+        mcv.put("22", 100L);
+        Histogram histogram = new Histogram(bucketList, mcv);
+        ColumnStatistic columnStatistic = new ColumnStatistic(1, 50, 0, 4, 500,
+                histogram, ColumnStatistic.StatisticType.ESTIMATE);
+
+        // histogram doesn't contain the constant
+        Optional<Histogram> notExist = BinaryPredicateStatisticCalculator.updateHistWithEqual(columnStatistic,
+                Optional.of(new ConstantOperator(12, Type.BIGINT)));
+        Assert.assertFalse(notExist.isPresent());
+
+        // histogram contains the constant in the mcv
+        Optional<Histogram> exist = BinaryPredicateStatisticCalculator.updateHistWithEqual(columnStatistic,
+                Optional.of(new ConstantOperator(22, Type.BIGINT)));
+        Assert.assertTrue(exist.isPresent());
+        Assert.assertEquals(exist.get().getBuckets().size(), 0);
+        Assert.assertEquals(exist.get().getMCV(), mcv);
+
+        // histogram contains the constant in a bucket
+        exist = BinaryPredicateStatisticCalculator.updateHistWithEqual(columnStatistic,
+                Optional.of(new ConstantOperator(2, Type.BIGINT)));
+        Assert.assertTrue(exist.isPresent());
+        Assert.assertEquals(exist.get().getBuckets().size(), 0);
+        Assert.assertTrue(exist.get().getMCV().containsKey("2"));
     }
 
     @Test
@@ -282,4 +388,164 @@ public class HistogramStatisticsTest {
         Assert.assertEquals(500L, estimated.getOutputRowCount(), 0.001);
     }
 
+
+    @Test
+    public void testUpdateHistWithJoin() {
+        // no intersection.
+        List<Bucket> bucketListLeft = new ArrayList<>();
+        bucketListLeft.add(new Bucket(1D, 4D, 100L, 20L));
+        bucketListLeft.add(new Bucket(15D, 24D, 200L, 20L));
+        Map<String, Long> mcvLeft = new HashMap<>();
+        mcvLeft.put("12", 300L);
+        mcvLeft.put("22", 100L);
+        Histogram histogramLeft = new Histogram(bucketListLeft, mcvLeft);
+        ColumnStatistic columnStatisticLeft = new ColumnStatistic(1, 50, 0, 4, 500,
+                histogramLeft, ColumnStatistic.StatisticType.ESTIMATE);
+
+        List<Bucket> bucketListRight = new ArrayList<>();
+        bucketListRight.add(new Bucket(5D, 11D, 100L, 20L));
+        bucketListRight.add(new Bucket(30D, 35D, 200L, 20L));
+        Map<String, Long> mcvRight = new HashMap<>();
+        mcvRight.put("25", 80L);
+        mcvRight.put("9", 50L);
+        Histogram histogramRight = new Histogram(bucketListRight, mcvRight);
+        ColumnStatistic columnStatisticRight = new ColumnStatistic(1, 50, 0, 4, 500,
+                histogramRight, ColumnStatistic.StatisticType.ESTIMATE);
+
+        Optional<Histogram> notExist = BinaryPredicateStatisticCalculator.updateHistWithJoin(columnStatisticLeft, Type.BIGINT,
+                columnStatisticRight, Type.BIGINT);
+        Assert.assertTrue(notExist.isEmpty());
+
+        // MCV to MCV intersection.
+        mcvLeft = new HashMap<>();
+        mcvLeft.put("10", 300L);
+        mcvLeft.put("22", 100L);
+        histogramLeft = new Histogram(null, mcvLeft);
+        columnStatisticLeft = new ColumnStatistic(1, 50, 0, 4, 500,
+                histogramLeft, ColumnStatistic.StatisticType.ESTIMATE);
+
+        mcvRight = new HashMap<>();
+        mcvRight.put("22", 80L);
+        mcvRight.put("9", 50L);
+        histogramRight = new Histogram(null, mcvRight);
+        columnStatisticRight = new ColumnStatistic(1, 50, 0, 4, 500,
+                histogramRight, ColumnStatistic.StatisticType.ESTIMATE);
+
+        Optional<Histogram> exist = BinaryPredicateStatisticCalculator.updateHistWithJoin(columnStatisticLeft, Type.BIGINT,
+                columnStatisticRight, Type.BIGINT);
+        Assert.assertTrue(exist.isPresent());
+        Assert.assertNull(exist.get().getBuckets());
+        Assert.assertEquals(exist.get().getMCV().size(), 1);
+        Assert.assertEquals(exist.get().getMCV().get("22").longValue(), 100 * 80);
+
+        // MCV to bucket intersection (upper).
+        bucketListLeft = new ArrayList<>();
+        bucketListLeft.add(new Bucket(1D, 4D, 100L, 20L));
+        bucketListLeft.add(new Bucket(15D, 23D, 200L, 20L));
+        mcvLeft = new HashMap<>();
+        mcvLeft.put("10", 300L);
+        mcvLeft.put("22", 100L);
+        histogramLeft = new Histogram(bucketListLeft, mcvLeft);
+        columnStatisticLeft = new ColumnStatistic(1, 50, 0, 4, 500,
+                histogramLeft, ColumnStatistic.StatisticType.ESTIMATE);
+
+        bucketListRight = new ArrayList<>();
+        bucketListRight.add(new Bucket(5D, 10D, 100L, 20L));
+        bucketListRight.add(new Bucket(30D, 35D, 200L, 20L));
+        mcvRight = new HashMap<>();
+        mcvRight.put("23", 80L);
+        mcvRight.put("9", 50L);
+        histogramRight = new Histogram(bucketListRight, mcvRight);
+        columnStatisticRight = new ColumnStatistic(1, 50, 0, 4, 500,
+                histogramRight, ColumnStatistic.StatisticType.ESTIMATE);
+
+        exist = BinaryPredicateStatisticCalculator.updateHistWithJoin(columnStatisticLeft, Type.BIGINT,
+                columnStatisticRight, Type.BIGINT);
+        Assert.assertTrue(exist.isPresent());
+        Assert.assertTrue(exist.get().getBuckets().isEmpty());
+        Assert.assertEquals(exist.get().getMCV().size(), 2);
+        Assert.assertEquals(exist.get().getMCV().get("10").longValue(), 300 * 20);
+        Assert.assertEquals(exist.get().getMCV().get("23").longValue(), 80 * 20);
+
+        // MCV to bucket intersection (not upper).
+        bucketListLeft = new ArrayList<>();
+        bucketListLeft.add(new Bucket(1D, 4D, 100L, 20L));
+        bucketListLeft.add(new Bucket(15D, 24D, 200L, 20L));
+        mcvLeft = new HashMap<>();
+        mcvLeft.put("10", 300L);
+        mcvLeft.put("22", 100L);
+        histogramLeft = new Histogram(bucketListLeft, mcvLeft);
+        columnStatisticLeft = new ColumnStatistic(1, 50, 0, 4, 500,
+                histogramLeft, ColumnStatistic.StatisticType.ESTIMATE);
+
+        bucketListRight = new ArrayList<>();
+        bucketListRight.add(new Bucket(5D, 11D, 100L, 20L));
+        bucketListRight.add(new Bucket(30D, 35D, 200L, 20L));
+        mcvRight = new HashMap<>();
+        mcvRight.put("23", 80L);
+        mcvRight.put("9", 50L);
+        histogramRight = new Histogram(bucketListRight, mcvRight);
+        columnStatisticRight = new ColumnStatistic(1, 50, 0, 4, 500,
+                histogramRight, ColumnStatistic.StatisticType.ESTIMATE);
+
+        exist = BinaryPredicateStatisticCalculator.updateHistWithJoin(columnStatisticLeft, Type.BIGINT,
+                columnStatisticRight, Type.BIGINT);
+        Assert.assertTrue(exist.isPresent());
+        Assert.assertTrue(exist.get().getBuckets().isEmpty());
+        Assert.assertEquals(exist.get().getMCV().size(), 2);
+        Assert.assertEquals(exist.get().getMCV().get("10").longValue(), 300 * 14);
+        Assert.assertEquals(exist.get().getMCV().get("23").longValue(), 80 * 9);
+
+        // bucket to bucket intersection (upper).
+        bucketListLeft = new ArrayList<>();
+        bucketListLeft.add(new Bucket(1D, 5D, 100L, 20L));
+        bucketListLeft.add(new Bucket(15D, 24D, 200L, 20L));
+        histogramLeft = new Histogram(bucketListLeft, new HashMap<>());
+        columnStatisticLeft = new ColumnStatistic(1, 50, 0, 4, 500,
+                histogramLeft, ColumnStatistic.StatisticType.ESTIMATE);
+
+        bucketListRight = new ArrayList<>();
+        bucketListRight.add(new Bucket(5D, 11D, 100L, 20L));
+        bucketListRight.add(new Bucket(30D, 35D, 200L, 20L));
+        histogramRight = new Histogram(bucketListRight, new HashMap<>());
+        columnStatisticRight = new ColumnStatistic(1, 50, 0, 4, 500,
+                histogramRight, ColumnStatistic.StatisticType.ESTIMATE);
+
+        exist = BinaryPredicateStatisticCalculator.updateHistWithJoin(columnStatisticLeft, Type.BIGINT,
+                columnStatisticRight, Type.BIGINT);
+        Assert.assertTrue(exist.isPresent());
+        Assert.assertTrue(exist.get().getMCV().isEmpty());
+        Assert.assertEquals(exist.get().getBuckets().size(), 1);
+        Bucket joinBucket = exist.get().getBuckets().get(0);
+        Assert.assertEquals(joinBucket.getLower(), 5D, 0.001);
+        Assert.assertEquals(joinBucket.getUpper(), 5D, 0.001);
+        Assert.assertEquals(joinBucket.getCount().longValue(), 20L * 14L);
+        Assert.assertEquals(joinBucket.getUpperRepeats().longValue(), 20L * 14L);
+
+        // bucket to bucket intersection (not upper).
+        bucketListLeft = new ArrayList<>();
+        bucketListLeft.add(new Bucket(1D, 9D, 100L, 20L));
+        bucketListLeft.add(new Bucket(15D, 24D, 200L, 20L));
+        histogramLeft = new Histogram(bucketListLeft, new HashMap<>());
+        columnStatisticLeft = new ColumnStatistic(1, 50, 0, 4, 500,
+                histogramLeft, ColumnStatistic.StatisticType.ESTIMATE);
+
+        bucketListRight = new ArrayList<>();
+        bucketListRight.add(new Bucket(5D, 11D, 100L, 20L));
+        bucketListRight.add(new Bucket(30D, 35D, 200L, 20L));
+        histogramRight = new Histogram(bucketListRight, new HashMap<>());
+        columnStatisticRight = new ColumnStatistic(1, 50, 0, 4, 500,
+                histogramRight, ColumnStatistic.StatisticType.ESTIMATE);
+
+        exist = BinaryPredicateStatisticCalculator.updateHistWithJoin(columnStatisticLeft, Type.BIGINT,
+                columnStatisticRight, Type.BIGINT);
+        Assert.assertTrue(exist.isPresent());
+        Assert.assertTrue(exist.get().getMCV().isEmpty());
+        Assert.assertEquals(exist.get().getBuckets().size(), 1);
+        joinBucket = exist.get().getBuckets().get(0);
+        Assert.assertEquals(joinBucket.getLower(), 5D, 0.001);
+        Assert.assertEquals(joinBucket.getUpper(), 9D, 0.001);
+        Assert.assertEquals(joinBucket.getCount().longValue(), 833);
+        Assert.assertEquals(joinBucket.getUpperRepeats().longValue(), 20L * 14L);
+    }
 }

--- a/test/conf/sr.conf
+++ b/test/conf/sr.conf
@@ -1,7 +1,7 @@
 [cluster]
-  host =
-  port =
-  user =
+  host = 127.0.0.1
+  port = 9030
+  user = root
   password =
   http_port =
   host_user =

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -2685,7 +2685,8 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
         tools.assert_true(res["status"], res['msg'])
         for expect in expects:
             plan_string = "\n".join(item[0] for item in res["result"])
-            tools.assert_true(plan_string.find(expect) > 0, "assert expect %s is not found in plan: %s" % (expect, plan_string))
+            tools.assert_true(plan_string.find(expect) > 0,
+                              "verbose plan of sql (%s) assert expect %s is not found in plan: %s" % (query, expect, plan_string))
 
     def assert_explain_costs_contains(self, query, *expects):
         """

--- a/test/sql/test_analyze_statistics/R/test_histogram
+++ b/test/sql/test_analyze_statistics/R/test_histogram
@@ -1,0 +1,319 @@
+-- name: test_histogram
+create database analyze_test_${uuid0};
+-- result:
+-- !result
+use analyze_test_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `t1` (
+    `k1`  date,
+    `k2`  int,
+    `k3`  int
+)
+PROPERTIES ('replication_num' = '1');
+-- result:
+-- !result
+CREATE TABLE `t2` LIKE `t1`;
+-- result:
+-- !result
+CREATE TABLE `t3` LIKE `t1`;
+-- result:
+-- !result
+INSERT INTO t1
+WITH series AS (
+    SELECT g1 FROM TABLE(generate_series(1, 300)) AS t(g1)
+)
+SELECT date_add('2020-01-01', s1.g1) as k1 , s1.g1, s2.g1
+FROM series s1, series s2
+WHERE s1.g1 <= s2.g1
+ORDER BY s1.g1;
+-- result:
+-- !result
+INSERT INTO t2
+WITH series AS (
+    SELECT g1 FROM TABLE(generate_series(1, 300)) AS t(g1)
+)
+SELECT date_add('2020-01-01', 300-s1.g1) as k1 , s1.g1, s2.g1
+FROM series s1, series s2
+WHERE s1.g1 <= s2.g1
+ORDER BY s1.g1;
+-- result:
+-- !result
+INSERT INTO t3
+WITH 
+series AS (
+    SELECT g1 FROM TABLE(generate_series(1, 300)) AS t(g1)
+)
+SELECT date_add('2020-01-01', s1.g1), s1.g1, s2.g1
+FROM series s1, series s2;
+-- result:
+-- !result
+SELECT k1, count(*)
+FROM t1
+GROUP BY k1
+ORDER BY k1
+LIMIT 10;
+-- result:
+2020-01-02	300
+2020-01-03	299
+2020-01-04	298
+2020-01-05	297
+2020-01-06	296
+2020-01-07	295
+2020-01-08	294
+2020-01-09	293
+2020-01-10	292
+2020-01-11	291
+-- !result
+SELECT k2, count(*)
+FROM t1
+GROUP BY k2
+ORDER BY k2
+LIMIT 10;
+-- result:
+1	300
+2	299
+3	298
+4	297
+5	296
+6	295
+7	294
+8	293
+9	292
+10	291
+-- !result
+SELECT k1, count(*)
+FROM t2
+GROUP BY k1
+ORDER BY k1
+LIMIT 10;
+-- result:
+2020-01-01	1
+2020-01-02	2
+2020-01-03	3
+2020-01-04	4
+2020-01-05	5
+2020-01-06	6
+2020-01-07	7
+2020-01-08	8
+2020-01-09	9
+2020-01-10	10
+-- !result
+SELECT k1, count(*)
+FROM t3
+GROUP BY k1
+ORDER BY k1
+LIMIT 10;
+-- result:
+2020-01-02	300
+2020-01-03	300
+2020-01-04	300
+2020-01-05	300
+2020-01-06	300
+2020-01-07	300
+2020-01-08	300
+2020-01-09	300
+2020-01-10	300
+2020-01-11	300
+-- !result
+[UC] ANALYZE FULL TABLE t1;
+-- result:
+analyze_test_5a0d63146e954344a23e1cde08fa0eb3.t1	analyze	status	OK
+-- !result
+[UC] ANALYZE FULL TABLE t2;
+-- result:
+analyze_test_5a0d63146e954344a23e1cde08fa0eb3.t2	analyze	status	OK
+-- !result
+[UC] ANALYZE FULL TABLE t3;
+-- result:
+analyze_test_5a0d63146e954344a23e1cde08fa0eb3.t3	analyze	status	OK
+-- !result
+SELECT min,max,row_count,hll_cardinality(ndv) FROM _statistics_.column_statistics WHERE table_name = 'analyze_test_${uuid0}.t1' and column_name = 'k1';
+-- result:
+2020-01-02	2020-10-27	45150	298
+-- !result
+SELECT min,max,row_count,hll_cardinality(ndv) FROM _statistics_.column_statistics WHERE table_name = 'analyze_test_${uuid0}.t2' and column_name = 'k1';
+-- result:
+2020-01-01	2020-10-26	45150	298
+-- !result
+SELECT min,max,row_count,hll_cardinality(ndv) FROM _statistics_.column_statistics WHERE table_name = 'analyze_test_${uuid0}.t3' and column_name = 'k1';
+-- result:
+2020-01-02	2020-10-27	90000	298
+-- !result
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM t1 WHERE k1="2020-01-02"', 'cardinality: 152')
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM t1 WHERE k1="2020-01-10"', 'cardinality: 152')
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM t1 WHERE k1="2020-01-30"', 'cardinality: 152')
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM t2 WHERE k1="2020-01-02"', 'cardinality: 152')
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM t2 WHERE k1="2020-01-10"', 'cardinality: 152')
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM t2 WHERE k1="2020-01-30"', 'cardinality: 152')
+-- result:
+None
+-- !result
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k1,k2,k3 PROPERTIES('histogram_sample_ratio' = '1.0');
+-- result:
+analyze_test_5a0d63146e954344a23e1cde08fa0eb3.t1	histogram	status	OK
+-- !result
+[UC] ANALYZE TABLE t2 UPDATE HISTOGRAM ON k1,k2,k3 PROPERTIES('histogram_sample_ratio' = '1.0');
+-- result:
+analyze_test_5a0d63146e954344a23e1cde08fa0eb3.t2	histogram	status	OK
+-- !result
+[UC] ANALYZE TABLE t3 UPDATE HISTOGRAM ON k1,k2,k3 PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '0');
+-- result:
+analyze_test_5a0d63146e954344a23e1cde08fa0eb3.t3	histogram	status	OK
+-- !result
+set enable_stats_to_optimize_skew_join = false;
+-- result:
+-- !result
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM t1 WHERE k2=120', 'cardinality: 181')
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM t1 WHERE k1="2020-05-11"', 'cardinality: 32')
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM t1 WHERE k1="2020-06-11"', 'cardinality: 139')
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM t1 WHERE k1="2020-07-11"', 'cardinality: 109')
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM t2 WHERE k1="2020-05-11"', 'cardinality: 49')
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM t2 WHERE k1="2020-06-11"', 'cardinality: 163')
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM t2 WHERE k1="2020-07-11"', 'cardinality: 193')
+-- result:
+None
+-- !result
+SELECT COUNT(*) FROM t1 JOIN t2 USING (k1);
+-- result:
+4589949
+-- !result
+SELECT COUNT(*) FROM t1 JOIN t2 USING (k1) WHERE t1.k1 BETWEEN "2020-01-21" AND "2020-01-30";
+-- result:
+70425
+-- !result
+SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k1 = n3.k1;
+-- result:
+1376984700
+-- !result
+SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k3 = n3.k3;
+-- result:
+1376984700
+-- !result
+set cbo_enable_histogram_join_estimation = false;
+-- result:
+-- !result
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1)', 'cardinality: 45150', 'cardinality: 6840680')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1) WHERE t1.k1 BETWEEN "2020-01-21" AND "2020-01-30" ', 'cardinality: 176', 'cardinality: 2765', 'cardinality: 1633')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k1 = n3.k1', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 6840680', 'cardinality: 2065977039')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k3 = n3.k3', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 6840680', 'cardinality: 2045385906')
+-- result:
+None
+-- !result
+set cbo_enable_histogram_join_estimation = true;
+-- result:
+-- !result
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1)', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 3645821')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1) WHERE t1.k1 BETWEEN "2020-01-21" AND "2020-01-30" ', 'cardinality: 176', 'cardinality: 2765', 'cardinality: 10239')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k1 = n3.k1', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 3645821', 'cardinality: 805345144')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k3 = n3.k3', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 3645821', 'cardinality: 1156602757')
+-- result:
+None
+-- !result
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k1,k2,k3 PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '400');
+-- result:
+analyze_test_5a0d63146e954344a23e1cde08fa0eb3.t1	histogram	status	OK
+-- !result
+[UC] ANALYZE TABLE t2 UPDATE HISTOGRAM ON k1,k2,k3 PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '400');
+-- result:
+analyze_test_5a0d63146e954344a23e1cde08fa0eb3.t2	histogram	status	OK
+-- !result
+[UC] ANALYZE TABLE t3 UPDATE HISTOGRAM ON k1,k2,k3 PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '400');
+-- result:
+analyze_test_5a0d63146e954344a23e1cde08fa0eb3.t3	histogram	status	OK
+-- !result
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1)', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 4589949')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1) WHERE t1.k1 BETWEEN "2020-01-21" AND "2020-01-30" ', 'cardinality: 255', 'cardinality: 2765', 'cardinality: 70425')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k1 = n3.k1', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 4589949', 'cardinality: 1376984700')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k3 = n3.k3', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 4589949', 'cardinality: 1376984700')
+-- result:
+None
+-- !result
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k1,k2,k3 WITH 256 BUCKETS PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '100');
+-- result:
+analyze_test_5a0d63146e954344a23e1cde08fa0eb3.t1	histogram	status	OK
+-- !result
+[UC] ANALYZE TABLE t2 UPDATE HISTOGRAM ON k1,k2,k3 WITH 256 BUCKETS PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '100');
+-- result:
+analyze_test_5a0d63146e954344a23e1cde08fa0eb3.t2	histogram	status	OK
+-- !result
+[UC] ANALYZE TABLE t3 UPDATE HISTOGRAM ON k1,k2,k3 WITH 256 BUCKETS PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '0');
+-- result:
+analyze_test_5a0d63146e954344a23e1cde08fa0eb3.t3	histogram	status	OK
+-- !result
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1)', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 4562636')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1) WHERE t1.k1 BETWEEN "2020-01-21" AND "2020-01-30" ', 'cardinality: 209', 'cardinality: 2765', 'cardinality: 24300')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k1 = n3.k1', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 4562636', 'cardinality: 1199835328')
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k3 = n3.k3', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 4562636', 'cardinality: 1446330752')
+-- result:
+None
+-- !result

--- a/test/sql/test_analyze_statistics/T/test_histogram
+++ b/test/sql/test_analyze_statistics/T/test_histogram
@@ -1,0 +1,156 @@
+-- name: test_histogram
+
+create database analyze_test_${uuid0};
+use analyze_test_${uuid0};
+
+CREATE TABLE `t1` (
+    `k1`  date,
+    `k2`  int,
+    `k3`  int
+)
+PROPERTIES ('replication_num' = '1');
+CREATE TABLE `t2` LIKE `t1`;
+CREATE TABLE `t3` LIKE `t1`;
+
+-- skew data on k1 column
+INSERT INTO t1
+WITH series AS (
+    SELECT g1 FROM TABLE(generate_series(1, 300)) AS t(g1)
+)
+SELECT date_add('2020-01-01', s1.g1) as k1 , s1.g1, s2.g1
+FROM series s1, series s2
+WHERE s1.g1 <= s2.g1
+ORDER BY s1.g1;
+
+-- t2 is asymmetric with t1
+INSERT INTO t2
+WITH series AS (
+    SELECT g1 FROM TABLE(generate_series(1, 300)) AS t(g1)
+)
+SELECT date_add('2020-01-01', 300-s1.g1) as k1 , s1.g1, s2.g1
+FROM series s1, series s2
+WHERE s1.g1 <= s2.g1
+ORDER BY s1.g1;
+
+-- t3 is distributed uniformly
+INSERT INTO t3
+WITH 
+series AS (
+    SELECT g1 FROM TABLE(generate_series(1, 300)) AS t(g1)
+)
+SELECT date_add('2020-01-01', s1.g1), s1.g1, s2.g1
+FROM series s1, series s2;
+
+SELECT k1, count(*)
+FROM t1
+GROUP BY k1
+ORDER BY k1
+LIMIT 10;
+
+SELECT k2, count(*)
+FROM t1
+GROUP BY k2
+ORDER BY k2
+LIMIT 10;
+
+SELECT k1, count(*)
+FROM t2
+GROUP BY k1
+ORDER BY k1
+LIMIT 10;
+
+SELECT k1, count(*)
+FROM t3
+GROUP BY k1
+ORDER BY k1
+LIMIT 10;
+
+-- without histogram, the card is not accurate
+[UC] ANALYZE FULL TABLE t1;
+[UC] ANALYZE FULL TABLE t2;
+[UC] ANALYZE FULL TABLE t3;
+
+SELECT min,max,row_count,hll_cardinality(ndv) FROM _statistics_.column_statistics WHERE table_name = 'analyze_test_${uuid0}.t1' and column_name = 'k1';
+SELECT min,max,row_count,hll_cardinality(ndv) FROM _statistics_.column_statistics WHERE table_name = 'analyze_test_${uuid0}.t2' and column_name = 'k1';
+SELECT min,max,row_count,hll_cardinality(ndv) FROM _statistics_.column_statistics WHERE table_name = 'analyze_test_${uuid0}.t3' and column_name = 'k1';
+
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM t1 WHERE k1="2020-01-02"', 'cardinality: 152')
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM t1 WHERE k1="2020-01-10"', 'cardinality: 152')
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM t1 WHERE k1="2020-01-30"', 'cardinality: 152')
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM t2 WHERE k1="2020-01-02"', 'cardinality: 152')
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM t2 WHERE k1="2020-01-10"', 'cardinality: 152')
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM t2 WHERE k1="2020-01-30"', 'cardinality: 152')
+
+-- with histogram
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k1,k2,k3 PROPERTIES('histogram_sample_ratio' = '1.0');
+[UC] ANALYZE TABLE t2 UPDATE HISTOGRAM ON k1,k2,k3 PROPERTIES('histogram_sample_ratio' = '1.0');
+[UC] ANALYZE TABLE t3 UPDATE HISTOGRAM ON k1,k2,k3 PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '0');
+
+-- SELECT buckets,mcv FROM _statistics_.histogram_statistics WHERE table_name = 'analyze_test_${uuid0}.t1' and column_name = 'k1';
+-- SELECT buckets,mcv FROM _statistics_.histogram_statistics WHERE table_name = 'analyze_test_${uuid0}.t2' and column_name = 'k1';
+-- SELECT buckets,mcv FROM _statistics_.histogram_statistics WHERE table_name = 'analyze_test_${uuid0}.t3' and column_name = 'k1';
+
+set enable_stats_to_optimize_skew_join = false;
+
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM t1 WHERE k2=120', 'cardinality: 181')
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM t1 WHERE k1="2020-05-11"', 'cardinality: 32')
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM t1 WHERE k1="2020-06-11"', 'cardinality: 139')
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM t1 WHERE k1="2020-07-11"', 'cardinality: 109')
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM t2 WHERE k1="2020-05-11"', 'cardinality: 49')
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM t2 WHERE k1="2020-06-11"', 'cardinality: 163')
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM t2 WHERE k1="2020-07-11"', 'cardinality: 193')
+
+-- expected results
+SELECT COUNT(*) FROM t1 JOIN t2 USING (k1);
+SELECT COUNT(*) FROM t1 JOIN t2 USING (k1) WHERE t1.k1 BETWEEN "2020-01-21" AND "2020-01-30";
+-- three table joins
+SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k1 = n3.k1;
+SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k3 = n3.k3;
+
+set cbo_enable_histogram_join_estimation = false;
+-- In these filter range, 01-10], the NDV will always be 10, so the join cardinality is 
+-- card(t1) * card(t2) / max(ndv(t1), ndv(t2)) 
+-- = card(t1) * card(t2) / 30
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1)', 'cardinality: 45150', 'cardinality: 6840680')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1) WHERE t1.k1 BETWEEN "2020-01-21" AND "2020-01-30" ', 'cardinality: 176', 'cardinality: 2765', 'cardinality: 1633')
+
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k1 = n3.k1', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 6840680', 'cardinality: 2065977039')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k3 = n3.k3', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 6840680', 'cardinality: 2045385906')
+
+set cbo_enable_histogram_join_estimation = true;
+
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1)', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 3645821')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1) WHERE t1.k1 BETWEEN "2020-01-21" AND "2020-01-30" ', 'cardinality: 176', 'cardinality: 2765', 'cardinality: 10239')
+
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k1 = n3.k1', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 3645821', 'cardinality: 805345144')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k3 = n3.k3', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 3645821', 'cardinality: 1156602757')
+
+-- more mcvs lead to better estimations.
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k1,k2,k3 PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '400');
+[UC] ANALYZE TABLE t2 UPDATE HISTOGRAM ON k1,k2,k3 PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '400');
+[UC] ANALYZE TABLE t3 UPDATE HISTOGRAM ON k1,k2,k3 PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '400');
+
+-- SELECT buckets,mcv FROM _statistics_.histogram_statistics WHERE table_name = 'analyze_test_${uuid0}.t1' and column_name = 'k1';
+-- SELECT buckets,mcv FROM _statistics_.histogram_statistics WHERE table_name = 'analyze_test_${uuid0}.t2' and column_name = 'k1';
+-- SELECT buckets,mcv FROM _statistics_.histogram_statistics WHERE table_name = 'analyze_test_${uuid0}.t3' and column_name = 'k1';
+
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1)', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 4589949')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1) WHERE t1.k1 BETWEEN "2020-01-21" AND "2020-01-30" ', 'cardinality: 255', 'cardinality: 2765', 'cardinality: 70425')
+
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k1 = n3.k1', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 4589949', 'cardinality: 1376984700')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k3 = n3.k3', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 4589949', 'cardinality: 1376984700')
+
+-- more buckets also lead to better estimations.
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k1,k2,k3 WITH 256 BUCKETS PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '100');
+[UC] ANALYZE TABLE t2 UPDATE HISTOGRAM ON k1,k2,k3 WITH 256 BUCKETS PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '100');
+[UC] ANALYZE TABLE t3 UPDATE HISTOGRAM ON k1,k2,k3 WITH 256 BUCKETS PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '0');
+
+-- SELECT buckets,mcv FROM _statistics_.histogram_statistics WHERE table_name = 'analyze_test_${uuid0}.t1' and column_name = 'k1';
+-- SELECT buckets,mcv FROM _statistics_.histogram_statistics WHERE table_name = 'analyze_test_${uuid0}.t2' and column_name = 'k1';
+-- SELECT buckets,mcv FROM _statistics_.histogram_statistics WHERE table_name = 'analyze_test_${uuid0}.t3' and column_name = 'k1';
+
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1)', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 4562636')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1) WHERE t1.k1 BETWEEN "2020-01-21" AND "2020-01-30" ', 'cardinality: 209', 'cardinality: 2765', 'cardinality: 24300')
+
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k1 = n3.k1', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 4562636', 'cardinality: 1199835328')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k3 = n3.k3', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 4562636', 'cardinality: 1446330752')


### PR DESCRIPTION
Signed-off-by: m-selmi <m.selmi@celonis.com>

(cherry picked from commit d175bb21fa4cf003eabaf582a6b8c88dc85dd9fe)

## Why I'm doing:

This is a manual backport of pull request https://github.com/StarRocks/starrocks/pull/57639 because the automatic one failed with conflicts.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1

