### PR TITLE
[Enhancement] add query progress api to show execute progress

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
@@ -80,6 +80,7 @@ import com.starrocks.http.rest.OAuth2Action;
 import com.starrocks.http.rest.ProfileAction;
 import com.starrocks.http.rest.QueryDetailAction;
 import com.starrocks.http.rest.QueryDumpAction;
+import com.starrocks.http.rest.QueryProgressAction;
 import com.starrocks.http.rest.RowCountAction;
 import com.starrocks.http.rest.SetConfigAction;
 import com.starrocks.http.rest.ShowDataAction;
@@ -196,6 +197,7 @@ public class HttpServer {
         ColocateMetaService.UpdateGroupAction.registerAction(controller);
         GlobalDictMetaService.ForbitTableAction.registerAction(controller);
         ProfileAction.registerAction(controller);
+        QueryProgressAction.registerAction(controller);
         QueryDetailAction.registerAction(controller);
         ConnectionAction.registerAction(controller);
         ShowDataAction.registerAction(controller);

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/QueryProgressAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/QueryProgressAction.java
@@ -1,0 +1,101 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/http/rest/ProfileAction.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.http.rest;
+
+import com.starrocks.common.util.CompressionUtils;
+import com.starrocks.common.util.ProfileManager;
+import com.starrocks.common.util.RuntimeProfileParser;
+import com.starrocks.http.ActionController;
+import com.starrocks.http.BaseRequest;
+import com.starrocks.http.BaseResponse;
+import com.starrocks.http.IllegalArgException;
+import com.starrocks.sql.ExplainAnalyzer;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+// This class is a RESTFUL interface to get query progress.
+// It will be used in query monitor.
+// Usage:
+//   http://fe_host:fe_http_port/api/query/progress?query_id=123456
+public class QueryProgressAction extends RestBaseAction {
+
+    private static final Logger LOG = LogManager.getLogger(QueryProgressAction.class);
+
+    public QueryProgressAction(ActionController controller) {
+        super(controller);
+    }
+
+    public static void registerAction(ActionController controller) throws IllegalArgException {
+        controller.registerHandler(HttpMethod.GET, "/api/query/progress", new QueryProgressAction(controller));
+    }
+
+    @Override
+    public void execute(BaseRequest request, BaseResponse response) {
+        String queryId = request.getSingleParameter("query_id");
+        if (queryId == null) {
+            response.getContent().append("not valid parameter");
+            sendResult(request, response, HttpResponseStatus.BAD_REQUEST);
+            return;
+        }
+
+        ProfileManager.ProfileElement profileElement = ProfileManager.getInstance().getProfileElement(queryId);
+        if (profileElement != null) {
+            String result = "";
+            //For short circuit query, 'ProfileElement#plan' is null
+            if (profileElement.plan == null &&
+                    profileElement.infoStrings.get(ProfileManager.QUERY_TYPE) != null &&
+                    !profileElement.infoStrings.get(ProfileManager.QUERY_TYPE).equals("Load")) {
+                result = "short circuit point query doesn't suppot get query progress, " +
+                        "you can set it off by using set enable_short_circuit=false";
+            } else {
+                try {
+                    result = ExplainAnalyzer.analyze(profileElement.plan,
+                            RuntimeProfileParser.parseFrom(
+                                    CompressionUtils.gzipDecompressString(profileElement.profileContent)));
+                } catch (Exception e) {
+                    result = "Failed to get query progress, query_id:" + queryId;
+                    LOG.warn(result, e);
+                }
+            }
+            response.getContent().append(result);
+            sendResult(request, response);
+        } else {
+            response.getContent().append("query id " + queryId + " not found.");
+            sendResult(request, response, HttpResponseStatus.NOT_FOUND);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/http/QueryProgressActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/QueryProgressActionTest.java
@@ -1,0 +1,153 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http;
+
+import com.google.gson.JsonObject;
+import com.starrocks.common.StarRocksException;
+import com.starrocks.common.util.ProfileManager;
+import com.starrocks.common.util.ProfilingExecPlan;
+import com.starrocks.common.util.RuntimeProfile;
+import com.starrocks.sql.ExplainAnalyzer;
+import mockit.Mock;
+import mockit.MockUp;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class QueryProgressActionTest extends StarRocksHttpTestCase {
+
+    static RuntimeProfile profile;
+    static RuntimeProfile summaryProfile;
+    static ProfileManager manager;
+    static ProfilingExecPlan plan = new ProfilingExecPlan();
+    //init profile manager, only contains a query: 123
+    static {
+        profile = new RuntimeProfile("");
+        summaryProfile = new RuntimeProfile("Summary");
+        summaryProfile.addInfoString(ProfileManager.QUERY_ID, "123");
+        summaryProfile.addInfoString(ProfileManager.QUERY_TYPE, "Query");
+        summaryProfile.addInfoString(ProfileManager.QUERY_STATE, "Running");
+        profile.addChild(summaryProfile);
+
+        manager = ProfileManager.getInstance();
+        manager.pushProfile(plan, profile);
+    }
+
+    private String sendHttp(String queryId) throws IOException {
+        Request request = new Request.Builder()
+                .get()
+                .addHeader("Authorization", rootAuth)
+                .url(BASE_URL + "/api/query/progress?query_id=" + queryId)
+                .build();
+        Response response = networkClient.newCall(request).execute();
+        String respStr = response.body().string();
+        return respStr;
+    }
+
+    @Test
+    public void testQueryProgressAction() throws IOException {
+        //note: in the ExplainAnalyzer, the internal class NodeInfo and NodeState is private,
+        //      here can't mockup parseProfile function, so mockup getQueryProgress function.
+        new MockUp<ExplainAnalyzer>() {
+            //@Mock
+            //public void parseProfile() {
+            //    ExplainAnalyzer.NodeInfo nodeInfo1 = new ExplainAnalyzer.NodeInfo(true, 1, true, null, null, null);
+            //    ExplainAnalyzer.NodeInfo nodeInfo2 = new ExplainAnalyzer.NodeInfo(true, 2, true, null, null, null);
+            //    ExplainAnalyzer.NodeInfo nodeInfo3 = new ExplainAnalyzer.NodeInfo(true, 3, true, null, null, null);
+            //    ExplainAnalyzer.NodeInfo nodeInfo4 = new ExplainAnalyzer.NodeInfo(true, 4, true, null, null, null);
+            //    ExplainAnalyzer.NodeInfo nodeInfo5 = new ExplainAnalyzer.NodeInfo(true, 5, true, null, null, null);
+            //
+            //    nodeInfo1.setState(NodeState.FINISHED);
+            //    nodeInfo2.setState(NodeState.FINISHED);
+            //    nodeInfo3.setState(NodeState.FINISHED);
+            //    nodeInfo4.setState(NodeState.RUNNING);
+            //    nodeInfo5.setState(NodeState.RUNNING);
+            //
+            //    Map<Integer, ExplainAnalyzer.NodeInfo> allNodeInfos = Maps.newHashMap();
+            //    allNodeInfos.put(nodeInfo1);
+            //    allNodeInfos.put(nodeInfo2);
+            //    allNodeInfos.put(nodeInfo3);
+            //    allNodeInfos.put(nodeInfo4);
+            //    allNodeInfos.put(nodeInfo5);
+            //}
+            //};
+            @Mock
+            public String getQueryProgress() throws StarRocksException {
+                try {
+                    JsonObject progressInfo = new JsonObject();
+                    progressInfo.addProperty("total_operator_num", 5);
+                    progressInfo.addProperty("finished_operator_num", 3);
+                    progressInfo.addProperty("progress_percent", "60.00%");
+
+                    JsonObject result = new JsonObject();
+                    result.addProperty("query_id", summaryProfile.getInfoString(manager.QUERY_ID));
+                    result.addProperty("state", summaryProfile.getInfoString(manager.QUERY_STATE));
+                    result.add("progress_info", progressInfo);
+                    return result.toString();
+                } catch (Exception e) {
+                    throw new StarRocksException("Failed to get query progress.");
+                }
+            }
+        };
+        new MockUp<ProfileManager>() {
+            @Mock
+            public ProfileManager.ProfileElement getProfileElement(String queryId) {
+                //return summaryProfile.getInfoString(ProfileManager.QUERY_ID).equals(queryId)
+                //                      ? manager.getAllProfileElements().get(0) : null;
+                return manager.hasProfile(queryId) ? manager.getAllProfileElements().get(0) : null;
+            }
+        };
+
+        //1.check query progress result
+        String existQueryId = "123";
+        String respStr1 = sendHttp(existQueryId);
+        String expResult = "{\"query_id\":\"123\",\"state\":\"Running\",\"progress_info\"" +
+                ":{\"total_operator_num\":5,\"finished_operator_num\":3,\"progress_percent\":\"60.00%\"}}";
+        Assert.assertEquals(respStr1, expResult);
+
+        //2.check query id not found
+        String notExistQueryId = "456";
+        String respStr2 = sendHttp(notExistQueryId);
+        Assert.assertTrue(respStr2.contains("query id 456 not found"));
+
+        //3.check not valid parameter
+        Request request = new Request.Builder()
+                .get()
+                .addHeader("Authorization", rootAuth)
+                .url(BASE_URL + "/api/query/progress?query_id_x=" + existQueryId)
+                .build();
+        Response response = networkClient.newCall(request).execute();
+        String respStr3 = response.body().string();
+        Assert.assertTrue(respStr3.contains("not valid parameter"));
+
+        //4.check short circuit point query
+        //for short circuit query, 'ProfileElement#plan' is null
+        manager.pushProfile(null, profile);
+        String respStr4 = sendHttp(existQueryId);
+        Assert.assertTrue(respStr4.contains("short circuit point query doesn't suppot get query progress"));
+        manager.pushProfile(plan, profile);
+
+        //5.check abnormal case, eg.summaryProfile is null
+        //manager.pushProfile(null, profile);
+        //manager.getProfileElement(existQueryId).infoStrings.put(ProfileManager.QUERY_TYPE, "Load");
+        //String queryType = manager.getProfileElement(existQueryId).infoStrings.get(ProfileManager.QUERY_TYPE);
+        summaryProfile = null;
+        String respStr5 = sendHttp(existQueryId);
+        Assert.assertTrue(respStr5.contains("Failed to get query progress"));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
When query takes a long time to execute and there is no way to know the progress, it is not user-friendly.

## What I'm doing:
Based on current runtime profile functionality, th PR implements a query progress api. 
usage: `http://fe_host:fe_http_port/api/query/progress?query_id=xxx`
statistical logic: `finished operator num / all operator num`
the return value example is as follows:
```
{
    "query_id": "5b58db65-1847-11f0-a3d8-fa163e7b32c6",
    "state": "Running",
    "progress_info": {
        "total_operator_num": 23,
        "finished_operator_num": 19,
        "progress_percent": "82.61%"
    }
}
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
