### PR TITLE
[Feature]  Support more intelligent/adaptive MV Refresh phrase1

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -136,6 +136,10 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER)) {
             partitionRefreshNumber = PropertyAnalyzer.analyzePartitionRefreshNumber(properties);
         }
+        String partitionRefreshMode = null;
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_MODE)) {
+            partitionRefreshMode = PropertyAnalyzer.analyzePartitionRefreshMode(properties);
+        }
         String resourceGroup = null;
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_RESOURCE_GROUP)) {
             resourceGroup = PropertyAnalyzer.analyzeResourceGroup(properties);
@@ -275,6 +279,11 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
                 materializedView.getTableProperty().getPartitionRefreshNumber() != partitionRefreshNumber) {
             curProp.put(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER, String.valueOf(partitionRefreshNumber));
             materializedView.getTableProperty().setPartitionRefreshNumber(partitionRefreshNumber);
+            isChanged = true;
+        } else if (propClone.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_MODE) &&
+                !materializedView.getTableProperty().getPartitionRefreshMode().equals(partitionRefreshMode)) {
+            curProp.put(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_MODE, String.valueOf(partitionRefreshMode));
+            materializedView.getTableProperty().setPartitionRefreshMode(partitionRefreshMode);
             isChanged = true;
         } else if (propClone.containsKey(PropertyAnalyzer.PROPERTIES_AUTO_REFRESH_PARTITIONS_LIMIT) &&
                 materializedView.getTableProperty().getAutoRefreshPartitionsLimit() != autoRefreshPartitionsLimit) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -136,9 +136,9 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER)) {
             partitionRefreshNumber = PropertyAnalyzer.analyzePartitionRefreshNumber(properties);
         }
-        String partitionRefreshMode = null;
-        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_MODE)) {
-            partitionRefreshMode = PropertyAnalyzer.analyzePartitionRefreshMode(properties);
+        String partitionRefreshStrategy = null;
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_STRATEGY)) {
+            partitionRefreshStrategy = PropertyAnalyzer.analyzePartitionRefreshStrategy(properties);
         }
         String resourceGroup = null;
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_RESOURCE_GROUP)) {
@@ -280,10 +280,10 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
             curProp.put(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER, String.valueOf(partitionRefreshNumber));
             materializedView.getTableProperty().setPartitionRefreshNumber(partitionRefreshNumber);
             isChanged = true;
-        } else if (propClone.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_MODE) &&
-                !materializedView.getTableProperty().getPartitionRefreshMode().equals(partitionRefreshMode)) {
-            curProp.put(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_MODE, String.valueOf(partitionRefreshMode));
-            materializedView.getTableProperty().setPartitionRefreshMode(partitionRefreshMode);
+        } else if (propClone.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_STRATEGY) &&
+                !materializedView.getTableProperty().getPartitionRefreshStrategy().equals(partitionRefreshStrategy)) {
+            curProp.put(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_STRATEGY, String.valueOf(partitionRefreshStrategy));
+            materializedView.getTableProperty().setPartitionRefreshStrategy(partitionRefreshStrategy);
             isChanged = true;
         } else if (propClone.containsKey(PropertyAnalyzer.PROPERTIES_AUTO_REFRESH_PARTITIONS_LIMIT) &&
                 materializedView.getTableProperty().getAutoRefreshPartitionsLimit() != autoRefreshPartitionsLimit) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -147,6 +147,11 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         DEFERRED
     }
 
+    public enum PartitionRefreshMode {
+        DEFAULT,
+        SMART
+    }
+
     @Override
     public boolean getUseFastSchemaEvolution() {
         return false;
@@ -1518,6 +1523,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                 .add(PropertyAnalyzer.PROPERTIES_AUTO_REFRESH_PARTITIONS_LIMIT)
                 .add(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER)
                 .add(PropertyAnalyzer.PROPERTIES_EXCLUDED_TRIGGER_TABLES)
+                .add(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_MODE)
                 .build();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -147,8 +147,21 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         DEFERRED
     }
 
+    /**
+     * Strategy for selecting candidate partitions to refresh during materialized view refresh.
+     */
     public enum PartitionRefreshStrategy {
+        /**
+         * STRICT: Traditional strategy.
+         * Selects a fixed number of candidate partitions based on partition_refresh_number.
+         */
         STRICT,
+
+        /**
+         * ADAPTIVE: Adaptive strategy.
+         * Selects candidate partitions based on thresholds mv_max_rows_per_refresh and mv_max_bytes_per_refresh.
+         * Stops selecting more partitions once either threshold is reached.
+         */
         ADAPTIVE
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -147,9 +147,9 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         DEFERRED
     }
 
-    public enum PartitionRefreshMode {
-        DEFAULT,
-        SMART
+    public enum PartitionRefreshStrategy {
+        STRICT,
+        ADAPTIVE
     }
 
     @Override
@@ -1523,7 +1523,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                 .add(PropertyAnalyzer.PROPERTIES_AUTO_REFRESH_PARTITIONS_LIMIT)
                 .add(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER)
                 .add(PropertyAnalyzer.PROPERTIES_EXCLUDED_TRIGGER_TABLES)
-                .add(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_MODE)
+                .add(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_STRATEGY)
                 .build();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -210,6 +210,10 @@ public class TableProperty implements Writable, GsonPostProcessable {
     private int partitionRefreshNumber = Config.default_mv_partition_refresh_number;
 
     // This property only applies to materialized views
+    // It represents the mode selected to determine the number of partitions to refresh
+    private String partitionRefreshMode = Config.default_mv_partition_refresh_mode;
+
+    // This property only applies to materialized views
     // When using the system to automatically refresh, the maximum range of the most recent partitions will be refreshed.
     // By default, all partitions will be refreshed.
     private int autoRefreshPartitionsLimit = INVALID;
@@ -419,6 +423,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
     public TableProperty buildMvProperties() {
         buildPartitionTTL();
         buildPartitionRefreshNumber();
+        buildMVPartitionRefreshMode();
         buildAutoRefreshPartitionsLimit();
         buildExcludedTriggerTables();
         buildResourceGroup();
@@ -528,6 +533,12 @@ public class TableProperty implements Writable, GsonPostProcessable {
         partitionRefreshNumber =
                 Integer.parseInt(properties.getOrDefault(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER,
                         String.valueOf(INVALID)));
+        return this;
+    }
+
+    public TableProperty buildMVPartitionRefreshMode() {
+        partitionRefreshMode = properties.getOrDefault(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_MODE,
+                Config.default_mv_partition_refresh_mode);
         return this;
     }
 
@@ -918,8 +929,16 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return partitionRefreshNumber;
     }
 
+    public String getPartitionRefreshMode() {
+        return partitionRefreshMode;
+    }
+
     public void setPartitionRefreshNumber(int partitionRefreshNumber) {
         this.partitionRefreshNumber = partitionRefreshNumber;
+    }
+
+    public void setPartitionRefreshMode(String partitionRefreshMode) {
+        this.partitionRefreshMode = partitionRefreshMode;
     }
 
     public void setResourceGroup(String resourceGroup) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -211,7 +211,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
 
     // This property only applies to materialized views
     // It represents the mode selected to determine the number of partitions to refresh
-    private String partitionRefreshMode = Config.default_mv_partition_refresh_mode;
+    private String partitionRefreshStrategy = Config.default_mv_partition_refresh_strategy;
 
     // This property only applies to materialized views
     // When using the system to automatically refresh, the maximum range of the most recent partitions will be refreshed.
@@ -423,7 +423,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
     public TableProperty buildMvProperties() {
         buildPartitionTTL();
         buildPartitionRefreshNumber();
-        buildMVPartitionRefreshMode();
+        buildMVPartitionRefreshStrategy();
         buildAutoRefreshPartitionsLimit();
         buildExcludedTriggerTables();
         buildResourceGroup();
@@ -536,9 +536,9 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return this;
     }
 
-    public TableProperty buildMVPartitionRefreshMode() {
-        partitionRefreshMode = properties.getOrDefault(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_MODE,
-                Config.default_mv_partition_refresh_mode);
+    public TableProperty buildMVPartitionRefreshStrategy() {
+        partitionRefreshStrategy = properties.getOrDefault(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_STRATEGY,
+                Config.default_mv_partition_refresh_strategy);
         return this;
     }
 
@@ -929,16 +929,16 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return partitionRefreshNumber;
     }
 
-    public String getPartitionRefreshMode() {
-        return partitionRefreshMode;
+    public String getPartitionRefreshStrategy() {
+        return partitionRefreshStrategy;
     }
 
     public void setPartitionRefreshNumber(int partitionRefreshNumber) {
         this.partitionRefreshNumber = partitionRefreshNumber;
     }
 
-    public void setPartitionRefreshMode(String partitionRefreshMode) {
-        this.partitionRefreshMode = partitionRefreshMode;
+    public void setPartitionRefreshStrategy(String partitionRefreshStrategy) {
+        this.partitionRefreshStrategy = partitionRefreshStrategy;
     }
 
     public void setResourceGroup(String resourceGroup) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3252,6 +3252,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "The default try lock timeout for mv refresh to try base table/mv dbs' lock")
     public static int mv_refresh_try_lock_timeout_ms = 30 * 1000;
 
+    @ConfField(mutable = true, comment = "materialized view can refresh at most 10 partition at a time")
+    public static int mv_max_partitions_num_per_refresh = 10;
+
     @ConfField(mutable = true, comment = "materialized view can refresh at most 100_000_000 rows of data at a time")
     public static long mv_max_rows_per_refresh = 100_000_000L;
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3252,6 +3252,12 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "The default try lock timeout for mv refresh to try base table/mv dbs' lock")
     public static int mv_refresh_try_lock_timeout_ms = 30 * 1000;
 
+    @ConfField(mutable = true, comment = "materialized view can refresh at most 100_000_000 rows of data at a time")
+    public static long mv_max_rows_per_refresh = 100_000_000L;
+
+    @ConfField(mutable = true, comment = "materialized view can refresh at most 20GB of data at a time")
+    public static long mv_max_bytes_per_refresh = 21474836480L;
+
     @ConfField(mutable = true, comment = "Whether enable to refresh materialized view in sync mode mergeable or not")
     public static boolean enable_mv_refresh_sync_refresh_mergeable = false;
 
@@ -3274,6 +3280,9 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static int default_mv_partition_refresh_number = 1;
+
+    @ConfField(mutable = true)
+    public static String default_mv_partition_refresh_mode = "default";
 
     @ConfField(mutable = true, comment = "Check the schema of materialized view's base table strictly or not")
     public static boolean enable_active_materialized_view_schema_strict_check = true;

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3282,7 +3282,7 @@ public class Config extends ConfigBase {
     public static int default_mv_partition_refresh_number = 1;
 
     @ConfField(mutable = true)
-    public static String default_mv_partition_refresh_mode = "default";
+    public static String default_mv_partition_refresh_strategy = "strict";
 
     @ConfField(mutable = true, comment = "Check the schema of materialized view's base table strictly or not")
     public static boolean enable_active_materialized_view_schema_strict_check = true;

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -207,7 +207,7 @@ public class PropertyAnalyzer {
     public static final String PROPERTIES_TIME_DRIFT_CONSTRAINT = "time_drift_constraint";
 
     public static final String PROPERTIES_AUTO_REFRESH_PARTITIONS_LIMIT = "auto_refresh_partitions_limit";
-    public static final String PROPERTIES_PARTITION_REFRESH_MODE = "partition_refresh_mode";
+    public static final String PROPERTIES_PARTITION_REFRESH_STRATEGY = "partition_refresh_strategy";
     public static final String PROPERTIES_PARTITION_REFRESH_NUMBER = "partition_refresh_number";
     public static final String PROPERTIES_EXCLUDED_TRIGGER_TABLES = "excluded_trigger_tables";
     public static final String PROPERTIES_EXCLUDED_REFRESH_TABLES = "excluded_refresh_tables";
@@ -652,19 +652,19 @@ public class PropertyAnalyzer {
         return partitionRefreshNumber;
     }
 
-    public static String analyzePartitionRefreshMode(Map<String, String> properties) {
-        String partitionRefreshMode = null;
-        if (properties != null && properties.containsKey(PROPERTIES_PARTITION_REFRESH_MODE)) {
-            partitionRefreshMode = properties.get(PROPERTIES_PARTITION_REFRESH_MODE);
+    public static String analyzePartitionRefreshStrategy(Map<String, String> properties) {
+        String partitionRefreshStrategy = null;
+        if (properties != null && properties.containsKey(PROPERTIES_PARTITION_REFRESH_STRATEGY)) {
+            partitionRefreshStrategy = properties.get(PROPERTIES_PARTITION_REFRESH_STRATEGY);
             try {
-                MaterializedView.PartitionRefreshMode.valueOf(partitionRefreshMode.toUpperCase());
+                MaterializedView.PartitionRefreshStrategy.valueOf(partitionRefreshStrategy.toUpperCase());
             } catch (IllegalArgumentException e) {
-                throw new IllegalArgumentException("Invalid partition_refresh_mode: " + partitionRefreshMode +
-                        ". Only 'default' or 'smart' are supported.");
+                throw new IllegalArgumentException("Invalid partition_refresh_strategy: " + partitionRefreshStrategy +
+                        ". Only 'strict' or 'adaptive' are supported.");
             }
-            properties.remove(PROPERTIES_PARTITION_REFRESH_MODE);
+            properties.remove(PROPERTIES_PARTITION_REFRESH_STRATEGY);
         }
-        return partitionRefreshMode;
+        return partitionRefreshStrategy;
     }
 
     public static List<TableName> analyzeExcludedTables(Map<String, String> properties,
@@ -1666,14 +1666,14 @@ public class PropertyAnalyzer {
                             + " does not support non-partitioned materialized view.");
                 }
             }
-            // partition refresh mode
-            if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_MODE)) {
-                String mode = PropertyAnalyzer.analyzePartitionRefreshMode(properties);
+            // partition refresh strategy
+            if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_STRATEGY)) {
+                String strategy = PropertyAnalyzer.analyzePartitionRefreshStrategy(properties);
                 materializedView.getTableProperty().getProperties()
-                        .put(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_MODE, mode);
-                materializedView.getTableProperty().setPartitionRefreshMode(mode);
+                        .put(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_STRATEGY, strategy);
+                materializedView.getTableProperty().setPartitionRefreshStrategy(strategy);
                 if (isNonPartitioned) {
-                    throw new AnalysisException(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_MODE
+                    throw new AnalysisException(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_STRATEGY
                             + " does not support non-partitioned materialized view.");
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -30,6 +30,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MaterializedView.PartitionRefreshMode;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
@@ -300,10 +301,29 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 logger.info("no partitions to refresh for materialized view");
                 return mvToRefreshedPartitions;
             }
+            // TODO(Hongkun Xu) Because non-OLAP tables cannot directly obtain partition information, currently SMART mode does
+            //  not support base tables that contain external tables. However, support for this scenario will be added in the future.
+            boolean hasExternalTable = mv.getBaseTableTypes().stream().anyMatch(type -> type != Table.TableType.OLAP);
+            if (hasExternalTable) {
+                logger.warn("materialized view {} has external table. so choose default refresh mode", mv.getId());
+                filterPartitionByRefreshNumber(mvToRefreshedPartitions, mvPotentialPartitionNames, mv,
+                        tentative);
+            } else {
+                PartitionRefreshMode partitionRefreshMode =
+                        PartitionRefreshMode.valueOf(mv.getTableProperty().getPartitionRefreshMode().trim().toUpperCase());
+                switch (partitionRefreshMode) {
+                    case SMART:
+                        filterPartitionByAdaptiveRefreshNumber(mvToRefreshedPartitions, mvPotentialPartitionNames, mv,
+                                tentative);
+                        break;
+                    case DEFAULT:
+                    default:
+                        // Only refresh the first partition refresh number partitions, other partitions will generate new tasks
+                        filterPartitionByRefreshNumber(mvToRefreshedPartitions, mvPotentialPartitionNames, mv,
+                                tentative);
+                }
+            }
 
-            // Only refresh the first partition refresh number partitions, other partitions will generate new tasks
-            filterPartitionByRefreshNumber(mvToRefreshedPartitions, mvPotentialPartitionNames, mv,
-                    tentative);
             int partitionRefreshNumber = mv.getTableProperty().getPartitionRefreshNumber();
             logger.info("filter partitions to refresh partitionRefreshNumber={}, partitionsToRefresh:{}, " +
                             "mvPotentialPartitionNames:{}, next start:{}, next end:{}, next list values:{}",
@@ -663,6 +683,30 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
         // do filter actions
         mvRefreshPartitioner.filterPartitionByRefreshNumber(partitionsToRefresh, mvPotentialPartitionNames, tentative);
+    }
+
+    @VisibleForTesting
+    public void filterPartitionByAdaptiveRefreshNumber(Set<String> partitionsToRefresh,
+                                                       Set<String> mvPotentialPartitionNames,
+                                                       MaterializedView mv) {
+        filterPartitionByAdaptiveRefreshNumber(partitionsToRefresh, mvPotentialPartitionNames, mv, false);
+    }
+
+    public void filterPartitionByAdaptiveRefreshNumber(Set<String> partitionsToRefresh,
+                                                       Set<String> mvPotentialPartitionNames,
+                                                       MaterializedView mv,
+                                                       boolean tentative) {
+        // refresh all partition when it's a sync refresh, otherwise updated partitions may be lost.
+        if (mvContext.executeOption != null && mvContext.executeOption.getIsSync()) {
+            return;
+        }
+        // ignore if mv is not partitioned.
+        if (!mv.isPartitionedTable()) {
+            return;
+        }
+
+        // do filter actions
+        mvRefreshPartitioner.filterPartitionByAdaptiveRefreshNumber(partitionsToRefresh, mvPotentialPartitionNames, tentative);
     }
 
     private void generateNextTaskRun() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -30,7 +30,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.MaterializedView;
-import com.starrocks.catalog.MaterializedView.PartitionRefreshMode;
+import com.starrocks.catalog.MaterializedView.PartitionRefreshStrategy;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
@@ -305,18 +305,18 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             //  not support base tables that contain external tables. However, support for this scenario will be added in the future.
             boolean hasExternalTable = mv.getBaseTableTypes().stream().anyMatch(type -> type != Table.TableType.OLAP);
             if (hasExternalTable) {
-                logger.warn("materialized view {} has external table. so choose default refresh mode", mv.getId());
+                logger.warn("materialized view {} has external table. so choose default refresh strategy", mv.getId());
                 filterPartitionByRefreshNumber(mvToRefreshedPartitions, mvPotentialPartitionNames, mv,
                         tentative);
             } else {
-                PartitionRefreshMode partitionRefreshMode =
-                        PartitionRefreshMode.valueOf(mv.getTableProperty().getPartitionRefreshMode().trim().toUpperCase());
-                switch (partitionRefreshMode) {
-                    case SMART:
+                PartitionRefreshStrategy partitionRefreshStrategy = PartitionRefreshStrategy.valueOf(
+                        mv.getTableProperty().getPartitionRefreshStrategy().trim().toUpperCase());
+                switch (partitionRefreshStrategy) {
+                    case ADAPTIVE:
                         filterPartitionByAdaptiveRefreshNumber(mvToRefreshedPartitions, mvPotentialPartitionNames, mv,
                                 tentative);
                         break;
-                    case DEFAULT:
+                    case STRICT:
                     default:
                         // Only refresh the first partition refresh number partitions, other partitions will generate new tasks
                         filterPartitionByRefreshNumber(mvToRefreshedPartitions, mvPotentialPartitionNames, mv,

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
@@ -487,6 +487,89 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
         }
     }
 
+    public void filterPartitionByAdaptiveRefreshNumber(Set<String> mvPartitionsToRefresh,
+                                                       Set<String> mvPotentialPartitionNames,
+                                                       boolean tentative) {
+        Map<String, PCell> partitionToCells = Maps.newHashMap();
+        Map<String, PListCell> listPartitionMap = mv.getListPartitionItems();
+        for (String partitionName : mvPartitionsToRefresh) {
+            PListCell listCell = listPartitionMap.get(partitionName);
+            if (listCell == null) {
+                logger.warn("Partition {} is not found in materialized view {}", partitionName, mv.getName());
+                continue;
+            }
+            partitionToCells.put(partitionName, listCell);
+        }
+
+        // filter by partition ttl
+        filterPartitionsByTTL(partitionToCells, false);
+        if (CollectionUtils.sizeIsEmpty(partitionToCells)) {
+            return;
+        }
+        Map<String, PListCell> toRefreshPartitions = partitionToCells.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> (PListCell) e.getValue()));
+
+        Map<String, Map<Table, Set<String>>> mvToBaseNameRefs = mvContext.getMvRefBaseTableIntersectedPartitions();
+
+        // TODO: Sort by List Partition's value is weird because there maybe meaningless or un-sortable,
+        // users should take care of `partition_ttl_number` for list partition.
+        LinkedHashMap<String, PListCell> sortedPartition = toRefreshPartitions.entrySet().stream()
+                .sorted((e1, e2) -> e2.getValue().compareTo(e1.getValue())) // reverse order(max heap)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
+        Iterator<String> toSelectedPartitionNameIter = sortedPartition.keySet().iterator();
+
+        // dynamically obtain the number of partitions to be refreshed this time
+        int adaptivePartitionRefreshNumber = getAdaptivePartitionRefreshNumber(toSelectedPartitionNameIter);
+        Iterator<Map.Entry<String, PListCell>> iter = sortedPartition.entrySet().iterator();
+        // iterate adaptivePartitionRefreshNumber times
+        for (int i = 0; i < adaptivePartitionRefreshNumber; i++) {
+            if (iter.hasNext()) {
+                iter.next();
+            }
+        }
+
+        // compute next partition list cells in the next task run
+        Set<PListCell> nextPartitionValues = Sets.newHashSet();
+        while (iter.hasNext()) {
+            Map.Entry<String, PListCell> entry = iter.next();
+            nextPartitionValues.add(entry.getValue());
+            // remove the partition which is not reserved
+            toRefreshPartitions.remove(entry.getKey());
+        }
+        logger.info("Filter partitions by adaptive_partition_number, ttl_number:{}, result:{}, remains:{}",
+                adaptivePartitionRefreshNumber, toRefreshPartitions, nextPartitionValues);
+        // do filter input mvPartitionsToRefresh since it's a reference
+        mvPartitionsToRefresh.retainAll(toRefreshPartitions.keySet());
+        if (CollectionUtils.isEmpty(nextPartitionValues)) {
+            return;
+        }
+        if (!tentative) {
+            // partitionNameIter has just been traversed, and endPartitionName is not updated
+            // will cause endPartitionName == null
+            mvContext.setNextPartitionValues(PListCell.batchSerialize(nextPartitionValues));
+        }
+    }
+
+    private int getAdaptivePartitionRefreshNumber(Iterator<String> partitionNameIter) {
+
+        Map<String, Map<Table, Set<String>>> mvToBaseNameRefs = mvContext.getMvRefBaseTableIntersectedPartitions();
+        MVRefreshPartitionSelector mvRefreshPartitionSelector =
+                new MVRefreshPartitionSelector(Config.mv_max_rows_per_refresh, Config.mv_max_bytes_per_refresh);
+
+        int adaptiveRefreshNumber = 0;
+        while (partitionNameIter.hasNext()) {
+            String partitionName = partitionNameIter.next();
+            Map<Table, Set<String>> refPartitionInfos = mvToBaseNameRefs.get(partitionName);
+            if (mvRefreshPartitionSelector.canAddPartition(refPartitionInfos)) {
+                mvRefreshPartitionSelector.addPartition(refPartitionInfos);
+                adaptiveRefreshNumber++;
+            } else {
+                break;
+            }
+        }
+        return adaptiveRefreshNumber;
+    }
+
     private void addListPartitions(Database database, MaterializedView materializedView,
                                    Map<String, PCell> adds, Map<String, String> partitionProperties,
                                    DistributionDesc distributionDesc) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
@@ -554,7 +554,8 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
 
         Map<String, Map<Table, Set<String>>> mvToBaseNameRefs = mvContext.getMvRefBaseTableIntersectedPartitions();
         MVRefreshPartitionSelector mvRefreshPartitionSelector =
-                new MVRefreshPartitionSelector(Config.mv_max_rows_per_refresh, Config.mv_max_bytes_per_refresh);
+                new MVRefreshPartitionSelector(Config.mv_max_rows_per_refresh, Config.mv_max_bytes_per_refresh,
+                        Config.mv_max_partitions_num_per_refresh);
 
         int adaptiveRefreshNumber = 0;
         while (partitionNameIter.hasNext()) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitioner.java
@@ -87,4 +87,10 @@ public final class MVPCTRefreshNonPartitioner extends MVPCTRefreshPartitioner {
                                                Set<String> mvPotentialPartitionNames, boolean tentative) {
         // do nothing
     }
+
+    @Override
+    public void filterPartitionByAdaptiveRefreshNumber(Set<String> mvPartitionsToRefresh,
+                                                       Set<String> mvPotentialPartitionNames, boolean tentative) {
+        // do nothing
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
@@ -144,6 +144,10 @@ public abstract class MVPCTRefreshPartitioner {
                                                         Set<String> mvPotentialPartitionNames,
                                                         boolean tentative);
 
+    public abstract void filterPartitionByAdaptiveRefreshNumber(Set<String> mvPartitionsToRefresh,
+                                                        Set<String> mvPotentialPartitionNames,
+                                                        boolean tentative);
+
     /**
      * Check whether the base table is supported partition refresh or not.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
@@ -457,6 +457,54 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
         setNextPartitionStartAndEnd(mvPartitionsToRefresh, mappedPartitionsToRefresh, partitionNameIter, tentative);
     }
 
+    public void filterPartitionByAdaptiveRefreshNumber(Set<String> mvPartitionsToRefresh,
+                                                       Set<String> mvPotentialPartitionNames,
+                                                       boolean tentative) {
+        Map<String, Range<PartitionKey>> mvRangePartitionMap = mv.getRangePartitionMap();
+
+        Map<String, Range<PartitionKey>> mappedPartitionsToRefresh = Maps.newHashMap();
+        Iterator<String> mvToRefreshPartitionsIter = mvPartitionsToRefresh.iterator();
+        while (mvToRefreshPartitionsIter.hasNext()) {
+            String mvPartitionName = mvToRefreshPartitionsIter.next();
+            // skip if partition is not in the mv's partition range map
+            if (!mvRangePartitionMap.containsKey(mvPartitionName)) {
+                logger.warn("Partition {} is not in the materialized view's partition range map, " +
+                        "remove it from refresh list", mvPartitionName);
+                mvToRefreshPartitionsIter.remove();
+                continue;
+            }
+            mappedPartitionsToRefresh.put(mvPartitionName, mvRangePartitionMap.get(mvPartitionName));
+        }
+        LinkedList<String> sortedPartition = mappedPartitionsToRefresh.entrySet().stream()
+                .sorted(Map.Entry.comparingByValue(RangeUtils.RANGE_COMPARATOR))
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toCollection(LinkedList::new));
+
+        Iterator<String> toSelectedPartitionNameIter = Config.materialized_view_refresh_ascending
+                ? sortedPartition.iterator() : sortedPartition.descendingIterator();
+        String mvRefreshPartition = "";
+        // dynamically obtain the number of partitions to be refreshed this time
+        int adaptivePartitionRefreshNumber = getAdaptivePartitionRefreshNumber(toSelectedPartitionNameIter);
+        Iterator<String> partitionNameIter = Config.materialized_view_refresh_ascending
+                ? sortedPartition.iterator() : sortedPartition.descendingIterator();
+
+        for (int i = 0; i < adaptivePartitionRefreshNumber; i++) {
+            if (partitionNameIter.hasNext()) {
+                mvRefreshPartition = partitionNameIter.next();
+                partitionNameIter.remove();
+            }
+            if (!mvPotentialPartitionNames.isEmpty() && mvPotentialPartitionNames.contains(mvRefreshPartition)) {
+                return;
+            }
+        }
+
+
+        if (!Config.materialized_view_refresh_ascending) {
+            partitionNameIter = sortedPartition.iterator();
+        }
+        setNextPartitionStartAndEnd(mvPartitionsToRefresh, mappedPartitionsToRefresh, partitionNameIter, tentative);
+    }
+
     private void setNextPartitionStartAndEnd(Set<String> partitionsToRefresh,
                                              Map<String, Range<PartitionKey>> mappedPartitionsToRefresh,
                                              Iterator<String> partitionNameIter,
@@ -487,6 +535,27 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
                 mvContext.setNextPartitionEnd(null);
             }
         }
+    }
+
+    private int getAdaptivePartitionRefreshNumber(Iterator<String> partitionNameIter) {
+
+        Map<String, Map<Table, Set<String>>> mvToBaseNameRefs = mvContext.getMvRefBaseTableIntersectedPartitions();
+        MVRefreshPartitionSelector mvRefreshPartitionSelector =
+                new MVRefreshPartitionSelector(Config.mv_max_rows_per_refresh, Config.mv_max_bytes_per_refresh);
+
+        int adaptiveRefreshNumber = 0;
+        while (partitionNameIter.hasNext()) {
+            String mvRefreshPartition = partitionNameIter.next();
+            Map<Table, Set<String>> refBaseTablesPartitions = mvToBaseNameRefs.get(mvRefreshPartition);
+            if (mvRefreshPartitionSelector.canAddPartition(refBaseTablesPartitions)) {
+                mvRefreshPartitionSelector.addPartition(refBaseTablesPartitions);
+                partitionNameIter.remove();
+                adaptiveRefreshNumber++;
+            } else {
+                break;
+            }
+        }
+        return adaptiveRefreshNumber;
     }
 
     private void addRangePartitions(Database database, MaterializedView materializedView,

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
@@ -541,7 +541,8 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
 
         Map<String, Map<Table, Set<String>>> mvToBaseNameRefs = mvContext.getMvRefBaseTableIntersectedPartitions();
         MVRefreshPartitionSelector mvRefreshPartitionSelector =
-                new MVRefreshPartitionSelector(Config.mv_max_rows_per_refresh, Config.mv_max_bytes_per_refresh);
+                new MVRefreshPartitionSelector(Config.mv_max_rows_per_refresh, Config.mv_max_bytes_per_refresh,
+                        Config.mv_max_partitions_num_per_refresh);
 
         int adaptiveRefreshNumber = 0;
         while (partitionNameIter.hasNext()) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshPartitionSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshPartitionSelector.java
@@ -1,0 +1,86 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.mv;
+
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Table;
+
+import java.util.Map;
+import java.util.Set;
+
+public class MVRefreshPartitionSelector {
+
+    private long currentTotalRows = 0;
+    private long currentTotalBytes = 0;
+
+    private final long maxRowsThreshold;
+    private final long maxBytesThreshold;
+
+    // ensure that at least one partition is selected
+    private boolean isFirstPartition = true;
+
+    public MVRefreshPartitionSelector(long maxRowsThreshold, long maxBytesThreshold) {
+        this.maxRowsThreshold = maxRowsThreshold;
+        this.maxBytesThreshold = maxBytesThreshold;
+    }
+
+    /**
+     * Check if the incoming partition set can be added based on current total usage and thresholds.
+     * Always allows the first partition.
+     */
+    public boolean canAddPartition(Map<Table, Set<String>> partitionSet) {
+        if (isFirstPartition) {
+            return true;
+        }
+
+        long[] usage = estimatePartitionUsage(partitionSet);
+        long incomingRows = usage[0];
+        long incomingBytes = usage[1];
+
+        return (currentTotalRows + incomingRows <= maxRowsThreshold) &&
+                (currentTotalBytes + incomingBytes <= maxBytesThreshold);
+    }
+
+    /**
+     * Actually add the given partition set to the total usage.
+     * This should be called after canAddPartitionSet() returns true.
+     */
+    public void addPartition(Map<Table, Set<String>> partitionSet) {
+        long[] usage = estimatePartitionUsage(partitionSet);
+        currentTotalRows += usage[0];
+        currentTotalBytes += usage[1];
+        isFirstPartition = false;
+    }
+
+    /**
+     * Estimate total row count and data size of a partition set.
+     *
+     * @return array of [rows, bytes]
+     */
+    private long[] estimatePartitionUsage(Map<Table, Set<String>> partitionSet) {
+        long totalRows = 0;
+        long totalBytes = 0;
+
+        for (Map.Entry<Table, Set<String>> entry : partitionSet.entrySet()) {
+            Table table = entry.getKey();
+            for (String partitionName : entry.getValue()) {
+                Partition partition = table.getPartition(partitionName);
+                totalRows += partition.getRowCount();
+                totalBytes += partition.getDataSize();
+            }
+        }
+        return new long[] {totalRows, totalBytes};
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshPartitionSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshPartitionSelector.java
@@ -24,16 +24,19 @@ public class MVRefreshPartitionSelector {
 
     private long currentTotalRows = 0;
     private long currentTotalBytes = 0;
+    private int currentTotalSelectedPartitions = 0;
 
     private final long maxRowsThreshold;
     private final long maxBytesThreshold;
+    private final int maxSelectedPartitions;
 
     // ensure that at least one partition is selected
     private boolean isFirstPartition = true;
 
-    public MVRefreshPartitionSelector(long maxRowsThreshold, long maxBytesThreshold) {
+    public MVRefreshPartitionSelector(long maxRowsThreshold, long maxBytesThreshold, int maxPartitionNum) {
         this.maxRowsThreshold = maxRowsThreshold;
         this.maxBytesThreshold = maxBytesThreshold;
+        this.maxSelectedPartitions = maxPartitionNum;
     }
 
     /**
@@ -43,6 +46,10 @@ public class MVRefreshPartitionSelector {
     public boolean canAddPartition(Map<Table, Set<String>> partitionSet) {
         if (isFirstPartition) {
             return true;
+        }
+
+        if (currentTotalSelectedPartitions >= maxSelectedPartitions) {
+            return false;
         }
 
         long[] usage = estimatePartitionUsage(partitionSet);
@@ -62,6 +69,7 @@ public class MVRefreshPartitionSelector {
         currentTotalRows += usage[0];
         currentTotalBytes += usage[1];
         isFirstPartition = false;
+        currentTotalSelectedPartitions++;
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -5101,6 +5101,80 @@ public class CreateMaterializedViewTest extends MVTestBase {
     }
 
     @Test
+    public void testCreateMVWithAdaptiveRefresh1() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE t3 (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt VARCHAR(10) not null,\n" +
+                "      province VARCHAR(64) not null\n" +
+                ")\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY LIST (province, dt, age) (\n" +
+                "     PARTITION p1 VALUES IN ((\"beijing\", \"2024-01-01\", \"10\")),\n" +
+                "     PARTITION p2 VALUES IN ((\"guangdong\", \"2024-01-01\", \"20\")), \n" +
+                "     PARTITION p3 VALUES IN ((\"beijing\", \"2024-01-02\", \"30\")),\n" +
+                "     PARTITION p4 VALUES IN ((\"guangdong\", \"2024-01-02\", \"40\")) \n" +
+                ")\n" +
+                "DISTRIBUTED BY RANDOM\n");
+        starRocksAssert.withMaterializedView("create materialized view mv1\n" +
+                "partition by (province, dt, age) \n" +
+                "REFRESH DEFERRED MANUAL \n" +
+                "properties (\n" +
+                "'replication_num' = '1',\n" +
+                "'partition_refresh_mode' = 'smart'" +
+                ") \n" +
+                "as select dt, province, age, sum(id) from t3 group by dt, province, age;");
+        MaterializedView mv = starRocksAssert.getMv("test", "mv1");
+        List<Column> mvPartitionCols = mv.getPartitionColumns();
+        Assert.assertEquals(3, mvPartitionCols.size());
+        Assert.assertEquals("province", mvPartitionCols.get(0).getName());
+        Assert.assertEquals("dt", mvPartitionCols.get(1).getName());
+        Assert.assertEquals("age", mvPartitionCols.get(2).getName());
+        String alterTableSql = "ALTER MATERIALIZED VIEW mv1 SET ('partition_refresh_mode' = 'default')";
+        starRocksAssert.alterMvProperties(alterTableSql);
+
+        starRocksAssert.dropMaterializedView("mv1");
+        starRocksAssert.dropTable("t3");
+    }
+
+    @Test
+    public void testCreateMVWithAdaptiveRefresh2() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE t3 (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt VARCHAR(10) not null,\n" +
+                "      province VARCHAR(64) not null\n" +
+                ")\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY LIST (province, dt, age) (\n" +
+                "     PARTITION p1 VALUES IN ((\"beijing\", \"2024-01-01\", \"10\")),\n" +
+                "     PARTITION p2 VALUES IN ((\"guangdong\", \"2024-01-01\", \"20\")), \n" +
+                "     PARTITION p3 VALUES IN ((\"beijing\", \"2024-01-02\", \"30\")),\n" +
+                "     PARTITION p4 VALUES IN ((\"guangdong\", \"2024-01-02\", \"40\")) \n" +
+                ")\n" +
+                "DISTRIBUTED BY RANDOM\n");
+        starRocksAssert.withMaterializedView("create materialized view mv1\n" +
+                "partition by (province, dt, age) \n" +
+                "REFRESH DEFERRED MANUAL \n" +
+                "properties (\n" +
+                "'replication_num' = '1',\n" +
+                "'partition_refresh_mode' = 'default'" +
+                ") \n" +
+                "as select dt, province, age, sum(id) from t3 group by dt, province, age;");
+        MaterializedView mv = starRocksAssert.getMv("test", "mv1");
+        List<Column> mvPartitionCols = mv.getPartitionColumns();
+        Assert.assertEquals(3, mvPartitionCols.size());
+        Assert.assertEquals("province", mvPartitionCols.get(0).getName());
+        Assert.assertEquals("dt", mvPartitionCols.get(1).getName());
+        Assert.assertEquals("age", mvPartitionCols.get(2).getName());
+
+        String alterTableSql = "ALTER MATERIALIZED VIEW mv1 SET ('partition_refresh_mode' = 'smart')";
+        starRocksAssert.alterMvProperties(alterTableSql);
+        starRocksAssert.dropMaterializedView("mv1");
+        starRocksAssert.dropTable("t3");
+    }
+
+    @Test
     public void testCreateMVWithRetentionCondition1() throws Exception {
         starRocksAssert.withTable("CREATE TABLE t3 (\n" +
                 "      id BIGINT,\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -5158,7 +5158,7 @@ public class CreateMaterializedViewTest extends MVTestBase {
                 "REFRESH DEFERRED MANUAL \n" +
                 "properties (\n" +
                 "'replication_num' = '1',\n" +
-                "'partition_refresh_strategy' = 'default'" +
+                "'partition_refresh_strategy' = 'strict'" +
                 ") \n" +
                 "as select dt, province, age, sum(id) from t3 group by dt, province, age;");
         MaterializedView mv = starRocksAssert.getMv("test", "mv1");

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -5121,7 +5121,7 @@ public class CreateMaterializedViewTest extends MVTestBase {
                 "REFRESH DEFERRED MANUAL \n" +
                 "properties (\n" +
                 "'replication_num' = '1',\n" +
-                "'partition_refresh_mode' = 'smart'" +
+                "'partition_refresh_strategy' = 'adaptive'" +
                 ") \n" +
                 "as select dt, province, age, sum(id) from t3 group by dt, province, age;");
         MaterializedView mv = starRocksAssert.getMv("test", "mv1");
@@ -5130,7 +5130,7 @@ public class CreateMaterializedViewTest extends MVTestBase {
         Assert.assertEquals("province", mvPartitionCols.get(0).getName());
         Assert.assertEquals("dt", mvPartitionCols.get(1).getName());
         Assert.assertEquals("age", mvPartitionCols.get(2).getName());
-        String alterTableSql = "ALTER MATERIALIZED VIEW mv1 SET ('partition_refresh_mode' = 'default')";
+        String alterTableSql = "ALTER MATERIALIZED VIEW mv1 SET ('partition_refresh_strategy' = 'strict')";
         starRocksAssert.alterMvProperties(alterTableSql);
 
         starRocksAssert.dropMaterializedView("mv1");
@@ -5158,7 +5158,7 @@ public class CreateMaterializedViewTest extends MVTestBase {
                 "REFRESH DEFERRED MANUAL \n" +
                 "properties (\n" +
                 "'replication_num' = '1',\n" +
-                "'partition_refresh_mode' = 'default'" +
+                "'partition_refresh_strategy' = 'default'" +
                 ") \n" +
                 "as select dt, province, age, sum(id) from t3 group by dt, province, age;");
         MaterializedView mv = starRocksAssert.getMv("test", "mv1");
@@ -5168,7 +5168,7 @@ public class CreateMaterializedViewTest extends MVTestBase {
         Assert.assertEquals("dt", mvPartitionCols.get(1).getName());
         Assert.assertEquals("age", mvPartitionCols.get(2).getName());
 
-        String alterTableSql = "ALTER MATERIALIZED VIEW mv1 SET ('partition_refresh_mode' = 'smart')";
+        String alterTableSql = "ALTER MATERIALIZED VIEW mv1 SET ('partition_refresh_strategy' = 'adaptive')";
         starRocksAssert.alterMvProperties(alterTableSql);
         starRocksAssert.dropMaterializedView("mv1");
         starRocksAssert.dropTable("t3");

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVRefreshPartitionSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVRefreshPartitionSelectorTest.java
@@ -1,0 +1,84 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.mv;
+
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Table;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.anyString;
+
+public class MVRefreshPartitionSelectorTest {
+
+    private Map<Table, Set<String>> mockPartitionSet(long rows, long bytes) {
+        Table table = Mockito.mock(Table.class);
+        Partition partition = Mockito.mock(Partition.class);
+
+        Mockito.when(partition.getRowCount()).thenReturn(rows);
+        Mockito.when(partition.getDataSize()).thenReturn(bytes);
+        Mockito.when(table.getPartition(anyString())).thenReturn(partition);
+
+        Map<Table, Set<String>> map = new HashMap<>();
+        map.put(table, new HashSet<>(Collections.singleton("p1")));
+        return map;
+    }
+
+    @Test
+    public void testFirstPartitionAlwaysAllowed() {
+        MVRefreshPartitionSelector selector = new MVRefreshPartitionSelector(1000, 10000);
+        Assert.assertTrue(selector.canAddPartition(mockPartitionSet(2000, 20000)));
+    }
+
+    @Test
+    public void testCanAddWithinThreshold() {
+        MVRefreshPartitionSelector selector = new MVRefreshPartitionSelector(1000, 10000);
+        selector.addPartition(mockPartitionSet(500, 5000)); // First one always allowed
+
+        Assert.assertTrue(selector.canAddPartition(mockPartitionSet(400, 4000)));
+    }
+
+    @Test
+    public void testExceedRowLimit() {
+        MVRefreshPartitionSelector selector = new MVRefreshPartitionSelector(1000, 10000);
+        selector.addPartition(mockPartitionSet(900, 5000));
+
+        Assert.assertFalse(selector.canAddPartition(mockPartitionSet(200, 1000))); // 900+200 > 1000
+    }
+
+    @Test
+    public void testExceedByteLimit() {
+        MVRefreshPartitionSelector selector = new MVRefreshPartitionSelector(1000, 10000);
+        selector.addPartition(mockPartitionSet(800, 9000));
+
+        Assert.assertFalse(selector.canAddPartition(mockPartitionSet(100, 2000))); // 9000+2000 > 10000
+    }
+
+    @Test
+    public void testAddPartitionAccumulatesUsage() {
+        MVRefreshPartitionSelector selector = new MVRefreshPartitionSelector(1000, 10000);
+        selector.addPartition(mockPartitionSet(300, 3000));
+        selector.addPartition(mockPartitionSet(400, 4000));
+
+        Assert.assertFalse(selector.canAddPartition(mockPartitionSet(400, 4000)));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVRefreshPartitionSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVRefreshPartitionSelectorTest.java
@@ -45,13 +45,13 @@ public class MVRefreshPartitionSelectorTest {
 
     @Test
     public void testFirstPartitionAlwaysAllowed() {
-        MVRefreshPartitionSelector selector = new MVRefreshPartitionSelector(1000, 10000);
+        MVRefreshPartitionSelector selector = new MVRefreshPartitionSelector(1000, 10000, 10);
         Assert.assertTrue(selector.canAddPartition(mockPartitionSet(2000, 20000)));
     }
 
     @Test
     public void testCanAddWithinThreshold() {
-        MVRefreshPartitionSelector selector = new MVRefreshPartitionSelector(1000, 10000);
+        MVRefreshPartitionSelector selector = new MVRefreshPartitionSelector(1000, 10000, 10);
         selector.addPartition(mockPartitionSet(500, 5000)); // First one always allowed
 
         Assert.assertTrue(selector.canAddPartition(mockPartitionSet(400, 4000)));
@@ -59,7 +59,7 @@ public class MVRefreshPartitionSelectorTest {
 
     @Test
     public void testExceedRowLimit() {
-        MVRefreshPartitionSelector selector = new MVRefreshPartitionSelector(1000, 10000);
+        MVRefreshPartitionSelector selector = new MVRefreshPartitionSelector(1000, 10000, 10);
         selector.addPartition(mockPartitionSet(900, 5000));
 
         Assert.assertFalse(selector.canAddPartition(mockPartitionSet(200, 1000))); // 900+200 > 1000
@@ -67,15 +67,32 @@ public class MVRefreshPartitionSelectorTest {
 
     @Test
     public void testExceedByteLimit() {
-        MVRefreshPartitionSelector selector = new MVRefreshPartitionSelector(1000, 10000);
+        MVRefreshPartitionSelector selector = new MVRefreshPartitionSelector(1000, 10000, 10);
         selector.addPartition(mockPartitionSet(800, 9000));
 
         Assert.assertFalse(selector.canAddPartition(mockPartitionSet(100, 2000))); // 9000+2000 > 10000
     }
 
     @Test
+    public void testExceedPartitionLimit() {
+        MVRefreshPartitionSelector selector = new MVRefreshPartitionSelector(1000, 10000, 10);
+        selector.addPartition(mockPartitionSet(10, 200));
+        selector.addPartition(mockPartitionSet(10, 200));
+        selector.addPartition(mockPartitionSet(10, 200));
+        selector.addPartition(mockPartitionSet(10, 200));
+        selector.addPartition(mockPartitionSet(10, 200));
+        selector.addPartition(mockPartitionSet(10, 200));
+        selector.addPartition(mockPartitionSet(10, 200));
+        selector.addPartition(mockPartitionSet(10, 200));
+        selector.addPartition(mockPartitionSet(10, 200));
+        selector.addPartition(mockPartitionSet(10, 200));
+
+        Assert.assertFalse(selector.canAddPartition(mockPartitionSet(10, 200)));
+    }
+
+    @Test
     public void testAddPartitionAccumulatesUsage() {
-        MVRefreshPartitionSelector selector = new MVRefreshPartitionSelector(1000, 10000);
+        MVRefreshPartitionSelector selector = new MVRefreshPartitionSelector(1000, 10000, 10);
         selector.addPartition(mockPartitionSet(300, 3000));
         selector.addPartition(mockPartitionSet(400, 4000));
 

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_with_smart_refresh
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_with_smart_refresh
@@ -183,7 +183,7 @@ PARTITION BY date_trunc('week', `dt`)
 DISTRIBUTED BY HASH(`dt`)
 REFRESH DEFERRED MANUAL
 PROPERTIES (
-    "partition_refresh_mode" = "smart"
+    "partition_refresh_strategy" = "adaptive"
 )
 AS select dt, sum(id) as s1 from u1 group by dt;
 -- result:
@@ -193,7 +193,7 @@ PARTITION BY date_trunc('week', `dt`)
 DISTRIBUTED BY HASH(`dt`)
 REFRESH DEFERRED MANUAL
 PROPERTIES (
-    "partition_refresh_mode" = "default"
+    "partition_refresh_strategy" = "strict"
 )
 AS select dt, sum(id) as s1 from u2 group by dt;
 -- result:
@@ -203,7 +203,7 @@ PARTITION BY date_trunc('week', `dt`)
 DISTRIBUTED BY HASH(`dt`)
 REFRESH DEFERRED MANUAL
 PROPERTIES (
-    "partition_refresh_mode" = "smart"
+    "partition_refresh_strategy" = "adaptive"
 )
 AS select dt, sum(id) as s1 from u3 group by dt;
 -- result:
@@ -213,7 +213,7 @@ PARTITION BY date_trunc('week', `dt`)
 DISTRIBUTED BY HASH(`dt`)
 REFRESH DEFERRED MANUAL
 PROPERTIES (
-    "partition_refresh_mode" = "default"
+    "partition_refresh_strategy" = "strict"
 )
 AS select dt, sum(id) as s1 from u4 group by dt;
 -- result:
@@ -223,7 +223,7 @@ PARTITION BY date_trunc('week', `dt`)
 DISTRIBUTED BY HASH(`dt`)
 REFRESH DEFERRED MANUAL
 PROPERTIES (
-    "partition_refresh_mode" = "default"
+    "partition_refresh_strategy" = "strict"
 )
 AS select dt, sum(id) as s1 from u5 group by dt;
 -- result:
@@ -233,7 +233,7 @@ PARTITION BY date_trunc('week', `dt`)
 DISTRIBUTED BY HASH(`dt`)
 REFRESH DEFERRED MANUAL
 PROPERTIES (
-    "partition_refresh_mode" = "smart"
+    "partition_refresh_strategy" = "adaptive"
 )
 AS select dt, sum(id) as s1 from u6 group by dt;
 -- result:
@@ -243,7 +243,7 @@ partition by dt
 REFRESH DEFERRED MANUAL
 distributed by hash(dt, province) buckets 10
 PROPERTIES (
-"partition_refresh_mode" = "smart",
+"partition_refresh_strategy" = "adaptive",
 "replication_num" = "1"
 )
 as select dt, province, sum(age) from u7 group by dt, province order by dt, province;

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_with_smart_refresh
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_with_smart_refresh
@@ -1,0 +1,931 @@
+-- name: test_mv_refresh_with_with_smart_refresh
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `u1` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `u2` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p1 VALUES [("2024-03-10"), ("2024-03-11")),
+  PARTITION p2 VALUES [("2024-03-11"), ("2024-03-12")),
+  PARTITION p3 VALUES [("2024-03-12"), ("2024-03-13")),
+  PARTITION p4 VALUES [("2024-03-13"), ("2024-03-14")),
+  PARTITION p5 VALUES [("2024-03-14"), ("2024-03-15")),
+  PARTITION p6 VALUES [("2024-04-01"), ("2024-04-02")),
+  PARTITION p7 VALUES [("2024-04-10"), ("2024-04-11"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `u3` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p1 VALUES [("2024-03-10"), ("2024-03-11")),
+  PARTITION p2 VALUES [("2024-03-11"), ("2024-03-12")),
+  PARTITION p3 VALUES [("2024-03-12"), ("2024-03-13")),
+  PARTITION p4 VALUES [("2024-03-13"), ("2024-03-14")),
+  PARTITION p5 VALUES [("2024-03-14"), ("2024-03-15")),
+  PARTITION p6 VALUES [("2024-04-10"), ("2024-04-11"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `u4` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p1 VALUES [("2023-01-01"), ("2024-01-01")),
+  PARTITION p2 VALUES [("2024-01-01"), ("2025-01-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `u5` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p1 VALUES [("2024-01-01"), ("2024-02-01")),
+  PARTITION p2 VALUES [("2024-02-01"), ("2024-03-01")),
+  PARTITION p3 VALUES [("2024-03-01"), ("2024-04-01")),
+  PARTITION p4 VALUES [("2024-04-01"), ("2024-05-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `u6` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE (dt) (
+  START ("2024-01-01") END ("2024-05-01") EVERY (INTERVAL 1 DAY)
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `u7` (
+      id BIGINT,
+      province VARCHAR(64) not null,
+      age SMALLINT,
+      dt VARCHAR(10) not null
+)
+DUPLICATE KEY(id)
+PARTITION BY LIST (province, dt) (
+     PARTITION p1 VALUES IN (("beijing", "2024-01-01")),
+     PARTITION p2 VALUES IN (("guangdong", "2024-01-01")),
+     PARTITION p3 VALUES IN (("beijing", "2024-01-02")),
+     PARTITION p4 VALUES IN (("guangdong", "2024-01-02"))
+)
+DISTRIBUTED BY RANDOM
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO u1 (id,dt) VALUES
+	 (131,'2024-04-10'),
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12'),
+	 (7,'2024-03-13'),
+	 (8,'2024-03-14'),
+	 (11,'2024-03-15'),
+	 (13,'2024-03-16'),
+	 (14,'2024-03-17'),
+	 (16,'2024-03-18');
+-- result:
+-- !result
+INSERT INTO u2 (id,dt) VALUES
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12'),
+	 (7,'2024-03-13');
+-- result:
+-- !result
+INSERT INTO u3 (id,dt) VALUES
+	 (131,'2024-04-10'),
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12'),
+	 (7,'2024-03-13'),
+	 (8,'2024-03-14');
+-- result:
+-- !result
+INSERT INTO u4 (id,dt) VALUES
+	 (13,'2024-03-16'),
+	 (14,'2024-03-17'),
+	 (16,'2024-03-18');
+-- result:
+-- !result
+INSERT INTO u5 (id,dt) VALUES
+	 (131,'2024-04-10'),
+	 (1,'2024-03-10'),
+	 (16,'2024-03-18');
+-- result:
+-- !result
+INSERT INTO u6 (id,dt) VALUES
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12');
+-- result:
+-- !result
+INSERT INTO u7 VALUES
+     (1, 'beijing', 20, '2024-01-01'),
+     (2, 'guangdong', 20, '2024-01-01'),
+     (3, 'guangdong', 20, '2024-01-02');
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv1`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+    "partition_refresh_mode" = "smart"
+)
+AS select dt, sum(id) as s1 from u1 group by dt;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv2`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+    "partition_refresh_mode" = "default"
+)
+AS select dt, sum(id) as s1 from u2 group by dt;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv3`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+    "partition_refresh_mode" = "smart"
+)
+AS select dt, sum(id) as s1 from u3 group by dt;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv4`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+    "partition_refresh_mode" = "default"
+)
+AS select dt, sum(id) as s1 from u4 group by dt;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv5`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+    "partition_refresh_mode" = "default"
+)
+AS select dt, sum(id) as s1 from u5 group by dt;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv6`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+    "partition_refresh_mode" = "smart"
+)
+AS select dt, sum(id) as s1 from u6 group by dt;
+-- result:
+-- !result
+create materialized view IF NOT EXISTS `test_mv7`
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10
+PROPERTIES (
+"partition_refresh_mode" = "smart",
+"replication_num" = "1"
+)
+as select dt, province, sum(age) from u7 group by dt, province order by dt, province;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv11`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL
+AS
+    select dt from u1
+    union all
+    select dt from u2;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv12`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL
+AS
+    select dt from u1
+    union all
+    select dt from u2
+    union all
+    select dt from u3
+    union all
+    select dt from u4
+    union all
+    select dt from u5
+    union all
+    select dt from u6;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv13`
+PARTITION BY dt
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL
+AS
+    select dt from test_mv1
+    union all
+    select dt from test_mv2
+    union all
+    select dt from test_mv3
+    union all
+    select dt from test_mv4
+    union all
+    select dt from test_mv5
+    union all
+    select dt from test_mv6;
+-- result:
+-- !result
+refresh materialized view test_mv1 with sync mode;
+refresh materialized view test_mv2 with sync mode;
+refresh materialized view test_mv3 with sync mode;
+refresh materialized view test_mv4 with sync mode;
+refresh materialized view test_mv5 with sync mode;
+refresh materialized view test_mv6 with sync mode;
+refresh materialized view test_mv7 with sync mode;
+refresh materialized view test_mv11 with sync mode;
+refresh materialized view test_mv12 with sync mode;
+refresh materialized view test_mv13 with sync mode;
+select count(1) from test_mv1;
+-- result:
+10
+-- !result
+select count(1) from test_mv2;
+-- result:
+4
+-- !result
+select count(1) from test_mv3;
+-- result:
+6
+-- !result
+select count(1) from test_mv4;
+-- result:
+3
+-- !result
+select count(1) from test_mv5;
+-- result:
+3
+-- !result
+select count(1) from test_mv6;
+-- result:
+3
+-- !result
+select count(1) from test_mv7;
+-- result:
+3
+-- !result
+select count(1) from test_mv11;
+-- result:
+14
+-- !result
+select count(1) from test_mv12;
+-- result:
+29
+-- !result
+select count(1) from test_mv13;
+-- result:
+29
+-- !result
+function: check_hit_materialized_view("select dt, sum(id) from u1 group by dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, sum(id) from u2 group by dt;", "test_mv2")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, sum(id) from u3 group by dt;", "test_mv3")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, sum(id) from u4 group by dt;", "test_mv4")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, sum(id) from u5 group by dt;", "test_mv5")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, sum(id) from u6 group by dt;", "test_mv6")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from u7 group by dt, province;", "test_mv7")
+-- result:
+None
+-- !result
+select dt, s1 from test_mv1 order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+2024-03-13	7
+2024-03-14	8
+2024-03-15	11
+2024-03-16	13
+2024-03-17	14
+2024-03-18	16
+2024-04-10	131
+-- !result
+select dt, s1 from test_mv2 order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+2024-03-13	7
+-- !result
+select dt, s1 from test_mv3 order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+2024-03-13	7
+2024-03-14	8
+2024-04-10	131
+-- !result
+select dt, s1 from test_mv4 order by 1;
+-- result:
+2024-03-16	13
+2024-03-17	14
+2024-03-18	16
+-- !result
+select dt, s1 from test_mv5 order by 1;
+-- result:
+2024-03-10	1
+2024-03-18	16
+2024-04-10	131
+-- !result
+select dt, s1 from test_mv6 order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+-- !result
+select dt, province from test_mv7 order by 1;
+-- result:
+2024-01-01	guangdong
+2024-01-01	beijing
+2024-01-02	guangdong
+-- !result
+select dt, count(1) from test_mv11 group by dt order by 1;
+-- result:
+2024-03-10	2
+2024-03-11	2
+2024-03-12	2
+2024-03-13	2
+2024-03-14	1
+2024-03-15	1
+2024-03-16	1
+2024-03-17	1
+2024-03-18	1
+2024-04-10	1
+-- !result
+select dt, count(1) from test_mv12 group by dt order by 1;
+-- result:
+2024-03-10	5
+2024-03-11	4
+2024-03-12	4
+2024-03-13	3
+2024-03-14	2
+2024-03-15	1
+2024-03-16	2
+2024-03-17	2
+2024-03-18	3
+2024-04-10	3
+-- !result
+select dt, count(1) from test_mv13 group by dt order by 1;
+-- result:
+2024-03-10	5
+2024-03-11	4
+2024-03-12	4
+2024-03-13	3
+2024-03-14	2
+2024-03-15	1
+2024-03-16	2
+2024-03-17	2
+2024-03-18	3
+2024-04-10	3
+-- !result
+set enable_materialized_view_rewrite = false;
+-- result:
+-- !result
+select dt, sum(id) from u1 group by dt order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+2024-03-13	7
+2024-03-14	8
+2024-03-15	11
+2024-03-16	13
+2024-03-17	14
+2024-03-18	16
+2024-04-10	131
+-- !result
+select dt, sum(id) from u2 group by dt order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+2024-03-13	7
+-- !result
+select dt, sum(id) from u3 group by dt order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+2024-03-13	7
+2024-03-14	8
+2024-04-10	131
+-- !result
+select dt, sum(id) from u4 group by dt order by 1;
+-- result:
+2024-03-16	13
+2024-03-17	14
+2024-03-18	16
+-- !result
+select dt, sum(id) from u5 group by dt order by 1;
+-- result:
+2024-03-10	1
+2024-03-18	16
+2024-04-10	131
+-- !result
+select dt, sum(id) from u6 group by dt order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+-- !result
+select dt, province, sum(age) from u7 group by dt, province order by dt, province;
+-- result:
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+select dt, count(1) from (
+    select dt from u1
+    union all
+    select dt from u2
+) t group by dt order by 1;
+-- result:
+2024-03-10	2
+2024-03-11	2
+2024-03-12	2
+2024-03-13	2
+2024-03-14	1
+2024-03-15	1
+2024-03-16	1
+2024-03-17	1
+2024-03-18	1
+2024-04-10	1
+-- !result
+select dt, count(1) from (
+    select dt from u1
+    union all
+    select dt from u2
+    union all
+    select dt from u3
+    union all
+    select dt from u4
+    union all
+    select dt from u5
+    union all
+    select dt from u6
+) t group by dt order by 1;
+-- result:
+2024-03-10	5
+2024-03-11	4
+2024-03-12	4
+2024-03-13	3
+2024-03-14	2
+2024-03-15	1
+2024-03-16	2
+2024-03-17	2
+2024-03-18	3
+2024-04-10	3
+-- !result
+select dt, count(1) from (
+  select dt from test_mv1
+  union all
+  select dt from test_mv2
+  union all
+  select dt from test_mv3
+  union all
+  select dt from test_mv4
+  union all
+  select dt from test_mv5
+  union all
+  select dt from test_mv6
+) t group by dt order by 1;
+-- result:
+2024-03-10	5
+2024-03-11	4
+2024-03-12	4
+2024-03-13	3
+2024-03-14	2
+2024-03-15	1
+2024-03-16	2
+2024-03-17	2
+2024-03-18	3
+2024-04-10	3
+-- !result
+set enable_materialized_view_rewrite = true;
+-- result:
+-- !result
+INSERT INTO u1 (id,dt) VALUES (131,'2024-04-10'), (1,'2024-03-10'), (2,'2024-03-11'), (4,'2024-03-12');
+-- result:
+-- !result
+INSERT INTO u2 (id,dt) VALUES (1,'2024-03-10'), (2,'2024-03-11');
+-- result:
+-- !result
+INSERT INTO u3 (id,dt) VALUES (131,'2024-04-10'), (1,'2024-03-10');
+-- result:
+-- !result
+INSERT INTO u4 (id,dt) VALUES (13,'2024-03-16'), (14,'2024-03-17');
+-- result:
+-- !result
+INSERT INTO u5 (id,dt) VALUES (131,'2024-04-10'), (1,'2024-03-10');
+-- result:
+-- !result
+INSERT INTO u6 (id,dt) VALUES (1,'2024-03-10'), (2,'2024-03-11'), (4,'2024-03-12');
+-- result:
+-- !result
+select count(1) from test_mv1;
+-- result:
+10
+-- !result
+select count(1) from test_mv2;
+-- result:
+4
+-- !result
+select count(1) from test_mv3;
+-- result:
+6
+-- !result
+select count(1) from test_mv4;
+-- result:
+3
+-- !result
+select count(1) from test_mv5;
+-- result:
+3
+-- !result
+select count(1) from test_mv6;
+-- result:
+3
+-- !result
+select count(1) from test_mv7;
+-- result:
+3
+-- !result
+select count(1) from test_mv11;
+-- result:
+14
+-- !result
+select count(1) from test_mv12;
+-- result:
+29
+-- !result
+select count(1) from test_mv13;
+-- result:
+29
+-- !result
+function: check_no_hit_materialized_view("select dt, sum(id) from u1 group by dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("select dt, sum(id) from u2 group by dt;", "test_mv2")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, sum(id) from u3 group by dt;", "test_mv3")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("select dt, sum(id) from u4 group by dt;", "test_mv4")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("select dt, sum(id) from u5 group by dt;", "test_mv5")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("select dt, sum(id) from u6 group by dt;", "test_mv6")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("select dt, sum(id) from u6 group by dt;", "test_mv6")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select dt, province, sum(age) from u7 group by dt, province;", "test_mv7")
+-- result:
+None
+-- !result
+select dt, s1 from test_mv1 order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+2024-03-13	7
+2024-03-14	8
+2024-03-15	11
+2024-03-16	13
+2024-03-17	14
+2024-03-18	16
+2024-04-10	131
+-- !result
+select dt, s1 from test_mv2 order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+2024-03-13	7
+-- !result
+select dt, s1 from test_mv3 order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+2024-03-13	7
+2024-03-14	8
+2024-04-10	131
+-- !result
+select dt, s1 from test_mv4 order by 1;
+-- result:
+2024-03-16	13
+2024-03-17	14
+2024-03-18	16
+-- !result
+select dt, s1 from test_mv5 order by 1;
+-- result:
+2024-03-10	1
+2024-03-18	16
+2024-04-10	131
+-- !result
+select dt, s1 from test_mv6 order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+-- !result
+select dt, province, sum(age) from u7 group by dt, province order by dt, province;
+-- result:
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+select dt, count(1) from test_mv11 group by dt order by 1;
+-- result:
+2024-03-10	2
+2024-03-11	2
+2024-03-12	2
+2024-03-13	2
+2024-03-14	1
+2024-03-15	1
+2024-03-16	1
+2024-03-17	1
+2024-03-18	1
+2024-04-10	1
+-- !result
+select dt, count(1) from test_mv12 group by dt order by 1;
+-- result:
+2024-03-10	5
+2024-03-11	4
+2024-03-12	4
+2024-03-13	3
+2024-03-14	2
+2024-03-15	1
+2024-03-16	2
+2024-03-17	2
+2024-03-18	3
+2024-04-10	3
+-- !result
+select dt, count(1) from test_mv13 group by dt order by 1;
+-- result:
+2024-03-10	5
+2024-03-11	4
+2024-03-12	4
+2024-03-13	3
+2024-03-14	2
+2024-03-15	1
+2024-03-16	2
+2024-03-17	2
+2024-03-18	3
+2024-04-10	3
+-- !result
+set enable_materialized_view_rewrite = false;
+-- result:
+-- !result
+select dt, sum(id) from u1 group by dt order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+2024-03-13	7
+2024-03-14	8
+2024-03-15	11
+2024-03-16	13
+2024-03-17	14
+2024-03-18	16
+2024-04-10	131
+-- !result
+select dt, sum(id) from u2 group by dt order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+2024-03-13	7
+-- !result
+select dt, sum(id) from u3 group by dt order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+2024-03-13	7
+2024-03-14	8
+2024-04-10	131
+-- !result
+select dt, sum(id) from u4 group by dt order by 1;
+-- result:
+2024-03-16	13
+2024-03-17	14
+2024-03-18	16
+-- !result
+select dt, sum(id) from u5 group by dt order by 1;
+-- result:
+2024-03-10	1
+2024-03-18	16
+2024-04-10	131
+-- !result
+select dt, sum(id) from u6 group by dt order by 1;
+-- result:
+2024-03-10	1
+2024-03-11	2
+2024-03-12	4
+-- !result
+select dt, province, sum(age) from u7 group by dt, province order by dt, province;
+-- result:
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+select dt, count(1) from (
+    select dt from u1
+    union all
+    select dt from u2
+) t group by dt order by 1;
+-- result:
+2024-03-10	2
+2024-03-11	2
+2024-03-12	2
+2024-03-13	2
+2024-03-14	1
+2024-03-15	1
+2024-03-16	1
+2024-03-17	1
+2024-03-18	1
+2024-04-10	1
+-- !result
+select dt, count(1) from (
+    select dt from u1
+    union all
+    select dt from u2
+    union all
+    select dt from u3
+    union all
+    select dt from u4
+    union all
+    select dt from u5
+    union all
+    select dt from u6
+) t group by dt order by 1;
+-- result:
+2024-03-10	5
+2024-03-11	4
+2024-03-12	4
+2024-03-13	3
+2024-03-14	2
+2024-03-15	1
+2024-03-16	2
+2024-03-17	2
+2024-03-18	3
+2024-04-10	3
+-- !result
+select dt, count(1) from (
+  select dt from test_mv1
+  union all
+  select dt from test_mv2
+  union all
+  select dt from test_mv3
+  union all
+  select dt from test_mv4
+  union all
+  select dt from test_mv5
+  union all
+  select dt from test_mv6
+) t group by dt order by 1;
+-- result:
+2024-03-10	5
+2024-03-11	4
+2024-03-12	4
+2024-03-13	3
+2024-03-14	2
+2024-03-15	1
+2024-03-16	2
+2024-03-17	2
+2024-03-18	3
+2024-04-10	3
+-- !result
+set enable_materialized_view_rewrite = true;
+-- result:
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+drop materialized view test_mv2;
+-- result:
+-- !result
+drop materialized view test_mv3;
+-- result:
+-- !result
+drop materialized view test_mv4;
+-- result:
+-- !result
+drop materialized view test_mv5;
+-- result:
+-- !result
+drop materialized view test_mv6;
+-- result:
+-- !result
+drop materialized view test_mv7;
+-- result:
+-- !result
+drop materialized view test_mv11;
+-- result:
+-- !result
+drop materialized view test_mv12;
+-- result:
+-- !result
+drop materialized view test_mv13;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_with_smart_refresh
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_with_smart_refresh
@@ -161,7 +161,7 @@ PARTITION BY date_trunc('week', `dt`)
 DISTRIBUTED BY HASH(`dt`)
 REFRESH DEFERRED MANUAL
 PROPERTIES (
-    "partition_refresh_mode" = "smart"
+    "partition_refresh_strategy" = "adaptive"
 )
 AS select dt, sum(id) as s1 from u1 group by dt;
 
@@ -170,7 +170,7 @@ PARTITION BY date_trunc('week', `dt`)
 DISTRIBUTED BY HASH(`dt`)
 REFRESH DEFERRED MANUAL
 PROPERTIES (
-    "partition_refresh_mode" = "default"
+    "partition_refresh_strategy" = "strict"
 )
 AS select dt, sum(id) as s1 from u2 group by dt;
 
@@ -179,7 +179,7 @@ PARTITION BY date_trunc('week', `dt`)
 DISTRIBUTED BY HASH(`dt`)
 REFRESH DEFERRED MANUAL
 PROPERTIES (
-    "partition_refresh_mode" = "smart"
+    "partition_refresh_strategy" = "adaptive"
 )
 AS select dt, sum(id) as s1 from u3 group by dt;
 
@@ -188,7 +188,7 @@ PARTITION BY date_trunc('week', `dt`)
 DISTRIBUTED BY HASH(`dt`)
 REFRESH DEFERRED MANUAL
 PROPERTIES (
-    "partition_refresh_mode" = "default"
+    "partition_refresh_strategy" = "strict"
 )
 AS select dt, sum(id) as s1 from u4 group by dt;
 
@@ -197,7 +197,7 @@ PARTITION BY date_trunc('week', `dt`)
 DISTRIBUTED BY HASH(`dt`)
 REFRESH DEFERRED MANUAL
 PROPERTIES (
-    "partition_refresh_mode" = "default"
+    "partition_refresh_strategy" = "strict"
 )
 AS select dt, sum(id) as s1 from u5 group by dt;
 
@@ -206,7 +206,7 @@ PARTITION BY date_trunc('week', `dt`)
 DISTRIBUTED BY HASH(`dt`)
 REFRESH DEFERRED MANUAL
 PROPERTIES (
-    "partition_refresh_mode" = "smart"
+    "partition_refresh_strategy" = "adaptive"
 )
 AS select dt, sum(id) as s1 from u6 group by dt;
 
@@ -215,7 +215,7 @@ partition by dt
 REFRESH DEFERRED MANUAL
 distributed by hash(dt, province) buckets 10
 PROPERTIES (
-"partition_refresh_mode" = "smart",
+"partition_refresh_strategy" = "adaptive",
 "replication_num" = "1"
 )
 as select dt, province, sum(age) from u7 group by dt, province order by dt, province;

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_with_smart_refresh
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_with_smart_refresh
@@ -1,0 +1,447 @@
+-- name: test_mv_refresh_with_with_smart_refresh
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE `u1` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `u2` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p1 VALUES [("2024-03-10"), ("2024-03-11")),
+  PARTITION p2 VALUES [("2024-03-11"), ("2024-03-12")),
+  PARTITION p3 VALUES [("2024-03-12"), ("2024-03-13")),
+  PARTITION p4 VALUES [("2024-03-13"), ("2024-03-14")),
+  PARTITION p5 VALUES [("2024-03-14"), ("2024-03-15")),
+  PARTITION p6 VALUES [("2024-04-01"), ("2024-04-02")),
+  PARTITION p7 VALUES [("2024-04-10"), ("2024-04-11"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `u3` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p1 VALUES [("2024-03-10"), ("2024-03-11")),
+  PARTITION p2 VALUES [("2024-03-11"), ("2024-03-12")),
+  PARTITION p3 VALUES [("2024-03-12"), ("2024-03-13")),
+  PARTITION p4 VALUES [("2024-03-13"), ("2024-03-14")),
+  PARTITION p5 VALUES [("2024-03-14"), ("2024-03-15")),
+  PARTITION p6 VALUES [("2024-04-10"), ("2024-04-11"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `u4` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p1 VALUES [("2023-01-01"), ("2024-01-01")),
+  PARTITION p2 VALUES [("2024-01-01"), ("2025-01-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `u5` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p1 VALUES [("2024-01-01"), ("2024-02-01")),
+  PARTITION p2 VALUES [("2024-02-01"), ("2024-03-01")),
+  PARTITION p3 VALUES [("2024-03-01"), ("2024-04-01")),
+  PARTITION p4 VALUES [("2024-04-01"), ("2024-05-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `u6` (
+  `id` int(11) NOT NULL,
+  `dt` date NOT NULL
+) ENGINE=OLAP
+PRIMARY KEY(`id`, `dt`)
+PARTITION BY RANGE (dt) (
+  START ("2024-01-01") END ("2024-05-01") EVERY (INTERVAL 1 DAY)
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `u7` (
+      id BIGINT,
+      province VARCHAR(64) not null,
+      age SMALLINT,
+      dt VARCHAR(10) not null
+)
+DUPLICATE KEY(id)
+PARTITION BY LIST (province, dt) (
+     PARTITION p1 VALUES IN (("beijing", "2024-01-01")),
+     PARTITION p2 VALUES IN (("guangdong", "2024-01-01")),
+     PARTITION p3 VALUES IN (("beijing", "2024-01-02")),
+     PARTITION p4 VALUES IN (("guangdong", "2024-01-02"))
+)
+DISTRIBUTED BY RANDOM
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO u1 (id,dt) VALUES
+	 (131,'2024-04-10'),
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12'),
+	 (7,'2024-03-13'),
+	 (8,'2024-03-14'),
+	 (11,'2024-03-15'),
+	 (13,'2024-03-16'),
+	 (14,'2024-03-17'),
+	 (16,'2024-03-18');
+INSERT INTO u2 (id,dt) VALUES
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12'),
+	 (7,'2024-03-13');
+INSERT INTO u3 (id,dt) VALUES
+	 (131,'2024-04-10'),
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12'),
+	 (7,'2024-03-13'),
+	 (8,'2024-03-14');
+INSERT INTO u4 (id,dt) VALUES
+	 (13,'2024-03-16'),
+	 (14,'2024-03-17'),
+	 (16,'2024-03-18');
+INSERT INTO u5 (id,dt) VALUES
+	 (131,'2024-04-10'),
+	 (1,'2024-03-10'),
+	 (16,'2024-03-18');
+INSERT INTO u6 (id,dt) VALUES
+	 (1,'2024-03-10'),
+	 (2,'2024-03-11'),
+	 (4,'2024-03-12');
+INSERT INTO u7 VALUES
+     (1, 'beijing', 20, '2024-01-01'),
+     (2, 'guangdong', 20, '2024-01-01'),
+     (3, 'guangdong', 20, '2024-01-02');
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv1`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+    "partition_refresh_mode" = "smart"
+)
+AS select dt, sum(id) as s1 from u1 group by dt;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv2`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+    "partition_refresh_mode" = "default"
+)
+AS select dt, sum(id) as s1 from u2 group by dt;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv3`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+    "partition_refresh_mode" = "smart"
+)
+AS select dt, sum(id) as s1 from u3 group by dt;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv4`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+    "partition_refresh_mode" = "default"
+)
+AS select dt, sum(id) as s1 from u4 group by dt;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv5`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+    "partition_refresh_mode" = "default"
+)
+AS select dt, sum(id) as s1 from u5 group by dt;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv6`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+    "partition_refresh_mode" = "smart"
+)
+AS select dt, sum(id) as s1 from u6 group by dt;
+
+create materialized view IF NOT EXISTS `test_mv7`
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10
+PROPERTIES (
+"partition_refresh_mode" = "smart",
+"replication_num" = "1"
+)
+as select dt, province, sum(age) from u7 group by dt, province order by dt, province;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv11`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL
+AS
+    select dt from u1
+    union all
+    select dt from u2;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv12`
+PARTITION BY date_trunc('week', `dt`)
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL
+AS
+    select dt from u1
+    union all
+    select dt from u2
+    union all
+    select dt from u3
+    union all
+    select dt from u4
+    union all
+    select dt from u5
+    union all
+    select dt from u6;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv13`
+PARTITION BY dt
+DISTRIBUTED BY HASH(`dt`)
+REFRESH DEFERRED MANUAL
+AS
+    select dt from test_mv1
+    union all
+    select dt from test_mv2
+    union all
+    select dt from test_mv3
+    union all
+    select dt from test_mv4
+    union all
+    select dt from test_mv5
+    union all
+    select dt from test_mv6;
+
+refresh materialized view test_mv1 with sync mode;
+refresh materialized view test_mv2 with sync mode;
+refresh materialized view test_mv3 with sync mode;
+refresh materialized view test_mv4 with sync mode;
+refresh materialized view test_mv5 with sync mode;
+refresh materialized view test_mv6 with sync mode;
+refresh materialized view test_mv7 with sync mode;
+
+refresh materialized view test_mv11 with sync mode;
+refresh materialized view test_mv12 with sync mode;
+refresh materialized view test_mv13 with sync mode;
+
+select count(1) from test_mv1;
+select count(1) from test_mv2;
+select count(1) from test_mv3;
+select count(1) from test_mv4;
+select count(1) from test_mv5;
+select count(1) from test_mv6;
+select count(1) from test_mv7;
+
+select count(1) from test_mv11;
+select count(1) from test_mv12;
+select count(1) from test_mv13;
+
+function: check_hit_materialized_view("select dt, sum(id) from u1 group by dt;", "test_mv1")
+function: check_hit_materialized_view("select dt, sum(id) from u2 group by dt;", "test_mv2")
+function: check_hit_materialized_view("select dt, sum(id) from u3 group by dt;", "test_mv3")
+function: check_hit_materialized_view("select dt, sum(id) from u4 group by dt;", "test_mv4")
+function: check_hit_materialized_view("select dt, sum(id) from u5 group by dt;", "test_mv5")
+function: check_hit_materialized_view("select dt, sum(id) from u6 group by dt;", "test_mv6")
+function: check_hit_materialized_view("select dt, province, sum(age) from u7 group by dt, province;", "test_mv7")
+
+select dt, s1 from test_mv1 order by 1;
+select dt, s1 from test_mv2 order by 1;
+select dt, s1 from test_mv3 order by 1;
+select dt, s1 from test_mv4 order by 1;
+select dt, s1 from test_mv5 order by 1;
+select dt, s1 from test_mv6 order by 1;
+select dt, province from test_mv7 order by 1;
+
+select dt, count(1) from test_mv11 group by dt order by 1;
+select dt, count(1) from test_mv12 group by dt order by 1;
+select dt, count(1) from test_mv13 group by dt order by 1;
+
+set enable_materialized_view_rewrite = false;
+select dt, sum(id) from u1 group by dt order by 1;
+select dt, sum(id) from u2 group by dt order by 1;
+select dt, sum(id) from u3 group by dt order by 1;
+select dt, sum(id) from u4 group by dt order by 1;
+select dt, sum(id) from u5 group by dt order by 1;
+select dt, sum(id) from u6 group by dt order by 1;
+select dt, province, sum(age) from u7 group by dt, province order by dt, province;
+
+select dt, count(1) from (
+    select dt from u1
+    union all
+    select dt from u2
+) t group by dt order by 1;
+
+select dt, count(1) from (
+    select dt from u1
+    union all
+    select dt from u2
+    union all
+    select dt from u3
+    union all
+    select dt from u4
+    union all
+    select dt from u5
+    union all
+    select dt from u6
+) t group by dt order by 1;
+
+select dt, count(1) from (
+  select dt from test_mv1
+  union all
+  select dt from test_mv2
+  union all
+  select dt from test_mv3
+  union all
+  select dt from test_mv4
+  union all
+  select dt from test_mv5
+  union all
+  select dt from test_mv6
+) t group by dt order by 1;
+set enable_materialized_view_rewrite = true;
+
+INSERT INTO u1 (id,dt) VALUES (131,'2024-04-10'), (1,'2024-03-10'), (2,'2024-03-11'), (4,'2024-03-12');
+INSERT INTO u2 (id,dt) VALUES (1,'2024-03-10'), (2,'2024-03-11');
+INSERT INTO u3 (id,dt) VALUES (131,'2024-04-10'), (1,'2024-03-10');
+INSERT INTO u4 (id,dt) VALUES (13,'2024-03-16'), (14,'2024-03-17');
+INSERT INTO u5 (id,dt) VALUES (131,'2024-04-10'), (1,'2024-03-10');
+INSERT INTO u6 (id,dt) VALUES (1,'2024-03-10'), (2,'2024-03-11'), (4,'2024-03-12');
+
+select count(1) from test_mv1;
+select count(1) from test_mv2;
+select count(1) from test_mv3;
+select count(1) from test_mv4;
+select count(1) from test_mv5;
+select count(1) from test_mv6;
+select count(1) from test_mv7;
+
+select count(1) from test_mv11;
+select count(1) from test_mv12;
+select count(1) from test_mv13;
+
+function: check_no_hit_materialized_view("select dt, sum(id) from u1 group by dt;", "test_mv1")
+function: check_no_hit_materialized_view("select dt, sum(id) from u2 group by dt;", "test_mv2")
+function: check_hit_materialized_view("select dt, sum(id) from u3 group by dt;", "test_mv3")
+function: check_no_hit_materialized_view("select dt, sum(id) from u4 group by dt;", "test_mv4")
+function: check_no_hit_materialized_view("select dt, sum(id) from u5 group by dt;", "test_mv5")
+function: check_no_hit_materialized_view("select dt, sum(id) from u6 group by dt;", "test_mv6")
+function: check_no_hit_materialized_view("select dt, sum(id) from u6 group by dt;", "test_mv6")
+function: check_hit_materialized_view("select dt, province, sum(age) from u7 group by dt, province;", "test_mv7")
+
+select dt, s1 from test_mv1 order by 1;
+select dt, s1 from test_mv2 order by 1;
+select dt, s1 from test_mv3 order by 1;
+select dt, s1 from test_mv4 order by 1;
+select dt, s1 from test_mv5 order by 1;
+select dt, s1 from test_mv6 order by 1;
+select dt, province, sum(age) from u7 group by dt, province order by dt, province;
+
+select dt, count(1) from test_mv11 group by dt order by 1;
+select dt, count(1) from test_mv12 group by dt order by 1;
+select dt, count(1) from test_mv13 group by dt order by 1;
+
+set enable_materialized_view_rewrite = false;
+select dt, sum(id) from u1 group by dt order by 1;
+select dt, sum(id) from u2 group by dt order by 1;
+select dt, sum(id) from u3 group by dt order by 1;
+select dt, sum(id) from u4 group by dt order by 1;
+select dt, sum(id) from u5 group by dt order by 1;
+select dt, sum(id) from u6 group by dt order by 1;
+select dt, province, sum(age) from u7 group by dt, province order by dt, province;
+
+select dt, count(1) from (
+    select dt from u1
+    union all
+    select dt from u2
+) t group by dt order by 1;
+
+select dt, count(1) from (
+    select dt from u1
+    union all
+    select dt from u2
+    union all
+    select dt from u3
+    union all
+    select dt from u4
+    union all
+    select dt from u5
+    union all
+    select dt from u6
+) t group by dt order by 1;
+
+select dt, count(1) from (
+  select dt from test_mv1
+  union all
+  select dt from test_mv2
+  union all
+  select dt from test_mv3
+  union all
+  select dt from test_mv4
+  union all
+  select dt from test_mv5
+  union all
+  select dt from test_mv6
+) t group by dt order by 1;
+set enable_materialized_view_rewrite = true;
+
+drop materialized view test_mv1;
+drop materialized view test_mv2;
+drop materialized view test_mv3;
+drop materialized view test_mv4;
+drop materialized view test_mv5;
+drop materialized view test_mv6;
+drop materialized view test_mv7;
+drop materialized view test_mv11;
+drop materialized view test_mv12;
+drop materialized view test_mv13;


### PR DESCRIPTION
## Why I'm doing:
MV's partition_refresh_number property has been set 1 since SR 3.3, but this can be efficient if there are too many partitions to fresh and per-partition contains no more rows. We may introduce a more adaptive method to adjust this by the base table data info.

## What I'm doing:
I designed a new smart partition refresh mode that uses both mv_max_rows_per_refresh and mv_max_bytes_per_refresh as thresholds. When a materialized view starts to refresh, this strategy selects as many partitions as possible until the number of related base table rows or total data size reaches either of the thresholds.

To enable this new refresh mode, simply set the materialized view property when creating or altering the MV. If you don't use this refresh mode. It will still choose legacy refresh mode.

```
PROPERTIES (
"partition_refresh_strategy" = "strict | adaptive"
)
```
Fixes #57981 https://github.com/StarRocks/starrocks/issues/56973

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
