### PR TITLE
[BugFix] fix heap-use-after-free when pk tablet apply retry

### DIFF
--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -936,7 +936,8 @@ void* StorageEngine::_schedule_apply_thread_callback(void* arg) {
             }
 
             if (!_bg_worker_stopped.load(std::memory_order_consume) && !_schedule_apply_tasks.empty()) {
-                _apply_tablet_changed_cv.wait_until(ul, _schedule_apply_tasks.top().first);
+                auto wait_time = _schedule_apply_tasks.top().first;
+                _apply_tablet_changed_cv.wait_until(ul, wait_time);
             }
         }
     }

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -3299,15 +3299,14 @@ void TabletUpdatesTest::update_and_recover(bool enable_persistent_index) {
     }
     ASSERT_EQ(N, read_tablet(_tablet, version - 1));
     ASSERT_EQ(N / 2, read_tablet(_tablet, old_version));
-    if (_tablet) {
-        (void)StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet->tablet_id());
-        _tablet.reset();
-    }
 }
 
 TEST_F(TabletUpdatesTest, test_update_and_recover) {
-    update_and_recover(true);
     update_and_recover(false);
+}
+
+TEST_F(TabletUpdatesTest, test_update_and_recover_peristent_index) {
+    update_and_recover(true);
 }
 
 void TabletUpdatesTest::test_recover_rowset_sorter() {


### PR DESCRIPTION
## Why I'm doing:;
BE ASAN meet `heap-use-after-free` issue:
```
==19580==ERROR: AddressSanitizer: heap-use-after-free on address 0x602000145ff0 at pc 0x0000123188d5 bp 0x7f421bd743e0 sp 0x7f421bd743d0
READ of size 8 at 0x602000145ff0 thread T55
 #0 0x123188d4 in std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >::time_since_epoch() const (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x123188d4)
    #1 0x12317b4e in auto std::chrono::operator<=><std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> >, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >(std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > > const&, std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > > const&) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x12317b4e)
    #2 0x1231ff29 in std::cv_status std::condition_variable::__wait_until_impl<std::chrono::duration<long, std::ratio<1l, 1000000000l> > >(std::unique_lock<std::mutex>&, std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > > const&) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1231ff29)
    #3 0x1231b260 in std::cv_status std::condition_variable::wait_until<std::chrono::duration<long, std::ratio<1l, 1000000000l> > >(std::unique_lock<std::mutex>&, std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > > const&) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1231b260)
    #4 0x1230980d in starrocks::StorageEngine::_schedule_apply_thread_callback(void*) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1230980d)
    #5 0x12300460 in starrocks::StorageEngine::start_schedule_apply_thread()::{lambda()#1}::operator()() const (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x12300460)
    #6 0x12316d00 in void std::__invoke_impl<void, starrocks::StorageEngine::start_schedule_apply_thread()::{lambda()#1}>(std::__invoke_other, starrocks::StorageEngine::start_schedule_apply_thread()::{lambda()#1}&&) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x12316d00)
    #7 0x123166e1 in std::__invoke_result<starrocks::StorageEngine::start_schedule_apply_thread()::{lambda()#1}>::type std::__invoke<starrocks::StorageEngine::start_schedule_apply_thread()::{lambda()#1}>(starrocks::StorageEngine::start_schedule_apply_thread()::{lambda()#1}&&) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x123166e1)
    #8 0x1231620d in void std::thread::_Invoker<std::tuple<starrocks::StorageEngine::start_schedule_apply_thread()::{lambda()#1}> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1231620d)
    #9 0x12315f41 in std::thread::_Invoker<std::tuple<starrocks::StorageEngine::start_schedule_apply_thread()::{lambda()#1}> >::operator()() (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x12315f41)
    #10 0x12315c8d in std::thread::_State_impl<std::thread::_Invoker<std::tuple<starrocks::StorageEngine::start_schedule_apply_thread()::{lambda()#1}> > >::_M_run() (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x12315c8d)
    #11 0x7f424de18252  (/lib/x86_64-linux-gnu/libstdc++.so.6+0xdc252)
    #12 0x7f424dba5ac2  (/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
    #13 0x7f424dc36a03 in __clone (/lib/x86_64-linux-gnu/libc.so.6+0x125a03)

0x602000145ff0 is located 0 bytes inside of 16-byte region [0x602000145ff0,0x602000146000)
freed by thread T319 here:
    #0 0x11ad71f7 in operator delete(void*) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x11ad71f7)
    #1 0x1c1384f7 in __gnu_cxx::new_allocator<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long> >::deallocate(std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long>*, unsigned long) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1c1384f7)
    #2 0x1c12dbd2 in std::allocator_traits<std::allocator<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long> > >::deallocate(std::allocator<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long> >&, std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long>*, unsigned long) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1c12dbd2)
    #3 0x1c123ee7 in std::_Vector_base<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long>, std::allocator<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long> > >::_M_deallocate(std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long>*, unsigned long) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1c123ee7)
    #4 0x1c12bb2f in void std::vector<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long>, std::allocator<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long> > >::_M_realloc_insert<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >&, long&>(__gnu_cxx::__normal_iterator<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long>*, std::vector<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long>, std::allocator<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long> > > >, std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >&, long&) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1c12bb2f)
    #5 0x1c12249e in std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long>& std::vector<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long>, std::allocator<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long> > >::emplace_back<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >&, long&>(std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >&, long&) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1c12249e)
    #6 0x1c11529f in void std::priority_queue<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long>, std::vector<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long>, std::allocator<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long> > >, std::greater<void> >::emplace<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >&, long&>(std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >&, long&) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1c11529f)
    #7 0x1c0ee06d in starrocks::StorageEngine::add_schedule_apply_task(long, std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1c0ee06d)
    #8 0x1c3a38b4 in starrocks::TabletUpdates::do_apply() (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1c3a38b4)
    #9 0x1c44cc35 in starrocks::ApplyCommitTask::run() (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1c44cc35)
    #10 0x1e8c3985 in starrocks::ThreadPool::dispatch_thread() (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e8c3985)
    #11 0x1e8e8151 in void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e8e8151)
    #12 0x1e8e7bf2 in std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e8e7bf2)
    #13 0x1e8e6aaf in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e8e6aaf)
    #14 0x1e8e5812 in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>() (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e8e5812)
    #15 0x1e8e2fdb in void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e8e2fdb)
    #16 0x1e8deeb3 in std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e8deeb3)
    #17 0x1e8da73c in std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e8da73c)
    #18 0x17aac9f1 in std::function<void ()>::operator()() const (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x17aac9f1)
    #19 0x1e8a6279 in starrocks::Thread::supervise_thread(void*) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e8a6279)
    #20 0x7f424dba5ac2  (/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)

previously allocated by thread T319 here:
    #0 0x11ad66d7 in operator new(unsigned long) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x11ad66d7)
    #1 0x1c13c06d in __gnu_cxx::new_allocator<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long> >::allocate(unsigned long, void const*) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1c13c06d)
    #2 0x1c1372df in std::allocator_traits<std::allocator<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long> > >::allocate(std::allocator<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long> >&, unsigned long) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1c1372df)
    #3 0x1c1323a5 in std::_Vector_base<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long>, std::allocator<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long> > >::_M_allocate(unsigned long) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1c1323a5)
    #4 0x1c12b99f in void std::vector<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long>, std::allocator<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long> > >::_M_realloc_insert<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >&, long&>(__gnu_cxx::__normal_iterator<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long>*, std::vector<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long>, std::allocator<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long> > > >, std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >&, long&) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1c12b99f)
    #5 0x1c12249e in std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long>& std::vector<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long>, std::allocator<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long> > >::emplace_back<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >&, long&>(std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >&, long&) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1c12249e)
    #6 0x1c11529f in void std::priority_queue<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long>, std::vector<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long>, std::allocator<std::pair<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, long> > >, std::greater<void> >::emplace<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >&, long&>(std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >&, long&) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1c11529f)
    #7 0x1c0ee06d in starrocks::StorageEngine::add_schedule_apply_task(long, std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1c0ee06d)
    #8 0x1c3a38b4 in starrocks::TabletUpdates::do_apply() (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1c3a38b4)
    #9 0x1c44cc35 in starrocks::ApplyCommitTask::run() (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1c44cc35)
    #10 0x1e8c3985 in starrocks::ThreadPool::dispatch_thread() (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e8c3985)
    #11 0x1e8e8151 in void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e8e8151)
    #12 0x1e8e7bf2 in std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e8e7bf2)
    #13 0x1e8e6aaf in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e8e6aaf)
    #14 0x1e8e5812 in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>() (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e8e5812)
    #15 0x1e8e2fdb in void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e8e2fdb)
    #16 0x1e8deeb3 in std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e8deeb3)
    #17 0x1e8da73c in std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e8da73c)
    #18 0x17aac9f1 in std::function<void ()>::operator()() const (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x17aac9f1)
    #19 0x1e8a6279 in starrocks::Thread::supervise_thread(void*) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e8a6279)
    #20 0x7f424dba5ac2  (/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
```

## What I'm doing:
1. Fix heap-use-after-free issue.
2. Refactor UT bugfix https://github.com/StarRocks/starrocks/pull/57044 .

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
