### PR TITLE
[Enhancement] Reduce mv refresh task run size and optimize logging messages

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3264,6 +3264,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "Whether enable profile in refreshing materialized view or not by default")
     public static boolean enable_mv_refresh_collect_profile = false;
 
+    @ConfField(mutable = true, comment = "Whether enable adding extra materialized view name logging for better debug")
+    public static boolean enable_mv_refresh_extra_prefix_logging = true;
+
     @ConfField(mutable = true, comment = "The max length for mv task run extra message's values(set/map) to avoid " +
             "occupying too much meta memory")
     public static int max_mv_task_run_meta_message_values_length = 16;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -150,8 +150,6 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     private TaskRun nextTaskRun = null;
 
     public PartitionBasedMvRefreshProcessor() {
-        // to avoid NPE in some test cases
-        this.logger = MVTraceUtils.getLogger(null, PartitionBasedMvRefreshProcessor.class);
     }
 
     @VisibleForTesting
@@ -855,12 +853,10 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     @Override
     public void prepare(TaskRunContext context) throws Exception {
         Map<String, String> properties = context.getProperties();
-        logger.info("prepare refresh mv, properties:{}", properties);
         // NOTE: mvId is set in Task's properties when creating
         long mvId = Long.parseLong(properties.get(MV_ID));
         this.db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(context.ctx.getDatabase());
         if (db == null) {
-            logger.warn("database {} do not exist when refreshing materialized view:{}", context.ctx.getDatabase(), mvId);
             throw new DmlException("database " + context.ctx.getDatabase() + " do not exist.");
         }
         Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), mvId);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
@@ -51,7 +51,7 @@ import java.util.stream.Collectors;
  */
 public class TaskRunHistoryTable {
 
-    public static final int INSERT_BATCH_SIZE = 128;
+    public static final int INSERT_BATCH_SIZE = 32;
     private static final int DEFAULT_RETENTION_DAYS = 7;
     public static final String DATABASE_NAME = StatsConstants.STATISTICS_DB_NAME;
     public static final String TABLE_NAME = "task_run_history";

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVTraceUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVTraceUtils.java
@@ -107,11 +107,13 @@ public class MVTraceUtils {
         return selectedPartitionNames;
     }
 
-    private static String getLogPrefix(MaterializedView mv) {
+    public static String getLogPrefix(MaterializedView mv) {
         if (mv == null || Strings.isNullOrEmpty(mv.getName())) {
             return "";
         } else {
-            return mv.getName();
+            StringBuilder sb = new StringBuilder();
+            sb.append(" [").append(mv.getName()).append("] ");
+            return sb.toString();
         }
     }
 
@@ -119,6 +121,6 @@ public class MVTraceUtils {
      * Get logger with mv name prefix.
      */
     public static Logger getLogger(MaterializedView mv, Class<?> clazz) {
-        return new StarRocksLoggerFactory(getLogPrefix(mv)).getLogger(clazz);
+        return StarRocksLoggerFactory.INSTANCE.getLogger(clazz, getLogPrefix(mv));
     }
 }


### PR DESCRIPTION
## Why I'm doing:
Found two bugs about MV refresh logs:

1. #52794 supports to add a prefix for each mv refresh for better logging, but  `fe.out` will output noisy logs for each mv refresh

```
WARN The Logger com.starrocks.scheduler.mv.MVVersionManager was created with the message factory 
org.apache.logging.log4j.spi.MessageFactory2Adapter@34f16b28 
and is now requested with the message factory 
com.starrocks.common.StarRocksLoggerFactory$PrefixedMessageFactory@7040f0e7, 
which may create log events with unexpected formatting.
.....
```

2. ` _statistics_.task_run_history` is used for recording task run's refresh history. If it insert fails, it will log as below. But for complex user's dined query, the one log may occupy more than `3MB`'s size(amazing....)
```
2025-03-26 10:20:30.953+08:00 WARN (TaskCleaner|127) [StmtExecutor.handleDMLStmt():2510] failed to handle stmt [INSERT INTO _statistics_.task_run_history (task_id, task_run_id, task_name, task_state, create_time, finish_time, expire_time, history_content_json) VALUES(384010978, '0b15082d-09df-11f0-9658-525400661868', 'dwd_prod_mgt_px_tblsmtrepairstaff_ri_927064_20250325', 'FAILED', '2025-03-26 09:10:01', '2025-03-26 09:12:31', '2025-04-02 09:10:01', '{\"queryId\":\"0b15082d-09df-11f0-9658-525400661868\",\"taskId\":384010978,\"taskName\":\"dwd_prod_mgt_px_tblsmtrepairstaff_ri_927064_20250325\",\"createTime\":1742951401677,\"catalogName\":\"default_catalog\",\"dbName\":\"default_cluster:cdm\",\"definition\":\"INSERT INTO 
```

## What I'm doing:
1. `PrefixedMessageFactory` should extends `MessageFactory2` rather than `MessageFactory`, otherwise it will add `MessageFactory2Adapter` for it.

```
    public static void checkMessageFactory(final ExtendedLogger logger, final MessageFactory messageFactory) {
        final String name = logger.getName();
        final MessageFactory loggerMessageFactory = logger.getMessageFactory();
        if (messageFactory != null && !loggerMessageFactory.equals(messageFactory)) {
            StatusLogger.getLogger().warn(
                    "The Logger {} was created with the message factory {} and is now requested with the "
                            + "message factory {}, which may create log events with unexpected formatting.", name,
                    loggerMessageFactory, messageFactory);
        } else if (messageFactory == null && !loggerMessageFactory.getClass().equals(DEFAULT_MESSAGE_FACTORY_CLASS)) {
            StatusLogger
                    .getLogger()
                    .warn("The Logger {} was created with the message factory {} and is now requested with a null "
                            + "message factory (defaults to {}), which may create log events with unexpected "
                            + "formatting.",
                            name, loggerMessageFactory, DEFAULT_MESSAGE_FACTORY_CLASS.getName());
        }
    }
```
2. Add `enable_mv_refresh_extra_prefix_logging` config to control to use it or not to avoid some bad cases(if there are too many mvs)
3. To reduce ` _statistics_.task_run_history` logging size:
- Remove unnecessary blanks for input query and shrink for complex user's defined query to 16KB(max size)
- Change ` _statistics_.task_run_history`  insert `INSERT_BATCH_SIZE`'s size from 128 to 32;
```
    public static final int INSERT_BATCH_SIZE = 32;
```


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
