### PR TITLE
[UT] eliminate NPE in UT MockCluster

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
@@ -110,6 +110,8 @@ import com.starrocks.thrift.TExportTaskRequest;
 import com.starrocks.thrift.TFetchDataParams;
 import com.starrocks.thrift.TFetchDataResult;
 import com.starrocks.thrift.TFinishTaskRequest;
+import com.starrocks.thrift.TGetTabletsInfoRequest;
+import com.starrocks.thrift.TGetTabletsInfoResult;
 import com.starrocks.thrift.THeartbeatResult;
 import com.starrocks.thrift.TMasterInfo;
 import com.starrocks.thrift.TMiniLoadEtlStatusRequest;
@@ -394,6 +396,11 @@ public class MockedBackend {
                 }
             }
             //            return new TTabletStatResult(Maps.newHashMap());
+        }
+
+        @Override
+        public TGetTabletsInfoResult get_tablets_info(TGetTabletsInfoRequest request) {
+            return new TGetTabletsInfoResult(new TStatus(TStatusCode.OK));
         }
 
         @Override


### PR DESCRIPTION
* add `get_tablets_info` implementation in MockedBackend.MockBeThriftClient


Fix the following NPE exception in during FE UT.
```
java.lang.NullPointerException: Cannot invoke "org.apache.thrift.protocol.TProtocol.writeMessageBegin(org.apache.thrift.protocol.TMessage)" because "this.oprot_" is null
	at org.apache.thrift.TServiceClient.sendBase(TServiceClient.java:72) ~[libthrift-0.20.0.jar:0.20.0]
	at org.apache.thrift.TServiceClient.sendBase(TServiceClient.java:64) ~[libthrift-0.20.0.jar:0.20.0]
	at com.starrocks.thrift.BackendService$Client.send_get_tablets_info(BackendService.java:594) ~[classes/:?]
	at com.starrocks.thrift.BackendService$Client.get_tablets_info(BackendService.java:586) ~[classes/:?]
	at com.starrocks.leader.TabletCollector.lambda$collect$0(TabletCollector.java:100) ~[classes/:?]
	at com.starrocks.rpc.ThriftRPCRequestExecutor.call(ThriftRPCRequestExecutor.java:67) ~[classes/:?]
	at com.starrocks.leader.TabletCollector.collect(TabletCollector.java:95) ~[classes/:?]
	at com.starrocks.leader.TabletCollector.runAfterCatalogReady(TabletCollector.java:57) ~[classes/:?]
	at com.starrocks.common.util.FrontendDaemon.runOneCycle(FrontendDaemon.java:72) ~[classes/:?]
	at com.starrocks.common.util.Daemon.run(Daemon.java:98) ~[classes/:?]
```

```
$ grep  this.oprot_ 7_FE\ UT.txt  | wc -l
     634
```
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
