### PR TITLE
[BugFix] Fix ClassCastException caused by alter mv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
@@ -38,7 +38,6 @@ import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
-import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.Utils;
 import com.starrocks.proto.TxnInfoPB;
@@ -153,7 +152,7 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
         AgentBatchTask batchTask = new AgentBatchTask();
         MarkedCountDownLatch<Long, Long> countDownLatch;
         try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
-            LakeTable table = getTableOrThrow(db, tableId);
+            OlapTable table = getTableOrThrow(db, tableId);
             Preconditions.checkState(table.getState() == OlapTable.OlapTableState.ROLLUP);
 
             if (enableTabletCreationOptimization) {
@@ -242,7 +241,7 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
 
         // Add shadow indexes to table.
         try (WriteLockedDatabase db = getWriteLockedDatabase(dbId)) {
-            LakeTable table = getTableOrThrow(db, tableId);
+            OlapTable table = getTableOrThrow(db, tableId);
             if (table.getState() != OlapTable.OlapTableState.ROLLUP) {
                 throw new IllegalStateException("Table State doesn't equal to ROLLUP, it is " + table.getState() + ".");
             }
@@ -294,7 +293,7 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
 
         Map<Long, List<TColumn>> indexToThriftColumns = new HashMap<>();
         try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
-            LakeTable tbl = getTableOrThrow(db, tableId);
+            OlapTable tbl = getTableOrThrow(db, tableId);
             Preconditions.checkState(tbl.getState() == OlapTable.OlapTableState.ROLLUP);
             for (Map.Entry<Long, MaterializedIndex> entry : this.physicalPartitionIdToRollupIndex.entrySet()) {
                 long partitionId = entry.getKey();
@@ -376,7 +375,7 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
         }
 
         try (WriteLockedDatabase db = getWriteLockedDatabase(dbId)) {
-            LakeTable table = getTableOrThrow(db, tableId);
+            OlapTable table = getTableOrThrow(db, tableId);
             commitVersionMap = new HashMap<>();
             for (long physicalPartitionId : physicalPartitionIdToRollupIndex.keySet()) {
                 PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
@@ -415,7 +414,7 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
         }
 
         try (WriteLockedDatabase db = getWriteLockedDatabase(dbId)) {
-            LakeTable table = (db != null) ? db.getTable(tableId) : null;
+            OlapTable table = (db != null) ? db.getTable(tableId) : null;
             if (table == null) {
                 LOG.info("database or table been dropped while doing schema change job {}", jobId);
                 return;
@@ -452,7 +451,7 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
         }
 
         try (WriteLockedDatabase db = getWriteLockedDatabase(dbId)) {
-            LakeTable table = (db != null) ? db.getTable(tableId) : null;
+            OlapTable table = (db != null) ? db.getTable(tableId) : null;
             if (table != null) {
                 removeRollupIndex(table);
             }
@@ -535,7 +534,7 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
         }
 
         try (WriteLockedDatabase db = getWriteLockedDatabase(dbId)) {
-            LakeTable table = (db != null) ? db.getTable(tableId) : null;
+            OlapTable table = (db != null) ? db.getTable(tableId) : null;
             if (table == null) {
                 return; // do nothing if the table has been dropped.
             }
@@ -606,7 +605,7 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
         return GlobalStateMgr.getCurrentState().getGtidGenerator().nextGtid();
     }
 
-    void addRollIndexToCatalog(@NotNull LakeTable tbl) {
+    void addRollIndexToCatalog(@NotNull OlapTable tbl) {
         for (Partition partition : tbl.getPartitions()) {
             for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
                 long partitionId = physicalPartition.getId();
@@ -634,7 +633,7 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
         }
     }
 
-    void updateNextVersion(@NotNull LakeTable table) {
+    void updateNextVersion(@NotNull OlapTable table) {
         for (long partitionId : physicalPartitionIdToRollupIndex.keySet()) {
             PhysicalPartition partition = table.getPhysicalPartition(partitionId);
             long commitVersion = commitVersionMap.get(partitionId);
@@ -646,7 +645,7 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
 
     boolean readyToPublishVersion() throws AlterCancelException {
         try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
-            LakeTable table = getTableOrThrow(db, tableId);
+            OlapTable table = getTableOrThrow(db, tableId);
             for (long partitionId : physicalPartitionIdToRollupIndex.keySet()) {
                 PhysicalPartition partition = table.getPhysicalPartition(partitionId);
                 Preconditions.checkState(partition != null, partitionId);
@@ -664,7 +663,7 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
 
     protected boolean lakePublishVersion() {
         try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
-            LakeTable table = getTableOrThrow(db, tableId);
+            OlapTable table = getTableOrThrow(db, tableId);
             for (long partitionId : physicalPartitionIdToRollupIndex.keySet()) {
                 PhysicalPartition physicalPartition = table.getPhysicalPartition(partitionId);
                 Preconditions.checkState(physicalPartition != null, partitionId);
@@ -704,7 +703,7 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
         }
     }
 
-    void removeRollupIndex(@NotNull LakeTable table) {
+    void removeRollupIndex(@NotNull OlapTable table) {
         TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
         for (Long partitionId : physicalPartitionIdToRollupIndex.keySet()) {
             MaterializedIndex rollupIndex = physicalPartitionIdToRollupIndex.get(partitionId);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJobBase.java
@@ -19,11 +19,11 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
-import com.starrocks.lake.LakeTable;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.task.AgentBatchTask;
@@ -91,8 +91,8 @@ public abstract class LakeTableSchemaChangeJobBase extends AlterJobV2 {
         abstract void unlock(Database db);
 
         @Nullable
-        LakeTable getTable(long tableId) {
-            return (LakeTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
+        OlapTable getTable(long tableId) {
+            return (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         }
 
         @Override
@@ -149,11 +149,11 @@ public abstract class LakeTableSchemaChangeJobBase extends AlterJobV2 {
     }
 
     @NotNull
-    LakeTable getTableOrThrow(@Nullable LockedDatabase db, long tableId) throws AlterCancelException {
+    OlapTable getTableOrThrow(@Nullable LockedDatabase db, long tableId) throws AlterCancelException {
         if (db == null) {
             throw new AlterCancelException("Database does not exist");
         }
-        LakeTable table = db.getTable(tableId);
+        OlapTable table = db.getTable(tableId);
         if (table == null) {
             throw new AlterCancelException("Table does not exist. tableId=" + tableId);
         }


### PR DESCRIPTION
## Why I'm doing:
```
,"tableId":1467128,"tableName":"events","errMsg":"","createTimeMs":1743703547031,"finishedTimeMs":-1,"timeoutMs":86400000,"warehouseId":0},
com.starrocks.journal.JournalInconsistentException: failed to load journal type 121
    at com.starrocks.epack.persist.EditLogEPack.loadJournal(EditLogEPack.java:153) ~[starrocks-fe.jar:?]
    at com.starrocks.server.GlobalStateMgr.replayJournalInner(GlobalStateMgr.java:2121) ~[starrocks-fe.jar:?]
    at com.starrocks.server.GlobalStateMgr.replayJournal(GlobalStateMgr.java:2070) ~[starrocks-fe.jar:?]
    at com.starrocks.server.GlobalStateMgr.transferToLeader(GlobalStateMgr.java:1355) ~[starrocks-fe.jar:?]
    at com.starrocks.server.GlobalStateMgr$1.transferToLeader(GlobalStateMgr.java:806) ~[starrocks-fe.jar:?]
    at com.starrocks.ha.StateChangeExecutor.runOneCycle(StateChangeExecutor.java:103) ~[starrocks-fe.jar:?]
    at com.starrocks.common.util.Daemon.run(Daemon.java:98) ~[starrocks-fe.jar:?]
Caused by: com.starrocks.journal.JournalInconsistentException: failed to load journal type 121
    at com.starrocks.persist.EditLog.loadJournal(EditLog.java:1204) ~[starrocks-fe.jar:?]
    at com.starrocks.epack.persist.EditLogEPack.loadJournal(EditLogEPack.java:149) ~[starrocks-fe.jar:?]
    ... 6 more
Caused by: java.lang.ClassCastException: class com.starrocks.lake.LakeMaterializedView cannot be cast to class com.starrocks.lake.LakeTable (com.starrocks.lake.LakeMaterializedView and com.starrocks.lake.LakeTable are in unnamed module of loader 'app')
    at com.starrocks.alter.LakeTableSchemaChangeJobBase$LockedDatabase.getTable(LakeTableSchemaChangeJobBase.java:95) ~[starrocks-fe.jar:?]
    at com.starrocks.alter.LakeTableSchemaChangeJob.replay(LakeTableSchemaChangeJob.java:753) ~[starrocks-fe.jar:?]
    at com.starrocks.alter.AlterHandler.replayAlterJobV2(AlterHandler.java:203) ~[starrocks-fe.jar:?]
    at com.starrocks.persist.EditLog.loadJournal(EditLog.java:714) ~[starrocks-fe.jar:?]
    at com.starrocks.epack.persist.EditLogEPack.loadJournal(EditLogEPack.java:149) ~[starrocks-fe.jar:?]
    ... 6 more
2025-04-04 09:52:34.274+01:00 WARN (stateChangeExecutor|87) [GlobalStateMgr.replayJournal():2072] got interrupt exception or inconsistent exception when replay journal 7184623, will exit, 
com.starrocks.journal.JournalInconsistentException: failed to load journal type 121
    at com.starrocks.epack.persist.EditLogEPack.loadJournal(EditLogEPack.java:153) ~[starrocks-fe.jar:?]
```
## What I'm doing:

Fixes #issue
https://starrocks.atlassian.net/browse/SR-33486
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
