### PR TITLE
[BugFix] Fix concurrent issue in committed_rs_map

### DIFF
--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -650,7 +650,8 @@ bool Tablet::add_committed_rowset(const RowsetSharedPtr& rowset) {
     }
 
     if (rowset->rowset_meta()->check_schema_id(_max_version_schema->id())) {
-        _committed_rs_map[rowset->rowset_id()] = rowset;
+        // make sure the operation of _committed_rs_map is atomic, otherwise you need to hold lock
+        _committed_rs_map.insert_or_assign(rowset->rowset_id(), rowset);
         return true;
     }
     return false;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -331,6 +331,7 @@ set(EXEC_FILES
         ./storage/table_reader_remote_test.cpp
         ./storage/table_reader_test.cpp
         ./storage/tablet_schema_test.cpp
+        ./storage/tablet_test.cpp
         ./storage/tablet_updates_test.cpp
         ./storage/tablet_updates_schema_change_test.cpp
         ./storage/update_manager_test.cpp

--- a/be/test/storage/tablet_test.cpp
+++ b/be/test/storage/tablet_test.cpp
@@ -1,0 +1,82 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/tablet.h"
+
+#include <gtest/gtest.h>
+
+#include <thread>
+#include <vector>
+
+#include "storage/data_dir.h"
+#include "storage/rowset/rowset.h"
+#include "storage/tablet_manager.h"
+
+namespace starrocks {
+
+using namespace std::chrono_literals;
+
+class TabletTest : public testing::Test {
+public:
+    TabletTest() {}
+};
+
+static void add_rowset(Tablet* tablet, std::shared_ptr<Rowset>* rowset, std::atomic<bool>* stop) {
+    while (!stop->load()) {
+        tablet->add_committed_rowset(*rowset);
+        std::this_thread::sleep_for(2us);
+    }
+}
+static void erase_rowset(Tablet* tablet, std::shared_ptr<Rowset>* rowset, std::atomic<bool>* stop) {
+    while (!stop->load()) {
+        tablet->erase_committed_rowset(*rowset);
+        std::this_thread::sleep_for(2us);
+    }
+}
+
+TEST_F(TabletTest, test_concurrent_add_remove_committed_rowsets) {
+    auto tablet_meta = std::make_shared<TabletMeta>();
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(KeysType::DUP_KEYS);
+    schema_pb.set_id(1024);
+    auto schema = std::make_shared<const TabletSchema>(schema_pb);
+    tablet_meta->set_tablet_schema(schema);
+    tablet_meta->set_tablet_id(1024);
+    auto rs_meta_pb = std::make_unique<RowsetMetaPB>();
+    rs_meta_pb->set_rowset_id("123");
+    rs_meta_pb->set_start_version(0);
+    rs_meta_pb->set_end_version(1);
+    rs_meta_pb->mutable_tablet_schema()->CopyFrom(schema_pb);
+    auto rowset_meta = std::make_shared<RowsetMeta>(rs_meta_pb);
+    auto rowset = std::make_shared<Rowset>(schema, "", rowset_meta);
+    DataDir data_dir("./data_dir");
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, &data_dir);
+    tablet->set_data_dir(&data_dir);
+    tablet->add_committed_rowset(rowset);
+    tablet->erase_committed_rowset(rowset);
+    std::vector<std::thread> all_threads;
+    std::atomic<bool> stop{false};
+    for (int i = 0; i < 10; ++i) {
+        all_threads.emplace_back(&add_rowset, tablet.get(), &rowset, &stop);
+    }
+    for (int i = 0; i < 10; ++i) {
+        all_threads.emplace_back(&erase_rowset, tablet.get(), &rowset, &stop);
+    }
+    std::this_thread::sleep_for(5s);
+    stop = true;
+    for (auto& t : all_threads) {
+        t.join();
+    }
+}
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
The `committed_rs_map` uses `phmap::parallel_flat_hash_map` with segmented locking to achieve thread-safe concurrent operations. However, in the function `add_committed_rowset`, the current implementation performs ​​non-atomic​​ operations:
```
_committed_rs_map[rowset->rowset_id()] = rowset; 
```
This bypasses the map's built-in locking mechanism because:

1. The operation splits into ​​two steps​​: a lookup (locked) followed by an assignment (protected)
2. Between these steps, other threads may modify the map(e.g erase) and the return value of first look up maybe invalid,  causing race conditions

The crash stack is like:
```
*** SIGSEGV (@0x0) received by PID 189038 (TID 0x153ccc5fd640) from PID 0; stack trace: ***
    @     0x153d7348ee18 __pthread_once_slow
    @          0x7d9f940 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x153d7442b9b9 os::Linux::chained_handler(int, siginfo_t*, void*)
    @     0x153d74431c7a JVM_handle_linux_signal
    @     0x153d74423a4c signalHandler(int, siginfo_t*, void*)
    @     0x153d7343e6f0 (/usr/lib64/libc.so.6+0x3e6ef)
    @          0x61ac885 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::operator=(std::__shared_count<(__gnu_cxx::_Lock_policy)2> const&) [clone .isra.0]
    @          0x61bf20b starrocks::Tablet::add_committed_rowset(std::shared_ptr<starrocks::Rowset> const&)
    @          0x626f365 starrocks::TxnManager::commit_txn(starrocks::KVStore*, long, long, long, int, starrocks::UniqueId const&, starrocks::PUniqueId co
nst&, std::shared_ptr<starrocks::Rowset> const&, bool)
    @          0x626f9b0 starrocks::TxnManager::commit_txn(long, std::shared_ptr<starrocks::Tablet> const&, long, starrocks::PUniqueId const&, std::shared
_ptr<starrocks::Rowset> const&, bool)
    @          0x636c0f9 starrocks::DeltaWriter::commit()
    @          0x60db507 starrocks::SegmentFlushTask::run()
    @          0x397eab3 starrocks::ThreadPool::dispatch_thread()
    @          0x3976d56 starrocks::Thread::supervise_thread(void*)
    @     0x153d73489c02 start_thread
    @     0x153d7350ec40 __clone3
```

## What I'm doing:
Replace with insert_or_assign() which is ​​fully atomic​​ under phmap's segmented lock:
```
// Thread-safe atomic operation
_committed_rs_map.insert_or_assign(rowset->rowset_id(), rowset);
```


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
