### PR TITLE
[Enhancement] Ensure pending time in query queue not calculated by query_timeout

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -212,6 +212,8 @@ public class ConnectContext {
     protected volatile Instant startTime = Instant.now();
     // last command end time
     protected volatile Instant endTime = Instant.ofEpochMilli(0);
+    // last command pending time(s), query's timeout should not contain pending time.
+    protected volatile int pendingTimeSecond = 0;
     // Cache thread info for this connection.
     protected ThreadInfo threadInfo;
 
@@ -694,12 +696,14 @@ public class ConnectContext {
     public void setStartTime() {
         startTime = Instant.now();
         returnRows = 0;
+        pendingTimeSecond = 0;
     }
 
     @VisibleForTesting
     public void setStartTime(Instant start) {
         startTime = start;
         returnRows = 0;
+        pendingTimeSecond = 0;
     }
 
     public void setEndTime() {
@@ -1101,8 +1105,29 @@ public class ConnectContext {
         }
     }
 
+    /**
+     * NOTE: The ExecTimeout should not contain the pending time which may be caused by QueryQueue's scheduler.
+     * </p>
+     * @return  Get the timeout for this session, unit: second
+     */
     public int getExecTimeout() {
+        return pendingTimeSecond + getExecTimeoutWithoutPendingTime();
+    }
+
+    private int getExecTimeoutWithoutPendingTime() {
         return executor != null ? executor.getExecTimeout() : sessionVariable.getQueryTimeoutS();
+    }
+
+    /**
+     * update the pending time for this session, unit: second
+     * @param pendingTimeSecond: the pending time for this session
+     */
+    public void setPendingTimeSecond(int pendingTimeSecond) {
+        this.pendingTimeSecond = pendingTimeSecond;
+    }
+
+    public long getPendingTimeSecond() {
+        return this.pendingTimeSecond;
     }
 
     private String getExecType() {
@@ -1113,10 +1138,15 @@ public class ConnectContext {
         return executor != null && executor.isExecLoadType();
     }
 
-    public void checkTimeout(long now) {
+    /**
+     * Check the connect context is timeout or not. If true, kill the connection, otherwise, return false.
+     * @param now : current time in milliseconds
+     * @return true if timeout, false otherwise
+     */
+    public boolean checkTimeout(long now) {
         long startTimeMillis = getStartTime();
         if (startTimeMillis <= 0) {
-            return;
+            return false;
         }
 
         long delta = now - startTimeMillis;
@@ -1157,6 +1187,7 @@ public class ConnectContext {
         if (killFlag) {
             kill(killConnection, errMsg);
         }
+        return killFlag;
     }
 
     // Helper to dump connection information.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -1397,4 +1397,8 @@ public class DefaultCoordinator extends Coordinator {
     public ResultReceiver getReceiver() {
         return receiver;
     }
+
+    public ConnectContext getConnectContext() {
+        return connectContext;
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryQueueManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryQueueManagerTest.java
@@ -590,15 +590,13 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
         }
 
         {
-            // 2.2 The coming query pending timeout, query_timeout (2) < pending_timeout (300).
+            // 2.2 The coming query query_timeout (2) < pending_timeout (300).
             GlobalVariable.setQueryQueuePendingTimeoutSecond(300);
             DefaultCoordinator coord =
                     getSchedulerWithQueryId("select /*+SET_VAR(query_timeout=2)*/ count(1) from lineitem");
-            Assert.assertThrows("pending timeout", StarRocksException.class,
-                    () -> manager.maybeWait(connectContext, coord));
-            ExceptionChecker.expectThrowsWithMsg(StarRocksException.class,
-                    "query/insert timeout",
-                    () -> manager.maybeWait(connectContext, coord));
+            // query should not be timeout even query_timeout is small because pending time is not in the query_timeout.
+            manager.maybeWait(connectContext, coord);
+            runningCoords.add(coord);
         }
 
         {
@@ -610,7 +608,7 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
                     throw new TException("mocked-release-slot-exception");
                 }
             });
-            GlobalVariable.setQueryQueuePendingTimeoutSecond(300);
+            GlobalVariable.setQueryQueuePendingTimeoutSecond(2);
             DefaultCoordinator coord =
                     getSchedulerWithQueryId("select /*+SET_VAR(query_timeout=2)*/ count(1) from lineitem");
             Assert.assertThrows("pending timeout", StarRocksException.class,
@@ -619,7 +617,7 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
         }
         {
             // 2.4 timeout by CheckTimer
-            Instant fakeStart = Instant.now().minusSeconds(3);
+            Instant fakeStart = Instant.now().minusSeconds(2);
             connectContext.setStartTime(fakeStart);
             DefaultCoordinator coord =
                     getSchedulerWithQueryId("select /*+SET_VAR(query_timeout=5)*/ count(1) from lineitem");
@@ -659,8 +657,10 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
         GlobalVariable.setEnableQueryQueueSelect(true);
         GlobalVariable.setQueryQueueConcurrencyLimit(concurrencyLimit);
 
-        // 1. Run `concurrencyLimit` queries first, and they shouldn't be queued.
+        // 1. Run `concurrencyLimit` queries first, and they shouldn't be queued. And they will be pending time-out and then
+        // required slots are released.
         List<DefaultCoordinator> runningCoords = new ArrayList<>();
+        GlobalVariable.setQueryQueuePendingTimeoutSecond(2);
         for (int i = 0; i < concurrencyLimit; i++) {
             DefaultCoordinator coord =
                     getSchedulerWithQueryId("select /*+SET_VAR(query_timeout=2)*/ count(1) from lineitem");
@@ -670,6 +670,7 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
 
             runningCoords.add(coord);
         }
+        GlobalVariable.setQueryQueuePendingTimeoutSecond(300);
 
         // 2. The coming query is allocated slots, after the previous queries with allocated slot is expired.
         DefaultCoordinator coord = getSchedulerWithQueryId("select count(1) from lineitem");
@@ -1615,6 +1616,34 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
             GlobalVariable.setEnableQueryQueueSelect(false);
             DefaultCoordinator coordinator = getSchedulerWithQueryId("select count(1) from lineitem");
             manager.maybeWait(connectContext, coordinator);
+        }
+    }
+
+    @Test
+    public void testSlotPendingTimeout() throws Exception {
+        GlobalVariable.setQueryQueuePendingTimeoutSecond(1);
+        GlobalVariable.setEnableQueryQueueSelect(true);
+        Thread.sleep(2000L);
+
+        {
+            DefaultCoordinator coordinator = getSchedulerWithQueryId("select count(1) from lineitem");
+            assertThatThrownBy(() -> manager.maybeWait(connectContext, coordinator))
+                    .isInstanceOf(StarRocksException.class)
+                    .hasMessageContaining("Failed to allocate resource to query: pending timeout");
+            assertThat(connectContext.getPendingTimeSecond() == 1);
+        }
+
+
+        {
+            GlobalVariable.setQueryQueuePendingTimeoutSecond(300);
+            // 2. The coming query is allocated slots, after the previous queries with allocated slot is expired.
+            DefaultCoordinator coord = getSchedulerWithQueryId("select count(1) from lineitem");
+            manager.maybeWait(connectContext, coord);
+            ConnectContext context = coord.getConnectContext();
+            Assert.assertTrue(context.getExecTimeout() == context.getPendingTimeSecond()
+                    + context.getSessionVariable().getQueryTimeoutS());
+
+            coord.onFinished();
         }
     }
 }


### PR DESCRIPTION
## Why I'm doing:
Currently, when `query_queue` is enabled, the pending time is counted as part of the `query_timeout`,
By default, the pending timeout is set to be the same as the query timeout (both are 300 seconds).

However, when performing auto-scaling based on the Query Queue, this behavior may cause queries to timeout simply due to long pending times, which is not the expected behavior.


## What I'm doing:
- Don't calculate query's pending time which is calculated by query queue into `query_timeout` if query queue is enabled.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
