### PR TITLE
[Enhancement] Modify the semantics of datacache_disk_size

### DIFF
--- a/be/src/cache/block_cache/disk_space_monitor.cpp
+++ b/be/src/cache/block_cache/disk_space_monitor.cpp
@@ -114,6 +114,8 @@ size_t DiskSpace::_cache_file_space_usage() {
 
 void DiskSpace::_update_disk_options() {
     _disk_opts.cache_lower_limit = config::datacache_min_disk_quota_for_adjustment;
+    _disk_opts.cache_upper_limit = DataCacheUtils::parse_conf_datacache_disk_size(_path, config::datacache_disk_size,
+                                                                                  _disk_stats.capacity_bytes);
     _disk_opts.low_level_size = _disk_stats.capacity_bytes * 0.01 * config::datacache_disk_low_level;
     _disk_opts.safe_level_size = _disk_stats.capacity_bytes * 0.01 * config::datacache_disk_safe_level;
     _disk_opts.high_level_size = _disk_stats.capacity_bytes * 0.01 * config::datacache_disk_high_level;
@@ -195,6 +197,9 @@ size_t DiskSpace::_check_cache_high_limit(int64_t cache_quota) {
     if (cache_quota > _disk_opts.safe_level_size) {
         LOG(INFO) << "Correct the cache quota because it reaches the high limit. quota: " << cache_quota;
         cache_quota = _disk_opts.safe_level_size;
+    }
+    if (cache_quota > _disk_opts.cache_upper_limit) {
+        cache_quota = _disk_opts.cache_upper_limit;
     }
     return cache_quota;
 }

--- a/be/src/cache/block_cache/disk_space_monitor.h
+++ b/be/src/cache/block_cache/disk_space_monitor.h
@@ -51,6 +51,7 @@ public:
 
     struct DiskOptions {
         int64_t cache_lower_limit = 0;
+        int64_t cache_upper_limit = 0;
 
         int64_t low_level_size = 0;
         int64_t safe_level_size = 0;

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1209,7 +1209,7 @@ CONF_mInt64(max_length_for_bitmap_function, "1000000");
 // Configuration items for datacache
 CONF_Bool(datacache_enable, "true");
 CONF_mString(datacache_mem_size, "0");
-CONF_mString(datacache_disk_size, "0");
+CONF_mString(datacache_disk_size, "100%");
 CONF_Int64(datacache_block_size, "262144"); // 256K
 CONF_Bool(datacache_checksum_enable, "false");
 CONF_Bool(datacache_direct_io_enable, "false");

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -463,7 +463,7 @@ Status CacheEnv::_init_datacache() {
             total_quota_bytes += disk_size;
         }
 
-        if (cache_options.disk_spaces.empty() || total_quota_bytes != 0) {
+        if (cache_options.disk_spaces.empty()) {
             config::datacache_auto_adjust_enable = false;
         }
 

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -425,7 +425,6 @@ Status CacheEnv::_init_datacache() {
         RETURN_IF_ERROR(DataCacheUtils::parse_conf_datacache_mem_size(config::datacache_mem_size, mem_limit,
                                                                       &cache_options.mem_space_size));
 
-        size_t total_quota_bytes = 0;
         for (auto& root_path : _store_paths) {
             // Because we have unified the datacache between datalake and starlet, we also need to unify the
             // cache path and quota.
@@ -460,7 +459,6 @@ Status CacheEnv::_init_datacache() {
             }
 #endif
             cache_options.disk_spaces.push_back({.path = datacache_path, .size = static_cast<size_t>(disk_size)});
-            total_quota_bytes += disk_size;
         }
 
         if (cache_options.disk_spaces.empty()) {


### PR DESCRIPTION
## Why I'm doing:

There are two purposes for modifying this configuration:
* Make the semantics of disk data cache consistent with those of memory data cache.
* Allow manual configuration of the upper limit of disk data cache while supporting automatic adjustment based on the current disk usage.

The semantics of `config::datacache_disk_size` before the modification: 
* `=0` indicates that the entire disk is used as disk cache, and the function of automatically adjusting according to the disk usage stats is enabled.
* `>0`, the automatic adjustment function of the disk cache will be disabled.

The semantics after the modification:
* This configuration represents the upper limit of disk data cache. Within this upper limit, the disk cache will be automatically adjusted according to the current disk usage.

## What I'm doing:

Modify the semantics of datacache_disk_size

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
