### PR TITLE
[Refactor] Use config::Alias to handle some compatibility configurations related to block_cache.

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1287,14 +1287,12 @@ CONF_String(datacache_eviction_policy, "slru");
 // the old configuration files.
 CONF_Bool(block_cache_enable, "false");
 CONF_Int64(block_cache_disk_size, "0");
-CONF_String(block_cache_disk_path, "${STARROCKS_HOME}/block_cache/");
-CONF_String(block_cache_meta_path, "${STARROCKS_HOME}/block_cache/");
-CONF_Int64(block_cache_block_size, "262144");   // 256K
 CONF_Int64(block_cache_mem_size, "2147483648"); // 2GB
-CONF_Int64(block_cache_max_concurrent_inserts, "1500000");
-CONF_Bool(block_cache_checksum_enable, "false");
-CONF_Bool(block_cache_direct_io_enable, "false");
-CONF_String(block_cache_engine, "");
+CONF_Alias(datacache_block_size, block_cache_block_size);
+CONF_Alias(datacache_max_concurrent_inserts, block_cache_max_concurrent_inserts);
+CONF_Alias(datacache_checksum_enable, block_cache_checksum_enable);
+CONF_Alias(datacache_direct_io_enable, block_cache_direct_io_enable);
+CONF_Alias(datacache_engine, block_cache_engine);
 
 CONF_mInt64(l0_l1_merge_ratio, "10");
 // max wal file size in l0

--- a/be/src/exprs/jit/jit_engine.cpp
+++ b/be/src/exprs/jit/jit_engine.cpp
@@ -132,10 +132,7 @@ Status JITEngine::init() {
 #if BE_TEST
     _func_cache = new_lru_cache(32000); // 1k capacity per cache of 32 shards in LRU cache
 #else
-    int64_t mem_limit = MemInfo::physical_mem();
-    if (GlobalEnv::GetInstance()->process_mem_tracker()->has_limit()) {
-        mem_limit = GlobalEnv::GetInstance()->process_mem_tracker()->limit();
-    }
+    int64_t mem_limit = GlobalEnv::GetInstance()->process_mem_limit();
     int64_t jit_lru_cache_size = config::jit_lru_cache_size;
     if (jit_lru_cache_size <= 0) {
         if (mem_limit < JIT_CACHE_LOWEST_LIMIT) {

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -165,9 +165,9 @@ public:
     std::shared_ptr<MemTracker> get_mem_tracker_by_type(MemTrackerType type);
     std::vector<std::shared_ptr<MemTracker>> mem_trackers() const;
 
-    StatusOr<int64_t> get_storage_page_cache_size();
-    int64_t check_storage_page_cache_size(int64_t storage_cache_limit);
     static int64_t calc_max_query_memory(int64_t process_mem_limit, int64_t percent);
+
+    int64_t process_mem_limit() const { return _process_mem_tracker->limit(); }
 
 private:
     static bool _is_init;
@@ -255,6 +255,9 @@ public:
     ObjectCache* external_table_meta_cache() const { return _starcache_based_object_cache.get(); }
     ObjectCache* external_table_page_cache() const { return _starcache_based_object_cache.get(); }
     StoragePageCache* page_cache() const { return _page_cache.get(); }
+
+    StatusOr<int64_t> get_storage_page_cache_limit();
+    int64_t check_storage_page_cache_limit(int64_t storage_cache_limit);
 
 private:
     Status _init_datacache();

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -154,7 +154,7 @@ public:
     void TEST_remove_compaction_cache(uint32_t tablet_id, int64_t txn_id);
 
     Status update_primary_index_memory_limit(int32_t update_memory_limit_percent) {
-        ASSIGN_OR_RETURN(int64_t byte_limits, ParseUtil::parse_mem_spec(config::mem_limit, MemInfo::physical_mem()));
+        int64_t byte_limits = GlobalEnv::GetInstance()->process_mem_limit();
         int32_t update_mem_percent = std::max(std::min(100, update_memory_limit_percent), 0);
         _index_cache.set_capacity(byte_limits * update_mem_percent);
         return Status::OK();

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -326,7 +326,7 @@ void* StorageEngine::_adjust_pagecache_callback(void* arg_this) {
             size_t bytes_to_dec = dec_advisor->bytes_should_gc(MonoTime::Now(), delta_high);
             evict_pagecache(cache, static_cast<int64_t>(bytes_to_dec), _bg_worker_stopped);
         } else {
-            auto ret = GlobalEnv::GetInstance()->get_storage_page_cache_size();
+            auto ret = CacheEnv::GetInstance()->get_storage_page_cache_limit();
             if (!ret.ok()) {
                 LOG(ERROR) << "Failed to get storage page size: " << ret.status();
                 continue;

--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -73,8 +73,7 @@ UpdateManager::UpdateManager(MemTracker* mem_tracker)
     _index_cache.set_mem_tracker(_index_cache_mem_tracker.get());
     _update_state_cache.set_mem_tracker(_update_state_mem_tracker.get());
 
-    auto ret = ParseUtil::parse_mem_spec(config::mem_limit, MemInfo::physical_mem());
-    int64_t byte_limits = ret.ok() ? ret.value() : 0;
+    int64_t byte_limits = GlobalEnv::GetInstance()->process_mem_limit();
     int32_t update_mem_percent = std::max(std::min(100, config::update_memory_limit_percent), 0);
     _index_cache.set_capacity(byte_limits * update_mem_percent / 100);
     _update_column_state_cache.set_mem_tracker(_update_state_mem_tracker.get());

--- a/be/src/storage/update_manager.h
+++ b/be/src/storage/update_manager.h
@@ -140,7 +140,7 @@ public:
     string topn_memory_stats(size_t topn);
 
     Status update_primary_index_memory_limit(int32_t update_memory_limit_percent) {
-        ASSIGN_OR_RETURN(int64_t byte_limits, ParseUtil::parse_mem_spec(config::mem_limit, MemInfo::physical_mem()));
+        int64_t byte_limits = GlobalEnv::GetInstance()->process_mem_limit();
         int32_t update_mem_percent = std::max(std::min(100, update_memory_limit_percent), 0);
         _index_cache.set_capacity(byte_limits * update_mem_percent);
         return Status::OK();
@@ -152,9 +152,6 @@ public:
     // Used in UT only
     bool TEST_update_state_exist(Tablet* tablet, Rowset* rowset);
     bool TEST_primary_index_refcnt(int64_t tablet_id, uint32_t expected_cnt);
-
-private:
-    void* _schedule_apply_thread_callback(void* arg);
 
 private:
     // default 6min

--- a/be/src/testutil/init_test_env.h
+++ b/be/src/testutil/init_test_env.h
@@ -82,11 +82,13 @@ int init_test_env(int argc, char** argv) {
     auto st = global_env->init();
     CHECK(st.ok()) << st;
 
+    auto compaction_mem_tracker = std::make_unique<MemTracker>();
+    auto update_mem_tracker = std::make_unique<MemTracker>();
     StorageEngine* engine = nullptr;
     EngineOptions options;
     options.store_paths = paths;
-    options.compaction_mem_tracker = global_env->compaction_mem_tracker();
-    options.update_mem_tracker = global_env->update_mem_tracker();
+    options.compaction_mem_tracker = compaction_mem_tracker.get();
+    options.update_mem_tracker = update_mem_tracker.get();
     Status s = StorageEngine::open(options, &engine);
     if (!s.ok()) {
         butil::DeleteFile(storage_root, true);

--- a/be/test/storage/task/engine_storage_migration_task_test.cpp
+++ b/be/test/storage/task/engine_storage_migration_task_test.cpp
@@ -654,13 +654,13 @@ int main(int argc, char** argv) {
         exit(-1);
     }
 
-    std::unique_ptr<starrocks::MemTracker> compaction_mem_tracker = std::make_unique<starrocks::MemTracker>();
-    std::unique_ptr<starrocks::MemTracker> update_mem_tracker = std::make_unique<starrocks::MemTracker>();
+    auto* global_env = starrocks::GlobalEnv::GetInstance();
+    (void)global_env->init();
     starrocks::StorageEngine* engine = nullptr;
     starrocks::EngineOptions options;
     options.store_paths = paths;
-    options.compaction_mem_tracker = compaction_mem_tracker.get();
-    options.update_mem_tracker = update_mem_tracker.get();
+    options.compaction_mem_tracker = global_env->process_mem_tracker();
+    options.update_mem_tracker = global_env->update_mem_tracker();
     starrocks::Status s = starrocks::StorageEngine::open(options, &engine);
     if (!s.ok()) {
         starrocks::fs::remove_all(root_path_1);
@@ -669,8 +669,6 @@ int main(int argc, char** argv) {
                 s.to_string().c_str());
         return -1;
     }
-    auto* global_env = starrocks::GlobalEnv::GetInstance();
-    (void)global_env->init();
     auto* exec_env = starrocks::ExecEnv::GetInstance();
     (void)exec_env->init(paths);
     int r = RUN_ALL_TESTS();


### PR DESCRIPTION
## Why I'm doing:

* Use config::Alias to handle some compatibility configurations related to block_cache.
   - block_cache_block_size
   - block_cache_max_concurrent_inserts
   - block_cache_checksum_enable
   - block_cache_direct_io_enable
   - block_cache_engine
* Remove unused config
  -  block_cache_disk_path
  -  block_cache_meta_path
* Move some function related to cache from `GlobalEnv` to `CacheEnv`.
* Adjust the environment initialization sequence during test setup.
* Replace the use of `MemInfo::physical_mem` with `process_mem_limit` for upper limit checks.

## What I'm doing:

Use config::Alias to handle some compatibility configurations related to block_cache.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
