### PR TITLE
[Enhancement] add query progress into /current_queries command result

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentQueryStatisticsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentQueryStatisticsProcDir.java
@@ -65,6 +65,7 @@ public class CurrentQueryStatisticsProcDir implements ProcDirInterface {
             .add("DiskSpillSize")
             .add("CPUTime")
             .add("ExecTime")
+            .add("ExecProgress")
             .add("Warehouse")
             .add("CustomQueryId")
             .add("ResourceGroup")

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsInfo.java
@@ -415,14 +415,14 @@ public class QueryStatisticsInfo {
                     JsonObject progressInfo = jsonObject.getAsJsonObject("progress_info");
                     result = progressInfo.get("progress_percent").getAsString();
                 } catch (JsonSyntaxException e) {
-                    LOG.warn("Failed to get query progress, query_id: {}, msg: {}", queryId, response.body());
+                    LOG.warn("failed to get query progress, query_id: {}, msg: {}", queryId, response.body());
                 }
             } else {
-                LOG.warn("Failed to get query progress, query_id: {}, status code: {}, msg: {}",
+                LOG.warn("failed to get query progress, query_id: {}, status code: {}, msg: {}",
                         queryId, response.statusCode(), response.body());
             }
         } catch (IOException | InterruptedException e) {
-            LOG.warn("Failed to get query progress, query_id: {}, msg: {}", queryId, e);
+            LOG.warn("failed to get query progress, query_id: {}, msg: {}", queryId, e);
         } finally {
             return result;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsInfo.java
@@ -368,6 +368,7 @@ public class QueryStatisticsInfo {
                 statistic.values().stream()
                         .sorted(Comparator.comparingLong(QueryStatisticsItem::getQueryStartTime))
                         .collect(Collectors.toList());
+        final HttpClient httpClient = HttpClient.newHttpClient();
         for (QueryStatisticsItem item : sorted) {
             final CurrentQueryInfoProvider.QueryStatistics statistics = statisticsMap.get(item.getQueryId());
 
@@ -379,7 +380,8 @@ public class QueryStatisticsInfo {
                     .withDb(item.getDb())
                     .withUser(item.getUser())
                     .withExecTime(item.getQueryExecTime())
-                    .withExecProgress(getExecProgress(FrontendOptions.getLocalHostAddress(), item.getQueryId()))
+                    .withExecProgress(getExecProgress(FrontendOptions.getLocalHostAddress(), 
+                                                      item.getQueryId(), httpClient))
                     .withWareHouseName(item.getWarehouseName())
                     .withCustomQueryId(item.getCustomQueryId())
                     .withResourceGroupName(item.getResourceGroupName());
@@ -396,12 +398,11 @@ public class QueryStatisticsInfo {
         return sortedRowData;
     }
 
-    private static String getExecProgress(String feIp, String queryId) {
+    private static String getExecProgress(String feIp, String queryId, HttpClient httpClient) {
         String result = "";
         try {
             String url = String.format("http://%s:%s/api/query/progress?query_id=%s",
                     feIp, Config.http_port, queryId);
-            HttpClient client = HttpClient.newHttpClient();
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(url))
                     .GET()

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsInfo.java
@@ -398,7 +398,7 @@ public class QueryStatisticsInfo {
         return sortedRowData;
     }
 
-    private static String getExecProgress(String feIp, String queryId, HttpClient httpClient) {
+    public static String getExecProgress(String feIp, String queryId, HttpClient httpClient) {
         String result = "";
         try {
             String url = String.format("http://%s:%s/api/query/progress?query_id=%s",
@@ -408,7 +408,7 @@ public class QueryStatisticsInfo {
                     .GET()
                     .build();
 
-            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
             if (response.statusCode() == HttpStatus.SC_OK) {
                 try {
                     JsonElement jsonElement = JsonParser.parseString(response.body());

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/CurrentGlobalQueryStatisticsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/CurrentGlobalQueryStatisticsProcDirTest.java
@@ -47,6 +47,7 @@ public class CurrentGlobalQueryStatisticsProcDirTest {
             .withSpillBytes(0)
             .withCpuCostNs(97323000)
             .withExecTime(3533000)
+            .withExecProgress("100%")
             .withWareHouseName("default_warehouse")
             .withCustomQueryId("")
             .withResourceGroupName("wg1");
@@ -65,6 +66,7 @@ public class CurrentGlobalQueryStatisticsProcDirTest {
             .withSpillBytes(0)
             .withCpuCostNs(96576000)
             .withExecTime(2086000)
+            .withExecProgress("100%")
             .withWareHouseName("default_warehouse")
             .withCustomQueryId("")
             .withResourceGroupName("wg2");
@@ -82,6 +84,7 @@ public class CurrentGlobalQueryStatisticsProcDirTest {
             .withSpillBytes(0)
             .withCpuCostNs(97456000)
             .withExecTime(3687000)
+            .withExecProgress("100%")
             .withWareHouseName("default_warehouse")
             .withCustomQueryId("")
             .withResourceGroupName("wg3");
@@ -100,6 +103,7 @@ public class CurrentGlobalQueryStatisticsProcDirTest {
             .withSpillBytes(0)
             .withCpuCostNs(96686000)
             .withExecTime(2196000)
+            .withExecProgress("100%")
             .withWareHouseName("default_warehouse")
             .withCustomQueryId("")
             .withResourceGroupName("wg");

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/CurrentQueryStatisticsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/CurrentQueryStatisticsProcDirTest.java
@@ -79,22 +79,22 @@ public class CurrentQueryStatisticsProcDirTest {
         // QueryId
         Assert.assertEquals("queryId1", list1.get(2));
         // Warehouse
-        Assert.assertEquals("wh1", list1.get(12));
+        Assert.assertEquals("wh1", list1.get(13));
         // CustomQueryId
-        Assert.assertEquals("abc1", list1.get(13));
+        Assert.assertEquals("abc1", list1.get(14));
         // ResourceGroupName
-        Assert.assertEquals("wg1", list1.get(14));
+        Assert.assertEquals("wg1", list1.get(15));
 
         List<String> list2 = rows.get(1);
         Assert.assertEquals(list2.size(), CurrentQueryStatisticsProcDir.TITLE_NAMES.size());
         // QueryId
         Assert.assertEquals("queryId2", list2.get(2));
         // Warehouse
-        Assert.assertEquals("wh1", list2.get(12));
+        Assert.assertEquals("wh1", list2.get(13));
         // CustomQueryId
-        Assert.assertEquals("abc2", list2.get(13));
+        Assert.assertEquals("abc2", list2.get(14));
         // ResourceGroupName
-        Assert.assertEquals("wg2", list2.get(14));
+        Assert.assertEquals("wg2", list2.get(15));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryStatisticsInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryStatisticsInfoTest.java
@@ -38,6 +38,7 @@ public class QueryStatisticsInfoTest {
                 firstQuery.getMemUsageBytes(),
                 firstQuery.getSpillBytes(),
                 firstQuery.getExecTime(),
+                firstQuery.getExecProgress(),
                 firstQuery.getWareHouseName(),
                 firstQuery.getCustomQueryId(),
                 firstQuery.getResourceGroupName()

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryStatisticsInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryStatisticsInfoTest.java
@@ -17,6 +17,13 @@ package com.starrocks.qe;
 import com.starrocks.thrift.TQueryStatisticsInfo;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 
 import static com.starrocks.common.proc.CurrentGlobalQueryStatisticsProcDirTest.QUERY_ONE_LOCAL;
 
@@ -52,5 +59,47 @@ public class QueryStatisticsInfoTest {
         TQueryStatisticsInfo firstQueryThrift = firstQuery.toThrift();
         QueryStatisticsInfo firstQueryTest = QueryStatisticsInfo.fromThrift(firstQueryThrift);
         Assert.assertEquals(firstQuery, firstQueryTest);
+    }
+
+    @Test
+    public void testGetExecProgress() throws Exception {
+        HttpClient mockHttpClient = Mockito.mock(HttpClient.class);
+        HttpResponse mockResponse = Mockito.mock(HttpResponse.class);
+        HttpRequest mockRequest = Mockito.mock(HttpRequest.class);
+        Mockito.when(mockRequest.uri()).thenReturn(URI.create("http://localhost:8030/api/query/progress?query_id=123"));
+        Mockito.when(mockHttpClient.send(Mockito.any(HttpRequest.class), Mockito.any())).thenReturn(mockResponse);
+        QueryStatisticsInfo info = new QueryStatisticsInfo();
+
+        //1.check query progress result    
+        String response1 = "{\"query_id\":\"123\",\"state\":\"Running\",\"progress_info\"" +
+                ":{\"total_operator_num\":5,\"finished_operator_num\":3,\"progress_percent\":\"60.00%\"}}";
+        Mockito.when(mockResponse.statusCode()).thenReturn(200);
+        Mockito.when(mockResponse.body()).thenReturn(response1);
+
+        String result1 = info.getExecProgress("localhost", "123", mockHttpClient);
+        Assert.assertEquals("60.00%", result1);
+
+        //2.check query id not found, like set enable_profile=false
+        String response2 = "query id 123 not found.";
+        Mockito.when(mockResponse.statusCode()).thenReturn(404);
+        Mockito.when(mockResponse.body()).thenReturn(response2);
+
+        String result2 = info.getExecProgress("localhost", "123", mockHttpClient);
+        Assert.assertEquals(result2, "");
+
+        //3.check short circuit query
+        String response3 = "short circuit point query doesn't suppot get query progress, " +
+                             "you can set it off by using set enable_short_circuit=false";
+        Mockito.when(mockResponse.statusCode()).thenReturn(200);
+        Mockito.when(mockResponse.body()).thenReturn(response3);
+
+        String result3 = info.getExecProgress("localhost", "123", mockHttpClient);
+        Assert.assertEquals(result3, "");
+
+        //4.check special case, like fe_ip:http_port is unreachable
+        Mockito.doThrow(new IOException("Network is unreachable")).when(mockHttpClient)
+                               .send(Mockito.any(HttpRequest.class), Mockito.any());
+        String result4 = info.getExecProgress("localhost", "123", mockHttpClient);
+        Assert.assertEquals(result4, "");
     }
 }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1619,9 +1619,10 @@ struct TQueryStatisticsInfo {
     10: optional i64 memUsageBytes
     11: optional i64 spillBytes
     12: optional i64 execTime
-    13: optional string wareHouseName
-    14: optional string customQueryId
-    15: optional string resourceGroupName
+    13: optional string execProgress
+    14: optional string wareHouseName
+    15: optional string customQueryId
+    16: optional string resourceGroupName
 }
 
 struct TGetQueryStatisticsResponse {


### PR DESCRIPTION
## Why I'm doing:
current `show proc '/global_current_queries'` and `show proc '/current_queries'` command's result does not have query progress info. there is no way to know the progress when query takes a long time to execute , it is not user friendly.

## What I'm doing:
add query progress into command's result, named as `ExecProgress`. 
query progress api: `/api/query/progress` #58110

```
MySQL [tpch]> show proc '/global_current_queries'\G;
*************************** 1. row ***************************
    StartTime: 2025-05-08 13:00:00
         feIp: xx.xx.xx
      QueryId: 3396cffc-2bd7-11f0-9dfa-fa163e7b32c6
 ConnectionId: 1
     Database: tpch
         User: root
    ScanBytes: 92.965 GB
     ScanRows: 2158965514 rows
  MemoryUsage: 11.875 GB
DiskSpillSize: 0.000 B
      CPUTime: 572.157 s
     ExecTime: 23.172 s
 ExecProgress: 82.61%
    Warehouse: default_warehouse
CustomQueryId: 
ResourceGroup: default_wg
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
