### PR TITLE
[BugFix] Fix flat json use large storage

### DIFF
--- a/be/src/column/json_column.cpp
+++ b/be/src/column/json_column.cpp
@@ -36,6 +36,14 @@ void JsonColumn::append_datum(const Datum& datum) {
     BaseClass::append(datum.get<JsonValue*>());
 }
 
+bool JsonColumn::append_strings_overflow(const Slice* data, size_t size, size_t max_length) {
+    for (size_t i = 0; i < size; i++) {
+        const auto& s = data[i];
+        append(JsonValue(s));
+    }
+    return true;
+}
+
 int JsonColumn::compare_at(size_t left_idx, size_t right_idx, const starrocks::Column& rhs,
                            int nan_direction_hint) const {
     JsonValue* x = get_object(left_idx);

--- a/be/src/column/json_column.h
+++ b/be/src/column/json_column.h
@@ -88,6 +88,9 @@ public:
 
     void append_default(size_t count) override;
 
+    // json column support dict-encode
+    bool append_strings_overflow(const Slice* data, size_t size, size_t max_length) override;
+
     size_t filter_range(const Filter& filter, size_t from, size_t to) override;
     int compare_at(size_t left, size_t right, const Column& rhs, int nan_direction_hint) const override;
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1456,6 +1456,12 @@ CONF_mBool(enable_compaction_flat_json, "true");
 // direct read flat json
 CONF_mBool(enable_lazy_dynamic_flat_json, "true");
 
+// enable flat complex type (/array/object/hyper type), diables for save storage
+CONF_mBool(enable_json_flat_complex_type, "false");
+
+// if disable flat complex type, check complex type rate in hyper-type column
+CONF_mDouble(json_flat_complex_type_factor, "0.3");
+
 // extract flat json column when row_num * null_factor > null_row_num
 CONF_mDouble(json_flat_null_factor, "0.3");
 

--- a/be/src/serde/column_array_serde.cpp
+++ b/be/src/serde/column_array_serde.cpp
@@ -347,7 +347,7 @@ public:
     // uint32: number of datums
     // datums: [size1[payload1][size2][payload2]
     static uint8_t* serialize(const JsonColumn& column, uint8_t* buff) {
-        buff = write_little_endian_32(kJsonMetaDefaultFormatVersion, buff);
+        buff = write_little_endian_32(kJsonMetaRemainFilterVersion, buff);
         buff = write_little_endian_32(column.get_pool().size(), buff);
         for (const auto& obj : column.get_pool()) {
             constexpr uint64_t size_field_length = sizeof(uint64_t);
@@ -363,7 +363,6 @@ public:
         uint32_t num_objects = 0;
         buff = read_little_endian_32(buff, &actual_version);
         buff = read_little_endian_32(buff, &num_objects);
-        CHECK_EQ(actual_version, kJsonMetaDefaultFormatVersion) << "Only format_version=1 is supported";
 
         column->reset_column();
         auto& pool = column->get_pool();

--- a/be/src/storage/rowset/binary_dict_page.cpp
+++ b/be/src/storage/rowset/binary_dict_page.cpp
@@ -298,5 +298,6 @@ Status BinaryDictPageDecoder<Type>::next_dict_codes(const SparseRange<>& range, 
 
 template class BinaryDictPageDecoder<TYPE_CHAR>;
 template class BinaryDictPageDecoder<TYPE_VARCHAR>;
+template class BinaryDictPageDecoder<TYPE_JSON>;
 
 } // namespace starrocks

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -136,11 +136,10 @@ Status ColumnReader::_init(ColumnMetaPB* meta, const TabletColumn* column) {
     if (_column_type == TYPE_JSON && meta->has_json_meta()) {
         // TODO(mofei) store format_version in ColumnReader
         const JsonMetaPB& json_meta = meta->json_meta();
-        CHECK_EQ(kJsonMetaDefaultFormatVersion, json_meta.format_version()) << "Only format_version=1 is supported";
         _is_flat_json = json_meta.is_flat();
         _has_remain = json_meta.has_remain();
 
-        if (json_meta.has_remain_filter()) {
+        if (json_meta.has_remain_filter() && json_meta.format_version() >= kJsonMetaRemainFilterVersion) {
             DCHECK(_has_remain);
             DCHECK(!json_meta.remain_filter().empty());
             RETURN_IF_ERROR(BloomFilter::create(BLOCK_BLOOM_FILTER, &_remain_filter));
@@ -897,7 +896,7 @@ StatusOr<std::unique_ptr<ColumnIterator>> ColumnReader::_new_json_iterator(Colum
                 }
 
                 if (_remain_filter != nullptr &&
-                    !_remain_filter->test_bytes(target_leafs[i]->path().data(), target_leafs[i]->path().size())) {
+                    !_remain_filter->test_bytes(target_leafs[k]->path().data(), target_leafs[k]->path().size())) {
                     need_remain = false;
                 } else {
                     need_remain = true;

--- a/be/src/storage/rowset/column_writer.cpp
+++ b/be/src/storage/rowset/column_writer.cpp
@@ -60,6 +60,7 @@
 #include "storage/rowset/page_io.h"
 #include "storage/rowset/struct_column_writer.h"
 #include "storage/rowset/zone_map_index.h"
+#include "types/logical_type.h"
 #include "util/bloom_filter.h"
 #include "util/compression/block_compression.h"
 #include "util/faststring.h"
@@ -492,7 +493,8 @@ Status ScalarColumnWriter::write_data() {
         PageFooterPB footer;
         footer.set_type(DICTIONARY_PAGE);
         footer.set_uncompressed_size(dict_body->size());
-        if (_encoding_info->type() == TYPE_CHAR || _encoding_info->type() == TYPE_VARCHAR) {
+        if (_encoding_info->type() == TYPE_CHAR || _encoding_info->type() == TYPE_VARCHAR ||
+            _encoding_info->type() == TYPE_JSON) {
             footer.mutable_dict_page_footer()->set_encoding(PLAIN_ENCODING);
         } else {
             footer.mutable_dict_page_footer()->set_encoding(BIT_SHUFFLE);

--- a/be/src/storage/rowset/encoding_info.cpp
+++ b/be/src/storage/rowset/encoding_info.cpp
@@ -295,6 +295,7 @@ EncodingInfoResolver::EncodingInfoResolver() {
 
     _add_map<TYPE_PERCENTILE, PLAIN_ENCODING>();
     _add_map<TYPE_JSON, PLAIN_ENCODING>();
+    _add_map<TYPE_JSON, DICT_ENCODING>();
 
     _add_map<TYPE_VARBINARY, PLAIN_ENCODING>();
 

--- a/be/src/storage/rowset/encoding_info.h
+++ b/be/src/storage/rowset/encoding_info.h
@@ -41,6 +41,7 @@
 #include "common/status.h"
 #include "gen_cpp/segment.pb.h"
 #include "storage/types.h"
+#include "types/logical_type.h"
 #include "util/slice.h"
 
 namespace starrocks {
@@ -78,7 +79,7 @@ inline bool numeric_types_support_dict_encoding(LogicalType type) {
 }
 
 inline bool supports_dict_encoding(LogicalType type) {
-    if (type == TYPE_VARCHAR || type == TYPE_CHAR) {
+    if (type == TYPE_VARCHAR || type == TYPE_CHAR || type == TYPE_JSON) {
         return true;
     }
     return numeric_types_support_dict_encoding(type);

--- a/be/src/storage/rowset/json_column_compactor.cpp
+++ b/be/src/storage/rowset/json_column_compactor.cpp
@@ -219,7 +219,7 @@ Status JsonColumnCompactor::append(const Column& column) {
 }
 
 Status JsonColumnCompactor::finish() {
-    _json_meta->mutable_json_meta()->set_format_version(kJsonMetaDefaultFormatVersion);
+    _json_meta->mutable_json_meta()->set_format_version(kJsonMetaRemainFilterVersion);
     _json_meta->mutable_json_meta()->set_has_remain(false);
     _json_meta->mutable_json_meta()->set_is_flat(false);
     return _json_writer->finish();

--- a/be/src/storage/rowset/json_column_writer.cpp
+++ b/be/src/storage/rowset/json_column_writer.cpp
@@ -55,7 +55,7 @@ FlatJsonColumnWriter::FlatJsonColumnWriter(const ColumnWriterOptions& opts, Type
           _flat_json_config(opts.flat_json_config) {}
 
 Status FlatJsonColumnWriter::init() {
-    _json_meta->mutable_json_meta()->set_format_version(kJsonMetaDefaultFormatVersion);
+    _json_meta->mutable_json_meta()->set_format_version(kJsonMetaRemainFilterVersion);
     _json_meta->mutable_json_meta()->set_has_remain(false);
     _json_meta->mutable_json_meta()->set_is_flat(false);
 
@@ -84,6 +84,7 @@ Status FlatJsonColumnWriter::_flat_column(Columns& json_datas) {
     // all json datas must full json
     JsonPathDeriver deriver;
     deriver.init_flat_json_config(_flat_json_config);
+    deriver.set_generate_filter(true);
 
     std::vector<const Column*> vc;
     for (const auto& js : json_datas) {
@@ -94,6 +95,7 @@ Status FlatJsonColumnWriter::_flat_column(Columns& json_datas) {
     _flat_paths = deriver.flat_paths();
     _flat_types = deriver.flat_types();
     _has_remain = deriver.has_remain_json();
+    _remain_filter = deriver.remain_fitler();
 
     VLOG(2) << "FlatJsonColumnWriter flat_column flat json: "
             << JsonFlatPath::debug_flat_json(_flat_paths, _flat_types, _has_remain);
@@ -138,7 +140,7 @@ Status FlatJsonColumnWriter::_init_flat_writers() {
     _json_meta->mutable_json_meta()->set_has_remain(_has_remain);
     _json_meta->mutable_json_meta()->set_is_flat(true);
 
-    if (_remain_filter != nullptr) {
+    if (_has_remain && _remain_filter != nullptr) {
         _json_meta->mutable_json_meta()->set_remain_filter(_remain_filter->data(), _remain_filter->size());
     }
 
@@ -171,11 +173,18 @@ Status FlatJsonColumnWriter::_init_flat_writers() {
         } else {
             opts.meta->set_is_nullable(true);
         }
-        opts.meta->set_encoding(DEFAULT_ENCODING);
-        opts.meta->set_compression(_json_meta->compression());
+
+        if (_flat_types[i] == TYPE_JSON && (!_has_remain || i != _flat_paths.size() - 1)) {
+            // try to use dict encoding for flat json
+            opts.meta->set_encoding(EncodingTypePB::DICT_ENCODING);
+            opts.meta->set_compression(_json_meta->compression());
+        } else {
+            opts.meta->set_encoding(_json_meta->encoding());
+            opts.meta->set_compression(_json_meta->compression());
+        }
 
         if (_flat_types[i] == LogicalType::TYPE_JSON) {
-            opts.meta->mutable_json_meta()->set_format_version(kJsonMetaDefaultFormatVersion);
+            opts.meta->mutable_json_meta()->set_format_version(kJsonMetaRemainFilterVersion);
             opts.meta->mutable_json_meta()->set_is_flat(false);
         }
 

--- a/be/src/storage/rowset/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/scalar_column_iterator.cpp
@@ -41,6 +41,7 @@
 #include "storage/rowset/column_reader.h"
 #include "storage/rowset/dict_page.h"
 #include "storage/rowset/encoding_info.h"
+#include "types/logical_type.h"
 #include "util/bitmap.h"
 
 namespace starrocks {
@@ -102,13 +103,16 @@ Status ScalarColumnIterator::init(const ColumnIteratorOptions& opts) {
     case TYPE_DECIMALV2:
         _init_dict_decoder_func = &ScalarColumnIterator::_do_init_dict_decoder<TYPE_DECIMALV2>;
         break;
+    case TYPE_JSON:
+        _init_dict_decoder_func = &ScalarColumnIterator::_do_init_dict_decoder<TYPE_JSON>;
+        break;
     default:
         return Status::NotSupported(strings::Substitute("dict encoding with unsupported $0 field type", column_type));
     }
 
     // TODO: The following logic is primarily used for optimizing queries for VARCHAR/CHAR types during
     // dictionary encoding. Can we also optimize queries for non-TYPE_VARCHAR types?
-    if (column_type != TYPE_VARCHAR && column_type != TYPE_CHAR) {
+    if (column_type != TYPE_VARCHAR && column_type != TYPE_CHAR && column_type != TYPE_JSON) {
         return Status::OK();
     }
     if (opts.check_dict_encoding) {
@@ -118,6 +122,8 @@ Status ScalarColumnIterator::init(const ColumnIteratorOptions& opts) {
             RETURN_IF(!_all_dict_encoded, Status::OK());
             if (column_type == TYPE_VARCHAR) {
                 RETURN_IF_ERROR(_load_dict_page<TYPE_VARCHAR>());
+            } else if (column_type == TYPE_JSON) {
+                RETURN_IF_ERROR(_load_dict_page<TYPE_JSON>());
             } else {
                 RETURN_IF_ERROR(_load_dict_page<TYPE_CHAR>());
             }
@@ -143,6 +149,12 @@ Status ScalarColumnIterator::init(const ColumnIteratorOptions& opts) {
         _next_dict_codes_func = &ScalarColumnIterator::_do_next_dict_codes<TYPE_VARCHAR>;
         _next_batch_dict_codes_func = &ScalarColumnIterator::_do_next_batch_dict_codes<TYPE_VARCHAR>;
         _fetch_all_dict_words_func = &ScalarColumnIterator::_fetch_all_dict_words<TYPE_VARCHAR>;
+    } else if (_all_dict_encoded && column_type == TYPE_JSON) {
+        _decode_dict_codes_func = &ScalarColumnIterator::_do_decode_dict_codes<TYPE_JSON>;
+        _dict_lookup_func = &ScalarColumnIterator::_do_dict_lookup<TYPE_JSON>;
+        _next_dict_codes_func = &ScalarColumnIterator::_do_next_dict_codes<TYPE_JSON>;
+        _next_batch_dict_codes_func = &ScalarColumnIterator::_do_next_batch_dict_codes<TYPE_JSON>;
+        _fetch_all_dict_words_func = &ScalarColumnIterator::_fetch_all_dict_words<TYPE_JSON>;
     }
     return Status::OK();
 }
@@ -349,7 +361,7 @@ Status ScalarColumnIterator::_load_dict_page() {
             _reader->read_page(_opts, _reader->get_dict_page_pointer(), &_dict_page_handle, &dict_data, &dict_footer));
     // ignore dict_footer.dict_page_footer().encoding() due to only
     // PLAIN_ENCODING is supported for dict page right now
-    if constexpr (Type == TYPE_CHAR || Type == TYPE_VARCHAR) {
+    if constexpr (Type == TYPE_CHAR || Type == TYPE_VARCHAR || Type == TYPE_JSON) {
         _dict_decoder = std::make_unique<BinaryPlainPageDecoder<Type>>(dict_data);
     } else {
         _dict_decoder = std::make_unique<BitShufflePageDecoder<Type>>(dict_data);
@@ -359,7 +371,7 @@ Status ScalarColumnIterator::_load_dict_page() {
 
 template <LogicalType Type>
 Status ScalarColumnIterator::_do_init_dict_decoder() {
-    if constexpr (Type == TYPE_CHAR || Type == TYPE_VARCHAR) {
+    if constexpr (Type == TYPE_CHAR || Type == TYPE_VARCHAR || Type == TYPE_JSON) {
         auto dict_page_decoder = down_cast<BinaryDictPageDecoder<Type>*>(_page->data_decoder());
         if (dict_page_decoder->encoding_type() == DICT_ENCODING) {
             if (_dict_decoder == nullptr) {
@@ -659,6 +671,9 @@ Status ScalarColumnIterator::fetch_dict_codes_by_rowid(const rowid_t* rowids, si
 int ScalarColumnIterator::dict_size() {
     if (_reader->column_type() == TYPE_CHAR) {
         auto dict = down_cast<BinaryPlainPageDecoder<TYPE_CHAR>*>(_dict_decoder.get());
+        return static_cast<int>(dict->dict_size());
+    } else if (_reader->column_type() == TYPE_JSON) {
+        auto dict = down_cast<BinaryPlainPageDecoder<TYPE_JSON>*>(_dict_decoder.get());
         return static_cast<int>(dict->dict_size());
     } else if (_reader->column_type() == TYPE_VARCHAR) {
         auto dict = down_cast<BinaryPlainPageDecoder<TYPE_VARCHAR>*>(_dict_decoder.get());

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -93,7 +93,7 @@ void SegmentWriter::_init_column_meta(ColumnMetaPB* meta, uint32_t column_id, co
     // TODO(mofei) set the format_version from column
     if (column.type() == TYPE_JSON) {
         JsonMetaPB* json_meta = meta->mutable_json_meta();
-        json_meta->set_format_version(kJsonMetaDefaultFormatVersion);
+        json_meta->set_format_version(kJsonMetaRemainFilterVersion);
         json_meta->set_has_remain(false);
         json_meta->set_is_flat(false);
     }

--- a/be/src/types/constexpr.h
+++ b/be/src/types/constexpr.h
@@ -34,6 +34,7 @@ const static uint8_t DEFAULT_HLL_LOG_K = 17;
 // For JSON type
 constexpr int kJsonDefaultSize = 128;
 constexpr int kJsonMetaDefaultFormatVersion = 1;
+constexpr int kJsonMetaRemainFilterVersion = 2;
 
 constexpr __int128 MAX_INT128 = ~((__int128)0x01 << 127);
 constexpr __int128 MIN_INT128 = ((__int128)0x01 << 127);

--- a/be/src/util/json_flattener.cpp
+++ b/be/src/util/json_flattener.cpp
@@ -51,6 +51,7 @@
 #include "util/bloom_filter.h"
 #include "util/json.h"
 #include "util/json_converter.h"
+#include "util/phmap/phmap.h"
 #include "util/runtime_profile.h"
 
 namespace starrocks {
@@ -191,6 +192,19 @@ static const FlatJsonHashMap<vpack::ValueType, uint8_t> JSON_TYPE_BITS {
         {vpack::ValueType::String, 16},    //  00010000, 16
 };
 
+// json base type
+static const phmap::flat_hash_set<vpack::ValueType> JSON_BASE_TYPE {
+        vpack::ValueType::None,
+        vpack::ValueType::Null,
+        vpack::ValueType::Bool,
+        vpack::ValueType::SmallInt,
+        vpack::ValueType::Int,
+        vpack::ValueType::UInt,
+        vpack::ValueType::Double,
+        vpack::ValueType::String,
+        vpack::ValueType::Binary,
+};
+
 // starrocks json fucntio only support read as bigint/string/bool/double, smallint will cast to bigint, so we save as bigint directly
 static const FlatJsonHashMap<uint8_t, LogicalType> JSON_BITS_TO_LOGICAL_TYPE {
     {JSON_TYPE_BITS.at(vpack::ValueType::None),        LogicalType::TYPE_TINYINT},
@@ -241,6 +255,7 @@ inline uint8_t get_compatibility_type(vpack::ValueType type1, uint8_t type2) {
 } // namespace flat_json
 
 static const double FILTER_TEST_FPP[]{0.05, 0.1, 0.15, 0.2, 0.25, 0.3};
+static const uint64_t FILTER_MAX_ELEMNT_NUMS = 1024;
 
 double estimate_filter_fpp(uint64_t element_nums) {
     uint32_t bytes[6];
@@ -527,25 +542,35 @@ void JsonPathDeriver::_derived(const Column* col, size_t mark_row) {
         // if the number of missed rows exceeds (1 - _min_json_sparsity_factor) * total_rows, then the path must not be extracted.
         if (((mark_row + i) % check_batch) == 0) {
             size_t hits_min = mark_row + i > ignore_max ? mark_row + i - ignore_max : 0;
-            _clean_sparsity_path(_path_root.get(), hits_min);
+            _clean_sparsity_path("", _path_root.get(), hits_min);
         }
     }
 }
 
-void JsonPathDeriver::_clean_sparsity_path(JsonFlatPath* node, size_t check_hits_min) {
+void JsonPathDeriver::_clean_sparsity_path(const std::string_view& name, JsonFlatPath* node, size_t check_hits_min) {
     for (auto& [key, child] : node->children) {
-        _clean_sparsity_path(child.get(), check_hits_min);
+        _clean_sparsity_path(key, child.get(), check_hits_min);
     }
     auto iter = node->children.begin();
     while (iter != node->children.end()) {
         auto desc = _derived_maps[iter->second.get()];
         if (desc.hits < check_hits_min) {
+            if (_generate_filter) {
+                _remain_keys.insert(iter->first);
+            }
             node->remain = true;
             _derived_maps.erase(iter->second.get());
             iter = node->children.erase(iter);
         } else {
             iter++;
         }
+    }
+    if (_generate_filter && node->remain) {
+        _remain_keys.insert(name);
+    }
+    if (_remain_keys.size() > FILTER_MAX_ELEMNT_NUMS) {
+        _generate_filter = false;
+        _remain_keys.clear();
     }
 }
 
@@ -575,6 +600,7 @@ void JsonPathDeriver::_visit_json_paths(const vpack::Slice& value, JsonFlatPath*
             auto desc = &_derived_maps[child];
             vpack::ValueType json_type = v.type();
             desc->type = flat_json::get_compatibility_type(json_type, desc->type);
+            desc->base_type_count += flat_json::JSON_BASE_TYPE.count(json_type);
             if (json_type == vpack::ValueType::UInt) {
                 desc->max = std::max(desc->max, v.getUIntUnchecked());
             }
@@ -605,7 +631,9 @@ uint32_t JsonPathDeriver::_dfs_finalize(JsonFlatPath* node, const std::string& a
         // check sparsity, same key may appear many times in json, so we need avoid duplicate compute hits
         auto desc = _derived_maps[node];
 
-        if (desc.multi_times <= 0 && desc.hits >= _total_rows * _min_json_sparsity_factory) {
+        bool is_base_type = desc.base_type_count >= desc.hits - (desc.hits * config::json_flat_complex_type_factor);
+        bool type_check = config::enable_json_flat_complex_type || is_base_type;
+        if (type_check && desc.multi_times <= 0 && desc.hits >= _total_rows * _min_json_sparsity_factory) {
             hit_leaf->emplace_back(node, absolute_path);
             node->type = flat_json::JSON_BITS_TO_LOGICAL_TYPE.at(desc.type);
             node->remain = false;
@@ -620,16 +648,12 @@ uint32_t JsonPathDeriver::_dfs_finalize(JsonFlatPath* node, const std::string& a
     }
 }
 
-void dfs_add_remain_keys(JsonFlatPath* node, std::set<std::string_view>* remain_keys) {
-    auto iter = node->children.begin();
-    while (iter != node->children.end()) {
-        auto child = iter->second.get();
-        dfs_add_remain_keys(child, remain_keys);
+void dfs_add_remain_keys(JsonFlatPath* node, std::unordered_set<std::string_view>* remain_keys) {
+    for (auto& [key, child] : node->children) {
         if (child->remain) {
-            node->remain |= true;
-            remain_keys->insert(iter->first);
+            remain_keys->insert(key);
+            dfs_add_remain_keys(child.get(), remain_keys);
         }
-        iter++;
     }
 }
 
@@ -670,23 +694,29 @@ void JsonPathDeriver::_finalize() {
         _types.emplace_back(node->type);
     }
 
-    std::set<std::string_view> remain_keys;
-    dfs_add_remain_keys(_path_root.get(), &remain_keys);
     _has_remain |= _path_root->remain;
     if (_has_remain && _generate_filter) {
-        double fpp = estimate_filter_fpp(remain_keys.size());
+        dfs_add_remain_keys(_path_root.get(), &_remain_keys);
+        if (_remain_keys.size() > FILTER_MAX_ELEMNT_NUMS) {
+            _generate_filter = false;
+            _remain_keys.clear();
+            return;
+        }
+        double fpp = estimate_filter_fpp(_remain_keys.size());
         if (fpp < 0) {
+            _remain_keys.clear();
             return;
         }
         std::unique_ptr<BloomFilter> bf;
         Status st = BloomFilter::create(BLOCK_BLOOM_FILTER, &bf);
         DCHECK(st.ok());
-        st = bf->init(remain_keys.size(), fpp, HASH_MURMUR3_X64_64);
+        st = bf->init(_remain_keys.size(), fpp, HASH_MURMUR3_X64_64);
         DCHECK(st.ok());
-        for (const auto& key : remain_keys) {
+        for (const auto& key : _remain_keys) {
             bf->add_bytes(key.data(), key.size());
         }
         _remain_filter = std::move(bf);
+        _remain_keys.clear();
     }
 }
 

--- a/be/test/exprs/flat_json_functions_test.cpp
+++ b/be/test/exprs/flat_json_functions_test.cpp
@@ -44,7 +44,10 @@ namespace starrocks {
 
 class FlatJsonQueryTestFixture2
         : public ::testing::TestWithParam<std::tuple<std::string, std::vector<std::string>, std::vector<LogicalType>,
-                                                     std::string, std::string>> {};
+                                                     std::string, std::string>> {
+    void SetUp() override { config::enable_json_flat_complex_type = true; }
+    void TearDown() override { config::enable_json_flat_complex_type = false; }
+};
 
 TEST_P(FlatJsonQueryTestFixture2, flat_json_query) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
@@ -144,7 +147,10 @@ INSTANTIATE_TEST_SUITE_P(FlatJsonQueryTest, FlatJsonQueryTestFixture2,
 // clang-format on
 
 class FlatJsonQueryErrorTestFixture
-        : public ::testing::TestWithParam<std::tuple<std::string, std::vector<std::string>, std::string>> {};
+        : public ::testing::TestWithParam<std::tuple<std::string, std::vector<std::string>, std::string>> {
+    void SetUp() override { config::enable_json_flat_complex_type = true; }
+    void TearDown() override { config::enable_json_flat_complex_type = false; }
+};
 
 TEST_P(FlatJsonQueryErrorTestFixture, json_query) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
@@ -203,7 +209,10 @@ INSTANTIATE_TEST_SUITE_P(
 
 class FlatJsonExistsTestFixture2
         : public ::testing::TestWithParam<
-                  std::tuple<std::string, std::vector<std::string>, std::vector<LogicalType>, std::string, bool>> {};
+                  std::tuple<std::string, std::vector<std::string>, std::vector<LogicalType>, std::string, bool>> {
+    void SetUp() override { config::enable_json_flat_complex_type = true; }
+    void TearDown() override { config::enable_json_flat_complex_type = false; }
+};
 
 TEST_P(FlatJsonExistsTestFixture2, flat_json_exists_test) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
@@ -283,7 +292,10 @@ INSTANTIATE_TEST_SUITE_P(FlatJsonExistsTest, FlatJsonExistsTestFixture2,
 
 class FlatJsonLengthTestFixture2
         : public ::testing::TestWithParam<
-                  std::tuple<std::string, std::vector<std::string>, std::vector<LogicalType>, std::string, int>> {};
+                  std::tuple<std::string, std::vector<std::string>, std::vector<LogicalType>, std::string, int>> {
+    void SetUp() override { config::enable_json_flat_complex_type = true; }
+    void TearDown() override { config::enable_json_flat_complex_type = false; }
+};
 
 TEST_P(FlatJsonLengthTestFixture2, flat_json_length_test) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
@@ -341,7 +353,10 @@ INSTANTIATE_TEST_SUITE_P(FlatJsonLengthTest, FlatJsonLengthTestFixture2,
 
 class FlatJsonKeysTestFixture2
         : public ::testing::TestWithParam<std::tuple<std::string, std::string, std::vector<std::string>,
-                                                     std::vector<LogicalType>, std::string>> {};
+                                                     std::vector<LogicalType>, std::string>> {
+    void SetUp() override { config::enable_json_flat_complex_type = true; }
+    void TearDown() override { config::enable_json_flat_complex_type = false; }
+};
 
 TEST_P(FlatJsonKeysTestFixture2, json_keys) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
@@ -416,6 +431,7 @@ using GetJsonXXXParam = std::tuple<std::string, std::string, std::vector<std::st
 class FlatGetJsonXXXTestFixture2 : public ::testing::TestWithParam<GetJsonXXXParam> {
 public:
     StatusOr<Columns> setup() {
+        config::enable_json_flat_complex_type = true;
         _ctx = std::unique_ptr<FunctionContext>(FunctionContext::create_test_context());
         auto ints = JsonColumn::create();
         ColumnBuilder<TYPE_VARCHAR> builder(1);
@@ -453,6 +469,7 @@ public:
     }
 
     void tear_down() {
+        config::enable_json_flat_complex_type = false;
         ASSERT_TRUE(JsonFunctions::native_json_path_close(
                             _ctx.get(), FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                             .ok());
@@ -580,7 +597,11 @@ INSTANTIATE_TEST_SUITE_P(GetJsonXXXTest, FlatGetJsonXXXTestFixture2,
 
 class FlatJsonDeriverPaths
         : public ::testing::TestWithParam<
-                  std::tuple<std::string, std::string, std::vector<std::string>, std::vector<LogicalType>>> {};
+                  std::tuple<std::string, std::string, std::vector<std::string>, std::vector<LogicalType>>> {
+public:
+    void SetUp() override { config::enable_json_flat_complex_type = true; }
+    void TearDown() override { config::enable_json_flat_complex_type = false; }
+};
 
 TEST_P(FlatJsonDeriverPaths, flat_json_path_test) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());

--- a/be/test/storage/rowset/flat_json_column_compact_test.cpp
+++ b/be/test/storage/rowset/flat_json_column_compact_test.cpp
@@ -53,9 +53,13 @@ public:
     ~FlatJsonColumnCompactTest() override = default;
 
 protected:
-    void SetUp() override { _meta.reset(new ColumnMetaPB()); }
+    void SetUp() override {
+        config::enable_json_flat_complex_type = true;
+        _meta.reset(new ColumnMetaPB());
+    }
 
     void TearDown() override {
+        config::enable_json_flat_complex_type = false;
         config::json_flat_null_factor = 0.3;
         config::json_flat_sparsity_factor = 0.9;
     }

--- a/be/test/storage/rowset/flat_json_column_rw_test.cpp
+++ b/be/test/storage/rowset/flat_json_column_rw_test.cpp
@@ -52,9 +52,13 @@ public:
     ~FlatJsonColumnRWTest() override = default;
 
 protected:
-    void SetUp() override { _meta.reset(new ColumnMetaPB()); }
+    void SetUp() override {
+        config::enable_json_flat_complex_type = true;
+        _meta.reset(new ColumnMetaPB());
+    }
 
     void TearDown() override {
+        config::enable_json_flat_complex_type = false;
         config::json_flat_sparsity_factor = 0.9;
         config::json_flat_null_factor = 0.3;
     }

--- a/be/test/util/json_flattener_test.cpp
+++ b/be/test/util/json_flattener_test.cpp
@@ -52,7 +52,11 @@ namespace starrocks {
 
 class JsonPathDeriverTest
         : public ::testing::TestWithParam<
-                  std::tuple<std::string, std::string, bool, std::vector<std::string>, std::vector<LogicalType>>> {};
+                  std::tuple<std::string, std::string, bool, std::vector<std::string>, std::vector<LogicalType>>> {
+public:
+    void SetUp() override { config::enable_json_flat_complex_type = true; }
+    void TearDown() override { config::enable_json_flat_complex_type = false; }
+};
 
 TEST_P(JsonPathDeriverTest, json_path_deriver_test) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
the compression ratio of the extracted JSON column (array type or object type) is lower than that of the original JSON column, it's will take FlatJson use large storage, will be useful in scenarios where the data is similar

1. Json add dict encode
2. Flat Json check is complex type, and default use dict encode
3. add `enable_flat_json_complex_type` to controll need extract complex type column

test case:
```
MySQL ssb> show data
+--------------------+----------------+---------------------+
| TableName          | Size           | ReplicaCount        |
+--------------------+----------------+---------------------+
| o1                 | 1.299 GB       | 1                   |
| o1_2               | 14.385 MB      | 1                   |
| o1l                | 508.000 B      | 1                   |
| o2                 | 2.531 GB       | 1                   |
| o2_1               | 1.299 GB       | 1                   |
| o2_2               | 129.577 KB     | 1                   |
| o2_4               | 14.550 MB      | 1                   |
| o2_5               | 14.651 MB      | 1                   |
| o2l                | 860.000 B      | 1                   |
+--------------------+----------------+---------------------+
```

e.g. table's data is `{"boo": false, "arr": [1, 2, 3]}` * 335544320 rows

| table | case | size | comment |
|------|------|----------|----------|
| o1_2 | Base(store as (varchar, varchar)) |14.385 MB | |
| o1 | Base(store as json) | 1.299 GB | |
| o2 | Before this PR(Flat JSON) | 2.531 GB | extact to JSON(boo), JSON(arra). extract&split storage let the compression ratio is lower than whole JSON storage |
| o2_1 | this PR(Flat JSON, disable extract complex type) | 1.299 GB | extact to JSON(boo), JSON(remain). `boo` will use dict encode |
| o2_4 | this PR(Flat JSON, enable extract complex type) | 14.550 MB | extact to JSON(boo), JSON(arr). `boo`/`arr` will use dict encode |


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
