### PR TITLE
[Enhancement] Optimize avro reader performance

### DIFF
--- a/be/src/formats/avro/cpp/avro_reader.h
+++ b/be/src/formats/avro/cpp/avro_reader.h
@@ -24,6 +24,7 @@
 namespace starrocks {
 
 struct ScannerCounter;
+class AdaptiveNullableColumn;
 class RandomAccessFile;
 class RuntimeState;
 class SlotDescriptor;
@@ -76,18 +77,24 @@ public:
     Status get_schema(std::vector<SlotDescriptor>* schema);
 
 private:
-    Status read_row(ChunkPtr& chunk, const avro::GenericRecord& record);
+    Status read_row(const avro::GenericRecord& record, const std::vector<AdaptiveNullableColumn*>& column_raw_ptrs);
 
     std::unique_ptr<avro::DataFileReader<avro::GenericDatum>> _file_reader = nullptr;
+    bool _is_inited = false;
 
-    // only used in read data
-    std::unique_ptr<avro::GenericDatum> _datum = nullptr;
+    // all belows are only used in read data
     std::string _filename = "";
-    RuntimeState* _state = nullptr;
-    ScannerCounter* _counter = nullptr;
     const std::vector<SlotDescriptor*>* _slot_descs = nullptr;
     const std::vector<avrocpp::ColumnReaderUniquePtr>* _column_readers = nullptr;
+    size_t _num_of_columns_from_file = 0;
     bool _col_not_found_as_null = false;
+
+    // reuse generic datum and field indexes for better performance
+    std::unique_ptr<avro::GenericDatum> _datum = nullptr;
+    std::vector<int64_t> _field_indexes;
+
+    RuntimeState* _state = nullptr;
+    ScannerCounter* _counter = nullptr;
 };
 
 using AvroReaderUniquePtr = std::unique_ptr<AvroReader>;

--- a/be/test/exec/avro_cpp_scanner_test.cpp
+++ b/be/test/exec/avro_cpp_scanner_test.cpp
@@ -43,7 +43,7 @@ public:
         auto avro_reader = std::make_unique<AvroReader>();
         CHECK_OK(avro_reader->init(std::make_unique<AvroBufferInputStream>(
                                            std::move(file_or.value()), config::avro_reader_buffer_size_bytes, _counter),
-                                   filename, _state.get(), _counter, nullptr, nullptr, true));
+                                   filename, _state.get(), _counter, nullptr, &_column_readers, true));
         return avro_reader;
     }
 
@@ -131,6 +131,7 @@ private:
     RuntimeProfile* _profile;
     std::shared_ptr<RuntimeState> _state;
     cctz::time_zone _timezone;
+    std::vector<avrocpp::ColumnReaderUniquePtr> _column_readers;
 };
 
 TEST_F(AvroCppScannerTest, test_read_primitive_types) {

--- a/be/test/formats/avro/cpp/avro_reader_test.cpp
+++ b/be/test/formats/avro/cpp/avro_reader_test.cpp
@@ -57,15 +57,13 @@ public:
         }
     }
 
-    std::vector<avrocpp::ColumnReaderUniquePtr> create_column_readers(const std::vector<SlotDescriptor*>& slot_descs,
-                                                                      const cctz::time_zone& timezone,
-                                                                      bool invalid_as_null) {
-        std::vector<avrocpp::ColumnReaderUniquePtr> column_readers;
+    void create_column_readers(const std::vector<SlotDescriptor*>& slot_descs, const cctz::time_zone& timezone,
+                               bool invalid_as_null) {
+        _column_readers.clear();
         for (auto* slot_desc : slot_descs) {
-            column_readers.emplace_back(avrocpp::ColumnReader::get_nullable_column_reader(
+            _column_readers.emplace_back(avrocpp::ColumnReader::get_nullable_column_reader(
                     slot_desc->col_name(), slot_desc->type(), timezone, invalid_as_null));
         }
-        return column_readers;
     }
 
     AvroReaderUniquePtr create_avro_reader(const std::string& filename) {
@@ -75,7 +73,7 @@ public:
         auto avro_reader = std::make_unique<AvroReader>();
         CHECK_OK(avro_reader->init(std::make_unique<AvroBufferInputStream>(
                                            std::move(file_or.value()), config::avro_reader_buffer_size_bytes, _counter),
-                                   filename, _state.get(), _counter, nullptr, nullptr, true));
+                                   filename, _state.get(), _counter, nullptr, &_column_readers, true));
         return avro_reader;
     }
 
@@ -96,6 +94,7 @@ private:
     ScannerCounter* _counter;
     std::shared_ptr<RuntimeState> _state;
     cctz::time_zone _timezone;
+    std::vector<avrocpp::ColumnReaderUniquePtr> _column_readers;
 };
 
 TEST_F(AvroReaderTest, test_get_schema_primitive_types) {
@@ -217,11 +216,10 @@ TEST_F(AvroReaderTest, test_get_schema_logical_types) {
 TEST_F(AvroReaderTest, test_read_primitive_types) {
     std::string filename = "primitive.avro";
     std::vector<SlotDescriptor*> slot_descs;
-    std::vector<avrocpp::ColumnReaderUniquePtr> column_readers;
     bool column_not_found_as_null = false;
     int rows_to_read = 2;
 
-    // init reader for read
+    // init reader for read schema
     auto reader = create_avro_reader(filename);
 
     std::vector<SlotDescriptor> tmp_slot_descs;
@@ -231,8 +229,12 @@ TEST_F(AvroReaderTest, test_read_primitive_types) {
         slot_descs.emplace_back(&slot_desc);
     }
 
-    column_readers = create_column_readers(slot_descs, _timezone, false);
-    reader->TEST_init(&slot_descs, &column_readers, column_not_found_as_null);
+    // create column readers
+    create_column_readers(slot_descs, _timezone, false);
+
+    // init reader for read data
+    // some fields such as _field_indexes does not inited normally, so init reader again.
+    reader->TEST_init(&slot_descs, &_column_readers, column_not_found_as_null);
 
     // create chunk
     auto chunk = create_src_chunk(slot_descs);
@@ -251,11 +253,10 @@ TEST_F(AvroReaderTest, test_read_primitive_types) {
 TEST_F(AvroReaderTest, test_read_complex_types) {
     std::string filename = "complex.avro";
     std::vector<SlotDescriptor*> slot_descs;
-    std::vector<avrocpp::ColumnReaderUniquePtr> column_readers;
     bool column_not_found_as_null = false;
     int rows_to_read = 2;
 
-    // init reader for read
+    // init reader for read schema
     auto reader = create_avro_reader(filename);
 
     std::vector<SlotDescriptor> tmp_slot_descs;
@@ -265,8 +266,12 @@ TEST_F(AvroReaderTest, test_read_complex_types) {
         slot_descs.emplace_back(&slot_desc);
     }
 
-    column_readers = create_column_readers(slot_descs, _timezone, false);
-    reader->TEST_init(&slot_descs, &column_readers, column_not_found_as_null);
+    // create column readers
+    create_column_readers(slot_descs, _timezone, false);
+
+    // init reader for read data
+    // some fields such as _field_indexes does not inited normally, so init reader again.
+    reader->TEST_init(&slot_descs, &_column_readers, column_not_found_as_null);
 
     // create chunk
     auto chunk = create_src_chunk(slot_descs);
@@ -286,11 +291,10 @@ TEST_F(AvroReaderTest, test_read_complex_types) {
 TEST_F(AvroReaderTest, test_read_complex_types_as_varchar) {
     std::string filename = "complex.avro";
     std::vector<SlotDescriptor*> slot_descs;
-    std::vector<avrocpp::ColumnReaderUniquePtr> column_readers;
     bool column_not_found_as_null = false;
     int rows_to_read = 2;
 
-    // init reader for read
+    // init reader for read schema
     auto reader = create_avro_reader(filename);
 
     std::vector<SlotDescriptor> tmp_slot_descs;
@@ -303,8 +307,12 @@ TEST_F(AvroReaderTest, test_read_complex_types_as_varchar) {
                                    TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH))));
     }
 
-    column_readers = create_column_readers(slot_descs, _timezone, false);
-    reader->TEST_init(&slot_descs, &column_readers, column_not_found_as_null);
+    // create column readers
+    create_column_readers(slot_descs, _timezone, false);
+
+    // init reader for read data
+    // some fields such as _field_indexes does not inited normally, so init reader again.
+    reader->TEST_init(&slot_descs, &_column_readers, column_not_found_as_null);
 
     // create chunk
     auto chunk = create_src_chunk(slot_descs);
@@ -326,11 +334,10 @@ TEST_F(AvroReaderTest, test_read_complex_types_as_varchar) {
 TEST_F(AvroReaderTest, test_read_complex_nest_types) {
     std::string filename = "complex_nest.avro";
     std::vector<SlotDescriptor*> slot_descs;
-    std::vector<avrocpp::ColumnReaderUniquePtr> column_readers;
     bool column_not_found_as_null = false;
     int rows_to_read = 2;
 
-    // init reader for read
+    // init reader for read schema
     auto reader = create_avro_reader(filename);
 
     std::vector<SlotDescriptor> tmp_slot_descs;
@@ -340,8 +347,12 @@ TEST_F(AvroReaderTest, test_read_complex_nest_types) {
         slot_descs.emplace_back(&slot_desc);
     }
 
-    column_readers = create_column_readers(slot_descs, _timezone, false);
-    reader->TEST_init(&slot_descs, &column_readers, column_not_found_as_null);
+    // create column readers
+    create_column_readers(slot_descs, _timezone, false);
+
+    // init reader for read data
+    // some fields such as _field_indexes does not inited normally, so init reader again.
+    reader->TEST_init(&slot_descs, &_column_readers, column_not_found_as_null);
 
     // create chunk
     auto chunk = create_src_chunk(slot_descs);
@@ -365,11 +376,10 @@ TEST_F(AvroReaderTest, test_read_complex_nest_types) {
 TEST_F(AvroReaderTest, test_read_logical_types) {
     std::string filename = "logical.avro";
     std::vector<SlotDescriptor*> slot_descs;
-    std::vector<avrocpp::ColumnReaderUniquePtr> column_readers;
     bool column_not_found_as_null = false;
     int rows_to_read = 2;
 
-    // init reader for read
+    // init reader for read schema
     auto reader = create_avro_reader(filename);
 
     std::vector<SlotDescriptor> tmp_slot_descs;
@@ -380,8 +390,12 @@ TEST_F(AvroReaderTest, test_read_logical_types) {
         slot_descs.emplace_back(&tmp_slot_descs[i]);
     }
 
-    column_readers = create_column_readers(slot_descs, _timezone, false);
-    reader->TEST_init(&slot_descs, &column_readers, column_not_found_as_null);
+    // create column readers
+    create_column_readers(slot_descs, _timezone, false);
+
+    // init reader for read data
+    // some fields such as _field_indexes does not inited normally, so init reader again.
+    reader->TEST_init(&slot_descs, &_column_readers, column_not_found_as_null);
 
     // create chunk
     auto chunk = create_src_chunk(slot_descs);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
1. generate field indexes when init reader. (`record.hasField(name)` and `record.field(name)` cost too much time)
2. reuse `GenericDatum` in reader.
3. generate column raw ptrs when read chunk start.

```
ssb lineorder 6001215 lines

SQL1: select count(lo_orderkey) from files("path" = "hdfs://hdfs/lineorder.avro", "format" = "avro");
4.62s -> 2.18s

SQL2: insert into blackhole() select * from files("path" = "hdfs://hdfs/lineorder.avro", "format" = "avro");
11.6s -> 5.36s
```

Fixes #58157 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
