### PR TITLE
[Enhancement] Prevent MV reload too many times to reduce FE's startup time

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -529,6 +529,10 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
 
     protected volatile ParseNode defineQueryParseNode = null;
 
+    // Use a flag to prevent MV reload too many times while recursively reloading every mv at FE start time
+    // and in each round of checkpoint
+    private boolean reloaded = false;
+
     public MaterializedView() {
         super(TableType.MATERIALIZED_VIEW);
         this.tableProperty = null;
@@ -732,6 +736,14 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
 
     public void setQueryOutputIndices(List<Integer> queryOutputIndices) {
         this.queryOutputIndices = queryOutputIndices;
+    }
+
+    public boolean isReloaded() {
+        return reloaded;
+    }
+
+    public void setReloaded(boolean reloaded) {
+        this.reloaded = reloaded;
     }
 
     /**
@@ -1035,16 +1047,31 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
 
     @Override
     public void onReload() {
+        onReload(false);
+    }
+
+    /**
+     * `postLoadImage` is used to distinct wether it's called after FE's image loading process,
+     * such as FE startup or checkpointing.
+     *
+     * Note!! The `onReload` method is called in some other scenarios such as - schema change of a materialize view.
+     * The reloaded flag was introduced only to increase the speed of FE startup and checkpointing.
+     * It shouldn't affect the behavior of other operations which might indeed need to do a reload process.
+     */
+    public void onReload(boolean postLoadImage) {
         try {
             boolean desiredActive = active;
             active = false;
-            boolean reloadActive = onReloadImpl();
+            boolean reloadActive = onReloadImpl(postLoadImage);
             if (desiredActive && reloadActive) {
                 setActive();
             }
         } catch (Throwable e) {
             LOG.error("reload mv failed: {}", this, e);
             setInactiveAndReason("reload failed: " + e.getMessage());
+        }
+        if (postLoadImage) {
+            reloaded = true;
         }
     }
 
@@ -1055,14 +1082,14 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      * NOTE: caller need to hold the db lock
      */
     public void fixRelationship() {
-        onReloadImpl();
+        onReloadImpl(false);
     }
 
     /**
      * @return active or not
      */
-    private boolean onReloadImpl() {
-        long startTime = System.currentTimeMillis();
+    private boolean onReloadImpl(boolean postLoadImage) {
+        long startMillis = System.currentTimeMillis();
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             LOG.warn("db:{} do not exist. materialized view id:{} name:{} should not exist", dbId, id, name);
@@ -1122,8 +1149,12 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                 continue;
             } else if (table.isMaterializedView()) {
                 MaterializedView baseMV = (MaterializedView) table;
+                // skip reloading only when postLoadImage is true
+                if (postLoadImage && baseMV.isReloaded()) {
+                    continue;
+                }
                 // recursive reload MV, to guarantee the order of hierarchical MV
-                baseMV.onReload();
+                baseMV.onReload(postLoadImage);
                 if (!baseMV.isActive()) {
                     LOG.warn("tableName :{} is invalid. set materialized view:{} to invalid",
                             baseTableInfo.getTableName(), id);
@@ -1153,7 +1184,8 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         GlobalConstraintManager globalConstraintManager = GlobalStateMgr.getCurrentState().getGlobalConstraintManager();
         globalConstraintManager.registerConstraint(this);
 
-        LOG.info("finish to reload mv:{} cost:{}(ms)", getName(), System.currentTimeMillis() - startTime);
+        long duration = System.currentTimeMillis() - startMillis;
+        LOG.info("finish reloading mv {} in {}ms, total base table count: {}", getName(), duration, baseTableInfos.size());
         return res;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1676,16 +1676,27 @@ public class GlobalStateMgr {
         }
     }
 
-    private void processMvRelatedMeta() {
+    @VisibleForTesting
+    public void processMvRelatedMeta() {
         long startMillis = System.currentTimeMillis();
         for (Database db : localMetastore.getIdToDb().values()) {
             for (MaterializedView mv : db.getMaterializedViews()) {
-                mv.onReload();
+                // set `postLoadImage` flag to true to indicate that this is called after image loading
+                mv.onReload(true);
+            }
+        }
+
+        // we should reset reloaded flags after each round of reloading for all materializedViews
+        int count = 0;
+        for (Database db : localMetastore.getIdToDb().values()) {
+            for (MaterializedView mv : db.getMaterializedViews()) {
+                count++;
+                mv.setReloaded(false);
             }
         }
 
         long duration = System.currentTimeMillis() - startMillis;
-        LOG.info("finish processing all tables' related materialized views in {}ms", duration);
+        LOG.info("finish processing all tables' related materialized views in {}ms, total mv count: {}", duration, count);
     }
 
     public void loadHeader(DataInputStream dis) throws IOException {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -893,4 +893,67 @@ public class MaterializedViewTest {
         Assert.assertTrue(mockDataProperty.getCooldownTimeMs() < 253402271999000L);
         // misbehavior
     }
+
+    @Test
+    public void testMaterializedViewReload() throws Exception {
+        starRocksAssert.withDatabase("test").useDatabase("test")
+                .withTable("CREATE TABLE base_table\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                        "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
+                .withMaterializedView("CREATE MATERIALIZED VIEW base_mv\n" +
+                        "PARTITION BY k1\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "REFRESH manual\n" +
+                        "as select k1,k2,v1 from base_table;")
+                .withMaterializedView("CREATE MATERIALIZED VIEW mv1\n" +
+                        "PARTITION BY k1\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "REFRESH manual\n" +
+                        "as select k1,k2,v1 from base_mv;")
+                .withMaterializedView("CREATE MATERIALIZED VIEW mv2\n" +
+                        "PARTITION BY k1\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "REFRESH manual\n" +
+                        "as select k1,k2,v1 from base_mv;");
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView baseMv = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), "base_mv"));
+        MaterializedView mv1 = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), "mv1"));
+        MaterializedView mv2 = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), "mv2"));
+
+        {
+            // before post image reload, all materialized views has `reloaded` flag set to false
+            Assert.assertFalse(mv1.isReloaded());
+            Assert.assertFalse(mv2.isReloaded());
+            Assert.assertFalse(baseMv.isReloaded());
+
+            GlobalStateMgr.getCurrentState().processMvRelatedMeta();
+
+            // after post image reload, all materialized views should have `reloaded` flag reset to false
+            Assert.assertFalse(mv1.isReloaded());
+            Assert.assertFalse(mv2.isReloaded());
+            Assert.assertFalse(baseMv.isReloaded());
+        }
+
+        {
+            boolean postLoadImage = true;
+            mv1.onReload(postLoadImage);
+            mv2.onReload(postLoadImage);
+            Assert.assertTrue(mv1.isReloaded());
+            Assert.assertTrue(mv2.isReloaded());
+            Assert.assertTrue(baseMv.isReloaded());
+        }
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

When there are many materialized views and the dependency among them is complicated, it might cost a lot of time to restart FE.

## What I'm doing:

Add a `reloaded` flag to `MaterializedView` to indicate a materialized view has been reloaded before, and no need to repeatedly reload it again and again when it was a sub-mv of some other materialized view 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
