### PR TITLE
[Enhancement] filter node with shutdown status in primary replica selection

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -88,7 +88,6 @@ import com.starrocks.sql.analyzer.RelationId;
 import com.starrocks.sql.analyzer.Scope;
 import com.starrocks.sql.analyzer.SelectAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
-import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TColumn;
 import com.starrocks.thrift.TDataSink;
@@ -887,11 +886,13 @@ public class OlapTableSink extends DataSink {
             Replica replica = replicas.get(i);
             boolean isHealthy = !replica.getLastWriteFail()
                     && !infoService.getBackend(replica.getBackendId()).getLastWriteFail();
-            //when single replica, to ensure the load job could loading normally, BE SHUTDOWN status could not be checked.
+            
+            //when the node is in shutdown, the isAlive() would be false, so here use isAlive() to check.
+            //when single replica, to ensure the load job could loading, node shutdown status should not be checked.
             if (replicas.size() > 1) {
-                isHealthy = isHealthy
-                        && infoService.getBackend(replica.getBackendId()).getStatus() != ComputeNode.Status.SHUTDOWN;
+                isHealthy = isHealthy && infoService.getBackend(replica.getBackendId()).isAlive();
             }
+            
             if (lowUsageIndex == -1 && isHealthy) {
                 lowUsageIndex = i;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -859,9 +859,8 @@ public class OlapTableSink extends DataSink {
                                          MaterializedIndex index,
                                          List<Long> selectedBackedIds,
                                          List<Replica> replicas) {
-        int lowUsageIndex = findPrimaryReplica(table, bePrimaryMap, infoService,
+        return findPrimaryReplica(table, bePrimaryMap, infoService,
                 index, selectedBackedIds, 0, replicas);
-        return lowUsageIndex;
     }
 
     private static int findPrimaryReplica(OlapTable table,
@@ -887,8 +886,9 @@ public class OlapTableSink extends DataSink {
             boolean isHealthy = !replica.getLastWriteFail()
                     && !infoService.getBackend(replica.getBackendId()).getLastWriteFail();
             
-            //when the node is in shutdown, the isAlive() would be false, so here use isAlive() to check.
-            //when single replica, to ensure the load job could loading, node shutdown status should not be checked.
+            // The isAlive() flag indicates node availability during shutdown sequences.
+            // For single-replica configurations, we bypass node status checks to maintain
+            // loading operation continuity despite shutdown transitions.
             if (replicas.size() > 1) {
                 isHealthy = isHealthy && infoService.getBackend(replica.getBackendId()).isAlive();
             }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -626,7 +626,7 @@ public class OlapTableSinkTest {
         int lowUsageIndex1 = OlapTableSink.findPrimaryReplica(olapTable, bePrimaryMap, infoService,
                 index, selectedBackedIds, multipleReplicaList);
         //note: even though in bePrimaryMap, primary replica num in be2 < primary replica num in be3,
-        //      but be2 is in shutting down, so choose replica3 as primary replica.
+        //      but be2 is in shutting down, so choose replica3 as primary replica. 
         Assert.assertEquals(multipleReplicaList.get(lowUsageIndex1).getId(), replica3.getId());
         Assert.assertEquals(multipleReplicaList.get(lowUsageIndex1).getBackendId(), be3.getId());
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -639,7 +639,7 @@ public class OlapTableSinkTest {
         int lowUsageIndex2 = OlapTableSink.findPrimaryReplica(olapTable, bePrimaryMap, infoService,
                 index, selectedBackedIds, singleReplicaList);
         //note: even though be2 is in shutting down, to ensure the load job could loading normally,
-        //      be2 SHUTDOWN status could not be checked, so choose replica4 as primary replica.
+        //      be2 SHUTDOWN status could not be checked, so choose replica4 as primary replica. 
         Assert.assertEquals(singleReplicaList.get(lowUsageIndex2).getId(), replica4.getId());
         Assert.assertEquals(singleReplicaList.get(lowUsageIndex2).getBackendId(), be2.getId());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -628,7 +628,7 @@ public class OlapTableSinkTest {
         Assert.assertEquals(multipleReplicaList.get(lowUsageIndex1).getId(), replica3.getId());
         Assert.assertEquals(multipleReplicaList.get(lowUsageIndex1).getBackendId(), be3.getId());
 
-        //2.check primary replica selection in single replica
+        //2.check primary replica selection in single replica 
         Replica replica4 = new Replica(44L, be2.getId(), Replica.ReplicaState.NORMAL, 1, 0);
         replica4.setLastWriteFail(false);
         List<Replica> singleReplicaList = new ArrayList<>();

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -626,7 +626,7 @@ public class OlapTableSinkTest {
         int lowUsageIndex1 = OlapTableSink.findPrimaryReplica(olapTable, bePrimaryMap, infoService,
                 index, selectedBackedIds, multipleReplicaList);
         //note: even though in bePrimaryMap, primary replica num in be2 < primary replica num in be3,
-        //      but be2 is in shutting down, so choose replica3 as primary replica. 
+        //      but be2 is in shutting down, so choose replica3 as primary replica.
         Assert.assertEquals(multipleReplicaList.get(lowUsageIndex1).getId(), replica3.getId());
         Assert.assertEquals(multipleReplicaList.get(lowUsageIndex1).getBackendId(), be3.getId());
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -628,7 +628,7 @@ public class OlapTableSinkTest {
         Assert.assertEquals(multipleReplicaList.get(lowUsageIndex1).getId(), replica3.getId());
         Assert.assertEquals(multipleReplicaList.get(lowUsageIndex1).getBackendId(), be3.getId());
 
-        //2.check primary replica selection in single replica 
+        //2.check primary replica selection in single replica
         Replica replica4 = new Replica(44L, be2.getId(), Replica.ReplicaState.NORMAL, 1, 0);
         replica4.setLastWriteFail(false);
         List<Replica> singleReplicaList = new ArrayList<>();


### PR DESCRIPTION
## Why I'm doing:
when upgrading need to restart backend, data load job maybe fail, especially for flink realtime load job (inside contains micro batch stream load).

## What I'm doing:
based on current backend graceful shutdown feature, during `loop_count_wait_fragments_finish`, the backend's status is in `SHUTDOWN`, when upgrading need to restart backend, filter backend with shutdown status in primary replica selection, it would reduce the probability of data load job fail, brings more friendly seamless upgrade experience.

for example:
use default table level's parameter value:
```
"replicated_storage" = "true",
"write_quorum" = "MAJORITY"
```

a tablet contains three replica: `r1、r2、r3`, storage in `be1、be2、be3`. when `be2` upgrade need restart:

**1.previous primary replica selection logic:**
`r2` is possible to be chosen as primary replica, during loading data to `r2` or distributing data to `r1/r3` maybe fails because of restart, cause entire load job fail.

**2.adjusted primary replica selection logic:**
only `r1` or `r3` could be chosen as primary replica(here assume `r1` is chosen as primary replica), 
with `"replicated_storage" = "true"`, `r1` would distribute data to `r2` and `r3`, even though distributing data to `r2` fail due to `be2` restart, with `"write_quorum" = "MAJORITY"` , the load job would success as long as distributing data to `r3` is successful. 

**other case:**
1.when single replica, to ensure the load job could loading normally, even though backend is in `SHUTDOWN`, the single replica would be chosen as primary replica.
2.when `"replicated_storage" = "false"`, data is directly loading to multiple replicas, without differentiating primary and secondary replicas, it is not related to primary replica selection.
3.when `"write_quorum" = "ONE"/"ALL"`, the adjusted primary replica selection logic might similarly reduce the probability of data load job fail.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
