### PR TITLE
[Enhancement] add athena partition projection table error msg for glue

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/metastore/GlueMetastoreClientDelegate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/metastore/GlueMetastoreClientDelegate.java
@@ -354,7 +354,7 @@ public class GlueMetastoreClientDelegate {
 
         try {
             Table table = glueMetastore.getTable(dbName, tableName);
-            MetastoreClientUtils.validateGlueTable(table);
+            MetastoreClientUtils.validateGlueTable(table, glueMetastore);
             return CatalogToHiveConverter.convertTable(table, dbName);
         } catch (SdkException e) {
             throw CatalogToHiveConverter.wrapInHiveException(e);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/util/HiveTableValidator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/util/HiveTableValidator.java
@@ -15,9 +15,14 @@
 
 package com.starrocks.connector.hive.glue.util;
 
+import com.starrocks.connector.hive.glue.metastore.AWSGlueMetastore;
 import org.apache.hadoop.hive.metastore.TableType;
+import org.apache.thrift.TException;
 import software.amazon.awssdk.services.glue.model.InvalidInputException;
 import software.amazon.awssdk.services.glue.model.Table;
+
+import java.util.List;
+import java.util.Map;
 
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_STORAGE;
@@ -28,7 +33,7 @@ import static org.apache.iceberg.BaseMetastoreTableOperations.TABLE_TYPE_PROP;
 public enum HiveTableValidator {
 
     REQUIRED_PROPERTIES_VALIDATOR {
-        public void validate(Table table) {
+        public void validate(Table table, AWSGlueMetastore metastore) {
             String missingProperty = null;
 
             if (notApplicableTableType(table)) {
@@ -54,6 +59,26 @@ public enum HiveTableValidator {
                         .message(String.format("%s cannot be null for table: %s", missingProperty, table.name()))
                         .build();
             }
+
+            for (Map.Entry<String, String> entry : table.parameters().entrySet()) {
+                String key = entry.getKey();
+                String value = entry.getValue();
+                if (key.equalsIgnoreCase("projection.enable") && "true".equalsIgnoreCase(value)) {
+                    // With partition projection enabled, the metadata may not store in glue.
+                    // Thus we can not get the partition meta
+                    // So read these tables may return no data
+                    // Just throw some exception to remind user
+                    List<software.amazon.awssdk.services.glue.model.Partition> partitions = null;
+                    try {
+                        partitions = metastore.getPartitions(table.databaseName(), table.name(), null, 1);
+                    } catch (TException e) {
+                        throw new RuntimeException("Get partitions failed", e);
+                    }
+                    if (partitions.isEmpty()) {
+                        throw new IllegalArgumentException("Partition projection table may not readable");
+                    }
+                }
+            }
         }
     };
 
@@ -63,7 +88,7 @@ public enum HiveTableValidator {
                 table.parameters().get(TABLE_TYPE_PROP).equalsIgnoreCase(ICEBERG_TABLE_TYPE_VALUE);
     }
 
-    public abstract void validate(Table table);
+    public abstract void validate(Table table, AWSGlueMetastore metastore);
 
     private static boolean notApplicableTableType(Table table) {
         if (isNotManagedOrExternalTable(table) ||

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/util/MetastoreClientUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/util/MetastoreClientUtils.java
@@ -16,6 +16,7 @@
 package com.starrocks.connector.hive.glue.util;
 
 import com.google.common.collect.Maps;
+import com.starrocks.connector.hive.glue.metastore.AWSGlueMetastore;
 import com.starrocks.connector.hive.glue.metastore.GlueMetastoreClientDelegate;
 import com.starrocks.connector.share.credential.CloudConfigurationConstants;
 import org.apache.commons.lang3.StringUtils;
@@ -84,11 +85,12 @@ public final class MetastoreClientUtils {
      *
      * @param table
      */
-    public static void validateGlueTable(software.amazon.awssdk.services.glue.model.Table table) {
+    public static void validateGlueTable(software.amazon.awssdk.services.glue.model.Table table, AWSGlueMetastore metastore)
+            throws InvalidObjectException {
         checkNotNull(table, "table cannot be null");
 
         for (HiveTableValidator validator : HiveTableValidator.values()) {
-            validator.validate(table);
+            validator.validate(table, metastore);
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:
Athena partition project table's meta may not stored in glue, thus the table can read no data.

## What I'm doing:

Throw exceptions to reminder users.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
