### PR TITLE
[Enhancement] support adaptive RocksDB write buffer configuration

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1369,6 +1369,13 @@ CONF_String(rocksdb_cf_options_string, "block_based_table_factory={block_cache={
 
 CONF_String(rocksdb_db_options_string, "create_if_missing=true;create_missing_column_families=true");
 
+// It is the memory percent of write buffer for meta in rocksdb.
+// default is 5% of system memory.
+CONF_mInt64(rocksdb_write_buffer_memory_percent, "5");
+// It is the max size of the write buffer for meta in rocksdb.
+// default is 1GB.
+CONF_mInt64(rocksdb_max_write_buffer_memory_bytes, "1073741824");
+
 // limit local exchange buffer's memory size per driver
 CONF_Int64(local_exchange_buffer_mem_limit_per_driver, "134217728"); // 128MB
 // only used for test. default: 128M

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1371,10 +1371,12 @@ CONF_String(rocksdb_db_options_string, "create_if_missing=true;create_missing_co
 
 // It is the memory percent of write buffer for meta in rocksdb.
 // default is 5% of system memory.
-CONF_mInt64(rocksdb_write_buffer_memory_percent, "5");
+// However, aside from this, the final calculated size of the write buffer memory
+// will not be less than 64MB nor exceed 1GB (rocksdb_max_write_buffer_memory_bytes).
+CONF_Int64(rocksdb_write_buffer_memory_percent, "5");
 // It is the max size of the write buffer for meta in rocksdb.
 // default is 1GB.
-CONF_mInt64(rocksdb_max_write_buffer_memory_bytes, "1073741824");
+CONF_Int64(rocksdb_max_write_buffer_memory_bytes, "1073741824");
 
 // limit local exchange buffer's memory size per driver
 CONF_Int64(local_exchange_buffer_mem_limit_per_driver, "134217728"); // 128MB

--- a/be/src/storage/kv_store.cpp
+++ b/be/src/storage/kv_store.cpp
@@ -49,7 +49,6 @@
 #include "runtime/exec_env.h"
 #include "storage/olap_define.h"
 #include "storage/rocksdb_status_adapter.h"
-#include "util/mem_info.h"
 #include "util/runtime_profile.h"
 #include "util/starrocks_metrics.h"
 
@@ -82,20 +81,25 @@ KVStore::~KVStore() {
     }
 }
 
-int64_t KVStore::calc_rocksdb_write_buffer_size() {
+int64_t KVStore::calc_rocksdb_write_buffer_size(MemTracker* mem_tracker) {
     // 1. Get the number of disks
     std::vector<starrocks::StorePath> paths;
-    parse_conf_store_paths(config::storage_root_path, &paths);
+    Status st = parse_conf_store_paths(config::storage_root_path, &paths);
+    if (!st.ok()) {
+        // ignore error, will treat disk count as 1
+        LOG(ERROR) << "parse_conf_store_paths failed, path=" << config::storage_root_path;
+    }
     int64_t disk_cnt = paths.size();
     // 2. Get the total memory bytes of BE
-    int64_t total_mem_bytes = MemInfo::physical_mem();
+    int64_t total_mem_bytes = mem_tracker->limit();
     // 3. Calculate the write buffer memory bytes
     int64_t write_buffer_mem_bytes =
             total_mem_bytes * std::max(std::min(100L, config::rocksdb_write_buffer_memory_percent), 0L) / 100L;
-    // 4. Calculate the write buffer size for each disk
-    int64_t write_buffer_mem_bytes_per_disk = write_buffer_mem_bytes / disk_cnt;
+    // 4. Calculate the write buffer size for each disk, and there will be 2 memtables by default,
+    //    so we will divide it by 2
+    int64_t write_buffer_mem_bytes_per_disk = write_buffer_mem_bytes / std::max(disk_cnt, 1L) / 2;
 
-    // should be around 64MB ~ rocksdb_max_write_buffer_memory_bytes
+    // should be around 64MB ~ 1GB rocksdb_max_write_buffer_memory_bytes
     int64_t res = std::min(std::max(67108864L, write_buffer_mem_bytes_per_disk),
                            config::rocksdb_max_write_buffer_memory_bytes);
 
@@ -125,7 +129,10 @@ Status KVStore::init(bool read_only) {
     cf_descs[2].options = meta_cf_options;
     cf_descs[2].options.prefix_extractor.reset(NewFixedPrefixTransform(PREFIX_LENGTH));
     cf_descs[2].options.compression = rocksdb::kSnappyCompression;
-    cf_descs[2].options.write_buffer_size = calc_rocksdb_write_buffer_size();
+    auto* tracker = GlobalEnv::GetInstance()->process_mem_tracker();
+    if (tracker != nullptr) {
+        cf_descs[2].options.write_buffer_size = calc_rocksdb_write_buffer_size(tracker);
+    }
     static_assert(NUM_COLUMN_FAMILY_INDEX == 3);
 
     rocksdb::Status s;

--- a/be/src/storage/kv_store.h
+++ b/be/src/storage/kv_store.h
@@ -102,6 +102,9 @@ public:
                           const std::string& end_key, WriteBatch* batch);
 
 private:
+    static int64_t calc_rocksdb_write_buffer_size();
+
+private:
     std::string _root_path;
     rocksdb::DB* _db;
     std::vector<rocksdb::ColumnFamilyHandle*> _handles;

--- a/be/src/storage/kv_store.h
+++ b/be/src/storage/kv_store.h
@@ -53,6 +53,7 @@ namespace starrocks {
 
 using ColumnFamilyHandle = rocksdb::ColumnFamilyHandle;
 using WriteBatch = rocksdb::WriteBatch;
+class MemTracker;
 
 class KVStore {
 public:
@@ -102,7 +103,7 @@ public:
                           const std::string& end_key, WriteBatch* batch);
 
 private:
-    static int64_t calc_rocksdb_write_buffer_size();
+    static int64_t calc_rocksdb_write_buffer_size(MemTracker* mem_tracker);
 
 private:
     std::string _root_path;

--- a/be/test/storage/kv_store_test.cpp
+++ b/be/test/storage/kv_store_test.cpp
@@ -41,8 +41,8 @@
 #include <string>
 
 #include "fs/fs_util.h"
+#include "runtime/mem_tracker.h"
 #include "storage/olap_define.h"
-#include "util/mem_info.h"
 
 #ifndef BE_TEST
 #define BE_TEST
@@ -157,19 +157,17 @@ TEST_F(KVStoreTest, TestOpDeleteRange) {
 }
 
 TEST_F(KVStoreTest, calc_rocksdb_write_buffer_size_test) {
-    int64_t old_val = config::rocksdb_max_write_buffer_memory_bytes;
-    config::rocksdb_max_write_buffer_memory_bytes = MemInfo::physical_mem();
+    MemTracker mem_tracker(4294967296);
 
     // case1: only one path
-    auto size = KVStore::calc_rocksdb_write_buffer_size();
-    ASSERT_EQ(size, MemInfo::physical_mem() * config::rocksdb_write_buffer_memory_percent / 100);
+    auto size = KVStore::calc_rocksdb_write_buffer_size(&mem_tracker);
+    ASSERT_EQ(size, 4294967296 * config::rocksdb_write_buffer_memory_percent / 100 / 2);
 
     // case2: two paths
     std::string old_val2 = config::storage_root_path;
     config::storage_root_path = "/storage;/storage2";
-    auto size2 = KVStore::calc_rocksdb_write_buffer_size();
-    ASSERT_EQ(size2, MemInfo::physical_mem() * config::rocksdb_write_buffer_memory_percent / 100 / 2);
-    config::rocksdb_max_write_buffer_memory_bytes = old_val;
+    auto size2 = KVStore::calc_rocksdb_write_buffer_size(&mem_tracker);
+    ASSERT_EQ(size2, 67108864L);
     config::storage_root_path = old_val2;
 }
 

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -4080,6 +4080,24 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Description: The maximum memory that the Query Pool can use. It is expressed as a percentage of the Process memory limit.
 - Introduced in: v3.1.0
 
+##### rocksdb_write_buffer_memory_percent
+
+- Default: 5
+- Type: Int64
+- Unit: -
+- Is mutable: No
+- Description: It is the memory percent of write buffer for meta in rocksdb. default is 5% of system memory. However, aside from this, the final calculated size of the write buffer memory will not be less than 64MB nor exceed 1G (rocksdb_max_write_buffer_memory_bytes)
+- Introduced in: v3.5.0
+
+##### rocksdb_max_write_buffer_memory_bytes
+
+- Default: 1073741824
+- Type: Int64
+- Unit: -
+- Is mutable: No
+- Description: It is the max size of the write buffer for meta in rocksdb. Default is 1GB.
+- Introduced in: v3.5.0
+
 <!--
 ##### datacache_block_size
 

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -4039,6 +4039,24 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：Query Pool 能够使用的最大内存上限。以 Process 内存上限的百分比来表示。
 - 引入版本：v3.1.0
 
+##### rocksdb_write_buffer_memory_percent
+
+- 默认值：5
+- 类型：Int64
+- 单位：-
+- 是否动态：否
+- 描述：rocksdb中write buffer可以使用的内存占比。默认值是百分之5，最终取值不会小于64MB，也不会大于1GB。
+- 引入版本：v3.5.0
+
+##### rocksdb_max_write_buffer_memory_bytes
+
+- 默认值：1073741824
+- 类型：Int64
+- 单位：-
+- 是否动态：否
+- 描述：rocksdb中write buffer内存的最大上限。
+- 引入版本：v3.5.0
+
 <!--
 ##### datacache_block_size
 


### PR DESCRIPTION
## Why I'm doing:
In the current implementation, the RocksDB instance storing metadata uses the default write buffer size of 64MB. In scenarios with heavy metadata write operations, this configuration may potentially cause metadata write blocking issues.

## What I'm doing:
Introduce an adaptive write buffer sizing strategy that defaults to using 5% of system memory for the write buffer, with a defined maximum upper limit.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
