### PR TITLE
[BugFix] Fix inconsistent delvector/dcg cache for migration

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -369,7 +369,7 @@ Status TabletUpdates::_load_from_pb(const TabletUpdatesPB& tablet_updates_pb) {
     l2.unlock(); // _rowsets_lock
 
     std::vector<TabletSegmentId> tsids_vec;
-    tsids_vec.resize(tsids.size());
+    tsids_vec.reserve(tsids.size());
     for (const auto& tsid : tsids) {
         tsids_vec.emplace_back(tsid);
     }

--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -250,6 +250,18 @@ void UpdateManager::clear_cache() {
     }
 }
 
+void UpdateManager::clear_cached_del_vec_by_tablet_id(int64_t tablet_id) {
+    std::lock_guard<std::mutex> lg(_del_vec_cache_lock);
+    for (auto iter = _del_vec_cache.begin(); iter != _del_vec_cache.end();) {
+        if (iter->first.tablet_id == tablet_id) {
+            _del_vec_cache_mem_tracker->release(iter->second->memory_usage());
+            iter = _del_vec_cache.erase(iter);
+        } else {
+            ++iter;
+        }
+    }
+}
+
 void UpdateManager::clear_cached_del_vec(const std::vector<TabletSegmentId>& tsids) {
     std::lock_guard<std::mutex> lg(_del_vec_cache_lock);
     for (const auto& tsid : tsids) {
@@ -299,6 +311,19 @@ StatusOr<size_t> UpdateManager::clear_delta_column_group_before_version(KVStore*
         WARN_IF_ERROR(fs->delete_file(filename), "delete file fail, filename: " + filename);
     }
     return clear_dcgs.size();
+}
+
+void UpdateManager::clear_cached_delta_column_group_by_tablet_id(int64_t tablet_id) {
+    std::lock_guard<std::mutex> lg(_delta_column_group_cache_lock);
+    for (auto iter = _delta_column_group_cache.begin(); iter != _delta_column_group_cache.end();) {
+        if (iter->first.tablet_id == tablet_id) {
+            _delta_column_group_cache_mem_tracker->release(
+                    StorageEngine::instance()->delta_column_group_list_memory_usage(iter->second));
+            iter = _delta_column_group_cache.erase(iter);
+        } else {
+            ++iter;
+        }
+    }
 }
 
 void UpdateManager::clear_cached_delta_column_group(const std::vector<TabletSegmentId>& tsids) {

--- a/be/src/storage/update_manager.h
+++ b/be/src/storage/update_manager.h
@@ -118,8 +118,10 @@ public:
 
     void clear_cache();
 
+    void clear_cached_del_vec_by_tablet_id(int64_t tablet_id);
     void clear_cached_del_vec(const std::vector<TabletSegmentId>& tsids);
 
+    void clear_cached_delta_column_group_by_tablet_id(int64_t tablet_id);
     void clear_cached_delta_column_group(const std::vector<TabletSegmentId>& tsids);
 
     StatusOr<size_t> clear_delta_column_group_before_version(KVStore* meta, const std::string& tablet_path,

--- a/be/test/storage/update_manager_test.cpp
+++ b/be/test/storage/update_manager_test.cpp
@@ -260,7 +260,6 @@ TEST_F(UpdateManagerTest, testEraseDelVectorCacheByTablet) {
 
     _update_manager->clear_cached_del_vec_by_tablet_id(1);
     ASSERT_EQ(0, _root_mem_tracker->consumption());
-
 }
 
 TEST_F(UpdateManagerTest, testEraseDCGCacheByTablet) {


### PR DESCRIPTION
## Problem:
Consider the following migration case for primary key tablet:
1. Suppose we have a tablet with two rowset: r1 (rowset seg id = 3) with segment_a(rowset seg id = 4) and segment_b(rowset seg id = 5) r2 (rowset seg id = 6) with segment_c(rowset seg id = 7) and segment_d(rowset seg id = 8)

2. Before we do the migration, we got the snapshot meta but have the reset rowset seg id like: r1 (rowset seg id = 0) with segment_a(rowset seg id = 1) and segment_b(rowset seg id = 2) r2 (rowset seg id = 3) with segment_c(rowset seg id = 4) and segment_d(rowset seg id = 5)

3. When we doing the migration, we will try to clear the delvector/dcg cache for the new tablet. But the problem is that we use the new rsid to erase the cache but the cache is actually contain the old one. So we just try to erase (1,2,4,5) but left (7 8) in the cache.

## Solution:
Try to remove the delvector/dcg cache by tablet id for migration.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
