### PR TITLE
[BugFix] use `maybe_unused` to supress unused return result

### DIFF
--- a/be/src/util/simdjson_util.h
+++ b/be/src/util/simdjson_util.h
@@ -36,7 +36,7 @@ private:
     SimdjsonParser() {
         // The `_parser` is only used for `unescape`ing, which touches nothing of the parser's internal structure,
         // so the capacity doesn't matter.
-        (void)_parser.allocate(0);
+        [[maybe_unused]] auto err = _parser.allocate(0);
     }
     ~SimdjsonParser() = default;
 


### PR DESCRIPTION
## Why I'm doing:

Build failed on CentOS7 environment.
```
19:28:47 In file included from /root/starrocks/be/src/formats/json/nullable_column.cpp:25:
19:28:47 /root/starrocks/be/src/util/simdjson_util.h: In constructor 'starrocks::{anonymous}::SimdjsonParser::SimdjsonParser()':
19:28:47 /root/starrocks/be/src/util/simdjson_util.h:39:31: error: ignoring return value of 'simdjson::error_code simdjson::fallback::ondemand::parser::allocate(std::size_t, std::size_t)' declared with attribute 'warn_unused_result' [-Werror=unused-result]
19:28:47    39 |         (void)_parser.allocate(0);
19:28:47       |               ~~~~~~~~~~~~~~~~^~~
19:28:47 cc1plus: all warnings being treated as errors
19:28:47 make[2]: *** [src/formats/CMakeFiles/Formats.dir/json/nullable_column.cpp.o] Error 1
19:28:47 make[1]: *** [src/formats/CMakeFiles/Formats.dir/all] Error 2
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
