### PR TITLE
[Enhancement] Support nested namespaces for iceberg rest catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -42,6 +42,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.RESTException;
 import org.apache.iceberg.rest.RESTCatalog;
+import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.view.View;
 import org.apache.iceberg.view.ViewBuilder;
 import org.apache.logging.log4j.LogManager;
@@ -68,9 +69,11 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
     public static final String KEY_CREDENTIAL_WITH_PREFIX = ICEBERG_CUSTOM_PROPERTIES_PREFIX + "credential";
     public static final String KEY_VENDED_CREDENTIALS_ENABLED = "vended-credentials-enabled";
+    public static final String KEY_NESTED_NAMESPACE_ENABLED = "rest.nested-namespace-enabled";
 
     private final Configuration conf;
     private final RESTCatalog delegate;
+    private final boolean nestedNamespaceEnabled;
 
     public IcebergRESTCatalog(String name, Configuration conf, Map<String, String> properties) {
         this.conf = conf;
@@ -95,6 +98,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             copiedProperties.put(AwsProperties.CLIENT_FACTORY, IcebergAwsClientFactory.class.getName());
         }
 
+        nestedNamespaceEnabled = PropertyUtil.propertyAsBoolean(copiedProperties, KEY_NESTED_NAMESPACE_ENABLED, false);
         // setup oauth2
         OAuth2SecurityConfig securityConfig = OAuth2SecurityConfigBuilder.build(copiedProperties);
         OAuth2SecurityProperties securityProperties = new OAuth2SecurityProperties(securityConfig);
@@ -107,6 +111,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     public IcebergRESTCatalog(RESTCatalog restCatalog, Configuration conf) {
         this.delegate = restCatalog;
         this.conf = conf;
+        this.nestedNamespaceEnabled = false;
     }
 
     @Override
@@ -126,7 +131,16 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
     @Override
     public List<String> listAllDatabases() {
-        return listNamespaces(Namespace.empty());
+        if (nestedNamespaceEnabled) {
+            return listNamespaces(Namespace.empty());
+        } else {
+            try {
+                return delegate.listNamespaces().stream().map(this::toDbName)
+                    .collect(Collectors.toList());
+            } catch (RESTException e) {
+                throw new StarRocksConnectorException("Failed to list namespaces", e);
+            }
+        }
     }
 
     private List<String> listNamespaces(Namespace parent) {
@@ -136,6 +150,15 @@ public class IcebergRESTCatalog implements IcebergCatalog {
                     .collect(toImmutableList());
         } catch (RESTException e) {
             throw new StarRocksConnectorException("Failed to list namespaces", e);
+        }
+    }
+
+    private String toDbName(Namespace namespace) {
+        if (!nestedNamespaceEnabled && namespace.length() != 1) {
+            throw new StarRocksConnectorException("Nested namespace is not enabled for this catalog, " +
+                    "add catalog property \"iceberg.catalog.rest.nested-namespace-enabled\" = \"true\" to enable it");
+        } else {
+            return namespace.level(0);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -135,7 +135,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             return listNamespaces(Namespace.empty());
         } else {
             try {
-                return delegate.listNamespaces().stream().map(this::toDbName)
+                return delegate.listNamespaces().stream().map(ns -> ns.level(0))
                     .collect(Collectors.toList());
             } catch (RESTException e) {
                 throw new StarRocksConnectorException("Failed to list namespaces", e);
@@ -150,15 +150,6 @@ public class IcebergRESTCatalog implements IcebergCatalog {
                     .collect(toImmutableList());
         } catch (RESTException e) {
             throw new StarRocksConnectorException("Failed to list namespaces", e);
-        }
-    }
-
-    private String toDbName(Namespace namespace) {
-        if (!nestedNamespaceEnabled && namespace.length() != 1) {
-            throw new StarRocksConnectorException("Nested namespace is not enabled for this catalog, " +
-                    "add catalog property \"iceberg.catalog.rest.nested-namespace-enabled\" = \"true\" to enable it");
-        } else {
-            return namespace.level(0);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -131,26 +131,22 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
     @Override
     public List<String> listAllDatabases() {
-        if (nestedNamespaceEnabled) {
-            return listNamespaces(Namespace.empty());
-        } else {
-            try {
+        try {
+            if (nestedNamespaceEnabled) {
+                return listNamespaces(Namespace.empty());
+            } else {
                 return delegate.listNamespaces().stream().map(ns -> ns.level(0))
-                    .collect(Collectors.toList());
-            } catch (RESTException e) {
-                throw new StarRocksConnectorException("Failed to list namespaces", e);
+                            .collect(Collectors.toList());
             }
+        } catch (RESTException e) {
+            throw new StarRocksConnectorException("Failed to list namespaces", e);
         }
     }
 
     private List<String> listNamespaces(Namespace parent) {
-        try {
-            return delegate.listNamespaces(parent).stream().
-                    flatMap(child -> Stream.concat(Stream.of(child.toString()), listNamespaces(child).stream()))
-                    .collect(toImmutableList());
-        } catch (RESTException e) {
-            throw new StarRocksConnectorException("Failed to list namespaces", e);
-        }
+        return delegate.listNamespaces(parent).stream().
+                flatMap(child -> Stream.concat(Stream.of(child.toString()), listNamespaces(child).stream()))
+                .collect(toImmutableList());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FeNameFormat.java
@@ -34,12 +34,15 @@ public class FeNameFormat {
     private static final String LABEL_REGEX = "^[-\\w]{1,128}$";
 
     public static final char[] SPECIAL_CHARACTERS_IN_DB_NAME = new char[] {'-', '~', '!', '@', '#', '$',
+            '%', '^', '&', '<', '>', '=', '+'};
+    public static final char[] SPECIAL_CHARACTERS_IN_ICEBERG_NAMESPACE = new char[] {'-', '~', '!', '@', '#', '$',
             '%', '^', '&', '<', '>', '=', '+', '.'};
     public static final String COMMON_NAME_REGEX = "^[a-zA-Z]\\w{0,63}$|^_[a-zA-Z0-9]\\w{0,62}$";
 
     // The length of db name is 256
     public static String DB_NAME_REGEX = "";
     public static final String TABLE_NAME_REGEX = "^[^\0]{1,1024}$";
+    public static String ICEBERG_NAMESPACE_REGEX = "";
 
     // Now we can not accept all characters because current design of delete save delete cond contains column name,
     // so it can not distinguish whether it is an operator or a column name
@@ -69,6 +72,12 @@ public class FeNameFormat {
         DB_NAME_REGEX = "^[a-zA-Z][\\w" + Pattern.quote(allowedSpecialCharacters) + "]{0,255}$|" +
                 "^_[a-zA-Z0-9][\\w" + Pattern.quote(allowedSpecialCharacters) + "]{0,254}$";
 
+        allowedSpecialCharacters = "";
+        for (Character c : SPECIAL_CHARACTERS_IN_ICEBERG_NAMESPACE) {
+            allowedSpecialCharacters += c;
+        }
+        ICEBERG_NAMESPACE_REGEX = "^[a-zA-Z][\\w" + Pattern.quote(allowedSpecialCharacters) + "]{0,255}$|" +
+                "^_[a-zA-Z0-9][\\w" + Pattern.quote(allowedSpecialCharacters) + "]{0,254}$";
     }
 
     // The length of db name is 256.
@@ -78,6 +87,16 @@ public class FeNameFormat {
         }
 
         if (!dbName.matches(DB_NAME_REGEX)) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_DB_NAME, dbName);
+        }
+    }
+
+    public static void checkNamespace(String dbName) {
+        if (Strings.isNullOrEmpty(dbName)) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_DB_NAME, dbName);
+        }
+
+        if (!dbName.matches(ICEBERG_NAMESPACE_REGEX)) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_DB_NAME, dbName);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FeNameFormat.java
@@ -34,7 +34,7 @@ public class FeNameFormat {
     private static final String LABEL_REGEX = "^[-\\w]{1,128}$";
 
     public static final char[] SPECIAL_CHARACTERS_IN_DB_NAME = new char[] {'-', '~', '!', '@', '#', '$',
-            '%', '^', '&', '<', '>', '=', '+'};
+            '%', '^', '&', '<', '>', '=', '+', '.'};
     public static final String COMMON_NAME_REGEX = "^[a-zA-Z]\\w{0,63}$|^_[a-zA-Z0-9]\\w{0,62}$";
 
     // The length of db name is 256

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -712,7 +712,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             catalogName = getIdentifierName(context.catalog);
         }
 
-        String dbName = getIdentifierName(context.database);
+        QualifiedName dbName = getQualifiedName(context.database);
 
         Map<String, String> properties = new HashMap<>();
         if (context.properties() != null) {
@@ -721,7 +721,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                 properties.put(property.getKey(), property.getValue());
             }
         }
-        return new CreateDbStmt(context.IF() != null, catalogName, dbName, properties, createPos(context));
+        return new CreateDbStmt(context.IF() != null, catalogName, dbName.toString(), properties, createPos(context));
     }
 
     @Override
@@ -731,8 +731,8 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             catalogName = getIdentifierName(context.catalog);
         }
 
-        String dbName = getIdentifierName(context.database);
-        return new DropDbStmt(context.IF() != null, catalogName, dbName, context.FORCE() != null,
+        QualifiedName dbName = getQualifiedName(context.database);
+        return new DropDbStmt(context.IF() != null, catalogName, dbName.toString(), context.FORCE() != null,
                 createPos(context));
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -376,11 +376,11 @@ alterDbQuotaStatement
     ;
 
 createDbStatement
-    : CREATE (DATABASE | SCHEMA) (IF NOT EXISTS)? (catalog=identifier '.')? database=identifier charsetDesc? collateDesc? properties?
+    : CREATE (DATABASE | SCHEMA) (IF NOT EXISTS)? (catalog=identifier '.')? database=qualifiedName charsetDesc? collateDesc? properties?
     ;
 
 dropDbStatement
-    : DROP (DATABASE | SCHEMA) (IF EXISTS)? (catalog=identifier '.')? database=identifier FORCE?
+    : DROP (DATABASE | SCHEMA) (IF EXISTS)? (catalog=identifier '.')? database=qualifiedName FORCE?
     ;
 
 showCreateDbStatement

--- a/fe/fe-core/src/test/java/com/starrocks/common/FeNameFormatTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/FeNameFormatTest.java
@@ -102,8 +102,16 @@ public class FeNameFormatTest {
 
 
         Assertions.assertThrows(SemanticException.class, () -> FeNameFormat.checkDbName("!abc"));
+        Assertions.assertThrows(SemanticException.class, () -> FeNameFormat.checkDbName("ab.c"));
         Assertions.assertThrows(SemanticException.class, () -> FeNameFormat.checkDbName("ab c"));
         Assertions.assertThrows(SemanticException.class, () -> FeNameFormat.checkDbName("ab\0c"));
+    }
+
+    @Test
+    public void testCheckNamespace() {
+        Assertions.assertDoesNotThrow(() -> FeNameFormat.checkNamespace("abc"));
+        Assertions.assertDoesNotThrow(() -> FeNameFormat.checkNamespace("ns1.ns2"));
+        Assertions.assertDoesNotThrow(() -> FeNameFormat.checkNamespace("ns1.ns2.ns3"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/common/FeNameFormatTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/FeNameFormatTest.java
@@ -102,7 +102,6 @@ public class FeNameFormatTest {
 
 
         Assertions.assertThrows(SemanticException.class, () -> FeNameFormat.checkDbName("!abc"));
-        Assertions.assertThrows(SemanticException.class, () -> FeNameFormat.checkDbName("ab.c"));
         Assertions.assertThrows(SemanticException.class, () -> FeNameFormat.checkDbName("ab c"));
         Assertions.assertThrows(SemanticException.class, () -> FeNameFormat.checkDbName("ab\0c"));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
@@ -89,8 +89,16 @@ public class IcebergRESTCatalogTest {
     public void testListAllDatabases(@Mocked RESTCatalog restCatalog) {
         new Expectations() {
             {
-                restCatalog.listNamespaces();
-                result = ImmutableList.of(Namespace.of("db1"), Namespace.of("db2"));
+                restCatalog.listNamespaces(Namespace.empty());
+                result = ImmutableList.of(Namespace.of("db1"));
+                times = 1;
+
+                restCatalog.listNamespaces(Namespace.of("db1"));
+                result = ImmutableList.of(Namespace.of("db1.ns1"));
+                times = 1;
+
+                restCatalog.listNamespaces(Namespace.of("db1.ns1"));
+                result = ImmutableList.of(Namespace.of("db1.ns1.ns2"));
                 times = 1;
             }
         };
@@ -99,7 +107,7 @@ public class IcebergRESTCatalogTest {
         IcebergRESTCatalog icebergRESTCatalog = new IcebergRESTCatalog(
                 "rest_native_catalog", new Configuration(), icebergProperties);
         List<String> dbs = icebergRESTCatalog.listAllDatabases();
-        Assert.assertEquals(Arrays.asList("db1", "db2"), dbs);
+        Assert.assertEquals(Arrays.asList("db1", "db1.ns1", "db1.ns1.ns2"), dbs);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
@@ -93,27 +93,13 @@ public class IcebergRESTCatalogTest {
         new Expectations() {
             {
                 restCatalog.listNamespaces();
-                result = ImmutableList.of(Namespace.of("ns", "ns1"));
-                times = 1;
-            }
-        };
-        Map<String, String> icebergProperties = new HashMap<>();
-        IcebergRESTCatalog icebergRESTCatalog = new IcebergRESTCatalog(
-                "rest_native_catalog", new Configuration(), icebergProperties);
-        ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class,
-                "Nested namespace is not enabled for this catalog, add catalog property " +
-                        "\"iceberg.catalog.rest.nested-namespace-enabled\" = \"true\" to enable it",
-                icebergRESTCatalog::listAllDatabases);
-
-        new Expectations() {
-            {
-                restCatalog.listNamespaces();
                 result = new RESTException("mocked");
                 times = 1;
             }
         };
 
-        icebergRESTCatalog = new IcebergRESTCatalog(
+        Map<String, String> icebergProperties = new HashMap<>();
+        IcebergRESTCatalog icebergRESTCatalog = new IcebergRESTCatalog(
                 "rest_native_catalog", new Configuration(), icebergProperties);
         ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class, "Failed to list namespaces",
                 icebergRESTCatalog::listAllDatabases);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateDbTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateDbTest.java
@@ -45,6 +45,9 @@ public class AnalyzeCreateDbTest {
         analyzeSuccess("CREATE Database `iceberg_catalog`.`iceberg_db`" +
                 " properties(\"location\" = \"hdfs://namenode:9000/user/warehouse/hive/iceberg_db.db\")");
 
+        analyzeSuccess("CREATE Database `iceberg_catalog`.`ns1`");
+        analyzeSuccess("CREATE Database `iceberg_catalog`.`ns1`.`ns2`");
+
         try {
             String stmt = "CREATE Database `not_exist_catalog`.`iceberg_db` properties(\"location\" = \"hdfs://namenode:9000/user/warehouse/hive/iceberg_db.db\")";
             UtFrameUtils.parseStmtWithNewParser(stmt, connectContext);


### PR DESCRIPTION
## Why I'm doing:
#53748 support read iceberg table with nested namespace, but sr cannot show/create/drop databases with nested namespace

## What I'm doing:
supoort show/create/drop nested namespace
```
StarRocks>set catalog polaris;
Query OK, 0 rows affected (0.00 sec)

StarRocks>show databases;
+--------------------+
| Database           |
+--------------------+
| ice_db             |
| information_schema |
| nested_ns          |
| nested_ns.ns1      |
+--------------------+
4 rows in set (0.02 sec)

StarRocks>create database polaris.nested_ns.ns1.ns2;
Query OK, 0 rows affected (0.02 sec)

StarRocks>show databases;
+--------------------+
| Database           |
+--------------------+
| ice_db             |
| information_schema |
| nested_ns          |
| nested_ns.ns1      |
| nested_ns.ns1.ns2  |
+--------------------+

StarRocks>use polaris.nested_ns.ns1.ns2;
Database changed
StarRocks>CREATE TABLE taxis
    -> (
    ->   trip_id bigint,
    ->   trip_distance float,
    ->   fare_amount double,
    ->   store_and_fwd_flag string,
    ->   vendor_id bigint
    -> )
    -> PARTITION BY (vendor_id);
Query OK, 0 rows affected

StarRocks>INSERT INTO taxis
    -> VALUES (1000371, 1.8, 15.32, 'N', 1), (1000372, 2.5, 22.15, 'N', 2), (1000373, 0.9, 9.01, 'N', 2), (1000374, 8.4, 42.13, 'Y', 1);
Query OK, 4 rows affected

StarRocks>select * from polaris.`nested_ns.ns1.ns2`.taxis;
+---------+---------------+-------------+--------------------+-----------+
| trip_id | trip_distance | fare_amount | store_and_fwd_flag | vendor_id |
+---------+---------------+-------------+--------------------+-----------+
| 1000372 |           2.5 |       22.15 | N                  |         2 |
| 1000373 |           0.9 |        9.01 | N                  |         2 |
| 1000371 |           1.8 |       15.32 | N                  |         1 |
| 1000374 |           8.4 |       42.13 | Y                  |         1 |
+---------+---------------+-------------+--------------------+-----------+
4 rows in set 

StarRocks>select * from `nested_ns.ns1.ns2`.taxis;
+---------+---------------+-------------+--------------------+-----------+
| trip_id | trip_distance | fare_amount | store_and_fwd_flag | vendor_id |
+---------+---------------+-------------+--------------------+-----------+
| 1000372 |           2.5 |       22.15 | N                  |         2 |
| 1000373 |           0.9 |        9.01 | N                  |         2 |
| 1000371 |           1.8 |       15.32 | N                  |         1 |
| 1000374 |           8.4 |       42.13 | Y                  |         1 |
+---------+---------------+-------------+--------------------+-----------+

StarRocks>drop database polaris.nested_ns.ns1.ns2;
ERROR 1064 (HY000): Database nested_ns.ns1.ns2 not empty

StarRocks>drop table polaris.`nested_ns.ns1.ns2`.taxis;
Query OK, 0 rows affected (0.08 sec)

StarRocks>drop database polaris.nested_ns.ns1.ns2;
Query OK, 0 rows affected (0.01 sec)

StarRocks>show databases;
+--------------------+
| Database           |
+--------------------+
| ice_db             |
| information_schema |
| nested_ns          |
| nested_ns.ns1      |
+--------------------+


```


Fixes #52451

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
