### PR TITLE
[BugFix] remove the unnecessary check for getPartitions in iceberg catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.connector.iceberg;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Database;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -249,9 +249,6 @@ public interface IcebergCatalog extends MemoryTrackable {
         // using partition metadata table scan is more  efficient than doing file scan, but limitation is
         // it only supports the latest snapshot id.
         if (snapshotId != -1) {
-            Preconditions.checkArgument(nativeTable.currentSnapshot().snapshotId() == snapshotId,
-                    "Ignore this error if snapshot id does not match. Iceberg partition metadata table only supports latest " +
-                            "snapshot. current = " + nativeTable.currentSnapshot().snapshotId() + ", expect = " + snapshotId);
             tableScan = tableScan.useSnapshot(snapshotId);
         }
         if (executorService != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -245,9 +245,6 @@ public interface IcebergCatalog extends MemoryTrackable {
         PartitionsTable partitionsTable = (PartitionsTable) MetadataTableUtils.
                 createMetadataTableInstance(nativeTable, MetadataTableType.PARTITIONS);
         TableScan tableScan = partitionsTable.newScan();
-        // NOTE: if there is an exception raise because of snapshot id is not the latest one, it's expected
-        // using partition metadata table scan is more  efficient than doing file scan, but limitation is
-        // it only supports the latest snapshot id.
         if (snapshotId != -1) {
             tableScan = tableScan.useSnapshot(snapshotId);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -23,7 +23,6 @@ import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.Pair;
 import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.ConnectorViewDefinition;
-import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.sql.ast.AlterViewStmt;
@@ -41,6 +40,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.util.StructProjection;
 import org.apache.iceberg.view.SQLViewRepresentation;
 import org.apache.iceberg.view.View;
@@ -59,6 +59,7 @@ import java.util.concurrent.ExecutorService;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.starrocks.catalog.IcebergView.STARROCKS_DIALECT;
+import static com.starrocks.connector.PartitionUtil.convertIcebergPartitionToPartitionName;
 import static com.starrocks.connector.iceberg.IcebergApiConverter.buildViewProperties;
 import static com.starrocks.connector.iceberg.IcebergApiConverter.convertDbNameToNamespace;
 import static com.starrocks.connector.iceberg.IcebergMetadata.LOCATION_PROPERTY;
@@ -238,20 +239,46 @@ public interface IcebergCatalog extends MemoryTrackable {
         return new ArrayList<>();
     }
 
+    default Map<String, Partition> getPartitionsByDataFiles(String dbName, String tableName, ExecutorService executorService,  Map<String, Partition> partitionMap) {
+        org.apache.iceberg.Table icebergTable = getTable(dbName, tableName);
+
+        if (icebergTable.specs().values().stream().allMatch(PartitionSpec::isUnpartitioned)) {
+            return partitionMap;
+        }
+
+        TableScan tableScan = icebergTable.newScan().planWith(executorService);
+        try (CloseableIterable<FileScanTask> fileScanTaskIterable = tableScan.planFiles();
+                CloseableIterator<FileScanTask> fileScanTaskIterator = fileScanTaskIterable.iterator()) {
+
+            while (fileScanTaskIterator.hasNext()) {
+                FileScanTask scanTask = fileScanTaskIterator.next();
+                StructLike partition = scanTask.file().partition();
+                String partitionName = convertIcebergPartitionToPartitionName(scanTask.spec(), partition);
+                long lastUpdated = -1;
+                Partition partitionData = new Partition(lastUpdated);
+                partitionMap.put(partitionName, partitionData);
+            }
+        } catch (IOException e) {
+            throw new StarRocksConnectorException(String.format("Failed to list iceberg partition names %s.%s",
+                    dbName, tableName), e);
+        }
+        return partitionMap;
+    }
+
     // --------------- partition APIs ---------------
     default Map<String, Partition> getPartitions(IcebergTable icebergTable, long snapshotId, ExecutorService executorService) {
         Table nativeTable = icebergTable.getNativeTable();
         Map<String, Partition> partitionMap = Maps.newHashMap();
         PartitionsTable partitionsTable = (PartitionsTable) MetadataTableUtils.
                 createMetadataTableInstance(nativeTable, MetadataTableType.PARTITIONS);
+
+        if (snapshotId != -1 && nativeTable.currentSnapshot().snapshotId() != snapshotId) {
+            return getPartitionsByDataFiles(icebergTable.getCatalogDBName(), icebergTable.getName(), executorService, partitionMap);
+        }
+
         TableScan tableScan = partitionsTable.newScan();
-        // NOTE: if there is an exception raise because of snapshot id is not the latest one, it's expected
-        // using partition metadata table scan is more  efficient than doing file scan, but limitation is
-        // it only supports the latest snapshot id.
+
         if (snapshotId != -1) {
-            Preconditions.checkArgument(nativeTable.currentSnapshot().snapshotId() == snapshotId,
-                    "Ignore this error if snapshot id does not match. Iceberg partition metadata table only supports latest " +
-                            "snapshot. current = " + nativeTable.currentSnapshot().snapshotId() + ", expect = " + snapshotId);
             tableScan = tableScan.useSnapshot(snapshotId);
         }
         if (executorService != null) {
@@ -322,7 +349,7 @@ public interface IcebergCatalog extends MemoryTrackable {
                         PartitionSpec spec = nativeTable.specs().get(specId);
 
                         String partitionName =
-                                PartitionUtil.convertIcebergPartitionToPartitionName(spec, partitionData);
+                                convertIcebergPartitionToPartitionName(spec, partitionData);
 
                         long lastUpdated = -1;
                         try {


### PR DESCRIPTION
## Why I'm doing:
Partition table scans are only supported for the latest snapshot ID. Therefore, for the latest snapshot, a partition metadata scan is necessary to enhance performance. However, a data file scan is required to handle other scenarios(old snapshot).
<img width="1532" alt="image" src="https://github.com/user-attachments/assets/2a2db0b4-7df5-4cff-9ffd-2149c256aa3c" />

## What I'm doing:

as title

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
