### PR TITLE
[BugFix] Fix mv refresh failed with external tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -1363,7 +1363,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 logger.debug("Collect olap base table {}'s refreshed partition infos: {}", baseTable.getName(), partitionInfos);
             }
             return partitionInfos;
-        } else if (ConnectorPartitionTraits.isSupportPCTRefresh(baseTable.getType())) {
+        } else if (MVPCTRefreshPartitioner.isPartitionRefreshSupported(baseTable)) {
             return getSelectedPartitionInfos(baseTable, Lists.newArrayList(refreshedPartitionNames), baseTableInfo);
         } else {
             // FIXME: base table does not support partition-level refresh and does not update the meta

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
@@ -35,6 +35,7 @@ import com.starrocks.scheduler.TableSnapshotInfo;
 import com.starrocks.scheduler.TaskRunContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AlterTableClauseAnalyzer;
+import com.starrocks.sql.analyzer.MaterializedViewAnalyzer;
 import com.starrocks.sql.ast.DropPartitionClause;
 import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.common.PCell;
@@ -134,7 +135,9 @@ public abstract class MVPCTRefreshPartitioner {
      * Check whether the base table is supported partition refresh or not.
      */
     public static boolean isPartitionRefreshSupported(Table baseTable) {
-        return ConnectorPartitionTraits.isSupportPCTRefresh(baseTable.getType());
+        // An external table is not supported to refresh by partition.
+        return ConnectorPartitionTraits.isSupportPCTRefresh(baseTable.getType()) &&
+                !MaterializedViewAnalyzer.isExternalTableFromResource(baseTable);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -246,6 +246,7 @@ public class MaterializedViewAnalyzer {
         }
         return false;
     }
+
     private static void processViews(QueryStatement queryStatement, Set<BaseTableInfo> baseTableInfos,
                                      boolean withCheck) {
         List<ViewRelation> viewRelations = AnalyzerUtils.collectViewRelations(queryStatement);
@@ -956,7 +957,7 @@ public class MaterializedViewAnalyzer {
                     throw new SemanticException("Materialized view partition expression %s could only ref to base table",
                             slotRef.toSql());
                 }
-                if (isExternalTableFromResource(table)) {
+                if (!FeConstants.isReplayFromQueryDump && isExternalTableFromResource(table)) {
                     throw new SemanticException("Materialized view partition expression %s could not ref to external table",
                             slotRef.toSql());
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -42,6 +42,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.ExpressionRangePartitionInfoV2;
+import com.starrocks.catalog.ExternalOlapTable;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.IcebergTable;
@@ -198,7 +199,7 @@ public class MaterializedViewAnalyzer {
                 continue;
             }
 
-            if (!FeConstants.isReplayFromQueryDump && isExternalTableFromResource(table)) {
+            if (!FeConstants.isReplayFromQueryDump && !isSupportedExternalTables(table)) {
                 throw new SemanticException(
                         "Only supports creating materialized views based on the external table " +
                                 "which created by catalog", tableNameInfo.getPos());
@@ -212,16 +213,39 @@ public class MaterializedViewAnalyzer {
         return SUPPORTED_TABLE_TYPE.contains(table.getType()) || table instanceof OlapTable;
     }
 
-    private static boolean isExternalTableFromResource(Table table) {
+    /**
+     * Check if the table is external table from resource.
+     */
+    public static boolean isExternalTableFromResource(Table table) {
+        // external olap table is not supported to use for creating materialized view.
+        if (table instanceof ExternalOlapTable) {
+            return true;
+        }
+        // olap table is not external table
         if (table instanceof OlapTable) {
-            return false;
-        } else if (table instanceof JDBCTable || table instanceof MysqlTable) {
             return false;
         }
         String catalog = table.getCatalogName();
         return Strings.isNullOrEmpty(catalog) || isResourceMappingCatalog(catalog);
     }
 
+    /**
+     * We can support some external tables for creating materialized view.
+     * For more details see: https://github.com/StarRocks/starrocks/issues/19581
+     * @param table : table to check
+     * @return true if the external table is supported for materialized view
+     */
+    public static boolean isSupportedExternalTables(Table table) {
+        // if the table is not external table, return true directly
+        if (!isExternalTableFromResource(table)) {
+            return true;
+        }
+        // only jdbc external table can be used for creating mv
+        if (table instanceof JDBCTable || table instanceof MysqlTable) {
+            return true;
+        }
+        return false;
+    }
     private static void processViews(QueryStatement queryStatement, Set<BaseTableInfo> baseTableInfos,
                                      boolean withCheck) {
         List<ViewRelation> viewRelations = AnalyzerUtils.collectViewRelations(queryStatement);
@@ -930,6 +954,10 @@ public class MaterializedViewAnalyzer {
                 Table table = tableNameTableMap.get(tableName);
                 if (table == null) {
                     throw new SemanticException("Materialized view partition expression %s could only ref to base table",
+                            slotRef.toSql());
+                }
+                if (isExternalTableFromResource(table)) {
+                    throw new SemanticException("Materialized view partition expression %s could not ref to external table",
                             slotRef.toSql());
                 }
                 if (table.isNativeTableOrMaterializedView()) {

--- a/test/sql/test_transparent_mv/R/test_mv_with_external_table
+++ b/test/sql/test_transparent_mv/R/test_mv_with_external_table
@@ -41,7 +41,7 @@ PROPERTIES (
   "type" = "jdbc",
   "user" = "${external_mysql_user}",
   "password" = "${external_mysql_password}",
-  "jdbc_uri"="jdbc:mysql://${external_mysql_ip}:${external_mysql_port}",
+  "jdbc_uri"="jdbc:mysql://${external_mysql_ip}:${external_mysql_port}/mv_mysql_db_${uuid0}",
   "driver_url"="https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar",
   "driver_class"="com.mysql.cj.jdbc.Driver"
 );
@@ -70,14 +70,13 @@ PROPERTIES (
 set new_planner_optimize_timeout=10000;
 -- result:
 -- !result
-CREATE MATERIALIZED VIEW test_mv1 
-PARTITION BY dt
-REFRESH DEFERRED MANUAL 
-PROPERTIES ("replication_num" = "1")
-AS 
-  SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt;
+select count(*) from external_mysql_t1;
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Materialized view partition expression `db_ecd68e4b8e784225b5ecc69ec97ee46c`.`external_mysql_t1`.`dt` could not ref to external table.')
+20
+-- !result
+select count(*) from external_mysql_t2;
+-- result:
+20
 -- !result
 CREATE MATERIALIZED VIEW test_mv1 
 PARTITION BY dt
@@ -86,7 +85,16 @@ PROPERTIES ("replication_num" = "1")
 AS 
   SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt;
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Materialized view partition expression `db_ecd68e4b8e784225b5ecc69ec97ee46c`.`external_mysql_t1`.`dt` could not ref to external table.')
+E: (1064, 'Getting analyzing error. Detail message: Materialized view partition expression `db_ca31a3fefd89443f8ad2d6699e123a4e`.`external_mysql_t1`.`dt` could not ref to external table.')
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt
+REFRESH DEFERRED MANUAL 
+PROPERTIES ("replication_num" = "1")
+AS 
+  SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt;
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Materialized view partition expression `db_ca31a3fefd89443f8ad2d6699e123a4e`.`external_mysql_t1`.`dt` could not ref to external table.')
 -- !result
 CREATE MATERIALIZED VIEW test_mv1 
 REFRESH DEFERRED MANUAL 
@@ -98,13 +106,19 @@ AS
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt;", "test_mv1")
 -- result:
-False
+True
 -- !result
 SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt order by 1, 2 limit 3;
 -- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
 -- !result
 SELECT dt, num FROM test_mv1 order by 1, 2 limit 3;
 -- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
 -- !result
 shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; INSERT INTO t1 VALUES (3,"2020-06-15");'
 -- result:
@@ -113,24 +127,36 @@ shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_
 -- !result
 function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt;", "test_mv1")
 -- result:
-False
+True
 -- !result
 SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt order by 1, 2 limit 3;
 -- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
 -- !result
 SELECT dt, num FROM test_mv1 order by 1, 2 limit 3;
 -- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
 -- !result
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt;", "test_mv1")
 -- result:
-False
+True
 -- !result
 SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt order by 1, 2 limit 3;
 -- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
 -- !result
 SELECT dt, num FROM test_mv1 order by 1, 2 limit 3;
 -- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
 -- !result
 drop materialized view default_catalog.db_${uuid0}.test_mv1;
 -- result:
@@ -149,10 +175,15 @@ False
 -- !result
 SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt order by 1, 2 limit 3;
 -- result:
-E: (1064, 'open JDBCScanner failed, error: java.sql.SQLException: No database selected\n\tat com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:129)\n\tat com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)\n\tat com.mysql.cj.jdbc.ClientPreparedStatement.executeInternal(ClientPreparedStatement.java:953)\n\tat com.mysql.cj.jdbc.ClientPreparedStatement.executeQuery(ClientPreparedStatement.java:1009)\n\tat com.zaxxer.hikari.pool.ProxyPreparedStatement.executeQuery(ProxyPreparedStatement.java:52)\n\tat com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeQuery(HikariProxyPreparedStatement.java)\n\tat com.starrocks.jdbcbridge.JDBCScanner.open(JDBCScanner.java:95)\n: BE:10001')
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
 -- !result
 SELECT dt, num FROM test_mv1 order by 1, 2 limit 3;
 -- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
 -- !result
 shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; INSERT INTO t1 VALUES (3,"2020-06-15");'
 -- result:
@@ -165,10 +196,15 @@ False
 -- !result
 SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt order by 1, 2 limit 3;
 -- result:
-E: (1064, 'open JDBCScanner failed, error: java.sql.SQLException: No database selected\n\tat com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:129)\n\tat com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)\n\tat com.mysql.cj.jdbc.ClientPreparedStatement.executeInternal(ClientPreparedStatement.java:953)\n\tat com.mysql.cj.jdbc.ClientPreparedStatement.executeQuery(ClientPreparedStatement.java:1009)\n\tat com.zaxxer.hikari.pool.ProxyPreparedStatement.executeQuery(ProxyPreparedStatement.java:52)\n\tat com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeQuery(HikariProxyPreparedStatement.java)\n\tat com.starrocks.jdbcbridge.JDBCScanner.open(JDBCScanner.java:95)\n: BE:10001')
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
 -- !result
 SELECT dt, num FROM test_mv1 order by 1, 2 limit 3;
 -- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
 -- !result
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt;", "test_mv1")
@@ -177,10 +213,15 @@ False
 -- !result
 SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt order by 1, 2 limit 3;
 -- result:
-E: (1064, 'open JDBCScanner failed, error: java.sql.SQLException: No database selected\n\tat com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:129)\n\tat com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)\n\tat com.mysql.cj.jdbc.ClientPreparedStatement.executeInternal(ClientPreparedStatement.java:953)\n\tat com.mysql.cj.jdbc.ClientPreparedStatement.executeQuery(ClientPreparedStatement.java:1009)\n\tat com.zaxxer.hikari.pool.ProxyPreparedStatement.executeQuery(ProxyPreparedStatement.java:52)\n\tat com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeQuery(HikariProxyPreparedStatement.java)\n\tat com.starrocks.jdbcbridge.JDBCScanner.open(JDBCScanner.java:95)\n: BE:10001')
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
 -- !result
 SELECT dt, num FROM test_mv1 order by 1, 2 limit 3;
 -- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
 -- !result
 drop materialized view default_catalog.db_${uuid0}.test_mv1;
 -- result:

--- a/test/sql/test_transparent_mv/R/test_mv_with_external_table
+++ b/test/sql/test_transparent_mv/R/test_mv_with_external_table
@@ -1,0 +1,192 @@
+-- name: test_mv_with_external_table @slow
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'create database mv_mysql_db_${uuid0};'
+-- result:
+0
+
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; CREATE TABLE t1 (num int, dt date) PARTITION BY range columns(dt) (PARTITION p20200614 VALUES LESS THAN ("2020-06-15"),PARTITION p20200617 VALUES LESS THAN ("2020-06-18"),PARTITION p20200620 VALUES LESS THAN ("2020-06-21"),PARTITION p20200623 VALUES LESS THAN ("2020-06-24"),PARTITION p20200701 VALUES LESS THAN ("2020-07-02"),PARTITION p20200704 VALUES LESS THAN ("2020-07-05"),PARTITION p20200707 VALUES LESS THAN ("2020-07-08"),PARTITION p20200710 VALUES LESS THAN ("2020-07-11"),PARTITION p20200715 VALUES LESS THAN ("2020-07-16"),PARTITION p20200718 VALUES LESS THAN ("2020-07-19"),PARTITION p20200721 VALUES LESS THAN ("2020-07-22"),PARTITION p20200724 VALUES LESS THAN ("2020-07-31"));'
+-- result:
+0
+
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; INSERT INTO t1 VALUES (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),(1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),(1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),(2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),(2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");'
+-- result:
+0
+
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; CREATE TABLE t2 (num int, dt date);'
+-- result:
+0
+
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; INSERT INTO t2 VALUES (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),(1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),(1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),(2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),(2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");'
+-- result:
+0
+
+-- !result
+set enable_materialized_view_transparent_union_rewrite = true;
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE EXTERNAL RESOURCE jdbc0_${uuid0}
+PROPERTIES (
+  "type" = "jdbc",
+  "user" = "${external_mysql_user}",
+  "password" = "${external_mysql_password}",
+  "jdbc_uri"="jdbc:mysql://${external_mysql_ip}:${external_mysql_port}",
+  "driver_url"="https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar",
+  "driver_class"="com.mysql.cj.jdbc.Driver"
+);
+-- result:
+-- !result
+CREATE EXTERNAL TABLE external_mysql_t1 (
+  num int,
+  dt date
+) ENGINE=JDBC
+PROPERTIES (
+  "resource" = "jdbc0_${uuid0}",
+  "table" = "t1"
+);
+-- result:
+-- !result
+CREATE EXTERNAL TABLE external_mysql_t2 (
+  num int,
+  dt date
+) ENGINE=JDBC
+PROPERTIES (
+  "resource" = "jdbc0_${uuid0}",
+  "table" = "t2"
+);
+-- result:
+-- !result
+set new_planner_optimize_timeout=10000;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt
+REFRESH DEFERRED MANUAL 
+PROPERTIES ("replication_num" = "1")
+AS 
+  SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt;
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Materialized view partition expression `db_ecd68e4b8e784225b5ecc69ec97ee46c`.`external_mysql_t1`.`dt` could not ref to external table.')
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt
+REFRESH DEFERRED MANUAL 
+PROPERTIES ("replication_num" = "1")
+AS 
+  SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt;
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Materialized view partition expression `db_ecd68e4b8e784225b5ecc69ec97ee46c`.`external_mysql_t1`.`dt` could not ref to external table.')
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+REFRESH DEFERRED MANUAL 
+PROPERTIES ("replication_num" = "1")
+AS 
+  SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt;", "test_mv1")
+-- result:
+False
+-- !result
+SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt order by 1, 2 limit 3;
+-- result:
+-- !result
+SELECT dt, num FROM test_mv1 order by 1, 2 limit 3;
+-- result:
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; INSERT INTO t1 VALUES (3,"2020-06-15");'
+-- result:
+0
+
+-- !result
+function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt;", "test_mv1")
+-- result:
+False
+-- !result
+SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt order by 1, 2 limit 3;
+-- result:
+-- !result
+SELECT dt, num FROM test_mv1 order by 1, 2 limit 3;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt;", "test_mv1")
+-- result:
+False
+-- !result
+SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt order by 1, 2 limit 3;
+-- result:
+-- !result
+SELECT dt, num FROM test_mv1 order by 1, 2 limit 3;
+-- result:
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+REFRESH DEFERRED MANUAL 
+PROPERTIES ("replication_num" = "1")
+AS 
+  SELECT dt, sum(num) as num FROM external_mysql_t2 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt;", "test_mv1")
+-- result:
+False
+-- !result
+SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt order by 1, 2 limit 3;
+-- result:
+E: (1064, 'open JDBCScanner failed, error: java.sql.SQLException: No database selected\n\tat com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:129)\n\tat com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)\n\tat com.mysql.cj.jdbc.ClientPreparedStatement.executeInternal(ClientPreparedStatement.java:953)\n\tat com.mysql.cj.jdbc.ClientPreparedStatement.executeQuery(ClientPreparedStatement.java:1009)\n\tat com.zaxxer.hikari.pool.ProxyPreparedStatement.executeQuery(ProxyPreparedStatement.java:52)\n\tat com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeQuery(HikariProxyPreparedStatement.java)\n\tat com.starrocks.jdbcbridge.JDBCScanner.open(JDBCScanner.java:95)\n: BE:10001')
+-- !result
+SELECT dt, num FROM test_mv1 order by 1, 2 limit 3;
+-- result:
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; INSERT INTO t1 VALUES (3,"2020-06-15");'
+-- result:
+0
+
+-- !result
+function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt;", "test_mv1")
+-- result:
+False
+-- !result
+SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt order by 1, 2 limit 3;
+-- result:
+E: (1064, 'open JDBCScanner failed, error: java.sql.SQLException: No database selected\n\tat com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:129)\n\tat com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)\n\tat com.mysql.cj.jdbc.ClientPreparedStatement.executeInternal(ClientPreparedStatement.java:953)\n\tat com.mysql.cj.jdbc.ClientPreparedStatement.executeQuery(ClientPreparedStatement.java:1009)\n\tat com.zaxxer.hikari.pool.ProxyPreparedStatement.executeQuery(ProxyPreparedStatement.java:52)\n\tat com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeQuery(HikariProxyPreparedStatement.java)\n\tat com.starrocks.jdbcbridge.JDBCScanner.open(JDBCScanner.java:95)\n: BE:10001')
+-- !result
+SELECT dt, num FROM test_mv1 order by 1, 2 limit 3;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt;", "test_mv1")
+-- result:
+False
+-- !result
+SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt order by 1, 2 limit 3;
+-- result:
+E: (1064, 'open JDBCScanner failed, error: java.sql.SQLException: No database selected\n\tat com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:129)\n\tat com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)\n\tat com.mysql.cj.jdbc.ClientPreparedStatement.executeInternal(ClientPreparedStatement.java:953)\n\tat com.mysql.cj.jdbc.ClientPreparedStatement.executeQuery(ClientPreparedStatement.java:1009)\n\tat com.zaxxer.hikari.pool.ProxyPreparedStatement.executeQuery(ProxyPreparedStatement.java:52)\n\tat com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeQuery(HikariProxyPreparedStatement.java)\n\tat com.starrocks.jdbcbridge.JDBCScanner.open(JDBCScanner.java:95)\n: BE:10001')
+-- !result
+SELECT dt, num FROM test_mv1 order by 1, 2 limit 3;
+-- result:
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'drop database mv_mysql_db_${uuid0};'
+-- result:
+0
+
+-- !result

--- a/test/sql/test_transparent_mv/R/test_mv_with_external_table
+++ b/test/sql/test_transparent_mv/R/test_mv_with_external_table
@@ -85,7 +85,7 @@ PROPERTIES ("replication_num" = "1")
 AS 
   SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt;
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Materialized view partition expression `db_ca31a3fefd89443f8ad2d6699e123a4e`.`external_mysql_t1`.`dt` could not ref to external table.')
+[REGEX].*`external_mysql_t1`.`dt` could not ref to external table.*
 -- !result
 CREATE MATERIALIZED VIEW test_mv1 
 PARTITION BY dt
@@ -94,7 +94,7 @@ PROPERTIES ("replication_num" = "1")
 AS 
   SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt;
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Materialized view partition expression `db_ca31a3fefd89443f8ad2d6699e123a4e`.`external_mysql_t1`.`dt` could not ref to external table.')
+[REGEX].*`external_mysql_t1`.`dt` could not ref to external table.*
 -- !result
 CREATE MATERIALIZED VIEW test_mv1 
 REFRESH DEFERRED MANUAL 

--- a/test/sql/test_transparent_mv/T/test_mv_with_external_table
+++ b/test/sql/test_transparent_mv/T/test_mv_with_external_table
@@ -1,0 +1,112 @@
+-- name: test_mv_with_external_table @slow
+-- create mysql table
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'create database mv_mysql_db_${uuid0};'
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; CREATE TABLE t1 (num int, dt date) PARTITION BY range columns(dt) (PARTITION p20200614 VALUES LESS THAN ("2020-06-15"),PARTITION p20200617 VALUES LESS THAN ("2020-06-18"),PARTITION p20200620 VALUES LESS THAN ("2020-06-21"),PARTITION p20200623 VALUES LESS THAN ("2020-06-24"),PARTITION p20200701 VALUES LESS THAN ("2020-07-02"),PARTITION p20200704 VALUES LESS THAN ("2020-07-05"),PARTITION p20200707 VALUES LESS THAN ("2020-07-08"),PARTITION p20200710 VALUES LESS THAN ("2020-07-11"),PARTITION p20200715 VALUES LESS THAN ("2020-07-16"),PARTITION p20200718 VALUES LESS THAN ("2020-07-19"),PARTITION p20200721 VALUES LESS THAN ("2020-07-22"),PARTITION p20200724 VALUES LESS THAN ("2020-07-31"));'
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; INSERT INTO t1 VALUES (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),(1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),(1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),(2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),(2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");'
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; CREATE TABLE t2 (num int, dt date);'
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; INSERT INTO t2 VALUES (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),(1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),(1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),(2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),(2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");'
+
+set enable_materialized_view_transparent_union_rewrite = true;
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+
+CREATE EXTERNAL RESOURCE jdbc0_${uuid0}
+PROPERTIES (
+  "type" = "jdbc",
+  "user" = "${external_mysql_user}",
+  "password" = "${external_mysql_password}",
+  "jdbc_uri"="jdbc:mysql://${external_mysql_ip}:${external_mysql_port}",
+  "driver_url"="https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar",
+  "driver_class"="com.mysql.cj.jdbc.Driver"
+);
+
+CREATE EXTERNAL TABLE external_mysql_t1 (
+  num int,
+  dt date
+) ENGINE=JDBC
+PROPERTIES (
+  "resource" = "jdbc0_${uuid0}",
+  "table" = "t1"
+);
+
+CREATE EXTERNAL TABLE external_mysql_t2 (
+  num int,
+  dt date
+) ENGINE=JDBC
+PROPERTIES (
+  "resource" = "jdbc0_${uuid0}",
+  "table" = "t2"
+);
+
+set new_planner_optimize_timeout=10000;
+
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt
+REFRESH DEFERRED MANUAL 
+PROPERTIES ("replication_num" = "1")
+AS 
+  SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt;
+
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt
+REFRESH DEFERRED MANUAL 
+PROPERTIES ("replication_num" = "1")
+AS 
+  SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt;
+
+-- test mv with t1
+CREATE MATERIALIZED VIEW test_mv1 
+REFRESH DEFERRED MANUAL 
+PROPERTIES ("replication_num" = "1")
+AS 
+  SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt;", "test_mv1")
+SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt order by 1, 2 limit 3;
+SELECT dt, num FROM test_mv1 order by 1, 2 limit 3;
+
+-- union rewrite
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; INSERT INTO t1 VALUES (3,"2020-06-15");'
+
+function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt;", "test_mv1")
+SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt order by 1, 2 limit 3;
+SELECT dt, num FROM test_mv1 order by 1, 2 limit 3;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt;", "test_mv1")
+SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt order by 1, 2 limit 3;
+SELECT dt, num FROM test_mv1 order by 1, 2 limit 3;
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+-- test mv with t2
+CREATE MATERIALIZED VIEW test_mv1 
+REFRESH DEFERRED MANUAL 
+PROPERTIES ("replication_num" = "1")
+AS 
+  SELECT dt, sum(num) as num FROM external_mysql_t2 GROUP BY dt;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt;", "test_mv1")
+SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt order by 1, 2 limit 3;
+SELECT dt, num FROM test_mv1 order by 1, 2 limit 3;
+
+-- union rewrite
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; INSERT INTO t1 VALUES (3,"2020-06-15");'
+
+function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt;", "test_mv1")
+SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt order by 1, 2 limit 3;
+SELECT dt, num FROM test_mv1 order by 1, 2 limit 3;
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt;", "test_mv1")
+SELECT dt, sum(num) as num FROM external_mysql_t1 GROUP BY dt order by 1, 2 limit 3;
+SELECT dt, num FROM test_mv1 order by 1, 2 limit 3;
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'drop database mv_mysql_db_${uuid0};'

--- a/test/sql/test_transparent_mv/T/test_mv_with_external_table
+++ b/test/sql/test_transparent_mv/T/test_mv_with_external_table
@@ -17,7 +17,7 @@ PROPERTIES (
   "type" = "jdbc",
   "user" = "${external_mysql_user}",
   "password" = "${external_mysql_password}",
-  "jdbc_uri"="jdbc:mysql://${external_mysql_ip}:${external_mysql_port}",
+  "jdbc_uri"="jdbc:mysql://${external_mysql_ip}:${external_mysql_port}/mv_mysql_db_${uuid0}",
   "driver_url"="https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar",
   "driver_class"="com.mysql.cj.jdbc.Driver"
 );
@@ -41,6 +41,8 @@ PROPERTIES (
 );
 
 set new_planner_optimize_timeout=10000;
+select count(*) from external_mysql_t1;
+select count(*) from external_mysql_t2;
 
 CREATE MATERIALIZED VIEW test_mv1 
 PARTITION BY dt


### PR DESCRIPTION
## Why I'm doing:

Even though https://github.com/StarRocks/starrocks/issues/19581 has supported external tables for mv refresh, but refresh mvs with external tables still failed as below:

```
mysql> show materialized views\G;
*************************** 1. row ***************************
                                  id: 16680
                       database_name: test
                                name: test_mv1
                        refresh_type: MANUAL
                           is_active: true
                     inactive_reason:
                      partition_type: UNPARTITIONED
                             task_id: 16688
                           task_name: mv-16680
             last_refresh_start_time: 2025-04-28 17:07:46
          last_refresh_finished_time: 2025-04-28 17:07:47
               last_refresh_duration: 1.009
                  last_refresh_state: FAILED
          last_refresh_force_refresh: false
        last_refresh_start_partition: NULL
          last_refresh_end_partition: NULL
last_refresh_base_refresh_partitions: {}
  last_refresh_mv_refresh_partitions: [test_mv1]
             last_refresh_error_code: -1
          last_refresh_error_message: Refresh mv test_mv1 failed after 1/0 times, error-msg : java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
        at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
        at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
        at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
        at java.base/java.util.Objects.checkIndex(Objects.java:359)
        at java.base/java.util.ArrayList.get(ArrayList.java:427)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.getSelectedPartitionInfos(PartitionBasedMvRefreshProcessor.java:1393)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.getRefreshedPartitionInfos(PartitionBasedMvRefreshProcessor.java:1367)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.updateBaseTablePartitionSnapshotInfos(PartitionBasedMvRefreshProcessor.java:1272)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedView(PartitionBasedMvRefreshProcessor.java:458)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedViewWithRetry(PartitionBasedMvRefreshProcessor.java:373)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doMvRefresh(PartitionBasedMvRefreshProcessor.java:334)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.processTaskRun(PartitionBasedMvRefreshProcessor.java:202)
        at com.starrocks.scheduler.TaskRun.executeTaskRun(TaskRun.java:288)
        at com.starrocks.scheduler.TaskRunExecutor.lambda$executeTaskRun$0(TaskRunExecutor.java:60)
        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
                                rows: 0
```

## What I'm doing:
- For mv with external tables,  refresh it as non-partitioned mv to avoid some extra checks.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
