### PR TITLE
[Feature] Support to cast json to map

### DIFF
--- a/be/src/exprs/CMakeLists.txt
+++ b/be/src/exprs/CMakeLists.txt
@@ -17,7 +17,7 @@ set(LIBRARY_OUTPUT_PATH "${BUILD_DIR}/src/exprs")
 # where to put generated binaries
 set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/src/exprs")
 
-set(EXPR_FILES 
+set(EXPR_FILES
   agg/data_sketch/ds_theta.cpp
   agg/factory/aggregate_factory.cpp
   agg/factory/aggregate_resolver_approx.cpp
@@ -50,6 +50,7 @@ set(EXPR_FILES
   cast_expr_array.cpp
   cast_expr_json.cpp
   cast_expr_struct.cpp
+  cast_expr_map.cpp
   cast_nested.cpp
   column_ref.cpp
   placeholder_ref.cpp
@@ -106,8 +107,8 @@ set(EXPR_FILES
 )
 
 if(STARROCKS_JIT_ENABLE)
-  set(EXPR_FILES ${EXPR_FILES} 
-      jit/ir_helper.cpp 
+  set(EXPR_FILES ${EXPR_FILES}
+      jit/ir_helper.cpp
       jit/jit_engine.cpp
       jit/jit_expr.cpp)
 

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -1148,8 +1148,8 @@ public:
             return Status::NotSupported("JIT casting does not support decimal");
         } else {
             ASSIGN_OR_RETURN(datum.value, IRHelper::cast_to_type(b, l, FromType, ToType));
-            if constexpr ((lt_is_integer<FromType> || lt_is_float<FromType>) &&
-                          (lt_is_integer<ToType> || lt_is_float<ToType>)) {
+            if constexpr ((lt_is_integer<FromType> || lt_is_float<FromType>)&&(lt_is_integer<ToType> ||
+                                                                               lt_is_float<ToType>)) {
                 typedef RunTimeCppType<FromType> FromCppType;
                 typedef RunTimeCppType<ToType> ToCppType;
 

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -1622,6 +1622,8 @@ Expr* VectorizedCastExprFactory::create_primitive_cast(ObjectPool* pool, const T
     if (from_type == TYPE_JSON && to_type == TYPE_MAP) {
         TypeDescriptor cast_to = TypeDescriptor::from_thrift(node.type);
 
+        // CastJsonToMap will first cast json to MAP<VARCHAR,JSON>, then cast to the target MAP<KEY,VALUE>
+        // If the target is already MAP<VARCHAR,JSON>, no need to set key/value cast expr
         Expr* key_cast_expr = nullptr;
         auto& key_desc = cast_to.children[0];
         if (key_desc.type != TYPE_VARCHAR) {

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -1148,8 +1148,8 @@ public:
             return Status::NotSupported("JIT casting does not support decimal");
         } else {
             ASSIGN_OR_RETURN(datum.value, IRHelper::cast_to_type(b, l, FromType, ToType));
-            if constexpr ((lt_is_integer<FromType> || lt_is_float<FromType>)&&(lt_is_integer<ToType> ||
-                                                                               lt_is_float<ToType>)) {
+            if constexpr ((lt_is_integer<FromType> || lt_is_float<FromType>) &&
+                          (lt_is_integer<ToType> || lt_is_float<ToType>)) {
                 typedef RunTimeCppType<FromType> FromCppType;
                 typedef RunTimeCppType<ToType> ToCppType;
 
@@ -1617,6 +1617,46 @@ Expr* VectorizedCastExprFactory::create_primitive_cast(ObjectPool* pool, const T
             pool->add(cast_input.release());
         }
         return new CastJsonToStruct(node, std::move(field_casts));
+    }
+
+    if (from_type == TYPE_JSON && to_type == TYPE_MAP) {
+        TypeDescriptor cast_to = TypeDescriptor::from_thrift(node.type);
+
+        Expr* key_cast_expr = nullptr;
+        auto& key_desc = cast_to.children[0];
+        if (key_desc.type != TYPE_VARCHAR) {
+            TypeDescriptor varchar_type = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
+            auto result = create_cast_expr(pool, varchar_type, key_desc, allow_throw_exception);
+            if (!result.ok()) {
+                LOG(ERROR) << "Fail to create cast expr from json to map, map key type: " << key_desc
+                           << ", status: " << result.status();
+                return nullptr;
+            }
+            key_cast_expr = result.value();
+            Expr* cast_input = create_slot_ref(varchar_type).release();
+            key_cast_expr->add_child(cast_input);
+            pool->add(key_cast_expr);
+            pool->add(cast_input);
+        }
+
+        Expr* value_cast_expr = nullptr;
+        auto& value_desc = cast_to.children[1];
+        if (value_desc.type != TYPE_JSON) {
+            TypeDescriptor json_type = TypeDescriptor::create_json_type();
+            auto result = create_cast_expr(pool, json_type, value_desc, allow_throw_exception);
+            if (!result.ok()) {
+                LOG(ERROR) << "Fail to create cast expr from json to map, map value type: " << value_desc
+                           << ", status: " << result.status();
+                return nullptr;
+            }
+            value_cast_expr = result.value();
+            Expr* cast_input = create_slot_ref(json_type).release();
+            value_cast_expr->add_child(cast_input);
+            pool->add(value_cast_expr);
+            pool->add(cast_input);
+        }
+
+        return new CastJsonToMap(node, key_cast_expr, value_cast_expr);
     }
 
     if (from_type == TYPE_VARCHAR && to_type == TYPE_OBJECT) {

--- a/be/src/exprs/cast_expr.h
+++ b/be/src/exprs/cast_expr.h
@@ -153,6 +153,27 @@ private:
     std::vector<JsonPath> _json_paths;
 };
 
+// Cast Json to MAP
+class CastJsonToMap final : public Expr {
+public:
+    CastJsonToMap(const TExprNode& node, Expr* key_cast_expr, Expr* value_cast_expr)
+            : Expr(node), _key_cast_expr(std::move(key_cast_expr)), _value_cast_expr(std::move(value_cast_expr)) {}
+
+    CastJsonToMap(const CastJsonToMap& rhs) : Expr(rhs) {}
+
+    ~CastJsonToMap() override = default;
+
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override;
+
+    Expr* clone(ObjectPool* pool) const override { return pool->add(new CastJsonToMap(*this)); }
+
+private:
+    // nullptr if MAP key is not TYPE_VARCHAR
+    Expr* _key_cast_expr;
+    // nullptr if MAP value is not TYPE_JSON
+    Expr* _value_cast_expr;
+};
+
 // cast one ARRAY to another ARRAY.
 // For example.
 //   cast ARRAY<tinyint> to ARRAY<int>

--- a/be/src/exprs/cast_expr_map.cpp
+++ b/be/src/exprs/cast_expr_map.cpp
@@ -1,0 +1,83 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "column/column_builder.h"
+#include "column/column_viewer.h"
+#include "column/map_column.h"
+#include "exprs/cast_expr.h"
+
+namespace starrocks {
+
+StatusOr<ColumnPtr> CastJsonToMap::evaluate_checked(ExprContext* context, Chunk* ptr) {
+    ASSIGN_OR_RETURN(ColumnPtr src_column, _children[0]->evaluate_checked(context, ptr));
+    if (ColumnHelper::count_nulls(src_column) == src_column->size()) {
+        return ColumnHelper::create_const_null_column(src_column->size());
+    }
+
+    ColumnViewer<TYPE_JSON> src_viewer(src_column);
+    NullColumn::MutablePtr null_column = NullColumn::create();
+    UInt32Column::MutablePtr offsets_column = UInt32Column::create();
+    ColumnBuilder<TYPE_VARCHAR> keys_builder(src_column->size());
+    ColumnBuilder<TYPE_JSON> values_builder(src_column->size());
+
+    // 1. Cast JsonObject to MAP<VARCHAR,JSON>
+    uint32_t offset = 0;
+    for (size_t i = 0; i < src_viewer.size(); i++) {
+        offsets_column->append(offset);
+        if (src_viewer.is_null(i)) {
+            null_column->append(1);
+            continue;
+        }
+        const JsonValue* json_value = src_viewer.value(i);
+        if (json_value && json_value->get_type() == JsonType::JSON_OBJECT) {
+            vpack::Slice json_slice = json_value->to_vslice();
+            DCHECK(json_slice.isObject());
+            for (const auto& pair : vpack::ObjectIterator(json_slice)) {
+                keys_builder.append(pair.key.copyString());
+                JsonValue value(pair.value);
+                values_builder.append(std::move(value));
+            }
+            offset += json_slice.length();
+            null_column->append(0);
+        } else {
+            null_column->append(1);
+        }
+    }
+    offsets_column->append(offset);
+    auto keys_column = keys_builder.build_nullable_column();
+    auto values_column = values_builder.build_nullable_column();
+
+    // 2. Cast key and value if needed
+    if (_key_cast_expr != nullptr) {
+        ChunkPtr chunk = std::make_shared<Chunk>();
+        SlotId slot_id = down_cast<ColumnRef*>(_key_cast_expr->get_child(0))->slot_id();
+        chunk->append_column(keys_column, slot_id);
+        ASSIGN_OR_RETURN(auto result, _key_cast_expr->evaluate_checked(context, chunk.get()));
+        keys_column = ColumnHelper::cast_to_nullable_column(result);
+    }
+    if (_value_cast_expr != nullptr) {
+        ChunkPtr chunk = std::make_shared<Chunk>();
+        SlotId slot_id = down_cast<ColumnRef*>(_value_cast_expr->get_child(0))->slot_id();
+        chunk->append_column(values_column, slot_id);
+        ASSIGN_OR_RETURN(auto result, _value_cast_expr->evaluate_checked(context, chunk.get()));
+        values_column = ColumnHelper::cast_to_nullable_column(result);
+    }
+
+    auto map_column = MapColumn::create(std::move(keys_column), std::move(values_column), std::move(offsets_column));
+    map_column->remove_duplicated_keys();
+    RETURN_IF_ERROR(map_column->unfold_const_children(_type));
+    return NullableColumn::create(std::move(map_column), std::move(null_column));
+}
+
+} // namespace starrocks

--- a/be/test/exprs/cast_expr_test.cpp
+++ b/be/test/exprs/cast_expr_test.cpp
@@ -2473,4 +2473,80 @@ TEST_F(VectorizedCastExprTest, json_to_struct) {
                                   R"({"star": "rocks", "number": 1})"));
 }
 
+TTypeDesc gen_map_type_desc(TPrimitiveType::type key_type, TPrimitiveType::type value_type) {
+    std::vector<TTypeNode> types_list;
+    TTypeNode type_map;
+
+    type_map.type = TTypeNodeType::MAP;
+    types_list.push_back(type_map);
+
+    TTypeNode type_key;
+    TScalarType key_scalar_type;
+    key_scalar_type.__set_type(key_type);
+    key_scalar_type.__set_precision(0);
+    key_scalar_type.__set_scale(0);
+    key_scalar_type.__set_len(0);
+    type_key.__set_scalar_type(key_scalar_type);
+    types_list.push_back(type_key);
+
+    TTypeNode type_value;
+    TScalarType value_scalar_type;
+    value_scalar_type.__set_type(value_type);
+    value_scalar_type.__set_precision(0);
+    value_scalar_type.__set_scale(0);
+    value_scalar_type.__set_len(0);
+    type_value.__set_scalar_type(value_scalar_type);
+    types_list.push_back(type_value);
+
+    TTypeDesc type_desc;
+    type_desc.__set_types(types_list);
+    return type_desc;
+}
+
+static std::string cast_json_to_map(LogicalType key_type, LogicalType value_type, const std::string& str) {
+    TExprNode cast_expr;
+    cast_expr.opcode = TExprOpcode::CAST;
+    cast_expr.node_type = TExprNodeType::CAST_EXPR;
+    cast_expr.num_children = 2;
+    cast_expr.__isset.opcode = true;
+    cast_expr.__isset.child_type = true;
+    cast_expr.child_type = to_thrift(TYPE_JSON);
+    cast_expr.type = gen_map_type_desc(to_thrift(key_type), to_thrift(value_type));
+
+    ObjectPool pool;
+    std::unique_ptr<Expr> expr(VectorizedCastExprFactory::from_thrift(&pool, cast_expr));
+
+    auto json = JsonValue::parse(str);
+    if (!json.ok()) {
+        return "INVALID JSON";
+    }
+
+    cast_expr.type = gen_type_desc(cast_expr.child_type);
+    MockVectorizedExpr<TYPE_JSON> col1(cast_expr, 1, &json.value());
+    expr->_children.push_back(&col1);
+
+    ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
+    if (ptr->size() != 1) {
+        return "EMPTY";
+    }
+    return ptr->debug_item(0);
+}
+
+TEST_F(VectorizedCastExprTest, json_to_map) {
+    EXPECT_EQ(R"({'1':1,'2':true,'3':null,'4':[5, 6, 7],'5':{"k51": "v51"}})",
+              cast_json_to_map(TYPE_VARCHAR, TYPE_JSON,
+                               R"({"1":1, "2":true, "3":null, "4":[5,6,7], "5":{"k51":"v51"}})"));
+    EXPECT_EQ(R"({'1':'1','2':'true','3':NULL,'4':'[5, 6, 7]','5':'{"k51": "v51"}'})",
+              cast_json_to_map(TYPE_VARCHAR, TYPE_VARCHAR,
+                               R"({"1":1, "2":true, "3":null, "4":[5,6,7], "5":{"k51":"v51"}})"));
+    EXPECT_EQ(R"({1:1,2:true,3:null,4:[5, 6, 7],5:{"k51": "v51"}})",
+              cast_json_to_map(TYPE_INT, TYPE_JSON, R"({"1":1, "2":true, "3":null, "4":[5,6,7], "5":{"k51":"v51"}})"));
+    EXPECT_EQ(
+            R"({1:'1',2:'true',3:NULL,4:'[5, 6, 7]',5:'{"k51": "v51"}'})",
+            cast_json_to_map(TYPE_INT, TYPE_VARCHAR, R"({"1":1, "2":true, "3":null, "4":[5,6,7], "5":{"k51":"v51"}})"));
+    EXPECT_EQ(R"(NULL)", cast_json_to_map(TYPE_VARCHAR, TYPE_JSON, R"([1,2,3])"));
+    EXPECT_EQ(R"({1:1,3:NULL,NULL:NULL})",
+              cast_json_to_map(TYPE_INT, TYPE_INT, R"({"1":1, "k2":2, "3":"v3", "k4":"v4"})"));
+}
+
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -1155,6 +1155,9 @@ public abstract class Type implements Cloneable {
             return false;
         } else if (from.isJsonType() && to.isStructType()) {
             return true;
+        } else if (from.isJsonType() && to.isMapType()) {
+            MapType map = (MapType) to;
+            return canCastTo(Type.VARCHAR, map.getKeyType()) && canCastTo(Type.JSON, map.getValueType());
         } else if (from.isBoolean() && to.isComplexType()) {
             // for mock nest type with NULL value, the cast must return NULL
             // like cast(map{1: NULL} as MAP<int, int>)

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
@@ -46,6 +46,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class TypeTest {
@@ -393,5 +394,25 @@ public class TypeTest {
         ScalarType type = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 10, 4);
         Assert.assertTrue(type == AggregateType.extendedPrecision(type, true));
         Assert.assertTrue(type != AggregateType.extendedPrecision(type, false));
+    }
+
+    @Test
+    public void testCastJsonToMap() {
+        Type jsonType = Type.JSON;
+        List<Type> mapTypes = Lists.newArrayList(
+                new MapType(Type.VARCHAR, Type.JSON),
+                new MapType(Type.INT, Type.VARCHAR),
+                new MapType(Type.VARCHAR, new ArrayType(Type.INT)),
+                new MapType(Type.VARCHAR, new ArrayType(Type.JSON)),
+                new MapType(Type.VARCHAR, new ArrayType(Type.JSON)),
+                new MapType(Type.VARCHAR, new MapType(Type.VARCHAR, Type.BOOLEAN)),
+                new MapType(Type.VARCHAR, new MapType(Type.INT, Type.JSON)),
+                new MapType(Type.VARCHAR, new MapType(Type.INT, new ArrayType(Type.VARCHAR))),
+                new MapType(Type.VARCHAR, new StructType(
+                        Arrays.asList(Type.INT, new ArrayType(Type.VARCHAR), new MapType(Type.INT, Type.JSON))))
+        );
+        for (Type mapType : mapTypes) {
+            Assert.assertTrue(Type.canCastTo(jsonType, mapType));
+        }
     }
 }

--- a/test/sql/test_cast/R/test_cast_json_to_map
+++ b/test/sql/test_cast/R/test_cast_json_to_map
@@ -1,0 +1,79 @@
+-- name: test_cast_json_to_map
+CREATE TABLE t (
+    c1 int,
+    c2 json
+) PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into t values
+(1, '[1,2,3]'),
+(2, '"abc"'),
+(3, 'null'),
+(4, 'true'),
+(5, '1'),
+(6, '{"1":1, "2":true, "3":null, "4":[5,6,7], "5":{"k51":"v51","k52":"v52"}}');
+-- result:
+-- !result
+select c1, cast(c2 as map<string,json>) as m from t order by c1;
+-- result:
+1	None
+2	None
+3	None
+4	None
+5	None
+6	{"1":'1',"2":'true',"3":'null',"4":'[5, 6, 7]',"5":'{"k51": "v51", "k52": "v52"}'}
+-- !result
+select c1, cast(c2 as map<int,json>) as m from t order by c1;
+-- result:
+1	None
+2	None
+3	None
+4	None
+5	None
+6	{1:'1',2:'true',3:'null',4:'[5, 6, 7]',5:'{"k51": "v51", "k52": "v52"}'}
+-- !result
+select c1, cast(c2 as map<string,string>) as m from t order by c1;
+-- result:
+1	None
+2	None
+3	None
+4	None
+5	None
+6	{"1":"1","2":"true","3":null,"4":"[5, 6, 7]","5":"{\"k51\": \"v51\", \"k52\": \"v52\"}"}
+-- !result
+select c1, cast(c2 as map<int,string>) as m from t order by c1;
+-- result:
+1	None
+2	None
+3	None
+4	None
+5	None
+6	{1:"1",2:"true",3:null,4:"[5, 6, 7]",5:"{\"k51\": \"v51\", \"k52\": \"v52\"}"}
+-- !result
+select c1, cast(c2 as map<string,array<int>>) as m from t order by c1;
+-- result:
+1	None
+2	None
+3	None
+4	None
+5	None
+6	{"1":null,"2":null,"3":null,"4":[5,6,7],"5":null}
+-- !result
+select c1, cast(c2 as map<string,struct<k51 string,k52 string>>) as m from t order by c1;
+-- result:
+1	None
+2	None
+3	None
+4	None
+5	None
+6	{"1":null,"2":null,"3":null,"4":{"k51":"5","k52":"6"},"5":{"k51":"v51","k52":"v52"}}
+-- !result
+select c1, cast(c2 as map<string,map<string,string>>) as m from t order by c1;
+-- result:
+1	None
+2	None
+3	None
+4	None
+5	None
+6	{"1":null,"2":null,"3":null,"4":null,"5":{"k51":"v51","k52":"v52"}}
+-- !result

--- a/test/sql/test_cast/T/test_cast_json_to_map
+++ b/test/sql/test_cast/T/test_cast_json_to_map
@@ -1,0 +1,12 @@
+-- name: test_cast_json_to_map
+CREATE TABLE t (
+    c1 int,
+    c2 json
+) PROPERTIES ("replication_num" = "1");
+
+insert into map_top_n values
+(1, map{"key1":1}),
+(2, map{"key1":5, "key2":6}),
+(3, map{"key1":2, "key2":3, "key4":4}),
+(4, map{"key1":12, "key2":13, "key3":14, "key4":15}),
+(5, map{"key1":7, "key2":8, "key3":9, "key4":10, "key5":11});

--- a/test/sql/test_cast/T/test_cast_json_to_map
+++ b/test/sql/test_cast/T/test_cast_json_to_map
@@ -4,9 +4,18 @@ CREATE TABLE t (
     c2 json
 ) PROPERTIES ("replication_num" = "1");
 
-insert into map_top_n values
-(1, map{"key1":1}),
-(2, map{"key1":5, "key2":6}),
-(3, map{"key1":2, "key2":3, "key4":4}),
-(4, map{"key1":12, "key2":13, "key3":14, "key4":15}),
-(5, map{"key1":7, "key2":8, "key3":9, "key4":10, "key5":11});
+insert into t values
+(1, '[1,2,3]'),
+(2, '"abc"'),
+(3, 'null'),
+(4, 'true'),
+(5, '1'),
+(6, '{"1":1, "2":true, "3":null, "4":[5,6,7], "5":{"k51":"v51","k52":"v52"}}');
+
+select c1, cast(c2 as map<string,json>) as m from t order by c1;
+select c1, cast(c2 as map<int,json>) as m from t order by c1;
+select c1, cast(c2 as map<string,string>) as m from t order by c1;
+select c1, cast(c2 as map<int,string>) as m from t order by c1;
+select c1, cast(c2 as map<string,array<int>>) as m from t order by c1;
+select c1, cast(c2 as map<string,struct<k51 string,k52 string>>) as m from t order by c1;
+select c1, cast(c2 as map<string,map<string,string>>) as m from t order by c1;


### PR DESCRIPTION
## Why I'm doing:
Currently we support a subset of jsonpath patterns to query json. It can only access data at specified paths, and can't support expression such as filter. For example, there is a json as the following. we want to filter all events with type `t1`. If jsonpath supports filter expression, we can do it by `json_query(data, '$.events.*[?(@.type=="t1")]')`.
```
{
      "events": {
            "id1": {
                 "type":"t1",
                 "msg": "msg1"
            },
            "id2": {
                 "type":"t2",
                 "msg":"msg2"
            }
      }
}
```
Instead of supporting more complex jsonpath patterns, we can do it in another way
* first converting events to a map, and each event is a key-value pair
* then use `map_filter` to filter the event
```
map_filter(
     (k,v) -> get_json_object(v, '$.type')=='t1',
     cast(get_json_object(data, '$.events') as map<string,json>)
)
```
Although it's not as efficient and convenient as jsonpath, it needs less effort for development because only need to support to cast json object to map. Before deciding to dedicate more effort to supporting complex jsonpath, we can use this method as a workaround. 

## What I'm doing:
support to cast json to map<key,value>
* only json object can be casted to map, other json value will be converted to NULL
* a json object is equivalent to map<varchar,json>, so target key and value can be any type if
   * VARCHAR can be casted to the key type
   * json can be casted to the value type

Fixes #58207

## What type of PR is this:

- [ ] BugFix
- [X] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
