### PR TITLE
[Feature] Stream Load/Routine Load support lambda expression

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/Load.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/Load.java
@@ -84,7 +84,9 @@ import com.starrocks.sql.analyzer.Scope;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.DataDescription;
 import com.starrocks.sql.ast.ImportColumnDesc;
+import com.starrocks.sql.ast.LambdaArgument;
 import com.starrocks.sql.ast.UserIdentity;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.thrift.TBrokerScanRangeParams;
 import com.starrocks.thrift.TFileFormatType;
 import com.starrocks.thrift.TOpType;
@@ -102,6 +104,7 @@ import java.util.stream.Collectors;
 import static com.starrocks.catalog.DefaultExpr.SUPPORTED_DEFAULT_FNS;
 import static com.starrocks.common.ErrorCode.ERR_EXPR_REFERENCED_COLUMN_NOT_FOUND;
 import static com.starrocks.common.ErrorCode.ERR_MAPPING_EXPR_INVALID;
+import static com.starrocks.sql.common.UnsupportedException.unsupportedException;
 
 public class Load {
     private static final Logger LOG = LogManager.getLogger(Load.class);
@@ -650,7 +653,7 @@ public class Load {
             // 1. analyze all exprs using varchar type
             Map<String, Expr> copiedExprsByName = Maps.newHashMap(exprsByName);
             Map<String, Expr> copiedMvDefineExpr = Maps.newHashMap(mvDefineExpr);
-            analyzeMappingExprs(tbl, analyzer, copiedExprsByName, copiedMvDefineExpr,
+            analyzeMappingExprs(tbl, analyzer, srcTupleDesc, copiedExprsByName, copiedMvDefineExpr,
                     slotDescByName, useVectorizedLoad);
 
             // 2. replace src slot desc with cast return type after expr analyzed
@@ -658,7 +661,7 @@ public class Load {
         }
 
         // 3. reanalyze all exprs using new type in vectorized load or using varchar in old load
-        analyzeMappingExprs(tbl, analyzer, exprsByName, mvDefineExpr, slotDescByName, useVectorizedLoad);
+        analyzeMappingExprs(tbl, analyzer, srcTupleDesc, exprsByName, mvDefineExpr, slotDescByName, useVectorizedLoad);
         LOG.debug("after init column, exprMap: {}", exprsByName);
     }
 
@@ -764,9 +767,9 @@ public class Load {
         }
     }
 
-    private static void analyzeMappingExprs(Table tbl, Analyzer analyzer, Map<String, Expr> exprsByName,
-                                            Map<String, Expr> mvDefineExpr, Map<String, SlotDescriptor> slotDescByName,
-                                            boolean useVectorizedLoad) throws StarRocksException {
+    private static void analyzeMappingExprs(Table tbl, Analyzer analyzer, TupleDescriptor srcTupleDesc,
+                Map<String, Expr> exprsByName, Map<String, Expr> mvDefineExpr,
+                Map<String, SlotDescriptor> slotDescByName, boolean useVectorizedLoad) throws StarRocksException {
         for (Map.Entry<String, Expr> entry : exprsByName.entrySet()) {
             // only for normal column here
             if (tbl.getColumn(entry.getKey()) != null && tbl.getColumn(entry.getKey()).isGeneratedColumn()) {
@@ -776,9 +779,17 @@ public class Load {
             ExprSubstitutionMap smap = new ExprSubstitutionMap();
             List<SlotRef> slots = Lists.newArrayList();
             entry.getValue().collect(SlotRef.class, slots);
+            // SlotRef for the lambda argument will be allocated SlotDescriptor when analyzing,
+            // so skip to check the descriptor for lambda argument
+            List<LambdaArgument> lambdaArguments = Lists.newArrayList();
+            entry.getValue().collect(LambdaArgument.class, lambdaArguments);
+            Set<String> lambdaArgumentNames = lambdaArguments.stream().map(LambdaArgument::getName).collect(Collectors.toSet());
             for (SlotRef slot : slots) {
                 SlotDescriptor slotDesc = slotDescByName.get(slot.getColumnName());
                 if (slotDesc == null) {
+                    if (lambdaArgumentNames.contains(slot.getColumnName())) {
+                        continue;
+                    }
                     ErrorReport.reportAnalysisException(ERR_EXPR_REFERENCED_COLUMN_NOT_FOUND, slot.getColumnName(),
                             AstToSQLBuilder.toSQL(entry.getValue()), entry.getKey());
                 }
@@ -793,7 +804,9 @@ public class Load {
             Expr expr = entry.getValue().clone(smap);
 
             try {
-                expr = Expr.analyzeAndCastFold(expr);
+                java.util.function.Function<SlotRef, ColumnRefOperator> resolveSlotFunc =
+                        (slotRef) -> resolveSlotRef(analyzer, srcTupleDesc, slotDescByName, slotRef);
+                expr = Expr.analyzeLoadExpr(expr, resolveSlotFunc);
             } catch (SemanticException e) {
                 ErrorReport.reportAnalysisException(ERR_MAPPING_EXPR_INVALID, AstToSQLBuilder.toSQL(entry.getValue()),
                         e.getDetailMsg(), entry.getKey());
@@ -891,6 +904,42 @@ public class Load {
             expr = Expr.analyzeAndCastFold(expr);
 
             exprsByName.put(entry.getKey(), expr);
+        }
+    }
+
+    /**
+     * Resolve {@code SlotRef} to {@code ColumnRefOperator} when analyzing
+     *
+     * @param analyzer the analyzer
+     * @param srcTupleDescriptor The tuple descriptor used to create a slot descriptor for the new SlotRef
+     * @param slotDescriptors slot descriptors that have been created. mapping from column name to slot descriptor
+     * @param node the slot ref to resolve
+     * @return The resolved column ref operator
+     */
+    private static ColumnRefOperator resolveSlotRef(Analyzer analyzer, TupleDescriptor srcTupleDescriptor,
+                                                    Map<String, SlotDescriptor> slotDescriptors, SlotRef node) {
+        if (!node.isFromLambda() && !node.isAnalyzed()) {
+            // The SlotRef for non-lambda argument is analyzed manually before using Analyzer
+            // TODO: delete old analyze in Load
+            String errMsg = String.format("The SlotRef not from lambda is not analyzed, %s", node.toSql());
+            LOG.warn(errMsg);
+            throw unsupportedException(errMsg);
+        }
+        if (node.isFromLambda()) {
+            SlotDescriptor descriptor = slotDescriptors.get(node.getColumnName());
+            if (descriptor == null) {
+                descriptor = analyzer.getDescTbl().addSlotDescriptor(srcTupleDescriptor);
+                descriptor.setType(node.getType());
+                descriptor.setLabel(node.getColumnName());
+                descriptor.setIsNullable(node.isNullable());
+                slotDescriptors.put(node.getColumnName(), descriptor);
+            }
+            return new ColumnRefOperator(descriptor.getId().asInt(),
+                    node.getType(), node.getColumnName(), node.isNullable());
+        } else {
+            String columnName = node.getColumnName() == null ? node.getLabel() : node.getColumnName();
+            return new ColumnRefOperator(node.getSlotId().asInt(),
+                    node.getType(), columnName, node.isNullable());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
@@ -419,7 +419,7 @@ public class StreamLoadScanNode extends LoadScanNode {
             }
             rangeDesc.setStart_offset(0);
             rangeDesc.setSize(-1);
-            rangeDesc.setNum_of_columns_from_file(paramCreateContext.tupleDescriptor.getSlots().size());
+            rangeDesc.setNum_of_columns_from_file(paramCreateContext.params.getSrc_slot_idsSize());
             rangeDesc.setCompression_type(streamLoadInfo.getPayloadCompressionType());
             brokerScanRange.addToRanges(rangeDesc);
             brokerScanRange.setBroker_addresses(Lists.newArrayList());

--- a/fe/fe-core/src/test/java/com/starrocks/load/LoadTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/LoadTest.java
@@ -38,7 +38,9 @@ import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.sql.ast.ImportColumnDesc;
+import com.starrocks.sql.ast.ImportColumnsStmt;
 import com.starrocks.thrift.TBrokerScanRangeParams;
 import com.starrocks.thrift.TFileFormatType;
 import mockit.Expectations;
@@ -307,5 +309,90 @@ public class LoadTest {
         Assert.assertEquals(TFileFormatType.FORMAT_CSV_DEFLATE, Load.getFormatType("csv", "hdfs://127.0.0.1:9000/some_file.deflate"));
         Assert.assertEquals(TFileFormatType.FORMAT_CSV_ZSTD, Load.getFormatType("csv", "hdfs://127.0.0.1:9000/some_file.zst"));
         Assert.assertEquals(TFileFormatType.FORMAT_CSV_PLAIN, Load.getFormatType("csv", "hdfs://127.0.0.1:9000/some_file"));
+    }
+
+    @Test
+    public void testLambda() throws Exception {
+        String c0Name = "c0";
+        columns.add(new Column(c0Name, Type.INT, true, null, true, null, ""));
+        String c1Name = "c1";
+        columns.add(new Column(c1Name, Type.STRING, false, null, true, null, ""));
+        String c2Name = "c2";
+        columns.add(new Column(c2Name, Type.STRING, false, null, true, null, ""));
+        String c3Name = "c3";
+        columns.add(new Column(c3Name, Type.STRING, false, null, true, null, ""));
+
+        new Expectations() {
+            {
+                table.getBaseSchema();
+                result = columns;
+                table.getColumn(c0Name);
+                result = columns.get(0);
+                table.getColumn(c1Name);
+                result = columns.get(1);
+                table.getColumn(c2Name);
+                result = columns.get(2);
+                table.getColumn(c3Name);
+                result = columns.get(3);
+            }
+        };
+
+        String columnsSQL =
+                "COLUMNS (" +
+                "   c0,t0,c1,t1," +
+                "   c2=get_json_string(" +
+                "           array_filter(" +
+                "               e -> get_json_string(e,'$.name')='Tom'," +
+                "               CAST(parse_json(t0) AS ARRAY<JSON>)" +
+                "           )[1]," +
+                "      '$.id')," +
+                "   c3=get_json_string(" +
+                "           map_values(" +
+                "               map_filter(" +
+                "                   (k,v) -> get_json_string(v,'$.name')='Jerry'," +
+                "                   CAST(parse_json(t1) AS MAP<STRING,JSON>)" +
+                "              )" +
+                "           )[1]," +
+                "       '$.id')" +
+                " )";
+        columnsFromPath.add("c1");
+        ImportColumnsStmt columnsStmt =
+                com.starrocks.sql.parser.SqlParser.parseImportColumns(columnsSQL, SqlModeHelper.MODE_DEFAULT);
+        columnExprs.addAll(columnsStmt.getColumns());
+        Load.initColumns(table, columnExprs, null, exprsByName, analyzer, srcTupleDesc,
+                slotDescByName, params, true, true, columnsFromPath);
+        Assert.assertEquals(7, slotDescByName.size());
+        Assert.assertTrue(slotDescByName.containsKey("c0"));
+        Assert.assertTrue(slotDescByName.containsKey("t0"));
+        Assert.assertTrue(slotDescByName.containsKey("c1"));
+        Assert.assertTrue(slotDescByName.containsKey("t1"));
+        Assert.assertTrue(slotDescByName.containsKey("e"));
+        Assert.assertTrue(slotDescByName.containsKey("k"));
+        Assert.assertTrue(slotDescByName.containsKey("v"));
+        Assert.assertEquals(4, params.getSrc_slot_idsSize());
+        Assert.assertEquals(2, exprsByName.size());
+        Assert.assertTrue(exprsByName.containsKey("c2"));
+        Assert.assertTrue(exprsByName.containsKey("c3"));
+
+        int t0SlotId = slotDescByName.get("t0").getId().asInt();
+        int eSlotId = slotDescByName.get("e").getId().asInt();
+        String c2ExprExplain = String.format(
+                "get_json_string[(array_filter(CAST(parse_json(<slot %d>) AS ARRAY<JSON>), " +
+                "array_map(<slot %d> -> get_json_string(<slot %d>, '$.name') = 'Tom', " +
+                "CAST(parse_json(<slot %d>) AS ARRAY<JSON>)))[1], '$.id'); args: JSON,VARCHAR; " +
+                "result: VARCHAR; args nullable: true; result nullable: true]",
+                    t0SlotId, eSlotId, eSlotId, t0SlotId);
+        Assert.assertEquals(c2ExprExplain, exprsByName.get("c2").explain());
+
+        int t1SlotId = slotDescByName.get("t1").getId().asInt();
+        int kSlotId = slotDescByName.get("k").getId().asInt();
+        int vSlotId = slotDescByName.get("v").getId().asInt();
+        String c3ExprExplain = String.format(
+                "get_json_string[(map_values(map_filter(CAST(parse_json(<slot %d>) AS MAP<VARCHAR(65533),JSON>), " +
+                "map_values(map_apply((<slot %d>, <slot %d>) -> map{<slot %d>:get_json_string(<slot %d>, '$.name') = 'Jerry'}, " +
+                "CAST(parse_json(<slot %d>) AS MAP<VARCHAR(65533),JSON>)))))[1], '$.id'); args: JSON,VARCHAR; " +
+                "result: VARCHAR; args nullable: true; result nullable: true]",
+                t1SlotId, kSlotId, vSlotId, kSlotId, vSlotId, t1SlotId);
+        Assert.assertEquals(c3ExprExplain, exprsByName.get("c3").explain());
     }
 }

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -1762,11 +1762,19 @@ class StarrocksSQLApiLib(object):
         show_sql = "show routine load for %s" % routine_load_task_name
         return self.execute_sql(show_sql, True)
 
-    def check_routine_load_progress(self, sum_data_count, task_name):
+    def running_load_count(self, db_name, table_name, load_type):
+        load_sql = "select count(*) from information_schema.loads where db_name='%s' and table_name='%s' and type='%s' and state not in ('FINISHED','CANCELLED')" % (
+            db_name, table_name, load_type)
+        res = self.execute_sql(load_sql, True)
+        tools.assert_true(res["status"])
+        return int(res["result"][0][0])
+
+    def check_routine_load_progress(self, sum_data_count, task_name, db_name, table_name):
         load_finished = False
         count = 0
         while count < 60:
             res = self.show_routine_load(task_name)
+            log.info("show routine load, %s" % res)
             tools.assert_true(res["status"])
             progress_dict = eval(res["result"][0][14])
             if "OFFSET_BEGINNING" in list(progress_dict.values()):
@@ -1782,10 +1790,13 @@ class StarrocksSQLApiLib(object):
             if current_data_count != sum_data_count:
                 time.sleep(5)
             else:
-                # Sleep for a little while to await the publishing finished.
-                time.sleep(10)
-                load_finished = True
-                break
+                running_load_count = self.running_load_count(db_name, table_name, "ROUTINE_LOAD")
+                if running_load_count == 0:
+                    load_finished = True
+                    break
+                log.info("routine load running loads %d, db: %s, table: %s, job: %s" % (
+                    running_load_count, db_name, table_name, task_name))
+                time.sleep(3)
             count += 1
         tools.assert_true(load_finished)
 
@@ -2453,7 +2464,6 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
         tools.assert_equal(200, res.status_code, f"failed to post http request [res={res}] [url={exec_url}]")
         return res.content.decode("utf-8")
 
-
     def manual_compact(self, database_name, table_name):
         sql = "show tablet from " + database_name + "." + table_name
         res = self.execute_sql(sql, True)
@@ -2689,7 +2699,8 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
         for expect in expects:
             plan_string = "\n".join(item[0] for item in res["result"])
             tools.assert_true(plan_string.find(expect) > 0,
-                              "verbose plan of sql (%s) assert expect %s is not found in plan: %s" % (query, expect, plan_string))
+                              "verbose plan of sql (%s) assert expect %s is not found in plan: %s" % (
+                                  query, expect, plan_string))
 
     def assert_explain_costs_contains(self, query, *expects):
         """

--- a/test/sql/test_routine_load/R/test_routine_load_lambda
+++ b/test/sql/test_routine_load/R/test_routine_load_lambda
@@ -1,0 +1,62 @@
+-- name: test_routine_load_lambda
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `test_lambda` (
+  `id` string,
+  `dt` datetime,
+  `method` string,
+  `ip`  string,
+  `path` string,
+  `vid` string,
+  `cid` string
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE ROUTINE LOAD test_lambda
+ON test_lambda
+COLUMNS (
+    id,dt,method,ip,path,tmp1,tmp2,
+    `vid`=get_json_string(array_filter(item -> get_json_string(item, '$.type')='type1', CAST(parse_json(tmp1) AS ARRAY<JSON>))[1], '$.vid'),
+    `cid`=get_json_string(map_values((map_filter((k, v)->get_json_string(v, '$.type')='type1',cast(parse_json(tmp2) AS map<string,json>))))[1],'$.cid')
+)
+PROPERTIES
+(
+  "format" = "json",
+  "jsonpaths" = "[
+      \"$.id\",
+      \"$.timestamp\",
+      \"$.http.request.method\",
+      \"$.http.request.headers.ip\",
+      \"$.http.request.path\",
+      \"$.events.context\",
+      \"$.agent.findings\"
+  ]"
+)
+FROM KAFKA
+(
+    "kafka_broker_list"="${broker_list}",
+    "kafka_topic" = "test-routine-load-lambda",
+    "property.kafka_default_offsets" = "OFFSET_BEGINNING"
+);
+-- result:
+-- !result
+function: check_routine_load_progress(1, "db_${uuid0}.test_lambda", "db_${uuid0}", "test_lambda")
+-- result:
+None
+-- !result
+sync;
+-- result:
+-- !result
+select * from db_${uuid0}.test_lambda order by id;
+-- result:
+1	2025-04-17 11:00:00	POST	127.0.0.1	/starrocks/test	vid1	cid1
+-- !result

--- a/test/sql/test_routine_load/T/test_routine_load_lambda
+++ b/test/sql/test_routine_load/T/test_routine_load_lambda
@@ -1,0 +1,51 @@
+-- name: test_routine_load_lambda
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE `test_lambda` (
+  `id` string,
+  `dt` datetime,
+  `method` string,
+  `ip`  string,
+  `path` string,
+  `vid` string,
+  `cid` string
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+
+CREATE ROUTINE LOAD test_lambda
+ON test_lambda
+COLUMNS (
+    id,dt,method,ip,path,tmp1,tmp2,
+    `vid`=get_json_string(array_filter(item -> get_json_string(item, '$.type')='type1', CAST(parse_json(tmp1) AS ARRAY<JSON>))[1], '$.vid'),
+    `cid`=get_json_string(map_values((map_filter((k, v)->get_json_string(v, '$.type')='type1',cast(parse_json(tmp2) AS map<string,json>))))[1],'$.cid')
+)
+PROPERTIES
+(
+  "format" = "json",
+  "jsonpaths" = "[
+      \"$.id\",
+      \"$.timestamp\",
+      \"$.http.request.method\",
+      \"$.http.request.headers.ip\",
+      \"$.http.request.path\",
+      \"$.events.context\",
+      \"$.agent.findings\"
+  ]"
+)
+FROM KAFKA
+(
+    "kafka_broker_list"="${broker_list}",
+    "kafka_topic" = "test-routine-load-lambda",
+    "property.kafka_default_offsets" = "OFFSET_BEGINNING"
+);
+
+function: check_routine_load_progress(1, "db_${uuid0}.test_lambda", "db_${uuid0}", "test_lambda")
+sync;
+
+select * from db_${uuid0}.test_lambda order by id;

--- a/test/sql/test_stream_load/R/test_stream_load_lambda
+++ b/test/sql/test_stream_load/R/test_stream_load_lambda
@@ -1,0 +1,38 @@
+-- name: test_stream_load_lambda
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `test_lambda` (
+  `id` string,
+  `dt` datetime,
+  `method` string,
+  `ip`  string,
+  `path` string,
+  `vid` string,
+  `cid` string
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+-- result:
+-- !result
+shell: curl --location-trusted -u root: -X PUT -T ${root_path}/sql/test_stream_load/data/test_load_lambda.json -H "Expect:100-continue" -H "format: json" -H "jsonpaths: [\"$.id\",\"$.timestamp\",\"$.http.request.method\",\"$.http.request.headers.ip\",\"$.http.request.path\",\"$.events.context\",\"$.agent.findings\"]" -H "columns: id,dt,method,ip,path,tmp1,tmp2,vid=get_json_string(array_filter(item -> get_json_string(item\, '$.type')='type1'\, CAST(parse_json(tmp1) AS ARRAY<JSON>))[1]\, '$.vid'),cid=get_json_string(map_values((map_filter((k\, v)->get_json_string(v\, '$.type')='type1'\,cast(parse_json(tmp2) AS map<string\,json>))))[1]\,'$.cid')" ${url}/api/db_${uuid0}/test_lambda/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+sync;
+-- result:
+-- !result
+select * from db_${uuid0}.test_lambda order by id;
+-- result:
+1	2025-04-17 11:00:00	POST	127.0.0.1	/starrocks/test	vid1	cid1
+-- !result

--- a/test/sql/test_stream_load/T/test_stream_load_lambda
+++ b/test/sql/test_stream_load/T/test_stream_load_lambda
@@ -1,0 +1,24 @@
+-- name: test_stream_load_lambda
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE `test_lambda` (
+  `id` string,
+  `dt` datetime,
+  `method` string,
+  `ip`  string,
+  `path` string,
+  `vid` string,
+  `cid` string
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+
+shell: curl --location-trusted -u root: -X PUT -T ${root_path}/sql/test_stream_load/data/test_load_lambda.json -H "Expect:100-continue" -H "format: json" -H "jsonpaths: [\"$.id\",\"$.timestamp\",\"$.http.request.method\",\"$.http.request.headers.ip\",\"$.http.request.path\",\"$.events.context\",\"$.agent.findings\"]" -H "columns: id,dt,method,ip,path,tmp1,tmp2,vid=get_json_string(array_filter(item -> get_json_string(item\, '$.type')='type1'\, CAST(parse_json(tmp1) AS ARRAY<JSON>))[1]\, '$.vid'),cid=get_json_string(map_values((map_filter((k\, v)->get_json_string(v\, '$.type')='type1'\,cast(parse_json(tmp2) AS map<string\,json>))))[1]\,'$.cid')" ${url}/api/db_${uuid0}/test_lambda/_stream_load
+sync;
+
+select * from db_${uuid0}.test_lambda order by id;

--- a/test/sql/test_stream_load/data/test_load_lambda.json
+++ b/test/sql/test_stream_load/data/test_load_lambda.json
@@ -1,0 +1,37 @@
+{
+  "id": 1,
+  "timestamp": "2025-04-17 11:00:00",
+  "agent": {
+    "findings": {
+      "f1": {
+        "type": "type1",
+        "cid": "cid1"
+      },
+      "f2": {
+        "type": "type2",
+        "cid": "cid2"
+      }
+    }
+  },
+  "events": {
+    "context": [
+      {
+        "type": "type1",
+        "vid": "vid1"
+      },
+      {
+        "type": "type2",
+        "vid": "vid2"
+      }
+    ]
+  },
+  "http": {
+    "request": {
+      "method": "POST",
+      "path": "/starrocks/test",
+      "headers": {
+        "ip": "127.0.0.1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Why I'm doing:
stream load/routine load support to map the column in source data to the target column after computed by expression, but it does not support lambda expression which limits the transform for nested data, such as array and map. For example, when loading the following json data using routine load, we want to get the event whose type is `t1`, and store it to a json column. 

```
{
      "events": [
            {
                 "id": 1,
                 "type":"t1",
                 "msg": "msg1"
            },
            {
                 "id": 2
                 "type":"t2",
                 "msg":"msg2"
            }
      ]
}
```

If support lambda expression in routine load `COLUMNS`, we  can do it by 
* set jsonpaths to `$.events` to get the json array, and assign it to `tmp`
* set `columns` clause to the following. It first casts the json array `events` to `array<json>`, then use `arrary_filter` + lambda expr to filter the data

```
 COLUMNS(
         tmp,
         dst_col=array_filter(
                        event->get_json_string(event,'$.type')=='t1',
                        cast(tmp as array<json>)
                 )[1]
 )
```
Actually we can use jsonpath filter expression to do it, it need more efforts for development. We can first support it by using array_filter + lambda expression.

## What I'm doing:
Support lambda expression for stream load and routine load. Because load uses a different way from query to analyze these expressions, so we need to modify the analyze process. The main change is that load scan node also needs to allocate slot descriptors for those lambda arguments. We can reuse `srcTupleDescriptor` to hold these slot descriptors. 

Fixes #58208

TODO: broker load will support lambda expression in another pr

## What type of PR is this:

- [ ] BugFix
- [X] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
