### PR TITLE
[BugFix] Fix admin execute ExecEnv.get_stack_trace_for_all_threads() failed

### DIFF
--- a/be/src/runtime/diagnose_daemon.cpp
+++ b/be/src/runtime/diagnose_daemon.cpp
@@ -103,7 +103,7 @@ void DiagnoseDaemon::_perform_stack_trace(const std::string& context) {
     }
     int64_t start_time = MonotonicMillis();
     int64_t id = _diagnose_id.fetch_add(1);
-    std::string stack_trace = get_stack_trace_for_all_threads(fmt::format("DIAGNOSE {} - ", id));
+    std::string stack_trace = get_stack_trace_for_all_threads_with_prefix(fmt::format("DIAGNOSE {} - ", id));
     _last_stack_trace_time_ms = MonotonicMillis();
     LOG(INFO) << "diagnose stack trace, id: " << id << ", cost: " << (_last_stack_trace_time_ms - start_time)
               << " ms, size: " << stack_trace.size() << ", context: [" << context << "]";

--- a/be/src/util/stack_util.cpp
+++ b/be/src/util/stack_util.cpp
@@ -272,8 +272,12 @@ std::string get_stack_trace_for_threads(const std::vector<int>& tids, int timeou
     return get_stack_trace_for_threads_with_pattern(tids, "", timeout_ms);
 }
 
-std::string get_stack_trace_for_all_threads(const std::string& line_prefix) {
+std::string get_stack_trace_for_all_threads_with_prefix(const std::string& line_prefix) {
     return get_stack_trace_for_threads_with_pattern(get_thread_id_list(), "", 3000, line_prefix);
+}
+
+std::string get_stack_trace_for_all_threads() {
+    return get_stack_trace_for_all_threads_with_prefix("");
 }
 
 std::string get_stack_trace_for_function(const std::string& function_pattern) {

--- a/be/src/util/stack_util.h
+++ b/be/src/util/stack_util.h
@@ -32,7 +32,8 @@ std::vector<int> get_thread_id_list();
 bool install_stack_trace_sighandler();
 std::string get_stack_trace_for_thread(int tid, int timeout_ms);
 std::string get_stack_trace_for_threads(const std::vector<int>& tids, int timeout_ms);
-std::string get_stack_trace_for_all_threads(const std::string& line_prefix = "");
+std::string get_stack_trace_for_all_threads_with_prefix(const std::string& line_prefix);
+std::string get_stack_trace_for_all_threads();
 // get all thread stack trace, and filter by function pattern
 std::string get_stack_trace_for_function(const std::string& function_pattern);
 

--- a/be/test/util/stack_util_test.cpp
+++ b/be/test/util/stack_util_test.cpp
@@ -39,7 +39,13 @@ void test_get_stack_trace_for_all_threads(const std::string& line_prefix) {
         std::snprintf(std::get<1>(*tuple), std::get<2>(*tuple), "mock_frame_%d", num_symbolize);
         num_symbolize += 1;
     });
-    std::string stack_trace = get_stack_trace_for_all_threads(line_prefix);
+
+    std::string stack_trace;
+    if (line_prefix.empty()) {
+        stack_trace = get_stack_trace_for_all_threads();
+    } else {
+        stack_trace = get_stack_trace_for_all_threads_with_prefix(line_prefix);
+    }
 
     std::vector<std::string> lines;
     std::istringstream stream(stack_trace);


### PR DESCRIPTION
## Why I'm doing:

```
mysql> admin execute on 10004 'System.print(ExecEnv.get_stack_trace_for_all_threads())';
+------------------------------------------------------------------------------------------+
| result                                                                                   |
+------------------------------------------------------------------------------------------+
| Runtime error: ExecEnv metaclass does not implement 'get_stack_trace_for_all_threads()'. |
|   at: main:1                                                                             |
+------------------------------------------------------------------------------------------+
2 rows in set (0.00 sec)
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
