### PR TITLE
[Enhancement] Support managed identity for azure adls2 storage volume in shared-data mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2714,6 +2714,16 @@ public class Config extends ConfigBase {
     public static String azure_adls2_shared_key = "";
     @ConfField
     public static String azure_adls2_sas_token = "";
+    @ConfField
+    public static boolean azure_adls2_oauth2_use_managed_identity = false;
+    @ConfField
+    public static String azure_adls2_oauth2_tenant_id = "";
+    @ConfField
+    public static String azure_adls2_oauth2_client_id = "";
+    @ConfField
+    public static String azure_adls2_oauth2_client_secret = "";
+    @ConfField
+    public static String azure_adls2_oauth2_oauth2_client_endpoint = "";
 
     @ConfField(mutable = true)
     public static int starmgr_grpc_timeout_seconds = 5;

--- a/fe/fe-core/src/main/java/com/starrocks/server/SharedDataStorageVolumeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/SharedDataStorageVolumeMgr.java
@@ -564,6 +564,16 @@ public class SharedDataStorageVolumeMgr extends StorageVolumeMgr {
                 params.put(CloudConfigurationConstants.AZURE_ADLS2_SHARED_KEY, Config.azure_adls2_shared_key);
                 params.put(CloudConfigurationConstants.AZURE_ADLS2_SAS_TOKEN, Config.azure_adls2_sas_token);
                 params.put(CloudConfigurationConstants.AZURE_ADLS2_ENDPOINT, Config.azure_adls2_endpoint);
+                params.put(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_USE_MANAGED_IDENTITY,
+                        String.valueOf(Config.azure_adls2_oauth2_use_managed_identity));
+                params.put(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_TENANT_ID,
+                        Config.azure_adls2_oauth2_tenant_id);
+                params.put(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_ID,
+                        Config.azure_adls2_oauth2_client_id);
+                params.put(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_SECRET,
+                        Config.azure_adls2_oauth2_client_secret);
+                params.put(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_ENDPOINT,
+                        Config.azure_adls2_oauth2_oauth2_client_endpoint);
                 break;
             default:
                 return params;

--- a/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
+++ b/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
@@ -341,6 +341,25 @@ public class StorageVolume implements Writable, GsonPostProcessable {
                 if (!Strings.isNullOrEmpty(sasToken)) {
                     params.put(CloudConfigurationConstants.AZURE_ADLS2_SAS_TOKEN, sasToken);
                 }
+                String tenantId = adls2credentialInfo.getTenantId();
+                if (!Strings.isNullOrEmpty(tenantId)) {
+                    params.put(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_TENANT_ID, tenantId);
+                }
+                String clientId = adls2credentialInfo.getClientId();
+                if (!Strings.isNullOrEmpty(clientId)) {
+                    params.put(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_ID, clientId);
+                }
+                if (!Strings.isNullOrEmpty(tenantId) && !Strings.isNullOrEmpty(clientId)) {
+                    params.put(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_USE_MANAGED_IDENTITY, "true");
+                }
+                String clientSecret = adls2credentialInfo.getClientSecret();
+                if (!Strings.isNullOrEmpty(clientSecret)) {
+                    params.put(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_SECRET, clientSecret);
+                }
+                String clientEndpoint = adls2credentialInfo.getAuthorityHost();
+                if (!Strings.isNullOrEmpty(clientEndpoint)) {
+                    params.put(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_ENDPOINT, clientEndpoint);
+                }
                 return params;
             }
             default:


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Support managed identity for azure adls2 storage volume in shared-data mode.

Managed identity config for azure adls2 in fe.conf:
```
cloud_native_storage_type = ADLS2
enable_load_volume_from_conf = true
azure_adls2_endpoint = https://<storage_account>.dfs.core.windows.net
azure_adls2_path = <file_system_name>/<dir_name>
azure_adls2_oauth2_use_managed_identity = true
azure_adls2_oauth2_tenant_id = <tenant_id>
azure_adls2_oauth2_client_id = <client_id>
``` 

Managed identity storage volume for azure adls2:
```
CREATE STORAGE VOLUME <storage_volume_name>
    TYPE = ADLS2
    LOCATIONS = ("adls2://<file_system_name>/<dir_name>")
    PROPERTIES (
        "azure.adls2.endpoint" = "https://<storage_account>.dfs.core.windows.net",
        "azure.adls2.oauth2_use_managed_identity" = "true",
        "azure.adls2.oauth2_tenant_id" = "<tenant_id>",
        "azure.adls2.oauth2_client_id" = "<client_id>"  
    );
``` 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
