### PR TITLE
[BugFix] fix touch_cache api in stream does not override correctly

### DIFF
--- a/be/src/io/seekable_input_stream.h
+++ b/be/src/io/seekable_input_stream.h
@@ -143,6 +143,8 @@ public:
 
     bool is_encrypted() const override { return _impl->is_encrypted(); };
 
+    Status touch_cache(int64_t offset, size_t length) override { return _impl->touch_cache(offset, length); }
+
 private:
     SeekableInputStream* _impl;
     Ownership _ownership;

--- a/be/test/io/seekable_input_stream_test.cpp
+++ b/be/test/io/seekable_input_stream_test.cpp
@@ -44,6 +44,8 @@ public:
 
     StatusOr<int64_t> get_size() override { return _contents.size(); }
 
+    Status touch_cache(int64_t offset, size_t length) override { return Status::InvalidArgument("TestInputStream"); }
+
 private:
     std::string _contents;
     int64_t _block_size;
@@ -117,6 +119,13 @@ PARALLEL_TEST(SeekableInputStreamTest, test_encrypted) {
 
     EncryptSeekableInputStream encrypted(std::move(s), {EncryptionAlgorithmPB::AES_128, "0000000000000000"});
     ASSERT_TRUE(encrypted.is_encrypted());
+}
+
+// NOLINTNEXTLINE
+PARALLEL_TEST(SeekableInputStreamTest, test_touch_cache) {
+    TestInputStream in("0123456789", 5);
+    SeekableInputStreamWrapper wrapper(&in, Ownership::kDontTakeOwnership);
+    ASSERT_TRUE(wrapper.touch_cache(0, 0).is_invalid_argument());
 }
 
 } // namespace starrocks::io


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

it will make cache select does not fill necessary data

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
