### PR TITLE
[BugFix] Fix a bug that when replay change refresh schema log will change the MV DDL for follower

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -409,8 +409,10 @@ public class AlterJobMgr {
             newMvRefreshScheme.setLastRefreshTime(oldRefreshScheme.getLastRefreshTime());
             final MaterializedView.RefreshType refreshType = log.getRefreshType();
             final MaterializedView.AsyncRefreshContext asyncRefreshContext = log.getAsyncRefreshContext();
+            final MaterializedView.RefreshMoment moment = oldRefreshScheme.getMoment();
             newMvRefreshScheme.setType(refreshType);
             newMvRefreshScheme.setAsyncRefreshContext(asyncRefreshContext);
+            newMvRefreshScheme.setMoment(moment);
 
             long maxChangedTableRefreshTime =
                     MvUtils.getMaxTablePartitionInfoRefreshTime(

--- a/fe/fe-core/src/test/java/com/starrocks/persist/ChangeMaterializedViewRefreshSchemeLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/ChangeMaterializedViewRefreshSchemeLogTest.java
@@ -22,6 +22,7 @@ import com.starrocks.alter.SystemHandler;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DataProperty;
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.PartitionInfo;
@@ -31,7 +32,11 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.common.Config;
 import com.starrocks.common.io.Text;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TTabletType;
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Mocked;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -57,7 +62,8 @@ public class ChangeMaterializedViewRefreshSchemeLogTest {
     }
 
     @Test
-    public void testNormal() throws IOException {
+    public void testNormal(@Mocked GlobalStateMgr globalStateMgr,
+                           @Injectable Database db) throws IOException {
         // 1. Write objects to file
         File file = new File(fileName);
         file.createNewFile();
@@ -74,6 +80,7 @@ public class ChangeMaterializedViewRefreshSchemeLogTest {
         partitionInfo.setIsInMemory(1, false);
         partitionInfo.setTabletType(1, TTabletType.TABLET_TYPE_DISK);
         MaterializedView.MvRefreshScheme refreshScheme = new MaterializedView.MvRefreshScheme();
+        refreshScheme.setMoment(MaterializedView.RefreshMoment.DEFERRED);
         final MaterializedView.AsyncRefreshContext asyncRefreshContext = refreshScheme.getAsyncRefreshContext();
         asyncRefreshContext.setStartTime(1655732457);
         asyncRefreshContext.setStep(1);
@@ -95,6 +102,20 @@ public class ChangeMaterializedViewRefreshSchemeLogTest {
         Assert.assertEquals(readChangeLogAsyncRefreshContext.getTimeUnit(), "DAY");
         Assert.assertEquals(readChangeLogAsyncRefreshContext.getStep(), 1);
         in.close();
+
+        new Expectations() {
+            {
+                globalStateMgr.getCurrentState().getLocalMetastore().getDb(anyLong);
+                result = db;
+
+                globalStateMgr.getCurrentState().getLocalMetastore().getTable(anyLong, anyLong);
+                result = materializedView;
+            }
+        };
+        new AlterJobMgr(null, null, null)
+                .replayChangeMaterializedViewRefreshScheme(changeLog);
+
+        Assert.assertEquals(materializedView.getRefreshScheme().getMoment(), MaterializedView.RefreshMoment.DEFERRED);
     }
 
     @Test


### PR DESCRIPTION
[BugFix] Fix a bug that when replay change refresh schema log will change the MV DDL

## Why I'm doing:
Fix one bug that when follower replay the change refresh schema log the follower will change the refresh moment for the MV.
It will make the MV have wrong DDL compare to the original DDL.
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
