### PR TITLE
[BugFix] Fix stack trace heap-use-after-free

### DIFF
--- a/be/src/util/stack_util.cpp
+++ b/be/src/util/stack_util.cpp
@@ -30,6 +30,9 @@
 #include "gutil/strings/substitute.h"
 #include "runtime/current_thread.h"
 #include "testutil/sync_point.h"
+#include "util/defer_op.h"
+#include "util/hash.h"
+#include "util/phmap/phmap.h"
 #include "util/time.h"
 
 namespace google {
@@ -101,14 +104,38 @@ struct StackTraceTaskHash {
     }
 };
 
+// allocate an id for each stack trace request
+std::atomic_int g_stack_trace_id{0};
+// TID -> StackTraceTask
+using StackTraceTaskMap = std::unordered_map<int, StackTraceTask>;
+using StackTraceTaskMapSharedPtr = std::shared_ptr<StackTraceTaskMap>;
+/// stack trace id -> StackTraceTaskMap
+using StackTraceMap = phmap::parallel_flat_hash_map<int32_t, StackTraceTaskMapSharedPtr, phmap::Hash<int32_t>,
+                                                    phmap::EqualTo<int32_t>, phmap::Allocator<int32_t>, 5, std::mutex>;
+StackTraceMap g_running_stack_trace;
+
 void get_stack_trace_sighandler(int signum, siginfo_t* siginfo, void* ucontext) {
     int64_t start_us = MonotonicMicros();
-    auto task = reinterpret_cast<StackTraceTask*>(siginfo->si_value.sival_ptr);
-    task->depth = google::glog_internal_namespace_::GetStackTrace(task->addrs, StackTraceTask::kMaxStackDepth, 2);
+    int tid = static_cast<int>(syscall(SYS_gettid));
+    auto stack_trace_id = siginfo->si_value.sival_int;
+    StackTraceTaskMapSharedPtr stack_trace_task_map;
+    bool ret =
+            g_running_stack_trace.if_contains(stack_trace_id, [&](const auto& value) { stack_trace_task_map = value; });
+    if (!ret) {
+        LOG(WARNING) << "stack trace id " << stack_trace_id << " not found, tid: " << tid;
+        return;
+    }
+    auto it = stack_trace_task_map->find(tid);
+    if (it == stack_trace_task_map->end()) {
+        LOG(WARNING) << "tid " << tid << " not found, stack trace id " << stack_trace_id;
+        return;
+    }
+    auto& task = it->second;
+    task.depth = google::glog_internal_namespace_::GetStackTrace(task.addrs, StackTraceTask::kMaxStackDepth, 2);
     // get_stack_trace_for_thread first checks done flag then gets the cost.
     // To ensure the cost is valid, set cost before done flag
-    task->cost_us = MonotonicMicros() - start_us;
-    task->done = true;
+    task.cost_us = MonotonicMicros() - start_us;
+    task.done = true;
 }
 
 bool install_stack_trace_sighandler() {
@@ -141,11 +168,15 @@ std::string get_stack_trace_for_thread(int tid, int timeout_ms) {
         }
         sighandler_installed = true;
     }
-    StackTraceTask task;
     const auto pid = getpid();
     const auto uid = getuid();
+    auto stack_trace_id = g_stack_trace_id.fetch_add(1);
+    StackTraceTaskMapSharedPtr tasks = std::make_shared<StackTraceTaskMap>();
+    tasks->emplace(tid, StackTraceTask());
+    g_running_stack_trace.insert_or_assign(stack_trace_id, tasks);
+    DeferOp defer([stack_trace_id]() { g_running_stack_trace.erase(stack_trace_id); });
     union sigval payload;
-    payload.sival_ptr = &task;
+    payload.sival_int = stack_trace_id;
     auto err = signal_thread(pid, tid, uid, SIGRTMIN, payload);
     if (0 != err) {
         auto msg = strings::Substitute("collect stack trace failed, signal thread error: $0 tid: $1", strerror(errno),
@@ -154,6 +185,7 @@ std::string get_stack_trace_for_thread(int tid, int timeout_ms) {
         return msg;
     }
     int timeout_us = timeout_ms * 1000;
+    auto& task = (*tasks)[tid];
     while (!task.done) {
         usleep(1000);
         timeout_us -= 1000;
@@ -163,7 +195,7 @@ std::string get_stack_trace_for_thread(int tid, int timeout_ms) {
             return msg;
         }
     }
-    std::string ret = "Stack trace tid: " + std::to_string(tid) + "\n" + task.to_string();
+    std::string ret = fmt::format("Stack trace id: {}, tid: {}\n{}", stack_trace_id, tid, task.to_string());
     LOG(INFO) << ret;
     return ret;
 }
@@ -180,12 +212,18 @@ std::string get_stack_trace_for_threads_with_pattern(const std::vector<int>& tid
         }
         sighandler_installed = true;
     }
-    vector<StackTraceTask> tasks(tids.size());
     const auto pid = getpid();
     const auto uid = getuid();
+    auto stack_trace_id = g_stack_trace_id.fetch_add(1);
+    StackTraceTaskMapSharedPtr tasks = std::make_shared<StackTraceTaskMap>();
+    for (int i = 0; i < tids.size(); ++i) {
+        tasks->emplace(tids[i], StackTraceTask());
+    }
+    g_running_stack_trace.insert_or_assign(stack_trace_id, tasks);
+    DeferOp defer([stack_trace_id]() { g_running_stack_trace.erase(stack_trace_id); });
     for (int i = 0; i < tids.size(); ++i) {
         union sigval payload;
-        payload.sival_ptr = &tasks[i];
+        payload.sival_int = stack_trace_id;
         auto err = signal_thread(pid, tids[i], uid, SIGRTMIN, payload);
         if (0 != err) {
             auto msg = strings::Substitute("collect stack trace failed, signal thread error: $0 tid: $1",
@@ -198,7 +236,7 @@ std::string get_stack_trace_for_threads_with_pattern(const std::vector<int>& tid
         usleep(1000);
         int done = 0;
         for (int i = 0; i < tids.size(); ++i) {
-            if (tasks[i].done) {
+            if ((*tasks)[tids[i]].done) {
                 ++done;
             }
         }
@@ -221,12 +259,13 @@ std::string get_stack_trace_for_threads_with_pattern(const std::vector<int>& tid
     // group threads with same stack trace together
     std::unordered_map<StackTraceTask, std::vector<int>, StackTraceTaskHash> task_map;
     for (int i = 0; i < tids.size(); ++i) {
-        if (tasks[i].done) {
-            task_map[tasks[i]].push_back(tids[i]);
+        auto& task = (*tasks)[tids[i]];
+        if (task.done) {
+            task_map[task].push_back(tids[i]);
             task_done_count += 1;
-            max_task_cost_us = std::max(max_task_cost_us, tasks[i].cost_us);
-            min_task_cost_us = std::min(min_task_cost_us, tasks[i].cost_us);
-            total_task_cost_us += tasks[i].cost_us;
+            max_task_cost_us = std::max(max_task_cost_us, task.cost_us);
+            min_task_cost_us = std::min(min_task_cost_us, task.cost_us);
+            total_task_cost_us += task.cost_us;
         }
     }
     string ret;
@@ -261,9 +300,10 @@ std::string get_stack_trace_for_threads_with_pattern(const std::vector<int>& tid
         avg_task_cost_us = total_task_cost_us / task_done_count;
     }
     ret += fmt::format(
-            "{}total {} threads, {} identical groups, finish {} threads, total cost {} us, symbolize cost {} us,"
+            "{}stack trace id {}, total {} threads, {} identical groups, finish {} threads, total cost {} us, "
+            "symbolize cost {} us,"
             " thread block(avg/min/max) {}/{}/{} us, ",
-            line_prefix, tids.size(), task_map.size(), task_done_count, (MonotonicMicros() - start_us),
+            line_prefix, stack_trace_id, tids.size(), task_map.size(), task_done_count, (MonotonicMicros() - start_us),
             total_symbolize_cost_us, avg_task_cost_us, min_task_cost_us, max_task_cost_us);
     return ret;
 }


### PR DESCRIPTION
## Why I'm doing:
if the target thread receives the signal or performs stack trace slow, `StackTraceTask` may have been released by the stack trace trigger thread, so heap-use-after-free can happen when the target thread accesses it

exception thrown by `LoadChannelTestForLakeTablet.test_load_diagnose`

```
==767697==ERROR: AddressSanitizer: heap-use-after-free on address 0x5330000149c0 at pc 0x00000d8af64f bp 0x7f827c27ba00 sp 0x7f827c27b1c0
WRITE of size 56 at 0x5330000149c0 thread T175 (brpc_timer)
    #0 0xd8af64e in memcpy ../../.././libsanitizer/sanitizer_common/sanitizer_common_interceptors_memintrinsics.inc:115
    #1 0x2370816c in google::glog_internal_namespace_::GetStackTrace(void**, int, int) glog-0.7.1/src/stacktrace_generic-inl.h:59
    #2 0x1eb1cfc4 in starrocks::get_stack_trace_sighandler(int, siginfo_t*, void*) /root/celerdata/be/src/util/stack_util.cpp:107
    #3 0x7f833d20f62f  (/lib64/libpthread.so.0+0xf62f) (BuildId: e10cc8f2b932fc3daeda22f8dac5ebb969524e5b)
    #4 0x7f833a2f8e28 in syscall (/lib64/libc.so.6+0xf8e28) (BuildId: 1a8fb61bb4614a483833d5334202ab50edda2a25)
    #5 0x238e9f4d in bthread::futex_wait_private(void*, int, timespec const*) src/bthread/sys_futex.h:40
    #6 0x238e9f4d in bthread::TimerThread::run() src/bthread/timer_thread.cpp:433
    #7 0x238ea71f in bthread::TimerThread::run_this(void*) src/bthread/timer_thread.cpp:122
    #8 0xd81a411 in asan_thread_start ../../.././libsanitizer/asan/asan_interceptors.cpp:234
    #9 0x7f833d207ea4 in start_thread (/lib64/libpthread.so.0+0x7ea4) (BuildId: e10cc8f2b932fc3daeda22f8dac5ebb969524e5b)
    #10 0x7f833a2feb0c in clone (/lib64/libc.so.6+0xfeb0c) (BuildId: 1a8fb61bb4614a483833d5334202ab50edda2a25)

0x5330000149c0 is located 82368 bytes inside of 97680-byte region [0x533000000800,0x533000018590)
freed by thread T203 (diagnose) here:
    #0 0xd8b2f60 in operator delete(void*) ../../.././libsanitizer/asan/asan_new_delete.cpp:152
    #1 0x1eb280b9 in std::__new_allocator<starrocks::StackTraceTask>::deallocate(starrocks::StackTraceTask*, unsigned long) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/new_allocator.h:172
    #2 0x1eb26320 in std::allocator<starrocks::StackTraceTask>::deallocate(starrocks::StackTraceTask*, unsigned long) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/allocator.h:208
    #3 0x1eb26320 in std::allocator_traits<std::allocator<starrocks::StackTraceTask> >::deallocate(std::allocator<starrocks::StackTraceTask>&, starrocks::StackTraceTask*, unsigned long) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/alloc_traits.h:513
    #4 0x1eb26320 in std::_Vector_base<starrocks::StackTraceTask, std::allocator<starrocks::StackTraceTask> >::_M_deallocate(starrocks::StackTraceTask*, unsigned long) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/stl_vector.h:389
    #5 0x1eb23e5b in std::_Vector_base<starrocks::StackTraceTask, std::allocator<starrocks::StackTraceTask> >::~_Vector_base() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/stl_vector.h:368
    #6 0x1eb238c7 in std::vector<starrocks::StackTraceTask, std::allocator<starrocks::StackTraceTask> >::~vector() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/stl_vector.h:738
    #7 0x1eb202fc in starrocks::get_stack_trace_for_threads_with_pattern(std::vector<int, std::allocator<int> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /root/celerdata/be/src/util/stack_util.cpp:269
    #8 0x1eb20c0e in starrocks::get_stack_trace_for_all_threads(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /root/celerdata/be/src/util/stack_util.cpp:276
    #9 0x1e6fae80 in starrocks::DiagnoseDaemon::_perform_stack_trace(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /root/celerdata/be/src/runtime/diagnose_daemon.cpp:106
    #10 0x1e6fa7a5 in starrocks::DiagnoseDaemon::_execute_request(starrocks::DiagnoseRequest const&) /root/celerdata/be/src/runtime/diagnose_daemon.cpp:89
    #11 0x1e6fa468 in operator() /root/celerdata/be/src/runtime/diagnose_daemon.cpp:77
    #12 0x1e6fb767 in __invoke_impl<void, starrocks::DiagnoseDaemon::diagnose(const starrocks::DiagnoseRequest&)::<lambda()>&> /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/invoke.h:61
    #13 0x1e6fb60b in __invoke_r<void, starrocks::DiagnoseDaemon::diagnose(const starrocks::DiagnoseRequest&)::<lambda()>&> /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/invoke.h:111
    #14 0x1e6fb3d9 in _M_invoke /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/std_function.h:290
    #15 0xde9bef9 in std::function<void ()>::operator()() const /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/std_function.h:591
    #16 0x1ebd8399 in starrocks::FunctionRunnable::run() /root/celerdata/be/src/util/threadpool.cpp:60
    #17 0x1ebd3389 in starrocks::ThreadPool::dispatch_thread() /root/celerdata/be/src/util/threadpool.cpp:632
    #18 0x12f0289c in void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) (/root/celerdata/be/ut_build_ASAN/test/starrocks_test+0x12f0289c)
    #19 0x12f01ba4 in std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/invoke.h:96
    #20 0x12f00bdd in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/functional:513
    #21 0x12efe819 in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/functional:598
    #22 0x12efa67d in void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/invoke.h:61
    #23 0x12ef7ed3 in std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/invoke.h:111
    #24 0x12ef34bd in std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/std_function.h:290
    #25 0xde9bef9 in std::function<void ()>::operator()() const /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/std_function.h:591
    #26 0x1ebbb2c0 in starrocks::Thread::supervise_thread(void*) /root/celerdata/be/src/util/thread.cpp:366
    #27 0xd81a411 in asan_thread_start ../../.././libsanitizer/asan/asan_interceptors.cpp:234

previously allocated by thread T203 (diagnose) here:
    #0 0xd8b2528 in operator new(unsigned long) ../../.././libsanitizer/asan/asan_new_delete.cpp:95
    #1 0x1eb287c3 in std::__new_allocator<starrocks::StackTraceTask>::allocate(unsigned long, void const*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/new_allocator.h:151
    #2 0x1eb26c79 in std::allocator<starrocks::StackTraceTask>::allocate(unsigned long) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/allocator.h:196
    #3 0x1eb26c79 in std::allocator_traits<std::allocator<starrocks::StackTraceTask> >::allocate(std::allocator<starrocks::StackTraceTask>&, unsigned long) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/alloc_traits.h:478
    #4 0x1eb26c79 in std::_Vector_base<starrocks::StackTraceTask, std::allocator<starrocks::StackTraceTask> >::_M_allocate(unsigned long) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/stl_vector.h:380
    #5 0x1eb261fe in std::_Vector_base<starrocks::StackTraceTask, std::allocator<starrocks::StackTraceTask> >::_M_create_storage(unsigned long) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/stl_vector.h:398
    #6 0x1eb23da4 in std::_Vector_base<starrocks::StackTraceTask, std::allocator<starrocks::StackTraceTask> >::_Vector_base(unsigned long, std::allocator<starrocks::StackTraceTask> const&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/stl_vector.h:334
    #7 0x1eb237f6 in std::vector<starrocks::StackTraceTask, std::allocator<starrocks::StackTraceTask> >::vector(unsigned long, std::allocator<starrocks::StackTraceTask> const&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/stl_vector.h:557
    #8 0x1eb1ea40 in starrocks::get_stack_trace_for_threads_with_pattern(std::vector<int, std::allocator<int> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /root/celerdata/be/src/util/stack_util.cpp:183
    #9 0x1eb20c0e in starrocks::get_stack_trace_for_all_threads(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /root/celerdata/be/src/util/stack_util.cpp:276
    #10 0x1e6fae80 in starrocks::DiagnoseDaemon::_perform_stack_trace(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /root/celerdata/be/src/runtime/diagnose_daemon.cpp:106
    #11 0x1e6fa7a5 in starrocks::DiagnoseDaemon::_execute_request(starrocks::DiagnoseRequest const&) /root/celerdata/be/src/runtime/diagnose_daemon.cpp:89
    #12 0x1e6fa468 in operator() /root/celerdata/be/src/runtime/diagnose_daemon.cpp:77
    #13 0x1e6fb767 in __invoke_impl<void, starrocks::DiagnoseDaemon::diagnose(const starrocks::DiagnoseRequest&)::<lambda()>&> /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/invoke.h:61
    #14 0x1e6fb60b in __invoke_r<void, starrocks::DiagnoseDaemon::diagnose(const starrocks::DiagnoseRequest&)::<lambda()>&> /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/invoke.h:111
    #15 0x1e6fb3d9 in _M_invoke /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/std_function.h:290
    #16 0xde9bef9 in std::function<void ()>::operator()() const /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/std_function.h:591
    #17 0x1ebd8399 in starrocks::FunctionRunnable::run() /root/celerdata/be/src/util/threadpool.cpp:60
    #18 0x1ebd3389 in starrocks::ThreadPool::dispatch_thread() /root/celerdata/be/src/util/threadpool.cpp:632
    #19 0x12f0289c in void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) (/root/celerdata/be/ut_build_ASAN/test/starrocks_test+0x12f0289c)
    #20 0x12f01ba4 in std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/invoke.h:96
    #21 0x12f00bdd in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/functional:513
    #22 0x12efe819 in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/functional:598
    #23 0x12efa67d in void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/invoke.h:61
    #24 0x12ef7ed3 in std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/invoke.h:111
    #25 0x12ef34bd in std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/std_function.h:290
    #26 0xde9bef9 in std::function<void ()>::operator()() const /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/std_function.h:591
    #27 0x1ebbb2c0 in starrocks::Thread::supervise_thread(void*) /root/celerdata/be/src/util/thread.cpp:366
    #28 0xd81a411 in asan_thread_start ../../.././libsanitizer/asan/asan_interceptors.cpp:234

Thread T175 (brpc_timer) created by T0 here:
    #0 0xd8a99ed in pthread_create ../../.././libsanitizer/asan/asan_interceptors.cpp:245
    #1 0x238e8993 in bthread::TimerThread::start(bthread::TimerThreadOptions const*) src/bthread/timer_thread.cpp:161
    #2 0x238e8b60 in init_global_timer_thread src/bthread/timer_thread.cpp:467
    #3 0x7f833d20620a in __pthread_once_slow (/lib64/libpthread.so.0+0x620a) (BuildId: e10cc8f2b932fc3daeda22f8dac5ebb969524e5b)

Thread T203 (diagnose) created by T0 here:
    #0 0xd8a99ed in pthread_create ../../.././libsanitizer/asan/asan_interceptors.cpp:245
    #1 0x1ebba7a5 in starrocks::Thread::start_thread(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<void ()> const&, unsigned long, scoped_refptr<starrocks::Thread>*) /root/celerdata/be/src/util/thread.cpp:321
    #2 0x1ebdbfb8 in starrocks::Status starrocks::Thread::create<void (starrocks::ThreadPool::*)(), starrocks::ThreadPool*>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, void (starrocks::ThreadPool::* const&)(), starrocks::ThreadPool* const&, scoped_refptr<starrocks::Thread>*) /root/celerdata/be/src/util/thread.h:71
    #3 0x1ebd4dd8 in starrocks::ThreadPool::create_thread() /root/celerdata/be/src/util/threadpool.cpp:691
    #4 0x1ebcf947 in starrocks::ThreadPool::do_submit(std::shared_ptr<starrocks::Runnable>, starrocks::ThreadPoolToken*, starrocks::ThreadPool::Priority) /root/celerdata/be/src/util/threadpool.cpp:454
    #5 0x1ebce404 in starrocks::ThreadPool::submit(std::shared_ptr<starrocks::Runnable>, starrocks::ThreadPool::Priority) /root/celerdata/be/src/util/threadpool.cpp:361
    #6 0x1ebce560 in starrocks::ThreadPool::submit_func(std::function<void ()>, starrocks::ThreadPool::Priority) /root/celerdata/be/src/util/threadpool.cpp:365
    #7 0x1e6fa5c9 in starrocks::DiagnoseDaemon::diagnose(starrocks::DiagnoseRequest const&) /root/celerdata/be/src/runtime/diagnose_daemon.cpp:77
    #8 0x1e483fed in starrocks::LoadChannel::diagnose(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, starrocks::PLoadDiagnoseRequest const*, starrocks::PLoadDiagnoseResult*) /root/celerdata/be/src/runtime/load_channel.cpp:451
    #9 0x12651f8e in starrocks::LoadChannelTestForLakeTablet_test_load_diagnose_Test::TestBody() /root/celerdata/be/test/runtime/load_channel_test.cpp:804
    #10 0x25b01820 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) googletest-release-1.10.0/googletest/src/gtest.cc:2433
    #11 0x25b01820 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) googletest-release-1.10.0/googletest/src/gtest.cc:2469
    #12 0x25af9145 in testing::Test::Run() googletest-release-1.10.0/googletest/src/gtest.cc:2508
    #13 0x25af9145 in testing::Test::Run() googletest-release-1.10.0/googletest/src/gtest.cc:2498
    #14 0x25af92ad in testing::TestInfo::Run() googletest-release-1.10.0/googletest/src/gtest.cc:2684
    #15 0x25af92ad in testing::TestInfo::Run() googletest-release-1.10.0/googletest/src/gtest.cc:2657
    #16 0x25af9396 in testing::TestSuite::Run() googletest-release-1.10.0/googletest/src/gtest.cc:2816
    #17 0x25af9396 in testing::TestSuite::Run() googletest-release-1.10.0/googletest/src/gtest.cc:2795
    #18 0x25af98f3 in testing::internal::UnitTestImpl::RunAllTests() googletest-release-1.10.0/googletest/src/gtest.cc:5338
    #19 0x25af9ad2 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) googletest-release-1.10.0/googletest/src/gtest.cc:2433
    #20 0x25af9ad2 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) googletest-release-1.10.0/googletest/src/gtest.cc:2469
    #21 0x25af9ad2 in testing::UnitTest::Run() googletest-release-1.10.0/googletest/src/gtest.cc:4925
    #22 0xd920240 in RUN_ALL_TESTS() (/root/celerdata/be/ut_build_ASAN/test/starrocks_test+0xd920240)
    #23 0xd90abb5 in starrocks::init_test_env(int, char**) /root/celerdata/be/src/testutil/init_test_env.h:113
    #24 0xd90b56f in main /root/celerdata/be/test/test_main.cpp:18
    #25 0x7f833a222554 in __libc_start_main (/lib64/libc.so.6+0x22554) (BuildId: 1a8fb61bb4614a483833d5334202ab50edda2a25)

```

## What I'm doing:
* allocate an id to each stack trace request, and register it's `StackTraceTask` map shared_ptr in the global map
* the thread performing stack trace tries to get the `StackTraceTask` map shared_ptr by stack trace id, and hold the reference to the map. If failed, do not continue, otherwise can ensure the `StackTraceTask` is no released

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
