### PR TITLE
[BugFix] fix crash caused by spill preagg strategy

### DIFF
--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -942,8 +942,10 @@ Status Aggregator::evaluate_groupby_exprs(Chunk* chunk) {
     return _evaluate_group_by_exprs(chunk);
 }
 
-Status Aggregator::output_chunk_by_streaming(Chunk* input_chunk, ChunkPtr* chunk, bool force_use_intermediate_as_output) {
-    return output_chunk_by_streaming(input_chunk, chunk, input_chunk->num_rows(), false, force_use_intermediate_as_output);
+Status Aggregator::output_chunk_by_streaming(Chunk* input_chunk, ChunkPtr* chunk,
+                                             bool force_use_intermediate_as_output) {
+    return output_chunk_by_streaming(input_chunk, chunk, input_chunk->num_rows(), false,
+                                     force_use_intermediate_as_output);
 }
 
 Status Aggregator::output_chunk_by_streaming(Chunk* input_chunk, ChunkPtr* chunk, size_t num_input_rows,
@@ -1008,7 +1010,6 @@ Status Aggregator::output_chunk_by_streaming(Chunk* input_chunk, ChunkPtr* chunk
                 result_chunk->append_column(std::move(_agg_input_columns[i][0]), slot_id);
             } else {
                 {
-
                     SCOPED_THREAD_LOCAL_STATE_ALLOCATOR_SETTER(_allocator.get());
                     _agg_functions[i]->convert_to_serialize_format(_agg_fn_ctxs[i], _agg_input_columns[i],
                                                                    result_chunk->num_rows(), &agg_result_column[i]);
@@ -1074,7 +1075,8 @@ Status Aggregator::convert_to_spill_format(Chunk* input_chunk, ChunkPtr* chunk) 
     return Status::OK();
 }
 
-Status Aggregator::output_chunk_by_streaming_with_selection(Chunk* input_chunk, ChunkPtr* chunk, bool force_use_intermediate_as_output) {
+Status Aggregator::output_chunk_by_streaming_with_selection(Chunk* input_chunk, ChunkPtr* chunk,
+                                                            bool force_use_intermediate_as_output) {
     // Streaming aggregate at least has one group by column
     const size_t num_input_rows = _group_by_columns[0]->size();
     for (auto& _group_by_column : _group_by_columns) {
@@ -1090,7 +1092,8 @@ Status Aggregator::output_chunk_by_streaming_with_selection(Chunk* input_chunk, 
         }
     }
 
-    RETURN_IF_ERROR(output_chunk_by_streaming(input_chunk, chunk, num_input_rows, true, force_use_intermediate_as_output));
+    RETURN_IF_ERROR(
+            output_chunk_by_streaming(input_chunk, chunk, num_input_rows, true, force_use_intermediate_as_output));
     return Status::OK();
 }
 

--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -942,12 +942,12 @@ Status Aggregator::evaluate_groupby_exprs(Chunk* chunk) {
     return _evaluate_group_by_exprs(chunk);
 }
 
-Status Aggregator::output_chunk_by_streaming(Chunk* input_chunk, ChunkPtr* chunk) {
-    return output_chunk_by_streaming(input_chunk, chunk, input_chunk->num_rows(), false);
+Status Aggregator::output_chunk_by_streaming(Chunk* input_chunk, ChunkPtr* chunk, bool force_use_intermediate_as_output) {
+    return output_chunk_by_streaming(input_chunk, chunk, input_chunk->num_rows(), false, force_use_intermediate_as_output);
 }
 
 Status Aggregator::output_chunk_by_streaming(Chunk* input_chunk, ChunkPtr* chunk, size_t num_input_rows,
-                                             bool use_selection) {
+                                             bool use_selection, bool force_use_intermediate_as_output) {
     // The input chunk is already intermediate-typed, so there is no need to convert it again.
     // Only when the input chunk is input-typed, we should convert it into intermediate-typed chunk.
     // is_passthrough is on indicate that the chunk is input-typed.
@@ -976,7 +976,6 @@ Status Aggregator::output_chunk_by_streaming(Chunk* input_chunk, ChunkPtr* chunk
     // build aggregate function values
     if (!_agg_fn_ctxs.empty()) {
         DCHECK(!_group_by_columns.empty());
-
         RETURN_IF_ERROR(evaluate_agg_fn_exprs(input_chunk));
         if (use_selection) {
             for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
@@ -1001,9 +1000,15 @@ Status Aggregator::output_chunk_by_streaming(Chunk* input_chunk, ChunkPtr* chunk
             auto slot_id = slots[id]->id();
             if (_is_merge_funcs[i] || use_intermediate_as_input) {
                 DCHECK(i < _agg_input_columns.size() && _agg_input_columns[i].size() >= 1);
+                if (force_use_intermediate_as_output) {
+                    if (agg_result_column[i]->is_nullable()) {
+                        _agg_input_columns[i][0] = ColumnHelper::cast_to_nullable_column(_agg_input_columns[i][0]);
+                    }
+                }
                 result_chunk->append_column(std::move(_agg_input_columns[i][0]), slot_id);
             } else {
                 {
+
                     SCOPED_THREAD_LOCAL_STATE_ALLOCATOR_SETTER(_allocator.get());
                     _agg_functions[i]->convert_to_serialize_format(_agg_fn_ctxs[i], _agg_input_columns[i],
                                                                    result_chunk->num_rows(), &agg_result_column[i]);
@@ -1069,7 +1074,7 @@ Status Aggregator::convert_to_spill_format(Chunk* input_chunk, ChunkPtr* chunk) 
     return Status::OK();
 }
 
-Status Aggregator::output_chunk_by_streaming_with_selection(Chunk* input_chunk, ChunkPtr* chunk) {
+Status Aggregator::output_chunk_by_streaming_with_selection(Chunk* input_chunk, ChunkPtr* chunk, bool force_use_intermediate_as_output) {
     // Streaming aggregate at least has one group by column
     const size_t num_input_rows = _group_by_columns[0]->size();
     for (auto& _group_by_column : _group_by_columns) {
@@ -1085,7 +1090,7 @@ Status Aggregator::output_chunk_by_streaming_with_selection(Chunk* input_chunk, 
         }
     }
 
-    RETURN_IF_ERROR(output_chunk_by_streaming(input_chunk, chunk, num_input_rows, true));
+    RETURN_IF_ERROR(output_chunk_by_streaming(input_chunk, chunk, num_input_rows, true, force_use_intermediate_as_output));
     return Status::OK();
 }
 

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -348,8 +348,10 @@ public:
     Status evaluate_agg_fn_exprs(Chunk* chunk, bool use_intermediate);
     Status evaluate_agg_input_column(Chunk* chunk, std::vector<ExprContext*>& agg_expr_ctxs, int i);
 
-    Status output_chunk_by_streaming(Chunk* input_chunk, ChunkPtr* chunk, bool force_use_intermediate_as_output = false);
-    Status output_chunk_by_streaming(Chunk* input_chunk, ChunkPtr* chunk, size_t num_input_rows, bool use_selection, bool force_use_intermediate_as_output = false);
+    Status output_chunk_by_streaming(Chunk* input_chunk, ChunkPtr* chunk,
+                                     bool force_use_intermediate_as_output = false);
+    Status output_chunk_by_streaming(Chunk* input_chunk, ChunkPtr* chunk, size_t num_input_rows, bool use_selection,
+                                     bool force_use_intermediate_as_output = false);
 
     // convert input chunk to spill format
     Status convert_to_spill_format(Chunk* input_chunk, ChunkPtr* chunk);
@@ -359,7 +361,8 @@ public:
     // and are mainly used in the first stage of two-stage aggregation when aggr reduction is low
     // selection[i] = 0: found in hash table
     // selection[1] = 1: not found in hash table
-    Status output_chunk_by_streaming_with_selection(Chunk* input_chunk, ChunkPtr* chunk, bool force_use_intermediate_as_output = false);
+    Status output_chunk_by_streaming_with_selection(Chunk* input_chunk, ChunkPtr* chunk,
+                                                    bool force_use_intermediate_as_output = false);
 
     // At first, we use single hash map, if hash map is too big,
     // we convert the single hash map to two level hash map.

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -348,8 +348,8 @@ public:
     Status evaluate_agg_fn_exprs(Chunk* chunk, bool use_intermediate);
     Status evaluate_agg_input_column(Chunk* chunk, std::vector<ExprContext*>& agg_expr_ctxs, int i);
 
-    Status output_chunk_by_streaming(Chunk* input_chunk, ChunkPtr* chunk);
-    Status output_chunk_by_streaming(Chunk* input_chunk, ChunkPtr* chunk, size_t num_input_rows, bool use_selection);
+    Status output_chunk_by_streaming(Chunk* input_chunk, ChunkPtr* chunk, bool force_use_intermediate_as_output = false);
+    Status output_chunk_by_streaming(Chunk* input_chunk, ChunkPtr* chunk, size_t num_input_rows, bool use_selection, bool force_use_intermediate_as_output = false);
 
     // convert input chunk to spill format
     Status convert_to_spill_format(Chunk* input_chunk, ChunkPtr* chunk);
@@ -359,7 +359,7 @@ public:
     // and are mainly used in the first stage of two-stage aggregation when aggr reduction is low
     // selection[i] = 0: found in hash table
     // selection[1] = 1: not found in hash table
-    Status output_chunk_by_streaming_with_selection(Chunk* input_chunk, ChunkPtr* chunk);
+    Status output_chunk_by_streaming_with_selection(Chunk* input_chunk, ChunkPtr* chunk, bool force_use_intermediate_as_output = false);
 
     // At first, we use single hash map, if hash map is too big,
     // we convert the single hash map to two level hash map.

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
@@ -194,7 +194,7 @@ Status SpillableAggregateBlockingSinkOperator::_try_to_spill_by_auto(RuntimeStat
         // use force streaming mode and spill all data
         SCOPED_TIMER(_aggregator->streaming_timer());
         ChunkPtr res = std::make_shared<Chunk>();
-        RETURN_IF_ERROR(_aggregator->output_chunk_by_streaming(chunk.get(), &res));
+        RETURN_IF_ERROR(_aggregator->output_chunk_by_streaming(chunk.get(), &res, true));
         _add_streaming_chunk(res);
         return _spill_all_data(state, true);
     } else if (build_hash_table) {
@@ -221,7 +221,7 @@ Status SpillableAggregateBlockingSinkOperator::_try_to_spill_by_auto(RuntimeStat
         if (hit_count == 0) {
             // put all data into buffer
             ChunkPtr tmp = std::make_shared<Chunk>();
-            RETURN_IF_ERROR(_aggregator->output_chunk_by_streaming(chunk.get(), &tmp));
+            RETURN_IF_ERROR(_aggregator->output_chunk_by_streaming(chunk.get(), &tmp, true));
             _add_streaming_chunk(std::move(tmp));
         } else if (hit_count == _aggregator->streaming_selection().size()) {
             // very high reduction
@@ -236,7 +236,7 @@ Status SpillableAggregateBlockingSinkOperator::_try_to_spill_by_auto(RuntimeStat
             {
                 SCOPED_TIMER(_aggregator->streaming_timer());
                 ChunkPtr res = std::make_shared<Chunk>();
-                RETURN_IF_ERROR(_aggregator->output_chunk_by_streaming_with_selection(chunk.get(), &res));
+                RETURN_IF_ERROR(_aggregator->output_chunk_by_streaming_with_selection(chunk.get(), &res, true));
                 _add_streaming_chunk(std::move(res));
             }
         }

--- a/be/src/exec/sorted_streaming_aggregator.cpp
+++ b/be/src/exec/sorted_streaming_aggregator.cpp
@@ -24,7 +24,8 @@
 #include "column/nullable_column.h"
 #include "column/vectorized_fwd.h"
 #include "common/object_pool.h"
-#include "exec/aggregate/agg_hash_map.h"
+
+#include "exprs/agg/aggregate_state_allocator.h"
 #include "exprs/expr_context.h"
 #include "glog/logging.h"
 #include "runtime/mem_pool.h"
@@ -421,6 +422,7 @@ Status SortedStreamingAggregator::_compute_group_by(size_t chunk_size) {
 }
 
 Status SortedStreamingAggregator::_update_states(size_t chunk_size, bool is_update) {
+    SCOPED_THREAD_LOCAL_STATE_ALLOCATOR_SETTER(_allocator.get());
     // TODO: split the states
     // allocate state stage
     {
@@ -472,6 +474,7 @@ Status SortedStreamingAggregator::_update_states(size_t chunk_size, bool is_upda
 
 Status SortedStreamingAggregator::_get_agg_result_columns(size_t chunk_size, const Buffer<uint8_t>& selector,
                                                           Columns& agg_result_columns) {
+    SCOPED_THREAD_LOCAL_STATE_ALLOCATOR_SETTER(_allocator.get());
     TRY_CATCH_ALLOC_SCOPE_START()
     auto use_intermediate = _use_intermediate_as_output();
     SCOPED_TIMER(_agg_stat->get_results_timer);
@@ -500,6 +503,7 @@ Status SortedStreamingAggregator::_get_agg_result_columns(size_t chunk_size, con
 
 void SortedStreamingAggregator::_close_group_by(size_t chunk_size, const Filter& selector) {
     // close stage
+    SCOPED_THREAD_LOCAL_STATE_ALLOCATOR_SETTER(_allocator.get());
     SCOPED_TIMER(_agg_stat->state_destroy_timer);
     if (_cmp_vector[0] != 0 && _last_state) {
         _destroy_state(_last_state);
@@ -531,6 +535,7 @@ StatusOr<ChunkPtr> SortedStreamingAggregator::pull_eos_chunk() {
     if (_last_state == nullptr && _last_columns.empty()) {
         return nullptr;
     }
+    SCOPED_THREAD_LOCAL_STATE_ALLOCATOR_SETTER(_allocator.get());
     bool use_intermediate = _use_intermediate_as_output();
     auto agg_result_columns = _create_agg_result_columns(1, use_intermediate);
     auto group_by_columns = _last_columns;

--- a/be/src/exec/sorted_streaming_aggregator.cpp
+++ b/be/src/exec/sorted_streaming_aggregator.cpp
@@ -24,7 +24,6 @@
 #include "column/nullable_column.h"
 #include "column/vectorized_fwd.h"
 #include "common/object_pool.h"
-
 #include "exprs/agg/aggregate_state_allocator.h"
 #include "exprs/expr_context.h"
 #include "glog/logging.h"

--- a/test/sql/test_spill/R/test_spill_agg_streaming_strategy
+++ b/test/sql/test_spill/R/test_spill_agg_streaming_strategy
@@ -66,3 +66,49 @@ select count(*), sum(x) from (select sum(k1) x from (select * from t1 union all 
 admin disable failpoint 'spill_always_selection_streaming';
 -- result:
 -- !result
+create table t2 (
+    c0 INT,
+    c1 BIGINT NOT NULL
+) DUPLICATE KEY(c0) DISTRIBUTED BY RANDOM BUCKETS 3 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t2 SELECT generate_series, 650000 - generate_series FROM TABLE(generate_series(1,  650000));
+-- result:
+-- !result
+admin enable failpoint 'spill_always_selection_streaming';
+-- result:
+-- !result
+set enable_spill=true;
+-- result:
+-- !result
+set pipeline_dop=1;
+-- result:
+-- !result
+set spill_mode='force';
+-- result:
+-- !result
+set streaming_preaggregation_mode='auto';
+-- result:
+-- !result
+set enable_agg_spill_preaggregation=true;
+-- result:
+-- !result
+insert into blackhole() select c0, sum(c1) from t2 group by c0;
+-- result:
+-- !result
+select count(distinct c0), c1 from t2 group by c1 order by c1 desc limit 10;
+-- result:
+1	649999
+1	649998
+1	649997
+1	649996
+1	649995
+1	649994
+1	649993
+1	649992
+1	649991
+1	649990
+-- !result
+admin disable failpoint 'spill_always_selection_streaming';
+-- result:
+-- !result

--- a/test/sql/test_spill/T/test_spill_agg_streaming_strategy
+++ b/test/sql/test_spill/T/test_spill_agg_streaming_strategy
@@ -25,3 +25,18 @@ select avg(k1) x from (select * from t1 union all select * from t1)t group by k2
 select count(*), sum(x) from (select sum(k1) x from (select * from t1 union all SELECT generate_series + 40960, generate_series + 40960 FROM TABLE(generate_series(1,  40960)))t group by k2 ) t;
 admin disable failpoint 'spill_always_selection_streaming';
 
+create table t2 (
+    c0 INT,
+    c1 BIGINT NOT NULL
+) DUPLICATE KEY(c0) DISTRIBUTED BY RANDOM BUCKETS 3 PROPERTIES('replication_num' = '1');
+insert into t2 SELECT generate_series, 650000 - generate_series FROM TABLE(generate_series(1,  650000));
+
+admin enable failpoint 'spill_always_selection_streaming';
+set enable_spill=true;
+set pipeline_dop=1;
+set spill_mode='force';
+set streaming_preaggregation_mode='auto';
+set enable_agg_spill_preaggregation=true;
+insert into blackhole() select c0, sum(c1) from t2 group by c0;
+select count(distinct c0), c1 from t2 group by c1 order by c1 desc limit 10;
+admin disable failpoint 'spill_always_selection_streaming';


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

fix https://github.com/StarRocks/StarRocksTest/issues/9421 https://github.com/StarRocks/StarRocksTest/issues/9422 https://github.com/StarRocks/StarRocksTest/issues/9423 https://github.com/StarRocks/StarRocksTest/issues/9442 https://github.com/StarRocks/StarRocksTest/issues/9443 https://github.com/StarRocks/StarRocksTest/issues/9457

Fixes #58029 

1. when we enable spill pre-aggregation strategy, the spilled chunk may come from hash map or streaming chunks, we should ensure that the nullable property for each column is same. otherwise, it will cause some unexpected problems.
2. ensure that the thread local agg state allocator is always set before invoking agg functions.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
