### PR TITLE
[BugFix] fix AggregateJoinPushDownRule can't apply to subquery

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewPushDownRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewPushDownRewriter.java
@@ -97,7 +97,7 @@ public class AggregatedMaterializedViewPushDownRewriter extends MaterializedView
             Optional<OptExpression> res = rewriteInfo.getOp();
             logMVRewrite(mvContext, "AggregateJoin pushdown rewrite success");
             OptExpression result = res.get();
-            setOptScanOpsHavePushDown(result);
+            setOpHasPushDown(result);
             return result;
         } else {
             logMVRewrite(mvContext, "AggregateJoin pushdown rewrite failed");
@@ -139,11 +139,6 @@ public class AggregatedMaterializedViewPushDownRewriter extends MaterializedView
         }
         deriveLogicalProperty(newQueryInput);
         return newQueryInput;
-    }
-
-    public static void setOptScanOpsHavePushDown(OptExpression input) {
-        List<LogicalScanOperator> scanOps = MvUtils.getScanOperator(input);
-        scanOps.stream().forEach(op -> op.setOpRuleMask(op.getOpRuleMask() | Operator.OP_PUSH_DOWN_BIT));
     }
 
     public static void setOpHasPushDown(OptExpression input) {


### PR DESCRIPTION
## Why I'm doing:

AggregateJoinPushDownRule can't apply to `test_pt2` in this sql. This bug has been fix in main/3.4 branch in #52234
 
```sql
SELECT sum(gmv)
FROM test_pt1 where id in (
    SELECT distinct id
	FROM test_pt2
	where test_pt2.id IN (
		 SELECT '1' FROM test_alias 
	)
);
```

`test_pt1` has related mv `test_pt1_mv`.
`test_pt2` has related mv `test_pt2_mv`

`test_pt1_mv` is hit, but `test_pt2_mv` is not.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1

