### PR TITLE
[Enhancement] bitmap_union support window_function

### DIFF
--- a/be/src/exec/analytor.cpp
+++ b/be/src/exec/analytor.cpp
@@ -247,7 +247,7 @@ Status Analytor::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* 
 
         for (size_t j = 0; j < _agg_expr_ctxs[i].size(); ++j) {
             // We always treat first argument as non const, because most window function has only one args
-            // and cant't handler const column within the function.
+            // and can't handler const column within the function.
             if (j == 0) {
                 _agg_intput_columns[i][j] =
                         ColumnHelper::create_column(_agg_expr_ctxs[i][j]->root()->type(), is_input_nullable);

--- a/be/src/exprs/agg/bitmap_union.h
+++ b/be/src/exprs/agg/bitmap_union.h
@@ -17,6 +17,7 @@
 #include "column/object_column.h"
 #include "column/vectorized_fwd.h"
 #include "exprs/agg/aggregate.h"
+#include "exprs/agg/aggregate_traits.h"
 #include "gutil/casts.h"
 #include "types/bitmap_value.h"
 
@@ -26,6 +27,10 @@ class BitmapUnionAggregateFunction final
         : public AggregateFunctionBatchHelper<BitmapValue, BitmapUnionAggregateFunction> {
 public:
     bool is_exception_safe() const override { return false; }
+
+    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
+        this->data(state).clear();
+    }
 
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
         const auto* col = down_cast<const BitmapColumn*>(columns[0]);
@@ -44,6 +49,15 @@ public:
         col->append(std::move(bitmap));
     }
 
+    void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
+                                              int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
+                                              int64_t frame_end) const override {
+        const auto* col = down_cast<const BitmapColumn*>(columns[0]);
+        for (size_t i = frame_start; i < frame_end; ++i) {
+            this->data(state) |= *(col->get_object(i));
+        }
+    }
+
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
                                      ColumnPtr* dst) const override {
         *dst = src[0];
@@ -53,6 +67,14 @@ public:
         auto* col = down_cast<BitmapColumn*>(to);
         auto& bitmap = const_cast<BitmapValue&>(this->data(state));
         col->append(std::move(bitmap));
+    }
+
+    void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
+                    size_t end) const override {
+        auto* col = down_cast<BitmapColumn*>(dst);
+        for (size_t i = start; i < end; i++) {
+            AggDataTypeTraits<TYPE_OBJECT>::assign_value(col, i, this->data(state));
+        }
     }
 
     std::string get_name() const override { return "bitmap_union"; }

--- a/be/src/exprs/agg/factory/aggregate_resolver_minmaxany.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_minmaxany.cpp
@@ -32,7 +32,7 @@ void AggregateFuncResolver::register_bitmap() {
             "bitmap_union_int", false, AggregateFactory::MakeBitmapUnionIntAggregateFunction<TYPE_INT>());
     add_aggregate_mapping<TYPE_BIGINT, TYPE_BIGINT, BitmapValue>(
             "bitmap_union_int", false, AggregateFactory::MakeBitmapUnionIntAggregateFunction<TYPE_BIGINT>());
-    add_aggregate_mapping<TYPE_OBJECT, TYPE_OBJECT, BitmapValue>("bitmap_union", false,
+    add_aggregate_mapping<TYPE_OBJECT, TYPE_OBJECT, BitmapValue>("bitmap_union", true,
                                                                  AggregateFactory::MakeBitmapUnionAggregateFunction());
 
     add_aggregate_mapping<TYPE_BOOLEAN, TYPE_OBJECT, BitmapValue>(

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -1214,7 +1214,7 @@ public class FunctionSet {
         addBuiltin(AggregateFunction.createBuiltin(BITMAP_UNION, Lists.newArrayList(Type.BITMAP),
                 Type.BITMAP,
                 Type.BITMAP,
-                true, false, true));
+                true, true, true));
 
         // Type.VARCHAR must before all other type, so bitmap_agg(varchar) can convert to bitmap_agg(bigint)
         addBuiltin(AggregateFunction.createBuiltin(BITMAP_AGG, Lists.newArrayList(Type.BIGINT),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyticAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyticAnalyzer.java
@@ -69,10 +69,11 @@ public class AnalyticAnalyzer {
         for (Expr e : analyticExpr.getFnCall().getChildren()) {
             if (e.getType().isBitmapType() &&
                     !analyticFunction.getFn().functionName().equals(FunctionSet.BITMAP_UNION_COUNT) &&
+                    !analyticFunction.getFn().functionName().equals(FunctionSet.BITMAP_UNION) &&
                     !analyticFunction.getFn().functionName().equals(FunctionSet.LEAD) &&
                     !analyticFunction.getFn().functionName().equals(FunctionSet.LAG)) {
-                throw new SemanticException("bitmap type could only used for bitmap_union_count/lead/lag window function",
-                        e.getPos());
+                throw new SemanticException("bitmap type could only used for bitmap_union_count/bitmap_union/lead/lag " +
+                        "window function", e.getPos());
             } else if (e.getType().isHllType() &&
                     !analyticFunction.getFn().functionName().equals(AnalyticExpr.HLL_UNION_AGG) &&
                     !analyticFunction.getFn().functionName().equals(FunctionSet.LEAD) &&

--- a/test/sql/test_window_function/R/test_bitmap_union_window_function
+++ b/test/sql/test_window_function/R/test_bitmap_union_window_function
@@ -1,0 +1,47 @@
+-- name: test_bitmap_union_window_function
+CREATE TABLE t1(
+    c1 int,
+    c2 bitmap
+)
+PRIMARY KEY(c1)
+DISTRIBUTED BY HASH(c1) BUCKETS 1
+PROPERTIES(
+    "replication_num"="1"
+);
+-- result:
+-- !result
+INSERT INTO t1 VALUES (1, to_bitmap(11)), (2, to_bitmap(22)), (3, null), (4, bitmap_empty()), (5, to_bitmap(55));
+-- result:
+-- !result
+SELECT c1, bitmap_to_string(bitmap_union(c2) over()) from t1 order by c1;
+-- result:
+1	11,22,55
+2	11,22,55
+3	11,22,55
+4	11,22,55
+5	11,22,55
+-- !result
+SELECT c1, bitmap_to_string(bitmap_union(c2) over(partition by c1)) from t1 order by c1;
+-- result:
+1	11
+2	22
+3	None
+4	
+5	55
+-- !result
+SELECT c1, bitmap_to_string(bitmap_union(c2) over(partition by c1%2)) from t1 order by c1;
+-- result:
+1	11,55
+2	22
+3	11,55
+4	22
+5	11,55
+-- !result
+SELECT c1, bitmap_to_string(bitmap_union(c2) over(partition by c1%2 order by c1)) from t1 order by c1;
+-- result:
+1	11
+2	22
+3	11
+4	22
+5	11,55
+-- !result

--- a/test/sql/test_window_function/T/test_bitmap_union_window_function
+++ b/test/sql/test_window_function/T/test_bitmap_union_window_function
@@ -1,0 +1,21 @@
+-- name: test_bitmap_union_window_function
+
+CREATE TABLE t1(
+    c1 int,
+    c2 bitmap
+)
+PRIMARY KEY(c1)
+DISTRIBUTED BY HASH(c1) BUCKETS 1
+PROPERTIES(
+    "replication_num"="1"
+);
+
+INSERT INTO t1 VALUES (1, to_bitmap(11)), (2, to_bitmap(22)), (3, null), (4, bitmap_empty()), (5, to_bitmap(55));
+
+SELECT c1, bitmap_to_string(bitmap_union(c2) over()) from t1 order by c1;
+
+SELECT c1, bitmap_to_string(bitmap_union(c2) over(partition by c1)) from t1 order by c1;
+
+SELECT c1, bitmap_to_string(bitmap_union(c2) over(partition by c1%2)) from t1 order by c1;
+
+SELECT c1, bitmap_to_string(bitmap_union(c2) over(partition by c1%2 order by c1)) from t1 order by c1;


### PR DESCRIPTION
## Why I'm doing:

At present, many users need to use window function + bitmap for some UV analysis, since users need to obtain user details and then perform some join operations, so `bitmap_union_count` cannot meet their needs. 
So `bitmap_union` needs to support window functions.

Business scenario:

```
with exp_tb as(
select group_id,
ds,
BITMAP_UNION(uid_bit) OVER (PARTITION BY group_id ORDER BY ds ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) uid_bit
from table_a where exp_id='1' and exp_version='v1'
)

select
group_id,
bitmap_count(s1.uid_bit) uv,
bitmap_count(BITMAP_AND(s1.uid_bit,s2.uid_bit_metrics)) * metrics_value all_metrics_value
from
exp_tb s1
left join
(select 
ds,
metrics_value,
uid_bit_metrics
from 
table_metrics)s2
on s1.ds=s2.ds
```

## What I'm doing:

bitmap_union support window_function

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
