### PR TITLE
[BugFix] fix partial compaction's segment deleted by abort transaction

### DIFF
--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -106,6 +106,10 @@ Status Rowset::add_partial_compaction_segments_info(TxnLogPB_OpCompaction* op_co
     bool clear_file_size_info = false;
     bool clear_encryption_meta = (metadata().segments_size() != metadata().segment_encryption_metas_size());
 
+    // NOTE: segments order must be kept, always already compacted segments, then compacted new segments,
+    //       at last uncompacted segments, otherwise it will have data consistency problem for tables like
+    //       UNIQUE table
+
     // 1. add already compacted segments first
     auto& already_compacted_segments = not_used_segments.first;
     for (size_t i = 0; i < metadata().next_compaction_offset(); ++i) {
@@ -130,11 +134,13 @@ Status Rowset::add_partial_compaction_segments_info(TxnLogPB_OpCompaction* op_co
     }
 
     // 2. add compacted segments in this round
+    op_compaction->set_new_segment_offset(op_compaction->output_rowset().segments_size());
     for (auto& file : writer->files()) {
         op_compaction->mutable_output_rowset()->add_segments(file.path);
         op_compaction->mutable_output_rowset()->add_segment_size(file.size.value());
         op_compaction->mutable_output_rowset()->add_segment_encryption_metas(file.encryption_meta);
     }
+    op_compaction->set_new_segment_count(writer->files().size());
 
     // 3. set next compaction offset
     op_compaction->mutable_output_rowset()->set_next_compaction_offset(op_compaction->output_rowset().segments_size());

--- a/be/src/storage/lake/transactions.h
+++ b/be/src/storage/lake/transactions.h
@@ -21,7 +21,8 @@
 
 namespace starrocks {
 class TxnInfoPB;
-}
+class TxnLogPB;
+} // namespace starrocks
 
 namespace starrocks::lake {
 
@@ -85,5 +86,9 @@ Status publish_log_version(TabletManager* tablet_mgr, int64_t tablet_id, std::sp
 // - txns A `std::span` of `TxnInfoPB` containing information of the transactions to be aborted.
 //
 void abort_txn(TabletManager* tablet_mgr, int64_t tablet_id, std::span<const TxnInfoPB> txns);
+
+// Collect files to delete for `abort_txn` in transaction log
+void collect_files_in_log(TabletManager* tablet_mgr, const TxnLogPB& txn_log,
+                          std::vector<std::string>* files_to_delete);
 
 } // namespace starrocks::lake

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -703,6 +703,8 @@ TEST_F(LakeServiceTest, test_abort) {
         log.mutable_op_compaction()->mutable_output_rowset()->set_data_size(4096);
         log.mutable_op_compaction()->mutable_output_rowset()->add_segments(generate_segment_file(txn_id));
         log.mutable_op_compaction()->mutable_output_rowset()->add_segments(generate_segment_file(txn_id));
+        log.mutable_op_compaction()->set_new_segment_offset(0);
+        log.mutable_op_compaction()->set_new_segment_count(2);
         ASSERT_OK(_tablet_mgr->put_txn_log(log));
 
         logs.emplace_back(log);

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -23,6 +23,7 @@
 #include "storage/lake/metacache.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_writer.h"
+#include "storage/lake/transactions.h"
 #include "storage/tablet_schema.h"
 #include "test_util.h"
 #include "testutil/assert.h"
@@ -85,13 +86,19 @@ public:
             ASSERT_OK(writer->write(chunk1));
             ASSERT_OK(writer->finish());
 
+            // segment #3
+            ASSERT_OK(writer->write(chunk0));
+            ASSERT_OK(writer->write(chunk1));
+            ASSERT_OK(writer->finish());
+
             auto files = writer->files();
-            ASSERT_EQ(2, files.size());
+            ASSERT_EQ(3, files.size());
 
             // add rowset metadata
             auto* rowset = _tablet_metadata->add_rowsets();
             rowset->set_overlapped(true);
             rowset->set_id(1);
+            rowset->set_next_compaction_offset(1);
             auto* segs = rowset->mutable_segments();
             for (auto& file : writer->files()) {
                 segs->Add(std::move(file.path));
@@ -125,7 +132,7 @@ TEST_F(LakeRowsetTest, test_load_segments) {
 
     // fill cache: false
     ASSIGN_OR_ABORT(auto segments1, rowset->segments(false));
-    ASSERT_EQ(2, segments1.size());
+    ASSERT_EQ(3, segments1.size());
     for (const auto& seg : segments1) {
         auto segment = cache->lookup_segment(seg->file_name());
         ASSERT_TRUE(segment == nullptr);
@@ -134,7 +141,7 @@ TEST_F(LakeRowsetTest, test_load_segments) {
     // fill data cache: false, fill metadata cache: true
     LakeIOOptions lake_io_opts{.fill_data_cache = false, .fill_metadata_cache = true};
     ASSIGN_OR_ABORT(auto segments2, rowset->segments(lake_io_opts));
-    ASSERT_EQ(2, segments2.size());
+    ASSERT_EQ(3, segments2.size());
     for (const auto& seg : segments2) {
         auto segment = cache->lookup_segment(seg->file_name());
         ASSERT_TRUE(segment != nullptr);
@@ -200,7 +207,7 @@ TEST_F(LakeRowsetTest, test_segment_update_cache_size) {
     }
 }
 
-TEST_F(LakeRowsetTest, test_add_partial_compaction_segments_info) {
+TEST_F(LakeRowsetTest, test_partial_compaction) {
     create_rowsets_for_testing();
 
     auto rs = std::make_shared<lake::Rowset>(_tablet_mgr.get(), _tablet_metadata, 0, 1 /* compaction_segment_limit */);
@@ -208,10 +215,11 @@ TEST_F(LakeRowsetTest, test_add_partial_compaction_segments_info) {
 
     ASSIGN_OR_ABORT(auto segments, rs->segments(false));
 
-    TxnLogPB_OpCompaction op_compaction;
+    TxnLogPB txn_log;
+    auto op_compaction = txn_log.mutable_op_compaction();
     uint64_t num_rows = 0;
     uint64_t data_size = 0;
-    EXPECT_EQ(op_compaction.output_rowset().segments_size(), 0);
+    EXPECT_EQ(op_compaction->output_rowset().segments_size(), 0);
 
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
     int64_t txn_id = next_id();
@@ -229,15 +237,30 @@ TEST_F(LakeRowsetTest, test_add_partial_compaction_segments_info) {
         Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
 
         ASSERT_OK(writer->open());
+        // generate segment x
         ASSERT_OK(writer->write(chunk0));
         ASSERT_OK(writer->finish());
-        ASSERT_EQ(1, writer->files().size());
+        // generate segment y
+        ASSERT_OK(writer->write(chunk0));
+        ASSERT_OK(writer->finish());
+        ASSERT_EQ(2, writer->files().size());
     }
 
-    EXPECT_TRUE(rs->add_partial_compaction_segments_info(&op_compaction, writer.get(), num_rows, data_size).ok());
-    EXPECT_EQ(op_compaction.output_rowset().segments_size(), 2);
+    // segments in old rowset will be a b c
+    // segments in new rowset will be a x y c
+    // x and y should be deleted
+    EXPECT_TRUE(rs->add_partial_compaction_segments_info(op_compaction, writer.get(), num_rows, data_size).ok());
+    EXPECT_EQ(op_compaction->output_rowset().segments_size(), 4);
+    EXPECT_EQ(op_compaction->new_segment_offset(), 1);
+    EXPECT_EQ(op_compaction->new_segment_count(), 2);
     EXPECT_TRUE(num_rows > 0);
     EXPECT_TRUE(data_size > 0);
+
+    std::vector<string> files_to_delete;
+    collect_files_in_log(_tablet_mgr.get(), txn_log, &files_to_delete);
+    EXPECT_EQ(files_to_delete.size(), 2);
+    EXPECT_TRUE(files_to_delete[0].find(writer->files()[0].path) != std::string::npos);
+    EXPECT_TRUE(files_to_delete[1].find(writer->files()[1].path) != std::string::npos);
 }
 
 } // namespace starrocks::lake

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -188,6 +188,14 @@ message TxnLogPB {
         optional PersistentIndexSstablePB output_sstable = 4;
         // Base version of compaction task, used for conflict check with partial update
         optional int64 compact_version = 5;
+        // For normal compaction, all segments in `output_rowset` will be new segments.
+        // For partial compaction, we put compacted segments and uncompacted segments
+        // together, and when compaction is aborted, we need to avoid uncompacted segments
+        // being deleted.
+        // e.g., a b x y e f, in `output_rowset`, a,b,e,f might be uncompacted segments,
+        // x and y might be new segments
+        optional int32 new_segment_offset = 6;
+        optional int32 new_segment_count = 7;
     }
 
     message OpSchemaChange {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

in partial compaction, some segments in rowset might be moved into new rowset, when compaction is aborted, those segments should not be deleted.

for upgrading, if compaction is aborted during upgrading, then its segments will not be deleted, which should be fine.
for downgrading, the behavior is the same, if compaction is aborted during downgrading, then its segments will be wrongly deleted, since this utility is turned off by default, so it's fine.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
