### PR TITLE
[Enhancement] Support customize warehouse parameter for _query_plan http action

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/http/TableQueryPlanActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TableQueryPlanActionTest.java
@@ -35,6 +35,7 @@
 package com.starrocks.http;
 
 import com.starrocks.rpc.ConfigurableSerDesFactory;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.thrift.TQueryPlanInfo;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -52,6 +53,7 @@ public class TableQueryPlanActionTest extends StarRocksHttpTestCase {
 
     private static final String PATH_URI = "/_query_plan";
     protected static String ES_TABLE_URL;
+    protected static String WAREHOUSE_KEY = "warehouse";
 
     @Override
     protected void doSetUp() throws Exception {
@@ -66,6 +68,7 @@ public class TableQueryPlanActionTest extends StarRocksHttpTestCase {
         Request request = new Request.Builder()
                 .post(body)
                 .addHeader("Authorization", rootAuth)
+                .addHeader(WAREHOUSE_KEY,  WarehouseManager.DEFAULT_WAREHOUSE_NAME)
                 .url(URI + PATH_URI)
                 .build();
         try (Response response = networkClient.newCall(request).execute()) {


### PR DESCRIPTION
```sh
curl -u root:'xxxx' \
--location 'http://localhost:8030/api/load_test/Employees/_query_plan' \
--header 'Content-Type: application/json' \
--header 'warehouse:sub_wh' \
--data '{"sql": "select * from load_test.Employees;"}'
```

log sample
```sh
2025-04-25 13:56:48.589+08:00 INFO (nioEventLoopGroup-6-1|152) [TableQueryPlanAction.executeWithoutPassword():157] receive SQL statement [select * from load_test.Employees;] from external service [ user ['root'@'%']] for database [load_test] table [Employees] warehouse [sub_wh]
2025-04-25 13:57:54.420+08:00 INFO (nioEventLoopGroup-6-2|153) [TableQueryPlanAction.executeWithoutPassword():157] receive SQL statement [select * from load_test.Employees;] from external service [ user ['root'@'%']] for database [load_test] table [Employees] warehouse [default_warehouse]
```

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
