### PR TITLE
[BugFix] Use mv's db rather than base table's db to aquire write lock

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mv/MVMetaVersionRepairer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/MVMetaVersionRepairer.java
@@ -41,13 +41,12 @@ public class MVMetaVersionRepairer {
     /**
      * Repair base table version changes for all related materialized views when table has no data changed but only version
      * changes which happens in cloud-native environment for background compaction.
-     * @param db table's database
      * @param table changed table
      * @param partitionRepairInfos table's changed partition infos
      */
-    public static void repairBaseTableVersionChanges(Database db, Table table,
+    public static void repairBaseTableVersionChanges(Table table,
                                                      List<MVRepairHandler.PartitionRepairInfo> partitionRepairInfos) {
-        if (db == null || table == null) {
+        if (table == null) {
             return;
         }
         if (!table.isNativeTableOrMaterializedView()) {
@@ -69,15 +68,15 @@ public class MVMetaVersionRepairer {
                 continue;
             }
 
-            // acquire db write lock to modify meta of mv
+            // acquire mvDb + mv write lock to modify meta of mv
             Locker locker = new Locker();
-            if (!locker.lockDatabaseAndCheckExist(db, mv, LockType.WRITE)) {
+            if (!locker.lockDatabaseAndCheckExist(mvDb, mv, LockType.WRITE)) {
                 continue;
             }
             try {
                 repairBaseTableTableVersionChange(mv, table, partitionRepairInfos);
             } finally {
-                locker.unLockTableWithIntensiveDbLock(db.getId(), mv.getId(), LockType.WRITE);
+                locker.unLockTableWithIntensiveDbLock(mvDb.getId(), mv.getId(), LockType.WRITE);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -5181,7 +5181,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
 
     @Override
     public void handleMVRepair(Database db, Table table, List<MVRepairHandler.PartitionRepairInfo> partitionRepairInfos) {
-        MVMetaVersionRepairer.repairBaseTableVersionChanges(db, table, partitionRepairInfos);
+        MVMetaVersionRepairer.repairBaseTableVersionChanges(table, partitionRepairInfos);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/planner/mv/MVMetaVersionRepairerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/mv/MVMetaVersionRepairerTest.java
@@ -104,7 +104,7 @@ public class MVMetaVersionRepairerTest extends MVTestBase {
 
                         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
                         Table baseTable = getTable("test", "m1");
-                        MVMetaVersionRepairer.repairBaseTableVersionChanges(db, baseTable, ImmutableList.of(partitionRepairInfo));
+                        MVMetaVersionRepairer.repairBaseTableVersionChanges(baseTable, ImmutableList.of(partitionRepairInfo));
 
                         // check mv version map after
                         baseTableVisibleVersionMap = asyncRefreshContext.getBaseTableVisibleVersionMap();
@@ -158,7 +158,7 @@ public class MVMetaVersionRepairerTest extends MVTestBase {
 
                         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
                         Table baseTable = getTable("test", "m1");
-                        MVMetaVersionRepairer.repairBaseTableVersionChanges(db, baseTable, ImmutableList.of(partitionRepairInfo));
+                        MVMetaVersionRepairer.repairBaseTableVersionChanges(baseTable, ImmutableList.of(partitionRepairInfo));
 
                         // Since mv has not refreshed, not repair it since mv's version map has not contained the old version
                         baseTableVisibleVersionMap = asyncRefreshContext.getBaseTableVisibleVersionMap();
@@ -218,7 +218,7 @@ public class MVMetaVersionRepairerTest extends MVTestBase {
 
                         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
                         Table baseTable = getTable("test", "m1");
-                        MVMetaVersionRepairer.repairBaseTableVersionChanges(db, baseTable, ImmutableList.of(partitionRepairInfo));
+                        MVMetaVersionRepairer.repairBaseTableVersionChanges(baseTable, ImmutableList.of(partitionRepairInfo));
 
                         baseTableVisibleVersionMap = asyncRefreshContext.getBaseTableVisibleVersionMap();
                         Assert.assertEquals(1, baseTableVisibleVersionMap.size());
@@ -286,7 +286,7 @@ public class MVMetaVersionRepairerTest extends MVTestBase {
 
                         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
                         Table baseTable = getTable("test", "m1");
-                        MVMetaVersionRepairer.repairBaseTableVersionChanges(db, baseTable, ImmutableList.of(partitionRepairInfo));
+                        MVMetaVersionRepairer.repairBaseTableVersionChanges(baseTable, ImmutableList.of(partitionRepairInfo));
 
                         baseTableVisibleVersionMap = asyncRefreshContext.getBaseTableVisibleVersionMap();
                         Assert.assertEquals(1, baseTableVisibleVersionMap.size());


### PR DESCRIPTION
## Why I'm doing:

- Use mv's db rather than base table's db to aquire write lock, otherwise dead lock may happen because it acquires a bad write lock

```
        // acquire db write lock to modify meta of mv
            // acquire mvDb + mv write lock to modify meta of mv
            Locker locker = new Locker();
            if (!locker.lockDatabaseAndCheckExist(db, mv, LockType.WRITE)) {
                continue;
            }
            try {
                repairBaseTableTableVersionChange(mv, table, partitionRepairInfos);
            } finally {
                locker.unLockTableWithIntensiveDbLock(db.getId(), mv.getId(), LockType.WRITE);
            }
        }
```
## What I'm doing:
- Use mv's db rather than base table's db to aquire write lock

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
