### PR TITLE
[BugFix] Fix race condition in BucketSequenceMorselQueue

### DIFF
--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -17,6 +17,7 @@
 #include <fmt/compile.h>
 
 #include <memory>
+#include <mutex>
 
 #include "common/statusor.h"
 #include "exec/olap_utils.h"
@@ -241,6 +242,7 @@ bool BucketSequenceMorselQueue::empty() const {
 }
 
 StatusOr<MorselPtr> BucketSequenceMorselQueue::try_get() {
+    std::lock_guard guard(_mutex);
     if (_unget_morsel != nullptr) {
         return std::move(_unget_morsel);
     }
@@ -262,6 +264,7 @@ std::string BucketSequenceMorselQueue::name() const {
 }
 
 StatusOr<bool> BucketSequenceMorselQueue::ready_for_next() const {
+    std::lock_guard guard(_mutex);
     if (_current_sequence < 0) {
         return true;
     }

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <mutex>
 #include <optional>
 
 #include "exec/query_cache/ticket_checker.h"
@@ -423,10 +424,11 @@ public:
 
 private:
     StatusOr<int64_t> _peek_sequence_id() const;
+    mutable std::mutex _mutex;
 
-    int64_t _current_sequence = -1;
     MorselQueuePtr _morsel_queue;
     query_cache::TicketCheckerPtr _ticket_checker;
+    int64_t _current_sequence = -1;
 };
 
 class SplitMorselQueue : public MorselQueue {


### PR DESCRIPTION
## Why I'm doing:

We are enabling per-bucket agg and event scheduler at the same time. ScanOperator::has_output is called when a scan task is completed. However, it is possible that ScanOperator::pull_chunk is being called from another thread. As a result, this can lead to concurrent calls to ScanMorselQueue's ready_for_next and try_get. This can lead to an unintended race condition.


## What I'm doing:

In this PR, we add locks to the try_get and ready_for_next interfaces of BucketMorselQueue. Because scan_defer_notify is called infrequently. We consider this contention to be acceptable.

a possiable stacktrace:
```
*** Aborted at 1746673587 (unix time) try "date -d @1746673587" if you are using GNU date ***
PC: @          0x4e16d40 starrocks::query_cache::TicketChecker::leave(long)
*** SIGSEGV (@0x18) received by PID 2264415 (TID 0x7fb2b2bfe640) LWP(2265249) from PID 24; stack trace: ***
    @     0x7fb34cd4fee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @          0xb7470d4 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7fb34ccf8520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @          0x4e16d40 starrocks::query_cache::TicketChecker::leave(long)
    @          0x4cd55d5 starrocks::pipeline::ScanOperator::pull_chunk(starrocks::RuntimeState*)
    @          0x4d688d9 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0x50e7ff1 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x3f8d05f starrocks::ThreadPool::dispatch_thread()
    @          0x3f84630 starrocks::Thread::supervise_thread(void*)
    @     0x7fb34cd4aac3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
    @     0x7fb34cddc850 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x12684f)
rpf@query-dev-ubuntu:/home/disk3/rpf/DorisDB_Test$ ./start_be1.sh
```



## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
