### PR TITLE
[BugFix] Optimize cost predicate to support external catalog tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/feature/FeatureExtractor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/feature/FeatureExtractor.java
@@ -15,7 +15,6 @@
 package com.starrocks.sql.optimizer.cost.feature;
 
 import com.google.common.collect.Lists;
-import com.starrocks.catalog.Table;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -46,8 +45,8 @@ public class FeatureExtractor {
         List<OperatorFeatures.ScanOperatorFeatures> scanNodes = Lists.newArrayList();
         root.collect(OperatorFeatures.ScanOperatorFeatures.class, scanNodes);
         if (CollectionUtils.isNotEmpty(scanNodes)) {
-            Set<Table> tables = scanNodes.stream()
-                    .map(OperatorFeatures.ScanOperatorFeatures::getTable)
+            Set<OperatorFeatures.TableFeature> tables = scanNodes.stream()
+                    .map(OperatorFeatures.ScanOperatorFeatures::getTableFeature)
                     .collect(Collectors.toSet());
             planFeatures.addTableFeatures(tables);
         }


### PR DESCRIPTION
## Why I'm doing:

`CostPredicate` can only support `OlapTable` before and it uses `tableId` as the table features which is limited for external tables.


## What I'm doing:
- Use `table name` as table features to support external catalog tables.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
