### PR TITLE
[Refactor] Move the interfaces related to metrics from BlockCache to LocalCache(StarCache).

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -48,8 +48,8 @@
 #include "agent/report_task.h"
 #include "agent/resource_group_usage_recorder.h"
 #include "agent/task_signatures_manager.h"
-#include "cache/block_cache/block_cache.h"
 #include "cache/block_cache/datacache_utils.h"
+#include "cache/block_cache/local_cache.h"
 #include "common/status.h"
 #include "exec/pipeline/query_context.h"
 #include "exec/workgroup/work_group.h"
@@ -839,9 +839,9 @@ void* ReportDataCacheMetricsTaskWorkerPool::_worker_thread_callback(void* arg_th
         request.__set_report_version(g_report_version.load(std::memory_order_relaxed));
 
         TDataCacheMetrics t_metrics{};
-        const BlockCache* cache = BlockCache::instance();
-        if (cache->is_initialized()) {
-            const DataCacheMetrics& metrics = cache->cache_metrics();
+        const LocalCache* cache = CacheEnv::GetInstance()->local_cache();
+        if (cache != nullptr && cache->is_initialized()) {
+            const DataCacheMetrics& metrics = cache->cache_metrics(0);
             DataCacheUtils::set_metrics_from_thrift(t_metrics, metrics);
         } else {
             t_metrics.__set_status(TDataCacheStatus::DISABLED);

--- a/be/src/bench/object_cache_bench.cpp
+++ b/be/src/bench/object_cache_bench.cpp
@@ -17,8 +17,8 @@
 #include <cstdlib>
 #include <random>
 
-#include "cache/block_cache/block_cache.h"
 #include "cache/block_cache/cache_options.h"
+#include "cache/block_cache/starcache_wrapper.h"
 #include "cache/object_cache/lrucache_module.h"
 #include "cache/object_cache/starcache_module.h"
 #include "common/config.h"
@@ -71,7 +71,7 @@ private:
     size_t _capacity = 100L * 1024 * 1024 * 1024;
     size_t _page_size = 1024;
 
-    std::shared_ptr<BlockCache> _block_cache;
+    std::shared_ptr<StarCacheWrapper> _local_cache;
     std::shared_ptr<LRUCacheModule> _lru_cache;
     std::shared_ptr<StarCacheModule> _star_cache;
 };
@@ -131,13 +131,13 @@ void ObjectCacheBench::init_cache(CacheType cache_type) {
         opt.engine = "starcache";
         opt.eviction_policy = config::datacache_eviction_policy;
 
-        _block_cache = std::make_shared<BlockCache>();
-        Status st = _block_cache->init(opt);
+        _local_cache = std::make_shared<StarCacheWrapper>();
+        Status st = _local_cache->init(opt);
         if (!st.ok()) {
             LOG(FATAL) << "init star cache failed: " << st;
         }
 
-        _star_cache = std::make_shared<StarCacheModule>(_block_cache->starcache_instance());
+        _star_cache = std::make_shared<StarCacheModule>(_local_cache->starcache_instance());
         LOG(INFO) << "init star cache succ";
     }
 }

--- a/be/src/cache/block_cache/block_cache.h
+++ b/be/src/cache/block_cache/block_cache.h
@@ -55,25 +55,15 @@ public:
     // Remove data from cache. The offset and size must be aligned by block size
     Status remove(const CacheKey& cache_key, off_t offset, size_t size);
 
-    // Update the datacache memory quota.
-    Status update_mem_quota(size_t quota_bytes, bool flush_to_disk);
-
-    // Update the datacache disk space infomation, such as disk quota or disk path.
-    Status update_disk_spaces(const std::vector<DirSpace>& spaces);
-
-    // Get datacache metrics.
-    // The level can be: 0, 1, 2. The higher the level, more detailed metrics will be returned.
-    const DataCacheMetrics cache_metrics(int level = 0) const;
-
     // Read data from remote cache
     Status read_buffer_from_remote_cache(const std::string& cache_key, size_t offset, size_t size, IOBuffer* buffer,
                                          ReadCacheOptions* options);
 
-    void record_read_local_cache(size_t size, int64_t lateny_us);
+    void record_read_local_cache(size_t size, int64_t latency_us);
 
-    void record_read_remote_cache(size_t size, int64_t lateny_us);
+    void record_read_remote_cache(size_t size, int64_t latency_us);
 
-    void record_read_remote_storage(size_t size, int64_t lateny_us, bool local_only);
+    void record_read_remote_storage(size_t size, int64_t latency_us, bool local_only);
 
     // Shutdown the cache instance to save some state meta
     Status shutdown();
@@ -82,34 +72,19 @@ public:
 
     bool is_initialized() const { return _initialized.load(std::memory_order_relaxed); }
 
-    bool has_mem_cache() const { return _mem_quota.load(std::memory_order_relaxed) > 0; }
+    bool available() const { return is_initialized() && _local_cache->available(); }
+    bool mem_cache_available() const { return is_initialized() && _local_cache->mem_cache_available(); }
 
-    bool has_disk_cache() const { return _disk_quota.load(std::memory_order_relaxed) > 0; }
-
-    bool available() const { return is_initialized() && (has_mem_cache() || has_disk_cache()); }
-    bool mem_cache_available() const { return is_initialized() && has_mem_cache(); }
-
-    void disk_spaces(std::vector<DirSpace>* spaces);
-
-    DataCacheEngineType engine_type();
-
-#ifdef WITH_STARCACHE
-    std::shared_ptr<starcache::StarCache> starcache_instance() { return _local_cache->starcache_instance(); }
-#endif
+    std::shared_ptr<LocalCache> local_cache() { return _local_cache; }
 
     static const size_t MAX_BLOCK_SIZE;
 
 private:
-    void _refresh_quota();
-
     size_t _block_size = 0;
     std::shared_ptr<LocalCache> _local_cache;
     std::shared_ptr<RemoteCache> _remote_cache;
     std::unique_ptr<DiskSpaceMonitor> _disk_space_monitor;
-    std::vector<std::string> _disk_paths;
     std::atomic<bool> _initialized = false;
-    std::atomic<size_t> _mem_quota = 0;
-    std::atomic<size_t> _disk_quota = 0;
 };
 
 } // namespace starrocks

--- a/be/src/cache/block_cache/disk_space_monitor.cpp
+++ b/be/src/cache/block_cache/disk_space_monitor.cpp
@@ -225,8 +225,11 @@ dev_t DiskSpace::FileSystemWrapper::device_id(const std::string& path) {
     return DataCacheUtils::disk_device_id(path);
 }
 
-DiskSpaceMonitor::DiskSpaceMonitor(BlockCache* cache)
+DiskSpaceMonitor::DiskSpaceMonitor(LocalCache* cache)
         : _cache(cache), _fs(std::make_shared<DiskSpace::FileSystemWrapper>()) {}
+
+DiskSpaceMonitor::DiskSpaceMonitor(LocalCache* cache, std::shared_ptr<DiskSpace::FileSystemWrapper> fs)
+        : _cache(cache), _fs(std::move(fs)) {}
 
 DiskSpaceMonitor::~DiskSpaceMonitor() {
     stop();
@@ -351,7 +354,7 @@ std::string DiskSpaceMonitor::to_string(const std::vector<DirSpace>& dir_spaces)
 }
 
 void DiskSpaceMonitor::_update_cache_stats() {
-    const auto metrics = _cache->cache_metrics();
+    const auto metrics = _cache->cache_metrics(0);
     _total_cache_usage = metrics.disk_used_bytes;
     _total_cache_quota = metrics.disk_quota_bytes;
 }

--- a/be/src/cache/block_cache/disk_space_monitor.h
+++ b/be/src/cache/block_cache/disk_space_monitor.h
@@ -20,6 +20,7 @@
 #include <unordered_map>
 
 #include "cache/block_cache/cache_options.h"
+#include "cache/block_cache/local_cache.h"
 #include "common/status.h"
 #include "fs/fs.h"
 #include "util/disk_info.h"
@@ -116,7 +117,8 @@ private:
 
 class DiskSpaceMonitor {
 public:
-    DiskSpaceMonitor(BlockCache* cache);
+    DiskSpaceMonitor(LocalCache* cache);
+    DiskSpaceMonitor(LocalCache* cache, std::shared_ptr<DiskSpace::FileSystemWrapper> fs);
     ~DiskSpaceMonitor();
 
     Status init(std::vector<DirSpace>* dir_spaces);
@@ -149,7 +151,7 @@ private:
 
     size_t _total_cache_usage = 0;
     size_t _total_cache_quota = 0;
-    BlockCache* _cache = nullptr;
+    LocalCache* _cache = nullptr;
     std::shared_ptr<DiskSpace::FileSystemWrapper> _fs = nullptr;
 };
 

--- a/be/src/cache/block_cache/local_cache.h
+++ b/be/src/cache/block_cache/local_cache.h
@@ -28,6 +28,7 @@ public:
 
     // Init KV cache
     virtual Status init(const CacheOptions& options) = 0;
+    virtual bool is_initialized() const = 0;
 
     // Write data to cache
     virtual Status write(const std::string& key, const IOBuffer& buffer, WriteCacheOptions* options) = 0;
@@ -45,14 +46,14 @@ public:
     // Update the datacache memory quota.
     virtual Status update_mem_quota(size_t quota_bytes, bool flush_to_disk) = 0;
 
-    // Update the datacache disk space infomation, such as disk quota or disk path.
+    // Update the datacache disk space information, such as disk quota or disk path.
     virtual Status update_disk_spaces(const std::vector<DirSpace>& spaces) = 0;
 
-    virtual const DataCacheMetrics cache_metrics(int level) = 0;
+    virtual const DataCacheMetrics cache_metrics(int level) const = 0;
 
-    virtual void record_read_remote(size_t size, int64_t lateny_us) = 0;
+    virtual void record_read_remote(size_t size, int64_t latency_us) = 0;
 
-    virtual void record_read_cache(size_t size, int64_t lateny_us) = 0;
+    virtual void record_read_cache(size_t size, int64_t latency_us) = 0;
 
     virtual Status shutdown() = 0;
 
@@ -61,6 +62,10 @@ public:
 #ifdef WITH_STARCACHE
     virtual std::shared_ptr<starcache::StarCache> starcache_instance() = 0;
 #endif
+
+    virtual bool available() const = 0;
+    virtual bool mem_cache_available() const = 0;
+    virtual void disk_spaces(std::vector<DirSpace>* spaces) const = 0;
 };
 
 } // namespace starrocks

--- a/be/src/cache/block_cache/starcache_wrapper.cpp
+++ b/be/src/cache/block_cache/starcache_wrapper.cpp
@@ -56,7 +56,11 @@ Status StarCacheWrapper::init(const CacheOptions& options) {
     _enable_tiered_cache = options.enable_tiered_cache;
     _enable_datacache_persistence = options.enable_datacache_persistence;
     _cache = std::make_shared<starcache::StarCache>();
-    return to_status(_cache->init(opt));
+    RETURN_IF_ERROR(to_status(_cache->init(opt)));
+
+    _refresh_quota();
+    _initialized.store(true, std::memory_order_relaxed);
+    return Status::OK();
 }
 
 Status StarCacheWrapper::write(const std::string& key, const IOBuffer& buffer, WriteCacheOptions* options) {
@@ -120,7 +124,9 @@ Status StarCacheWrapper::remove(const std::string& key) {
 }
 
 Status StarCacheWrapper::update_mem_quota(size_t quota_bytes, bool flush_to_disk) {
-    return to_status(_cache->update_mem_quota(quota_bytes, flush_to_disk));
+    Status st = to_status(_cache->update_mem_quota(quota_bytes, flush_to_disk));
+    _refresh_quota();
+    return st;
 }
 
 Status StarCacheWrapper::update_disk_spaces(const std::vector<DirSpace>& spaces) {
@@ -129,14 +135,16 @@ Status StarCacheWrapper::update_disk_spaces(const std::vector<DirSpace>& spaces)
     for (auto& dir : spaces) {
         disk_spaces.push_back({.path = dir.path, .quota_bytes = dir.size});
     }
-    return to_status(_cache->update_disk_spaces(disk_spaces));
+    Status st = to_status(_cache->update_disk_spaces(disk_spaces));
+    _refresh_quota();
+    return st;
 }
 
-const DataCacheMetrics StarCacheWrapper::cache_metrics(int level) {
+const DataCacheMetrics StarCacheWrapper::cache_metrics(int level) const {
     auto metrics = _cache->metrics(level);
-    // Now the EEXIST is treated as an failed status in starcache, which will cause the write_fail_count too large
+    // Now the EEXIST is treated as a failed status in starcache, which will cause the write_fail_count too large
     // in many cases because we write cache with `overwrite=false` now. It makes users confused.
-    // As real writing failure rarely occursso currently, so we temporarily adjust it here.
+    // As real writing failure rarely occur currently, so we temporarily adjust it here.
     // Once the starcache library is update, the following lines will be removed.
     if (metrics.detail_l2) {
         metrics.detail_l2->write_success_count += metrics.detail_l2->write_fail_count;
@@ -145,21 +153,35 @@ const DataCacheMetrics StarCacheWrapper::cache_metrics(int level) {
     return metrics;
 }
 
-void StarCacheWrapper::record_read_remote(size_t size, int64_t lateny_us) {
+void StarCacheWrapper::record_read_remote(size_t size, int64_t latency_us) {
     if (_cache_adaptor) {
-        return _cache_adaptor->record_read_remote(size, lateny_us);
+        return _cache_adaptor->record_read_remote(size, latency_us);
     }
 }
 
-void StarCacheWrapper::record_read_cache(size_t size, int64_t lateny_us) {
+void StarCacheWrapper::record_read_cache(size_t size, int64_t latency_us) {
     if (_cache_adaptor) {
-        return _cache_adaptor->record_read_cache(size, lateny_us);
+        return _cache_adaptor->record_read_cache(size, latency_us);
     }
 }
 
 Status StarCacheWrapper::shutdown() {
     // TODO: starcache implement shutdown to release memory
     return Status::OK();
+}
+
+void StarCacheWrapper::_refresh_quota() {
+    auto metrics = cache_metrics(0);
+    _mem_quota.store(metrics.mem_quota_bytes, std::memory_order_relaxed);
+    _disk_quota.store(metrics.disk_quota_bytes, std::memory_order_relaxed);
+}
+
+void StarCacheWrapper::disk_spaces(std::vector<DirSpace>* spaces) const {
+    spaces->clear();
+    auto metrics = cache_metrics(0);
+    for (auto& dir : metrics.disk_dir_spaces) {
+        spaces->push_back({.path = dir.path, .size = dir.quota_bytes});
+    }
 }
 
 } // namespace starrocks

--- a/be/src/exec/schema_scanner/schema_be_datacache_metrics_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_datacache_metrics_scanner.cpp
@@ -15,9 +15,10 @@
 #include "exec/schema_scanner/schema_be_datacache_metrics_scanner.h"
 
 #include "agent/master_info.h"
-#include "cache/block_cache/block_cache.h"
+#include "cache/block_cache/local_cache.h"
 #include "column/datum.h"
 #include "gutil/strings/substitute.h"
+#include "runtime/exec_env.h"
 #include "runtime/string_value.h"
 
 namespace starrocks {
@@ -63,9 +64,9 @@ Status SchemaBeDataCacheMetricsScanner::get_next(ChunkPtr* chunk, bool* eos) {
 
     row.emplace_back(_be_id);
 
-    const BlockCache* cache = BlockCache::instance();
-    if (cache->is_initialized()) {
-        // retrive different priority's used bytes from level = 2 metrics
+    const LocalCache* cache = CacheEnv::GetInstance()->local_cache();
+    if (cache != nullptr && cache->is_initialized()) {
+        // retrieve different priority's used bytes from level = 2 metrics
         metrics = cache->cache_metrics(2);
 
         switch (metrics.status) {

--- a/be/src/http/action/datacache_action.cpp
+++ b/be/src/http/action/datacache_action.cpp
@@ -21,8 +21,8 @@
 
 #include <string>
 
-#include "cache/block_cache/block_cache.h"
 #include "cache/block_cache/block_cache_hit_rate_counter.hpp"
+#include "cache/block_cache/local_cache.h"
 #include "http/http_channel.h"
 #include "http/http_headers.h"
 #include "http/http_request.h"
@@ -71,9 +71,9 @@ void DataCacheAction::handle(HttpRequest* req) {
     if (!_check_request(req)) {
         return;
     }
-    if (!_block_cache || !_block_cache->is_initialized()) {
+    if (!_local_cache || !_local_cache->is_initialized()) {
         _handle_error(req, strings::Substitute("Cache system is not ready"));
-    } else if (_block_cache->engine_type() != DataCacheEngineType::STARCACHE) {
+    } else if (_local_cache->engine_type() != DataCacheEngineType::STARCACHE) {
         _handle_error(req, strings::Substitute("No more metrics for current cache engine type"));
     } else if (req->param(ACTION_KEY) == ACTION_STAT) {
         _handle_stat(req);
@@ -97,7 +97,7 @@ void DataCacheAction::_handle_stat(HttpRequest* req) {
     _handle(req, [=](rapidjson::Document& root) {
 #ifdef WITH_STARCACHE
         auto& allocator = root.GetAllocator();
-        auto&& metrics = _block_cache->cache_metrics(2);
+        auto&& metrics = _local_cache->cache_metrics(2);
         std::string status = cache_status_str(metrics.status);
 
         rapidjson::Value status_value;

--- a/be/src/http/action/datacache_action.h
+++ b/be/src/http/action/datacache_action.h
@@ -28,10 +28,10 @@
 
 namespace starrocks {
 
-class BlockCache;
+class LocalCache;
 class DataCacheAction : public HttpHandler {
 public:
-    explicit DataCacheAction(BlockCache* block_cache) : _block_cache(block_cache) {}
+    explicit DataCacheAction(LocalCache* local_cache) : _local_cache(local_cache) {}
     ~DataCacheAction() override = default;
 
     void handle(HttpRequest* req) override;
@@ -43,7 +43,7 @@ private:
     void _handle_app_stat(HttpRequest* req);
     void _handle_error(HttpRequest* req, const std::string& error_msg);
 
-    BlockCache* _block_cache;
+    LocalCache* _local_cache;
 };
 
 } // namespace starrocks

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -106,6 +106,11 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             return Status::OK();
         });
         _config_callback.emplace("datacache_mem_size", [&]() -> Status {
+            LocalCache* cache = CacheEnv::GetInstance()->local_cache();
+            if (cache == nullptr || !cache->is_initialized()) {
+                return Status::InternalError("Loacl cache is not initialized");
+            }
+
             size_t mem_size = 0;
             Status st = DataCacheUtils::parse_conf_datacache_mem_size(
                     config::datacache_mem_size, GlobalEnv::GetInstance()->process_mem_limit(), &mem_size);
@@ -113,11 +118,16 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
                 LOG(WARNING) << "Failed to update datacache mem size";
                 return st;
             }
-            return BlockCache::instance()->update_mem_quota(mem_size, true);
+            return cache->update_mem_quota(mem_size, true);
         });
         _config_callback.emplace("datacache_disk_size", [&]() -> Status {
+            LocalCache* cache = CacheEnv::GetInstance()->local_cache();
+            if (cache == nullptr || !cache->is_initialized()) {
+                return Status::InternalError("Local cache is not initialized");
+            }
+
             std::vector<DirSpace> spaces;
-            BlockCache::instance()->disk_spaces(&spaces);
+            cache->disk_spaces(&spaces);
             for (auto& space : spaces) {
                 ASSIGN_OR_RETURN(int64_t disk_size, DataCacheUtils::parse_conf_datacache_disk_size(
                                                             space.path, config::datacache_disk_size, -1));
@@ -127,7 +137,7 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
                 }
                 space.size = disk_size;
             }
-            return BlockCache::instance()->update_disk_spaces(spaces);
+            return cache->update_disk_spaces(spaces);
         });
         _config_callback.emplace("max_compaction_concurrency", [&]() -> Status {
             if (!config::enable_event_based_compaction_framework) {

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -108,7 +108,7 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
         _config_callback.emplace("datacache_mem_size", [&]() -> Status {
             LocalCache* cache = CacheEnv::GetInstance()->local_cache();
             if (cache == nullptr || !cache->is_initialized()) {
-                return Status::InternalError("Loacl cache is not initialized");
+                return Status::InternalError("Local cache is not initialized");
             }
 
             size_t mem_size = 0;

--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -57,9 +57,9 @@ Status SharedBufferedInputStream::_sort_and_check_overlap(std::vector<IORange>& 
     // check io range is not overlapped.
     for (size_t i = 1; i < ranges.size(); i++) {
         if (ranges[i].offset < (ranges[i - 1].offset + ranges[i - 1].size)) {
-            LOG(WARNING) << "io ranges are overalpped" << ranges[i].offset << " "
+            LOG(WARNING) << "io ranges are overlapped" << ranges[i].offset << " "
                          << ranges[i - 1].offset + ranges[i - 1].size;
-            return Status::RuntimeError("io ranges are overalpped");
+            return Status::RuntimeError("io ranges are overlapped");
         }
     }
 

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -252,6 +252,8 @@ public:
 
     void try_release_resource_before_core_dump();
 
+    void set_local_cache(std::shared_ptr<LocalCache> local_cache) { _local_cache = std::move(local_cache); }
+
     LocalCache* local_cache() { return _local_cache.get(); }
     BlockCache* block_cache() const { return _block_cache.get(); }
     ObjectCache* external_table_meta_cache() const { return _starcache_based_object_cache.get(); }

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -48,8 +48,8 @@
 #include "storage/options.h"
 #include "util/threadpool.h"
 // NOTE: Be careful about adding includes here. This file is included by many files.
-// Unnecssary includes will cause compilatio very slow.
-// So please consider use forward declaraion as much as possible.
+// Unnecessary includes will cause compilation very slow.
+// So please consider use forward declaration as much as possible.
 
 namespace starrocks {
 class AgentServer;
@@ -82,6 +82,7 @@ class ProfileReportWorker;
 class QuerySpillManager;
 class BlockCache;
 class ObjectCache;
+class LocalCache;
 class StoragePageCache;
 struct RfTracePoint;
 
@@ -251,6 +252,7 @@ public:
 
     void try_release_resource_before_core_dump();
 
+    LocalCache* local_cache() { return _local_cache.get(); }
     BlockCache* block_cache() const { return _block_cache.get(); }
     ObjectCache* external_table_meta_cache() const { return _starcache_based_object_cache.get(); }
     ObjectCache* external_table_page_cache() const { return _starcache_based_object_cache.get(); }
@@ -267,6 +269,8 @@ private:
 
     GlobalEnv* _global_env;
     std::vector<StorePath> _store_paths;
+
+    std::shared_ptr<LocalCache> _local_cache;
 
     std::shared_ptr<BlockCache> _block_cache;
     std::shared_ptr<ObjectCache> _starcache_based_object_cache;

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -513,10 +513,10 @@ void RuntimeState::update_load_datacache_metrics(TReportExecStatusParams* load_p
         }
 #endif // USE_STAROS
     } else {
-        const BlockCache* cache = BlockCache::instance();
-        if (cache->is_initialized()) {
+        const LocalCache* cache = CacheEnv::GetInstance()->local_cache();
+        if (cache != nullptr && cache->is_initialized()) {
             TDataCacheMetrics t_metrics{};
-            DataCacheUtils::set_metrics_from_thrift(t_metrics, cache->cache_metrics());
+            DataCacheUtils::set_metrics_from_thrift(t_metrics, cache->cache_metrics(0));
             metrics.__set_metrics(t_metrics);
             load_params->__set_load_datacache_metrics(metrics);
         }

--- a/be/src/service/service_be/http_service.cpp
+++ b/be/src/service/service_be/http_service.cpp
@@ -263,7 +263,7 @@ Status HttpServiceBE::start() {
     _ev_http_server->register_handler(HttpMethod::PUT, "/api/query_cache/{action}", query_cache_action);
     _http_handlers.emplace_back(query_cache_action);
 
-    auto* datacache_action = new DataCacheAction(_cache_env->block_cache());
+    auto* datacache_action = new DataCacheAction(_cache_env->local_cache());
     _ev_http_server->register_handler(HttpMethod::GET, "/api/datacache/{action}", datacache_action);
     _http_handlers.emplace_back(datacache_action);
 

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -120,9 +120,9 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     LOG(INFO) << process_name << " start step " << start_step++ << ": storage engine start bg threads successfully";
 
 #ifdef USE_STAROS
-    auto* block_cache = cache_env->block_cache();
-    if (config::datacache_unified_instance_enable && block_cache->is_initialized()) {
-        init_staros_worker(block_cache->starcache_instance());
+    auto* local_cache = cache_env->local_cache();
+    if (config::datacache_unified_instance_enable && local_cache->is_initialized()) {
+        init_staros_worker(local_cache->starcache_instance());
     } else {
         init_staros_worker(nullptr);
     }

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -42,7 +42,7 @@
 #include <cstdio>
 #include <memory>
 
-#include "cache/block_cache/block_cache.h"
+#include "cache/block_cache/local_cache.h"
 #ifdef USE_STAROS
 #include "fslib/star_cache_handler.h"
 #endif
@@ -50,7 +50,6 @@
 #include "gutil/strtoint.h"      //  for atoi64
 #include "io/io_profiler.h"
 #include "jemalloc/jemalloc.h"
-#include "runtime/mem_tracker.h"
 #include "runtime/runtime_filter_worker.h"
 #include "storage/page_cache.h"
 #include "util/metrics.h"
@@ -302,9 +301,9 @@ void SystemMetrics::_update_datacache_mem_tracker() {
     int64_t datacache_mem_bytes = 0;
     auto* datacache_mem_tracker = GlobalEnv::GetInstance()->datacache_mem_tracker();
     if (datacache_mem_tracker) {
-        BlockCache* block_cache = BlockCache::instance();
-        if (block_cache != nullptr && block_cache->is_initialized()) {
-            auto datacache_metrics = block_cache->cache_metrics();
+        LocalCache* local_cache = CacheEnv::GetInstance()->local_cache();
+        if (local_cache != nullptr && local_cache->is_initialized()) {
+            auto datacache_metrics = local_cache->cache_metrics(0);
             datacache_mem_bytes = datacache_metrics.mem_used_bytes + datacache_metrics.meta_used_bytes;
         }
 #ifdef USE_STAROS

--- a/be/test/cache/block_cache/disk_space_monitor_test.cpp
+++ b/be/test/cache/block_cache/disk_space_monitor_test.cpp
@@ -121,9 +121,8 @@ TEST_F(DiskSpaceMonitorTest, adjust_for_empty_cache_dir) {
     SCOPED_UPDATE(int64_t, config::datacache_disk_safe_level, 70);
     SCOPED_UPDATE(int64_t, config::datacache_min_disk_quota_for_adjustment, 0);
 
-    auto space_monitor = std::make_unique<DiskSpaceMonitor>(nullptr);
-    MockFileSystem* mock_fs = new MockFileSystem;
-    space_monitor->_fs.reset(mock_fs);
+    auto mock_fs = std::make_shared<MockFileSystem>();
+    auto space_monitor = std::make_unique<DiskSpaceMonitor>(nullptr, mock_fs);
 
     SpaceInfo space_info = {.capacity = 1000 * GB, .free = 800 * GB, .available = 500 * GB};
     mock_fs->set_space(1, "disk1", space_info);
@@ -150,9 +149,8 @@ TEST_F(DiskSpaceMonitorTest, adjust_for_dirty_cache_dir) {
     SCOPED_UPDATE(int64_t, config::datacache_disk_safe_level, 70);
     SCOPED_UPDATE(int64_t, config::datacache_disk_low_level, 60);
 
-    auto space_monitor = std::make_unique<DiskSpaceMonitor>(nullptr);
-    MockFileSystem* mock_fs = new MockFileSystem;
-    space_monitor->_fs.reset(mock_fs);
+    auto mock_fs = std::make_shared<MockFileSystem>();
+    auto space_monitor = std::make_unique<DiskSpaceMonitor>(nullptr, mock_fs);
 
     SpaceInfo space_info = {.capacity = 1000 * GB, .free = 800 * GB, .available = 200 * GB};
     mock_fs->set_space(1, "disk1", space_info);
@@ -185,40 +183,41 @@ TEST_F(DiskSpaceMonitorTest, auto_increase_cache_quota) {
     SCOPED_UPDATE(int64_t, config::datacache_disk_low_level, 60);
 
     auto options = create_simple_options(kBlockSize, 0, 20 * MB);
-    auto cache = create_cache(options);
+    auto block_cache = create_cache(options);
+    auto cache = block_cache->local_cache();
 
     MockFileSystem* mock_fs = new MockFileSystem;
     SpaceInfo space_info = {.capacity = 500 * MB, .free = 400 * MB, .available = 300 * MB};
     mock_fs->set_space(1, ".", space_info);
 
-    auto& space_monitor = cache->_disk_space_monitor;
+    auto& space_monitor = block_cache->_disk_space_monitor;
     space_monitor->_fs.reset(mock_fs);
     space_monitor->init(&options.disk_spaces);
 
     // Fill cache data
     {
-        insert_to_cache(cache.get(), 19);
-        auto metrics = cache->cache_metrics();
+        insert_to_cache(block_cache.get(), 19);
+        auto metrics = cache->cache_metrics(0);
         int64_t used_rate = metrics.disk_used_bytes * 100 / metrics.disk_quota_bytes;
         ASSERT_GT(used_rate, DiskSpace::kAutoIncreaseThreshold);
     }
 
     {
-        auto metrics = cache->cache_metrics();
+        auto metrics = cache->cache_metrics(0);
         ASSERT_EQ(metrics.disk_quota_bytes, 20 * MB);
     }
 
     {
         config::datacache_auto_adjust_enable = true;
         sleep(3);
-        auto metrics = cache->cache_metrics();
+        auto metrics = cache->cache_metrics(0);
         ASSERT_EQ(metrics.disk_quota_bytes, 20 * MB);
     }
 
     {
         config::datacache_disk_idle_seconds_for_expansion = 1;
         sleep(3);
-        auto metrics = cache->cache_metrics();
+        auto metrics = cache->cache_metrics(0);
         // other: 500M - 300M - 19M = 181M
         // new quota: 500 * 0.7 - other = 169M, 169M/10 * 10 = 160M
         ASSERT_EQ(metrics.disk_quota_bytes, 160 * MB);
@@ -240,40 +239,41 @@ TEST_F(DiskSpaceMonitorTest, auto_increase_cache_quota_with_limit) {
     DeferOp defer([]() { config::datacache_disk_size = "100%"; });
 
     auto options = create_simple_options(kBlockSize, 0, 20 * MB);
-    auto cache = create_cache(options);
+    auto block_cache = create_cache(options);
+    auto cache = block_cache->local_cache();
 
     MockFileSystem* mock_fs = new MockFileSystem;
     SpaceInfo space_info = {.capacity = 500 * MB, .free = 400 * MB, .available = 300 * MB};
     mock_fs->set_space(1, ".", space_info);
 
-    auto& space_monitor = cache->_disk_space_monitor;
+    auto& space_monitor = block_cache->_disk_space_monitor;
     space_monitor->_fs.reset(mock_fs);
     space_monitor->init(&options.disk_spaces);
 
     // Fill cache data
     {
-        insert_to_cache(cache.get(), 19);
-        auto metrics = cache->cache_metrics();
+        insert_to_cache(block_cache.get(), 19);
+        auto metrics = cache->cache_metrics(0);
         int64_t used_rate = metrics.disk_used_bytes * 100 / metrics.disk_quota_bytes;
         ASSERT_GT(used_rate, DiskSpace::kAutoIncreaseThreshold);
     }
 
     {
-        auto metrics = cache->cache_metrics();
+        auto metrics = cache->cache_metrics(0);
         ASSERT_EQ(metrics.disk_quota_bytes, 20 * MB);
     }
 
     {
         config::datacache_auto_adjust_enable = true;
         sleep(3);
-        auto metrics = cache->cache_metrics();
+        auto metrics = cache->cache_metrics(0);
         ASSERT_EQ(metrics.disk_quota_bytes, 20 * MB);
     }
 
     {
         config::datacache_disk_idle_seconds_for_expansion = 1;
         sleep(3);
-        auto metrics = cache->cache_metrics();
+        auto metrics = cache->cache_metrics(0);
         // other: 500M - 300M - 19M = 181M
         // new quota: 500 * 0.7 - other = 169M, 169M/10 * 10 = 160M
         // max: 500 * 0.25 = 125M, 125M/10 * 10 = 120M
@@ -295,26 +295,27 @@ TEST_F(DiskSpaceMonitorTest, auto_decrease_cache_quota) {
     SCOPED_UPDATE(int64_t, config::datacache_disk_low_level, 60);
 
     auto options = create_simple_options(kBlockSize, 0, 50 * MB);
-    auto cache = create_cache(options);
+    auto block_cache = create_cache(options);
+    auto cache = block_cache->local_cache();
 
     MockFileSystem* mock_fs = new MockFileSystem;
     SpaceInfo space_info = {.capacity = 100 * MB, .free = 20 * MB, .available = 10 * MB};
     mock_fs->set_space(1, ".", space_info);
 
-    auto& space_monitor = cache->_disk_space_monitor;
+    auto& space_monitor = block_cache->_disk_space_monitor;
     space_monitor->_fs.reset(mock_fs);
     space_monitor->init(&options.disk_spaces);
 
     // Fill cache data
     {
-        insert_to_cache(cache.get(), 50);
-        auto metrics = cache->cache_metrics();
+        insert_to_cache(block_cache.get(), 50);
+        auto metrics = cache->cache_metrics(0);
         int64_t used_rate = metrics.disk_used_bytes * 100 / metrics.disk_quota_bytes;
         ASSERT_GT(used_rate, DiskSpace::kAutoIncreaseThreshold);
     }
 
     {
-        auto metrics = cache->cache_metrics();
+        auto metrics = cache->cache_metrics(0);
         ASSERT_EQ(metrics.disk_quota_bytes, 50 * MB);
     }
 
@@ -322,7 +323,7 @@ TEST_F(DiskSpaceMonitorTest, auto_decrease_cache_quota) {
         config::datacache_auto_adjust_enable = true;
         size_t new_quota = 0;
         for (int i = 0; i < 6; ++i) {
-            auto metrics = cache->cache_metrics();
+            auto metrics = cache->cache_metrics(0);
             if (metrics.disk_quota_bytes > 0 && metrics.disk_quota_bytes != 50 * MB) {
                 config::datacache_auto_adjust_enable = false;
                 new_quota = metrics.disk_quota_bytes;
@@ -349,26 +350,27 @@ TEST_F(DiskSpaceMonitorTest, auto_decrease_cache_quota_to_zero) {
     SCOPED_UPDATE(int64_t, config::datacache_disk_low_level, 60);
 
     auto options = create_simple_options(kBlockSize, 0, 50 * MB);
-    auto cache = create_cache(options);
+    auto block_cache = create_cache(options);
+    auto cache = block_cache->local_cache();
 
     MockFileSystem* mock_fs = new MockFileSystem;
     SpaceInfo space_info = {.capacity = 100 * MB, .free = 20 * MB, .available = 10 * MB};
     mock_fs->set_space(1, ".", space_info);
 
-    auto& space_monitor = cache->_disk_space_monitor;
+    auto& space_monitor = block_cache->_disk_space_monitor;
     space_monitor->_fs.reset(mock_fs);
     space_monitor->init(&options.disk_spaces);
 
     // Fill cache data
     {
-        insert_to_cache(cache.get(), 50);
-        auto metrics = cache->cache_metrics();
+        insert_to_cache(block_cache.get(), 50);
+        auto metrics = cache->cache_metrics(0);
         int64_t used_rate = metrics.disk_used_bytes * 100 / metrics.disk_quota_bytes;
         ASSERT_GT(used_rate, DiskSpace::kAutoIncreaseThreshold);
     }
 
     {
-        auto metrics = cache->cache_metrics();
+        auto metrics = cache->cache_metrics(0);
         ASSERT_EQ(metrics.disk_quota_bytes, 50 * MB);
     }
 
@@ -376,7 +378,7 @@ TEST_F(DiskSpaceMonitorTest, auto_decrease_cache_quota_to_zero) {
         config::datacache_auto_adjust_enable = true;
         size_t new_quota = 0;
         for (int i = 0; i < 6; ++i) {
-            auto metrics = cache->cache_metrics();
+            auto metrics = cache->cache_metrics(0);
             if (metrics.disk_quota_bytes > 0 && metrics.disk_quota_bytes != 50 * MB) {
                 config::datacache_auto_adjust_enable = false;
                 new_quota = metrics.disk_quota_bytes;
@@ -400,14 +402,15 @@ TEST_F(DiskSpaceMonitorTest, get_directory_capacity) {
     SCOPED_UPDATE(bool, config::datacache_auto_adjust_enable, false);
 
     auto options = create_simple_options(kBlockSize, 0, 20 * MB);
-    auto cache = create_cache(options);
+    auto block_cache = create_cache(options);
+    auto cache = block_cache->local_cache();
 
     // Fill cache data
     {
-        insert_to_cache(cache.get(), 20);
+        insert_to_cache(block_cache.get(), 20);
 
         auto& disk_spaces = options.disk_spaces;
-        auto& space_monitor = cache->_disk_space_monitor;
+        auto& space_monitor = block_cache->_disk_space_monitor;
         size_t capacity = 0;
         for (auto& space : disk_spaces) {
             auto ret = space_monitor->_fs->directory_size(space.path);

--- a/be/test/cache/object_cache/object_cache_test.cpp
+++ b/be/test/cache/object_cache/object_cache_test.cpp
@@ -40,7 +40,8 @@ protected:
             _cache_opt.capacity = _mem_quota;
             ASSERT_OK(fs::create_directories(_cache_dir));
             _init_block_cache();
-            _cache = std::make_shared<StarCacheModule>(_block_cache->starcache_instance());
+            _local_cache = _block_cache->local_cache();
+            _cache = std::make_shared<StarCacheModule>(_local_cache->starcache_instance());
         }
     }
     void TearDown() override {
@@ -66,6 +67,7 @@ protected:
     std::string _cache_dir = "./object_cache_test";
     int64_t _mem_quota = 0;
     std::shared_ptr<BlockCache> _block_cache;
+    std::shared_ptr<LocalCache> _local_cache;
     std::shared_ptr<ObjectCache> _cache;
     ObjectCacheOptions _cache_opt;
     ObjectCacheWriteOptions _write_opt;

--- a/be/test/cache/object_cache/starcache_module_test.cpp
+++ b/be/test/cache/object_cache/starcache_module_test.cpp
@@ -27,7 +27,8 @@ protected:
         ASSERT_OK(fs::create_directories(cache_dir));
 
         _init_block_cache();
-        _cache = std::make_shared<StarCacheModule>(_block_cache->starcache_instance());
+        _local_cache = _block_cache->local_cache();
+        _cache = std::make_shared<StarCacheModule>(_local_cache->starcache_instance());
     }
     void TearDown() override {
         ASSERT_OK(_block_cache->shutdown());
@@ -62,6 +63,7 @@ protected:
 
     std::string cache_dir = "./starcache_module_test";
     std::shared_ptr<BlockCache> _block_cache;
+    std::shared_ptr<LocalCache> _local_cache;
     std::shared_ptr<ObjectCache> _cache;
     ObjectCacheWriteOptions _write_opt;
     size_t _value_size = 256 * 1024;

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -3350,7 +3350,8 @@ TEST_F(FileReaderTest, TestReadFooterCache) {
     options.engine = "starcache";
     Status status = block_cache->init(options);
     ASSERT_TRUE(status.ok());
-    auto cache = std::make_shared<StarCacheModule>(block_cache->starcache_instance());
+    auto local_cache = block_cache->local_cache();
+    auto cache = std::make_shared<StarCacheModule>(local_cache->starcache_instance());
 
     auto file = _create_file(_file1_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),

--- a/be/test/http/action/update_config_action_test.cpp
+++ b/be/test/http/action/update_config_action_test.cpp
@@ -62,8 +62,9 @@ TEST_F(UpdateConfigActionTest, update_datacache_disk_size) {
     st = action.update_config("datacache_disk_size", "100000000");
     ASSERT_TRUE(st.ok());
 
+    auto local_cache = cache->local_cache();
     std::vector<DirSpace> spaces;
-    cache->disk_spaces(&spaces);
+    local_cache->disk_spaces(&spaces);
     ASSERT_EQ(spaces.size(), 1);
     ASSERT_EQ(spaces[0].size, 100000000);
 

--- a/be/test/http/action/update_config_action_test.cpp
+++ b/be/test/http/action/update_config_action_test.cpp
@@ -53,6 +53,7 @@ TEST_F(UpdateConfigActionTest, update_datacache_disk_size) {
     options.engine = "starcache";
     Status st = BlockCache::instance()->init(options);
     ASSERT_TRUE(st.ok());
+    CacheEnv::GetInstance()->set_local_cache(cache->local_cache());
 
     UpdateConfigAction action(ExecEnv::GetInstance());
 

--- a/be/test/http/datacache_action_test.cpp
+++ b/be/test/http/datacache_action_test.cpp
@@ -76,7 +76,7 @@ TEST_F(DataCacheActionTest, stat_success) {
     auto cache = std::make_shared<BlockCache>();
     ASSERT_TRUE(init_datacache_instance("starcache", cache.get()).ok());
 
-    DataCacheAction action(cache.get());
+    DataCacheAction action(cache->local_cache().get());
 
     HttpRequest request(_evhttp_req);
     request._method = HttpMethod::GET;
@@ -96,7 +96,7 @@ TEST_F(DataCacheActionTest, app_stat_success) {
     counter->reset();
     ASSERT_TRUE(init_datacache_instance("starcache", cache.get()).ok());
 
-    DataCacheAction action(cache.get());
+    DataCacheAction action(cache->local_cache().get());
 
     {
         HttpRequest request(_evhttp_req);
@@ -136,7 +136,7 @@ TEST_F(DataCacheActionTest, app_stat_success) {
 
 TEST_F(DataCacheActionTest, stat_with_uninitialized_cache) {
     auto cache = std::make_shared<BlockCache>();
-    DataCacheAction action(cache.get());
+    DataCacheAction action(cache->local_cache().get());
 
     HttpRequest request(_evhttp_req);
     request._method = HttpMethod::GET;

--- a/be/test/storage/update_manager_test.cpp
+++ b/be/test/storage/update_manager_test.cpp
@@ -268,7 +268,6 @@ TEST_F(UpdateManagerTest, testEraseDCGCacheByTablet) {
     tsid.tablet_id = _tablet->tablet_id();
     tsid.segment_id = 1;
     _update_manager->set_cached_empty_delta_column_group(_tablet->data_dir()->get_meta(), tsid);
-    [[maybe_unused]] auto init_consumption = _root_mem_tracker->consumption();
 
     _update_manager->clear_cached_delta_column_group_by_tablet_id(_tablet->tablet_id());
     ASSERT_EQ(0, _root_mem_tracker->consumption());


### PR DESCRIPTION
## Why I'm doing:

`StarCache` is currently the cache engine for local caching. Both `ObjectCache` and `BlockCache` are implemented based on `StarCache` and are used for different scenarios. Therefore, the interfaces for collecting cache metrics and updating configurations should be bound to `StarCache` instead of `BlockCache`.

![image](https://github.com/user-attachments/assets/9615fa24-44c3-41c4-a9ae-08192fffc8c0)

## What I'm doing:

* Move the interfaces related to metrics or updating configuration from `BlockCache` to `LocalCache(StarCache)`
* Fix some spelling problems.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
