### PR TITLE
[BugFix] Remove useless fe config enable_block_list_for_stream_load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3674,10 +3674,4 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static boolean enable_trace_historical_node = false;
-
-    /**
-     * Whether to enable block list to filter BE/CN for stream load
-     */
-    @ConfField(mutable = true)
-    public static boolean enable_block_list_for_stream_load = true;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
@@ -37,7 +37,6 @@ package com.starrocks.http.rest;
 import com.google.common.base.Strings;
 import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.authorization.PrivilegeType;
-import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
@@ -101,12 +100,10 @@ public class LoadAction extends RestBaseAction {
             nodeIds = systemInfoService.getAvailableBackends().stream().map(be -> be.getId()).collect(Collectors.toList());
         }
 
-        if (Config.enable_block_list_for_stream_load) {
-            List<Long> filterNodeIds = nodeIds.stream()
-                                              .filter(id -> !SimpleScheduler.isInBlocklist(id)).collect(Collectors.toList());
-            if (filterNodeIds != null && !filterNodeIds.isEmpty()) {
-                nodeIds = filterNodeIds;
-            }
+        List<Long> filterNodeIds = nodeIds.stream()
+                .filter(id -> !SimpleScheduler.isInBlocklist(id)).collect(Collectors.toList());
+        if (filterNodeIds != null && !filterNodeIds.isEmpty()) {
+            nodeIds = filterNodeIds;
         }
 
         if (CollectionUtils.isEmpty(nodeIds)) {

--- a/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
@@ -128,6 +128,8 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
 
         };
 
+        // For ut stable
+        GlobalStateMgr.getServingState().isReady();
     }
 
     /**


### PR DESCRIPTION
## Why I'm doing:
FE config enable_block_list_for_stream_load is useless, remove it.

## What I'm doing:
Remove useless fe config enable_block_list_for_stream_load.
Fix unstable ut.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
