### PR TITLE
[Enhancement]  Remove duplicates during join selectivity estimation with histograms

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
@@ -479,10 +479,10 @@ public class BinaryPredicateStatisticCalculator {
                 long leftBucketRowCount = leftBucket.getCount() - prevLeftBucketRowCount;
                 long rightBucketRowCount = rightBucket.getCount() - prevRightBucketRowCount;
                 if (dataTypeLeft.isFixedPointType()) {
-                    leftBucketDistinctRowCount = (long) (leftBucket.getUpper() - leftBucket.getLower());
+                    leftBucketDistinctRowCount = (long) (leftBucket.getUpper() - leftBucket.getLower() + 1);
                 }
                 if (dataTypeRight.isFixedPointType()) {
-                    rightBucketDistinctRowCount = (long) (rightBucket.getUpper() - rightBucket.getLower());
+                    rightBucketDistinctRowCount = (long) (rightBucket.getUpper() - rightBucket.getLower() + 1);
                 }
 
                 // merge the upper repeats.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Bucket.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Bucket.java
@@ -46,6 +46,10 @@ public class Bucket {
         return upperRepeats;
     }
 
+    public boolean isInBucket(double value) {
+        return lower <= value && value <= upper;
+    }
+
     public Optional<Long> getRowCountInBucket(double value, Long previousBucketCount, double distinctValuesCount,
                                               boolean useFixedPointEstimation) {
         if (lower <= value && value < upper) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Histogram.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Histogram.java
@@ -73,6 +73,27 @@ public class Histogram {
         return getRowCountInBucket(valueOpt.get(), totalDistinctCount, constantOperator.getType().isFixedPointType());
     }
 
+    public int getBucketIndex(double value) {
+        int left = 0;
+        int right = buckets.size() - 1;
+        while (left <= right) {
+            int mid = (left + right) / 2;
+            Bucket bucket = buckets.get(mid);
+
+            if (bucket.isInBucket(value)) {
+                return mid;
+            }
+
+            if (value < bucket.getLower()) {
+                right = mid - 1;
+            } else {
+                left = mid + 1;
+            }
+        }
+
+        return -1;
+    }
+
     public Optional<Long> getRowCountInBucket(double value, double distinctValuesCount, boolean useFixedPointEstimation) {
         int left = 0;
         int right = buckets.size() - 1;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticRangeValues.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticRangeValues.java
@@ -69,6 +69,10 @@ public class StatisticRangeValues {
         return this.high - this.low;
     }
 
+    public boolean contains(double value) {
+        return value >= low && value <= high;
+    }
+
     // Calculate the proportion of coverage between column statistic range
     public double overlapPercentWith(@NotNull StatisticRangeValues other) {
         if (this.isEmpty() || other.isEmpty()) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
@@ -234,7 +234,7 @@ public class HistogramStatisticsTest {
         Assert.assertEquals(estimated.getColumnStatistics().size(), 2);
         Assert.assertEquals(estimated.getColumnStatistic(leftColumnRefOperator).getHistogram(), leftHistogram);
         Assert.assertEquals(estimated.getColumnStatistic(rightColumnRefOperator).getHistogram(), rightHistogram);
-        Assert.assertEquals(83576, estimated.getOutputRowCount(), 0.1);
+        Assert.assertEquals(82982, estimated.getOutputRowCount(), 0.1);
     }
 
     @Test
@@ -545,7 +545,7 @@ public class HistogramStatisticsTest {
         joinBucket = exist.get().getBuckets().get(0);
         Assert.assertEquals(joinBucket.getLower(), 5D, 0.001);
         Assert.assertEquals(joinBucket.getUpper(), 9D, 0.001);
-        Assert.assertEquals(joinBucket.getCount().longValue(), 833);
+        Assert.assertEquals(joinBucket.getCount().longValue(), 714);
         Assert.assertEquals(joinBucket.getUpperRepeats().longValue(), 20L * 14L);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
@@ -182,6 +182,7 @@ public class HistogramStatisticsTest {
         leftMcv.put("59", 500L);
         leftMcv.put("38", 300L);
         leftMcv.put("17", 200L);
+        leftMcv.put("44", 120L);
         Histogram leftHistogram = new Histogram(leftBucketList, leftMcv);
 
         ColumnRefOperator rightColumnRefOperator = new ColumnRefOperator(1, Type.BIGINT, "v2", true);
@@ -198,6 +199,7 @@ public class HistogramStatisticsTest {
         rightMcv.put("99", 500L);
         rightMcv.put("16", 300L);
         rightMcv.put("17", 200L);
+        rightMcv.put("63", 150L);
         Histogram rightHistogram = new Histogram(rightBucketList, rightMcv);
 
         Statistics.Builder builder = Statistics.builder();
@@ -234,7 +236,7 @@ public class HistogramStatisticsTest {
         Assert.assertEquals(estimated.getColumnStatistics().size(), 2);
         Assert.assertEquals(estimated.getColumnStatistic(leftColumnRefOperator).getHistogram(), leftHistogram);
         Assert.assertEquals(estimated.getColumnStatistic(rightColumnRefOperator).getHistogram(), rightHistogram);
-        Assert.assertEquals(82982, estimated.getOutputRowCount(), 0.1);
+        Assert.assertEquals(76086.88, estimated.getOutputRowCount(), 0.1);
     }
 
     @Test
@@ -546,6 +548,62 @@ public class HistogramStatisticsTest {
         Assert.assertEquals(joinBucket.getLower(), 5D, 0.001);
         Assert.assertEquals(joinBucket.getUpper(), 9D, 0.001);
         Assert.assertEquals(joinBucket.getCount().longValue(), 714);
+        Assert.assertEquals(joinBucket.getUpperRepeats().longValue(), 20L * 14L);
+
+        // bucket to MCV/bucket intersection with overlap (upper).
+        bucketListLeft = new ArrayList<>();
+        bucketListLeft.add(new Bucket(1D, 5D, 100L, 20L));
+        bucketListLeft.add(new Bucket(15D, 24D, 200L, 20L));
+        histogramLeft = new Histogram(bucketListLeft, new HashMap<>());
+        columnStatisticLeft = new ColumnStatistic(1, 50, 0, 4, 500,
+                histogramLeft, ColumnStatistic.StatisticType.ESTIMATE);
+
+        bucketListRight = new ArrayList<>();
+        bucketListRight.add(new Bucket(5D, 11D, 100L, 20L));
+        bucketListRight.add(new Bucket(30D, 35D, 200L, 20L));
+        mcvRight = new HashMap<>();
+        mcvRight.put("5", 80L);
+        histogramRight = new Histogram(bucketListRight, mcvRight);
+        columnStatisticRight = new ColumnStatistic(1, 50, 0, 4, 500,
+                histogramRight, ColumnStatistic.StatisticType.ESTIMATE);
+
+        exist = BinaryPredicateStatisticCalculator.updateHistWithJoin(columnStatisticLeft, Type.BIGINT,
+                columnStatisticRight, Type.BIGINT);
+        Assert.assertTrue(exist.isPresent());
+        Assert.assertTrue(exist.get().getBuckets().isEmpty());
+        Assert.assertEquals(exist.get().getMCV().size(), 1);
+        Assert.assertEquals(exist.get().getMCV().get("5").longValue(), 20 * 80);
+
+        // bucket to MCV/bucket intersection with overlap (not upper).
+        bucketListLeft = new ArrayList<>();
+        bucketListLeft.add(new Bucket(1D, 9D, 100L, 20L));
+        bucketListLeft.add(new Bucket(15D, 24D, 200L, 20L));
+        mcvLeft = new HashMap<>();
+        mcvLeft.put("8", 30L);
+        histogramLeft = new Histogram(bucketListLeft, mcvLeft);
+        columnStatisticLeft = new ColumnStatistic(1, 50, 0, 4, 500,
+                histogramLeft, ColumnStatistic.StatisticType.ESTIMATE);
+
+        bucketListRight = new ArrayList<>();
+        bucketListRight.add(new Bucket(5D, 11D, 100L, 20L));
+        bucketListRight.add(new Bucket(30D, 35D, 200L, 20L));
+        mcvRight = new HashMap<>();
+        mcvRight.put("6", 20L);
+        histogramRight = new Histogram(bucketListRight, mcvRight);
+        columnStatisticRight = new ColumnStatistic(1, 50, 0, 4, 500,
+                histogramRight, ColumnStatistic.StatisticType.ESTIMATE);
+
+        exist = BinaryPredicateStatisticCalculator.updateHistWithJoin(columnStatisticLeft, Type.BIGINT,
+                columnStatisticRight, Type.BIGINT);
+        Assert.assertTrue(exist.isPresent());
+        Assert.assertEquals(exist.get().getMCV().size(), 2);
+        Assert.assertEquals(exist.get().getMCV().get("8").longValue(), 30 * 14);
+        Assert.assertEquals(exist.get().getMCV().get("6").longValue(), 20 * 10);
+        Assert.assertEquals(exist.get().getBuckets().size(), 1);
+        joinBucket = exist.get().getBuckets().get(0);
+        Assert.assertEquals(joinBucket.getLower(), 5D, 0.001);
+        Assert.assertEquals(joinBucket.getUpper(), 9D, 0.001);
+        Assert.assertEquals(joinBucket.getCount().longValue(), 790);
         Assert.assertEquals(joinBucket.getUpperRepeats().longValue(), 20L * 14L);
     }
 }

--- a/test/sql/test_analyze_statistics/R/test_histogram
+++ b/test/sql/test_analyze_statistics/R/test_histogram
@@ -118,15 +118,15 @@ LIMIT 10;
 -- !result
 [UC] ANALYZE FULL TABLE t1;
 -- result:
-analyze_test_5a0d63146e954344a23e1cde08fa0eb3.t1	analyze	status	OK
+analyze_test_96cb1f9afb97449d98aa33f5443d6b27.t1	analyze	status	OK
 -- !result
 [UC] ANALYZE FULL TABLE t2;
 -- result:
-analyze_test_5a0d63146e954344a23e1cde08fa0eb3.t2	analyze	status	OK
+analyze_test_96cb1f9afb97449d98aa33f5443d6b27.t2	analyze	status	OK
 -- !result
 [UC] ANALYZE FULL TABLE t3;
 -- result:
-analyze_test_5a0d63146e954344a23e1cde08fa0eb3.t3	analyze	status	OK
+analyze_test_96cb1f9afb97449d98aa33f5443d6b27.t3	analyze	status	OK
 -- !result
 SELECT min,max,row_count,hll_cardinality(ndv) FROM _statistics_.column_statistics WHERE table_name = 'analyze_test_${uuid0}.t1' and column_name = 'k1';
 -- result:
@@ -166,15 +166,15 @@ None
 -- !result
 [UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k1,k2,k3 PROPERTIES('histogram_sample_ratio' = '1.0');
 -- result:
-analyze_test_5a0d63146e954344a23e1cde08fa0eb3.t1	histogram	status	OK
+analyze_test_96cb1f9afb97449d98aa33f5443d6b27.t1	histogram	status	OK
 -- !result
 [UC] ANALYZE TABLE t2 UPDATE HISTOGRAM ON k1,k2,k3 PROPERTIES('histogram_sample_ratio' = '1.0');
 -- result:
-analyze_test_5a0d63146e954344a23e1cde08fa0eb3.t2	histogram	status	OK
+analyze_test_96cb1f9afb97449d98aa33f5443d6b27.t2	histogram	status	OK
 -- !result
 [UC] ANALYZE TABLE t3 UPDATE HISTOGRAM ON k1,k2,k3 PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '0');
 -- result:
-analyze_test_5a0d63146e954344a23e1cde08fa0eb3.t3	histogram	status	OK
+analyze_test_96cb1f9afb97449d98aa33f5443d6b27.t3	histogram	status	OK
 -- !result
 set enable_stats_to_optimize_skew_join = false;
 -- result:
@@ -257,21 +257,21 @@ function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 
 -- result:
 None
 -- !result
-function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k3 = n3.k3', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 3645821', 'cardinality: 1156602757')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k3 = n3.k3', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 3645821', 'cardinality: 981208729')
 -- result:
 None
 -- !result
 [UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k1,k2,k3 PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '400');
 -- result:
-analyze_test_5a0d63146e954344a23e1cde08fa0eb3.t1	histogram	status	OK
+analyze_test_96cb1f9afb97449d98aa33f5443d6b27.t1	histogram	status	OK
 -- !result
 [UC] ANALYZE TABLE t2 UPDATE HISTOGRAM ON k1,k2,k3 PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '400');
 -- result:
-analyze_test_5a0d63146e954344a23e1cde08fa0eb3.t2	histogram	status	OK
+analyze_test_96cb1f9afb97449d98aa33f5443d6b27.t2	histogram	status	OK
 -- !result
 [UC] ANALYZE TABLE t3 UPDATE HISTOGRAM ON k1,k2,k3 PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '400');
 -- result:
-analyze_test_5a0d63146e954344a23e1cde08fa0eb3.t3	histogram	status	OK
+analyze_test_96cb1f9afb97449d98aa33f5443d6b27.t3	histogram	status	OK
 -- !result
 function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1)', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 4589949')
 -- result:
@@ -291,15 +291,15 @@ None
 -- !result
 [UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k1,k2,k3 WITH 256 BUCKETS PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '100');
 -- result:
-analyze_test_5a0d63146e954344a23e1cde08fa0eb3.t1	histogram	status	OK
+analyze_test_96cb1f9afb97449d98aa33f5443d6b27.t1	histogram	status	OK
 -- !result
 [UC] ANALYZE TABLE t2 UPDATE HISTOGRAM ON k1,k2,k3 WITH 256 BUCKETS PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '100');
 -- result:
-analyze_test_5a0d63146e954344a23e1cde08fa0eb3.t2	histogram	status	OK
+analyze_test_96cb1f9afb97449d98aa33f5443d6b27.t2	histogram	status	OK
 -- !result
 [UC] ANALYZE TABLE t3 UPDATE HISTOGRAM ON k1,k2,k3 WITH 256 BUCKETS PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '0');
 -- result:
-analyze_test_5a0d63146e954344a23e1cde08fa0eb3.t3	histogram	status	OK
+analyze_test_96cb1f9afb97449d98aa33f5443d6b27.t3	histogram	status	OK
 -- !result
 function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1)', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 4562636')
 -- result:
@@ -313,7 +313,7 @@ function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 
 -- result:
 None
 -- !result
-function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k3 = n3.k3', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 4562636', 'cardinality: 1446330752')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k3 = n3.k3', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 4562636', 'cardinality: 1363007924')
 -- result:
 None
 -- !result

--- a/test/sql/test_analyze_statistics/R/test_histogram
+++ b/test/sql/test_analyze_statistics/R/test_histogram
@@ -118,15 +118,15 @@ LIMIT 10;
 -- !result
 [UC] ANALYZE FULL TABLE t1;
 -- result:
-analyze_test_96cb1f9afb97449d98aa33f5443d6b27.t1	analyze	status	OK
+analyze_test_8c7763a546f04759a8380cee5f251ce4.t1	analyze	status	OK
 -- !result
 [UC] ANALYZE FULL TABLE t2;
 -- result:
-analyze_test_96cb1f9afb97449d98aa33f5443d6b27.t2	analyze	status	OK
+analyze_test_8c7763a546f04759a8380cee5f251ce4.t2	analyze	status	OK
 -- !result
 [UC] ANALYZE FULL TABLE t3;
 -- result:
-analyze_test_96cb1f9afb97449d98aa33f5443d6b27.t3	analyze	status	OK
+analyze_test_8c7763a546f04759a8380cee5f251ce4.t3	analyze	status	OK
 -- !result
 SELECT min,max,row_count,hll_cardinality(ndv) FROM _statistics_.column_statistics WHERE table_name = 'analyze_test_${uuid0}.t1' and column_name = 'k1';
 -- result:
@@ -166,15 +166,15 @@ None
 -- !result
 [UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k1,k2,k3 PROPERTIES('histogram_sample_ratio' = '1.0');
 -- result:
-analyze_test_96cb1f9afb97449d98aa33f5443d6b27.t1	histogram	status	OK
+analyze_test_8c7763a546f04759a8380cee5f251ce4.t1	histogram	status	OK
 -- !result
 [UC] ANALYZE TABLE t2 UPDATE HISTOGRAM ON k1,k2,k3 PROPERTIES('histogram_sample_ratio' = '1.0');
 -- result:
-analyze_test_96cb1f9afb97449d98aa33f5443d6b27.t2	histogram	status	OK
+analyze_test_8c7763a546f04759a8380cee5f251ce4.t2	histogram	status	OK
 -- !result
 [UC] ANALYZE TABLE t3 UPDATE HISTOGRAM ON k1,k2,k3 PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '0');
 -- result:
-analyze_test_96cb1f9afb97449d98aa33f5443d6b27.t3	histogram	status	OK
+analyze_test_8c7763a546f04759a8380cee5f251ce4.t3	histogram	status	OK
 -- !result
 set enable_stats_to_optimize_skew_join = false;
 -- result:
@@ -245,33 +245,33 @@ None
 set cbo_enable_histogram_join_estimation = true;
 -- result:
 -- !result
-function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1)', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 3645821')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1)', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 1371887')
 -- result:
 None
 -- !result
-function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1) WHERE t1.k1 BETWEEN "2020-01-21" AND "2020-01-30" ', 'cardinality: 176', 'cardinality: 2765', 'cardinality: 10239')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1) WHERE t1.k1 BETWEEN "2020-01-21" AND "2020-01-30" ', 'cardinality: 176', 'cardinality: 2765', 'cardinality: 9141')
 -- result:
 None
 -- !result
-function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k1 = n3.k1', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 3645821', 'cardinality: 805345144')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k1 = n3.k1', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 1371887', 'cardinality: 158442101')
 -- result:
 None
 -- !result
-function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k3 = n3.k3', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 3645821', 'cardinality: 981208729')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k3 = n3.k3', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 1371887', 'cardinality: 369219306')
 -- result:
 None
 -- !result
 [UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k1,k2,k3 PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '400');
 -- result:
-analyze_test_96cb1f9afb97449d98aa33f5443d6b27.t1	histogram	status	OK
+analyze_test_8c7763a546f04759a8380cee5f251ce4.t1	histogram	status	OK
 -- !result
 [UC] ANALYZE TABLE t2 UPDATE HISTOGRAM ON k1,k2,k3 PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '400');
 -- result:
-analyze_test_96cb1f9afb97449d98aa33f5443d6b27.t2	histogram	status	OK
+analyze_test_8c7763a546f04759a8380cee5f251ce4.t2	histogram	status	OK
 -- !result
 [UC] ANALYZE TABLE t3 UPDATE HISTOGRAM ON k1,k2,k3 PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '400');
 -- result:
-analyze_test_96cb1f9afb97449d98aa33f5443d6b27.t3	histogram	status	OK
+analyze_test_8c7763a546f04759a8380cee5f251ce4.t3	histogram	status	OK
 -- !result
 function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1)', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 4589949')
 -- result:
@@ -291,29 +291,29 @@ None
 -- !result
 [UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k1,k2,k3 WITH 256 BUCKETS PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '100');
 -- result:
-analyze_test_96cb1f9afb97449d98aa33f5443d6b27.t1	histogram	status	OK
+analyze_test_8c7763a546f04759a8380cee5f251ce4.t1	histogram	status	OK
 -- !result
 [UC] ANALYZE TABLE t2 UPDATE HISTOGRAM ON k1,k2,k3 WITH 256 BUCKETS PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '100');
 -- result:
-analyze_test_96cb1f9afb97449d98aa33f5443d6b27.t2	histogram	status	OK
+analyze_test_8c7763a546f04759a8380cee5f251ce4.t2	histogram	status	OK
 -- !result
 [UC] ANALYZE TABLE t3 UPDATE HISTOGRAM ON k1,k2,k3 WITH 256 BUCKETS PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '0');
 -- result:
-analyze_test_96cb1f9afb97449d98aa33f5443d6b27.t3	histogram	status	OK
+analyze_test_8c7763a546f04759a8380cee5f251ce4.t3	histogram	status	OK
 -- !result
-function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1)', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 4562636')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1)', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 3759365')
 -- result:
 None
 -- !result
-function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1) WHERE t1.k1 BETWEEN "2020-01-21" AND "2020-01-30" ', 'cardinality: 209', 'cardinality: 2765', 'cardinality: 24300')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1) WHERE t1.k1 BETWEEN "2020-01-21" AND "2020-01-30" ', 'cardinality: 209', 'cardinality: 2765', 'cardinality: 22917')
 -- result:
 None
 -- !result
-function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k1 = n3.k1', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 4562636', 'cardinality: 1199835328')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k1 = n3.k1', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 3759365', 'cardinality: 831855052')
 -- result:
 None
 -- !result
-function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k3 = n3.k3', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 4562636', 'cardinality: 1363007924')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k3 = n3.k3', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 3759365', 'cardinality: 1123044723')
 -- result:
 None
 -- !result

--- a/test/sql/test_analyze_statistics/T/test_histogram
+++ b/test/sql/test_analyze_statistics/T/test_histogram
@@ -119,11 +119,11 @@ function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 
 
 set cbo_enable_histogram_join_estimation = true;
 
-function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1)', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 3645821')
-function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1) WHERE t1.k1 BETWEEN "2020-01-21" AND "2020-01-30" ', 'cardinality: 176', 'cardinality: 2765', 'cardinality: 10239')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1)', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 1371887')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1) WHERE t1.k1 BETWEEN "2020-01-21" AND "2020-01-30" ', 'cardinality: 176', 'cardinality: 2765', 'cardinality: 9141')
 
-function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k1 = n3.k1', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 3645821', 'cardinality: 805345144')
-function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k3 = n3.k3', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 3645821', 'cardinality: 981208729')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k1 = n3.k1', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 1371887', 'cardinality: 158442101')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k3 = n3.k3', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 1371887', 'cardinality: 369219306')
 
 -- more mcvs lead to better estimations.
 [UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k1,k2,k3 PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '400');
@@ -149,8 +149,8 @@ function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 
 -- SELECT buckets,mcv FROM _statistics_.histogram_statistics WHERE table_name = 'analyze_test_${uuid0}.t2' and column_name = 'k1';
 -- SELECT buckets,mcv FROM _statistics_.histogram_statistics WHERE table_name = 'analyze_test_${uuid0}.t3' and column_name = 'k1';
 
-function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1)', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 4562636')
-function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1) WHERE t1.k1 BETWEEN "2020-01-21" AND "2020-01-30" ', 'cardinality: 209', 'cardinality: 2765', 'cardinality: 24300')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1)', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 3759365')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1) WHERE t1.k1 BETWEEN "2020-01-21" AND "2020-01-30" ', 'cardinality: 209', 'cardinality: 2765', 'cardinality: 22917')
 
-function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k1 = n3.k1', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 4562636', 'cardinality: 1199835328')
-function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k3 = n3.k3', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 4562636', 'cardinality: 1363007924')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k1 = n3.k1', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 3759365', 'cardinality: 831855052')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k3 = n3.k3', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 3759365', 'cardinality: 1123044723')

--- a/test/sql/test_analyze_statistics/T/test_histogram
+++ b/test/sql/test_analyze_statistics/T/test_histogram
@@ -123,7 +123,7 @@ function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (
 function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1) WHERE t1.k1 BETWEEN "2020-01-21" AND "2020-01-30" ', 'cardinality: 176', 'cardinality: 2765', 'cardinality: 10239')
 
 function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k1 = n3.k1', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 3645821', 'cardinality: 805345144')
-function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k3 = n3.k3', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 3645821', 'cardinality: 1156602757')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k3 = n3.k3', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 3645821', 'cardinality: 981208729')
 
 -- more mcvs lead to better estimations.
 [UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k1,k2,k3 PROPERTIES('histogram_sample_ratio' = '1.0', "histogram_mcv_size" = '400');
@@ -153,4 +153,4 @@ function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (
 function: assert_explain_costs_contains('SELECT COUNT(*) FROM t1 JOIN t2 USING (k1) WHERE t1.k1 BETWEEN "2020-01-21" AND "2020-01-30" ', 'cardinality: 209', 'cardinality: 2765', 'cardinality: 24300')
 
 function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k1 = n3.k1', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 4562636', 'cardinality: 1199835328')
-function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k3 = n3.k3', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 4562636', 'cardinality: 1446330752')
+function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 ON n1.k1 = n2.k1) JOIN t3 n3 ON n1.k3 = n3.k3', 'cardinality: 45150', 'cardinality: 45150', 'cardinality: 90000', 'cardinality: 4562636', 'cardinality: 1363007924')


### PR DESCRIPTION
## Why I'm doing:

This change builds on top of https://github.com/StarRocks/starrocks/pull/57639. 
As pointed out in the [comment](https://github.com/StarRocks/starrocks/pull/57639#discussion_r2039181804) by @stephen-shelby the algorithm implemented to compute the join estimation includes duplicates between the mcv2bucket and bucket2bucket intersections. 
This change should get rid of the duplicates.

## What I'm doing:

Duplicate estimation occurs in the following case: for some entry e
- left histogram has mcv1 of e and bucket1 that includes e.
- right histogram has bucket2 that includes e.
- mcv1 matches with bucket2.
- bucket1 matches with bucket2.

In this case mcv1 falls in the intersection between bucket1 and bucket2. The count of e in bucket2 will be used twice in the estimation, first against the count in mcv1, then against the count in bucket1.

In order to avoid this case:
- when computing mcv2bucket intersection, keep track of the estimated matches of each mcv.
- when computing bucket2bucket intersection:
    - check the mcvs that fall in the intersection.
    - remove the already used mcv from the intersection by subtracting their count.
    - reduce the distinct count by the number of already used mcvs in the intersection. 

 
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
