### PR TITLE
[Enhancement] Add more query queue metrics

### DIFF
--- a/be/src/exec/schema_scanner/schema_warehouse_metrics.cpp
+++ b/be/src/exec/schema_scanner/schema_warehouse_metrics.cpp
@@ -39,6 +39,7 @@ SchemaScanner::ColumnDesc WarehouseMetricsScanner::_s_columns[] = {
         {"SUM_REQUIRED_SLOTS", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
         {"REMAIN_SLOTS", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
         {"MAX_SLOTS", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
+        {"EXTRA_MESSAGE", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
 };
 
 WarehouseMetricsScanner::WarehouseMetricsScanner()
@@ -98,7 +99,8 @@ Status WarehouseMetricsScanner::fill_chunk(ChunkPtr* chunk) {
                            Slice(item.max_required_slots),
                            Slice(item.sum_required_slots),
                            Slice(item.remain_slots),
-                           Slice(item.max_slots)};
+                           Slice(item.max_slots),
+                           Slice(item.extra_message)};
     for (const auto& [slot_id, index] : slot_id_map) {
         Column* column = (*chunk)->get_column_by_slot_id(slot_id).get();
         column->append_datum(datum_array[slot_id - 1]);

--- a/be/src/exec/schema_scanner/schema_warehouse_queries.cpp
+++ b/be/src/exec/schema_scanner/schema_warehouse_queries.cpp
@@ -33,6 +33,11 @@ SchemaScanner::ColumnDesc WarehouseQueriesScanner::_s_columns[] = {
         {"EST_COSTS_SLOTS", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
         {"ALLOCATE_SLOTS", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
         {"QUEUED_WAIT_SECONDS", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
+        {"QUERY", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
+        {"QUERY_START_TIME", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
+        {"QUERY_END_TIME", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
+        {"QUERY_DURATION", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
+        {"EXTRA_MESSAGE", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
 };
 
 WarehouseQueriesScanner::WarehouseQueriesScanner()
@@ -82,9 +87,18 @@ Status WarehouseQueriesScanner::get_next(ChunkPtr* chunk, bool* eos) {
 Status WarehouseQueriesScanner::fill_chunk(ChunkPtr* chunk) {
     auto& slot_id_map = (*chunk)->get_slot_id_to_index_map();
     const TGetWarehouseQueriesResponseItem& item = _response.queries[_idx++];
-    DatumArray datum_array{
-            Slice(item.warehouse_id),    Slice(item.warehouse_name), Slice(item.query_id),           Slice(item.state),
-            Slice(item.est_costs_slots), Slice(item.allocate_slots), Slice(item.queued_wait_seconds)};
+    DatumArray datum_array{Slice(item.warehouse_id),
+                           Slice(item.warehouse_name),
+                           Slice(item.query_id),
+                           Slice(item.state),
+                           Slice(item.est_costs_slots),
+                           Slice(item.allocate_slots),
+                           Slice(item.queued_wait_seconds),
+                           Slice(item.query),
+                           Slice(item.query_start_time),
+                           Slice(item.query_end_time),
+                           Slice(item.query_duration),
+                           Slice(item.extra_message)};
     for (const auto& [slot_id, index] : slot_id_map) {
         Column* column = (*chunk)->get_column_by_slot_id(slot_id).get();
         column->append_datum(datum_array[slot_id - 1]);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/WarehouseMetricsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/WarehouseMetricsSystemTable.java
@@ -43,6 +43,7 @@ public class WarehouseMetricsSystemTable {
                         .column("SUM_REQUIRED_SLOTS", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .column("REMAIN_SLOTS", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .column("MAX_SLOTS", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("EXTRA_MESSAGE", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .build(), TSchemaTableType.SCH_WAREHOUSE_METRICS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/WarehouseQueriesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/WarehouseQueriesSystemTable.java
@@ -38,6 +38,11 @@ public class WarehouseQueriesSystemTable {
                         .column("EST_COSTS_SLOTS", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .column("ALLOCATE_SLOTS", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .column("QUEUED_WAIT_SECONDS", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("QUERY", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("QUERY_START_TIME", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("QUERY_END_TIME", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("QUERY_DURATION", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("EXTRA_MESSAGE", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .build(), TSchemaTableType.SCH_WAREHOUSE_QUERIES);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -727,6 +727,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "Slot estimator strategy of queue based queries: MBE/PBE/MAX/MIN")
     public static String query_queue_slots_estimator_strategy = SlotEstimatorFactory.EstimatorPolicy.createDefault().name();
 
+    @ConfField(mutable = true, comment = "The max number of history allocated slots for a query queue")
+    public static int max_query_queue_history_slots_number = 0;
+
     /**
      * Used to estimate the number of slots of a query based on the cardinality of the Source Node. It is equal to the
      * cardinality of the Source Node divided by the configuration value and is limited to between [1, DOP*numBEs].

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -291,6 +291,9 @@ public class ConnectContext {
     // thread id is the thread who created this ConnectContext's id
     private AtomicLong currentThreadId = null;
 
+    // listeners for this connection
+    private List<Listener> listeners = Lists.newArrayList();
+
     public void setExplicitTxnState(ExplicitTxnState explicitTxnState) {
         this.explicitTxnState = explicitTxnState;
     }
@@ -1483,5 +1486,27 @@ public class ConnectContext {
 
     public void setCurrentThreadId(long currentThreadId) {
         this.currentThreadId = new AtomicLong(currentThreadId);
+    }
+
+    public interface Listener {
+        /**
+         * Trigger when query is finished
+         */
+        void onQueryFinished(ConnectContext state);
+    }
+
+    public void registerListener(Listener listener) {
+        this.listeners.add(listener);
+    }
+
+    public void onQueryFinished() {
+        for (Listener listener : listeners) {
+            try {
+                listener.onQueryFinished(this);
+            } catch (Exception e) {
+                // ignore
+                LOG.warn("onQueryFinished error", e);
+            }
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -868,6 +868,9 @@ public class StmtExecutor {
                 isForwardToLeaderOpt = Optional.of(true);
                 forwardToLeader();
             }
+
+            // process post-action after query is finished
+            context.onQueryFinished();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
@@ -530,6 +530,14 @@ public class JobSpec {
         return isSyncStreamLoad;
     }
 
+    public boolean isJobNeedCheckQueue() {
+        // The queries only using schema meta will never been queued, because a MySQL client will
+        // query schema meta after the connection is established.
+        boolean notNeed =
+                this.scanNodes.isEmpty() || this.scanNodes.stream().allMatch(SchemaScanNode.class::isInstance);
+        return !notNeed;
+    }
+
     public static class Builder {
         private final JobSpec instance = new JobSpec();
 
@@ -653,13 +661,7 @@ public class JobSpec {
             if (!instance.connectContext.isNeedQueued()) {
                 return false;
             }
-
-            // The queries only using schema meta will never been queued, because a MySQL client will
-            // query schema meta after the connection is established.
-            boolean notNeed =
-                    instance.scanNodes.isEmpty() || instance.scanNodes.stream().allMatch(SchemaScanNode.class::isInstance);
-            return !notNeed;
+            return instance.isJobNeedCheckQueue();
         }
     }
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/BaseSlotManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/BaseSlotManager.java
@@ -180,6 +180,18 @@ public abstract class BaseSlotManager {
     }
 
     /**
+     * The max query queue concurrency limit for the slot manager.
+     * NOTE:
+     * - SlotTracker will always to allocate slot when running queries is below than the concurrency limit.
+     * - If the concurrency limit is less than 0, it means that the slot tracker will not limit the concurrency but will be
+     * controlled
+     *  by another resource usage monitor.
+     */
+    public int getQueryQueueConcurrencyLimit(long warehouseId) {
+        return GlobalVariable.getQueryQueueConcurrencyLimit();
+    }
+
+    /**
      * Whether the slot manager supports query queue v2.
      */
     public boolean isEnableQueryQueueV2(long warehouseId) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/BaseSlotTracker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/BaseSlotTracker.java
@@ -14,10 +14,17 @@
 
 package com.starrocks.qe.scheduler.slot;
 
+import com.google.api.client.util.Lists;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.Config;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.metric.MetricRepo;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.GlobalVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
+import com.starrocks.service.ExecuteEnv;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.warehouse.Warehouse;
 import org.apache.logging.log4j.LogManager;
@@ -25,14 +32,18 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 
 /**
@@ -59,6 +70,8 @@ public abstract class BaseSlotTracker {
 
     protected List<BaseSlotTracker.Listener> listeners;
     protected SlotSelectionStrategy slotSelectionStrategy;
+    // history slots to record the slots which have been released for monitoring
+    private final Queue<LogicalSlot> historySlots = new ConcurrentLinkedQueue();
 
     public BaseSlotTracker(ResourceUsageMonitor resourceUsageMonitor, long warehouseId) {
         this.resourceUsageMonitor = resourceUsageMonitor;
@@ -81,10 +94,6 @@ public abstract class BaseSlotTracker {
 
     public long getQueuePendingLength() {
         return pendingSlots.size();
-    }
-
-    public long getAllocatedLength() {
-        return allocatedSlots.size();
     }
 
     public Optional<Integer> getMaxRequiredSlots() {
@@ -120,14 +129,33 @@ public abstract class BaseSlotTracker {
     public abstract Optional<Integer> getMaxSlots();
 
     /**
+     * Check if the slot tracker is beyond the capacity limit.
+     * @param slot : The slot to be checked.
+     * @return True if the slot tracker is beyond the capacity limit, false otherwise.
+     */
+    protected boolean isResourceCapacityEnough(LogicalSlot slot) {
+        final BaseSlotManager slotManager = GlobalStateMgr.getCurrentState().getSlotManager();
+        if (GlobalVariable.isQueryQueueMaxQueuedQueriesEffective() &&
+                pendingSlots.size() >= slotManager.getQueryQueueMaxQueuedQueries(slot.getWarehouseId())) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Get the extra message of the slot tracker.
+     */
+    public Optional<ExtraMessage> getExtraMessage() {
+        return Optional.empty();
+    }
+
+    /**
      * Add a slot requirement.
      * @param slot The required slot.
      * @return True if the slot is required successfully or already required , false if the query queue is full.
      */
     public boolean requireSlot(LogicalSlot slot) {
-        final BaseSlotManager slotManager = GlobalStateMgr.getCurrentState().getSlotManager();
-        if (GlobalVariable.isQueryQueueMaxQueuedQueriesEffective() &&
-                pendingSlots.size() >= slotManager.getQueryQueueMaxQueuedQueries(slot.getWarehouseId())) {
+        if (!isResourceCapacityEnough(slot)) {
             return false;
         }
 
@@ -143,6 +171,9 @@ public abstract class BaseSlotTracker {
 
         listeners.forEach(listener -> listener.onRequireSlot(slot));
         slot.onRequire();
+
+        // try to register the slot to the connected context
+        tryRegisterConnectContext(slot);
 
         return true;
     }
@@ -180,6 +211,50 @@ public abstract class BaseSlotTracker {
      * @return The released slot, or null if the slot has not been required or allocated.
      */
     public LogicalSlot releaseSlot(TUniqueId slotId) {
+        LogicalSlot slot = releaseSlotImpl(slotId);
+        if (slot != null) {
+            tryAddIntoHistorySlots(slot);
+        }
+        return slot;
+    }
+
+    protected void tryAddIntoHistorySlots(LogicalSlot slot) {
+        if (Config.max_query_queue_history_slots_number <= 0) {
+            return;
+        }
+        while (historySlots.size() > Config.max_query_queue_history_slots_number) {
+            historySlots.poll();
+        }
+        historySlots.add(slot);
+    }
+
+    /**
+     * Try to register the slot to the connected context for more observing information.
+     * @param slot: The slot to be registered.
+     */
+    protected void tryRegisterConnectContext(LogicalSlot slot) {
+        // ignore the slot is null or slot's extra message has been set
+        if (Config.max_query_queue_history_slots_number <= 0 ||
+                slot == null || (slot.getExtraMessage() != null && slot.getExtraMessage().isPresent())) {
+            return;
+        }
+        // find the connected context and register the logical slot
+        try {
+            TUniqueId slotId = slot.getSlotId();
+            UUID queryId = UUIDUtil.fromTUniqueid(slotId);
+            ConnectContext ctx = ExecuteEnv.getInstance().getScheduler().findContextByQueryId(queryId.toString());
+            if (ctx == null) {
+                LOG.debug("Failed to find the context for queryId: {}", queryId);
+                return;
+            }
+            LOG.debug("Registering the slot {} to context {}", slot, ctx);
+            ctx.registerListener(new LogicalSlot.ConnectContextListener(slot));
+        } catch (Exception e) {
+            LOG.warn("Failed to register the slot to context", e);
+        }
+    }
+
+    protected LogicalSlot releaseSlotImpl(TUniqueId slotId) {
         LogicalSlot slot = slots.remove(slotId);
         if (slot == null) {
             return null;
@@ -241,7 +316,24 @@ public abstract class BaseSlotTracker {
     }
 
     public Collection<LogicalSlot> getSlots() {
-        return slots.values();
+        if (Config.max_query_queue_history_slots_number > 0) {
+            List<LogicalSlot> result = Lists.newArrayList();
+            // the newest slots are in the front
+            result.addAll(slots.values());
+            List<LogicalSlot> histories = Lists.newArrayList(historySlots);
+            if (!histories.isEmpty()) {
+                Collections.reverse(histories);
+                result.addAll(histories);
+            }
+            return result;
+        } else {
+            return slots.values();
+        }
+    }
+
+    @VisibleForTesting
+    public Collection<LogicalSlot> getHistorySlots() {
+        return historySlots;
     }
 
     public LogicalSlot getSlot(TUniqueId slotId) {
@@ -280,6 +372,29 @@ public abstract class BaseSlotTracker {
         @Override
         public void onReleaseSlot(LogicalSlot slot) {
             pipelineDriverAllocator.release(slot);
+        }
+    }
+
+    /**
+     * Extra message for the slot tracker.
+     */
+    public static class ExtraMessage {
+        @SerializedName("Concurrency")
+        private final long concurrency;
+        @SerializedName("QueryQueueOption")
+        private final QueryQueueOptions.V2 v2;
+
+        public ExtraMessage(long concurrency, QueryQueueOptions.V2 v2) {
+            this.concurrency = concurrency;
+            this.v2 = v2;
+        }
+
+        public long getConcurrency() {
+            return concurrency;
+        }
+
+        public QueryQueueOptions.V2 getV2() {
+            return v2;
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2.java
@@ -19,6 +19,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.starrocks.metric.LongCounterMetric;
 import com.starrocks.metric.MetricRepo;
+import com.starrocks.qe.GlobalVariable;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.thrift.TUniqueId;
 import org.apache.commons.compress.utils.Lists;
@@ -59,9 +61,11 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
     private int numAllocatedSmallSlots = 0;
 
     private final long warehouseId;
+    private final BaseSlotManager slotManager;
 
     public SlotSelectionStrategyV2(long warehouseId) {
         this.warehouseId = warehouseId;
+        this.slotManager = GlobalStateMgr.getCurrentState().getSlotManager();
     }
 
     public QueryQueueOptions getOpts() {
@@ -129,11 +133,11 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
         updateOptionsPeriodically();
 
         List<LogicalSlot> slotsToAllocate = Lists.newArrayList();
-
+        // allocate small slots
         int curNumAllocatedSmallSlots = numAllocatedSmallSlots;
         for (SlotContext slotContext : requiringSmallSlots.values()) {
             LogicalSlot slot = slotContext.getSlot();
-            if (curNumAllocatedSmallSlots + slot.getNumPhysicalSlots() > opts.v2().getTotalSmallSlots()) {
+            if (!isSmallSlotAvailable(slotTracker, slot, curNumAllocatedSmallSlots)) {
                 break;
             }
 
@@ -144,10 +148,11 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
             curNumAllocatedSmallSlots += slot.getNumPhysicalSlots();
         }
 
+        // allocate normal slots
         int numAllocatedSlots = slotTracker.getNumAllocatedSlots() - numAllocatedSmallSlots;
         while (!requiringQueue.isEmpty()) {
             SlotContext slotContext = requiringQueue.peak();
-            if (!isGlobalSlotAvailable(numAllocatedSlots, slotContext.getSlot())) {
+            if (!isGlobalSlotAvailable(slotTracker, numAllocatedSlots, slotContext.getSlot())) {
                 break;
             }
 
@@ -197,13 +202,42 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
                     .forEach(slotContext -> requiringQueue.add(slotContext));
 
             LOG.info("updated SlotSelectionStrategy to {}", newOpts.toString());
-
         }
     }
 
-    private boolean isGlobalSlotAvailable(int numAllocatedSlots, LogicalSlot slot) {
+    private boolean isSmallSlotAvailable(BaseSlotTracker slotTracker,
+                                         LogicalSlot slot,
+                                         int curNumAllocatedSmallSlots) {
+        // if the small slot limit is reached, return false
+        if (curNumAllocatedSmallSlots + slot.getNumPhysicalSlots() > opts.v2().getTotalSmallSlots()) {
+            return false;
+        }
+        // if the concurrency limit is set and the limit is reached, return false
+        if (!isQueryConcurrencyLimitAvailable(slotTracker)) {
+            return false;
+        }
+        return true;
+    }
+
+    private boolean isGlobalSlotAvailable(BaseSlotTracker slotTracker, int numAllocatedSlots, LogicalSlot slot) {
+        // check the total slots limit is reached
         final int numTotalSlots = opts.v2().getTotalSlots();
-        return numAllocatedSlots == 0 || numAllocatedSlots + slot.getNumPhysicalSlots() <= numTotalSlots;
+        if (numAllocatedSlots != 0 && numAllocatedSlots + slot.getNumPhysicalSlots() > numTotalSlots) {
+            return false;
+        }
+        // if the concurrency limit is set and the limit is reached, return false
+        if (!isQueryConcurrencyLimitAvailable(slotTracker)) {
+            return false;
+        }
+        return true;
+    }
+
+    private boolean isQueryConcurrencyLimitAvailable(BaseSlotTracker slotTracker) {
+        // if the query queue limit is not set(by default), return true
+        if (!GlobalVariable.isQueryQueueConcurrencyLimitEffective()) {
+            return true;
+        }
+        return slotTracker.getNumAllocatedSlots() <= GlobalVariable.getQueryQueueConcurrencyLimit();
     }
 
     private static boolean isSmallSlot(LogicalSlot slot) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/warehouse/WarehouseMetricEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/warehouse/WarehouseMetricEntity.java
@@ -65,7 +65,7 @@ public class WarehouseMetricEntity {
                 "current warehouse query running length") {
             @Override
             public Long getValue() {
-                return tracker.getAllocatedLength();
+                return (long) tracker.getNumAllocatedSlots();
             }
         };
         queueRunningLength.addLabel(new MetricLabel("field", "query_running_length"));

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryQueueManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryQueueManagerTest.java
@@ -177,6 +177,7 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
             // 1. ScanNodes is empty.
             DefaultCoordinator coordinator = getSchedulerWithQueryId("select 1");
             Assert.assertFalse(coordinator.getJobSpec().isNeedQueued());
+            Assert.assertFalse(coordinator.getJobSpec().isJobNeedCheckQueue());
         }
 
         {
@@ -184,6 +185,7 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
             DefaultCoordinator coordinator =
                     getSchedulerWithQueryId("select TABLE_CATALOG from information_schema.tables");
             Assert.assertFalse(coordinator.getJobSpec().isNeedQueued());
+            Assert.assertFalse(coordinator.getJobSpec().isJobNeedCheckQueue());
         }
 
         {
@@ -191,6 +193,7 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
             DefaultCoordinator coordinator = getSchedulerWithQueryId(
                     "select TABLE_CATALOG from information_schema.tables UNION ALL select count(1) from lineitem");
             Assert.assertTrue(coordinator.getJobSpec().isNeedQueued());
+            Assert.assertTrue(coordinator.getJobSpec().isJobNeedCheckQueue());
         }
 
         {

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/LogicalSlotTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/LogicalSlotTest.java
@@ -1,0 +1,96 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler.slot;
+
+import com.starrocks.common.Config;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.QueryState;
+import com.starrocks.server.WarehouseManager;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertTrue;
+
+public class LogicalSlotTest {
+
+    private static LogicalSlot generateSlot(int numSlots) {
+        return new LogicalSlot(UUIDUtil.genTUniqueId(), "fe", WarehouseManager.DEFAULT_WAREHOUSE_ID,
+                LogicalSlot.ABSENT_GROUP_ID, numSlots, 0, 0, 0,
+                0, 0);
+    }
+
+    @Test
+    public void testExtraMessage() {
+        LogicalSlot slot1 = generateSlot(1);
+        assertTrue(slot1.getExtraMessage().isEmpty());
+
+        ConnectContext connectContext = new ConnectContext();
+        LogicalSlot.ExtraMessage extraMessage = new LogicalSlot.ExtraMessage(connectContext);
+        assertTrue(extraMessage.getQuery().isEmpty());
+        assertTrue(extraMessage.getMemCostBytes() == -1);
+        assertTrue(extraMessage.getPlanMemCostBytes() == -1);
+        assertTrue(extraMessage.getQueryStartTime() != 0);
+        assertTrue(extraMessage.getQueryEndTime() != 0);
+        assertTrue(extraMessage.getQueryDuration() >= 0);
+        assertTrue(extraMessage.getPredictMemBytes() == 0L);
+        assertTrue(extraMessage.getQueryState().equals(QueryState.MysqlStateType.OK));
+        String json = GsonUtils.GSON.toJson(extraMessage);
+        assertTrue(json.equals("{\"QueryState\":\"OK\",\"PlanMemCostBytes\":-1,\"MemCostBytes\":-1,\"PredictMemBytes\":0}"));
+    }
+
+    @Test
+    public void testExtraMessageWithNull() {
+        LogicalSlot slot1 = generateSlot(1);
+        assertTrue(slot1.getExtraMessage().isEmpty());
+
+        LogicalSlot.ExtraMessage extraMessage = new LogicalSlot.ExtraMessage(null);
+        assertTrue(extraMessage.getQuery().isEmpty());
+        assertTrue(extraMessage.getMemCostBytes() == 0);
+        assertTrue(extraMessage.getPlanMemCostBytes() == 0);
+        assertTrue(extraMessage.getQueryStartTime() == 0);
+        assertTrue(extraMessage.getQueryEndTime() >= 0);
+        assertTrue(extraMessage.getQueryDuration() >= 0);
+        assertTrue(extraMessage.getPredictMemBytes() == 0L);
+        assertTrue(extraMessage.getQueryState().equals(QueryState.MysqlStateType.OK));
+
+        System.out.println(GsonUtils.GSON.toJson(extraMessage));
+        String json = GsonUtils.GSON.toJson(extraMessage);
+        assertTrue(json.equals("{\"QueryState\":\"OK\",\"PlanMemCostBytes\":0,\"MemCostBytes\":0,\"PredictMemBytes\":0}"));
+    }
+
+    @Test
+    public void testConnectContextListener() {
+        LogicalSlot slot1 = generateSlot(1);
+        LogicalSlot.ConnectContextListener listener = new LogicalSlot.ConnectContextListener(slot1);
+        ConnectContext connectContext = new ConnectContext();
+        connectContext.setStartTime();
+
+        connectContext.registerListener(listener);
+
+        connectContext.onQueryFinished();
+        Optional<LogicalSlot.ExtraMessage> extraMessage = slot1.getExtraMessage();
+        assertTrue(extraMessage.isEmpty());
+
+        Config.max_query_queue_history_slots_number = 10;
+        connectContext.onQueryFinished();
+        extraMessage = slot1.getExtraMessage();
+        assertTrue(extraMessage.isPresent());
+        assertTrue(extraMessage.get().getQueryStartTime() == connectContext.getStartTime());
+        Config.max_query_queue_history_slots_number = 0;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/WarehouseQueryQueueOptionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/WarehouseQueryQueueOptionsTest.java
@@ -104,7 +104,7 @@ public class WarehouseQueryQueueOptionsTest {
             QueryQueueOptions.V2 v2 = opts.v2();
             assertThat(v2.getNumWorkers()).isEqualTo(3);
             assertThat(v2.getNumRowsPerSlot()).isEqualTo(Config.query_queue_v2_num_rows_per_slot);
-            assertThat(v2.getTotalSlots()).isEqualTo(3);
+            assertThat(QueryQueueOptions.correctSlotNum(v2.getTotalSlots())).isEqualTo(3);
             assertThat(v2.getTotalSmallSlots()).isEqualTo(1);
             assertThat(v2.getCpuCostsPerSlot()).isEqualTo(Config.query_queue_v2_cpu_costs_per_slot);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/warehouse/WarehouseMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/warehouse/WarehouseMetricsTest.java
@@ -20,6 +20,8 @@ package com.starrocks.qe.scheduler.warehouse;
 import com.starrocks.thrift.TGetWarehouseMetricsResponeItem;
 import org.junit.Test;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class WarehouseMetricsTest {
@@ -42,7 +44,8 @@ public class WarehouseMetricsTest {
 
     @Test
     public void testCreateWarehouseMetrics() {
-        WarehouseMetrics warehouseMetrics = new WarehouseMetrics(1, "test", 1, 1, 1, 1, 1, 1, 1, 1, 1);
+        WarehouseMetrics warehouseMetrics = new WarehouseMetrics(1, "test", 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                Optional.empty());
         TGetWarehouseMetricsResponeItem thrift = warehouseMetrics.toThrift();
         assertThat(thrift.getWarehouse_id()).isEqualTo("1");
         assertThat(thrift.getWarehouse_name()).isEqualTo("test");

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/warehouse/WarehouseQueryMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/warehouse/WarehouseQueryMetricsTest.java
@@ -35,12 +35,14 @@ public class WarehouseQueryMetricsTest {
         assertThat(thrift.getEst_costs_slots()).isEqualTo("0");
         assertThat(thrift.getAllocate_slots()).isEqualTo("0");
         assertThat(thrift.getQueued_wait_seconds()).isEqualTo("0.0");
+        assertThat(thrift.getQuery()).isEqualTo("");
     }
 
     @Test
     public void testCreateWarehouseQueryMetrics() {
         WarehouseQueryMetrics metrics = new WarehouseQueryMetrics(1, "test",
-                null, LogicalSlot.State.ALLOCATED, 1, 1, 1);
+                null, LogicalSlot.State.ALLOCATED, 1, 1, 1,
+                "select 1", null);
         TGetWarehouseQueriesResponseItem thrift = metrics.toThrift();
         assertThat(thrift.getWarehouse_id()).isEqualTo("1");
         assertThat(thrift.getWarehouse_name()).isEqualTo("test");
@@ -49,5 +51,6 @@ public class WarehouseQueryMetricsTest {
         assertThat(thrift.getEst_costs_slots()).isEqualTo("1");
         assertThat(thrift.getAllocate_slots()).isEqualTo("1");
         assertThat(thrift.getQueued_wait_seconds()).isEqualTo("1.0");
+        assertThat(thrift.getQuery()).isEqualTo("select 1");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
@@ -483,10 +483,10 @@ public class InformationSchemaDataSourceTest {
         Assert.assertNotNull(response.getMetrics());
 
         starRocksAssert.query("select * from information_schema.warehouse_metrics;")
-                .explainContains(" OUTPUT EXPRS:1: WAREHOUSE_ID | 2: WAREHOUSE_NAME " +
-                        "| 3: QUEUE_PENDING_LENGTH | 4: QUEUE_RUNNING_LENGTH | 5: MAX_PENDING_LENGTH " +
-                        "| 6: MAX_PENDING_TIME_SECOND | 7: EARLIEST_QUERY_WAIT_TIME | 8: MAX_REQUIRED_SLOTS " +
-                        "| 9: SUM_REQUIRED_SLOTS | 10: REMAIN_SLOTS | 11: MAX_SLOTS\n");
+                .explainContains(" OUTPUT EXPRS:1: WAREHOUSE_ID | 2: WAREHOUSE_NAME | 3: QUEUE_PENDING_LENGTH " +
+                        "| 4: QUEUE_RUNNING_LENGTH | 5: MAX_PENDING_LENGTH | 6: MAX_PENDING_TIME_SECOND " +
+                        "| 7: EARLIEST_QUERY_WAIT_TIME | 8: MAX_REQUIRED_SLOTS | 9: SUM_REQUIRED_SLOTS | 10: REMAIN_SLOTS " +
+                        "| 11: MAX_SLOTS | 12: EXTRA_MESSAGE\n");
     }
 
     @Test
@@ -504,7 +504,8 @@ public class InformationSchemaDataSourceTest {
         Assert.assertTrue(response.getQueries().isEmpty());
 
         starRocksAssert.query("select * from information_schema.warehouse_queries;")
-                .explainContains(" OUTPUT EXPRS:1: WAREHOUSE_ID | 2: WAREHOUSE_NAME | 3: QUERY_ID " +
-                        "| 4: STATE | 5: EST_COSTS_SLOTS | 6: ALLOCATE_SLOTS | 7: QUEUED_WAIT_SECONDS");
+                .explainContains(" OUTPUT EXPRS:1: WAREHOUSE_ID | 2: WAREHOUSE_NAME | 3: QUERY_ID | 4: STATE " +
+                        "| 5: EST_COSTS_SLOTS | 6: ALLOCATE_SLOTS | 7: QUEUED_WAIT_SECONDS " +
+                        "| 8: QUERY | 9: QUERY_START_TIME | 10: QUERY_END_TIME | 11: QUERY_DURATION | 12: EXTRA_MESSAGE\n");
     }
 }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1989,6 +1989,7 @@ struct TGetWarehouseMetricsResponeItem {
     9: optional string sum_required_slots;
     10: optional string remain_slots;
     11: optional string max_slots;
+    12: optional string extra_message;
 }
 struct TGetWarehouseMetricsRespone {
     1:optional list<TGetWarehouseMetricsResponeItem> metrics;
@@ -2005,6 +2006,11 @@ struct TGetWarehouseQueriesResponseItem {
     5: optional string est_costs_slots;
     6: optional string allocate_slots;
     7: optional string queued_wait_seconds;
+    8: optional string query;
+    9: optional string query_start_time;
+    10: optional string query_end_time;
+    11: optional string query_duration;
+    12: optional string extra_message;
 }
 struct TGetWarehouseQueriesResponse {
     1: optional list<TGetWarehouseQueriesResponseItem> queries;

--- a/test/sql/test_information_schema/R/test_warehouse_metrics
+++ b/test/sql/test_information_schema/R/test_warehouse_metrics
@@ -18,6 +18,7 @@ MAX_REQUIRED_SLOTS	varchar(2048)	YES	false	None
 SUM_REQUIRED_SLOTS	varchar(2048)	YES	false	None	
 REMAIN_SLOTS	varchar(2048)	YES	false	None	
 MAX_SLOTS	varchar(2048)	YES	false	None	
+EXTRA_MESSAGE	varchar(2048)	YES	false	None	
 -- !result
 SELECT * FROM information_schema.warehouse_metrics;
 -- result:

--- a/test/sql/test_information_schema/R/test_warehouse_queries
+++ b/test/sql/test_information_schema/R/test_warehouse_queries
@@ -14,6 +14,11 @@ STATE	varchar(2048)	YES	false	None
 EST_COSTS_SLOTS	varchar(2048)	YES	false	None	
 ALLOCATE_SLOTS	varchar(2048)	YES	false	None	
 QUEUED_WAIT_SECONDS	varchar(2048)	YES	false	None	
+QUERY	varchar(2048)	YES	false	None	
+QUERY_START_TIME	varchar(2048)	YES	false	None	
+QUERY_END_TIME	varchar(2048)	YES	false	None	
+QUERY_DURATION	varchar(2048)	YES	false	None	
+EXTRA_MESSAGE	varchar(2048)	YES	false	None	
 -- !result
 SELECT * FROM information_schema.warehouse_queries;
 -- result:


### PR DESCRIPTION
## Why I'm doing:
When `query queue` is enabled, it's diffcult to track query's allocating and connect context info, and it's also hard to explain query queue's strategy better or not.

## What I'm doing:
1. Add `extra_message` for `warehouse_metrics` and `wareshouse_queries` information schema tables to track more informations

wareshouse_queries
```
   1: optional string warehouse_id;
    2: optional string warehouse_name;
    3: optional string query_id;
    4: optional string state;
    5: optional string est_costs_slots;
    6: optional string allocate_slots;
    7: optional string queued_wait_seconds;
    8: optional string query; // the applied query's prefix 
    9: optional string query_start_time; // the query's start time
    10: optional string query_end_time; // the query's end time
    11: optional string query_duration; // the query's duration
    12: optional string extra_message; // other message
```

wareshouse_queries's extra_message:
```
  public static class ExtraMessage {
        @SerializedName("QueryState")
        private final QueryState.MysqlStateType queryState;
        @SerializedName("PlanMemCostBytes")
        private final long planMemCostBytes;
        @SerializedName("MemCostBytes")
        private final long memCostBytes;
        @SerializedName("PredictMemBytes")
        private final long predictMemBytes;
}
```

warehouse_metrics table:
```
    1: optional string warehouse_id;
    2: optional string warehouse_name;
    3: optional string queue_pending_length;
    4: optional string queue_running_length;
    5: optional string max_pending_length;
    6: optional string max_pending_time_second;
    7: optional string earliest_query_wait_time;
    8: optional string max_required_slots;
    9: optional string sum_required_slots;
    10: optional string remain_slots;
    11: optional string max_slots;
    12: optional string extra_message; // new added extra_message column
```
warehouse_metrics's extra message includes the current concurrency and its options:
```
   public static class ExtraMessage {
        @SerializedName("Concurrency")
        private final long concurrency;
        @SerializedName("QueryQueueOption")
        private final QueryQueueOptions.V2 v2;
}
```

2. We only reserve the running slots now, slots info will be released after query is done which is not good for analysis later.Add `max_query_queue_history_slots_number` to keep the finished slots in the memory, default 0 means it will not change the current behavior.

3. Support `query cucurrency limit` for `SlotSelectionStrategyV2` by reusing the global  variable `query_queue_concurrency_limit`. 
NOTE:
- by default it's not enabled when `query_queue_concurrency_limit` is <= 0;
- If `query_queue_concurrency_limit` is greater than 0, `slotTracker` will limit the max concurrency limit to avoid bigquery's OOM cases.
 

Examples:
```

mysql> select * from information_schema.warehouse_queries;
+--------------+-------------------+--------------------------------------+----------+-----------------+----------------+---------------------+------------------+---------------------+---------------------+----------------+----------------------------------------------------------------------------------------------------+
| WAREHOUSE_ID | WAREHOUSE_NAME    | QUERY_ID                             | STATE    | EST_COSTS_SLOTS | ALLOCATE_SLOTS | QUEUED_WAIT_SECONDS | QUERY            | QUERY_START_TIME    | QUERY_END_TIME      | QUERY_DURATION | EXTRA_MESSAGE                                                                                      |
+--------------+-------------------+--------------------------------------+----------+-----------------+----------------+---------------------+------------------+---------------------+---------------------+----------------+----------------------------------------------------------------------------------------------------+
| 0            | default_warehouse | 7d12e8d0-1f3e-11f0-86cc-00163e0436cb | RELEASED | 1               | 1              | 0.015               | /*+ (q15.sql) */ | 2025-04-22 13:56:09 | 2025-04-22 13:56:19 | 9589           | {"QueryState":"EOF","PlanMemCostBytes":370,"MemCostBytes":1118047880,"PredictMemBytes":0}          |
| 0            | default_warehouse | 7d0ad27c-1f3e-11f0-86cc-00163e0436cb | RELEASED | 1               | 1              | 17.34               | /*+ (q06.sql) */ | 2025-04-22 13:56:09 | 2025-04-22 13:56:33 | 23766          | {"QueryState":"EOF","PlanMemCostBytes":61,"MemCostBytes":902013632,"PredictMemBytes":0}            |
| 0            | default_warehouse | 7d08d6aa-1f3e-11f0-86cc-00163e0436cb | RELEASED | 2               | 2              | 8.524               | /*+ (q08.sql) */ | 2025-04-22 13:56:09 | 2025-04-22 13:56:27 | 18457          | {"QueryState":"EOF","PlanMemCostBytes":267000284,"MemCostBytes":956049168,"PredictMemBytes":0}     


mysql> select * from information_schema.warehouse_metrics;
+--------------+-------------------+----------------------+----------------------+--------------------+-------------------------+--------------------------+--------------------+--------------------+--------------+-----------+-----------------------------------------+
| WAREHOUSE_ID | WAREHOUSE_NAME    | QUEUE_PENDING_LENGTH | QUEUE_RUNNING_LENGTH | MAX_PENDING_LENGTH | MAX_PENDING_TIME_SECOND | EARLIEST_QUERY_WAIT_TIME | MAX_REQUIRED_SLOTS | SUM_REQUIRED_SLOTS | REMAIN_SLOTS | MAX_SLOTS | EXTRA_MESSAGE                           |
+--------------+-------------------+----------------------+----------------------+--------------------+-------------------------+--------------------------+--------------------+--------------------+--------------+-----------+-----------------------------------------+
| 0            | default_warehouse | 0                    | 0                    | 1024               | 300                     | 0.0                      | 0                  | 0                  | 12           | 12        | {"Concurrency":0,"QueryQueueOption":{}} |
+--------------+-------------------+----------------------+----------------------+--------------------+-------------------------+--------------------------+--------------------+--------------------+--------------+-----------+-----------------------------------------+
1 row in set (0.02 sec)

```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
