### PR TITLE
[Enhancement] support option on explain

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ExpressionPrinter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ExpressionPrinter.java
@@ -46,6 +46,9 @@ public class ExpressionPrinter<C> extends ScalarOperatorVisitor<String, C> {
     }
 
     public String print(ScalarOperator scalarOperator) {
+        if (scalarOperator == null) {
+            return "";
+        }
         return scalarOperator.accept(this, null);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/summary/QueryHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/summary/QueryHistory.java
@@ -119,7 +119,7 @@ public class QueryHistory {
         SPMAst2SQLBuilder builder = new SPMAst2SQLBuilder(false, true);
         sqlDigest = builder.build((QueryStatement) statement);
 
-        Explain explain = new Explain(true, true, "\t", "|");
+        Explain explain = new Explain(true, true, "\t", " |");
         String planStr = explain.print(plan.getPhysicalPlan(), plan.getOutputColumns());
         jsonMaps.put("sql_digest", sqlDigest);
         jsonMaps.put("plan", planStr);

--- a/fe/fe-core/src/main/java/com/starrocks/summary/QueryHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/summary/QueryHistory.java
@@ -119,7 +119,8 @@ public class QueryHistory {
         SPMAst2SQLBuilder builder = new SPMAst2SQLBuilder(false, true);
         sqlDigest = builder.build((QueryStatement) statement);
 
-        String planStr = Explain.toString(plan.getPhysicalPlan(), plan.getOutputColumns());
+        Explain explain = new Explain(true, true, "\t", "|");
+        String planStr = explain.print(plan.getPhysicalPlan(), plan.getOutputColumns());
         jsonMaps.put("sql_digest", sqlDigest);
         jsonMaps.put("plan", planStr);
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExplainTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExplainTest.java
@@ -1,0 +1,54 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.sql.Explain;
+import org.junit.jupiter.api.Test;
+
+public class ExplainTest extends PlanTestBase {
+    @Test
+    public void testExplain() throws Exception {
+        String sql = "SELECT DISTINCT t0.v1 FROM t0 LEFT JOIN t1 ON t0.v1 = t1.v4";
+        ExecPlan execPlan = getExecPlan(sql);
+        String plan1 = Explain.toString(execPlan.getPhysicalPlan(), execPlan.getOutputColumns());
+        assertContains(plan1, "- Output => [1:v1]\n"
+                + "    - AGGREGATE(GLOBAL) [1:v1]\n"
+                + "            Estimates: {row: 1, cpu: ?, memory: ?, network: ?, cost: 96.0}\n"
+                + "        - HASH/LEFT OUTER JOIN [1:v1 = 4:v4] => [1:v1]\n"
+                + "                Estimates: {row: 1, cpu: ?, memory: ?, network: ?, cost: 72.0}\n"
+                + "            - EXCHANGE(SHUFFLE) [1]\n"
+                + "                    Estimates: {row: 1, cpu: ?, memory: ?, network: ?, cost: 20.0}\n"
+                + "                - SCAN [t0] => [1:v1]\n"
+                + "                        Estimates: {row: 1, cpu: ?, memory: ?, network: ?, cost: 4.0}\n"
+                + "                        partitionRatio: 0/1, tabletRatio: 0/0\n"
+                + "            - EXCHANGE(SHUFFLE) [4]\n"
+                + "                    Estimates: {row: 1, cpu: ?, memory: ?, network: ?, cost: 20.0}\n"
+                + "                - SCAN [t1] => [4:v4]\n"
+                + "                        Estimates: {row: 1, cpu: ?, memory: ?, network: ?, cost: 4.0}\n"
+                + "                        partitionRatio: 0/1, tabletRatio: 0/0");
+
+        Explain explain = new Explain(true, true, " ", " |");
+        String plan2 = explain.print(execPlan.getPhysicalPlan(), execPlan.getOutputColumns());
+        assertContains(plan2, "- Output => [1:v1]\n"
+                + " - AGGREGATE(GLOBAL) [1:v1] {rows: 1}\n"
+                + "  - HASH/LEFT OUTER JOIN [1:v1 = 4:v4] => [1:v1] {rows: 1}\n"
+                + "   - EXCHANGE(SHUFFLE) [1] {rows: 1}\n"
+                + "    - SCAN [t0] => [1:v1] {rows: 1}\n"
+                + "      |partitionRatio: 0/1, tabletRatio: 0/0\n"
+                + "   - EXCHANGE(SHUFFLE) [4] {rows: 1}\n"
+                + "    - SCAN [t1] => [4:v4] {rows: 1}\n"
+                + "      |partitionRatio: 0/1, tabletRatio: 0/0");
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

add option to control explain's behavior, to reduce plan size in query history
* to control step character
* to control the prefix character of properties
* to control need print costs?


e.g. before:
```
- Output => [7:coalesce, 2:v2]
    - SCAN [t0] => [2:v2, 7:coalesce]
            Estimates: {row: 1, cpu: ?, memory: ?, network: ?, cost: 16.0}
            partitionRatio: 0/1, tabletRatio: 0/0
            7:coalesce := coalesce(CASE WHEN cast(1:v1 as varchar(1048576)) = 'cccc' THEN 'cccc' ELSE 'null' END, cast(1:v1 as varchar))
            predicate: coalesce('cccc', cast(1:v1 as varchar)) = '1'
```

after:
```
- Output => [7:coalesce, 2:v2]
\t- SCAN [t0] => [2:v2, 7:coalesce] {rows: 1}
\t\t|partitionRatio: 0/1, tabletRatio: 0/0
\t\t|7:coalesce := coalesce(CASE WHEN cast(1:v1 as varchar(1048576)) = 'cccc' THEN 'cccc' ELSE 'null' END, cast(1:v1 as varchar))
\t\t|predicate: coalesce('cccc', cast(1:v1 as varchar)) = '1'
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
