### PR TITLE
[BugFix] Fix agg state functions's pre aggregation for table with agg state columns

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PreAggregateTurnOnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PreAggregateTurnOnRule.java
@@ -355,8 +355,6 @@ public class PreAggregateTurnOnRule implements TreeRewriteRule {
                     return false;
                 }
             }
-
-
             if ((FunctionSet.BITMAP_UNION.equalsIgnoreCase(queryAggFuncName)
                     || FunctionSet.BITMAP_UNION_COUNT.equalsIgnoreCase(queryAggFuncName))) {
                 if (!AggregateType.BITMAP_UNION.equals(column.getAggregationType())) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/combinator/AggStateCombinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/combinator/AggStateCombinatorTest.java
@@ -525,8 +525,6 @@ public class AggStateCombinatorTest extends MVTestBase {
                 });
     }
 
-
-
     @Test
     public void testCreateAggStateTableWithAllFunctions() {
         var builtInAggregateFunctions = getBuiltInAggFunctions();
@@ -574,6 +572,9 @@ public class AggStateCombinatorTest extends MVTestBase {
                                 Joiner.on(",").join(unionColumns) + " from test_agg_state_table group by k1";
                         String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql1);
                         PlanTestBase.assertContains(plan, "  0:OlapScanNode\n" +
+                                "     table: test_agg_state_table, rollup: test_agg_state_table\n" +
+                                "     preAggregation: on");
+                        PlanTestBase.assertContains(plan, "  0:OlapScanNode\n" +
                                 "     table: test_agg_state_table, rollup: test_agg_state_table");
                     }
 
@@ -586,6 +587,9 @@ public class AggStateCombinatorTest extends MVTestBase {
                         String sql1 = "select k1, " +
                                 Joiner.on(",").join(mergeColumns) + " from test_agg_state_table group by k1";
                         String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql1);
+                        PlanTestBase.assertContains(plan, "  0:OlapScanNode\n" +
+                                "     table: test_agg_state_table, rollup: test_agg_state_table\n" +
+                                "     preAggregation: on");
                         PlanTestBase.assertContains(plan, "  0:OlapScanNode\n" +
                                 "     table: test_agg_state_table, rollup: test_agg_state_table");
                     }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/PreAggregationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/PreAggregationTest.java
@@ -17,14 +17,16 @@ package com.starrocks.planner;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.StarRocksTestBase;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class PreAggregationTest {
+public class PreAggregationTest extends StarRocksTestBase {
     private static ConnectContext connectContext;
     private static StarRocksAssert starRocksAssert;
     private static String DB_NAME = "test";
@@ -40,7 +42,21 @@ public class PreAggregationTest {
         connectContext.setQueryId(UUIDUtil.genUUID());
         starRocksAssert = new StarRocksAssert(connectContext);
         starRocksAssert.withDatabase(DB_NAME).useDatabase(DB_NAME);
+    }
 
+    public String getFragmentPlan(String sql) throws Exception {
+        return UtFrameUtils.getPlanAndFragment(connectContext, sql).second.
+                getExplainString(TExplainLevel.NORMAL);
+    }
+
+    public static void assertContains(String text, String... pattern) {
+        for (String s : pattern) {
+            Assert.assertTrue(text, text.contains(s));
+        }
+    }
+
+    @Test
+    public void testPreAggregationCaseWhen() throws Exception {
         starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `test_agg_2` (\n" +
                 "  `k1` int(11) NULL,\n" +
                 "  `k2` int(11) NULL,\n" +
@@ -57,30 +73,6 @@ public class PreAggregationTest {
                 " \"replication_num\" = \"1\"\n" +
                 ");");
 
-        starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `test_agg_3` (\n" +
-                "  `k1` int(11) NULL,\n" +
-                "  `v1` int SUM NULL\n" +
-                ") ENGINE=OLAP\n" +
-                "AGGREGATE KEY(`k1`)\n" +
-                "DISTRIBUTED BY HASH(`k1`) BUCKETS 1\n" +
-                "PROPERTIES (\n" +
-                " \"replication_num\" = \"1\"\n" +
-                ");");
-    }
-
-    public String getFragmentPlan(String sql) throws Exception {
-        return UtFrameUtils.getPlanAndFragment(connectContext, sql).second.
-                getExplainString(TExplainLevel.NORMAL);
-    }
-
-    public static void assertContains(String text, String... pattern) {
-        for (String s : pattern) {
-            Assert.assertTrue(text, text.contains(s));
-        }
-    }
-
-    @Test
-    public void testPreAggregationCaseWhen() throws Exception {
         String sql = "select sum(case when k1 = 1 then v1 else +0 end), " +
                            " sum(case when k1 = 1 then v1 else -0 end), " +
                            " sum(case when k1 = 1 then v2 else +0 end), " +
@@ -125,6 +117,16 @@ public class PreAggregationTest {
 
     @Test
     public void testMetricTypeOfAggTableNotMatchAggragationReturnType() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `test_agg_3` (\n" +
+                "  `k1` int(11) NULL,\n" +
+                "  `v1` int SUM NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "AGGREGATE KEY(`k1`)\n" +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 1\n" +
+                "PROPERTIES (\n" +
+                " \"replication_num\" = \"1\"\n" +
+                ");");
+
         String sql = "select \n" +
                 "col1, \n" +
                 "col2 \n" +
@@ -141,5 +143,39 @@ public class PreAggregationTest {
         assertContains(plan, "  1:Project\n" +
                 "  |  <slot 1> : 1: k1\n" +
                 "  |  <slot 4> : ifnull(CAST(2: v1 AS BIGINT), 0)");
+    }
+
+    @Test
+    public void testPreAggregationOnOff1() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE test_agg_table1(\n" +
+                " dt VARCHAR(10),\n" +
+                " hll_id ds_hll_count_distinct(varchar not null, int),\n" +
+                " hll_province ds_hll_count_distinct(varchar, int),\n" +
+                " hll_age ds_hll_count_distinct(varchar, int),\n" +
+                " hll_dt ds_hll_count_distinct(varchar not null, int),\n" +
+                " dt_bitmap bitmap bitmap_union,\n" +
+                " dt_hll hll hll_union\n" +
+                ")\n" +
+                " AGGREGATE KEY(dt)\n" +
+                " DISTRIBUTED BY HASH(dt) BUCKETS 1\n" +
+                " PROPERTIES (\n" +
+                " \"replication_num\" = \"1\"\n" +
+                ");");
+        String[] queries = {
+                "select ds_hll_count_distinct_merge(hll_id) from test_agg_table1",
+                "select ds_hll_count_distinct_union(hll_id) from test_agg_table1;",
+                "select bitmap_union(dt_bitmap) from test_agg_table1;",
+                "select bitmap_union_count(dt_bitmap) from test_agg_table1;",
+                "select hll_union_agg(dt_hll) from test_agg_table1;",
+                "select hll_raw_agg(dt_hll) from test_agg_table1;",
+                "select ds_hll_count_distinct_merge(hll_id), ds_hll_count_distinct_merge(hll_province), " +
+                        "ds_hll_count_distinct_merge(hll_age), ds_hll_count_distinct_merge(hll_dt) from test_agg_table1;",
+        };
+        for (String sql : queries) {
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "     TABLE: test_agg_table1\n" +
+                    "     PREAGGREGATION: ON");
+            PlanTestBase.assertNotContains(plan, "PREAGGREGATION: OFF. Reason:");
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Query agg functions with agg state function `PREAGGREGATION` state is `OFF` which may have performance issue:
```
CREATE TABLE test_hll_sketch (
       dt VARCHAR(10),
       hll_id ds_hll_count_distinct(varchar not null, int),
       hll_province ds_hll_count_distinct(varchar, int),
       hll_age ds_hll_count_distinct(varchar, int),
       hll_dt ds_hll_count_distinct(varchar not null, int)
     )
     AGGREGATE KEY(dt)
     DISTRIBUTED BY HASH(dt) BUCKETS 4;

explain select ds_hll_count_distinct_merge(hll_id), ds_hll_count_distinct_merge(hll_province), ds_hll_count_distinct_merge(hll_age), ds_hll_count_distinct_merge(hll_dt) from test_hll_sketch;

5:OlapScanNode
TABLE: ads_metrics_onsite_realtime_staging
PREAGGREGATION: OFF. Reason: Aggregate Operator not match: DS_HLL_COUNT_DISTINCT_UNION <--> AGG_STATE_UNION
```
## What I'm doing:
- if the storage column is agg state column and query's agg function is the same agg, turn on pre-aggregation

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
