### PR TITLE
[BugFix] Fix the bug that disk data cache cannot be expanded

### DIFF
--- a/be/src/cache/block_cache/disk_space_monitor.cpp
+++ b/be/src/cache/block_cache/disk_space_monitor.cpp
@@ -147,7 +147,7 @@ bool DiskSpace::_allow_expansion(const AdjustContext& ctx) {
         return false;
     }
     if (ctx.total_cache_quota > 0) {
-        double cache_used_rate = static_cast<double>(ctx.total_cache_usage / ctx.total_cache_quota);
+        double cache_used_rate = static_cast<double>(ctx.total_cache_usage) / ctx.total_cache_quota;
         if (cache_used_rate < kAutoIncreaseThreshold) {
             return false;
         }

--- a/be/test/cache/block_cache/disk_space_monitor_test.cpp
+++ b/be/test/cache/block_cache/disk_space_monitor_test.cpp
@@ -185,7 +185,7 @@ TEST_F(DiskSpaceMonitorTest, auto_increase_cache_quota) {
     {
         size_t batch_size = MB;
         const std::string cache_key = "test_file";
-        for (size_t i = 0; i < 20; ++i) {
+        for (size_t i = 0; i < 19; ++i) {
             char ch = 'a' + i % 26;
             std::string value(batch_size, ch);
             Status st = cache->write(cache_key + std::to_string(i), 0, batch_size, value.c_str());
@@ -212,9 +212,9 @@ TEST_F(DiskSpaceMonitorTest, auto_increase_cache_quota) {
         config::datacache_disk_idle_seconds_for_expansion = 1;
         sleep(3);
         auto metrics = cache->cache_metrics();
-        // other: 500M - 300M - 20M = 180M
-        // new quota: 500 * 0.7 - other = 170M
-        ASSERT_EQ(metrics.disk_quota_bytes, 170 * MB);
+        // other: 500M - 300M - 19M = 181M
+        // new quota: 500 * 0.7 - other = 169M, 169M/10 * 10 = 160M
+        ASSERT_EQ(metrics.disk_quota_bytes, 160 * MB);
     }
 
     cache->shutdown();


### PR DESCRIPTION
## Why I'm doing:

```
double cache_used_rate = static_cast<double>(ctx.total_cache_usage / ctx.total_cache_quota);
```

`total_cache_usage` and `total_cache_quota` is all bigint, if `total_cache_usage < total_cache_quota` `cache_used_rate`  is always 0, so it will not be extended.

## What I'm doing:

Fix the bug that disk data cache cannot be expanded.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
