### PR TITLE
[BugFix] Fix event scheduler UAF when preparation fails

### DIFF
--- a/be/src/exec/chunk_buffer_memory_manager.h
+++ b/be/src/exec/chunk_buffer_memory_manager.h
@@ -45,7 +45,7 @@ public:
         size_t prev_memusage = _memory_usage.fetch_add(memory_usage);
         size_t prev_num_rows = _buffered_num_rows.fetch_add(num_rows);
         bool is_full =
-                prev_memusage + memory_usage >= _max_memory_usage || prev_num_rows + num_rows >= _max_buffered_rows;
+                prev_memusage + memory_usage >= _max_memory_usage || prev_num_rows + num_rows > _max_buffered_rows;
         bool expect = false;
         bool full_changed = prev_full != is_full;
         if (!full_changed) {

--- a/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
@@ -69,6 +69,7 @@ ExchangeSourceOperatorFactory::~ExchangeSourceOperatorFactory() {
         // `_stream_recvr` design, moves the responsibility from the operator to the operator factory.
         LOG(INFO) << "ExchangeSourceOperatorFactory::_stream_recvr_cnt=" << _stream_recvr_cnt
                   << ", the _stream_recvr is created without properly cleaned. Force close it!";
+        _stream_recvr->detach_observer();
         _stream_recvr->close();
     }
 }

--- a/be/src/exec/pipeline/schedule/observer.h
+++ b/be/src/exec/pipeline/schedule/observer.h
@@ -110,6 +110,8 @@ public:
         }
     }
 
+    void detach_observers() { _observers.clear(); }
+
     void notify_source_observers() {
         for (auto* observer : _observers) {
             observer->source_trigger();

--- a/be/src/exprs/agg/factory/aggregate_factory.cpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.cpp
@@ -21,8 +21,11 @@
 #include "exprs/agg/factory/aggregate_resolver.hpp"
 #include "types/logical_type.h"
 #include "udf/java/java_function_fwd.h"
+#include "util/failpoint/fail_point.h"
 
 namespace starrocks {
+
+DEFINE_FAIL_POINT(not_exist_agg_function);
 
 AggregateFuncResolver::AggregateFuncResolver() {
     register_avg();
@@ -156,6 +159,7 @@ static const AggregateFunction* get_function(const std::string& name, LogicalTyp
 
 const AggregateFunction* get_aggregate_function(const std::string& name, LogicalType arg_type, LogicalType return_type,
                                                 bool is_null, TFunctionBinaryType::type binary_type, int func_version) {
+    FAIL_POINT_TRIGGER_RETURN(not_exist_agg_function, nullptr);
     return get_function(name, arg_type, return_type, false, is_null, binary_type, func_version);
 }
 

--- a/be/src/runtime/data_stream_recvr.cpp
+++ b/be/src/runtime/data_stream_recvr.cpp
@@ -282,7 +282,6 @@ void DataStreamRecvr::close() {
     if (_closed) {
         return;
     }
-
     for (auto& _sender_queue : _sender_queues) {
         _sender_queue->close();
     }

--- a/be/src/runtime/data_stream_recvr.h
+++ b/be/src/runtime/data_stream_recvr.h
@@ -139,6 +139,8 @@ public:
     void attach_observer(RuntimeState* state, pipeline::PipelineObserver* observer) {
         _observable.add_observer(state, observer);
     }
+    void detach_observer() { _observable.detach_observers(); }
+
     auto defer_notify() {
         return DeferOp([query_ctx = _query_ctx, this]() {
             if (auto ctx = query_ctx.lock()) {

--- a/test/sql/test_exception/R/test_exception_function_call
+++ b/test/sql/test_exception/R/test_exception_function_call
@@ -35,3 +35,12 @@ admin enable failpoint 'expr_prepare_fragment_thread_local_call_failed';
 admin disable failpoint 'expr_prepare_fragment_thread_local_call_failed';
 -- result:
 -- !result
+admin enable failpoint 'not_exist_agg_function';
+-- result:
+-- !result
+[UC]select * from (select l.c0,r.c1  from t0 l join [bucket](select regexp_replace(sum(c1), '1', '2') c1, c0 from t0 group by c0) r on l.c0 = r.c0) t;
+-- result:
+-- !result
+admin disable failpoint 'not_exist_agg_function';
+-- result:
+-- !result

--- a/test/sql/test_exception/T/test_exception_function_call
+++ b/test/sql/test_exception/T/test_exception_function_call
@@ -17,3 +17,7 @@ admin disable failpoint 'expr_prepare_fragment_local_call_failed';
 admin enable failpoint 'expr_prepare_fragment_thread_local_call_failed';
 [UC]select max(regexp_replace(c1, '1', '2')) from t0;
 admin disable failpoint 'expr_prepare_fragment_thread_local_call_failed';
+
+admin enable failpoint 'not_exist_agg_function';
+[UC]select * from (select l.c0,r.c1  from t0 l join [bucket](select regexp_replace(sum(c1), '1', '2') c1, c0 from t0 group by c0) r on l.c0 = r.c0) t;
+admin disable failpoint 'not_exist_agg_function';


### PR DESCRIPTION
## Why I'm doing:

the reproduce case see test_exception_function_call

## What I'm doing:

```
==3078036==ERROR: AddressSanitizer: heap-use-after-free on address 0x617000976cc4 at pc 0x00001548cfd9 bp 0x7ffda90a4890 sp 0x7ffda90a4880
WRITE of size 4 at 0x617000976cc4 thread T567
[New Thread 0x7ff6bee18640 (LWP 3083509)]
    #0 0x1548cfd8 in std::__atomic_base<int>::fetch_or(int, std::memory_order) /usr/include/c++/11/bits/atomic_base.h:648
    #1 0x1548cfd8 in starrocks::pipeline::PipelineObserver::_active_event(int) be/src/exec/pipeline/schedule/observer.h:89
    #2 0x1548ce55 in starrocks::pipeline::PipelineObserver::source_trigger() be/src/exec/pipeline/schedule/observer.h:43
    #3 0x1548d24f in starrocks::pipeline::Observable::notify_source_observers() be/src/exec/pipeline/schedule/observer.h:115
    #4 0x2194da48 in starrocks::DataStreamRecvr::defer_notify()::{lambda()#1}::operator()() const be/src/runtime/data_stream_recvr.h:145
    #5 0x2194e159 in starrocks::DeferOp<starrocks::DataStreamRecvr::defer_notify()::{lambda()#1}>::~DeferOp() be/src/util/defer_op.h:49
    #6 0x219440f0 in starrocks::DataStreamRecvr::cancel_stream() be/src/runtime/data_stream_recvr.cpp:278
    #7 0x216d5cee in starrocks::DataStreamMgr::deregister_recvr(starrocks::TUniqueId const&, int) be/src/runtime/data_stream_mgr.cpp:199
    #8 0x21944535 in starrocks::DataStreamRecvr::close() be/src/runtime/data_stream_recvr.cpp:291
    #9 0x1785d287 in starrocks::pipeline::ExchangeSourceOperatorFactory::~ExchangeSourceOperatorFactory() be/src/exec/pipeline/exchange/exchange_source_operator.cpp:72
    #10 0x14e6dfaa in void std::destroy_at<starrocks::pipeline::ExchangeSourceOperatorFactory>(starrocks::pipeline::ExchangeSourceOperatorFactory*) /usr/include/c++/11/bits/stl_construct.h:88
    #11 0x14e6dd3b in void std::allocator_traits<std::allocator<starrocks::pipeline::ExchangeSourceOperatorFactory> >::destroy<starrocks::pipeline::ExchangeSourceOperatorFactory>(std::allocator<starrocks::pipeline::ExchangeSourceOperatorFactory>&, starrocks::pipeline::ExchangeSourceOperatorFactory*) /usr/include/c++/11/bits/alloc_traits.h:537
    #12 0x14e6d6d0 in std::_Sp_counted_ptr_inplace<starrocks::pipeline::ExchangeSourceOperatorFactory, std::allocator<starrocks::pipeline::ExchangeSourceOperatorFactory>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /usr/include/c++/11/bits/shared_ptr_base.h:528
    #13 0x1442af6c in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /usr/include/c++/11/bits/shared_ptr_base.h:168
    #14 0x14425921 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /usr/include/c++/11/bits/shared_ptr_base.h:705
    #15 0x14db8f37 in std::__shared_ptr<starrocks::pipeline::OperatorFactory, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /usr/include/c++/11/bits/shared_ptr_base.h:1154
    #16 0x14db8f57 in std::shared_ptr<starrocks::pipeline::OperatorFactory>::~shared_ptr() /usr/include/c++/11/bits/shared_ptr.h:122
    #17 0x14dee8f3 in void std::destroy_at<std::shared_ptr<starrocks::pipeline::OperatorFactory> >(std::shared_ptr<starrocks::pipeline::OperatorFactory>*) /usr/include/c++/11/bits/stl_construct.h:88
    #18 0x14df436e in void std::_Destroy<std::shared_ptr<starrocks::pipeline::OperatorFactory> >(std::shared_ptr<starrocks::pipeline::OperatorFactory>*) /usr/include/c++/11/bits/stl_construct.h:149
    #19 0x14def28b in void std::_Destroy_aux<false>::__destroy<std::shared_ptr<starrocks::pipeline::OperatorFactory>*>(std::shared_ptr<starrocks::pipeline::OperatorFactory>*, std::shared_ptr<starrocks::pipeline::OperatorFactory>*) /usr/include/c++/11/bits/stl_construct.h:163
    #20 0x14dea76f in void std::_Destroy<std::shared_ptr<starrocks::pipeline::OperatorFactory>*>(std::shared_ptr<starrocks::pipeline::OperatorFactory>*, std::shared_ptr<starrocks::pipeline::OperatorFactory>*) /usr/include/c++/11/bits/stl_construct.h:196
    #21 0x14de3e96 in void std::_Destroy<std::shared_ptr<starrocks::pipeline::OperatorFactory>*, std::shared_ptr<starrocks::pipeline::OperatorFactory> >(std::shared_ptr<starrocks::pipeline::OperatorFactory>*, std::shared_ptr<starrocks::pipeline::OperatorFactory>*, std::allocator<std::shared_ptr<starrocks::pipeline::OperatorFactory> >&) /usr/include/c++/11/bits/alloc_traits.h:848
    #22 0x14ddbac7 in std::vector<std::shared_ptr<starrocks::pipeline::OperatorFactory>, std::allocator<std::shared_ptr<starrocks::pipeline::OperatorFactory> > >::~vector() /usr/include/c++/11/bits/stl_vector.h:680
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
