### PR TITLE
[BugFix] fix can't rewrite to month mv when query a month time range

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/DateTruncEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/DateTruncEquivalent.java
@@ -110,10 +110,16 @@ public class DateTruncEquivalent extends IPredicateRewriteEquivalent {
             if (!right.isConstantRef() || !left.equals(eqContext.getEquivalent())) {
                 return null;
             }
+            BinaryPredicateOperator predicate = (BinaryPredicateOperator) newInput.clone();
+            // ds >= '2020-01-01' and ds <= '2020-01-31' => ds >= '2020-01-01' and ds < '2020-02-01'
+            if (left.getType().isDate() && predicate.getBinaryType() == BinaryType.LE && right.getType().isDate()) {
+                predicate.setBinaryType(BinaryType.LT);
+                right = ScalarOperatorFunctions.daysAdd((ConstantOperator) right, ConstantOperator.createInt(1));
+                predicate.setChild(1, right);
+            }
             if (!isEquivalent(eqContext.getInput(), (ConstantOperator) right)) {
                 return null;
             }
-            BinaryPredicateOperator predicate = (BinaryPredicateOperator) newInput.clone();
             if (!isSupportedBinaryType(predicate.getBinaryType())) {
                 return null;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
@@ -911,6 +911,64 @@ public class MvRewritePartialPartitionTest extends MVTestBase {
     }
 
     @Test
+    public void testPartialPartitionRewriteWithDateTruncExpr3() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE base_tbl1 (\n" +
+                " ds date,\n" +
+                " v1 INT,\n" +
+                " v2 INT)\n" +
+                " DUPLICATE KEY(ds)\n" +
+                " PARTITION BY RANGE(`ds`)\n" +
+                " (\n" +
+                "  PARTITION `p1` VALUES [('2020-01-01') , ('2020-01-02')),\n" +
+                "  PARTITION `p2` VALUES [('2020-01-03') , ('2020-01-04')),\n" +
+                "  PARTITION `p3` VALUES [('2020-02-02') , ('2020-02-03'))\n" +
+                " )\n" +
+                " DISTRIBUTED BY HASH(ds) properties('replication_num'='1');");
+        executeInsertSql(connectContext, "insert into base_tbl1 values " +
+                " (\"2020-01-01\",1,1),(\"2020-01-03\",1,2),(\"2020-02-02\",2,1);");
+
+        createAndRefreshMv("CREATE MATERIALIZED VIEW test_month_mv1 \n" +
+                " PARTITION BY ds \n" +
+                " DISTRIBUTED BY HASH(ds) BUCKETS 10\n" +
+                " REFRESH MANUAL\n" +
+                " AS SELECT " +
+                " date_trunc('month', `ds`) AS ds, sum(v1) " +
+                " FROM base_tbl1 " +
+                " group by ds;");
+
+        {
+            String query = "select sum(v1) " +
+                    " FROM base_tbl1 where ds >= '2020-01-01' and ds <= '2020-01-31'";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "test_month_mv1");
+        }
+
+        {
+            String query = "select sum(v1) " +
+                    " FROM base_tbl1 where ds >= '2020-01-01' and ds < '2020-02-01'";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "test_month_mv1");
+        }
+
+        {
+            String query = "select sum(v1) " +
+                    " FROM base_tbl1 where ds >= '2020-01-01' and ds <= '2020-02-29'";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "test_month_mv1");
+        }
+
+        {
+            String query = "select sum(v1) " +
+                    " FROM base_tbl1 where ds >= '2020-01-01' and ds < '2020-03-01'";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "test_month_mv1");
+        }
+
+        dropMv("test", "test_mv1");
+        starRocksAssert.dropTable("base_tbl1");
+    }
+
+    @Test
     public void testPartialPartitionRewriteWithTimeSliceExpr1() throws Exception {
         starRocksAssert.withTable("CREATE TABLE base_tbl1 (\n" +
                 " k1 datetime,\n" +


### PR DESCRIPTION
## Why I'm doing:

Below query can be be rewritten:
```sql
MV       : select sum(gmv) as sum_gmv, date_trunc('month', dt) as dt from t group by dt
Query  : select sum(gmv) from t where dt >= '2023-11-01' and dt < '2023-12-01'
```

But below query can't be rewritten:
```sql
MV       : select sum(gmv) as sum_gmv, date_trunc('month', dt) as dt from t group by dt
Query  : select sum(gmv) from t where dt >= '2023-11-01' and dt <= '2023-11-30'
```


## What I'm doing:
change `dt >= '2023-11-01' and dt <= '2023-11-30'` to `dt >= '2023-11-01' and dt < '2023-12-01'`
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
