### PR TITLE
[BugFix] Fix wrong plan when mv multi stage rewrite is enabled

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -464,7 +464,6 @@ public class QueryOptimizer extends Optimizer {
         }
         context.getQueryMaterializationContext().setCurrentRewriteStage(MvRewriteStrategy.MVRewriteStage.PHASE1);
 
-        scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.PARTITION_PRUNE_RULES);
         scheduler.rewriteIterative(tree, rootTaskContext, new MergeTwoProjectRule());
         scheduler.rewriteIterative(tree, rootTaskContext, new MergeProjectWithChildRule());
         // do rule based mv rewrite

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -471,9 +471,15 @@ public class QueryOptimizer extends Optimizer {
         // do rule based mv rewrite
         doRuleBasedMaterializedViewRewrite(tree, rootTaskContext);
 
+        // `RuleSet.PARTITION_PRUNE_RULES` should be used very carefully, since it contains bitset to mark
+        // whether it has been applied, so this action will prevent partition pruning later.
+        // reset partition prune bit to do partition prune again because:
+        // 1. partition prune is not done well since some predicates have not been pushed down.
+        // 2. it may generate bad plans if we do not do partition prune again.
         MvUtils.getScanOperator(tree).forEach(scan -> {
             scan.resetOpRuleBit(OP_PARTITION_PRUNED);
         });
+
         new SeparateProjectRule().rewrite(tree, rootTaskContext);
         deriveLogicalProperty(tree);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
@@ -483,4 +483,84 @@ public class MVTestBase extends StarRocksTestBase {
     protected boolean hasNonDeterministicFunction(OptExpression root) {
         return root.getOp().accept(new NonDeterministicVisitor(), root, null);
     }
+
+    /**
+     * TestListener is a base class that can be used to test cases in multi-variable environments.
+     */
+    public abstract class TestListener {
+        protected boolean val;
+
+        public abstract void onBeforeCase(ConnectContext connectContext);
+
+        public abstract void onAfterCase(ConnectContext connectContext);
+    }
+
+    public class EnableMVRewriteListener extends TestListener {
+        @Override
+        public void onBeforeCase(ConnectContext connectContext) {
+            this.val = connectContext.getSessionVariable().isEnableMaterializedViewRewrite();
+            connectContext.getSessionVariable().setEnableMaterializedViewRewrite(true);
+        }
+
+        @Override
+        public void onAfterCase(ConnectContext connectContext) {
+            connectContext.getSessionVariable().setEnableMaterializedViewRewrite(val);
+        }
+    }
+
+    public class DisableMVRewriteListener extends TestListener {
+        @Override
+        public void onBeforeCase(ConnectContext connectContext) {
+            this.val = connectContext.getSessionVariable().isEnableMaterializedViewRewrite();
+            connectContext.getSessionVariable().setEnableMaterializedViewRewrite(false);
+        }
+
+        @Override
+        public void onAfterCase(ConnectContext connectContext) {
+            connectContext.getSessionVariable().setEnableMaterializedViewRewrite(val);
+        }
+    }
+
+    public class EnableMVMultiStageRewriteListener extends TestListener {
+        @Override
+        public void onBeforeCase(ConnectContext connectContext) {
+            this.val = connectContext.getSessionVariable().isEnableMaterializedViewMultiStagesRewrite();
+            connectContext.getSessionVariable().setEnableMaterializedViewMultiStagesRewrite(true);
+        }
+
+        @Override
+        public void onAfterCase(ConnectContext connectContext) {
+            connectContext.getSessionVariable().setEnableMaterializedViewMultiStagesRewrite(val);
+        }
+    }
+
+    public class DisableMVMultiStageRewriteListener extends TestListener {
+        @Override
+        public void onBeforeCase(ConnectContext connectContext) {
+            this.val = connectContext.getSessionVariable().isEnableMaterializedViewMultiStagesRewrite();
+            connectContext.getSessionVariable().setEnableMaterializedViewMultiStagesRewrite(false);
+        }
+
+        @Override
+        public void onAfterCase(ConnectContext connectContext) {
+            connectContext.getSessionVariable().setEnableMaterializedViewMultiStagesRewrite(val);
+        }
+    }
+
+    public interface ExceptionRunnable {
+        public abstract void run() throws Exception;
+    }
+
+    protected void doTest(List<TestListener> listeners, ExceptionRunnable testCase) {
+        for (TestListener listener : listeners) {
+            listener.onBeforeCase(connectContext);
+            try {
+                testCase.run();
+            } catch (Exception e) {
+                Assert.fail(e.getMessage());
+            } finally {
+                listener.onAfterCase(connectContext);
+            }
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
@@ -784,7 +784,7 @@ public class MvRewriteHiveTest extends MVTestBase {
     }
 
     @Test
-    public void testHivePartitionPruneWithLeftJoin1() {
+    public void testHivePartitionPruneWithLeftJoin() {
         String mv1 = "CREATE MATERIALIZED VIEW mv1\n" +
                 "DISTRIBUTED BY RANDOM\n" +
                 "PROPERTIES (\"force_external_table_query_rewrite\" = \"true\") AS \n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
@@ -455,7 +455,7 @@ public class MvRewriteHiveTest extends MVTestBase {
                 "FROM `hive0`.`partitioned_db`.`lineitem_par` as a \n " +
                 "GROUP BY " +
                 "`l_orderkey`, `l_suppkey`, `l_shipdate`;";
-        String plan = getFragmentPlan(query1);
+        String plan = getFragmentPlan(query1, "MV");
         PlanTestBase.assertNotContains(plan, "hive_partitioned_mv");
         dropMv("test", "hive_partitioned_mv");
     }
@@ -794,10 +794,8 @@ public class MvRewriteHiveTest extends MVTestBase {
 
 
         final List<TestListener> listeners = ImmutableList.of(
-                // enable mv
                 new EnableMVRewriteListener(),
                 new DisableMVRewriteListener(),
-
                 new EnableMVMultiStageRewriteListener(),
                 new DisableMVMultiStageRewriteListener()
         );
@@ -810,7 +808,8 @@ public class MvRewriteHiveTest extends MVTestBase {
                 {
                     String query = "SELECT o_orderkey, l_suppkey, l_shipdate, l_orderkey  " +
                             " FROM hive0.partitioned_db.lineitem_par as a " +
-                            " LEFT JOIN hive0.partitioned_db.orders as b ON b.o_orderkey=a.l_orderkey and l_shipdate='1998-01-01';";
+                            " LEFT JOIN hive0.partitioned_db.orders as b " +
+                            " ON b.o_orderkey=a.l_orderkey and l_shipdate='1998-01-01';";
 
                     String plan = getFragmentPlan(query);
                     PlanTestBase.assertContains(plan, "  4:HASH JOIN\n" +

--- a/test/sql/test_transparent_mv/R/test_mv_rewrite_with_multi_stages
+++ b/test/sql/test_transparent_mv/R/test_mv_rewrite_with_multi_stages
@@ -228,3 +228,6 @@ drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 force;
 drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 force;
 -- result:
 -- !result
+drop database mv_hive_${uuid0}.mv_hive_db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_transparent_mv/R/test_mv_rewrite_with_multi_stages
+++ b/test/sql/test_transparent_mv/R/test_mv_rewrite_with_multi_stages
@@ -1,0 +1,229 @@
+-- name: test_mv_rewrite_with_multi_stages
+create external catalog mv_hive_${uuid0}
+properties
+(
+    "type" = "hive",
+    "hive.catalog.type" = "hive",
+    "hive.metastore.uris" = "${hive_metastore_uris}"
+);
+-- result:
+-- !result
+set new_planner_optimize_timeout=10000;
+-- result:
+-- !result
+set enable_materialized_view_multi_stages_rewrite=true;
+-- result:
+-- !result
+set enable_materialized_view_rewrite=true;
+-- result:
+-- !result
+set catalog mv_hive_${uuid0};
+-- result:
+-- !result
+create database mv_hive_db_${uuid0};
+-- result:
+-- !result
+use mv_hive_db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 (
+  num int,
+  dt date
+)
+PARTITION BY (dt);
+-- result:
+-- !result
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24");
+-- result:
+-- !result
+CREATE TABLE mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 (
+  num int,
+  dt date
+)
+PARTITION BY (dt);
+-- result:
+-- !result
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(14,"2020-06-24"), (5,"2020-06-24");
+-- result:
+-- !result
+CREATE TABLE mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 (
+  num int,
+  dt date
+)
+PARTITION BY (dt);
+-- result:
+-- !result
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"), (NULL,"2020-06-24");
+-- result:
+-- !result
+CREATE TABLE mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 (
+  num int,
+  dt date
+)
+PARTITION BY (dt);
+-- result:
+-- !result
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"), (NULL,"2020-06-24");
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+set materialized_view_union_rewrite_mode=2;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+REFRESH DEFERRED MANUAL 
+AS 
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num;
+-- result:
+-- !result
+function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num ORDER BY 1, 2, 3, 4;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num and t1.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num and t2.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num where t1.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num where t2.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
+-- result:
+False
+-- !result
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num ORDER BY 1, 2, 3, 4;
+-- result:
+1	2020-06-15	1	2020-06-15
+2	2020-06-18	2	2020-06-18
+3	2020-06-21	3	2020-06-21
+4	2020-06-24	None	None
+-- !result
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num and t1.dt = '2020-06-24' order by 1, 2, 3, 4;
+-- result:
+1	2020-06-15	None	None
+2	2020-06-18	None	None
+3	2020-06-21	None	None
+4	2020-06-24	None	None
+-- !result
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num and t2.dt = '2020-06-24' order by 1, 2, 3, 4;
+-- result:
+1	2020-06-15	None	None
+2	2020-06-18	None	None
+3	2020-06-21	None	None
+4	2020-06-24	None	None
+-- !result
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num where t1.dt = '2020-06-24' order by 1, 2, 3, 4;
+-- result:
+4	2020-06-24	None	None
+-- !result
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num where t2.dt = '2020-06-24' order by 1, 2, 3, 4;
+-- result:
+-- !result
+function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t3.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num where t1.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num where t3.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
+-- result:
+False
+-- !result
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' order by 1, 2, 3, 4;
+-- result:
+1	2020-06-15	1	None
+2	2020-06-18	2	None
+3	2020-06-21	3	None
+4	2020-06-24	None	2020-06-24
+-- !result
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t3.dt = '2020-06-24' order by 1, 2, 3, 4;
+-- result:
+1	2020-06-15	1	None
+2	2020-06-18	2	None
+3	2020-06-21	3	None
+4	2020-06-24	None	2020-06-24
+-- !result
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num where t1.dt = '2020-06-24' order by 1, 2, 3, 4;
+-- result:
+4	2020-06-24	None	2020-06-24
+-- !result
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num where t3.dt = '2020-06-24' order by 1, 2, 3, 4;
+-- result:
+4	2020-06-24	None	2020-06-24
+-- !result
+function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 as t4 on t1.num=t4.num and t4.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 as t4 on t1.num=t4.num and t1.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 as t4 on t1.num=t4.num where t4.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 as t4 on t1.num=t4.num where t1.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
+-- result:
+False
+-- !result
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 as t4 on t1.num=t4.num and t4.dt = '2020-06-24' order by 1, 2, 3, 4;
+-- result:
+1	2020-06-15	1	2020-06-15
+2	2020-06-18	2	2020-06-18
+3	2020-06-21	3	2020-06-21
+4	2020-06-24	None	None
+-- !result
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 as t4 on t1.num=t4.num and t1.dt = '2020-06-24' order by 1, 2, 3, 4;
+-- result:
+1	2020-06-15	1	2020-06-15
+2	2020-06-18	2	2020-06-18
+3	2020-06-21	3	2020-06-21
+4	2020-06-24	None	None
+-- !result
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 as t4 on t1.num=t4.num where t4.dt = '2020-06-24' order by 1, 2, 3, 4;
+-- result:
+4	2020-06-24	None	None
+-- !result
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 as t4 on t1.num=t4.num where t1.dt = '2020-06-24' order by 1, 2, 3, 4;
+-- result:
+4	2020-06-24	None	None
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 force;
+-- result:
+-- !result
+drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 force;
+-- result:
+-- !result
+drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 force;
+-- result:
+-- !result
+drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 force;
+-- result:
+-- !result

--- a/test/sql/test_transparent_mv/R/test_mv_rewrite_with_multi_stages
+++ b/test/sql/test_transparent_mv/R/test_mv_rewrite_with_multi_stages
@@ -88,9 +88,10 @@ AS
 SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num;
 -- result:
 -- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num ORDER BY 1, 2, 3, 4;", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num and t1.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
 -- result:
@@ -102,11 +103,11 @@ False
 -- !result
 function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num where t1.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num where t2.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
 -- result:
-False
+True
 -- !result
 SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num ORDER BY 1, 2, 3, 4;
 -- result:
@@ -138,19 +139,19 @@ SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM m
 -- !result
 function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t3.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num where t1.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num where t3.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
 -- result:
-False
+True
 -- !result
 SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' order by 1, 2, 3, 4;
 -- result:
@@ -176,19 +177,19 @@ SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM m
 -- !result
 function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 as t4 on t1.num=t4.num and t4.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 as t4 on t1.num=t4.num and t1.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 as t4 on t1.num=t4.num where t4.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 as t4 on t1.num=t4.num where t1.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
 -- result:
-False
+True
 -- !result
 SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 as t4 on t1.num=t4.num and t4.dt = '2020-06-24' order by 1, 2, 3, 4;
 -- result:

--- a/test/sql/test_transparent_mv/R/test_mv_rewrite_with_multi_stages
+++ b/test/sql/test_transparent_mv/R/test_mv_rewrite_with_multi_stages
@@ -79,9 +79,6 @@ create database db_${uuid0};
 use db_${uuid0};
 -- result:
 -- !result
-set materialized_view_union_rewrite_mode=2;
--- result:
--- !result
 CREATE MATERIALIZED VIEW test_mv1 
 REFRESH DEFERRED MANUAL 
 AS 
@@ -130,12 +127,31 @@ SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM m
 3	2020-06-21	None	None
 4	2020-06-24	None	None
 -- !result
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num and t2.dt = '2020-06-24' and t2.num > 1 order by 1, 2, 3, 4;
+-- result:
+1	2020-06-15	None	None
+2	2020-06-18	None	None
+3	2020-06-21	None	None
+4	2020-06-24	None	None
+-- !result
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num and t2.num > 1 order by 1, 2, 3, 4;
+-- result:
+1	2020-06-15	None	None
+2	2020-06-18	2	2020-06-18
+3	2020-06-21	3	2020-06-21
+4	2020-06-24	None	None
+-- !result
 SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num where t1.dt = '2020-06-24' order by 1, 2, 3, 4;
 -- result:
 4	2020-06-24	None	None
 -- !result
-SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num where t2.dt = '2020-06-24' order by 1, 2, 3, 4;
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num where t2.dt = '2020-06-24' and t2.num > 1 order by 1, 2, 3, 4;
 -- result:
+-- !result
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num where t2.num > 1 order by 1, 2, 3, 4;
+-- result:
+2	2020-06-18	2	2020-06-18
+3	2020-06-21	3	2020-06-21
 -- !result
 function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
 -- result:
@@ -167,11 +183,22 @@ SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM m
 3	2020-06-21	3	None
 4	2020-06-24	None	2020-06-24
 -- !result
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t3.dt = '2020-06-24' and t3.num > 1 order by 1, 2, 3, 4;
+-- result:
+1	2020-06-15	1	None
+2	2020-06-18	2	None
+3	2020-06-21	3	None
+4	2020-06-24	None	2020-06-24
+-- !result
 SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num where t1.dt = '2020-06-24' order by 1, 2, 3, 4;
 -- result:
 4	2020-06-24	None	2020-06-24
 -- !result
 SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num where t3.dt = '2020-06-24' order by 1, 2, 3, 4;
+-- result:
+4	2020-06-24	None	2020-06-24
+-- !result
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num where t3.dt = '2020-06-24' and t3.num > 1 order by 1, 2, 3, 4;
 -- result:
 4	2020-06-24	None	2020-06-24
 -- !result

--- a/test/sql/test_transparent_mv/R/test_transparent_mv_hive
+++ b/test/sql/test_transparent_mv/R/test_transparent_mv_hive
@@ -1181,3 +1181,6 @@ drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 force;
 drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 force;
 -- result:
 -- !result
+drop database mv_hive_${uuid0}.mv_hive_db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_transparent_mv/R/test_transparent_mv_union_hive
+++ b/test/sql/test_transparent_mv/R/test_transparent_mv_union_hive
@@ -480,3 +480,6 @@ drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 force;
 drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 force;
 -- result:
 -- !result
+drop database mv_hive_${uuid0}.mv_hive_db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_transparent_mv/R/test_transparent_mv_union_hive2
+++ b/test/sql/test_transparent_mv/R/test_transparent_mv_union_hive2
@@ -468,3 +468,6 @@ drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 force;
 drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 force;
 -- result:
 -- !result
+drop database mv_hive_${uuid0}.mv_hive_db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_transparent_mv/T/test_mv_rewrite_with_multi_stages
+++ b/test/sql/test_transparent_mv/T/test_mv_rewrite_with_multi_stages
@@ -1,0 +1,106 @@
+-- name: test_mv_rewrite_with_multi_stages
+
+create external catalog mv_hive_${uuid0}
+properties
+(
+    "type" = "hive",
+    "hive.catalog.type" = "hive",
+    "hive.metastore.uris" = "${hive_metastore_uris}"
+);
+
+set new_planner_optimize_timeout=10000;
+set enable_materialized_view_multi_stages_rewrite=true;
+set enable_materialized_view_rewrite=true;
+-- create hive table
+set catalog mv_hive_${uuid0};
+
+create database mv_hive_db_${uuid0};
+use mv_hive_db_${uuid0};
+
+CREATE TABLE mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 (
+  num int,
+  dt date
+)
+PARTITION BY (dt);
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24");
+
+CREATE TABLE mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 (
+  num int,
+  dt date
+)
+PARTITION BY (dt);
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(14,"2020-06-24"), (5,"2020-06-24");
+
+
+CREATE TABLE mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 (
+  num int,
+  dt date
+)
+PARTITION BY (dt);
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"), (NULL,"2020-06-24");
+
+CREATE TABLE mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 (
+  num int,
+  dt date
+)
+PARTITION BY (dt);
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"), (NULL,"2020-06-24");
+
+-- create mv
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+set materialized_view_union_rewrite_mode=2;
+
+-- NOTE: test mv with the single table
+CREATE MATERIALIZED VIEW test_mv1 
+REFRESH DEFERRED MANUAL 
+AS 
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num;
+
+
+-- test t1 and t2
+function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num ORDER BY 1, 2, 3, 4;", "test_mv1")
+function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num and t1.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
+function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num and t2.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
+function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num where t1.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
+function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num where t2.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
+
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num ORDER BY 1, 2, 3, 4;
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num and t1.dt = '2020-06-24' order by 1, 2, 3, 4;
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num and t2.dt = '2020-06-24' order by 1, 2, 3, 4;
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num where t1.dt = '2020-06-24' order by 1, 2, 3, 4;
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num where t2.dt = '2020-06-24' order by 1, 2, 3, 4;
+
+-- test t1 and t2 and t3
+
+function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
+function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t3.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
+function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num where t1.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
+function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num where t3.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
+
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' order by 1, 2, 3, 4;
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t3.dt = '2020-06-24' order by 1, 2, 3, 4;
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num where t1.dt = '2020-06-24' order by 1, 2, 3, 4;
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num where t3.dt = '2020-06-24' order by 1, 2, 3, 4;
+
+-- test t1 and t2 and t3 and t4
+function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 as t4 on t1.num=t4.num and t4.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
+function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 as t4 on t1.num=t4.num and t1.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
+function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 as t4 on t1.num=t4.num where t4.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
+function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 as t4 on t1.num=t4.num where t1.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")
+
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 as t4 on t1.num=t4.num and t4.dt = '2020-06-24' order by 1, 2, 3, 4;
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 as t4 on t1.num=t4.num and t1.dt = '2020-06-24' order by 1, 2, 3, 4;
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 as t4 on t1.num=t4.num where t4.dt = '2020-06-24' order by 1, 2, 3, 4;
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 as t4 on t1.num=t4.num where t1.dt = '2020-06-24' order by 1, 2, 3, 4;
+
+DROP MATERIALIZED VIEW test_mv1;
+drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 force;
+drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 force;
+drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 force;
+drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 force;

--- a/test/sql/test_transparent_mv/T/test_mv_rewrite_with_multi_stages
+++ b/test/sql/test_transparent_mv/T/test_mv_rewrite_with_multi_stages
@@ -54,7 +54,6 @@ INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 VALUES
 set catalog default_catalog;
 create database db_${uuid0};
 use db_${uuid0};
-set materialized_view_union_rewrite_mode=2;
 
 -- NOTE: test mv with the single table
 CREATE MATERIALIZED VIEW test_mv1 
@@ -74,8 +73,11 @@ function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, 
 SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num ORDER BY 1, 2, 3, 4;
 SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num and t1.dt = '2020-06-24' order by 1, 2, 3, 4;
 SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num and t2.dt = '2020-06-24' order by 1, 2, 3, 4;
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num and t2.dt = '2020-06-24' and t2.num > 1 order by 1, 2, 3, 4;
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num and t2.num > 1 order by 1, 2, 3, 4;
 SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num where t1.dt = '2020-06-24' order by 1, 2, 3, 4;
-SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num where t2.dt = '2020-06-24' order by 1, 2, 3, 4;
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num where t2.dt = '2020-06-24' and t2.num > 1 order by 1, 2, 3, 4;
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num where t2.num > 1 order by 1, 2, 3, 4;
 
 -- test t1 and t2 and t3
 
@@ -86,8 +88,10 @@ function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, 
 
 SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' order by 1, 2, 3, 4;
 SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t3.dt = '2020-06-24' order by 1, 2, 3, 4;
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t3.dt = '2020-06-24' and t3.num > 1 order by 1, 2, 3, 4;
 SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num where t1.dt = '2020-06-24' order by 1, 2, 3, 4;
 SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num where t3.dt = '2020-06-24' order by 1, 2, 3, 4;
+SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t3.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num where t3.dt = '2020-06-24' and t3.num > 1 order by 1, 2, 3, 4;
 
 -- test t1 and t2 and t3 and t4
 function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 as t3 on t1.num=t3.num and t1.dt = '2020-06-24' left join  mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 as t4 on t1.num=t4.num and t4.dt = '2020-06-24' order by 1, 2, 3, 4;", "test_mv1")

--- a/test/sql/test_transparent_mv/T/test_mv_rewrite_with_multi_stages
+++ b/test/sql/test_transparent_mv/T/test_mv_rewrite_with_multi_stages
@@ -105,3 +105,4 @@ drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 force;
 drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 force;
 drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t3 force;
 drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t4 force;
+drop database mv_hive_${uuid0}.mv_hive_db_${uuid0} force;

--- a/test/sql/test_transparent_mv/T/test_mv_rewrite_with_multi_stages
+++ b/test/sql/test_transparent_mv/T/test_mv_rewrite_with_multi_stages
@@ -62,6 +62,7 @@ REFRESH DEFERRED MANUAL
 AS 
 SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num;
 
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 
 -- test t1 and t2
 function: print_hit_materialized_view("SELECT t1.num as t1_num, t1.dt as t1_dt, t2.num as t2_num, t2.dt as t2_dt FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 as t1 left join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 as t2 on t1.num=t2.num ORDER BY 1, 2, 3, 4;", "test_mv1")

--- a/test/sql/test_transparent_mv/T/test_transparent_mv_hive
+++ b/test/sql/test_transparent_mv/T/test_transparent_mv_hive
@@ -362,3 +362,4 @@ drop materialized view default_catalog.db_${uuid0}.test_mv12;
 
 drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 force;
 drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 force;
+drop database mv_hive_${uuid0}.mv_hive_db_${uuid0};

--- a/test/sql/test_transparent_mv/T/test_transparent_mv_union_hive
+++ b/test/sql/test_transparent_mv/T/test_transparent_mv_union_hive
@@ -158,3 +158,4 @@ SELECT * FROM (SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db
 DROP MATERIALIZED VIEW test_mv1;
 drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 force;
 drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 force;
+drop database mv_hive_${uuid0}.mv_hive_db_${uuid0} force;

--- a/test/sql/test_transparent_mv/T/test_transparent_mv_union_hive2
+++ b/test/sql/test_transparent_mv/T/test_transparent_mv_union_hive2
@@ -173,3 +173,4 @@ SELECT * FROM (SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db
 DROP MATERIALIZED VIEW test_mv1;
 drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 force;
 drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 force;
+drop database mv_hive_${uuid0}.mv_hive_db_${uuid0} force;


### PR DESCRIPTION
## Why I'm doing:
When https://github.com/StarRocks/starrocks/pull/56932 is merged, mv rewrite may generate bad plans for query with left joins, plan may loss partition predicates in some cases.

The root cause is `RuleSet.PARTITION_PRUNE_RULES` cannot be redo even if mv rewrite has failed.

## What I'm doing:

`RuleSet.PARTITION_PRUNE_RULES` should be used very carefully, since it contains bitset to mark whether it has been applied, so this action will prevent partition pruning later. reset partition prune bit to do partition prune again because:
 1. partition prune is not done well since some predicates have not been pushed down.
 2. it may generate bad plans if we do not do partition prune again.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
