### PR TITLE
[BugFix] Subfield pushdown generate duplicate outer column refs on TableFunction

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PushDownSubfieldRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PushDownSubfieldRule.java
@@ -46,6 +46,7 @@ import com.starrocks.sql.optimizer.task.TaskContext;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /*
  * Push down subfield expression to scan node
@@ -561,7 +562,9 @@ public class PushDownSubfieldRule implements TreeRewriteRule {
                     localContext.put(columnRef, expr);
                 }
             }
-
+            // remove already-existing outer column refs.
+            extraOuterColRefs = extraOuterColRefs.stream()
+                    .filter(columnRef -> !outerColRefSet.contains(columnRef)).collect(Collectors.toList());
             ColumnRefSet childSubfieldOutputs = ColumnRefSet.of();
             childSubfieldOutputs.union(extraOuterColRefs);
             Optional<Operator> project = generatePushDownProject(optExpression, childSubfieldOutputs, localContext);


### PR DESCRIPTION
## Why I'm doing:
Sqltest test_unnest_left_join@test_unnest_left_join fails, since outerColumnRefs of table function contains duplicate slots led by subfield pushdown.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
