### PR TITLE
[Refactor] Refactor the DiskSpaceMonitor for subsequent modifications

### DIFF
--- a/be/src/cache/block_cache/disk_space_monitor.cpp
+++ b/be/src/cache/block_cache/disk_space_monitor.cpp
@@ -31,31 +31,21 @@ const size_t DiskSpace::kQuotaAlignUnit = 10uL * 1024 * 1024;
 const double DiskSpace::kAutoIncreaseThreshold = 0.9;
 
 Status DiskSpace::init_spaces(const std::vector<DirSpace>& dir_spaces) {
+    _dir_spaces = dir_spaces;
     Status st = _update_disk_stats();
     if (!st.ok()) {
         LOG(ERROR) << "fail to init disk space, reason: " << st.message();
         return st;
     }
-    _dir_spaces = dir_spaces;
+    _update_disk_options();
 
-    // Revise the original disk space state.
-    // The disk space occupied by old datacache files should be excluded because these space can
-    // be reused by datacache .
-    _revise_disk_stats_by_cache_dir();
-
-    // We check this switch after some infomation are initialized, because even if it is off now,
-    // we still need these infomation once the switch is turn on online.
+    // We check this switch after some information are initialized, because even if it is off now,
+    // we still need this information once the switch is turn on online.
     if (!config::datacache_auto_adjust_enable) {
         return st;
     }
 
-    int64_t other_usage = _disk_stats.used_bytes();
-    int64_t cache_quota = _disk_stats.capacity_bytes * 0.01 * config::datacache_disk_safe_level - other_usage;
-    if (cache_quota > 0) {
-        cache_quota = _check_cache_limit(cache_quota);
-    } else {
-        cache_quota = 0;
-    }
+    int64_t cache_quota = _calc_new_cache_quota(_cache_file_space_usage());
     _update_spaces_by_cache_quota(cache_quota);
     return st;
 }
@@ -66,22 +56,19 @@ bool DiskSpace::adjust_spaces(const AdjustContext& ctx) {
         LOG(ERROR) << "fail to check and adjust cache disk spaces, reason: " << st.message();
         return false;
     }
+    _update_disk_options();
 
-    double used_rate = _disk_stats.used_rate();
-    int64_t cur_level = static_cast<int64_t>(used_rate * 100);
-    if (cur_level < config::datacache_disk_low_level) {
-        _disk_free_period += config::datacache_disk_adjust_interval_seconds;
+    if (_disk_stats.used_bytes() < _disk_opts.low_level_size) {
+        _disk_free_period += _disk_opts.adjust_interval_s;
         if (!_allow_expansion(ctx)) {
             return false;
         }
-    } else if (cur_level <= config::datacache_disk_high_level) {
+    } else if (_disk_stats.used_bytes() <= _disk_opts.high_level_size) {
         return false;
     }
 
     int64_t old_cache_quota = cache_quota();
-    int64_t other_usage = _disk_stats.used_bytes() - _cache_usage(ctx);
-    int64_t new_cache_quota = _disk_stats.capacity_bytes * 0.01 * config::datacache_disk_safe_level - other_usage;
-    new_cache_quota = _check_cache_limit(new_cache_quota);
+    int64_t new_cache_quota = _calc_new_cache_quota(_cache_usage(ctx));
     _update_spaces_by_cache_quota(new_cache_quota);
 
     _disk_free_period = 0;
@@ -105,23 +92,33 @@ Status DiskSpace::_update_disk_stats() {
     auto& space_info = ret.value();
     _disk_stats.capacity_bytes = space_info.capacity;
     _disk_stats.available_bytes = space_info.available;
-    VLOG(2) << "Get disk statistics, capaticy: " << _disk_stats.capacity_bytes
-            << ", available: " << _disk_stats.available_bytes << ", used_rate: " << _disk_stats.used_rate();
+    VLOG(2) << "Get disk statistics, capacity: " << _disk_stats.capacity_bytes
+            << ", available: " << _disk_stats.available_bytes << ", used_bytes: " << _disk_stats.used_bytes();
 
     return Status::OK();
 }
 
-void DiskSpace::_revise_disk_stats_by_cache_dir() {
+size_t DiskSpace::_cache_file_space_usage() {
+    size_t size = 0;
     for (auto& dir : _dir_spaces) {
         auto ret = _fs->directory_size(dir.path);
-        if (ret.ok() && ret.value() > 0) {
-            // The space under datacache directories can be reused, so ignore their usage.
-            _disk_stats.available_bytes += ret.value();
-            if (_disk_stats.available_bytes > _disk_stats.capacity_bytes) {
-                _disk_stats.available_bytes = _disk_stats.capacity_bytes;
-            }
+        if (ret.ok()) {
+            size += ret.value();
         }
     }
+    if (size > _disk_stats.capacity_bytes) {
+        size = _disk_stats.capacity_bytes;
+    }
+    return size;
+}
+
+void DiskSpace::_update_disk_options() {
+    _disk_opts.cache_lower_limit = config::datacache_min_disk_quota_for_adjustment;
+    _disk_opts.low_level_size = _disk_stats.capacity_bytes * 0.01 * config::datacache_disk_low_level;
+    _disk_opts.safe_level_size = _disk_stats.capacity_bytes * 0.01 * config::datacache_disk_safe_level;
+    _disk_opts.high_level_size = _disk_stats.capacity_bytes * 0.01 * config::datacache_disk_high_level;
+    _disk_opts.adjust_interval_s = config::datacache_disk_adjust_interval_seconds;
+    _disk_opts.idle_for_expansion_s = config::datacache_disk_idle_seconds_for_expansion;
 }
 
 void DiskSpace::_update_spaces_by_cache_quota(size_t cache_avail_bytes) {
@@ -142,8 +139,20 @@ size_t DiskSpace::_cache_usage(const AdjustContext& ctx) {
     return usage;
 }
 
+size_t DiskSpace::_calc_new_cache_quota(size_t cur_cache_usage) {
+    int64_t other_usage = _disk_stats.used_bytes() - cur_cache_usage;
+    int64_t new_cache_quota = _disk_opts.safe_level_size - other_usage;
+    if (new_cache_quota > 0) {
+        new_cache_quota = _check_cache_limit(new_cache_quota);
+    } else {
+        new_cache_quota = 0;
+    }
+
+    return new_cache_quota;
+}
+
 bool DiskSpace::_allow_expansion(const AdjustContext& ctx) {
-    if (_disk_free_period < config::datacache_disk_idle_seconds_for_expansion) {
+    if (_disk_free_period < _disk_opts.idle_for_expansion_s) {
         return false;
     }
     if (ctx.total_cache_quota > 0) {
@@ -164,7 +173,7 @@ size_t DiskSpace::_check_cache_limit(int64_t cache_quota) {
 }
 
 size_t DiskSpace::_check_cache_low_limit(int64_t cache_quota) {
-    if (cache_quota < config::datacache_min_disk_quota_for_adjustment) {
+    if (cache_quota < _disk_opts.cache_lower_limit) {
         if (_disabled) {
             // If the cache quata is already disabled, skip adjusting it repeatedly.
             VLOG(1) << "Skip updating the disk cache quota because the target quota is less than"
@@ -183,21 +192,19 @@ size_t DiskSpace::_check_cache_low_limit(int64_t cache_quota) {
 }
 
 size_t DiskSpace::_check_cache_high_limit(int64_t cache_quota) {
-    size_t high_limit = _disk_stats.capacity_bytes * config::datacache_disk_safe_level * 0.01;
-    if (cache_quota > high_limit) {
+    if (cache_quota > _disk_opts.safe_level_size) {
         LOG(INFO) << "Correct the cache quota because it reaches the high limit. quota: " << cache_quota;
-        return high_limit;
+        cache_quota = _disk_opts.safe_level_size;
     }
     return cache_quota;
 }
 
 StatusOr<size_t> DiskSpace::FileSystemWrapper::directory_size(const std::string& dir) {
     size_t capacity = 0;
-    auto st = FileSystem::Default()->iterate_dir2(dir, [&](DirEntry entry) {
+    RETURN_IF_ERROR(FileSystem::Default()->iterate_dir2(dir, [&](DirEntry entry) {
         capacity += entry.size.value();
         return true;
-    });
-    RETURN_IF_ERROR(st);
+    }));
     return capacity;
 }
 
@@ -230,9 +237,8 @@ Status DiskSpaceMonitor::init(std::vector<DirSpace>* dir_spaces) {
 
     _disk_spaces.clear();
     for (auto& disk2spaces : disk_to_dir_spaces) {
-        auto& device_id = disk2spaces.first;
         auto& dirs = disk2spaces.second;
-        _disk_spaces.emplace_back(device_id, dirs[0].path, _fs);
+        _disk_spaces.emplace_back(dirs[0].path, _fs);
         auto& disk_space = _disk_spaces.back();
         RETURN_IF_ERROR(disk_space.init_spaces(dirs));
     }


### PR DESCRIPTION
## Why I'm doing:

* Merge the duplicate code for calc new cache quota.
* Unify the configurations required by the `DiskSpaceMonitor` to facilitate subsequent modifications and the addition of new configurations.
* Remove unused item `_device_id`.
* Use size instead of rate to check disk usage.

## What I'm doing:

Refactor the DiskSpaceMonitor for subsequent modifications

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
