### PR TITLE
[Enhancement] support vacuum for shared tablet meta

### DIFF
--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -25,6 +25,7 @@
 #include "storage/lake/fixed_location_provider.h"
 #include "storage/lake/join_path.h"
 #include "storage/lake/meta_file.h"
+#include "storage/lake/metacache.h"
 #include "storage/lake/tablet_metadata.h"
 #include "storage/lake/txn_log.h"
 #include "test_util.h"
@@ -1632,6 +1633,182 @@ TEST(LakeVacuumTest2, test_delete_files_retry4) {
     ASSERT_TRUE(future.get().ok());
     ASSERT_FALSE(fs::path_exist("test_vacuum_delete_files_retry.txt"));
     EXPECT_GT(attempts, 1);
+}
+
+// NOLINTNEXTLINE
+TEST_P(LakeVacuumTest, test_vacuum_shared_metadata) {
+    create_data_file("00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat");
+    create_data_file("00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1e.dat");
+    create_data_file("00000000000259e4_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat");
+    create_data_file("00000000000259e4_a542395a-bff5-48a7-a3a7-2ed05691b58d.dat");
+
+    auto t600_v1 = json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 600,
+        "version": 1,
+        "rowsets": []
+        }
+        )DEL");
+
+    auto t601_v1 = json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 601,
+        "version": 1,
+        "rowsets": []
+        }
+        )DEL");
+
+    auto t600_v2 = json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 600,
+        "version": 2,
+        "rowsets": [
+            {
+                "segments": [
+                    "00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"
+                ],
+                "data_size": 4096
+            }
+        ]
+        }
+        )DEL");
+
+    auto t601_v2 = json_to_pb<TabletMetadataPB>(R"DEL(
+            {
+            "id": 601,
+            "version": 2,
+            "rowsets": [
+                {
+                    "segments": [
+                        "00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1e.dat"
+                    ],
+                    "data_size": 4096
+                }
+            ]
+            }
+            )DEL");
+
+    auto t600_v3 = json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 600,
+        "version": 3,
+        "rowsets": [
+            {
+                "segments": [
+                    "00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat",
+                    "00000000000259e4_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat"
+                ],
+                "data_size": 8192
+            }
+        ]
+        }
+        )DEL");
+
+    auto t601_v3 = json_to_pb<TabletMetadataPB>(R"DEL(
+            {
+            "id": 601,
+            "version": 3,
+            "rowsets": [
+                {
+                    "segments": [
+                        "00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1e.dat",
+                        "00000000000259e4_a542395a-bff5-48a7-a3a7-2ed05691b58d.dat"
+                    ],
+                    "data_size": 8192
+                }
+            ]
+            }
+            )DEL");
+
+    // create SharedTabletMetadata
+    std::map<int64_t, TabletMetadataPB> tablet_metas_v1;
+    tablet_metas_v1[600] = *t600_v1;
+    tablet_metas_v1[601] = *t601_v1;
+    ASSERT_OK(_tablet_mgr->put_aggregate_tablet_metadata(tablet_metas_v1));
+    std::map<int64_t, TabletMetadataPB> tablet_metas_v2;
+    tablet_metas_v2[600] = *t600_v2;
+    tablet_metas_v2[601] = *t601_v2;
+    ASSERT_OK(_tablet_mgr->put_aggregate_tablet_metadata(tablet_metas_v2));
+    std::map<int64_t, TabletMetadataPB> tablet_metas_v3;
+    tablet_metas_v3[600] = *t600_v3;
+    tablet_metas_v3[601] = *t601_v3;
+    ASSERT_OK(_tablet_mgr->put_aggregate_tablet_metadata(tablet_metas_v3));
+    auto* metacache = _tablet_mgr->metacache();
+    metacache->cache_tablet_metadata(_tablet_mgr->tablet_metadata_location(600, 1), t600_v1);
+    metacache->cache_tablet_metadata(_tablet_mgr->tablet_metadata_location(601, 1), t601_v1);
+    metacache->cache_tablet_metadata(_tablet_mgr->tablet_metadata_location(600, 2), t600_v2);
+    metacache->cache_tablet_metadata(_tablet_mgr->tablet_metadata_location(601, 2), t601_v2);
+    metacache->cache_tablet_metadata(_tablet_mgr->tablet_metadata_location(600, 3), t600_v3);
+    metacache->cache_tablet_metadata(_tablet_mgr->tablet_metadata_location(601, 3), t601_v3);
+
+    int64_t grace_timestamp = 1687331159;
+
+    SyncPoint::GetInstance()->SetCallBack("collect_files_to_vacuum:get_file_modified_time", [=](void* arg) {
+        *(uint64_t*)arg = grace_timestamp; // modification time of version 3 tablet metadata
+    });
+
+    SyncPoint::GetInstance()->EnableProcessing();
+
+    // No file will be deleted
+    {
+        VacuumRequest request;
+        VacuumResponse response;
+        request.set_delete_txn_log(true);
+        request.add_tablet_ids(600);
+        request.add_tablet_ids(601);
+        request.set_min_retain_version(3);
+        request.set_grace_timestamp(grace_timestamp);
+        request.set_min_active_txn_id(12345);
+        request.set_enable_partition_aggregation(true);
+        vacuum(_tablet_mgr.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+        EXPECT_EQ(0, response.vacuumed_files());
+        // The size of deleted metadata files is not counted in vacuumed_file_size.
+        EXPECT_EQ(0, response.vacuumed_file_size());
+
+        EXPECT_TRUE(file_exist(tablet_metadata_filename(0, 1)));
+        // version 2 is the last version created before "grace_timestamp", should be retained
+        EXPECT_TRUE(file_exist(tablet_metadata_filename(0, 2)));
+        EXPECT_TRUE(file_exist(tablet_metadata_filename(0, 3)));
+
+        EXPECT_TRUE(file_exist("00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"));
+        EXPECT_TRUE(file_exist("00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1e.dat"));
+        EXPECT_TRUE(file_exist("00000000000259e4_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat"));
+        EXPECT_TRUE(file_exist("00000000000259e4_a542395a-bff5-48a7-a3a7-2ed05691b58d.dat"));
+    }
+
+    // tablet metadata of version 1, 2 will be deleted.
+    {
+        VacuumRequest request;
+        VacuumResponse response;
+        request.set_delete_txn_log(true);
+        request.add_tablet_ids(600);
+        request.add_tablet_ids(601);
+        request.set_min_retain_version(3);
+        // Now version 3 becomes the last version created before grace_timestamp, version 1/2 can be
+        // deleted
+        request.set_grace_timestamp(grace_timestamp + 1);
+        request.set_min_active_txn_id(12345);
+        request.set_enable_partition_aggregation(true);
+        vacuum(_tablet_mgr.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+        EXPECT_EQ(2, response.vacuumed_files());
+        EXPECT_EQ(0, response.vacuumed_file_size());
+
+        EXPECT_FALSE(file_exist(tablet_metadata_filename(0, 1)));
+        EXPECT_FALSE(file_exist(tablet_metadata_filename(0, 2)));
+        EXPECT_TRUE(file_exist(tablet_metadata_filename(0, 3)));
+
+        EXPECT_TRUE(file_exist("00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"));
+        EXPECT_TRUE(file_exist("00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1e.dat"));
+        EXPECT_TRUE(file_exist("00000000000259e4_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat"));
+        EXPECT_TRUE(file_exist("00000000000259e4_a542395a-bff5-48a7-a3a7-2ed05691b58d.dat"));
+    }
+
+    SyncPoint::GetInstance()->ClearCallBack("collect_files_to_vacuum:get_file_modified_time");
+    SyncPoint::GetInstance()->DisableProcessing();
 }
 
 } // namespace starrocks::lake

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -30,6 +30,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.lake.LakeAggregator;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.proto.TabletInfoPB;
 import com.starrocks.proto.VacuumRequest;
@@ -163,6 +164,7 @@ public class AutovacuumDaemon extends FrontendDaemon {
         long startTime = System.currentTimeMillis();
         long minActiveTxnId = computeMinActiveTxnId(db, table);
         long preExtraFileSize = 0;
+        // if enable partition aggregation, there will be only one node (Aggregator).
         Map<ComputeNode, List<TabletInfoPB>> nodeToTablets = new HashMap<>();
 
         Locker locker = new Locker();
@@ -183,17 +185,26 @@ public class AutovacuumDaemon extends FrontendDaemon {
 
         WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
         Warehouse warehouse = warehouseManager.getBackgroundWarehouse();
+        ComputeNode pickNode = null;
         for (Tablet tablet : tablets) {
             LakeTablet lakeTablet = (LakeTablet) tablet;
-            ComputeNode node = warehouseManager.getComputeNodeAssignedToTablet(warehouse.getId(), lakeTablet);
 
-            if (node == null) {
+            if (table.enablePartitionAggregation()) {
+                // if enable partition aggregation, there will be only one node.
+                if (pickNode == null) {
+                    pickNode = LakeAggregator.chooseAggregatorNode(warehouse.getId());
+                }
+            } else {
+                pickNode = warehouseManager.getComputeNodeAssignedToTablet(warehouse.getId(), lakeTablet);
+            }
+
+            if (pickNode == null) {
                 return;
             }
             TabletInfoPB tabletInfo = new TabletInfoPB();
             tabletInfo.setTabletId(tablet.getId());
             tabletInfo.setMinVersion(lakeTablet.getMinVersion());
-            nodeToTablets.computeIfAbsent(node, k -> Lists.newArrayList()).add(tabletInfo);
+            nodeToTablets.computeIfAbsent(pickNode, k -> Lists.newArrayList()).add(tabletInfo);
         }
 
         boolean hasError = false;
@@ -216,6 +227,7 @@ public class AutovacuumDaemon extends FrontendDaemon {
             vacuumRequest.minActiveTxnId = minActiveTxnId;
             vacuumRequest.partitionId = partition.getId();
             vacuumRequest.deleteTxnLog = needDeleteTxnLog;
+            vacuumRequest.enablePartitionAggregation = table.enablePartitionAggregation();
             // Perform deletion of txn log on the first node only.
             needDeleteTxnLog = false;
             try {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/GlobalStateMgrTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/GlobalStateMgrTestUtil.java
@@ -62,6 +62,7 @@ public class GlobalStateMgrTestUtil {
     public static String testDb1 = "testDb1";
     public static long testDbId1 = 1;
     public static String testTable1 = "testTable1";
+    public static String testTable2 = "testTable2";
     public static String testTable7 = "testTable7";
     public static long testTableId1 = 2;
     public static String testPartition1 = "testPartition1";

--- a/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
@@ -54,6 +54,7 @@ import static org.mockito.Mockito.when;
 public class VacuumTest {
     private static Database db;
     private static OlapTable olapTable;
+    private static OlapTable olapTable2;
     private static PhysicalPartition partition;
     private static WarehouseManager warehouseManager;
     private static ComputeNode computeNode;
@@ -82,9 +83,21 @@ public class VacuumTest {
                     "DISTRIBUTED BY HASH(v1) BUCKETS 1\n" +
                     "PROPERTIES('replication_num' = '1');");
 
+        starRocksAssert.withTable("CREATE TABLE testTable2\n" +
+                    "(\n" +
+                    "    v1 date,\n" +
+                    "    v2 int,\n" +
+                    "    v3 int\n" +
+                    ")\n" +
+                    "DUPLICATE KEY(`v1`)\n" +
+                    "DISTRIBUTED BY HASH(v1) BUCKETS 1\n" +
+                    "PROPERTIES('enable_partition_aggregation' = 'true');");
+
         db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
         olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
                     .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable1);
+        olapTable2 = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable2);
 
         warehouseManager = mock(WarehouseManager.class);
         computeNode = mock(ComputeNode.class);
@@ -101,6 +114,7 @@ public class VacuumTest {
     @AfterClass
     public static void clear() {
         db.dropTable(olapTable.getName());
+        db.dropTable(olapTable2.getName());
     }
 
     @Test
@@ -138,6 +152,45 @@ public class VacuumTest {
         try (MockedStatic<BrpcProxy> mockBrpcProxyStatic = mockStatic(BrpcProxy.class)) {
             mockBrpcProxyStatic.when(() -> BrpcProxy.getLakeService(anyString(), anyInt())).thenReturn(lakeService);
             autovacuumDaemon.testVacuumPartitionImpl(db, olapTable, partition);
+        }
+        Assert.assertEquals(7L, partition.getLastSuccVacuumVersion());
+    }
+
+    @Test
+    public void testAggregateVacuum() throws Exception {
+        GlobalStateMgr currentState = GlobalStateMgr.getCurrentState();
+        partition = olapTable2.getPhysicalPartitions().stream().findFirst().orElse(null);
+        partition.setVisibleVersion(10L, System.currentTimeMillis());
+        partition.setMinRetainVersion(10L);
+        partition.setLastSuccVacuumVersion(4L);
+
+        AutovacuumDaemon autovacuumDaemon = new AutovacuumDaemon();
+
+        VacuumResponse mockResponse = new VacuumResponse();
+        mockResponse.status = new StatusPB();
+        mockResponse.status.statusCode = 0;
+        mockResponse.vacuumedFiles = 10L;
+        mockResponse.vacuumedFileSize = 1024L;
+        mockResponse.vacuumedVersion = 5L;
+        mockResponse.extraFileSize = 1024L;
+        mockResponse.tabletInfos = new ArrayList<>();
+
+        Future<VacuumResponse> mockFuture = mock(Future.class);
+        when(mockFuture.get()).thenReturn(mockResponse);
+
+        lakeService = mock(LakeService.class);
+        when(lakeService.vacuum(any(VacuumRequest.class))).thenReturn(mockFuture);
+        try (MockedStatic<BrpcProxy> mockBrpcProxyStatic = mockStatic(BrpcProxy.class)) {
+            mockBrpcProxyStatic.when(() -> BrpcProxy.getLakeService(anyString(), anyInt())).thenReturn(lakeService);
+            autovacuumDaemon.testVacuumPartitionImpl(db, olapTable2, partition);
+        }
+        
+        Assert.assertEquals(5L, partition.getLastSuccVacuumVersion());
+
+        mockResponse.vacuumedVersion = 7L;
+        try (MockedStatic<BrpcProxy> mockBrpcProxyStatic = mockStatic(BrpcProxy.class)) {
+            mockBrpcProxyStatic.when(() -> BrpcProxy.getLakeService(anyString(), anyInt())).thenReturn(lakeService);
+            autovacuumDaemon.testVacuumPartitionImpl(db, olapTable2, partition);
         }
         Assert.assertEquals(7L, partition.getLastSuccVacuumVersion());
     }

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -288,6 +288,8 @@ message VacuumRequest {
     optional int64 partition_id = 6;
     // The tablet infos to be vacuumed.
     repeated TabletInfoPB tablet_infos = 7;
+    // Whether enable partition aggregation
+    optional bool enable_partition_aggregation = 8;
 }
 
 message VacuumResponse {


### PR DESCRIPTION
## Why I'm doing:
Following the feature plan #58316 , we are going to reduce object storage API cost though combine TabletMeta file from per tablet to per transaction.
And after pr#57889 , we already support read and write `SharedTabletMetadataPB`, but we doesn't support vacuum yet. 

## What I'm doing:
This pull request introduces a new feature for partition-level aggregation during vacuuming operations in the StarRocks Lake storage system. The changes span both the backend (`be`) and frontend (`fe`) components, adding support for aggregating metadata deletions at the partition level and selecting a single aggregator node for vacuum operations when the feature is enabled.

### Backend Changes (C++)

* **Partition-Level Metadata Aggregation**:
  - Introduced a new `VacuumTabletMetaVerionRange` struct to track the version range of tablet metadata files that can be deleted. This struct is used to calculate the deletable range across multiple tablets. (`be/src/storage/lake/vacuum.cpp`, [be/src/storage/lake/vacuum.cppR44-R67](diffhunk://#diff-891803f977da48b5a81315b3d324316e8bdd578537dc5bdeef32cf34ebb5f750R44-R67))
  - Modified the `vacuum_tablet_metadata` and `collect_files_to_vacuum` functions to support partition-level aggregation by using the `VacuumTabletMetaVerionRange` struct and conditionally aggregating deletions. (`be/src/storage/lake/vacuum.cpp`, [[1]](diffhunk://#diff-891803f977da48b5a81315b3d324316e8bdd578537dc5bdeef32cf34ebb5f750R407-R415) [[2]](diffhunk://#diff-891803f977da48b5a81315b3d324316e8bdd578537dc5bdeef32cf34ebb5f750R448-R476)

* **API Extension**:
  - Added a new `enable_partition_aggregation` field to the `VacuumRequest` protobuf message to enable or disable this feature. (`gensrc/proto/lake_service.proto`, [gensrc/proto/lake_service.protoR276-R277](diffhunk://#diff-5bc50165e4af00c12c8ba0f59f743353ad2f5420e0045cb23d6ae82b867aa337R276-R277))

### Frontend Changes (Java)

* **Aggregator Node Selection**:
  - Added a new `LakeAggregator` class to select a compute node (aggregator) for partition-level vacuuming. The selection strategy currently uses a random node from the available compute nodes. (`fe/fe-core/src/main/java/com/starrocks/lake/LakeAggregator.java`, [fe/fe-core/src/main/java/com/starrocks/lake/LakeAggregator.javaR1-R52](diffhunk://#diff-50fd29bf55becb49ac4691918d60de7d38ce3bfee4d6da1126c897a52b8e9121R1-R52))

* **Integration with Vacuum Process**:
  - Updated the `AutovacuumDaemon` to use the `LakeAggregator` for selecting a single aggregator node when partition aggregation is enabled. Adjusted the logic for assigning tablets to nodes accordingly. (`fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java`, [[1]](diffhunk://#diff-ef2b090ae7f6222d36e455ac002b330a56c8d1cda7f082182d2905870d274859R188-R207) [[2]](diffhunk://#diff-ef2b090ae7f6222d36e455ac002b330a56c8d1cda7f082182d2905870d274859R230)

These changes collectively enable more efficient vacuuming at the partition level, reducing overhead by aggregating deletions and leveraging a single node for metadata operations when applicable.

Fixes #58316

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
