### PR TITLE
[BugFix] Check if dict filtering in slot can be used for all expressions

### DIFF
--- a/be/src/formats/parquet/column_reader.h
+++ b/be/src/formats/parquet/column_reader.h
@@ -114,6 +114,11 @@ public:
 
     virtual void set_need_parse_levels(bool need_parse_levels) = 0;
 
+    virtual bool can_use_dict_filter(ExprContext* ctx, bool is_decode_needed, const SlotId slotId,
+                                     const std::vector<std::string>& sub_field_path, const size_t& layer) {
+        return false;
+    }
+
     virtual bool try_to_use_dict_filter(ExprContext* ctx, bool is_decode_needed, const SlotId slotId,
                                         const std::vector<std::string>& sub_field_path, const size_t& layer) {
         return false;

--- a/be/src/formats/parquet/complex_column_reader.h
+++ b/be/src/formats/parquet/complex_column_reader.h
@@ -182,6 +182,9 @@ public:
         }
     }
 
+    bool can_use_dict_filter(ExprContext* ctx, bool is_decode_needed, const SlotId slotId,
+                             const std::vector<std::string>& sub_field_path, const size_t& layer) override;
+
     bool try_to_use_dict_filter(ExprContext* ctx, bool is_decode_needed, const SlotId slotId,
                                 const std::vector<std::string>& sub_field_path, const size_t& layer) override;
 

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -151,8 +151,9 @@ private:
     // Extract dict filter columns and conjuncts
     void _process_columns_and_conjunct_ctxs();
 
-    bool _try_to_use_dict_filter(const GroupReaderParam::Column& column, ExprContext* ctx,
-                                 std::vector<std::string>& sub_field_path, bool is_decode_needed);
+    std::vector<std::vector<std::string>> _get_expression_subfields(ExprContext* ctx);
+
+    bool _can_use_dict_filter(const GroupReaderParam::Column& column, ExprContext* ctx, bool is_decode_needed);
 
     void _init_read_chunk();
 

--- a/be/src/formats/parquet/scalar_column_reader.h
+++ b/be/src/formats/parquet/scalar_column_reader.h
@@ -154,6 +154,9 @@ public:
     bool try_to_use_dict_filter(ExprContext* ctx, bool is_decode_needed, const SlotId slotId,
                                 const std::vector<std::string>& sub_field_path, const size_t& layer) override;
 
+    bool can_use_dict_filter(ExprContext* ctx, bool is_decode_needed, const SlotId slotId,
+                             const std::vector<std::string>& sub_field_path, const size_t& layer) override;
+
     Status rewrite_conjunct_ctxs_to_predicate(bool* is_group_filtered, const std::vector<std::string>& sub_field_path,
                                               const size_t& layer) override {
         DCHECK_EQ(sub_field_path.size(), layer);
@@ -231,6 +234,9 @@ public:
 
     bool try_to_use_dict_filter(ExprContext* ctx, bool is_decode_needed, const SlotId slotId,
                                 const std::vector<std::string>& sub_field_path, const size_t& layer) override;
+
+    bool can_use_dict_filter(ExprContext* ctx, bool is_decode_needed, const SlotId slotId,
+                             const std::vector<std::string>& sub_field_path, const size_t& layer) override;
 
     Status rewrite_conjunct_ctxs_to_predicate(bool* is_group_filtered, const std::vector<std::string>& sub_field_path,
                                               const size_t& layer) override {


### PR DESCRIPTION
## Why I'm doing:
Attempting to fix CN crash, described in the issue below

## What I'm doing:
Not allowing to use dict filter for slot if any expression working with it, can't use dict filter.
We achieve this by adding `can_use_dict_filter` and first calling it for all expressions.

Fixes https://github.com/StarRocks/starrocks/issues/58236

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1

**P.S.**
We tested this change on branch 3.3.12. I backported our changed into 3.5, but since we don't run it, **potentially there could be some issues.**
