### PR TITLE
[BugFix] Fix the display of the configuration with an alias

### DIFF
--- a/be/src/common/configbase.cpp
+++ b/be/src/common/configbase.cpp
@@ -267,7 +267,7 @@ std::vector<ConfigInfo> list_configs() {
     std::vector<ConfigInfo> infos;
     for (const auto& [name, field] : Field::fields()) {
         auto& info = infos.emplace_back();
-        info.name = field->name();
+        info.name = name;
         info.value = field->value();
         info.type = field->type();
         info.defval = field->defval();

--- a/be/test/common/config_test.cpp
+++ b/be/test/common/config_test.cpp
@@ -51,6 +51,9 @@ private:
 
 class ConfigTest : public testing::Test {
     void SetUp() override { config::TEST_clear_configs(); }
+
+protected:
+    void find_conf_and_check_value(const std::string& name, int64_t count, const std::string& value);
 };
 
 TEST_F(ConfigTest, test_init) {
@@ -495,6 +498,22 @@ TEST_F(ConfigTest, test_alias03) {
 
     EXPECT_TRUE(config::init(ss));
     EXPECT_EQ(8090, cfg_int32);
+
+    find_conf_and_check_value("cfg_int32", 1, "8090");
+    find_conf_and_check_value("cfg_int32_alias1", 1, "8090");
+    find_conf_and_check_value("cfg_int32_alias2", 1, "8090");
+}
+
+void ConfigTest::find_conf_and_check_value(const std::string& name, int64_t count, const std::string& value) {
+    auto configs = config::list_configs();
+    int64_t find_count = 0;
+    for (const auto& config : configs) {
+        if (config.name == name) {
+            ASSERT_EQ(config.value, value);
+            find_count++;
+        }
+    }
+    ASSERT_EQ(count, find_count);
 }
 
 TEST_F(ConfigTest, test_alias04) {


### PR DESCRIPTION
## Why I'm doing:

The display of the aliased config is duplicated.

```
CONF_Int32(be_http_port, "8040");
CONF_Alias(be_http_port, webserver_port);
```

Before the pr:

```
mysql> select * from information_schema.be_configs where name="be_http_port";
+-------+--------------+-------+-------+---------+---------+
| BE_ID | NAME         | VALUE | TYPE  | DEFAULT | MUTABLE |
+-------+--------------+-------+-------+---------+---------+
| 10002 | be_http_port | 8290  | int32 | 8040    |       0 |
| 10002 | be_http_port | 8290  | int32 | 8040    |       0 |
+-------+--------------+-------+-------+---------+---------+
2 rows in set (0.01 sec)                          

mysql> select * from information_schema.be_configs where name="webserver_port";
Empty set (0.01 sec)  
```

After the pr:
```
mysql> select * from information_schema.be_configs where name="webserver_port";
+-------+----------------+-------+-------+---------+---------+
| BE_ID | NAME           | VALUE | TYPE  | DEFAULT | MUTABLE |
+-------+----------------+-------+-------+---------+---------+
| 10002 | webserver_port | 8290  | int32 | 8040    |       0 |
+-------+----------------+-------+-------+---------+---------+
1 row in set (0.01 sec)

mysql> select * from information_schema.be_configs where name="be_http_port";
+-------+--------------+-------+-------+---------+---------+
| BE_ID | NAME         | VALUE | TYPE  | DEFAULT | MUTABLE |
+-------+--------------+-------+-------+---------+---------+
| 10002 | be_http_port | 8290  | int32 | 8040    |       0 |
+-------+--------------+-------+-------+---------+---------+
1 row in set (0.01 sec)
```

## What I'm doing:

Fix the display of alias config

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
