### PR TITLE
[Feature] VacuumFull Implementation

### DIFF
--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -320,7 +320,6 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_limited_memory(const Chunk
 
 Status AggregateStreamingSinkOperator::reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) {
     _is_finished = false;
-    // TODO(cbrennan): Add this back once it doesn't break test compilation
     ONCE_RESET(_set_finishing_once);
     return _aggregator->reset_state(state, refill_chunks, this);
 }

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -320,6 +320,7 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_limited_memory(const Chunk
 
 Status AggregateStreamingSinkOperator::reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) {
     _is_finished = false;
+    // TODO(cbrennan): Add this back once it doesn't break test compilation
     ONCE_RESET(_set_finishing_once);
     return _aggregator->reset_state(state, refill_chunks, this);
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
@@ -108,7 +108,10 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
      */
     private long visibleTxnId = -1;
 
+    // Autovacuum
     private volatile long lastVacuumTime = 0;
+    // Full vacuum (orphan data files and redundant db/table/partition)
+    private volatile long lastFullVacuumTime;
 
     private volatile long minRetainVersion = 0;
 
@@ -191,6 +194,14 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
 
     public void setLastVacuumTime(long lastVacuumTime) {
         this.lastVacuumTime = lastVacuumTime;
+    }
+
+    public long getLastFullVacuumTime() {
+        return lastFullVacuumTime;
+    }
+
+    public void setLastFullVacuumTime(long lastVacuumTime) {
+        this.lastFullVacuumTime = lastVacuumTime;
     }
 
     public long getMinRetainVersion() {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2897,6 +2897,9 @@ public class Config extends ConfigBase {
     @ConfField(comment = "how many partitions can autovacuum be executed simultaneously at most")
     public static int lake_autovacuum_parallel_partitions = 8;
 
+    @ConfField(comment = "how many partitions can fullvacuum execute simultaneously at most")
+    public static int lake_fullvacuum_parallel_partitions = 128;
+
     @ConfField(mutable = true, comment = "the minimum delay between autovacuum runs on any given partition")
     public static long lake_autovacuum_partition_naptime_seconds = 180;
 
@@ -2916,6 +2919,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = 
             "Determine whether a vacuum operation needs to be initiated based on the vacuum version.\n")
     public static boolean lake_autovacuum_detect_vaccumed_version = true;
+
+    @ConfField(mutable = true, comment = "the minimum delay between full vacuum runs on any given partition")
+    public static long lake_fullvacuum_partition_naptime_seconds = 3600 * 24;
 
     @ConfField(mutable = true, comment =
             "Whether enable throttling ingestion speed when compaction score exceeds the threshold.\n" +

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/FullVacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/FullVacuumDaemon.java
@@ -1,0 +1,282 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.lake.vacuum;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.io.Writable;
+import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.lake.LakeTablet;
+import com.starrocks.proto.VacuumFullRequest;
+import com.starrocks.proto.VacuumFullResponse;
+import com.starrocks.rpc.BrpcProxy;
+import com.starrocks.rpc.LakeService;
+import com.starrocks.rpc.RpcException;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.warehouse.Warehouse;
+import org.apache.hadoop.util.BlockingThreadPoolExecutorService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static com.starrocks.rpc.LakeService.TIMEOUT_VACUUM_FULL;
+
+public class FullVacuumDaemon extends FrontendDaemon implements Writable {
+    private static final Logger LOG = LogManager.getLogger(FullVacuumDaemon.class);
+
+    private final Set<Long> vacuumingPartitions = Sets.newConcurrentHashSet();
+
+    private final Map<Long, AtomicInteger> cnIdToRunningFullVacuum = new ConcurrentHashMap<>();
+
+    private final BlockingThreadPoolExecutorService executorService =
+            BlockingThreadPoolExecutorService.newInstance(Config.lake_fullvacuum_parallel_partitions, 0, TIMEOUT_VACUUM_FULL,
+                    TimeUnit.MILLISECONDS, "fullvacuum");
+
+    public FullVacuumDaemon() {
+        // Check every minute if we should run a full vacuum
+        super("FullVacuumDaemon", 1000 * 60);
+    }
+
+    @Override
+    protected void runAfterCatalogReady() {
+        if (FeConstants.runningUnitTest) {
+            return;
+        }
+        List<Long> dbIds = GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIds();
+        for (Long dbId : dbIds) {
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
+            if (db == null) {
+                continue;
+            }
+
+            List<Table> tables = new ArrayList<>();
+            for (Table table : GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId())) {
+                if (table.isCloudNativeTableOrMaterializedView()) {
+                    tables.add(table);
+                }
+            }
+
+            // Full vacuum cleans up two types of data (orphan data files and redundant db/table/partition)
+            // 1. Cleanup Orphan Data Files: Data files not referenced by tablet metadata.
+            for (Table table : tables) {
+                vacuumTable(db, table);
+            }
+            //  2. Redundant db/table/partition: Dbs, tables, or partitions that have been deleted in FE but not in the object storage.
+            // TODO Implement
+
+        }
+    }
+
+    public boolean shouldVacuum(PhysicalPartition partition) {
+        long current = System.currentTimeMillis();
+        // prevent vacuum too frequent
+        return current >= partition.getLastFullVacuumTime() + Config.lake_fullvacuum_partition_naptime_seconds * 1000;
+    }
+
+    private void vacuumTable(Database db, Table baseTable) {
+        OlapTable table = (OlapTable) baseTable;
+        List<PhysicalPartition> partitions;
+
+        Locker locker = new Locker();
+        locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(baseTable.getId()), LockType.READ);
+        try {
+            partitions = table.getPhysicalPartitions().stream().filter(this::shouldVacuum).toList();
+        } finally {
+            locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(baseTable.getId()), LockType.READ);
+        }
+
+        for (PhysicalPartition partition : partitions) {
+            if (vacuumingPartitions.add(partition.getId())) {
+                executorService.execute(() -> vacuumPartition(db, table, partition));
+            }
+        }
+    }
+
+    private void vacuumPartition(Database db, OlapTable table, PhysicalPartition partition) {
+        try {
+            vacuumPartitionImpl(db, table, partition);
+        } finally {
+            vacuumingPartitions.remove(partition.getId());
+        }
+    }
+
+    private ComputeNode selectNodeWithMinVacuum(Collection<ComputeNode> involvedNodes) {
+        ComputeNode chosenNode = null;
+        int minRunning = Integer.MAX_VALUE;
+
+        for (ComputeNode node : involvedNodes) {
+            AtomicInteger currentlyRunningFullVacuum =
+                    cnIdToRunningFullVacuum.computeIfAbsent(node.getId(), id -> new AtomicInteger(0));
+
+            int currentRunning = currentlyRunningFullVacuum.get();
+            if (currentRunning < minRunning) {
+                minRunning = currentRunning;
+                chosenNode = node;
+            }
+        }
+
+        if (chosenNode == null || chosenNode.getHost() == null) {
+            LOG.error("Could not find usable ComputeNode to send full vacuum. Problem: {}",
+                    chosenNode == null ? "ComputeNode is null" : "Host is null");
+            return null;
+        } else {
+            cnIdToRunningFullVacuum.get(chosenNode.getId()).incrementAndGet();
+        }
+
+        return chosenNode;
+    }
+
+    private void vacuumPartitionImpl(Database db, OlapTable table, PhysicalPartition partition) {
+        LOG.info("Running orphan file deletion task for table={}, partition={}.", table.getName(), partition.getId());
+        List<Tablet> tablets = new ArrayList<>();
+        long visibleVersion;
+        long startTime = System.currentTimeMillis();
+        long minActiveTxnId = computeMinActiveTxnId(db, table);
+
+        Locker locker = new Locker();
+        locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
+        try {
+            for (MaterializedIndex index : partition.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)) {
+                tablets.addAll(index.getTablets());
+            }
+            visibleVersion = partition.getVisibleVersion();
+        } finally {
+            locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
+        }
+
+        if (visibleVersion <= 1) {
+            LOG.info("skipping full vacuum of partition={} because its visible version is {}", partition.getId(), visibleVersion);
+            partition.setLastFullVacuumTime(startTime);
+            return;
+        }
+
+        WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+        Warehouse warehouse = warehouseManager.getBackgroundWarehouse();
+        List<Long> allTabletIds = new ArrayList<>(tablets.size());
+        Set<ComputeNode> involvedNodes = new HashSet<>();
+
+        for (Tablet tablet : tablets) {
+            LakeTablet lakeTablet = (LakeTablet) tablet;
+            ComputeNode node = warehouseManager.getComputeNodeAssignedToTablet(warehouse.getId(), lakeTablet);
+
+            if (node == null) {
+                LOG.error("Could not get CN for tablet={}, returning early.", tablet.getId());
+                return;
+            }
+            allTabletIds.add(tablet.getId());
+            involvedNodes.add(node);
+        }
+        VacuumFullRequest vacuumFullRequest = new VacuumFullRequest();
+        vacuumFullRequest.setPartitionId(partition.getId());
+        // All tablet ids must be part of the request, since the CN will delete any + all tablets unspecified by the request.
+        vacuumFullRequest.setTabletIds(allTabletIds);
+        // TODO(cbrennan) min check version is an optimization to save compute on deleting metadata, but at some point this
+        //  should be something other than the default of 1.
+        vacuumFullRequest.setMinCheckVersion(1L);
+        vacuumFullRequest.setMaxCheckVersion(visibleVersion);
+        vacuumFullRequest.setMinActiveTxnId(minActiveTxnId);
+
+        ComputeNode chosenNode = selectNodeWithMinVacuum(involvedNodes);
+        if (chosenNode == null) {
+            return;
+        }
+
+        LOG.info(
+                "Sending full vacuum request to cn={}: table={}, partition={}, tablet_ids={}, max_check_version={}, " +
+                        "min_active_txn_id={}",
+                chosenNode.getHost(), table.getName(), vacuumFullRequest.getPartitionId(), vacuumFullRequest.getTabletIds(),
+                vacuumFullRequest.maxCheckVersion, vacuumFullRequest.minActiveTxnId);
+
+
+        boolean hasError = false;
+        long vacuumedFiles = 0;
+        long vacuumedFileSize = 0;
+        long vacuumedVersion = Long.MAX_VALUE;
+        Future<VacuumFullResponse> responseFuture = null;
+        try {
+            LakeService service = BrpcProxy.getLakeService(chosenNode.getHost(), chosenNode.getBrpcPort());
+            responseFuture = service.vacuumFull(vacuumFullRequest);
+        } catch (RpcException e) {
+            LOG.error("failed to send full vacuum request for partition {}.{}.{}", db.getFullName(), table.getName(),
+                    partition.getId(), e);
+            hasError = true;
+        }
+
+        try {
+            VacuumFullResponse response = responseFuture.get();
+            if (response.status.statusCode != 0) {
+                hasError = true;
+                LOG.warn("Vacuumed {}.{}.{} with error: {}", db.getFullName(), table.getName(), partition.getId(),
+                        response.status.errorMsgs.get(0));
+            } else {
+                vacuumedFiles += response.vacuumedFiles;
+                vacuumedFileSize += response.vacuumedFileSize;
+            }
+        } catch (InterruptedException e) {
+            LOG.warn("thread interrupted");
+            Thread.currentThread().interrupt();
+            hasError = true;
+        } catch (ExecutionException e) {
+            LOG.error("failed to full vacuum {}.{}.{}: {}", db.getFullName(), table.getName(), partition.getId(),
+                    e.getMessage());
+            hasError = true;
+        } finally {
+            cnIdToRunningFullVacuum.get(chosenNode.getId()).decrementAndGet();
+        }
+
+        partition.setLastFullVacuumTime(startTime);
+
+        LOG.info("Full vacuumed {}.{}.{} hasError={} vacuumedFiles={} vacuumedFileSize={} " +
+                        "visibleVersion={} minActiveTxnId={} vacuumVersion={} cost={}ms", db.getFullName(), table.getName(),
+                partition.getId(), hasError, vacuumedFiles, vacuumedFileSize, visibleVersion, minActiveTxnId, vacuumedVersion,
+                System.currentTimeMillis() - startTime);
+    }
+
+    @VisibleForTesting
+    public static long computeMinActiveTxnId(Database db, Table table) {
+        long a = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getMinActiveTxnIdOfDatabase(db.getId());
+        Optional<Long> b = GlobalStateMgr.getCurrentState().getSchemaChangeHandler().getActiveTxnIdOfTable(table.getId());
+        return Math.min(a, b.orElse(Long.MAX_VALUE));
+    }
+
+    public void testVacuumPartitionImpl(Database db, OlapTable table, PhysicalPartition partition) {
+        vacuumPartitionImpl(db, table, partition);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
@@ -45,6 +45,8 @@ import com.starrocks.proto.UnlockTabletMetadataRequest;
 import com.starrocks.proto.UnlockTabletMetadataResponse;
 import com.starrocks.proto.UploadSnapshotsRequest;
 import com.starrocks.proto.UploadSnapshotsResponse;
+import com.starrocks.proto.VacuumFullRequest;
+import com.starrocks.proto.VacuumFullResponse;
 import com.starrocks.proto.VacuumRequest;
 import com.starrocks.proto.VacuumResponse;
 
@@ -67,6 +69,7 @@ public interface LakeService {
     long TIMEOUT_PUBLISH_LOG_VERSION_BATCH = MILLIS_PER_MINUTE;
     long TIMEOUT_ABORT_COMPACTION = 5 * MILLIS_PER_SECOND;
     long TIMEOUT_VACUUM = MILLIS_PER_HOUR;
+    long TIMEOUT_VACUUM_FULL = MILLIS_PER_HOUR * 4;
 
     @ProtobufRPC(serviceName = "LakeService", methodName = "publish_version", onceTalkTimeout = TIMEOUT_PUBLISH_VERSION)
     Future<PublishVersionResponse> publishVersion(PublishVersionRequest request);
@@ -116,5 +119,8 @@ public interface LakeService {
 
     @ProtobufRPC(serviceName = "LakeService", methodName = "vacuum", onceTalkTimeout = TIMEOUT_VACUUM)
     Future<VacuumResponse> vacuum(VacuumRequest request);
+
+    @ProtobufRPC(serviceName = "LakeService", methodName = "vacuum_full", onceTalkTimeout = TIMEOUT_VACUUM_FULL)
+    Future<VacuumFullResponse> vacuumFull(VacuumFullRequest request);
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/LakeServiceWithMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/LakeServiceWithMetrics.java
@@ -43,6 +43,8 @@ import com.starrocks.proto.UnlockTabletMetadataRequest;
 import com.starrocks.proto.UnlockTabletMetadataResponse;
 import com.starrocks.proto.UploadSnapshotsRequest;
 import com.starrocks.proto.UploadSnapshotsResponse;
+import com.starrocks.proto.VacuumFullRequest;
+import com.starrocks.proto.VacuumFullResponse;
 import com.starrocks.proto.VacuumRequest;
 import com.starrocks.proto.VacuumResponse;
 
@@ -154,5 +156,11 @@ public class LakeServiceWithMetrics implements LakeService {
     public Future<VacuumResponse> vacuum(VacuumRequest request) {
         increaseMetrics();
         return lakeService.vacuum(request);
+    }
+
+    @Override
+    public Future<VacuumFullResponse> vacuumFull(VacuumFullRequest request) {
+        increaseMetrics();
+        return lakeService.vacuumFull(request);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -143,6 +143,7 @@ import com.starrocks.lake.compaction.CompactionControlScheduler;
 import com.starrocks.lake.compaction.CompactionMgr;
 import com.starrocks.lake.snapshot.ClusterSnapshotMgr;
 import com.starrocks.lake.vacuum.AutovacuumDaemon;
+import com.starrocks.lake.vacuum.FullVacuumDaemon;
 import com.starrocks.leader.CheckpointController;
 import com.starrocks.leader.ReportHandler;
 import com.starrocks.leader.TabletCollector;
@@ -478,6 +479,7 @@ public class GlobalStateMgr {
     private final StorageVolumeMgr storageVolumeMgr;
 
     private AutovacuumDaemon autovacuumDaemon;
+    private FullVacuumDaemon fullVacuumDaemon;
 
     private final PipeManager pipeManager;
     private final PipeListener pipeListener;
@@ -765,6 +767,7 @@ public class GlobalStateMgr {
         if (RunMode.isSharedDataMode()) {
             this.storageVolumeMgr = new SharedDataStorageVolumeMgr();
             this.autovacuumDaemon = new AutovacuumDaemon();
+            this.fullVacuumDaemon = new FullVacuumDaemon();
         } else {
             this.storageVolumeMgr = new SharedNothingStorageVolumeMgr();
         }
@@ -1432,6 +1435,7 @@ public class GlobalStateMgr {
 
             starMgrMetaSyncer.start();
             autovacuumDaemon.start();
+            fullVacuumDaemon.start();
         }
 
         if (Config.enable_safe_mode) {

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
@@ -90,6 +90,8 @@ import com.starrocks.proto.UnlockTabletMetadataRequest;
 import com.starrocks.proto.UnlockTabletMetadataResponse;
 import com.starrocks.proto.UploadSnapshotsRequest;
 import com.starrocks.proto.UploadSnapshotsResponse;
+import com.starrocks.proto.VacuumFullRequest;
+import com.starrocks.proto.VacuumFullResponse;
 import com.starrocks.proto.VacuumRequest;
 import com.starrocks.proto.VacuumResponse;
 import com.starrocks.rpc.LakeService;
@@ -1183,6 +1185,11 @@ public class PseudoBackend {
 
         @Override
         public Future<VacuumResponse> vacuum(VacuumRequest request) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public Future<VacuumFullResponse> vacuumFull(VacuumFullRequest request) {
             return CompletableFuture.completedFuture(null);
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
@@ -76,6 +76,8 @@ import com.starrocks.proto.UnlockTabletMetadataRequest;
 import com.starrocks.proto.UnlockTabletMetadataResponse;
 import com.starrocks.proto.UploadSnapshotsRequest;
 import com.starrocks.proto.UploadSnapshotsResponse;
+import com.starrocks.proto.VacuumFullRequest;
+import com.starrocks.proto.VacuumFullResponse;
 import com.starrocks.proto.VacuumRequest;
 import com.starrocks.proto.VacuumResponse;
 import com.starrocks.rpc.BrpcProxy;
@@ -622,6 +624,11 @@ public class MockedBackend {
 
         @Override
         public Future<VacuumResponse> vacuum(VacuumRequest request) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public Future<VacuumFullResponse> vacuumFull(VacuumFullRequest request) {
             return CompletableFuture.completedFuture(null);
         }
     }

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -284,10 +284,11 @@ message VacuumResponse {
 }
 
 message VacuumFullRequest {
-    repeated int64 tablet_ids = 1;
-    optional int64 min_check_version = 2;
-    optional int64 max_check_version = 3;
-    optional int64 min_active_txn_id = 4;
+    optional int64 partition_id = 5; // The id of the partition to vacuum
+    repeated int64 tablet_ids = 1; // The ids of the tablets, ignore other tablets
+    optional int64 min_check_version = 2; // Ignore version < min_check_version, default 1 (set by FE)
+    optional int64 max_check_version = 3; // Ignore version >= max_check_version, default visible version
+    optional int64 min_active_txn_id = 4; // Delete txn log files with txn IDs less than min_active_txn_id
 }
 
 message VacuumFullResponse {

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -283,12 +283,16 @@ message VacuumResponse {
     repeated TabletInfoPB tablet_infos = 5;
 }
 
+// 1. Before the orphaned data file cleanup starts, VacuumFull will delete metadata files which satisfy the following:
+// (tablet_id not in request.tablet_ids OR version < min_check_version)
+// 2. Then, orphaned data files will be determined. We use min_active_txn_id to filter out new data files, then we open
+// any remaining metadata files with version <= max_check_version and note that the data files referenced are not orphans.
 message VacuumFullRequest {
     optional int64 partition_id = 5; // The id of the partition to vacuum
     repeated int64 tablet_ids = 1; // The ids of the tablets, ignore other tablets
-    optional int64 min_check_version = 2; // Ignore version < min_check_version, default 1 (set by FE)
-    optional int64 max_check_version = 3; // Ignore version >= max_check_version, default visible version
-    optional int64 min_active_txn_id = 4; // Delete txn log files with txn IDs less than min_active_txn_id
+    optional int64 min_check_version = 2; // Delete metadata files with version < min_check_version, default 1 (set by FE)
+    optional int64 max_check_version = 3; // Ignore metadata files with version >= max_check_version, default visible version
+    optional int64 min_active_txn_id = 4;
 }
 
 message VacuumFullResponse {

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -288,10 +288,15 @@ message VacuumResponse {
 // 2. Then, orphaned data files will be determined. We use min_active_txn_id to filter out new data files, then we open
 // any remaining metadata files with version <= max_check_version and note that the data files referenced are not orphans.
 message VacuumFullRequest {
-    optional int64 partition_id = 5; // The id of the partition to vacuum
-    repeated int64 tablet_ids = 1; // The ids of the tablets, ignore other tablets
-    optional int64 min_check_version = 2; // Delete metadata files with version < min_check_version, default 1 (set by FE)
-    optional int64 max_check_version = 3; // Ignore metadata files with version >= max_check_version, default visible version
+    // The id of the partition to vacuum
+    optional int64 partition_id = 5; 
+    // The ids of the tablets to consider, delete metadata for other tablets
+    repeated int64 tablet_ids = 1; 
+     // Delete metadata files with version < min_check_version, default 1 (set by FE)
+    optional int64 min_check_version = 2;
+    // Ignore metadata files with version >= max_check_version, default visible version
+    optional int64 max_check_version = 3;
+    // Don't delete files with txn_id >= min_active_txn_id
     optional int64 min_active_txn_id = 4;
 }
 


### PR DESCRIPTION
## Why I'm doing:

Disaster recovery based on cluster snapshot is implemented in StarRocks shared-data mode. The data in a cluster snapshot may be newer than the metadata version, potentially containing additional data files written after the metadata version. When a cluster is restored from a cluster snapshot, it needs to align the data with the metadata. To speed up the recovery process, only necessary data alignment is performed during the restoration. After the cluster is restored, some useless data might be left on the object storage. These useless data do not affect the normal operation of the cluster but occupy storage space unnecessarily, leading to storage waste. Full vacuum is used to delete these useless data to reclaim storage space.

## What I'm doing:

FullVacuum RPC implementation on backend
1. Before the orphaned data file cleanup starts, VacuumFull will delete metadata files which satisfy the following: (tablet_id not in request.tablet_ids OR version < min_check_version)
2. Then, orphaned data files will be determined. We use min_active_txn_id to filter out new data files, then we open any remaining metadata files with version <= max_check_version and note that the data files referenced are not orphans.

New Daemon on the frontend which triggers full vacuum on each partition every 24 hours (configurable)
1. Basically a copy of the AutoVacuumDaemon, except it triggers a different RPC and has different frequency
2. Unlike AutoVacuum, we don't broadcast requests based on tablet owners, since each RPC is handled by just a single CN (it's doing work for an entire partition, not just a set of tablets). Because it's not obvious to which CN a given request should be sent, this just does a simple balancing of work across CN, aiming to choose the CN with the fewest running full vacuums. 


TODO in a later PR: add cleanup of now-obsolete db/table/partition which no longer exist in FE metadata but are still on storage. 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
