### PR TITLE
[BugFix] LargeStringLiterals in filters of JDBCScanNode/MySQLScanNode is truncated and appended to ellipsis

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
@@ -46,6 +46,7 @@ import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Pair;
 import com.starrocks.common.TreeNode;
 import com.starrocks.common.io.Writable;
 import com.starrocks.planner.FragmentNormalizer;
@@ -84,8 +85,10 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Root of the expr node hierarchy.
@@ -284,6 +287,32 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
             return type;
         }
         return originType;
+    }
+
+    private Optional<Expr> replaceLargeStringLiteralImpl() {
+        if (this instanceof LargeStringLiteral) {
+            return Optional.of(new StringLiteral(((LargeStringLiteral) this).getValue()));
+        }
+        if (children == null || children.isEmpty()) {
+            return Optional.empty();
+        }
+        List<Pair<Expr, Optional<Expr>>> childAndNewChildPairList = children.stream()
+                .map(child -> Pair.create(child, child.replaceLargeStringLiteralImpl()))
+                .collect(Collectors.toList());
+        if (childAndNewChildPairList.stream().noneMatch(p -> p.second.isPresent())) {
+            return Optional.empty();
+        }
+
+        for (int i = 0; i < this.children.size(); ++i) {
+            Pair<Expr, Optional<Expr>> childPair = childAndNewChildPairList.get(i);
+            Expr newChild = childPair.second.orElse(childPair.first);
+            setChild(i, newChild);
+        }
+        return Optional.of(this);
+    }
+
+    public Expr replaceLargeStringLiteral() {
+        return this.replaceLargeStringLiteralImpl().orElse(this);
     }
 
     // Used to differ from getOriginType(), return originType directly.

--- a/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
@@ -140,6 +140,7 @@ public class JDBCScanNode extends ScanNode {
 
         ArrayList<Expr> jdbcConjuncts = Expr.cloneList(conjuncts, sMap);
         for (Expr p : jdbcConjuncts) {
+            p = p.replaceLargeStringLiteral();
             filters.add(AstToStringBuilder.toString(p));
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/MysqlScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/MysqlScanNode.java
@@ -152,6 +152,7 @@ public class MysqlScanNode extends ScanNode {
         }
         ArrayList<Expr> mysqlConjuncts = Expr.cloneList(conjuncts, sMap);
         for (Expr p : mysqlConjuncts) {
+            p = p.replaceLargeStringLiteral();
             filters.add(p.toMySql());
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MySqlAndJDBCScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MySqlAndJDBCScanNodeTest.java
@@ -1,0 +1,101 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.planner;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
+import com.starrocks.analysis.BinaryPredicate;
+import com.starrocks.analysis.BinaryType;
+import com.starrocks.analysis.CompoundPredicate;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.InPredicate;
+import com.starrocks.analysis.LargeStringLiteral;
+import com.starrocks.analysis.SlotDescriptor;
+import com.starrocks.analysis.SlotId;
+import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.StringLiteral;
+import com.starrocks.analysis.TupleDescriptor;
+import com.starrocks.analysis.TupleId;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.JDBCTable;
+import com.starrocks.catalog.MysqlTable;
+import com.starrocks.catalog.Type;
+import com.starrocks.common.DdlException;
+import com.starrocks.sql.parser.NodePosition;
+import org.assertj.core.util.Lists;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class MySqlAndJDBCScanNodeTest {
+
+    private List<Expr> createConjuncts() {
+        Expr slotRef = new SlotRef("col", new SlotDescriptor(new SlotId(1), "col", Type.VARCHAR, true));
+        Expr expr0 = new InPredicate(slotRef,
+                Lists.newArrayList(new LargeStringLiteral(Strings.repeat("ABCDE", 11), NodePosition.ZERO)), true);
+        Expr expr1 = new BinaryPredicate(BinaryType.EQ, slotRef, StringLiteral.create("ABC"));
+        Expr expr2 = new CompoundPredicate(CompoundPredicate.Operator.OR, expr0, expr1);
+        return Lists.newArrayList(expr0, expr1, expr2);
+    }
+
+    @Test
+    public void testFiltersInMySQLScanNode() throws DdlException {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("host", "127.0.0.1");
+        properties.put("port", "3036");
+        properties.put("user", "root");
+        properties.put("password", "123456");
+        properties.put("database", "test_db");
+        properties.put("table", "test_table");
+        MysqlTable mysqlTable = new MysqlTable(1, "mysql_table",
+                Collections.singletonList(new Column("col", Type.VARCHAR)), properties);
+        TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(1));
+        tupleDesc.setTable(mysqlTable);
+        MysqlScanNode scanNode = new MysqlScanNode(new PlanNodeId(1), tupleDesc, mysqlTable);
+        scanNode.getConjuncts().addAll(createConjuncts());
+        scanNode.computeColumnsAndFilters();
+        String nodeString = scanNode.getExplainString();
+        Assert.assertTrue(nodeString, nodeString.contains("SELECT * FROM `test_table` " +
+                "WHERE (col NOT IN ('ABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDE')) " +
+                "AND (col = 'ABC') AND " +
+                "((col NOT IN ('ABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDE')) OR " +
+                "(col = 'ABC'))"));
+    }
+
+    @Test
+    public void testFiltersInJDBCScanNode() throws DdlException {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("user", "root");
+        properties.put("password", "123456");
+        properties.put("jdbc_uri", "jdbc:mysql://localhost:3306");
+        properties.put("driver_url", "driver_url");
+        properties.put("checksum", "checksum");
+        properties.put("driver_class", "driver_class");
+        JDBCTable mysqlTable = new JDBCTable(1, "jdbc_table",
+                Collections.singletonList(new Column("col", Type.VARCHAR)), properties);
+        TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(1));
+        tupleDesc.setTable(mysqlTable);
+        JDBCScanNode scanNode = new JDBCScanNode(new PlanNodeId(1), tupleDesc, mysqlTable);
+        scanNode.getConjuncts().addAll(createConjuncts());
+        scanNode.computeColumnsAndFilters();
+        String nodeString = scanNode.getExplainString();
+        Assert.assertTrue(nodeString, nodeString.contains("SELECT * FROM `jdbc_table` WHERE " +
+                "(`col` NOT IN ('ABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDE')) AND " +
+                "(`col` = 'ABC') AND ((`col` NOT IN ('ABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDE')) " +
+                "OR (`col` = 'ABC'))\n"));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Conjuncts in JDBCScanNode/MySQLScanNode is converted into string-type filters which are dispatched to other db server to process. the LargeStringLiteral(length exceeds 50) is truncated mistakenly and appended to ellipsis(...).  
```java
    public static StringLiteral create(String value) {
        if (value.length() > LargeStringLiteral.LEN_LIMIT) {
            return new LargeStringLiteral(value, NodePosition.ZERO);
        } else {
            return new StringLiteral(value);
        }
    }
```

```java
    @Override
    public String toSqlImpl() {
        if (shortSqlStr == null) {
            String fullSql = toFullSqlImpl();
            fullSql = fullSql.substring(0, LEN_LIMIT);
            shortSqlStr = fullSql + "...'";
        }
        return shortSqlStr;
    }
```
## What I'm doing:

Convert LargeStringLiteral to StringLiteral for JDBCScanNode/MySQLScanNode

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
