### PR TITLE
[Enhancement] Optimizing read parquet null columns

### DIFF
--- a/be/src/formats/parquet/column_chunk_reader.h
+++ b/be/src/formats/parquet/column_chunk_reader.h
@@ -80,30 +80,13 @@ public:
     LevelDecoder& def_level_decoder() { return _def_level_decoder; }
     LevelDecoder& rep_level_decoder() { return _rep_level_decoder; }
 
-    Status decode_values(size_t n, const uint16_t* is_nulls, ColumnContentType content_type, Column* dst,
+    Status decode_values(size_t n, const NullInfos& null_infos, ColumnContentType content_type, Column* dst,
                          const FilterData* filter = nullptr) {
         SCOPED_RAW_TIMER(&_opts.stats->value_decode_ns);
         if (_current_row_group_no_null || _current_page_no_null) {
             return _cur_decoder->next_batch(n, content_type, dst, filter);
         }
-        size_t idx = 0;
-        size_t off = 0;
-        while (idx < n) {
-            bool is_null = is_nulls[idx++];
-            size_t run = 1;
-            while (idx < n && is_nulls[idx] == is_null) {
-                idx++;
-                run++;
-            }
-            if (is_null) {
-                dst->append_nulls(run);
-            } else {
-                const FilterData* forward_filter = filter ? filter + off : filter;
-                RETURN_IF_ERROR(_cur_decoder->next_batch(run, content_type, dst, forward_filter));
-            }
-            off += run;
-        }
-        return Status::OK();
+        return _cur_decoder->next_batch_with_nulls(n, null_infos, content_type, dst, filter);
     }
 
     Status decode_values(size_t n, ColumnContentType content_type, Column* dst, const FilterData* filter = nullptr) {

--- a/be/src/formats/parquet/encoding.h
+++ b/be/src/formats/parquet/encoding.h
@@ -79,6 +79,8 @@ public:
     // It will return ERROR if caller wants to read out-of-bound data.
     virtual Status next_batch(size_t count, ColumnContentType content_type, Column* dst,
                               const FilterData* filter = nullptr) = 0;
+    virtual Status next_batch_with_nulls(size_t count, const NullInfos& null_infos, ColumnContentType content_type,
+                                         Column* dst, const FilterData* filter);
 
     virtual Status skip(size_t values_to_skip) = 0;
 

--- a/be/src/formats/parquet/encoding_dict.h
+++ b/be/src/formats/parquet/encoding_dict.h
@@ -20,6 +20,7 @@
 #include "column/column.h"
 #include "column/column_helper.h"
 #include "column/nullable_column.h"
+#include "column/vectorized_fwd.h"
 #include "common/config.h"
 #include "common/status.h"
 #include "formats/parquet/encoding.h"
@@ -125,9 +126,33 @@ public:
         return Status::OK();
     }
 
+    Status next_batch_with_nulls(size_t count, const NullInfos& null_infos, ColumnContentType content_type, Column* dst,
+                                 const FilterData* filter) override {
+        if (_get_dict_size() > _dict_size_threshold && config::parquet_cache_aware_dict_decoder_enable) {
+            return _do_next_batch_with_nulls(count, null_infos, content_type, dst, filter);
+        } else {
+            return _do_next_batch_with_nulls(count, null_infos, content_type, dst, nullptr);
+        }
+        return Status::OK();
+    }
+
 protected:
+    void _next_null_column(size_t count, const NullInfos& null_infos, NullableColumn* dst) {
+        size_t null_cnt = null_infos.num_nulls;
+        NullColumn* null_column = down_cast<NullableColumn*>(dst)->mutable_null_column();
+        const uint8_t* __restrict is_nulls = null_infos.nulls_data();
+        auto& null_data = null_column->get_data();
+        size_t prev_num_rows = null_data.size();
+        raw::stl_vector_resize_uninitialized(&null_data, count + prev_num_rows);
+        uint8_t* __restrict__ dst_nulls = null_data.data() + prev_num_rows;
+        memcpy(dst_nulls, is_nulls, count);
+        down_cast<NullableColumn*>(dst)->set_has_null(null_cnt > 0);
+    }
+
     virtual size_t _get_dict_size() const = 0;
     virtual Status _next_batch_value(size_t count, Column* dst, const FilterData* filter) = 0;
+    virtual Status _do_next_batch_with_nulls(size_t count, const NullInfos& null_infos, ColumnContentType content_type,
+                                             Column* dst, const FilterData* filter) = 0;
     RleBatchDecoder<uint32_t> _rle_batch_reader;
 
 private:
@@ -168,61 +193,132 @@ public:
         return Status::OK();
     }
 
-    Status next_batch_with_nulls(size_t count, const NullInfos& null_infos, ColumnContentType content_type, Column* dst,
-                                 const FilterData* filter) override {
-        const uint8_t* __restrict is_nulls = null_infos.nulls_data();
+    Status _do_next_batch_with_nulls(size_t count, const NullInfos& null_infos, ColumnContentType content_type,
+                                     Column* dst, const FilterData* filter) override {
         CHECK(dst->is_nullable());
-        size_t null_cnt = null_infos.num_nulls;
-        FixedLengthColumn<T>* data_column = nullptr;
-        if (dst->is_nullable()) {
-            NullColumn* null_column = down_cast<NullableColumn*>(dst)->mutable_null_column();
-            auto& null_data = null_column->get_data();
-            size_t prev_num_rows = null_data.size();
-            raw::stl_vector_resize_uninitialized(&null_data, count + prev_num_rows);
-            uint8_t* __restrict__ dst_nulls = null_data.data() + prev_num_rows;
-            memcpy(dst_nulls, is_nulls, count);
-            down_cast<NullableColumn*>(dst)->set_has_null(null_cnt > 0);
-            data_column = down_cast<FixedLengthColumn<T>*>(down_cast<NullableColumn*>(dst)->data_column().get());
+        if (null_infos.num_ranges <= 2) {
+            return Decoder::next_batch_with_nulls(count, null_infos, content_type, dst, filter);
         }
-        size_t cur_size = data_column->size();
-        data_column->resize_uninitialized(cur_size + count);
-        T* __restrict__ data = data_column->get_data().data() + cur_size;
+        size_t cur_size = dst->size();
+        _next_null_column(count, null_infos, down_cast<NullableColumn*>(dst));
 
-        size_t read_count = count - null_cnt;
-        T read_data[read_count];
-
-        if (read_count == 0) {
-            return Status::OK();
+        switch (content_type) {
+        case DICT_CODE: {
+            return next_dict_code_batch_with_nulls(count, cur_size, null_infos, dst);
         }
-        auto ret = _rle_batch_reader.GetBatchWithDict(_dict.data(), _dict.size(), read_data, read_count);
-        if (UNLIKELY(ret <= 0)) {
-            return Status::InternalError("DictDecoder GetBatchWithDict failed");
+        case VALUE: {
+            return next_value_batch_with_nulls(count, cur_size, null_infos, dst, filter);
         }
+        default:
+            return Status::NotSupported("read type not supported");
+        }
+        return Status::OK();
+    }
 
-        if (read_count < count / 10) {
+    template <class DataType>
+    void assign_data_with_nulls(size_t count, size_t num_non_nulls, const uint8_t* nulls, const DataType* src_data,
+                                DataType* dst_data) {
+        // opt branch for process sparse column
+        if (num_non_nulls < count / 10) {
             size_t cnt = 0;
             size_t i = 0;
             for (i = 0; i + 32 <= count; i += 32) {
                 // Load the next 32 elements of is_nulls into a mask
-                __m256i loaded = _mm256_loadu_si256((__m256i*)&is_nulls[i]);
+                __m256i loaded = _mm256_loadu_si256((__m256i*)&nulls[i]);
                 int mask = _mm256_movemask_epi8(_mm256_cmpeq_epi8(loaded, _mm256_setzero_si256()));
                 phmap::priv::BitMask<uint32_t, 32> bitmask(mask);
                 for (auto idx : bitmask) {
-                    data[i + idx] = read_data[cnt++];
+                    dst_data[i + idx] = src_data[cnt++];
                 }
             }
+            // process tail elements
             for (; i < count; ++i) {
-                data[i] = read_data[cnt];
-                cnt += !is_nulls[i];
+                dst_data[i] = src_data[cnt];
+                cnt += !nulls[i];
             }
-            CHECK_EQ(cnt, read_count) << "count:" << count << " null_cnt:" << null_cnt;
+            CHECK_EQ(cnt, num_non_nulls) << "count:" << count << " null_cnt:" << count - num_non_nulls;
         } else {
             size_t cnt = 0;
             for (size_t i = 0; i < count; ++i) {
-                data[i] = read_data[cnt];
+                dst_data[i] = src_data[cnt];
+                cnt += !nulls[i];
+            }
+            CHECK_EQ(cnt, num_non_nulls) << "count:" << count << " null_cnt:" << count - num_non_nulls;
+        }
+    }
+
+    Status next_dict_code_batch_with_nulls(size_t count, size_t cur_size, const NullInfos& null_infos, Column* dst) {
+        size_t null_cnt = null_infos.num_nulls;
+        auto nullable_column = down_cast<NullableColumn*>(dst);
+
+        size_t read_count = count - null_cnt;
+        uint32_t read_dict_data[read_count];
+        if (read_count == 0) {
+            return Status::OK();
+        }
+        auto decoded_num = _rle_batch_reader.GetBatch(read_dict_data, read_count);
+        if (decoded_num < count) {
+            return Status::InternalError("didn't get enough data from dict-decoder");
+        }
+
+        Int32Column* data_column = down_cast<Int32Column*>(nullable_column->data_column().get());
+        data_column->resize_uninitialized(cur_size + count);
+        int32_t* __restrict__ data = data_column->get_data().data() + cur_size;
+        assign_data_with_nulls(count, read_count, null_infos.nulls_data(), (int32_t*)read_dict_data, data);
+
+        return Status::OK();
+    }
+
+    Status next_value_batch_with_nulls(size_t count, size_t cur_size, const NullInfos& null_infos, Column* dst,
+                                       const FilterData* filter) {
+        CHECK(dst->is_nullable());
+        const uint8_t* __restrict is_nulls = null_infos.nulls_data();
+        // assign null infos
+        size_t null_cnt = null_infos.num_nulls;
+        auto nullable_column = down_cast<NullableColumn*>(dst);
+        FixedLengthColumn<T>* data_column = down_cast<FixedLengthColumn<T>*>(nullable_column->data_column().get());
+
+        size_t read_count = count - null_cnt;
+
+        if (read_count == 0) {
+            return Status::OK();
+        }
+
+        // resize data
+        data_column->resize_uninitialized(cur_size + count);
+        T* __restrict__ data = data_column->get_data().data() + cur_size;
+
+        if (filter) {
+            _indexes.reserve(read_count);
+            auto decoded_num = _rle_batch_reader.GetBatch(&_indexes[0], read_count);
+            if (decoded_num < read_count) {
+                return Status::InternalError("didn't get enough data from dict-decoder");
+            }
+
+            auto flag = 0;
+            size_t size = _dict.size();
+            for (int i = 0; i < read_count; i++) {
+                flag |= _indexes[i] >= size;
+            }
+            if (UNLIKELY(flag)) {
+                return Status::InternalError("Index not in dictionary bounds");
+            }
+
+            size_t cnt = 0;
+            for (int i = 0; i < count; i++) {
+                if (filter[i] & !is_nulls[i]) {
+                    data[i] = _dict[_indexes[cnt]];
+                }
                 cnt += !is_nulls[i];
             }
-            CHECK_EQ(cnt, read_count) << "count:" << count << " null_cnt:" << null_cnt;
+        } else {
+            T read_data[read_count];
+            auto ret = _rle_batch_reader.GetBatchWithDict(_dict.data(), _dict.size(), read_data, read_count);
+            if (UNLIKELY(ret <= 0)) {
+                return Status::InternalError("DictDecoder GetBatchWithDict failed");
+            }
+
+            assign_data_with_nulls(count, read_count, null_infos.nulls_data(), read_data, data);
         }
 
         return Status::OK();
@@ -393,6 +489,10 @@ public:
 private:
     size_t _get_dict_size() const override { return _dict_data.size(); }
 
+    Status _do_next_batch_with_nulls(size_t count, const NullInfos& null_infos, ColumnContentType content_type,
+                                     Column* dst, const FilterData* filter) override {
+        return Decoder::next_batch_with_nulls(count, null_infos, content_type, dst, filter);
+    }
     Status _next_batch_value(size_t count, Column* dst, const FilterData* filter) override {
         if (filter) {
             _indexes.reserve(count);

--- a/be/src/formats/parquet/encoding_dict.h
+++ b/be/src/formats/parquet/encoding_dict.h
@@ -173,7 +173,7 @@ public:
         const uint8_t* __restrict is_nulls = null_infos.nulls_data();
         CHECK(dst->is_nullable());
         size_t null_cnt = null_infos.num_nulls;
-        FixedLengthColumn<T>* data_column /* = nullptr */;
+        FixedLengthColumn<T>* data_column = nullptr;
         if (dst->is_nullable()) {
             NullColumn* null_column = down_cast<NullableColumn*>(dst)->mutable_null_column();
             auto& null_data = null_column->get_data();

--- a/be/src/formats/parquet/encoding_plain.h
+++ b/be/src/formats/parquet/encoding_plain.h
@@ -14,9 +14,12 @@
 
 #pragma once
 
+#include <cstring>
+
 #include "column/column.h"
 #include "column/column_helper.h"
 #include "column/nullable_column.h"
+#include "column/vectorized_fwd.h"
 #include "common/status.h"
 #include "formats/parquet/encoding.h"
 #include "gutil/strings/substitute.h"
@@ -24,6 +27,7 @@
 #include "util/bit_util.h"
 #include "util/coding.h"
 #include "util/faststring.h"
+#include "util/raw_container.h"
 #include "util/slice.h"
 
 namespace starrocks::parquet {

--- a/be/src/formats/parquet/stored_column_reader.cpp
+++ b/be/src/formats/parquet/stored_column_reader.cpp
@@ -467,7 +467,7 @@ Status OptionalStoredColumnReader::_read_values_on_levels(size_t num_values,
         size_t level_parsed = 0;
         RETURN_IF_ERROR(_decode_levels(&num_values, &level_parsed, &def_levels));
         DCHECK_EQ(num_values, level_parsed);
-        _null_infos.resize(num_values);
+        _null_infos.reset_with_capacity(num_values);
         size_t num_ranges = 1;
         size_t num_nulls{};
         // decode def levels
@@ -484,7 +484,7 @@ Status RepeatedStoredColumnReader::_read_values_on_levels(size_t num_values,
                                                           starrocks::parquet::ColumnContentType content_type,
                                                           starrocks::Column* dst, bool append_default,
                                                           const FilterData* filter) {
-    _null_infos.resize(num_values);
+    _null_infos.reset_with_capacity(num_values);
 
     int null_pos = 0;
     level_t* def_levels = _reader->def_level_decoder().get_forward_levels(num_values);

--- a/be/src/formats/parquet/utils.h
+++ b/be/src/formats/parquet/utils.h
@@ -45,4 +45,19 @@ private:
     inline static const std::vector<std::string> cache_key_prefix{"ft", "pg"};
 };
 
+struct NullInfos {
+    std::vector<uint8_t> is_nulls;
+    size_t num_nulls{};
+    size_t num_ranges{};
+
+    uint8_t* nulls_data() { return is_nulls.data(); }
+    const uint8_t* nulls_data() const { return is_nulls.data(); }
+
+    void resize(size_t num_rows) {
+        is_nulls.resize(num_rows);
+        num_nulls = 0;
+        num_ranges = 0;
+    }
+};
+
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/utils.h
+++ b/be/src/formats/parquet/utils.h
@@ -16,6 +16,7 @@
 
 #include "gen_cpp/parquet_types.h"
 #include "gen_cpp/types.pb.h"
+#include "util/raw_container.h"
 
 namespace starrocks::parquet {
 
@@ -46,18 +47,23 @@ private:
 };
 
 struct NullInfos {
-    std::vector<uint8_t> is_nulls;
+    // The number of nulls contained in the null vector.
     size_t num_nulls{};
+    // The number of Runs in null info. (null[i] ! = null[i + 1]) This is an estimated value.
     size_t num_ranges{};
 
-    uint8_t* nulls_data() { return is_nulls.data(); }
-    const uint8_t* nulls_data() const { return is_nulls.data(); }
+    uint8_t* nulls_data() { return _is_nulls.data(); }
+    const uint8_t* nulls_data() const { return _is_nulls.data(); }
 
-    void resize(size_t num_rows) {
-        is_nulls.resize(num_rows);
+    // This function only reserves space but does no actual initialization.
+    void reset_with_capacity(size_t num_rows) {
+        _is_nulls.resize(num_rows);
         num_nulls = 0;
         num_ranges = 0;
     }
+
+private:
+    raw::RawVector<uint8_t> _is_nulls;
 };
 
 } // namespace starrocks::parquet

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -433,7 +433,6 @@ set(EXEC_FILES
         ./simd/simd_test.cpp
         ./simd/simd_selector_test.cpp
         ./simd/simd_mulselector_test.cpp
-        ./simd/delta_decode_test.cpp
         ./util/phmap_test.cpp
         ./util/aes_util_test.cpp
         ./util/await_test.cpp
@@ -533,6 +532,11 @@ set(EXEC_FILES
         ./udf/java/java_native_method_test.cpp
         ./udf/java/java_data_converter_test.cpp
         )
+
+if (${USE_AVX512})
+    list(APPEND EXEC_FILES ./simd/delta_decode_test.cpp)
+endif()
+
 
 if ("${WITH_STARCACHE}" STREQUAL "ON")
     list(APPEND EXEC_FILES ./cache/block_cache/block_cache_test.cpp)

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -216,6 +216,7 @@ set(EXEC_FILES
         ./formats/parquet/parquet_cli_reader_test.cpp
         ./formats/parquet/parquet_ut_base.cpp
         ./formats/parquet/page_index_test.cpp
+        ./formats/parquet/dict_encoding_test.cpp
         ./formats/disk_range_test.cpp
         ./geo/geo_types_test.cpp
         ./geo/wkt_parse_test.cpp

--- a/be/test/formats/parquet/dict_encoding_test.cpp
+++ b/be/test/formats/parquet/dict_encoding_test.cpp
@@ -124,5 +124,20 @@ TEST(DictEncodingReadTest, BasicTest) {
         EXPECT_EQ(dst->debug_item(2), "NULL");
         EXPECT_EQ(dst->size(), chunk_size);
     }
+    {
+        // all null
+        for (size_t i = 0; i < chunk_size; ++i) {
+            infos.nulls_data()[i] = 1;
+        }
+        infos.num_nulls = chunk_size;
+        TypeDescriptor type_desc = TypeDescriptor(TYPE_INT);
+        auto dst = ColumnHelper::create_column(type_desc, true);
+        auto filter = std::make_unique<uint8_t[]>(chunk_size);
+        ASSERT_OK(decoder.next_batch_with_nulls(chunk_size, infos, ColumnContentType::VALUE, dst.get(), filter.get()));
+        EXPECT_EQ(dst->debug_item(0), "NULL");
+        EXPECT_EQ(dst->debug_item(1), "NULL");
+        EXPECT_EQ(dst->debug_item(2), "NULL");
+        EXPECT_EQ(dst->size(), chunk_size);
+    }
 }
 } // namespace starrocks::parquet

--- a/be/test/formats/parquet/dict_encoding_test.cpp
+++ b/be/test/formats/parquet/dict_encoding_test.cpp
@@ -1,0 +1,116 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <stdexcept>
+
+#include "column/column_helper.h"
+#include "column/type_traits.h"
+#include "formats/parquet/encoding.h"
+#include "formats/parquet/encoding_dict.h"
+#include "formats/parquet/utils.h"
+#include "runtime/types.h"
+#include "testutil/assert.h"
+#include "types/logical_type.h"
+#include "util/slice.h"
+
+namespace starrocks::parquet {
+template <LogicalType LT>
+class FakeDictDecoder final : public Decoder {
+public:
+    Status set_data(const Slice& data) override { throw std::runtime_error("not supported function set_data"); }
+    Status skip(size_t values_to_skip) override { throw std::runtime_error("not supported skip"); }
+    Status next_batch(size_t count, ColumnContentType content_type, Column* dst,
+                      const FilterData* filter = nullptr) override {
+        throw std::runtime_error("not supported skip");
+    }
+    Status next_batch(size_t count, uint8_t* dst) override {
+        using RT = RunTimeCppType<LT>;
+        auto* spec_dst = reinterpret_cast<RT*>(dst);
+        for (size_t i = 0; i < count; ++i) {
+            spec_dst[i] = i;
+        }
+        return Status::OK();
+    }
+};
+
+TEST(DictEncodingReadTest, BasicTest) {
+    constexpr LogicalType PT = LogicalType::TYPE_INT;
+    using RT = RunTimeCppType<PT>;
+    faststring fs;
+    RleEncoder<RT> encoder(&fs, 32);
+    {
+        for (size_t i = 0; i < 4096; ++i) {
+            encoder.Put(i % 9 + 1, 10);
+        }
+    }
+
+    DictDecoder<RT> decoder;
+    FakeDictDecoder<PT> inner_decoder;
+    faststring fs2;
+    fs2.resize(fs.length() + 1);
+    fs2.data()[0] = 32;
+    memcpy(fs2.data() + 1, fs.data(), fs.length());
+    ASSERT_OK(decoder.set_data(Slice(fs2.data(), fs2.length())));
+    ASSERT_OK(decoder.set_dict(10, 10, &inner_decoder));
+
+    // read dict code
+    size_t chunk_size = 4096;
+    NullInfos infos;
+    infos.reset_with_capacity(chunk_size);
+    {
+        // interleave
+        infos.num_nulls = 0;
+        for (size_t i = 0; i < chunk_size; ++i) {
+            infos.nulls_data()[i] = i % 2;
+            infos.num_nulls += infos.nulls_data()[i];
+        }
+        infos.num_ranges = chunk_size / 2;
+    }
+    {
+        TypeDescriptor type_desc = TypeDescriptor(TYPE_INT);
+        auto dst = ColumnHelper::create_column(type_desc, true);
+        ASSERT_OK(decoder.next_batch_with_nulls(chunk_size, infos, ColumnContentType::DICT_CODE, dst.get(), nullptr));
+        EXPECT_EQ(dst->debug_item(0), "1");
+        EXPECT_EQ(dst->debug_item(1), "NULL");
+        EXPECT_EQ(dst->debug_item(2), "1");
+        EXPECT_EQ(dst->size(), chunk_size);
+    }
+    {
+        TypeDescriptor type_desc = TypeDescriptor(TYPE_INT);
+        auto dst = ColumnHelper::create_column(type_desc, true);
+        auto filter = std::make_unique<uint8_t[]>(chunk_size);
+        memset(filter.get(), 0x01, chunk_size);
+        filter[0] = 0;
+        ASSERT_OK(decoder.next_batch_with_nulls(chunk_size, infos, ColumnContentType::DICT_CODE, dst.get(),
+                                                filter.get()));
+        EXPECT_EQ(dst->debug_item(0), "7");
+        EXPECT_EQ(dst->debug_item(1), "NULL");
+        EXPECT_EQ(dst->debug_item(2), "7");
+        EXPECT_EQ(dst->size(), chunk_size);
+    }
+
+    {
+        // sparse
+        for (size_t i = 0; i < chunk_size; ++i) {
+            infos.nulls_data()[i] = 1;
+        }
+        infos.nulls_data()[0] = 0;
+        infos.nulls_data()[1000] = 0;
+        infos.nulls_data()[2000] = 0;
+        infos.nulls_data()[3000] = 0;
+        infos.nulls_data()[4000] = 0;
+
+        infos.num_nulls = chunk_size - 5;
+        infos.num_ranges = chunk_size / 2;
+    }
+    {
+        TypeDescriptor type_desc = TypeDescriptor(TYPE_INT);
+        auto dst = ColumnHelper::create_column(type_desc, true);
+        ASSERT_OK(decoder.next_batch_with_nulls(chunk_size, infos, ColumnContentType::DICT_CODE, dst.get(), nullptr));
+        EXPECT_EQ(dst->debug_item(0), "5");
+        EXPECT_EQ(dst->debug_item(1), "NULL");
+        EXPECT_EQ(dst->debug_item(2), "NULL");
+        EXPECT_EQ(dst->size(), chunk_size);
+    }
+}
+} // namespace starrocks::parquet


### PR DESCRIPTION

## Why I'm doing:

There are two main optimizations in this PR.
1. using uint8_t array as the output of auto-vectorized null column process
2. optimize the logic of reading sparse columns.

These two optimizations can improve on sparse columns by about 20%+


| baseline | patched | SQL  |
| -------- | ------- | ---- |
|  2575        |    2064     |  SELECT MAX(decimal_value) FROM test_data_100p GROUP BY smallint_10f    |
|  1014        |    996     |  SELECT MAX(smallint_10f) FROM test_data_100p GROUP BY smallint_10f    |
|  2416        |    2044     |  SELECT MAX(decimal_value) FROM test_data_100p GROUP BY bigint_10f    |
|  1359        |    1227     |  SELECT MAX(smallint_1000f) FROM test_data_100p GROUP BY bigint_10f    |
|  1517        |    1212     |  SELECT MAX(int_60p) FROM test_data_100p GROUP BY bigint_10f    |

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
