### PR TITLE
[BugFix] Fix window func bug for bitmap/hll/percentile type

### DIFF
--- a/be/src/exprs/agg/window.h
+++ b/be/src/exprs/agg/window.h
@@ -97,7 +97,7 @@ struct ValueWindowStrategy<LT, StringLTGuard<LT>> {
     static constexpr bool use_append = true;
 };
 template <LogicalType LT>
-struct ValueWindowStrategy<LT, ObjectFamilyLTGuard<LT>> {
+struct ValueWindowStrategy<LT, JsonGuard<LT>> {
     /// The dst Object column hasn't been resized.
     static constexpr bool use_append = true;
 };

--- a/test/sql/test_window_function/R/test_window_functions_with_hll_bitmap
+++ b/test/sql/test_window_function/R/test_window_functions_with_hll_bitmap
@@ -1,0 +1,58 @@
+-- name: test_window_functions_with_hll_bitmap
+CREATE TABLE test_ignore_nulls_page_uv (
+    page_id INT NOT NULL,
+    visit_date datetime NOT NULL,
+    visit_users BITMAP BITMAP_UNION NOT NULL,
+    click_times hll hll_union
+)AGGREGATE KEY(page_id, visit_date)
+DISTRIBUTED BY HASH(page_id) BUCKETS 3;
+-- result:
+-- !result
+INSERT INTO test_ignore_nulls_page_uv VALUES (1, '2020-06-23 01:30:30', to_bitmap(1001), hll_hash(5));
+-- result:
+-- !result
+INSERT INTO test_ignore_nulls_page_uv VALUES (1, '2020-06-23 01:30:30', to_bitmap(1001), hll_hash(5));
+-- result:
+-- !result
+INSERT INTO test_ignore_nulls_page_uv VALUES (1, '2020-06-23 01:30:30', to_bitmap(1002), hll_hash(10));
+-- result:
+-- !result
+INSERT INTO test_ignore_nulls_page_uv VALUES (1, '2020-06-23 02:30:30', to_bitmap(1002), hll_hash(5));
+-- result:
+-- !result
+select HLL_CARDINALITY(lag(click_times IGNORE NULLS) over(order by visit_date)) as val from test_ignore_nulls_page_uv order by val;
+-- result:
+None
+2
+-- !result
+select HLL_CARDINALITY(lead(click_times IGNORE NULLS) over(order by visit_date)) as val from test_ignore_nulls_page_uv order by val;
+-- result:
+None
+1
+-- !result
+select HLL_CARDINALITY(first_value(click_times) over(order by visit_date)) as val from test_ignore_nulls_page_uv order by val;
+-- result:
+E: (1064, 'Getting analyzing error at line 1, column 35. Detail message: hll type could only used for hll_union_agg/lead/lag window function.')
+-- !result
+select HLL_CARDINALITY(last_value(click_times) over(order by visit_date)) as val from test_ignore_nulls_page_uv order by val;
+-- result:
+E: (1064, 'Getting analyzing error at line 1, column 34. Detail message: hll type could only used for hll_union_agg/lead/lag window function.')
+-- !result
+select BITMAP_COUNT(lag(visit_users) over(order by visit_date)) as val from test_ignore_nulls_page_uv order by val;
+-- result:
+0
+2
+-- !result
+select BITMAP_COUNT(lead(visit_users) over(order by visit_date)) as val from test_ignore_nulls_page_uv order by val;
+-- result:
+0
+1
+-- !result
+select BITMAP_COUNT(first_value(visit_users) over(order by visit_date)) as val from test_ignore_nulls_page_uv order by val;
+-- result:
+E: (1064, 'Getting analyzing error at line 1, column 32. Detail message: bitmap type could only used for bitmap_union_count/bitmap_union/lead/lag window function.')
+-- !result
+select BITMAP_COUNT(last_value(visit_users) over(order by visit_date)) as val from test_ignore_nulls_page_uv order by val;
+-- result:
+E: (1064, 'Getting analyzing error at line 1, column 31. Detail message: bitmap type could only used for bitmap_union_count/bitmap_union/lead/lag window function.')
+-- !result

--- a/test/sql/test_window_function/T/test_window_functions_with_hll_bitmap
+++ b/test/sql/test_window_function/T/test_window_functions_with_hll_bitmap
@@ -1,0 +1,24 @@
+-- name: test_window_functions_with_hll_bitmap
+
+CREATE TABLE test_ignore_nulls_page_uv (
+    page_id INT NOT NULL,
+    visit_date datetime NOT NULL,
+    visit_users BITMAP BITMAP_UNION NOT NULL,
+    click_times hll hll_union
+)AGGREGATE KEY(page_id, visit_date)
+DISTRIBUTED BY HASH(page_id) BUCKETS 3;
+
+INSERT INTO test_ignore_nulls_page_uv VALUES (1, '2020-06-23 01:30:30', to_bitmap(1001), hll_hash(5));
+INSERT INTO test_ignore_nulls_page_uv VALUES (1, '2020-06-23 01:30:30', to_bitmap(1001), hll_hash(5));
+INSERT INTO test_ignore_nulls_page_uv VALUES (1, '2020-06-23 01:30:30', to_bitmap(1002), hll_hash(10));
+INSERT INTO test_ignore_nulls_page_uv VALUES (1, '2020-06-23 02:30:30', to_bitmap(1002), hll_hash(5));
+
+select HLL_CARDINALITY(lag(click_times IGNORE NULLS) over(order by visit_date)) as val from test_ignore_nulls_page_uv order by val;
+select HLL_CARDINALITY(lead(click_times IGNORE NULLS) over(order by visit_date)) as val from test_ignore_nulls_page_uv order by val;
+select HLL_CARDINALITY(first_value(click_times) over(order by visit_date)) as val from test_ignore_nulls_page_uv order by val;
+select HLL_CARDINALITY(last_value(click_times) over(order by visit_date)) as val from test_ignore_nulls_page_uv order by val;
+
+select BITMAP_COUNT(lag(visit_users) over(order by visit_date)) as val from test_ignore_nulls_page_uv order by val;
+select BITMAP_COUNT(lead(visit_users) over(order by visit_date)) as val from test_ignore_nulls_page_uv order by val;
+select BITMAP_COUNT(first_value(visit_users) over(order by visit_date)) as val from test_ignore_nulls_page_uv order by val;
+select BITMAP_COUNT(last_value(visit_users) over(order by visit_date)) as val from test_ignore_nulls_page_uv order by val;


### PR DESCRIPTION
## Why I'm doing:

https://github.com/StarRocks/starrocks/pull/58697 introduces a bug for `hll/percentile/bitmap` types:

```
*** Aborted at 1746674032 (unix time) try "date -d @1746674032" if you are using GNU date ***
PC: @     0x7f308c5009fc pthread_kill
*** SIGABRT (@0x3ea002371a0) received by PID 2322848 (TID 0x7f2d11332640) LWP(2323886) from PID 2322848; stack trace: ***
    @         0x1d405447 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7f308c503ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @         0x1d404c54 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f308c4ac520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @     0x7f308c5009fc pthread_kill
    @     0x7f308c4ac476 raise
    @     0x7f308c4927f3 abort
    @          0xdc6750d starrocks::failure_function()
    @         0x1d3f9a4a google::LogMessage::Fail()
    @         0x1d3fb484 google::LogMessageFatal::~LogMessageFatal()
    @          0xdce7f72 starrocks::Chunk::check_or_die()
    @          0xdce279a starrocks::Chunk::append_column(starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, int)
    @          0xe2a74e9 starrocks::Analytor::_output_result_chunk(std::shared_ptr<starrocks::Chunk>*)
    @          0xe2a294e starrocks::Analytor::_materializing_process(starrocks::RuntimeState*)
    @          0xe29b364 starrocks::Analytor::finish_process(starrocks::RuntimeState*)
    @          0xfd1cdee starrocks::pipeline::AnalyticSinkOperator::set_finishing(starrocks::RuntimeState*)
    @          0xfbeadee starrocks::pipeline::PipelineDriver::_mark_operator_finishing(std::shared_ptr<starrocks::pipeline::Operator>&, starrocks::RuntimeState*)
    @          0xfbdf813 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @         0x10bbc863 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @         0x10bbaeb2 starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}::operator()() const
    @         0x10bc5fbc void std::__invoke_impl<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(std::__invoke_other, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&)
    @         0x10bc539a std::enable_if<is_invocable_r_v<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>, void>::type std::__invoke_r<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(starrocks::pipeline::GlobalDriver@
    @         0x10bc4d4f std::_Function_handler<void (), starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}>::_M_invoke(std::_Any_data const&)
    @          0xc138fdc std::function<void ()>::operator()() const
    @          0xc9940a8 starrocks::FunctionRunnable::run()
    @          0xc98eefe starrocks::ThreadPool::dispatch_thread()
    @          0xc9b13fa void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
    @          0xc9afd0d std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
    @          0xc9ae79a void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>)
    @          0xc9acd6a void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>()
    @          0xc9aae52 void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&)
    @          0xc9a8520 std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::_Bind<void (starrocks::ThreadPool:@

```


Since in original implmentation, `hll/percentile/bitmap` types use `resize` instead of `reserve`, after https://github.com/StarRocks/starrocks/pull/58697, it use `use_append` instead of `assign` which will cause length inconsistent.

```
        // Binary column cound't call resize method like Numeric Column,
        // so we only reserve it.
        if (_agg_fn_types[i].result_type.type == LogicalType::TYPE_CHAR ||
            _agg_fn_types[i].result_type.type == LogicalType::TYPE_VARCHAR ||
            _agg_fn_types[i].result_type.type == LogicalType::TYPE_JSON ||
            _agg_fn_types[i].result_type.type == LogicalType::TYPE_ARRAY ||
            _agg_fn_types[i].result_type.type == LogicalType::TYPE_MAP ||
            _agg_fn_types[i].result_type.type == LogicalType::TYPE_STRUCT) {
            _result_window_columns[i]->reserve(chunk_size);
        } else {
            _result_window_columns[i]->resize(chunk_size);
        }
```
## What I'm doing:
- Treat  `hll/percentile/bitmap`  like `json` type and add specific tests.

Fixes https://github.com/StarRocks/StarRocksTest/issues/9591

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
