### PR TITLE
[UT] Fix unstable LoadActionTest and TransactionLoadActionTest

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SimpleScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SimpleScheduler.java
@@ -60,12 +60,12 @@ public class SimpleScheduler {
 
     private static final HostBlacklist HOST_BLACKLIST = new HostBlacklist();
 
-    static {
-        HOST_BLACKLIST.startAutoUpdate();
-    }
-
     public static HostBlacklist getHostBlacklist() {
         return HOST_BLACKLIST;
+    }
+
+    public static void startAutoUpdate() {
+        HOST_BLACKLIST.startAutoUpdate();
     }
 
     @Nullable

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -192,6 +192,7 @@ import com.starrocks.qe.JournalObservable;
 import com.starrocks.qe.QueryStatisticsInfo;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.ShowExecutor;
+import com.starrocks.qe.SimpleScheduler;
 import com.starrocks.qe.VariableMgr;
 import com.starrocks.qe.scheduler.slot.BaseSlotManager;
 import com.starrocks.qe.scheduler.slot.GlobalSlotProvider;
@@ -1494,6 +1495,7 @@ public class GlobalStateMgr {
         connectorTableTriggerAnalyzeMgr.start();
 
         PredicateColumnsMgr.getInstance().startDaemon();
+        SimpleScheduler.startAutoUpdate();
     }
 
     private void transferToNonLeader(FrontendNodeType newType) {

--- a/fe/fe-core/src/test/java/com/starrocks/http/LoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/LoadActionTest.java
@@ -92,7 +92,7 @@ public class LoadActionTest extends StarRocksHttpTestCase {
         };
 
         try (Response response = noRedirectClient.newCall(request).execute()) {
-            assertEquals(307, response.code());
+            assertEquals(response.message(), 307, response.code());
             String location = response.header("Location");
             assertTrue(redirectLocations.contains(location));
         }

--- a/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
@@ -127,9 +127,6 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
             }
 
         };
-
-        // For ut stable
-        GlobalStateMgr.getServingState().isReady();
     }
 
     /**


### PR DESCRIPTION
## Why I'm doing:
After #57919 , tests in LoadActionTest/TransactionLoadActionTest are unstable even after #58163 has tried to fix it. The exception means a `FrontendDaemon` tries to access `GlobalStateMgr#getServingState()`, but the method is not mocked.
```
 Missing 1 invocation to:
 com.starrocks.server.GlobalStateMgr#getServingState()
 Caused by: Missing invocations
     at com.starrocks.server.GlobalStateMgr.getServingState(GlobalStateMgr.java)
     at com.starrocks.common.util.FrontendDaemon.runOneCycle(FrontendDaemon.java:60)
     at com.starrocks.common.util.Daemon.run(Daemon.java:98)
```

## What I'm doing:
#57919 needs to access `SimpleScheduler` which starts `UpdateBlacklistThread` in the static block. The thread is a `FrontendDaemon`, and needs to access `GlobalStateMgr.getServingState`. But LoadActionTest/TransactionLoadActionTest does not mock it, so the exception is thrown.  Actually LoadActionTest/TransactionLoadActionTest does not depend on `UpdateBlacklistThread`, so no need to mock the method. And starting the daemon in the static block is not recommended, so move the start to `GlobalStateMgr#startAllNodeTypeDaemonThreads` to fix it


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
