### PR TITLE
[BugFix] safe processing simdjson unescape key and string

### DIFF
--- a/be/src/exec/json_scanner.cpp
+++ b/be/src/exec/json_scanner.cpp
@@ -38,6 +38,7 @@
 #include "runtime/runtime_state.h"
 #include "runtime/types.h"
 #include "util/runtime_profile.h"
+#include "util/simdjson_util.h"
 
 namespace starrocks {
 
@@ -510,11 +511,12 @@ Status JsonReader::_read_rows(Chunk* chunk, int32_t rows_to_read, int32_t* rows_
 Status JsonReader::_construct_row_without_jsonpath(simdjson::ondemand::object* row, Chunk* chunk) {
     _parsed_columns.assign(chunk->num_columns(), false);
 
+    faststring buffer;
     try {
         uint32_t key_index = 0;
         for (auto field : *row) {
             int column_index;
-            std::string_view key = field.unescaped_key();
+            std::string_view key = field_unescaped_key_safe(field, &buffer);
 
             // _prev_parsed_position records the chunk column index for each key of previous parsed json object.
             // For example, if previous json object is

--- a/be/src/formats/json/binary_column.cpp
+++ b/be/src/formats/json/binary_column.cpp
@@ -19,6 +19,7 @@
 #include "common/status.h"
 #include "gutil/strings/substitute.h"
 #include "util/json.h"
+#include "util/simdjson_util.h"
 
 namespace starrocks {
 
@@ -41,7 +42,8 @@ static Status add_column_with_numeric_value(BinaryColumn* column, const TypeDesc
 static Status add_column_with_string_value(BinaryColumn* column, const TypeDescriptor& type_desc,
                                            const std::string& name, simdjson::ondemand::value* value) {
     // simdjson::value::get_string() returns string without quotes.
-    std::string_view sv = value->get_string();
+    faststring buffer;
+    std::string_view sv = value_get_string_safe(value, &buffer);
 
     if (type_desc.len < sv.size()) {
         auto err_msg =

--- a/be/src/formats/json/map_column.cpp
+++ b/be/src/formats/json/map_column.cpp
@@ -37,7 +37,8 @@ Status add_map_column(Column* column, const TypeDescriptor& type_desc, const std
         for (auto field : obj) {
             {
                 // This is a tricky way to transform a std::string to simdjson:ondemand:value
-                std::string_view field_name_str = field.unescaped_key();
+                // NOTE: no need to unescape the string as it will be passed into the parser again.
+                std::string_view field_name_str = field.escaped_key();
                 auto dummy_json = simdjson::padded_string(R"({"dummy_key": ")" + std::string(field_name_str) + R"("})");
                 simdjson::ondemand::document doc = parser.iterate(dummy_json);
                 simdjson::ondemand::object obj = doc.get_object();

--- a/be/src/formats/json/nullable_column.cpp
+++ b/be/src/formats/json/nullable_column.cpp
@@ -22,6 +22,7 @@
 #include "formats/json/struct_column.h"
 #include "gutil/strings/substitute.h"
 #include "types/logical_type.h"
+#include "util/simdjson_util.h"
 #include "util/string_parser.hpp"
 
 namespace starrocks {
@@ -151,7 +152,8 @@ static Status add_boolean_column(Column* column, const TypeDescriptor& type_desc
         }
 
         case simdjson::ondemand::json_type::string: {
-            std::string_view s = value->get_string();
+            faststring buffer;
+            std::string_view s = value_get_string_safe(value, &buffer);
             StringParser::ParseResult r;
             auto v = StringParser::string_to_int<int32_t>(s.data(), s.size(), &r);
             if (r != StringParser::PARSE_SUCCESS || std::isnan(v) || std::isinf(v)) {

--- a/be/src/formats/json/numeric_column.cpp
+++ b/be/src/formats/json/numeric_column.cpp
@@ -17,6 +17,7 @@
 #include "column/fixed_length_column.h"
 #include "gutil/strings/substitute.h"
 #include "util/numeric_types.h"
+#include "util/simdjson_util.h"
 #include "util/string_parser.hpp"
 
 namespace starrocks {
@@ -131,7 +132,8 @@ static Status add_column_with_numeric_value(FixedLengthColumn<T>* column, const 
 template <typename T>
 static Status add_column_with_string_value(FixedLengthColumn<T>* column, const TypeDescriptor& type_desc,
                                            const std::string& name, simdjson::ondemand::value* value) {
-    std::string_view sv = value->get_string();
+    faststring buffer;
+    std::string_view sv = value_get_string_safe(value, &buffer);
 
     StringParser::ParseResult parse_result = StringParser::PARSE_SUCCESS;
 

--- a/be/src/util/json_converter.cpp
+++ b/be/src/util/json_converter.cpp
@@ -17,6 +17,7 @@
 #include "gutil/strings/substitute.h"
 #include "simdjson.h"
 #include "util/json.h"
+#include "util/simdjson_util.h"
 #include "velocypack/ValueType.h"
 #include "velocypack/vpack.h"
 
@@ -81,7 +82,9 @@ private:
             break;
         }
         case so::json_type::string: {
-            RETURN_IF_ERROR(convert(value.get_string().value(), field_name, is_object, builder));
+            faststring buffer;
+            auto str = value_get_string_safe(&value, &buffer);
+            RETURN_IF_ERROR(convert(str.value(), field_name, is_object, builder));
             break;
         }
         case so::json_type::boolean: {
@@ -103,9 +106,10 @@ private:
             builder->add(vpack::Value(vpack::ValueType::Object));
         }
         for (auto field : obj) {
-            std::string_view key = field.unescaped_key();
+            faststring buffer;
+            auto key = field_unescaped_key_safe(field, &buffer);
             auto value = field.value().value();
-            RETURN_IF_ERROR(convert(value, key, true, builder));
+            RETURN_IF_ERROR(convert(value, key.value(), true, builder));
         }
         builder->close();
         return Status::OK();

--- a/be/src/util/simdjson_util.h
+++ b/be/src/util/simdjson_util.h
@@ -1,0 +1,116 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// for DCHECK
+#include "common/logging.h"
+#include "simdjson.h"
+#include "util/faststring.h"
+
+namespace starrocks {
+
+namespace {
+
+// A singleton wrapper of the simdjson::ondemand::parser for `unescape()` interface only.
+class SimdjsonParser {
+public:
+    static simdjson::simdjson_result<std::string_view> unescape(simdjson::ondemand::raw_json_string in, uint8_t*& dst,
+                                                                bool allow_replacement = false) noexcept {
+        static SimdjsonParser s_wrapper;
+        return s_wrapper._parser.unescape(in, dst, allow_replacement);
+    }
+
+private:
+    SimdjsonParser() {
+        // The `_parser` is only used for `unescape`ing, which touches nothing of the parser's internal structure,
+        // so the capacity doesn't matter.
+        (void)_parser.allocate(0);
+    }
+    ~SimdjsonParser() = default;
+
+private:
+    simdjson::ondemand::parser _parser;
+};
+} // namespace
+
+/**
+ * Safely retrieves an unescaped JSON key while preventing buffer overflow risks
+ *
+ * This function provides a safe alternative to simdjson_result<field>::unescaped_key() by:
+ * 1. Directly returning the original key from JSON token buffer when no unescaping is needed
+ * 2. Using caller-provided buffer for unescaping when necessary, avoiding reliance on parser's internal buffers
+ *
+ * Background: The native unescaped_key() may eventually overflow its internal buffer with repeated use.
+ * Our solution prioritizes safety by:
+ * - Checking if the key contains escaped characters using SIMDJSON's internal validation
+ * - Using stack-allocated buffers through the caller-managed faststring when unescaping is required
+ *
+ * @tparam T        simdjson result type (automatically deduced)
+ * @param result    simdjson result object containing the field to examine
+ * @param buffer    Pre-allocated memory buffer for unescaping operations. Caller must maintain
+ *                  the buffer's lifetime until the returned string_view is no longer needed.
+ * @return simdjson_result<std::string_view> View of the unescaped key, either pointing to
+ *         the original JSON buffer or the caller-provided buffer
+ * @throws simdjson_error If key retrieval or unescaping fails
+ */
+template <typename T>
+inline simdjson::simdjson_result<std::string_view> field_unescaped_key_safe(simdjson::simdjson_result<T> field,
+                                                                            faststring* buffer) {
+    std::string_view escaped_key = field.escaped_key();
+    if (escaped_key.find('\\') == std::string_view::npos) {
+        // fast path, `escaped_key` is the same as `unescaped_key` on the token buff, safe to return
+        return escaped_key;
+    } else {
+        auto padded_size = escaped_key.size() + simdjson::SIMDJSON_PADDING;
+        // reserve() is good enough, but faststring does additional ASAN POISON on unused bytes
+        buffer->resize(padded_size);
+        uint8_t* pos = buffer->data();
+        return SimdjsonParser::unescape(field.key().value(), pos);
+    }
+}
+
+/**
+ * Safely extracts and unescapes a string value from a simdjson::ondemand::value object.
+ *
+ * This function addresses a safety issue with simdjson's native get_string() method. The original
+ * implementation copies strings into an internal buffer that isn't rewound until document processing
+ * completes. While the buffer has some additional capacity beyond the input size, repeated string
+ * operations can eventually exceed buffer boundaries, potentially causing heap-buffer-overflow.
+ *
+ * This implementation performs unescaping directly into the caller-provided buffer, ensuring safe
+ * memory access patterns.
+ *
+ * @param value   The simdjson::ondemand::value containing the string to extract. Must be of type
+ *                simdjson::ondemand::json_type::string (enforced by DCHECK).
+ * @param buffer  Pre-allocated buffer where the unescaped string will be stored. The caller must
+ *                maintain buffer validity for the lifetime of any returned string_view.
+ * @return        simdjson_result containing a string_view referencing the unescaped data in the
+ *                caller's buffer, or an error code if parsing fails.
+ */
+inline simdjson::simdjson_result<std::string_view> value_get_string_safe(simdjson::ondemand::value* value,
+                                                                         faststring* buffer) {
+    DCHECK(value->type() == simdjson::ondemand::json_type::string);
+
+    // Reserve sufficient space including SIMDJSON's required padding
+    const size_t padded_size = value->raw_json_token().size() + simdjson::SIMDJSON_PADDING;
+    // reserve() is good enough, but faststring does additional ASAN POISON on unused bytes
+    buffer->resize(padded_size);
+
+    // Perform unescaping directly into the caller's buffer
+    uint8_t* output_pos = buffer->data();
+    return SimdjsonParser::unescape(value->get_raw_json_string(), output_pos);
+}
+
+} // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -491,6 +491,7 @@ set(EXEC_FILES
         ./util/gc_helper_test.cpp
         ./util/lru_cache_test.cpp
         ./util/arrow/starrocks_column_to_arrow_test.cpp
+        ./util/simdjson_util_test.cpp
         ./util/starrocks_metrics_test.cpp
         ./util/system_metrics_test.cpp
         ./util/ratelimit_test.cpp

--- a/be/test/exec/json_scanner_test.cpp
+++ b/be/test/exec/json_scanner_test.cpp
@@ -20,6 +20,7 @@
 
 #include "column/chunk.h"
 #include "column/datum_tuple.h"
+#include "fs/fs_util.h"
 #include "gen_cpp/Descriptors_types.h"
 #include "runtime/descriptor_helper.h"
 #include "runtime/descriptors.h"
@@ -145,6 +146,13 @@ protected:
         TUniqueId id;
         runtime_state->init_mem_trackers(id);
         return runtime_state;
+    }
+
+    static void write_json_to_file(std::string filename, std::string json_data) {
+        std::ofstream ofs;
+        ofs.open(filename, std::ofstream::out);
+        ofs << json_data;
+        ofs.close();
     }
 
     void SetUp() override {
@@ -1445,6 +1453,43 @@ TEST_F(JsonScannerTest, test_null_with_jsonpath) {
 
     ASSERT_OK(scanner->open());
     ASSERT_TRUE(scanner->get_next().status().is_data_quality_error());
+}
+
+TEST_F(JsonScannerTest, test_repeated_jsonpaths) {
+    std::string json_data =
+            R"({"level1":{"level2":"long long long long long long long long long long long long long long string"}})";
+    std::string json_filename = "be/test/exec/test_data/json_scanner/test_repeated_jsonpaths.json";
+
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TYPE_JSON);
+    types.emplace_back(TYPE_JSON);
+    types.emplace_back(TYPE_JSON);
+    types.emplace_back(TYPE_JSON);
+    types.emplace_back(TYPE_JSON);
+    types.emplace_back(TYPE_JSON);
+
+    write_json_to_file(json_filename, json_data);
+
+    std::vector<TBrokerRangeDesc> ranges;
+    TBrokerRangeDesc range;
+    range.format_type = TFileFormatType::FORMAT_JSON;
+    range.file_type = TFileType::FILE_LOCAL;
+    range.strip_outer_array = false;
+    range.__isset.strip_outer_array = false;
+    range.__isset.jsonpaths = true;
+    range.jsonpaths = R"(["$.level1.level2", "$", "$.level1.level2", "$", "$.level1.level2", "$"])";
+    range.__isset.json_root = false;
+    range.__set_path(json_filename);
+    ranges.emplace_back(range);
+
+    auto scanner = create_json_scanner(
+            types, ranges, {"level1_level2_1", "root1", "level1_level2_2", "root2", "level1_level2_3", "root3"});
+
+    ASSERT_OK(scanner->open());
+    auto st = scanner->get_next().status();
+    ASSERT_TRUE(st.ok()) << st;
+
+    (void)fs::delete_file(json_filename);
 }
 
 TEST_F(JsonScannerTest, file_stream) {

--- a/be/test/util/simdjson_util_test.cpp
+++ b/be/test/util/simdjson_util_test.cpp
@@ -1,0 +1,246 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/simdjson_util.h"
+
+#include <gtest/gtest.h>
+
+namespace starrocks {
+
+class SimdJsonUtilTest : public ::testing::Test {
+public:
+    void TearDown() override { buffer.clear(); }
+
+    // Helper to parse JSON and get string value
+    simdjson::ondemand::value get_value(const simdjson::padded_string& json) {
+        doc = parser.iterate(json);
+        return doc.find_field("value");
+    }
+
+protected:
+    simdjson::ondemand::parser parser;
+    simdjson::ondemand::document doc;
+    faststring buffer;
+};
+
+TEST_F(SimdJsonUtilTest, HandlesUnescapedKey) {
+    auto json = R"({"normal_key": 123})"_padded;
+    auto doc = parser.iterate(json);
+
+    for (auto field : doc.get_object()) {
+        auto result = field_unescaped_key_safe(field, &buffer);
+
+        ASSERT_EQ(simdjson::SUCCESS, result.error());
+        ASSERT_EQ(result.value(), "normal_key");
+        ASSERT_EQ(result.value(), field.unescaped_key().value());
+        ASSERT_NE((void*)result.value().data(), (void*)buffer.data());
+        ASSERT_EQ(buffer.size(), 0);
+    }
+}
+
+TEST_F(SimdJsonUtilTest, HandlesEscapedKey) {
+    auto json = R"({"escaped_\"key": 456})"_padded;
+    auto doc = parser.iterate(json);
+
+    for (auto field : doc.get_object()) {
+        auto result = field_unescaped_key_safe(field, &buffer);
+
+        ASSERT_EQ(simdjson::SUCCESS, result.error());
+        ASSERT_EQ(result.value(), std::string_view("escaped_\"key"));
+        ASSERT_EQ(result.value(), field.unescaped_key().value());
+        ASSERT_EQ((void*)result.value().data(), (void*)buffer.data());
+        ASSERT_GT(buffer.size(), 0);
+    }
+}
+
+TEST_F(SimdJsonUtilTest, HandlesMultipleEscapes) {
+    auto json = R"({"complex\\\"key\/": true})"_padded;
+    auto doc = parser.iterate(json);
+
+    for (auto field : doc.get_object()) {
+        auto result = field_unescaped_key_safe(field, &buffer);
+
+        ASSERT_EQ(simdjson::SUCCESS, result.error());
+        ASSERT_EQ(result.value(), std::string_view("complex\\\"key/"));
+        ASSERT_EQ(result.value(), field.unescaped_key().value());
+        ASSERT_EQ((void*)result.value().data(), (void*)buffer.data());
+        ASSERT_GT(buffer.size(), 12);
+    }
+}
+
+TEST_F(SimdJsonUtilTest, FieldUnescapeKeyHandlesBufferReuse) {
+    auto json = R"({"key1": 1, "key\"2": 2})"_padded;
+    auto doc = parser.iterate(json);
+
+    size_t first_buffer_size = 0;
+    for (auto field : doc.get_object()) {
+        auto result = field_unescaped_key_safe(field, &buffer);
+
+        ASSERT_EQ(simdjson::SUCCESS, result.error());
+        ASSERT_EQ(result.value(), field.unescaped_key().value());
+        if (result.value() == std::string_view("key1")) {
+            ASSERT_EQ(buffer.size(), 0);
+        } else {
+            first_buffer_size = buffer.size();
+            ASSERT_GT(first_buffer_size, 0);
+        }
+    }
+
+    doc.rewind();
+    for (auto field : doc.get_object()) {
+        auto result = field_unescaped_key_safe(field, &buffer);
+
+        ASSERT_EQ(simdjson::SUCCESS, result.error());
+        ASSERT_EQ(result.value(), field.unescaped_key().value());
+        if (result.value() == std::string_view("key\"2")) {
+            ASSERT_GE(buffer.capacity(), first_buffer_size);
+        }
+    }
+}
+
+TEST_F(SimdJsonUtilTest, HandlesInvalidField) {
+    simdjson::simdjson_result<simdjson::ondemand::field> invalid_field;
+    ASSERT_THROW(field_unescaped_key_safe(invalid_field, &buffer), simdjson::simdjson_error);
+}
+
+TEST_F(SimdJsonUtilTest, HandlesLargeKey) {
+    const std::string big_key(1024, 'a');
+    auto json = R"({")" + big_key + R"(": "value"})";
+    auto padded_json = simdjson::padded_string(json);
+    auto doc = parser.iterate(padded_json);
+
+    for (auto field : doc.get_object()) {
+        auto result = field_unescaped_key_safe(field, &buffer);
+
+        ASSERT_EQ(simdjson::SUCCESS, result.error());
+        ASSERT_EQ(result.value(), field.unescaped_key().value());
+        ASSERT_NE((void*)result.value().data(), (void*)buffer.data());
+        ASSERT_EQ(result.value(), big_key);
+        ASSERT_EQ(buffer.size(), 0);
+    }
+}
+
+TEST_F(SimdJsonUtilTest, HandlesBasicString) {
+    auto json = R"({"value": "simple string"})"_padded;
+    auto value = get_value(json);
+
+    auto result = value_get_string_safe(&value, &buffer);
+
+    ASSERT_EQ(simdjson::SUCCESS, result.error());
+    ASSERT_EQ(result.value(), value.get_string().value());
+    EXPECT_EQ(result.value(), std::string_view("simple string"));
+    ASSERT_EQ((void*)result.value().data(), (void*)buffer.data());
+    EXPECT_EQ(buffer.size(), value.raw_json_token().size() + simdjson::SIMDJSON_PADDING);
+}
+
+TEST_F(SimdJsonUtilTest, HandlesEscapedCharacters) {
+    auto json = R"({"value": "Escaped\nNewline\tTab\"Quote"})"_padded;
+    auto value = get_value(json);
+
+    auto result = value_get_string_safe(&value, &buffer);
+
+    ASSERT_EQ(simdjson::SUCCESS, result.error());
+    EXPECT_EQ(result.value(), std::string_view("Escaped\nNewline\tTab\"Quote"));
+    ASSERT_EQ(result.value(), value.get_string().value());
+    ASSERT_EQ((void*)result.value().data(), (void*)buffer.data());
+    EXPECT_GT(buffer.size(), value.raw_json_token().size());
+}
+
+TEST_F(SimdJsonUtilTest, HandlesEmptyString) {
+    auto json = R"({"value": ""})"_padded;
+    auto value = get_value(json);
+
+    auto result = value_get_string_safe(&value, &buffer);
+
+    ASSERT_EQ(simdjson::SUCCESS, result.error());
+    ASSERT_EQ(result.value(), value.get_string().value());
+    EXPECT_EQ(result.value(), std::string_view(""));
+    ASSERT_EQ((void*)result.value().data(), (void*)buffer.data());
+    EXPECT_EQ(buffer.size(), simdjson::SIMDJSON_PADDING + 2); // including the two quotes
+}
+
+TEST_F(SimdJsonUtilTest, HandlesUnicodeEscape) {
+    auto json = R"({"value": "Utf-8: \u6C49\u5B57"})"_padded;
+    auto value = get_value(json);
+
+    auto result = value_get_string_safe(&value, &buffer);
+
+    ASSERT_EQ(simdjson::SUCCESS, result.error());
+    ASSERT_EQ(result.value(), value.get_string().value());
+    EXPECT_EQ(result.value(), std::string_view("Utf-8: 汉字"));
+    ASSERT_EQ((void*)result.value().data(), (void*)buffer.data());
+    EXPECT_GT(buffer.size(), value.raw_json_token().size());
+}
+
+TEST_F(SimdJsonUtilTest, ValueGetStringHandlesBufferReuse) {
+    uint8_t* buffer_pos = nullptr;
+    // Firs call with larger string
+    {
+        auto json = R"({"value": "buffer reuse with escapes\n"})"_padded;
+        auto value = get_value(json);
+        auto result = value_get_string_safe(&value, &buffer);
+        ASSERT_EQ(result.value(), value.get_string().value());
+        ASSERT_EQ(simdjson::SUCCESS, result.error());
+        ASSERT_EQ((void*)result.value().data(), (void*)buffer.data());
+        buffer_pos = buffer.data();
+    }
+    // Second call with small string
+    {
+        auto json = R"({"value": "test"})"_padded;
+        auto value = get_value(json);
+        auto result = value_get_string_safe(&value, &buffer);
+        ASSERT_EQ(simdjson::SUCCESS, result.error());
+        ASSERT_EQ(result.value(), value.get_string().value());
+        ASSERT_EQ((void*)result.value().data(), (void*)buffer.data());
+        EXPECT_EQ(result.value(), std::string_view("test"));
+
+        // buffer_pos pointed to the same location
+        EXPECT_EQ(buffer_pos, buffer.data());
+    }
+}
+
+TEST_F(SimdJsonUtilTest, HandlesInvalidStringType) {
+#ifdef NDEBUG
+    auto json = R"({"value": 123})"_padded;
+    auto value = get_value(json);
+    // Release build should throw
+    EXPECT_THROW(value_get_string_safe(&value, &buffer), simdjson::simdjson_error);
+#endif
+}
+
+TEST_F(SimdJsonUtilTest, HandlesMalformedEscapes) {
+    auto json = R"({"value": "bad escape \xC3\x28"})"_padded;
+    auto value = get_value(json);
+
+    auto result = value_get_string_safe(&value, &buffer);
+
+    // Should propagate parsing error
+    EXPECT_EQ(result.error(), simdjson::STRING_ERROR);
+}
+
+TEST_F(SimdJsonUtilTest, HandlesLargeString) {
+    const std::string big_str(4096, 'x');
+    auto json = simdjson::padded_string(R"({"value": ")" + big_str + R"("})");
+    auto value = get_value(json);
+
+    auto result = value_get_string_safe(&value, &buffer);
+
+    ASSERT_EQ(simdjson::SUCCESS, result.error());
+    ASSERT_EQ(result.value(), value.get_string().value());
+    EXPECT_EQ(result.value(), big_str);
+    ASSERT_EQ((void*)result.value().data(), (void*)buffer.data());
+    EXPECT_EQ(buffer.size(), big_str.size() + 2 + simdjson::SIMDJSON_PADDING); // 2 for quotes
+}
+
+} // namespace starrocks


### PR DESCRIPTION
* replace all simdjson unescape() and get_string() call to a safe version.
* potentially performance degradation due to temp faststring object used for the unescaping.

## Why I'm doing:

## What I'm doing:

Fixes #58321

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
