### PR TITLE
[BugFix] Fix data file lost when upgrade from versions below 3.2

### DIFF
--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -140,10 +140,7 @@ void Rowset::make_commit(int64_t version, uint32_t rowset_seg_id) {
 /**
  * Checks if all files associated with this rowset exist on disk.
  * 
- * This method verifies the existence of:
- * 1. All segment files
- * 2. All delete files
- * 3. All update files
+ * This method verifies the existence of: All segment files
  * 
  * If any file is missing, it logs a warning message with the expected path
  * and tablet ID, then returns false.
@@ -157,20 +154,6 @@ bool Rowset::check_file_existence() {
             LOG(WARNING) << "Segment file does not exist. Expected path: " << seg_path
                          << ". This might occur if the file was deleted or not generated correctly. "
                          << "Tablet ID: " << _rowset_meta->tablet_id();
-            return false;
-        }
-    }
-    for (int i = 0; i < num_delete_files(); ++i) {
-        std::string path = segment_del_file_path(_rowset_path, rowset_id(), i);
-        if (!fs::path_exist(path)) {
-            LOG(WARNING) << "del file not exist. path:" << path << ", tablet_id:" << _rowset_meta->tablet_id();
-            return false;
-        }
-    }
-    for (int i = 0; i < num_update_files(); ++i) {
-        std::string path = segment_upt_file_path(_rowset_path, rowset_id(), i);
-        if (!fs::path_exist(path)) {
-            LOG(WARNING) << "upt file not exist. path:" << path << ", tablet_id:" << _rowset_meta->tablet_id();
             return false;
         }
     }

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -381,6 +381,9 @@ public:
 
     size_t segment_memory_usage();
 
+    // check if the rowset files exist
+    bool check_file_existence();
+
 protected:
     friend class RowsetFactory;
 

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -112,11 +112,22 @@ Status TabletManager::_add_tablet_unlocked(const TabletSharedPtr& new_tablet, bo
         int64_t new_time = 0;
         int64_t old_version = 0;
         int64_t new_version = 0;
+        bool old_file_existence = true;
+        bool new_file_existence = true;
         if (new_tablet->updates() != nullptr) {
             old_time = old_tablet->updates()->max_rowset_creation_time();
             new_time = new_tablet->updates()->max_rowset_creation_time();
             old_version = old_tablet->updates()->max_version();
             new_version = new_tablet->updates()->max_version();
+            // Currently, we only perform file existence checks on Primary Key tables
+            // to determine tablet priority. This is because prior to version 3.2,
+            // the tablet priority evaluation logic was unstable and could lead to
+            // accidental garbage collection (GC) of data files during multiple BE restarts.
+            // Therefore, we've implemented file existence checks here specifically to bypass
+            // tablets whose data files might have been incorrectly GC'd. As for non-PK tables,
+            // since they don't carry this risk, we can safely ignore them for now.
+            old_file_existence = old_tablet->updates()->rowset_check_file_existence();
+            new_file_existence = new_tablet->updates()->rowset_check_file_existence();
         } else {
             old_tablet->obtain_header_rdlock();
             auto old_rowset = old_tablet->rowset_with_max_version();
@@ -127,11 +138,21 @@ Status TabletManager::_add_tablet_unlocked(const TabletSharedPtr& new_tablet, bo
             new_version = (new_rowset == nullptr) ? -1 : new_rowset->end_version();
             old_tablet->release_header_lock();
         }
-        bool replace_old = (new_version > old_version) || (new_version == old_version && new_time > old_time) ||
-                           // use for migration of primary key empty tablet
-                           (new_tablet->updates() != nullptr && old_version == 1 && new_version == 1);
 
-        if (replace_old) {
+        auto replace_old_fn = [&]() {
+            // Tablet with guaranteed data file existence is prioritized for adoption.
+            if (old_file_existence && !new_file_existence) {
+                return false;
+            } else if (!old_file_existence && new_file_existence) {
+                return true;
+            } else {
+                return (new_version > old_version) || (new_version == old_version && new_time > old_time) ||
+                       // use for migration of primary key empty tablet
+                       (new_tablet->updates() != nullptr && old_version == 1 && new_version == 1);
+            }
+        };
+
+        if (replace_old_fn()) {
             RETURN_IF_ERROR(_drop_tablet_unlocked(old_tablet->tablet_id(), kMoveFilesToTrash));
             RETURN_IF_ERROR(_update_tablet_map_and_partition_info(new_tablet));
             LOG(INFO) << "Added duplicated tablet. tablet_id=" << new_tablet->tablet_id()

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -5932,4 +5932,22 @@ void TabletUpdates::rewrite_rs_meta(bool is_fatal) {
             << ", pending rowset num=" << pending_rs << ", published rowset num=" << published_rs;
 }
 
+bool TabletUpdates::rowset_check_file_existence() const {
+    vector<RowsetSharedPtr> all_rowsets;
+    {
+        // 1. fetch rowsets
+        std::lock_guard<std::mutex> lg(_rowsets_lock);
+        for (auto& [rowset_id, rowset] : _rowsets) {
+            all_rowsets.push_back(rowset);
+        }
+    }
+    // 2. check rowset file
+    for (auto& rowset : all_rowsets) {
+        if (!rowset->check_file_existence()) {
+            return false;
+        }
+    }
+    return true;
+}
+
 } // namespace starrocks

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -389,6 +389,8 @@ public:
     Status breakpoint_check();
     Status compaction_random(MemTracker* mem_tracker);
 
+    bool rowset_check_file_existence() const;
+
 private:
     friend class Tablet;
     friend class PrimaryIndex;

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -481,11 +481,9 @@ void TabletUpdatesTest::test_writeread_with_delete(bool enable_persistent_index)
     // Delete [0, 1, 2 ... N/2)
     Int64Column deletes;
     deletes.append_numbers(keys.data(), sizeof(int64_t) * keys.size() / 2);
-    auto r2 = create_rowset(_tablet, {}, &deletes);
-    ASSERT_TRUE(_tablet->rowset_commit(3, r2).ok());
+    ASSERT_TRUE(_tablet->rowset_commit(3, create_rowset(_tablet, {}, &deletes)).ok());
     ASSERT_EQ(3, _tablet->updates()->max_version());
     ASSERT_EQ(N / 2, read_tablet(_tablet, 3));
-    ASSERT_TRUE(r2->check_file_existence());
     ASSERT_TRUE(_tablet->updates()->rowset_check_file_existence());
 
     // Delete [0, 1, 2 ... N) and insert [N, N+1, N+2 ... 2*N)
@@ -522,21 +520,9 @@ TEST_F(TabletUpdatesTest, test_rowset_file_existence) {
     ASSERT_EQ(2, _tablet->updates()->max_version());
     ASSERT_TRUE(r1->check_file_existence());
 
-    // Delete [0, 1, 2 ... N/2)
-    Int64Column deletes;
-    deletes.append_numbers(keys.data(), sizeof(int64_t) * keys.size() / 2);
-    auto r2 = create_rowset(_tablet, {}, &deletes);
-    ASSERT_TRUE(_tablet->rowset_commit(3, r2).ok());
-    ASSERT_EQ(3, _tablet->updates()->max_version());
-    ASSERT_EQ(N / 2, read_tablet(_tablet, 3));
-    ASSERT_TRUE(r2->check_file_existence());
-    ASSERT_TRUE(_tablet->updates()->rowset_check_file_existence());
-
     // delete files from rs1 and rs2
     r1->remove();
-    r2->remove();
     ASSERT_FALSE(r1->check_file_existence());
-    ASSERT_FALSE(r2->check_file_existence());
     ASSERT_FALSE(_tablet->updates()->rowset_check_file_existence());
 }
 


### PR DESCRIPTION
## Why I'm doing:
Prior to version 3.2, a bug existed in the priority evaluation logic when loading PK tablets: if duplicate tablets were encountered, the system couldn't guarantee loading the newest tablet. (Fixed after 3.2 by #25522) 
This created a critical issue - if an older tablet was loaded, the newer tablet's data files might get garbage collected. Then after another restart, when the system attempted to load the newer tablet, the corresponding data files would be missing, ultimately resulting in errors. 
This issue will only happen below 3.2 or upgrade from below 3.2.

## What I'm doing:
The solution involves implementing a data file existence check when loading PK tablets. Tablets with intact data files are given the highest priority and get loaded first.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
