### PR TITLE
[BugFix] Fix concurrency limit in SlotSelectionStrategyV2 strategy

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/BaseSlotTracker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/BaseSlotTracker.java
@@ -340,8 +340,14 @@ public abstract class BaseSlotTracker {
         return slots.get(slotId);
     }
 
+    // allocated slots that mean the slots which have been allocated and not released.
     public int getNumAllocatedSlots() {
         return numAllocatedSlots;
+    }
+
+    // return the number of allocated slots which is the current concurrency in the query queue
+    public int getCurrentCurrency() {
+        return allocatedSlots.size();
     }
 
     public long getWarehouseId() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2.java
@@ -234,10 +234,11 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
 
     private boolean isQueryConcurrencyLimitAvailable(BaseSlotTracker slotTracker) {
         // if the query queue limit is not set(by default), return true
-        if (!GlobalVariable.isQueryQueueConcurrencyLimitEffective()) {
+        int queryQueueConcurrencyLimit = slotManager.getQueryQueueConcurrencyLimit(warehouseId);
+        if (queryQueueConcurrencyLimit <= 0) {
             return true;
         }
-        return slotTracker.getNumAllocatedSlots() <= GlobalVariable.getQueryQueueConcurrencyLimit();
+        return slotTracker.getCurrentCurrency() <= queryQueueConcurrencyLimit;
     }
 
     private static boolean isSmallSlot(LogicalSlot slot) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2.java
@@ -19,7 +19,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.starrocks.metric.LongCounterMetric;
 import com.starrocks.metric.MetricRepo;
-import com.starrocks.qe.GlobalVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.thrift.TUniqueId;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/warehouse/WarehouseMetricEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/warehouse/WarehouseMetricEntity.java
@@ -65,7 +65,7 @@ public class WarehouseMetricEntity {
                 "current warehouse query running length") {
             @Override
             public Long getValue() {
-                return (long) tracker.getNumAllocatedSlots();
+                return (long) tracker.getCurrentCurrency();
             }
         };
         queueRunningLength.addLabel(new MetricLabel("field", "query_running_length"));

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/warehouse/WarehouseMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/warehouse/WarehouseMetrics.java
@@ -69,7 +69,7 @@ public class WarehouseMetrics {
         long maxSlots = tracker.getMaxSlots().map(s -> QueryQueueOptions.correctSlotNum(s)).orElse(0);
         final Optional<BaseSlotTracker.ExtraMessage> extraMessage = tracker.getExtraMessage();
         return new WarehouseMetrics(tracker.getWarehouseId(), tracker.getWarehouseName(),
-                tracker.getQueuePendingLength(), tracker.getNumAllocatedSlots(), tracker.getMaxQueueQueueLength(),
+                tracker.getQueuePendingLength(), tracker.getCurrentCurrency(), tracker.getMaxQueueQueueLength(),
                 tracker.getEarliestQueryWaitTimeSecond(), tracker.getMaxQueuePendingTimeSecond(),
                 maxRequestSlots, sumRequestSlots, remainSlots, maxSlots, extraMessage);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2Test.java
@@ -18,7 +18,6 @@ import com.google.api.client.util.Lists;
 import com.google.common.collect.ImmutableList;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.UUIDUtil;
-import com.starrocks.epack.warehouse.WarehouseProperty;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.qe.GlobalVariable;
 import com.starrocks.server.WarehouseManager;

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2Test.java
@@ -18,9 +18,12 @@ import com.google.api.client.util.Lists;
 import com.google.common.collect.ImmutableList;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.epack.warehouse.WarehouseProperty;
 import com.starrocks.metric.MetricRepo;
+import com.starrocks.qe.GlobalVariable;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.BackendResourceStat;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -402,5 +405,75 @@ public class SlotSelectionStrategyV2Test {
         assertThat(slots.size() == historySlots.size() + slotTracker.getSlots().size());
 
         Config.max_query_queue_history_slots_number = 0;
+    }
+
+    @Test
+    public void testConcurrencyLimit1() {
+        QueryQueueOptions opts = QueryQueueOptions.createFromEnv(WarehouseManager.DEFAULT_WAREHOUSE_ID);
+        SlotSelectionStrategyV2 strategy = new SlotSelectionStrategyV2(WarehouseManager.DEFAULT_WAREHOUSE_ID);
+        SlotTracker slotTracker = new SlotTracker(ImmutableList.of(strategy));
+
+        int oldVal = GlobalVariable.getQueryQueueConcurrencyLimit();
+        GlobalVariable.setQueryQueueConcurrencyLimit(10);
+
+        LogicalSlot slot1 = generateSlot(opts.v2().getTotalSlots() / 2 + 1);
+        LogicalSlot slot2 = generateSlot(opts.v2().getTotalSlots() / 2);
+        LogicalSlot slot3 = generateSlot(2);
+
+        // 1. Require and allocate slot1.
+        slotTracker.requireSlot(slot1);
+        Assertions.assertThat(strategy.peakSlotsToAllocate(slotTracker)).containsExactly(slot1);
+        slotTracker.allocateSlot(slot1);
+
+        // 2. Require slot2.
+        slotTracker.requireSlot(slot2);
+        Assertions.assertThat(strategy.peakSlotsToAllocate(slotTracker)).isEmpty();
+
+        // 3. Require enough small slots to make its priority lower.
+        Assertions.assertThat(slotTracker.getCurrentCurrency()).isEqualTo(1);
+        {
+            List<LogicalSlot> smallSlots = IntStream.range(0, 10)
+                    .mapToObj(i -> generateSlot(2))
+                    .collect(Collectors.toList());
+            smallSlots.forEach(slotTracker::requireSlot);
+
+            int concurrency = slotTracker.getCurrentCurrency();
+            int numPeakedSmallSlots = 0;
+            List<LogicalSlot> runningSmallSlots = com.google.common.collect.Lists.newArrayList();
+            while (concurrency < 9) {
+                List<LogicalSlot> peakSlots = strategy.peakSlotsToAllocate(slotTracker);
+                Assertions.assertThat(peakSlots.isEmpty()).isFalse();
+                numPeakedSmallSlots += peakSlots.size();
+                peakSlots.forEach(slotTracker::allocateSlot);
+                concurrency = slotTracker.getCurrentCurrency();
+                runningSmallSlots.addAll(peakSlots);
+            }
+            Assertions.assertThat(numPeakedSmallSlots == 10);
+            // since concurrency is 10, all small slots are blocked.
+            Assertions.assertThat(strategy.peakSlotsToAllocate(slotTracker)).isEmpty();
+            // release all running slots
+            runningSmallSlots.forEach(slot -> Assertions.assertThat(slotTracker.releaseSlot(slot.getSlotId())).isSameAs(slot));
+        }
+        Assertions.assertThat(slotTracker.getCurrentCurrency()).isEqualTo(1);
+
+        // Try peak the only rest slot2, but it is blocked by slot1.
+        Assertions.assertThat(strategy.peakSlotsToAllocate(slotTracker)).isEmpty();
+
+        // 4. slot3 cannot be peaked because it is blocked by slot2.
+        for (int i = 0; i < 10; i++) {
+            slotTracker.requireSlot(slot3);
+            // if current concurrency is zero, always peak one
+            Assertions.assertThat(strategy.peakSlotsToAllocate(slotTracker)).isEmpty();
+            Assertions.assertThat(slotTracker.releaseSlot(slot3.getSlotId())).isSameAs(slot3);
+        }
+        slotTracker.requireSlot(slot3);
+        Assertions.assertThat(strategy.peakSlotsToAllocate(slotTracker)).isEmpty();
+
+        // 5. slot2 and slot3 can be peaked after releasing slot1.
+        slotTracker.releaseSlot(slot1.getSlotId());
+        Assertions.assertThat(strategy.peakSlotsToAllocate(slotTracker)).containsExactly(slot2, slot3);
+
+        // reset concurrency limit
+        GlobalVariable.setQueryQueueConcurrencyLimit(oldVal);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

https://github.com/StarRocks/starrocks/pull/58293 has supported query concurrency limit for SlotSelectionStrategyV2 by reusing the global variable `query_queue_concurrency_limit`, but use the wrong `Concurrency` metrics.

## What I'm doing:
- Add `getCurrentCurrency` in `SlotTracker` rather than `getNumAllocatedSlots`  and fix the bug.
```
  // return the number of allocated slots which is the current concurrency in the query queue
    public int getCurrentCurrency() {
        return allocatedSlots.size();
    }

```
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
