### PR TITLE
[BugFix] Fix uniqueness checking for column unique id in schema change

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
@@ -617,6 +617,16 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
             }
         }
 
+        // If upgraded from an old version and do roll up,
+        // the schema saved in indexSchemaMap is the schema in the old version, whose uniqueId is -1,
+        // so here we initialize column uniqueId here.
+        int maxId = rollupSchema.size() > 1 ? rollupSchema.size() - 1: 0;
+        for (int i = 0; i < rollupSchema.size(); i++) {
+            Column col = rollupSchema.get(i);
+            Preconditions.checkState(col.getUniqueId() <= 0, col.getUniqueId());
+            col.setUniqueId(i);
+        }
+
         tbl.setIndexMeta(rollupIndexId, rollupIndexName, rollupSchema, rollupSchemaVersion /* initial schema version */,
                 rollupSchemaHash, rollupShortKeyColumnCount, TStorageType.COLUMN, rollupKeysType, origStmt);
         MaterializedIndexMeta indexMeta = tbl.getIndexMetaByIndexId(rollupIndexId);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
@@ -620,11 +620,13 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
         // If upgraded from an old version and do roll up,
         // the schema saved in indexSchemaMap is the schema in the old version, whose uniqueId is -1,
         // so here we initialize column uniqueId here.
-        int maxId = rollupSchema.size() > 1 ? rollupSchema.size() - 1: 0;
-        for (int i = 0; i < rollupSchema.size(); i++) {
-            Column col = rollupSchema.get(i);
-            Preconditions.checkState(col.getUniqueId() <= 0, col.getUniqueId());
-            col.setUniqueId(i);
+        boolean needRestoreColumnUniqueId = (rollupSchema.get(0).getUniqueId() < 0);
+        if (needRestoreColumnUniqueId) {
+            for (int i = 0; i < rollupSchema.size(); i++) {
+                Column col = rollupSchema.get(i);
+                Preconditions.checkState(col.getUniqueId() <= 0, col.getUniqueId());
+                col.setUniqueId(i);
+            }
         }
 
         tbl.setIndexMeta(rollupIndexId, rollupIndexName, rollupSchema, rollupSchemaVersion /* initial schema version */,

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
@@ -620,14 +620,7 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
         // If upgraded from an old version and do roll up,
         // the schema saved in indexSchemaMap is the schema in the old version, whose uniqueId is -1,
         // so here we initialize column uniqueId here.
-        boolean needRestoreColumnUniqueId = (rollupSchema.get(0).getUniqueId() < 0);
-        if (needRestoreColumnUniqueId) {
-            for (int i = 0; i < rollupSchema.size(); i++) {
-                Column col = rollupSchema.get(i);
-                Preconditions.checkState(col.getUniqueId() <= 0, col.getUniqueId());
-                col.setUniqueId(i);
-            }
-        }
+        restoreColumnUniqueIdIfNeed(rollupSchema);
 
         tbl.setIndexMeta(rollupIndexId, rollupIndexName, rollupSchema, rollupSchemaVersion /* initial schema version */,
                 rollupSchemaHash, rollupShortKeyColumnCount, TStorageType.COLUMN, rollupKeysType, origStmt);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -246,11 +246,13 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
             // the schema saved in indexSchemaMap is the schema in the old version, whose uniqueId is -1,
             // so here we initialize column uniqueId here.
             List<Column> columns = indexSchemaMap.get(shadowIdxId);
-            int maxId = columns.size() > 1 ? columns.size() - 1: 0;
-            for (int i = 0; i < columns.size(); i++) {
-                Column col = columns.get(i);
-                Preconditions.checkState(col.getUniqueId() <= 0, col.getUniqueId());
-                col.setUniqueId(i);
+            boolean needRestoreColumnUniqueId = (columns.get(0).getUniqueId() < 0);
+            if (needRestoreColumnUniqueId) {
+                for (int i = 0; i < columns.size(); i++) {
+                    Column col = columns.get(i);
+                    Preconditions.checkState(col.getUniqueId() <= 0, col.getUniqueId());
+                    col.setUniqueId(i);
+                }
             }
 
             table.setIndexMeta(shadowIdxId, indexIdToName.get(shadowIdxId), indexSchemaMap.get(shadowIdxId), 0, 0,

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -245,15 +245,7 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
             // If upgraded from an old version and do schema change,
             // the schema saved in indexSchemaMap is the schema in the old version, whose uniqueId is -1,
             // so here we initialize column uniqueId here.
-            List<Column> columns = indexSchemaMap.get(shadowIdxId);
-            boolean needRestoreColumnUniqueId = (columns.get(0).getUniqueId() < 0);
-            if (needRestoreColumnUniqueId) {
-                for (int i = 0; i < columns.size(); i++) {
-                    Column col = columns.get(i);
-                    Preconditions.checkState(col.getUniqueId() <= 0, col.getUniqueId());
-                    col.setUniqueId(i);
-                }
-            }
+            restoreColumnUniqueIdIfNeed(indexSchemaMap.get(shadowIdxId));
 
             table.setIndexMeta(shadowIdxId, indexIdToName.get(shadowIdxId), indexSchemaMap.get(shadowIdxId), 0, 0,
                     indexShortKeyMap.get(shadowIdxId), TStorageType.COLUMN,

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -242,6 +242,17 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
                 sortKeyColumnUniqueIds = sortKeyUniqueIds;
             }
 
+            // If upgraded from an old version and do schema change,
+            // the schema saved in indexSchemaMap is the schema in the old version, whose uniqueId is -1,
+            // so here we initialize column uniqueId here.
+            List<Column> columns = indexSchemaMap.get(shadowIdxId);
+            int maxId = columns.size() > 1 ? columns.size() - 1: 0;
+            for (int i = 0; i < columns.size(); i++) {
+                Column col = columns.get(i);
+                Preconditions.checkState(col.getUniqueId() <= 0, col.getUniqueId());
+                col.setUniqueId(i);
+            }
+
             table.setIndexMeta(shadowIdxId, indexIdToName.get(shadowIdxId), indexSchemaMap.get(shadowIdxId), 0, 0,
                     indexShortKeyMap.get(shadowIdxId), TStorageType.COLUMN,
                     table.getKeysTypeByIndexId(indexIdMap.get(shadowIdxId)), null, sortKeyColumnIndexes,

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJobBase.java
@@ -16,8 +16,10 @@
 package com.starrocks.alter;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.io.Text;
@@ -35,6 +37,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
@@ -55,6 +58,17 @@ public abstract class LakeTableSchemaChangeJobBase extends AlterJobV2 {
 
     public LakeTableSchemaChangeJobBase(JobType jobType) {
         super(jobType);
+    }
+
+    protected void restoreColumnUniqueIdIfNeed(List<Column> columns) {
+        boolean needRestoreColumnUniqueId = (columns.get(0).getUniqueId() < 0);
+        if (needRestoreColumnUniqueId) {
+            for (int i = 0; i < columns.size(); i++) {
+                Column col = columns.get(i);
+                Preconditions.checkState(col.getUniqueId() <= 0, col.getUniqueId());
+                col.setUniqueId(i);
+            }
+        }
     }
 
     @Nullable

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -90,6 +90,7 @@ import com.starrocks.common.util.Util;
 import com.starrocks.common.util.WriteQuorum;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.lake.DataCacheInfo;
+import com.starrocks.lake.LakeTableHelper;
 import com.starrocks.lake.StarOSAgent;
 import com.starrocks.lake.StorageInfo;
 import com.starrocks.persist.ColocatePersistInfo;
@@ -446,6 +447,14 @@ public class OlapTable extends Table {
             olapTable.curBinlogConfig = new BinlogConfig(this.curBinlogConfig);
         }
         olapTable.dbName = this.dbName;
+    }
+
+    protected void restoreColumnUniqueIdIfNeed() {
+        boolean needRestoreColumnUniqueId = (indexIdToMeta.values().stream().findFirst().
+                get().getSchema().get(0).getUniqueId() < 0);
+        if (needRestoreColumnUniqueId) {
+            setMaxColUniqueId(LakeTableHelper.restoreColumnUniqueId(this));
+        }
     }
 
     public void addDoubleWritePartition(long sourcePartitionId, long tempPartitionId) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeMaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeMaterializedView.java
@@ -220,10 +220,6 @@ public class LakeMaterializedView extends MaterializedView {
     @Override
     public void gsonPostProcess() throws IOException {
         super.gsonPostProcess();
-        boolean needRestoreColumnUniqueId = indexIdToMeta.values().stream().findFirst().
-                get().getSchema().get(0).getUniqueId() == -1;
-        if (needRestoreColumnUniqueId) {
-            setMaxColUniqueId(LakeTableHelper.restoreColumnUniqueId(this));
-        }
+        restoreColumnUniqueIdIfNeed();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeMaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeMaterializedView.java
@@ -220,7 +220,9 @@ public class LakeMaterializedView extends MaterializedView {
     @Override
     public void gsonPostProcess() throws IOException {
         super.gsonPostProcess();
-        if (getMaxColUniqueId() <= 0) {
+        boolean needRestoreColumnUniqueId = indexIdToMeta.values().stream().findFirst().
+                get().getSchema().get(0).getUniqueId() == -1;
+        if (needRestoreColumnUniqueId) {
             setMaxColUniqueId(LakeTableHelper.restoreColumnUniqueId(this));
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
@@ -265,11 +265,7 @@ public class LakeTable extends OlapTable {
     @Override
     public void gsonPostProcess() throws IOException {
         super.gsonPostProcess();
-        boolean needRestoreColumnUniqueId = (indexIdToMeta.values().stream().findFirst().
-                get().getSchema().get(0).getUniqueId() < 0);
-        if (needRestoreColumnUniqueId) {
-            setMaxColUniqueId(LakeTableHelper.restoreColumnUniqueId(this));
-        }
+        restoreColumnUniqueIdIfNeed();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
@@ -265,7 +265,9 @@ public class LakeTable extends OlapTable {
     @Override
     public void gsonPostProcess() throws IOException {
         super.gsonPostProcess();
-        if (getMaxColUniqueId() <= 0) {
+        boolean needRestoreColumnUniqueId = indexIdToMeta.values().stream().findFirst().
+                get().getSchema().get(0).getUniqueId() == -1;
+        if (needRestoreColumnUniqueId) {
             setMaxColUniqueId(LakeTableHelper.restoreColumnUniqueId(this));
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
@@ -265,8 +265,8 @@ public class LakeTable extends OlapTable {
     @Override
     public void gsonPostProcess() throws IOException {
         super.gsonPostProcess();
-        boolean needRestoreColumnUniqueId = indexIdToMeta.values().stream().findFirst().
-                get().getSchema().get(0).getUniqueId() == -1;
+        boolean needRestoreColumnUniqueId = (indexIdToMeta.values().stream().findFirst().
+                get().getSchema().get(0).getUniqueId() < 0);
         if (needRestoreColumnUniqueId) {
             setMaxColUniqueId(LakeTableHelper.restoreColumnUniqueId(this));
         }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeRollupJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeRollupJobTest.java
@@ -204,7 +204,7 @@ public class LakeRollupJobTest {
     }
 
     @Test
-    public void testrestoreColumnUniqueIdIfNeed() {
+    public void testRestoreColumnUniqueIdIfNeed() {
         Column a = new Column();
         Column b = new Column();
         List<Column> columns = List.of(a, b);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeRollupJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeRollupJobTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.alter;
 
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.FeConstants;
@@ -28,6 +29,7 @@ import com.starrocks.task.AgentBatchTask;
 import com.starrocks.utframe.MockedWarehouseManager;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
+import dev.failsafe.internal.util.Lists;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.AfterClass;
@@ -199,5 +201,16 @@ public class LakeRollupJobTest {
         });
         Assert.assertTrue(exception.getMessage().contains("No alive backend"));
         Assert.assertEquals(AlterJobV2.JobState.PENDING, lakeRollupJob3.getJobState());
+    }
+
+    @Test
+    public void testrestoreColumnUniqueIdIfNeed() {
+        Column a = new Column();
+        Column b = new Column();
+        List<Column> columns = List.of(a, b);
+
+        lakeRollupJob.restoreColumnUniqueIdIfNeed(columns);
+        Assert.assertEquals(a.getUniqueId(), 0);
+        Assert.assertEquals(b.getUniqueId(), 1);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeRollupJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeRollupJobTest.java
@@ -29,7 +29,6 @@ import com.starrocks.task.AgentBatchTask;
 import com.starrocks.utframe.MockedWarehouseManager;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
-import dev.failsafe.internal.util.Lists;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.AfterClass;

--- a/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
@@ -388,9 +388,9 @@ public class CreateLakeTableTest {
                         "properties('enable_persistent_index' = 'true', 'persistent_index_type' = 'cloud_native');"));
         LakeTable lakeTable = getLakeTable("lake_test", "test_unique_id");
         // Clear unique id first
-        lakeTable.setMaxColUniqueId(0);
+        lakeTable.setMaxColUniqueId(-1);
         for (Column column : lakeTable.getColumns()) {
-            column.setUniqueId(0);
+            column.setUniqueId(-1);
         }
         lakeTable.gsonPostProcess();
         Assert.assertEquals(3, lakeTable.getMaxColUniqueId());


### PR DESCRIPTION
## Why I'm doing:
After making a schema change in an earlier version, when upgrading to version 3.3, the following error will be reported when making a schema change again
![image](https://github.com/user-attachments/assets/835445c7-e226-43c4-a7a5-94f5fe857561)

The current compatibility logic  of uniqueid is implementd in `gsonPostProcess` method of `LakeTable`. If no checkpoint is done before upgrade, when the edit log replayed, the unique id in the schema saved in the scheme change job is -1, so that when added to the catalog,  the compatibility is not consided.
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
