### PR TITLE
[Enhancement] Remove unnecessary retries during pk apply

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -904,6 +904,8 @@ bool TabletUpdates::_is_retryable(Status& status) {
     case TStatusCode::TIMEOUT:
         return true;
     case TStatusCode::CORRUPTION:
+    case TStatusCode::NOT_IMPLEMENTED_ERROR:
+    case TStatusCode::INVALID_ARGUMENT:
         return false;
     default:
         return _check_status_msg(status.message()) || _retry_times_limit();


### PR DESCRIPTION
## Why I'm doing:
After this PR(https://github.com/StarRocks/starrocks/pull/57354), if a PK table fails during the apply process, we will attempt a retry unless the apply returns a 'corruption' status. However, besides 'corruption', there are other statuses where retries are guaranteed to fail.

## What I'm doing:
Add more statuses for skip retries during apply.

Fixes #https://github.com/StarRocks/StarRocksTest/issues/9574

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
