### PR TITLE
[Enhancement] Improve tablet delta writer thread number

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -421,7 +421,9 @@ CONF_mBool(enable_load_channel_rpc_async, "true");
 CONF_mInt32(load_channel_rpc_thread_pool_num, "-1");
 // The queue size for Load channel rpc thread pool
 CONF_Int32(load_channel_rpc_thread_pool_queue_size, "1024000");
-CONF_mInt32(number_tablet_writer_threads, "16");
+// Number of thread for async delta writer.
+// Default value is max(cpucores/2, 16)
+CONF_mInt32(number_tablet_writer_threads, "0");
 CONF_mInt64(max_queueing_memtable_per_tablet, "2");
 // when memory limit exceed and memtable last update time exceed this time, memtable will be flushed
 // 0 means disable

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -321,10 +321,11 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
                     config::load_channel_rpc_thread_pool_num);
         });
         _config_callback.emplace("number_tablet_writer_threads", [&]() -> Status {
-            LOG(INFO) << "set number_tablet_writer_threads:" << config::number_tablet_writer_threads;
+            int max_delta_writer_thread_num = caculate_delta_writer_thread_num(config::number_tablet_writer_threads);
+            LOG(INFO) << "set max delta writer thread num: " << max_delta_writer_thread_num;
             bthreads::ThreadPoolExecutor* executor = static_cast<bthreads::ThreadPoolExecutor*>(
                     StorageEngine::instance()->async_delta_writer_executor());
-            return executor->get_thread_pool()->update_max_threads(config::number_tablet_writer_threads);
+            return executor->get_thread_pool()->update_max_threads(max_delta_writer_thread_num);
         });
         _config_callback.emplace("compact_threads", [&]() -> Status {
             auto tablet_manager = _exec_env->lake_tablet_manager();

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -224,7 +224,7 @@ Status StorageEngine::_open(const EngineOptions& options) {
     std::unique_ptr<ThreadPool> thread_pool;
     RETURN_IF_ERROR(ThreadPoolBuilder("delta_writer")
                             .set_min_threads(1)
-                            .set_max_threads(std::max<int>(1, config::number_tablet_writer_threads))
+                            .set_max_threads(caculate_delta_writer_thread_num(config::number_tablet_writer_threads))
                             .set_max_queue_size(40960 /*a random chosen number that should big enough*/)
                             .set_idle_timeout(MonoDelta::FromMilliseconds(/*5 minutes=*/5 * 60 * 1000))
                             .build(&thread_pool));

--- a/be/src/storage/utils.cpp
+++ b/be/src/storage/utils.cpp
@@ -397,4 +397,13 @@ bool is_tracker_hit_hard_limit(MemTracker* tracker, double hard_limit_ratio) {
            (tracker->parent() != nullptr && tracker->parent()->limit_exceeded());
 }
 
+int caculate_delta_writer_thread_num(int thread_num_from_config) {
+    if (thread_num_from_config > 0) {
+        return thread_num_from_config;
+    }
+
+    // The minimum value 16 is for compatibility with previous versions.
+    return std::max<int>(CpuInfo::num_cores() / 2, 16);
+}
+
 } // namespace starrocks

--- a/be/src/storage/utils.h
+++ b/be/src/storage/utils.h
@@ -177,4 +177,6 @@ bool is_tracker_hit_hard_limit(MemTracker* tracker, double hard_limit_ratio);
         }                                                     \
     } while (0)
 
+int caculate_delta_writer_thread_num(int thread_num_from_config);
+
 } // namespace starrocks

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -1685,11 +1685,11 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 ##### number_tablet_writer_threads
 
-- Default: 16
+- Default: 0
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: The number of threads used for Stream Load. This configuration is changed to dynamic from v3.1.7 onwards.
+- Description: The number of tablet writer threads used in ingestion, such as Stream Load, Broker Load and Insert. When the parameter is set to less than or equal to 0, the system uses half of the number of CPU cores, with a minimum of 16. When the parameter is set to greater than 0, the system uses that value. This configuration is changed to dynamic from v3.1.7 onwards.
 - Introduced in: -
 
 <!--

--- a/docs/ja/administration/management/BE_configuration.md
+++ b/docs/ja/administration/management/BE_configuration.md
@@ -1178,11 +1178,11 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 ##### number_tablet_writer_threads
 
-- デフォルト: 16
+- デフォルト: 0
 - タイプ: Int
 - 単位: -
 - 可変: はい
-- 説明: Stream Load に使用されるスレッドの数。この設定は v3.1.7 以降、動的に変更されました。
+- 説明: インポート用の tablet writer のスレッド数，Stream Load、Broker Load、Insert などに使用されます。パラメータが 0 以下に設定されている場合、システムは CPU コア数の半分（最小で 16）を使用します。パラメータが 0 より大きい値に設定されている場合、システムはその値を使用します。この設定は v3.1.7 以降、動的に変更されました。
 - 導入バージョン: -
 
 ##### streaming_load_max_mb

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -1614,11 +1614,11 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 ##### number_tablet_writer_threads
 
-- 默认值：16
+- 默认值：0
 - 类型：Int
 - 单位：-
 - 是否动态：是
-- 描述：用于 Stream Load 的线程数。自 v3.1.7 起变为动态参数。
+- 描述：导入用的 tablet writer 线程数, 用于 Stream Load、Broker Load、Insert 等。当参数设置为小于等于 0 时，系统使用 CPU 核数的二分之一，最小为 16。当参数设置为大于 0 时，系统使用该值。自 v3.1.7 起变为动态参数。
 - 引入版本：-
 
 <!--


### PR DESCRIPTION
## Why I'm doing:
`number_tablet_writer_threads` 16 is a little small for the BE machines with many CPU cores.

## What I'm doing:

- When `number_tablet_writer_threads` is set to less than or equal to 0, the system uses half of the number of CPU cores, with a minimum of 16. 
- When the parameter is set to greater than 0, the system uses that value.
- The default value is 0.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
