### PR TITLE
[Enhancement] Colocate/Bucket-shuffle intersect/union/except

### DIFF
--- a/be/src/exec/except_node.cpp
+++ b/be/src/exec/except_node.cpp
@@ -42,6 +42,15 @@ Status ExceptNode::init(const TPlanNode& tnode, RuntimeState* state) {
         RETURN_IF_ERROR(Expr::create_expr_trees(_pool, texprs, &ctxs, state));
         _child_expr_lists.push_back(ctxs);
     }
+
+    if (tnode.except_node.__isset.local_partition_by_exprs) {
+        auto& local_partition_by_exprs = tnode.except_node.local_partition_by_exprs;
+        for (auto& texprs : local_partition_by_exprs) {
+            std::vector<ExprContext*> ctxs;
+            RETURN_IF_ERROR(Expr::create_expr_trees(_pool, texprs, &ctxs, state));
+            _local_partition_by_exprs.push_back(ctxs);
+        }
+    }
     return Status::OK();
 }
 
@@ -247,8 +256,15 @@ pipeline::OpFactories ExceptNode::decompose_to_pipeline(pipeline::PipelineBuilde
 
     // Use the first child to build the hast table by ExceptBuildSinkOperator.
     OpFactories ops_with_except_build_sink = child(0)->decompose_to_pipeline(context);
-    ops_with_except_build_sink = context->maybe_interpolate_local_shuffle_exchange(
-            runtime_state(), id(), ops_with_except_build_sink, _child_expr_lists[0]);
+
+    if (_local_partition_by_exprs.empty()) {
+        ops_with_except_build_sink = context->maybe_interpolate_local_shuffle_exchange(
+                runtime_state(), id(), ops_with_except_build_sink, _child_expr_lists[0]);
+    } else {
+        ops_with_except_build_sink = context->maybe_interpolate_local_bucket_shuffle_exchange(
+                runtime_state(), id(), ops_with_except_build_sink, _local_partition_by_exprs[0]);
+    }
+
     ops_with_except_build_sink.emplace_back(std::make_shared<ExceptBuildSinkOperatorFactory>(
             context->next_operator_id(), id(), except_partition_ctx_factory, _child_expr_lists[0]));
     // Initialize OperatorFactory's fields involving runtime filters.
@@ -260,8 +276,13 @@ pipeline::OpFactories ExceptNode::decompose_to_pipeline(pipeline::PipelineBuilde
     // Use the rest children to erase keys from the hash table by ExceptProbeSinkOperator.
     for (size_t i = 1; i < _children.size(); i++) {
         OpFactories ops_with_except_probe_sink = child(i)->decompose_to_pipeline(context);
-        ops_with_except_probe_sink = context->maybe_interpolate_local_shuffle_exchange(
-                runtime_state(), id(), ops_with_except_probe_sink, _child_expr_lists[i]);
+        if (_local_partition_by_exprs.empty()) {
+            ops_with_except_probe_sink = context->maybe_interpolate_local_shuffle_exchange(
+                    runtime_state(), id(), ops_with_except_probe_sink, _child_expr_lists[i]);
+        } else {
+            ops_with_except_probe_sink = context->maybe_interpolate_local_bucket_shuffle_exchange(
+                    runtime_state(), id(), ops_with_except_probe_sink, _local_partition_by_exprs[i]);
+        }
         ops_with_except_probe_sink.emplace_back(std::make_shared<ExceptProbeSinkOperatorFactory>(
                 context->next_operator_id(), id(), except_partition_ctx_factory, _child_expr_lists[i], i - 1));
         // Initialize OperatorFactory's fields involving runtime filters.

--- a/be/src/exec/except_node.h
+++ b/be/src/exec/except_node.h
@@ -73,6 +73,7 @@ private:
     const TupleDescriptor* _tuple_desc;
     // Exprs materialized by this node. The i-th result expr list refers to the i-th child.
     std::vector<std::vector<ExprContext*>> _child_expr_lists;
+    std::vector<std::vector<ExprContext*>> _local_partition_by_exprs;
 
     struct ExceptColumnTypes {
         TypeDescriptor result_type;

--- a/be/src/exec/intersect_node.cpp
+++ b/be/src/exec/intersect_node.cpp
@@ -47,6 +47,15 @@ Status IntersectNode::init(const TPlanNode& tnode, RuntimeState* state) {
         RETURN_IF_ERROR(Expr::create_expr_trees(_pool, texprs, &ctxs, state));
         _child_expr_lists.push_back(ctxs);
     }
+
+    if (tnode.intersect_node.__isset.local_partition_by_exprs) {
+        auto& local_partition_by_exprs = tnode.intersect_node.local_partition_by_exprs;
+        for (auto& texprs : local_partition_by_exprs) {
+            std::vector<ExprContext*> ctxs;
+            RETURN_IF_ERROR(Expr::create_expr_trees(_pool, texprs, &ctxs, state));
+            _local_partition_by_exprs.push_back(ctxs);
+        }
+    }
     return Status::OK();
 }
 
@@ -253,9 +262,13 @@ pipeline::OpFactories IntersectNode::decompose_to_pipeline(pipeline::PipelineBui
 
     // Use the first child to build the hast table by IntersectBuildSinkOperator.
     OpFactories ops_with_intersect_build_sink = child(0)->decompose_to_pipeline(context);
-    ops_with_intersect_build_sink = context->maybe_interpolate_local_shuffle_exchange(
-            runtime_state(), id(), ops_with_intersect_build_sink, _child_expr_lists[0]);
-
+    if (_local_partition_by_exprs.empty()) {
+        ops_with_intersect_build_sink = context->maybe_interpolate_local_shuffle_exchange(
+                runtime_state(), id(), ops_with_intersect_build_sink, _child_expr_lists[0]);
+    } else {
+        ops_with_intersect_build_sink = context->maybe_interpolate_local_bucket_shuffle_exchange(
+                runtime_state(), id(), ops_with_intersect_build_sink, _local_partition_by_exprs[0]);
+    }
     ops_with_intersect_build_sink.emplace_back(std::make_shared<IntersectBuildSinkOperatorFactory>(
             context->next_operator_id(), id(), intersect_partition_ctx_factory, _child_expr_lists[0],
             _has_outer_join_child));
@@ -266,8 +279,13 @@ pipeline::OpFactories IntersectNode::decompose_to_pipeline(pipeline::PipelineBui
     // Use the rest children to erase keys from the hast table by IntersectProbeSinkOperator.
     for (size_t i = 1; i < _children.size(); i++) {
         OpFactories ops_with_intersect_probe_sink = child(i)->decompose_to_pipeline(context);
-        ops_with_intersect_probe_sink = context->maybe_interpolate_local_shuffle_exchange(
-                runtime_state(), id(), ops_with_intersect_probe_sink, _child_expr_lists[i]);
+        if (_local_partition_by_exprs.empty()) {
+            ops_with_intersect_probe_sink = context->maybe_interpolate_local_shuffle_exchange(
+                    runtime_state(), id(), ops_with_intersect_probe_sink, _child_expr_lists[i]);
+        } else {
+            ops_with_intersect_probe_sink = context->maybe_interpolate_local_bucket_shuffle_exchange(
+                    runtime_state(), id(), ops_with_intersect_probe_sink, _local_partition_by_exprs[i]);
+        }
         ops_with_intersect_probe_sink.emplace_back(std::make_shared<IntersectProbeSinkOperatorFactory>(
                 context->next_operator_id(), id(), intersect_partition_ctx_factory, _child_expr_lists[i], i - 1));
         // Initialize OperatorFactory's fields involving runtime filters.

--- a/be/src/exec/intersect_node.h
+++ b/be/src/exec/intersect_node.h
@@ -71,6 +71,7 @@ private:
     bool _has_outer_join_child = false;
     // Exprs materialized by this node. The i-th result expr list refers to the i-th child.
     std::vector<std::vector<ExprContext*>> _child_expr_lists;
+    std::vector<std::vector<ExprContext*>> _local_partition_by_exprs;
 
     struct IntersectColumnTypes {
         TypeDescriptor result_type;

--- a/be/src/exec/pipeline/pipeline_builder.cpp
+++ b/be/src/exec/pipeline/pipeline_builder.cpp
@@ -210,6 +210,13 @@ OpFactories PipelineBuilderContext::maybe_interpolate_local_shuffle_exchange(
                                                         self_partition_exprs_generator(), source_op->partition_type());
 }
 
+OpFactories PipelineBuilderContext::maybe_interpolate_local_bucket_shuffle_exchange(
+        RuntimeState* state, int32_t plan_node_id, OpFactories& pred_operators,
+        const std::vector<ExprContext*>& partition_expr_ctxs) {
+    return _do_maybe_interpolate_local_shuffle_exchange(state, plan_node_id, pred_operators, partition_expr_ctxs,
+                                                        TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED);
+}
+
 OpFactories PipelineBuilderContext::_do_maybe_interpolate_local_shuffle_exchange(
         RuntimeState* state, int32_t plan_node_id, OpFactories& pred_operators,
         const std::vector<ExprContext*>& partition_expr_ctxs, const TPartitionType::type part_type) {
@@ -304,6 +311,10 @@ void PipelineBuilderContext::interpolate_spill_process(size_t plan_node_id,
 }
 
 OpFactories PipelineBuilderContext::interpolate_grouped_exchange(int32_t plan_node_id, OpFactories& pred_operators) {
+    return interpolate_grouped_exchange(plan_node_id, pred_operators, {});
+}
+OpFactories PipelineBuilderContext::interpolate_grouped_exchange(int32_t plan_node_id, OpFactories& pred_operators,
+                                                                 const std::vector<ExprContext*>& partition_by_exprs) {
     size_t physical_dop = degree_of_parallelism();
     auto* source_op = source_operator(pred_operators);
     int logical_dop = source_op->degree_of_parallelism();
@@ -313,9 +324,18 @@ OpFactories PipelineBuilderContext::interpolate_grouped_exchange(int32_t plan_no
 
     auto mem_mgr =
             std::make_shared<ChunkBufferMemoryManager>(logical_dop, config::local_exchange_buffer_mem_limit_per_driver);
+
     auto local_shuffle_source =
             std::make_shared<LocalExchangeSourceOperatorFactory>(next_operator_id(), plan_node_id, mem_mgr);
-    auto local_exchanger = std::make_shared<PassthroughExchanger>(mem_mgr, local_shuffle_source.get());
+
+    std::shared_ptr<LocalExchanger> local_exchanger;
+    if (partition_by_exprs.empty()) {
+        local_exchanger = std::make_shared<PassthroughExchanger>(mem_mgr, local_shuffle_source.get());
+    } else {
+        local_exchanger = std::make_shared<PartitionExchanger>(mem_mgr, local_shuffle_source.get(),
+                                                               TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED,
+                                                               partition_by_exprs);
+    }
     auto group_exchange_sink = std::make_shared<GroupedExecutionSinkFactory>(next_operator_id(), plan_node_id,
                                                                              local_exchanger, _current_execution_group);
     pred_operators.emplace_back(std::move(group_exchange_sink));
@@ -335,8 +355,13 @@ OpFactories PipelineBuilderContext::interpolate_grouped_exchange(int32_t plan_no
 
 OpFactories PipelineBuilderContext::maybe_interpolate_grouped_exchange(int32_t plan_node_id,
                                                                        OpFactories& pred_operators) {
+    return maybe_interpolate_grouped_exchange(plan_node_id, pred_operators, {});
+}
+
+OpFactories PipelineBuilderContext::maybe_interpolate_grouped_exchange(
+        int32_t plan_node_id, OpFactories& pred_operators, const std::vector<ExprContext*>& partition_by_expr) {
     if (dynamic_cast<ColocateExecutionGroup*>(_current_execution_group) != nullptr) {
-        return interpolate_grouped_exchange(plan_node_id, pred_operators);
+        return interpolate_grouped_exchange(plan_node_id, pred_operators, partition_by_expr);
     }
     return pred_operators;
 }

--- a/be/src/exec/pipeline/pipeline_builder.h
+++ b/be/src/exec/pipeline/pipeline_builder.h
@@ -118,10 +118,6 @@ public:
     OpFactories interpolate_grouped_exchange(int32_t plan_node_id, OpFactories& pred_operators);
     OpFactories maybe_interpolate_grouped_exchange(int32_t plan_node_id, OpFactories& pred_operators);
 
-    OpFactories interpolate_grouped_exchange(int32_t plan_node_id, OpFactories& pred_operators,
-                                             const std::vector<ExprContext*>& partition_by_exprs);
-    OpFactories maybe_interpolate_grouped_exchange(int32_t plan_node_id, OpFactories& pred_operators,
-                                                   const std::vector<ExprContext*>& partition_by_exprs);
     // Uses local exchange to gather the output chunks of multiple predecessor pipelines
     // into a new pipeline, which the successor operator belongs to.
     // Append a LocalExchangeSinkOperator to the tail of each pipeline.

--- a/be/src/exec/pipeline/pipeline_builder.h
+++ b/be/src/exec/pipeline/pipeline_builder.h
@@ -103,6 +103,9 @@ public:
                                                          OpFactories& pred_operators,
                                                          const PartitionExprsGenerator& self_partition_exprs_generator);
 
+    OpFactories maybe_interpolate_local_bucket_shuffle_exchange(RuntimeState* state, int32_t plan_node_id,
+                                                                OpFactories& pred_operators,
+                                                                const std::vector<ExprContext*>& partition_expr_ctxs);
     // The intput data is already ordered by partition_exprs. Then we can use a simply approach to split them into different channels
     // as long as the data of the same partition_exprs are in the same channel.
     OpFactories maybe_interpolate_local_ordered_partition_exchange(
@@ -115,6 +118,10 @@ public:
     OpFactories interpolate_grouped_exchange(int32_t plan_node_id, OpFactories& pred_operators);
     OpFactories maybe_interpolate_grouped_exchange(int32_t plan_node_id, OpFactories& pred_operators);
 
+    OpFactories interpolate_grouped_exchange(int32_t plan_node_id, OpFactories& pred_operators,
+                                             const std::vector<ExprContext*>& partition_by_exprs);
+    OpFactories maybe_interpolate_grouped_exchange(int32_t plan_node_id, OpFactories& pred_operators,
+                                                   const std::vector<ExprContext*>& partition_by_exprs);
     // Uses local exchange to gather the output chunks of multiple predecessor pipelines
     // into a new pipeline, which the successor operator belongs to.
     // Append a LocalExchangeSinkOperator to the tail of each pipeline.

--- a/be/src/exec/union_node.cpp
+++ b/be/src/exec/union_node.cpp
@@ -363,7 +363,12 @@ pipeline::OpFactories UnionNode::decompose_to_pipeline(pipeline::PipelineBuilder
     // UnionPassthroughOperator is used for the passthrough sub-node.
     for (; i < _first_materialized_child_idx; i++) {
         auto child_ops = child(i)->decompose_to_pipeline(context);
-        child_ops = context->maybe_interpolate_grouped_exchange(_id, child_ops);
+        if (!_local_partition_by_exprs.empty()) {
+            child_ops = context->maybe_interpolate_local_bucket_shuffle_exchange(
+                    context->runtime_state(), _id, child_ops, _local_partition_by_exprs[i]);
+        } else {
+            child_ops = context->maybe_interpolate_grouped_exchange(_id, child_ops);
+        }
         operators_list.emplace_back(child_ops);
 
         UnionPassthroughOperator::SlotMap* dst2src_slot_map = nullptr;
@@ -390,10 +395,7 @@ pipeline::OpFactories UnionNode::decompose_to_pipeline(pipeline::PipelineBuilder
     for (; i < _children.size(); i++) {
         auto child_ops = child(i)->decompose_to_pipeline(context);
         std::vector<ExprContext*> partition_by_exprs;
-        if (!_local_partition_by_exprs.empty()) {
-            partition_by_exprs = _local_partition_by_exprs[i];
-        }
-        child_ops = context->maybe_interpolate_grouped_exchange(_id, child_ops, partition_by_exprs);
+        child_ops = context->maybe_interpolate_grouped_exchange(_id, child_ops);
         operators_list.emplace_back(child_ops);
 
         const auto& dst_tuple_desc =

--- a/be/src/exec/union_node.h
+++ b/be/src/exec/union_node.h
@@ -63,6 +63,7 @@ private:
 
     std::vector<std::vector<ExprContext*>> _const_expr_lists;
     std::vector<std::vector<ExprContext*>> _child_expr_lists;
+    std::vector<std::vector<ExprContext*>> _local_partition_by_exprs;
 
     // the map from slot id of output chunk to slot id of child chunk
     // There may be multiple DestSlotId mapped to the same SrcSlotId,

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SetOperationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SetOperationNode.java
@@ -104,6 +104,7 @@ public abstract class SetOperationNode extends PlanNode {
 
     protected List<Map<Integer, Integer>> outputSlotIdToChildSlotIdMaps = Lists.newArrayList();
 
+    protected List<List<Expr>> localPartitionByExprsList = Lists.newArrayList();
     protected SetOperationNode(PlanNodeId id, TupleId tupleId, String planNodeName) {
         super(id, tupleId.asList(), planNodeName);
         setOpResultExprs_ = Lists.newArrayList();
@@ -148,6 +149,10 @@ public abstract class SetOperationNode extends PlanNode {
         this.outputSlotIdToChildSlotIdMaps = outputSlotIdToChildSlotIdMaps;
     }
 
+    public void setLocalPartitionByExprsList(List<List<Expr>> localPartitionByExprsList) {
+        this.localPartitionByExprsList = localPartitionByExprsList;
+    }
+
     public void setSetOperationOutputList(List<Expr> setOperationOutputList) {
         this.setOperationOutputList = setOperationOutputList;
     }
@@ -172,13 +177,21 @@ public abstract class SetOperationNode extends PlanNode {
     protected void toThrift(TPlanNode msg, TPlanNodeType nodeType) {
         Preconditions.checkState(materializedResultExprLists_.size() == children.size());
         List<List<TExpr>> texprLists = Lists.newArrayList();
+
         for (List<Expr> exprList : materializedResultExprLists_) {
             texprLists.add(Expr.treesToThrift(exprList));
         }
+
         List<List<TExpr>> constTexprLists = Lists.newArrayList();
         for (List<Expr> constTexprList : materializedConstExprLists_) {
             constTexprLists.add(Expr.treesToThrift(constTexprList));
         }
+
+        List<List<TExpr>> tlocalPartitionByExprsList = Lists.newArrayList();
+        for (List<Expr> localPartitionByExprs : localPartitionByExprsList) {
+            tlocalPartitionByExprsList.add(Expr.treesToThrift(localPartitionByExprs));
+        }
+
         Preconditions.checkState(firstMaterializedChildIdx_ <= children.size());
         switch (nodeType) {
             case UNION_NODE:
@@ -186,16 +199,25 @@ public abstract class SetOperationNode extends PlanNode {
                         tupleId_.asInt(), texprLists, constTexprLists, firstMaterializedChildIdx_);
                 msg.union_node.setPass_through_slot_maps(outputSlotIdToChildSlotIdMaps);
                 msg.node_type = TPlanNodeType.UNION_NODE;
+                if (!tlocalPartitionByExprsList.isEmpty()) {
+                    msg.union_node.setLocal_partition_by_exprs(tlocalPartitionByExprsList);
+                }
                 break;
             case INTERSECT_NODE:
                 msg.intersect_node = new TIntersectNode(
                         tupleId_.asInt(), texprLists, constTexprLists, firstMaterializedChildIdx_);
                 msg.node_type = TPlanNodeType.INTERSECT_NODE;
+                if (!tlocalPartitionByExprsList.isEmpty()) {
+                    msg.intersect_node.setLocal_partition_by_exprs(tlocalPartitionByExprsList);
+                }
                 break;
             case EXCEPT_NODE:
                 msg.except_node = new TExceptNode(
                         tupleId_.asInt(), texprLists, constTexprLists, firstMaterializedChildIdx_);
                 msg.node_type = TPlanNodeType.EXCEPT_NODE;
+                if (!tlocalPartitionByExprsList.isEmpty()) {
+                    msg.except_node.setLocal_partition_by_exprs(tlocalPartitionByExprsList);
+                }
                 break;
             default:
                 LOG.error("Node type: " + nodeType.toString() + " is invalid.");

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -192,6 +192,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CHUNK_SIZE = "chunk_size";
     public static final String STREAMING_PREAGGREGATION_MODE = "streaming_preaggregation_mode";
     public static final String DISABLE_COLOCATE_JOIN = "disable_colocate_join";
+    public static final String DISABLE_COLOCATE_SET = "disable_colocate_set";
     public static final String DISABLE_BUCKET_JOIN = "disable_bucket_join";
     public static final String PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM = "parallel_fragment_exec_instance_num";
     public static final String MAX_PARALLEL_SCAN_INSTANCE_NUM = "max_parallel_scan_instance_num";
@@ -1172,6 +1173,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = DISABLE_COLOCATE_JOIN)
     private boolean disableColocateJoin = false;
 
+    @VariableMgr.VarAttr(name = DISABLE_COLOCATE_SET)
+    private boolean disableColocateSet = false;
     @VariableMgr.VarAttr(name = CBO_USE_CORRELATED_JOIN_ESTIMATE, flag = VariableMgr.INVISIBLE)
     private boolean useCorrelatedJoinEstimate = true;
 
@@ -3088,6 +3091,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isDisableColocateJoin() {
         return disableColocateJoin;
+    }
+
+    public boolean isDisableColocateSet() {
+        return disableColocateSet;
+    }
+
+    public void setDisableColocateSet(boolean value) {
+        disableColocateSet = value;
     }
 
     public int getParallelExecInstanceNum() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.optimizer;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -39,9 +40,11 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalAssertOneRowOperato
 import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEAnchorOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEConsumeOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEProduceOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalExceptOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHashJoinOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalIntersectOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalJDBCScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalLimitOperator;
@@ -53,8 +56,10 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalRepeatOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalSchemaScanOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalSetOperation;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalTableFunctionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalTopNOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalValuesOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -70,8 +75,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.starrocks.sql.optimizer.base.HashDistributionDesc.SourceType.LOCAL;
 import static com.starrocks.sql.optimizer.base.HashDistributionDesc.SourceType.SHUFFLE_AGG;
 import static com.starrocks.sql.optimizer.base.HashDistributionDesc.SourceType.SHUFFLE_JOIN;
 
@@ -203,6 +210,87 @@ public class OutputPropertyDeriver extends PropertyDeriverBase<PhysicalPropertyS
         }
 
         return physicalPropertySet;
+    }
+
+    @Override
+    public PhysicalPropertySet visitPhysicalUnion(PhysicalUnionOperator node, ExpressionContext context) {
+        return processPhysicalSetOperation(node, context);
+    }
+
+    @Override
+    public PhysicalPropertySet visitPhysicalExcept(PhysicalExceptOperator node, ExpressionContext context) {
+        return processPhysicalSetOperation(node, context);
+    }
+
+    @Override
+    public PhysicalPropertySet visitPhysicalIntersect(PhysicalIntersectOperator node, ExpressionContext context) {
+        return processPhysicalSetOperation(node, context);
+    }
+
+    private PhysicalPropertySet processPhysicalSetOperation(PhysicalSetOperation node, ExpressionContext context) {
+        DistributionSpec inputDistSpec = childrenOutputProperties.get(0).getDistributionProperty().getSpec();
+        if (inputDistSpec.getType().equals(DistributionSpec.DistributionType.ROUND_ROBIN)) {
+            return visitOperator(node, context);
+        }
+
+        if (!(inputDistSpec instanceof HashDistributionSpec)) {
+            return visitOperator(node, context);
+        }
+
+        HashDistributionSpec inputHashDistSpec = (HashDistributionSpec) inputDistSpec;
+        HashDistributionDesc inputHashDistDesc = inputHashDistSpec.getHashDistributionDesc();
+
+        if (inputHashDistDesc.isLocal()) {
+            List<DistributionCol> inputColumns = node.getChildOutputColumns().get(0)
+                    .stream()
+                    .map(col -> new DistributionCol(col.getId(), true))
+                    .collect(Collectors.toList());
+
+            List<DistributionCol> outputColumns = node.getOutputColumnRefOp()
+                    .stream()
+                    .map(col -> new DistributionCol(col.getId(), true))
+                    .collect(Collectors.toList());
+
+            List<List<DistributionCol>> outputShuffleColumns = Lists.newArrayList();
+            for (int i = 0; i < inputHashDistDesc.getDistributionCols().size(); ++i) {
+                DistributionCol inputCol = inputHashDistDesc.getDistributionCols().get(i);
+                List<DistributionCol> outputShuffleCols = IntStream.range(0, inputColumns.size())
+                        .filter(k -> inputHashDistSpec.getEquivDesc().isConnected(inputCol, inputColumns.get(k)))
+                        .mapToObj(outputColumns::get)
+                        .collect(Collectors.toList());
+                outputShuffleColumns.add(outputShuffleCols);
+            }
+            Preconditions.checkArgument(outputShuffleColumns.stream().allMatch(cols -> cols.size() > 0));
+            List<Integer> columnIds = outputShuffleColumns.stream()
+                    .map(cols -> cols.get(0).getColId())
+                    .collect(Collectors.toList());
+
+            HashDistributionDesc hashDistDesc = new HashDistributionDesc(columnIds, LOCAL);
+            EquivalentDescriptor equivalentDescriptor = new EquivalentDescriptor(
+                    inputHashDistSpec.getEquivDesc().getTableId(), inputHashDistSpec.getEquivDesc().getPartitionIds());
+
+            List<DistributionCol> shuffleColumns = outputShuffleColumns.stream()
+                    .map(cols -> cols.get(0))
+                    .collect(Collectors.toList());
+
+            equivalentDescriptor.initDistributionUnionFind(shuffleColumns);
+            outputShuffleColumns.forEach(columns -> columns.stream().skip(1)
+                    .forEach(col -> equivalentDescriptor.unionDistributionCols(columns.get(0), col)));
+
+            HashDistributionSpec hashDistSpec = new HashDistributionSpec(hashDistDesc, equivalentDescriptor);
+            PhysicalPropertySet propertySet =
+                    new PhysicalPropertySet(DistributionProperty.createProperty(hashDistSpec));
+            return mergeCTEProperty(propertySet);
+        } else {
+            List<Integer> columnIds = node.getOutputColumnRefOp().stream()
+                    .map(ColumnRefOperator::getId)
+                    .collect(Collectors.toList());
+            HashDistributionDesc hashDistDesc = new HashDistributionDesc(columnIds, SHUFFLE_JOIN);
+            HashDistributionSpec hashDistSpec = DistributionSpec.createHashDistributionSpec(hashDistDesc);
+            PhysicalPropertySet propertySet =
+                    new PhysicalPropertySet(DistributionProperty.createProperty(hashDistSpec));
+            return mergeCTEProperty(propertySet);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/HashDistributionSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/HashDistributionSpec.java
@@ -116,8 +116,10 @@ public class HashDistributionSpec extends DistributionSpec {
             return true;
         }
 
-        if (spec.type.equals(DistributionType.ROUND_ROBIN)) {
-            return true;
+        // For union operator(not union distinct), if its children is colocate ScanOperator, an
+        // round-robin distribution enforcer is required to generate a random-shuffle ExchangeNode
+        if (this.getHashDistributionDesc().isLocal() && spec.type.equals(DistributionType.ROUND_ROBIN)) {
+            return false;
         }
 
         if (!spec.type.equals(DistributionType.SHUFFLE)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -37,6 +37,10 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.base.DistributionCol;
+import com.starrocks.sql.optimizer.base.DistributionSpec;
+import com.starrocks.sql.optimizer.base.EquivalentDescriptor;
+import com.starrocks.sql.optimizer.base.HashDistributionSpec;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHiveScanOperator;
@@ -44,6 +48,7 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalIcebergScanOperator
 import com.starrocks.sql.optimizer.operator.physical.PhysicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalSetOperation;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalTableFunctionOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
@@ -426,6 +431,58 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 result.outputStringColumns.union(c);
             }
         });
+        result.decodeStringColumns.except(disableRewriteStringColumns);
+        result.inputStringColumns.except(disableRewriteStringColumns);
+        return result;
+    }
+
+    @Override
+    public DecodeInfo visitPhysicalUnion(OptExpression optExpression, DecodeInfo context) {
+        return visitPhysicalSetOperation(optExpression, context);
+    }
+
+    @Override
+    public DecodeInfo visitPhysicalIntersect(OptExpression optExpression, DecodeInfo context) {
+        return visitPhysicalSetOperation(optExpression, context);
+    }
+
+    @Override
+    public DecodeInfo visitPhysicalExcept(OptExpression optExpression, DecodeInfo context) {
+        return visitPhysicalSetOperation(optExpression, context);
+    }
+
+    private DecodeInfo visitPhysicalSetOperation(OptExpression optExpression, DecodeInfo context) {
+        if (context.outputStringColumns.isEmpty()) {
+            return DecodeInfo.EMPTY;
+        }
+        DistributionSpec dist = optExpression.getOutputProperty().getDistributionProperty().getSpec();
+        if (!(dist instanceof HashDistributionSpec)) {
+            return visit(optExpression, context);
+        }
+        PhysicalSetOperation setOp = optExpression.getOp().cast();
+        DecodeInfo result = context.createOutputInfo();
+        ColumnRefSet shuffleColumnIds = ColumnRefSet.of();
+        for (int i = 0; i < optExpression.arity(); ++i) {
+            OptExpression child = optExpression.inputAt(i);
+            DistributionSpec childDistSpec = child.getOutputProperty().getDistributionProperty().getSpec();
+            Preconditions.checkState(childDistSpec instanceof HashDistributionSpec);
+            HashDistributionSpec childHashDistSpec = (HashDistributionSpec) childDistSpec;
+            if (childHashDistSpec.getHashDistributionDesc().isLocal()) {
+                continue;
+            }
+            int childIdx = i;
+            EquivalentDescriptor childEqvDesc = childHashDistSpec.getEquivDesc();
+            childHashDistSpec.getShuffleColumns().forEach(shuffleCol -> setOp.getChildOutputColumns().get(childIdx)
+                    .stream()
+                    .filter(colRef -> childEqvDesc.isConnected(shuffleCol, new DistributionCol(colRef.getId(), true)))
+                    .forEach(shuffleColumnIds::union));
+        }
+
+        if (!result.inputStringColumns.containsAny(shuffleColumnIds)) {
+            return result;
+        }
+        shuffleColumnIds.getStream().forEach(c -> disableRewriteStringColumns.union(c));
+        result.outputStringColumns.except(shuffleColumnIds);
         result.decodeStringColumns.except(disableRewriteStringColumns);
         result.inputStringColumns.except(disableRewriteStringColumns);
         return result;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
@@ -113,6 +113,7 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
     // 4. Add enforcer for node if it can not satisfy the requirements.
     @Override
     public void execute() {
+
         if (groupExpression.isUnused()) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -3159,9 +3159,7 @@ public class PlanFragmentBuilder {
             }
 
             SetOperationNode setOperationNode;
-            boolean isUnion = false;
             if (operatorType.equals(OperatorType.PHYSICAL_UNION)) {
-                isUnion = true;
                 setOperationNode = new UnionNode(context.getNextNodeId(), setOperationTuple.getId());
                 setOperationNode.setFirstMaterializedChildIdx_(optExpr.arity());
             } else if (operatorType.equals(OperatorType.PHYSICAL_EXCEPT)) {
@@ -3171,12 +3169,34 @@ public class PlanFragmentBuilder {
             } else {
                 throw new StarRocksPlannerException("Unsupported set operation", INTERNAL_ERROR);
             }
-            currentExecGroup.add(setOperationNode, true);
+
+            List<PlanFragment> inputFragments = Lists.newArrayListWithCapacity(optExpr.arity());
+            List<ExecGroup> inputExecGroups = Lists.newArrayListWithCapacity(optExpr.arity());
+            for (int i = 0; i < optExpr.arity(); ++i) {
+                PlanFragment inputFragment = visit(optExpr.inputAt(i), context);
+                inputFragment.getPlanRoot().forceCollectExecStats();
+                ExecGroup inputExecGroup = currentExecGroup;
+                currentExecGroup = execGroups.newExecGroup();
+                inputFragments.add(inputFragment);
+                inputExecGroups.add(inputExecGroup);
+            }
+
+            List<List<Expr>> materializedResultExprLists = Lists.newArrayList();
+            ScalarOperatorToExpr.FormatterContext formatterContext =
+                    new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr());
 
             List<Map<Integer, Integer>> outputSlotIdToChildSlotIdMaps = new ArrayList<>();
             for (int childIdx = 0; childIdx < optExpr.arity(); ++childIdx) {
                 Map<Integer, Integer> slotIdMap = new HashMap<>();
                 List<ColumnRefOperator> childOutput = setOperation.getChildOutputColumns().get(childIdx);
+
+                List<Expr> materializedExpressions = Lists.newArrayList();
+                // keep output column order
+                for (ColumnRefOperator ref : childOutput) {
+                    materializedExpressions.add(ScalarOperatorToExpr.buildExecExpression(ref, formatterContext));
+                }
+                materializedResultExprLists.add(materializedExpressions);
+
                 Preconditions.checkState(childOutput.size() == setOperation.getOutputColumnRefOp().size());
                 for (int columnIdx = 0; columnIdx < setOperation.getOutputColumnRefOp().size(); ++columnIdx) {
                     Integer resultColumnIdx = setOperation.getOutputColumnRefOp().get(columnIdx).getId();
@@ -3186,57 +3206,8 @@ public class PlanFragmentBuilder {
                 Preconditions.checkState(slotIdMap.size() == setOperation.getOutputColumnRefOp().size());
             }
             setOperationNode.setOutputSlotIdToChildSlotIdMaps(outputSlotIdToChildSlotIdMaps);
-
             Preconditions.checkState(optExpr.getInputs().size() == setOperation.getChildOutputColumns().size());
 
-            PlanFragment setOperationFragment =
-                    new PlanFragment(context.getNextFragmentId(), setOperationNode, DataPartition.RANDOM);
-            List<List<Expr>> materializedResultExprLists = Lists.newArrayList();
-
-            ScalarOperatorToExpr.FormatterContext formatterContext =
-                    new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr());
-            List<PlanFragment> childFragments = Lists.newArrayList();
-            for (int i = 0; i < optExpr.getInputs().size(); i++) {
-                List<ColumnRefOperator> childOutput = setOperation.getChildOutputColumns().get(i);
-                ExecGroup setExecGroup = this.currentExecGroup;
-                this.currentExecGroup = execGroups.newExecGroup();
-                PlanFragment fragment = visit(optExpr.getInputs().get(i), context);
-                this.currentExecGroup = setExecGroup;
-
-                List<Expr> materializedExpressions = Lists.newArrayList();
-
-                // keep output column order
-                for (ColumnRefOperator ref : childOutput) {
-                    materializedExpressions.add(ScalarOperatorToExpr.buildExecExpression(ref, formatterContext));
-                }
-
-                materializedResultExprLists.add(materializedExpressions);
-
-                if (isUnion) {
-                    fragment.setOutputPartition(DataPartition.RANDOM);
-                } else {
-                    fragment.setOutputPartition(DataPartition.hashPartitioned(materializedExpressions));
-                }
-
-                // nothing distribute can satisfy set-operator, must shuffle data
-                ExchangeNode exchangeNode =
-                        new ExchangeNode(context.getNextNodeId(), fragment.getPlanRoot(), fragment.getDataPartition());
-                this.currentExecGroup.add(exchangeNode, true);
-
-                childFragments.add(fragment);
-                exchangeNode.setFragment(setOperationFragment);
-                setOperationNode.addChild(exchangeNode);
-            }
-
-            // keep the fragment child order with execution order
-            // for intersect and except. child(0) is build node.
-            for (int i = setOperationNode.getChildren().size() - 1; i >= 0; i--) {
-                final PlanFragment planFragment = childFragments.get(i);
-                planFragment.setDestination((ExchangeNode) setOperationNode.getChild(i));
-            }
-
-            // reset column is nullable, for handle union select xx join select xxx...
-            setOperationNode.setHasNullableGenerateChild();
             List<Expr> setOutputList = Lists.newArrayList();
             for (int index = 0; index < setOperation.getOutputColumnRefOp().size(); index++) {
                 ColumnRefOperator columnRefOperator = setOperation.getOutputColumnRefOp().get(index);
@@ -3251,13 +3222,59 @@ public class PlanFragmentBuilder {
                 setOutputList.add(new SlotRef(String.valueOf(columnRefOperator.getId()), slotDesc));
             }
             setOperationTuple.computeMemLayout();
-
             setOperationNode.setSetOperationOutputList(setOutputList);
             setOperationNode.setMaterializedResultExprLists_(materializedResultExprLists);
             setOperationNode.setLimit(setOperation.getLimit());
             setOperationNode.computeStatistics(optExpr.getStatistics());
+            DistributionSpec spec = optExpr.getRequiredProperties().get(0).getDistributionProperty().getSpec();
+            boolean isColocate = (spec instanceof HashDistributionSpec) &&
+                    ((HashDistributionSpec) spec).getHashDistributionDesc().isLocal();
+            PlanFragment setOperationFragment =
+                    new PlanFragment(context.getNextFragmentId(), setOperationNode, DataPartition.RANDOM);
 
+            ExecGroup execGroup = execGroups.newExecGroup();
+            // TODO(by satanson): only all children of Set operator are colocate branch, we turn on execGroup.
+            //  if colocate set operator has bucket-shuffle branch, BE need tackle this situation to avoid
+            //  query hanging forever.
+            boolean canExecGroup = true;
+            for (int i = 0; i < optExpr.arity(); ++i) {
+                PlanFragment inputFragment = inputFragments.get(i);
+                context.getFragments().remove(inputFragment);
+                setOperationNode.addChild(inputFragment.getPlanRoot());
+                setOperationFragment.addChildren(inputFragment.getChildren());
+                setOperationFragment.mergeQueryDictExprs(inputFragment.getQueryGlobalDictExprs());
+                setOperationFragment.mergeQueryGlobalDicts(inputFragment.getQueryGlobalDicts());
+                ExecGroup inputExecGroup = inputExecGroups.get(i);
+                execGroups.remove(inputExecGroup);
+                if (inputFragment.getPlanRoot() instanceof ExchangeNode) {
+                    canExecGroup = false;
+                    if (isColocate) {
+                        inputFragment.getChildren().forEach(fragment -> {
+                            fragment.setOutputPartition(
+                                    new DataPartition(TPartitionType.BUCKET_SHUFFLE_HASH_PARTITIONED,
+                                            fragment.getOutputPartition().getPartitionExprs()));
+                        });
+                    }
+                } else {
+                    execGroup.merge(inputExecGroup);
+                    execGroups.remove(inputExecGroup);
+                }
+            }
+
+            setOperationFragment.setPlanRoot(setOperationNode);
+            // reset column is nullable, for handle union select xx join select xxx...
+            setOperationNode.setHasNullableGenerateChild();
             context.getFragments().add(setOperationFragment);
+            execGroup.add(setOperationNode);
+
+
+            setOperationNode.setColocate(isColocate);
+            if (canExecGroup && isColocate && ConnectContext.get().getSessionVariable().isEnableGroupExecution()) {
+                execGroup.setColocateGroup();
+            } else {
+                execGroup.disableColocateGroup(setOperationNode);
+            }
+            currentExecGroup = execGroup;
             return setOperationFragment;
         }
 
@@ -3979,7 +3996,7 @@ public class PlanFragmentBuilder {
             splitConsumeFragment.setQueryGlobalDicts(splitProduceFragment.getQueryGlobalDicts());
             splitConsumeFragment.setQueryGlobalDictExprs(splitProduceFragment.getQueryGlobalDictExprs());
             splitConsumeFragment.setLoadGlobalDicts(splitProduceFragment.getLoadGlobalDicts());
-            
+
             if (consumerOperator.hasLimit()) {
                 splitConsumeFragment.getPlanRoot().setLimit(consumerOperator.getLimit());
             }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -323,8 +323,11 @@ public class SelectStmtTest {
 
     private void assertNoCastStringAsStringInPlan(String sql) throws Exception {
         ExecPlan execPlan = UtFrameUtils.getPlanAndFragment(starRocksAssert.getCtx(), sql).second;
-        List<ScalarOperator> operators = execPlan.getPhysicalPlan().getInputs().stream().flatMap(input ->
-                input.getOp().getProjection().getColumnRefMap().values().stream()).collect(Collectors.toList());
+        List<ScalarOperator> operators = execPlan.getPhysicalPlan().getInputs().stream()
+                .filter(input -> input.getOp().getProjection() != null &&
+                        input.getOp().getProjection().getColumnRefMap() != null)
+                .flatMap(input -> input.getOp().getProjection().getColumnRefMap().values().stream())
+                .collect(Collectors.toList());
         Assert.assertTrue(operators.stream().noneMatch(op -> (op instanceof CastOperator) &&
                 op.getType().isStringType() &&
                 op.getChild(0).getType().isStringType()));

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/SchedulerTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/SchedulerTestBase.java
@@ -112,7 +112,7 @@ public class SchedulerTestBase extends SchedulerTestNoneDBBase {
                 "    \"replication_num\" = \"1\"\n" +
                 ");\n");
 
-        starRocksAssert.withTable("CREATE TABLE `lineitem_partition` (\n" +
+        String lineItemSql = "CREATE TABLE `lineitem_partition` (\n" +
                 "  `L_ORDERKEY` int(11) NOT NULL COMMENT \"\",\n" +
                 "  `L_PARTKEY` int(11) NOT NULL COMMENT \"\",\n" +
                 "  `L_SUPPKEY` int(11) NOT NULL COMMENT \"\",\n" +
@@ -144,7 +144,14 @@ public class SchedulerTestBase extends SchedulerTestNoneDBBase {
                 "PROPERTIES (\n" +
                 "    \"replication_num\" = \"1\",\n" +
                 "    \"colocate_with\" = \"" + tpchGroup + "\"\n" +
-                ");");
+                ");";
+        starRocksAssert.withTable(lineItemSql);
+        starRocksAssert.withTable(lineItemSql.replace("lineitem_partition", "lineitem0"));
+        starRocksAssert.withTable(lineItemSql.replace("lineitem_partition", "lineitem1"));
+        starRocksAssert.withTable(
+                lineItemSql.replace("lineitem_partition", "lineitem2").replace(tpchGroup, tpchGroup + "xx"));
+        starRocksAssert.withTable(
+                lineItemSql.replace("lineitem_partition", "lineitem3").replace(tpchGroup, tpchGroup + "xx"));
 
         starRocksAssert.withTable("CREATE TABLE customer (\n" +
                 "    c_custkey       INT NOT NULL,\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/plan/SchedulerColocateSetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/plan/SchedulerColocateSetTest.java
@@ -1,0 +1,303 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler.plan;
+
+import com.starrocks.qe.scheduler.SchedulerTestBase;
+import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
+
+/**
+ * Attention: cases need execute in a fix order or the result may change.
+ */
+@TestMethodOrder(MethodOrderer.MethodName.class)
+public class SchedulerColocateSetTest extends SchedulerTestBase {
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        SchedulerTestBase.beforeClass();
+    }
+
+    @AfterAll
+    public static void afterAll() throws Exception {
+        SchedulerTestBase.beforeClass();
+    }
+
+    void runFileUnitTestHelper(String sql, String resultFile) {
+        String enableColocateSetResult = resultFile + "_enable_colocate_set";
+        String disableColocateSetResult = resultFile + "_disable_colocate_set";
+        runFileUnitTest(sql, enableColocateSetResult);
+        String sql2 = sql.replace("select", "select /*+ SET_VAR(disable_colocate_set=true)*/");
+        runFileUnitTest(sql2, disableColocateSetResult);
+    }
+
+    @Test
+    public void testColocateIntersect() {
+        String sql = "select * from lineitem0 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'\n" +
+                "intersect\n" +
+                "select * from lineitem1 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'\n" +
+                "intersect\n" +
+                "select * from lineitem2 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'\n" +
+                "intersect\n" +
+                "select * from lineitem3 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'";
+        runFileUnitTestHelper(sql, "scheduler/colocate_set/intersect_q1");
+    }
+
+    @Test
+    public void testColocateIntersectWithAggBelow1() {
+        String sql = "with cte as(\n" +
+                "select L_ORDERKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem0 " +
+                "where L_SHIPDATE between '1993-01-01' AND '1993-12-31' " +
+                "group by L_ORDERKEY\n" +
+                "intersect\n" +
+                "select L_ORDERKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem1 " +
+                "where L_SHIPDATE between '1993-01-01' AND '1993-12-31' " +
+                "group by L_ORDERKEY\n" +
+                "intersect\n" +
+                "select L_ORDERKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem2 " +
+                "where L_SHIPDATE between '1993-01-01' AND '1993-12-31' " +
+                "group by L_ORDERKEY\n" +
+                "intersect\n" +
+                "select L_ORDERKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem3 " +
+                "where L_SHIPDATE between '1993-01-01' AND '1993-12-31' " +
+                "group by L_ORDERKEY\n" +
+                ")\n" +
+                "select L_ORDERKEY, sum(L_QUANTITY_SUM)\n" +
+                "from cte\n" +
+                "group by L_ORDERKEY;";
+        runFileUnitTestHelper(sql, "scheduler/colocate_set/intersect_q2");
+    }
+
+    @Test
+    public void testColocateIntersectWithAggBelow2() {
+        String sql = "with cte as(\n" +
+                "select L_ORDERKEY, L_PARTKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem0 " +
+                "where L_SHIPDATE between '1993-01-01' AND '1993-12-31' \n" +
+                "group by L_ORDERKEY,L_PARTKEY\n" +
+                "intersect\n" +
+                "select L_ORDERKEY, L_PARTKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem1 " +
+                "where L_SHIPDATE between '1993-01-01' AND '1993-12-31' \n" +
+                "group by L_ORDERKEY,L_PARTKEY\n" +
+                "intersect\n" +
+                "select L_ORDERKEY, L_PARTKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem2 " +
+                "where L_SHIPDATE between '1993-01-01' AND '1993-12-31' \n" +
+                "group by L_ORDERKEY,L_PARTKEY\n" +
+                "intersect\n" +
+                "select L_ORDERKEY, L_PARTKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem3 " +
+                "where L_SHIPDATE between '1993-01-01' AND '1993-12-31' \n" +
+                "group by L_ORDERKEY,L_PARTKEY\n" +
+                ")\n" +
+                "select L_ORDERKEY, L_PARTKEY, sum(L_QUANTITY_SUM)\n" +
+                "from cte\n" +
+                "group by L_ORDERKEY,L_PARTKEY;";
+        runFileUnitTestHelper(sql, "scheduler/colocate_set/intersect_q3");
+    }
+
+    @Test
+    public void testColocateIntersectWithAggBelow3() {
+        String sql = "with cte as(\n" +
+                "select L_PARTKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem0 " +
+                "where L_SHIPDATE between '1993-01-01' AND '1993-12-31' \n" +
+                "group by L_ORDERKEY,L_PARTKEY\n" +
+                "intersect\n" +
+                "select L_PARTKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem1 " +
+                "where L_SHIPDATE between '1993-01-01' AND '1993-12-31' \n" +
+                "group by L_ORDERKEY,L_PARTKEY\n" +
+                "intersect\n" +
+                "select L_PARTKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem2 " +
+                "where L_SHIPDATE between '1993-01-01' AND '1993-12-31' \n" +
+                "group by L_ORDERKEY,L_PARTKEY\n" +
+                "intersect\n" +
+                "select L_PARTKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem3 " +
+                "where L_SHIPDATE between '1993-01-01' AND '1993-12-31' \n" +
+                "group by L_ORDERKEY,L_PARTKEY\n" +
+                ")\n" +
+                "select L_PARTKEY, sum(L_QUANTITY_SUM)\n" +
+                "from cte\n" +
+                "group by L_PARTKEY;";
+        runFileUnitTestHelper(sql, "scheduler/colocate_set/intersect_q4");
+    }
+
+    @Test
+    public void testColocateIntersectWithJoinAbove() {
+        String sql = "with cte as(\n" +
+                "select L_ORDERKEY, L_PARTKEY\n" +
+                "from lineitem0 \n" +
+                "where L_SHIPDATE between '1993-01-01' AND '1993-12-31'\n" +
+                "INTERSECT\n" +
+                "select L_ORDERKEY, L_PARTKEY\n" +
+                "from lineitem1\n" +
+                "where L_SHIPDATE between '1993-01-01' AND '1993-12-31' \n" +
+                ")\n" +
+                "select cte.* \n" +
+                "from cte \n" +
+                "     inner join [bucket] orders on L_ORDERKEY = O_ORDERKEY\n" +
+                "     inner join [broadcast] part on L_PARTKEY = P_PARTKEY;";
+        runFileUnitTestHelper(sql, "scheduler/colocate_set/intersect_q5");
+    }
+
+    @Test
+    public void testColocateExcept() {
+        String sql = "select * from lineitem0 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'\n" +
+                "except\n" +
+                "select * from lineitem1 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'\n" +
+                "except\n" +
+                "select * from lineitem2 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'\n" +
+                "except\n" +
+                "select * from lineitem3 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'";
+        runFileUnitTestHelper(sql, "scheduler/colocate_set/except_q1");
+    }
+
+    @Test
+    public void testColocateExceptWithAggAbove1() {
+        String sql = "with cte as(\n" +
+                "select * from lineitem0 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'\n" +
+                "except\n" +
+                "select * from lineitem1 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'\n" +
+                "except\n" +
+                "select * from lineitem2 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'\n" +
+                "except\n" +
+                "select * from lineitem3 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'\n" +
+                ")\n" +
+                "select L_ORDERKEY, sum(L_QUANTITY)\n" +
+                "from cte\n" +
+                "group by L_ORDERKEY;\n";
+        System.out.println(sql);
+        runFileUnitTestHelper(sql, "scheduler/colocate_set/except_q2");
+    }
+
+    @Test
+    public void testColocateExceptWithAggAbove2() {
+        String sql = "with cte as(\n" +
+                "select * from lineitem0 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'\n" +
+                "except\n" +
+                "select * from lineitem1 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'\n" +
+                "except\n" +
+                "select * from lineitem2 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'\n" +
+                "except\n" +
+                "select * from lineitem3 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'\n" +
+                ")\n" +
+                "select L_ORDERKEY, L_PARTKEY, sum(L_QUANTITY)\n" +
+                "from cte\n" +
+                "group by L_ORDERKEY, L_PARTKEY;\n";
+        runFileUnitTestHelper(sql, "scheduler/colocate_set/except_q3");
+    }
+
+    @Test
+    public void testColocateExceptWithAggAbove3() {
+        String sql = "with cte as(\n" +
+                "select * from lineitem0 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'\n" +
+                "except\n" +
+                "select * from lineitem1 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'\n" +
+                "except\n" +
+                "select * from lineitem2 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'\n" +
+                "except\n" +
+                "select * from lineitem3 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'\n" +
+                ")\n" +
+                "select L_PARTKEY, sum(L_QUANTITY)\n" +
+                "from cte\n" +
+                "group by L_PARTKEY;\n";
+        runFileUnitTestHelper(sql, "scheduler/colocate_set/except_q4");
+    }
+
+    @Test
+    public void testRandomUnionDistinct() {
+        String sql = "select * from lineitem0 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'\n" +
+                "union\n" +
+                "select * from lineitem1 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'\n" +
+                "union\n" +
+                "select * from lineitem2 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'\n" +
+                "union\n" +
+                "select * from lineitem3 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'";
+        runFileUnitTestHelper(sql, "scheduler/colocate_set/union_q1");
+    }
+
+    @Test
+    public void testColocateUnionDistinct() {
+        String sql = "select * from lineitem0 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'\n" +
+                "union\n" +
+                "select * from lineitem1 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'";
+        runFileUnitTestHelper(sql, "scheduler/colocate_set/union_q2");
+    }
+
+    @Test
+    public void testRandomUnionAll() {
+        String sql = "select * from lineitem0 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'\n" +
+                "union all\n" +
+                "select * from lineitem1 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'\n" +
+                "union all\n" +
+                "select * from lineitem2 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'\n" +
+                "union all\n" +
+                "select * from lineitem3 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'";
+        runFileUnitTestHelper(sql, "scheduler/colocate_set/union_q3");
+    }
+
+    @Test
+    public void testColocateUnionDistinctWithJoinBelow1() {
+        String sql = "with cte as(\n" +
+                "select L_ORDERKEY, O_ORDERDATE, P_NAME\n" +
+                "from lineitem0 \n" +
+                "     inner join [bucket] orders on L_ORDERKEY = O_ORDERKEY\n" +
+                "     inner join [broadcast] part on L_PARTKEY = P_PARTKEY\n" +
+                "where L_SHIPDATE between '1993-01-01' AND '1993-12-31' \n" +
+                "UNION\n" +
+                "select L_ORDERKEY, O_ORDERDATE, P_NAME\n" +
+                "from lineitem1\n" +
+                "     inner join [bucket] orders on L_ORDERKEY = O_ORDERKEY\n" +
+                "     inner join [broadcast] part on L_PARTKEY = P_PARTKEY \n" +
+                "where L_SHIPDATE between '1993-01-01' AND '1993-12-31' \n" +
+                ")\n" +
+                "select * from cte;";
+        runFileUnitTestHelper(sql, "scheduler/colocate_set/union_q4");
+    }
+
+    @Test
+    public void testColocateUnionDistinctWithJoinBelow2() {
+        String sql = "with cte as(\n" +
+                "select O_ORDERDATE, P_NAME\n" +
+                "from lineitem0 \n" +
+                "     inner join [bucket] orders on L_ORDERKEY = O_ORDERKEY\n" +
+                "     inner join [broadcast] part on L_PARTKEY = P_PARTKEY\n" +
+                "where L_SHIPDATE between '1993-01-01' AND '1993-12-31' \n" +
+                "UNION\n" +
+                "select O_ORDERDATE, P_NAME\n" +
+                "from lineitem1\n" +
+                "     inner join [bucket] orders on L_ORDERKEY = O_ORDERKEY\n" +
+                "     inner join [broadcast] part on L_PARTKEY = P_PARTKEY \n" +
+                "where L_SHIPDATE between '1993-01-01' AND '1993-12-31' \n" +
+                ")\n" +
+                "select * from cte;";
+        runFileUnitTestHelper(sql, "scheduler/colocate_set/union_q5");
+    }
+
+    @Test
+    public void testColocateUnionDistinctWithJoinAbove() {
+        String sql = "with cte as(\n" +
+                "select L_ORDERKEY, L_PARTKEY\n" +
+                "from lineitem0 \n" +
+                "where L_SHIPDATE between '1993-01-01' AND '1993-12-31'\n" +
+                "UNION\n" +
+                "select L_ORDERKEY, L_PARTKEY\n" +
+                "from lineitem1\n" +
+                "where L_SHIPDATE between '1993-01-01' AND '1993-12-31' \n" +
+                ")\n" +
+                "select cte.* \n" +
+                "from cte \n" +
+                "     inner join [bucket] orders on L_ORDERKEY = O_ORDERKEY\n" +
+                "     inner join [broadcast] part on L_PARTKEY = P_PARTKEY; ";
+        runFileUnitTestHelper(sql, "scheduler/colocate_set/union_q6");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
@@ -399,7 +399,7 @@ class ParserTest {
     void testWrongVariableName() {
         VariableMgr variableMgr = new VariableMgr();
         String res = variableMgr.findSimilarVarNames("disable_coloce_join");
-        assertContains(res, "{'disable_colocate_join', 'disable_join_reorder', 'disable_function_fold_constants'}");
+        assertContains(res, "{'disable_colocate_join', 'disable_colocate_set', 'disable_join_reorder'");
 
         res = variableMgr.findSimilarVarNames("SQL_AUTO_NULL");
         assertContains(res, "{'SQL_AUTO_IS_NULL', 'sql_dialect', 'spill_storage_volume'}");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupExecutionPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupExecutionPlanTest.java
@@ -112,18 +112,20 @@ public class GroupExecutionPlanTest extends PlanTestBase {
             // bucket-shuffle join
             querys.add("select * from colocate1 l join [bucket] colocate2 r on l.k1=r.k1 and l.k2=r.k2;");
             // intersect
-            querys.add("select k1, k2 from colocate1 l intersect select k1, k2 from colocate2 r;");
+            querys.add("select /*+SET_VAR(disable_colocate_set=true)*/ k1, k2 from colocate1 l intersect " +
+                    "select k1, k2 from colocate2 r;");
             querys.add("select k1 from colocate1 l intersect select k1 from colocate2 r;");
             // union all
             querys.add("select k1 from colocate1 l union all select k1 from colocate2 r");
             querys.add("select distinct k1 from (select k1 from colocate1 l union all select k1 from colocate2 r) t;");
             // unoin
             querys.add("select k1 from colocate1 l union select k1 from colocate2 r");
-            querys.add("select k1,k2 from colocate1 l union select k1,k2 from colocate2 r");
+            querys.add("select /*+SET_VAR(disable_colocate_set=true)*/ k1,k2 from colocate1 l " +
+                    "union select k1,k2 from colocate2 r");
             // except
             querys.add("select distinct k1 from (select k1 from colocate1 l except select k1 from colocate2 r) t;");
-            querys.add(
-                    "select distinct k1,k2 from (select k1,k2 from colocate1 l except select k1,k2 from colocate2 r) t;");
+            querys.add("select /*+SET_VAR(disable_colocate_set=true)*/ distinct k1,k2 " +
+                    "from (select k1,k2 from colocate1 l except select k1,k2 from colocate2 r) t;");
             // physical limit
             querys.add(
                     "select distinct k1 from (select k1 from colocate1 l union all select k1 from colocate2 r limit 10) t;");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -263,26 +263,15 @@ public class LowCardinalityTest extends PlanTestBase {
                 "select cte1.L_SHIPMODE, cte1.L_COMMENT from cte1 join[broadcast] cte2 on cte1.L_SHIPMODE = cte2.P_COMMENT";
 
         String plan = getVerboseExplain(sql);
-        Assert.assertTrue(plan, plan.contains("  3:Decode\n" +
+        Assert.assertTrue(plan, plan.contains("  4:Decode\n" +
                 "  |  <dict id 50> : <string id 18>\n" +
                 "  |  cardinality: 1\n" +
                 "  |  \n" +
-                "  2:AGGREGATE (update finalize)\n" +
-                "  |  aggregate: max[([49: L_COMMENT, INT, false]); args: INT; result: INT; " +
-                "args nullable: false; result nullable: true]\n" +
-                "  |  group by: [15: L_SHIPMODE, CHAR, false]\n" +
-                "  |  cardinality: 1\n" +
-                "  |  \n" +
-                "  1:OlapScanNode\n" +
-                "     table: lineitem, rollup: lineitem\n" +
-                "     preAggregation: on\n" +
-                "     dict_col=L_COMMENT\n" +
-                "     partitionsRatio=0/1, tabletsRatio=0/0\n" +
-                "     tabletList=\n" +
-                "     actualRows=0, avgRowSize=54.0\n" +
+                "  3:EXCHANGE\n" +
+                "     distribution type: ROUND_ROBIN\n" +
                 "     cardinality: 1\n" +
                 "     probe runtime filters:\n" +
-                "     - filter_id = 0, probe_expr = (15: L_SHIPMODE)"));
+                "     - filter_id = 0, probe_expr = (<slot 15>)"));
     }
 
     @Test
@@ -1979,7 +1968,7 @@ public class LowCardinalityTest extends PlanTestBase {
                 "   w1 t1 \n" +
                 "   JOIN [broadcast] part_v2 t2 ON t1.P_NAME2 = t2.P_NAME AND t1.P_NAME = t2.P_NAME;";
         String plan = getCostExplain(sql);
-        assertContains(plan, "  3:Decode\n" +
+        assertContains(plan, "  4:Decode\n" +
                 "  |  <dict id 38> : <string id 2>\n" +
                 "  |  cardinality: 1\n" +
                 "  |  probe runtime filters:\n" +
@@ -1989,21 +1978,11 @@ public class LowCardinalityTest extends PlanTestBase {
                 "  |  * P_BRAND-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN\n" +
                 "  |  * cast-->[-Infinity, Infinity, 0.0, 16.0, 3.0] ESTIMATE\n" +
                 "  |  \n" +
-                "  2:Project\n" +
-                "  |  output columns:\n" +
-                "  |  12 <-> CASE WHEN DictDecode(38: P_NAME, [<place-holder> = 'a']) THEN 'a1' " +
-                "WHEN DictDecode(39: P_BRAND, [<place-holder> = 'b']) THEN 'b1' ELSE 'c1' END\n" +
-                "  |  38 <-> [38: P_NAME, INT, false]\n" +
-                "  |  cardinality: 1\n" +
-                "  |  probe runtime filters:\n" +
-                "  |  - filter_id = 0, probe_expr = (<slot 12>)\n" +
-                "  |  column statistics: \n" +
-                "  |  * cast-->[-Infinity, Infinity, 0.0, 16.0, 3.0] ESTIMATE\n" +
-                "  |  \n" +
-                "  1:OlapScanNode\n" +
-                "     table: part_v2, rollup: part_v2\n" +
-                "     preAggregation: on\n" +
-                "     dict_col=P_NAME,P_BRAND");
+                "  3:EXCHANGE\n" +
+                "     distribution type: ROUND_ROBIN\n" +
+                "     cardinality: 1\n" +
+                "     probe runtime filters:\n" +
+                "     - filter_id = 0, probe_expr = (<slot 12>)");
         System.out.println(plan);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -669,15 +669,10 @@ public class PlanFragmentWithCostTest extends PlanWithCostTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "  0:INTERSECT\n" +
                 "  |  \n" +
-                "  |----4:EXCHANGE\n" +
+                "  |----3:EXCHANGE\n" +
                 "  |    \n" +
-                "  |----6:EXCHANGE\n" +
+                "  |----5:EXCHANGE\n" +
                 "  |    \n" +
-                "  2:EXCHANGE\n");
-        assertContains(plan, "  STREAM DATA SINK\n" +
-                "    EXCHANGE ID: 02\n" +
-                "    HASH_PARTITIONED: 4: v7\n" +
-                "\n" +
                 "  1:OlapScanNode\n" +
                 "     TABLE: t2");
         setTableStatistics(t0, 10000);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -598,6 +598,7 @@ public class PlanTestNoneDBBase {
                     actualSchedulerPlan =
                             UtFrameUtils.getPlanAndStartScheduling(connectContext, sql.toString()).first;
                 } catch (Exception ex) {
+                    ex.printStackTrace();
                     if (!exceptString.toString().isEmpty()) {
                         Assert.assertEquals(exceptString.toString(), ex.getMessage());
                         return true;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneUKFKJoinRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneUKFKJoinRuleTest.java
@@ -536,7 +536,7 @@ public class PruneUKFKJoinRuleTest extends TPCDSPlanTestBase {
 
     @Test
     public void testQ74() throws Exception {
-        assertPlans(Q74, true);
+        assertPlans(Q74, false);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
@@ -245,12 +245,14 @@ public class SetTest extends PlanTestBase {
                 "  |  cardinality: 2\n" +
                 "  |  \n" +
                 "  |----11:EXCHANGE\n" +
+                "  |       distribution type: ROUND_ROBIN\n" +
                 "  |       cardinality: 1\n" +
                 "  |    \n" +
                 "  2:EXCHANGE\n" +
+                "     distribution type: ROUND_ROBIN\n" +
                 "     cardinality: 1\n" +
                 "\n" +
-                "PLAN FRAGMENT 1(F02)\n" +
+                "PLAN FRAGMENT 1(F06)\n" +
                 "\n" +
                 "  Input Partition: RANDOM\n" +
                 "  OutPut Partition: RANDOM\n" +
@@ -268,7 +270,8 @@ public class SetTest extends PlanTestBase {
                 "  |      [12, INT, true] | [13, BIGINT, true] | [14, BIGINT, true]\n" +
                 "  |  child exprs:\n" +
                 "  |      [7: cast, INT, true] | [5: v5, BIGINT, true] | [6: v6, BIGINT, true]\n" +
-                "  |      [11: cast, INT, true] | [9: v8, BIGINT, true] | [10: v9, BIGINT, true]");
+                "  |      [11: cast, INT, true] | [9: v8, BIGINT, true] | [10: v9, BIGINT, true]\n" +
+                "  |  cardinality: 1");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SplitScanToUnionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SplitScanToUnionTest.java
@@ -166,14 +166,14 @@ class SplitScanToUnionTest extends DistributedEnvPlanTestBase {
         list.add(arguments);
 
         sql = "select max(p_type) from part where p_name = 'a' or p_size = 1 group by p_name";
-        arguments = Arguments.of(sql, ImmutableList.of("UNION", "7:Decode", "3:Decode"));
+        arguments = Arguments.of(sql, ImmutableList.of("UNION", "8:Decode", "4:Decode"));
         list.add(arguments);
 
         sql = "select max(p_type) from part left semi join (" +
                 "select * from orders where O_COMMENT != 'c' and (O_CUSTKEY in (1, 100, 1000) or O_CLERK = 'a' )" +
                 " " +
                 ") t on p_size = O_ORDERKEY where p_type > 'a' and (p_name = 'a' or p_size = 1)";
-        arguments = Arguments.of(sql, ImmutableList.of("UNION", "3:Decode", "7:Decode"));
+        arguments = Arguments.of(sql, ImmutableList.of("UNION", "4:Decode", "8:Decode"));
         list.add(arguments);
 
         return list.stream();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPushAggTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPushAggTest.java
@@ -193,7 +193,7 @@ public class TPCDSPushAggTest extends TPCDS1TTestBase {
                 Arguments.of("Q68", 1, 1, false, 3, true, 1, false, 1, false),
                 Arguments.of("Q70", 4, 6, true, 6, true, 6, true, 6, true),
                 Arguments.of("Q71", 2, 2, false, 8, true, 8, true, 8, true),
-                Arguments.of("Q74", 8, 8, true, 8, true, 8, true, 8, true),
+                Arguments.of("Q74", 8, 8, true, 16, true, 16, true, 16, true),
                 Arguments.of("Q75", 4, 4, false, 16, true, 4, false, 4, false),
                 Arguments.of("Q77", 14, 26, true, 26, true, 26, true, 26, true),
                 Arguments.of("Q78", 6, 6, false, 9, true, 6, false, 6, false),

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/agg-pushdown-disable_on_broadcast_join.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/agg-pushdown-disable_on_broadcast_join.sql
@@ -270,10 +270,12 @@ select sum(v2) from (select * from t0 union all select * from t1) x group by v1;
 AGGREGATE ([GLOBAL] aggregate [{10: sum=sum(11: sum)}] group by [[7: v1]] having [null]
     EXCHANGE SHUFFLE[7]
         UNION
-            AGGREGATE ([GLOBAL] aggregate [{12: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                SCAN (columns[1: v1, 2: v2] predicate[null])
-            AGGREGATE ([GLOBAL] aggregate [{13: sum=sum(5: v5)}] group by [[4: v4]] having [null]
-                SCAN (columns[4: v4, 5: v5] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                AGGREGATE ([GLOBAL] aggregate [{12: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                    SCAN (columns[1: v1, 2: v2] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                AGGREGATE ([GLOBAL] aggregate [{13: sum=sum(5: v5)}] group by [[4: v4]] having [null]
+                    SCAN (columns[4: v4, 5: v5] predicate[null])
 [end]
 
 [sql]
@@ -282,13 +284,15 @@ select sum(v2) from (select t0.* from t0 join t1 on t0.v1 = t1.v4 union all sele
 AGGREGATE ([GLOBAL] aggregate [{13: sum=sum(14: sum)}] group by [[10: v1]] having [null]
     EXCHANGE SHUFFLE[10]
         UNION
-            INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
-                AGGREGATE ([GLOBAL] aggregate [{15: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                    SCAN (columns[1: v1, 2: v2] predicate[1: v1 IS NOT NULL])
-                EXCHANGE SHUFFLE[4]
-                    SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
-            AGGREGATE ([GLOBAL] aggregate [{16: sum=sum(8: v5)}] group by [[7: v4]] having [null]
-                SCAN (columns[7: v4, 8: v5] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+                    AGGREGATE ([GLOBAL] aggregate [{15: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                        SCAN (columns[1: v1, 2: v2] predicate[1: v1 IS NOT NULL])
+                    EXCHANGE SHUFFLE[4]
+                        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
+            EXCHANGE ROUND_ROBIN
+                AGGREGATE ([GLOBAL] aggregate [{16: sum=sum(8: v5)}] group by [[7: v4]] having [null]
+                    SCAN (columns[7: v4, 8: v5] predicate[null])
 [end]
 
 [sql]
@@ -299,13 +303,15 @@ select sum(v2) from (
 AGGREGATE ([GLOBAL] aggregate [{13: sum=sum(14: sum)}] group by [[10: v1]] having [null]
     EXCHANGE SHUFFLE[10]
         UNION
-            INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
-                AGGREGATE ([GLOBAL] aggregate [{15: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                    SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 1])
-                EXCHANGE SHUFFLE[4]
-                    SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
-            AGGREGATE ([GLOBAL] aggregate [{16: sum=sum(8: v5)}] group by [[7: v4]] having [null]
-                SCAN (columns[7: v4, 8: v5] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+                    AGGREGATE ([GLOBAL] aggregate [{15: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                        SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 1])
+                    EXCHANGE SHUFFLE[4]
+                        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
+            EXCHANGE ROUND_ROBIN
+                AGGREGATE ([GLOBAL] aggregate [{16: sum=sum(8: v5)}] group by [[7: v4]] having [null]
+                    SCAN (columns[7: v4, 8: v5] predicate[null])
 [end]
 
 [sql]
@@ -318,11 +324,13 @@ where abs(x.v2) = 2;
 AGGREGATE ([GLOBAL] aggregate [{13: sum=sum(11: v2)}] group by [[]] having [null]
     EXCHANGE GATHER
         UNION
-            INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
-                SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 2])
-                EXCHANGE SHUFFLE[4]
-                    SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
-            SCAN (columns[8: v5] predicate[abs(8: v5) = 2])
+            EXCHANGE ROUND_ROBIN
+                INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+                    SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 2])
+                    EXCHANGE SHUFFLE[4]
+                        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
+            EXCHANGE ROUND_ROBIN
+                SCAN (columns[8: v5] predicate[abs(8: v5) = 2])
 [end]
 
 [sql]
@@ -338,16 +346,18 @@ group by v1;
 AGGREGATE ([GLOBAL] aggregate [{16: sum=sum(17: sum)}] group by [[13: v1]] having [null]
     EXCHANGE SHUFFLE[13]
         UNION
-            INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
-                AGGREGATE ([GLOBAL] aggregate [{18: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                    SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 2])
-                EXCHANGE SHUFFLE[4]
-                    SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
-            INNER JOIN (join-predicate [11: v8 = 8: v5] post-join-predicate [null])
-                AGGREGATE ([GLOBAL] aggregate [{19: sum=sum(11: v8)}] group by [[10: v7, 11: v8]] having [null]
-                    SCAN (columns[10: v7, 11: v8] predicate[abs(11: v8) = 2])
-                EXCHANGE BROADCAST
-                    SCAN (columns[8: v5] predicate[abs(8: v5) = 2])
+            EXCHANGE ROUND_ROBIN
+                INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+                    AGGREGATE ([GLOBAL] aggregate [{18: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                        SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 2])
+                    EXCHANGE SHUFFLE[4]
+                        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
+            EXCHANGE ROUND_ROBIN
+                INNER JOIN (join-predicate [11: v8 = 8: v5] post-join-predicate [null])
+                    AGGREGATE ([GLOBAL] aggregate [{19: sum=sum(11: v8)}] group by [[10: v7, 11: v8]] having [null]
+                        SCAN (columns[10: v7, 11: v8] predicate[abs(11: v8) = 2])
+                    EXCHANGE BROADCAST
+                        SCAN (columns[8: v5] predicate[abs(8: v5) = 2])
 [end]
 
 [sql]
@@ -363,16 +373,18 @@ group by x.v1;
 AGGREGATE ([GLOBAL] aggregate [{16: sum=sum(17: sum)}] group by [[13: v1]] having [null]
     EXCHANGE SHUFFLE[13]
         UNION
-            INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
-                AGGREGATE ([GLOBAL] aggregate [{18: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                    SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 2])
-                EXCHANGE SHUFFLE[4]
-                    SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
-            INNER JOIN (join-predicate [11: v8 = 8: v5] post-join-predicate [null])
-                AGGREGATE ([GLOBAL] aggregate [{19: sum=sum(11: v8)}] group by [[10: v7, 11: v8]] having [null]
-                    SCAN (columns[10: v7, 11: v8] predicate[abs(11: v8) = 2])
-                EXCHANGE BROADCAST
-                    SCAN (columns[8: v5] predicate[abs(8: v5) = 2])
+            EXCHANGE ROUND_ROBIN
+                INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+                    AGGREGATE ([GLOBAL] aggregate [{18: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                        SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 2])
+                    EXCHANGE SHUFFLE[4]
+                        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
+            EXCHANGE ROUND_ROBIN
+                INNER JOIN (join-predicate [11: v8 = 8: v5] post-join-predicate [null])
+                    AGGREGATE ([GLOBAL] aggregate [{19: sum=sum(11: v8)}] group by [[10: v7, 11: v8]] having [null]
+                        SCAN (columns[10: v7, 11: v8] predicate[abs(11: v8) = 2])
+                    EXCHANGE BROADCAST
+                        SCAN (columns[8: v5] predicate[abs(8: v5) = 2])
 [end]
 
 [sql]
@@ -387,16 +399,22 @@ group by v1
 AGGREGATE ([GLOBAL] aggregate [{22: sum=sum(23: sum)}] group by [[19: v1]] having [null]
     EXCHANGE SHUFFLE[19]
         UNION
-            UNION
-                AGGREGATE ([GLOBAL] aggregate [{26: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                    SCAN (columns[1: v1, 2: v2] predicate[null])
-                AGGREGATE ([GLOBAL] aggregate [{27: sum=sum(5: v5)}] group by [[4: v4]] having [null]
-                    SCAN (columns[4: v4, 5: v5] predicate[null])
-            UNION
-                AGGREGATE ([GLOBAL] aggregate [{28: sum=sum(11: v5)}] group by [[10: v4]] having [null]
-                    SCAN (columns[10: v4, 11: v5] predicate[null])
-                AGGREGATE ([GLOBAL] aggregate [{29: sum=sum(14: v8)}] group by [[13: v7]] having [null]
-                    SCAN (columns[13: v7, 14: v8] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                UNION
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([GLOBAL] aggregate [{26: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                            SCAN (columns[1: v1, 2: v2] predicate[null])
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([GLOBAL] aggregate [{27: sum=sum(5: v5)}] group by [[4: v4]] having [null]
+                            SCAN (columns[4: v4, 5: v5] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                UNION
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([GLOBAL] aggregate [{28: sum=sum(11: v5)}] group by [[10: v4]] having [null]
+                            SCAN (columns[10: v4, 11: v5] predicate[null])
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([GLOBAL] aggregate [{29: sum=sum(14: v8)}] group by [[13: v7]] having [null]
+                            SCAN (columns[13: v7, 14: v8] predicate[null])
 [end]
 
 [sql]
@@ -411,16 +429,22 @@ group by v1
 AGGREGATE ([GLOBAL] aggregate [{22: sum=sum(23: sum)}] group by [[19: v1]] having [null]
     EXCHANGE SHUFFLE[19]
         UNION
-            UNION
-                AGGREGATE ([GLOBAL] aggregate [{26: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                    SCAN (columns[1: v1, 2: v2] predicate[null])
-                AGGREGATE ([GLOBAL] aggregate [{27: sum=sum(5: v5)}] group by [[4: v4]] having [null]
-                    SCAN (columns[4: v4, 5: v5] predicate[null])
-            UNION
-                AGGREGATE ([GLOBAL] aggregate [{28: sum=sum(11: v5)}] group by [[10: v4]] having [null]
-                    SCAN (columns[10: v4, 11: v5] predicate[null])
-                AGGREGATE ([GLOBAL] aggregate [{29: sum=sum(14: v8)}] group by [[13: v7]] having [null]
-                    SCAN (columns[13: v7, 14: v8] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                UNION
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([GLOBAL] aggregate [{26: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                            SCAN (columns[1: v1, 2: v2] predicate[null])
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([GLOBAL] aggregate [{27: sum=sum(5: v5)}] group by [[4: v4]] having [null]
+                            SCAN (columns[4: v4, 5: v5] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                UNION
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([GLOBAL] aggregate [{28: sum=sum(11: v5)}] group by [[10: v4]] having [null]
+                            SCAN (columns[10: v4, 11: v5] predicate[null])
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([GLOBAL] aggregate [{29: sum=sum(14: v8)}] group by [[13: v7]] having [null]
+                            SCAN (columns[13: v7, 14: v8] predicate[null])
 [end]
 
 [sql]
@@ -436,16 +460,20 @@ AGGREGATE ([GLOBAL] aggregate [{19: sum=sum(20: sum)}] group by [[8: v2]] having
     EXCHANGE SHUFFLE[8]
         INNER JOIN (join-predicate [8: v2 = 17: v5 AND add(8: v2, 17: v5) = 1] post-join-predicate [null])
             UNION
-                AGGREGATE ([GLOBAL] aggregate [{21: sum=sum(2: v2)}] group by [[2: v2]] having [null]
-                    EXCHANGE SHUFFLE[2]
-                        SCAN (columns[2: v2] predicate[2: v2 IS NOT NULL])
-                AGGREGATE ([GLOBAL] aggregate [{22: sum=sum(5: v5)}] group by [[5: v5]] having [null]
-                    EXCHANGE SHUFFLE[5]
-                        SCAN (columns[5: v5] predicate[5: v5 IS NOT NULL])
+                EXCHANGE ROUND_ROBIN
+                    AGGREGATE ([GLOBAL] aggregate [{21: sum=sum(2: v2)}] group by [[2: v2]] having [null]
+                        EXCHANGE SHUFFLE[2]
+                            SCAN (columns[2: v2] predicate[2: v2 IS NOT NULL])
+                EXCHANGE ROUND_ROBIN
+                    AGGREGATE ([GLOBAL] aggregate [{22: sum=sum(5: v5)}] group by [[5: v5]] having [null]
+                        EXCHANGE SHUFFLE[5]
+                            SCAN (columns[5: v5] predicate[5: v5 IS NOT NULL])
             EXCHANGE BROADCAST
                 UNION
-                    SCAN (columns[11: v5] predicate[11: v5 IS NOT NULL])
-                    SCAN (columns[14: v8] predicate[14: v8 IS NOT NULL])
+                    EXCHANGE ROUND_ROBIN
+                        SCAN (columns[11: v5] predicate[11: v5 IS NOT NULL])
+                    EXCHANGE ROUND_ROBIN
+                        SCAN (columns[14: v8] predicate[14: v8 IS NOT NULL])
 [end]
 
 [sql]
@@ -461,12 +489,16 @@ AGGREGATE ([GLOBAL] aggregate [{19: sum=sum(8: v2)}] group by [[]] having [null]
         TOP-N (order by [[7: v1 ASC NULLS FIRST]])
             INNER JOIN (join-predicate [8: v2 = 17: v5] post-join-predicate [null])
                 UNION
-                    SCAN (columns[1: v1, 2: v2] predicate[2: v2 IS NOT NULL])
-                    SCAN (columns[4: v4, 5: v5] predicate[5: v5 IS NOT NULL])
+                    EXCHANGE ROUND_ROBIN
+                        SCAN (columns[1: v1, 2: v2] predicate[2: v2 IS NOT NULL])
+                    EXCHANGE ROUND_ROBIN
+                        SCAN (columns[4: v4, 5: v5] predicate[5: v5 IS NOT NULL])
                 EXCHANGE BROADCAST
                     UNION
-                        SCAN (columns[11: v5] predicate[11: v5 IS NOT NULL])
-                        SCAN (columns[14: v8] predicate[14: v8 IS NOT NULL])
+                        EXCHANGE ROUND_ROBIN
+                            SCAN (columns[11: v5] predicate[11: v5 IS NOT NULL])
+                        EXCHANGE ROUND_ROBIN
+                            SCAN (columns[14: v8] predicate[14: v8 IS NOT NULL])
 [end]
 
 [sql]
@@ -564,3 +596,4 @@ AGGREGATE ([GLOBAL] aggregate [{7: sum=sum(9: sum), 8: sum=sum(10: sum)}] group 
         EXCHANGE SHUFFLE[4]
             SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
 [end]
+

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/agg-pushdown-enable_on_broadcast_join.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/agg-pushdown-enable_on_broadcast_join.sql
@@ -270,10 +270,12 @@ select sum(v2) from (select * from t0 union all select * from t1) x group by v1;
 AGGREGATE ([GLOBAL] aggregate [{10: sum=sum(11: sum)}] group by [[7: v1]] having [null]
     EXCHANGE SHUFFLE[7]
         UNION
-            AGGREGATE ([GLOBAL] aggregate [{12: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                SCAN (columns[1: v1, 2: v2] predicate[null])
-            AGGREGATE ([GLOBAL] aggregate [{13: sum=sum(5: v5)}] group by [[4: v4]] having [null]
-                SCAN (columns[4: v4, 5: v5] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                AGGREGATE ([GLOBAL] aggregate [{12: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                    SCAN (columns[1: v1, 2: v2] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                AGGREGATE ([GLOBAL] aggregate [{13: sum=sum(5: v5)}] group by [[4: v4]] having [null]
+                    SCAN (columns[4: v4, 5: v5] predicate[null])
 [end]
 
 [sql]
@@ -282,13 +284,15 @@ select sum(v2) from (select t0.* from t0 join t1 on t0.v1 = t1.v4 union all sele
 AGGREGATE ([GLOBAL] aggregate [{13: sum=sum(14: sum)}] group by [[10: v1]] having [null]
     EXCHANGE SHUFFLE[10]
         UNION
-            AGGREGATE ([GLOBAL] aggregate [{15: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
-                    SCAN (columns[1: v1, 2: v2] predicate[1: v1 IS NOT NULL])
-                    EXCHANGE SHUFFLE[4]
-                        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
-            AGGREGATE ([GLOBAL] aggregate [{16: sum=sum(8: v5)}] group by [[7: v4]] having [null]
-                SCAN (columns[7: v4, 8: v5] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                AGGREGATE ([GLOBAL] aggregate [{15: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                    INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+                        SCAN (columns[1: v1, 2: v2] predicate[1: v1 IS NOT NULL])
+                        EXCHANGE SHUFFLE[4]
+                            SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
+            EXCHANGE ROUND_ROBIN
+                AGGREGATE ([GLOBAL] aggregate [{16: sum=sum(8: v5)}] group by [[7: v4]] having [null]
+                    SCAN (columns[7: v4, 8: v5] predicate[null])
 [end]
 
 [sql]
@@ -299,13 +303,15 @@ select sum(v2) from (
 AGGREGATE ([GLOBAL] aggregate [{13: sum=sum(14: sum)}] group by [[10: v1]] having [null]
     EXCHANGE SHUFFLE[10]
         UNION
-            AGGREGATE ([GLOBAL] aggregate [{15: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
-                    SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 1])
-                    EXCHANGE SHUFFLE[4]
-                        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
-            AGGREGATE ([GLOBAL] aggregate [{16: sum=sum(8: v5)}] group by [[7: v4]] having [null]
-                SCAN (columns[7: v4, 8: v5] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                AGGREGATE ([GLOBAL] aggregate [{15: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                    INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+                        SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 1])
+                        EXCHANGE SHUFFLE[4]
+                            SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
+            EXCHANGE ROUND_ROBIN
+                AGGREGATE ([GLOBAL] aggregate [{16: sum=sum(8: v5)}] group by [[7: v4]] having [null]
+                    SCAN (columns[7: v4, 8: v5] predicate[null])
 [end]
 
 [sql]
@@ -318,11 +324,13 @@ where abs(x.v2) = 2;
 AGGREGATE ([GLOBAL] aggregate [{13: sum=sum(11: v2)}] group by [[]] having [null]
     EXCHANGE GATHER
         UNION
-            INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
-                SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 2])
-                EXCHANGE SHUFFLE[4]
-                    SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
-            SCAN (columns[8: v5] predicate[abs(8: v5) = 2])
+            EXCHANGE ROUND_ROBIN
+                INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+                    SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 2])
+                    EXCHANGE SHUFFLE[4]
+                        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
+            EXCHANGE ROUND_ROBIN
+                SCAN (columns[8: v5] predicate[abs(8: v5) = 2])
 [end]
 
 [sql]
@@ -338,16 +346,18 @@ group by v1;
 AGGREGATE ([GLOBAL] aggregate [{16: sum=sum(17: sum)}] group by [[13: v1]] having [null]
     EXCHANGE SHUFFLE[13]
         UNION
-            AGGREGATE ([GLOBAL] aggregate [{18: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
-                    SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 2])
-                    EXCHANGE SHUFFLE[4]
-                        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
-            INNER JOIN (join-predicate [11: v8 = 8: v5] post-join-predicate [null])
-                AGGREGATE ([GLOBAL] aggregate [{19: sum=sum(11: v8)}] group by [[10: v7, 11: v8]] having [null]
-                    SCAN (columns[10: v7, 11: v8] predicate[abs(11: v8) = 2])
-                EXCHANGE BROADCAST
-                    SCAN (columns[8: v5] predicate[abs(8: v5) = 2])
+            EXCHANGE ROUND_ROBIN
+                AGGREGATE ([GLOBAL] aggregate [{18: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                    INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+                        SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 2])
+                        EXCHANGE SHUFFLE[4]
+                            SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
+            EXCHANGE ROUND_ROBIN
+                INNER JOIN (join-predicate [11: v8 = 8: v5] post-join-predicate [null])
+                    AGGREGATE ([GLOBAL] aggregate [{19: sum=sum(11: v8)}] group by [[10: v7, 11: v8]] having [null]
+                        SCAN (columns[10: v7, 11: v8] predicate[abs(11: v8) = 2])
+                    EXCHANGE BROADCAST
+                        SCAN (columns[8: v5] predicate[abs(8: v5) = 2])
 [end]
 
 [sql]
@@ -363,16 +373,18 @@ group by x.v1;
 AGGREGATE ([GLOBAL] aggregate [{16: sum=sum(17: sum)}] group by [[13: v1]] having [null]
     EXCHANGE SHUFFLE[13]
         UNION
-            AGGREGATE ([GLOBAL] aggregate [{18: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
-                    SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 2])
-                    EXCHANGE SHUFFLE[4]
-                        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
-            INNER JOIN (join-predicate [11: v8 = 8: v5] post-join-predicate [null])
-                AGGREGATE ([GLOBAL] aggregate [{19: sum=sum(11: v8)}] group by [[10: v7, 11: v8]] having [null]
-                    SCAN (columns[10: v7, 11: v8] predicate[abs(11: v8) = 2])
-                EXCHANGE BROADCAST
-                    SCAN (columns[8: v5] predicate[abs(8: v5) = 2])
+            EXCHANGE ROUND_ROBIN
+                AGGREGATE ([GLOBAL] aggregate [{18: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                    INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+                        SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 2])
+                        EXCHANGE SHUFFLE[4]
+                            SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
+            EXCHANGE ROUND_ROBIN
+                INNER JOIN (join-predicate [11: v8 = 8: v5] post-join-predicate [null])
+                    AGGREGATE ([GLOBAL] aggregate [{19: sum=sum(11: v8)}] group by [[10: v7, 11: v8]] having [null]
+                        SCAN (columns[10: v7, 11: v8] predicate[abs(11: v8) = 2])
+                    EXCHANGE BROADCAST
+                        SCAN (columns[8: v5] predicate[abs(8: v5) = 2])
 [end]
 
 [sql]
@@ -387,16 +399,22 @@ group by v1
 AGGREGATE ([GLOBAL] aggregate [{22: sum=sum(23: sum)}] group by [[19: v1]] having [null]
     EXCHANGE SHUFFLE[19]
         UNION
-            UNION
-                AGGREGATE ([GLOBAL] aggregate [{26: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                    SCAN (columns[1: v1, 2: v2] predicate[null])
-                AGGREGATE ([GLOBAL] aggregate [{27: sum=sum(5: v5)}] group by [[4: v4]] having [null]
-                    SCAN (columns[4: v4, 5: v5] predicate[null])
-            UNION
-                AGGREGATE ([GLOBAL] aggregate [{28: sum=sum(11: v5)}] group by [[10: v4]] having [null]
-                    SCAN (columns[10: v4, 11: v5] predicate[null])
-                AGGREGATE ([GLOBAL] aggregate [{29: sum=sum(14: v8)}] group by [[13: v7]] having [null]
-                    SCAN (columns[13: v7, 14: v8] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                UNION
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([GLOBAL] aggregate [{26: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                            SCAN (columns[1: v1, 2: v2] predicate[null])
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([GLOBAL] aggregate [{27: sum=sum(5: v5)}] group by [[4: v4]] having [null]
+                            SCAN (columns[4: v4, 5: v5] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                UNION
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([GLOBAL] aggregate [{28: sum=sum(11: v5)}] group by [[10: v4]] having [null]
+                            SCAN (columns[10: v4, 11: v5] predicate[null])
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([GLOBAL] aggregate [{29: sum=sum(14: v8)}] group by [[13: v7]] having [null]
+                            SCAN (columns[13: v7, 14: v8] predicate[null])
 [end]
 
 [sql]
@@ -411,16 +429,22 @@ group by v1
 AGGREGATE ([GLOBAL] aggregate [{22: sum=sum(23: sum)}] group by [[19: v1]] having [null]
     EXCHANGE SHUFFLE[19]
         UNION
-            UNION
-                AGGREGATE ([GLOBAL] aggregate [{26: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                    SCAN (columns[1: v1, 2: v2] predicate[null])
-                AGGREGATE ([GLOBAL] aggregate [{27: sum=sum(5: v5)}] group by [[4: v4]] having [null]
-                    SCAN (columns[4: v4, 5: v5] predicate[null])
-            UNION
-                AGGREGATE ([GLOBAL] aggregate [{28: sum=sum(11: v5)}] group by [[10: v4]] having [null]
-                    SCAN (columns[10: v4, 11: v5] predicate[null])
-                AGGREGATE ([GLOBAL] aggregate [{29: sum=sum(14: v8)}] group by [[13: v7]] having [null]
-                    SCAN (columns[13: v7, 14: v8] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                UNION
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([GLOBAL] aggregate [{26: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                            SCAN (columns[1: v1, 2: v2] predicate[null])
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([GLOBAL] aggregate [{27: sum=sum(5: v5)}] group by [[4: v4]] having [null]
+                            SCAN (columns[4: v4, 5: v5] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                UNION
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([GLOBAL] aggregate [{28: sum=sum(11: v5)}] group by [[10: v4]] having [null]
+                            SCAN (columns[10: v4, 11: v5] predicate[null])
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([GLOBAL] aggregate [{29: sum=sum(14: v8)}] group by [[13: v7]] having [null]
+                            SCAN (columns[13: v7, 14: v8] predicate[null])
 [end]
 
 [sql]
@@ -436,16 +460,20 @@ AGGREGATE ([GLOBAL] aggregate [{19: sum=sum(20: sum)}] group by [[8: v2]] having
     EXCHANGE SHUFFLE[8]
         INNER JOIN (join-predicate [8: v2 = 17: v5 AND add(8: v2, 17: v5) = 1] post-join-predicate [null])
             UNION
-                AGGREGATE ([GLOBAL] aggregate [{21: sum=sum(2: v2)}] group by [[2: v2]] having [null]
-                    EXCHANGE SHUFFLE[2]
-                        SCAN (columns[2: v2] predicate[2: v2 IS NOT NULL])
-                AGGREGATE ([GLOBAL] aggregate [{22: sum=sum(5: v5)}] group by [[5: v5]] having [null]
-                    EXCHANGE SHUFFLE[5]
-                        SCAN (columns[5: v5] predicate[5: v5 IS NOT NULL])
+                EXCHANGE ROUND_ROBIN
+                    AGGREGATE ([GLOBAL] aggregate [{21: sum=sum(2: v2)}] group by [[2: v2]] having [null]
+                        EXCHANGE SHUFFLE[2]
+                            SCAN (columns[2: v2] predicate[2: v2 IS NOT NULL])
+                EXCHANGE ROUND_ROBIN
+                    AGGREGATE ([GLOBAL] aggregate [{22: sum=sum(5: v5)}] group by [[5: v5]] having [null]
+                        EXCHANGE SHUFFLE[5]
+                            SCAN (columns[5: v5] predicate[5: v5 IS NOT NULL])
             EXCHANGE BROADCAST
                 UNION
-                    SCAN (columns[11: v5] predicate[11: v5 IS NOT NULL])
-                    SCAN (columns[14: v8] predicate[14: v8 IS NOT NULL])
+                    EXCHANGE ROUND_ROBIN
+                        SCAN (columns[11: v5] predicate[11: v5 IS NOT NULL])
+                    EXCHANGE ROUND_ROBIN
+                        SCAN (columns[14: v8] predicate[14: v8 IS NOT NULL])
 [end]
 
 [sql]
@@ -461,12 +489,16 @@ AGGREGATE ([GLOBAL] aggregate [{19: sum=sum(8: v2)}] group by [[]] having [null]
         TOP-N (order by [[7: v1 ASC NULLS FIRST]])
             INNER JOIN (join-predicate [8: v2 = 17: v5] post-join-predicate [null])
                 UNION
-                    SCAN (columns[1: v1, 2: v2] predicate[2: v2 IS NOT NULL])
-                    SCAN (columns[4: v4, 5: v5] predicate[5: v5 IS NOT NULL])
+                    EXCHANGE ROUND_ROBIN
+                        SCAN (columns[1: v1, 2: v2] predicate[2: v2 IS NOT NULL])
+                    EXCHANGE ROUND_ROBIN
+                        SCAN (columns[4: v4, 5: v5] predicate[5: v5 IS NOT NULL])
                 EXCHANGE BROADCAST
                     UNION
-                        SCAN (columns[11: v5] predicate[11: v5 IS NOT NULL])
-                        SCAN (columns[14: v8] predicate[14: v8 IS NOT NULL])
+                        EXCHANGE ROUND_ROBIN
+                            SCAN (columns[11: v5] predicate[11: v5 IS NOT NULL])
+                        EXCHANGE ROUND_ROBIN
+                            SCAN (columns[14: v8] predicate[14: v8 IS NOT NULL])
 [end]
 
 [sql]

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/preagg-pushdown-disable_on_broadcast_join.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/preagg-pushdown-disable_on_broadcast_join.sql
@@ -119,10 +119,12 @@ select sum(v2) from (select * from t0 union all select * from t1) x group by v1;
 AGGREGATE ([GLOBAL] aggregate [{10: sum=sum(11: sum)}] group by [[7: v1]] having [null]
     EXCHANGE SHUFFLE[7]
         UNION
-            AGGREGATE ([LOCAL] aggregate [{12: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                SCAN (columns[1: v1, 2: v2] predicate[null])
-            AGGREGATE ([LOCAL] aggregate [{13: sum=sum(5: v5)}] group by [[4: v4]] having [null]
-                SCAN (columns[4: v4, 5: v5] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                AGGREGATE ([LOCAL] aggregate [{12: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                    SCAN (columns[1: v1, 2: v2] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                AGGREGATE ([LOCAL] aggregate [{13: sum=sum(5: v5)}] group by [[4: v4]] having [null]
+                    SCAN (columns[4: v4, 5: v5] predicate[null])
 [end]
 
 [sql]
@@ -131,13 +133,15 @@ select sum(v2) from (select t0.* from t0 join t1 on t0.v1 = t1.v4 union all sele
 AGGREGATE ([GLOBAL] aggregate [{13: sum=sum(14: sum)}] group by [[10: v1]] having [null]
     EXCHANGE SHUFFLE[10]
         UNION
-            INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
-                AGGREGATE ([LOCAL] aggregate [{15: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                    SCAN (columns[1: v1, 2: v2] predicate[1: v1 IS NOT NULL])
-                EXCHANGE SHUFFLE[4]
-                    SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
-            AGGREGATE ([LOCAL] aggregate [{16: sum=sum(8: v5)}] group by [[7: v4]] having [null]
-                SCAN (columns[7: v4, 8: v5] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+                    AGGREGATE ([LOCAL] aggregate [{15: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                        SCAN (columns[1: v1, 2: v2] predicate[1: v1 IS NOT NULL])
+                    EXCHANGE SHUFFLE[4]
+                        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
+            EXCHANGE ROUND_ROBIN
+                AGGREGATE ([LOCAL] aggregate [{16: sum=sum(8: v5)}] group by [[7: v4]] having [null]
+                    SCAN (columns[7: v4, 8: v5] predicate[null])
 [end]
 
 [sql]
@@ -148,15 +152,16 @@ select sum(v2) from (
 AGGREGATE ([GLOBAL] aggregate [{13: sum=sum(14: sum)}] group by [[10: v1]] having [null]
     EXCHANGE SHUFFLE[10]
         UNION
-            INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
-                AGGREGATE ([LOCAL] aggregate [{15: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                    SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 1])
-                EXCHANGE SHUFFLE[4]
-                    SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
-            AGGREGATE ([LOCAL] aggregate [{16: sum=sum(8: v5)}] group by [[7: v4]] having [null]
-                SCAN (columns[7: v4, 8: v5] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+                    AGGREGATE ([LOCAL] aggregate [{15: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                        SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 1])
+                    EXCHANGE SHUFFLE[4]
+                        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
+            EXCHANGE ROUND_ROBIN
+                AGGREGATE ([LOCAL] aggregate [{16: sum=sum(8: v5)}] group by [[7: v4]] having [null]
+                    SCAN (columns[7: v4, 8: v5] predicate[null])
 [end]
-
 
 [sql]
 select sum(v2) from
@@ -171,16 +176,18 @@ group by v1;
 AGGREGATE ([GLOBAL] aggregate [{16: sum=sum(17: sum)}] group by [[13: v1]] having [null]
     EXCHANGE SHUFFLE[13]
         UNION
-            INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
-                AGGREGATE ([LOCAL] aggregate [{18: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                    SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 2])
-                EXCHANGE SHUFFLE[4]
-                    SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
-            INNER JOIN (join-predicate [11: v8 = 8: v5] post-join-predicate [null])
-                AGGREGATE ([LOCAL] aggregate [{19: sum=sum(11: v8)}] group by [[10: v7, 11: v8]] having [null]
-                    SCAN (columns[10: v7, 11: v8] predicate[abs(11: v8) = 2])
-                EXCHANGE BROADCAST
-                    SCAN (columns[8: v5] predicate[abs(8: v5) = 2])
+            EXCHANGE ROUND_ROBIN
+                INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+                    AGGREGATE ([LOCAL] aggregate [{18: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                        SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 2])
+                    EXCHANGE SHUFFLE[4]
+                        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
+            EXCHANGE ROUND_ROBIN
+                INNER JOIN (join-predicate [11: v8 = 8: v5] post-join-predicate [null])
+                    AGGREGATE ([LOCAL] aggregate [{19: sum=sum(11: v8)}] group by [[10: v7, 11: v8]] having [null]
+                        SCAN (columns[10: v7, 11: v8] predicate[abs(11: v8) = 2])
+                    EXCHANGE BROADCAST
+                        SCAN (columns[8: v5] predicate[abs(8: v5) = 2])
 [end]
 
 [sql]
@@ -196,16 +203,18 @@ group by x.v1;
 AGGREGATE ([GLOBAL] aggregate [{16: sum=sum(17: sum)}] group by [[13: v1]] having [null]
     EXCHANGE SHUFFLE[13]
         UNION
-            INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
-                AGGREGATE ([LOCAL] aggregate [{18: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                    SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 2])
-                EXCHANGE SHUFFLE[4]
-                    SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
-            INNER JOIN (join-predicate [11: v8 = 8: v5] post-join-predicate [null])
-                AGGREGATE ([LOCAL] aggregate [{19: sum=sum(11: v8)}] group by [[10: v7, 11: v8]] having [null]
-                    SCAN (columns[10: v7, 11: v8] predicate[abs(11: v8) = 2])
-                EXCHANGE BROADCAST
-                    SCAN (columns[8: v5] predicate[abs(8: v5) = 2])
+            EXCHANGE ROUND_ROBIN
+                INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+                    AGGREGATE ([LOCAL] aggregate [{18: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                        SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 2])
+                    EXCHANGE SHUFFLE[4]
+                        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
+            EXCHANGE ROUND_ROBIN
+                INNER JOIN (join-predicate [11: v8 = 8: v5] post-join-predicate [null])
+                    AGGREGATE ([LOCAL] aggregate [{19: sum=sum(11: v8)}] group by [[10: v7, 11: v8]] having [null]
+                        SCAN (columns[10: v7, 11: v8] predicate[abs(11: v8) = 2])
+                    EXCHANGE BROADCAST
+                        SCAN (columns[8: v5] predicate[abs(8: v5) = 2])
 [end]
 
 [sql]
@@ -220,16 +229,22 @@ group by v1
 AGGREGATE ([GLOBAL] aggregate [{22: sum=sum(23: sum)}] group by [[19: v1]] having [null]
     EXCHANGE SHUFFLE[19]
         UNION
-            UNION
-                AGGREGATE ([LOCAL] aggregate [{26: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                    SCAN (columns[1: v1, 2: v2] predicate[null])
-                AGGREGATE ([LOCAL] aggregate [{27: sum=sum(5: v5)}] group by [[4: v4]] having [null]
-                    SCAN (columns[4: v4, 5: v5] predicate[null])
-            UNION
-                AGGREGATE ([LOCAL] aggregate [{28: sum=sum(11: v5)}] group by [[10: v4]] having [null]
-                    SCAN (columns[10: v4, 11: v5] predicate[null])
-                AGGREGATE ([LOCAL] aggregate [{29: sum=sum(14: v8)}] group by [[13: v7]] having [null]
-                    SCAN (columns[13: v7, 14: v8] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                UNION
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([LOCAL] aggregate [{26: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                            SCAN (columns[1: v1, 2: v2] predicate[null])
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([LOCAL] aggregate [{27: sum=sum(5: v5)}] group by [[4: v4]] having [null]
+                            SCAN (columns[4: v4, 5: v5] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                UNION
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([LOCAL] aggregate [{28: sum=sum(11: v5)}] group by [[10: v4]] having [null]
+                            SCAN (columns[10: v4, 11: v5] predicate[null])
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([LOCAL] aggregate [{29: sum=sum(14: v8)}] group by [[13: v7]] having [null]
+                            SCAN (columns[13: v7, 14: v8] predicate[null])
 [end]
 
 [sql]
@@ -244,16 +259,22 @@ group by v1
 AGGREGATE ([GLOBAL] aggregate [{22: sum=sum(23: sum)}] group by [[19: v1]] having [null]
     EXCHANGE SHUFFLE[19]
         UNION
-            UNION
-                AGGREGATE ([LOCAL] aggregate [{26: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                    SCAN (columns[1: v1, 2: v2] predicate[null])
-                AGGREGATE ([LOCAL] aggregate [{27: sum=sum(5: v5)}] group by [[4: v4]] having [null]
-                    SCAN (columns[4: v4, 5: v5] predicate[null])
-            UNION
-                AGGREGATE ([LOCAL] aggregate [{28: sum=sum(11: v5)}] group by [[10: v4]] having [null]
-                    SCAN (columns[10: v4, 11: v5] predicate[null])
-                AGGREGATE ([LOCAL] aggregate [{29: sum=sum(14: v8)}] group by [[13: v7]] having [null]
-                    SCAN (columns[13: v7, 14: v8] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                UNION
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([LOCAL] aggregate [{26: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                            SCAN (columns[1: v1, 2: v2] predicate[null])
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([LOCAL] aggregate [{27: sum=sum(5: v5)}] group by [[4: v4]] having [null]
+                            SCAN (columns[4: v4, 5: v5] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                UNION
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([LOCAL] aggregate [{28: sum=sum(11: v5)}] group by [[10: v4]] having [null]
+                            SCAN (columns[10: v4, 11: v5] predicate[null])
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([LOCAL] aggregate [{29: sum=sum(14: v8)}] group by [[13: v7]] having [null]
+                            SCAN (columns[13: v7, 14: v8] predicate[null])
 [end]
 
 [sql]
@@ -269,16 +290,19 @@ AGGREGATE ([GLOBAL] aggregate [{19: sum=sum(20: sum)}] group by [[8: v2]] having
     EXCHANGE SHUFFLE[8]
         INNER JOIN (join-predicate [8: v2 = 17: v5 AND add(8: v2, 17: v5) = 1] post-join-predicate [null])
             UNION
-                AGGREGATE ([LOCAL] aggregate [{21: sum=sum(2: v2)}] group by [[2: v2]] having [null]
-                    SCAN (columns[2: v2] predicate[2: v2 IS NOT NULL])
-                AGGREGATE ([LOCAL] aggregate [{22: sum=sum(5: v5)}] group by [[5: v5]] having [null]
-                    SCAN (columns[5: v5] predicate[5: v5 IS NOT NULL])
+                EXCHANGE ROUND_ROBIN
+                    AGGREGATE ([LOCAL] aggregate [{21: sum=sum(2: v2)}] group by [[2: v2]] having [null]
+                        SCAN (columns[2: v2] predicate[2: v2 IS NOT NULL])
+                EXCHANGE ROUND_ROBIN
+                    AGGREGATE ([LOCAL] aggregate [{22: sum=sum(5: v5)}] group by [[5: v5]] having [null]
+                        SCAN (columns[5: v5] predicate[5: v5 IS NOT NULL])
             EXCHANGE BROADCAST
                 UNION
-                    SCAN (columns[11: v5] predicate[11: v5 IS NOT NULL])
-                    SCAN (columns[14: v8] predicate[14: v8 IS NOT NULL])
+                    EXCHANGE ROUND_ROBIN
+                        SCAN (columns[11: v5] predicate[11: v5 IS NOT NULL])
+                    EXCHANGE ROUND_ROBIN
+                        SCAN (columns[14: v8] predicate[14: v8 IS NOT NULL])
 [end]
-
 
 [sql]
 select sum(v2) from t0, t1 group by v1;
@@ -314,3 +338,4 @@ AGGREGATE ([GLOBAL] aggregate [{7: sum=sum(9: sum), 8: sum=sum(10: sum)}] group 
         EXCHANGE SHUFFLE[4]
             SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
 [end]
+

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/preagg-pushdown-enable_on_broadcast_join.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/preagg-pushdown-enable_on_broadcast_join.sql
@@ -119,10 +119,12 @@ select sum(v2) from (select * from t0 union all select * from t1) x group by v1;
 AGGREGATE ([GLOBAL] aggregate [{10: sum=sum(11: sum)}] group by [[7: v1]] having [null]
     EXCHANGE SHUFFLE[7]
         UNION
-            AGGREGATE ([LOCAL] aggregate [{12: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                SCAN (columns[1: v1, 2: v2] predicate[null])
-            AGGREGATE ([LOCAL] aggregate [{13: sum=sum(5: v5)}] group by [[4: v4]] having [null]
-                SCAN (columns[4: v4, 5: v5] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                AGGREGATE ([LOCAL] aggregate [{12: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                    SCAN (columns[1: v1, 2: v2] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                AGGREGATE ([LOCAL] aggregate [{13: sum=sum(5: v5)}] group by [[4: v4]] having [null]
+                    SCAN (columns[4: v4, 5: v5] predicate[null])
 [end]
 
 [sql]
@@ -131,13 +133,15 @@ select sum(v2) from (select t0.* from t0 join t1 on t0.v1 = t1.v4 union all sele
 AGGREGATE ([GLOBAL] aggregate [{13: sum=sum(14: sum)}] group by [[10: v1]] having [null]
     EXCHANGE SHUFFLE[10]
         UNION
-            AGGREGATE ([LOCAL] aggregate [{15: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
-                    SCAN (columns[1: v1, 2: v2] predicate[1: v1 IS NOT NULL])
-                    EXCHANGE SHUFFLE[4]
-                        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
-            AGGREGATE ([LOCAL] aggregate [{16: sum=sum(8: v5)}] group by [[7: v4]] having [null]
-                SCAN (columns[7: v4, 8: v5] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                AGGREGATE ([LOCAL] aggregate [{15: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                    INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+                        SCAN (columns[1: v1, 2: v2] predicate[1: v1 IS NOT NULL])
+                        EXCHANGE SHUFFLE[4]
+                            SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
+            EXCHANGE ROUND_ROBIN
+                AGGREGATE ([LOCAL] aggregate [{16: sum=sum(8: v5)}] group by [[7: v4]] having [null]
+                    SCAN (columns[7: v4, 8: v5] predicate[null])
 [end]
 
 [sql]
@@ -148,13 +152,15 @@ select sum(v2) from (
 AGGREGATE ([GLOBAL] aggregate [{13: sum=sum(14: sum)}] group by [[10: v1]] having [null]
     EXCHANGE SHUFFLE[10]
         UNION
-            AGGREGATE ([LOCAL] aggregate [{15: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
-                    SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 1])
-                    EXCHANGE SHUFFLE[4]
-                        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
-            AGGREGATE ([LOCAL] aggregate [{16: sum=sum(8: v5)}] group by [[7: v4]] having [null]
-                SCAN (columns[7: v4, 8: v5] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                AGGREGATE ([LOCAL] aggregate [{15: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                    INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+                        SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 1])
+                        EXCHANGE SHUFFLE[4]
+                            SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
+            EXCHANGE ROUND_ROBIN
+                AGGREGATE ([LOCAL] aggregate [{16: sum=sum(8: v5)}] group by [[7: v4]] having [null]
+                    SCAN (columns[7: v4, 8: v5] predicate[null])
 [end]
 
 [sql]
@@ -170,16 +176,18 @@ group by v1;
 AGGREGATE ([GLOBAL] aggregate [{16: sum=sum(17: sum)}] group by [[13: v1]] having [null]
     EXCHANGE SHUFFLE[13]
         UNION
-            AGGREGATE ([LOCAL] aggregate [{18: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
-                    SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 2])
-                    EXCHANGE SHUFFLE[4]
-                        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
-            INNER JOIN (join-predicate [11: v8 = 8: v5] post-join-predicate [null])
-                AGGREGATE ([LOCAL] aggregate [{19: sum=sum(11: v8)}] group by [[10: v7, 11: v8]] having [null]
-                    SCAN (columns[10: v7, 11: v8] predicate[abs(11: v8) = 2])
-                EXCHANGE BROADCAST
-                    SCAN (columns[8: v5] predicate[abs(8: v5) = 2])
+            EXCHANGE ROUND_ROBIN
+                AGGREGATE ([LOCAL] aggregate [{18: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                    INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+                        SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 2])
+                        EXCHANGE SHUFFLE[4]
+                            SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
+            EXCHANGE ROUND_ROBIN
+                INNER JOIN (join-predicate [11: v8 = 8: v5] post-join-predicate [null])
+                    AGGREGATE ([LOCAL] aggregate [{19: sum=sum(11: v8)}] group by [[10: v7, 11: v8]] having [null]
+                        SCAN (columns[10: v7, 11: v8] predicate[abs(11: v8) = 2])
+                    EXCHANGE BROADCAST
+                        SCAN (columns[8: v5] predicate[abs(8: v5) = 2])
 [end]
 
 [sql]
@@ -195,16 +203,18 @@ group by x.v1;
 AGGREGATE ([GLOBAL] aggregate [{16: sum=sum(17: sum)}] group by [[13: v1]] having [null]
     EXCHANGE SHUFFLE[13]
         UNION
-            AGGREGATE ([LOCAL] aggregate [{18: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
-                    SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 2])
-                    EXCHANGE SHUFFLE[4]
-                        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
-            INNER JOIN (join-predicate [11: v8 = 8: v5] post-join-predicate [null])
-                AGGREGATE ([LOCAL] aggregate [{19: sum=sum(11: v8)}] group by [[10: v7, 11: v8]] having [null]
-                    SCAN (columns[10: v7, 11: v8] predicate[abs(11: v8) = 2])
-                EXCHANGE BROADCAST
-                    SCAN (columns[8: v5] predicate[abs(8: v5) = 2])
+            EXCHANGE ROUND_ROBIN
+                AGGREGATE ([LOCAL] aggregate [{18: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                    INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+                        SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 2])
+                        EXCHANGE SHUFFLE[4]
+                            SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
+            EXCHANGE ROUND_ROBIN
+                INNER JOIN (join-predicate [11: v8 = 8: v5] post-join-predicate [null])
+                    AGGREGATE ([LOCAL] aggregate [{19: sum=sum(11: v8)}] group by [[10: v7, 11: v8]] having [null]
+                        SCAN (columns[10: v7, 11: v8] predicate[abs(11: v8) = 2])
+                    EXCHANGE BROADCAST
+                        SCAN (columns[8: v5] predicate[abs(8: v5) = 2])
 [end]
 
 [sql]
@@ -219,16 +229,22 @@ group by v1
 AGGREGATE ([GLOBAL] aggregate [{22: sum=sum(23: sum)}] group by [[19: v1]] having [null]
     EXCHANGE SHUFFLE[19]
         UNION
-            UNION
-                AGGREGATE ([LOCAL] aggregate [{26: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                    SCAN (columns[1: v1, 2: v2] predicate[null])
-                AGGREGATE ([LOCAL] aggregate [{27: sum=sum(5: v5)}] group by [[4: v4]] having [null]
-                    SCAN (columns[4: v4, 5: v5] predicate[null])
-            UNION
-                AGGREGATE ([LOCAL] aggregate [{28: sum=sum(11: v5)}] group by [[10: v4]] having [null]
-                    SCAN (columns[10: v4, 11: v5] predicate[null])
-                AGGREGATE ([LOCAL] aggregate [{29: sum=sum(14: v8)}] group by [[13: v7]] having [null]
-                    SCAN (columns[13: v7, 14: v8] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                UNION
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([LOCAL] aggregate [{26: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                            SCAN (columns[1: v1, 2: v2] predicate[null])
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([LOCAL] aggregate [{27: sum=sum(5: v5)}] group by [[4: v4]] having [null]
+                            SCAN (columns[4: v4, 5: v5] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                UNION
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([LOCAL] aggregate [{28: sum=sum(11: v5)}] group by [[10: v4]] having [null]
+                            SCAN (columns[10: v4, 11: v5] predicate[null])
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([LOCAL] aggregate [{29: sum=sum(14: v8)}] group by [[13: v7]] having [null]
+                            SCAN (columns[13: v7, 14: v8] predicate[null])
 [end]
 
 [sql]
@@ -243,16 +259,22 @@ group by v1
 AGGREGATE ([GLOBAL] aggregate [{22: sum=sum(23: sum)}] group by [[19: v1]] having [null]
     EXCHANGE SHUFFLE[19]
         UNION
-            UNION
-                AGGREGATE ([LOCAL] aggregate [{26: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                    SCAN (columns[1: v1, 2: v2] predicate[null])
-                AGGREGATE ([LOCAL] aggregate [{27: sum=sum(5: v5)}] group by [[4: v4]] having [null]
-                    SCAN (columns[4: v4, 5: v5] predicate[null])
-            UNION
-                AGGREGATE ([LOCAL] aggregate [{28: sum=sum(11: v5)}] group by [[10: v4]] having [null]
-                    SCAN (columns[10: v4, 11: v5] predicate[null])
-                AGGREGATE ([LOCAL] aggregate [{29: sum=sum(14: v8)}] group by [[13: v7]] having [null]
-                    SCAN (columns[13: v7, 14: v8] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                UNION
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([LOCAL] aggregate [{26: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                            SCAN (columns[1: v1, 2: v2] predicate[null])
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([LOCAL] aggregate [{27: sum=sum(5: v5)}] group by [[4: v4]] having [null]
+                            SCAN (columns[4: v4, 5: v5] predicate[null])
+            EXCHANGE ROUND_ROBIN
+                UNION
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([LOCAL] aggregate [{28: sum=sum(11: v5)}] group by [[10: v4]] having [null]
+                            SCAN (columns[10: v4, 11: v5] predicate[null])
+                    EXCHANGE ROUND_ROBIN
+                        AGGREGATE ([LOCAL] aggregate [{29: sum=sum(14: v8)}] group by [[13: v7]] having [null]
+                            SCAN (columns[13: v7, 14: v8] predicate[null])
 [end]
 
 [sql]
@@ -268,14 +290,18 @@ AGGREGATE ([GLOBAL] aggregate [{19: sum=sum(20: sum)}] group by [[8: v2]] having
     EXCHANGE SHUFFLE[8]
         INNER JOIN (join-predicate [8: v2 = 17: v5 AND add(8: v2, 17: v5) = 1] post-join-predicate [null])
             UNION
-                AGGREGATE ([LOCAL] aggregate [{21: sum=sum(2: v2)}] group by [[2: v2]] having [null]
-                    SCAN (columns[2: v2] predicate[2: v2 IS NOT NULL])
-                AGGREGATE ([LOCAL] aggregate [{22: sum=sum(5: v5)}] group by [[5: v5]] having [null]
-                    SCAN (columns[5: v5] predicate[5: v5 IS NOT NULL])
+                EXCHANGE ROUND_ROBIN
+                    AGGREGATE ([LOCAL] aggregate [{21: sum=sum(2: v2)}] group by [[2: v2]] having [null]
+                        SCAN (columns[2: v2] predicate[2: v2 IS NOT NULL])
+                EXCHANGE ROUND_ROBIN
+                    AGGREGATE ([LOCAL] aggregate [{22: sum=sum(5: v5)}] group by [[5: v5]] having [null]
+                        SCAN (columns[5: v5] predicate[5: v5 IS NOT NULL])
             EXCHANGE BROADCAST
                 UNION
-                    SCAN (columns[11: v5] predicate[11: v5 IS NOT NULL])
-                    SCAN (columns[14: v8] predicate[14: v8 IS NOT NULL])
+                    EXCHANGE ROUND_ROBIN
+                        SCAN (columns[11: v5] predicate[11: v5 IS NOT NULL])
+                    EXCHANGE ROUND_ROBIN
+                        SCAN (columns[14: v8] predicate[14: v8 IS NOT NULL])
 [end]
 
 [sql]

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/set-operation.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/set-operation.sql
@@ -3,7 +3,8 @@ select v1 from (select v1,v2,v3 from t0 except select v4,v5,v6 from t1) as a
 [result]
 EXCEPT
     SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
-    SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
+    EXCHANGE SHUFFLE[4]
+        SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
 [end]
 
 [sql]
@@ -11,15 +12,18 @@ select v1 from (select v1,v2,v3 from t0 intersect select v4,v5,v6 from t1) as a
 [result]
 INTERSECT
     SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
-    SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
+    EXCHANGE SHUFFLE[4]
+        SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
 [end]
 
 [sql]
 select v1 from (select v1,v2,v3 from t0 union all select v4,v5,v6 from t1) as a
 [result]
 UNION
-    SCAN (columns[1: v1] predicate[null])
-    SCAN (columns[4: v4] predicate[null])
+    EXCHANGE ROUND_ROBIN
+        SCAN (columns[1: v1] predicate[null])
+    EXCHANGE ROUND_ROBIN
+        SCAN (columns[4: v4] predicate[null])
 [end]
 
 [sql]
@@ -29,25 +33,32 @@ AGGREGATE ([GLOBAL] aggregate [{}] group by [[7: v1, 8: v2, 9: v3]] having [null
     EXCHANGE SHUFFLE[7, 8, 9]
         AGGREGATE ([LOCAL] aggregate [{}] group by [[7: v1, 8: v2, 9: v3]] having [null]
             UNION
-                SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
-                SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
+                EXCHANGE ROUND_ROBIN
+                    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
+                EXCHANGE ROUND_ROBIN
+                    SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
 [end]
 
 [sql]
 select v1,v2,v3 from t0 union all select v4,v5,v6 from t1
 [result]
 UNION
-    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
-    SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
+    EXCHANGE ROUND_ROBIN
+        SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
+    EXCHANGE ROUND_ROBIN
+        SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
 [end]
 
 [sql]
 select v1 from t0 union all select v4 from t1 union all select v7 from t2;
 [result]
 UNION
-    SCAN (columns[1: v1] predicate[null])
-    SCAN (columns[4: v4] predicate[null])
-    SCAN (columns[7: v7] predicate[null])
+    EXCHANGE ROUND_ROBIN
+        SCAN (columns[1: v1] predicate[null])
+    EXCHANGE ROUND_ROBIN
+        SCAN (columns[4: v4] predicate[null])
+    EXCHANGE ROUND_ROBIN
+        SCAN (columns[7: v7] predicate[null])
 [end]
 
 [sql]
@@ -55,8 +66,10 @@ select v1 from t0 except select v4 from t1 except select v7 from t2;
 [result]
 EXCEPT
     SCAN (columns[1: v1] predicate[null])
-    SCAN (columns[4: v4] predicate[null])
-    SCAN (columns[7: v7] predicate[null])
+    EXCHANGE SHUFFLE[4]
+        SCAN (columns[4: v4] predicate[null])
+    EXCHANGE SHUFFLE[7]
+        SCAN (columns[7: v7] predicate[null])
 [end]
 
 [sql]
@@ -64,17 +77,22 @@ select v1 from t0 intersect select v4 from t1 intersect select v7 from t2;
 [result]
 INTERSECT
     SCAN (columns[1: v1] predicate[null])
-    SCAN (columns[4: v4] predicate[null])
-    SCAN (columns[7: v7] predicate[null])
+    EXCHANGE SHUFFLE[4]
+        SCAN (columns[4: v4] predicate[null])
+    EXCHANGE SHUFFLE[7]
+        SCAN (columns[7: v7] predicate[null])
 [end]
 
 [sql]
 with testC (v) as (select v1 from t0 union all select v4 from t1 union all select v7 from t2) select * from testC;
 [result]
 UNION
-    SCAN (columns[1: v1] predicate[null])
-    SCAN (columns[4: v4] predicate[null])
-    SCAN (columns[7: v7] predicate[null])
+    EXCHANGE ROUND_ROBIN
+        SCAN (columns[1: v1] predicate[null])
+    EXCHANGE ROUND_ROBIN
+        SCAN (columns[4: v4] predicate[null])
+    EXCHANGE ROUND_ROBIN
+        SCAN (columns[7: v7] predicate[null])
 [end]
 
 [sql]
@@ -84,10 +102,13 @@ AGGREGATE ([GLOBAL] aggregate [{}] group by [[11: v1]] having [null]
     EXCHANGE SHUFFLE[11]
         AGGREGATE ([LOCAL] aggregate [{}] group by [[11: v1]] having [null]
             UNION
-                INTERSECT
-                    SCAN (columns[1: v1] predicate[null])
-                    SCAN (columns[4: v4] predicate[null])
-                SCAN (columns[8: v7] predicate[null])
+                EXCHANGE ROUND_ROBIN
+                    INTERSECT
+                        SCAN (columns[1: v1] predicate[null])
+                        EXCHANGE SHUFFLE[4]
+                            SCAN (columns[4: v4] predicate[null])
+                EXCHANGE ROUND_ROBIN
+                    SCAN (columns[8: v7] predicate[null])
 [end]
 
 [sql]
@@ -97,38 +118,49 @@ AGGREGATE ([GLOBAL] aggregate [{}] group by [[11: v1]] having [null]
     EXCHANGE SHUFFLE[11]
         AGGREGATE ([LOCAL] aggregate [{}] group by [[11: v1]] having [null]
             UNION
-                EXCEPT
-                    SCAN (columns[1: v1] predicate[null])
-                    SCAN (columns[4: v4] predicate[null])
-                SCAN (columns[8: v7] predicate[null])
+                EXCHANGE ROUND_ROBIN
+                    EXCEPT
+                        SCAN (columns[1: v1] predicate[null])
+                        EXCHANGE SHUFFLE[4]
+                            SCAN (columns[4: v4] predicate[null])
+                EXCHANGE ROUND_ROBIN
+                    SCAN (columns[8: v7] predicate[null])
 [end]
 
 [sql]
 select v1 from t0 except select v4 from t1 union all select v7 from t2;
 [result]
 UNION
-    EXCEPT
-        SCAN (columns[1: v1] predicate[null])
-        SCAN (columns[4: v4] predicate[null])
-    SCAN (columns[8: v7] predicate[null])
+    EXCHANGE ROUND_ROBIN
+        EXCEPT
+            SCAN (columns[1: v1] predicate[null])
+            EXCHANGE SHUFFLE[4]
+                SCAN (columns[4: v4] predicate[null])
+    EXCHANGE ROUND_ROBIN
+        SCAN (columns[8: v7] predicate[null])
 [end]
 
 [sql]
 select v1 from (select v1 from t0 union all select v4 from t1 union all select v7 from t2) a
 [result]
 UNION
-    SCAN (columns[1: v1] predicate[null])
-    SCAN (columns[4: v4] predicate[null])
-    SCAN (columns[7: v7] predicate[null])
+    EXCHANGE ROUND_ROBIN
+        SCAN (columns[1: v1] predicate[null])
+    EXCHANGE ROUND_ROBIN
+        SCAN (columns[4: v4] predicate[null])
+    EXCHANGE ROUND_ROBIN
+        SCAN (columns[7: v7] predicate[null])
 [end]
 
 [sql]
 select v1,sum(v2) from t0 group by v1 union all select v4,v5 from t1;
 [result]
 UNION
-    AGGREGATE ([GLOBAL] aggregate [{4: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-        SCAN (columns[1: v1, 2: v2] predicate[null])
-    SCAN (columns[5: v4, 6: v5] predicate[null])
+    EXCHANGE ROUND_ROBIN
+        AGGREGATE ([GLOBAL] aggregate [{4: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+            SCAN (columns[1: v1, 2: v2] predicate[null])
+    EXCHANGE ROUND_ROBIN
+        SCAN (columns[5: v4, 6: v5] predicate[null])
 [end]
 
 [sql]
@@ -138,9 +170,11 @@ AGGREGATE ([GLOBAL] aggregate [{}] group by [[8: v1, 9: sum]] having [null]
     EXCHANGE SHUFFLE[8, 9]
         AGGREGATE ([LOCAL] aggregate [{}] group by [[8: v1, 9: sum]] having [null]
             UNION
-                AGGREGATE ([GLOBAL] aggregate [{4: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                    SCAN (columns[1: v1, 2: v2] predicate[null])
-                SCAN (columns[5: v4, 6: v5] predicate[null])
+                EXCHANGE ROUND_ROBIN
+                    AGGREGATE ([GLOBAL] aggregate [{4: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                        SCAN (columns[1: v1, 2: v2] predicate[null])
+                EXCHANGE ROUND_ROBIN
+                    SCAN (columns[5: v4, 6: v5] predicate[null])
 [end]
 
 [sql]
@@ -150,33 +184,41 @@ AGGREGATE ([GLOBAL] aggregate [{}] group by [[8: v1, 9: sum]] having [null]
     EXCHANGE SHUFFLE[8, 9]
         AGGREGATE ([LOCAL] aggregate [{}] group by [[8: v1, 9: sum]] having [null]
             UNION
-                AGGREGATE ([GLOBAL] aggregate [{4: sum=sum(2: v2)}] group by [[1: v1]] having [null]
-                    SCAN (columns[1: v1, 2: v2] predicate[null])
-                SCAN (columns[5: v4, 6: v5] predicate[null])
+                EXCHANGE ROUND_ROBIN
+                    AGGREGATE ([GLOBAL] aggregate [{4: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                        SCAN (columns[1: v1, 2: v2] predicate[null])
+                EXCHANGE ROUND_ROBIN
+                    SCAN (columns[5: v4, 6: v5] predicate[null])
 [end]
 
 [sql]
 select v from (select sum(v1) as v from t0 union select v4 from t1 except select v1 /2 + 0.5 from t0) a;
 [result]
 EXCEPT
-    AGGREGATE ([GLOBAL] aggregate [{}] group by [[8: sum]] having [null]
-        EXCHANGE SHUFFLE[8]
-            AGGREGATE ([LOCAL] aggregate [{}] group by [[8: sum]] having [null]
-                UNION
-                    AGGREGATE ([GLOBAL] aggregate [{4: sum=sum(4: sum)}] group by [[]] having [null]
-                        EXCHANGE GATHER
-                            AGGREGATE ([LOCAL] aggregate [{4: sum=sum(1: v1)}] group by [[]] having [null]
-                                SCAN (columns[1: v1] predicate[null])
-                    SCAN (columns[5: v4] predicate[null])
-    SCAN (columns[10: v1] predicate[null])
+    EXCHANGE SHUFFLE[9]
+        AGGREGATE ([GLOBAL] aggregate [{}] group by [[8: sum]] having [null]
+            EXCHANGE SHUFFLE[8]
+                AGGREGATE ([LOCAL] aggregate [{}] group by [[8: sum]] having [null]
+                    UNION
+                        EXCHANGE ROUND_ROBIN
+                            AGGREGATE ([GLOBAL] aggregate [{4: sum=sum(4: sum)}] group by [[]] having [null]
+                                EXCHANGE GATHER
+                                    AGGREGATE ([LOCAL] aggregate [{4: sum=sum(1: v1)}] group by [[]] having [null]
+                                        SCAN (columns[1: v1] predicate[null])
+                        EXCHANGE ROUND_ROBIN
+                            SCAN (columns[5: v4] predicate[null])
+    EXCHANGE SHUFFLE[13]
+        SCAN (columns[10: v1] predicate[null])
 [end]
 
 [sql]
 select v from (select v1 as v from t0 union all select v4 from t1) a where v = 1
 [result]
 UNION
-    SCAN (columns[1: v1] predicate[1: v1 = 1])
-    SCAN (columns[4: v4] predicate[4: v4 = 1])
+    EXCHANGE ROUND_ROBIN
+        SCAN (columns[1: v1] predicate[1: v1 = 1])
+    EXCHANGE ROUND_ROBIN
+        SCAN (columns[4: v4] predicate[4: v4 = 1])
 [end]
 
 [sql]
@@ -186,8 +228,10 @@ AGGREGATE ([GLOBAL] aggregate [{}] group by [[7: v1]] having [null]
     EXCHANGE SHUFFLE[7]
         AGGREGATE ([LOCAL] aggregate [{}] group by [[7: v1]] having [null]
             UNION
-                SCAN (columns[1: v1] predicate[1: v1 = 1])
-                SCAN (columns[4: v4] predicate[4: v4 = 1])
+                EXCHANGE ROUND_ROBIN
+                    SCAN (columns[1: v1] predicate[1: v1 = 1])
+                EXCHANGE ROUND_ROBIN
+                    SCAN (columns[4: v4] predicate[4: v4 = 1])
 [end]
 
 [sql]
@@ -197,11 +241,13 @@ AGGREGATE ([GLOBAL] aggregate [{}] group by [[8: sum]] having [null]
     EXCHANGE SHUFFLE[8]
         AGGREGATE ([LOCAL] aggregate [{}] group by [[8: sum]] having [null]
             UNION
-                AGGREGATE ([GLOBAL] aggregate [{4: sum=sum(4: sum)}] group by [[]] having [4: sum = 1]
-                    EXCHANGE GATHER
-                        AGGREGATE ([LOCAL] aggregate [{4: sum=sum(1: v1)}] group by [[]] having [null]
-                            SCAN (columns[1: v1] predicate[null])
-                SCAN (columns[5: v4] predicate[5: v4 = 1])
+                EXCHANGE ROUND_ROBIN
+                    AGGREGATE ([GLOBAL] aggregate [{4: sum=sum(4: sum)}] group by [[]] having [4: sum = 1]
+                        EXCHANGE GATHER
+                            AGGREGATE ([LOCAL] aggregate [{4: sum=sum(1: v1)}] group by [[]] having [null]
+                                SCAN (columns[1: v1] predicate[null])
+                EXCHANGE ROUND_ROBIN
+                    SCAN (columns[5: v4] predicate[5: v4 = 1])
 [end]
 
 [sql]
@@ -209,7 +255,8 @@ select v from (select v1 as v from t0 except select v4 from t1) a where v = 1
 [result]
 EXCEPT
     SCAN (columns[1: v1] predicate[1: v1 = 1])
-    SCAN (columns[4: v4] predicate[4: v4 = 1])
+    EXCHANGE SHUFFLE[4]
+        SCAN (columns[4: v4] predicate[4: v4 = 1])
 [end]
 
 [sql]
@@ -217,31 +264,38 @@ select v from (select v1 as v from t0 intersect select v4 from t1) a where v = 1
 [result]
 INTERSECT
     SCAN (columns[1: v1] predicate[1: v1 = 1])
-    SCAN (columns[4: v4] predicate[4: v4 = 1])
+    EXCHANGE SHUFFLE[4]
+        SCAN (columns[4: v4] predicate[4: v4 = 1])
 [end]
 
 [sql]
 select * from (select v2,v3,v1 from t0 union all select v4,v5,v6 from t1) a where a.v3 = 3
 [result]
 UNION
-    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[3: v3 = 3])
-    SCAN (columns[4: v4, 5: v5, 6: v6] predicate[5: v5 = 3])
+    EXCHANGE ROUND_ROBIN
+        SCAN (columns[1: v1, 2: v2, 3: v3] predicate[3: v3 = 3])
+    EXCHANGE ROUND_ROBIN
+        SCAN (columns[4: v4, 5: v5, 6: v6] predicate[5: v5 = 3])
 [end]
 
 [sql]
 select v1 from (select v1, v2 from t0 union all select 1,1 from t1) t
 [result]
 UNION
-    SCAN (columns[1: v1] predicate[null])
-    SCAN (columns[4: v4] predicate[null])
+    EXCHANGE ROUND_ROBIN
+        SCAN (columns[1: v1] predicate[null])
+    EXCHANGE ROUND_ROBIN
+        SCAN (columns[4: v4] predicate[null])
 [end]
 
 [sql]
 select v1 from (select 1 as v1, v2 from t0 union all select 1,1 from t1) t
 [result]
 UNION
-    SCAN (columns[1: v1] predicate[null])
-    SCAN (columns[5: v4] predicate[null])
+    EXCHANGE ROUND_ROBIN
+        SCAN (columns[1: v1] predicate[null])
+    EXCHANGE ROUND_ROBIN
+        SCAN (columns[5: v4] predicate[null])
 [end]
 
 [sql]
@@ -251,11 +305,16 @@ AGGREGATE ([GLOBAL] aggregate [{}] group by [[18: expr]] having [null]
     EXCHANGE SHUFFLE[18]
         AGGREGATE ([LOCAL] aggregate [{}] group by [[18: expr]] having [null]
             UNION
-                UNION
-                    SCAN (columns[1: v1] predicate[null])
-                    SCAN (columns[5: v1] predicate[null])
-                SCAN (columns[10: v1] predicate[null])
-                SCAN (columns[14: v1] predicate[null])
+                EXCHANGE ROUND_ROBIN
+                    UNION
+                        EXCHANGE ROUND_ROBIN
+                            SCAN (columns[1: v1] predicate[null])
+                        EXCHANGE ROUND_ROBIN
+                            SCAN (columns[5: v1] predicate[null])
+                EXCHANGE ROUND_ROBIN
+                    SCAN (columns[10: v1] predicate[null])
+                EXCHANGE ROUND_ROBIN
+                    SCAN (columns[14: v1] predicate[null])
 [end]
 
 [sql]
@@ -265,23 +324,34 @@ AGGREGATE ([GLOBAL] aggregate [{}] group by [[18: expr]] having [null]
     EXCHANGE SHUFFLE[18]
         AGGREGATE ([LOCAL] aggregate [{}] group by [[18: expr]] having [null]
             UNION
-                UNION
-                    SCAN (columns[1: v1] predicate[null])
-                    SCAN (columns[5: v1] predicate[null])
-                    SCAN (columns[9: v1] predicate[null])
-                SCAN (columns[14: v1] predicate[null])
+                EXCHANGE ROUND_ROBIN
+                    UNION
+                        EXCHANGE ROUND_ROBIN
+                            SCAN (columns[1: v1] predicate[null])
+                        EXCHANGE ROUND_ROBIN
+                            SCAN (columns[5: v1] predicate[null])
+                        EXCHANGE ROUND_ROBIN
+                            SCAN (columns[9: v1] predicate[null])
+                EXCHANGE ROUND_ROBIN
+                    SCAN (columns[14: v1] predicate[null])
 [end]
 
 [sql]
 select 1 from t0 union select 2 from t0 union all select 2 from t0 union all select 3 from t0;
 [result]
 UNION
-    AGGREGATE ([GLOBAL] aggregate [{}] group by [[9: expr]] having [null]
-        EXCHANGE SHUFFLE[9]
-            AGGREGATE ([LOCAL] aggregate [{}] group by [[9: expr]] having [null]
-                UNION
-                    SCAN (columns[1: v1] predicate[null])
-                    SCAN (columns[5: v1] predicate[null])
-    SCAN (columns[10: v1] predicate[null])
-    SCAN (columns[14: v1] predicate[null])
+    EXCHANGE ROUND_ROBIN
+        AGGREGATE ([GLOBAL] aggregate [{}] group by [[9: expr]] having [null]
+            EXCHANGE SHUFFLE[9]
+                AGGREGATE ([LOCAL] aggregate [{}] group by [[9: expr]] having [null]
+                    UNION
+                        EXCHANGE ROUND_ROBIN
+                            SCAN (columns[1: v1] predicate[null])
+                        EXCHANGE ROUND_ROBIN
+                            SCAN (columns[5: v1] predicate[null])
+    EXCHANGE ROUND_ROBIN
+        SCAN (columns[10: v1] predicate[null])
+    EXCHANGE ROUND_ROBIN
+        SCAN (columns[14: v1] predicate[null])
 [end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/except_q1_disable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/except_q1_disable_colocate_set.sql
@@ -1,0 +1,269 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F09)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F09#0)
+      BE: 10002
+
+PLAN FRAGMENT 1(F08)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F08#0)
+      DESTINATIONS: 0-F09#0
+      BE: 10003
+    INSTANCE(2-F08#1)
+      DESTINATIONS: 0-F09#0
+      BE: 10002
+    INSTANCE(3-F08#2)
+      DESTINATIONS: 0-F09#0
+      BE: 10001
+
+PLAN FRAGMENT 2(F06)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F06#0)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10001
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2202,tabletID=2205
+          2. partitionID=2202,tabletID=2211
+          3. partitionID=2202,tabletID=2217
+          4. partitionID=2202,tabletID=2223
+          5. partitionID=2202,tabletID=2229
+          6. partitionID=2202,tabletID=2235
+    INSTANCE(5-F06#1)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10002
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2202,tabletID=2207
+          2. partitionID=2202,tabletID=2213
+          3. partitionID=2202,tabletID=2219
+          4. partitionID=2202,tabletID=2225
+          5. partitionID=2202,tabletID=2231
+          6. partitionID=2202,tabletID=2237
+    INSTANCE(6-F06#2)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10003
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2202,tabletID=2203
+          2. partitionID=2202,tabletID=2209
+          3. partitionID=2202,tabletID=2215
+          4. partitionID=2202,tabletID=2221
+          5. partitionID=2202,tabletID=2227
+          6. partitionID=2202,tabletID=2233
+
+PLAN FRAGMENT 3(F04)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F04#0)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10001
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=1934,tabletID=1937
+          2. partitionID=1934,tabletID=1943
+          3. partitionID=1934,tabletID=1949
+          4. partitionID=1934,tabletID=1955
+          5. partitionID=1934,tabletID=1961
+          6. partitionID=1934,tabletID=1967
+    INSTANCE(8-F04#1)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10002
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=1934,tabletID=1939
+          2. partitionID=1934,tabletID=1945
+          3. partitionID=1934,tabletID=1951
+          4. partitionID=1934,tabletID=1957
+          5. partitionID=1934,tabletID=1963
+          6. partitionID=1934,tabletID=1969
+    INSTANCE(9-F04#2)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10003
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=1934,tabletID=1935
+          2. partitionID=1934,tabletID=1941
+          3. partitionID=1934,tabletID=1947
+          4. partitionID=1934,tabletID=1953
+          5. partitionID=1934,tabletID=1959
+          6. partitionID=1934,tabletID=1965
+
+PLAN FRAGMENT 4(F02)
+  DOP: 16
+  INSTANCES
+    INSTANCE(10-F02#0)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10001
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(11-F02#1)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10002
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(12-F02#2)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10003
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 5(F00)
+  DOP: 16
+  INSTANCES
+    INSTANCE(13-F00#0)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10001
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+    INSTANCE(14-F00#1)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10002
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+    INSTANCE(15-F00#2)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10003
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:69: L_ORDERKEY | 70: L_PARTKEY | 71: L_SUPPKEY | 72: L_LINENUMBER | 73: L_QUANTITY | 74: L_EXTENDEDPRICE | 75: L_DISCOUNT | 76: L_TAX | 77: L_RETURNFLAG | 78: L_LINESTATUS | 79: L_SHIPDATE | 80: L_COMMITDATE | 81: L_RECEIPTDATE | 82: L_SHIPINSTRUCT | 83: L_SHIPMODE | 84: L_COMMENT | 85: PAD
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  9:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 09
+    UNPARTITIONED
+
+  0:EXCEPT
+  |  
+  |----4:EXCHANGE
+  |    
+  |----6:EXCHANGE
+  |    
+  |----8:EXCHANGE
+  |    
+  2:EXCHANGE
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 08
+    HASH_PARTITIONED: 52: L_ORDERKEY, 53: L_PARTKEY, 54: L_SUPPKEY, 55: L_LINENUMBER, 56: L_QUANTITY, 57: L_EXTENDEDPRICE, 58: L_DISCOUNT, 59: L_TAX, 60: L_RETURNFLAG, 61: L_LINESTATUS, 62: L_SHIPDATE, 63: L_COMMITDATE, 64: L_RECEIPTDATE, 65: L_SHIPINSTRUCT, 66: L_SHIPMODE, 67: L_COMMENT, 68: PAD
+
+  7:OlapScanNode
+     TABLE: lineitem3
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem3
+     tabletRatio=18/18
+     tabletList=2203,2205,2207,2209,2211,2213,2215,2217,2219,2221 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 06
+    HASH_PARTITIONED: 35: L_ORDERKEY, 36: L_PARTKEY, 37: L_SUPPKEY, 38: L_LINENUMBER, 39: L_QUANTITY, 40: L_EXTENDEDPRICE, 41: L_DISCOUNT, 42: L_TAX, 43: L_RETURNFLAG, 44: L_LINESTATUS, 45: L_SHIPDATE, 46: L_COMMITDATE, 47: L_RECEIPTDATE, 48: L_SHIPINSTRUCT, 49: L_SHIPMODE, 50: L_COMMENT, 51: PAD
+
+  5:OlapScanNode
+     TABLE: lineitem2
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem2
+     tabletRatio=18/18
+     tabletList=1935,1937,1939,1941,1943,1945,1947,1949,1951,1953 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 4
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 04
+    HASH_PARTITIONED: 18: L_ORDERKEY, 19: L_PARTKEY, 20: L_SUPPKEY, 21: L_LINENUMBER, 22: L_QUANTITY, 23: L_EXTENDEDPRICE, 24: L_DISCOUNT, 25: L_TAX, 26: L_RETURNFLAG, 27: L_LINESTATUS, 28: L_SHIPDATE, 29: L_COMMITDATE, 30: L_RECEIPTDATE, 31: L_SHIPINSTRUCT, 32: L_SHIPMODE, 33: L_COMMENT, 34: PAD
+
+  3:OlapScanNode
+     TABLE: lineitem1
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem1
+     tabletRatio=18/18
+     tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 5
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 02
+    HASH_PARTITIONED: 1: L_ORDERKEY, 2: L_PARTKEY, 3: L_SUPPKEY, 4: L_LINENUMBER, 5: L_QUANTITY, 6: L_EXTENDEDPRICE, 7: L_DISCOUNT, 8: L_TAX, 9: L_RETURNFLAG, 10: L_LINESTATUS, 11: L_SHIPDATE, 12: L_COMMITDATE, 13: L_RECEIPTDATE, 14: L_SHIPINSTRUCT, 15: L_SHIPMODE, 16: L_COMMENT, 17: PAD
+
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=17.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/except_q1_enable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/except_q1_enable_colocate_set.sql
@@ -1,0 +1,223 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F07)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F07#0)
+      BE: 10001
+
+PLAN FRAGMENT 1(F06)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F06#0)
+      DESTINATIONS: 0-F07#0
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+        2:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(2-F06#1)
+      DESTINATIONS: 0-F07#0
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+        2:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(3-F06#2)
+      DESTINATIONS: 0-F07#0
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+        2:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 2(F04)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F04#0)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10001
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=2202,tabletID=2205
+          2. partitionID=2202,tabletID=2211
+          3. partitionID=2202,tabletID=2217
+          4. partitionID=2202,tabletID=2223
+          5. partitionID=2202,tabletID=2229
+          6. partitionID=2202,tabletID=2235
+    INSTANCE(5-F04#1)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10002
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=2202,tabletID=2207
+          2. partitionID=2202,tabletID=2213
+          3. partitionID=2202,tabletID=2219
+          4. partitionID=2202,tabletID=2225
+          5. partitionID=2202,tabletID=2231
+          6. partitionID=2202,tabletID=2237
+    INSTANCE(6-F04#2)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10003
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=2202,tabletID=2203
+          2. partitionID=2202,tabletID=2209
+          3. partitionID=2202,tabletID=2215
+          4. partitionID=2202,tabletID=2221
+          5. partitionID=2202,tabletID=2227
+          6. partitionID=2202,tabletID=2233
+
+PLAN FRAGMENT 3(F02)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F02#0)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10001
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1934,tabletID=1937
+          2. partitionID=1934,tabletID=1943
+          3. partitionID=1934,tabletID=1949
+          4. partitionID=1934,tabletID=1955
+          5. partitionID=1934,tabletID=1961
+          6. partitionID=1934,tabletID=1967
+    INSTANCE(8-F02#1)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10002
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1934,tabletID=1939
+          2. partitionID=1934,tabletID=1945
+          3. partitionID=1934,tabletID=1951
+          4. partitionID=1934,tabletID=1957
+          5. partitionID=1934,tabletID=1963
+          6. partitionID=1934,tabletID=1969
+    INSTANCE(9-F02#2)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10003
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1934,tabletID=1935
+          2. partitionID=1934,tabletID=1941
+          3. partitionID=1934,tabletID=1947
+          4. partitionID=1934,tabletID=1953
+          5. partitionID=1934,tabletID=1959
+          6. partitionID=1934,tabletID=1965
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:69: L_ORDERKEY | 70: L_PARTKEY | 71: L_SUPPKEY | 72: L_LINENUMBER | 73: L_QUANTITY | 74: L_EXTENDEDPRICE | 75: L_DISCOUNT | 76: L_TAX | 77: L_RETURNFLAG | 78: L_LINESTATUS | 79: L_SHIPDATE | 80: L_COMMITDATE | 81: L_RECEIPTDATE | 82: L_SHIPINSTRUCT | 83: L_SHIPMODE | 84: L_COMMENT | 85: PAD
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  7:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 07
+    UNPARTITIONED
+
+  0:EXCEPT
+  |  
+  |----2:OlapScanNode
+  |       TABLE: lineitem1
+  |       PREAGGREGATION: ON
+  |       partitions=1/7
+  |       rollup: lineitem1
+  |       tabletRatio=18/18
+  |       tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+  |       cardinality=1
+  |       avgRowSize=17.0
+  |    
+  |----4:EXCHANGE
+  |    
+  |----6:EXCHANGE
+  |    
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 06
+    BUCKET_SHUFFLE_HASH_PARTITIONED: 52: L_ORDERKEY
+
+  5:OlapScanNode
+     TABLE: lineitem3
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem3
+     tabletRatio=18/18
+     tabletList=2203,2205,2207,2209,2211,2213,2215,2217,2219,2221 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 04
+    BUCKET_SHUFFLE_HASH_PARTITIONED: 35: L_ORDERKEY
+
+  3:OlapScanNode
+     TABLE: lineitem2
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem2
+     tabletRatio=18/18
+     tabletList=1935,1937,1939,1941,1943,1945,1947,1949,1951,1953 ...
+     cardinality=1
+     avgRowSize=17.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/except_q2_disable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/except_q2_disable_colocate_set.sql
@@ -1,0 +1,305 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F10)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F10#0)
+      BE: 10002
+
+PLAN FRAGMENT 1(F09)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F09#0)
+      DESTINATIONS: 0-F10#0
+      BE: 10001
+    INSTANCE(2-F09#1)
+      DESTINATIONS: 0-F10#0
+      BE: 10002
+    INSTANCE(3-F09#2)
+      DESTINATIONS: 0-F10#0
+      BE: 10003
+
+PLAN FRAGMENT 2(F08)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F08#0)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10003
+    INSTANCE(5-F08#1)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10002
+    INSTANCE(6-F08#2)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10001
+
+PLAN FRAGMENT 3(F06)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F06#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2202,tabletID=2205
+          2. partitionID=2202,tabletID=2211
+          3. partitionID=2202,tabletID=2217
+          4. partitionID=2202,tabletID=2223
+          5. partitionID=2202,tabletID=2229
+          6. partitionID=2202,tabletID=2235
+    INSTANCE(8-F06#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2202,tabletID=2207
+          2. partitionID=2202,tabletID=2213
+          3. partitionID=2202,tabletID=2219
+          4. partitionID=2202,tabletID=2225
+          5. partitionID=2202,tabletID=2231
+          6. partitionID=2202,tabletID=2237
+    INSTANCE(9-F06#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2202,tabletID=2203
+          2. partitionID=2202,tabletID=2209
+          3. partitionID=2202,tabletID=2215
+          4. partitionID=2202,tabletID=2221
+          5. partitionID=2202,tabletID=2227
+          6. partitionID=2202,tabletID=2233
+
+PLAN FRAGMENT 4(F04)
+  DOP: 16
+  INSTANCES
+    INSTANCE(10-F04#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=1934,tabletID=1937
+          2. partitionID=1934,tabletID=1943
+          3. partitionID=1934,tabletID=1949
+          4. partitionID=1934,tabletID=1955
+          5. partitionID=1934,tabletID=1961
+          6. partitionID=1934,tabletID=1967
+    INSTANCE(11-F04#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=1934,tabletID=1939
+          2. partitionID=1934,tabletID=1945
+          3. partitionID=1934,tabletID=1951
+          4. partitionID=1934,tabletID=1957
+          5. partitionID=1934,tabletID=1963
+          6. partitionID=1934,tabletID=1969
+    INSTANCE(12-F04#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=1934,tabletID=1935
+          2. partitionID=1934,tabletID=1941
+          3. partitionID=1934,tabletID=1947
+          4. partitionID=1934,tabletID=1953
+          5. partitionID=1934,tabletID=1959
+          6. partitionID=1934,tabletID=1965
+
+PLAN FRAGMENT 5(F02)
+  DOP: 16
+  INSTANCES
+    INSTANCE(13-F02#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(14-F02#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(15-F02#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 6(F00)
+  DOP: 16
+  INSTANCES
+    INSTANCE(16-F00#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+    INSTANCE(17-F00#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+    INSTANCE(18-F00#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:69: L_ORDERKEY | 86: sum
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  13:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: HASH_PARTITIONED: 69: L_ORDERKEY
+
+  STREAM DATA SINK
+    EXCHANGE ID: 13
+    UNPARTITIONED
+
+  12:AGGREGATE (merge finalize)
+  |  output: sum(86: sum)
+  |  group by: 69: L_ORDERKEY
+  |  
+  11:EXCHANGE
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 11
+    HASH_PARTITIONED: 69: L_ORDERKEY
+
+  10:AGGREGATE (update serialize)
+  |  STREAMING
+  |  output: sum(73: L_QUANTITY)
+  |  group by: 69: L_ORDERKEY
+  |  
+  9:Project
+  |  <slot 69> : 69: L_ORDERKEY
+  |  <slot 73> : 73: L_QUANTITY
+  |  
+  0:EXCEPT
+  |  
+  |----4:EXCHANGE
+  |    
+  |----6:EXCHANGE
+  |    
+  |----8:EXCHANGE
+  |    
+  2:EXCHANGE
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 08
+    HASH_PARTITIONED: 52: L_ORDERKEY, 53: L_PARTKEY, 54: L_SUPPKEY, 55: L_LINENUMBER, 56: L_QUANTITY, 57: L_EXTENDEDPRICE, 58: L_DISCOUNT, 59: L_TAX, 60: L_RETURNFLAG, 61: L_LINESTATUS, 62: L_SHIPDATE, 63: L_COMMITDATE, 64: L_RECEIPTDATE, 65: L_SHIPINSTRUCT, 66: L_SHIPMODE, 67: L_COMMENT, 68: PAD
+
+  7:OlapScanNode
+     TABLE: lineitem3
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem3
+     tabletRatio=18/18
+     tabletList=2203,2205,2207,2209,2211,2213,2215,2217,2219,2221 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 4
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 06
+    HASH_PARTITIONED: 35: L_ORDERKEY, 36: L_PARTKEY, 37: L_SUPPKEY, 38: L_LINENUMBER, 39: L_QUANTITY, 40: L_EXTENDEDPRICE, 41: L_DISCOUNT, 42: L_TAX, 43: L_RETURNFLAG, 44: L_LINESTATUS, 45: L_SHIPDATE, 46: L_COMMITDATE, 47: L_RECEIPTDATE, 48: L_SHIPINSTRUCT, 49: L_SHIPMODE, 50: L_COMMENT, 51: PAD
+
+  5:OlapScanNode
+     TABLE: lineitem2
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem2
+     tabletRatio=18/18
+     tabletList=1935,1937,1939,1941,1943,1945,1947,1949,1951,1953 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 5
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 04
+    HASH_PARTITIONED: 18: L_ORDERKEY, 19: L_PARTKEY, 20: L_SUPPKEY, 21: L_LINENUMBER, 22: L_QUANTITY, 23: L_EXTENDEDPRICE, 24: L_DISCOUNT, 25: L_TAX, 26: L_RETURNFLAG, 27: L_LINESTATUS, 28: L_SHIPDATE, 29: L_COMMITDATE, 30: L_RECEIPTDATE, 31: L_SHIPINSTRUCT, 32: L_SHIPMODE, 33: L_COMMENT, 34: PAD
+
+  3:OlapScanNode
+     TABLE: lineitem1
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem1
+     tabletRatio=18/18
+     tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 6
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 02
+    HASH_PARTITIONED: 1: L_ORDERKEY, 2: L_PARTKEY, 3: L_SUPPKEY, 4: L_LINENUMBER, 5: L_QUANTITY, 6: L_EXTENDEDPRICE, 7: L_DISCOUNT, 8: L_TAX, 9: L_RETURNFLAG, 10: L_LINESTATUS, 11: L_SHIPDATE, 12: L_COMMITDATE, 13: L_RECEIPTDATE, 14: L_SHIPINSTRUCT, 15: L_SHIPMODE, 16: L_COMMENT, 17: PAD
+
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=17.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/except_q2_enable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/except_q2_enable_colocate_set.sql
@@ -1,0 +1,231 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F07)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F07#0)
+      BE: 10001
+
+PLAN FRAGMENT 1(F06)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F06#0)
+      DESTINATIONS: 0-F07#0
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+        2:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(2-F06#1)
+      DESTINATIONS: 0-F07#0
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+        2:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(3-F06#2)
+      DESTINATIONS: 0-F07#0
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+        2:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 2(F04)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F04#0)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10001
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=2202,tabletID=2205
+          2. partitionID=2202,tabletID=2211
+          3. partitionID=2202,tabletID=2217
+          4. partitionID=2202,tabletID=2223
+          5. partitionID=2202,tabletID=2229
+          6. partitionID=2202,tabletID=2235
+    INSTANCE(5-F04#1)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10002
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=2202,tabletID=2207
+          2. partitionID=2202,tabletID=2213
+          3. partitionID=2202,tabletID=2219
+          4. partitionID=2202,tabletID=2225
+          5. partitionID=2202,tabletID=2231
+          6. partitionID=2202,tabletID=2237
+    INSTANCE(6-F04#2)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10003
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=2202,tabletID=2203
+          2. partitionID=2202,tabletID=2209
+          3. partitionID=2202,tabletID=2215
+          4. partitionID=2202,tabletID=2221
+          5. partitionID=2202,tabletID=2227
+          6. partitionID=2202,tabletID=2233
+
+PLAN FRAGMENT 3(F02)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F02#0)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10001
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1934,tabletID=1937
+          2. partitionID=1934,tabletID=1943
+          3. partitionID=1934,tabletID=1949
+          4. partitionID=1934,tabletID=1955
+          5. partitionID=1934,tabletID=1961
+          6. partitionID=1934,tabletID=1967
+    INSTANCE(8-F02#1)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10002
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1934,tabletID=1939
+          2. partitionID=1934,tabletID=1945
+          3. partitionID=1934,tabletID=1951
+          4. partitionID=1934,tabletID=1957
+          5. partitionID=1934,tabletID=1963
+          6. partitionID=1934,tabletID=1969
+    INSTANCE(9-F02#2)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10003
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1934,tabletID=1935
+          2. partitionID=1934,tabletID=1941
+          3. partitionID=1934,tabletID=1947
+          4. partitionID=1934,tabletID=1953
+          5. partitionID=1934,tabletID=1959
+          6. partitionID=1934,tabletID=1965
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:69: L_ORDERKEY | 86: sum
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  9:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 09
+    UNPARTITIONED
+
+  8:AGGREGATE (update finalize)
+  |  output: sum(73: L_QUANTITY)
+  |  group by: 69: L_ORDERKEY
+  |  
+  7:Project
+  |  <slot 69> : 69: L_ORDERKEY
+  |  <slot 73> : 73: L_QUANTITY
+  |  
+  0:EXCEPT
+  |  
+  |----2:OlapScanNode
+  |       TABLE: lineitem1
+  |       PREAGGREGATION: ON
+  |       partitions=1/7
+  |       rollup: lineitem1
+  |       tabletRatio=18/18
+  |       tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+  |       cardinality=1
+  |       avgRowSize=17.0
+  |    
+  |----4:EXCHANGE
+  |    
+  |----6:EXCHANGE
+  |    
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 06
+    BUCKET_SHUFFLE_HASH_PARTITIONED: 52: L_ORDERKEY
+
+  5:OlapScanNode
+     TABLE: lineitem3
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem3
+     tabletRatio=18/18
+     tabletList=2203,2205,2207,2209,2211,2213,2215,2217,2219,2221 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 04
+    BUCKET_SHUFFLE_HASH_PARTITIONED: 35: L_ORDERKEY
+
+  3:OlapScanNode
+     TABLE: lineitem2
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem2
+     tabletRatio=18/18
+     tabletList=1935,1937,1939,1941,1943,1945,1947,1949,1951,1953 ...
+     cardinality=1
+     avgRowSize=17.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/except_q3_disable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/except_q3_disable_colocate_set.sql
@@ -1,0 +1,306 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F10)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F10#0)
+      BE: 10002
+
+PLAN FRAGMENT 1(F09)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F09#0)
+      DESTINATIONS: 0-F10#0
+      BE: 10001
+    INSTANCE(2-F09#1)
+      DESTINATIONS: 0-F10#0
+      BE: 10002
+    INSTANCE(3-F09#2)
+      DESTINATIONS: 0-F10#0
+      BE: 10003
+
+PLAN FRAGMENT 2(F08)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F08#0)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10003
+    INSTANCE(5-F08#1)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10002
+    INSTANCE(6-F08#2)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10001
+
+PLAN FRAGMENT 3(F06)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F06#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2202,tabletID=2205
+          2. partitionID=2202,tabletID=2211
+          3. partitionID=2202,tabletID=2217
+          4. partitionID=2202,tabletID=2223
+          5. partitionID=2202,tabletID=2229
+          6. partitionID=2202,tabletID=2235
+    INSTANCE(8-F06#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2202,tabletID=2207
+          2. partitionID=2202,tabletID=2213
+          3. partitionID=2202,tabletID=2219
+          4. partitionID=2202,tabletID=2225
+          5. partitionID=2202,tabletID=2231
+          6. partitionID=2202,tabletID=2237
+    INSTANCE(9-F06#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2202,tabletID=2203
+          2. partitionID=2202,tabletID=2209
+          3. partitionID=2202,tabletID=2215
+          4. partitionID=2202,tabletID=2221
+          5. partitionID=2202,tabletID=2227
+          6. partitionID=2202,tabletID=2233
+
+PLAN FRAGMENT 4(F04)
+  DOP: 16
+  INSTANCES
+    INSTANCE(10-F04#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=1934,tabletID=1937
+          2. partitionID=1934,tabletID=1943
+          3. partitionID=1934,tabletID=1949
+          4. partitionID=1934,tabletID=1955
+          5. partitionID=1934,tabletID=1961
+          6. partitionID=1934,tabletID=1967
+    INSTANCE(11-F04#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=1934,tabletID=1939
+          2. partitionID=1934,tabletID=1945
+          3. partitionID=1934,tabletID=1951
+          4. partitionID=1934,tabletID=1957
+          5. partitionID=1934,tabletID=1963
+          6. partitionID=1934,tabletID=1969
+    INSTANCE(12-F04#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=1934,tabletID=1935
+          2. partitionID=1934,tabletID=1941
+          3. partitionID=1934,tabletID=1947
+          4. partitionID=1934,tabletID=1953
+          5. partitionID=1934,tabletID=1959
+          6. partitionID=1934,tabletID=1965
+
+PLAN FRAGMENT 5(F02)
+  DOP: 16
+  INSTANCES
+    INSTANCE(13-F02#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(14-F02#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(15-F02#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 6(F00)
+  DOP: 16
+  INSTANCES
+    INSTANCE(16-F00#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+    INSTANCE(17-F00#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+    INSTANCE(18-F00#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:69: L_ORDERKEY | 70: L_PARTKEY | 86: sum
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  13:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: HASH_PARTITIONED: 69: L_ORDERKEY, 70: L_PARTKEY
+
+  STREAM DATA SINK
+    EXCHANGE ID: 13
+    UNPARTITIONED
+
+  12:AGGREGATE (merge finalize)
+  |  output: sum(86: sum)
+  |  group by: 69: L_ORDERKEY, 70: L_PARTKEY
+  |  
+  11:EXCHANGE
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 11
+    HASH_PARTITIONED: 69: L_ORDERKEY, 70: L_PARTKEY
+
+  10:AGGREGATE (update serialize)
+  |  STREAMING
+  |  output: sum(73: L_QUANTITY)
+  |  group by: 69: L_ORDERKEY, 70: L_PARTKEY
+  |  
+  9:Project
+  |  <slot 69> : 69: L_ORDERKEY
+  |  <slot 70> : 70: L_PARTKEY
+  |  <slot 73> : 73: L_QUANTITY
+  |  
+  0:EXCEPT
+  |  
+  |----4:EXCHANGE
+  |    
+  |----6:EXCHANGE
+  |    
+  |----8:EXCHANGE
+  |    
+  2:EXCHANGE
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 08
+    HASH_PARTITIONED: 52: L_ORDERKEY, 53: L_PARTKEY, 54: L_SUPPKEY, 55: L_LINENUMBER, 56: L_QUANTITY, 57: L_EXTENDEDPRICE, 58: L_DISCOUNT, 59: L_TAX, 60: L_RETURNFLAG, 61: L_LINESTATUS, 62: L_SHIPDATE, 63: L_COMMITDATE, 64: L_RECEIPTDATE, 65: L_SHIPINSTRUCT, 66: L_SHIPMODE, 67: L_COMMENT, 68: PAD
+
+  7:OlapScanNode
+     TABLE: lineitem3
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem3
+     tabletRatio=18/18
+     tabletList=2203,2205,2207,2209,2211,2213,2215,2217,2219,2221 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 4
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 06
+    HASH_PARTITIONED: 35: L_ORDERKEY, 36: L_PARTKEY, 37: L_SUPPKEY, 38: L_LINENUMBER, 39: L_QUANTITY, 40: L_EXTENDEDPRICE, 41: L_DISCOUNT, 42: L_TAX, 43: L_RETURNFLAG, 44: L_LINESTATUS, 45: L_SHIPDATE, 46: L_COMMITDATE, 47: L_RECEIPTDATE, 48: L_SHIPINSTRUCT, 49: L_SHIPMODE, 50: L_COMMENT, 51: PAD
+
+  5:OlapScanNode
+     TABLE: lineitem2
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem2
+     tabletRatio=18/18
+     tabletList=1935,1937,1939,1941,1943,1945,1947,1949,1951,1953 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 5
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 04
+    HASH_PARTITIONED: 18: L_ORDERKEY, 19: L_PARTKEY, 20: L_SUPPKEY, 21: L_LINENUMBER, 22: L_QUANTITY, 23: L_EXTENDEDPRICE, 24: L_DISCOUNT, 25: L_TAX, 26: L_RETURNFLAG, 27: L_LINESTATUS, 28: L_SHIPDATE, 29: L_COMMITDATE, 30: L_RECEIPTDATE, 31: L_SHIPINSTRUCT, 32: L_SHIPMODE, 33: L_COMMENT, 34: PAD
+
+  3:OlapScanNode
+     TABLE: lineitem1
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem1
+     tabletRatio=18/18
+     tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 6
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 02
+    HASH_PARTITIONED: 1: L_ORDERKEY, 2: L_PARTKEY, 3: L_SUPPKEY, 4: L_LINENUMBER, 5: L_QUANTITY, 6: L_EXTENDEDPRICE, 7: L_DISCOUNT, 8: L_TAX, 9: L_RETURNFLAG, 10: L_LINESTATUS, 11: L_SHIPDATE, 12: L_COMMITDATE, 13: L_RECEIPTDATE, 14: L_SHIPINSTRUCT, 15: L_SHIPMODE, 16: L_COMMENT, 17: PAD
+
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=17.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/except_q3_enable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/except_q3_enable_colocate_set.sql
@@ -1,0 +1,232 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F07)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F07#0)
+      BE: 10001
+
+PLAN FRAGMENT 1(F06)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F06#0)
+      DESTINATIONS: 0-F07#0
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+        2:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(2-F06#1)
+      DESTINATIONS: 0-F07#0
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+        2:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(3-F06#2)
+      DESTINATIONS: 0-F07#0
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+        2:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 2(F04)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F04#0)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10001
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=2202,tabletID=2205
+          2. partitionID=2202,tabletID=2211
+          3. partitionID=2202,tabletID=2217
+          4. partitionID=2202,tabletID=2223
+          5. partitionID=2202,tabletID=2229
+          6. partitionID=2202,tabletID=2235
+    INSTANCE(5-F04#1)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10002
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=2202,tabletID=2207
+          2. partitionID=2202,tabletID=2213
+          3. partitionID=2202,tabletID=2219
+          4. partitionID=2202,tabletID=2225
+          5. partitionID=2202,tabletID=2231
+          6. partitionID=2202,tabletID=2237
+    INSTANCE(6-F04#2)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10003
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=2202,tabletID=2203
+          2. partitionID=2202,tabletID=2209
+          3. partitionID=2202,tabletID=2215
+          4. partitionID=2202,tabletID=2221
+          5. partitionID=2202,tabletID=2227
+          6. partitionID=2202,tabletID=2233
+
+PLAN FRAGMENT 3(F02)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F02#0)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10001
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1934,tabletID=1937
+          2. partitionID=1934,tabletID=1943
+          3. partitionID=1934,tabletID=1949
+          4. partitionID=1934,tabletID=1955
+          5. partitionID=1934,tabletID=1961
+          6. partitionID=1934,tabletID=1967
+    INSTANCE(8-F02#1)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10002
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1934,tabletID=1939
+          2. partitionID=1934,tabletID=1945
+          3. partitionID=1934,tabletID=1951
+          4. partitionID=1934,tabletID=1957
+          5. partitionID=1934,tabletID=1963
+          6. partitionID=1934,tabletID=1969
+    INSTANCE(9-F02#2)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10003
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1934,tabletID=1935
+          2. partitionID=1934,tabletID=1941
+          3. partitionID=1934,tabletID=1947
+          4. partitionID=1934,tabletID=1953
+          5. partitionID=1934,tabletID=1959
+          6. partitionID=1934,tabletID=1965
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:69: L_ORDERKEY | 70: L_PARTKEY | 86: sum
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  9:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 09
+    UNPARTITIONED
+
+  8:AGGREGATE (update finalize)
+  |  output: sum(73: L_QUANTITY)
+  |  group by: 69: L_ORDERKEY, 70: L_PARTKEY
+  |  
+  7:Project
+  |  <slot 69> : 69: L_ORDERKEY
+  |  <slot 70> : 70: L_PARTKEY
+  |  <slot 73> : 73: L_QUANTITY
+  |  
+  0:EXCEPT
+  |  
+  |----2:OlapScanNode
+  |       TABLE: lineitem1
+  |       PREAGGREGATION: ON
+  |       partitions=1/7
+  |       rollup: lineitem1
+  |       tabletRatio=18/18
+  |       tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+  |       cardinality=1
+  |       avgRowSize=17.0
+  |    
+  |----4:EXCHANGE
+  |    
+  |----6:EXCHANGE
+  |    
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 06
+    BUCKET_SHUFFLE_HASH_PARTITIONED: 52: L_ORDERKEY
+
+  5:OlapScanNode
+     TABLE: lineitem3
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem3
+     tabletRatio=18/18
+     tabletList=2203,2205,2207,2209,2211,2213,2215,2217,2219,2221 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 04
+    BUCKET_SHUFFLE_HASH_PARTITIONED: 35: L_ORDERKEY
+
+  3:OlapScanNode
+     TABLE: lineitem2
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem2
+     tabletRatio=18/18
+     tabletList=1935,1937,1939,1941,1943,1945,1947,1949,1951,1953 ...
+     cardinality=1
+     avgRowSize=17.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/except_q4_disable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/except_q4_disable_colocate_set.sql
@@ -1,0 +1,305 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F10)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F10#0)
+      BE: 10002
+
+PLAN FRAGMENT 1(F09)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F09#0)
+      DESTINATIONS: 0-F10#0
+      BE: 10001
+    INSTANCE(2-F09#1)
+      DESTINATIONS: 0-F10#0
+      BE: 10003
+    INSTANCE(3-F09#2)
+      DESTINATIONS: 0-F10#0
+      BE: 10002
+
+PLAN FRAGMENT 2(F08)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F08#0)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10001
+    INSTANCE(5-F08#1)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10002
+    INSTANCE(6-F08#2)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10003
+
+PLAN FRAGMENT 3(F06)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F06#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2202,tabletID=2205
+          2. partitionID=2202,tabletID=2211
+          3. partitionID=2202,tabletID=2217
+          4. partitionID=2202,tabletID=2223
+          5. partitionID=2202,tabletID=2229
+          6. partitionID=2202,tabletID=2235
+    INSTANCE(8-F06#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2202,tabletID=2207
+          2. partitionID=2202,tabletID=2213
+          3. partitionID=2202,tabletID=2219
+          4. partitionID=2202,tabletID=2225
+          5. partitionID=2202,tabletID=2231
+          6. partitionID=2202,tabletID=2237
+    INSTANCE(9-F06#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2202,tabletID=2203
+          2. partitionID=2202,tabletID=2209
+          3. partitionID=2202,tabletID=2215
+          4. partitionID=2202,tabletID=2221
+          5. partitionID=2202,tabletID=2227
+          6. partitionID=2202,tabletID=2233
+
+PLAN FRAGMENT 4(F04)
+  DOP: 16
+  INSTANCES
+    INSTANCE(10-F04#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=1934,tabletID=1937
+          2. partitionID=1934,tabletID=1943
+          3. partitionID=1934,tabletID=1949
+          4. partitionID=1934,tabletID=1955
+          5. partitionID=1934,tabletID=1961
+          6. partitionID=1934,tabletID=1967
+    INSTANCE(11-F04#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=1934,tabletID=1939
+          2. partitionID=1934,tabletID=1945
+          3. partitionID=1934,tabletID=1951
+          4. partitionID=1934,tabletID=1957
+          5. partitionID=1934,tabletID=1963
+          6. partitionID=1934,tabletID=1969
+    INSTANCE(12-F04#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=1934,tabletID=1935
+          2. partitionID=1934,tabletID=1941
+          3. partitionID=1934,tabletID=1947
+          4. partitionID=1934,tabletID=1953
+          5. partitionID=1934,tabletID=1959
+          6. partitionID=1934,tabletID=1965
+
+PLAN FRAGMENT 5(F02)
+  DOP: 16
+  INSTANCES
+    INSTANCE(13-F02#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(14-F02#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(15-F02#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 6(F00)
+  DOP: 16
+  INSTANCES
+    INSTANCE(16-F00#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+    INSTANCE(17-F00#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+    INSTANCE(18-F00#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:70: L_PARTKEY | 86: sum
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  13:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: HASH_PARTITIONED: 70: L_PARTKEY
+
+  STREAM DATA SINK
+    EXCHANGE ID: 13
+    UNPARTITIONED
+
+  12:AGGREGATE (merge finalize)
+  |  output: sum(86: sum)
+  |  group by: 70: L_PARTKEY
+  |  
+  11:EXCHANGE
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 11
+    HASH_PARTITIONED: 70: L_PARTKEY
+
+  10:AGGREGATE (update serialize)
+  |  STREAMING
+  |  output: sum(73: L_QUANTITY)
+  |  group by: 70: L_PARTKEY
+  |  
+  9:Project
+  |  <slot 70> : 70: L_PARTKEY
+  |  <slot 73> : 73: L_QUANTITY
+  |  
+  0:EXCEPT
+  |  
+  |----4:EXCHANGE
+  |    
+  |----6:EXCHANGE
+  |    
+  |----8:EXCHANGE
+  |    
+  2:EXCHANGE
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 08
+    HASH_PARTITIONED: 52: L_ORDERKEY, 53: L_PARTKEY, 54: L_SUPPKEY, 55: L_LINENUMBER, 56: L_QUANTITY, 57: L_EXTENDEDPRICE, 58: L_DISCOUNT, 59: L_TAX, 60: L_RETURNFLAG, 61: L_LINESTATUS, 62: L_SHIPDATE, 63: L_COMMITDATE, 64: L_RECEIPTDATE, 65: L_SHIPINSTRUCT, 66: L_SHIPMODE, 67: L_COMMENT, 68: PAD
+
+  7:OlapScanNode
+     TABLE: lineitem3
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem3
+     tabletRatio=18/18
+     tabletList=2203,2205,2207,2209,2211,2213,2215,2217,2219,2221 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 4
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 06
+    HASH_PARTITIONED: 35: L_ORDERKEY, 36: L_PARTKEY, 37: L_SUPPKEY, 38: L_LINENUMBER, 39: L_QUANTITY, 40: L_EXTENDEDPRICE, 41: L_DISCOUNT, 42: L_TAX, 43: L_RETURNFLAG, 44: L_LINESTATUS, 45: L_SHIPDATE, 46: L_COMMITDATE, 47: L_RECEIPTDATE, 48: L_SHIPINSTRUCT, 49: L_SHIPMODE, 50: L_COMMENT, 51: PAD
+
+  5:OlapScanNode
+     TABLE: lineitem2
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem2
+     tabletRatio=18/18
+     tabletList=1935,1937,1939,1941,1943,1945,1947,1949,1951,1953 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 5
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 04
+    HASH_PARTITIONED: 18: L_ORDERKEY, 19: L_PARTKEY, 20: L_SUPPKEY, 21: L_LINENUMBER, 22: L_QUANTITY, 23: L_EXTENDEDPRICE, 24: L_DISCOUNT, 25: L_TAX, 26: L_RETURNFLAG, 27: L_LINESTATUS, 28: L_SHIPDATE, 29: L_COMMITDATE, 30: L_RECEIPTDATE, 31: L_SHIPINSTRUCT, 32: L_SHIPMODE, 33: L_COMMENT, 34: PAD
+
+  3:OlapScanNode
+     TABLE: lineitem1
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem1
+     tabletRatio=18/18
+     tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 6
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 02
+    HASH_PARTITIONED: 1: L_ORDERKEY, 2: L_PARTKEY, 3: L_SUPPKEY, 4: L_LINENUMBER, 5: L_QUANTITY, 6: L_EXTENDEDPRICE, 7: L_DISCOUNT, 8: L_TAX, 9: L_RETURNFLAG, 10: L_LINESTATUS, 11: L_SHIPDATE, 12: L_COMMITDATE, 13: L_RECEIPTDATE, 14: L_SHIPINSTRUCT, 15: L_SHIPMODE, 16: L_COMMENT, 17: PAD
+
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=17.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/except_q4_enable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/except_q4_enable_colocate_set.sql
@@ -1,0 +1,259 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F08)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F08#0)
+      BE: 10001
+
+PLAN FRAGMENT 1(F07)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F07#0)
+      DESTINATIONS: 0-F08#0
+      BE: 10003
+    INSTANCE(2-F07#1)
+      DESTINATIONS: 0-F08#0
+      BE: 10002
+    INSTANCE(3-F07#2)
+      DESTINATIONS: 0-F08#0
+      BE: 10001
+
+PLAN FRAGMENT 2(F06)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F06#0)
+      DESTINATIONS: 1-F07#0,2-F07#1,3-F07#2
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+        2:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(5-F06#1)
+      DESTINATIONS: 1-F07#0,2-F07#1,3-F07#2
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+        2:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(6-F06#2)
+      DESTINATIONS: 1-F07#0,2-F07#1,3-F07#2
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+        2:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 3(F04)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F04#0)
+      DESTINATIONS: 6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1
+      BE: 10001
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=2202,tabletID=2205
+          2. partitionID=2202,tabletID=2211
+          3. partitionID=2202,tabletID=2217
+          4. partitionID=2202,tabletID=2223
+          5. partitionID=2202,tabletID=2229
+          6. partitionID=2202,tabletID=2235
+    INSTANCE(8-F04#1)
+      DESTINATIONS: 6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1
+      BE: 10002
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=2202,tabletID=2207
+          2. partitionID=2202,tabletID=2213
+          3. partitionID=2202,tabletID=2219
+          4. partitionID=2202,tabletID=2225
+          5. partitionID=2202,tabletID=2231
+          6. partitionID=2202,tabletID=2237
+    INSTANCE(9-F04#2)
+      DESTINATIONS: 6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1
+      BE: 10003
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=2202,tabletID=2203
+          2. partitionID=2202,tabletID=2209
+          3. partitionID=2202,tabletID=2215
+          4. partitionID=2202,tabletID=2221
+          5. partitionID=2202,tabletID=2227
+          6. partitionID=2202,tabletID=2233
+
+PLAN FRAGMENT 4(F02)
+  DOP: 16
+  INSTANCES
+    INSTANCE(10-F02#0)
+      DESTINATIONS: 6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1
+      BE: 10001
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1934,tabletID=1937
+          2. partitionID=1934,tabletID=1943
+          3. partitionID=1934,tabletID=1949
+          4. partitionID=1934,tabletID=1955
+          5. partitionID=1934,tabletID=1961
+          6. partitionID=1934,tabletID=1967
+    INSTANCE(11-F02#1)
+      DESTINATIONS: 6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1
+      BE: 10002
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1934,tabletID=1939
+          2. partitionID=1934,tabletID=1945
+          3. partitionID=1934,tabletID=1951
+          4. partitionID=1934,tabletID=1957
+          5. partitionID=1934,tabletID=1963
+          6. partitionID=1934,tabletID=1969
+    INSTANCE(12-F02#2)
+      DESTINATIONS: 6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1,6-F06#2,4-F06#0,5-F06#1
+      BE: 10003
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1934,tabletID=1935
+          2. partitionID=1934,tabletID=1941
+          3. partitionID=1934,tabletID=1947
+          4. partitionID=1934,tabletID=1953
+          5. partitionID=1934,tabletID=1959
+          6. partitionID=1934,tabletID=1965
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:70: L_PARTKEY | 86: sum
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  11:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: HASH_PARTITIONED: 70: L_PARTKEY
+
+  STREAM DATA SINK
+    EXCHANGE ID: 11
+    UNPARTITIONED
+
+  10:AGGREGATE (merge finalize)
+  |  output: sum(86: sum)
+  |  group by: 70: L_PARTKEY
+  |  
+  9:EXCHANGE
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 09
+    HASH_PARTITIONED: 70: L_PARTKEY
+
+  8:AGGREGATE (update serialize)
+  |  STREAMING
+  |  output: sum(73: L_QUANTITY)
+  |  group by: 70: L_PARTKEY
+  |  
+  7:Project
+  |  <slot 70> : 70: L_PARTKEY
+  |  <slot 73> : 73: L_QUANTITY
+  |  
+  0:EXCEPT
+  |  
+  |----2:OlapScanNode
+  |       TABLE: lineitem1
+  |       PREAGGREGATION: ON
+  |       partitions=1/7
+  |       rollup: lineitem1
+  |       tabletRatio=18/18
+  |       tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+  |       cardinality=1
+  |       avgRowSize=17.0
+  |    
+  |----4:EXCHANGE
+  |    
+  |----6:EXCHANGE
+  |    
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 06
+    BUCKET_SHUFFLE_HASH_PARTITIONED: 52: L_ORDERKEY
+
+  5:OlapScanNode
+     TABLE: lineitem3
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem3
+     tabletRatio=18/18
+     tabletList=2203,2205,2207,2209,2211,2213,2215,2217,2219,2221 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 4
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 04
+    BUCKET_SHUFFLE_HASH_PARTITIONED: 35: L_ORDERKEY
+
+  3:OlapScanNode
+     TABLE: lineitem2
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem2
+     tabletRatio=18/18
+     tabletList=1935,1937,1939,1941,1943,1945,1947,1949,1951,1953 ...
+     cardinality=1
+     avgRowSize=17.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/intersect_q1_disable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/intersect_q1_disable_colocate_set.sql
@@ -1,0 +1,269 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F09)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F09#0)
+      BE: 10002
+
+PLAN FRAGMENT 1(F08)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F08#0)
+      DESTINATIONS: 0-F09#0
+      BE: 10003
+    INSTANCE(2-F08#1)
+      DESTINATIONS: 0-F09#0
+      BE: 10002
+    INSTANCE(3-F08#2)
+      DESTINATIONS: 0-F09#0
+      BE: 10001
+
+PLAN FRAGMENT 2(F06)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F06#0)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10001
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2202,tabletID=2205
+          2. partitionID=2202,tabletID=2211
+          3. partitionID=2202,tabletID=2217
+          4. partitionID=2202,tabletID=2223
+          5. partitionID=2202,tabletID=2229
+          6. partitionID=2202,tabletID=2235
+    INSTANCE(5-F06#1)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10002
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2202,tabletID=2207
+          2. partitionID=2202,tabletID=2213
+          3. partitionID=2202,tabletID=2219
+          4. partitionID=2202,tabletID=2225
+          5. partitionID=2202,tabletID=2231
+          6. partitionID=2202,tabletID=2237
+    INSTANCE(6-F06#2)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10003
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2202,tabletID=2203
+          2. partitionID=2202,tabletID=2209
+          3. partitionID=2202,tabletID=2215
+          4. partitionID=2202,tabletID=2221
+          5. partitionID=2202,tabletID=2227
+          6. partitionID=2202,tabletID=2233
+
+PLAN FRAGMENT 3(F04)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F04#0)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10001
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=1934,tabletID=1937
+          2. partitionID=1934,tabletID=1943
+          3. partitionID=1934,tabletID=1949
+          4. partitionID=1934,tabletID=1955
+          5. partitionID=1934,tabletID=1961
+          6. partitionID=1934,tabletID=1967
+    INSTANCE(8-F04#1)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10002
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=1934,tabletID=1939
+          2. partitionID=1934,tabletID=1945
+          3. partitionID=1934,tabletID=1951
+          4. partitionID=1934,tabletID=1957
+          5. partitionID=1934,tabletID=1963
+          6. partitionID=1934,tabletID=1969
+    INSTANCE(9-F04#2)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10003
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=1934,tabletID=1935
+          2. partitionID=1934,tabletID=1941
+          3. partitionID=1934,tabletID=1947
+          4. partitionID=1934,tabletID=1953
+          5. partitionID=1934,tabletID=1959
+          6. partitionID=1934,tabletID=1965
+
+PLAN FRAGMENT 4(F02)
+  DOP: 16
+  INSTANCES
+    INSTANCE(10-F02#0)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10001
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(11-F02#1)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10002
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(12-F02#2)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10003
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 5(F00)
+  DOP: 16
+  INSTANCES
+    INSTANCE(13-F00#0)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10001
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+    INSTANCE(14-F00#1)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10002
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+    INSTANCE(15-F00#2)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10003
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:69: L_ORDERKEY | 70: L_PARTKEY | 71: L_SUPPKEY | 72: L_LINENUMBER | 73: L_QUANTITY | 74: L_EXTENDEDPRICE | 75: L_DISCOUNT | 76: L_TAX | 77: L_RETURNFLAG | 78: L_LINESTATUS | 79: L_SHIPDATE | 80: L_COMMITDATE | 81: L_RECEIPTDATE | 82: L_SHIPINSTRUCT | 83: L_SHIPMODE | 84: L_COMMENT | 85: PAD
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  9:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 09
+    UNPARTITIONED
+
+  0:INTERSECT
+  |  
+  |----4:EXCHANGE
+  |    
+  |----6:EXCHANGE
+  |    
+  |----8:EXCHANGE
+  |    
+  2:EXCHANGE
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 08
+    HASH_PARTITIONED: 52: L_ORDERKEY, 53: L_PARTKEY, 54: L_SUPPKEY, 55: L_LINENUMBER, 56: L_QUANTITY, 57: L_EXTENDEDPRICE, 58: L_DISCOUNT, 59: L_TAX, 60: L_RETURNFLAG, 61: L_LINESTATUS, 62: L_SHIPDATE, 63: L_COMMITDATE, 64: L_RECEIPTDATE, 65: L_SHIPINSTRUCT, 66: L_SHIPMODE, 67: L_COMMENT, 68: PAD
+
+  7:OlapScanNode
+     TABLE: lineitem3
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem3
+     tabletRatio=18/18
+     tabletList=2203,2205,2207,2209,2211,2213,2215,2217,2219,2221 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 06
+    HASH_PARTITIONED: 35: L_ORDERKEY, 36: L_PARTKEY, 37: L_SUPPKEY, 38: L_LINENUMBER, 39: L_QUANTITY, 40: L_EXTENDEDPRICE, 41: L_DISCOUNT, 42: L_TAX, 43: L_RETURNFLAG, 44: L_LINESTATUS, 45: L_SHIPDATE, 46: L_COMMITDATE, 47: L_RECEIPTDATE, 48: L_SHIPINSTRUCT, 49: L_SHIPMODE, 50: L_COMMENT, 51: PAD
+
+  5:OlapScanNode
+     TABLE: lineitem2
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem2
+     tabletRatio=18/18
+     tabletList=1935,1937,1939,1941,1943,1945,1947,1949,1951,1953 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 4
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 04
+    HASH_PARTITIONED: 18: L_ORDERKEY, 19: L_PARTKEY, 20: L_SUPPKEY, 21: L_LINENUMBER, 22: L_QUANTITY, 23: L_EXTENDEDPRICE, 24: L_DISCOUNT, 25: L_TAX, 26: L_RETURNFLAG, 27: L_LINESTATUS, 28: L_SHIPDATE, 29: L_COMMITDATE, 30: L_RECEIPTDATE, 31: L_SHIPINSTRUCT, 32: L_SHIPMODE, 33: L_COMMENT, 34: PAD
+
+  3:OlapScanNode
+     TABLE: lineitem1
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem1
+     tabletRatio=18/18
+     tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 5
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 02
+    HASH_PARTITIONED: 1: L_ORDERKEY, 2: L_PARTKEY, 3: L_SUPPKEY, 4: L_LINENUMBER, 5: L_QUANTITY, 6: L_EXTENDEDPRICE, 7: L_DISCOUNT, 8: L_TAX, 9: L_RETURNFLAG, 10: L_LINESTATUS, 11: L_SHIPDATE, 12: L_COMMITDATE, 13: L_RECEIPTDATE, 14: L_SHIPINSTRUCT, 15: L_SHIPMODE, 16: L_COMMENT, 17: PAD
+
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=17.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/intersect_q1_enable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/intersect_q1_enable_colocate_set.sql
@@ -1,0 +1,223 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F07)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F07#0)
+      BE: 10001
+
+PLAN FRAGMENT 1(F06)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F06#0)
+      DESTINATIONS: 0-F07#0
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+        2:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(2-F06#1)
+      DESTINATIONS: 0-F07#0
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+        2:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(3-F06#2)
+      DESTINATIONS: 0-F07#0
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+        2:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 2(F04)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F04#0)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10001
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=2202,tabletID=2205
+          2. partitionID=2202,tabletID=2211
+          3. partitionID=2202,tabletID=2217
+          4. partitionID=2202,tabletID=2223
+          5. partitionID=2202,tabletID=2229
+          6. partitionID=2202,tabletID=2235
+    INSTANCE(5-F04#1)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10002
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=2202,tabletID=2207
+          2. partitionID=2202,tabletID=2213
+          3. partitionID=2202,tabletID=2219
+          4. partitionID=2202,tabletID=2225
+          5. partitionID=2202,tabletID=2231
+          6. partitionID=2202,tabletID=2237
+    INSTANCE(6-F04#2)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10003
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=2202,tabletID=2203
+          2. partitionID=2202,tabletID=2209
+          3. partitionID=2202,tabletID=2215
+          4. partitionID=2202,tabletID=2221
+          5. partitionID=2202,tabletID=2227
+          6. partitionID=2202,tabletID=2233
+
+PLAN FRAGMENT 3(F02)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F02#0)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10001
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1934,tabletID=1937
+          2. partitionID=1934,tabletID=1943
+          3. partitionID=1934,tabletID=1949
+          4. partitionID=1934,tabletID=1955
+          5. partitionID=1934,tabletID=1961
+          6. partitionID=1934,tabletID=1967
+    INSTANCE(8-F02#1)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10002
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1934,tabletID=1939
+          2. partitionID=1934,tabletID=1945
+          3. partitionID=1934,tabletID=1951
+          4. partitionID=1934,tabletID=1957
+          5. partitionID=1934,tabletID=1963
+          6. partitionID=1934,tabletID=1969
+    INSTANCE(9-F02#2)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10003
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1934,tabletID=1935
+          2. partitionID=1934,tabletID=1941
+          3. partitionID=1934,tabletID=1947
+          4. partitionID=1934,tabletID=1953
+          5. partitionID=1934,tabletID=1959
+          6. partitionID=1934,tabletID=1965
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:69: L_ORDERKEY | 70: L_PARTKEY | 71: L_SUPPKEY | 72: L_LINENUMBER | 73: L_QUANTITY | 74: L_EXTENDEDPRICE | 75: L_DISCOUNT | 76: L_TAX | 77: L_RETURNFLAG | 78: L_LINESTATUS | 79: L_SHIPDATE | 80: L_COMMITDATE | 81: L_RECEIPTDATE | 82: L_SHIPINSTRUCT | 83: L_SHIPMODE | 84: L_COMMENT | 85: PAD
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  7:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 07
+    UNPARTITIONED
+
+  0:INTERSECT
+  |  
+  |----2:OlapScanNode
+  |       TABLE: lineitem1
+  |       PREAGGREGATION: ON
+  |       partitions=1/7
+  |       rollup: lineitem1
+  |       tabletRatio=18/18
+  |       tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+  |       cardinality=1
+  |       avgRowSize=17.0
+  |    
+  |----4:EXCHANGE
+  |    
+  |----6:EXCHANGE
+  |    
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 06
+    BUCKET_SHUFFLE_HASH_PARTITIONED: 52: L_ORDERKEY
+
+  5:OlapScanNode
+     TABLE: lineitem3
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem3
+     tabletRatio=18/18
+     tabletList=2203,2205,2207,2209,2211,2213,2215,2217,2219,2221 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 04
+    BUCKET_SHUFFLE_HASH_PARTITIONED: 35: L_ORDERKEY
+
+  3:OlapScanNode
+     TABLE: lineitem2
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem2
+     tabletRatio=18/18
+     tabletList=1935,1937,1939,1941,1943,1945,1947,1949,1951,1953 ...
+     cardinality=1
+     avgRowSize=17.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/intersect_q2_disable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/intersect_q2_disable_colocate_set.sql
@@ -1,0 +1,345 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F10)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F10#0)
+      BE: 10002
+
+PLAN FRAGMENT 1(F09)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F09#0)
+      DESTINATIONS: 0-F10#0
+      BE: 10001
+    INSTANCE(2-F09#1)
+      DESTINATIONS: 0-F10#0
+      BE: 10002
+    INSTANCE(3-F09#2)
+      DESTINATIONS: 0-F10#0
+      BE: 10003
+
+PLAN FRAGMENT 2(F08)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F08#0)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10003
+    INSTANCE(5-F08#1)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10002
+    INSTANCE(6-F08#2)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10001
+
+PLAN FRAGMENT 3(F06)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F06#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        13:OlapScanNode
+          1. partitionID=2202,tabletID=2205
+          2. partitionID=2202,tabletID=2211
+          3. partitionID=2202,tabletID=2217
+          4. partitionID=2202,tabletID=2223
+          5. partitionID=2202,tabletID=2229
+          6. partitionID=2202,tabletID=2235
+    INSTANCE(8-F06#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        13:OlapScanNode
+          1. partitionID=2202,tabletID=2207
+          2. partitionID=2202,tabletID=2213
+          3. partitionID=2202,tabletID=2219
+          4. partitionID=2202,tabletID=2225
+          5. partitionID=2202,tabletID=2231
+          6. partitionID=2202,tabletID=2237
+    INSTANCE(9-F06#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        13:OlapScanNode
+          1. partitionID=2202,tabletID=2203
+          2. partitionID=2202,tabletID=2209
+          3. partitionID=2202,tabletID=2215
+          4. partitionID=2202,tabletID=2221
+          5. partitionID=2202,tabletID=2227
+          6. partitionID=2202,tabletID=2233
+
+PLAN FRAGMENT 4(F04)
+  DOP: 16
+  INSTANCES
+    INSTANCE(10-F04#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        9:OlapScanNode
+          1. partitionID=1934,tabletID=1937
+          2. partitionID=1934,tabletID=1943
+          3. partitionID=1934,tabletID=1949
+          4. partitionID=1934,tabletID=1955
+          5. partitionID=1934,tabletID=1961
+          6. partitionID=1934,tabletID=1967
+    INSTANCE(11-F04#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        9:OlapScanNode
+          1. partitionID=1934,tabletID=1939
+          2. partitionID=1934,tabletID=1945
+          3. partitionID=1934,tabletID=1951
+          4. partitionID=1934,tabletID=1957
+          5. partitionID=1934,tabletID=1963
+          6. partitionID=1934,tabletID=1969
+    INSTANCE(12-F04#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        9:OlapScanNode
+          1. partitionID=1934,tabletID=1935
+          2. partitionID=1934,tabletID=1941
+          3. partitionID=1934,tabletID=1947
+          4. partitionID=1934,tabletID=1953
+          5. partitionID=1934,tabletID=1959
+          6. partitionID=1934,tabletID=1965
+
+PLAN FRAGMENT 5(F02)
+  DOP: 16
+  INSTANCES
+    INSTANCE(13-F02#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        5:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(14-F02#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        5:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(15-F02#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        5:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 6(F00)
+  DOP: 16
+  INSTANCES
+    INSTANCE(16-F00#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+    INSTANCE(17-F00#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+    INSTANCE(18-F00#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:73: L_ORDERKEY | 75: sum
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  20:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: HASH_PARTITIONED: 73: L_ORDERKEY
+
+  STREAM DATA SINK
+    EXCHANGE ID: 20
+    UNPARTITIONED
+
+  19:AGGREGATE (merge finalize)
+  |  output: sum(75: sum)
+  |  group by: 73: L_ORDERKEY
+  |  
+  18:EXCHANGE
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 18
+    HASH_PARTITIONED: 73: L_ORDERKEY
+
+  17:AGGREGATE (update serialize)
+  |  STREAMING
+  |  output: sum(74: sum)
+  |  group by: 73: L_ORDERKEY
+  |  
+  0:INTERSECT
+  |  
+  |----8:EXCHANGE
+  |    
+  |----12:EXCHANGE
+  |    
+  |----16:EXCHANGE
+  |    
+  4:EXCHANGE
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 16
+    HASH_PARTITIONED: 55: L_ORDERKEY, 72: sum
+
+  15:AGGREGATE (update finalize)
+  |  output: sum(59: L_QUANTITY)
+  |  group by: 55: L_ORDERKEY
+  |  
+  14:Project
+  |  <slot 55> : 55: L_ORDERKEY
+  |  <slot 59> : 59: L_QUANTITY
+  |  
+  13:OlapScanNode
+     TABLE: lineitem3
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem3
+     tabletRatio=18/18
+     tabletList=2203,2205,2207,2209,2211,2213,2215,2217,2219,2221 ...
+     cardinality=1
+     avgRowSize=3.0
+
+PLAN FRAGMENT 4
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 12
+    HASH_PARTITIONED: 37: L_ORDERKEY, 54: sum
+
+  11:AGGREGATE (update finalize)
+  |  output: sum(41: L_QUANTITY)
+  |  group by: 37: L_ORDERKEY
+  |  
+  10:Project
+  |  <slot 37> : 37: L_ORDERKEY
+  |  <slot 41> : 41: L_QUANTITY
+  |  
+  9:OlapScanNode
+     TABLE: lineitem2
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem2
+     tabletRatio=18/18
+     tabletList=1935,1937,1939,1941,1943,1945,1947,1949,1951,1953 ...
+     cardinality=1
+     avgRowSize=3.0
+
+PLAN FRAGMENT 5
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 08
+    HASH_PARTITIONED: 19: L_ORDERKEY, 36: sum
+
+  7:AGGREGATE (update finalize)
+  |  output: sum(23: L_QUANTITY)
+  |  group by: 19: L_ORDERKEY
+  |  
+  6:Project
+  |  <slot 19> : 19: L_ORDERKEY
+  |  <slot 23> : 23: L_QUANTITY
+  |  
+  5:OlapScanNode
+     TABLE: lineitem1
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem1
+     tabletRatio=18/18
+     tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+     cardinality=1
+     avgRowSize=3.0
+
+PLAN FRAGMENT 6
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 04
+    HASH_PARTITIONED: 1: L_ORDERKEY, 18: sum
+
+  3:AGGREGATE (update finalize)
+  |  output: sum(5: L_QUANTITY)
+  |  group by: 1: L_ORDERKEY
+  |  
+  2:Project
+  |  <slot 1> : 1: L_ORDERKEY
+  |  <slot 5> : 5: L_QUANTITY
+  |  
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=3.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/intersect_q2_enable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/intersect_q2_enable_colocate_set.sql
@@ -1,0 +1,265 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F07)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F07#0)
+      BE: 10001
+
+PLAN FRAGMENT 1(F06)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F06#0)
+      DESTINATIONS: 0-F07#0
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+        4:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(2-F06#1)
+      DESTINATIONS: 0-F07#0
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+        4:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(3-F06#2)
+      DESTINATIONS: 0-F07#0
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+        4:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 2(F04)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F04#0)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        11:OlapScanNode
+          1. partitionID=2202,tabletID=2205
+          2. partitionID=2202,tabletID=2211
+          3. partitionID=2202,tabletID=2217
+          4. partitionID=2202,tabletID=2223
+          5. partitionID=2202,tabletID=2229
+          6. partitionID=2202,tabletID=2235
+    INSTANCE(5-F04#1)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        11:OlapScanNode
+          1. partitionID=2202,tabletID=2207
+          2. partitionID=2202,tabletID=2213
+          3. partitionID=2202,tabletID=2219
+          4. partitionID=2202,tabletID=2225
+          5. partitionID=2202,tabletID=2231
+          6. partitionID=2202,tabletID=2237
+    INSTANCE(6-F04#2)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        11:OlapScanNode
+          1. partitionID=2202,tabletID=2203
+          2. partitionID=2202,tabletID=2209
+          3. partitionID=2202,tabletID=2215
+          4. partitionID=2202,tabletID=2221
+          5. partitionID=2202,tabletID=2227
+          6. partitionID=2202,tabletID=2233
+
+PLAN FRAGMENT 3(F02)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F02#0)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        7:OlapScanNode
+          1. partitionID=1934,tabletID=1937
+          2. partitionID=1934,tabletID=1943
+          3. partitionID=1934,tabletID=1949
+          4. partitionID=1934,tabletID=1955
+          5. partitionID=1934,tabletID=1961
+          6. partitionID=1934,tabletID=1967
+    INSTANCE(8-F02#1)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        7:OlapScanNode
+          1. partitionID=1934,tabletID=1939
+          2. partitionID=1934,tabletID=1945
+          3. partitionID=1934,tabletID=1951
+          4. partitionID=1934,tabletID=1957
+          5. partitionID=1934,tabletID=1963
+          6. partitionID=1934,tabletID=1969
+    INSTANCE(9-F02#2)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        7:OlapScanNode
+          1. partitionID=1934,tabletID=1935
+          2. partitionID=1934,tabletID=1941
+          3. partitionID=1934,tabletID=1947
+          4. partitionID=1934,tabletID=1953
+          5. partitionID=1934,tabletID=1959
+          6. partitionID=1934,tabletID=1965
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:73: L_ORDERKEY | 75: sum
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  16:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 16
+    UNPARTITIONED
+
+  15:AGGREGATE (update finalize)
+  |  output: sum(74: sum)
+  |  group by: 73: L_ORDERKEY
+  |  
+  0:INTERSECT
+  |  
+  |----6:AGGREGATE (update finalize)
+  |    |  output: sum(23: L_QUANTITY)
+  |    |  group by: 19: L_ORDERKEY
+  |    |  
+  |    5:Project
+  |    |  <slot 19> : 19: L_ORDERKEY
+  |    |  <slot 23> : 23: L_QUANTITY
+  |    |  
+  |    4:OlapScanNode
+  |       TABLE: lineitem1
+  |       PREAGGREGATION: ON
+  |       partitions=1/7
+  |       rollup: lineitem1
+  |       tabletRatio=18/18
+  |       tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+  |       cardinality=1
+  |       avgRowSize=3.0
+  |    
+  |----10:EXCHANGE
+  |    
+  |----14:EXCHANGE
+  |    
+  3:AGGREGATE (update finalize)
+  |  output: sum(5: L_QUANTITY)
+  |  group by: 1: L_ORDERKEY
+  |  
+  2:Project
+  |  <slot 1> : 1: L_ORDERKEY
+  |  <slot 5> : 5: L_QUANTITY
+  |  
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=3.0
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 14
+    BUCKET_SHUFFLE_HASH_PARTITIONED: 55: L_ORDERKEY
+
+  13:AGGREGATE (update finalize)
+  |  output: sum(59: L_QUANTITY)
+  |  group by: 55: L_ORDERKEY
+  |  
+  12:Project
+  |  <slot 55> : 55: L_ORDERKEY
+  |  <slot 59> : 59: L_QUANTITY
+  |  
+  11:OlapScanNode
+     TABLE: lineitem3
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem3
+     tabletRatio=18/18
+     tabletList=2203,2205,2207,2209,2211,2213,2215,2217,2219,2221 ...
+     cardinality=1
+     avgRowSize=3.0
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 10
+    BUCKET_SHUFFLE_HASH_PARTITIONED: 37: L_ORDERKEY
+
+  9:AGGREGATE (update finalize)
+  |  output: sum(41: L_QUANTITY)
+  |  group by: 37: L_ORDERKEY
+  |  
+  8:Project
+  |  <slot 37> : 37: L_ORDERKEY
+  |  <slot 41> : 41: L_QUANTITY
+  |  
+  7:OlapScanNode
+     TABLE: lineitem2
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem2
+     tabletRatio=18/18
+     tabletList=1935,1937,1939,1941,1943,1945,1947,1949,1951,1953 ...
+     cardinality=1
+     avgRowSize=3.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/intersect_q3_disable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/intersect_q3_disable_colocate_set.sql
@@ -1,0 +1,349 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F10)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F10#0)
+      BE: 10002
+
+PLAN FRAGMENT 1(F09)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F09#0)
+      DESTINATIONS: 0-F10#0
+      BE: 10001
+    INSTANCE(2-F09#1)
+      DESTINATIONS: 0-F10#0
+      BE: 10002
+    INSTANCE(3-F09#2)
+      DESTINATIONS: 0-F10#0
+      BE: 10003
+
+PLAN FRAGMENT 2(F08)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F08#0)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10003
+    INSTANCE(5-F08#1)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10002
+    INSTANCE(6-F08#2)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10001
+
+PLAN FRAGMENT 3(F06)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F06#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        13:OlapScanNode
+          1. partitionID=2202,tabletID=2205
+          2. partitionID=2202,tabletID=2211
+          3. partitionID=2202,tabletID=2217
+          4. partitionID=2202,tabletID=2223
+          5. partitionID=2202,tabletID=2229
+          6. partitionID=2202,tabletID=2235
+    INSTANCE(8-F06#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        13:OlapScanNode
+          1. partitionID=2202,tabletID=2207
+          2. partitionID=2202,tabletID=2213
+          3. partitionID=2202,tabletID=2219
+          4. partitionID=2202,tabletID=2225
+          5. partitionID=2202,tabletID=2231
+          6. partitionID=2202,tabletID=2237
+    INSTANCE(9-F06#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        13:OlapScanNode
+          1. partitionID=2202,tabletID=2203
+          2. partitionID=2202,tabletID=2209
+          3. partitionID=2202,tabletID=2215
+          4. partitionID=2202,tabletID=2221
+          5. partitionID=2202,tabletID=2227
+          6. partitionID=2202,tabletID=2233
+
+PLAN FRAGMENT 4(F04)
+  DOP: 16
+  INSTANCES
+    INSTANCE(10-F04#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        9:OlapScanNode
+          1. partitionID=1934,tabletID=1937
+          2. partitionID=1934,tabletID=1943
+          3. partitionID=1934,tabletID=1949
+          4. partitionID=1934,tabletID=1955
+          5. partitionID=1934,tabletID=1961
+          6. partitionID=1934,tabletID=1967
+    INSTANCE(11-F04#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        9:OlapScanNode
+          1. partitionID=1934,tabletID=1939
+          2. partitionID=1934,tabletID=1945
+          3. partitionID=1934,tabletID=1951
+          4. partitionID=1934,tabletID=1957
+          5. partitionID=1934,tabletID=1963
+          6. partitionID=1934,tabletID=1969
+    INSTANCE(12-F04#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        9:OlapScanNode
+          1. partitionID=1934,tabletID=1935
+          2. partitionID=1934,tabletID=1941
+          3. partitionID=1934,tabletID=1947
+          4. partitionID=1934,tabletID=1953
+          5. partitionID=1934,tabletID=1959
+          6. partitionID=1934,tabletID=1965
+
+PLAN FRAGMENT 5(F02)
+  DOP: 16
+  INSTANCES
+    INSTANCE(13-F02#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        5:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(14-F02#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        5:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(15-F02#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        5:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 6(F00)
+  DOP: 16
+  INSTANCES
+    INSTANCE(16-F00#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+    INSTANCE(17-F00#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+    INSTANCE(18-F00#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:73: L_ORDERKEY | 74: L_PARTKEY | 76: sum
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  20:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: HASH_PARTITIONED: 73: L_ORDERKEY, 74: L_PARTKEY
+
+  STREAM DATA SINK
+    EXCHANGE ID: 20
+    UNPARTITIONED
+
+  19:AGGREGATE (merge finalize)
+  |  output: sum(76: sum)
+  |  group by: 73: L_ORDERKEY, 74: L_PARTKEY
+  |  
+  18:EXCHANGE
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 18
+    HASH_PARTITIONED: 73: L_ORDERKEY, 74: L_PARTKEY
+
+  17:AGGREGATE (update serialize)
+  |  STREAMING
+  |  output: sum(75: sum)
+  |  group by: 73: L_ORDERKEY, 74: L_PARTKEY
+  |  
+  0:INTERSECT
+  |  
+  |----8:EXCHANGE
+  |    
+  |----12:EXCHANGE
+  |    
+  |----16:EXCHANGE
+  |    
+  4:EXCHANGE
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 16
+    HASH_PARTITIONED: 55: L_ORDERKEY, 56: L_PARTKEY, 72: sum
+
+  15:AGGREGATE (update finalize)
+  |  output: sum(59: L_QUANTITY)
+  |  group by: 55: L_ORDERKEY, 56: L_PARTKEY
+  |  
+  14:Project
+  |  <slot 55> : 55: L_ORDERKEY
+  |  <slot 56> : 56: L_PARTKEY
+  |  <slot 59> : 59: L_QUANTITY
+  |  
+  13:OlapScanNode
+     TABLE: lineitem3
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem3
+     tabletRatio=18/18
+     tabletList=2203,2205,2207,2209,2211,2213,2215,2217,2219,2221 ...
+     cardinality=1
+     avgRowSize=4.0
+
+PLAN FRAGMENT 4
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 12
+    HASH_PARTITIONED: 37: L_ORDERKEY, 38: L_PARTKEY, 54: sum
+
+  11:AGGREGATE (update finalize)
+  |  output: sum(41: L_QUANTITY)
+  |  group by: 37: L_ORDERKEY, 38: L_PARTKEY
+  |  
+  10:Project
+  |  <slot 37> : 37: L_ORDERKEY
+  |  <slot 38> : 38: L_PARTKEY
+  |  <slot 41> : 41: L_QUANTITY
+  |  
+  9:OlapScanNode
+     TABLE: lineitem2
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem2
+     tabletRatio=18/18
+     tabletList=1935,1937,1939,1941,1943,1945,1947,1949,1951,1953 ...
+     cardinality=1
+     avgRowSize=4.0
+
+PLAN FRAGMENT 5
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 08
+    HASH_PARTITIONED: 19: L_ORDERKEY, 20: L_PARTKEY, 36: sum
+
+  7:AGGREGATE (update finalize)
+  |  output: sum(23: L_QUANTITY)
+  |  group by: 19: L_ORDERKEY, 20: L_PARTKEY
+  |  
+  6:Project
+  |  <slot 19> : 19: L_ORDERKEY
+  |  <slot 20> : 20: L_PARTKEY
+  |  <slot 23> : 23: L_QUANTITY
+  |  
+  5:OlapScanNode
+     TABLE: lineitem1
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem1
+     tabletRatio=18/18
+     tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+     cardinality=1
+     avgRowSize=4.0
+
+PLAN FRAGMENT 6
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 04
+    HASH_PARTITIONED: 1: L_ORDERKEY, 2: L_PARTKEY, 18: sum
+
+  3:AGGREGATE (update finalize)
+  |  output: sum(5: L_QUANTITY)
+  |  group by: 1: L_ORDERKEY, 2: L_PARTKEY
+  |  
+  2:Project
+  |  <slot 1> : 1: L_ORDERKEY
+  |  <slot 2> : 2: L_PARTKEY
+  |  <slot 5> : 5: L_QUANTITY
+  |  
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=4.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/intersect_q3_enable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/intersect_q3_enable_colocate_set.sql
@@ -1,0 +1,269 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F07)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F07#0)
+      BE: 10001
+
+PLAN FRAGMENT 1(F06)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F06#0)
+      DESTINATIONS: 0-F07#0
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+        4:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(2-F06#1)
+      DESTINATIONS: 0-F07#0
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+        4:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(3-F06#2)
+      DESTINATIONS: 0-F07#0
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+        4:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 2(F04)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F04#0)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        11:OlapScanNode
+          1. partitionID=2202,tabletID=2205
+          2. partitionID=2202,tabletID=2211
+          3. partitionID=2202,tabletID=2217
+          4. partitionID=2202,tabletID=2223
+          5. partitionID=2202,tabletID=2229
+          6. partitionID=2202,tabletID=2235
+    INSTANCE(5-F04#1)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        11:OlapScanNode
+          1. partitionID=2202,tabletID=2207
+          2. partitionID=2202,tabletID=2213
+          3. partitionID=2202,tabletID=2219
+          4. partitionID=2202,tabletID=2225
+          5. partitionID=2202,tabletID=2231
+          6. partitionID=2202,tabletID=2237
+    INSTANCE(6-F04#2)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        11:OlapScanNode
+          1. partitionID=2202,tabletID=2203
+          2. partitionID=2202,tabletID=2209
+          3. partitionID=2202,tabletID=2215
+          4. partitionID=2202,tabletID=2221
+          5. partitionID=2202,tabletID=2227
+          6. partitionID=2202,tabletID=2233
+
+PLAN FRAGMENT 3(F02)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F02#0)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        7:OlapScanNode
+          1. partitionID=1934,tabletID=1937
+          2. partitionID=1934,tabletID=1943
+          3. partitionID=1934,tabletID=1949
+          4. partitionID=1934,tabletID=1955
+          5. partitionID=1934,tabletID=1961
+          6. partitionID=1934,tabletID=1967
+    INSTANCE(8-F02#1)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        7:OlapScanNode
+          1. partitionID=1934,tabletID=1939
+          2. partitionID=1934,tabletID=1945
+          3. partitionID=1934,tabletID=1951
+          4. partitionID=1934,tabletID=1957
+          5. partitionID=1934,tabletID=1963
+          6. partitionID=1934,tabletID=1969
+    INSTANCE(9-F02#2)
+      DESTINATIONS: 3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1,3-F06#2,1-F06#0,2-F06#1
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        7:OlapScanNode
+          1. partitionID=1934,tabletID=1935
+          2. partitionID=1934,tabletID=1941
+          3. partitionID=1934,tabletID=1947
+          4. partitionID=1934,tabletID=1953
+          5. partitionID=1934,tabletID=1959
+          6. partitionID=1934,tabletID=1965
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:73: L_ORDERKEY | 74: L_PARTKEY | 76: sum
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  16:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 16
+    UNPARTITIONED
+
+  15:AGGREGATE (update finalize)
+  |  output: sum(75: sum)
+  |  group by: 73: L_ORDERKEY, 74: L_PARTKEY
+  |  
+  0:INTERSECT
+  |  
+  |----6:AGGREGATE (update finalize)
+  |    |  output: sum(23: L_QUANTITY)
+  |    |  group by: 19: L_ORDERKEY, 20: L_PARTKEY
+  |    |  
+  |    5:Project
+  |    |  <slot 19> : 19: L_ORDERKEY
+  |    |  <slot 20> : 20: L_PARTKEY
+  |    |  <slot 23> : 23: L_QUANTITY
+  |    |  
+  |    4:OlapScanNode
+  |       TABLE: lineitem1
+  |       PREAGGREGATION: ON
+  |       partitions=1/7
+  |       rollup: lineitem1
+  |       tabletRatio=18/18
+  |       tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+  |       cardinality=1
+  |       avgRowSize=4.0
+  |    
+  |----10:EXCHANGE
+  |    
+  |----14:EXCHANGE
+  |    
+  3:AGGREGATE (update finalize)
+  |  output: sum(5: L_QUANTITY)
+  |  group by: 1: L_ORDERKEY, 2: L_PARTKEY
+  |  
+  2:Project
+  |  <slot 1> : 1: L_ORDERKEY
+  |  <slot 2> : 2: L_PARTKEY
+  |  <slot 5> : 5: L_QUANTITY
+  |  
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=4.0
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 14
+    BUCKET_SHUFFLE_HASH_PARTITIONED: 55: L_ORDERKEY
+
+  13:AGGREGATE (update finalize)
+  |  output: sum(59: L_QUANTITY)
+  |  group by: 55: L_ORDERKEY, 56: L_PARTKEY
+  |  
+  12:Project
+  |  <slot 55> : 55: L_ORDERKEY
+  |  <slot 56> : 56: L_PARTKEY
+  |  <slot 59> : 59: L_QUANTITY
+  |  
+  11:OlapScanNode
+     TABLE: lineitem3
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem3
+     tabletRatio=18/18
+     tabletList=2203,2205,2207,2209,2211,2213,2215,2217,2219,2221 ...
+     cardinality=1
+     avgRowSize=4.0
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 10
+    BUCKET_SHUFFLE_HASH_PARTITIONED: 37: L_ORDERKEY
+
+  9:AGGREGATE (update finalize)
+  |  output: sum(41: L_QUANTITY)
+  |  group by: 37: L_ORDERKEY, 38: L_PARTKEY
+  |  
+  8:Project
+  |  <slot 37> : 37: L_ORDERKEY
+  |  <slot 38> : 38: L_PARTKEY
+  |  <slot 41> : 41: L_QUANTITY
+  |  
+  7:OlapScanNode
+     TABLE: lineitem2
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem2
+     tabletRatio=18/18
+     tabletList=1935,1937,1939,1941,1943,1945,1947,1949,1951,1953 ...
+     cardinality=1
+     avgRowSize=4.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/intersect_q4_disable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/intersect_q4_disable_colocate_set.sql
@@ -1,0 +1,365 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F10)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F10#0)
+      BE: 10002
+
+PLAN FRAGMENT 1(F09)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F09#0)
+      DESTINATIONS: 0-F10#0
+      BE: 10003
+    INSTANCE(2-F09#1)
+      DESTINATIONS: 0-F10#0
+      BE: 10002
+    INSTANCE(3-F09#2)
+      DESTINATIONS: 0-F10#0
+      BE: 10001
+
+PLAN FRAGMENT 2(F08)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F08#0)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10001
+    INSTANCE(5-F08#1)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10003
+    INSTANCE(6-F08#2)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10002
+
+PLAN FRAGMENT 3(F06)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F06#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        16:OlapScanNode
+          1. partitionID=2202,tabletID=2205
+          2. partitionID=2202,tabletID=2211
+          3. partitionID=2202,tabletID=2217
+          4. partitionID=2202,tabletID=2223
+          5. partitionID=2202,tabletID=2229
+          6. partitionID=2202,tabletID=2235
+    INSTANCE(8-F06#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        16:OlapScanNode
+          1. partitionID=2202,tabletID=2207
+          2. partitionID=2202,tabletID=2213
+          3. partitionID=2202,tabletID=2219
+          4. partitionID=2202,tabletID=2225
+          5. partitionID=2202,tabletID=2231
+          6. partitionID=2202,tabletID=2237
+    INSTANCE(9-F06#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        16:OlapScanNode
+          1. partitionID=2202,tabletID=2203
+          2. partitionID=2202,tabletID=2209
+          3. partitionID=2202,tabletID=2215
+          4. partitionID=2202,tabletID=2221
+          5. partitionID=2202,tabletID=2227
+          6. partitionID=2202,tabletID=2233
+
+PLAN FRAGMENT 4(F04)
+  DOP: 16
+  INSTANCES
+    INSTANCE(10-F04#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        11:OlapScanNode
+          1. partitionID=1934,tabletID=1937
+          2. partitionID=1934,tabletID=1943
+          3. partitionID=1934,tabletID=1949
+          4. partitionID=1934,tabletID=1955
+          5. partitionID=1934,tabletID=1961
+          6. partitionID=1934,tabletID=1967
+    INSTANCE(11-F04#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        11:OlapScanNode
+          1. partitionID=1934,tabletID=1939
+          2. partitionID=1934,tabletID=1945
+          3. partitionID=1934,tabletID=1951
+          4. partitionID=1934,tabletID=1957
+          5. partitionID=1934,tabletID=1963
+          6. partitionID=1934,tabletID=1969
+    INSTANCE(12-F04#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        11:OlapScanNode
+          1. partitionID=1934,tabletID=1935
+          2. partitionID=1934,tabletID=1941
+          3. partitionID=1934,tabletID=1947
+          4. partitionID=1934,tabletID=1953
+          5. partitionID=1934,tabletID=1959
+          6. partitionID=1934,tabletID=1965
+
+PLAN FRAGMENT 5(F02)
+  DOP: 16
+  INSTANCES
+    INSTANCE(13-F02#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        6:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(14-F02#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        6:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(15-F02#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        6:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 6(F00)
+  DOP: 16
+  INSTANCES
+    INSTANCE(16-F00#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+    INSTANCE(17-F00#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+    INSTANCE(18-F00#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:73: L_PARTKEY | 75: sum
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  24:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: HASH_PARTITIONED: 73: L_PARTKEY
+
+  STREAM DATA SINK
+    EXCHANGE ID: 24
+    UNPARTITIONED
+
+  23:AGGREGATE (merge finalize)
+  |  output: sum(75: sum)
+  |  group by: 73: L_PARTKEY
+  |  
+  22:EXCHANGE
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 22
+    HASH_PARTITIONED: 73: L_PARTKEY
+
+  21:AGGREGATE (update serialize)
+  |  STREAMING
+  |  output: sum(74: sum)
+  |  group by: 73: L_PARTKEY
+  |  
+  0:INTERSECT
+  |  
+  |----10:EXCHANGE
+  |    
+  |----15:EXCHANGE
+  |    
+  |----20:EXCHANGE
+  |    
+  5:EXCHANGE
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 20
+    HASH_PARTITIONED: 56: L_PARTKEY, 72: sum
+
+  19:Project
+  |  <slot 56> : 56: L_PARTKEY
+  |  <slot 72> : 72: sum
+  |  
+  18:AGGREGATE (update finalize)
+  |  output: sum(59: L_QUANTITY)
+  |  group by: 55: L_ORDERKEY, 56: L_PARTKEY
+  |  
+  17:Project
+  |  <slot 55> : 55: L_ORDERKEY
+  |  <slot 56> : 56: L_PARTKEY
+  |  <slot 59> : 59: L_QUANTITY
+  |  
+  16:OlapScanNode
+     TABLE: lineitem3
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem3
+     tabletRatio=18/18
+     tabletList=2203,2205,2207,2209,2211,2213,2215,2217,2219,2221 ...
+     cardinality=1
+     avgRowSize=4.0
+
+PLAN FRAGMENT 4
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 15
+    HASH_PARTITIONED: 38: L_PARTKEY, 54: sum
+
+  14:Project
+  |  <slot 38> : 38: L_PARTKEY
+  |  <slot 54> : 54: sum
+  |  
+  13:AGGREGATE (update finalize)
+  |  output: sum(41: L_QUANTITY)
+  |  group by: 37: L_ORDERKEY, 38: L_PARTKEY
+  |  
+  12:Project
+  |  <slot 37> : 37: L_ORDERKEY
+  |  <slot 38> : 38: L_PARTKEY
+  |  <slot 41> : 41: L_QUANTITY
+  |  
+  11:OlapScanNode
+     TABLE: lineitem2
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem2
+     tabletRatio=18/18
+     tabletList=1935,1937,1939,1941,1943,1945,1947,1949,1951,1953 ...
+     cardinality=1
+     avgRowSize=4.0
+
+PLAN FRAGMENT 5
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 10
+    HASH_PARTITIONED: 20: L_PARTKEY, 36: sum
+
+  9:Project
+  |  <slot 20> : 20: L_PARTKEY
+  |  <slot 36> : 36: sum
+  |  
+  8:AGGREGATE (update finalize)
+  |  output: sum(23: L_QUANTITY)
+  |  group by: 19: L_ORDERKEY, 20: L_PARTKEY
+  |  
+  7:Project
+  |  <slot 19> : 19: L_ORDERKEY
+  |  <slot 20> : 20: L_PARTKEY
+  |  <slot 23> : 23: L_QUANTITY
+  |  
+  6:OlapScanNode
+     TABLE: lineitem1
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem1
+     tabletRatio=18/18
+     tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+     cardinality=1
+     avgRowSize=4.0
+
+PLAN FRAGMENT 6
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 05
+    HASH_PARTITIONED: 2: L_PARTKEY, 18: sum
+
+  4:Project
+  |  <slot 2> : 2: L_PARTKEY
+  |  <slot 18> : 18: sum
+  |  
+  3:AGGREGATE (update finalize)
+  |  output: sum(5: L_QUANTITY)
+  |  group by: 1: L_ORDERKEY, 2: L_PARTKEY
+  |  
+  2:Project
+  |  <slot 1> : 1: L_ORDERKEY
+  |  <slot 2> : 2: L_PARTKEY
+  |  <slot 5> : 5: L_QUANTITY
+  |  
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=4.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/intersect_q4_enable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/intersect_q4_enable_colocate_set.sql
@@ -1,0 +1,365 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F10)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F10#0)
+      BE: 10001
+
+PLAN FRAGMENT 1(F09)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F09#0)
+      DESTINATIONS: 0-F10#0
+      BE: 10001
+    INSTANCE(2-F09#1)
+      DESTINATIONS: 0-F10#0
+      BE: 10002
+    INSTANCE(3-F09#2)
+      DESTINATIONS: 0-F10#0
+      BE: 10003
+
+PLAN FRAGMENT 2(F08)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F08#0)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10003
+    INSTANCE(5-F08#1)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10002
+    INSTANCE(6-F08#2)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10001
+
+PLAN FRAGMENT 3(F06)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F06#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        16:OlapScanNode
+          1. partitionID=2202,tabletID=2205
+          2. partitionID=2202,tabletID=2211
+          3. partitionID=2202,tabletID=2217
+          4. partitionID=2202,tabletID=2223
+          5. partitionID=2202,tabletID=2229
+          6. partitionID=2202,tabletID=2235
+    INSTANCE(8-F06#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        16:OlapScanNode
+          1. partitionID=2202,tabletID=2207
+          2. partitionID=2202,tabletID=2213
+          3. partitionID=2202,tabletID=2219
+          4. partitionID=2202,tabletID=2225
+          5. partitionID=2202,tabletID=2231
+          6. partitionID=2202,tabletID=2237
+    INSTANCE(9-F06#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        16:OlapScanNode
+          1. partitionID=2202,tabletID=2203
+          2. partitionID=2202,tabletID=2209
+          3. partitionID=2202,tabletID=2215
+          4. partitionID=2202,tabletID=2221
+          5. partitionID=2202,tabletID=2227
+          6. partitionID=2202,tabletID=2233
+
+PLAN FRAGMENT 4(F04)
+  DOP: 16
+  INSTANCES
+    INSTANCE(10-F04#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        11:OlapScanNode
+          1. partitionID=1934,tabletID=1937
+          2. partitionID=1934,tabletID=1943
+          3. partitionID=1934,tabletID=1949
+          4. partitionID=1934,tabletID=1955
+          5. partitionID=1934,tabletID=1961
+          6. partitionID=1934,tabletID=1967
+    INSTANCE(11-F04#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        11:OlapScanNode
+          1. partitionID=1934,tabletID=1939
+          2. partitionID=1934,tabletID=1945
+          3. partitionID=1934,tabletID=1951
+          4. partitionID=1934,tabletID=1957
+          5. partitionID=1934,tabletID=1963
+          6. partitionID=1934,tabletID=1969
+    INSTANCE(12-F04#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        11:OlapScanNode
+          1. partitionID=1934,tabletID=1935
+          2. partitionID=1934,tabletID=1941
+          3. partitionID=1934,tabletID=1947
+          4. partitionID=1934,tabletID=1953
+          5. partitionID=1934,tabletID=1959
+          6. partitionID=1934,tabletID=1965
+
+PLAN FRAGMENT 5(F02)
+  DOP: 16
+  INSTANCES
+    INSTANCE(13-F02#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        6:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(14-F02#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        6:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(15-F02#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        6:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 6(F00)
+  DOP: 16
+  INSTANCES
+    INSTANCE(16-F00#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+    INSTANCE(17-F00#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+    INSTANCE(18-F00#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:73: L_PARTKEY | 75: sum
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  24:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: HASH_PARTITIONED: 73: L_PARTKEY
+
+  STREAM DATA SINK
+    EXCHANGE ID: 24
+    UNPARTITIONED
+
+  23:AGGREGATE (merge finalize)
+  |  output: sum(75: sum)
+  |  group by: 73: L_PARTKEY
+  |  
+  22:EXCHANGE
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 22
+    HASH_PARTITIONED: 73: L_PARTKEY
+
+  21:AGGREGATE (update serialize)
+  |  STREAMING
+  |  output: sum(74: sum)
+  |  group by: 73: L_PARTKEY
+  |  
+  0:INTERSECT
+  |  
+  |----10:EXCHANGE
+  |    
+  |----15:EXCHANGE
+  |    
+  |----20:EXCHANGE
+  |    
+  5:EXCHANGE
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 20
+    HASH_PARTITIONED: 56: L_PARTKEY, 72: sum
+
+  19:Project
+  |  <slot 56> : 56: L_PARTKEY
+  |  <slot 72> : 72: sum
+  |  
+  18:AGGREGATE (update finalize)
+  |  output: sum(59: L_QUANTITY)
+  |  group by: 55: L_ORDERKEY, 56: L_PARTKEY
+  |  
+  17:Project
+  |  <slot 55> : 55: L_ORDERKEY
+  |  <slot 56> : 56: L_PARTKEY
+  |  <slot 59> : 59: L_QUANTITY
+  |  
+  16:OlapScanNode
+     TABLE: lineitem3
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem3
+     tabletRatio=18/18
+     tabletList=2203,2205,2207,2209,2211,2213,2215,2217,2219,2221 ...
+     cardinality=1
+     avgRowSize=4.0
+
+PLAN FRAGMENT 4
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 15
+    HASH_PARTITIONED: 38: L_PARTKEY, 54: sum
+
+  14:Project
+  |  <slot 38> : 38: L_PARTKEY
+  |  <slot 54> : 54: sum
+  |  
+  13:AGGREGATE (update finalize)
+  |  output: sum(41: L_QUANTITY)
+  |  group by: 37: L_ORDERKEY, 38: L_PARTKEY
+  |  
+  12:Project
+  |  <slot 37> : 37: L_ORDERKEY
+  |  <slot 38> : 38: L_PARTKEY
+  |  <slot 41> : 41: L_QUANTITY
+  |  
+  11:OlapScanNode
+     TABLE: lineitem2
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem2
+     tabletRatio=18/18
+     tabletList=1935,1937,1939,1941,1943,1945,1947,1949,1951,1953 ...
+     cardinality=1
+     avgRowSize=4.0
+
+PLAN FRAGMENT 5
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 10
+    HASH_PARTITIONED: 20: L_PARTKEY, 36: sum
+
+  9:Project
+  |  <slot 20> : 20: L_PARTKEY
+  |  <slot 36> : 36: sum
+  |  
+  8:AGGREGATE (update finalize)
+  |  output: sum(23: L_QUANTITY)
+  |  group by: 19: L_ORDERKEY, 20: L_PARTKEY
+  |  
+  7:Project
+  |  <slot 19> : 19: L_ORDERKEY
+  |  <slot 20> : 20: L_PARTKEY
+  |  <slot 23> : 23: L_QUANTITY
+  |  
+  6:OlapScanNode
+     TABLE: lineitem1
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem1
+     tabletRatio=18/18
+     tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+     cardinality=1
+     avgRowSize=4.0
+
+PLAN FRAGMENT 6
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 05
+    HASH_PARTITIONED: 2: L_PARTKEY, 18: sum
+
+  4:Project
+  |  <slot 2> : 2: L_PARTKEY
+  |  <slot 18> : 18: sum
+  |  
+  3:AGGREGATE (update finalize)
+  |  output: sum(5: L_QUANTITY)
+  |  group by: 1: L_ORDERKEY, 2: L_PARTKEY
+  |  
+  2:Project
+  |  <slot 1> : 1: L_ORDERKEY
+  |  <slot 2> : 2: L_PARTKEY
+  |  <slot 5> : 5: L_QUANTITY
+  |  
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=4.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/intersect_q5_disable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/intersect_q5_disable_colocate_set.sql
@@ -1,0 +1,318 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F11)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F11#0)
+      BE: 10002
+
+PLAN FRAGMENT 1(F08)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F08#0)
+      DESTINATIONS: 0-F11#0
+      BE: 10001
+    INSTANCE(2-F08#1)
+      DESTINATIONS: 0-F11#0
+      BE: 10002
+    INSTANCE(3-F08#2)
+      DESTINATIONS: 0-F11#0
+      BE: 10003
+
+PLAN FRAGMENT 2(F09)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F09#0)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10001
+      SCAN RANGES
+        12:OlapScanNode
+          1. partitionID=2488,tabletID=2491
+          2. partitionID=2488,tabletID=2497
+          3. partitionID=2488,tabletID=2503
+          4. partitionID=2488,tabletID=2509
+          5. partitionID=2488,tabletID=2515
+          6. partitionID=2488,tabletID=2521
+    INSTANCE(5-F09#1)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10002
+      SCAN RANGES
+        12:OlapScanNode
+          1. partitionID=2488,tabletID=2493
+          2. partitionID=2488,tabletID=2499
+          3. partitionID=2488,tabletID=2505
+          4. partitionID=2488,tabletID=2511
+          5. partitionID=2488,tabletID=2517
+          6. partitionID=2488,tabletID=2523
+    INSTANCE(6-F09#2)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10003
+      SCAN RANGES
+        12:OlapScanNode
+          1. partitionID=2488,tabletID=2489
+          2. partitionID=2488,tabletID=2495
+          3. partitionID=2488,tabletID=2501
+          4. partitionID=2488,tabletID=2507
+          5. partitionID=2488,tabletID=2513
+          6. partitionID=2488,tabletID=2519
+
+PLAN FRAGMENT 3(F06)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F06#0)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10001
+      SCAN RANGES
+        8:OlapScanNode
+          1. partitionID=2448,tabletID=2451
+          2. partitionID=2448,tabletID=2457
+          3. partitionID=2448,tabletID=2463
+          4. partitionID=2448,tabletID=2469
+          5. partitionID=2448,tabletID=2475
+          6. partitionID=2448,tabletID=2481
+    INSTANCE(8-F06#1)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10002
+      SCAN RANGES
+        8:OlapScanNode
+          1. partitionID=2448,tabletID=2453
+          2. partitionID=2448,tabletID=2459
+          3. partitionID=2448,tabletID=2465
+          4. partitionID=2448,tabletID=2471
+          5. partitionID=2448,tabletID=2477
+          6. partitionID=2448,tabletID=2483
+    INSTANCE(9-F06#2)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10003
+      SCAN RANGES
+        8:OlapScanNode
+          1. partitionID=2448,tabletID=2449
+          2. partitionID=2448,tabletID=2455
+          3. partitionID=2448,tabletID=2461
+          4. partitionID=2448,tabletID=2467
+          5. partitionID=2448,tabletID=2473
+          6. partitionID=2448,tabletID=2479
+
+PLAN FRAGMENT 4(F04)
+  DOP: 16
+  INSTANCES
+    INSTANCE(10-F04#0)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10003
+    INSTANCE(11-F04#1)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10002
+    INSTANCE(12-F04#2)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10001
+
+PLAN FRAGMENT 5(F02)
+  DOP: 16
+  INSTANCES
+    INSTANCE(13-F02#0)
+      DESTINATIONS: 10-F04#0,11-F04#1,12-F04#2
+      BE: 10001
+      SCAN RANGES
+        4:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(14-F02#1)
+      DESTINATIONS: 10-F04#0,11-F04#1,12-F04#2
+      BE: 10002
+      SCAN RANGES
+        4:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(15-F02#2)
+      DESTINATIONS: 10-F04#0,11-F04#1,12-F04#2
+      BE: 10003
+      SCAN RANGES
+        4:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 6(F00)
+  DOP: 16
+  INSTANCES
+    INSTANCE(16-F00#0)
+      DESTINATIONS: 10-F04#0,11-F04#1,12-F04#2
+      BE: 10001
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+    INSTANCE(17-F00#1)
+      DESTINATIONS: 10-F04#0,11-F04#1,12-F04#2
+      BE: 10002
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+    INSTANCE(18-F00#2)
+      DESTINATIONS: 10-F04#0,11-F04#1,12-F04#2
+      BE: 10003
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:35: L_ORDERKEY | 36: L_PARTKEY
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  16:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: HASH_PARTITIONED: 35: L_ORDERKEY
+
+  STREAM DATA SINK
+    EXCHANGE ID: 16
+    UNPARTITIONED
+
+  15:Project
+  |  <slot 35> : 35: L_ORDERKEY
+  |  <slot 36> : 36: L_PARTKEY
+  |  
+  14:HASH JOIN
+  |  join op: INNER JOIN (BROADCAST)
+  |  colocate: false, reason: 
+  |  equal join conjunct: 36: L_PARTKEY = 46: p_partkey
+  |  
+  |----13:EXCHANGE
+  |    
+  11:Project
+  |  <slot 35> : 35: L_ORDERKEY
+  |  <slot 36> : 36: L_PARTKEY
+  |  
+  10:HASH JOIN
+  |  join op: INNER JOIN (PARTITIONED)
+  |  colocate: false, reason: 
+  |  equal join conjunct: 35: L_ORDERKEY = 37: o_orderkey
+  |  
+  |----9:EXCHANGE
+  |    
+  7:EXCHANGE
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 13
+    UNPARTITIONED
+
+  12:OlapScanNode
+     TABLE: part
+     PREAGGREGATION: ON
+     partitions=1/1
+     rollup: part
+     tabletRatio=18/18
+     tabletList=2489,2491,2493,2495,2497,2499,2501,2503,2505,2507 ...
+     cardinality=1
+     avgRowSize=8.0
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 09
+    HASH_PARTITIONED: 37: o_orderkey
+
+  8:OlapScanNode
+     TABLE: orders
+     PREAGGREGATION: ON
+     partitions=1/1
+     rollup: orders
+     tabletRatio=18/18
+     tabletList=2449,2451,2453,2455,2457,2459,2461,2463,2465,2467 ...
+     cardinality=1
+     avgRowSize=8.0
+
+PLAN FRAGMENT 4
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 07
+    HASH_PARTITIONED: 35: L_ORDERKEY
+
+  0:INTERSECT
+  |  
+  |----6:EXCHANGE
+  |    
+  3:EXCHANGE
+
+PLAN FRAGMENT 5
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 06
+    HASH_PARTITIONED: 18: L_ORDERKEY, 19: L_PARTKEY
+
+  5:Project
+  |  <slot 18> : 18: L_ORDERKEY
+  |  <slot 19> : 19: L_PARTKEY
+  |  
+  4:OlapScanNode
+     TABLE: lineitem1
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem1
+     tabletRatio=18/18
+     tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+     cardinality=1
+     avgRowSize=3.0
+
+PLAN FRAGMENT 6
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 03
+    HASH_PARTITIONED: 1: L_ORDERKEY, 2: L_PARTKEY
+
+  2:Project
+  |  <slot 1> : 1: L_ORDERKEY
+  |  <slot 2> : 2: L_PARTKEY
+  |  
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=3.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/intersect_q5_enable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/intersect_q5_enable_colocate_set.sql
@@ -1,0 +1,249 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F07)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F07#0)
+      BE: 10001
+
+PLAN FRAGMENT 1(F02)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F02#0)
+      DESTINATIONS: 0-F07#0
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(2-F02#1)
+      DESTINATIONS: 0-F07#0
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(3-F02#2)
+      DESTINATIONS: 0-F07#0
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 2(F05)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F05#0)
+      DESTINATIONS: 1-F02#0,2-F02#1,3-F02#2
+      BE: 10001
+      SCAN RANGES
+        9:OlapScanNode
+          1. partitionID=2488,tabletID=2491
+          2. partitionID=2488,tabletID=2497
+          3. partitionID=2488,tabletID=2503
+          4. partitionID=2488,tabletID=2509
+          5. partitionID=2488,tabletID=2515
+          6. partitionID=2488,tabletID=2521
+    INSTANCE(5-F05#1)
+      DESTINATIONS: 1-F02#0,2-F02#1,3-F02#2
+      BE: 10002
+      SCAN RANGES
+        9:OlapScanNode
+          1. partitionID=2488,tabletID=2493
+          2. partitionID=2488,tabletID=2499
+          3. partitionID=2488,tabletID=2505
+          4. partitionID=2488,tabletID=2511
+          5. partitionID=2488,tabletID=2517
+          6. partitionID=2488,tabletID=2523
+    INSTANCE(6-F05#2)
+      DESTINATIONS: 1-F02#0,2-F02#1,3-F02#2
+      BE: 10003
+      SCAN RANGES
+        9:OlapScanNode
+          1. partitionID=2488,tabletID=2489
+          2. partitionID=2488,tabletID=2495
+          3. partitionID=2488,tabletID=2501
+          4. partitionID=2488,tabletID=2507
+          5. partitionID=2488,tabletID=2513
+          6. partitionID=2488,tabletID=2519
+
+PLAN FRAGMENT 3(F03)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F03#0)
+      DESTINATIONS: 3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1
+      BE: 10001
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=2448,tabletID=2451
+          2. partitionID=2448,tabletID=2457
+          3. partitionID=2448,tabletID=2463
+          4. partitionID=2448,tabletID=2469
+          5. partitionID=2448,tabletID=2475
+          6. partitionID=2448,tabletID=2481
+    INSTANCE(8-F03#1)
+      DESTINATIONS: 3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1
+      BE: 10002
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=2448,tabletID=2453
+          2. partitionID=2448,tabletID=2459
+          3. partitionID=2448,tabletID=2465
+          4. partitionID=2448,tabletID=2471
+          5. partitionID=2448,tabletID=2477
+          6. partitionID=2448,tabletID=2483
+    INSTANCE(9-F03#2)
+      DESTINATIONS: 3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1
+      BE: 10003
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=2448,tabletID=2449
+          2. partitionID=2448,tabletID=2455
+          3. partitionID=2448,tabletID=2461
+          4. partitionID=2448,tabletID=2467
+          5. partitionID=2448,tabletID=2473
+          6. partitionID=2448,tabletID=2479
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:35: L_ORDERKEY | 36: L_PARTKEY
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  13:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 13
+    UNPARTITIONED
+
+  12:Project
+  |  <slot 35> : 35: L_ORDERKEY
+  |  <slot 36> : 36: L_PARTKEY
+  |  
+  11:HASH JOIN
+  |  join op: INNER JOIN (BROADCAST)
+  |  colocate: false, reason: 
+  |  equal join conjunct: 36: L_PARTKEY = 46: p_partkey
+  |  
+  |----10:EXCHANGE
+  |    
+  8:Project
+  |  <slot 35> : 35: L_ORDERKEY
+  |  <slot 36> : 36: L_PARTKEY
+  |  
+  7:HASH JOIN
+  |  join op: INNER JOIN (BUCKET_SHUFFLE)
+  |  colocate: false, reason: 
+  |  equal join conjunct: 35: L_ORDERKEY = 37: o_orderkey
+  |  
+  |----6:EXCHANGE
+  |    
+  0:INTERSECT
+  |  
+  |----4:Project
+  |    |  <slot 18> : 18: L_ORDERKEY
+  |    |  <slot 19> : 19: L_PARTKEY
+  |    |  
+  |    3:OlapScanNode
+  |       TABLE: lineitem1
+  |       PREAGGREGATION: ON
+  |       partitions=1/7
+  |       rollup: lineitem1
+  |       tabletRatio=18/18
+  |       tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+  |       cardinality=1
+  |       avgRowSize=3.0
+  |    
+  2:Project
+  |  <slot 1> : 1: L_ORDERKEY
+  |  <slot 2> : 2: L_PARTKEY
+  |  
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=3.0
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 10
+    UNPARTITIONED
+
+  9:OlapScanNode
+     TABLE: part
+     PREAGGREGATION: ON
+     partitions=1/1
+     rollup: part
+     tabletRatio=18/18
+     tabletList=2489,2491,2493,2495,2497,2499,2501,2503,2505,2507 ...
+     cardinality=1
+     avgRowSize=8.0
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 06
+    BUCKET_SHUFFLE_HASH_PARTITIONED: 37: o_orderkey
+
+  5:OlapScanNode
+     TABLE: orders
+     PREAGGREGATION: ON
+     partitions=1/1
+     rollup: orders
+     tabletRatio=18/18
+     tabletList=2449,2451,2453,2455,2457,2459,2461,2463,2465,2467 ...
+     cardinality=1
+     avgRowSize=8.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/union_q1_disable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/union_q1_disable_colocate_set.sql
@@ -1,0 +1,299 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F10)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F10#0)
+      BE: 10002
+
+PLAN FRAGMENT 1(F09)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F09#0)
+      DESTINATIONS: 0-F10#0
+      BE: 10003
+    INSTANCE(2-F09#1)
+      DESTINATIONS: 0-F10#0
+      BE: 10002
+    INSTANCE(3-F09#2)
+      DESTINATIONS: 0-F10#0
+      BE: 10001
+
+PLAN FRAGMENT 2(F08)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F08#0)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10001
+    INSTANCE(5-F08#1)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10003
+    INSTANCE(6-F08#2)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10002
+
+PLAN FRAGMENT 3(F06)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F06#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2202,tabletID=2205
+          2. partitionID=2202,tabletID=2211
+          3. partitionID=2202,tabletID=2217
+          4. partitionID=2202,tabletID=2223
+          5. partitionID=2202,tabletID=2229
+          6. partitionID=2202,tabletID=2235
+    INSTANCE(8-F06#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2202,tabletID=2207
+          2. partitionID=2202,tabletID=2213
+          3. partitionID=2202,tabletID=2219
+          4. partitionID=2202,tabletID=2225
+          5. partitionID=2202,tabletID=2231
+          6. partitionID=2202,tabletID=2237
+    INSTANCE(9-F06#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2202,tabletID=2203
+          2. partitionID=2202,tabletID=2209
+          3. partitionID=2202,tabletID=2215
+          4. partitionID=2202,tabletID=2221
+          5. partitionID=2202,tabletID=2227
+          6. partitionID=2202,tabletID=2233
+
+PLAN FRAGMENT 4(F04)
+  DOP: 16
+  INSTANCES
+    INSTANCE(10-F04#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=1934,tabletID=1937
+          2. partitionID=1934,tabletID=1943
+          3. partitionID=1934,tabletID=1949
+          4. partitionID=1934,tabletID=1955
+          5. partitionID=1934,tabletID=1961
+          6. partitionID=1934,tabletID=1967
+    INSTANCE(11-F04#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=1934,tabletID=1939
+          2. partitionID=1934,tabletID=1945
+          3. partitionID=1934,tabletID=1951
+          4. partitionID=1934,tabletID=1957
+          5. partitionID=1934,tabletID=1963
+          6. partitionID=1934,tabletID=1969
+    INSTANCE(12-F04#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=1934,tabletID=1935
+          2. partitionID=1934,tabletID=1941
+          3. partitionID=1934,tabletID=1947
+          4. partitionID=1934,tabletID=1953
+          5. partitionID=1934,tabletID=1959
+          6. partitionID=1934,tabletID=1965
+
+PLAN FRAGMENT 5(F02)
+  DOP: 16
+  INSTANCES
+    INSTANCE(13-F02#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(14-F02#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(15-F02#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 6(F00)
+  DOP: 16
+  INSTANCES
+    INSTANCE(16-F00#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+    INSTANCE(17-F00#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+    INSTANCE(18-F00#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:69: L_ORDERKEY | 70: L_PARTKEY | 71: L_SUPPKEY | 72: L_LINENUMBER | 73: L_QUANTITY | 74: L_EXTENDEDPRICE | 75: L_DISCOUNT | 76: L_TAX | 77: L_RETURNFLAG | 78: L_LINESTATUS | 79: L_SHIPDATE | 80: L_COMMITDATE | 81: L_RECEIPTDATE | 82: L_SHIPINSTRUCT | 83: L_SHIPMODE | 84: L_COMMENT | 85: PAD
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  12:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: HASH_PARTITIONED: 69: L_ORDERKEY, 70: L_PARTKEY, 71: L_SUPPKEY, 72: L_LINENUMBER, 73: L_QUANTITY, 74: L_EXTENDEDPRICE, 75: L_DISCOUNT, 76: L_TAX, 77: L_RETURNFLAG, 78: L_LINESTATUS, 79: L_SHIPDATE, 80: L_COMMITDATE, 81: L_RECEIPTDATE, 82: L_SHIPINSTRUCT, 83: L_SHIPMODE, 84: L_COMMENT, 85: PAD
+
+  STREAM DATA SINK
+    EXCHANGE ID: 12
+    UNPARTITIONED
+
+  11:AGGREGATE (merge finalize)
+  |  group by: 69: L_ORDERKEY, 70: L_PARTKEY, 71: L_SUPPKEY, 72: L_LINENUMBER, 73: L_QUANTITY, 74: L_EXTENDEDPRICE, 75: L_DISCOUNT, 76: L_TAX, 77: L_RETURNFLAG, 78: L_LINESTATUS, 79: L_SHIPDATE, 80: L_COMMITDATE, 81: L_RECEIPTDATE, 82: L_SHIPINSTRUCT, 83: L_SHIPMODE, 84: L_COMMENT, 85: PAD
+  |  
+  10:EXCHANGE
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 10
+    HASH_PARTITIONED: 69: L_ORDERKEY, 70: L_PARTKEY, 71: L_SUPPKEY, 72: L_LINENUMBER, 73: L_QUANTITY, 74: L_EXTENDEDPRICE, 75: L_DISCOUNT, 76: L_TAX, 77: L_RETURNFLAG, 78: L_LINESTATUS, 79: L_SHIPDATE, 80: L_COMMITDATE, 81: L_RECEIPTDATE, 82: L_SHIPINSTRUCT, 83: L_SHIPMODE, 84: L_COMMENT, 85: PAD
+
+  9:AGGREGATE (update serialize)
+  |  STREAMING
+  |  group by: 69: L_ORDERKEY, 70: L_PARTKEY, 71: L_SUPPKEY, 72: L_LINENUMBER, 73: L_QUANTITY, 74: L_EXTENDEDPRICE, 75: L_DISCOUNT, 76: L_TAX, 77: L_RETURNFLAG, 78: L_LINESTATUS, 79: L_SHIPDATE, 80: L_COMMITDATE, 81: L_RECEIPTDATE, 82: L_SHIPINSTRUCT, 83: L_SHIPMODE, 84: L_COMMENT, 85: PAD
+  |  
+  0:UNION
+  |  
+  |----4:EXCHANGE
+  |    
+  |----6:EXCHANGE
+  |    
+  |----8:EXCHANGE
+  |    
+  2:EXCHANGE
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 08
+    RANDOM
+
+  7:OlapScanNode
+     TABLE: lineitem3
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem3
+     tabletRatio=18/18
+     tabletList=2203,2205,2207,2209,2211,2213,2215,2217,2219,2221 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 4
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 06
+    RANDOM
+
+  5:OlapScanNode
+     TABLE: lineitem2
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem2
+     tabletRatio=18/18
+     tabletList=1935,1937,1939,1941,1943,1945,1947,1949,1951,1953 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 5
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 04
+    RANDOM
+
+  3:OlapScanNode
+     TABLE: lineitem1
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem1
+     tabletRatio=18/18
+     tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 6
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 02
+    RANDOM
+
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=17.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/union_q1_enable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/union_q1_enable_colocate_set.sql
@@ -1,0 +1,299 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F10)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F10#0)
+      BE: 10001
+
+PLAN FRAGMENT 1(F09)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F09#0)
+      DESTINATIONS: 0-F10#0
+      BE: 10001
+    INSTANCE(2-F09#1)
+      DESTINATIONS: 0-F10#0
+      BE: 10002
+    INSTANCE(3-F09#2)
+      DESTINATIONS: 0-F10#0
+      BE: 10003
+
+PLAN FRAGMENT 2(F08)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F08#0)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10003
+    INSTANCE(5-F08#1)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10002
+    INSTANCE(6-F08#2)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10001
+
+PLAN FRAGMENT 3(F06)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F06#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2202,tabletID=2205
+          2. partitionID=2202,tabletID=2211
+          3. partitionID=2202,tabletID=2217
+          4. partitionID=2202,tabletID=2223
+          5. partitionID=2202,tabletID=2229
+          6. partitionID=2202,tabletID=2235
+    INSTANCE(8-F06#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2202,tabletID=2207
+          2. partitionID=2202,tabletID=2213
+          3. partitionID=2202,tabletID=2219
+          4. partitionID=2202,tabletID=2225
+          5. partitionID=2202,tabletID=2231
+          6. partitionID=2202,tabletID=2237
+    INSTANCE(9-F06#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2202,tabletID=2203
+          2. partitionID=2202,tabletID=2209
+          3. partitionID=2202,tabletID=2215
+          4. partitionID=2202,tabletID=2221
+          5. partitionID=2202,tabletID=2227
+          6. partitionID=2202,tabletID=2233
+
+PLAN FRAGMENT 4(F04)
+  DOP: 16
+  INSTANCES
+    INSTANCE(10-F04#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=1934,tabletID=1937
+          2. partitionID=1934,tabletID=1943
+          3. partitionID=1934,tabletID=1949
+          4. partitionID=1934,tabletID=1955
+          5. partitionID=1934,tabletID=1961
+          6. partitionID=1934,tabletID=1967
+    INSTANCE(11-F04#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=1934,tabletID=1939
+          2. partitionID=1934,tabletID=1945
+          3. partitionID=1934,tabletID=1951
+          4. partitionID=1934,tabletID=1957
+          5. partitionID=1934,tabletID=1963
+          6. partitionID=1934,tabletID=1969
+    INSTANCE(12-F04#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=1934,tabletID=1935
+          2. partitionID=1934,tabletID=1941
+          3. partitionID=1934,tabletID=1947
+          4. partitionID=1934,tabletID=1953
+          5. partitionID=1934,tabletID=1959
+          6. partitionID=1934,tabletID=1965
+
+PLAN FRAGMENT 5(F02)
+  DOP: 16
+  INSTANCES
+    INSTANCE(13-F02#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(14-F02#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(15-F02#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 6(F00)
+  DOP: 16
+  INSTANCES
+    INSTANCE(16-F00#0)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10001
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+    INSTANCE(17-F00#1)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10002
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+    INSTANCE(18-F00#2)
+      DESTINATIONS: 4-F08#0,5-F08#1,6-F08#2
+      BE: 10003
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:69: L_ORDERKEY | 70: L_PARTKEY | 71: L_SUPPKEY | 72: L_LINENUMBER | 73: L_QUANTITY | 74: L_EXTENDEDPRICE | 75: L_DISCOUNT | 76: L_TAX | 77: L_RETURNFLAG | 78: L_LINESTATUS | 79: L_SHIPDATE | 80: L_COMMITDATE | 81: L_RECEIPTDATE | 82: L_SHIPINSTRUCT | 83: L_SHIPMODE | 84: L_COMMENT | 85: PAD
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  12:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: HASH_PARTITIONED: 69: L_ORDERKEY, 70: L_PARTKEY, 71: L_SUPPKEY, 72: L_LINENUMBER, 73: L_QUANTITY, 74: L_EXTENDEDPRICE, 75: L_DISCOUNT, 76: L_TAX, 77: L_RETURNFLAG, 78: L_LINESTATUS, 79: L_SHIPDATE, 80: L_COMMITDATE, 81: L_RECEIPTDATE, 82: L_SHIPINSTRUCT, 83: L_SHIPMODE, 84: L_COMMENT, 85: PAD
+
+  STREAM DATA SINK
+    EXCHANGE ID: 12
+    UNPARTITIONED
+
+  11:AGGREGATE (merge finalize)
+  |  group by: 69: L_ORDERKEY, 70: L_PARTKEY, 71: L_SUPPKEY, 72: L_LINENUMBER, 73: L_QUANTITY, 74: L_EXTENDEDPRICE, 75: L_DISCOUNT, 76: L_TAX, 77: L_RETURNFLAG, 78: L_LINESTATUS, 79: L_SHIPDATE, 80: L_COMMITDATE, 81: L_RECEIPTDATE, 82: L_SHIPINSTRUCT, 83: L_SHIPMODE, 84: L_COMMENT, 85: PAD
+  |  
+  10:EXCHANGE
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 10
+    HASH_PARTITIONED: 69: L_ORDERKEY, 70: L_PARTKEY, 71: L_SUPPKEY, 72: L_LINENUMBER, 73: L_QUANTITY, 74: L_EXTENDEDPRICE, 75: L_DISCOUNT, 76: L_TAX, 77: L_RETURNFLAG, 78: L_LINESTATUS, 79: L_SHIPDATE, 80: L_COMMITDATE, 81: L_RECEIPTDATE, 82: L_SHIPINSTRUCT, 83: L_SHIPMODE, 84: L_COMMENT, 85: PAD
+
+  9:AGGREGATE (update serialize)
+  |  STREAMING
+  |  group by: 69: L_ORDERKEY, 70: L_PARTKEY, 71: L_SUPPKEY, 72: L_LINENUMBER, 73: L_QUANTITY, 74: L_EXTENDEDPRICE, 75: L_DISCOUNT, 76: L_TAX, 77: L_RETURNFLAG, 78: L_LINESTATUS, 79: L_SHIPDATE, 80: L_COMMITDATE, 81: L_RECEIPTDATE, 82: L_SHIPINSTRUCT, 83: L_SHIPMODE, 84: L_COMMENT, 85: PAD
+  |  
+  0:UNION
+  |  
+  |----4:EXCHANGE
+  |    
+  |----6:EXCHANGE
+  |    
+  |----8:EXCHANGE
+  |    
+  2:EXCHANGE
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 08
+    RANDOM
+
+  7:OlapScanNode
+     TABLE: lineitem3
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem3
+     tabletRatio=18/18
+     tabletList=2203,2205,2207,2209,2211,2213,2215,2217,2219,2221 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 4
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 06
+    RANDOM
+
+  5:OlapScanNode
+     TABLE: lineitem2
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem2
+     tabletRatio=18/18
+     tabletList=1935,1937,1939,1941,1943,1945,1947,1949,1951,1953 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 5
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 04
+    RANDOM
+
+  3:OlapScanNode
+     TABLE: lineitem1
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem1
+     tabletRatio=18/18
+     tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 6
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 02
+    RANDOM
+
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=17.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/union_q2_disable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/union_q2_disable_colocate_set.sql
@@ -1,0 +1,185 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F06)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F06#0)
+      BE: 10002
+
+PLAN FRAGMENT 1(F05)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F05#0)
+      DESTINATIONS: 0-F06#0
+      BE: 10001
+    INSTANCE(2-F05#1)
+      DESTINATIONS: 0-F06#0
+      BE: 10002
+    INSTANCE(3-F05#2)
+      DESTINATIONS: 0-F06#0
+      BE: 10003
+
+PLAN FRAGMENT 2(F04)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F04#0)
+      DESTINATIONS: 1-F05#0,2-F05#1,3-F05#2
+      BE: 10003
+    INSTANCE(5-F04#1)
+      DESTINATIONS: 1-F05#0,2-F05#1,3-F05#2
+      BE: 10002
+    INSTANCE(6-F04#2)
+      DESTINATIONS: 1-F05#0,2-F05#1,3-F05#2
+      BE: 10001
+
+PLAN FRAGMENT 3(F02)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F02#0)
+      DESTINATIONS: 4-F04#0,5-F04#1,6-F04#2
+      BE: 10001
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(8-F02#1)
+      DESTINATIONS: 4-F04#0,5-F04#1,6-F04#2
+      BE: 10002
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(9-F02#2)
+      DESTINATIONS: 4-F04#0,5-F04#1,6-F04#2
+      BE: 10003
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 4(F00)
+  DOP: 16
+  INSTANCES
+    INSTANCE(10-F00#0)
+      DESTINATIONS: 4-F04#0,5-F04#1,6-F04#2
+      BE: 10001
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+    INSTANCE(11-F00#1)
+      DESTINATIONS: 4-F04#0,5-F04#1,6-F04#2
+      BE: 10002
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+    INSTANCE(12-F00#2)
+      DESTINATIONS: 4-F04#0,5-F04#1,6-F04#2
+      BE: 10003
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:35: L_ORDERKEY | 36: L_PARTKEY | 37: L_SUPPKEY | 38: L_LINENUMBER | 39: L_QUANTITY | 40: L_EXTENDEDPRICE | 41: L_DISCOUNT | 42: L_TAX | 43: L_RETURNFLAG | 44: L_LINESTATUS | 45: L_SHIPDATE | 46: L_COMMITDATE | 47: L_RECEIPTDATE | 48: L_SHIPINSTRUCT | 49: L_SHIPMODE | 50: L_COMMENT | 51: PAD
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  8:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: HASH_PARTITIONED: 35: L_ORDERKEY, 36: L_PARTKEY, 37: L_SUPPKEY, 38: L_LINENUMBER, 39: L_QUANTITY, 40: L_EXTENDEDPRICE, 41: L_DISCOUNT, 42: L_TAX, 43: L_RETURNFLAG, 44: L_LINESTATUS, 45: L_SHIPDATE, 46: L_COMMITDATE, 47: L_RECEIPTDATE, 48: L_SHIPINSTRUCT, 49: L_SHIPMODE, 50: L_COMMENT, 51: PAD
+
+  STREAM DATA SINK
+    EXCHANGE ID: 08
+    UNPARTITIONED
+
+  7:AGGREGATE (merge finalize)
+  |  group by: 35: L_ORDERKEY, 36: L_PARTKEY, 37: L_SUPPKEY, 38: L_LINENUMBER, 39: L_QUANTITY, 40: L_EXTENDEDPRICE, 41: L_DISCOUNT, 42: L_TAX, 43: L_RETURNFLAG, 44: L_LINESTATUS, 45: L_SHIPDATE, 46: L_COMMITDATE, 47: L_RECEIPTDATE, 48: L_SHIPINSTRUCT, 49: L_SHIPMODE, 50: L_COMMENT, 51: PAD
+  |  
+  6:EXCHANGE
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 06
+    HASH_PARTITIONED: 35: L_ORDERKEY, 36: L_PARTKEY, 37: L_SUPPKEY, 38: L_LINENUMBER, 39: L_QUANTITY, 40: L_EXTENDEDPRICE, 41: L_DISCOUNT, 42: L_TAX, 43: L_RETURNFLAG, 44: L_LINESTATUS, 45: L_SHIPDATE, 46: L_COMMITDATE, 47: L_RECEIPTDATE, 48: L_SHIPINSTRUCT, 49: L_SHIPMODE, 50: L_COMMENT, 51: PAD
+
+  5:AGGREGATE (update serialize)
+  |  STREAMING
+  |  group by: 35: L_ORDERKEY, 36: L_PARTKEY, 37: L_SUPPKEY, 38: L_LINENUMBER, 39: L_QUANTITY, 40: L_EXTENDEDPRICE, 41: L_DISCOUNT, 42: L_TAX, 43: L_RETURNFLAG, 44: L_LINESTATUS, 45: L_SHIPDATE, 46: L_COMMITDATE, 47: L_RECEIPTDATE, 48: L_SHIPINSTRUCT, 49: L_SHIPMODE, 50: L_COMMENT, 51: PAD
+  |  
+  0:UNION
+  |  
+  |----4:EXCHANGE
+  |    
+  2:EXCHANGE
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 04
+    RANDOM
+
+  3:OlapScanNode
+     TABLE: lineitem1
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem1
+     tabletRatio=18/18
+     tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 4
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 02
+    RANDOM
+
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=17.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/union_q2_enable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/union_q2_enable_colocate_set.sql
@@ -1,0 +1,112 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F03)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F03#0)
+      BE: 10001
+
+PLAN FRAGMENT 1(F02)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F02#0)
+      DESTINATIONS: 0-F03#0
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+        2:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(2-F02#1)
+      DESTINATIONS: 0-F03#0
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+        2:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(3-F02#2)
+      DESTINATIONS: 0-F03#0
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+        2:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:35: L_ORDERKEY | 36: L_PARTKEY | 37: L_SUPPKEY | 38: L_LINENUMBER | 39: L_QUANTITY | 40: L_EXTENDEDPRICE | 41: L_DISCOUNT | 42: L_TAX | 43: L_RETURNFLAG | 44: L_LINESTATUS | 45: L_SHIPDATE | 46: L_COMMITDATE | 47: L_RECEIPTDATE | 48: L_SHIPINSTRUCT | 49: L_SHIPMODE | 50: L_COMMENT | 51: PAD
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  4:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 04
+    UNPARTITIONED
+
+  3:AGGREGATE (update finalize)
+  |  group by: 35: L_ORDERKEY, 36: L_PARTKEY, 37: L_SUPPKEY, 38: L_LINENUMBER, 39: L_QUANTITY, 40: L_EXTENDEDPRICE, 41: L_DISCOUNT, 42: L_TAX, 43: L_RETURNFLAG, 44: L_LINESTATUS, 45: L_SHIPDATE, 46: L_COMMITDATE, 47: L_RECEIPTDATE, 48: L_SHIPINSTRUCT, 49: L_SHIPMODE, 50: L_COMMENT, 51: PAD
+  |  
+  0:UNION
+  |  
+  |----2:OlapScanNode
+  |       TABLE: lineitem1
+  |       PREAGGREGATION: ON
+  |       partitions=1/7
+  |       rollup: lineitem1
+  |       tabletRatio=18/18
+  |       tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+  |       cardinality=1
+  |       avgRowSize=17.0
+  |    
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=17.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/union_q3_disable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/union_q3_disable_colocate_set.sql
@@ -1,0 +1,269 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F09)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F09#0)
+      BE: 10002
+
+PLAN FRAGMENT 1(F08)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F08#0)
+      DESTINATIONS: 0-F09#0
+      BE: 10001
+    INSTANCE(2-F08#1)
+      DESTINATIONS: 0-F09#0
+      BE: 10002
+    INSTANCE(3-F08#2)
+      DESTINATIONS: 0-F09#0
+      BE: 10003
+
+PLAN FRAGMENT 2(F06)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F06#0)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10001
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2202,tabletID=2205
+          2. partitionID=2202,tabletID=2211
+          3. partitionID=2202,tabletID=2217
+          4. partitionID=2202,tabletID=2223
+          5. partitionID=2202,tabletID=2229
+          6. partitionID=2202,tabletID=2235
+    INSTANCE(5-F06#1)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10002
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2202,tabletID=2207
+          2. partitionID=2202,tabletID=2213
+          3. partitionID=2202,tabletID=2219
+          4. partitionID=2202,tabletID=2225
+          5. partitionID=2202,tabletID=2231
+          6. partitionID=2202,tabletID=2237
+    INSTANCE(6-F06#2)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10003
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2202,tabletID=2203
+          2. partitionID=2202,tabletID=2209
+          3. partitionID=2202,tabletID=2215
+          4. partitionID=2202,tabletID=2221
+          5. partitionID=2202,tabletID=2227
+          6. partitionID=2202,tabletID=2233
+
+PLAN FRAGMENT 3(F04)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F04#0)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10001
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=1934,tabletID=1937
+          2. partitionID=1934,tabletID=1943
+          3. partitionID=1934,tabletID=1949
+          4. partitionID=1934,tabletID=1955
+          5. partitionID=1934,tabletID=1961
+          6. partitionID=1934,tabletID=1967
+    INSTANCE(8-F04#1)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10002
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=1934,tabletID=1939
+          2. partitionID=1934,tabletID=1945
+          3. partitionID=1934,tabletID=1951
+          4. partitionID=1934,tabletID=1957
+          5. partitionID=1934,tabletID=1963
+          6. partitionID=1934,tabletID=1969
+    INSTANCE(9-F04#2)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10003
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=1934,tabletID=1935
+          2. partitionID=1934,tabletID=1941
+          3. partitionID=1934,tabletID=1947
+          4. partitionID=1934,tabletID=1953
+          5. partitionID=1934,tabletID=1959
+          6. partitionID=1934,tabletID=1965
+
+PLAN FRAGMENT 4(F02)
+  DOP: 16
+  INSTANCES
+    INSTANCE(10-F02#0)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10001
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(11-F02#1)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10002
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(12-F02#2)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10003
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 5(F00)
+  DOP: 16
+  INSTANCES
+    INSTANCE(13-F00#0)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10001
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+    INSTANCE(14-F00#1)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10002
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+    INSTANCE(15-F00#2)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10003
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:69: L_ORDERKEY | 70: L_PARTKEY | 71: L_SUPPKEY | 72: L_LINENUMBER | 73: L_QUANTITY | 74: L_EXTENDEDPRICE | 75: L_DISCOUNT | 76: L_TAX | 77: L_RETURNFLAG | 78: L_LINESTATUS | 79: L_SHIPDATE | 80: L_COMMITDATE | 81: L_RECEIPTDATE | 82: L_SHIPINSTRUCT | 83: L_SHIPMODE | 84: L_COMMENT | 85: PAD
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  9:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 09
+    UNPARTITIONED
+
+  0:UNION
+  |  
+  |----4:EXCHANGE
+  |    
+  |----6:EXCHANGE
+  |    
+  |----8:EXCHANGE
+  |    
+  2:EXCHANGE
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 08
+    RANDOM
+
+  7:OlapScanNode
+     TABLE: lineitem3
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem3
+     tabletRatio=18/18
+     tabletList=2203,2205,2207,2209,2211,2213,2215,2217,2219,2221 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 06
+    RANDOM
+
+  5:OlapScanNode
+     TABLE: lineitem2
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem2
+     tabletRatio=18/18
+     tabletList=1935,1937,1939,1941,1943,1945,1947,1949,1951,1953 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 4
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 04
+    RANDOM
+
+  3:OlapScanNode
+     TABLE: lineitem1
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem1
+     tabletRatio=18/18
+     tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 5
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 02
+    RANDOM
+
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=17.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/union_q3_enable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/union_q3_enable_colocate_set.sql
@@ -1,0 +1,269 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F09)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F09#0)
+      BE: 10001
+
+PLAN FRAGMENT 1(F08)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F08#0)
+      DESTINATIONS: 0-F09#0
+      BE: 10003
+    INSTANCE(2-F08#1)
+      DESTINATIONS: 0-F09#0
+      BE: 10002
+    INSTANCE(3-F08#2)
+      DESTINATIONS: 0-F09#0
+      BE: 10001
+
+PLAN FRAGMENT 2(F06)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F06#0)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10001
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2202,tabletID=2205
+          2. partitionID=2202,tabletID=2211
+          3. partitionID=2202,tabletID=2217
+          4. partitionID=2202,tabletID=2223
+          5. partitionID=2202,tabletID=2229
+          6. partitionID=2202,tabletID=2235
+    INSTANCE(5-F06#1)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10002
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2202,tabletID=2207
+          2. partitionID=2202,tabletID=2213
+          3. partitionID=2202,tabletID=2219
+          4. partitionID=2202,tabletID=2225
+          5. partitionID=2202,tabletID=2231
+          6. partitionID=2202,tabletID=2237
+    INSTANCE(6-F06#2)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10003
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2202,tabletID=2203
+          2. partitionID=2202,tabletID=2209
+          3. partitionID=2202,tabletID=2215
+          4. partitionID=2202,tabletID=2221
+          5. partitionID=2202,tabletID=2227
+          6. partitionID=2202,tabletID=2233
+
+PLAN FRAGMENT 3(F04)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F04#0)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10001
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=1934,tabletID=1937
+          2. partitionID=1934,tabletID=1943
+          3. partitionID=1934,tabletID=1949
+          4. partitionID=1934,tabletID=1955
+          5. partitionID=1934,tabletID=1961
+          6. partitionID=1934,tabletID=1967
+    INSTANCE(8-F04#1)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10002
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=1934,tabletID=1939
+          2. partitionID=1934,tabletID=1945
+          3. partitionID=1934,tabletID=1951
+          4. partitionID=1934,tabletID=1957
+          5. partitionID=1934,tabletID=1963
+          6. partitionID=1934,tabletID=1969
+    INSTANCE(9-F04#2)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10003
+      SCAN RANGES
+        5:OlapScanNode
+          1. partitionID=1934,tabletID=1935
+          2. partitionID=1934,tabletID=1941
+          3. partitionID=1934,tabletID=1947
+          4. partitionID=1934,tabletID=1953
+          5. partitionID=1934,tabletID=1959
+          6. partitionID=1934,tabletID=1965
+
+PLAN FRAGMENT 4(F02)
+  DOP: 16
+  INSTANCES
+    INSTANCE(10-F02#0)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10001
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(11-F02#1)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10002
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(12-F02#2)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10003
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 5(F00)
+  DOP: 16
+  INSTANCES
+    INSTANCE(13-F00#0)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10001
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+    INSTANCE(14-F00#1)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10002
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+    INSTANCE(15-F00#2)
+      DESTINATIONS: 1-F08#0,2-F08#1,3-F08#2
+      BE: 10003
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:69: L_ORDERKEY | 70: L_PARTKEY | 71: L_SUPPKEY | 72: L_LINENUMBER | 73: L_QUANTITY | 74: L_EXTENDEDPRICE | 75: L_DISCOUNT | 76: L_TAX | 77: L_RETURNFLAG | 78: L_LINESTATUS | 79: L_SHIPDATE | 80: L_COMMITDATE | 81: L_RECEIPTDATE | 82: L_SHIPINSTRUCT | 83: L_SHIPMODE | 84: L_COMMENT | 85: PAD
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  9:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 09
+    UNPARTITIONED
+
+  0:UNION
+  |  
+  |----4:EXCHANGE
+  |    
+  |----6:EXCHANGE
+  |    
+  |----8:EXCHANGE
+  |    
+  2:EXCHANGE
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 08
+    RANDOM
+
+  7:OlapScanNode
+     TABLE: lineitem3
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem3
+     tabletRatio=18/18
+     tabletList=2203,2205,2207,2209,2211,2213,2215,2217,2219,2221 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 06
+    RANDOM
+
+  5:OlapScanNode
+     TABLE: lineitem2
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem2
+     tabletRatio=18/18
+     tabletList=1935,1937,1939,1941,1943,1945,1947,1949,1951,1953 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 4
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 04
+    RANDOM
+
+  3:OlapScanNode
+     TABLE: lineitem1
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem1
+     tabletRatio=18/18
+     tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+     cardinality=1
+     avgRowSize=17.0
+
+PLAN FRAGMENT 5
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 02
+    RANDOM
+
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=17.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/union_q4_disable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/union_q4_disable_colocate_set.sql
@@ -1,0 +1,467 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F14)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F14#0)
+      BE: 10002
+
+PLAN FRAGMENT 1(F13)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F13#0)
+      DESTINATIONS: 0-F14#0
+      BE: 10001
+    INSTANCE(2-F13#1)
+      DESTINATIONS: 0-F14#0
+      BE: 10002
+    INSTANCE(3-F13#2)
+      DESTINATIONS: 0-F14#0
+      BE: 10003
+
+PLAN FRAGMENT 2(F12)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F12#0)
+      DESTINATIONS: 1-F13#0,2-F13#1,3-F13#2
+      BE: 10003
+    INSTANCE(5-F12#1)
+      DESTINATIONS: 1-F13#0,2-F13#1,3-F13#2
+      BE: 10002
+    INSTANCE(6-F12#2)
+      DESTINATIONS: 1-F13#0,2-F13#1,3-F13#2
+      BE: 10001
+
+PLAN FRAGMENT 3(F06)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F06#0)
+      DESTINATIONS: 4-F12#0,5-F12#1,6-F12#2
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        12:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(8-F06#1)
+      DESTINATIONS: 4-F12#0,5-F12#1,6-F12#2
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        12:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(9-F06#2)
+      DESTINATIONS: 4-F12#0,5-F12#1,6-F12#2
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        12:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 4(F09)
+  DOP: 16
+  INSTANCES
+    INSTANCE(10-F09#0)
+      DESTINATIONS: 7-F06#0,8-F06#1,9-F06#2
+      BE: 10001
+      SCAN RANGES
+        18:OlapScanNode
+          1. partitionID=2488,tabletID=2491
+          2. partitionID=2488,tabletID=2497
+          3. partitionID=2488,tabletID=2503
+          4. partitionID=2488,tabletID=2509
+          5. partitionID=2488,tabletID=2515
+          6. partitionID=2488,tabletID=2521
+    INSTANCE(11-F09#1)
+      DESTINATIONS: 7-F06#0,8-F06#1,9-F06#2
+      BE: 10002
+      SCAN RANGES
+        18:OlapScanNode
+          1. partitionID=2488,tabletID=2493
+          2. partitionID=2488,tabletID=2499
+          3. partitionID=2488,tabletID=2505
+          4. partitionID=2488,tabletID=2511
+          5. partitionID=2488,tabletID=2517
+          6. partitionID=2488,tabletID=2523
+    INSTANCE(12-F09#2)
+      DESTINATIONS: 7-F06#0,8-F06#1,9-F06#2
+      BE: 10003
+      SCAN RANGES
+        18:OlapScanNode
+          1. partitionID=2488,tabletID=2489
+          2. partitionID=2488,tabletID=2495
+          3. partitionID=2488,tabletID=2501
+          4. partitionID=2488,tabletID=2507
+          5. partitionID=2488,tabletID=2513
+          6. partitionID=2488,tabletID=2519
+
+PLAN FRAGMENT 5(F07)
+  DOP: 16
+  INSTANCES
+    INSTANCE(13-F07#0)
+      DESTINATIONS: 9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1
+      BE: 10001
+      SCAN RANGES
+        14:OlapScanNode
+          1. partitionID=2448,tabletID=2451
+          2. partitionID=2448,tabletID=2457
+          3. partitionID=2448,tabletID=2463
+          4. partitionID=2448,tabletID=2469
+          5. partitionID=2448,tabletID=2475
+          6. partitionID=2448,tabletID=2481
+    INSTANCE(14-F07#1)
+      DESTINATIONS: 9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1
+      BE: 10002
+      SCAN RANGES
+        14:OlapScanNode
+          1. partitionID=2448,tabletID=2453
+          2. partitionID=2448,tabletID=2459
+          3. partitionID=2448,tabletID=2465
+          4. partitionID=2448,tabletID=2471
+          5. partitionID=2448,tabletID=2477
+          6. partitionID=2448,tabletID=2483
+    INSTANCE(15-F07#2)
+      DESTINATIONS: 9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1
+      BE: 10003
+      SCAN RANGES
+        14:OlapScanNode
+          1. partitionID=2448,tabletID=2449
+          2. partitionID=2448,tabletID=2455
+          3. partitionID=2448,tabletID=2461
+          4. partitionID=2448,tabletID=2467
+          5. partitionID=2448,tabletID=2473
+          6. partitionID=2448,tabletID=2479
+
+PLAN FRAGMENT 6(F00)
+  DOP: 16
+  INSTANCES
+    INSTANCE(16-F00#0)
+      DESTINATIONS: 4-F12#0,5-F12#1,6-F12#2
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+    INSTANCE(17-F00#1)
+      DESTINATIONS: 4-F12#0,5-F12#1,6-F12#2
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+    INSTANCE(18-F00#2)
+      DESTINATIONS: 4-F12#0,5-F12#1,6-F12#2
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+
+PLAN FRAGMENT 7(F03)
+  DOP: 16
+  INSTANCES
+    INSTANCE(19-F03#0)
+      DESTINATIONS: 16-F00#0,17-F00#1,18-F00#2
+      BE: 10001
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2488,tabletID=2491
+          2. partitionID=2488,tabletID=2497
+          3. partitionID=2488,tabletID=2503
+          4. partitionID=2488,tabletID=2509
+          5. partitionID=2488,tabletID=2515
+          6. partitionID=2488,tabletID=2521
+    INSTANCE(20-F03#1)
+      DESTINATIONS: 16-F00#0,17-F00#1,18-F00#2
+      BE: 10002
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2488,tabletID=2493
+          2. partitionID=2488,tabletID=2499
+          3. partitionID=2488,tabletID=2505
+          4. partitionID=2488,tabletID=2511
+          5. partitionID=2488,tabletID=2517
+          6. partitionID=2488,tabletID=2523
+    INSTANCE(21-F03#2)
+      DESTINATIONS: 16-F00#0,17-F00#1,18-F00#2
+      BE: 10003
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2488,tabletID=2489
+          2. partitionID=2488,tabletID=2495
+          3. partitionID=2488,tabletID=2501
+          4. partitionID=2488,tabletID=2507
+          5. partitionID=2488,tabletID=2513
+          6. partitionID=2488,tabletID=2519
+
+PLAN FRAGMENT 8(F01)
+  DOP: 16
+  INSTANCES
+    INSTANCE(22-F01#0)
+      DESTINATIONS: 18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1
+      BE: 10001
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=2448,tabletID=2451
+          2. partitionID=2448,tabletID=2457
+          3. partitionID=2448,tabletID=2463
+          4. partitionID=2448,tabletID=2469
+          5. partitionID=2448,tabletID=2475
+          6. partitionID=2448,tabletID=2481
+    INSTANCE(23-F01#1)
+      DESTINATIONS: 18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1
+      BE: 10002
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=2448,tabletID=2453
+          2. partitionID=2448,tabletID=2459
+          3. partitionID=2448,tabletID=2465
+          4. partitionID=2448,tabletID=2471
+          5. partitionID=2448,tabletID=2477
+          6. partitionID=2448,tabletID=2483
+    INSTANCE(24-F01#2)
+      DESTINATIONS: 18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1
+      BE: 10003
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=2448,tabletID=2449
+          2. partitionID=2448,tabletID=2455
+          3. partitionID=2448,tabletID=2461
+          4. partitionID=2448,tabletID=2467
+          5. partitionID=2448,tabletID=2473
+          6. partitionID=2448,tabletID=2479
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:71: L_ORDERKEY | 72: o_orderdate | 73: p_name
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  26:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: HASH_PARTITIONED: 71: L_ORDERKEY, 72: o_orderdate, 73: p_name
+
+  STREAM DATA SINK
+    EXCHANGE ID: 26
+    UNPARTITIONED
+
+  25:AGGREGATE (merge finalize)
+  |  group by: 71: L_ORDERKEY, 72: o_orderdate, 73: p_name
+  |  
+  24:EXCHANGE
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 24
+    HASH_PARTITIONED: 71: L_ORDERKEY, 72: o_orderdate, 73: p_name
+
+  23:AGGREGATE (update serialize)
+  |  STREAMING
+  |  group by: 71: L_ORDERKEY, 72: o_orderdate, 73: p_name
+  |  
+  0:UNION
+  |  
+  |----22:EXCHANGE
+  |    
+  11:EXCHANGE
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 22
+    RANDOM
+
+  21:Project
+  |  <slot 36> : 36: L_ORDERKEY
+  |  <slot 54> : 54: o_orderdate
+  |  <slot 63> : 63: p_name
+  |  
+  20:HASH JOIN
+  |  join op: INNER JOIN (BROADCAST)
+  |  colocate: false, reason: 
+  |  equal join conjunct: 37: L_PARTKEY = 62: p_partkey
+  |  
+  |----19:EXCHANGE
+  |    
+  17:Project
+  |  <slot 36> : 36: L_ORDERKEY
+  |  <slot 37> : 37: L_PARTKEY
+  |  <slot 54> : 54: o_orderdate
+  |  
+  16:HASH JOIN
+  |  join op: INNER JOIN (BUCKET_SHUFFLE)
+  |  colocate: false, reason: 
+  |  equal join conjunct: 36: L_ORDERKEY = 53: o_orderkey
+  |  
+  |----15:EXCHANGE
+  |    
+  13:Project
+  |  <slot 36> : 36: L_ORDERKEY
+  |  <slot 37> : 37: L_PARTKEY
+  |  
+  12:OlapScanNode
+     TABLE: lineitem1
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem1
+     tabletRatio=18/18
+     tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+     cardinality=1
+     avgRowSize=3.0
+
+PLAN FRAGMENT 4
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 19
+    UNPARTITIONED
+
+  18:OlapScanNode
+     TABLE: part
+     PREAGGREGATION: ON
+     partitions=1/1
+     rollup: part
+     tabletRatio=18/18
+     tabletList=2489,2491,2493,2495,2497,2499,2501,2503,2505,2507 ...
+     cardinality=1
+     avgRowSize=63.0
+
+PLAN FRAGMENT 5
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 15
+    BUCKET_SHUFFLE_HASH_PARTITIONED: 53: o_orderkey
+
+  14:OlapScanNode
+     TABLE: orders
+     PREAGGREGATION: ON
+     partitions=1/1
+     rollup: orders
+     tabletRatio=18/18
+     tabletList=2449,2451,2453,2455,2457,2459,2461,2463,2465,2467 ...
+     cardinality=1
+     avgRowSize=12.0
+
+PLAN FRAGMENT 6
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 11
+    RANDOM
+
+  10:Project
+  |  <slot 1> : 1: L_ORDERKEY
+  |  <slot 19> : 19: o_orderdate
+  |  <slot 28> : 28: p_name
+  |  
+  9:HASH JOIN
+  |  join op: INNER JOIN (BROADCAST)
+  |  colocate: false, reason: 
+  |  equal join conjunct: 2: L_PARTKEY = 27: p_partkey
+  |  
+  |----8:EXCHANGE
+  |    
+  6:Project
+  |  <slot 1> : 1: L_ORDERKEY
+  |  <slot 2> : 2: L_PARTKEY
+  |  <slot 19> : 19: o_orderdate
+  |  
+  5:HASH JOIN
+  |  join op: INNER JOIN (BUCKET_SHUFFLE)
+  |  colocate: false, reason: 
+  |  equal join conjunct: 1: L_ORDERKEY = 18: o_orderkey
+  |  
+  |----4:EXCHANGE
+  |    
+  2:Project
+  |  <slot 1> : 1: L_ORDERKEY
+  |  <slot 2> : 2: L_PARTKEY
+  |  
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=3.0
+
+PLAN FRAGMENT 7
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 08
+    UNPARTITIONED
+
+  7:OlapScanNode
+     TABLE: part
+     PREAGGREGATION: ON
+     partitions=1/1
+     rollup: part
+     tabletRatio=18/18
+     tabletList=2489,2491,2493,2495,2497,2499,2501,2503,2505,2507 ...
+     cardinality=1
+     avgRowSize=63.0
+
+PLAN FRAGMENT 8
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 04
+    BUCKET_SHUFFLE_HASH_PARTITIONED: 18: o_orderkey
+
+  3:OlapScanNode
+     TABLE: orders
+     PREAGGREGATION: ON
+     partitions=1/1
+     rollup: orders
+     tabletRatio=18/18
+     tabletList=2449,2451,2453,2455,2457,2459,2461,2463,2465,2467 ...
+     cardinality=1
+     avgRowSize=12.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/union_q4_enable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/union_q4_enable_colocate_set.sql
@@ -1,0 +1,388 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F11)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F11#0)
+      BE: 10001
+
+PLAN FRAGMENT 1(F10)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F10#0)
+      DESTINATIONS: 0-F11#0
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+        11:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(2-F10#1)
+      DESTINATIONS: 0-F11#0
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+        11:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(3-F10#2)
+      DESTINATIONS: 0-F11#0
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+        11:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 2(F08)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F08#0)
+      DESTINATIONS: 1-F10#0,2-F10#1,3-F10#2
+      BE: 10001
+      SCAN RANGES
+        17:OlapScanNode
+          1. partitionID=2488,tabletID=2491
+          2. partitionID=2488,tabletID=2497
+          3. partitionID=2488,tabletID=2503
+          4. partitionID=2488,tabletID=2509
+          5. partitionID=2488,tabletID=2515
+          6. partitionID=2488,tabletID=2521
+    INSTANCE(5-F08#1)
+      DESTINATIONS: 1-F10#0,2-F10#1,3-F10#2
+      BE: 10002
+      SCAN RANGES
+        17:OlapScanNode
+          1. partitionID=2488,tabletID=2493
+          2. partitionID=2488,tabletID=2499
+          3. partitionID=2488,tabletID=2505
+          4. partitionID=2488,tabletID=2511
+          5. partitionID=2488,tabletID=2517
+          6. partitionID=2488,tabletID=2523
+    INSTANCE(6-F08#2)
+      DESTINATIONS: 1-F10#0,2-F10#1,3-F10#2
+      BE: 10003
+      SCAN RANGES
+        17:OlapScanNode
+          1. partitionID=2488,tabletID=2489
+          2. partitionID=2488,tabletID=2495
+          3. partitionID=2488,tabletID=2501
+          4. partitionID=2488,tabletID=2507
+          5. partitionID=2488,tabletID=2513
+          6. partitionID=2488,tabletID=2519
+
+PLAN FRAGMENT 3(F06)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F06#0)
+      DESTINATIONS: 3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1
+      BE: 10001
+      SCAN RANGES
+        13:OlapScanNode
+          1. partitionID=2448,tabletID=2451
+          2. partitionID=2448,tabletID=2457
+          3. partitionID=2448,tabletID=2463
+          4. partitionID=2448,tabletID=2469
+          5. partitionID=2448,tabletID=2475
+          6. partitionID=2448,tabletID=2481
+    INSTANCE(8-F06#1)
+      DESTINATIONS: 3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1
+      BE: 10002
+      SCAN RANGES
+        13:OlapScanNode
+          1. partitionID=2448,tabletID=2453
+          2. partitionID=2448,tabletID=2459
+          3. partitionID=2448,tabletID=2465
+          4. partitionID=2448,tabletID=2471
+          5. partitionID=2448,tabletID=2477
+          6. partitionID=2448,tabletID=2483
+    INSTANCE(9-F06#2)
+      DESTINATIONS: 3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1
+      BE: 10003
+      SCAN RANGES
+        13:OlapScanNode
+          1. partitionID=2448,tabletID=2449
+          2. partitionID=2448,tabletID=2455
+          3. partitionID=2448,tabletID=2461
+          4. partitionID=2448,tabletID=2467
+          5. partitionID=2448,tabletID=2473
+          6. partitionID=2448,tabletID=2479
+
+PLAN FRAGMENT 4(F03)
+  DOP: 16
+  INSTANCES
+    INSTANCE(10-F03#0)
+      DESTINATIONS: 1-F10#0,2-F10#1,3-F10#2
+      BE: 10001
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2488,tabletID=2491
+          2. partitionID=2488,tabletID=2497
+          3. partitionID=2488,tabletID=2503
+          4. partitionID=2488,tabletID=2509
+          5. partitionID=2488,tabletID=2515
+          6. partitionID=2488,tabletID=2521
+    INSTANCE(11-F03#1)
+      DESTINATIONS: 1-F10#0,2-F10#1,3-F10#2
+      BE: 10002
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2488,tabletID=2493
+          2. partitionID=2488,tabletID=2499
+          3. partitionID=2488,tabletID=2505
+          4. partitionID=2488,tabletID=2511
+          5. partitionID=2488,tabletID=2517
+          6. partitionID=2488,tabletID=2523
+    INSTANCE(12-F03#2)
+      DESTINATIONS: 1-F10#0,2-F10#1,3-F10#2
+      BE: 10003
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2488,tabletID=2489
+          2. partitionID=2488,tabletID=2495
+          3. partitionID=2488,tabletID=2501
+          4. partitionID=2488,tabletID=2507
+          5. partitionID=2488,tabletID=2513
+          6. partitionID=2488,tabletID=2519
+
+PLAN FRAGMENT 5(F01)
+  DOP: 16
+  INSTANCES
+    INSTANCE(13-F01#0)
+      DESTINATIONS: 3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1
+      BE: 10001
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=2448,tabletID=2451
+          2. partitionID=2448,tabletID=2457
+          3. partitionID=2448,tabletID=2463
+          4. partitionID=2448,tabletID=2469
+          5. partitionID=2448,tabletID=2475
+          6. partitionID=2448,tabletID=2481
+    INSTANCE(14-F01#1)
+      DESTINATIONS: 3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1
+      BE: 10002
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=2448,tabletID=2453
+          2. partitionID=2448,tabletID=2459
+          3. partitionID=2448,tabletID=2465
+          4. partitionID=2448,tabletID=2471
+          5. partitionID=2448,tabletID=2477
+          6. partitionID=2448,tabletID=2483
+    INSTANCE(15-F01#2)
+      DESTINATIONS: 3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1,3-F10#2,1-F10#0,2-F10#1
+      BE: 10003
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=2448,tabletID=2449
+          2. partitionID=2448,tabletID=2455
+          3. partitionID=2448,tabletID=2461
+          4. partitionID=2448,tabletID=2467
+          5. partitionID=2448,tabletID=2473
+          6. partitionID=2448,tabletID=2479
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:71: L_ORDERKEY | 72: o_orderdate | 73: p_name
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  22:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 22
+    UNPARTITIONED
+
+  21:AGGREGATE (update finalize)
+  |  group by: 71: L_ORDERKEY, 72: o_orderdate, 73: p_name
+  |  
+  0:UNION
+  |  
+  |----20:Project
+  |    |  <slot 36> : 36: L_ORDERKEY
+  |    |  <slot 54> : 54: o_orderdate
+  |    |  <slot 63> : 63: p_name
+  |    |  
+  |    19:HASH JOIN
+  |    |  join op: INNER JOIN (BROADCAST)
+  |    |  colocate: false, reason: 
+  |    |  equal join conjunct: 37: L_PARTKEY = 62: p_partkey
+  |    |  
+  |    |----18:EXCHANGE
+  |    |    
+  |    16:Project
+  |    |  <slot 36> : 36: L_ORDERKEY
+  |    |  <slot 37> : 37: L_PARTKEY
+  |    |  <slot 54> : 54: o_orderdate
+  |    |  
+  |    15:HASH JOIN
+  |    |  join op: INNER JOIN (BUCKET_SHUFFLE)
+  |    |  colocate: false, reason: 
+  |    |  equal join conjunct: 36: L_ORDERKEY = 53: o_orderkey
+  |    |  
+  |    |----14:EXCHANGE
+  |    |    
+  |    12:Project
+  |    |  <slot 36> : 36: L_ORDERKEY
+  |    |  <slot 37> : 37: L_PARTKEY
+  |    |  
+  |    11:OlapScanNode
+  |       TABLE: lineitem1
+  |       PREAGGREGATION: ON
+  |       partitions=1/7
+  |       rollup: lineitem1
+  |       tabletRatio=18/18
+  |       tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+  |       cardinality=1
+  |       avgRowSize=3.0
+  |    
+  10:Project
+  |  <slot 1> : 1: L_ORDERKEY
+  |  <slot 19> : 19: o_orderdate
+  |  <slot 28> : 28: p_name
+  |  
+  9:HASH JOIN
+  |  join op: INNER JOIN (BROADCAST)
+  |  colocate: false, reason: 
+  |  equal join conjunct: 2: L_PARTKEY = 27: p_partkey
+  |  
+  |----8:EXCHANGE
+  |    
+  6:Project
+  |  <slot 1> : 1: L_ORDERKEY
+  |  <slot 2> : 2: L_PARTKEY
+  |  <slot 19> : 19: o_orderdate
+  |  
+  5:HASH JOIN
+  |  join op: INNER JOIN (BUCKET_SHUFFLE)
+  |  colocate: false, reason: 
+  |  equal join conjunct: 1: L_ORDERKEY = 18: o_orderkey
+  |  
+  |----4:EXCHANGE
+  |    
+  2:Project
+  |  <slot 1> : 1: L_ORDERKEY
+  |  <slot 2> : 2: L_PARTKEY
+  |  
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=3.0
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 18
+    UNPARTITIONED
+
+  17:OlapScanNode
+     TABLE: part
+     PREAGGREGATION: ON
+     partitions=1/1
+     rollup: part
+     tabletRatio=18/18
+     tabletList=2489,2491,2493,2495,2497,2499,2501,2503,2505,2507 ...
+     cardinality=1
+     avgRowSize=63.0
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 14
+    BUCKET_SHUFFLE_HASH_PARTITIONED: 53: o_orderkey
+
+  13:OlapScanNode
+     TABLE: orders
+     PREAGGREGATION: ON
+     partitions=1/1
+     rollup: orders
+     tabletRatio=18/18
+     tabletList=2449,2451,2453,2455,2457,2459,2461,2463,2465,2467 ...
+     cardinality=1
+     avgRowSize=12.0
+
+PLAN FRAGMENT 4
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 08
+    UNPARTITIONED
+
+  7:OlapScanNode
+     TABLE: part
+     PREAGGREGATION: ON
+     partitions=1/1
+     rollup: part
+     tabletRatio=18/18
+     tabletList=2489,2491,2493,2495,2497,2499,2501,2503,2505,2507 ...
+     cardinality=1
+     avgRowSize=63.0
+
+PLAN FRAGMENT 5
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 04
+    BUCKET_SHUFFLE_HASH_PARTITIONED: 18: o_orderkey
+
+  3:OlapScanNode
+     TABLE: orders
+     PREAGGREGATION: ON
+     partitions=1/1
+     rollup: orders
+     tabletRatio=18/18
+     tabletList=2449,2451,2453,2455,2457,2459,2461,2463,2465,2467 ...
+     cardinality=1
+     avgRowSize=12.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/union_q5_disable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/union_q5_disable_colocate_set.sql
@@ -1,0 +1,463 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F14)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F14#0)
+      BE: 10002
+
+PLAN FRAGMENT 1(F13)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F13#0)
+      DESTINATIONS: 0-F14#0
+      BE: 10003
+    INSTANCE(2-F13#1)
+      DESTINATIONS: 0-F14#0
+      BE: 10002
+    INSTANCE(3-F13#2)
+      DESTINATIONS: 0-F14#0
+      BE: 10001
+
+PLAN FRAGMENT 2(F12)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F12#0)
+      DESTINATIONS: 1-F13#0,2-F13#1,3-F13#2
+      BE: 10001
+    INSTANCE(5-F12#1)
+      DESTINATIONS: 1-F13#0,2-F13#1,3-F13#2
+      BE: 10003
+    INSTANCE(6-F12#2)
+      DESTINATIONS: 1-F13#0,2-F13#1,3-F13#2
+      BE: 10002
+
+PLAN FRAGMENT 3(F06)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F06#0)
+      DESTINATIONS: 4-F12#0,5-F12#1,6-F12#2
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        12:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(8-F06#1)
+      DESTINATIONS: 4-F12#0,5-F12#1,6-F12#2
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        12:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(9-F06#2)
+      DESTINATIONS: 4-F12#0,5-F12#1,6-F12#2
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        12:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 4(F09)
+  DOP: 16
+  INSTANCES
+    INSTANCE(10-F09#0)
+      DESTINATIONS: 7-F06#0,8-F06#1,9-F06#2
+      BE: 10001
+      SCAN RANGES
+        18:OlapScanNode
+          1. partitionID=2488,tabletID=2491
+          2. partitionID=2488,tabletID=2497
+          3. partitionID=2488,tabletID=2503
+          4. partitionID=2488,tabletID=2509
+          5. partitionID=2488,tabletID=2515
+          6. partitionID=2488,tabletID=2521
+    INSTANCE(11-F09#1)
+      DESTINATIONS: 7-F06#0,8-F06#1,9-F06#2
+      BE: 10002
+      SCAN RANGES
+        18:OlapScanNode
+          1. partitionID=2488,tabletID=2493
+          2. partitionID=2488,tabletID=2499
+          3. partitionID=2488,tabletID=2505
+          4. partitionID=2488,tabletID=2511
+          5. partitionID=2488,tabletID=2517
+          6. partitionID=2488,tabletID=2523
+    INSTANCE(12-F09#2)
+      DESTINATIONS: 7-F06#0,8-F06#1,9-F06#2
+      BE: 10003
+      SCAN RANGES
+        18:OlapScanNode
+          1. partitionID=2488,tabletID=2489
+          2. partitionID=2488,tabletID=2495
+          3. partitionID=2488,tabletID=2501
+          4. partitionID=2488,tabletID=2507
+          5. partitionID=2488,tabletID=2513
+          6. partitionID=2488,tabletID=2519
+
+PLAN FRAGMENT 5(F07)
+  DOP: 16
+  INSTANCES
+    INSTANCE(13-F07#0)
+      DESTINATIONS: 9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1
+      BE: 10001
+      SCAN RANGES
+        14:OlapScanNode
+          1. partitionID=2448,tabletID=2451
+          2. partitionID=2448,tabletID=2457
+          3. partitionID=2448,tabletID=2463
+          4. partitionID=2448,tabletID=2469
+          5. partitionID=2448,tabletID=2475
+          6. partitionID=2448,tabletID=2481
+    INSTANCE(14-F07#1)
+      DESTINATIONS: 9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1
+      BE: 10002
+      SCAN RANGES
+        14:OlapScanNode
+          1. partitionID=2448,tabletID=2453
+          2. partitionID=2448,tabletID=2459
+          3. partitionID=2448,tabletID=2465
+          4. partitionID=2448,tabletID=2471
+          5. partitionID=2448,tabletID=2477
+          6. partitionID=2448,tabletID=2483
+    INSTANCE(15-F07#2)
+      DESTINATIONS: 9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1
+      BE: 10003
+      SCAN RANGES
+        14:OlapScanNode
+          1. partitionID=2448,tabletID=2449
+          2. partitionID=2448,tabletID=2455
+          3. partitionID=2448,tabletID=2461
+          4. partitionID=2448,tabletID=2467
+          5. partitionID=2448,tabletID=2473
+          6. partitionID=2448,tabletID=2479
+
+PLAN FRAGMENT 6(F00)
+  DOP: 16
+  INSTANCES
+    INSTANCE(16-F00#0)
+      DESTINATIONS: 4-F12#0,5-F12#1,6-F12#2
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+    INSTANCE(17-F00#1)
+      DESTINATIONS: 4-F12#0,5-F12#1,6-F12#2
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+    INSTANCE(18-F00#2)
+      DESTINATIONS: 4-F12#0,5-F12#1,6-F12#2
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+
+PLAN FRAGMENT 7(F03)
+  DOP: 16
+  INSTANCES
+    INSTANCE(19-F03#0)
+      DESTINATIONS: 16-F00#0,17-F00#1,18-F00#2
+      BE: 10001
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2488,tabletID=2491
+          2. partitionID=2488,tabletID=2497
+          3. partitionID=2488,tabletID=2503
+          4. partitionID=2488,tabletID=2509
+          5. partitionID=2488,tabletID=2515
+          6. partitionID=2488,tabletID=2521
+    INSTANCE(20-F03#1)
+      DESTINATIONS: 16-F00#0,17-F00#1,18-F00#2
+      BE: 10002
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2488,tabletID=2493
+          2. partitionID=2488,tabletID=2499
+          3. partitionID=2488,tabletID=2505
+          4. partitionID=2488,tabletID=2511
+          5. partitionID=2488,tabletID=2517
+          6. partitionID=2488,tabletID=2523
+    INSTANCE(21-F03#2)
+      DESTINATIONS: 16-F00#0,17-F00#1,18-F00#2
+      BE: 10003
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2488,tabletID=2489
+          2. partitionID=2488,tabletID=2495
+          3. partitionID=2488,tabletID=2501
+          4. partitionID=2488,tabletID=2507
+          5. partitionID=2488,tabletID=2513
+          6. partitionID=2488,tabletID=2519
+
+PLAN FRAGMENT 8(F01)
+  DOP: 16
+  INSTANCES
+    INSTANCE(22-F01#0)
+      DESTINATIONS: 18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1
+      BE: 10001
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=2448,tabletID=2451
+          2. partitionID=2448,tabletID=2457
+          3. partitionID=2448,tabletID=2463
+          4. partitionID=2448,tabletID=2469
+          5. partitionID=2448,tabletID=2475
+          6. partitionID=2448,tabletID=2481
+    INSTANCE(23-F01#1)
+      DESTINATIONS: 18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1
+      BE: 10002
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=2448,tabletID=2453
+          2. partitionID=2448,tabletID=2459
+          3. partitionID=2448,tabletID=2465
+          4. partitionID=2448,tabletID=2471
+          5. partitionID=2448,tabletID=2477
+          6. partitionID=2448,tabletID=2483
+    INSTANCE(24-F01#2)
+      DESTINATIONS: 18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1
+      BE: 10003
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=2448,tabletID=2449
+          2. partitionID=2448,tabletID=2455
+          3. partitionID=2448,tabletID=2461
+          4. partitionID=2448,tabletID=2467
+          5. partitionID=2448,tabletID=2473
+          6. partitionID=2448,tabletID=2479
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:71: o_orderdate | 72: p_name
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  26:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: HASH_PARTITIONED: 71: o_orderdate, 72: p_name
+
+  STREAM DATA SINK
+    EXCHANGE ID: 26
+    UNPARTITIONED
+
+  25:AGGREGATE (merge finalize)
+  |  group by: 71: o_orderdate, 72: p_name
+  |  
+  24:EXCHANGE
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 24
+    HASH_PARTITIONED: 71: o_orderdate, 72: p_name
+
+  23:AGGREGATE (update serialize)
+  |  STREAMING
+  |  group by: 71: o_orderdate, 72: p_name
+  |  
+  0:UNION
+  |  
+  |----22:EXCHANGE
+  |    
+  11:EXCHANGE
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 22
+    RANDOM
+
+  21:Project
+  |  <slot 54> : 54: o_orderdate
+  |  <slot 63> : 63: p_name
+  |  
+  20:HASH JOIN
+  |  join op: INNER JOIN (BROADCAST)
+  |  colocate: false, reason: 
+  |  equal join conjunct: 37: L_PARTKEY = 62: p_partkey
+  |  
+  |----19:EXCHANGE
+  |    
+  17:Project
+  |  <slot 37> : 37: L_PARTKEY
+  |  <slot 54> : 54: o_orderdate
+  |  
+  16:HASH JOIN
+  |  join op: INNER JOIN (BUCKET_SHUFFLE)
+  |  colocate: false, reason: 
+  |  equal join conjunct: 36: L_ORDERKEY = 53: o_orderkey
+  |  
+  |----15:EXCHANGE
+  |    
+  13:Project
+  |  <slot 36> : 36: L_ORDERKEY
+  |  <slot 37> : 37: L_PARTKEY
+  |  
+  12:OlapScanNode
+     TABLE: lineitem1
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem1
+     tabletRatio=18/18
+     tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+     cardinality=1
+     avgRowSize=3.0
+
+PLAN FRAGMENT 4
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 19
+    UNPARTITIONED
+
+  18:OlapScanNode
+     TABLE: part
+     PREAGGREGATION: ON
+     partitions=1/1
+     rollup: part
+     tabletRatio=18/18
+     tabletList=2489,2491,2493,2495,2497,2499,2501,2503,2505,2507 ...
+     cardinality=1
+     avgRowSize=63.0
+
+PLAN FRAGMENT 5
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 15
+    BUCKET_SHUFFLE_HASH_PARTITIONED: 53: o_orderkey
+
+  14:OlapScanNode
+     TABLE: orders
+     PREAGGREGATION: ON
+     partitions=1/1
+     rollup: orders
+     tabletRatio=18/18
+     tabletList=2449,2451,2453,2455,2457,2459,2461,2463,2465,2467 ...
+     cardinality=1
+     avgRowSize=12.0
+
+PLAN FRAGMENT 6
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 11
+    RANDOM
+
+  10:Project
+  |  <slot 19> : 19: o_orderdate
+  |  <slot 28> : 28: p_name
+  |  
+  9:HASH JOIN
+  |  join op: INNER JOIN (BROADCAST)
+  |  colocate: false, reason: 
+  |  equal join conjunct: 2: L_PARTKEY = 27: p_partkey
+  |  
+  |----8:EXCHANGE
+  |    
+  6:Project
+  |  <slot 2> : 2: L_PARTKEY
+  |  <slot 19> : 19: o_orderdate
+  |  
+  5:HASH JOIN
+  |  join op: INNER JOIN (BUCKET_SHUFFLE)
+  |  colocate: false, reason: 
+  |  equal join conjunct: 1: L_ORDERKEY = 18: o_orderkey
+  |  
+  |----4:EXCHANGE
+  |    
+  2:Project
+  |  <slot 1> : 1: L_ORDERKEY
+  |  <slot 2> : 2: L_PARTKEY
+  |  
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=3.0
+
+PLAN FRAGMENT 7
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 08
+    UNPARTITIONED
+
+  7:OlapScanNode
+     TABLE: part
+     PREAGGREGATION: ON
+     partitions=1/1
+     rollup: part
+     tabletRatio=18/18
+     tabletList=2489,2491,2493,2495,2497,2499,2501,2503,2505,2507 ...
+     cardinality=1
+     avgRowSize=63.0
+
+PLAN FRAGMENT 8
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 04
+    BUCKET_SHUFFLE_HASH_PARTITIONED: 18: o_orderkey
+
+  3:OlapScanNode
+     TABLE: orders
+     PREAGGREGATION: ON
+     partitions=1/1
+     rollup: orders
+     tabletRatio=18/18
+     tabletList=2449,2451,2453,2455,2457,2459,2461,2463,2465,2467 ...
+     cardinality=1
+     avgRowSize=12.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/union_q5_enable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/union_q5_enable_colocate_set.sql
@@ -1,0 +1,463 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F14)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F14#0)
+      BE: 10001
+
+PLAN FRAGMENT 1(F13)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F13#0)
+      DESTINATIONS: 0-F14#0
+      BE: 10001
+    INSTANCE(2-F13#1)
+      DESTINATIONS: 0-F14#0
+      BE: 10002
+    INSTANCE(3-F13#2)
+      DESTINATIONS: 0-F14#0
+      BE: 10003
+
+PLAN FRAGMENT 2(F12)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F12#0)
+      DESTINATIONS: 1-F13#0,2-F13#1,3-F13#2
+      BE: 10003
+    INSTANCE(5-F12#1)
+      DESTINATIONS: 1-F13#0,2-F13#1,3-F13#2
+      BE: 10002
+    INSTANCE(6-F12#2)
+      DESTINATIONS: 1-F13#0,2-F13#1,3-F13#2
+      BE: 10001
+
+PLAN FRAGMENT 3(F06)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F06#0)
+      DESTINATIONS: 4-F12#0,5-F12#1,6-F12#2
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        12:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(8-F06#1)
+      DESTINATIONS: 4-F12#0,5-F12#1,6-F12#2
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        12:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(9-F06#2)
+      DESTINATIONS: 4-F12#0,5-F12#1,6-F12#2
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        12:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 4(F09)
+  DOP: 16
+  INSTANCES
+    INSTANCE(10-F09#0)
+      DESTINATIONS: 7-F06#0,8-F06#1,9-F06#2
+      BE: 10001
+      SCAN RANGES
+        18:OlapScanNode
+          1. partitionID=2488,tabletID=2491
+          2. partitionID=2488,tabletID=2497
+          3. partitionID=2488,tabletID=2503
+          4. partitionID=2488,tabletID=2509
+          5. partitionID=2488,tabletID=2515
+          6. partitionID=2488,tabletID=2521
+    INSTANCE(11-F09#1)
+      DESTINATIONS: 7-F06#0,8-F06#1,9-F06#2
+      BE: 10002
+      SCAN RANGES
+        18:OlapScanNode
+          1. partitionID=2488,tabletID=2493
+          2. partitionID=2488,tabletID=2499
+          3. partitionID=2488,tabletID=2505
+          4. partitionID=2488,tabletID=2511
+          5. partitionID=2488,tabletID=2517
+          6. partitionID=2488,tabletID=2523
+    INSTANCE(12-F09#2)
+      DESTINATIONS: 7-F06#0,8-F06#1,9-F06#2
+      BE: 10003
+      SCAN RANGES
+        18:OlapScanNode
+          1. partitionID=2488,tabletID=2489
+          2. partitionID=2488,tabletID=2495
+          3. partitionID=2488,tabletID=2501
+          4. partitionID=2488,tabletID=2507
+          5. partitionID=2488,tabletID=2513
+          6. partitionID=2488,tabletID=2519
+
+PLAN FRAGMENT 5(F07)
+  DOP: 16
+  INSTANCES
+    INSTANCE(13-F07#0)
+      DESTINATIONS: 9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1
+      BE: 10001
+      SCAN RANGES
+        14:OlapScanNode
+          1. partitionID=2448,tabletID=2451
+          2. partitionID=2448,tabletID=2457
+          3. partitionID=2448,tabletID=2463
+          4. partitionID=2448,tabletID=2469
+          5. partitionID=2448,tabletID=2475
+          6. partitionID=2448,tabletID=2481
+    INSTANCE(14-F07#1)
+      DESTINATIONS: 9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1
+      BE: 10002
+      SCAN RANGES
+        14:OlapScanNode
+          1. partitionID=2448,tabletID=2453
+          2. partitionID=2448,tabletID=2459
+          3. partitionID=2448,tabletID=2465
+          4. partitionID=2448,tabletID=2471
+          5. partitionID=2448,tabletID=2477
+          6. partitionID=2448,tabletID=2483
+    INSTANCE(15-F07#2)
+      DESTINATIONS: 9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1,9-F06#2,7-F06#0,8-F06#1
+      BE: 10003
+      SCAN RANGES
+        14:OlapScanNode
+          1. partitionID=2448,tabletID=2449
+          2. partitionID=2448,tabletID=2455
+          3. partitionID=2448,tabletID=2461
+          4. partitionID=2448,tabletID=2467
+          5. partitionID=2448,tabletID=2473
+          6. partitionID=2448,tabletID=2479
+
+PLAN FRAGMENT 6(F00)
+  DOP: 16
+  INSTANCES
+    INSTANCE(16-F00#0)
+      DESTINATIONS: 4-F12#0,5-F12#1,6-F12#2
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+    INSTANCE(17-F00#1)
+      DESTINATIONS: 4-F12#0,5-F12#1,6-F12#2
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+    INSTANCE(18-F00#2)
+      DESTINATIONS: 4-F12#0,5-F12#1,6-F12#2
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+
+PLAN FRAGMENT 7(F03)
+  DOP: 16
+  INSTANCES
+    INSTANCE(19-F03#0)
+      DESTINATIONS: 16-F00#0,17-F00#1,18-F00#2
+      BE: 10001
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2488,tabletID=2491
+          2. partitionID=2488,tabletID=2497
+          3. partitionID=2488,tabletID=2503
+          4. partitionID=2488,tabletID=2509
+          5. partitionID=2488,tabletID=2515
+          6. partitionID=2488,tabletID=2521
+    INSTANCE(20-F03#1)
+      DESTINATIONS: 16-F00#0,17-F00#1,18-F00#2
+      BE: 10002
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2488,tabletID=2493
+          2. partitionID=2488,tabletID=2499
+          3. partitionID=2488,tabletID=2505
+          4. partitionID=2488,tabletID=2511
+          5. partitionID=2488,tabletID=2517
+          6. partitionID=2488,tabletID=2523
+    INSTANCE(21-F03#2)
+      DESTINATIONS: 16-F00#0,17-F00#1,18-F00#2
+      BE: 10003
+      SCAN RANGES
+        7:OlapScanNode
+          1. partitionID=2488,tabletID=2489
+          2. partitionID=2488,tabletID=2495
+          3. partitionID=2488,tabletID=2501
+          4. partitionID=2488,tabletID=2507
+          5. partitionID=2488,tabletID=2513
+          6. partitionID=2488,tabletID=2519
+
+PLAN FRAGMENT 8(F01)
+  DOP: 16
+  INSTANCES
+    INSTANCE(22-F01#0)
+      DESTINATIONS: 18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1
+      BE: 10001
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=2448,tabletID=2451
+          2. partitionID=2448,tabletID=2457
+          3. partitionID=2448,tabletID=2463
+          4. partitionID=2448,tabletID=2469
+          5. partitionID=2448,tabletID=2475
+          6. partitionID=2448,tabletID=2481
+    INSTANCE(23-F01#1)
+      DESTINATIONS: 18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1
+      BE: 10002
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=2448,tabletID=2453
+          2. partitionID=2448,tabletID=2459
+          3. partitionID=2448,tabletID=2465
+          4. partitionID=2448,tabletID=2471
+          5. partitionID=2448,tabletID=2477
+          6. partitionID=2448,tabletID=2483
+    INSTANCE(24-F01#2)
+      DESTINATIONS: 18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1,18-F00#2,16-F00#0,17-F00#1
+      BE: 10003
+      SCAN RANGES
+        3:OlapScanNode
+          1. partitionID=2448,tabletID=2449
+          2. partitionID=2448,tabletID=2455
+          3. partitionID=2448,tabletID=2461
+          4. partitionID=2448,tabletID=2467
+          5. partitionID=2448,tabletID=2473
+          6. partitionID=2448,tabletID=2479
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:71: o_orderdate | 72: p_name
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  26:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: HASH_PARTITIONED: 71: o_orderdate, 72: p_name
+
+  STREAM DATA SINK
+    EXCHANGE ID: 26
+    UNPARTITIONED
+
+  25:AGGREGATE (merge finalize)
+  |  group by: 71: o_orderdate, 72: p_name
+  |  
+  24:EXCHANGE
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 24
+    HASH_PARTITIONED: 71: o_orderdate, 72: p_name
+
+  23:AGGREGATE (update serialize)
+  |  STREAMING
+  |  group by: 71: o_orderdate, 72: p_name
+  |  
+  0:UNION
+  |  
+  |----22:EXCHANGE
+  |    
+  11:EXCHANGE
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 22
+    RANDOM
+
+  21:Project
+  |  <slot 54> : 54: o_orderdate
+  |  <slot 63> : 63: p_name
+  |  
+  20:HASH JOIN
+  |  join op: INNER JOIN (BROADCAST)
+  |  colocate: false, reason: 
+  |  equal join conjunct: 37: L_PARTKEY = 62: p_partkey
+  |  
+  |----19:EXCHANGE
+  |    
+  17:Project
+  |  <slot 37> : 37: L_PARTKEY
+  |  <slot 54> : 54: o_orderdate
+  |  
+  16:HASH JOIN
+  |  join op: INNER JOIN (BUCKET_SHUFFLE)
+  |  colocate: false, reason: 
+  |  equal join conjunct: 36: L_ORDERKEY = 53: o_orderkey
+  |  
+  |----15:EXCHANGE
+  |    
+  13:Project
+  |  <slot 36> : 36: L_ORDERKEY
+  |  <slot 37> : 37: L_PARTKEY
+  |  
+  12:OlapScanNode
+     TABLE: lineitem1
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem1
+     tabletRatio=18/18
+     tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+     cardinality=1
+     avgRowSize=3.0
+
+PLAN FRAGMENT 4
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 19
+    UNPARTITIONED
+
+  18:OlapScanNode
+     TABLE: part
+     PREAGGREGATION: ON
+     partitions=1/1
+     rollup: part
+     tabletRatio=18/18
+     tabletList=2489,2491,2493,2495,2497,2499,2501,2503,2505,2507 ...
+     cardinality=1
+     avgRowSize=63.0
+
+PLAN FRAGMENT 5
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 15
+    BUCKET_SHUFFLE_HASH_PARTITIONED: 53: o_orderkey
+
+  14:OlapScanNode
+     TABLE: orders
+     PREAGGREGATION: ON
+     partitions=1/1
+     rollup: orders
+     tabletRatio=18/18
+     tabletList=2449,2451,2453,2455,2457,2459,2461,2463,2465,2467 ...
+     cardinality=1
+     avgRowSize=12.0
+
+PLAN FRAGMENT 6
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 11
+    RANDOM
+
+  10:Project
+  |  <slot 19> : 19: o_orderdate
+  |  <slot 28> : 28: p_name
+  |  
+  9:HASH JOIN
+  |  join op: INNER JOIN (BROADCAST)
+  |  colocate: false, reason: 
+  |  equal join conjunct: 2: L_PARTKEY = 27: p_partkey
+  |  
+  |----8:EXCHANGE
+  |    
+  6:Project
+  |  <slot 2> : 2: L_PARTKEY
+  |  <slot 19> : 19: o_orderdate
+  |  
+  5:HASH JOIN
+  |  join op: INNER JOIN (BUCKET_SHUFFLE)
+  |  colocate: false, reason: 
+  |  equal join conjunct: 1: L_ORDERKEY = 18: o_orderkey
+  |  
+  |----4:EXCHANGE
+  |    
+  2:Project
+  |  <slot 1> : 1: L_ORDERKEY
+  |  <slot 2> : 2: L_PARTKEY
+  |  
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=3.0
+
+PLAN FRAGMENT 7
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 08
+    UNPARTITIONED
+
+  7:OlapScanNode
+     TABLE: part
+     PREAGGREGATION: ON
+     partitions=1/1
+     rollup: part
+     tabletRatio=18/18
+     tabletList=2489,2491,2493,2495,2497,2499,2501,2503,2505,2507 ...
+     cardinality=1
+     avgRowSize=63.0
+
+PLAN FRAGMENT 8
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 04
+    BUCKET_SHUFFLE_HASH_PARTITIONED: 18: o_orderkey
+
+  3:OlapScanNode
+     TABLE: orders
+     PREAGGREGATION: ON
+     partitions=1/1
+     rollup: orders
+     tabletRatio=18/18
+     tabletList=2449,2451,2453,2455,2457,2459,2461,2463,2465,2467 ...
+     cardinality=1
+     avgRowSize=12.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/union_q6_disable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/union_q6_disable_colocate_set.sql
@@ -1,0 +1,348 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F12)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F12#0)
+      BE: 10002
+
+PLAN FRAGMENT 1(F09)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F09#0)
+      DESTINATIONS: 0-F12#0
+      BE: 10001
+    INSTANCE(2-F09#1)
+      DESTINATIONS: 0-F12#0
+      BE: 10003
+    INSTANCE(3-F09#2)
+      DESTINATIONS: 0-F12#0
+      BE: 10002
+
+PLAN FRAGMENT 2(F10)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F10#0)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10001
+      SCAN RANGES
+        15:OlapScanNode
+          1. partitionID=2488,tabletID=2491
+          2. partitionID=2488,tabletID=2497
+          3. partitionID=2488,tabletID=2503
+          4. partitionID=2488,tabletID=2509
+          5. partitionID=2488,tabletID=2515
+          6. partitionID=2488,tabletID=2521
+    INSTANCE(5-F10#1)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10002
+      SCAN RANGES
+        15:OlapScanNode
+          1. partitionID=2488,tabletID=2493
+          2. partitionID=2488,tabletID=2499
+          3. partitionID=2488,tabletID=2505
+          4. partitionID=2488,tabletID=2511
+          5. partitionID=2488,tabletID=2517
+          6. partitionID=2488,tabletID=2523
+    INSTANCE(6-F10#2)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10003
+      SCAN RANGES
+        15:OlapScanNode
+          1. partitionID=2488,tabletID=2489
+          2. partitionID=2488,tabletID=2495
+          3. partitionID=2488,tabletID=2501
+          4. partitionID=2488,tabletID=2507
+          5. partitionID=2488,tabletID=2513
+          6. partitionID=2488,tabletID=2519
+
+PLAN FRAGMENT 3(F07)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F07#0)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10001
+      SCAN RANGES
+        11:OlapScanNode
+          1. partitionID=2448,tabletID=2451
+          2. partitionID=2448,tabletID=2457
+          3. partitionID=2448,tabletID=2463
+          4. partitionID=2448,tabletID=2469
+          5. partitionID=2448,tabletID=2475
+          6. partitionID=2448,tabletID=2481
+    INSTANCE(8-F07#1)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10002
+      SCAN RANGES
+        11:OlapScanNode
+          1. partitionID=2448,tabletID=2453
+          2. partitionID=2448,tabletID=2459
+          3. partitionID=2448,tabletID=2465
+          4. partitionID=2448,tabletID=2471
+          5. partitionID=2448,tabletID=2477
+          6. partitionID=2448,tabletID=2483
+    INSTANCE(9-F07#2)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10003
+      SCAN RANGES
+        11:OlapScanNode
+          1. partitionID=2448,tabletID=2449
+          2. partitionID=2448,tabletID=2455
+          3. partitionID=2448,tabletID=2461
+          4. partitionID=2448,tabletID=2467
+          5. partitionID=2448,tabletID=2473
+          6. partitionID=2448,tabletID=2479
+
+PLAN FRAGMENT 4(F05)
+  DOP: 16
+  INSTANCES
+    INSTANCE(10-F05#0)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10001
+    INSTANCE(11-F05#1)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10002
+    INSTANCE(12-F05#2)
+      DESTINATIONS: 1-F09#0,2-F09#1,3-F09#2
+      BE: 10003
+
+PLAN FRAGMENT 5(F04)
+  DOP: 16
+  INSTANCES
+    INSTANCE(13-F04#0)
+      DESTINATIONS: 10-F05#0,11-F05#1,12-F05#2
+      BE: 10003
+    INSTANCE(14-F04#1)
+      DESTINATIONS: 10-F05#0,11-F05#1,12-F05#2
+      BE: 10002
+    INSTANCE(15-F04#2)
+      DESTINATIONS: 10-F05#0,11-F05#1,12-F05#2
+      BE: 10001
+
+PLAN FRAGMENT 6(F02)
+  DOP: 16
+  INSTANCES
+    INSTANCE(16-F02#0)
+      DESTINATIONS: 13-F04#0,14-F04#1,15-F04#2
+      BE: 10001
+      SCAN RANGES
+        4:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(17-F02#1)
+      DESTINATIONS: 13-F04#0,14-F04#1,15-F04#2
+      BE: 10002
+      SCAN RANGES
+        4:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(18-F02#2)
+      DESTINATIONS: 13-F04#0,14-F04#1,15-F04#2
+      BE: 10003
+      SCAN RANGES
+        4:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 7(F00)
+  DOP: 16
+  INSTANCES
+    INSTANCE(19-F00#0)
+      DESTINATIONS: 13-F04#0,14-F04#1,15-F04#2
+      BE: 10001
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+    INSTANCE(20-F00#1)
+      DESTINATIONS: 13-F04#0,14-F04#1,15-F04#2
+      BE: 10002
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+    INSTANCE(21-F00#2)
+      DESTINATIONS: 13-F04#0,14-F04#1,15-F04#2
+      BE: 10003
+      SCAN RANGES
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:35: L_ORDERKEY | 36: L_PARTKEY
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  19:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: HASH_PARTITIONED: 35: L_ORDERKEY
+
+  STREAM DATA SINK
+    EXCHANGE ID: 19
+    UNPARTITIONED
+
+  18:Project
+  |  <slot 35> : 35: L_ORDERKEY
+  |  <slot 36> : 36: L_PARTKEY
+  |  
+  17:HASH JOIN
+  |  join op: INNER JOIN (BROADCAST)
+  |  colocate: false, reason: 
+  |  equal join conjunct: 36: L_PARTKEY = 46: p_partkey
+  |  
+  |----16:EXCHANGE
+  |    
+  14:Project
+  |  <slot 35> : 35: L_ORDERKEY
+  |  <slot 36> : 36: L_PARTKEY
+  |  
+  13:HASH JOIN
+  |  join op: INNER JOIN (PARTITIONED)
+  |  colocate: false, reason: 
+  |  equal join conjunct: 35: L_ORDERKEY = 37: o_orderkey
+  |  
+  |----12:EXCHANGE
+  |    
+  10:EXCHANGE
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 16
+    UNPARTITIONED
+
+  15:OlapScanNode
+     TABLE: part
+     PREAGGREGATION: ON
+     partitions=1/1
+     rollup: part
+     tabletRatio=18/18
+     tabletList=2489,2491,2493,2495,2497,2499,2501,2503,2505,2507 ...
+     cardinality=1
+     avgRowSize=8.0
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 12
+    HASH_PARTITIONED: 37: o_orderkey
+
+  11:OlapScanNode
+     TABLE: orders
+     PREAGGREGATION: ON
+     partitions=1/1
+     rollup: orders
+     tabletRatio=18/18
+     tabletList=2449,2451,2453,2455,2457,2459,2461,2463,2465,2467 ...
+     cardinality=1
+     avgRowSize=8.0
+
+PLAN FRAGMENT 4
+ OUTPUT EXPRS:
+  PARTITION: HASH_PARTITIONED: 35: L_ORDERKEY, 36: L_PARTKEY
+
+  STREAM DATA SINK
+    EXCHANGE ID: 10
+    HASH_PARTITIONED: 35: L_ORDERKEY
+
+  9:AGGREGATE (merge finalize)
+  |  group by: 35: L_ORDERKEY, 36: L_PARTKEY
+  |  
+  8:EXCHANGE
+
+PLAN FRAGMENT 5
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 08
+    HASH_PARTITIONED: 35: L_ORDERKEY, 36: L_PARTKEY
+
+  7:AGGREGATE (update serialize)
+  |  STREAMING
+  |  group by: 35: L_ORDERKEY, 36: L_PARTKEY
+  |  
+  0:UNION
+  |  
+  |----6:EXCHANGE
+  |    
+  3:EXCHANGE
+
+PLAN FRAGMENT 6
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 06
+    RANDOM
+
+  5:Project
+  |  <slot 18> : 18: L_ORDERKEY
+  |  <slot 19> : 19: L_PARTKEY
+  |  
+  4:OlapScanNode
+     TABLE: lineitem1
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem1
+     tabletRatio=18/18
+     tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+     cardinality=1
+     avgRowSize=3.0
+
+PLAN FRAGMENT 7
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 03
+    RANDOM
+
+  2:Project
+  |  <slot 1> : 1: L_ORDERKEY
+  |  <slot 2> : 2: L_PARTKEY
+  |  
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=3.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/union_q6_enable_colocate_set.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/colocate_set/union_q6_enable_colocate_set.sql
@@ -1,0 +1,252 @@
+
+[scheduler]
+PLAN FRAGMENT 0(F07)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F07#0)
+      BE: 10001
+
+PLAN FRAGMENT 1(F02)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F02#0)
+      DESTINATIONS: 0-F07#0
+      BE: 10001
+      SCAN RANGES
+        BUCKET SEQUENCES: [16, 1, 4, 7, 10, 13]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1400
+          2. partitionID=1397,tabletID=1406
+          3. partitionID=1397,tabletID=1412
+          4. partitionID=1397,tabletID=1418
+          5. partitionID=1397,tabletID=1424
+          6. partitionID=1397,tabletID=1430
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1668
+          2. partitionID=1665,tabletID=1674
+          3. partitionID=1665,tabletID=1680
+          4. partitionID=1665,tabletID=1686
+          5. partitionID=1665,tabletID=1692
+          6. partitionID=1665,tabletID=1698
+    INSTANCE(2-F02#1)
+      DESTINATIONS: 0-F07#0
+      BE: 10002
+      SCAN RANGES
+        BUCKET SEQUENCES: [17, 2, 5, 8, 11, 14]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1402
+          2. partitionID=1397,tabletID=1408
+          3. partitionID=1397,tabletID=1414
+          4. partitionID=1397,tabletID=1420
+          5. partitionID=1397,tabletID=1426
+          6. partitionID=1397,tabletID=1432
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1670
+          2. partitionID=1665,tabletID=1676
+          3. partitionID=1665,tabletID=1682
+          4. partitionID=1665,tabletID=1688
+          5. partitionID=1665,tabletID=1694
+          6. partitionID=1665,tabletID=1700
+    INSTANCE(3-F02#2)
+      DESTINATIONS: 0-F07#0
+      BE: 10003
+      SCAN RANGES
+        BUCKET SEQUENCES: [0, 3, 6, 9, 12, 15]
+        1:OlapScanNode
+          1. partitionID=1397,tabletID=1398
+          2. partitionID=1397,tabletID=1404
+          3. partitionID=1397,tabletID=1410
+          4. partitionID=1397,tabletID=1416
+          5. partitionID=1397,tabletID=1422
+          6. partitionID=1397,tabletID=1428
+        3:OlapScanNode
+          1. partitionID=1665,tabletID=1666
+          2. partitionID=1665,tabletID=1672
+          3. partitionID=1665,tabletID=1678
+          4. partitionID=1665,tabletID=1684
+          5. partitionID=1665,tabletID=1690
+          6. partitionID=1665,tabletID=1696
+
+PLAN FRAGMENT 2(F05)
+  DOP: 16
+  INSTANCES
+    INSTANCE(4-F05#0)
+      DESTINATIONS: 1-F02#0,2-F02#1,3-F02#2
+      BE: 10001
+      SCAN RANGES
+        10:OlapScanNode
+          1. partitionID=2488,tabletID=2491
+          2. partitionID=2488,tabletID=2497
+          3. partitionID=2488,tabletID=2503
+          4. partitionID=2488,tabletID=2509
+          5. partitionID=2488,tabletID=2515
+          6. partitionID=2488,tabletID=2521
+    INSTANCE(5-F05#1)
+      DESTINATIONS: 1-F02#0,2-F02#1,3-F02#2
+      BE: 10002
+      SCAN RANGES
+        10:OlapScanNode
+          1. partitionID=2488,tabletID=2493
+          2. partitionID=2488,tabletID=2499
+          3. partitionID=2488,tabletID=2505
+          4. partitionID=2488,tabletID=2511
+          5. partitionID=2488,tabletID=2517
+          6. partitionID=2488,tabletID=2523
+    INSTANCE(6-F05#2)
+      DESTINATIONS: 1-F02#0,2-F02#1,3-F02#2
+      BE: 10003
+      SCAN RANGES
+        10:OlapScanNode
+          1. partitionID=2488,tabletID=2489
+          2. partitionID=2488,tabletID=2495
+          3. partitionID=2488,tabletID=2501
+          4. partitionID=2488,tabletID=2507
+          5. partitionID=2488,tabletID=2513
+          6. partitionID=2488,tabletID=2519
+
+PLAN FRAGMENT 3(F03)
+  DOP: 16
+  INSTANCES
+    INSTANCE(7-F03#0)
+      DESTINATIONS: 3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1
+      BE: 10001
+      SCAN RANGES
+        6:OlapScanNode
+          1. partitionID=2448,tabletID=2451
+          2. partitionID=2448,tabletID=2457
+          3. partitionID=2448,tabletID=2463
+          4. partitionID=2448,tabletID=2469
+          5. partitionID=2448,tabletID=2475
+          6. partitionID=2448,tabletID=2481
+    INSTANCE(8-F03#1)
+      DESTINATIONS: 3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1
+      BE: 10002
+      SCAN RANGES
+        6:OlapScanNode
+          1. partitionID=2448,tabletID=2453
+          2. partitionID=2448,tabletID=2459
+          3. partitionID=2448,tabletID=2465
+          4. partitionID=2448,tabletID=2471
+          5. partitionID=2448,tabletID=2477
+          6. partitionID=2448,tabletID=2483
+    INSTANCE(9-F03#2)
+      DESTINATIONS: 3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1,3-F02#2,1-F02#0,2-F02#1
+      BE: 10003
+      SCAN RANGES
+        6:OlapScanNode
+          1. partitionID=2448,tabletID=2449
+          2. partitionID=2448,tabletID=2455
+          3. partitionID=2448,tabletID=2461
+          4. partitionID=2448,tabletID=2467
+          5. partitionID=2448,tabletID=2473
+          6. partitionID=2448,tabletID=2479
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:35: L_ORDERKEY | 36: L_PARTKEY
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  14:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 14
+    UNPARTITIONED
+
+  13:Project
+  |  <slot 35> : 35: L_ORDERKEY
+  |  <slot 36> : 36: L_PARTKEY
+  |  
+  12:HASH JOIN
+  |  join op: INNER JOIN (BROADCAST)
+  |  colocate: false, reason: 
+  |  equal join conjunct: 36: L_PARTKEY = 46: p_partkey
+  |  
+  |----11:EXCHANGE
+  |    
+  9:Project
+  |  <slot 35> : 35: L_ORDERKEY
+  |  <slot 36> : 36: L_PARTKEY
+  |  
+  8:HASH JOIN
+  |  join op: INNER JOIN (BUCKET_SHUFFLE)
+  |  colocate: false, reason: 
+  |  equal join conjunct: 35: L_ORDERKEY = 37: o_orderkey
+  |  
+  |----7:EXCHANGE
+  |    
+  5:AGGREGATE (update finalize)
+  |  group by: 35: L_ORDERKEY, 36: L_PARTKEY
+  |  
+  0:UNION
+  |  
+  |----4:Project
+  |    |  <slot 18> : 18: L_ORDERKEY
+  |    |  <slot 19> : 19: L_PARTKEY
+  |    |  
+  |    3:OlapScanNode
+  |       TABLE: lineitem1
+  |       PREAGGREGATION: ON
+  |       partitions=1/7
+  |       rollup: lineitem1
+  |       tabletRatio=18/18
+  |       tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
+  |       cardinality=1
+  |       avgRowSize=3.0
+  |    
+  2:Project
+  |  <slot 1> : 1: L_ORDERKEY
+  |  <slot 2> : 2: L_PARTKEY
+  |  
+  1:OlapScanNode
+     TABLE: lineitem0
+     PREAGGREGATION: ON
+     partitions=1/7
+     rollup: lineitem0
+     tabletRatio=18/18
+     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
+     cardinality=1
+     avgRowSize=3.0
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 11
+    UNPARTITIONED
+
+  10:OlapScanNode
+     TABLE: part
+     PREAGGREGATION: ON
+     partitions=1/1
+     rollup: part
+     tabletRatio=18/18
+     tabletList=2489,2491,2493,2495,2497,2499,2501,2503,2505,2507 ...
+     cardinality=1
+     avgRowSize=8.0
+
+PLAN FRAGMENT 3
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 07
+    BUCKET_SHUFFLE_HASH_PARTITIONED: 37: o_orderkey
+
+  6:OlapScanNode
+     TABLE: orders
+     PREAGGREGATION: ON
+     partitions=1/1
+     rollup: orders
+     tabletRatio=18/18
+     tabletList=2449,2451,2453,2455,2457,2459,2461,2463,2465,2467 ...
+     cardinality=1
+     avgRowSize=8.0
+[end]
+

--- a/fe/fe-core/src/test/resources/sql/scheduler/insert/insert.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/insert/insert.sql
@@ -11,55 +11,55 @@ PLAN FRAGMENT 0(F00)
       SCAN RANGES (per driver sequence)
         0:OlapScanNode
           DriverSequence#0
-            1. partitionID=1001,tabletID=1004
+            1. partitionID=1004,tabletID=1005
           DriverSequence#1
-            2. partitionID=1001,tabletID=1010
+            2. partitionID=1004,tabletID=1011
           DriverSequence#2
-            3. partitionID=1001,tabletID=1016
+            3. partitionID=1004,tabletID=1017
           DriverSequence#3
-            4. partitionID=1001,tabletID=1022
+            4. partitionID=1004,tabletID=1023
           DriverSequence#4
-            5. partitionID=1001,tabletID=1028
+            5. partitionID=1004,tabletID=1029
           DriverSequence#5
-            6. partitionID=1001,tabletID=1034
+            6. partitionID=1004,tabletID=1035
           DriverSequence#6
-            7. partitionID=1001,tabletID=1040
+            7. partitionID=1004,tabletID=1041
     INSTANCE(1-F00#1)
       BE: 10002
       DOP: 7
       SCAN RANGES (per driver sequence)
         0:OlapScanNode
           DriverSequence#0
-            1. partitionID=1001,tabletID=1006
+            1. partitionID=1004,tabletID=1007
           DriverSequence#1
-            2. partitionID=1001,tabletID=1012
+            2. partitionID=1004,tabletID=1013
           DriverSequence#2
-            3. partitionID=1001,tabletID=1018
+            3. partitionID=1004,tabletID=1019
           DriverSequence#3
-            4. partitionID=1001,tabletID=1024
+            4. partitionID=1004,tabletID=1025
           DriverSequence#4
-            5. partitionID=1001,tabletID=1030
+            5. partitionID=1004,tabletID=1031
           DriverSequence#5
-            6. partitionID=1001,tabletID=1036
+            6. partitionID=1004,tabletID=1037
           DriverSequence#6
-            7. partitionID=1001,tabletID=1042
+            7. partitionID=1004,tabletID=1043
     INSTANCE(2-F00#2)
       BE: 10003
       DOP: 6
       SCAN RANGES (per driver sequence)
         0:OlapScanNode
           DriverSequence#0
-            1. partitionID=1001,tabletID=1008
+            1. partitionID=1004,tabletID=1009
           DriverSequence#1
-            2. partitionID=1001,tabletID=1014
+            2. partitionID=1004,tabletID=1015
           DriverSequence#2
-            3. partitionID=1001,tabletID=1020
+            3. partitionID=1004,tabletID=1021
           DriverSequence#3
-            4. partitionID=1001,tabletID=1026
+            4. partitionID=1004,tabletID=1027
           DriverSequence#4
-            5. partitionID=1001,tabletID=1032
+            5. partitionID=1004,tabletID=1033
           DriverSequence#5
-            6. partitionID=1001,tabletID=1038
+            6. partitionID=1004,tabletID=1039
 
 [fragment]
 PLAN FRAGMENT 0
@@ -77,7 +77,7 @@ PLAN FRAGMENT 0
      partitions=1/1
      rollup: lineitem
      tabletRatio=20/20
-     tabletList=1004,1006,1008,1010,1012,1014,1016,1018,1020,1022 ...
+     tabletList=1005,1007,1009,1011,1013,1015,1017,1019,1021,1023 ...
      cardinality=1
      avgRowSize=150.0
 [end]
@@ -88,31 +88,31 @@ select * from nation
 UNION ALL
 select r_regionkey, r_name, r_regionkey, r_comment  from region
 [scheduler]
-PLAN FRAGMENT 0(F00)
+PLAN FRAGMENT 0(F04)
   DOP: 16
   INSTANCES
-    INSTANCE(0-F00#0)
+    INSTANCE(0-F04#0)
       BE: 10003
 
 PLAN FRAGMENT 1(F02)
   DOP: 16
   INSTANCES
     INSTANCE(1-F02#0)
-      DESTINATIONS: 0-F00#0
+      DESTINATIONS: 0-F04#0
       BE: 10001
       SCAN RANGES
         3:OlapScanNode
-          1. partitionID=1479,tabletID=1482
+          1. partitionID=2568,tabletID=2569
 
-PLAN FRAGMENT 2(F01)
+PLAN FRAGMENT 2(F00)
   DOP: 16
   INSTANCES
-    INSTANCE(2-F01#0)
-      DESTINATIONS: 0-F00#0
+    INSTANCE(2-F00#0)
+      DESTINATIONS: 0-F04#0
       BE: 10003
       SCAN RANGES
         1:OlapScanNode
-          1. partitionID=1357,tabletID=1360
+          1. partitionID=2442,tabletID=2443
 
 [fragment]
 PLAN FRAGMENT 0
@@ -144,7 +144,7 @@ PLAN FRAGMENT 1
      partitions=1/1
      rollup: region
      tabletRatio=1/1
-     tabletList=1482
+     tabletList=2569
      cardinality=1
      avgRowSize=181.0
 
@@ -162,7 +162,7 @@ PLAN FRAGMENT 2
      partitions=1/1
      rollup: nation
      tabletRatio=1/1
-     tabletList=1360
+     tabletList=2443
      cardinality=1
      avgRowSize=33.0
 [end]

--- a/fe/fe-core/src/test/resources/sql/scheduler/union/union.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/union/union.sql
@@ -3,41 +3,41 @@ select n_nationkey from nation
 UNION ALL
 select r_regionkey from region
 [scheduler]
-PLAN FRAGMENT 0(F03)
+PLAN FRAGMENT 0(F05)
   DOP: 16
   INSTANCES
-    INSTANCE(0-F03#0)
+    INSTANCE(0-F05#0)
       BE: 10001
 
-PLAN FRAGMENT 1(F00)
+PLAN FRAGMENT 1(F04)
   DOP: 16
   INSTANCES
-    INSTANCE(1-F00#0)
-      DESTINATIONS: 0-F03#0
+    INSTANCE(1-F04#0)
+      DESTINATIONS: 0-F05#0
       BE: 10003
-    INSTANCE(2-F00#1)
-      DESTINATIONS: 0-F03#0
+    INSTANCE(2-F04#1)
+      DESTINATIONS: 0-F05#0
       BE: 10001
 
 PLAN FRAGMENT 2(F02)
   DOP: 16
   INSTANCES
     INSTANCE(3-F02#0)
-      DESTINATIONS: 1-F00#0,2-F00#1
+      DESTINATIONS: 1-F04#0,2-F04#1
       BE: 10001
       SCAN RANGES
         3:OlapScanNode
-          1. partitionID=1479,tabletID=1482
+          1. partitionID=2568,tabletID=2569
 
-PLAN FRAGMENT 3(F01)
+PLAN FRAGMENT 3(F00)
   DOP: 16
   INSTANCES
-    INSTANCE(4-F01#0)
-      DESTINATIONS: 1-F00#0,2-F00#1
+    INSTANCE(4-F00#0)
+      DESTINATIONS: 1-F04#0,2-F04#1
       BE: 10003
       SCAN RANGES
         1:OlapScanNode
-          1. partitionID=1357,tabletID=1360
+          1. partitionID=2442,tabletID=2443
 
 [fragment]
 PLAN FRAGMENT 0
@@ -76,7 +76,7 @@ PLAN FRAGMENT 2
      partitions=1/1
      rollup: region
      tabletRatio=1/1
-     tabletList=1482
+     tabletList=2569
      cardinality=1
      avgRowSize=4.0
 
@@ -94,7 +94,7 @@ PLAN FRAGMENT 3
      partitions=1/1
      rollup: nation
      tabletRatio=1/1
-     tabletList=1360
+     tabletList=2443
      cardinality=1
      avgRowSize=4.0
 [end]

--- a/fe/fe-core/src/test/resources/sql/scheduler/union/union_ungather.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/union/union_ungather.sql
@@ -4,42 +4,43 @@ with
     w2 as (select * from w1 UNION ALL select * from w1)
 select /*+SET_VAR(cbo_cte_reuse=true,cbo_cte_reuse_rate=0)*/ count(1) from w2 group by L_SUPPKEY
 [scheduler]
-    PLAN FRAGMENT 0(F04)
+PLAN FRAGMENT 0(F06)
   DOP: 16
   INSTANCES
-    INSTANCE(0-F04#0)
+    INSTANCE(0-F06#0)
       BE: 10002
 
-PLAN FRAGMENT 1(F01)
+PLAN FRAGMENT 1(F05)
   DOP: 16
   INSTANCES
-    INSTANCE(1-F01#0)
-      DESTINATIONS: 0-F04#0
+    INSTANCE(1-F05#0)
+      DESTINATIONS: 0-F06#0
       BE: 10002
 
 PLAN FRAGMENT 2(F03)
   DOP: 16
   INSTANCES
     INSTANCE(2-F03#0)
-      DESTINATIONS: 1-F01#0
+      DESTINATIONS: 1-F05#0
       BE: 10002
 
-PLAN FRAGMENT 3(F02)
+PLAN FRAGMENT 3(F01)
   DOP: 16
   INSTANCES
-    INSTANCE(3-F02#0)
-      DESTINATIONS: 1-F01#0
+    INSTANCE(3-F01#0)
+      DESTINATIONS: 1-F05#0
       BE: 10002
 
 PLAN FRAGMENT 4(F00)
   DOP: 16
   INSTANCES
     INSTANCE(4-F00#0)
-      DESTINATIONS: 3-F02#0,2-F03#0
+      DESTINATIONS: 3-F01#0,2-F03#0
       BE: 10002
       SCAN RANGES
         0:OlapScanNode
-          1. partitionID=1001,tabletID=1006
+          1. partitionID=1004,tabletID=1007
+
 [fragment]
 PLAN FRAGMENT 0
  OUTPUT EXPRS:69: count
@@ -49,11 +50,11 @@ PLAN FRAGMENT 0
 
   12:Project
   |  <slot 69> : 69: count
-  |
+  |  
   11:AGGREGATE (merge finalize)
   |  output: count(69: count)
   |  group by: 54: L_SUPPKEY
-  |
+  |  
   10:EXCHANGE
 
 PLAN FRAGMENT 1
@@ -61,18 +62,18 @@ PLAN FRAGMENT 1
   PARTITION: RANDOM
 
   STREAM DATA SINK
-  EXCHANGE ID: 10
-  HASH_PARTITIONED: 54: L_SUPPKEY
+    EXCHANGE ID: 10
+    HASH_PARTITIONED: 54: L_SUPPKEY
 
   9:AGGREGATE (update serialize)
   |  STREAMING
   |  output: count(1)
   |  group by: 54: L_SUPPKEY
-  |
+  |  
   2:UNION
-  |
+  |  
   |----8:EXCHANGE
-  |
+  |    
   5:EXCHANGE
 
 PLAN FRAGMENT 2
@@ -85,7 +86,7 @@ PLAN FRAGMENT 2
 
   7:Project
   |  <slot 37> : 3: L_SUPPKEY
-  |
+  |  
   6:EXCHANGE
 
 PLAN FRAGMENT 3
@@ -98,7 +99,7 @@ PLAN FRAGMENT 3
 
   4:Project
   |  <slot 20> : 3: L_SUPPKEY
-  |
+  |  
   3:EXCHANGE
 
 PLAN FRAGMENT 4
@@ -123,7 +124,7 @@ PLAN FRAGMENT 4
      partitions=1/1
      rollup: lineitem
      tabletRatio=1/20
-     tabletList=1006
+     tabletList=1007
      cardinality=1
      avgRowSize=12.0
 [end]

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -1066,6 +1066,8 @@ struct TUnionNode {
     20: optional list<map<Types.TSlotId, Types.TSlotId>> pass_through_slot_maps
     // union node' local exchanger type with parent node, default is PASSTHROUGH
     21: optional TLocalExchangerType local_exchanger_type
+
+    22: optional list<list<Exprs.TExpr>> local_partition_by_exprs
 }
 
 struct TIntersectNode {
@@ -1080,6 +1082,8 @@ struct TIntersectNode {
     4: required i64 first_materialized_child_idx
     
     5: optional bool has_outer_join_child
+
+    6: optional list<list<Exprs.TExpr>> local_partition_by_exprs
 }
 
 struct TExceptNode {
@@ -1092,6 +1096,8 @@ struct TExceptNode {
     3: required list<list<Exprs.TExpr>> const_expr_lists
     // Index of the first child that needs to be materialized.
     4: required i64 first_materialized_child_idx
+
+    5: optional list<list<Exprs.TExpr>> local_partition_by_exprs
 }
 
 

--- a/test/sql/test_colocate_set/R/test_colocate_set
+++ b/test/sql/test_colocate_set/R/test_colocate_set
@@ -1,0 +1,366 @@
+-- name: test_colocate_set
+DROP TABLE if exists lineitem0;
+-- result:
+-- !result
+CREATE TABLE if not exists lineitem0
+(
+L_SHIPDATE DATE NOT NULL,
+L_ORDERKEY BIGINT NOT NULL,
+L_PARTKEY BIGINT NOT NULL,
+L_QUANTITY DECIMAL128(7, 2) NOT NULL 
+) ENGINE=OLAP
+DUPLICATE KEY(`L_SHIPDATE`, `L_ORDERKEY` )
+COMMENT "OLAP"
+PARTITION BY RANGE(L_SHIPDATE) (
+ START ("1993-01-01") END ("1993-01-31") EVERY (INTERVAL 1 day)
+ )
+DISTRIBUTED BY HASH(`L_ORDERKEY` ) BUCKETS 64
+PROPERTIES(
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "default",
+"colocate_with" = "colocate_set_group1" 
+);
+-- result:
+-- !result
+DROP TABLE if exists lineitem1;
+-- result:
+-- !result
+CREATE TABLE if not exists lineitem1
+(
+L_SHIPDATE DATE NOT NULL,
+L_ORDERKEY BIGINT NOT NULL,
+L_PARTKEY BIGINT NOT NULL,
+L_QUANTITY DECIMAL128(7, 2) NOT NULL 
+) ENGINE=OLAP
+DUPLICATE KEY(`L_SHIPDATE`, `L_ORDERKEY` )
+COMMENT "OLAP"
+PARTITION BY RANGE(L_SHIPDATE) (
+ START ("1993-01-01") END ("1993-01-31") EVERY (INTERVAL 1 day)
+ )
+DISTRIBUTED BY HASH(`L_ORDERKEY` ) BUCKETS 64
+PROPERTIES(
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "default",
+"colocate_with" = "colocate_set_group1" 
+);
+-- result:
+-- !result
+DROP TABLE if exists lineitem2;
+-- result:
+-- !result
+CREATE TABLE if not exists lineitem2
+(
+L_SHIPDATE DATE NOT NULL,
+L_ORDERKEY BIGINT NOT NULL,
+L_PARTKEY BIGINT NOT NULL,
+L_QUANTITY DECIMAL128(7, 2) NOT NULL 
+) ENGINE=OLAP
+DUPLICATE KEY(`L_SHIPDATE`, `L_ORDERKEY` )
+COMMENT "OLAP"
+PARTITION BY RANGE(L_SHIPDATE) (
+ START ("1993-01-01") END ("1993-01-31") EVERY (INTERVAL 1 day)
+ )
+DISTRIBUTED BY HASH(`L_ORDERKEY` ) BUCKETS 64
+PROPERTIES(
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "default",
+"colocate_with" = "colocate_set_group2" 
+);
+-- result:
+-- !result
+DROP TABLE if exists lineitem3;
+-- result:
+-- !result
+CREATE TABLE if not exists lineitem3
+(
+L_SHIPDATE DATE NOT NULL,
+L_ORDERKEY BIGINT NOT NULL,
+L_PARTKEY BIGINT NOT NULL,
+L_QUANTITY DECIMAL128(7, 2) NOT NULL 
+) ENGINE=OLAP
+DUPLICATE KEY(`L_SHIPDATE`, `L_ORDERKEY` )
+COMMENT "OLAP"
+PARTITION BY RANGE(L_SHIPDATE) (
+ START ("1993-01-01") END ("1993-01-31") EVERY (INTERVAL 1 day)
+ )
+DISTRIBUTED BY HASH(`L_ORDERKEY` ) BUCKETS 64
+PROPERTIES(
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "default",
+"colocate_with" = "colocate_set_group2" 
+);
+-- result:
+-- !result
+insert into lineitem0 
+select 
+   days_add('1993-01-01', cast(rand()*30 as int)) L_SHIPDATE,
+   cast(rand()*10 as bigint) L_ORDERKEY,
+   cast(rand()*10 as bigint) L_PARTKEY,
+   cast(100.00 + cast(rand()*10 as int) as decimal(7, 2)) L_QUANTITY
+from table(generate_series(1, 100000));
+-- result:
+-- !result
+insert into lineitem1 
+select 
+   days_add('1993-01-01', cast(rand()*30 as int)) L_SHIPDATE,
+   cast(rand()*10 as bigint) L_ORDERKEY,
+   cast(rand()*10 as bigint) L_PARTKEY,
+   cast(100.00 + cast(rand()*10 as int) as decimal(7, 2)) L_QUANTITY
+from table(generate_series(1, 100000));
+-- result:
+-- !result
+insert into lineitem2 
+select 
+   days_add('1993-01-01', cast(rand()*30 as int)) L_SHIPDATE,
+   cast(rand()*10 as bigint) L_ORDERKEY,
+   cast(rand()*10 as bigint) L_PARTKEY,
+   cast(100.00 + cast(rand()*10 as int) as decimal(7, 2)) L_QUANTITY
+from table(generate_series(1, 100000));
+-- result:
+-- !result
+insert into lineitem3 
+select 
+   days_add('1993-01-01', cast(rand()*30 as int)) L_SHIPDATE,
+   cast(rand()*10 as bigint) L_ORDERKEY,
+   cast(rand()*10 as bigint) L_PARTKEY,
+   cast(100.00 + cast(rand()*10 as int) as decimal(7, 2)) L_QUANTITY
+from table(generate_series(1, 100000));
+-- result:
+-- !result
+DROP TABLE if exists orders;
+-- result:
+-- !result
+CREATE TABLE if not exists orders
+(
+O_ORDERKEY BIGINT NOT NULL,
+O_ORDERDATE DATE NOT NULL 
+) ENGINE=OLAP
+DUPLICATE KEY(`O_ORDERKEY`, `O_ORDERDATE` )
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`O_ORDERKEY`, `O_ORDERDATE` ) BUCKETS 64
+PROPERTIES(
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "default" 
+);
+-- result:
+-- !result
+DROP TABLE if exists part;
+-- result:
+-- !result
+CREATE TABLE if not exists part
+(
+P_PARTKEY BIGINT NOT NULL,
+P_NAME VARCHAR(10) NOT NULL 
+) ENGINE=OLAP
+DUPLICATE KEY(`P_PARTKEY`, `P_NAME` )
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`P_PARTKEY`, `P_NAME` ) BUCKETS 64
+PROPERTIES(
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "default" 
+);
+-- result:
+-- !result
+insert into orders 
+select 
+   cast(rand()*10 as bigint) O_ORDERKEY,
+   days_add('1993-01-01', cast(rand()*30 as int)) O_ORDERDATE
+from table(generate_series(1, 10000));
+-- result:
+-- !result
+insert into part 
+select 
+   cast(rand()*10 as bigint) P_PARTKEY,
+   concat('part#', cast(rand()*30 as int)) P_NAME
+from table(generate_series(1, 10000));
+-- result:
+-- !result
+create table result (v bigint) properties("replication_num"="1");
+-- result:
+-- !result
+insert into result with cte as(
+select L_ORDERKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem0 where L_SHIPDATE between '1993-01-01' AND '1993-12-31' group by L_ORDERKEY
+except
+select L_ORDERKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem1 where L_SHIPDATE between '1993-01-01' AND '1993-12-31' group by L_ORDERKEY
+except
+select L_ORDERKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem2 where L_SHIPDATE between '1993-01-01' AND '1993-12-31' group by L_ORDERKEY
+except
+select L_ORDERKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem3 where L_SHIPDATE between '1993-01-01' AND '1993-12-31' group by L_ORDERKEY
+),
+cte1 as(select L_ORDERKEY, sum(L_QUANTITY_SUM) L_QUANTITY_SUM
+from cte
+group by L_ORDERKEY
+)
+select /*+SET_VAR(disable_colocate_set=false)*/ sum(murmur_hash3_32(L_ORDERKEY,L_QUANTITY_SUM)) as v from cte1;
+-- result:
+-- !result
+insert into result with cte as(
+select L_ORDERKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem0 where L_SHIPDATE between '1993-01-01' AND '1993-12-31' group by L_ORDERKEY
+except
+select L_ORDERKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem1 where L_SHIPDATE between '1993-01-01' AND '1993-12-31' group by L_ORDERKEY
+except
+select L_ORDERKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem2 where L_SHIPDATE between '1993-01-01' AND '1993-12-31' group by L_ORDERKEY
+except
+select L_ORDERKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem3 where L_SHIPDATE between '1993-01-01' AND '1993-12-31' group by L_ORDERKEY
+),
+cte1 as(select L_ORDERKEY, sum(L_QUANTITY_SUM) L_QUANTITY_SUM
+from cte
+group by L_ORDERKEY
+)
+select /*+SET_VAR(disable_colocate_set=true)*/ sum(murmur_hash3_32(L_ORDERKEY,L_QUANTITY_SUM)) as v from cte1;
+-- result:
+-- !result
+select assert_true(count(1)=2 and count(distinct v)=1) from result;
+-- result:
+1
+-- !result
+truncate table result;
+-- result:
+-- !result
+insert into result with cte as(
+select L_ORDERKEY, L_PARTKEY
+from lineitem0 
+where L_SHIPDATE between '1993-01-01' AND '1993-12-31'
+INTERSECT
+select L_ORDERKEY, L_PARTKEY
+from lineitem1
+where L_SHIPDATE between '1993-01-01' AND '1993-12-31' 
+),
+cte1 as(
+select cte.* 
+from cte 
+     inner join [bucket] orders on L_ORDERKEY = O_ORDERKEY
+     inner join [broadcast] part on L_PARTKEY = P_PARTKEY
+where O_ORDERKEY = 4 and O_ORDERDATE = '1993-01-24'
+  and P_PARTKEY =2 and P_NAME = "part#0"
+)
+select /*+SET_VAR(disable_colocate_set=false)*/ sum(murmur_hash3_32(L_ORDERKEY,L_PARTKEY)) as v from cte1;
+-- result:
+-- !result
+insert into result with cte as(
+select L_ORDERKEY, L_PARTKEY
+from lineitem0 
+where L_SHIPDATE between '1993-01-01' AND '1993-12-31'
+INTERSECT
+select L_ORDERKEY, L_PARTKEY
+from lineitem1
+where L_SHIPDATE between '1993-01-01' AND '1993-12-31' 
+),
+cte1 as(
+select cte.* 
+from cte 
+     inner join [bucket] orders on L_ORDERKEY = O_ORDERKEY
+     inner join [broadcast] part on L_PARTKEY = P_PARTKEY
+where O_ORDERKEY = 4 and O_ORDERDATE = '1993-01-24'
+  and P_PARTKEY =2 and P_NAME = "part#0"
+)
+select /*+SET_VAR(disable_colocate_set=true)*/ sum(murmur_hash3_32(L_ORDERKEY,L_PARTKEY)) as v from cte1;
+-- result:
+-- !result
+select assert_true(count(1)=2 and count(distinct v)=1) from result;
+-- result:
+1
+-- !result
+truncate table result;
+-- result:
+-- !result
+insert into result with cte as(
+select L_ORDERKEY, L_PARTKEY
+from lineitem0 
+where L_SHIPDATE between '1993-01-01' AND '1993-12-31'
+UNION
+select L_ORDERKEY, L_PARTKEY
+from lineitem1
+where L_SHIPDATE between '1993-01-01' AND '1993-12-31' 
+),
+cte1 as(
+select cte.* 
+from cte 
+     inner join [bucket] orders on L_ORDERKEY = O_ORDERKEY
+     inner join [broadcast] part on L_PARTKEY = P_PARTKEY
+where O_ORDERKEY = 4 and O_ORDERDATE = '1993-01-24'
+  and P_PARTKEY =2 and P_NAME = "part#0"
+)
+select /*+SET_VAR(disable_colocate_set=false)*/ sum(murmur_hash3_32(L_ORDERKEY,L_PARTKEY)) as v from cte1;
+-- result:
+-- !result
+insert into result with cte as(
+select L_ORDERKEY, L_PARTKEY
+from lineitem0 
+where L_SHIPDATE between '1993-01-01' AND '1993-12-31'
+UNION
+select L_ORDERKEY, L_PARTKEY
+from lineitem1
+where L_SHIPDATE between '1993-01-01' AND '1993-12-31' 
+),
+cte1 as(
+select cte.* 
+from cte 
+     inner join [bucket] orders on L_ORDERKEY = O_ORDERKEY
+     inner join [broadcast] part on L_PARTKEY = P_PARTKEY
+where O_ORDERKEY = 4 and O_ORDERDATE = '1993-01-24'
+  and P_PARTKEY =2 and P_NAME = "part#0"
+)
+select /*+SET_VAR(disable_colocate_set=true)*/ sum(murmur_hash3_32(L_ORDERKEY,L_PARTKEY)) as v from cte1;
+-- result:
+-- !result
+select assert_true(count(1)=2 and count(distinct v)=1) from result;
+-- result:
+1
+-- !result
+truncate table result;
+-- result:
+-- !result
+insert into result with cte as(
+select O_ORDERDATE, P_NAME
+from lineitem0 
+     inner join [bucket] orders on L_ORDERKEY = O_ORDERKEY
+     inner join [broadcast] part on L_PARTKEY = P_PARTKEY
+where L_SHIPDATE between '1993-01-01' AND '1993-12-31'
+and O_ORDERKEY = 4 and O_ORDERDATE = '1993-01-24'
+  and P_PARTKEY =2 and P_NAME = "part#0" 
+UNION
+select O_ORDERDATE, P_NAME
+from lineitem1
+     inner join [bucket] orders on L_ORDERKEY = O_ORDERKEY
+     inner join [broadcast] part on L_PARTKEY = P_PARTKEY 
+where L_SHIPDATE between '1993-01-01' AND '1993-12-31' 
+and O_ORDERKEY = 4 and O_ORDERDATE = '1993-01-24'
+  and P_PARTKEY =2 and P_NAME = "part#0"
+)
+select /*+SET_VAR(disable_colocate_set=false)*/ sum(murmur_hash3_32(O_ORDERDATE, P_NAME)) from cte;
+-- result:
+-- !result
+insert into result with cte as(
+select O_ORDERDATE, P_NAME
+from lineitem0 
+     inner join [bucket] orders on L_ORDERKEY = O_ORDERKEY
+     inner join [broadcast] part on L_PARTKEY = P_PARTKEY
+where L_SHIPDATE between '1993-01-01' AND '1993-12-31'
+and O_ORDERKEY = 4 and O_ORDERDATE = '1993-01-24'
+  and P_PARTKEY =2 and P_NAME = "part#0" 
+UNION
+select O_ORDERDATE, P_NAME
+from lineitem1
+     inner join [bucket] orders on L_ORDERKEY = O_ORDERKEY
+     inner join [broadcast] part on L_PARTKEY = P_PARTKEY 
+where L_SHIPDATE between '1993-01-01' AND '1993-12-31' 
+and O_ORDERKEY = 4 and O_ORDERDATE = '1993-01-24'
+  and P_PARTKEY =2 and P_NAME = "part#0"
+)
+select /*+SET_VAR(disable_colocate_set=true)*/ sum(murmur_hash3_32(O_ORDERDATE, P_NAME)) from cte;
+-- result:
+-- !result
+select assert_true(count(1)=2 and count(distinct v)=1) from result;
+-- result:
+1
+-- !result
+truncate table result;
+-- result:
+-- !result

--- a/test/sql/test_colocate_set/T/test_colocate_set
+++ b/test/sql/test_colocate_set/T/test_colocate_set
@@ -1,0 +1,298 @@
+-- name: test_colocate_set
+ DROP TABLE if exists lineitem0;
+
+ CREATE TABLE if not exists lineitem0
+ (
+ L_SHIPDATE DATE NOT NULL,
+ L_ORDERKEY BIGINT NOT NULL,
+ L_PARTKEY BIGINT NOT NULL,
+ L_QUANTITY DECIMAL128(7, 2) NOT NULL 
+ ) ENGINE=OLAP
+ DUPLICATE KEY(`L_SHIPDATE`, `L_ORDERKEY` )
+ COMMENT "OLAP"
+ PARTITION BY RANGE(L_SHIPDATE) (
+  START ("1993-01-01") END ("1993-01-31") EVERY (INTERVAL 1 day)
+  )
+ DISTRIBUTED BY HASH(`L_ORDERKEY` ) BUCKETS 64
+ PROPERTIES(
+ "replication_num" = "1",
+ "in_memory" = "false",
+ "storage_format" = "default",
+ "colocate_with" = "colocate_set_group1" 
+ );
+ DROP TABLE if exists lineitem1;
+
+ CREATE TABLE if not exists lineitem1
+ (
+ L_SHIPDATE DATE NOT NULL,
+ L_ORDERKEY BIGINT NOT NULL,
+ L_PARTKEY BIGINT NOT NULL,
+ L_QUANTITY DECIMAL128(7, 2) NOT NULL 
+ ) ENGINE=OLAP
+ DUPLICATE KEY(`L_SHIPDATE`, `L_ORDERKEY` )
+ COMMENT "OLAP"
+ PARTITION BY RANGE(L_SHIPDATE) (
+  START ("1993-01-01") END ("1993-01-31") EVERY (INTERVAL 1 day)
+  )
+ DISTRIBUTED BY HASH(`L_ORDERKEY` ) BUCKETS 64
+ PROPERTIES(
+ "replication_num" = "1",
+ "in_memory" = "false",
+ "storage_format" = "default",
+ "colocate_with" = "colocate_set_group1" 
+ );
+ DROP TABLE if exists lineitem2;
+
+ CREATE TABLE if not exists lineitem2
+ (
+ L_SHIPDATE DATE NOT NULL,
+ L_ORDERKEY BIGINT NOT NULL,
+ L_PARTKEY BIGINT NOT NULL,
+ L_QUANTITY DECIMAL128(7, 2) NOT NULL 
+ ) ENGINE=OLAP
+ DUPLICATE KEY(`L_SHIPDATE`, `L_ORDERKEY` )
+ COMMENT "OLAP"
+ PARTITION BY RANGE(L_SHIPDATE) (
+  START ("1993-01-01") END ("1993-01-31") EVERY (INTERVAL 1 day)
+  )
+ DISTRIBUTED BY HASH(`L_ORDERKEY` ) BUCKETS 64
+ PROPERTIES(
+ "replication_num" = "1",
+ "in_memory" = "false",
+ "storage_format" = "default",
+ "colocate_with" = "colocate_set_group2" 
+ );
+ DROP TABLE if exists lineitem3;
+
+ CREATE TABLE if not exists lineitem3
+ (
+ L_SHIPDATE DATE NOT NULL,
+ L_ORDERKEY BIGINT NOT NULL,
+ L_PARTKEY BIGINT NOT NULL,
+ L_QUANTITY DECIMAL128(7, 2) NOT NULL 
+ ) ENGINE=OLAP
+ DUPLICATE KEY(`L_SHIPDATE`, `L_ORDERKEY` )
+ COMMENT "OLAP"
+ PARTITION BY RANGE(L_SHIPDATE) (
+  START ("1993-01-01") END ("1993-01-31") EVERY (INTERVAL 1 day)
+  )
+ DISTRIBUTED BY HASH(`L_ORDERKEY` ) BUCKETS 64
+ PROPERTIES(
+ "replication_num" = "1",
+ "in_memory" = "false",
+ "storage_format" = "default",
+ "colocate_with" = "colocate_set_group2" 
+ );
+insert into lineitem0 
+select 
+   days_add('1993-01-01', cast(rand()*30 as int)) L_SHIPDATE,
+   cast(rand()*10 as bigint) L_ORDERKEY,
+   cast(rand()*10 as bigint) L_PARTKEY,
+   cast(100.00 + cast(rand()*10 as int) as decimal(7, 2)) L_QUANTITY
+from table(generate_series(1, 100000));
+insert into lineitem1 
+select 
+   days_add('1993-01-01', cast(rand()*30 as int)) L_SHIPDATE,
+   cast(rand()*10 as bigint) L_ORDERKEY,
+   cast(rand()*10 as bigint) L_PARTKEY,
+   cast(100.00 + cast(rand()*10 as int) as decimal(7, 2)) L_QUANTITY
+from table(generate_series(1, 100000));
+insert into lineitem2 
+select 
+   days_add('1993-01-01', cast(rand()*30 as int)) L_SHIPDATE,
+   cast(rand()*10 as bigint) L_ORDERKEY,
+   cast(rand()*10 as bigint) L_PARTKEY,
+   cast(100.00 + cast(rand()*10 as int) as decimal(7, 2)) L_QUANTITY
+from table(generate_series(1, 100000));
+insert into lineitem3 
+select 
+   days_add('1993-01-01', cast(rand()*30 as int)) L_SHIPDATE,
+   cast(rand()*10 as bigint) L_ORDERKEY,
+   cast(rand()*10 as bigint) L_PARTKEY,
+   cast(100.00 + cast(rand()*10 as int) as decimal(7, 2)) L_QUANTITY
+from table(generate_series(1, 100000));
+ DROP TABLE if exists orders;
+
+ CREATE TABLE if not exists orders
+ (
+ O_ORDERKEY BIGINT NOT NULL,
+ O_ORDERDATE DATE NOT NULL 
+ ) ENGINE=OLAP
+ DUPLICATE KEY(`O_ORDERKEY`, `O_ORDERDATE` )
+ COMMENT "OLAP"
+ DISTRIBUTED BY HASH(`O_ORDERKEY`, `O_ORDERDATE` ) BUCKETS 64
+ PROPERTIES(
+ "replication_num" = "1",
+ "in_memory" = "false",
+ "storage_format" = "default" 
+ );
+ DROP TABLE if exists part;
+
+ CREATE TABLE if not exists part
+ (
+ P_PARTKEY BIGINT NOT NULL,
+ P_NAME VARCHAR(10) NOT NULL 
+ ) ENGINE=OLAP
+ DUPLICATE KEY(`P_PARTKEY`, `P_NAME` )
+ COMMENT "OLAP"
+ DISTRIBUTED BY HASH(`P_PARTKEY`, `P_NAME` ) BUCKETS 64
+ PROPERTIES(
+ "replication_num" = "1",
+ "in_memory" = "false",
+ "storage_format" = "default" 
+ );
+insert into orders 
+select 
+   cast(rand()*10 as bigint) O_ORDERKEY,
+   days_add('1993-01-01', cast(rand()*30 as int)) O_ORDERDATE
+from table(generate_series(1, 10000));
+insert into part 
+select 
+   cast(rand()*10 as bigint) P_PARTKEY,
+   concat('part#', cast(rand()*30 as int)) P_NAME
+from table(generate_series(1, 10000));
+create table result (v bigint) properties("replication_num"="1");
+insert into result with cte as(
+select L_ORDERKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem0 where L_SHIPDATE between '1993-01-01' AND '1993-12-31' group by L_ORDERKEY
+except
+select L_ORDERKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem1 where L_SHIPDATE between '1993-01-01' AND '1993-12-31' group by L_ORDERKEY
+except
+select L_ORDERKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem2 where L_SHIPDATE between '1993-01-01' AND '1993-12-31' group by L_ORDERKEY
+except
+select L_ORDERKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem3 where L_SHIPDATE between '1993-01-01' AND '1993-12-31' group by L_ORDERKEY
+),
+cte1 as(select L_ORDERKEY, sum(L_QUANTITY_SUM) L_QUANTITY_SUM
+from cte
+group by L_ORDERKEY
+)
+select /*+SET_VAR(disable_colocate_set=false)*/ sum(murmur_hash3_32(L_ORDERKEY,L_QUANTITY_SUM)) as v from cte1;
+insert into result with cte as(
+select L_ORDERKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem0 where L_SHIPDATE between '1993-01-01' AND '1993-12-31' group by L_ORDERKEY
+except
+select L_ORDERKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem1 where L_SHIPDATE between '1993-01-01' AND '1993-12-31' group by L_ORDERKEY
+except
+select L_ORDERKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem2 where L_SHIPDATE between '1993-01-01' AND '1993-12-31' group by L_ORDERKEY
+except
+select L_ORDERKEY, sum(L_QUANTITY) L_QUANTITY_SUM from lineitem3 where L_SHIPDATE between '1993-01-01' AND '1993-12-31' group by L_ORDERKEY
+),
+cte1 as(select L_ORDERKEY, sum(L_QUANTITY_SUM) L_QUANTITY_SUM
+from cte
+group by L_ORDERKEY
+)
+select /*+SET_VAR(disable_colocate_set=true)*/ sum(murmur_hash3_32(L_ORDERKEY,L_QUANTITY_SUM)) as v from cte1;
+select assert_true(count(1)=2 and count(distinct v)=1) from result;
+truncate table result;
+insert into result with cte as(
+select L_ORDERKEY, L_PARTKEY
+from lineitem0 
+where L_SHIPDATE between '1993-01-01' AND '1993-12-31'
+INTERSECT
+select L_ORDERKEY, L_PARTKEY
+from lineitem1
+where L_SHIPDATE between '1993-01-01' AND '1993-12-31' 
+),
+cte1 as(
+select cte.* 
+from cte 
+     inner join [bucket] orders on L_ORDERKEY = O_ORDERKEY
+     inner join [broadcast] part on L_PARTKEY = P_PARTKEY
+where O_ORDERKEY = 4 and O_ORDERDATE = '1993-01-24'
+  and P_PARTKEY =2 and P_NAME = "part#0"
+)
+select /*+SET_VAR(disable_colocate_set=false)*/ sum(murmur_hash3_32(L_ORDERKEY,L_PARTKEY)) as v from cte1;
+insert into result with cte as(
+select L_ORDERKEY, L_PARTKEY
+from lineitem0 
+where L_SHIPDATE between '1993-01-01' AND '1993-12-31'
+INTERSECT
+select L_ORDERKEY, L_PARTKEY
+from lineitem1
+where L_SHIPDATE between '1993-01-01' AND '1993-12-31' 
+),
+cte1 as(
+select cte.* 
+from cte 
+     inner join [bucket] orders on L_ORDERKEY = O_ORDERKEY
+     inner join [broadcast] part on L_PARTKEY = P_PARTKEY
+where O_ORDERKEY = 4 and O_ORDERDATE = '1993-01-24'
+  and P_PARTKEY =2 and P_NAME = "part#0"
+)
+select /*+SET_VAR(disable_colocate_set=true)*/ sum(murmur_hash3_32(L_ORDERKEY,L_PARTKEY)) as v from cte1;
+select assert_true(count(1)=2 and count(distinct v)=1) from result;
+truncate table result;
+insert into result with cte as(
+select L_ORDERKEY, L_PARTKEY
+from lineitem0 
+where L_SHIPDATE between '1993-01-01' AND '1993-12-31'
+UNION
+select L_ORDERKEY, L_PARTKEY
+from lineitem1
+where L_SHIPDATE between '1993-01-01' AND '1993-12-31' 
+),
+cte1 as(
+select cte.* 
+from cte 
+     inner join [bucket] orders on L_ORDERKEY = O_ORDERKEY
+     inner join [broadcast] part on L_PARTKEY = P_PARTKEY
+where O_ORDERKEY = 4 and O_ORDERDATE = '1993-01-24'
+  and P_PARTKEY =2 and P_NAME = "part#0"
+)
+select /*+SET_VAR(disable_colocate_set=false)*/ sum(murmur_hash3_32(L_ORDERKEY,L_PARTKEY)) as v from cte1;
+insert into result with cte as(
+select L_ORDERKEY, L_PARTKEY
+from lineitem0 
+where L_SHIPDATE between '1993-01-01' AND '1993-12-31'
+UNION
+select L_ORDERKEY, L_PARTKEY
+from lineitem1
+where L_SHIPDATE between '1993-01-01' AND '1993-12-31' 
+),
+cte1 as(
+select cte.* 
+from cte 
+     inner join [bucket] orders on L_ORDERKEY = O_ORDERKEY
+     inner join [broadcast] part on L_PARTKEY = P_PARTKEY
+where O_ORDERKEY = 4 and O_ORDERDATE = '1993-01-24'
+  and P_PARTKEY =2 and P_NAME = "part#0"
+)
+select /*+SET_VAR(disable_colocate_set=true)*/ sum(murmur_hash3_32(L_ORDERKEY,L_PARTKEY)) as v from cte1;
+select assert_true(count(1)=2 and count(distinct v)=1) from result;
+truncate table result;
+insert into result with cte as(
+select O_ORDERDATE, P_NAME
+from lineitem0 
+     inner join [bucket] orders on L_ORDERKEY = O_ORDERKEY
+     inner join [broadcast] part on L_PARTKEY = P_PARTKEY
+where L_SHIPDATE between '1993-01-01' AND '1993-12-31'
+and O_ORDERKEY = 4 and O_ORDERDATE = '1993-01-24'
+  and P_PARTKEY =2 and P_NAME = "part#0" 
+UNION
+select O_ORDERDATE, P_NAME
+from lineitem1
+     inner join [bucket] orders on L_ORDERKEY = O_ORDERKEY
+     inner join [broadcast] part on L_PARTKEY = P_PARTKEY 
+where L_SHIPDATE between '1993-01-01' AND '1993-12-31' 
+and O_ORDERKEY = 4 and O_ORDERDATE = '1993-01-24'
+  and P_PARTKEY =2 and P_NAME = "part#0"
+)
+select /*+SET_VAR(disable_colocate_set=false)*/ sum(murmur_hash3_32(O_ORDERDATE, P_NAME)) from cte;
+insert into result with cte as(
+select O_ORDERDATE, P_NAME
+from lineitem0 
+     inner join [bucket] orders on L_ORDERKEY = O_ORDERKEY
+     inner join [broadcast] part on L_PARTKEY = P_PARTKEY
+where L_SHIPDATE between '1993-01-01' AND '1993-12-31'
+and O_ORDERKEY = 4 and O_ORDERDATE = '1993-01-24'
+  and P_PARTKEY =2 and P_NAME = "part#0" 
+UNION
+select O_ORDERDATE, P_NAME
+from lineitem1
+     inner join [bucket] orders on L_ORDERKEY = O_ORDERKEY
+     inner join [broadcast] part on L_PARTKEY = P_PARTKEY 
+where L_SHIPDATE between '1993-01-01' AND '1993-12-31' 
+and O_ORDERKEY = 4 and O_ORDERDATE = '1993-01-24'
+  and P_PARTKEY =2 and P_NAME = "part#0"
+)
+select /*+SET_VAR(disable_colocate_set=true)*/ sum(murmur_hash3_32(O_ORDERDATE, P_NAME)) from cte;
+select assert_true(count(1)=2 and count(distinct v)=1) from result;
+truncate table result;


### PR DESCRIPTION
## Why I'm doing:
Two optimization:
optimization 1: colocate union distinct/intersect/except: when children of these set operators are all in the same colocate group, each BE only processes its local data instead of exchaging data to other BE(s). 

optimization 2: one-phase aggregation, colocate hash-join and bucket-shuffle hash-join below or above these set operators need not interpolate exchange operator to adjust data distribution.

use session variable disable_colocate_set to control this feature, false(default) means turn on this feature, true means turn off.

Colocate union distinct is stricter than intersect/execept, only all of the children are iso-distribution, then union distinct can generate colocate plan, since union distinct has two-stage distinct aggregation, it is hard to determine wether bucket shuffle of non-iso-distribution children and one-stage distinct aggregation outperform old plan which contains two-stage distinct aggregation and each child of union operator adopt random exchange(in BE, random exchange work in passthrough way).

In colocate plan of intersect/except,  non-iso-distribution children adopt bucket shuffle.

for an example:

query as follows, both lineitem{0..3} in the same colocate group and there bucket key is L_ORDERKEY.

```sql
 with cte as(
  select * from lineitem0 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'
  except
  select * from lineitem1 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'
  except
  select * from lineitem2 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'
  except
  select * from lineitem3 where L_SHIPDATE between '1993-01-01' AND '1993-12-31'
  )
 select L_ORDERKEY, sum(L_QUANTITY)
 from cte
 group by L_ORDERKEY;
```

Colocate plan (set disable_colocate_set=false, in default)
```
PLAN FRAGMENT 0
 OUTPUT EXPRS:69: L_ORDERKEY | 86: sum
  PARTITION: UNPARTITIONED

  RESULT SINK

  9:EXCHANGE

PLAN FRAGMENT 1
 OUTPUT EXPRS:
  PARTITION: RANDOM

  STREAM DATA SINK
    EXCHANGE ID: 09
    UNPARTITIONED

  8:AGGREGATE (update finalize)
  |  output: sum(73: L_QUANTITY)
  |  group by: 69: L_ORDERKEY
  |  
  7:Project
  |  <slot 69> : 69: L_ORDERKEY
  |  <slot 73> : 73: L_QUANTITY
  |  
  6:EXCEPT
  |  
  |----1:OlapScanNode
  |       TABLE: lineitem1
  |       PREAGGREGATION: ON
  |       partitions=1/7
  |       rollup: lineitem1
  |       tabletRatio=18/18
  |       tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
  |       cardinality=1
  |       avgRowSize=17.0
  |    
  |----3:EXCHANGE
  |    
  |----5:EXCHANGE
  |    
  0:OlapScanNode
     TABLE: lineitem0
     PREAGGREGATION: ON
     partitions=1/7
     rollup: lineitem0
     tabletRatio=18/18
     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
     cardinality=1
     avgRowSize=17.0

PLAN FRAGMENT 2
 OUTPUT EXPRS:
  PARTITION: RANDOM

  STREAM DATA SINK
    EXCHANGE ID: 05
    BUCKET_SHUFFLE_HASH_PARTITIONED: 52: L_ORDERKEY

  4:OlapScanNode
     TABLE: lineitem3
     PREAGGREGATION: ON
     partitions=1/7
     rollup: lineitem3
     tabletRatio=18/18
     tabletList=2203,2205,2207,2209,2211,2213,2215,2217,2219,2221 ...
     cardinality=1
     avgRowSize=17.0

PLAN FRAGMENT 3
 OUTPUT EXPRS:
  PARTITION: RANDOM

  STREAM DATA SINK
    EXCHANGE ID: 03
    BUCKET_SHUFFLE_HASH_PARTITIONED: 35: L_ORDERKEY

  2:OlapScanNode
     TABLE: lineitem2
     PREAGGREGATION: ON
     partitions=1/7
     rollup: lineitem2
     tabletRatio=18/18
     tabletList=1935,1937,1939,1941,1943,1945,1947,1949,1951,1953 ...
     cardinality=1
     avgRowSize=17.0
```

Non-Colocate plan (set disable_colocate_set=true)

```
PLAN FRAGMENT 0
 OUTPUT EXPRS:69: L_ORDERKEY | 86: sum
  PARTITION: UNPARTITIONED

  RESULT SINK

  13:EXCHANGE

PLAN FRAGMENT 1
 OUTPUT EXPRS:
  PARTITION: HASH_PARTITIONED: 69: L_ORDERKEY

  STREAM DATA SINK
    EXCHANGE ID: 13
    UNPARTITIONED

  12:AGGREGATE (merge finalize)
  |  output: sum(86: sum)
  |  group by: 69: L_ORDERKEY
  |  
  11:EXCHANGE

PLAN FRAGMENT 2
 OUTPUT EXPRS:
  PARTITION: RANDOM

  STREAM DATA SINK
    EXCHANGE ID: 11
    HASH_PARTITIONED: 69: L_ORDERKEY

  10:AGGREGATE (update serialize)
  |  STREAMING
  |  output: sum(73: L_QUANTITY)
  |  group by: 69: L_ORDERKEY
  |  
  9:Project
  |  <slot 69> : 69: L_ORDERKEY
  |  <slot 73> : 73: L_QUANTITY
  |  
  8:EXCEPT
  |  
  |----3:EXCHANGE
  |    
  |----5:EXCHANGE
  |    
  |----7:EXCHANGE
  |    
  1:EXCHANGE

PLAN FRAGMENT 3
 OUTPUT EXPRS:
  PARTITION: RANDOM

  STREAM DATA SINK
    EXCHANGE ID: 07
    HASH_PARTITIONED: 52: L_ORDERKEY, 53: L_PARTKEY, 54: L_SUPPKEY, 55: L_LINENUMBER, 56: L_QUANTITY, 57: L_EXTENDEDPRICE, 58: L_DISCOUNT, 59: L_TAX, 60: L_RETURNFLAG, 61: L_LINESTATUS, 62: L_SHIPDATE, 63: L_COMMITDATE, 64: L_RECEIPTDATE, 65: L_SHIPINSTRUCT, 66: L_SHIPMODE, 67: L_COMMENT, 68: PAD

  6:OlapScanNode
     TABLE: lineitem3
     PREAGGREGATION: ON
     partitions=1/7
     rollup: lineitem3
     tabletRatio=18/18
     tabletList=2203,2205,2207,2209,2211,2213,2215,2217,2219,2221 ...
     cardinality=1
     avgRowSize=17.0

PLAN FRAGMENT 4
 OUTPUT EXPRS:
  PARTITION: RANDOM

  STREAM DATA SINK
    EXCHANGE ID: 05
    HASH_PARTITIONED: 35: L_ORDERKEY, 36: L_PARTKEY, 37: L_SUPPKEY, 38: L_LINENUMBER, 39: L_QUANTITY, 40: L_EXTENDEDPRICE, 41: L_DISCOUNT, 42: L_TAX, 43: L_RETURNFLAG, 44: L_LINESTATUS, 45: L_SHIPDATE, 46: L_COMMITDATE, 47: L_RECEIPTDATE, 48: L_SHIPINSTRUCT, 49: L_SHIPMODE, 50: L_COMMENT, 51: PAD

  4:OlapScanNode
     TABLE: lineitem2
     PREAGGREGATION: ON
     partitions=1/7
     rollup: lineitem2
     tabletRatio=18/18
     tabletList=1935,1937,1939,1941,1943,1945,1947,1949,1951,1953 ...
     cardinality=1
     avgRowSize=17.0

PLAN FRAGMENT 5
 OUTPUT EXPRS:
  PARTITION: RANDOM

  STREAM DATA SINK
    EXCHANGE ID: 03
    HASH_PARTITIONED: 18: L_ORDERKEY, 19: L_PARTKEY, 20: L_SUPPKEY, 21: L_LINENUMBER, 22: L_QUANTITY, 23: L_EXTENDEDPRICE, 24: L_DISCOUNT, 25: L_TAX, 26: L_RETURNFLAG, 27: L_LINESTATUS, 28: L_SHIPDATE, 29: L_COMMITDATE, 30: L_RECEIPTDATE, 31: L_SHIPINSTRUCT, 32: L_SHIPMODE, 33: L_COMMENT, 34: PAD

  2:OlapScanNode
     TABLE: lineitem1
     PREAGGREGATION: ON
     partitions=1/7
     rollup: lineitem1
     tabletRatio=18/18
     tabletList=1666,1668,1670,1672,1674,1676,1678,1680,1682,1684 ...
     cardinality=1
     avgRowSize=17.0

PLAN FRAGMENT 6
 OUTPUT EXPRS:
  PARTITION: RANDOM

  STREAM DATA SINK
    EXCHANGE ID: 01
    HASH_PARTITIONED: 1: L_ORDERKEY, 2: L_PARTKEY, 3: L_SUPPKEY, 4: L_LINENUMBER, 5: L_QUANTITY, 6: L_EXTENDEDPRICE, 7: L_DISCOUNT, 8: L_TAX, 9: L_RETURNFLAG, 10: L_LINESTATUS, 11: L_SHIPDATE, 12: L_COMMITDATE, 13: L_RECEIPTDATE, 14: L_SHIPINSTRUCT, 15: L_SHIPMODE, 16: L_COMMENT, 17: PAD

  0:OlapScanNode
     TABLE: lineitem0
     PREAGGREGATION: ON
     partitions=1/7
     rollup: lineitem0
     tabletRatio=18/18
     tabletList=1398,1400,1402,1404,1406,1408,1410,1412,1414,1416 ...
     cardinality=1
     avgRowSize=17.0
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
