### PR TITLE
[BugFix] Replace the old `disk_id` with `device_id` for disk instances in datacache disk monitor because the `DiskInfo::disk_id()` may return -1 in some virtualization environments. (backport #57452)

### DIFF
--- a/be/src/block_cache/datacache_utils.cpp
+++ b/be/src/block_cache/datacache_utils.cpp
@@ -15,6 +15,7 @@
 #include "block_cache/datacache_utils.h"
 
 #include <fmt/format.h>
+#include <sys/stat.h>
 
 #include <filesystem>
 
@@ -161,7 +162,7 @@ Status DataCacheUtils::change_disk_path(const std::string& old_disk_path, const 
     std::filesystem::path old_path(old_disk_path);
     std::filesystem::path new_path(new_disk_path);
     if (std::filesystem::exists(old_path)) {
-        if (DiskInfo::disk_id(old_path.c_str()) != DiskInfo::disk_id(new_path.c_str())) {
+        if (disk_device_id(old_path.c_str()) != disk_device_id(new_path.c_str())) {
             LOG(ERROR) << "fail to rename the old dataache directory [" << old_path.string() << "] to the new one ["
                        << new_path.string() << "] because they are located on different disks.";
             return Status::InternalError("The old datacache directory is different from the new one");
@@ -178,6 +179,14 @@ Status DataCacheUtils::change_disk_path(const std::string& old_disk_path, const 
         }
     }
     return Status::OK();
+}
+
+dev_t DataCacheUtils::disk_device_id(const std::string& disk_path) {
+    struct stat s;
+    if (stat(disk_path.c_str(), &s) != 0) {
+        return 0;
+    }
+    return s.st_dev;
 }
 
 } // namespace starrocks

--- a/be/src/block_cache/datacache_utils.h
+++ b/be/src/block_cache/datacache_utils.h
@@ -39,6 +39,8 @@ public:
     static void clean_residual_datacache(const std::string& disk_path);
 
     static Status change_disk_path(const std::string& old_disk_path, const std::string& new_disk_path);
+
+    static dev_t disk_device_id(const std::string& disk_path);
 };
 
 } // namespace starrocks

--- a/be/src/block_cache/disk_space_monitor.h
+++ b/be/src/block_cache/disk_space_monitor.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <sys/stat.h>
+
 #include <atomic>
 #include <mutex>
 #include <thread>
@@ -30,10 +32,10 @@ class BlockCache;
 class DiskSpaceMonitor {
 public:
     struct DiskStats {
-        int disk_id = 0;
+        dev_t device_id = 0;
         std::string path;
-        size_t capacity_bytes = 0;
-        size_t available_bytes = 0;
+        int64_t capacity_bytes = 0;
+        int64_t available_bytes = 0;
     };
 
     // Wrap a new class to make it easy controlled in unittest.
@@ -43,7 +45,7 @@ public:
 
         virtual StatusOr<size_t> directory_size(const std::string& dir);
 
-        virtual int disk_id(const std::string& path) { return DiskInfo::disk_id(path.c_str()); }
+        virtual dev_t device_id(const std::string& path);
 
         virtual ~FileSystemWrapper() {}
     };
@@ -90,12 +92,12 @@ private:
     }
 
     std::vector<DirSpace> _dir_spaces;
-    // <disk_id, DiskStats>
-    std::unordered_map<int, DiskStats> _disk_stats;
+    // <device_id, DiskStats>
+    std::unordered_map<dev_t, DiskStats> _disk_stats;
 
     // The datacache can be configured to have multiple data directories on the same physical disk.
-    // <disk_id, dir_space_index_list>
-    std::unordered_map<int, std::vector<uint32_t>> _disk_to_dirs;
+    // <device_id, dir_space_index_list>
+    std::unordered_map<dev_t, std::vector<uint32_t>> _disk_to_dirs;
     // Max directory count in one disk
     size_t _max_disk_dirs = 0;
     // Minimum directory count in one disk

--- a/be/src/block_cache/starcache_wrapper.cpp
+++ b/be/src/block_cache/starcache_wrapper.cpp
@@ -54,7 +54,7 @@ Status StarCacheWrapper::init(const CacheOptions& options) {
 
     _enable_tiered_cache = options.enable_tiered_cache;
     _enable_datacache_persistence = options.enable_datacache_persistence;
-    _cache = std::make_unique<starcache::StarCache>();
+    _cache = std::make_shared<starcache::StarCache>();
     return to_status(_cache->init(opt));
 }
 


### PR DESCRIPTION
## Why I'm doing:
Now we use disk_id to distinguish different disks in datacache disk monitor. However, sometime the `DiskInfo::disk_id()` may return -1 in some virtualization environments, this may cause some unexpected behavior.

## What I'm doing:
* We use the device_id to replace the disk_id to distinguish different disks, it is easy to obtain and more stable.
* Add validation for new cache quota to avoid it exceeding the expected range.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1

