### PR TITLE
[BugFix] fix wrong transform from inner join to semi

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Projection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Projection.java
@@ -78,7 +78,7 @@ public class Projection {
         columnRefMap.values().stream().forEach(e -> usedColumns.union(e.getUsedColumns()));
         commonSubOperatorMap.values().stream().forEach(e -> usedColumns.union(e.getUsedColumns()));
         // remove some of columnRefMap's used columns which are from commonSubOperatorMap's output column
-        commonSubOperatorMap.keySet().stream().forEach(e -> usedColumns.union(e.getUsedColumns()));
+        commonSubOperatorMap.keySet().stream().forEach(e -> usedColumns.except(e.getUsedColumns()));
         return usedColumns;
     }
 


### PR DESCRIPTION
## Why I'm doing:
for sql like distinct on inner join, we can transform inner join to semi join if inner join's output is only from one child. But if join OptExpression has projection, then join OptExpression's output columns may not same as join operator's output columns if projection is like "ColumnRef(1): ColumnRef(2)"

## What I'm doing:
1. if join OptExpression has projection, use projection's used column as join operator's output column
2. only transfrom inner to semi if inner join's output is only from one child. 
Fixes [#issue](https://github.com/StarRocks/StarRocksTest/issues/9593), it should transfrom inner to left semi, but tranform it into right semi which cause empty set

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
