### PR TITLE
[Doc] adjust pageBoost placement

### DIFF
--- a/docs/en/administration/cluster_snapshot.md
+++ b/docs/en/administration/cluster_snapshot.md
@@ -1,9 +1,11 @@
 ---
 displayed_sidebar: docs
 sidebar_label: "Cluster Snapshot"
-pageBoost: 100
 keywords: ['backup','restore','shared data']
 ---
+<head>
+  <meta pageBoost="100" />
+</head>
 
 # Automated Cluster Snapshot
 


### PR DESCRIPTION
Only keywords and description metadata can be added in frontmatter. To add other metadata it has to be added to the HTML `<head />`

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1