### PR TITLE
[BugFix] Fix set_index_filter_only when parsing predicates from runtime filters

### DIFF
--- a/be/src/exec/olap_scan_prepare.cpp
+++ b/be/src/exec/olap_scan_prepare.cpp
@@ -1103,6 +1103,7 @@ Status ChunkPredicateBuilder<E, Type>::_get_column_predicates(PredicateParser* p
         for (const auto& filter : filters) {
             std::unique_ptr<ColumnPredicate> p(parser->parse_thrift_cond(filter));
             RETURN_IF(!p, Status::RuntimeError("invalid filter"));
+            p->set_index_filter_only(filter.is_index_filter_only);
             col_preds_owner.emplace_back(std::move(p));
         }
         return Status::OK();


### PR DESCRIPTION
## Why I'm doing:

#57699 accidentally removes the row `p->set_index_filter_only(f.is_index_filter_only);`


This will result that evaluation of predicates, generated by RF, costs too much time.

![img_v3_02lc_262deec8-3cad-4093-9fc8-20123e204abg](https://github.com/user-attachments/assets/9a4cfd9c-f99d-4263-a124-a556fecf4f26)


Before #57699 
![QQ_1744709994781](https://github.com/user-attachments/assets/4c376f79-079f-410a-b813-305c4aed20cb)


After #57699 
![QQ_1744709974429](https://github.com/user-attachments/assets/1d83610c-ac85-47f8-a59f-3c5bb8a4aa70)


## What I'm doing:

Fix https://github.com/StarRocks/StarRocksTest/issues/9544.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
