### PR TITLE
[BugFix] fix No space left on device error when do load spill

### DIFF
--- a/be/src/exec/spill/block_manager.h
+++ b/be/src/exec/spill/block_manager.h
@@ -114,6 +114,8 @@ struct AcquireBlockOptions {
     bool exclusive = false;
     size_t block_size = 0;
     BlockAffinityGroup affinity_group = kDefaultBlockAffinityGroup;
+    // force to use remote block
+    bool force_remote = false;
 };
 
 // BlockManager is used to manage the life cycle of the Block.

--- a/be/src/exec/spill/hybird_block_manager.cpp
+++ b/be/src/exec/spill/hybird_block_manager.cpp
@@ -44,7 +44,7 @@ DEFINE_FAIL_POINT(force_allocate_remote_block);
 StatusOr<BlockPtr> HyBirdBlockManager::acquire_block(const AcquireBlockOptions& opts) {
     bool enable_allocate_local_block = true;
     FAIL_POINT_TRIGGER_EXECUTE(force_allocate_remote_block, { enable_allocate_local_block = false; });
-    if (enable_allocate_local_block) {
+    if (enable_allocate_local_block && !opts.force_remote) {
         auto local_block = _local_block_manager->acquire_block(opts);
         if (local_block.ok()) {
             return local_block;

--- a/be/src/storage/lake/load_spill_block_manager.cpp
+++ b/be/src/storage/lake/load_spill_block_manager.cpp
@@ -110,7 +110,7 @@ Status LoadSpillBlockManager::init() {
 }
 
 // acquire Block from BlockManager
-StatusOr<spill::BlockPtr> LoadSpillBlockManager::acquire_block(size_t block_size) {
+StatusOr<spill::BlockPtr> LoadSpillBlockManager::acquire_block(size_t block_size, bool force_remote) {
     spill::AcquireBlockOptions opts;
     opts.query_id = _load_id; // load id as query id
     opts.fragment_instance_id =
@@ -118,6 +118,7 @@ StatusOr<spill::BlockPtr> LoadSpillBlockManager::acquire_block(size_t block_size
     opts.plan_node_id = 0;
     opts.name = "load_spill";
     opts.block_size = block_size;
+    opts.force_remote = force_remote;
     return _block_manager->acquire_block(opts);
 }
 

--- a/be/src/storage/lake/load_spill_block_manager.h
+++ b/be/src/storage/lake/load_spill_block_manager.h
@@ -78,7 +78,7 @@ public:
     bool is_initialized() const { return _initialized; }
 
     // acquire Block from BlockManager
-    StatusOr<spill::BlockPtr> acquire_block(size_t block_size);
+    StatusOr<spill::BlockPtr> acquire_block(size_t block_size, bool force_remote = false);
     // return Block to BlockManager
     Status release_block(spill::BlockPtr block);
 

--- a/be/src/storage/lake/spill_mem_table_sink.cpp
+++ b/be/src/storage/lake/spill_mem_table_sink.cpp
@@ -36,7 +36,6 @@ Status LoadSpillOutputDataStream::append(RuntimeState* state, const std::vector<
     // preallocate block
     RETURN_IF_ERROR(_preallocate(total_size));
     // append data
-    _append_bytes += total_size;
     auto st = _block->append(data);
     if (st.is_capacity_limit_exceeded()) {
         // No space left on device
@@ -44,7 +43,9 @@ Status LoadSpillOutputDataStream::append(RuntimeState* state, const std::vector<
         RETURN_IF_ERROR(_switch_to_remote_block(total_size));
         st = _block->append(data);
     }
-    _append_bytes += total_size;
+    if (st.ok()) {
+        _append_bytes += total_size;
+    }
     return st;
 }
 

--- a/be/src/storage/lake/spill_mem_table_sink.h
+++ b/be/src/storage/lake/spill_mem_table_sink.h
@@ -48,6 +48,9 @@ private:
     // Freeze current block and append it to block container
     Status _freeze_current_block();
 
+    // Switch to remote block when local disk is full
+    Status _switch_to_remote_block(size_t block_size);
+
 private:
     LoadSpillBlockManager* _block_manager = nullptr;
     spill::BlockPtr _block;


### PR DESCRIPTION
## Why I'm doing:
If local disk space is full, but the disk usage cost by spill doesn't exceed `spill_max_dir_bytes_ratio`, then `_block->append` may fail and throw error like:
```
E20250414 22:46:42.545266 47492797445888 async_delta_writer.cpp:189] Fail to write. tablet_id: 66817 txn_id: 4237: Capaticy limit exceeded: /home/disk1/sr/be/spill/7127bdbb-70aa-45d1-890d-77f22d86acee/00000000-0001-0501-0000-00000000108d-load_spill-0-0: No space left on device
be/src/exec/spill/log_block_manager.cpp:156 _writable_file->pre_allocate(total_size)
be/src/exec/spill/log_block_manager.cpp:216 _container->append_data(data, total_size)
be/src/exec/spill/serde.cpp:159 output->append(state, {Slice(serialize_buffer.data(), written_bytes)}, written_bytes, chunk->num_rows())
be/src/storage/lake/spill_mem_table_sink.cpp:124 _spiller->serde()->serialize(_runtime_state.get(), ctx, each_chunk, output, true)
be/src/storage/lake/spill_mem_table_sink.cpp:144 _do_spill(chunk, output)
be/src/storage/memtable.cpp:344 _sink->flush_chunk(*_result_chunk, seg_info, eos, flush_data_size)
```

This case will happen when spill and datacache share a same local disk.

## What I'm doing:

If no space left on device when do block append, force switch to remote block spill.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
