### PR TITLE
[BugFix] fix partial column update loss under fast schema evolution in cloud native table

### DIFF
--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -374,6 +374,11 @@ void MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compact
                 it++;
             }
         }
+
+        if (_tablet_meta->historical_schemas().count(_tablet_meta->schema().id()) <= 0) {
+            auto& item = (*_tablet_meta->mutable_historical_schemas())[_tablet_meta->schema().id()];
+            item.CopyFrom(_tablet_meta->schema());
+        }
     }
 
     VLOG(2) << fmt::format(

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -667,7 +667,11 @@ StatusOr<TabletSchemaPtr> TabletManager::get_tablet_schema_by_id(int64_t tablet_
 // So we will check the schema version of all input rowsets and select the latest tablet schema.
 StatusOr<TabletSchemaPtr> TabletManager::get_output_rowset_schema(std::vector<uint32_t>& input_rowset,
                                                                   const TabletMetadata* metadata) {
-    if (metadata->rowset_to_schema().empty() || input_rowset.size() <= 0) {
+    if (metadata->rowset_to_schema().empty() || metadata->schema().keys_type() == PRIMARY_KEYS ||
+        input_rowset.size() <= 0) {
+        // We can't pick schema from input rowset because when do column mode partial update, it will lost
+        // latest add column data. And alsp primary key table doesn't support partial segment compaction now,
+        // so we can use latest schema as compaction schema safely.
         return GlobalTabletSchemaMap::Instance()->emplace(metadata->schema()).first;
     }
     TabletSchemaPtr tablet_schema = GlobalTabletSchemaMap::Instance()->emplace(metadata->schema()).first;

--- a/be/test/storage/lake/alter_tablet_meta_test.cpp
+++ b/be/test/storage/lake/alter_tablet_meta_test.cpp
@@ -296,6 +296,7 @@ void AlterTabletMetaTest::test_alter_update_tablet_schema(KeysType keys_type) {
     }
 
     // compaction
+    auto schema_id3 = tablet_metadata->schema().id();
     {
         TxnLogPB log;
         auto op_compaction_meta = log.mutable_op_compaction();
@@ -323,10 +324,17 @@ void AlterTabletMetaTest::test_alter_update_tablet_schema(KeysType keys_type) {
         ASSERT_TRUE(tablet_metadata->rowsets_size() == 2);
         ASSERT_TRUE(tablet_metadata->rowset_to_schema().size() == 2);
         ASSERT_TRUE(tablet_metadata->historical_schemas().size() == 2);
-        ASSERT_TRUE(tablet_metadata->historical_schemas().count(schema_id1) > 0);
-        ASSERT_TRUE(tablet_metadata->historical_schemas().count(schema_id2) > 0);
-        ASSERT_TRUE(tablet_metadata->rowset_to_schema().at(rowset_id0) == schema_id1);
-        ASSERT_TRUE(tablet_metadata->rowset_to_schema().at(rowset_id1) == schema_id2);
+        if (keys_type == PRIMARY_KEYS) {
+            ASSERT_TRUE(tablet_metadata->rowset_to_schema().at(rowset_id0) == schema_id1);
+            ASSERT_TRUE(tablet_metadata->rowset_to_schema().at(rowset_id1) == schema_id3);
+            ASSERT_TRUE(tablet_metadata->historical_schemas().count(schema_id1) > 0);
+            ASSERT_TRUE(tablet_metadata->historical_schemas().count(schema_id3) > 0);
+        } else {
+            ASSERT_TRUE(tablet_metadata->rowset_to_schema().at(rowset_id0) == schema_id1);
+            ASSERT_TRUE(tablet_metadata->rowset_to_schema().at(rowset_id1) == schema_id2);
+            ASSERT_TRUE(tablet_metadata->historical_schemas().count(schema_id1) > 0);
+            ASSERT_TRUE(tablet_metadata->historical_schemas().count(schema_id2) > 0);
+        }
     }
 
     // compaction one rowset
@@ -356,19 +364,20 @@ void AlterTabletMetaTest::test_alter_update_tablet_schema(KeysType keys_type) {
         auto rowset_id1 = tablet_metadata->rowsets(1).id();
         ASSERT_TRUE(tablet_metadata->rowsets_size() == 2);
         ASSERT_TRUE(tablet_metadata->rowset_to_schema().size() == 2);
-        ASSERT_TRUE(tablet_metadata->historical_schemas().size() == 2);
-        ASSERT_TRUE(tablet_metadata->historical_schemas().count(schema_id1) > 0);
-        ASSERT_TRUE(tablet_metadata->historical_schemas().count(schema_id2) > 0);
         if (keys_type == PRIMARY_KEYS) {
-            ASSERT_TRUE(tablet_metadata->rowset_to_schema().at(rowset_id0) == schema_id2);
-            ASSERT_TRUE(tablet_metadata->rowset_to_schema().at(rowset_id1) == schema_id1);
+            ASSERT_TRUE(tablet_metadata->rowset_to_schema().at(rowset_id0) == schema_id3);
+            ASSERT_TRUE(tablet_metadata->rowset_to_schema().at(rowset_id1) == schema_id3);
+            ASSERT_TRUE(tablet_metadata->historical_schemas().size() == 1);
+            ASSERT_TRUE(tablet_metadata->historical_schemas().count(schema_id3) > 0);
         } else {
             ASSERT_TRUE(tablet_metadata->rowset_to_schema().at(rowset_id0) == schema_id1);
             ASSERT_TRUE(tablet_metadata->rowset_to_schema().at(rowset_id1) == schema_id2);
+            ASSERT_TRUE(tablet_metadata->historical_schemas().size() == 2);
+            ASSERT_TRUE(tablet_metadata->historical_schemas().count(schema_id1) > 0);
+            ASSERT_TRUE(tablet_metadata->historical_schemas().count(schema_id2) > 0);
         }
     }
 
-    auto schema_id3 = tablet_metadata->schema().id();
     {
         TxnLogPB log;
         auto op_write_meta = log.mutable_op_write();
@@ -392,15 +401,17 @@ void AlterTabletMetaTest::test_alter_update_tablet_schema(KeysType keys_type) {
         auto rowset_id2 = tablet_metadata->rowsets(2).id();
         ASSERT_TRUE(tablet_metadata->rowsets_size() == 3);
         ASSERT_TRUE(tablet_metadata->rowset_to_schema().size() == 3);
-        ASSERT_TRUE(tablet_metadata->historical_schemas().size() == 3);
-        ASSERT_TRUE(tablet_metadata->historical_schemas().count(schema_id1) > 0);
-        ASSERT_TRUE(tablet_metadata->historical_schemas().count(schema_id2) > 0);
         if (keys_type == PRIMARY_KEYS) {
-            ASSERT_TRUE(tablet_metadata->rowset_to_schema().at(rowset_id0) == schema_id2);
-            ASSERT_TRUE(tablet_metadata->rowset_to_schema().at(rowset_id1) == schema_id1);
+            ASSERT_TRUE(tablet_metadata->rowset_to_schema().at(rowset_id0) == schema_id3);
+            ASSERT_TRUE(tablet_metadata->rowset_to_schema().at(rowset_id1) == schema_id3);
+            ASSERT_TRUE(tablet_metadata->historical_schemas().count(schema_id3) > 0);
+            ASSERT_TRUE(tablet_metadata->historical_schemas().size() == 1);
         } else {
             ASSERT_TRUE(tablet_metadata->rowset_to_schema().at(rowset_id0) == schema_id1);
             ASSERT_TRUE(tablet_metadata->rowset_to_schema().at(rowset_id1) == schema_id2);
+            ASSERT_TRUE(tablet_metadata->historical_schemas().count(schema_id1) > 0);
+            ASSERT_TRUE(tablet_metadata->historical_schemas().count(schema_id2) > 0);
+            ASSERT_TRUE(tablet_metadata->historical_schemas().size() == 3);
         }
         ASSERT_TRUE(tablet_metadata->rowset_to_schema().at(rowset_id2) == schema_id3);
     }
@@ -433,15 +444,16 @@ void AlterTabletMetaTest::test_alter_update_tablet_schema(KeysType keys_type) {
         auto rowset_id1 = tablet_metadata->rowsets(1).id();
         ASSERT_TRUE(tablet_metadata->rowsets_size() == 2);
         ASSERT_TRUE(tablet_metadata->rowset_to_schema().size() == 2);
-        ASSERT_TRUE(tablet_metadata->historical_schemas().size() == 2);
         if (keys_type == PRIMARY_KEYS) {
-            ASSERT_TRUE(tablet_metadata->historical_schemas().count(schema_id2) > 0);
-            ASSERT_TRUE(tablet_metadata->rowset_to_schema().at(rowset_id0) == schema_id2);
+            ASSERT_TRUE(tablet_metadata->historical_schemas().count(schema_id3) > 0);
+            ASSERT_TRUE(tablet_metadata->rowset_to_schema().at(rowset_id0) == schema_id3);
             ASSERT_TRUE(tablet_metadata->rowset_to_schema().at(rowset_id1) == schema_id3);
+            ASSERT_TRUE(tablet_metadata->historical_schemas().size() == 1);
         } else {
             ASSERT_TRUE(tablet_metadata->historical_schemas().count(schema_id1) > 0);
             ASSERT_TRUE(tablet_metadata->rowset_to_schema().at(rowset_id0) == schema_id1);
             ASSERT_TRUE(tablet_metadata->rowset_to_schema().at(rowset_id1) == schema_id3);
+            ASSERT_TRUE(tablet_metadata->historical_schemas().size() == 2);
         }
     }
 }


### PR DESCRIPTION
## Why I'm doing:
We can't pick schema from input rowset because when do column mode partial update, it will lost latest add column data. So instead we will return latest schema. 
Same issue as #56460 mention, and now it's on cloud native table.

## What I'm doing:
Fix it.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
