### PR TITLE
[BugFix] Fix mv active/inactive bug with list partition mv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -81,6 +81,8 @@ import com.starrocks.persist.metablock.SRMetaBlockWriter;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.scheduler.Task;
 import com.starrocks.scheduler.TaskBuilder;
+import com.starrocks.scheduler.TaskManager;
+import com.starrocks.scheduler.TaskRunManager;
 import com.starrocks.scheduler.mv.MVTimelinessMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Analyzer;
@@ -213,10 +215,13 @@ public class AlterJobMgr {
             QueryStatement mvQueryStatement = null;
             try {
                 mvQueryStatement = recreateMVQuery(materializedView, context, createMvSql);
-            } catch (SemanticException e) {
+            } catch (Exception e) {
+                LOG.warn("Can not active materialized view [%s]" +
+                        " because analyze materialized view define sql: \n\n%s" +
+                        "\n\nCause an error: %s", materializedView.getName(), createMvSql, e);
                 throw new SemanticException("Can not active materialized view [%s]" +
                         " because analyze materialized view define sql: \n\n%s" +
-                        "\n\nCause an error: %s", materializedView.getName(), createMvSql, e.getDetailMsg());
+                        "\n\nCause an error: %s", materializedView.getName(), createMvSql, e.getMessage());
             }
 
             // Skip checks to maintain eventual consistency when replay
@@ -227,6 +232,13 @@ public class AlterJobMgr {
             materializedView.setActive();
         } else if (AlterMaterializedViewStatusClause.INACTIVE.equalsIgnoreCase(status)) {
             materializedView.setInactiveAndReason(reason);
+            // clear running & pending task runs since the mv has been inactive
+            final TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
+            Task currentTask = taskManager.getTask(TaskBuilder.getMvTaskName(materializedView.getId()));
+            if (currentTask != null) {
+                TaskRunManager taskRunManager = taskManager.getTaskRunManager();
+                taskRunManager.killTaskRun(currentTask.getId(), true);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
@@ -362,6 +362,17 @@ public class ListPartitionInfo extends PartitionInfo {
 
     @Override
     public String toSql(OlapTable table, List<Long> partitionId) {
+        return toSql(table, automaticPartition);
+    }
+
+    /**
+     * Generate the SQL statement for creating a list partition
+     * @param table : table
+     * @param isAutomaticPartition : whether the partition type is automatic or by values. If true, only generate partition-by
+     *                             columns without partition values.
+     * @return : SQL statement for the list partition
+     */
+    public String toSql(OlapTable table, boolean isAutomaticPartition) {
         String replicationNumStr = table.getTableProperty()
                 .getProperties().get(PROPERTIES_REPLICATION_NUM);
         short tableReplicationNum = replicationNumStr == null ?
@@ -369,7 +380,7 @@ public class ListPartitionInfo extends PartitionInfo {
 
         StringBuilder sb = new StringBuilder();
         sb.append("PARTITION BY ");
-        if (!automaticPartition) {
+        if (!isAutomaticPartition) {
             sb.append("LIST");
         }
         sb.append("(");
@@ -377,7 +388,7 @@ public class ListPartitionInfo extends PartitionInfo {
                 .map(item -> "`" + item.getName() + "`")
                 .collect(Collectors.joining(",")));
         sb.append(")");
-        if (!automaticPartition) {
+        if (!isAutomaticPartition) {
             List<Long> partitionIds = getPartitionIds(false);
             sb.append("(\n");
             if (!idToValues.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1347,7 +1347,16 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         // partition
         PartitionInfo partitionInfo = this.getPartitionInfo();
         if (!partitionInfo.isUnPartitioned()) {
-            sb.append("\n").append(partitionInfo.toSql(this, null));
+            // NOTE: This part of the code is mainly for compatibility with existing materialized views, explicitly by using
+            // isAutomaticPartition.
+            // If isAutoMaticPartition is false, it may generate bad partition sql which will cause error in replay.
+            if (partitionInfo instanceof ListPartitionInfo) {
+                ListPartitionInfo listPartitionInfo = (ListPartitionInfo) partitionInfo;
+                String sql = listPartitionInfo.toSql(this, true);
+                sb.append("\n").append(sql);
+            } else {
+                sb.append("\n").append(partitionInfo.toSql(this, null));
+            }
         }
 
         // distribution

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -376,7 +376,7 @@ public class TaskManager implements MemoryTrackable {
                     }
                     periodFutureMap.remove(task.getId());
                 }
-                if (!killTask(task.getName(), false)) {
+                if (!killTask(task.getName(), true)) {
                     LOG.warn("kill task failed: {}", task.getName());
                 }
                 idToTaskMap.remove(task.getId());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -28,6 +28,7 @@ import com.starrocks.scheduler.history.TaskRunHistory;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.scheduler.persist.TaskRunStatusChange;
 import com.starrocks.server.GlobalStateMgr;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -101,6 +102,14 @@ public class TaskRunManager implements MemoryTrackable {
                 LOG.warn("failed to complete future for task run: {}", taskRun);
             }
 
+            // mark pending tasks as failed
+            Set<TaskRun> pendingTaskRuns = taskRunScheduler.getPendingTaskRunsByTaskId(taskId);
+            if (CollectionUtils.isNotEmpty(pendingTaskRuns)) {
+                for (TaskRun pendingTaskRun : pendingTaskRuns) {
+                    taskRunScheduler.removePendingTaskRun(pendingTaskRun, Constants.TaskRunState.FAILED);
+                }
+            }
+
             // kill the task run
             ConnectContext runCtx = taskRun.getRunCtx();
             if (runCtx != null) {
@@ -111,6 +120,7 @@ public class TaskRunManager implements MemoryTrackable {
         } finally {
             // if it's force, remove it from running TaskRun map no matter it's killed or not
             if (force) {
+                // remove it from running TaskRun map
                 taskRunScheduler.removeRunningTask(taskRun.getTaskId());
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3135,7 +3135,9 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                         newPartitionColumns.add(mvPartitionColumn);
                     }
                 }
-                return new ListPartitionInfo(PartitionType.LIST, newPartitionColumns);
+                ListPartitionInfo listPartitionInfo = new ListPartitionInfo(PartitionType.LIST, newPartitionColumns);
+                listPartitionInfo.setAutomaticPartition(true);
+                return listPartitionInfo;
             } else {
                 if (partitionByExprs.size() > 1) {
                     throw new DdlException("Only support one partition column for range partition");

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3135,9 +3135,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                         newPartitionColumns.add(mvPartitionColumn);
                     }
                 }
-                ListPartitionInfo listPartitionInfo = new ListPartitionInfo(PartitionType.LIST, newPartitionColumns);
-                listPartitionInfo.setAutomaticPartition(true);
-                return listPartitionInfo;
+                return new ListPartitionInfo(PartitionType.LIST, newPartitionColumns);
             } else {
                 if (partitionByExprs.size() > 1) {
                     throw new DdlException("Only support one partition column for range partition");

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ListPartitionInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ListPartitionInfoTest.java
@@ -240,4 +240,20 @@ public class ListPartitionInfoTest {
         return table;
     }
 
+    @Test
+    public void testToSqlWithAutomaticPartition() {
+        {
+            String sql = this.listPartitionInfo.toSql(this.findTableForSingleListPartition(), false);
+            String target = "PARTITION BY LIST(`province`)(\n" +
+                    "  PARTITION p1 VALUES IN (\'guangdong\', \'tianjin\'),\n" +
+                    "  PARTITION p2 VALUES IN (\'shanghai\', \'beijing\')\n" +
+                    ")";
+            Assert.assertEquals(sql, target);
+        }
+        {
+            String sql = this.listPartitionInfo.toSql(this.findTableForSingleListPartition(), true);
+            String target = "PARTITION BY (`province`)";
+            Assert.assertEquals(sql, target);
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunManagerTest.java
@@ -1,0 +1,112 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.common.FeConstants;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.utframe.UtFrameUtils;
+import com.starrocks.warehouse.DefaultWarehouse;
+import org.apache.commons.collections4.CollectionUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+
+public class TaskRunManagerTest {
+
+    private static final int N = 100;
+    private static ConnectContext connectContext;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        FeConstants.runningUnitTest = true;
+        UtFrameUtils.createMinStarRocksCluster();
+
+        connectContext = UtFrameUtils.createDefaultCtx();
+        GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
+        globalStateMgr.getWarehouseMgr().addWarehouse(new DefaultWarehouse(1, "w1"));
+        globalStateMgr.getWarehouseMgr().addWarehouse(new DefaultWarehouse(2, "w2"));
+    }
+
+    private static ExecuteOption makeExecuteOption(boolean isMergeRedundant, boolean isSync, int priority) {
+        ExecuteOption executeOption = new ExecuteOption(Constants.TaskRunPriority.LOWEST.value(), isMergeRedundant,
+                Maps.newHashMap());
+        executeOption.setSync(isSync);
+        executeOption.setPriority(priority);
+        return executeOption;
+    }
+
+    private TaskRun makeTaskRun(long taskId, Task task, ExecuteOption executeOption) {
+        return makeTaskRun(taskId, task, executeOption, -1);
+    }
+
+    private TaskRun makeTaskRun(long taskId, Task task, ExecuteOption executeOption, long createTime) {
+        TaskRun taskRun = TaskRunBuilder
+                .newBuilder(task)
+                .setExecuteOption(executeOption)
+                .build();
+        taskRun.setTaskId(taskId);
+        // submitTaskRun needs task run status is empty
+        if (createTime >= 0) {
+            taskRun.initStatus("1", createTime);
+            taskRun.getStatus().setPriority(executeOption.getPriority());
+        }
+        return taskRun;
+    }
+
+    @Test
+    public void testKillTaskRun() {
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        List<TaskRun> taskRuns = Lists.newArrayList();
+        long taskId = 100;
+
+        TaskRunScheduler scheduler = new TaskRunScheduler();
+        TaskRunManager taskRunManager = new TaskRunManager(scheduler);
+
+        boolean[] forces = {false, true};
+        for (boolean force : forces) {
+            for (int i = 0; i < N; i++) {
+                TaskRun taskRun = makeTaskRun(taskId, task, makeExecuteOption(true, false, 1));
+                taskRuns.add(taskRun);
+                scheduler.addPendingTaskRun(taskRun);
+            }
+
+            scheduler.scheduledPendingTaskRun(taskRun -> {
+                Assert.assertTrue(taskRun.getTaskId() == taskId);
+            });
+
+            Assert.assertTrue(scheduler.getRunningTaskRun(taskId) != null);
+            Assert.assertTrue(scheduler.getRunnableTaskRun(taskId) != null);
+            Assert.assertTrue(scheduler.getPendingTaskRunsByTaskId(taskId).size() == N - 1);
+
+            // no matter whether force is true or not, we always clear running and pending task run
+            taskRunManager.killTaskRun(taskId, force);
+
+            System.out.println("force:" + force);
+            Assert.assertTrue(CollectionUtils.isEmpty(scheduler.getPendingTaskRunsByTaskId(taskId)));
+            if (force) {
+                Assert.assertTrue(scheduler.getRunningTaskRun(taskId) == null);
+            } else {
+                Assert.assertTrue(scheduler.getRunningTaskRun(taskId) != null);
+                scheduler.removeRunningTask(taskId);
+            }
+        }
+    }
+}

--- a/test/sql/test_materialized_view/R/test_mv_inactive_list
+++ b/test/sql/test_materialized_view/R/test_mv_inactive_list
@@ -1,4 +1,4 @@
--- name: test_mv_refresh
+-- name: test_mv_inactive_list
 create database db_${uuid0};
 -- result:
 -- !result
@@ -12,12 +12,7 @@ CREATE TABLE t1 (
 )
 DUPLICATE KEY(k1)
 COMMENT "OLAP"
-PARTITION BY RANGE(`k1`)
-(
-    PARTITION `p202006` VALUES LESS THAN ("2020-07-01"),
-    PARTITION `p202007` VALUES LESS THAN ("2020-08-01"),
-    PARTITION `p202008` VALUES LESS THAN ("2020-09-01")
-)
+PARTITION BY (k1, k2)
 PROPERTIES (
     "replication_num" = "1"
 );
@@ -46,7 +41,7 @@ function: print_hit_materialized_view("SELECT k1,min(k2) as k2 FROM t1 GROUP BY 
 -- result:
 True
 -- !result
-[UC]ALTER VIEW v1 AS SELECT k1,avg(k2) as k2,avg(k3) as k3 FROM t1 GROUP BY k1;
+[UC]ALTER MATERIALIZED VIEW mv1 inactive;
 -- result:
 -- !result
 function: print_hit_materialized_view("SELECT k1,min(k2) as k2 FROM t1 GROUP BY k1 order by 1;", "mv1")
@@ -60,21 +55,14 @@ False
 [UC]REFRESH MATERIALIZED VIEW mv1 with sync mode;
 [UC]ALTER MATERIALIZED VIEW mv1 active;
 -- result:
-[REGEX].*Can not active materialized view [mv_on_view_1] because analyze materialized view define sql.*
--- !result
-[UC]ALTER VIEW v1 AS SELECT k1,max(k2) as k2,max(k3) as k3 FROM t1 GROUP BY k1;
--- result:
--- !result
-[UC]ALTER MATERIALIZED VIEW mv1 active;
--- result:
 -- !result
 function: print_hit_materialized_view("SELECT k1,min(k2) as k2 FROM t1 GROUP BY k1 order by 1;", "mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("SELECT k1,min(k2) as k2 FROM t1 GROUP BY k1 order by 1;", "mv1")
 -- result:
-False
+True
 -- !result
 SELECT k1,min(k2) as k2 FROM t1 GROUP BY k1 order by 1;
 -- result:

--- a/test/sql/test_materialized_view/R/test_mv_on_view
+++ b/test/sql/test_materialized_view/R/test_mv_on_view
@@ -89,7 +89,7 @@ None
 -- !result
 [UC] ALTER MATERIALIZED VIEW mv_on_view_1 ACTIVE;
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Can not active materialized view [mv_on_view_1] because analyze materialized view define sql: \n\nCREATE MATERIALIZED VIEW `mv_on_view_1` (`event_day`, `sum_pv`)\nDISTRIBUTED BY RANDOM\nREFRESH ASYNC\nPROPERTIES (\n"replicated_storage" = "true",\n"replication_num" = "1",\n"storage_medium" = "HDD"\n)\nAS SELECT `db_mv_on_view`.`view1`.`event_day`, `db_mv_on_view`.`view1`.`sum_pv`\nFROM `db_mv_on_view`.`view1`;\n\nCause an error: View db_mv_on_view.view1 references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them: Getting analyzing error. Detail message: Column \'`db_mv_on_view`.`jj`.`pv`\' cannot be resolved..')
+[REGEX].*Can not active materialized view [mv_on_view_1] because analyze materialized view define sql.*
 -- !result
 SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_view_1';
 -- result:

--- a/test/sql/test_materialized_view/T/test_mv_inactive_list
+++ b/test/sql/test_materialized_view/T/test_mv_inactive_list
@@ -1,10 +1,8 @@
--- name: test_mv_refresh
+-- name: test_mv_inactive_list
+
 create database db_${uuid0};
--- result:
--- !result
 use db_${uuid0};
--- result:
--- !result
+
 CREATE TABLE t1 (
     k1 date,
     k2 int,
@@ -12,80 +10,31 @@ CREATE TABLE t1 (
 )
 DUPLICATE KEY(k1)
 COMMENT "OLAP"
-PARTITION BY RANGE(`k1`)
-(
-    PARTITION `p202006` VALUES LESS THAN ("2020-07-01"),
-    PARTITION `p202007` VALUES LESS THAN ("2020-08-01"),
-    PARTITION `p202008` VALUES LESS THAN ("2020-09-01")
-)
+PARTITION BY (k1, k2)
 PROPERTIES (
     "replication_num" = "1"
 );
--- result:
--- !result
 INSERT INTO t1 VALUES ('2020-06-02',1,1),('2020-06-02',2,2),('2020-07-02',3,3);
--- result:
--- !result
 CREATE VIEW v1 AS SELECT k1,min(k2) as k2,min(k3) as k3 FROM t1 GROUP BY k1;
--- result:
--- !result
+
 CREATE MATERIALIZED VIEW mv1 REFRESH MANUAL AS select k1, k2 from v1;
--- result:
--- !result
 [UC]REFRESH MATERIALIZED VIEW mv1 with sync mode;
+
 SELECT k1,min(k2) as k2 FROM t1 GROUP BY k1 order by 1;
--- result:
-2020-06-02	1
-2020-07-02	3
--- !result
 function: print_hit_materialized_view("SELECT k1,min(k2) as k2 FROM t1 GROUP BY k1 order by 1;", "mv1")
--- result:
-True
--- !result
 function: print_hit_materialized_view("SELECT k1,min(k2) as k2 FROM t1 GROUP BY k1 order by 1;", "mv1")
--- result:
-True
--- !result
-[UC]ALTER VIEW v1 AS SELECT k1,avg(k2) as k2,avg(k3) as k3 FROM t1 GROUP BY k1;
--- result:
--- !result
+
+[UC]ALTER MATERIALIZED VIEW mv1 inactive;
+
 function: print_hit_materialized_view("SELECT k1,min(k2) as k2 FROM t1 GROUP BY k1 order by 1;", "mv1")
--- result:
-False
--- !result
 function: print_hit_materialized_view("SELECT k1,min(k2) as k2 FROM t1 GROUP BY k1 order by 1;", "mv1")
--- result:
-False
--- !result
+
 [UC]REFRESH MATERIALIZED VIEW mv1 with sync mode;
 [UC]ALTER MATERIALIZED VIEW mv1 active;
--- result:
-[REGEX].*Can not active materialized view [mv_on_view_1] because analyze materialized view define sql.*
--- !result
-[UC]ALTER VIEW v1 AS SELECT k1,max(k2) as k2,max(k3) as k3 FROM t1 GROUP BY k1;
--- result:
--- !result
-[UC]ALTER MATERIALIZED VIEW mv1 active;
--- result:
--- !result
+
 function: print_hit_materialized_view("SELECT k1,min(k2) as k2 FROM t1 GROUP BY k1 order by 1;", "mv1")
--- result:
-False
--- !result
 function: print_hit_materialized_view("SELECT k1,min(k2) as k2 FROM t1 GROUP BY k1 order by 1;", "mv1")
--- result:
-False
--- !result
 SELECT k1,min(k2) as k2 FROM t1 GROUP BY k1 order by 1;
--- result:
-2020-06-02	1
-2020-07-02	3
--- !result
 SELECT k1,max(k2) FROM t1 GROUP BY k1 order by 1;
--- result:
-2020-06-02	2
-2020-07-02	3
--- !result
+
 drop database db_${uuid0} force;
--- result:
--- !result


### PR DESCRIPTION
## Why I'm doing:
Since v3.3 has supported List Partition for MV(https://github.com/StarRocks/starrocks/issues/46087), but I met some issues when using MV for list partition:
- MV for List Partition cannot be actived because its generated ddl stmt is wrong and cannot be parsed if mv's partition is empty.
- When `inactive` a mv with running and pending task runs,  the  running and pending task runs still exist even the mv has been inactived.

## What I'm doing:
1. Set `isAutoMaticPartition` to true to generate mv's partition expression sql correctly.  If isAutoMaticPartition is false, it may generate bad partition sql which will cause error in replay.
2. `Inactive MV` will call `killTaskRun` to clear running/pending task runs with this mv.

Fixes https://github.com/StarRocks/starrocks/issues/46087

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
