### PR TITLE
[Enhancement] Query feedback supports parameterization

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/feedback/OperatorTuningGuides.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/feedback/OperatorTuningGuides.java
@@ -22,6 +22,7 @@ import com.starrocks.qe.feedback.guide.TuningGuide;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 public class OperatorTuningGuides {
@@ -40,6 +41,21 @@ public class OperatorTuningGuides {
 
         public OperatorGuideInfo(int nodeId) {
             this.nodeId = nodeId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            OperatorGuideInfo that = (OperatorGuideInfo) o;
+            return nodeId == that.nodeId && Objects.equals(tuningGuides, that.tuningGuides);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(nodeId);
         }
     }
 
@@ -131,6 +147,19 @@ public class OperatorTuningGuides {
             sb.append("\n");
         }
         return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        return Objects.equals(operatorIdToTuningGuideInfo, ((OperatorTuningGuides) o).operatorIdToTuningGuideInfo);
+    }
+
+    @Override
+    public int hashCode() {
+        return 1;
     }
 
     public static class OptimizedRecord {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/feedback/ParameterizedPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/feedback/ParameterizedPredicate.java
@@ -1,0 +1,466 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.feedback;
+
+import com.google.common.collect.BoundType;
+import com.google.common.collect.Range;
+import com.google.common.collect.TreeRangeSet;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
+import com.starrocks.sql.optimizer.rewrite.scalar.MvNormalizePredicateRule;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.AndRangePredicate;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.ColumnRangePredicate;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.OrRangePredicate;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.PredicateExtractor;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.PredicateSplit;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.RangePredicate;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.StringJoiner;
+
+/**
+ * Represents a predicate that can be parameterized for comparison and merging operations.
+ * This class analyzes predicates to determine if they have compatible structures and
+ * supports both comparing predicates and merging their range constraints.
+ */
+public class ParameterizedPredicate {
+    // Whether the predicate has a structure suitable for comparison operations
+    private boolean isValidForComparison;
+    private boolean enableParameterizedMode = false;
+    private final ScalarOperator originPredicate;
+
+    // The part of the predicate that couldn't be converted to range predicates
+    private ScalarOperator residualPredicate;
+    private final Map<ColumnRefOperator, ColumnRangePredicate> columnRangePredicates = new HashMap<>();
+
+    public ParameterizedPredicate(ScalarOperator predicate) {
+        this.originPredicate = predicate;
+        try {
+            analyzePredicate();
+        } catch (Exception e) {
+            // ignore
+        }
+
+    }
+
+    /**
+     * Analyzes the predicate to determine if it's valid for comparison and extracts its components.
+     */
+    private void analyzePredicate() {
+        PredicateSplit splitPredicate = PredicateSplit.splitPredicate(originPredicate);
+
+        // Equal predicates are not supported for comparison
+        if (splitPredicate.getEqualPredicates() != null) {
+            this.isValidForComparison = false;
+            return;
+        }
+
+        // Process the residual predicates
+        this.residualPredicate = normalizedPredicate(splitPredicate.getResidualPredicates());
+
+        // Process range predicates if present
+        ScalarOperator rangePredicates = splitPredicate.getRangePredicates();
+        if (rangePredicates == null) {
+            return;
+        }
+
+        processRangePredicates(rangePredicates);
+    }
+
+    /**
+     * Processes range predicates by normalizing, extracting, and validating them.
+     *
+     * @param rangePredicates The range predicates to process
+     */
+    private void processRangePredicates(ScalarOperator rangePredicates) {
+        ScalarOperator normalizedRangePredicate = normalizedPredicate(rangePredicates);
+        if (normalizedRangePredicate == null) {
+            return;
+        }
+
+        RangePredicate rangePredicate = extractRangePredicate(normalizedRangePredicate);
+        if (!isValidRangePredicate(rangePredicate)) {
+            this.isValidForComparison = false;
+            return;
+        }
+
+        extractColumnPredicatesRecursive(rangePredicate);
+        this.isValidForComparison = true;
+    }
+
+
+    public boolean match(ParameterizedPredicate other) {
+        if (!isValidForComparison || !other.isValidForComparison) {
+            return false;
+        }
+
+        if (!Objects.equals(residualPredicate, other.residualPredicate)) {
+            return false;
+        }
+
+        if (columnRangePredicates.isEmpty() && other.columnRangePredicates.isEmpty()) {
+            return true;
+        }
+
+        if (columnRangePredicates.size() != other.columnRangePredicates.size()) {
+            return false;
+        }
+
+        for (Map.Entry<ColumnRefOperator, ColumnRangePredicate> entry : columnRangePredicates.entrySet()) {
+            ColumnRefOperator columnRefOperator = entry.getKey();
+            ColumnRangePredicate columnRangePredicate = entry.getValue();
+            ColumnRangePredicate otherColumnRangePredicate = other.columnRangePredicates.get(columnRefOperator);
+            if (otherColumnRangePredicate == null) {
+                return false;
+            }
+
+            if (!enableParameterizedMode && !otherColumnRangePredicate.enclose(columnRangePredicate)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Merges the column ranges from the source predicate into this predicate.
+     * This operation modifies the current predicate by expanding its ranges.
+     *
+     * @param source The source predicate whose ranges will be merged into this one
+     */
+    public void mergeColumnRange(ParameterizedPredicate source) {
+        if (!isValidForComparison || !source.isValidForComparison) {
+            return;
+        }
+
+        if (columnRangePredicates.isEmpty() || source.columnRangePredicates.isEmpty()) {
+            return;
+        }
+
+        for (Map.Entry<ColumnRefOperator, ColumnRangePredicate> entry : columnRangePredicates.entrySet()) {
+            ColumnRefOperator columnRefOperator = entry.getKey();
+            ColumnRangePredicate columnRangePredicate = entry.getValue();
+            ColumnRangePredicate otherColumnRangePredicate = source.columnRangePredicates.get(columnRefOperator);
+            if (otherColumnRangePredicate == null) {
+                continue;
+            }
+
+            ColumnRangePredicate mergedRangePredicate = mergeRanges(columnRangePredicate, otherColumnRangePredicate);
+            columnRangePredicates.put(columnRefOperator, mergedRangePredicate);
+        }
+
+    }
+
+    /**
+     * Merges two column range predicates into a single column range predicate.
+     * The merge strategy varies based on the types and relationships of the ranges:
+     * 1. Single points merging (e.g., x=1 and x=5):
+     *    - Creates a closed range between the points (e.g., 1 <= x <= 5)
+     *    - If points are identical, keeps as a single point
+     * 2. Point and range merging (e.g., x=3 and 1 <= x <= 10):
+     *    - If point is within range, keeps the original range
+     *    - If point is outside range, extends the range to include the point (e.g., 1 and [3, 5] becomes [1, 5])
+     *    - For unbounded ranges, preserves unboundedness while including the point
+     * 3. General ranges merging:
+     *    - For overlapping/intersecting ranges, creates their union (e.g., [1,5] and [3,8] becomes [1,8])
+     *    - For disjoint ranges, keeps both ranges separate (e.g., [1,5] and [8,10] stays as two ranges)
+     *    - The TreeRangeSet automatically handles merging of adjacent or overlapping ranges
+     * The method operates only on ranges for the same column reference, returning null
+     * if column references don't match between predicates.
+     *
+     * @param target The target column range predicate
+     * @param source The source column range predicate
+     * @return A new column range predicate containing the merged ranges
+     */
+    public ColumnRangePredicate mergeRanges(ColumnRangePredicate target, ColumnRangePredicate source) {
+        if (target == null || source == null) {
+            return target;
+        }
+
+        if (!Objects.equals(target.getColumnRef(), source.getColumnRef())) {
+            return null;
+        }
+
+        Set<Range<ConstantOperator>> targetRanges = target.getColumnRanges().asRanges();
+        Set<Range<ConstantOperator>> sourceRanges = source.getColumnRanges().asRanges();
+
+        // Handle simple case: single range in both predicates
+        if (targetRanges.size() == 1 && sourceRanges.size() == 1) {
+            return mergeSimpleRanges(
+                    target.getExpression(),
+                    targetRanges.iterator().next(),
+                    sourceRanges.iterator().next()
+            );
+        }
+
+        // Handle general case: multiple ranges
+        return mergeComplexRanges(target.getExpression(), targetRanges, sourceRanges);
+    }
+
+    /**
+     * Merges two simple ranges (one range per predicate).
+     *
+     * @param expression The scalar operator expression
+     * @param targetRange The target range
+     * @param sourceRange The source range
+     * @return A new column range predicate with the merged range
+     */
+    private ColumnRangePredicate mergeSimpleRanges(
+            ScalarOperator expression,
+            Range<ConstantOperator> targetRange,
+            Range<ConstantOperator> sourceRange) {
+
+        if (isSinglePoint(targetRange) && isSinglePoint(sourceRange)) {
+            return mergeSinglePoints(expression, targetRange, sourceRange);
+        }
+
+        if (isSinglePoint(targetRange) || isSinglePoint(sourceRange)) {
+            return mergePointAndRange(expression, targetRange, sourceRange);
+        }
+
+        // General case: merge two ranges
+        TreeRangeSet<ConstantOperator> resultRanges = TreeRangeSet.create();
+        resultRanges.add(targetRange);
+        resultRanges.add(sourceRange);
+        return new ColumnRangePredicate(expression, resultRanges);
+    }
+
+    /**
+     * Merges complex ranges (multiple ranges per predicate).
+     *
+     * @param expression The scalar operator expression
+     * @param targetRanges The target ranges
+     * @param sourceRanges The source ranges
+     * @return A new column range predicate with the merged ranges
+     */
+    private ColumnRangePredicate mergeComplexRanges(
+            ScalarOperator expression,
+            Set<Range<ConstantOperator>> targetRanges,
+            Set<Range<ConstantOperator>> sourceRanges) {
+
+        TreeRangeSet<ConstantOperator> resultRanges = TreeRangeSet.create();
+        resultRanges.addAll(targetRanges);
+        resultRanges.addAll(sourceRanges);
+        return new ColumnRangePredicate(expression, resultRanges);
+    }
+
+    private ColumnRangePredicate mergeSinglePoints(
+            ScalarOperator expression,
+            Range<ConstantOperator> targetRange,
+            Range<ConstantOperator> sourceRange) {
+
+        ConstantOperator targetPoint = targetRange.lowerEndpoint();
+        ConstantOperator sourcePoint = sourceRange.lowerEndpoint();
+        TreeRangeSet<ConstantOperator> resultRanges = TreeRangeSet.create();
+
+        int compareResult = targetPoint.compareTo(sourcePoint);
+        Range<ConstantOperator> mergedRange;
+
+        if (compareResult == 0) {
+            // Points are equal, keep one of them
+            mergedRange = targetRange;
+        } else if (compareResult < 0) {
+            // Target point is smaller, create range from target to source
+            mergedRange = Range.closed(targetPoint, sourcePoint);
+        } else {
+            // Source point is smaller, create range from source to target
+            mergedRange = Range.closed(sourcePoint, targetPoint);
+        }
+
+        resultRanges.add(mergedRange);
+        return new ColumnRangePredicate(expression, resultRanges);
+    }
+
+    /**
+     * Merges a point range with a non-point range.
+     *
+     * @param expression The scalar operator expression
+     * @param targetRange The first range
+     * @param sourceRange The second range
+     * @return A new column range predicate with the merged range
+     */
+    private ColumnRangePredicate mergePointAndRange(
+            ScalarOperator expression,
+            Range<ConstantOperator> targetRange,
+            Range<ConstantOperator> sourceRange) {
+
+        // Determine which range is the point and which is the normal range
+        Range<ConstantOperator> pointRange = isSinglePoint(targetRange) ? targetRange : sourceRange;
+        Range<ConstantOperator> normalRange = isSinglePoint(targetRange) ? sourceRange : targetRange;
+        ConstantOperator point = pointRange.lowerEndpoint();
+        TreeRangeSet<ConstantOperator> resultRanges = TreeRangeSet.create();
+
+        // Handle unbounded ranges
+        if (!normalRange.hasLowerBound() && !normalRange.hasUpperBound()) {
+            resultRanges.add(normalRange);
+            return new ColumnRangePredicate(expression, resultRanges);
+        }
+
+        if (!normalRange.hasLowerBound()) {
+            if (normalRange.contains(point)) {
+                resultRanges.add(normalRange);
+            } else {
+                resultRanges.add(Range.atMost(point));
+            }
+            return new ColumnRangePredicate(expression, resultRanges);
+        }
+
+        if (!normalRange.hasUpperBound()) {
+            if (normalRange.contains(point)) {
+                resultRanges.add(normalRange);
+            } else {
+                resultRanges.add(Range.atLeast(point));
+            }
+            return new ColumnRangePredicate(expression, resultRanges);
+        }
+
+        // Handle bounded ranges
+        if (normalRange.contains(point)) {
+            // Point is within the range, keep the original range
+            resultRanges.add(normalRange);
+        } else if (point.compareTo(normalRange.lowerEndpoint()) < 0) {
+            // Point is below the range, extend the lower bound
+            resultRanges.add(Range.range(
+                    point, BoundType.CLOSED,
+                    normalRange.upperEndpoint(), normalRange.upperBoundType()));
+        } else {
+            // Point is above the range, extend the upper bound
+            resultRanges.add(Range.range(
+                    normalRange.lowerEndpoint(), normalRange.lowerBoundType(),
+                    point, BoundType.CLOSED));
+        }
+
+        return new ColumnRangePredicate(expression, resultRanges);
+    }
+
+    /**
+     * Checks if a range represents a single point.
+     * A single point is a closed range where lower and upper endpoints are equal.
+     *
+     * @param range The range to check
+     * @return true if the range represents a single point, false otherwise
+     */
+    private boolean isSinglePoint(Range<ConstantOperator> range) {
+        return range.hasLowerBound() && range.hasUpperBound()
+                && range.lowerBoundType() == BoundType.CLOSED
+                && range.upperBoundType() == BoundType.CLOSED
+                && range.lowerEndpoint().equals(range.upperEndpoint());
+    }
+
+    private ScalarOperator normalizedPredicate(ScalarOperator predicate) {
+        if (predicate == null) {
+            return null;
+        }
+        return new MvNormalizePredicateRule().visit(predicate, new ScalarOperatorRewriteContext());
+    }
+
+    private RangePredicate extractRangePredicate(ScalarOperator predicate) {
+        PredicateExtractor extractor = new PredicateExtractor();
+        return predicate.accept(extractor, new PredicateExtractor.PredicateExtractorContext());
+    }
+
+    public boolean isValidRangePredicate(RangePredicate predicate) {
+        Set<ColumnRefOperator> seenColumns = new HashSet<>();
+        return validatePredicateStructure(predicate, seenColumns);
+    }
+
+    /**
+     * Validates the structure of a range predicate.
+     * A valid predicate must not contain OR predicates or duplicate column references.
+     *
+     * @param predicate The predicate to validate
+     * @param seenColumns Set of columns already seen in the predicate tree
+     * @return true if the predicate structure is valid, false otherwise
+     */
+    private boolean validatePredicateStructure(RangePredicate predicate, Set<ColumnRefOperator> seenColumns) {
+        if (predicate == null) {
+            return true;
+        }
+
+        if (predicate instanceof OrRangePredicate) {
+            return false;
+        }
+
+        if (predicate instanceof ColumnRangePredicate) {
+            ColumnRefOperator column = ((ColumnRangePredicate) predicate).getColumnRef();
+
+            if (seenColumns.contains(column)) {
+                return false;
+            }
+
+            seenColumns.add(column);
+            return true;
+        }
+
+        if (predicate instanceof AndRangePredicate andPredicate) {
+            for (RangePredicate child : andPredicate.getChildPredicates()) {
+                if (!validatePredicateStructure(child, seenColumns)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return true;
+    }
+
+    private void extractColumnPredicatesRecursive(RangePredicate predicate) {
+        if (predicate == null) {
+            return;
+        }
+
+        if (predicate instanceof ColumnRangePredicate columnRangePredicate) {
+            columnRangePredicates.put(columnRangePredicate.getColumnRef(), columnRangePredicate);
+        } else if (predicate instanceof AndRangePredicate) {
+            for (RangePredicate child : predicate.getChildPredicates()) {
+                extractColumnPredicatesRecursive(child);
+            }
+        }
+    }
+
+    public boolean isEnableParameterizedMode() {
+        return enableParameterizedMode;
+    }
+
+    public void enableParameterizedMode() {
+        this.enableParameterizedMode = true;
+    }
+
+    public void disableParameterizedMode() {
+        this.enableParameterizedMode = false;
+    }
+
+    public Map<ColumnRefOperator, ColumnRangePredicate> getColumnRangePredicates() {
+        return columnRangePredicates;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", ParameterizedPredicate.class.getSimpleName() + "[", "]")
+                .add("isValidForComparison=" + isValidForComparison)
+                .add("enableParameterizedMode=" + enableParameterizedMode)
+                .add("originPredicate=" + originPredicate.toString())
+                .add("residualPredicate=" + residualPredicate.toString())
+                .add("columnRangePredicates=" + columnRangePredicates)
+                .toString();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/feedback/guide/JoinTuningGuide.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/feedback/guide/JoinTuningGuide.java
@@ -25,6 +25,8 @@ import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalDistributionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHashJoinOperator;
 
+import java.util.Objects;
+
 import static com.starrocks.sql.optimizer.rule.transformation.JoinCommutativityRule.JOIN_COMMUTATIVITY_MAP;
 
 public abstract class JoinTuningGuide implements TuningGuide {
@@ -97,5 +99,19 @@ public abstract class JoinTuningGuide implements TuningGuide {
         LEFT_INPUT_OVERESTIMATED,
         RIGHT_INPUT_UNDERESTIMATED,
         RIGHT_INPUT_OVERESTIMATED
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        JoinTuningGuide that = (JoinTuningGuide) o;
+        return type == that.type;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/feedback/guide/StreamingAggTuningGuide.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/feedback/guide/StreamingAggTuningGuide.java
@@ -55,5 +55,18 @@ public class StreamingAggTuningGuide implements TuningGuide {
         return Optional.of(builder.build());
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return 1;
+    }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/feedback/skeleton/SkeletonNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/feedback/skeleton/SkeletonNode.java
@@ -25,7 +25,6 @@ import com.starrocks.sql.optimizer.statistics.Statistics;
 import java.util.Objects;
 
 public class SkeletonNode extends TreeNode<SkeletonNode> {
-
     protected final int operatorId;
 
     // nodeId is not used in `hashCode` and `equals`, because rewrite phase has not set nodeIds to physical operators.
@@ -35,7 +34,7 @@ public class SkeletonNode extends TreeNode<SkeletonNode> {
 
     protected final long limit;
 
-    protected final ScalarOperator predicate;
+    protected ScalarOperator predicate;
 
     protected final Statistics statistics;
 
@@ -76,6 +75,18 @@ public class SkeletonNode extends TreeNode<SkeletonNode> {
 
     public Statistics getStatistics() {
         return statistics;
+    }
+
+    public ScalarOperator getPredicate() {
+        return predicate;
+    }
+
+    public long getLimit() {
+        return limit;
+    }
+
+    public OperatorType getType() {
+        return type;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AndRangePredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AndRangePredicate.java
@@ -51,6 +51,7 @@ public class AndRangePredicate extends RangePredicate {
         }
     }
 
+
     @Override
     public ScalarOperator toScalarOperator() {
         List<ScalarOperator> children = Lists.newArrayList();

--- a/fe/fe-core/src/test/java/com/starrocks/qe/feedback/parameterization/ParameterizedPredicateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/feedback/parameterization/ParameterizedPredicateTest.java
@@ -1,0 +1,523 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.feedback.parameterization;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Range;
+import com.google.common.collect.TreeRangeSet;
+import com.starrocks.analysis.BinaryType;
+import com.starrocks.catalog.Type;
+import com.starrocks.qe.feedback.ParameterizedPredicate;
+import com.starrocks.qe.feedback.skeleton.ScanNode;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.AndRangePredicate;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.ColumnRangePredicate;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.OrRangePredicate;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.RangePredicate;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.CompoundType;
+
+public class ParameterizedPredicateTest {
+    private ColumnRefOperator colRef1;
+    private ColumnRefOperator colRef2;
+    private ColumnRefOperator colRef3;
+    private ColumnRefOperator stringCol;
+    private ColumnRefOperator dateCol;
+    private ColumnRefOperator datetimeCol;
+    private ColumnRefOperator stringDateCol;
+
+    @Before
+    public void setUp() {
+        colRef1 = new ColumnRefOperator(1, Type.INT, "int_col", false);
+        colRef2 = new ColumnRefOperator(2, Type.DOUBLE, "double_col", false);
+        colRef3 = new ColumnRefOperator(3, Type.BIGINT, "bigint_col", false);
+        stringCol = new ColumnRefOperator(4, Type.VARCHAR, "string_col", false);
+        dateCol = new ColumnRefOperator(5, Type.DATE, "date_col", false);
+        datetimeCol = new ColumnRefOperator(6, Type.DATETIME, "datetime_col", false);
+        stringDateCol = new ColumnRefOperator(7, Type.VARCHAR, "string_date_col", false);
+    }
+
+    private ScanNode createScanNode(ScalarOperator predicate) {
+        PhysicalScanOperator scanOp = PhysicalOlapScanOperator.builder()
+                .setPredicate(predicate)
+                .setColRefToColumnMetaMap(Map.of())
+                .build();
+        OptExpression optExpression = new OptExpression(scanOp);
+        return new ScanNode(optExpression);
+    }
+
+    private BinaryPredicateOperator createBinaryPredicate(ColumnRefOperator col, BinaryType type, ConstantOperator constant) {
+        return new BinaryPredicateOperator(type, col, constant);
+    }
+
+    private CompoundPredicateOperator createCompoundPredicate(CompoundType type, ScalarOperator left, ScalarOperator right) {
+        return new CompoundPredicateOperator(type, left, right);
+    }
+
+    private CallOperator createStr2DateCall(ColumnRefOperator stringCol, String format) {
+        List<ScalarOperator> args = new ArrayList<>();
+        args.add(stringCol);
+        args.add(ConstantOperator.createVarchar(format));
+        return new CallOperator("str2date", Type.DATE, args);
+    }
+
+    private ColumnRangePredicate createColumnRangePredicate(ColumnRefOperator col, int lower, int upper) {
+        TreeRangeSet<ConstantOperator> rangeSet = TreeRangeSet.create();
+        rangeSet.add(Range.closed(ConstantOperator.createInt(lower), ConstantOperator.createInt(upper)));
+        BinaryPredicateOperator expr = createBinaryPredicate(col, BinaryType.GE, ConstantOperator.createInt(lower));
+        return new ColumnRangePredicate(expr, rangeSet);
+    }
+
+    private ColumnRangePredicate createColumnRangePredicate(ColumnRefOperator col, double lower, double upper) {
+        TreeRangeSet<ConstantOperator> rangeSet = TreeRangeSet.create();
+        rangeSet.add(Range.closed(ConstantOperator.createDouble(lower), ConstantOperator.createDouble(upper)));
+        BinaryPredicateOperator expr = createBinaryPredicate(col, BinaryType.GE, ConstantOperator.createDouble(lower));
+        return new ColumnRangePredicate(expr, rangeSet);
+    }
+
+    @Test
+    public void testIsValidRangePredicate() {
+        ColumnRangePredicate singleColPred = createColumnRangePredicate(colRef1, 10, 100);
+        ParameterizedPredicate parameterizedPredicate = new ParameterizedPredicate(singleColPred.toScalarOperator());
+        Assert.assertTrue(parameterizedPredicate.isValidRangePredicate(singleColPred));
+
+        List<RangePredicate> andChildren = new ArrayList<>();
+        andChildren.add(createColumnRangePredicate(colRef1, 10, 100));
+        andChildren.add(createColumnRangePredicate(colRef2, 1.0, 10.0));
+        AndRangePredicate andPred = new AndRangePredicate(andChildren);
+        parameterizedPredicate = new ParameterizedPredicate(andPred.toScalarOperator());
+        Assert.assertTrue(parameterizedPredicate.isValidRangePredicate(andPred));
+
+        List<RangePredicate> orChildren = new ArrayList<>();
+        orChildren.add(createColumnRangePredicate(colRef1, 10, 100));
+        orChildren.add(createColumnRangePredicate(colRef2, 1.0, 10.0));
+        OrRangePredicate orPred = new OrRangePredicate(orChildren);
+        parameterizedPredicate = new ParameterizedPredicate(orPred.toScalarOperator());
+        Assert.assertFalse(parameterizedPredicate.isValidRangePredicate(orPred));
+
+        List<RangePredicate> duplicateChildren = new ArrayList<>();
+        duplicateChildren.add(createColumnRangePredicate(colRef1, 10, 100));
+        duplicateChildren.add(createColumnRangePredicate(colRef1, 200, 300));
+        AndRangePredicate duplicatePred = new AndRangePredicate(duplicateChildren);
+        parameterizedPredicate = new ParameterizedPredicate(duplicatePred.toScalarOperator());
+        Assert.assertFalse(parameterizedPredicate.isValidRangePredicate(duplicatePred));
+    }
+
+    @Test
+    public void testMergeRangeNullCases() {
+        ColumnRangePredicate pred1 = createColumnRangePredicate(colRef1, 10, 100);
+        ParameterizedPredicate parameterizedPredicate = new ParameterizedPredicate(pred1.toScalarOperator());
+        Assert.assertEquals(pred1, parameterizedPredicate.mergeRanges(pred1, null));
+        Assert.assertNull(parameterizedPredicate.mergeRanges(null, pred1));
+
+        Assert.assertNull(parameterizedPredicate.mergeRanges(null, null));
+
+        ColumnRangePredicate pred2 = createColumnRangePredicate(colRef2, 1.0, 10.0);
+        Assert.assertNull(parameterizedPredicate.mergeRanges(pred1, pred2));
+    }
+
+    @Test
+    public void testMergeRangeSinglePoints() {
+        ColumnRangePredicate point1 = createColumnRangePredicate(colRef1, 10, 10);
+        ColumnRangePredicate point2 = createColumnRangePredicate(colRef1, 10, 10);
+        ParameterizedPredicate parameterizedPredicate1 = new ParameterizedPredicate(point1.toScalarOperator());
+        ParameterizedPredicate parameterizedPredicate2 = new ParameterizedPredicate(point2.toScalarOperator());
+        parameterizedPredicate1.mergeColumnRange(parameterizedPredicate2);
+
+        ColumnRangePredicate merged = parameterizedPredicate1.getColumnRangePredicates().get(colRef1);
+        Assert.assertNotNull(merged);
+        Assert.assertEquals(1, merged.getColumnRanges().asRanges().size());
+        Range<ConstantOperator> range = merged.getColumnRanges().asRanges().iterator().next();
+        Assert.assertEquals(ConstantOperator.createInt(10), range.lowerEndpoint());
+        Assert.assertEquals(ConstantOperator.createInt(10), range.upperEndpoint());
+
+        ColumnRangePredicate point3 = createColumnRangePredicate(colRef1, 10, 10);
+        ColumnRangePredicate point4 = createColumnRangePredicate(colRef1, 20, 20);
+        ParameterizedPredicate parameterizedPredicate3 = new ParameterizedPredicate(point3.toScalarOperator());
+        ParameterizedPredicate parameterizedPredicate4 = new ParameterizedPredicate(point4.toScalarOperator());
+        parameterizedPredicate3.mergeColumnRange(parameterizedPredicate4);
+        merged = parameterizedPredicate3.getColumnRangePredicates().get(colRef1);
+
+        Assert.assertNotNull(merged);
+        Assert.assertEquals(1, merged.getColumnRanges().asRanges().size());
+        range = merged.getColumnRanges().asRanges().iterator().next();
+        Assert.assertEquals(ConstantOperator.createInt(10), range.lowerEndpoint());
+        Assert.assertEquals(ConstantOperator.createInt(20), range.upperEndpoint());
+
+        parameterizedPredicate3 = new ParameterizedPredicate(point4.toScalarOperator());
+        parameterizedPredicate4 = new ParameterizedPredicate(point3.toScalarOperator());
+        parameterizedPredicate3.mergeColumnRange(parameterizedPredicate4);
+        merged = parameterizedPredicate3.getColumnRangePredicates().get(colRef1);
+        Assert.assertNotNull(merged);
+        Assert.assertEquals(1, merged.getColumnRanges().asRanges().size());
+        range = merged.getColumnRanges().asRanges().iterator().next();
+        Assert.assertEquals(ConstantOperator.createInt(10), range.lowerEndpoint());
+        Assert.assertEquals(ConstantOperator.createInt(20), range.upperEndpoint());
+    }
+
+    @Test
+    public void testMergeRangePointAndRange() {
+        ColumnRangePredicate range1 = createColumnRangePredicate(colRef1, 10, 100);
+        ColumnRangePredicate point1 = createColumnRangePredicate(colRef1, 50, 50);
+        ParameterizedPredicate parameterizedPredicate1 = new ParameterizedPredicate(range1.toScalarOperator());
+        ParameterizedPredicate parameterizedPredicate2 = new ParameterizedPredicate(point1.toScalarOperator());
+        parameterizedPredicate1.mergeColumnRange(parameterizedPredicate2);
+
+        ColumnRangePredicate merged = parameterizedPredicate1.getColumnRangePredicates().get(colRef1);
+        Assert.assertNotNull(merged);
+        Assert.assertEquals(1, merged.getColumnRanges().asRanges().size());
+        Range<ConstantOperator> range = merged.getColumnRanges().asRanges().iterator().next();
+        Assert.assertEquals(ConstantOperator.createInt(10), range.lowerEndpoint());
+        Assert.assertEquals(ConstantOperator.createInt(100), range.upperEndpoint());
+
+        ColumnRangePredicate range2 = createColumnRangePredicate(colRef1, 10, 100);
+        ColumnRangePredicate point2 = createColumnRangePredicate(colRef1, 5, 5);
+        parameterizedPredicate1 = new ParameterizedPredicate(range2.toScalarOperator());
+        parameterizedPredicate2 = new ParameterizedPredicate(point2.toScalarOperator());
+        parameterizedPredicate1.mergeColumnRange(parameterizedPredicate2);
+        merged = parameterizedPredicate1.getColumnRangePredicates().get(colRef1);
+
+        Assert.assertNotNull(merged);
+        Assert.assertEquals(1, merged.getColumnRanges().asRanges().size());
+        range = merged.getColumnRanges().asRanges().iterator().next();
+        Assert.assertEquals(ConstantOperator.createInt(5), range.lowerEndpoint());
+        Assert.assertEquals(ConstantOperator.createInt(100), range.upperEndpoint());
+
+        ColumnRangePredicate range3 = createColumnRangePredicate(colRef1, 10, 100);
+        ColumnRangePredicate point3 = createColumnRangePredicate(colRef1, 150, 150);
+        ParameterizedPredicate parameterizedPredicate3 = new ParameterizedPredicate(range3.toScalarOperator());
+        ParameterizedPredicate parameterizedPredicate4 = new ParameterizedPredicate(point3.toScalarOperator());
+        parameterizedPredicate3.mergeColumnRange(parameterizedPredicate4);
+        merged = parameterizedPredicate3.getColumnRangePredicates().get(colRef1);
+
+        Assert.assertNotNull(merged);
+        Assert.assertEquals(1, merged.getColumnRanges().asRanges().size());
+        range = merged.getColumnRanges().asRanges().iterator().next();
+        Assert.assertEquals(ConstantOperator.createInt(10), range.lowerEndpoint());
+        Assert.assertEquals(ConstantOperator.createInt(150), range.upperEndpoint());
+    }
+
+    @Test
+    public void testMergeRangeUnboundedRanges() {
+        TreeRangeSet<ConstantOperator> rangeSet1 = TreeRangeSet.create();
+        rangeSet1.add(Range.lessThan(ConstantOperator.createInt(100)));
+        BinaryPredicateOperator expr1 = createBinaryPredicate(colRef1, BinaryType.LT, ConstantOperator.createInt(100));
+        ColumnRangePredicate unboundedLower = new ColumnRangePredicate(expr1, rangeSet1);
+
+        TreeRangeSet<ConstantOperator> rangeSet2 = TreeRangeSet.create();
+        rangeSet2.add(Range.greaterThan(ConstantOperator.createInt(10)));
+        BinaryPredicateOperator expr2 = createBinaryPredicate(colRef1, BinaryType.GT, ConstantOperator.createInt(10));
+        ColumnRangePredicate unboundedUpper = new ColumnRangePredicate(expr2, rangeSet2);
+
+        ColumnRangePredicate point = createColumnRangePredicate(colRef1, 50, 50);
+
+        ParameterizedPredicate target = new ParameterizedPredicate(unboundedLower.toScalarOperator());
+        ParameterizedPredicate source = new ParameterizedPredicate(point.toScalarOperator());
+        target.mergeColumnRange(source);
+        ColumnRangePredicate merged = target.getColumnRangePredicates().get(colRef1);
+        Assert.assertNotNull(merged);
+        Assert.assertEquals(1, merged.getColumnRanges().asRanges().size());
+        Assert.assertEquals(100, merged.getColumnRanges().asRanges().iterator().next().upperEndpoint().getInt());
+
+        target = new ParameterizedPredicate(unboundedUpper.toScalarOperator());
+        source = new ParameterizedPredicate(point.toScalarOperator());
+        target.mergeColumnRange(source);
+        merged = target.getColumnRangePredicates().get(colRef1);
+        Assert.assertNotNull(merged);
+        Assert.assertEquals(1, merged.getColumnRanges().asRanges().size());
+
+        TreeRangeSet<ConstantOperator> rangeSet3 = TreeRangeSet.create();
+        rangeSet3.add(Range.all());
+        BinaryPredicateOperator expr3 = createBinaryPredicate(colRef1, BinaryType.EQ, ConstantOperator.createInt(1));
+        ColumnRangePredicate unboundedAll = new ColumnRangePredicate(expr3, rangeSet3);
+
+        merged = source.mergeRanges(unboundedAll, point);
+        Assert.assertNotNull(merged);
+        Assert.assertEquals(1, merged.getColumnRanges().asRanges().size());
+        Assert.assertFalse(merged.getColumnRanges().asRanges().iterator().next().hasLowerBound());
+        Assert.assertFalse(merged.getColumnRanges().asRanges().iterator().next().hasUpperBound());
+    }
+
+    @Test
+    public void testMergeRangeMultipleRanges() {
+        TreeRangeSet<ConstantOperator> rangeSet1 = TreeRangeSet.create();
+        rangeSet1.add(Range.closed(ConstantOperator.createInt(10), ConstantOperator.createInt(20)));
+        rangeSet1.add(Range.closed(ConstantOperator.createInt(30), ConstantOperator.createInt(40)));
+        BinaryPredicateOperator expr1 = createBinaryPredicate(colRef1, BinaryType.GE, ConstantOperator.createInt(10));
+        ColumnRangePredicate multiRange1 = new ColumnRangePredicate(expr1, rangeSet1);
+
+        TreeRangeSet<ConstantOperator> rangeSet2 = TreeRangeSet.create();
+        rangeSet2.add(Range.closed(ConstantOperator.createInt(15), ConstantOperator.createInt(25)));
+        rangeSet2.add(Range.closed(ConstantOperator.createInt(35), ConstantOperator.createInt(45)));
+        BinaryPredicateOperator expr2 = createBinaryPredicate(colRef1, BinaryType.GE, ConstantOperator.createInt(15));
+        ColumnRangePredicate multiRange2 = new ColumnRangePredicate(expr2, rangeSet2);
+
+        ParameterizedPredicate target = new ParameterizedPredicate(multiRange1.toScalarOperator());
+        ParameterizedPredicate source = new ParameterizedPredicate(multiRange2.toScalarOperator());
+        target.mergeColumnRange(source);
+        ColumnRangePredicate merged = target.getColumnRangePredicates().get(colRef1);
+
+        Assert.assertNotNull(merged);
+        Assert.assertEquals(2, merged.getColumnRanges().asRanges().size());
+        List<Range<ConstantOperator>> ranges = Lists.newArrayList(merged.getColumnRanges().asRanges());
+        Range<ConstantOperator> range1 = ranges.get(0);
+        Assert.assertEquals(ConstantOperator.createInt(10), range1.lowerEndpoint());
+        Assert.assertEquals(ConstantOperator.createInt(25), range1.upperEndpoint());
+
+        Range<ConstantOperator> range2 = ranges.get(1);
+        Assert.assertEquals(ConstantOperator.createInt(30), range2.lowerEndpoint());
+        Assert.assertEquals(ConstantOperator.createInt(45), range2.upperEndpoint());
+    }
+
+    @Test
+    public void testMergePredicateRangeSimplePredicates() {
+        BinaryPredicateOperator pred1 = createBinaryPredicate(colRef1, BinaryType.GE, ConstantOperator.createInt(10));
+        BinaryPredicateOperator pred2 = createBinaryPredicate(colRef1, BinaryType.LE, ConstantOperator.createInt(100));
+        ParameterizedPredicate target = new ParameterizedPredicate(pred1);
+        ParameterizedPredicate source = new ParameterizedPredicate(pred2);
+        target.mergeColumnRange(source);
+        ColumnRangePredicate merged = target.getColumnRangePredicates().get(colRef1);
+        ScalarOperator predicates = merged.toScalarOperator();
+        Assert.assertTrue(predicates.isTrue());
+    }
+
+    @Test
+    public void testMergePredicateRangeCompoundPredicates() {
+        BinaryPredicateOperator intPred1 = createBinaryPredicate(colRef1, BinaryType.GE, ConstantOperator.createInt(10));
+        BinaryPredicateOperator doublePred1 = createBinaryPredicate(colRef2, BinaryType.GE, ConstantOperator.createDouble(1.0));
+        CompoundPredicateOperator compound1 = createCompoundPredicate(CompoundType.AND, intPred1, doublePred1);
+
+        BinaryPredicateOperator intPred2 = createBinaryPredicate(colRef1, BinaryType.LE, ConstantOperator.createInt(100));
+        BinaryPredicateOperator doublePred2 = createBinaryPredicate(colRef2, BinaryType.LE, ConstantOperator.createDouble(10.0));
+        CompoundPredicateOperator compound2 = createCompoundPredicate(CompoundType.AND, intPred2, doublePred2);
+
+        ParameterizedPredicate target = new ParameterizedPredicate(compound1);
+        ParameterizedPredicate source = new ParameterizedPredicate(compound2);
+        target.mergeColumnRange(source);
+        ColumnRangePredicate merged = target.getColumnRangePredicates().get(colRef1);
+        ScalarOperator predicates = merged.toScalarOperator();
+        Assert.assertTrue(predicates.isTrue());
+    }
+
+    @Test
+    public void testMergePredicateRangeNestedCompoundPredicates() {
+        BinaryPredicateOperator intPred1 = createBinaryPredicate(colRef1, BinaryType.GE, ConstantOperator.createInt(10));
+        BinaryPredicateOperator doublePred1 = createBinaryPredicate(colRef2, BinaryType.GE, ConstantOperator.createDouble(1.0));
+        CompoundPredicateOperator innerCompound1 = createCompoundPredicate(CompoundType.AND, intPred1, doublePred1);
+        BinaryPredicateOperator bigintPred1 = createBinaryPredicate(colRef3, BinaryType.GE, ConstantOperator.createBigint(100));
+        CompoundPredicateOperator outerCompound1 = createCompoundPredicate(CompoundType.AND, innerCompound1, bigintPred1);
+
+        BinaryPredicateOperator intPred2 = createBinaryPredicate(colRef1, BinaryType.LE, ConstantOperator.createInt(100));
+        BinaryPredicateOperator doublePred2 = createBinaryPredicate(colRef2, BinaryType.LE, ConstantOperator.createDouble(10.0));
+        CompoundPredicateOperator innerCompound2 = createCompoundPredicate(CompoundType.AND, intPred2, doublePred2);
+        BinaryPredicateOperator bigintPred2 = createBinaryPredicate(colRef3, BinaryType.LE, ConstantOperator.createBigint(1000));
+        CompoundPredicateOperator outerCompound2 = createCompoundPredicate(CompoundType.AND, innerCompound2, bigintPred2);
+
+        ParameterizedPredicate target = new ParameterizedPredicate(outerCompound1);
+        ParameterizedPredicate source = new ParameterizedPredicate(outerCompound2);
+        target.mergeColumnRange(source);
+        Assert.assertTrue(target.getColumnRangePredicates().get(colRef1).toScalarOperator().isTrue());
+        Assert.assertTrue(target.getColumnRangePredicates().get(colRef2).toScalarOperator().isTrue());
+        Assert.assertTrue(target.getColumnRangePredicates().get(colRef3).toScalarOperator().isTrue());
+    }
+
+    @Test
+    public void testMergePredicateRangeWithOrPredicates() {
+        BinaryPredicateOperator intPred1 = createBinaryPredicate(colRef1, BinaryType.GE, ConstantOperator.createInt(10));
+        BinaryPredicateOperator doublePred1 = createBinaryPredicate(colRef2, BinaryType.GE, ConstantOperator.createDouble(1.0));
+        CompoundPredicateOperator orPred = createCompoundPredicate(CompoundType.OR, intPred1, doublePred1);
+
+        BinaryPredicateOperator intPred2 = createBinaryPredicate(colRef1, BinaryType.LE, ConstantOperator.createInt(100));
+        ParameterizedPredicate target = new ParameterizedPredicate(orPred);
+        ParameterizedPredicate source = new ParameterizedPredicate(intPred2);
+        target.mergeColumnRange(source);
+        Assert.assertTrue(target.getColumnRangePredicates().isEmpty());
+    }
+
+    @Test
+    public void testMergePredicateRangeWithDuplicateColumns() {
+        BinaryPredicateOperator intPred1 = createBinaryPredicate(colRef1, BinaryType.GE, ConstantOperator.createInt(10));
+        BinaryPredicateOperator intPred2 = createBinaryPredicate(colRef1, BinaryType.LE, ConstantOperator.createInt(100));
+        CompoundPredicateOperator compound = createCompoundPredicate(CompoundType.AND, intPred1, intPred2);
+
+        BinaryPredicateOperator intPred3 = createBinaryPredicate(colRef1, BinaryType.GE, ConstantOperator.createInt(20));
+        BinaryPredicateOperator intPred4 = createBinaryPredicate(colRef1, BinaryType.LE, ConstantOperator.createInt(80));
+        CompoundPredicateOperator compound2 = createCompoundPredicate(CompoundType.AND, intPred3, intPred4);
+        ParameterizedPredicate target = new ParameterizedPredicate(compound);
+        ParameterizedPredicate source = new ParameterizedPredicate(compound2);
+        target.mergeColumnRange(source);
+        ColumnRangePredicate merged = target.getColumnRangePredicates().get(colRef1);
+        Assert.assertEquals(compound, merged.toScalarOperator());
+    }
+
+    @Test
+    public void testMergeRangeWithStringType() {
+        BinaryPredicateOperator pred1 = createBinaryPredicate(stringCol, BinaryType.GE, ConstantOperator.createVarchar("appl"));
+        BinaryPredicateOperator pred2 = createBinaryPredicate(stringCol, BinaryType.LE, ConstantOperator.createVarchar("orang"));
+
+        ParameterizedPredicate target = new ParameterizedPredicate(pred1);
+        ParameterizedPredicate source = new ParameterizedPredicate(pred2);
+        target.mergeColumnRange(source);
+        Assert.assertTrue(target.getColumnRangePredicates().get(stringCol).toScalarOperator().isTrue());
+    }
+
+    @Test
+    public void testMergeRangeWithDateType() {
+        LocalDateTime startDate = LocalDateTime.of(2023, 1, 1, 0, 0, 0);
+        LocalDateTime endDate = LocalDateTime.of(2023, 12, 31, 0, 0, 0);
+        BinaryPredicateOperator pred1 = createBinaryPredicate(dateCol, BinaryType.GE,
+                ConstantOperator.createDate(startDate));
+        BinaryPredicateOperator pred2 = createBinaryPredicate(dateCol, BinaryType.LE,
+                ConstantOperator.createDate(endDate));
+        ParameterizedPredicate target = new ParameterizedPredicate(pred1);
+        ParameterizedPredicate source = new ParameterizedPredicate(pred2);
+        target.mergeColumnRange(source);
+        Assert.assertTrue(target.getColumnRangePredicates().get(dateCol).toScalarOperator().isTrue());
+    }
+
+    @Test
+    public void testMergeRangeWithDateTimeType() {
+        LocalDateTime startDateTime = LocalDateTime.of(2023, 1, 1, 0, 0, 0);
+        LocalDateTime endDateTime = LocalDateTime.of(2022, 12, 31, 23, 59, 59);
+
+        BinaryPredicateOperator pred1 = createBinaryPredicate(datetimeCol, BinaryType.GE,
+                ConstantOperator.createDatetime(startDateTime));
+        BinaryPredicateOperator pred2 = createBinaryPredicate(datetimeCol, BinaryType.LE,
+                ConstantOperator.createDatetime(endDateTime));
+
+        ParameterizedPredicate target = new ParameterizedPredicate(pred1);
+        ParameterizedPredicate source = new ParameterizedPredicate(pred2);
+        target.mergeColumnRange(source);
+        Assert.assertEquals(2, target.getColumnRangePredicates().get(datetimeCol).getColumnRanges().asRanges().size());
+    }
+
+    @Test
+    public void testMergeRangeWithStr2DateFunction() {
+        CallOperator str2dateCall = createStr2DateCall(stringDateCol, "%Y-%m-%d");
+
+        LocalDateTime startDate = LocalDateTime.of(2023, 1, 1, 0, 0, 0);
+        LocalDateTime endDate = LocalDateTime.of(2023, 12, 31, 0, 0, 0);
+
+        BinaryPredicateOperator pred1 = new BinaryPredicateOperator(BinaryType.GE, str2dateCall,
+                ConstantOperator.createDate(startDate));
+        BinaryPredicateOperator pred2 = new BinaryPredicateOperator(BinaryType.GE, str2dateCall,
+                ConstantOperator.createDate(endDate));
+        ParameterizedPredicate target = new ParameterizedPredicate(pred1);
+        ParameterizedPredicate source = new ParameterizedPredicate(pred2);
+        target.mergeColumnRange(source);
+        Assert.assertEquals(ConstantOperator.createVarchar("2023-01-01").toString(),
+                target.getColumnRangePredicates().get(stringDateCol).getColumnRanges().asRanges().iterator().next()
+                        .lowerEndpoint().toString());
+    }
+
+    @Test
+    public void testMergeRangeWithMixedTypes() {
+        BinaryPredicateOperator intPred = createBinaryPredicate(colRef1, BinaryType.GE, ConstantOperator.createInt(10));
+        BinaryPredicateOperator stringPred = createBinaryPredicate(stringCol, BinaryType.GE,
+                ConstantOperator.createVarchar("apple"));
+        BinaryPredicateOperator datePred = createBinaryPredicate(dateCol, BinaryType.GE,
+                ConstantOperator.createDate(LocalDateTime.of(2023, 1, 1, 0, 0, 0)));
+
+        CompoundPredicateOperator compound1 = createCompoundPredicate(CompoundType.AND, intPred, stringPred);
+        CompoundPredicateOperator mixedPred1 = createCompoundPredicate(CompoundType.AND, compound1, datePred);
+
+        BinaryPredicateOperator intPred2 = createBinaryPredicate(colRef1, BinaryType.GE, ConstantOperator.createInt(100));
+        BinaryPredicateOperator stringPred2 = createBinaryPredicate(stringCol, BinaryType.GE,
+                ConstantOperator.createVarchar("orange"));
+        BinaryPredicateOperator datePred2 = createBinaryPredicate(dateCol, BinaryType.GE,
+                ConstantOperator.createDate(LocalDateTime.of(2023, 12, 31, 0, 0, 0)));
+
+        CompoundPredicateOperator compound2 = createCompoundPredicate(CompoundType.AND, intPred2, stringPred2);
+        CompoundPredicateOperator mixedPred2 = createCompoundPredicate(CompoundType.AND, compound2, datePred2);
+        ParameterizedPredicate target = new ParameterizedPredicate(mixedPred1);
+        ParameterizedPredicate source = new ParameterizedPredicate(mixedPred2);
+        target.mergeColumnRange(source);
+        Range<ConstantOperator> intColRange = target.getColumnRangePredicates().get(colRef1).getColumnRanges()
+                .asRanges().iterator().next();
+        Range<ConstantOperator> stringColRange = target.getColumnRangePredicates().get(stringCol).getColumnRanges()
+                .asRanges().iterator().next();
+        Range<ConstantOperator> dateColRange = target.getColumnRangePredicates().get(dateCol).getColumnRanges()
+                .asRanges().iterator().next();
+        Assert.assertEquals(10, intColRange.lowerEndpoint().getInt());
+        Assert.assertEquals("apple", stringColRange.lowerEndpoint().toString());
+        Assert.assertEquals("2023-01-01", dateColRange.lowerEndpoint().toString());
+
+    }
+
+    @Test
+    public void testMergeRangeWithEmptyRanges() {
+        BinaryPredicateOperator pred1 = createBinaryPredicate(colRef1, BinaryType.GT, ConstantOperator.createInt(100));
+        BinaryPredicateOperator pred2 = createBinaryPredicate(colRef1, BinaryType.LT, ConstantOperator.createInt(50));
+        ParameterizedPredicate target = new ParameterizedPredicate(pred1);
+        ParameterizedPredicate source = new ParameterizedPredicate(pred2);
+        target.mergeColumnRange(source);
+        Assert.assertEquals(2, target.getColumnRangePredicates().get(colRef1).getColumnRanges().asRanges().size());
+    }
+
+    @Test
+    public void testParameterizedMode() {
+        ScanNode scanNode = createScanNode(null);
+        Assert.assertFalse(scanNode.isEnableParameterizedMode());
+
+        scanNode.enableParameterizedMode();
+        Assert.assertTrue(scanNode.isEnableParameterizedMode());
+
+        scanNode.disableParameterizedMode();
+        Assert.assertFalse(scanNode.isEnableParameterizedMode());
+    }
+
+    @Test
+    public void testDifferentBinaryPredicateTypes() {
+        BinaryPredicateOperator eqPred = createBinaryPredicate(colRef1, BinaryType.EQ, ConstantOperator.createInt(50));
+        BinaryPredicateOperator nePred = createBinaryPredicate(colRef1, BinaryType.NE, ConstantOperator.createInt(50));
+        BinaryPredicateOperator ltPred = createBinaryPredicate(colRef1, BinaryType.LT, ConstantOperator.createInt(100));
+        BinaryPredicateOperator lePred = createBinaryPredicate(colRef1, BinaryType.LE, ConstantOperator.createInt(100));
+        BinaryPredicateOperator gtPred = createBinaryPredicate(colRef1, BinaryType.GT, ConstantOperator.createInt(10));
+        BinaryPredicateOperator gePred = createBinaryPredicate(colRef1, BinaryType.GE, ConstantOperator.createInt(10));
+
+        ParameterizedPredicate target = new ParameterizedPredicate(eqPred);
+        ParameterizedPredicate source = new ParameterizedPredicate(ltPred);
+        target.mergeColumnRange(source);
+        Assert.assertEquals("1: int_col < 100", target.getColumnRangePredicates().get(colRef1).toScalarOperator().toString());
+
+        target = new ParameterizedPredicate(gePred);
+        source = new ParameterizedPredicate(lePred);
+        target.mergeColumnRange(source);
+        Assert.assertEquals(ConstantOperator.TRUE, target.getColumnRangePredicates().get(colRef1).toScalarOperator());
+
+        target = new ParameterizedPredicate(gtPred);
+        source = new ParameterizedPredicate(nePred);
+        target.mergeColumnRange(source);
+        Assert.assertEquals(ConstantOperator.TRUE, target.getColumnRangePredicates().get(colRef1).toScalarOperator());
+    }
+}
+
+

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/ColumnRangePredicateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/ColumnRangePredicateTest.java
@@ -209,4 +209,5 @@ public class ColumnRangePredicateTest {
             Assert.assertEquals(ConstantOperator.TRUE, ret);
         }
     }
+
 }

--- a/test/sql/test_feedback/R/test_parameterized
+++ b/test/sql/test_feedback/R/test_parameterized
@@ -1,0 +1,117 @@
+-- name: test_parameterized
+DROP DATABASE IF EXISTS test_feedback;
+-- result:
+-- !result
+CREATE DATABASE test_feedback;
+-- result:
+-- !result
+USE test_feedback;
+-- result:
+-- !result
+CREATE TABLE `test_feedback_parameterized` (
+  `date_col` date NULL COMMENT "",
+  `skew_city` string NULL COMMENT "",
+  `col1` int(11) NULL COMMENT "",
+  `col2` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+COMMENT "OLAP"
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into test_feedback_parameterized select "2000-01-01", "hangzhou", generate_series, 500 from TABLE(generate_series(1, 5000000));
+-- result:
+-- !result
+insert into test_feedback_parameterized select "2000-01-02", "hangzhou", generate_series, 500 from TABLE(generate_series(1, 5000000));
+-- result:
+-- !result
+insert into test_feedback_parameterized select "2000-01-03", "hangzhou", generate_series, 500 from TABLE(generate_series(1, 5000000));
+-- result:
+-- !result
+insert into test_feedback_parameterized select "2000-01-03", generate_series, generate_series, 500 from TABLE(generate_series(1, 10000));
+-- result:
+-- !result
+analyze table test_feedback_parameterized;
+-- result:
+test_feedback.test_feedback_parameterized	analyze	status	OK
+-- !result
+set enable_global_runtime_filter = false;
+-- result:
+-- !result
+truncate plan advisor;
+-- result:
+[REGEX]Clear all plan advisor in FE.*
+-- !result
+function: assert_explain_not_contains("select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou') t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t", "RightChildEstimationErrorTuningGuide")
+-- result:
+None
+-- !result
+alter plan advisor add select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou') t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t;
+-- result:
+[REGEX]Add query into plan advisor in FE.*
+-- !result
+function: assert_explain_contains("select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou') t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t", "RightChildEstimationErrorTuningGuide")
+-- result:
+None
+-- !result
+function: assert_explain_not_contains("select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou') t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-03') t", "RightChildEstimationErrorTuningGuide")
+-- result:
+None
+-- !result
+alter plan advisor add select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou') t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-03') t;
+-- result:
+[REGEX]Add query into plan advisor in FE.*
+-- !result
+function: assert_explain_contains("select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou') t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-03') t", "RightChildEstimationErrorTuningGuide")
+-- result:
+None
+-- !result
+function: assert_explain_contains("select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou') t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-02') t", "RightChildEstimationErrorTuningGuide")
+-- result:
+None
+-- !result
+function: assert_explain_not_contains("select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou' and col2 = 500) t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t", "RightChildEstimationErrorTuningGuide")
+-- result:
+None
+-- !result
+alter plan advisor add select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou' and col2 = 500) t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t;
+-- result:
+[REGEX]Add query into plan advisor in FE.*
+-- !result
+function: assert_explain_contains("select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou' and col2 = 500) t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t", "RightChildEstimationErrorTuningGuide")
+-- result:
+None
+-- !result
+function: assert_explain_not_contains("select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou' and col2 >= 500) t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t", "RightChildEstimationErrorTuningGuide")
+-- result:
+None
+-- !result
+alter plan advisor add select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou' and col2 >= 500) t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t;
+-- result:
+[REGEX]Add query into plan advisor in FE.*
+-- !result
+function: assert_explain_contains("select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou' and col2 >= 500) t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t", "RightChildEstimationErrorTuningGuide")
+-- result:
+None
+-- !result
+function: assert_explain_not_contains("select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou' and col2 < 600) t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t", "RightChildEstimationErrorTuningGuide")
+-- result:
+None
+-- !result
+alter plan advisor add select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou' and col2 < 600) t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t;
+-- result:
+[REGEX]Add query into plan advisor in FE.*
+-- !result
+function: assert_explain_contains("select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou' and col2 < 600) t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t", "RightChildEstimationErrorTuningGuide")
+-- result:
+None
+-- !result
+function: assert_explain_contains("select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou' and col2 < 550) t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t", "RightChildEstimationErrorTuningGuide")
+-- result:
+None
+-- !result
+truncate plan advisor;
+-- result:
+[REGEX]Clear all plan advisor in FE.*
+-- !result

--- a/test/sql/test_feedback/T/test_parameterized
+++ b/test/sql/test_feedback/T/test_parameterized
@@ -1,0 +1,62 @@
+-- name: test_parameterized
+
+DROP DATABASE IF EXISTS test_feedback;
+CREATE DATABASE test_feedback;
+USE test_feedback;
+
+CREATE TABLE `test_feedback_parameterized` (
+  `date_col` date NULL COMMENT "",
+  `skew_city` string NULL COMMENT "",
+  `col1` int(11) NULL COMMENT "",
+  `col2` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+COMMENT "OLAP"
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into test_feedback_parameterized select "2000-01-01", "hangzhou", generate_series, 500 from TABLE(generate_series(1, 5000000));
+insert into test_feedback_parameterized select "2000-01-02", "hangzhou", generate_series, 500 from TABLE(generate_series(1, 5000000));
+insert into test_feedback_parameterized select "2000-01-03", "hangzhou", generate_series, 500 from TABLE(generate_series(1, 5000000));
+
+insert into test_feedback_parameterized select "2000-01-03", generate_series, generate_series, 500 from TABLE(generate_series(1, 10000));
+
+analyze table test_feedback_parameterized;
+set enable_global_runtime_filter = false;
+
+truncate plan advisor;
+
+-- test date_col = 2020-01-01
+function: assert_explain_not_contains("select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou') t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t", "RightChildEstimationErrorTuningGuide")
+alter plan advisor add select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou') t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t;
+function: assert_explain_contains("select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou') t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t", "RightChildEstimationErrorTuningGuide")
+
+-- test date_col = 2020-01-03
+function: assert_explain_not_contains("select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou') t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-03') t", "RightChildEstimationErrorTuningGuide")
+alter plan advisor add select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou') t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-03') t;
+function: assert_explain_contains("select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou') t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-03') t", "RightChildEstimationErrorTuningGuide")
+
+-- test date_col = 2020-01-02 reuse tuning guide
+function: assert_explain_contains("select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou') t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-02') t", "RightChildEstimationErrorTuningGuide")
+
+-- test col2 = 500
+function: assert_explain_not_contains("select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou' and col2 = 500) t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t", "RightChildEstimationErrorTuningGuide")
+alter plan advisor add select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou' and col2 = 500) t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t;
+function: assert_explain_contains("select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou' and col2 = 500) t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t", "RightChildEstimationErrorTuningGuide")
+
+-- test col2 >= 500
+function: assert_explain_not_contains("select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou' and col2 >= 500) t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t", "RightChildEstimationErrorTuningGuide")
+alter plan advisor add select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou' and col2 >= 500) t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t;
+function: assert_explain_contains("select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou' and col2 >= 500) t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t", "RightChildEstimationErrorTuningGuide")
+
+-- test col2 < 600
+function: assert_explain_not_contains("select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou' and col2 < 600) t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t", "RightChildEstimationErrorTuningGuide")
+alter plan advisor add select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou' and col2 < 600) t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t;
+function: assert_explain_contains("select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou' and col2 < 600) t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t", "RightChildEstimationErrorTuningGuide")
+
+-- test col2 is True after merge ranges. test col2 < 550
+function: assert_explain_contains("select count(*) from (select * from test_feedback_parameterized  t1 join (select * from test_feedback_parameterized where skew_city = 'hangzhou' and col2 < 550) t2 on t1.col1 = t2.col1 where t1.date_col='2000-01-01') t", "RightChildEstimationErrorTuningGuide")
+
+truncate plan advisor;
+
+


### PR DESCRIPTION
## Why I'm doing:
StarRocks supports query feedback since version 3.4. However, if a query generates a tuning guide, only the same query will be used. The usage scenarios are very limited. So we need to support query feedback parameterization.

## What I'm doing:
This patch supports parameterized methods based on range merging. Using a predicate `where col = 1` for simple example.
The first query with `col = 1` would generate a tuning plan and tuning plan will be cached in current fe node memory. we call this origin query plan 'baseline'. The next query with `col = 10` would generate a tuning plan. if the tuning plan is the same as the former. we will merge the predicate range for baseline. Next, for the query plan of  predicate `col` in the Range [1,10], if the baseline is the same, we will  reuse the tuning guides.

Merge Strategy:
Mainly reused the related operations of `RangePredicate`

1. point-point   point 1 and pint 10 will becomes range [1, 10]
2. point-range     1 and [3, 5] -> [1, 5].   4 and [1, 10] -> [1, 10]
3. range-range   [1, 5] and [2, 7] -> [1, 7].   [1, 3] and [5, 6] -> [1, 3] and [5, 6]

Fallback:
If a predicate has a performance rollback using the tuning guide, due to we have recorded the query time and baseline time for each tuning. If we find that the average time recorded by the tuned plan is greater than the baseline, we will delete the tuning guide and not use it again. 

Limitation:
1. Only parameterization pushed down to scan node predicates is supported
2. Not support or predicate 
3. Parameterization of binary predicates is supported. The residual predicates need exact matching to reuse.

We also support some simple semantic equivalence operations, such as `str2date (date_str_col, '%Y-%m-%d') > = '2020-01-01'`.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
