### PR TITLE
[BugFix] Fix pk index load executor submit task crash

### DIFF
--- a/be/src/storage/persistent_index_load_executor.cpp
+++ b/be/src/storage/persistent_index_load_executor.cpp
@@ -111,7 +111,7 @@ StatusOr<std::shared_ptr<CountDownLatch>> PersistentIndexLoadExecutor::submit_ta
     std::lock_guard<std::mutex> lock(_lock);
     auto it = _running_tablets.find(tablet_id);
     if (it != _running_tablets.end()) {
-        return std::move(it->second);
+        return it->second;
     }
 
     auto latch = std::make_shared<CountDownLatch>(1);

--- a/be/test/storage/persistent_index_load_executor_test.cpp
+++ b/be/test/storage/persistent_index_load_executor_test.cpp
@@ -190,7 +190,7 @@ TEST_F(PersistentIndexLoadExecutorTest, test_submit_task) {
     ASSERT_TRUE(index_entry->value().is_loaded());
 }
 
-TEST_F(PersistentIndexLoadExecutorTest, test_submit_task_twice) {
+TEST_F(PersistentIndexLoadExecutorTest, test_submit_task_many_times) {
     const int64_t key_start = 0;
     const int num_row = 100000;
     const size_t num_segment = 10;
@@ -221,12 +221,18 @@ TEST_F(PersistentIndexLoadExecutorTest, test_submit_task_twice) {
     Status st = _tablet->data_dir()->get_meta()->remove(starrocks::META_COLUMN_FAMILY_INDEX, key);
     CHECK_OK(st);
 
-    // submit task to rebuild persistent index and not wait
+    // submit task to rebuild persistent index and not wait, many times
     auto* pindex_load_executor = manager->get_pindex_load_executor();
     st = pindex_load_executor->submit_task_and_wait_for(_tablet, 0);
     ASSERT_TRUE(st.is_time_out());
 
-    // submit task again, wait to finish
+    st = pindex_load_executor->submit_task_and_wait_for(_tablet, 0);
+    ASSERT_TRUE(st.is_time_out());
+
+    st = pindex_load_executor->submit_task_and_wait_for(_tablet, 0);
+    ASSERT_TRUE(st.is_time_out());
+
+    // submit task and wait to finish
     st = pindex_load_executor->submit_task_and_wait_for(_tablet, 60);
     CHECK_OK(st);
     index_entry = index_cache.get_or_create(tablet_id);


### PR DESCRIPTION
## Why I'm doing:
```
*** Aborted at 1745890184 (unix time) try "date -d @1745890184" if you are using GNU date ***
PC: @     0x2b787e0b7387 __GI_raise
*** SIGABRT (@0x3e800000801) received by PID 2049 (TID 0x2b788de05700) LWP(2222) from PID 2049; stack trace: ***
    @     0x2b787bcad20b __pthread_once_slow
    @          0xb74f214 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x2b787bcb6630 (/usr/lib64/libpthread-2.17.so+0xf62f)
    @     0x2b787e0b7387 __GI_raise
    @     0x2b787e0b8a78 __GI_abort
    @          0x394c1d7 __gnu_cxx::__verbose_terminate_handler() [clone .cold]
    @          0xedefd96 __cxxabiv1::__terminate(void (*)())
    @          0x394c06f std::terminate()
    @          0xedeff33 __cxa_throw
    @          0x394e823 std::__throw_system_error(int)
    @          0x34a8f13 starrocks::PersistentIndexLoadExecutor::submit_task_and_wait_for(std::shared_ptr<starrocks::Tablet> const&, int) [clone .cold]
    @          0x7158207 starrocks::UpdateManager::on_rowset_finished(starrocks::Tablet*, starrocks::Rowset*)
    @          0x731cb24 starrocks::DeltaWriter::commit()
    @          0x6f9fbc3 starrocks::SegmentFlushTask::run()
    @          0x3f90528 starrocks::ThreadPool::dispatch_thread()
    @          0x3f877b0 starrocks::Thread::supervise_thread(void*)
    @     0x2b787bcaeea5 start_thread
    @     0x2b787e17fb0d __clone
```

When submitting the task for the second time, std::move will move the latch value and the latch in the map is changed to nullptr.

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/9568

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
