### PR TITLE
[Enhancement] Remove page_size from interface of object cache

### DIFF
--- a/be/src/bench/filter_data_bench.cpp
+++ b/be/src/bench/filter_data_bench.cpp
@@ -75,9 +75,9 @@ template <typename T>
 static inline size_t filter_simd_compress(const Filter& filter, T* data) {
     std::vector<uint8> bit_mask(filter.size() / 8);
 
-    constexpr size_t filter_batch_size = 64;
-    auto mask_offset = 0;
 #ifdef __AVX512BW__
+    auto mask_offset = 0;
+    constexpr size_t filter_batch_size = 64;
     const __m512i zero64 = _mm512_setzero_si512();
     for (size_t i = 0; i < filter.size(); i += filter_batch_size) {
         int64 m = _mm512_cmpneq_epi8_mask(_mm512_loadu_si512(reinterpret_cast<const __m512i*>(filter.data() + i)),
@@ -88,12 +88,12 @@ static inline size_t filter_simd_compress(const Filter& filter, T* data) {
     }
 #endif
     constexpr size_t batch_size = 512 / (sizeof(T) * 8);
-    constexpr size_t mask_batch_size = batch_size / 8;
     size_t res = 0;
     size_t batches = bit_mask.size() * 8 / batch_size;
     if constexpr (sizeof(T) * 8 == 32) {
         for (size_t i = 0; i < batches; i++) {
 #ifdef __AVX512F__
+            constexpr size_t mask_batch_size = batch_size / 8;
             __mmask16 m = *(reinterpret_cast<const uint16_t*>(bit_mask.data() + i * mask_batch_size));
             __m512i src = _mm512_loadu_epi32(data + i * batch_size);
             _mm512_mask_compressstoreu_epi32(data + res, m, src);

--- a/be/src/bench/filter_data_bench.cpp
+++ b/be/src/bench/filter_data_bench.cpp
@@ -88,12 +88,14 @@ static inline size_t filter_simd_compress(const Filter& filter, T* data) {
     }
 #endif
     constexpr size_t batch_size = 512 / (sizeof(T) * 8);
+#ifdef __AVX512F__
+    constexpr size_t mask_batch_size = batch_size / 8;
+#endif
     size_t res = 0;
     size_t batches = bit_mask.size() * 8 / batch_size;
     if constexpr (sizeof(T) * 8 == 32) {
         for (size_t i = 0; i < batches; i++) {
 #ifdef __AVX512F__
-            constexpr size_t mask_batch_size = batch_size / 8;
             __mmask16 m = *(reinterpret_cast<const uint16_t*>(bit_mask.data() + i * mask_batch_size));
             __m512i src = _mm512_loadu_epi32(data + i * batch_size);
             _mm512_mask_compressstoreu_epi32(data + res, m, src);

--- a/be/src/bench/object_cache_bench.cpp
+++ b/be/src/bench/object_cache_bench.cpp
@@ -150,7 +150,7 @@ void ObjectCacheBench::prepare_sequence_data(ObjectCache* cache, int64_t count) 
         *(int*)ptr = 1;
         ObjectCacheHandlePtr handle = nullptr;
         ObjectCacheWriteOptions options;
-        Status st = cache->insert(key, ptr, _page_size, _page_size, deleter, &handle, &options);
+        Status st = cache->insert(key, ptr, _page_size, deleter, &handle, &options);
         if (!st.ok()) {
             if (!st.is_already_exist()) {
                 LOG(FATAL) << "insert failed: " << st;
@@ -169,7 +169,7 @@ void ObjectCacheBench::prepare_data(ObjectCache* cache, int64_t count) {
         *(int*)ptr = 1;
         ObjectCacheHandlePtr handle = nullptr;
         ObjectCacheWriteOptions options;
-        Status st = cache->insert(key, ptr, _page_size, _page_size, deleter, &handle, &options);
+        Status st = cache->insert(key, ptr, _page_size, deleter, &handle, &options);
         if (!st.ok()) {
             if (!st.is_already_exist()) {
                 LOG(FATAL) << "insert failed: " << st;
@@ -236,7 +236,7 @@ void ObjectCacheBench::random_insert_multi_threads(benchmark::State* state, Obje
         *(int*)ptr = 1;
         ObjectCacheHandlePtr handle = nullptr;
         ObjectCacheWriteOptions options;
-        Status st = cache->insert(key, ptr, page_size, page_size, deleter, &handle, &options);
+        Status st = cache->insert(key, ptr, page_size, deleter, &handle, &options);
         if (!st.ok()) {
             if (!st.is_already_exist()) {
                 LOG(FATAL) << "insert failed: " << st;

--- a/be/src/cache/object_cache/lrucache_module.cpp
+++ b/be/src/cache/object_cache/lrucache_module.cpp
@@ -32,9 +32,8 @@ LRUCacheModule::~LRUCacheModule() {
     }
 }
 
-Status LRUCacheModule::insert(const std::string& key, void* value, size_t size,
-                              ObjectCacheDeleter deleter, ObjectCacheHandlePtr* handle,
-                              ObjectCacheWriteOptions* options) {
+Status LRUCacheModule::insert(const std::string& key, void* value, size_t size, ObjectCacheDeleter deleter,
+                              ObjectCacheHandlePtr* handle, ObjectCacheWriteOptions* options) {
     if (!_check_write(size, options)) {
         return Status::InternalError("cache insertion is rejected");
     }

--- a/be/src/cache/object_cache/lrucache_module.cpp
+++ b/be/src/cache/object_cache/lrucache_module.cpp
@@ -32,13 +32,13 @@ LRUCacheModule::~LRUCacheModule() {
     }
 }
 
-Status LRUCacheModule::insert(const std::string& key, void* value, size_t size, size_t charge,
+Status LRUCacheModule::insert(const std::string& key, void* value, size_t size,
                               ObjectCacheDeleter deleter, ObjectCacheHandlePtr* handle,
                               ObjectCacheWriteOptions* options) {
-    if (!_check_write(charge, options)) {
+    if (!_check_write(size, options)) {
         return Status::InternalError("cache insertion is rejected");
     }
-    auto* lru_handle = _cache->insert(key, value, size, charge, deleter, static_cast<CachePriority>(options->priority));
+    auto* lru_handle = _cache->insert(key, value, size, deleter, static_cast<CachePriority>(options->priority));
     if (handle) {
         *handle = reinterpret_cast<ObjectCacheHandlePtr>(lru_handle);
     }

--- a/be/src/cache/object_cache/lrucache_module.h
+++ b/be/src/cache/object_cache/lrucache_module.h
@@ -28,7 +28,7 @@ public:
 
     virtual ~LRUCacheModule();
 
-    Status insert(const std::string& key, void* value, size_t size, size_t charge, ObjectCacheDeleter deleter,
+    Status insert(const std::string& key, void* value, size_t size, ObjectCacheDeleter deleter,
                   ObjectCacheHandlePtr* handle, ObjectCacheWriteOptions* options) override;
 
     Status lookup(const std::string& key, ObjectCacheHandlePtr* handle, ObjectCacheReadOptions* options) override;

--- a/be/src/cache/object_cache/object_cache.h
+++ b/be/src/cache/object_cache/object_cache.h
@@ -31,7 +31,7 @@ public:
     // Insert object to cache, the `ptr` is the object pointer.
     // size: the size of the value.
     // charge: the actual memory size allocated for this value.
-    virtual Status insert(const std::string& key, void* value, size_t size, size_t charge, ObjectCacheDeleter deleter,
+    virtual Status insert(const std::string& key, void* value, size_t size, ObjectCacheDeleter deleter,
                           ObjectCacheHandlePtr* handle, ObjectCacheWriteOptions* options = nullptr) = 0;
 
     // Lookup object from cache, the `handle` wraps the object pointer.

--- a/be/src/cache/object_cache/starcache_module.cpp
+++ b/be/src/cache/object_cache/starcache_module.cpp
@@ -24,9 +24,8 @@ StarCacheModule::StarCacheModule(std::shared_ptr<starcache::StarCache> star_cach
     _initialized.store(true, std::memory_order_release);
 }
 
-Status StarCacheModule::insert(const std::string& key, void* value, size_t size, size_t charge,
-                               ObjectCacheDeleter deleter, ObjectCacheHandlePtr* handle,
-                               ObjectCacheWriteOptions* options) {
+Status StarCacheModule::insert(const std::string& key, void* value, size_t size, ObjectCacheDeleter deleter,
+                               ObjectCacheHandlePtr* handle, ObjectCacheWriteOptions* options) {
     starcache::ObjectHandle* obj_hdl = new starcache::ObjectHandle;
     auto obj_deleter = [deleter, key, value] {
         // For temporary compatibility with old deleters.

--- a/be/src/cache/object_cache/starcache_module.h
+++ b/be/src/cache/object_cache/starcache_module.h
@@ -25,7 +25,7 @@ public:
     StarCacheModule(std::shared_ptr<starcache::StarCache> star_cache);
     virtual ~StarCacheModule() = default;
 
-    Status insert(const std::string& key, void* value, size_t size, size_t charge, ObjectCacheDeleter deleter,
+    Status insert(const std::string& key, void* value, size_t size, ObjectCacheDeleter deleter,
                   ObjectCacheHandlePtr* handle, ObjectCacheWriteOptions* options) override;
 
     Status lookup(const std::string& key, ObjectCacheHandlePtr* handle, ObjectCacheReadOptions* options) override;

--- a/be/src/exec/query_cache/cache_manager.cpp
+++ b/be/src/exec/query_cache/cache_manager.cpp
@@ -26,7 +26,7 @@ static void delete_cache_entry(const CacheKey& key, void* value) {
 void CacheManager::populate(const std::string& key, const CacheValue& value) {
     auto* cache_value = new CacheValue(value);
     size_t value_size = cache_value->size();
-    auto* handle = _cache.insert(key, cache_value, value_size, value_size, &delete_cache_entry, CachePriority::NORMAL);
+    auto* handle = _cache.insert(key, cache_value, value_size, &delete_cache_entry, CachePriority::NORMAL);
     _cache.release(handle);
 }
 

--- a/be/src/exprs/jit/jit_engine.cpp
+++ b/be/src/exprs/jit/jit_engine.cpp
@@ -98,13 +98,12 @@ Status JitObjectCache::register_func(JITScalarFunction func) {
     // put into LRU cache
     auto* cache = new JitCacheEntry(_obj_code, _func);
     GlobalEnv::GetInstance()->jit_cache_mem_tracker()->consume(cache_func_size);
-    auto* handle = _lru_cache->insert(
-            _cache_key, (void*)cache, cache_func_size, cache_func_size, [](const CacheKey& key, void* value) {
-                auto* entry = ((JitCacheEntry*)value);
-                // maybe release earlier as the std::shared_ptr<llvm::MemoryBuffer> is hold by caller
-                GlobalEnv::GetInstance()->jit_cache_mem_tracker()->release(entry->obj_buff->getBufferSize());
-                delete entry;
-            });
+    auto* handle = _lru_cache->insert(_cache_key, (void*)cache, cache_func_size, [](const CacheKey& key, void* value) {
+        auto* entry = ((JitCacheEntry*)value);
+        // maybe release earlier as the std::shared_ptr<llvm::MemoryBuffer> is hold by caller
+        GlobalEnv::GetInstance()->jit_cache_mem_tracker()->release(entry->obj_buff->getBufferSize());
+        delete entry;
+    });
     if (handle == nullptr) {
         delete cache;
         LOG(WARNING) << "JIT register func failed, func = " << _cache_key << ", ir size = " << cache_func_size;

--- a/be/src/formats/parquet/metadata.cpp
+++ b/be/src/formats/parquet/metadata.cpp
@@ -482,8 +482,7 @@ StatusOr<FileMetaDataPtr> FileMetaDataParser::get_file_metadata() {
         auto deleter = [](const CacheKey& key, void* value) { delete (FileMetaDataPtr*)value; };
         ObjectCacheWriteOptions options;
         options.evict_probability = _datacache_options->datacache_evict_probability;
-        st = _cache->insert(metacache_key, capture, file_metadata_size, file_metadata_size, deleter, &cache_handle,
-                            &options);
+        st = _cache->insert(metacache_key, capture, file_metadata_size, deleter, &cache_handle, &options);
     } else {
         LOG(ERROR) << "Parsing unexpected parquet file metadata size";
     }

--- a/be/src/fs/fd_cache.cpp
+++ b/be/src/fs/fd_cache.cpp
@@ -33,7 +33,7 @@ FdCache::~FdCache() {
 
 FdCache::Handle* FdCache::insert(std::string_view path, int fd) {
     void* value = reinterpret_cast<void*>(static_cast<uintptr_t>(fd)); // NOLINT
-    Cache::Handle* h = _cache->insert(CacheKey(path.data(), path.size()), value, 1, 1, fd_deleter);
+    Cache::Handle* h = _cache->insert(CacheKey(path.data(), path.size()), value, 1, fd_deleter);
     return reinterpret_cast<FdCache::Handle*>(h);
 }
 

--- a/be/src/service/staros_worker.cpp
+++ b/be/src/service/staros_worker.cpp
@@ -386,7 +386,7 @@ std::shared_ptr<std::string> StarOSWorker::insert_fs_cache(const std::string& ke
 
     CacheKey cache_key(key);
     auto value = new CacheValue(fs_cache_key, fs);
-    auto handle = _fs_cache->insert(cache_key, value, 1, 1, cache_value_deleter);
+    auto handle = _fs_cache->insert(cache_key, value, 1, cache_value_deleter);
     if (handle == nullptr) {
         delete value;
         return nullptr;

--- a/be/src/storage/lake/metacache.cpp
+++ b/be/src/storage/lake/metacache.cpp
@@ -89,7 +89,7 @@ Metacache::Metacache(int64_t cache_capacity) : _cache(new_lru_cache(cache_capaci
 Metacache::~Metacache() = default;
 
 void Metacache::insert(std::string_view key, CacheValue* ptr, size_t size) {
-    Cache::Handle* handle = _cache->insert(CacheKey(key), ptr, size, size, cache_value_deleter);
+    Cache::Handle* handle = _cache->insert(CacheKey(key), ptr, size, cache_value_deleter);
     _cache->release(handle);
 }
 

--- a/be/src/storage/page_cache.cpp
+++ b/be/src/storage/page_cache.cpp
@@ -116,7 +116,7 @@ Status StoragePageCache::insert(const CacheKey& key, const Slice& data, PageCach
     Slice* cache_item = new Slice(data.data, data.size);
     auto deleter = [](const starrocks::CacheKey& key, void* value) {
         auto* cache_item = (Slice*)value;
-        delete[] (uint8_t*)cache_item->data;
+        delete[](uint8_t*) cache_item->data;
         delete cache_item;
     };
 

--- a/be/src/storage/page_cache.cpp
+++ b/be/src/storage/page_cache.cpp
@@ -115,8 +115,8 @@ Status StoragePageCache::insert(const CacheKey& key, const Slice& data, PageCach
 
     Slice* cache_item = new Slice(data.data, data.size);
     auto deleter = [](const starrocks::CacheKey& key, void* value) {
-        auto* cache_item = (Slice*) value;
-        delete[](uint8_t*) cache_item->data;
+        auto* cache_item = (Slice*)value;
+        delete[] (uint8_t*)cache_item->data;
         delete cache_item;
     };
 

--- a/be/src/storage/rowset/metadata_cache.cpp
+++ b/be/src/storage/rowset/metadata_cache.cpp
@@ -53,7 +53,7 @@ void MetadataCache::set_capacity(size_t capacity) {
 }
 
 void MetadataCache::_insert(const std::string& key, std::weak_ptr<Rowset>* ptr, size_t size) {
-    Cache::Handle* handle = _cache->insert(CacheKey(key), ptr, size, size, _cache_value_deleter);
+    Cache::Handle* handle = _cache->insert(CacheKey(key), ptr, size, _cache_value_deleter);
     _cache->release(handle);
 }
 

--- a/be/src/storage/rowset/page_handle.h
+++ b/be/src/storage/rowset/page_handle.h
@@ -91,7 +91,8 @@ public:
         if (_is_data_owner) {
             return _data;
         }
-        return _cache_data.data();
+        Slice* item = (Slice*)_cache_data.data().data;
+        return Slice{item->data, item->size};
     }
 
     int64_t mem_usage() const {

--- a/be/src/storage/rowset/page_io.cpp
+++ b/be/src/storage/rowset/page_io.cpp
@@ -172,11 +172,9 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
     {
         SCOPED_RAW_TIMER(&opts.stats->io_ns);
         // todo override is_cache_hit
+        RETURN_IF_ERROR(opts.read_file->read_at_fully(opts.page_pointer.offset, page_slice.data, page_slice.size));
         if (opts.read_file->is_cache_hit()) {
-            RETURN_IF_ERROR(opts.read_file->read_at_fully(opts.page_pointer.offset, page_slice.data, page_slice.size));
             ++opts.stats->pages_from_local_disk;
-        } else {
-            RETURN_IF_ERROR(opts.read_file->read_at_fully(opts.page_pointer.offset, page_slice.data, page_slice.size));
         }
         opts.stats->compressed_bytes_read_request += page_size;
         ++opts.stats->io_count_request;

--- a/be/src/storage/sstable/table.cpp
+++ b/be/src/storage/sstable/table.cpp
@@ -195,7 +195,7 @@ Iterator* Table::BlockReader(void* arg, const ReadOptions& options, const Slice&
                     block = new Block(contents);
                     if (contents.cachable && options.fill_cache) {
                         size_t block_size = block->size();
-                        cache_handle = block_cache->insert(key, block, block_size, block_size, &DeleteCachedBlock);
+                        cache_handle = block_cache->insert(key, block, block_size, &DeleteCachedBlock);
                     }
                 }
                 if (options.stat != nullptr) {

--- a/be/src/util/lru_cache.cpp
+++ b/be/src/util/lru_cache.cpp
@@ -294,10 +294,10 @@ void LRUCache::_evict_one_entry(LRUHandle* e) {
     _usage -= e->charge;
 }
 
-Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value, size_t value_size, size_t charge,
+Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value, size_t value_size,
                                 void (*deleter)(const CacheKey& key, void* value), CachePriority priority) {
     size_t key_mem_size = sizeof(LRUHandle) - 1 + key.size();
-    size_t kv_mem_size = charge + key_mem_size;
+    size_t kv_mem_size = value_size + key_mem_size;
     auto* e = reinterpret_cast<LRUHandle*>(malloc(key_mem_size));
     e->value = value;
     e->deleter = deleter;
@@ -429,10 +429,10 @@ bool ShardedLRUCache::adjust_capacity(int64_t delta, size_t min_capacity) {
     return true;
 }
 
-Cache::Handle* ShardedLRUCache::insert(const CacheKey& key, void* value, size_t value_size, size_t charge,
+Cache::Handle* ShardedLRUCache::insert(const CacheKey& key, void* value, size_t value_size,
                                        void (*deleter)(const CacheKey& key, void* value), CachePriority priority) {
     const uint32_t hash = _hash_slice(key);
-    return _shards[_shard(hash)].insert(key, hash, value, value_size, charge, deleter, priority);
+    return _shards[_shard(hash)].insert(key, hash, value, value_size, deleter, priority);
 }
 
 Cache::Handle* ShardedLRUCache::lookup(const CacheKey& key) {

--- a/be/src/util/lru_cache.h
+++ b/be/src/util/lru_cache.h
@@ -132,7 +132,7 @@ public:
     //
     // When the inserted entry is no longer needed, the key and
     // value will be passed to "deleter".
-    virtual Handle* insert(const CacheKey& key, void* value, size_t value_size, size_t charge,
+    virtual Handle* insert(const CacheKey& key, void* value, size_t value_size,
                            void (*deleter)(const CacheKey& key, void* value),
                            CachePriority priority = CachePriority::NORMAL) = 0;
 
@@ -268,7 +268,7 @@ public:
     void set_capacity(size_t capacity);
 
     // Like Cache methods, but with an extra "hash" parameter.
-    Cache::Handle* insert(const CacheKey& key, uint32_t hash, void* value, size_t value_size, size_t charge,
+    Cache::Handle* insert(const CacheKey& key, uint32_t hash, void* value, size_t value_size,
                           void (*deleter)(const CacheKey& key, void* value),
                           CachePriority priority = CachePriority::NORMAL);
     Cache::Handle* lookup(const CacheKey& key, uint32_t hash);
@@ -314,7 +314,7 @@ class ShardedLRUCache : public Cache {
 public:
     explicit ShardedLRUCache(size_t capacity);
     ~ShardedLRUCache() override = default;
-    Handle* insert(const CacheKey& key, void* value, size_t value_size, size_t charge,
+    Handle* insert(const CacheKey& key, void* value, size_t value_size,
                    void (*deleter)(const CacheKey& key, void* value),
                    CachePriority priority = CachePriority::NORMAL) override;
     Handle* lookup(const CacheKey& key) override;

--- a/be/test/cache/object_cache/lrucache_module_test.cpp
+++ b/be/test/cache/object_cache/lrucache_module_test.cpp
@@ -54,7 +54,7 @@ void LRUCacheModuleTest::_insert_data() {
         *ptr = i;
 
         ObjectCacheHandlePtr handle = nullptr;
-        ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, _value_size, &Deleter, &handle, &_write_opt));
+        ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, &Deleter, &handle, &_write_opt));
         _cache->release(handle);
     }
 }

--- a/be/test/cache/object_cache/object_cache_test.cpp
+++ b/be/test/cache/object_cache/object_cache_test.cpp
@@ -98,7 +98,7 @@ void ObjectCacheTest::_insert_data() {
         *ptr = i;
 
         ObjectCacheHandlePtr handle = nullptr;
-        ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, _value_size, &Deleter, &handle, &_write_opt));
+        ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, &Deleter, &handle, &_write_opt));
         _cache->release(handle);
     }
 }

--- a/be/test/cache/object_cache/starcache_module_test.cpp
+++ b/be/test/cache/object_cache/starcache_module_test.cpp
@@ -87,7 +87,7 @@ void StarCacheModuleTest::insert_value(int i) {
     int* ptr = (int*)malloc(_value_size);
     *ptr = i;
     ObjectCacheHandlePtr handle = nullptr;
-    ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, _value_size, &Deleter, &handle, &_write_opt));
+    ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, &Deleter, &handle, &_write_opt));
     _cache->release(handle);
 }
 
@@ -103,37 +103,35 @@ TEST_F(StarCacheModuleTest, insert_success) {
 
 TEST_F(StarCacheModuleTest, test_charge_size) {
     size_t mem_size = 4096;
-    size_t value_size = sizeof(int);
     void* ptr = malloc(mem_size);
     int* value = new (ptr) int;
     *value = 10;
     ObjectCacheHandlePtr handle = nullptr;
-    ASSERT_OK(_cache->insert("1", (void*)ptr, value_size, mem_size, &Deleter, &handle, nullptr));
+    ASSERT_OK(_cache->insert("1", (void*)ptr, mem_size, &Deleter, &handle, nullptr));
     _cache->release(handle);
 
     ObjectCacheHandlePtr lookup_handle = nullptr;
     ASSERT_OK(_cache->lookup("1", &lookup_handle, nullptr));
     auto value_slice = _cache->value_slice(lookup_handle);
-    ASSERT_EQ(value_slice.size, value_size);
-    ASSERT_EQ(*(int*)(value_slice.data + value_slice.size - value_size), 10);
+    ASSERT_EQ(value_slice.size, mem_size);
+    ASSERT_EQ(*(int*)(value_slice.data), 10);
     _cache->release(lookup_handle);
 }
 
 TEST_F(StarCacheModuleTest, test_charge_size_with_write_option) {
     size_t mem_size = 4096;
-    size_t value_size = sizeof(int);
     void* ptr = malloc(mem_size);
     int* value = new (ptr) int;
     *value = 10;
     ObjectCacheHandlePtr handle = nullptr;
-    ASSERT_OK(_cache->insert("1", (void*)ptr, value_size, mem_size, &Deleter, &handle, &_write_opt));
+    ASSERT_OK(_cache->insert("1", (void*)ptr, mem_size, &Deleter, &handle, &_write_opt));
     _cache->release(handle);
 
     ObjectCacheHandlePtr lookup_handle = nullptr;
     ASSERT_OK(_cache->lookup("1", &lookup_handle, nullptr));
     auto value_slice = _cache->value_slice(lookup_handle);
-    ASSERT_EQ(value_slice.size, value_size);
-    ASSERT_EQ(*(int*)(value_slice.data + value_slice.size - value_size), 10);
+    ASSERT_EQ(value_slice.size, mem_size);
+    ASSERT_EQ(*(int*)(value_slice.data), 10);
     _cache->release(lookup_handle);
 }
 
@@ -142,7 +140,7 @@ TEST_F(StarCacheModuleTest, insert_with_null_options) {
     int* ptr = (int*)malloc(_value_size);
     *ptr = 0;
     ObjectCacheHandlePtr handle = nullptr;
-    ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, _value_size, &Deleter, &handle, nullptr));
+    ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, &Deleter, &handle, nullptr));
     _cache->release(handle);
 }
 
@@ -151,12 +149,12 @@ TEST_F(StarCacheModuleTest, insert_and_release_old_handle) {
     int* ptr = (int*)malloc(_value_size);
     *ptr = 0;
     ObjectCacheHandlePtr handle = nullptr;
-    ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, _value_size, &Deleter, &handle, &_write_opt));
+    ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, &Deleter, &handle, &_write_opt));
 
     key = int_to_string(6, 1);
     ptr = (int*)malloc(_value_size);
     *ptr = 1;
-    ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, _value_size, &Deleter, &handle, &_write_opt));
+    ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, &Deleter, &handle, &_write_opt));
     _cache->release(handle);
 }
 

--- a/be/test/exprs/jit_func_cache_test.cpp
+++ b/be/test/exprs/jit_func_cache_test.cpp
@@ -39,8 +39,8 @@ public:
     }
 
     void mock_insert(string expr_name) {
-        auto* handle = engine->get_func_cache()->insert(expr_name, nullptr, 1000, 1000,
-                                                        [](const CacheKey& key, void* value) {});
+        auto* handle =
+                engine->get_func_cache()->insert(expr_name, nullptr, 1000, [](const CacheKey& key, void* value) {});
         if (handle != nullptr) {
             engine->get_func_cache()->release(handle);
         }

--- a/be/test/storage/page_cache_test.cpp
+++ b/be/test/storage/page_cache_test.cpp
@@ -75,10 +75,10 @@ TEST_F(StoragePageCacheTest, normal) {
         PageCacheHandle handle;
 
         ASSERT_OK(_page_cache->insert(key, data, &handle, false));
-        ASSERT_EQ(handle.data().data, data.data);
+        ASSERT_EQ(((Slice*)handle.data().data)->data, data.data);
 
         ASSERT_TRUE(_page_cache->lookup(key, &handle));
-        ASSERT_EQ(data.data, handle.data().data);
+        ASSERT_EQ(data.data, ((Slice*)handle.data().data)->data);
     }
 
     {
@@ -88,7 +88,7 @@ TEST_F(StoragePageCacheTest, normal) {
         PageCacheHandle handle;
 
         ASSERT_OK(_page_cache->insert(memory_key, data, &handle, true));
-        ASSERT_EQ(handle.data().data, data.data);
+        ASSERT_EQ(((Slice*)handle.data().data)->data, data.data);
 
         ASSERT_TRUE(_page_cache->lookup(memory_key, &handle));
     }

--- a/be/test/util/lru_cache_test.cpp
+++ b/be/test/util/lru_cache_test.cpp
@@ -105,13 +105,12 @@ public:
 
     void Insert(int key, int value, int charge) {
         std::string result;
-        _cache->release(
-                _cache->insert(EncodeKey(&result, key), EncodeValue(value), charge, charge, &CacheTest::Deleter));
+        _cache->release(_cache->insert(EncodeKey(&result, key), EncodeValue(value), charge, &CacheTest::Deleter));
     }
 
     void InsertDurable(int key, int value, int charge) {
         std::string result;
-        _cache->release(_cache->insert(EncodeKey(&result, key), EncodeValue(value), charge, charge, &CacheTest::Deleter,
+        _cache->release(_cache->insert(EncodeKey(&result, key), EncodeValue(value), charge, &CacheTest::Deleter,
                                        CachePriority::DURABLE));
     }
 
@@ -237,7 +236,7 @@ static void deleter(const CacheKey& key, void* v) {
 
 static void insert_LRUCache(LRUCache& cache, const CacheKey& key, int value, CachePriority priority) {
     uint32_t hash = key.hash(key.data(), key.size(), 0);
-    cache.release(cache.insert(key, hash, EncodeValue(value), value, value, &deleter, priority));
+    cache.release(cache.insert(key, hash, EncodeValue(value), value, &deleter, priority));
 }
 
 TEST_F(CacheTest, Usage) {
@@ -329,7 +328,7 @@ TEST_F(CacheTest, SetCapacity) {
         std::string result;
         auto cache_key = EncodeKey(&result, i);
         key_mem_size_1 += sizeof(LRUHandle) - 1 + cache_key.size();
-        handles[i] = _cache->insert(cache_key, EncodeValue(1000 + kCacheSize), 1, 1, &CacheTest::Deleter);
+        handles[i] = _cache->insert(cache_key, EncodeValue(1000 + kCacheSize), 1, &CacheTest::Deleter);
     }
     ASSERT_EQ(kCacheSize, _cache->get_capacity());
     ASSERT_EQ(32 + key_mem_size_1, _cache->get_memory_usage());
@@ -346,7 +345,7 @@ TEST_F(CacheTest, SetCapacity) {
         std::string result;
         auto cache_key = EncodeKey(&result, i);
         key_mem_size_2 += sizeof(LRUHandle) - 1 + cache_key.size();
-        handles[i] = _cache->insert(cache_key, EncodeValue(1000 + kCacheSize), 1, 1, &CacheTest::Deleter);
+        handles[i] = _cache->insert(cache_key, EncodeValue(1000 + kCacheSize), 1, &CacheTest::Deleter);
     }
     ASSERT_EQ(kCacheSize * 2, _cache->get_capacity());
     ASSERT_EQ(64 + key_mem_size_1 + key_mem_size_2, _cache->get_memory_usage());


### PR DESCRIPTION
## Why I'm doing:

Currently, the interface of starcache don't support `charge_size`, so when we use star cache to implement object cache, the memory statistics is not accurate. The reason why the current object cache interface requires both `charge_size` and `value_size` to be passed is that when calling lookup, it depends on `value_size` to parse the data. If it can be ensured that the value is self-parsable, `value_size` is actually not necessary.

## What I'm doing:

Remove charge_size from interface of object cache

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
