### PR TITLE
[BugFix] fix two level hash map lose null value

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1631,5 +1631,5 @@ CONF_mInt32(big_query_sec, "1");
 CONF_mInt64(split_exchanger_buffer_chunk_num, "1000");
 
 // when to split hashmap/hashset into two level hashmap/hashset, negative number means use default value
-CONF_mInt16(two_level_memory_threshold,"-1");
+CONF_mInt16(two_level_memory_threshold, "-1");
 } // namespace starrocks::config

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1631,5 +1631,5 @@ CONF_mInt32(big_query_sec, "1");
 CONF_mInt64(split_exchanger_buffer_chunk_num, "1000");
 
 // when to split hashmap/hashset into two level hashmap/hashset, negative number means use default value
-CONF_mInt16(two_level_memory_threshold, "-1");
+CONF_mInt64(two_level_memory_threshold, "-1");
 } // namespace starrocks::config

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1629,4 +1629,7 @@ CONF_mInt64(rf_branchless_ratio, "8");
 CONF_mInt32(big_query_sec, "1");
 
 CONF_mInt64(split_exchanger_buffer_chunk_num, "1000");
+
+// when to split hashmap/hashset into two level hashmap/hashset, negative number means use default value
+CONF_mInt16(two_level_memory_threshold,"-1");
 } // namespace starrocks::config

--- a/be/src/exec/aggregate/agg_hash_map.h
+++ b/be/src/exec/aggregate/agg_hash_map.h
@@ -152,6 +152,8 @@ struct AggHashMapWithOneNumberKeyWithNullable
 
     AggDataPtr get_null_key_data() { return null_key_data; }
 
+    void set_null_key_data(AggDataPtr data) { null_key_data = data; }
+
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
     void compute_agg_states(size_t chunk_size, const Columns& key_columns, MemPool* pool, Func&& allocate_func,
                             Buffer<AggDataPtr>* agg_states, Filter* not_founds) {
@@ -370,6 +372,8 @@ struct AggHashMapWithOneStringKeyWithNullable
     AggHashMapWithOneStringKeyWithNullable(Args&&... args) : Base(std::forward<Args>(args)...) {}
 
     AggDataPtr get_null_key_data() { return null_key_data; }
+
+    void set_null_key_data(AggDataPtr data) { null_key_data = data; }
 
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
     void compute_agg_states(size_t chunk_size, const Columns& key_columns, MemPool* pool, Func&& allocate_func,
@@ -605,6 +609,7 @@ struct AggHashMapWithSerializedKey : public AggHashMapWithKey<HashMap, AggHashMa
               _chunk_size(chunk_size) {}
 
     AggDataPtr get_null_key_data() { return nullptr; }
+    void set_null_key_data(AggDataPtr data) {}
 
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
     void compute_agg_states(size_t chunk_size, const Columns& key_columns, MemPool* pool, Func&& allocate_func,
@@ -853,6 +858,7 @@ struct AggHashMapWithSerializedKeyFixedSize
     }
 
     AggDataPtr get_null_key_data() { return nullptr; }
+    void set_null_key_data(AggDataPtr data) {}
 
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
     ALWAYS_NOINLINE void compute_agg_prefetch(size_t chunk_size, const Columns& key_columns,

--- a/be/src/exec/aggregate/agg_hash_set.h
+++ b/be/src/exec/aggregate/agg_hash_set.h
@@ -192,6 +192,7 @@ struct AggHashSetOfOneNumberKey : public AggHashSet<HashSet, AggHashSetOfOneNumb
     }
 
     static constexpr bool has_single_null_key = false;
+    bool has_null_key = false;
     ResultVector results;
     std::vector<size_t> hashes;
 };
@@ -382,6 +383,7 @@ struct AggHashSetOfOneStringKey : public AggHashSet<HashSet, AggHashSetOfOneStri
     }
 
     static constexpr bool has_single_null_key = false;
+    bool has_null_key = false;
     ResultVector results;
     std::vector<KeyType> cache;
 };
@@ -621,6 +623,7 @@ struct AggHashSetOfSerializedKey : public AggHashSet<HashSet, AggHashSetOfSerial
     }
 
     static constexpr bool has_single_null_key = false;
+    bool has_null_key = false;
 
     Buffer<uint32_t> slice_sizes;
     size_t max_one_row_size = 8;
@@ -742,6 +745,7 @@ struct AggHashSetOfSerializedKeyFixedSize : public AggHashSet<HashSet, AggHashSe
     }
 
     static constexpr bool has_single_null_key = false;
+    bool has_null_key = false;
 
     Buffer<uint32_t> slice_sizes;
     std::unique_ptr<MemPool> _mem_pool;

--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -1099,14 +1099,14 @@ Status Aggregator::output_chunk_by_streaming_with_selection(Chunk* input_chunk, 
 
 void Aggregator::try_convert_to_two_level_map() {
     auto current_size = _hash_map_variant.reserved_memory_usage(mem_pool());
-    if (current_size > two_level_memory_threshold) {
+    if (current_size > get_two_level_threahold()) {
         _hash_map_variant.convert_to_two_level(_state);
     }
 }
 
 void Aggregator::try_convert_to_two_level_set() {
     auto current_size = _hash_set_variant.reserved_memory_usage(mem_pool());
-    if (current_size > two_level_memory_threshold) {
+    if (current_size > get_two_level_threahold()) {
         _hash_set_variant.convert_to_two_level(_state);
     }
 }

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -596,6 +596,13 @@ protected:
     Status _create_aggregate_function(starrocks::RuntimeState* state, const TFunction& fn, bool is_result_nullable,
                                       const AggregateFunction** ret);
 
+    int64_t get_two_level_threahold() {
+        if (config::two_level_memory_threshold < 0) {
+            return two_level_memory_threshold;
+        }
+        return config::two_level_memory_threshold;
+    }
+
     template <class HashMapWithKey>
     friend struct AllocateState;
 };

--- a/test/sql/test_agg/R/test_agg_split_two_phase
+++ b/test/sql/test_agg/R/test_agg_split_two_phase
@@ -1,0 +1,24 @@
+-- name: test_agg_split_two_phase
+create table t0 (
+    c0 STRING,
+    c1 STRING
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 3 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t0 SELECT generate_series, generate_series FROM TABLE(generate_series(1,  1500));
+-- result:
+-- !result
+insert into t0 SELECT generate_series, NULL FROM TABLE(generate_series(1,  1500));
+-- result:
+-- !result
+update information_schema.be_configs set value = "0" where name= "two_level_memory_threshold";
+-- result:
+-- !result
+select c1 from t0 where c1 is null group by c1;
+-- result:
+None
+-- !result
+select c1, count(*) from t0 where c1 is null group by c1;
+-- result:
+None	1500
+-- !result

--- a/test/sql/test_agg/T/test_agg_split_two_phase
+++ b/test/sql/test_agg/T/test_agg_split_two_phase
@@ -1,0 +1,13 @@
+-- name: test_agg_split_two_phase
+create table t0 (
+    c0 STRING,
+    c1 STRING
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 3 PROPERTIES('replication_num' = '1');
+
+insert into t0 SELECT generate_series, generate_series FROM TABLE(generate_series(1,  1500));
+insert into t0 SELECT generate_series, NULL FROM TABLE(generate_series(1,  1500));
+update information_schema.be_configs set value = "0" where name= "two_level_memory_threshold";
+
+select c1 from t0 where c1 is null group by c1;
+select c1, count(*) from t0 where c1 is null group by c1;
+


### PR DESCRIPTION
## Why I'm doing:
fix https://github.com/StarRocks/StarRocksTest/issues/9526
introduced by https://github.com/StarRocks/starrocks/pull/57268

## What I'm doing:
when split hashmap/set into two phase hashmap/set, keep null value

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
