### PR TITLE
[Enhancement] use IcebergAwsClientFactory to create aws client for iceberg REST catalog with vended credentials

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergAwsClientFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergAwsClientFactoryTest.java
@@ -16,6 +16,8 @@ package com.starrocks.connector.iceberg;
 
 import com.starrocks.connector.share.credential.CloudConfigurationConstants;
 import com.starrocks.connector.share.iceberg.IcebergAwsClientFactory;
+import org.apache.iceberg.aws.AwsClientProperties;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.junit.Assert;
 import org.junit.Test;
 import software.amazon.awssdk.regions.Region;
@@ -44,6 +46,26 @@ public class IcebergAwsClientFactoryTest {
 
         Assert.assertNull(factory.dynamo());
         Assert.assertNull(factory.kms());
+    }
+
+    @Test
+    public void testVendedCredentials() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(CloudConfigurationConstants.AWS_S3_ACCESS_KEY, "ak");
+        properties.put(CloudConfigurationConstants.AWS_S3_SECRET_KEY, "sk");
+        properties.put(CloudConfigurationConstants.AWS_S3_ENDPOINT, "endpoint");
+        properties.put(CloudConfigurationConstants.AWS_S3_REGION, "xxx");
+        IcebergAwsClientFactory factory = new IcebergAwsClientFactory();
+        factory.initialize(properties);
+        Assert.assertNotNull(factory.s3());
+        // test vended credentials
+        properties = new HashMap<>();
+        properties.put(S3FileIOProperties.ACCESS_KEY_ID, "ak");
+        properties.put(S3FileIOProperties.SECRET_ACCESS_KEY, "sk");
+        properties.put(AwsClientProperties.CLIENT_REGION, "xxx");
+        factory = new IcebergAwsClientFactory();
+        factory.initialize(properties);
+        Assert.assertNotNull(factory.s3());
     }
 
     @Test

--- a/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/iceberg/IcebergAwsClientFactory.java
+++ b/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/iceberg/IcebergAwsClientFactory.java
@@ -15,7 +15,9 @@
 package com.starrocks.connector.share.iceberg;
 
 import org.apache.iceberg.aws.AwsClientFactory;
+import org.apache.iceberg.aws.AwsClientProperties;
 import org.apache.iceberg.aws.AwsProperties;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -106,14 +108,18 @@ public class IcebergAwsClientFactory implements AwsClientFactory {
 
         s3UseAWSSDKDefaultBehavior = Boolean.parseBoolean(properties.getOrDefault(AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR, "false"));
         s3UseInstanceProfile = Boolean.parseBoolean(properties.getOrDefault(AWS_S3_USE_INSTANCE_PROFILE, "false"));
-        s3AccessKey = properties.getOrDefault(AWS_S3_ACCESS_KEY, "");
-        s3SecretKey = properties.getOrDefault(AWS_S3_SECRET_KEY, "");
-        s3SessionToken = properties.getOrDefault(AWS_S3_SESSION_TOKEN, "");
+        s3AccessKey = properties.getOrDefault(S3FileIOProperties.ACCESS_KEY_ID,
+                properties.getOrDefault(AWS_S3_ACCESS_KEY, ""));
+        s3SecretKey = properties.getOrDefault(S3FileIOProperties.SECRET_ACCESS_KEY,
+                properties.getOrDefault(AWS_S3_SECRET_KEY, ""));
+        s3SessionToken = properties.getOrDefault(S3FileIOProperties.SESSION_TOKEN,
+                properties.getOrDefault(AWS_S3_SESSION_TOKEN, ""));
         s3IamRoleArn = properties.getOrDefault(AWS_S3_IAM_ROLE_ARN, "");
         s3StsRegion = properties.getOrDefault(AWS_S3_STS_REGION, "");
         s3StsEndpoint = properties.getOrDefault(AWS_S3_STS_ENDPOINT, "");
         s3ExternalId = properties.getOrDefault(AWS_S3_EXTERNAL_ID, "");
-        s3Region = properties.getOrDefault(AWS_S3_REGION, "");
+        s3Region = properties.getOrDefault(AwsClientProperties.CLIENT_REGION,
+                properties.getOrDefault(AWS_S3_REGION, ""));
         s3Endpoint = properties.getOrDefault(AWS_S3_ENDPOINT, "");
         s3EnablePathStyleAccess =
                 Boolean.parseBoolean(properties.getOrDefault(AWS_S3_ENABLE_PATH_STYLE_ACCESS, "false"));


### PR DESCRIPTION
## Why I'm doing:
Iceberg REST castalog would not use IcebergAwsClientFactory when enable vended credentials, this will result in some properties in catalog not worked.
## What I'm doing:
1. Still use IcebergAwsClientFactory for iceberg rest catalog when enable vended credentials
2. In IcebergAwsClientFactory, respect the properties from vended credentials
according to https://github.com/apache/iceberg/blob/4b131c5eca995c33b2ce67cac1aaf865f1138bd6/open-api/rest-catalog-open-api.yaml#L1863
we should respect these properties:
![image](https://github.com/user-attachments/assets/991acc2b-fcab-454e-b595-2ac994e41be0)


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
