### PR TITLE
[BugFix] Disable broadcast join if broadcast_row_limit is set equal or below than 0

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -3412,6 +3412,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return broadcastRowCountLimit;
     }
 
+    public void setBroadcastRowCountLimit(long broadcastRowCountLimit) {
+        this.broadcastRowCountLimit = broadcastRowCountLimit;
+    }
+
     public double getBroadcastRightTableScaleFactor() {
         return broadcastRightTableScaleFactor;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
@@ -306,6 +306,10 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
         // shuffling large left-hand table data
         ConnectContext ctx = ConnectContext.get();
         SessionVariable sv = ConnectContext.get().getSessionVariable();
+        // If the broadcast join is not enabled, return false directly
+        if (sv.getBroadcastRowCountLimit() <= 0) {
+            return false;
+        }
         int beNum = Math.max(1, ctx.getAliveBackendNumber());
         Statistics leftChildStats = groupExpression.getInputs().get(curChildIndex - 1).getStatistics();
         Statistics rightChildStats = groupExpression.getInputs().get(curChildIndex).getStatistics();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -2321,4 +2321,54 @@ public class PlanFragmentWithCostTest extends PlanWithCostTestBase {
         assertContains(plan, "province-->[-Infinity, Infinity, 0.0, 1.0, 2.0]");
         assertContains(plan, "dt-->[-Infinity, Infinity, 0.0, 1.0, 2.0]");
     }
+
+    @Test
+    public void testBroadcastJoin() throws Exception {
+        GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t0");
+        setTableStatistics(t0, 10000000);
+        OlapTable t1 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t1");
+        setTableStatistics(t1, 10000);
+
+        String sql = "select * " +
+                " from t0 join t1 on t0.v3 = t1.v6 " +
+                "         join t2 on t0.v2 = t2.v8 and t1.v5 = t2.v7";
+        {
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  4:HASH JOIN\n" +
+                    "  |  join op: INNER JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 5: v5 = 7: v7");
+            assertContains(plan, "6:HASH JOIN\n" +
+                    "  |  join op: INNER JOIN (BROADCAST)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 2: v2 = 8: v8\n" +
+                    "  |  equal join conjunct: 3: v3 = 6: v6");
+        }
+
+        long originLimit = connectContext.getSessionVariable().getBroadcastRowCountLimit();
+        {
+            // broadcast join should be disabled
+            connectContext.getSessionVariable().setBroadcastRowCountLimit(0);
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  8:HASH JOIN\n" +
+                    "  |  join op: INNER JOIN (PARTITIONED)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 2: v2 = 8: v8\n" +
+                    "  |  equal join conjunct: 3: v3 = 6: v6\n" +
+                    "  |  \n" +
+                    "  |----7:EXCHANGE\n" +
+                    "  |    \n" +
+                    "  1:EXCHANGE");
+            assertContains(plan, "  6:HASH JOIN\n" +
+                    "  |  join op: INNER JOIN (PARTITIONED)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 5: v5 = 7: v7\n" +
+                    "  |  \n" +
+                    "  |----5:EXCHANGE\n" +
+                    "  |    \n" +
+                    "  3:EXCHANGE");
+            connectContext.getSessionVariable().setBroadcastRowCountLimit(originLimit);
+        }
+    }
 }


### PR DESCRIPTION
## Why I'm doing:


`broadcast_row_limit is` not enough to disable broadcast join for now, because broadcast join is controled by both broadcast_row_limit and broadcast_right_table_scale_factor as below.

It's difficult o disable broadcast join for a more stable plan in some cases:
```
if (leftOutputSize < rightOutputSize * beNum * sv.getBroadcastRightTableScaleFactor()
        && rightChildStats.getOutputRowCount() > sv.getBroadcastRowCountLimit()) {
    return false;
}
```


## What I'm doing:
- it's better to disable broadcast join directly if broadcast_row_limit is set zero or less 

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
