### PR TITLE
[Refactor] Use BlockCache::is_initialized instead of config::datacache_enable to  indicate whether to enable the BlockCache.

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -839,8 +839,8 @@ void* ReportDataCacheMetricsTaskWorkerPool::_worker_thread_callback(void* arg_th
         request.__set_report_version(g_report_version.load(std::memory_order_relaxed));
 
         TDataCacheMetrics t_metrics{};
-        if (config::datacache_enable) {
-            const BlockCache* cache = BlockCache::instance();
+        const BlockCache* cache = BlockCache::instance();
+        if (cache->is_initialized()) {
             const DataCacheMetrics& metrics = cache->cache_metrics();
             DataCacheUtils::set_metrics_from_thrift(t_metrics, metrics);
         } else {

--- a/be/src/cache/block_cache/block_cache.h
+++ b/be/src/cache/block_cache/block_cache.h
@@ -26,7 +26,6 @@ namespace starrocks {
 class BlockCache {
 public:
     using CacheKey = std::string;
-    using DeleterFunc = std::function<void()>;
 
     // Return a singleton block cache instance
     static BlockCache* instance();
@@ -88,6 +87,7 @@ public:
     bool has_disk_cache() const { return _disk_quota.load(std::memory_order_relaxed) > 0; }
 
     bool available() const { return is_initialized() && (has_mem_cache() || has_disk_cache()); }
+    bool mem_cache_available() const { return is_initialized() && has_mem_cache(); }
 
     void disk_spaces(std::vector<DirSpace>* spaces);
 

--- a/be/src/cache/block_cache/disk_space_monitor.cpp
+++ b/be/src/cache/block_cache/disk_space_monitor.cpp
@@ -290,7 +290,7 @@ bool DiskSpaceMonitor::is_stopped() {
 void DiskSpaceMonitor::_adjust_datacache_callback() {
     while (!is_stopped()) {
         std::unique_lock<std::mutex> lck(_mutex);
-        if (config::datacache_enable && config::datacache_auto_adjust_enable &&
+        if (BlockCache::instance()->is_initialized() && config::datacache_auto_adjust_enable &&
             !_updating.load(std::memory_order_acquire)) {
             if (_adjust_spaces_by_disk_usage()) {
                 auto dir_spaces = all_dir_spaces();

--- a/be/src/cache/block_cache/disk_space_monitor.cpp
+++ b/be/src/cache/block_cache/disk_space_monitor.cpp
@@ -290,7 +290,7 @@ bool DiskSpaceMonitor::is_stopped() {
 void DiskSpaceMonitor::_adjust_datacache_callback() {
     while (!is_stopped()) {
         std::unique_lock<std::mutex> lck(_mutex);
-        if (BlockCache::instance()->is_initialized() && config::datacache_auto_adjust_enable &&
+        if (_cache->is_initialized() && config::datacache_auto_adjust_enable &&
             !_updating.load(std::memory_order_acquire)) {
             if (_adjust_spaces_by_disk_usage()) {
                 auto dir_spaces = all_dir_spaces();

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -897,7 +897,7 @@ CONF_mInt32(max_hdfs_file_handle, "1000");
 
 CONF_Int64(max_segment_file_size, "1073741824");
 
-// Rewrite partial semgent or not.
+// Rewrite partial segment or not.
 // if true, partial segment will be rewrite into new segment file first and append other column data
 // if false, the data of other column will be append into partial segment file and rebuild segment footer
 // we may need the both implementations for perf test for now, so use it to decide which implementations to use
@@ -955,7 +955,7 @@ CONF_mBool(orc_coalesce_read_enable, "true");
 // Default is 8MB for tiny stripe threshold size
 CONF_Int32(orc_tiny_stripe_threshold_size, "8388608");
 
-// When the ORC file file size is smaller than orc_loading_buffer_size,
+// When the ORC file size is smaller than orc_loading_buffer_size,
 // we'll read the whole file at once instead of reading a footer first.
 CONF_Int32(orc_loading_buffer_size, "8388608");
 
@@ -1038,7 +1038,7 @@ CONF_Int64(send_rpc_runtime_filter_timeout_ms, "1000");
 // this is a default value, maybe changed by global_runtime_filter_rpc_http_min_size in session variable.
 CONF_Int64(send_runtime_filter_via_http_rpc_min_size, "67108864");
 
-// -1: ulimited, 0: limit by memory use, >0: limit by queue_size
+// -1: unlimited, 0: limit by memory use, >0: limit by queue_size
 CONF_mInt64(runtime_filter_queue_limit, "-1");
 
 CONF_Int64(rpc_connect_timeout_ms, "30000");
@@ -1148,7 +1148,7 @@ CONF_String(dependency_librdkafka_debug, "all");
 // DEBUG: 0, INFO: 1, WARN: 2, ERROR: 3, WARN by default
 CONF_mInt16(pulsar_client_log_level, "2");
 
-// max loop count when be waiting its fragments finish. It has no effect if the var is configured with value <= 0.
+// max loop count when be waiting its fragments to finish. It has no effect if the var is configured with value <= 0.
 CONF_mInt64(loop_count_wait_fragments_finish, "2");
 
 // the maximum number of connections in the connection pool for a single jdbc url
@@ -1217,8 +1217,8 @@ CONF_Bool(datacache_direct_io_enable, "false");
 // 0 means unlimited.
 CONF_Int64(datacache_max_concurrent_inserts, "1500000");
 // Total memory limit for in-flight cache jobs.
-// Once this is reached, cache populcation will be rejected until the flying memory usage gets under the limit.
-// If zero, the datacache module will automatically calculate a resonable default value based on block size.
+// Once this is reached, cache population will be rejected until the flying memory usage gets under the limit.
+// If zero, the datacache module will automatically calculate a reasonable default value based on block size.
 CONF_Int64(datacache_max_flying_memory_mb, "2");
 // An io adaptor factor to control the io traffic between cache and network.
 // The larger this parameter, the more requests will be sent to the network.

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -97,7 +97,7 @@ Status HiveDataSource::open(RuntimeState* state) {
     RETURN_IF_ERROR(_check_all_slots_nullable());
 
     // Check that the system meets the requirements for enabling DataCache
-    if (config::datacache_enable && BlockCache::instance()->available()) {
+    if (BlockCache::instance()->available()) {
         // setup priority & ttl seconds
         int8_t datacache_priority = 0;
         int64_t datacache_ttl_seconds = 0;
@@ -161,7 +161,7 @@ Status HiveDataSource::open(RuntimeState* state) {
         _scan_range.datacache_options.priority == -1) {
         _datacache_options.enable_datacache = false;
     }
-    _use_file_metacache = config::datacache_enable && BlockCache::instance()->has_mem_cache();
+    _use_file_metacache = BlockCache::instance()->mem_cache_available();
     if (state->query_options().__isset.enable_file_metacache) {
         _use_file_metacache &= state->query_options().enable_file_metacache;
     }

--- a/be/src/exec/schema_scanner/schema_be_datacache_metrics_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_datacache_metrics_scanner.cpp
@@ -63,8 +63,8 @@ Status SchemaBeDataCacheMetricsScanner::get_next(ChunkPtr* chunk, bool* eos) {
 
     row.emplace_back(_be_id);
 
-    if (config::datacache_enable) {
-        const BlockCache* cache = BlockCache::instance();
+    const BlockCache* cache = BlockCache::instance();
+    if (cache->is_initialized()) {
         // retrive different priority's used bytes from level = 2 metrics
         metrics = cache->cache_metrics(2);
 

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -70,7 +70,7 @@ Status FileReader::init(HdfsScannerContext* ctx) {
     _scanner_ctx = ctx;
 #ifdef WITH_STARCACHE
     // Only support file metacache in starcache engine
-    if (ctx->use_file_metacache && config::datacache_enable) {
+    if (ctx->use_file_metacache && BlockCache::instance()->mem_cache_available()) {
         _cache = CacheEnv::GetInstance()->external_table_meta_cache();
     }
 #endif

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -513,8 +513,8 @@ void RuntimeState::update_load_datacache_metrics(TReportExecStatusParams* load_p
         }
 #endif // USE_STAROS
     } else {
-        if (config::datacache_enable) {
-            const BlockCache* cache = BlockCache::instance();
+        const BlockCache* cache = BlockCache::instance();
+        if (cache->is_initialized()) {
             TDataCacheMetrics t_metrics{};
             DataCacheUtils::set_metrics_from_thrift(t_metrics, cache->cache_metrics());
             metrics.__set_metrics(t_metrics);


### PR DESCRIPTION
## Why I'm doing:

For the convenience of writing test cases and suppot the dynamic enabling and disabling of the data cache later.  Therefore, `config::datacache_enable` should no longer be used to determine the status of the block cache specifically.

Currently behavior:

* BlockCache::initialized: block cache is initialized and we can collect metrics of the block cache.
* BlockCache::is_available: At least one quota of the block cache is non-zero, meaning the block cache can be used to store or lookup block data.

## What I'm doing:

Use BlockCache::is_initialized instead of config::datacache_enable to  indicate whether to enable the BlockCache.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
