### PR TITLE
[Enhancement] Merge commit supports to get load profile (backport #58545)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/LoadExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/LoadExecutor.java
@@ -31,7 +31,6 @@ import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.load.EtlStatus;
-import com.starrocks.load.loadv2.LoadErrorUtils;
 import com.starrocks.load.loadv2.LoadJob;
 import com.starrocks.load.loadv2.LoadJobFinalOperation;
 import com.starrocks.load.streamload.StreamLoadInfo;
@@ -321,7 +320,7 @@ public class LoadExecutor implements Runnable {
     }
 
     private boolean isProfileEnabled() {
-        return (context != null && context.isProfileEnabled()) || LoadErrorUtils.enableProfileAfterError(coordinator);
+        return context != null && context.isProfileEnabled();
     }
 
     private void reportProfile() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadKvParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadKvParams.java
@@ -359,9 +359,7 @@ public class StreamLoadKvParams implements StreamLoadParams {
 
     @Override
     public String toString() {
-        return "StreamLoadKvParams{" +
-                "params=" + params +
-                '}';
+        return "params={" + params + '}';
     }
 
     public static StreamLoadKvParams fromHttpHeaders(HttpHeaders httpHeaders) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -3536,6 +3536,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return profileTimeout;
     }
 
+    public void setRuntimeProfileReportInterval(int runtimeProfileReportInterval) {
+        this.runtimeProfileReportInterval = runtimeProfileReportInterval;
+    }
+
     public int getRuntimeProfileReportInterval() {
         return runtimeProfileReportInterval;
     }

--- a/test/sql/test_profile/R/test_merge_commit_profile
+++ b/test/sql/test_profile/R/test_merge_commit_profile
@@ -1,0 +1,45 @@
+-- name: test_merge_commit_profile
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `t0`
+(
+    `id` int(11) NOT NULL COMMENT "用户 ID",
+    `name` varchar(65533) NULL COMMENT "用户姓名",
+    `score` int(11) NOT NULL COMMENT "用户得分"
+)
+ENGINE=OLAP
+PRIMARY KEY(`id`)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+ "replication_num" = "1"
+);
+-- result:
+-- !result
+alter table t0 set('enable_load_profile'='true');
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("stream_load_profile_collect_threshold_second" = "1");
+-- result:
+-- !result
+shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue"  -H "format:json" -H "enable_merge_commit:true" -H "merge_commit_interval_ms:3000" -H "merge_commit_parallel:4" -d '{"id":1,"name":"n1","score":1}' ${url}/api/db_${uuid0}/t0/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+sync;
+-- result:
+-- !result
+select * from t0 order by id;
+-- result:
+1	n1	1
+-- !result
+ADMIN SET FRONTEND CONFIG ("stream_load_profile_collect_threshold_second" = "0");
+-- result:
+-- !result

--- a/test/sql/test_profile/T/test_merge_commit_profile
+++ b/test/sql/test_profile/T/test_merge_commit_profile
@@ -1,0 +1,26 @@
+-- name: test_merge_commit_profile
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE `t0`
+(
+    `id` int(11) NOT NULL COMMENT "用户 ID",
+    `name` varchar(65533) NULL COMMENT "用户姓名",
+    `score` int(11) NOT NULL COMMENT "用户得分"
+)
+ENGINE=OLAP
+PRIMARY KEY(`id`)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+ "replication_num" = "1"
+);
+
+alter table t0 set('enable_load_profile'='true');
+ADMIN SET FRONTEND CONFIG ("stream_load_profile_collect_threshold_second" = "1");
+
+shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue"  -H "format:json" -H "enable_merge_commit:true" -H "merge_commit_interval_ms:3000" -H "merge_commit_parallel:4" -d '{"id":1,"name":"n1","score":1}' ${url}/api/db_${uuid0}/t0/_stream_load
+
+sync;
+select * from t0 order by id;
+
+ADMIN SET FRONTEND CONFIG ("stream_load_profile_collect_threshold_second" = "0");

--- a/test/sql/test_stream_load/R/test_merge_commit
+++ b/test/sql/test_stream_load/R/test_merge_commit
@@ -1,0 +1,114 @@
+-- name: test_merge_commit
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `t0`
+(
+    `id` int(11) NOT NULL COMMENT "用户 ID",
+    `name` varchar(65533) NULL COMMENT "用户姓名",
+    `score` int(11) NOT NULL COMMENT "用户得分"
+)
+ENGINE=OLAP
+PRIMARY KEY(`id`)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+ "replication_num" = "1"
+);
+-- result:
+-- !result
+
+CONCURRENCY {
+-- thread name 1:
+shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue"  -H "format:json" -H "enable_merge_commit:true" -H "merge_commit_interval_ms:3000" -H "merge_commit_parallel:4" -d '{"id":1,"name":"n1","score":1}' ${url}/api/db_${uuid0}/t0/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+
+-- thread name 2:
+shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue"  -H "format:json" -H "enable_merge_commit:true" -H "merge_commit_interval_ms:3000" -H "merge_commit_parallel:4" -d '{"id":2,"name":"n2","score":2}' ${url}/api/db_${uuid0}/t0/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+
+-- thread name 3:
+shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue"  -H "format:json" -H "enable_merge_commit:true" -H "merge_commit_interval_ms:3000" -H "merge_commit_parallel:4" -d '{"id":3,"name":"n3","score":3}' ${url}/api/db_${uuid0}/t0/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+
+} END CONCURRENCY
+
+sync;
+-- result:
+-- !result
+select * from t0 order by id;
+-- result:
+1	n1	1
+2	n2	2
+3	n3	3
+-- !result
+
+CONCURRENCY {
+-- thread name 4:
+shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue"  -H "format:json" -H "enable_merge_commit:true" -H "merge_commit_interval_ms:3000" -H "merge_commit_parallel:4" -H "merge_commit_async:true" -d '{"id":4,"name":"n4","score":4}' ${url}/api/db_${uuid0}/t0/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+
+-- thread name 5:
+shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue"  -H "format:json" -H "enable_merge_commit:true" -H "merge_commit_interval_ms:3000" -H "merge_commit_parallel:4" -H "merge_commit_async:true" -d '{"id":5,"name":"n5","score":5}' ${url}/api/db_${uuid0}/t0/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+
+-- thread name 6:
+shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue"  -H "format:json" -H "enable_merge_commit:true" -H "merge_commit_interval_ms:3000" -H "merge_commit_parallel:4" -H "merge_commit_async:true" -d '{"id":6,"name":"n6","score":6}' ${url}/api/db_${uuid0}/t0/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+
+} END CONCURRENCY
+
+select sleep(5);
+-- result:
+1
+-- !result
+sync;
+-- result:
+-- !result
+select * from t0 order by id;
+-- result:
+1	n1	1
+2	n2	2
+3	n3	3
+4	n4	4
+5	n5	5
+6	n6	6
+-- !result

--- a/test/sql/test_stream_load/T/test_merge_commit
+++ b/test/sql/test_stream_load/T/test_merge_commit
@@ -1,0 +1,49 @@
+-- name: test_merge_commit
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE `t0`
+(
+    `id` int(11) NOT NULL COMMENT "用户 ID",
+    `name` varchar(65533) NULL COMMENT "用户姓名",
+    `score` int(11) NOT NULL COMMENT "用户得分"
+)
+ENGINE=OLAP
+PRIMARY KEY(`id`)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+ "replication_num" = "1"
+);
+
+CONCURRENCY {
+
+-- thread name 1:
+shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue"  -H "format:json" -H "enable_merge_commit:true" -H "merge_commit_interval_ms:3000" -H "merge_commit_parallel:4" -d '{"id":1,"name":"n1","score":1}' ${url}/api/db_${uuid0}/t0/_stream_load
+
+-- thread name 2:
+shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue"  -H "format:json" -H "enable_merge_commit:true" -H "merge_commit_interval_ms:3000" -H "merge_commit_parallel:4" -d '{"id":2,"name":"n2","score":2}' ${url}/api/db_${uuid0}/t0/_stream_load
+
+-- thread name 3:
+shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue"  -H "format:json" -H "enable_merge_commit:true" -H "merge_commit_interval_ms:3000" -H "merge_commit_parallel:4" -d '{"id":3,"name":"n3","score":3}' ${url}/api/db_${uuid0}/t0/_stream_load
+
+} END CONCURRENCY
+
+sync;
+select * from t0 order by id;
+
+CONCURRENCY {
+
+-- thread name 4:
+shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue"  -H "format:json" -H "enable_merge_commit:true" -H "merge_commit_interval_ms:3000" -H "merge_commit_parallel:4" -H "merge_commit_async:true" -d '{"id":4,"name":"n4","score":4}' ${url}/api/db_${uuid0}/t0/_stream_load
+
+-- thread name 5:
+shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue"  -H "format:json" -H "enable_merge_commit:true" -H "merge_commit_interval_ms:3000" -H "merge_commit_parallel:4" -H "merge_commit_async:true" -d '{"id":5,"name":"n5","score":5}' ${url}/api/db_${uuid0}/t0/_stream_load
+
+-- thread name 6:
+shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue"  -H "format:json" -H "enable_merge_commit:true" -H "merge_commit_interval_ms:3000" -H "merge_commit_parallel:4" -H "merge_commit_async:true" -d '{"id":6,"name":"n6","score":6}' ${url}/api/db_${uuid0}/t0/_stream_load
+
+} END CONCURRENCY
+
+select sleep(5);
+sync;
+select * from t0 order by id;


### PR DESCRIPTION
## Why I'm doing:
support to get profile of merge commit

## What I'm doing:
the way to enable profile is same as stream load
1. first alter table to enable the profile
```
alter table t set('enable_load_profile'='true');
```
2. use FE load_profile_collect_interval_second to control the sample interval
3. use FE stream_load_profile_collect_threshold_second to control the threshold to report

Fixes #issue
backport #58545

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [X] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1

