### PR TITLE
[Enhancement] skip pk preload when pk index try lock fail and memory limit exceed

### DIFF
--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -748,7 +748,8 @@ Status DeltaWriter::commit() {
     auto rowset_build_ts = watch.elapsed_time();
 
     if (_tablet->keys_type() == KeysType::PRIMARY_KEYS && !config::skip_pk_preload &&
-        !_storage_engine->update_manager()->mem_tracker()->limit_exceeded_by_ratio(config::memory_high_level)) {
+        !_storage_engine->update_manager()->mem_tracker()->limit_exceeded_by_ratio(config::memory_high_level) &&
+        !_storage_engine->update_manager()->update_state_mem_tracker()->any_limit_exceeded()) {
         auto st = _storage_engine->update_manager()->on_rowset_finished(_tablet.get(), _cur_rowset.get());
         if (!st.ok()) {
             _set_state(kAborted, st);

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -50,12 +50,12 @@ Status RowsetUpdateState::load(Tablet* tablet, Rowset* rowset) {
     std::call_once(_load_once_flag, [&] {
         _tablet_id = tablet->tablet_id();
         _status = _do_load(tablet, rowset);
-        if (!_status.ok()) {
+        if (!_status.ok() && !_status.is_mem_limit_exceeded() && !_status.is_time_out()) {
             LOG(WARNING) << "load RowsetUpdateState error: " << _status << " tablet:" << _tablet_id << " stack:\n"
                          << get_stack_trace();
-            if (_status.is_mem_limit_exceeded()) {
-                LOG(WARNING) << CurrentThread::mem_tracker()->debug_string();
-            }
+        }
+        if (_status.is_mem_limit_exceeded()) {
+            LOG(WARNING) << CurrentThread::mem_tracker()->debug_string();
         }
     });
     return _status;
@@ -413,9 +413,9 @@ Status RowsetUpdateState::_prepare_partial_update_states(Tablet* tablet, Rowset*
 
     int64_t t_read_index = MonotonicMillis();
     if (need_lock) {
-        RETURN_IF_ERROR(tablet->updates()->get_rss_rowids_by_pk(tablet, *_upserts[idx],
-                                                                &(_partial_update_states[idx].read_version),
-                                                                &(_partial_update_states[idx].src_rss_rowids)));
+        RETURN_IF_ERROR(tablet->updates()->get_rss_rowids_by_pk(
+                tablet, *_upserts[idx], &(_partial_update_states[idx].read_version),
+                &(_partial_update_states[idx].src_rss_rowids), 3000 /* timeout_ms */));
     } else {
         RETURN_IF_ERROR(tablet->updates()->get_rss_rowids_by_pk_unlock(tablet, *_upserts[idx],
                                                                        &(_partial_update_states[idx].read_version),

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -5485,6 +5485,7 @@ Status TabletUpdates::get_column_values(const std::vector<uint32_t>& column_ids,
 
 Status TabletUpdates::get_rss_rowids_by_pk(Tablet* tablet, const Column& keys, EditVersion* read_version,
                                            std::vector<uint64_t>* rss_rowids, int64_t timeout_ms) {
+    TEST_ERROR_POINT("TabletUpdates::get_rss_rowids_by_pk");
     if (timeout_ms <= 0) {
         _index_lock.lock();
     } else {

--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -58,7 +58,12 @@ UpdateManager::UpdateManager(MemTracker* mem_tracker)
           _update_state_cache(std::numeric_limits<size_t>::max()),
           _update_column_state_cache(std::numeric_limits<size_t>::max()) {
     _update_mem_tracker = mem_tracker;
-    _update_state_mem_tracker = std::make_unique<MemTracker>(-1, "rowset_update_state", mem_tracker);
+    int64_t preload_mem_limit = -1;
+    if (_update_mem_tracker != nullptr) {
+        preload_mem_limit = (int64_t)_update_mem_tracker->limit() *
+                            std::max(std::min(100, config::lake_pk_preload_memory_limit_percent), 0) / 100;
+    }
+    _update_state_mem_tracker = std::make_unique<MemTracker>(preload_mem_limit, "rowset_update_state", mem_tracker);
     _index_cache_mem_tracker = std::make_unique<MemTracker>(-1, "index_cache", mem_tracker);
     _del_vec_cache_mem_tracker = std::make_unique<MemTracker>(-1, "del_vec_cache", mem_tracker);
     _compaction_state_mem_tracker = std::make_unique<MemTracker>(-1, "compaction_state", mem_tracker);
@@ -527,7 +532,11 @@ Status UpdateManager::on_rowset_finished(Tablet* tablet, Rowset* rowset) {
         if (st.ok()) {
             _update_column_state_cache.release(state_entry);
         } else {
-            LOG(WARNING) << "load RowsetColumnUpdateState error: " << st << " tablet: " << tablet->tablet_id();
+            if (st.is_mem_limit_exceeded() || st.is_time_out()) {
+                VLOG(2) << "load RowsetColumnUpdateState error: " << st << " tablet: " << tablet->tablet_id();
+            } else {
+                LOG(WARNING) << "load RowsetColumnUpdateState error: " << st << " tablet: " << tablet->tablet_id();
+            }
             _update_column_state_cache.remove(state_entry);
         }
     } else {
@@ -539,7 +548,11 @@ Status UpdateManager::on_rowset_finished(Tablet* tablet, Rowset* rowset) {
         if (st.ok()) {
             _update_state_cache.release(state_entry);
         } else {
-            LOG(WARNING) << "load RowsetUpdateState error: " << st << " tablet: " << tablet->tablet_id();
+            if (st.is_mem_limit_exceeded() || st.is_time_out()) {
+                VLOG(2) << "load RowsetUpdateState error: " << st << " tablet: " << tablet->tablet_id();
+            } else {
+                LOG(WARNING) << "load RowsetUpdateState error: " << st << " tablet: " << tablet->tablet_id();
+            }
             _update_state_cache.remove(state_entry);
         }
     }
@@ -571,9 +584,9 @@ Status UpdateManager::on_rowset_finished(Tablet* tablet, Rowset* rowset) {
 
     FAIL_POINT_TRIGGER_EXECUTE(on_rowset_finished_failed_due_to_mem,
                                { st = Status::MemoryLimitExceeded("on_rowset_finished failed"); });
-    // if failed due to memory limit which is not a critical issue. we don't need to abort the ingestion
-    // and we can still commit the txn.
-    if (st.is_mem_limit_exceeded()) {
+    // if failed due to memory limit or wait index lock timeout which is not a critical issue.
+    // we don't need to abort the ingestion and we can still commit the txn.
+    if (st.is_mem_limit_exceeded() || st.is_time_out()) {
         return Status::OK();
     }
     return st;

--- a/be/src/storage/update_manager.h
+++ b/be/src/storage/update_manager.h
@@ -129,6 +129,8 @@ public:
 
     MemTracker* mem_tracker() const { return _update_mem_tracker; }
 
+    MemTracker* update_state_mem_tracker() const { return _update_state_mem_tracker.get(); }
+
     string memory_stats();
 
     string detail_memory_stats();

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -4066,4 +4066,39 @@ TEST_F(TabletUpdatesTest, test_apply_breakpoint_check_pindex) {
     test_apply_breakpoint_check(true);
 }
 
+TEST_F(TabletUpdatesTest, test_on_rowset_finished_lock_timeout) {
+    _tablet = create_tablet(rand(), rand());
+    _tablet->set_enable_persistent_index(true);
+    std::vector<int64_t> keys;
+    int N = 100;
+    for (int i = 0; i < N; i++) {
+        keys.push_back(i);
+    }
+    {
+        auto rs0 = create_rowset(_tablet, keys);
+        int32_t version = 2;
+        auto st = _tablet->rowset_commit(version, rs0);
+        ASSERT_TRUE(st.ok()) << st.to_string();
+        ASSERT_EQ(version, _tablet->updates()->max_version());
+        ASSERT_EQ(version, _tablet->updates()->version_history_count());
+        ASSERT_EQ(N, read_tablet(_tablet, version));
+    }
+
+    {
+        int32_t version = 3;
+        std::vector<int32_t> column_indexes = {0, 1};
+        std::shared_ptr<TabletSchema> partial_schema = TabletSchema::create(_tablet->tablet_schema(), column_indexes);
+        RowsetSharedPtr partial_rowset = create_partial_rowset(_tablet, keys, column_indexes, partial_schema);
+        TEST_ENABLE_ERROR_POINT("TabletUpdates::get_rss_rowids_by_pk", Status::TimedOut("injected internal error"));
+        SyncPoint::GetInstance()->EnableProcessing();
+        StorageEngine::instance()->update_manager()->on_rowset_finished(_tablet.get(), partial_rowset.get());
+        TEST_DISABLE_ERROR_POINT("TabletUpdates::get_rss_rowids_by_pk");
+        SyncPoint::GetInstance()->DisableProcessing();
+        auto st = _tablet->rowset_commit(version, partial_rowset);
+        ASSERT_TRUE(st.ok()) << st.to_string();
+
+        ASSERT_EQ(N, read_tablet(_tablet, version));
+    }
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
The PK table moves part of the workload from the apply phase to the import phase by performing preload during the import phase, thereby reducing the latency of the apply phase. However, this also brings several issues:
1. During the preload phase, the PK index lock needs to be acquired. If the lock wait time is too long, it may cause the import to reach a timeout.
2. Additionally, the state loaded during the preload phase may consume excessive memory.

## What I'm doing:
1. Use try lock when do preload, only wait for 5s. We can skip preload if try lock fail
2. Preload state memory limit can be controlled by `lake_pk_preload_memory_limit_percent`.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
