### PR TITLE
[Enhancement] Add uuid support for the postgres jdbc catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
@@ -118,6 +118,9 @@ public class PostgresSchemaResolver extends JDBCSchemaResolver {
                 }
                 primitiveType = PrimitiveType.UNKNOWN_TYPE;
                 break;
+            case Types.BINARY:
+            case Types.VARBINARY:
+                return ScalarType.createVarbinary(ScalarType.CATALOG_MAX_VARCHAR_LENGTH);
             case Types.DATE:
                 primitiveType = PrimitiveType.DATE;
                 break;
@@ -130,7 +133,7 @@ public class PostgresSchemaResolver extends JDBCSchemaResolver {
         }
 
         if (typeName.equalsIgnoreCase("uuid")) {
-            return ScalarType.createVarcharType(36);
+            return ScalarType.createVarbinary(columnSize);
         }
 
         if (primitiveType != PrimitiveType.DECIMAL32) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
@@ -129,6 +129,10 @@ public class PostgresSchemaResolver extends JDBCSchemaResolver {
                 break;
         }
 
+        if (typeName.equalsIgnoreCase("uuid")) {
+            return ScalarType.createVarcharType(36);
+        }
+
         if (primitiveType != PrimitiveType.DECIMAL32) {
             return ScalarType.createType(primitiveType);
         } else {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/PostgresSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/PostgresSchemaResolverTest.java
@@ -56,7 +56,7 @@ public class PostgresSchemaResolverTest {
         tableResult.addColumn("TABLE_NAME", Arrays.asList("tbl1", "tbl2", "tbl3"));
         columnResult = new MockResultSet("columns");
         columnResult.addColumn("DATA_TYPE", Arrays.asList(Types.BIT, Types.INTEGER, Types.INTEGER, Types.REAL, Types.DOUBLE,
-                Types.NUMERIC, Types.CHAR, Types.VARCHAR, Types.VARCHAR, Types.DATE, Types.TIMESTAMP, Types.VARCHAR));
+                Types.NUMERIC, Types.CHAR, Types.VARCHAR, Types.VARCHAR, Types.DATE, Types.TIMESTAMP, Types.VARBINARY));
         columnResult.addColumn("TYPE_NAME", Arrays.asList("BOOL", "INTEGER", "SERIAL", "FLOAT4", "FLOAT8",
                 "NUMERIC", "CHAR", "VARCHAR", "TEXT", "DATE", "TIMESTAMP", "UUID"));
         columnResult.addColumn("COLUMN_SIZE", Arrays.asList(1, 10, 10, 8, 17, 10, 10, 10, 2147483647, 13, 29, 36));
@@ -172,7 +172,7 @@ public class PostgresSchemaResolverTest {
             Assert.assertNull(properties.get(JDBCTable.JDBC_TABLENAME));
             Assert.assertEquals(12, table.getColumns().size());
             Assert.assertTrue(table.getColumn("h").getType().isStringType());
-            Assert.assertTrue(table.getColumn("l").getType().isStringType());
+            Assert.assertTrue(table.getColumn("l").getType().isBinaryType());
         } catch (Exception e) {
             System.out.println(e.getMessage());
             Assert.fail();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/PostgresSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/PostgresSchemaResolverTest.java
@@ -56,13 +56,14 @@ public class PostgresSchemaResolverTest {
         tableResult.addColumn("TABLE_NAME", Arrays.asList("tbl1", "tbl2", "tbl3"));
         columnResult = new MockResultSet("columns");
         columnResult.addColumn("DATA_TYPE", Arrays.asList(Types.BIT, Types.INTEGER, Types.INTEGER, Types.REAL, Types.DOUBLE,
-                Types.NUMERIC, Types.CHAR, Types.VARCHAR, Types.VARCHAR, Types.DATE, Types.TIMESTAMP));
+                Types.NUMERIC, Types.CHAR, Types.VARCHAR, Types.VARCHAR, Types.DATE, Types.TIMESTAMP, Types.VARCHAR));
         columnResult.addColumn("TYPE_NAME", Arrays.asList("BOOL", "INTEGER", "SERIAL", "FLOAT4", "FLOAT8",
-                "NUMERIC", "CHAR", "VARCHAR", "TEXT", "DATE", "TIMESTAMP"));
-        columnResult.addColumn("COLUMN_SIZE", Arrays.asList(1, 10, 10, 8, 17, 10, 10, 10, 2147483647, 13, 29));
-        columnResult.addColumn("DECIMAL_DIGITS", Arrays.asList(0, 0, 0, 8, 17, 2, 0, 0, 0, 0, 6));
-        columnResult.addColumn("COLUMN_NAME", Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"));
-        columnResult.addColumn("IS_NULLABLE", Arrays.asList("YES", "NO", "NO", "NO", "NO", "NO", "NO", "YES", "NO", "NO", "NO"));
+                "NUMERIC", "CHAR", "VARCHAR", "TEXT", "DATE", "TIMESTAMP", "UUID"));
+        columnResult.addColumn("COLUMN_SIZE", Arrays.asList(1, 10, 10, 8, 17, 10, 10, 10, 2147483647, 13, 29, 36));
+        columnResult.addColumn("DECIMAL_DIGITS", Arrays.asList(0, 0, 0, 8, 17, 2, 0, 0, 0, 0, 6, 0));
+        columnResult.addColumn("COLUMN_NAME", Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"));
+        columnResult.addColumn("IS_NULLABLE", Arrays.asList("YES", "NO", "NO", "NO", "NO", "NO", "NO", "YES", "NO", "NO",
+                "NO", "NO"));
         properties = new HashMap<>();
         properties.put(JDBCResource.DRIVER_CLASS, "org.postgresql.Driver");
         properties.put(JDBCResource.URI, "jdbc:postgresql://127.0.0.1:5432/t1");
@@ -169,8 +170,9 @@ public class PostgresSchemaResolverTest {
             Assert.assertEquals("catalog.test.tbl1", table.getUUID());
             Assert.assertEquals("tbl1", table.getName());
             Assert.assertNull(properties.get(JDBCTable.JDBC_TABLENAME));
-            Assert.assertEquals(11, table.getColumns().size());
+            Assert.assertEquals(12, table.getColumns().size());
             Assert.assertTrue(table.getColumn("h").getType().isStringType());
+            Assert.assertTrue(table.getColumn("l").getType().isStringType());
         } catch (Exception e) {
             System.out.println(e.getMessage());
             Assert.fail();


### PR DESCRIPTION
## Why I'm doing:

I tried to use external catalog with the postgres database. I faced with errors when fetch uuid columns (unsupported type). This PR fix this issue (tested on the dev-environment).

## What I'm doing:

Fixes #58010

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
