### PR TITLE
[BugFix] Fix finishCheckpoint bug when checkpoint is failed on worker node

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/journal/CheckpointWorker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/CheckpointWorker.java
@@ -82,7 +82,7 @@ public abstract class CheckpointWorker extends FrontendDaemon {
         createImage(np.epoch, np.journalId);
     }
 
-    private void init() {
+    protected void init() {
         this.servingGlobalState = GlobalStateMgr.getServingState();
     }
 
@@ -104,7 +104,7 @@ public abstract class CheckpointWorker extends FrontendDaemon {
         finishCheckpoint(epoch, journalId, true, "success");
     }
 
-    private boolean preCheckParamValid(long epoch, long journalId) {
+    protected boolean preCheckParamValid(long epoch, long journalId) {
         if (journalId < getImageJournalId()) {
             finishCheckpoint(epoch, journalId, false, "journalId is too small");
             return false;

--- a/fe/fe-core/src/main/java/com/starrocks/journal/CheckpointWorker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/CheckpointWorker.java
@@ -33,6 +33,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
 
 public abstract class CheckpointWorker extends FrontendDaemon {
     public static final Logger LOG = LogManager.getLogger(CheckpointWorker.class);
@@ -40,7 +41,7 @@ public abstract class CheckpointWorker extends FrontendDaemon {
     protected final Journal journal;
 
     // the next checkpoint task(epoch, journalId) to do
-    private NextPoint nextPoint;
+    private final AtomicReference<NextPoint> nextPoint = new AtomicReference<>();
     protected GlobalStateMgr servingGlobalState;
 
     public CheckpointWorker(String name, Journal journal) {
@@ -65,7 +66,7 @@ public abstract class CheckpointWorker extends FrontendDaemon {
                     journalId, journal.getMaxJournalId()));
         }
 
-        nextPoint = new NextPoint(epoch, journalId);
+        nextPoint.set(new NextPoint(epoch, journalId));
         LOG.info("set next point to epoch:{}, journalId:{}", epoch, journalId);
     }
 
@@ -73,19 +74,12 @@ public abstract class CheckpointWorker extends FrontendDaemon {
     protected void runAfterCatalogReady() {
         init();
 
-        if (nextPoint == null) {
+        NextPoint np = nextPoint.getAndSet(null);
+        if (np == null) {
             return;
         }
 
-        if (nextPoint.journalId <= getImageJournalId()) {
-            return;
-        }
-
-        if (nextPoint.epoch != servingGlobalState.getEpoch()) {
-            return;
-        }
-
-        createImage(nextPoint.epoch, nextPoint.journalId);
+        createImage(np.epoch, np.journalId);
     }
 
     private void init() {
@@ -93,6 +87,10 @@ public abstract class CheckpointWorker extends FrontendDaemon {
     }
 
     private void createImage(long epoch, long journalId) {
+        if (!preCheckParamValid(epoch, journalId)) {
+            return;
+        }
+
         try {
             doCheckpoint(epoch, journalId);
         } catch (Exception e) {
@@ -104,6 +102,22 @@ public abstract class CheckpointWorker extends FrontendDaemon {
         cleanOldImages();
 
         finishCheckpoint(epoch, journalId, true, "success");
+    }
+
+    private boolean preCheckParamValid(long epoch, long journalId) {
+        if (journalId < getImageJournalId()) {
+            finishCheckpoint(epoch, journalId, false, "journalId is too small");
+            return false;
+        }
+        if (journalId == getImageJournalId()) {
+            finishCheckpoint(epoch, journalId, true, "success");
+            return false;
+        }
+        if (epoch != servingGlobalState.getEpoch()) {
+            finishCheckpoint(epoch, journalId, false, "epoch outdated");
+            return false;
+        }
+        return true;
     }
 
     private void cleanOldImages() {

--- a/fe/fe-core/src/main/java/com/starrocks/leader/CheckpointController.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/CheckpointController.java
@@ -202,7 +202,12 @@ public class CheckpointController extends FrontendDaemon {
         }
 
         try {
-            Pair<Boolean, String> ret = result.poll(Config.checkpoint_timeout_seconds, TimeUnit.SECONDS);
+            long startNs = System.nanoTime();
+            Pair<Boolean, String> ret = null;
+            while (ret == null
+                    && System.nanoTime() - startNs < TimeUnit.SECONDS.toNanos(Config.checkpoint_timeout_seconds)) {
+                ret = result.poll(1, TimeUnit.SECONDS);
+            }
             if (ret == null) {
                 LOG.warn("do checkpoint timeout on node: {}", workerNodeName);
                 return Pair.create(false, workerNodeName);

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -3108,7 +3108,11 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         }
 
         try {
-            controller.finishCheckpoint(request.getJournal_id(), request.getNode_name());
+            if (request.isIs_success()) {
+                controller.finishCheckpoint(request.getJournal_id(), request.getNode_name());
+            } else {
+                controller.cancelCheckpoint(request.getNode_name(), request.getMessage());
+            }
             response.setStatus(new TStatus(OK));
             return response;
         } catch (CheckpointException e) {

--- a/fe/fe-core/src/test/java/com/starrocks/journal/CheckpointWorkerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/journal/CheckpointWorkerTest.java
@@ -1,0 +1,69 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.journal;
+
+import com.starrocks.common.Config;
+import com.starrocks.ha.BDBHA;
+import com.starrocks.server.GlobalStateMgr;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CheckpointWorkerTest {
+    private final List<File> tmpDirs = new ArrayList<>();
+
+    public void createImageFile() throws Exception {
+        File metaDir = Files.createTempDirectory(Paths.get("."), "CheckpointWorkerTest").toFile();
+        tmpDirs.add(metaDir);
+        Config.meta_dir = metaDir.getAbsolutePath();
+        new File(Config.meta_dir + "/image/v2/").mkdirs();
+
+        Files.createFile(Path.of(Config.meta_dir, "image", "v2", "image.1000"));
+    }
+
+    @After
+    public void cleanup() throws Exception {
+        for (File tmpDir : tmpDirs) {
+            FileUtils.deleteDirectory(tmpDir);
+        }
+    }
+
+    @Test
+    public void testPreCheckParamValid() throws Exception {
+        BDBHA bdbha = mock(BDBHA.class);
+        when(bdbha.getLatestEpoch()).thenReturn(10L);
+        GlobalStateMgr.getServingState().setHaProtocol(bdbha);
+
+        createImageFile();
+
+        Assert.assertTrue(new File(Config.meta_dir + "/image/v2/image.1000").exists());
+
+        CheckpointWorker worker = new GlobalStateCheckpointWorker(null);
+        worker.init();
+        Assert.assertFalse(worker.preCheckParamValid(9, 999));
+        Assert.assertFalse(worker.preCheckParamValid(9, 1000));
+        Assert.assertFalse(worker.preCheckParamValid(9, 1001));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
1. cancelCheckpoint if `request.isIs_success()` is false in finishCheckpoint API.
2. Do not retry on worker node. Controller will retry checkpoint if failed.

Fixes https://github.com/StarRocks/StarRocksTest/issues/9556

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
