### PR TITLE
[BugFix] Fix cancel query for external low cardinality

### DIFF
--- a/be/src/exec/pipeline/fragment_context.cpp
+++ b/be/src/exec/pipeline/fragment_context.cpp
@@ -244,9 +244,12 @@ void FragmentContext::set_stream_load_contexts(const std::vector<StreamLoadConte
 }
 
 // Note: this function should be thread safe
-void FragmentContext::cancel(const Status& status) {
+void FragmentContext::cancel(const Status& status, bool cancelled_by_fe) {
     if (!status.ok() && _runtime_state != nullptr && _runtime_state->query_ctx() != nullptr) {
         _runtime_state->query_ctx()->release_workgroup_token_once();
+        if (cancelled_by_fe) {
+            _runtime_state->query_ctx()->set_cancelled_by_fe();
+        }
     }
 
     _runtime_state->set_is_cancelled(true);

--- a/be/src/exec/pipeline/fragment_context.h
+++ b/be/src/exec/pipeline/fragment_context.h
@@ -90,7 +90,7 @@ public:
         return status == nullptr ? Status::OK() : *status;
     }
 
-    void cancel(const Status& status);
+    void cancel(const Status& status, bool cancelled_by_fe = false);
 
     void finish() { cancel(Status::OK()); }
 

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -99,6 +99,7 @@ Status FragmentExecutor::_prepare_query_ctx(ExecEnv* exec_env, const UnifiedExec
     const auto& query_id = params.query_id;
     const auto& fragment_instance_id = request.fragment_instance_id();
     const auto& query_options = request.common().query_options;
+    const auto& t_desc_tbl = request.common().desc_tbl;
 
     auto&& existing_query_ctx = exec_env->query_context_mgr()->get(query_id);
     if (existing_query_ctx) {
@@ -108,7 +109,8 @@ Status FragmentExecutor::_prepare_query_ctx(ExecEnv* exec_env, const UnifiedExec
         }
     }
 
-    ASSIGN_OR_RETURN(_query_ctx, exec_env->query_context_mgr()->get_or_register(query_id));
+    const bool query_ctx_should_exist = t_desc_tbl.__isset.is_cached && t_desc_tbl.is_cached;
+    ASSIGN_OR_RETURN(_query_ctx, exec_env->query_context_mgr()->get_or_register(query_id, query_ctx_should_exist));
     _query_ctx->set_exec_env(exec_env);
     if (params.__isset.instances_number) {
         _query_ctx->set_total_fragments(params.instances_number);

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -110,7 +110,7 @@ void QueryContext::cancel(const Status& status, bool cancelled_by_fe) {
     _is_cancelled = true;
     if (cancelled_by_fe) {
         // only update when confirm cancelled from fe
-        _cancelled_by_fe = true;
+        set_cancelled_by_fe();
     }
     if (_cancelled_status.load() != nullptr) {
         return;
@@ -387,7 +387,8 @@ QueryContextManager::~QueryContextManager() {
         return query_ctx->get_cancelled_status();           \
     }
 
-StatusOr<QueryContext*> QueryContextManager::get_or_register(const TUniqueId& query_id) {
+StatusOr<QueryContext*> QueryContextManager::get_or_register(const TUniqueId& query_id,
+                                                             bool return_error_if_not_exist) {
     size_t i = _slot_idx(query_id);
     auto& mutex = _mutexes[i];
     auto& context_map = _context_maps[i];
@@ -420,6 +421,10 @@ StatusOr<QueryContext*> QueryContextManager::get_or_register(const TUniqueId& qu
                 context_map.emplace(query_id, std::move(ctx));
                 return raw_ctx_ptr;
             }
+        }
+
+        if (return_error_if_not_exist) {
+            return Status::Cancelled("Query terminates prematurely");
         }
 
         // finally, find no query contexts, so create a new one

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -154,6 +154,7 @@ public:
     FragmentContextManager* fragment_mgr();
 
     void cancel(const Status& status, bool cancelled_by_fe);
+    void set_cancelled_by_fe() { _cancelled_by_fe = true; }
 
     void set_is_runtime_filter_coordinator(bool flag) { _is_runtime_filter_coordinator = flag; }
 
@@ -386,7 +387,7 @@ public:
     QueryContextManager(size_t log2_num_slots);
     ~QueryContextManager();
     Status init();
-    StatusOr<QueryContext*> get_or_register(const TUniqueId& query_id);
+    StatusOr<QueryContext*> get_or_register(const TUniqueId& query_id, bool return_error_if_not_exist = false);
     QueryContextPtr get(const TUniqueId& query_id, bool need_prepared = false);
     size_t size();
     bool remove(const TUniqueId& query_id);

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -566,7 +566,7 @@ void PInternalServiceImplBase<T>::_cancel_plan_fragment(google::protobuf::RpcCon
                         "FragmentContext already destroyed: query_id=$0, fragment_instance_id=$1", print_id(query_id),
                         print_id(tid));
             } else {
-                fragment_ctx->cancel(Status::Cancelled(reason_string));
+                fragment_ctx->cancel(Status::Cancelled(reason_string), true);
             }
         }
     } else {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteExceptionHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteExceptionHandler.java
@@ -38,6 +38,7 @@ import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.statistics.IRelaxDictManager;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TExplainLevel;
+import com.starrocks.thrift.TStatusCode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -64,6 +65,11 @@ public class ExecuteExceptionHandler {
         } else {
             throw e;
         }
+    }
+
+    public static boolean isRetryableStatus(TStatusCode statusCode) {
+        return statusCode == TStatusCode.REMOTE_FILE_NOT_FOUND || statusCode == TStatusCode.GLOBAL_DICT_ERROR ||
+                statusCode == TStatusCode.THRIFT_RPC_ERROR;
     }
 
     // If modifications are made to the partition files of a Hive table by user,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteExceptionHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteExceptionHandler.java
@@ -68,8 +68,9 @@ public class ExecuteExceptionHandler {
     }
 
     public static boolean isRetryableStatus(TStatusCode statusCode) {
-        return statusCode == TStatusCode.REMOTE_FILE_NOT_FOUND || statusCode == TStatusCode.GLOBAL_DICT_ERROR ||
-                statusCode == TStatusCode.THRIFT_RPC_ERROR;
+        return statusCode == TStatusCode.REMOTE_FILE_NOT_FOUND
+                || statusCode == TStatusCode.THRIFT_RPC_ERROR
+                || statusCode == TStatusCode.GLOBAL_DICT_NOT_MATCH;
     }
 
     // If modifications are made to the partition files of a Hive table by user,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Deployer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Deployer.java
@@ -23,6 +23,7 @@ import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ExecuteExceptionHandler;
 import com.starrocks.qe.scheduler.dag.ExecutionDAG;
 import com.starrocks.qe.scheduler.dag.ExecutionFragment;
 import com.starrocks.qe.scheduler.dag.FragmentInstance;
@@ -260,6 +261,12 @@ public class Deployer {
             // Otherwise, the cancellation RPC may arrive at BE before the delivery fragment instance RPC,
             // causing the instances to become stale and only able to be released after a timeout.
             if (firstErrResult == null) {
+                firstErrResult = res;
+                firstErrExecution = execution;
+            } else if (firstErrResult.getStatusCode() == TStatusCode.CANCELLED &&
+                    ExecuteExceptionHandler.isRetryableStatus(res.getStatusCode())) {
+                // If the first error is cancelled and the subsequent error is retryable, we store the latter to give a chance
+                // to retry this query.
                 firstErrResult = res;
                 firstErrExecution = execution;
             }

--- a/test/sql/test_low_cardinality/R/test_low_cardinality_parquet_cancel
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality_parquet_cancel
@@ -1,0 +1,290 @@
+-- name: test_low_cardinality_parquet_cancel @sequential
+create external catalog ice_cat_${uuid0}
+properties (
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog ice_cat_${uuid0};
+-- result:
+-- !result
+create database ice_db_${uuid0};
+-- result:
+-- !result
+use ice_db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+);
+-- result:
+-- !result
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+-- result:
+-- !result
+insert into __row_util_base select * from __row_util_base; 
+insert into __row_util_base select * from __row_util_base; 
+insert into __row_util_base select * from __row_util_base; 
+insert into __row_util_base select * from __row_util_base; 
+insert into __row_util_base select * from __row_util_base; 
+insert into __row_util_base select * from __row_util_base;
+-- result:
+-- !result
+insert into __row_util_base select * from __row_util_base;
+-- result:
+-- !result
+CREATE TABLE __row_util (
+  idx bigint NULL
+);
+-- result:
+-- !result
+insert into __row_util select row_number() over() as idx from __row_util_base;
+-- result:
+-- !result
+CREATE TABLE t2 (
+    k1 bigint NULL,
+
+    c_int1 int null,
+    c_int2 int null,
+    c_str1 string null,
+    c_str2 string null
+);
+-- result:
+-- !result
+INSERT INTO t2
+SELECT
+    idx,
+
+    idx,
+    idx,
+
+    concat('varchar-', idx % 100),
+    concat('varchar-', idx % 10)
+FROM __row_util;
+-- result:
+-- !result
+[UC]ANALYZE TABLE t2;
+-- result:
+ice_cat_09d512fb7ac14840955c15127eb73256.ice_db_09d512fb7ac14840955c15127eb73256.t2	analyze	status	OK
+-- !result
+with w1 as (
+    select c_str1, c_str2, c_int1, c_int2 from t2 group by c_str1, c_str2, c_int1, c_int2
+)
+select /*+SET_VAR(cbo_cte_reuse=false)*/ sum(x), sum(y)
+from (
+    select count(tt1.c_str1) as x , count(tt1.c_str2) as y
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        t2 tt1 join [shuffle] t2 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        t2 tt1 join [shuffle] t2 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+)t;
+-- result:
+7680000	7680000
+-- !result
+admin enable failpoint 'parquet_reader_returns_global_dict_not_match_status' with 0.5 probability;
+-- result:
+-- !result
+with w1 as (
+    select c_str1, c_str2, c_int1, c_int2 from t2 group by c_str1, c_str2, c_int1, c_int2
+)
+select /*+SET_VAR(cbo_cte_reuse=false)*/ sum(x), sum(y)
+from (
+    select count(tt1.c_str1) as x , count(tt1.c_str2) as y
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        t2 tt1 join [shuffle] t2 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        t2 tt1 join [shuffle] t2 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+)t;
+-- result:
+7680000	7680000
+-- !result
+with w1 as (
+    select c_str1, c_str2, c_int1, c_int2 from t2 group by c_str1, c_str2, c_int1, c_int2
+)
+select /*+SET_VAR(cbo_cte_reuse=false)*/ sum(x), sum(y)
+from (
+    select count(tt1.c_str1) as x , count(tt1.c_str2) as y
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        t2 tt1 join [shuffle] t2 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        t2 tt1 join [shuffle] t2 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+)t;
+-- result:
+7680000	7680000
+-- !result
+admin enable failpoint 'parquet_reader_returns_global_dict_not_match_status';
+-- result:
+-- !result
+with w1 as (
+    select c_str1, c_str2, c_int1, c_int2 from t2 group by c_str1, c_str2, c_int1, c_int2
+)
+select /*+SET_VAR(cbo_cte_reuse=false)*/ sum(x), sum(y)
+from (
+    select count(tt1.c_str1) as x , count(tt1.c_str2) as y
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        t2 tt1 join [shuffle] t2 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        t2 tt1 join [shuffle] t2 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+)t;
+-- result:
+7680000	7680000
+-- !result
+with w1 as (
+    select c_str1, c_str2, c_int1, c_int2 from t2 group by c_str1, c_str2, c_int1, c_int2
+)
+select /*+SET_VAR(cbo_cte_reuse=false)*/ sum(x), sum(y)
+from (
+    select count(tt1.c_str1) as x , count(tt1.c_str2) as y
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        t2 tt1 join [shuffle] t2 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        t2 tt1 join [shuffle] t2 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+)t;
+-- result:
+7680000	7680000
+-- !result
+admin disable failpoint 'parquet_reader_returns_global_dict_not_match_status';
+-- result:
+-- !result
+with w1 as (
+    select c_str1, c_str2, c_int1, c_int2 from t2 group by c_str1, c_str2, c_int1, c_int2
+)
+select /*+SET_VAR(cbo_cte_reuse=false)*/ sum(x), sum(y)
+from (
+    select count(tt1.c_str1) as x , count(tt1.c_str2) as y
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        t2 tt1 join [shuffle] t2 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        t2 tt1 join [shuffle] t2 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+)t;
+-- result:
+7680000	7680000
+-- !result
+drop table t2 force;
+-- result:
+-- !result
+drop table __row_util force;
+-- result:
+-- !result
+drop table __row_util_base force;
+-- result:
+-- !result
+drop database ice_db_${uuid0};
+-- result:
+-- !result
+drop catalog ice_cat_${uuid0};
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result

--- a/test/sql/test_low_cardinality/T/test_low_cardinality_parquet_cancel
+++ b/test/sql/test_low_cardinality/T/test_low_cardinality_parquet_cancel
@@ -1,0 +1,260 @@
+-- name: test_low_cardinality_parquet_cancel @sequential
+
+-- Prepare Data.
+create external catalog ice_cat_${uuid0}
+properties (
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog ice_cat_${uuid0};
+create database ice_db_${uuid0};
+use ice_db_${uuid0};
+
+
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+);
+
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+insert into __row_util_base select * from __row_util_base; 
+insert into __row_util_base select * from __row_util_base; 
+insert into __row_util_base select * from __row_util_base; 
+insert into __row_util_base select * from __row_util_base; 
+insert into __row_util_base select * from __row_util_base; 
+insert into __row_util_base select * from __row_util_base;
+insert into __row_util_base select * from __row_util_base;
+
+CREATE TABLE __row_util (
+  idx bigint NULL
+);
+
+insert into __row_util select row_number() over() as idx from __row_util_base;
+
+
+CREATE TABLE t2 (
+    k1 bigint NULL,
+
+    c_int1 int null,
+    c_int2 int null,
+    c_str1 string null,
+    c_str2 string null
+);
+
+INSERT INTO t2
+SELECT
+    idx,
+
+    idx,
+    idx,
+
+    concat('varchar-', idx % 100),
+    concat('varchar-', idx % 10)
+FROM __row_util;
+
+
+-- Query
+
+[UC]ANALYZE TABLE t2;
+
+
+with w1 as (
+    select c_str1, c_str2, c_int1, c_int2 from t2 group by c_str1, c_str2, c_int1, c_int2
+)
+select /*+SET_VAR(cbo_cte_reuse=false)*/ sum(x), sum(y)
+from (
+    select count(tt1.c_str1) as x , count(tt1.c_str2) as y
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        t2 tt1 join [shuffle] t2 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        t2 tt1 join [shuffle] t2 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+)t;
+
+
+
+admin enable failpoint 'parquet_reader_returns_global_dict_not_match_status' with 0.5 probability;
+
+with w1 as (
+    select c_str1, c_str2, c_int1, c_int2 from t2 group by c_str1, c_str2, c_int1, c_int2
+)
+select /*+SET_VAR(cbo_cte_reuse=false)*/ sum(x), sum(y)
+from (
+    select count(tt1.c_str1) as x , count(tt1.c_str2) as y
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        t2 tt1 join [shuffle] t2 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        t2 tt1 join [shuffle] t2 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+)t;
+
+with w1 as (
+    select c_str1, c_str2, c_int1, c_int2 from t2 group by c_str1, c_str2, c_int1, c_int2
+)
+select /*+SET_VAR(cbo_cte_reuse=false)*/ sum(x), sum(y)
+from (
+    select count(tt1.c_str1) as x , count(tt1.c_str2) as y
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        t2 tt1 join [shuffle] t2 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        t2 tt1 join [shuffle] t2 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+)t;
+
+
+admin enable failpoint 'parquet_reader_returns_global_dict_not_match_status';
+
+with w1 as (
+    select c_str1, c_str2, c_int1, c_int2 from t2 group by c_str1, c_str2, c_int1, c_int2
+)
+select /*+SET_VAR(cbo_cte_reuse=false)*/ sum(x), sum(y)
+from (
+    select count(tt1.c_str1) as x , count(tt1.c_str2) as y
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        t2 tt1 join [shuffle] t2 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        t2 tt1 join [shuffle] t2 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+)t;
+
+with w1 as (
+    select c_str1, c_str2, c_int1, c_int2 from t2 group by c_str1, c_str2, c_int1, c_int2
+)
+select /*+SET_VAR(cbo_cte_reuse=false)*/ sum(x), sum(y)
+from (
+    select count(tt1.c_str1) as x , count(tt1.c_str2) as y
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        t2 tt1 join [shuffle] t2 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        t2 tt1 join [shuffle] t2 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+)t;
+
+
+admin disable failpoint 'parquet_reader_returns_global_dict_not_match_status';
+
+with w1 as (
+    select c_str1, c_str2, c_int1, c_int2 from t2 group by c_str1, c_str2, c_int1, c_int2
+)
+select /*+SET_VAR(cbo_cte_reuse=false)*/ sum(x), sum(y)
+from (
+    select count(tt1.c_str1) as x , count(tt1.c_str2) as y
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        t2 tt1 join [shuffle] t2 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        t2 tt1 join [shuffle] t2 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+    union all 
+    select count(tt1.c_str1) , count(tt1.c_str2)
+    from 
+        w1 tt1 join [shuffle] w1 tt2 on tt1.c_int1 = tt2.c_int1
+)t;
+
+
+
+drop table t2 force;
+drop table __row_util force;
+drop table __row_util_base force;
+drop database ice_db_${uuid0};
+drop catalog ice_cat_${uuid0};
+
+
+set catalog default_catalog;


### PR DESCRIPTION
## Why I'm doing:

**TPC-DS 1T Q72/Q71 Occasionally Reports "Query Terminates Prematurely" Instead of Normal Finish**  

When using the execution plan optimized by low-cardinality external parquet tables, the BE may throw a `GLOBAL_DICT_NOT_MATCH` error to the FE during execution, prompting the FE to retry.  

**Specific Handling Workflow**  
1. When the BE detects a `GLOBAL_DICT_NOT_MATCH` error, it calls `query_ctx->cancel()` and moves the `query_ctx` to `second_map`.  
2. When subsequent flying fragment instances arrive at the BE, `QueryContextManager::get_or_register` directly returns the `GLOBAL_DICT_NOT_MATCH` error.  
3. After receiving the `GLOBAL_DICT_NOT_MATCH` error from the BE, the FE sends a **cancel fragment RPC** to terminate the fragment instances on the BE.  

---  

**Three Issues**  

### Problem 1: `query_ctx` Is Released Before a Fragment Instance Arrives at the BE  
In Step 2 above, the following scenario may occur:  
1. When the first flying fragment instance arrives at the BE, `get_or_register` returns the `GLOBAL_DICT_NOT_MATCH` error and removes the `query_ctx` from `second_map`. This is to release the `query_ctx` promptly; otherwise, it might linger until `delivery_timeout`.  
2. When the second flying fragment instance arrives, the `query_ctx` no longer exists, causing a "Query terminates prematurely" error.  

```cpp
StatusOr<QueryContext*> QueryContextManager::get_or_register(const TUniqueId& query_id,
                                                             bool return_error_if_not_exist) {
                                                               auto it = context_map.find(query_id);
        auto sc_it = sc_map.find(query_id);
        if (it != context_map.end()) {
            RETURN_CANCELLED_STATUS_IF_CTX_CANCELLED(it->second);
            return it->second.get();
        } else {
            // lookup query context for the second chance in sc_map
            if (sc_it != sc_map.end()) {
                auto ctx = std::move(sc_it->second);
                sc_map.erase(sc_it);                              // =================== Here ===================
                RETURN_CANCELLED_STATUS_IF_CTX_CANCELLED(ctx);
            }
        }
}
```

**Solution**  
When the FE processes the `deploy fragment instance` response, instead of retaining only the first error status:  
- If the first error status is `Cancelled` but subsequent error statuses are retryable, preserve the more actionable error status.  

---  

### Problem 2: New `query_ctx` Created Unnecessarily  
> When the second flying fragment instance arrives and finds no `query_ctx`, it throws "Query terminates prematurely".  

In Problem 1, this also creates a new `query_ctx`, which will linger until `delivery_timeout`.  

**Solution**  
- In `get_or_register`, if the `query_ctx` does not exist **and** `t_desc_tbl.__isset.is_cached && t_desc_tbl.is_cached` is true, directly return the "Query terminates prematurely" error without creating a new `query_ctx`.  

---  

### Problem 3: Missing `_cancelled_by_fe` Flag in Cancel Fragment RPC  
In Step 3, only the **cancel query_ctx RPC** sets the `_cancelled_by_fe` flag. The **cancel fragment instance RPC** (used by the normal scheduler) does not set this flag.  

**Solution**  
- Ensure the **cancel fragment instance RPC** also sets the `_cancelled_by_fe` flag.  

---  

### Left Issue
Introduced by `_cancelled_by_fe` flag, a small chance remains that a cancelled `query_ctx` lingers until `delivery_timeout`:  
- If the FE does not send a **cancel RPC** to the BE **and** some fragment instances are not deployed to the BE, the `query_ctx` cannot be released because `QueryContext::is_dead` conditions are unmet:  
  - **FE does not send cancel RPC**: Occurs when all prepared fragment instances on the BE report failures to the FE, and the FE detects no active fragment instances on the BE.  
  - **Undeployed fragment instances**: If some fragment instances remain undeployed while the BE has already reported failures, the remaining instances will not be deployed.  

```cpp  
bool is_dead() const {  
    return _num_active_fragments == 0 && (_num_fragments == _total_fragments || _cancelled_by_fe);  
}  
```  


## What I'm doing:


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
