### PR TITLE
[BugFix] Avoid task run hanging after killTaskRun

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -87,7 +87,7 @@ public class TaskManager implements MemoryTrackable {
 
     // include PENDING/RUNNING taskRun;
     private final TaskRunManager taskRunManager;
-    private final TaskRunScheduler taskRunScheduler;
+    private final TaskRunScheduler taskRunScheduler = new TaskRunScheduler();
 
     // The periodScheduler is used to generate the corresponding TaskRun on time for the Periodical Task.
     // This scheduler can use the time wheel to optimize later.
@@ -107,9 +107,8 @@ public class TaskManager implements MemoryTrackable {
         idToTaskMap = Maps.newConcurrentMap();
         nameToTaskMap = Maps.newConcurrentMap();
         periodFutureMap = Maps.newConcurrentMap();
-        taskRunManager = new TaskRunManager();
+        taskRunManager = new TaskRunManager(taskRunScheduler);
         taskLock = new QueryableReentrantLock(true);
-        taskRunScheduler = taskRunManager.getTaskRunScheduler();
     }
 
     public void start() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -108,9 +108,6 @@ public class TaskRunManager implements MemoryTrackable {
                 return true;
             }
             return false;
-        } catch (Exception e) {
-            LOG.warn("failed to kill task run: {}", taskRun, e);
-            throw e;
         } finally {
             // if it's force, remove it from running TaskRun map no matter it's killed or not
             if (force) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -42,7 +43,7 @@ public class TaskRunManager implements MemoryTrackable {
 
     private static final Logger LOG = LogManager.getLogger(TaskRunManager.class);
 
-    private final TaskRunScheduler taskRunScheduler = new TaskRunScheduler();
+    private final TaskRunScheduler taskRunScheduler;
 
     // include SUCCESS/FAILED/CANCEL taskRun
     private final TaskRunHistory taskRunHistory = new TaskRunHistory();
@@ -51,6 +52,10 @@ public class TaskRunManager implements MemoryTrackable {
     private final TaskRunExecutor taskRunExecutor = new TaskRunExecutor();
 
     private final QueryableReentrantLock taskRunLock = new QueryableReentrantLock(true);
+
+    public TaskRunManager(TaskRunScheduler taskRunScheduler) {
+        this.taskRunScheduler = taskRunScheduler;
+    }
 
     public SubmitResult submitTaskRun(TaskRun taskRun, ExecuteOption option) {
         LOG.info("submit task run:{}", taskRun);
@@ -87,19 +92,31 @@ public class TaskRunManager implements MemoryTrackable {
             return false;
         }
         try {
+            // mark killed
             taskRun.kill();
+
+            // set the future to be done to avoid the task run hanging
+            CompletableFuture<Constants.TaskRunState> future = taskRun.getFuture();
+            if (future != null && !future.completeExceptionally(new RuntimeException("TaskRun killed"))) {
+                LOG.warn("failed to complete future for task run: {}", taskRun);
+            }
+
+            // kill the task run
             ConnectContext runCtx = taskRun.getRunCtx();
             if (runCtx != null) {
                 runCtx.kill(false, "kill TaskRun");
                 return true;
             }
+            return false;
+        } catch (Exception e) {
+            LOG.warn("failed to kill task run: {}", taskRun, e);
+            throw e;
         } finally {
             // if it's force, remove it from running TaskRun map no matter it's killed or not
             if (force) {
                 taskRunScheduler.removeRunningTask(taskRun.getTaskId());
             }
         }
-        return false;
     }
 
     // At present, only the manual and automatic tasks of the materialized view have different priorities.

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/KillTaskRunTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/KillTaskRunTest.java
@@ -1,0 +1,116 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler;
+
+import com.starrocks.qe.ConnectContext;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class KillTaskRunTest {
+    private TaskRunScheduler taskRunScheduler;
+    private TaskRunManager taskRunManager;
+
+    @Before
+    public void setUp() {
+        taskRunScheduler = mock(TaskRunScheduler.class);
+        taskRunManager = new TaskRunManager(taskRunScheduler);
+    }
+
+    @Test
+    public void testKillTaskRun_Success() {
+        long taskId = 123L;
+        TaskRun mockTaskRun = mock(TaskRun.class);
+        CompletableFuture<Constants.TaskRunState> future = new CompletableFuture<>();
+        ConnectContext ctx = mock(ConnectContext.class);
+
+        when(taskRunScheduler.getRunningTaskRun(taskId)).thenReturn(mockTaskRun);
+        when(mockTaskRun.getFuture()).thenReturn(future);
+        when(mockTaskRun.getRunCtx()).thenReturn(ctx);
+
+        boolean result = taskRunManager.killTaskRun(taskId, false);
+        assertTrue(result);
+
+        verify(mockTaskRun).kill();
+        assertTrue(future.isCompletedExceptionally());
+        verify(ctx).kill(eq(false), anyString());
+        verify(taskRunScheduler, never()).removeRunningTask(anyLong());
+    }
+
+    @Test
+    public void testKillTaskRun_FutureAlreadyDone() {
+        long taskId = 456L;
+        TaskRun mockTaskRun = mock(TaskRun.class);
+        CompletableFuture<Constants.TaskRunState> future = new CompletableFuture<>();
+        future.complete(Constants.TaskRunState.SUCCESS);
+
+        when(taskRunScheduler.getRunningTaskRun(taskId)).thenReturn(mockTaskRun);
+        when(mockTaskRun.getFuture()).thenReturn(future);
+        when(mockTaskRun.getRunCtx()).thenReturn(mock(ConnectContext.class));
+
+        boolean result = taskRunManager.killTaskRun(taskId, false);
+        assertTrue(result);
+
+        verify(mockTaskRun).kill();
+    }
+
+    @Test
+    public void testKillTaskRun_NullCtx() {
+        long taskId = 789L;
+        TaskRun mockTaskRun = mock(TaskRun.class);
+        CompletableFuture<Constants.TaskRunState> future = new CompletableFuture<>();
+
+        when(taskRunScheduler.getRunningTaskRun(taskId)).thenReturn(mockTaskRun);
+        when(mockTaskRun.getFuture()).thenReturn(future);
+        when(mockTaskRun.getRunCtx()).thenReturn(null);
+
+        boolean result = taskRunManager.killTaskRun(taskId, false);
+        assertFalse(result);
+    }
+
+    @Test
+    public void testKillTaskRun_NullTask() {
+        boolean result = taskRunManager.killTaskRun(999L, false);
+        assertFalse(result);
+    }
+
+    @Test
+    public void testKillTaskRun_ForceRemoveAlways() {
+        long taskId = 888L;
+        TaskRun mockTaskRun = mock(TaskRun.class);
+        CompletableFuture<Constants.TaskRunState> future = new CompletableFuture<>();
+
+        when(taskRunScheduler.getRunningTaskRun(taskId)).thenReturn(mockTaskRun);
+        when(mockTaskRun.getTaskId()).thenReturn(taskId);
+        when(mockTaskRun.getFuture()).thenReturn(future);
+        when(mockTaskRun.getRunCtx()).thenReturn(null);
+
+        boolean result = taskRunManager.killTaskRun(taskId, true);
+        assertFalse(result);
+
+        verify(taskRunScheduler).removeRunningTask(taskId);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -67,6 +67,7 @@ public class TaskManagerTest {
     private static StarRocksAssert starRocksAssert;
     private static final ExecuteOption DEFAULT_MERGE_OPTION = makeExecuteOption(true, false);
     private static final ExecuteOption DEFAULT_NO_MERGE_OPTION = makeExecuteOption(false, false);
+    private final TaskRunScheduler taskRunScheduler = new TaskRunScheduler();
 
     @Before
     public void setUp() {
@@ -227,7 +228,7 @@ public class TaskManagerTest {
     @Test
     public void testTaskRunMergePriorityFirst() {
 
-        TaskRunManager taskRunManager = new TaskRunManager();
+        TaskRunManager taskRunManager = new TaskRunManager(taskRunScheduler);
         Task task = new Task("test");
         task.setDefinition("select 1");
 
@@ -263,7 +264,7 @@ public class TaskManagerTest {
     @Test
     public void testTaskRunMergePriorityFirst2() {
 
-        TaskRunManager taskRunManager = new TaskRunManager();
+        TaskRunManager taskRunManager = new TaskRunManager(taskRunScheduler);
         Task task = new Task("test");
         task.setDefinition("select 1");
 
@@ -300,7 +301,7 @@ public class TaskManagerTest {
     @Test
     public void testTaskRunMergeTimeFirst() {
 
-        TaskRunManager taskRunManager = new TaskRunManager();
+        TaskRunManager taskRunManager = new TaskRunManager(taskRunScheduler);
         Task task = new Task("test");
         task.setDefinition("select 1");
 
@@ -337,7 +338,7 @@ public class TaskManagerTest {
     @Test
     public void testTaskRunMergeTimeFirst2() {
 
-        TaskRunManager taskRunManager = new TaskRunManager();
+        TaskRunManager taskRunManager = new TaskRunManager(taskRunScheduler);
         Task task = new Task("test");
         task.setDefinition("select 1");
 
@@ -374,7 +375,7 @@ public class TaskManagerTest {
     @Test
     public void testTaskRunNotMerge() {
 
-        TaskRunManager taskRunManager = new TaskRunManager();
+        TaskRunManager taskRunManager = new TaskRunManager(taskRunScheduler);
         Task task = new Task("test");
         task.setDefinition("select 1");
 
@@ -493,7 +494,7 @@ public class TaskManagerTest {
     @Test
     public void testForceGC() {
         Config.enable_task_history_archive = false;
-        TaskRunManager taskRunManager = new TaskRunManager();
+        TaskRunManager taskRunManager = new TaskRunManager(taskRunScheduler);
         for (int i = 0; i < 100; i++) {
             TaskRunStatus taskRunStatus = new TaskRunStatus();
             taskRunStatus.setQueryId("test" + i);
@@ -509,7 +510,7 @@ public class TaskManagerTest {
 
     @Test
     public void testForceGC2() {
-        TaskRunManager taskRunManager = new TaskRunManager();
+        TaskRunManager taskRunManager = new TaskRunManager(taskRunScheduler);
         for (int i = 0; i < 10; i++) {
             TaskRunStatus taskRunStatus = new TaskRunStatus();
             taskRunStatus.setQueryId("test" + i);
@@ -565,7 +566,7 @@ public class TaskManagerTest {
 
     @Test
     public void testTaskRunMergeRedundant1() {
-        TaskRunManager taskRunManager = new TaskRunManager();
+        TaskRunManager taskRunManager = new TaskRunManager(taskRunScheduler);
         Task task = new Task("test");
         task.setDefinition("select 1");
         long taskId = 1;


### PR DESCRIPTION
## Why I'm doing:
- After executing `cancel refresh materialized view <name>`, the refreshed mv task run with sync mode may hang until query timeout even the command has return successfully.

## What I'm doing:

- Set the future to be done to avoid the task run hanging in killTaskRun which will invoke the future directly.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
