### PR TITLE
[BugFix] Fix the issue where tablets fail to load completely from datadir

### DIFF
--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -269,7 +269,7 @@ std::string DataDir::get_root_path_from_schema_hash_path_in_trash(const std::str
             .string();
 }
 
-// We will igore error throw by load(),
+// [NOTICE] We will igore error throw by load(),
 // so we must ensure that all tablets are either properly loaded or handled within load().
 Status DataDir::load() {
     // load tablet
@@ -303,7 +303,7 @@ Status DataDir::load() {
         LOG(WARNING) << "load tablets from rocksdb timeout, try to compact meta and retry. path: " << _path;
         Status s = _kv_store->compact();
         if (!s.ok()) {
-            // Only print log, do not return error.
+            // We don't need to make sure compact MUST success. Just ignore the error.
             LOG(ERROR) << "data dir " << _path << " compact meta before load failed";
         }
         for (auto tablet_id : tablet_ids) {
@@ -353,7 +353,7 @@ Status DataDir::load() {
             tablet->tablet_meta()->to_meta_pb(&tablet_meta_pb);
             Status s = TabletMetaManager::save(this, tablet_meta_pb);
             if (!s.ok()) {
-                // Only print log, do not return error.
+                // Only print log, do not return error. We can handle it later.
                 LOG(ERROR) << "data dir " << _path << " save tablet meta failed: " << s.message();
             }
         }

--- a/be/src/storage/data_dir.h
+++ b/be/src/storage/data_dir.h
@@ -128,7 +128,7 @@ public:
     static std::string get_root_path_from_schema_hash_path_in_trash(const std::string& schema_hash_dir_in_trash);
 
     // load data from meta and data files
-    Status load();
+    void load();
 
     // this function scans the paths in data dir to collect the paths to check
     // this is a producer function. After scan, it will notify the perform_path_gc function to gc

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -171,6 +171,8 @@ void StorageEngine::load_data_dirs(const std::vector<DataDir*>& data_dirs) {
         threads.emplace_back([data_dir] {
             auto res = data_dir->load();
             if (!res.ok()) {
+                // We will igore error throw by data_dir->load(),
+                // so we must ensure that all tablets are either properly loaded or handled within load().
                 LOG(WARNING) << "Fail to load data dir=" << data_dir->path() << ", res=" << res.to_string();
             }
         });

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -168,14 +168,7 @@ void StorageEngine::load_data_dirs(const std::vector<DataDir*>& data_dirs) {
     std::vector<std::thread> threads;
     threads.reserve(data_dirs.size());
     for (auto data_dir : data_dirs) {
-        threads.emplace_back([data_dir] {
-            auto res = data_dir->load();
-            if (!res.ok()) {
-                // We will igore error throw by data_dir->load(),
-                // so we must ensure that all tablets are either properly loaded or handled within load().
-                LOG(WARNING) << "Fail to load data dir=" << data_dir->path() << ", res=" << res.to_string();
-            }
-        });
+        threads.emplace_back([data_dir] { (void)data_dir->load(); });
         Thread::set_thread_name(threads.back(), "load_data_dir");
 
         threads.emplace_back([data_dir] {


### PR DESCRIPTION
## Why I'm doing:
You can get more info about this issue from #58203

Conclusion is that this BUG occurs because our code fails to properly handle exceptions during the data directory loading process, resulting in a large number of tablets failing to load correctly. Consequently, when this BE node processes subsequently added tablets, it conflicts with the metadata of existing tablets, leading to a "file not found" error state.

## What I'm doing:

Ensure that ​​DataDir::load​​ does not get interrupted by unnecessary exception throws during execution, as the outer layer does not handle error codes. So we must ensure that all tablets are either properly loaded or handled within load().

Fixes #58203

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
