### PR TITLE
[BugFix] Disable to create materialized view if base table is partiitoned by from_unixtime

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -41,6 +41,7 @@ import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.ExpressionRangePartitionInfoV2;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.IcebergTable;
@@ -1165,6 +1166,16 @@ public class MaterializedViewAnalyzer {
                             "must be base table partition column");
                 }
                 partitionColumns.forEach(partitionColumn1 -> checkPartitionColumnType(partitionColumn1));
+                // disable from_unix_time/cast for creating materialized view
+                if (rangePartitionInfo instanceof ExpressionRangePartitionInfoV2) {
+                    ExpressionRangePartitionInfoV2 rangePartitionInfoV2 = (ExpressionRangePartitionInfoV2) rangePartitionInfo;
+                    if (rangePartitionInfoV2.getPartitionColumnIdExprs().size() != 1) {
+                        throw new SemanticException("Materialized view related base table partition columns " +
+                                "only supports single column");
+                    }
+                    Expr partitionColumnExpr = rangePartitionInfoV2.getPartitionColumnIdExprs().get(0).getExpr();
+                    checkBaseTableSupportedPartitionFunc(partitionColumnExpr, table);
+                }
             } else if (partitionInfo.isListPartition()) {
                 ListPartitionInfo listPartitionInfo = (ListPartitionInfo) partitionInfo;
                 Set<String> partitionColumns = listPartitionInfo.getPartitionColumns(table.getIdToColumn()).stream()
@@ -1178,6 +1189,30 @@ public class MaterializedViewAnalyzer {
             } else {
                 throw new SemanticException("Materialized view related base table partition type: " +
                         partitionInfo.getType().name() + " not supports");
+            }
+        }
+
+        /**
+         * Check if the partition function of base table is supported.
+         * @param partitionByExpr : base table's partition function
+         * @param table : base table
+         */
+        private void checkBaseTableSupportedPartitionFunc(Expr partitionByExpr,
+                                                          OlapTable table) {
+            if (partitionByExpr instanceof SlotRef) {
+                // do nothing
+            } else if (partitionByExpr instanceof FunctionCallExpr) {
+                FunctionCallExpr functionCallExpr = (FunctionCallExpr) partitionByExpr;
+                String functionName = functionCallExpr.getFnName().getFunction();
+                if (!PartitionFunctionChecker.FN_NAME_TO_PATTERN.containsKey(functionName)) {
+                    throw new SemanticException(String.format("Materialized view partition function derived from " +
+                            functionName + " of base table %s is not supported yet", table.getName()),
+                            functionCallExpr.getPos());
+                }
+            } else {
+                throw new SemanticException(String.format("Materialized view partition function derived from " +
+                        partitionByExpr.toSql() + " of base table %s is not supported yet", table.getName()),
+                        partitionByExpr.getPos());
             }
         }
 


### PR DESCRIPTION
## Why I'm doing:
Create  MV with `from_unixtime` is ok but refresh mv will fail:
```
CREATE TABLE t1 (
        sku_id varchar(100),
        total_amount decimal,
        id int,
        create_time int
)
PARTITION BY RANGE(from_unixtime(create_time))(
START ("2021-01-01") END ("2021-01-10") EVERY (INTERVAL 1 DAY)
);
insert into t1 values ("1", 2, 3, 1609516800);
create materialized view mv1 refresh manual partition by create_time as select id,create_time from t1;
```
![image](https://github.com/user-attachments/assets/1b8e32b3-13ac-462f-8f10-c09907fef2f7)

## What I'm doing:
- Disable to create mv if base table is partitioned by `from_unixtime`


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
