### PR TITLE
[BugFix] Fix possible duplicate finishInstance calls

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1186,6 +1186,11 @@ CONF_mInt64(mem_limited_chunk_queue_block_size, "8388608");
 
 CONF_Int32(internal_service_query_rpc_thread_num, "-1");
 CONF_Int32(internal_service_datacache_rpc_thread_num, "-1");
+// The retry times of rpc request to report exec rpc request to FE. The default value is 10,
+// which means that the rpc request will be retried 10 times if it fails if it's fragment instatnce finish rpc.
+// Report exec rpc request is important for load job, if one fragment instance finish report failed,
+// the load job will be hang until timeout.
+CONF_mInt32(report_exec_rpc_request_retry_num, "10");
 
 /*
  * When compile with ENABLE_STATUS_FAILED, every use of RETURN_INJECT has probability of 1/cardinality_of_inject

--- a/be/src/exec/pipeline/exec_state_reporter.cpp
+++ b/be/src/exec/pipeline/exec_state_reporter.cpp
@@ -153,9 +153,11 @@ Status ExecStateReporter::report_exec_status(const TReportExecStatusParams& para
     TReportExecStatusResult res;
     Status rpc_status;
 
+    // since the caller(report_exec_state) has already retried {@code config::report_exec_rpc_request_retry_num} times,
+    // no need to retry again.
     rpc_status = ThriftRpcHelper::rpc<FrontendServiceClient>(
             fe_addr, [&res, &params](FrontendServiceConnection& client) { client->reportExecStatus(res, params); },
-            config::thrift_rpc_timeout_ms);
+            config::thrift_rpc_timeout_ms, 1);
 
     if (rpc_status.ok()) {
         rpc_status = Status(res.status);

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -31,6 +31,7 @@
 namespace starrocks::pipeline {
 
 DEFINE_FAIL_POINT(operator_return_failed_status);
+DEFINE_FAIL_POINT(report_exec_state_failed_status);
 
 GlobalDriverExecutor::GlobalDriverExecutor(const std::string& name, std::unique_ptr<ThreadPool> thread_pool,
                                            bool enable_resource_group, const CpuUtil::CpuIds& cpuids,
@@ -359,15 +360,24 @@ void GlobalDriverExecutor::report_exec_state(QueryContext* query_ctx, FragmentCo
 
     auto report_task = [params, exec_env, fe_addr, fragment_id]() {
         int retry_times = 0;
-        while (retry_times++ < 3) {
+        int max_retry_times = config::report_exec_rpc_request_retry_num;
+        while (retry_times++ < max_retry_times) {
             auto status = ExecStateReporter::report_exec_status(*params, exec_env, fe_addr);
+
+            FAIL_POINT_TRIGGER_EXECUTE(report_exec_state_failed_status, {
+                if (status.ok()) {
+                    status = Status::InternalError("injected failed status");
+                }
+            });
+
             if (!status.ok()) {
                 if (status.is_not_found()) {
                     VLOG(1) << "[Driver] Fail to report exec state due to query not found: fragment_instance_id="
                             << print_id(fragment_id);
                 } else {
                     LOG(WARNING) << "[Driver] Fail to report exec state: fragment_instance_id=" << print_id(fragment_id)
-                                 << ", status: " << status.to_string() << ", retry_times=" << retry_times;
+                                 << ", status: " << status.to_string() << ", retry_times=" << retry_times
+                                 << ", max_retry_times=" << max_retry_times;
                     // if it is done exec state report, we should retry
                     if (params->__isset.done && params->done) {
                         continue;

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -721,7 +721,7 @@ void FragmentMgr::report_fragments(const std::vector<TUniqueId>& non_pipeline_ne
                     config::thrift_rpc_timeout_ms);
 
             if (!rpc_status.ok()) {
-                LOG(WARNING) << "thrift rpc error:" << rpc_status;
+                LOG(WARNING) << "batch report exec status rpc error:" << rpc_status;
                 continue;
             }
 

--- a/be/src/runtime/profile_report_worker.cpp
+++ b/be/src/runtime/profile_report_worker.cpp
@@ -110,15 +110,16 @@ void ProfileReportWorker::_start_report_profile() {
 void ProfileReportWorker::execute() {
     LOG(INFO) << "ProfileReportWorker start working.";
 
-    int32_t interval = config::profile_report_interval;
-
     while (!_stop.load(std::memory_order_consume)) {
         _start_report_profile();
 
+        // interval can be changed by config dynamically
+        int32_t interval = config::profile_report_interval;
         if (interval <= 0) {
             LOG(WARNING) << "profile_report_interval config is illegal: " << interval << ", force set to 1";
             interval = 1;
         }
+
         nap_sleep(interval, [this] { return _stop.load(std::memory_order_consume); });
     }
     LOG(INFO) << "ProfileReportWorker going to exit.";

--- a/be/src/util/thrift_rpc_helper.cpp
+++ b/be/src/util/thrift_rpc_helper.cpp
@@ -115,12 +115,14 @@ Status ThriftRpcHelper::rpc(const std::string& ip, const int32_t port,
         if (status.ok()) {
             return Status::OK();
         }
-        LOG(WARNING) << status;
+        LOG(WARNING) << "rpc failed: " << status << ", retry times: " << i << "/" << retry_times
+                     << ", address=" << address << ", timeout_ms=" << timeout_ms;
         SleepFor(MonoDelta::FromMilliseconds(config::thrift_client_retry_interval_ms));
         // reopen failure will disable this connection to prevent it from being used again.
         auto st = client.reopen(timeout_ms);
         if (!st.ok()) {
-            LOG(WARNING) << "client reopen failed. address=" << address << ", status=" << st.message();
+            LOG(WARNING) << "rpc client reopen failed. address=" << address << ", status=" << st.message()
+                         << ", retry times: " << i << "/" << retry_times;
             break;
         }
     } while (i++ < retry_times);

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -5258,3 +5258,12 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Is mutable: No
 - Description: The maximum length of input values for bitmap functions.
 - Introduced in: -
+
+##### report_exec_rpc_request_retry_num
+
+- Default: 10
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: The retry times of rpc request to report exec rpc request to FE. The default value is 10, which means that the rpc request will be retried 10 times if it fails only if it's fragment instatnce finish rpc. Report exec rpc request is important for load job, if one fragment instance finish report failed, the load job will be hang until timeout.
+- Introduced in: -

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -5250,3 +5250,12 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 是否动态：否
 - 描述：bitmap 函数输入值的最大长度。
 - 引入版本：-
+
+##### report_exec_rpc_request_retry_num
+
+- 默认值：10
+- 类型: Int
+- 单位：-
+- 是否动态：是
+- 描述：用于向 FE 汇报执行状态的 RPC 请求的重试次数。默认值为 10，意味着如果该 RPC 请求失败（仅限于 fragment instance 的 finish RPC），将最多重试 10 次。该请求对于导入任务（load job）非常重要，如果某个 fragment instance 的完成状态报告失败，整个导入任务将会一直挂起，直到超时。
+-引入版本：-

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -1094,63 +1094,31 @@ public class DefaultCoordinator extends Coordinator {
         // The exec status would affect query schedule, so it must be updated no matter what exceptions happen.
         // Otherwise, the query might hang until timeout
         if (!execState.updateExecStatus(params)) {
+            LOG.info("duplicate report fragment exec status, query id: {}, instance id: {}, backend id: {}, " +
+                            "status: {}, exec state: {}",
+                    DebugUtil.printId(jobSpec.getQueryId()),
+                    DebugUtil.printId(params.getFragment_instance_id()),
+                    params.getBackend_id(), params.status, execState.getState());
             return;
         }
 
-        String instanceId = DebugUtil.printId(params.getFragment_instance_id());
+        final String instanceId = DebugUtil.printId(params.getFragment_instance_id());
+        final boolean isDone = params.isDone();
         // Create a CompletableFuture chain for handling updates
-        CompletableFuture<Void> future = CompletableFuture.completedFuture(null)
+        final CompletableFuture<Void> future = CompletableFuture.completedFuture(null)
                 .thenRun(() -> {
                     try {
-                        queryProfile.updateProfile(execState, params);
-                        execState.updateRunningProfile(params);
+                        updateRuntimeProfile(params, execState, instanceId);
                     } catch (Throwable e) {
-                        LOG.warn("update profile failed {}", instanceId, e);
+                        LOG.warn("update runtime profile failed {}", instanceId, e);
                     }
                 })
                 .thenRun(() -> {
-                    try {
-                        lock();
-                        queryProfile.updateLoadChannelProfile(params);
-                    } catch (Throwable e) {
-                        LOG.warn("update load channel profile failed {}", instanceId, e);
-                    } finally {
-                        unlock();
+                    // update load info if it's a isDone rpc
+                    if (isDone && execState.isFinished()) {
+                        updateFinishInstance(params, execState, instanceId);
                     }
                 })
-                .thenRun(() -> {
-                    Status status = new Status(params.status);
-                    if (!(returnedAllResults && status.isCancelled()) && !status.ok()) {
-                        ConnectContext ctx = connectContext;
-                        if (ctx != null) {
-                            ctx.setErrorCodeOnce(status.getErrorCodeString());
-                        }
-                        LOG.warn("exec state report failed status={}, query_id={}, instance_id={}, backend_id={}",
-                                status, DebugUtil.printId(jobSpec.getQueryId()),
-                                DebugUtil.printId(params.getFragment_instance_id()),
-                                params.getBackend_id());
-                        updateStatus(status, params.getFragment_instance_id());
-                    }
-                })
-                .thenRun(() -> {
-                    if (execState.isFinished()) {
-                        try {
-                            lock();
-                            queryProfile.updateLoadInformation(execState, params);
-                        } catch (Throwable e) {
-                            LOG.warn("update load information failed {}", instanceId, e);
-                        } finally {
-                            unlock();
-                        }
-                    }
-                })
-                .thenRun(() -> {
-                    // NOTE: it's critical for query execution, and must be put after the profile update
-                    if (execState.isFinished()) {
-                        queryProfile.finishInstance(params.getFragment_instance_id());
-                    }
-                })
-                .thenRun(() -> updateJobProgress(params))
                 .handle((result, ex) -> {
                     // all block are independent, continue the execution no matter what exception happen
                     if (ex != null) {
@@ -1165,6 +1133,77 @@ public class DefaultCoordinator extends Coordinator {
         } catch (Exception e) {
             LOG.warn("Error occurred during updateFragmentExecStatus {}", instanceId, e);
         }
+    }
+
+    /**
+     * Update runtime profile and load profile no matter the input params is a finish or runtime profile
+     */
+    private void updateRuntimeProfile(TReportExecStatusParams params,
+                                      FragmentInstanceExecState execState,
+                                      String instanceId) {
+        // update profile
+        try {
+            queryProfile.updateProfile(execState, params);
+            execState.updateRunningProfile(params);
+        } catch (Throwable e) {
+            LOG.warn("update profile failed {}", instanceId, e);
+        }
+
+        // update load profile
+        try {
+            lock();
+            queryProfile.updateLoadChannelProfile(params);
+        } catch (Throwable e) {
+            LOG.warn("update load channel profile failed {}", instanceId, e);
+        } finally {
+            unlock();
+        }
+
+        // update job progress
+        try {
+            updateJobProgress(params);
+        } catch (Throwable e) {
+            LOG.warn("update job progress failed {}", instanceId, e);
+        }
+
+        // update status
+        Status status = new Status(params.status);
+        if (!(returnedAllResults && status.isCancelled()) && !status.ok()) {
+            ConnectContext ctx = connectContext;
+            if (ctx != null) {
+                ctx.setErrorCodeOnce(status.getErrorCodeString());
+            }
+            LOG.warn("exec state report failed status={}, query_id={}, instance_id={}, backend_id={}",
+                    status, DebugUtil.printId(jobSpec.getQueryId()),
+                    DebugUtil.printId(params.getFragment_instance_id()),
+                    params.getBackend_id());
+            updateStatus(status, params.getFragment_instance_id());
+        }
+    }
+
+    /**
+     * Update the instance only if the instance is finished.
+     */
+    private void updateFinishInstance(TReportExecStatusParams params,
+                                      FragmentInstanceExecState execState,
+                                      String instanceId) {
+        // For DML jobs, finishInstance is ensured to be called only after instance finished and should not be
+        // called repeatedly. Otherwise, it will cause commit with wrong commit info.
+        if (jobSpec.isLoadType() && execState.getState().isFinished() && queryProfile.isFinished()) {
+            throw new RuntimeException(String.format("updateFinishInstance called after fragment instatnce is finished:%s, query_id:%s",
+                    instanceId, DebugUtil.printId(params.getQuery_id())));
+        }
+        try {
+            lock();
+            queryProfile.updateLoadInformation(execState, params);
+        } catch (Throwable e) {
+            LOG.warn("update load information failed {}", instanceId, e);
+        } finally {
+            unlock();
+        }
+
+        // NOTE: it's critical for query execution, and must be put after the profile update
+        queryProfile.finishInstance(params.getFragment_instance_id());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -1190,7 +1190,7 @@ public class DefaultCoordinator extends Coordinator {
         // For DML jobs, finishInstance is ensured to be called only after instance finished and should not be
         // called repeatedly. Otherwise, it will cause commit with wrong commit info.
         if (jobSpec.isLoadType() && execState.getState().isFinished() && queryProfile.isFinished()) {
-            throw new RuntimeException(String.format("updateFinishInstance called after fragment instatnce is finished:%s, query_id:%s",
+            throw new RuntimeException(String.format("updateFinishInstance called after fragment is finished:%s, query_id:%s",
                     instanceId, DebugUtil.printId(params.getQuery_id())));
         }
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
@@ -129,14 +129,14 @@ public class QueryRuntimeProfile {
     // ------------------------------------------------------------------------------------
     // Fields for export.
     // ------------------------------------------------------------------------------------
-    private final List<String> exportFiles = Lists.newArrayList();
-    private final List<TTabletCommitInfo> commitInfos = Lists.newArrayList();
-    private final List<TTabletFailInfo> failInfos = Lists.newArrayList();
+    private final List<String> exportFiles = Lists.newCopyOnWriteArrayList();
+    private final List<TTabletCommitInfo> commitInfos = Lists.newCopyOnWriteArrayList();
+    private final List<TTabletFailInfo> failInfos = Lists.newCopyOnWriteArrayList();
 
     // ------------------------------------------------------------------------------------
     // Fields for external table sink
     // ------------------------------------------------------------------------------------
-    private final List<TSinkCommitInfo> sinkCommitInfos = Lists.newArrayList();
+    private final List<TSinkCommitInfo> sinkCommitInfos = Lists.newCopyOnWriteArrayList();
 
     // Fields for datacache
     private final DataCacheSelectMetrics dataCacheSelectMetrics = new DataCacheSelectMetrics();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
@@ -75,7 +75,7 @@ import java.util.stream.Collectors;
 public class FragmentInstanceExecState {
     private static final Logger LOG = LogManager.getLogger(FragmentInstanceExecState.class);
 
-    private State state = State.CREATED;
+    private volatile State state = State.CREATED;
 
     private final JobSpec jobSpec;
     private final PlanFragmentId fragmentId;
@@ -479,6 +479,10 @@ public class FragmentInstanceExecState {
         }
     }
 
+    public State getState() {
+        return state;
+    }
+
     public enum State {
         CREATED,
         DEPLOYING,
@@ -494,6 +498,10 @@ public class FragmentInstanceExecState {
 
         public boolean isTerminal() {
             return this == FINISHED || this == FAILED;
+        }
+
+        public boolean isFinished() {
+            return this == FINISHED;
         }
     }
 

--- a/test/sql/test_insert_overwrite/R/test_insert_with_profile
+++ b/test/sql/test_insert_overwrite/R/test_insert_with_profile
@@ -1,0 +1,56 @@
+-- name: test_insert_with_profile
+create table t1(k int) 
+distributed by hash(k) buckets 96;
+-- result:
+-- !result
+create table t2(k int) 
+distributed by hash(k) buckets 96;
+-- result:
+-- !result
+set enable_profile=true;
+-- result:
+-- !result
+set big_query_profile_threshold='1s';
+-- result:
+-- !result
+set runtime_profile_report_interval=1;
+-- result:
+-- !result
+set pipeline_dop=96;
+-- result:
+-- !result
+insert into t1 select * from TABLE(generate_series(0, 10));
+-- result:
+-- !result
+select count(*) from t1;
+-- result:
+11
+-- !result
+admin enable failpoint 'report_exec_state_failed_status';
+-- result:
+-- !result
+insert into t2 select a.k from t1 a join t1 b on a.k = b.k where a.k = 0 and b.k = 0;
+-- result:
+-- !result
+insert into t2 select a.k from t1 a join t1 b on a.k = b.k where a.k = 0 and b.k = 0;
+-- result:
+-- !result
+insert into t2 select a.k from t1 a join t1 b on a.k = b.k where a.k = 0 and b.k = 0;
+-- result:
+-- !result
+insert into t2 select a.k from t1 a join t1 b on a.k = b.k where a.k = 0 and b.k = 0;
+-- result:
+-- !result
+insert into t2 select a.k from t1 a join t1 b on a.k = b.k where a.k = 0 and b.k = 0;
+-- result:
+-- !result
+insert into t2 select a.k from t1 a join t1 b on a.k = b.k where a.k = 0 and b.k = 0;
+-- result:
+-- !result
+insert into t2 select a.k from t1 a join t1 b on a.k = b.k where a.k = 0 and b.k = 0;
+-- result:
+-- !result
+select count(*) from t2;
+-- result:
+7
+-- !result

--- a/test/sql/test_insert_overwrite/T/test_insert_with_profile
+++ b/test/sql/test_insert_overwrite/T/test_insert_with_profile
@@ -1,0 +1,26 @@
+-- name: test_insert_with_profile
+create table t1(k int) 
+distributed by hash(k) buckets 96;
+
+create table t2(k int) 
+distributed by hash(k) buckets 96;
+
+set enable_profile=true;
+set big_query_profile_threshold='1s';
+set runtime_profile_report_interval=1;
+set pipeline_dop=96;
+
+insert into t1 select * from TABLE(generate_series(0, 10));
+select count(*) from t1;
+
+admin enable failpoint 'report_exec_state_failed_status';
+
+insert into t2 select a.k from t1 a join t1 b on a.k = b.k where a.k = 0 and b.k = 0;
+insert into t2 select a.k from t1 a join t1 b on a.k = b.k where a.k = 0 and b.k = 0;
+insert into t2 select a.k from t1 a join t1 b on a.k = b.k where a.k = 0 and b.k = 0;
+insert into t2 select a.k from t1 a join t1 b on a.k = b.k where a.k = 0 and b.k = 0;
+insert into t2 select a.k from t1 a join t1 b on a.k = b.k where a.k = 0 and b.k = 0;
+insert into t2 select a.k from t1 a join t1 b on a.k = b.k where a.k = 0 and b.k = 0;
+insert into t2 select a.k from t1 a join t1 b on a.k = b.k where a.k = 0 and b.k = 0;
+
+select count(*) from t2;


### PR DESCRIPTION
## Why I'm doing:

I found a bug which one instance may call `finishInstance` multi times which may cause `profileDoneSignal`'s count down incorrect:
```
❯ grep c0ae89be-283f-11f0-9ec2-0050569a5b3f fe.log.20250504-5
2025-05-04 00:57:52.926+08:00 INFO (starrocks-mysql-nio-pool-16578|16034887) [QueryRuntimeProfile.attachInstances():227] Attach instances, query_id: c0ae89be-283f-11f0-9ec2-0050569a5b3b, instance_size: 8, instance_ids: [c0ae89be-283f-11f0-9ec2-0050569a5b3d, c0ae89be-283f-11f0-9ec2-0050569a5b3e, c0ae89be-283f-11f0-9ec2-0050569a5b3f, c0ae89be-283f-11f0-9ec2-0050569a5b40, c0ae89be-283f-11f0-9ec2-0050569a5b41, c0ae89be-283f-11f0-9ec2-0050569a5b42, c0ae89be-283f-11f0-9ec2-0050569a5b43, c0ae89be-283f-11f0-9ec2-0050569a5b3c]
2025-05-04 00:58:44.524+08:00 INFO (thrift-server-pool-7638300|16089094) [QueryRuntimeProfile.updateLoadInformation():417] Update load information, instance_id: c0ae89be-283f-11f0-9ec2-0050569a5b3f, query_id: c0ae89be-283f-11f0-9ec2-0050569a5b3b
2025-05-04 00:58:44.528+08:00 INFO (thrift-server-pool-7638300|16089094) [QueryRuntimeProfile.finishInstance():252] Finish instances, query_id: c0ae89be-283f-11f0-9ec2-0050569a5b3b, instance_id: c0ae89be-283f-11f0-9ec2-0050569a5b3f, count: 1
2025-05-04 00:58:44.530+08:00 INFO (thrift-server-pool-7637970|16088233) [QueryRuntimeProfile.updateLoadInformation():417] Update load information, instance_id: c0ae89be-283f-11f0-9ec2-0050569a5b3f, query_id: c0ae89be-283f-11f0-9ec2-0050569a5b3b
2025-05-04 00:58:44.530+08:00 INFO (thrift-server-pool-7637970|16088233) [QueryRuntimeProfile.finishInstance():252] Finish instances, query_id: c0ae89be-283f-11f0-9ec2-0050569a5b3b, instance_id: c0ae89be-283f-11f0-9ec2-0050569a5b3f, count: 0
2025-05-04 00:58:44.535+08:00 INFO (thrift-server-pool-7638370|16089454) [QueryRuntimeProfile.updateLoadInformation():417] Update load information, instance_id: c0ae89be-283f-11f0-9ec2-0050569a5b3f, query_id: c0ae89be-283f-11f0-9ec2-0050569a5b3b
2025-05-04 00:58:44.535+08:00 INFO (thrift-server-pool-7638370|16089454) [QueryRuntimeProfile.finishInstance():252] Finish instances, query_id: c0ae89be-283f-11f0-9ec2-0050569a5b3b, instance_id: c0ae89be-283f-11f0-9ec2-0050569a5b3f, count: 0
2025-05-04 00:58:44.537+08:00 INFO (thrift-server-pool-7638239|16088912) [QueryRuntimeProfile.updateLoadInformation():417] Update load information, instance_id: c0ae89be-283f-11f0-9ec2-0050569a5b3f, query_id: c0ae89be-283f-11f0-9ec2-0050569a5b3b
2025-05-04 00:58:44.537+08:00 INFO (thrift-server-pool-7638239|16088912) [DefaultCoordinator.lambda$updateFragmentExecStatus$10():1023] update load information successfully, tablet commit info size: 5, instanceId: c0ae89be-283f-11f0-9ec2-0050569a5b3f, query id: c0ae89be-283f-11f0-9ec2-0050569a5b3b
2025-05-04 00:58:44.537+08:00 INFO (thrift-server-pool-7638239|16088912) [QueryRuntimeProfile.finishInstance():252] Finish instances, query_id: c0ae89be-283f-11f0-9ec2-0050569a5b3b, instance_id: c0ae89be-283f-11f0-9ec2-0050569a5b3f, count: 0

```

And `updateExecStatus` is not safe: when `params.isDone()` is `false` which means it's a runtime profile report, it may also call `finishInstance` in `updateFragmentExecStatus`:
```
    /**
     * Update the execution state and profile from the report RPC.
     *
     * @param params The report RPC request.
     * @return true if the state is updated. Otherwise, return false.
     */
    public synchronized boolean updateExecStatus(TReportExecStatusParams params) {
        switch (state) {
            case CREATED:
            case FINISHED: // duplicate packet
            case FAILED:
                return false;
            case DEPLOYING:
            case EXECUTING:
            case CANCELLING:
            default:
                if (params.isDone()) {
                    if (params.getStatus() == null || params.getStatus().getStatus_code() == TStatusCode.OK) {
                        transitionState(State.FINISHED);
                    } else {
                        transitionState(State.FAILED);
                    }
                }
                return true;
        }
    }
```

## What I'm doing:
1. Fix `updateExecStatus` to distinguish requests with  `isDone=false` and `isDone=true`;
2. Split `updateFragmentExecStatus` into `updateRuntimeProfile` and `updateFinishInstance` to separate `isDone=false` and `isDone=true`' request.
3. Add `report_exec_state_failed_status` failpoint to mock rpc fails.
4. Change `report_exec_status`'s retry time to 1 since the caller(report_exec_state) has already retried 3 times, we don't need to retry again;
5. Add `report_exec_rpc_request_retry_num` to control report rpc retry number;
6.   For DML jobs, finishInstance is ensured to be called only after instance finished and should not be called repeatedly. Otherwise, it will cause commit with wrong commit info.


Fixes 
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1