### PR TITLE
[BugFix] Fix overflow of FixedLengthColumn::max_serialize_size for HashJoin

### DIFF
--- a/be/src/serde/column_array_serde.cpp
+++ b/be/src/serde/column_array_serde.cpp
@@ -151,7 +151,9 @@ template <typename T, bool sorted>
 class FixedLengthColumnSerde {
 public:
     static int64_t max_serialized_size(const FixedLengthColumnBase<T>& column, const int encode_level) {
-        uint32_t size = sizeof(T) * column.size();
+        // NOTE that `serialize` and `deserialize` will store and load the size as uint32_t.
+        // If you use `serialize` and `deserialize`, please make sure that the size of the column is less than 2^32.
+        int64_t size = sizeof(T) * column.size();
         if (EncodeContext::enable_encode_integer(encode_level) && size >= ENCODE_SIZE_LIMIT) {
             return sizeof(uint32_t) + sizeof(uint64_t) +
                    std::max((int64_t)size, (int64_t)streamvbyte_max_compressedbytes(upper_int32(size)));


### PR DESCRIPTION
## Why I'm doing:

ColumnArraySerde is used for serializing and deserializing columns, containing three functions: `max_serialized_size`, `serialize`, and `deserialize`.  

ColumnArraySerde is utilized by both **Exchange** and **HashJoin**, but their usage scenarios differ:  
- **Exchange** employs all three functions of ColumnArraySerde: `max_serialized_size`, `serialize`, and `deserialize`.  
- **HashJoin** applies `ColumnArraySerde::max_serialized_size` and `Column::serialize` to a chunk composed of all builder-side data, but does **not** use `deserialize`.  

**HashJoin** may encounter overflow when invoking `ColumnArraySerde::max_serialized_size` on a `FixedLengthColumn`:  
- `FixedLengthColumnSerde::max_serialized_size` uses `uint32_t` to store the byte count of the column, despite its return type being `int64_t`.  
- The maximum number of rows in the builder is `UINT32_MAX`, and `UINT32_MAX * sizeof(type)` could exceed the range of `uint32_t`.  

This issue **only affects HashJoin**, not Exchange:  
- Exchange serializes chunks with `chunk_size` rows of data (default value 4096), while HashJoin concatenates **all builder data into a single chunk**.  

Note: `FixedLengthColumnSerde::serialize` and `FixedLengthColumnSerde::deserialize` use `uint32_t` to store the byte count, differing from the `int64_t` return type of `max_serialized_size`. However, this is safe because:  
- HashJoin's byte count might exceed `uint32_t`, but it **does not use** `FixedLengthColumnSerde::serialize` or `deserialize`.  
- Exchange's byte count will not exceed `uint32_t`, as each chunk it serializes contains only `chunk_size` rows (default 4096).

### Test
```sql

CREATE TABLE __row_util_base (
  k1 bigint NULL
) ENGINE=OLAP
DUPLICATE KEY(`k1`)
DISTRIBUTED BY HASH(`k1`) BUCKETS 32
PROPERTIES (
    "replication_num" = "1"
);
insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
insert into __row_util_base select * from __row_util_base; -- 20000
insert into __row_util_base select * from __row_util_base; -- 40000
insert into __row_util_base select * from __row_util_base; -- 80000
insert into __row_util_base select * from __row_util_base; -- 160000
insert into __row_util_base select * from __row_util_base; -- 320000
insert into __row_util_base select * from __row_util_base; -- 640000
insert into __row_util_base select * from __row_util_base; -- 1280000
insert into __row_util_base select * from __row_util_base; -- 320000
insert into __row_util_base select * from __row_util_base; -- 640000
insert into __row_util_base select * from __row_util_base; -- 1280000

insert into __row_util_base select * from __row_util_base; -- 320000
insert into __row_util_base select * from __row_util_base; -- 640000
insert into __row_util_base select * from __row_util_base; -- 1280000
insert into __row_util_base select * from __row_util_base; -- 320000
insert into __row_util_base select * from __row_util_base; -- 640000
insert into __row_util_base select * from __row_util_base; -- 1280000
insert into __row_util_base select * from __row_util_base; -- 1280000
-- 1310720000 rows

CREATE TABLE __row_util (
  idx bigint NULL
) ENGINE=OLAP
DUPLICATE KEY(`idx`)
DISTRIBUTED BY HASH(`idx`) BUCKETS 32
PROPERTIES (
    "replication_num" = "1"
);
insert into __row_util select row_number() over() as idx from __row_util_base;

with w1 as (
    select cast(idx as largeint) as c1, idx % 2 = 0 as c2 from __row_util where idx <= 540000000
)
select count(t1.c1) from w1 t1 join [broadcast] w1 t2 on t1.c1 = t2.c1 and t1.c2 = t2.c2;
```

BE crashed
```
*** Aborted at 1746583517 (unix time) try "date -d @1746583517" if you are using GNU date ***
PC: @          0x4722141 starrocks::FixedLengthColumnBase<__int128>::serialize(unsigned long, unsigned char*) const
*** SIGSEGV (@0x2b16f4e00000) received by PID 3019 (TID 0x2afc68232700) LWP(3355) from PID 18446744073522905088; stack trace: ***
    @     0x2afc3d42720b __pthread_once_slow
    @          0xb7538d4 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x2afc3d430630 (/usr/lib64/[libpthread-2.17.so](http://libpthread-2.17.so/)+0xf62f)
    @          0x4722141 starrocks::FixedLengthColumnBase<__int128>::serialize(unsigned long, unsigned char*) const
    @          0x49962d8 starrocks::SerializedJoinBuildFunc::_build_columns(starrocks::JoinHashTableItems*, starrocks::HashTableProbeState*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starr@
    @          0x4998d73 starrocks::SerializedJoinBuildFunc::construct_hash_table(starrocks::RuntimeState*, starrocks::JoinHashTableItems*, starrocks::HashTableProbeState*)
    @          0x49a16ae starrocks::JoinHashTable::build(starrocks::RuntimeState*)
    @          0x502a719 starrocks::SingleHashJoinBuilder::build(starrocks::RuntimeState*)
    @          0x502a850 starrocks::AdaptivePartitionHashJoinBuilder::build(starrocks::RuntimeState*)
    @          0x5016372 starrocks::HashJoiner::build_ht(starrocks::RuntimeState*)
    @          0x4dbbf6e starrocks::pipeline::HashJoinBuildOperator::set_finishing(starrocks::RuntimeState*)
    @          0x4d6af8c starrocks::pipeline::PipelineDriver::_mark_operator_finishing(std::shared_ptr<starrocks::pipeline::Operator>&, starrocks::RuntimeState*)
    @          0x4d6ef57 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0x50ee4f1 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x3f9121f starrocks::ThreadPool::dispatch_thread()
    @          0x3f887f0 starrocks::Thread::supervise_thread(void*)
    @     0x2afc3d428ea5 start_thread
    @     0x2afc3f8f9b0d __clone
```

or gave wrong result
```
+--------------+
| count(t1.c1) |
+--------------+
| 333924151    |
+--------------+
```

## What I'm doing:



Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
