### PR TITLE
[BugFix] revert flat json meta version update

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1456,6 +1456,9 @@ CONF_mBool(enable_compaction_flat_json, "true");
 // direct read flat json
 CONF_mBool(enable_lazy_dynamic_flat_json, "true");
 
+// enable flat json remain filter
+CONF_mBool(enable_json_flat_remain_filter, "true");
+
 // enable flat complex type (/array/object/hyper type), diables for save storage
 CONF_mBool(enable_json_flat_complex_type, "false");
 

--- a/be/src/serde/column_array_serde.cpp
+++ b/be/src/serde/column_array_serde.cpp
@@ -347,7 +347,7 @@ public:
     // uint32: number of datums
     // datums: [size1[payload1][size2][payload2]
     static uint8_t* serialize(const JsonColumn& column, uint8_t* buff) {
-        buff = write_little_endian_32(kJsonMetaRemainFilterVersion, buff);
+        buff = write_little_endian_32(kJsonMetaDefaultFormatVersion, buff);
         buff = write_little_endian_32(column.get_pool().size(), buff);
         for (const auto& obj : column.get_pool()) {
             constexpr uint64_t size_field_length = sizeof(uint64_t);

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -139,7 +139,7 @@ Status ColumnReader::_init(ColumnMetaPB* meta, const TabletColumn* column) {
         _is_flat_json = json_meta.is_flat();
         _has_remain = json_meta.has_remain();
 
-        if (json_meta.has_remain_filter() && json_meta.format_version() >= kJsonMetaRemainFilterVersion) {
+        if (json_meta.has_remain_filter() && config::enable_json_flat_remain_filter) {
             DCHECK(_has_remain);
             DCHECK(!json_meta.remain_filter().empty());
             RETURN_IF_ERROR(BloomFilter::create(BLOCK_BLOOM_FILTER, &_remain_filter));

--- a/be/src/storage/rowset/json_column_compactor.cpp
+++ b/be/src/storage/rowset/json_column_compactor.cpp
@@ -219,7 +219,7 @@ Status JsonColumnCompactor::append(const Column& column) {
 }
 
 Status JsonColumnCompactor::finish() {
-    _json_meta->mutable_json_meta()->set_format_version(kJsonMetaRemainFilterVersion);
+    _json_meta->mutable_json_meta()->set_format_version(kJsonMetaDefaultFormatVersion);
     _json_meta->mutable_json_meta()->set_has_remain(false);
     _json_meta->mutable_json_meta()->set_is_flat(false);
     return _json_writer->finish();

--- a/be/src/storage/rowset/json_column_writer.cpp
+++ b/be/src/storage/rowset/json_column_writer.cpp
@@ -55,7 +55,7 @@ FlatJsonColumnWriter::FlatJsonColumnWriter(const ColumnWriterOptions& opts, Type
           _flat_json_config(opts.flat_json_config) {}
 
 Status FlatJsonColumnWriter::init() {
-    _json_meta->mutable_json_meta()->set_format_version(kJsonMetaRemainFilterVersion);
+    _json_meta->mutable_json_meta()->set_format_version(kJsonMetaDefaultFormatVersion);
     _json_meta->mutable_json_meta()->set_has_remain(false);
     _json_meta->mutable_json_meta()->set_is_flat(false);
 
@@ -184,7 +184,7 @@ Status FlatJsonColumnWriter::_init_flat_writers() {
         }
 
         if (_flat_types[i] == LogicalType::TYPE_JSON) {
-            opts.meta->mutable_json_meta()->set_format_version(kJsonMetaRemainFilterVersion);
+            opts.meta->mutable_json_meta()->set_format_version(kJsonMetaDefaultFormatVersion);
             opts.meta->mutable_json_meta()->set_is_flat(false);
         }
 

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -93,7 +93,7 @@ void SegmentWriter::_init_column_meta(ColumnMetaPB* meta, uint32_t column_id, co
     // TODO(mofei) set the format_version from column
     if (column.type() == TYPE_JSON) {
         JsonMetaPB* json_meta = meta->mutable_json_meta();
-        json_meta->set_format_version(kJsonMetaRemainFilterVersion);
+        json_meta->set_format_version(kJsonMetaDefaultFormatVersion);
         json_meta->set_has_remain(false);
         json_meta->set_is_flat(false);
     }

--- a/be/src/types/constexpr.h
+++ b/be/src/types/constexpr.h
@@ -34,7 +34,6 @@ const static uint8_t DEFAULT_HLL_LOG_K = 17;
 // For JSON type
 constexpr int kJsonDefaultSize = 128;
 constexpr int kJsonMetaDefaultFormatVersion = 1;
-constexpr int kJsonMetaRemainFilterVersion = 2;
 
 constexpr __int128 MAX_INT128 = ~((__int128)0x01 << 127);
 constexpr __int128 MIN_INT128 = ((__int128)0x01 << 127);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
revert some code from: https://github.com/StarRocks/starrocks/pull/58178
the early version use `CHECK_EQ` to check json meta version, shit!

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
