### PR TITLE
[BugFix] Fix a bug in neon_select_if_common_implement

### DIFF
--- a/be/src/simd/selector.h
+++ b/be/src/simd/selector.h
@@ -441,13 +441,14 @@ inline void neon_select_if_common_implement(uint8_t*& selector, T*& dst, const T
             }
         }
 
-        dst += 16;
+        const int elements_per_iteration = neon_width / data_size;
+        dst += elements_per_iteration;
         selector += 16;
         if constexpr (!left_const) {
-            a += 16;
+            a += elements_per_iteration;
         }
         if constexpr (!right_const) {
-            b += 16;
+            b += elements_per_iteration;
         }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

There is a bug in neon_select_if_common_implement. `dst`, `a`, `b` are T*, we should not increment them by 16 elements.

## What I'm doing:

This PR fixes this bug.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
