### PR TITLE
[BugFix] AggTable's metric type not match corresponding aggregate function's return type

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/planner/PreAggregationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/PreAggregationTest.java
@@ -56,6 +56,16 @@ public class PreAggregationTest {
                 "PROPERTIES (\n" +
                 " \"replication_num\" = \"1\"\n" +
                 ");");
+
+        starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `test_agg_3` (\n" +
+                "  `k1` int(11) NULL,\n" +
+                "  `v1` int SUM NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "AGGREGATE KEY(`k1`)\n" +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 1\n" +
+                "PROPERTIES (\n" +
+                " \"replication_num\" = \"1\"\n" +
+                ");");
     }
 
     public String getFragmentPlan(String sql) throws Exception {
@@ -111,5 +121,25 @@ public class PreAggregationTest {
         assertContains(plan, "0:OlapScanNode\n" +
                 "     TABLE: test_agg_2\n" +
                 "     PREAGGREGATION: ON\n");
+    }
+
+    @Test
+    public void testMetricTypeOfAggTableNotMatchAggragationReturnType() throws Exception {
+        String sql = "select \n" +
+                "col1, \n" +
+                "col2 \n" +
+                "from (\n" +
+                "select k1 col1, \n" +
+                "IFNULL(SUM(v1),0) col2 \n" +
+                "from test_agg_3 \n" +
+                "group by k1\n" +
+                ")tmp \n" +
+                "where 1=1 and col2 > 1 \n" +
+                "order by col1 \n" +
+                "asc limit 0,5";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  1:Project\n" +
+                "  |  <slot 1> : 1: k1\n" +
+                "  |  <slot 4> : ifnull(CAST(2: v1 AS BIGINT), 0)");
     }
 }


### PR DESCRIPTION
## Why I'm doing:
in AggTable,may metric definition is `col int sum`, but in query sum(col)'s type is bigint, so after replace sum(col) wit col, we must guarantee the same ColumnRefOperator points to the same type expr, so we must cast col as bigint, otherwise during executing, ExchangeSink would send serialize the column as int column while the ExchangeSource would derserialize it in bigint column.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
