### PR TITLE
[Enhancement] make FoldConstantsRule support hash functions.

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -903,6 +903,13 @@ under the License.
             <groupId>tools.profiler</groupId>
             <artifactId>async-profiler</artifactId>
         </dependency>
+
+        <!-- for xx_hash3_64 -->
+        <dependency>
+            <groupId>net.openhft</groupId>
+            <artifactId>zero-allocation-hashing</artifactId>
+            <version>0.16</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -248,6 +248,9 @@ public class ScalarOperatorFunctions {
         Preconditions.checkArgument(input.length > 0);
         long hashValue = HashFunctions.XX_HASH3_64_SEED;
         for (ConstantOperator constantOperator : input) {
+            if (constantOperator.isNull()) {
+                return ConstantOperator.createNull(Type.BIGINT);
+            }
             hashValue = HashFunctions.hash64(constantOperator.getVarchar(), hashValue);
         }
         return ConstantOperator.createBigint(hashValue);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -112,6 +112,12 @@ public class ScalarOperatorFunctionsTest {
     }
 
     @Test
+    public void xxHash64() {
+        assertEquals(8354710922730016039L, ScalarOperatorFunctions.xxHash64(
+                ConstantOperator.createVarchar("41c630d2-e339-380b-a65a-f295ca422070")).getBigint());
+    }
+
+    @Test
     public void timeDiff() {
         assertEquals(-2534400.0, ScalarOperatorFunctions.timeDiff(O_DT_20101102_183010, O_DT_20101202_023010).getTime(),
                 1);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -115,6 +115,10 @@ public class ScalarOperatorFunctionsTest {
     public void xxHash64() {
         assertEquals(8354710922730016039L, ScalarOperatorFunctions.xxHash64(
                 ConstantOperator.createVarchar("41c630d2-e339-380b-a65a-f295ca422070")).getBigint());
+
+        assertEquals(2897331577432926379L, ScalarOperatorFunctions.xxHash64(
+                ConstantOperator.createVarchar("41c630d2-e339-380b-a65a-f295ca422070"),
+                ConstantOperator.createVarchar("cd824fbe-8134-8015-7f4a-000004ffffff")).getBigint());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -113,6 +113,13 @@ public class ScalarOperatorFunctionsTest {
 
     @Test
     public void xxHash64() {
+        ConstantOperator operator = ScalarOperatorFunctions.xxHash64(ConstantOperator.createNull(Type.VARCHAR));
+        assertTrue(operator.isNull());
+        assertEquals(Type.BIGINT, operator.getType());
+
+        assertEquals(-2612172575022167352L, ScalarOperatorFunctions.xxHash64(
+                ConstantOperator.createVarchar("NULL")).getBigint());
+
         assertEquals(8354710922730016039L, ScalarOperatorFunctions.xxHash64(
                 ConstantOperator.createVarchar("41c630d2-e339-380b-a65a-f295ca422070")).getBigint());
 


### PR DESCRIPTION
## Why I'm doing:

Executing SQLs like below:

```sql
CREATE DATABASE IF NOT EXISTS test;
CREATE TABLE `test`.`test` (
  `id` varchar(100) NULL COMMENT "",
  `name` varchar(100) NULL COMMENT "",
  `hash_id` bigint(20) NULL AS xx_hash3_64(`id`) COMMENT ""
) ENGINE=OLAP
DUPLICATE KEY(`id`)
DISTRIBUTED BY HASH(`hash_id`) BUCKETS 20
PROPERTIES (
"compression" = "LZ4",
"fast_schema_evolution" = "true",
"replicated_storage" = "true",
"replication_num" = "1"
);

insert into test.test select uuid(), last_query_id() from table(generate_series(1,1000));

trace logs optimizer select * from test where hash_id = xx_hash3_64('41c630d2-e339-380b-a65a-f295ca422070');
```

There might be a rule like:
```
| 1ms|    [TRACE QUERY 1a937aa9-2b0c-11f0-a1f6-00163e371dee] APPLY RULE TF_PUSH_DOWN_PREDICATE_PROJECT 41                                                                                                                                       |
| Original Expression:                                                                                                                                                                                                                          |
| LogicalFilterOperator {predicate=3: hash_id = xx_hash3_64(41c630d2-e339-380b-a65a-f295ca422070)}                                                                                                                                                                            |
|                                                                                                                                                                                                                                               |
| ->  LogicalProjectOperator {projection=[1: id, 2: name, 3: hash_id]}                                                                                                                                                                          |
|                                                                                                                                                                                                                                               |
|     ->  LogicalOlapScanOperator {table=11031, selectedPartitionId=null, selectedIndexId=11032, outputColumns=[1: id, 2: name, 3: hash_id], predicate=null, prunedPartitionPredicates=[], limit=-1}                                            |
| 1ms|                                                                                                                                                                                                                                          |
| New Expression:                                                                                                                                                                                                                               |
| 0:LogicalProjectOperator {projection=[1: id, 2: name, 3: hash_id]}                                                                                                                                                                            |
|                                                                                                                                                                                                                                               |
| ->  LogicalFilterOperator {predicate=3: hash_id = xx_hash3_64(41c630d2-e339-380b-a65a-f295ca422070) }                                                                                                                                                                        |
|                                                                                                                                                                                                                                               |
|     ->  LogicalOlapScanOperator {table=11031, selectedPartitionId=null, selectedIndexId=11032, outputColumns=[1: id, 2: name, 3: hash_id], predicate=null, prunedPartitionPredicates=[], limit=-1}                                            |
|
```

That will lead to a query plan like:

```
|   0:OlapScanNode                                  |
|      TABLE: test                                  |
|      PREAGGREGATION: ON                           |
|      PREDICATES: 3: hash_id = xx_hash3_64(41c630d2-e339-380b-a65a-f295ca422070) |
|      partitions=1/1                               |
|      rollup: test                                 |
|      tabletRatio=20/20                             |
|      tabletList=11057                             |
|      cardinality=1                                |
|      avgRowSize=80.0                              |
+---------------------------------------------------+
```

Though we are definitely sure that `hash_id = xx_hash3_64(41c630d2-e339-380b-a65a-f295ca422070)` only happens on one tablet, this query will scan all tablets. It is a lack of efficiency.

## What I'm doing:

Support hash functions to rewrite constant values. After rewrite, we will see a query plan like:

```
|   0:OlapScanNode                                  |
|      TABLE: test                                  |
|      PREAGGREGATION: ON                           |
|      PREDICATES: 3: hash_id = 8354710922730016039 |
|      partitions=1/1                               |
|      rollup: test                                 |
|      tabletRatio=1/20                             |
|      tabletList=11057                             |
|      cardinality=1                                |
|      avgRowSize=80.0                              |
+---------------------------------------------------+
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
