### PR TITLE
[Enhancement] Modify the semantics of parse_mem_str to distinguish between handling parsing errors and special values.

### DIFF
--- a/be/src/cache/block_cache/datacache_utils.cpp
+++ b/be/src/cache/block_cache/datacache_utils.cpp
@@ -48,7 +48,7 @@ void DataCacheUtils::set_metrics_from_thrift(TDataCacheMetrics& t_metrics, const
 
 Status DataCacheUtils::parse_conf_datacache_mem_size(const std::string& conf_mem_size_str, int64_t mem_limit,
                                                      size_t* mem_size) {
-    int64_t parsed_mem_size = ParseUtil::parse_mem_spec(conf_mem_size_str, mem_limit);
+    ASSIGN_OR_RETURN(int64_t parsed_mem_size, ParseUtil::parse_mem_spec(conf_mem_size_str, mem_limit));
     if (mem_limit > 0 && parsed_mem_size > mem_limit) {
         LOG(WARNING) << "the configured datacache memory size exceeds the limit, decreased it to the limit value."
                      << "mem_size: " << parsed_mem_size << ", mem_limit: " << mem_limit;
@@ -62,19 +62,20 @@ Status DataCacheUtils::parse_conf_datacache_mem_size(const std::string& conf_mem
     return Status::OK();
 }
 
-int64_t DataCacheUtils::parse_conf_datacache_disk_size(const std::string& disk_path, const std::string& disk_size_str,
+StatusOr<int64_t> DataCacheUtils::parse_conf_datacache_disk_size(const std::string& disk_path, const std::string& disk_size_str,
                                                        int64_t disk_limit) {
     if (disk_limit <= 0) {
         std::filesystem::path dpath(disk_path);
         std::error_code ec;
         auto space_info = std::filesystem::space(dpath, ec);
         if (ec) {
-            LOG(ERROR) << "fail to get disk space info, path: " << dpath << ", error: " << ec.message();
-            return -1;
+            auto err_str = fmt::format("fail to get disk space info, path: {}, error: {}", disk_path, ec.message());
+            LOG(ERROR) << err_str;
+            return Status::InternalError(err_str);
         }
         disk_limit = space_info.capacity;
     }
-    int64_t disk_size = ParseUtil::parse_mem_spec(disk_size_str, disk_limit);
+    ASSIGN_OR_RETURN(int64_t disk_size, ParseUtil::parse_mem_spec(disk_size_str, disk_limit));
     if (disk_size > disk_limit) {
         LOG(WARNING) << "the configured datacache disk size exceeds the disk limit, decreased it to the limit value."
                      << ", path: " << disk_path << ", disk_size: " << disk_size << ", disk_limit: " << disk_limit;

--- a/be/src/cache/block_cache/datacache_utils.cpp
+++ b/be/src/cache/block_cache/datacache_utils.cpp
@@ -62,8 +62,8 @@ Status DataCacheUtils::parse_conf_datacache_mem_size(const std::string& conf_mem
     return Status::OK();
 }
 
-StatusOr<int64_t> DataCacheUtils::parse_conf_datacache_disk_size(const std::string& disk_path, const std::string& disk_size_str,
-                                                       int64_t disk_limit) {
+StatusOr<int64_t> DataCacheUtils::parse_conf_datacache_disk_size(const std::string& disk_path,
+                                                                 const std::string& disk_size_str, int64_t disk_limit) {
     if (disk_limit <= 0) {
         std::filesystem::path dpath(disk_path);
         std::error_code ec;

--- a/be/src/cache/block_cache/datacache_utils.h
+++ b/be/src/cache/block_cache/datacache_utils.h
@@ -26,8 +26,8 @@ public:
     static Status parse_conf_datacache_mem_size(const std::string& conf_mem_size_str, int64_t mem_limit,
                                                 size_t* mem_size);
 
-    static int64_t parse_conf_datacache_disk_size(const std::string& disk_path, const std::string& disk_size_str,
-                                                  int64_t disk_limit);
+    static StatusOr<int64_t> parse_conf_datacache_disk_size(const std::string& disk_path,
+                                                            const std::string& disk_size_str, int64_t disk_limit);
 
     static Status parse_conf_datacache_disk_paths(const std::string& config_path, std::vector<std::string>* paths,
                                                   bool ignore_broken_disk);

--- a/be/src/cache/block_cache/disk_space_monitor.cpp
+++ b/be/src/cache/block_cache/disk_space_monitor.cpp
@@ -17,6 +17,7 @@
 #include "cache/block_cache/block_cache.h"
 #include "cache/block_cache/datacache_utils.h"
 #include "common/config.h"
+#include "common/statusor.h"
 #include "util/await.h"
 #include "util/thread.h"
 
@@ -37,7 +38,7 @@ Status DiskSpace::init_spaces(const std::vector<DirSpace>& dir_spaces) {
         LOG(ERROR) << "fail to init disk space, reason: " << st.message();
         return st;
     }
-    _update_disk_options();
+    RETURN_IF_ERROR(_update_disk_options());
 
     // We check this switch after some information are initialized, because even if it is off now,
     // we still need this information once the switch is turn on online.
@@ -56,7 +57,11 @@ bool DiskSpace::adjust_spaces(const AdjustContext& ctx) {
         LOG(ERROR) << "fail to check and adjust cache disk spaces, reason: " << st.message();
         return false;
     }
-    _update_disk_options();
+    st = _update_disk_options();
+    if (!st.ok()) {
+        LOG(ERROR) << "Failed to update disk options, reason: " << st;
+        return false;
+    }
 
     if (_disk_stats.used_bytes() < _disk_opts.low_level_size) {
         _disk_free_period += _disk_opts.adjust_interval_s;
@@ -112,15 +117,18 @@ size_t DiskSpace::_cache_file_space_usage() {
     return size;
 }
 
-void DiskSpace::_update_disk_options() {
+Status DiskSpace::_update_disk_options() {
     _disk_opts.cache_lower_limit = config::datacache_min_disk_quota_for_adjustment;
-    _disk_opts.cache_upper_limit = DataCacheUtils::parse_conf_datacache_disk_size(_path, config::datacache_disk_size,
-                                                                                  _disk_stats.capacity_bytes);
+    ASSIGN_OR_RETURN(_disk_opts.cache_upper_limit,
+                     DataCacheUtils::parse_conf_datacache_disk_size(_path, config::datacache_disk_size,
+                                                                    _disk_stats.capacity_bytes));
     _disk_opts.low_level_size = _disk_stats.capacity_bytes * 0.01 * config::datacache_disk_low_level;
     _disk_opts.safe_level_size = _disk_stats.capacity_bytes * 0.01 * config::datacache_disk_safe_level;
     _disk_opts.high_level_size = _disk_stats.capacity_bytes * 0.01 * config::datacache_disk_high_level;
     _disk_opts.adjust_interval_s = config::datacache_disk_adjust_interval_seconds;
     _disk_opts.idle_for_expansion_s = config::datacache_disk_idle_seconds_for_expansion;
+
+    return Status::OK();
 }
 
 void DiskSpace::_update_spaces_by_cache_quota(size_t cache_avail_bytes) {

--- a/be/src/cache/block_cache/disk_space_monitor.h
+++ b/be/src/cache/block_cache/disk_space_monitor.h
@@ -87,7 +87,7 @@ public:
 
 private:
     Status _update_disk_stats();
-    void _update_disk_options();
+    Status _update_disk_options();
 
     void _update_spaces_by_cache_quota(size_t cache_avalil_bytes);
 

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -89,7 +89,7 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             return Status::OK();
         });
         _config_callback.emplace("storage_page_cache_limit", [&]() -> Status {
-            int64_t cache_limit = GlobalEnv::GetInstance()->get_storage_page_cache_size();
+            ASSIGN_OR_RETURN(int64_t cache_limit, GlobalEnv::GetInstance()->get_storage_page_cache_size());
             cache_limit = GlobalEnv::GetInstance()->check_storage_page_cache_size(cache_limit);
             StoragePageCache::instance()->set_capacity(cache_limit);
             return Status::OK();
@@ -98,7 +98,7 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             if (config::disable_storage_page_cache) {
                 StoragePageCache::instance()->set_capacity(0);
             } else {
-                int64_t cache_limit = GlobalEnv::GetInstance()->get_storage_page_cache_size();
+                ASSIGN_OR_RETURN(int64_t cache_limit, GlobalEnv::GetInstance()->get_storage_page_cache_size());
                 cache_limit = GlobalEnv::GetInstance()->check_storage_page_cache_size(cache_limit);
                 StoragePageCache::instance()->set_capacity(cache_limit);
             }
@@ -122,8 +122,8 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             std::vector<DirSpace> spaces;
             BlockCache::instance()->disk_spaces(&spaces);
             for (auto& space : spaces) {
-                int64_t disk_size =
-                        DataCacheUtils::parse_conf_datacache_disk_size(space.path, config::datacache_disk_size, -1);
+                ASSIGN_OR_RETURN(int64_t disk_size, DataCacheUtils::parse_conf_datacache_disk_size(
+                                                            space.path, config::datacache_disk_size, -1));
                 if (disk_size < 0) {
                     LOG(WARNING) << "Failed to update datacache disk spaces for the invalid disk_size: " << disk_size;
                     return Status::InternalError("Fail to update datacache disk spaces");

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -144,8 +144,8 @@ static int64_t calc_max_compaction_memory(int64_t process_mem_limit) {
     return std::min<int64_t>(limit, process_mem_limit * percent / 100);
 }
 
-static int64_t calc_max_consistency_memory(int64_t process_mem_limit) {
-    int64_t limit = ParseUtil::parse_mem_spec(config::consistency_max_memory_limit, process_mem_limit);
+static StatusOr<int64_t> calc_max_consistency_memory(int64_t process_mem_limit) {
+    ASSIGN_OR_RETURN(int64_t limit, ParseUtil::parse_mem_spec(config::consistency_max_memory_limit, process_mem_limit));
     int64_t percent = config::consistency_max_memory_limit_percent;
 
     if (process_mem_limit < 0) {
@@ -178,7 +178,7 @@ Status GlobalEnv::_init_mem_tracker() {
     int64_t bytes_limit = 0;
     std::stringstream ss;
     // --mem_limit="" means no memory limit
-    bytes_limit = ParseUtil::parse_mem_spec(config::mem_limit, MemInfo::physical_mem());
+    ASSIGN_OR_RETURN(bytes_limit, ParseUtil::parse_mem_spec(config::mem_limit, MemInfo::physical_mem()));
     // use 90% of mem_limit as the soft mem limit of BE
     bytes_limit = bytes_limit * 0.9;
     if (bytes_limit <= 0) {
@@ -242,7 +242,7 @@ Status GlobalEnv::_init_mem_tracker() {
     _passthrough_mem_tracker = regist_tracker(MemTrackerType::PASSTHROUGH, -1, nullptr);
     _passthrough_mem_tracker->set_level(2);
     _clone_mem_tracker = regist_tracker(MemTrackerType::CLONE, -1, process_mem_tracker());
-    int64_t consistency_mem_limit = calc_max_consistency_memory(_process_mem_tracker->limit());
+    ASSIGN_OR_RETURN(int64_t consistency_mem_limit, calc_max_consistency_memory(_process_mem_tracker->limit()));
     _consistency_mem_tracker =
             regist_tracker(MemTrackerType::CONSISTENCY, consistency_mem_limit, process_mem_tracker());
     _datacache_mem_tracker = regist_tracker(MemTrackerType::DATACACHE, -1, process_mem_tracker());
@@ -277,7 +277,7 @@ void GlobalEnv::_reset_tracker() {
     }
 }
 
-int64_t GlobalEnv::get_storage_page_cache_size() {
+StatusOr<int64_t> GlobalEnv::get_storage_page_cache_size() {
     int64_t mem_limit = MemInfo::physical_mem();
     if (process_mem_tracker()->has_limit()) {
         mem_limit = process_mem_tracker()->limit();
@@ -376,7 +376,7 @@ Status CacheEnv::_init_starcache_based_object_cache() {
 
 Status CacheEnv::_init_lru_base_object_cache() {
     ObjectCacheOptions options;
-    int64_t storage_cache_limit = _global_env->get_storage_page_cache_size();
+    ASSIGN_OR_RETURN(int64_t storage_cache_limit, _global_env->get_storage_page_cache_size());
     storage_cache_limit = _global_env->check_storage_page_cache_size(storage_cache_limit);
     options.capacity = storage_cache_limit;
 
@@ -446,8 +446,8 @@ Status CacheEnv::_init_datacache() {
                 return Status::InternalError("Fail to create datacache directory");
             }
 
-            int64_t disk_size =
-                    DataCacheUtils::parse_conf_datacache_disk_size(datacache_path, config::datacache_disk_size, -1);
+            ASSIGN_OR_RETURN(int64_t disk_size, DataCacheUtils::parse_conf_datacache_disk_size(
+                                                        datacache_path, config::datacache_disk_size, -1));
 #ifdef USE_STAROS
             // If the `datacache_disk_size` is manually set a positive value, we will use the maximum cache quota between
             // dataleke and starlet cache as the quota of the unified cache. Otherwise, the cache quota will remain zero

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -453,8 +453,10 @@ Status CacheEnv::_init_datacache() {
             // dataleke and starlet cache as the quota of the unified cache. Otherwise, the cache quota will remain zero
             // and then automatically adjusted based on the current avalible disk space.
             if (config::datacache_unified_instance_enable && (!config::datacache_auto_adjust_enable || disk_size > 0)) {
-                int64_t starlet_cache_size = DataCacheUtils::parse_conf_datacache_disk_size(
-                        datacache_path, fmt::format("{}%", config::starlet_star_cache_disk_size_percent), -1);
+                ASSIGN_OR_RETURN(
+                        int64_t starlet_cache_size,
+                        DataCacheUtils::parse_conf_datacache_disk_size(
+                                datacache_path, fmt::format("{}%", config::starlet_star_cache_disk_size_percent), -1));
                 disk_size = std::max(disk_size, starlet_cache_size);
             }
 #endif

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -165,7 +165,7 @@ public:
     std::shared_ptr<MemTracker> get_mem_tracker_by_type(MemTrackerType type);
     std::vector<std::shared_ptr<MemTracker>> mem_trackers() const;
 
-    int64_t get_storage_page_cache_size();
+    StatusOr<int64_t> get_storage_page_cache_size();
     int64_t check_storage_page_cache_size(int64_t storage_cache_limit);
     static int64_t calc_max_query_memory(int64_t process_mem_limit, int64_t percent);
 

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -154,7 +154,7 @@ public:
     void TEST_remove_compaction_cache(uint32_t tablet_id, int64_t txn_id);
 
     Status update_primary_index_memory_limit(int32_t update_memory_limit_percent) {
-        int64_t byte_limits = ParseUtil::parse_mem_spec(config::mem_limit, MemInfo::physical_mem());
+        ASSIGN_OR_RETURN(int64_t byte_limits, ParseUtil::parse_mem_spec(config::mem_limit, MemInfo::physical_mem()));
         int32_t update_mem_percent = std::max(std::min(100, update_memory_limit_percent), 0);
         _index_cache.set_capacity(byte_limits * update_mem_percent);
         return Status::OK();

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -326,7 +326,12 @@ void* StorageEngine::_adjust_pagecache_callback(void* arg_this) {
             size_t bytes_to_dec = dec_advisor->bytes_should_gc(MonoTime::Now(), delta_high);
             evict_pagecache(cache, static_cast<int64_t>(bytes_to_dec), _bg_worker_stopped);
         } else {
-            int64_t max_cache_size = std::max(GlobalEnv::GetInstance()->get_storage_page_cache_size(), kcacheMinSize);
+            auto ret = GlobalEnv::GetInstance()->get_storage_page_cache_size();
+            if (!ret.ok()) {
+                LOG(ERROR) << "Failed to get storage page size: " << ret.status();
+                continue;
+            }
+            int64_t max_cache_size = std::max(ret.value(), kcacheMinSize);
             int64_t cur_cache_size = cache->get_capacity();
             if (cur_cache_size >= max_cache_size) {
                 continue;

--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -67,7 +67,8 @@ UpdateManager::UpdateManager(MemTracker* mem_tracker)
     _index_cache.set_mem_tracker(_index_cache_mem_tracker.get());
     _update_state_cache.set_mem_tracker(_update_state_mem_tracker.get());
 
-    int64_t byte_limits = ParseUtil::parse_mem_spec(config::mem_limit, MemInfo::physical_mem());
+    auto ret = ParseUtil::parse_mem_spec(config::mem_limit, MemInfo::physical_mem());
+    int64_t byte_limits = ret.ok() ? ret.value() : 0;
     int32_t update_mem_percent = std::max(std::min(100, config::update_memory_limit_percent), 0);
     _index_cache.set_capacity(byte_limits * update_mem_percent / 100);
     _update_column_state_cache.set_mem_tracker(_update_state_mem_tracker.get());

--- a/be/src/storage/update_manager.h
+++ b/be/src/storage/update_manager.h
@@ -136,7 +136,7 @@ public:
     string topn_memory_stats(size_t topn);
 
     Status update_primary_index_memory_limit(int32_t update_memory_limit_percent) {
-        int64_t byte_limits = ParseUtil::parse_mem_spec(config::mem_limit, MemInfo::physical_mem());
+        ASSIGN_OR_RETURN(int64_t byte_limits, ParseUtil::parse_mem_spec(config::mem_limit, MemInfo::physical_mem()));
         int32_t update_mem_percent = std::max(std::min(100, update_memory_limit_percent), 0);
         _index_cache.set_capacity(byte_limits * update_mem_percent);
         return Status::OK();

--- a/be/src/util/parse_util.cpp
+++ b/be/src/util/parse_util.cpp
@@ -35,6 +35,7 @@
 #include "util/parse_util.h"
 
 #include <fmt/format.h>
+
 #include "util/string_parser.hpp"
 
 namespace starrocks {

--- a/be/src/util/parse_util.h
+++ b/be/src/util/parse_util.h
@@ -37,6 +37,8 @@
 #include <boost/cstdint.hpp>
 #include <string>
 
+#include "common/statusor.h"
+
 namespace starrocks {
 
 // Utility class for parsing information from strings.
@@ -48,9 +50,8 @@ public:
     // '<float>[mM]' -> megabytes
     // '<float>[gG]' -> in gigabytes
     // '<int>%'      -> in percent of memory_limit
-    // Returns 0 if mem_spec_str is empty or '-1'.
-    // Returns -1 if parsing failed.
-    static int64_t parse_mem_spec(const std::string& mem_spec_str, const int64_t memory_limit);
+    // empty -> return 0
+    static StatusOr<int64_t> parse_mem_spec(const std::string& mem_spec_str, const int64_t memory_limit);
 };
 
 } // namespace starrocks

--- a/be/src/util/parse_util.h
+++ b/be/src/util/parse_util.h
@@ -50,7 +50,10 @@ public:
     // '<float>[mM]' -> megabytes
     // '<float>[gG]' -> in gigabytes
     // '<int>%'      -> in percent of memory_limit
-    // empty -> return 0
+    // Return 0 if mem_spec_str is empty.
+    // Return -1, means no limit and will automatically adjust
+    // The caller needs to handle other legitimate negative values.
+    // If parsing mem_spec_str fails, it will return an error.
     static StatusOr<int64_t> parse_mem_spec(const std::string& mem_spec_str, const int64_t memory_limit);
 };
 

--- a/be/test/cache/block_cache/datacache_utils_test.cpp
+++ b/be/test/cache/block_cache/datacache_utils_test.cpp
@@ -20,6 +20,7 @@
 
 #include "fs/fs_util.h"
 #include "gen_cpp/DataCache_types.h"
+#include "testutil/assert.h"
 
 namespace starrocks {
 class DataCacheUtilsTest : public ::testing::Test {};
@@ -79,20 +80,20 @@ TEST_F(DataCacheUtilsTest, parse_cache_space_size_str) {
     std::string disk_path = cache_dir;
     const int64_t kMaxLimit = 20L * 1024 * 1024 * 1024 * 1024; // 20T
     int64_t disk_size = 10;
-    ASSERT_EQ(DataCacheUtils::parse_conf_datacache_disk_size(disk_path, "10", kMaxLimit), disk_size);
+    ASSERT_EQ(DataCacheUtils::parse_conf_datacache_disk_size(disk_path, "10", kMaxLimit).value(), disk_size);
     disk_size *= 1024;
-    ASSERT_EQ(DataCacheUtils::parse_conf_datacache_disk_size(disk_path, "10K", kMaxLimit), disk_size);
+    ASSERT_EQ(DataCacheUtils::parse_conf_datacache_disk_size(disk_path, "10K", kMaxLimit).value(), disk_size);
     disk_size *= 1024;
-    ASSERT_EQ(DataCacheUtils::parse_conf_datacache_disk_size(disk_path, "10M", kMaxLimit), disk_size);
+    ASSERT_EQ(DataCacheUtils::parse_conf_datacache_disk_size(disk_path, "10M", kMaxLimit).value(), disk_size);
     disk_size *= 1024;
-    ASSERT_EQ(DataCacheUtils::parse_conf_datacache_disk_size(disk_path, "10G", kMaxLimit), disk_size);
+    ASSERT_EQ(DataCacheUtils::parse_conf_datacache_disk_size(disk_path, "10G", kMaxLimit).value(), disk_size);
     disk_size *= 1024;
-    ASSERT_EQ(DataCacheUtils::parse_conf_datacache_disk_size(disk_path, "10T", kMaxLimit), disk_size);
+    ASSERT_EQ(DataCacheUtils::parse_conf_datacache_disk_size(disk_path, "10T", kMaxLimit).value(), disk_size);
 
     // The disk size exceed disk limit
-    ASSERT_EQ(DataCacheUtils::parse_conf_datacache_disk_size(disk_path, "10T", 1024), 1024);
+    ASSERT_EQ(DataCacheUtils::parse_conf_datacache_disk_size(disk_path, "10T", 1024).value(), 1024);
 
-    disk_size = DataCacheUtils::parse_conf_datacache_disk_size(disk_path, "10%", kMaxLimit);
+    ASSIGN_OR_ASSERT_FAIL(disk_size, DataCacheUtils::parse_conf_datacache_disk_size(disk_path, "10%", kMaxLimit));
     ASSERT_EQ(disk_size, int64_t(10.0 / 100.0 * kMaxLimit));
 
     fs::remove_all(cache_dir).ok();

--- a/be/test/util/parse_util_test.cpp
+++ b/be/test/util/parse_util_test.cpp
@@ -69,6 +69,7 @@ TEST(TestParseMemSpec, Normal) {
 
     test_parse_mem_spec("20%", test_memory_limit * 0.2);
     test_parse_mem_spec("-1", -1);
+    test_parse_mem_spec("", 0);
 }
 
 TEST(TestParseMemSpec, Bad) {

--- a/be/test/util/parse_util_test.cpp
+++ b/be/test/util/parse_util_test.cpp
@@ -38,12 +38,14 @@
 
 #include <string>
 
+#include "testutil/assert.h"
+
 namespace starrocks {
 
 const static int64_t test_memory_limit = 10000;
 
 static void test_parse_mem_spec(const std::string& mem_spec_str, int64_t result) {
-    int64_t bytes = ParseUtil::parse_mem_spec(mem_spec_str, test_memory_limit);
+    ASSIGN_OR_ASSERT_FAIL(int64_t bytes, ParseUtil::parse_mem_spec(mem_spec_str, test_memory_limit));
     ASSERT_EQ(result, bytes);
 }
 
@@ -65,28 +67,15 @@ TEST(TestParseMemSpec, Normal) {
     test_parse_mem_spec("8t", 8L * 1024 * 1024 * 1024 * 1024L);
     test_parse_mem_spec("128T", 128L * 1024 * 1024 * 1024 * 1024L);
 
-    int64_t bytes = ParseUtil::parse_mem_spec("20%", test_memory_limit);
-    ASSERT_EQ(bytes, test_memory_limit * 0.2);
+    test_parse_mem_spec("20%", test_memory_limit * 0.2);
+    test_parse_mem_spec("-1", -1);
 }
 
 TEST(TestParseMemSpec, Bad) {
-    std::vector<std::string> bad_values;
-    bad_values.emplace_back("1gib");
-    bad_values.emplace_back("1%b");
-    bad_values.emplace_back("1b%");
-    bad_values.emplace_back("gb");
-    bad_values.emplace_back("1GMb");
-    bad_values.emplace_back("1b1Mb");
-    bad_values.emplace_back("1kib");
-    bad_values.emplace_back("1Bb");
-    bad_values.emplace_back("1%%");
-    bad_values.emplace_back("1.1");
-    bad_values.emplace_back("1pb");
-    bad_values.emplace_back("1eb");
-    bad_values.emplace_back("%");
+    std::vector<std::string> bad_values{{"1gib"}, {"1%b"}, {"1b%"}, {"gb"},  {"1GMb"}, {"1b1Mb"}, {"1kib"},
+                                        {"1Bb"},  {"1%%"}, {"1.1"}, {"1pb"}, {"1eb"},  {"%"}};
     for (const auto& value : bad_values) {
-        int64_t bytes = ParseUtil::parse_mem_spec(value, test_memory_limit);
-        ASSERT_EQ(-1, bytes);
+        ASSERT_ERROR(ParseUtil::parse_mem_spec(value, test_memory_limit));
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:

We plan to use `-1` to indicate no memory limit later. Therefore, we need to distinguish between a parsing error and the case of no limit. So, when `parse_mem_str` fails, it will return an error code instead of -1.

## What I'm doing:

Modify the semantics of parse_mem_str to distinguish between handlingparsing errors and special values.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
