### PR TITLE
[Refactor] Decouple the initialization of DiskMonitor, LocalCache, and RemoteCache from the initialization of BlockCache.

### DIFF
--- a/be/src/cache/block_cache/block_cache.h
+++ b/be/src/cache/block_cache/block_cache.h
@@ -34,7 +34,8 @@ public:
     ~BlockCache();
 
     // Init the block cache instance
-    Status init(const CacheOptions& options);
+    Status init(const CacheOptions& options, std::shared_ptr<LocalCache> local_cache,
+                std::shared_ptr<RemoteCache> remote_cache);
 
     // Write data buffer to cache, the `offset` must be aligned by block size
     Status write(const CacheKey& cache_key, off_t offset, const IOBuffer& buffer, WriteCacheOptions* options = nullptr);
@@ -83,7 +84,6 @@ private:
     size_t _block_size = 0;
     std::shared_ptr<LocalCache> _local_cache;
     std::shared_ptr<RemoteCache> _remote_cache;
-    std::unique_ptr<DiskSpaceMonitor> _disk_space_monitor;
     std::atomic<bool> _initialized = false;
 };
 

--- a/be/src/cache/block_cache/local_cache.h
+++ b/be/src/cache/block_cache/local_cache.h
@@ -59,10 +59,6 @@ public:
 
     virtual DataCacheEngineType engine_type() = 0;
 
-#ifdef WITH_STARCACHE
-    virtual std::shared_ptr<starcache::StarCache> starcache_instance() = 0;
-#endif
-
     virtual bool available() const = 0;
     virtual bool mem_cache_available() const = 0;
     virtual void disk_spaces(std::vector<DirSpace>* spaces) const = 0;

--- a/be/src/cache/block_cache/starcache_wrapper.cpp
+++ b/be/src/cache/block_cache/starcache_wrapper.cpp
@@ -16,6 +16,7 @@
 
 #include <filesystem>
 
+#include "cache/block_cache/disk_space_monitor.h"
 #include "cache/status.h"
 #include "common/logging.h"
 #include "common/statusor.h"
@@ -60,6 +61,9 @@ Status StarCacheWrapper::init(const CacheOptions& options) {
 
     _refresh_quota();
     _initialized.store(true, std::memory_order_relaxed);
+
+    LOG(INFO) << "init starcache engine, block_size: " << options.block_size
+              << ", disk_spaces: " << DiskSpaceMonitor::to_string(options.disk_spaces);
     return Status::OK();
 }
 

--- a/be/src/cache/block_cache/starcache_wrapper.h
+++ b/be/src/cache/block_cache/starcache_wrapper.h
@@ -51,7 +51,7 @@ public:
 
     DataCacheEngineType engine_type() override { return DataCacheEngineType::STARCACHE; }
 
-    std::shared_ptr<starcache::StarCache> starcache_instance() override { return _cache; }
+    std::shared_ptr<starcache::StarCache> starcache_instance() { return _cache; }
     bool has_mem_cache() const { return _mem_quota.load(std::memory_order_relaxed) > 0; }
     bool has_disk_cache() const { return _disk_quota.load(std::memory_order_relaxed) > 0; }
     bool available() const override { return is_initialized() && (has_mem_cache() || has_disk_cache()); }

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -41,6 +41,8 @@
 #include "agent/agent_server.h"
 #include "agent/master_info.h"
 #include "cache/block_cache/block_cache.h"
+#include "cache/block_cache/disk_space_monitor.h"
+#include "cache/block_cache/peer_cache_wrapper.h"
 #include "cache/object_cache/lrucache_module.h"
 #include "common/config.h"
 #include "common/configbase.h"
@@ -109,6 +111,7 @@
 #endif
 
 #ifdef WITH_STARCACHE
+#include "cache/block_cache/starcache_wrapper.h"
 #include "cache/object_cache/starcache_module.h"
 #endif
 
@@ -350,6 +353,12 @@ Status CacheEnv::init(const std::vector<StorePath>& store_paths) {
 }
 
 void CacheEnv::destroy() {
+    if (_disk_space_monitor != nullptr) {
+        _disk_space_monitor->stop();
+        _disk_space_monitor.reset();
+        LOG(INFO) << "disk space monitor stop successfully";
+    }
+
     _page_cache.reset();
     LOG(INFO) << "pagecache shutdown successfully";
 
@@ -366,7 +375,8 @@ void CacheEnv::destroy() {
 Status CacheEnv::_init_starcache_based_object_cache() {
 #ifdef WITH_STARCACHE
     if (_local_cache != nullptr && _local_cache->is_initialized()) {
-        _starcache_based_object_cache = std::make_shared<StarCacheModule>(_local_cache->starcache_instance());
+        auto* starcache = reinterpret_cast<StarCacheWrapper*>(_local_cache.get());
+        _starcache_based_object_cache = std::make_shared<StarCacheModule>(starcache->starcache_instance());
     }
 #endif
     return Status::OK();
@@ -410,79 +420,97 @@ Status CacheEnv::_init_datacache() {
 #endif
 
     if (config::datacache_enable) {
-        CacheOptions cache_options;
-        RETURN_IF_ERROR(DataCacheUtils::parse_conf_datacache_mem_size(
-                config::datacache_mem_size, _global_env->process_mem_limit(), &cache_options.mem_space_size));
-
-        for (auto& root_path : _store_paths) {
-            // Because we have unified the datacache between datalake and starlet, we also need to unify the
-            // cache path and quota.
-            // To reuse the old cache data in `starlet_cache` directory, we try to rename it to the new `datacache`
-            // directory if it exists. To avoid the risk of cross disk renaming of a large amount of cached data,
-            // we do not automatically rename it when the source and destination directories are on different disks.
-            // In this case, users should manually remount the directories and restart them.
-            std::string datacache_path = root_path.path + "/datacache";
-            std::string starlet_cache_path = root_path.path + "/starlet_cache/star_cache";
-#ifdef USE_STAROS
-            if (config::datacache_unified_instance_enable) {
-                RETURN_IF_ERROR(DataCacheUtils::change_disk_path(starlet_cache_path, datacache_path));
-            }
-#endif
-            // Create it if not exist
-            Status st = FileSystem::Default()->create_dir_if_missing(datacache_path);
-            if (!st.ok()) {
-                LOG(ERROR) << "Fail to create datacache directory: " << datacache_path << ", reason: " << st.message();
-                return Status::InternalError("Fail to create datacache directory");
-            }
-
-            ASSIGN_OR_RETURN(int64_t disk_size, DataCacheUtils::parse_conf_datacache_disk_size(
-                                                        datacache_path, config::datacache_disk_size, -1));
-#ifdef USE_STAROS
-            // If the `datacache_disk_size` is manually set a positive value, we will use the maximum cache quota between
-            // dataleke and starlet cache as the quota of the unified cache. Otherwise, the cache quota will remain zero
-            // and then automatically adjusted based on the current avalible disk space.
-            if (config::datacache_unified_instance_enable && (!config::datacache_auto_adjust_enable || disk_size > 0)) {
-                ASSIGN_OR_RETURN(
-                        int64_t starlet_cache_size,
-                        DataCacheUtils::parse_conf_datacache_disk_size(
-                                datacache_path, fmt::format("{}%", config::starlet_star_cache_disk_size_percent), -1));
-                disk_size = std::max(disk_size, starlet_cache_size);
-            }
-#endif
-            cache_options.disk_spaces.push_back({.path = datacache_path, .size = static_cast<size_t>(disk_size)});
-        }
-
-        if (cache_options.disk_spaces.empty()) {
-            config::datacache_auto_adjust_enable = false;
-        }
-
-        // Adjust the default engine based on build switches.
-        if (config::datacache_engine == "") {
 #if defined(WITH_STARCACHE)
-            config::datacache_engine = "starcache";
-#endif
-        }
-        cache_options.block_size = config::datacache_block_size;
-        cache_options.max_flying_memory_mb = config::datacache_max_flying_memory_mb;
-        cache_options.max_concurrent_inserts = config::datacache_max_concurrent_inserts;
-        cache_options.enable_checksum = config::datacache_checksum_enable;
-        cache_options.enable_direct_io = config::datacache_direct_io_enable;
-        cache_options.enable_tiered_cache = config::datacache_tiered_cache_enable;
-        cache_options.skip_read_factor = config::datacache_skip_read_factor;
-        cache_options.scheduler_threads_per_cpu = config::datacache_scheduler_threads_per_cpu;
-        cache_options.enable_datacache_persistence = config::datacache_persistence_enable;
-        cache_options.inline_item_count_limit = config::datacache_inline_item_count_limit;
-        cache_options.engine = config::datacache_engine;
-        cache_options.eviction_policy = config::datacache_eviction_policy;
-        RETURN_IF_ERROR(_block_cache->init(cache_options));
+        ASSIGN_OR_RETURN(auto cache_options, _init_cache_options());
 
-        _local_cache = _block_cache->local_cache();
+        // init starcache & disk monitor
+        _local_cache = std::make_shared<StarCacheWrapper>();
+        _disk_space_monitor = std::make_shared<DiskSpaceMonitor>(_local_cache.get());
+        RETURN_IF_ERROR(_disk_space_monitor->init(&cache_options.disk_spaces));
+        RETURN_IF_ERROR(_local_cache->init(cache_options));
+        _disk_space_monitor->start();
+
+        // init remote cache
+        _remote_cache = std::make_shared<PeerCacheWrapper>();
+        RETURN_IF_ERROR(_remote_cache->init(cache_options));
+
+        // init block cache
+        RETURN_IF_ERROR(_block_cache->init(cache_options, _local_cache, _remote_cache));
 
         LOG(INFO) << "datacache init successfully";
+#endif
     } else {
         LOG(INFO) << "starts by skipping the datacache initialization";
     }
     return Status::OK();
+}
+
+StatusOr<CacheOptions> CacheEnv::_init_cache_options() {
+    CacheOptions cache_options;
+    RETURN_IF_ERROR(DataCacheUtils::parse_conf_datacache_mem_size(
+            config::datacache_mem_size, _global_env->process_mem_limit(), &cache_options.mem_space_size));
+
+    for (auto& root_path : _store_paths) {
+        // Because we have unified the datacache between datalake and starlet, we also need to unify the
+        // cache path and quota.
+        // To reuse the old cache data in `starlet_cache` directory, we try to rename it to the new `datacache`
+        // directory if it exists. To avoid the risk of cross disk renaming of a large amount of cached data,
+        // we do not automatically rename it when the source and destination directories are on different disks.
+        // In this case, users should manually remount the directories and restart them.
+        std::string datacache_path = root_path.path + "/datacache";
+        std::string starlet_cache_path = root_path.path + "/starlet_cache/star_cache";
+#ifdef USE_STAROS
+        if (config::datacache_unified_instance_enable) {
+            RETURN_IF_ERROR(DataCacheUtils::change_disk_path(starlet_cache_path, datacache_path));
+        }
+#endif
+        // Create it if not exist
+        Status st = FileSystem::Default()->create_dir_if_missing(datacache_path);
+        if (!st.ok()) {
+            LOG(ERROR) << "Fail to create datacache directory: " << datacache_path << ", reason: " << st.message();
+            return Status::InternalError("Fail to create datacache directory");
+        }
+
+        ASSIGN_OR_RETURN(int64_t disk_size, DataCacheUtils::parse_conf_datacache_disk_size(
+                                                    datacache_path, config::datacache_disk_size, -1));
+#ifdef USE_STAROS
+        // If the `datacache_disk_size` is manually set a positive value, we will use the maximum cache quota between
+        // dataleke and starlet cache as the quota of the unified cache. Otherwise, the cache quota will remain zero
+        // and then automatically adjusted based on the current avalible disk space.
+        if (config::datacache_unified_instance_enable && (!config::datacache_auto_adjust_enable || disk_size > 0)) {
+            ASSIGN_OR_RETURN(
+                    int64_t starlet_cache_size,
+                    DataCacheUtils::parse_conf_datacache_disk_size(
+                            datacache_path, fmt::format("{}%", config::starlet_star_cache_disk_size_percent), -1));
+            disk_size = std::max(disk_size, starlet_cache_size);
+        }
+#endif
+        cache_options.disk_spaces.push_back({.path = datacache_path, .size = static_cast<size_t>(disk_size)});
+    }
+
+    if (cache_options.disk_spaces.empty()) {
+        config::datacache_auto_adjust_enable = false;
+    }
+
+    // Adjust the default engine based on build switches.
+    if (config::datacache_engine == "") {
+#if defined(WITH_STARCACHE)
+        config::datacache_engine = "starcache";
+#endif
+    }
+    cache_options.block_size = config::datacache_block_size;
+    cache_options.max_flying_memory_mb = config::datacache_max_flying_memory_mb;
+    cache_options.max_concurrent_inserts = config::datacache_max_concurrent_inserts;
+    cache_options.enable_checksum = config::datacache_checksum_enable;
+    cache_options.enable_direct_io = config::datacache_direct_io_enable;
+    cache_options.enable_tiered_cache = config::datacache_tiered_cache_enable;
+    cache_options.skip_read_factor = config::datacache_skip_read_factor;
+    cache_options.scheduler_threads_per_cpu = config::datacache_scheduler_threads_per_cpu;
+    cache_options.enable_datacache_persistence = config::datacache_persistence_enable;
+    cache_options.inline_item_count_limit = config::datacache_inline_item_count_limit;
+    cache_options.engine = config::datacache_engine;
+    cache_options.eviction_policy = config::datacache_eviction_policy;
+    return cache_options;
 }
 
 void CacheEnv::try_release_resource_before_core_dump() {

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -83,7 +83,10 @@ class QuerySpillManager;
 class BlockCache;
 class ObjectCache;
 class LocalCache;
+class RemoteCache;
 class StoragePageCache;
+class DiskSpaceMonitor;
+struct CacheOptions;
 struct RfTracePoint;
 
 class BackendServiceClient;
@@ -256,6 +259,7 @@ public:
 
     LocalCache* local_cache() { return _local_cache.get(); }
     BlockCache* block_cache() const { return _block_cache.get(); }
+    void set_block_cache(std::shared_ptr<BlockCache> block_cache) { _block_cache = std::move(block_cache); }
     ObjectCache* external_table_meta_cache() const { return _starcache_based_object_cache.get(); }
     ObjectCache* external_table_page_cache() const { return _starcache_based_object_cache.get(); }
     StoragePageCache* page_cache() const { return _page_cache.get(); }
@@ -264,6 +268,7 @@ public:
     int64_t check_storage_page_cache_limit(int64_t storage_cache_limit);
 
 private:
+    StatusOr<CacheOptions> _init_cache_options();
     Status _init_datacache();
     Status _init_starcache_based_object_cache();
     Status _init_lru_base_object_cache();
@@ -273,11 +278,14 @@ private:
     std::vector<StorePath> _store_paths;
 
     std::shared_ptr<LocalCache> _local_cache;
+    std::shared_ptr<RemoteCache> _remote_cache;
 
     std::shared_ptr<BlockCache> _block_cache;
     std::shared_ptr<ObjectCache> _starcache_based_object_cache;
     std::shared_ptr<ObjectCache> _lru_based_object_cache;
     std::shared_ptr<StoragePageCache> _page_cache;
+
+    std::shared_ptr<DiskSpaceMonitor> _disk_space_monitor;
 };
 
 // Execution environment for queries/plan fragments.

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -122,7 +122,8 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
 #ifdef USE_STAROS
     auto* local_cache = cache_env->local_cache();
     if (config::datacache_unified_instance_enable && local_cache->is_initialized()) {
-        init_staros_worker(local_cache->starcache_instance());
+        auto* starcache = reinterpret_cast<StarCacheWrapper*>(local_cache.get());
+        init_staros_worker(star_cache->starcache_instance());
     } else {
         init_staros_worker(nullptr);
     }

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -22,6 +22,7 @@
 #include "agent/heartbeat_server.h"
 #include "backend_service.h"
 #include "cache/block_cache/block_cache.h"
+#include "cache/block_cache/starcache_wrapper.h"
 #include "common/config.h"
 #include "common/daemon.h"
 #include "common/process_exit.h"

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -123,7 +123,7 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
 #ifdef USE_STAROS
     auto* local_cache = cache_env->local_cache();
     if (config::datacache_unified_instance_enable && local_cache->is_initialized()) {
-        auto* starcache = reinterpret_cast<StarCacheWrapper*>(local_cache.get());
+        auto* starcache = reinterpret_cast<StarCacheWrapper*>(local_cache);
         init_staros_worker(starcache->starcache_instance());
     } else {
         init_staros_worker(nullptr);

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -124,7 +124,7 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     auto* local_cache = cache_env->local_cache();
     if (config::datacache_unified_instance_enable && local_cache->is_initialized()) {
         auto* starcache = reinterpret_cast<StarCacheWrapper*>(local_cache.get());
-        init_staros_worker(star_cache->starcache_instance());
+        init_staros_worker(starcache->starcache_instance());
     } else {
         init_staros_worker(nullptr);
     }

--- a/be/test/cache/block_cache/block_cache_test.cpp
+++ b/be/test/cache/block_cache/block_cache_test.cpp
@@ -14,17 +14,17 @@
 
 #include "cache/block_cache/block_cache.h"
 
-#include <fmt/format.h>
 #include <gtest/gtest.h>
 
 #include <cstring>
 #include <filesystem>
 
 #include "cache/block_cache/datacache_utils.h"
+#include "cache/block_cache/test_cache_utils.h"
 #include "common/logging.h"
 #include "common/statusor.h"
 #include "fs/fs_util.h"
-#include "storage/options.h"
+#include "testutil/assert.h"
 
 namespace starrocks {
 
@@ -75,20 +75,10 @@ TEST_F(BlockCacheTest, hybrid_cache) {
     const std::string cache_dir = "./block_disk_cache3";
     ASSERT_TRUE(fs::create_directories(cache_dir).ok());
 
-    std::unique_ptr<BlockCache> cache(new BlockCache);
     const size_t block_size = 256 * 1024;
-
-    CacheOptions options;
-    options.mem_space_size = 2 * 1024 * 1024;
-    size_t quota = 50 * 1024 * 1024;
-    options.disk_spaces.push_back({.path = cache_dir, .size = quota});
-    options.block_size = block_size;
-    options.max_concurrent_inserts = 100000;
-    options.max_flying_memory_mb = 100;
-    options.enable_direct_io = false;
-    options.engine = "starcache";
-    Status status = cache->init(options);
-    ASSERT_TRUE(status.ok());
+    CacheOptions options = TestCacheUtils::create_simple_options(block_size, 2 * MB);
+    options.disk_spaces.push_back({.path = cache_dir, .size = 50 * MB});
+    auto cache = TestCacheUtils::create_cache(options);
 
     const size_t batch_size = block_size;
     const size_t rounds = 10;
@@ -114,8 +104,7 @@ TEST_F(BlockCacheTest, hybrid_cache) {
 
     // remove cache
     char value[1024] = {0};
-    status = cache->remove(cache_key, 0, batch_size);
-    ASSERT_TRUE(status.ok());
+    ASSERT_OK(cache->remove(cache_key, 0, batch_size));
 
     auto res = cache->read(cache_key, 0, batch_size, value);
     ASSERT_TRUE(res.status().is_not_found());
@@ -124,39 +113,30 @@ TEST_F(BlockCacheTest, hybrid_cache) {
     res = cache->read(cache_key, block_size * 1000, batch_size, value);
     ASSERT_TRUE(res.status().is_not_found());
 
-    cache->shutdown();
-    fs::remove_all(cache_dir);
+    ASSERT_OK(cache->shutdown());
+    ASSERT_OK(fs::remove_all(cache_dir));
 }
 
 TEST_F(BlockCacheTest, write_with_overwrite_option) {
-    std::unique_ptr<BlockCache> cache(new BlockCache);
     const size_t block_size = 1024 * 1024;
 
-    CacheOptions options;
-    options.mem_space_size = 20 * 1024 * 1024;
-    options.block_size = block_size;
-    options.max_concurrent_inserts = 100000;
-    options.max_flying_memory_mb = 100;
-    options.engine = "starcache";
+    CacheOptions options = TestCacheUtils::create_simple_options(block_size, 20 * MB);
     options.inline_item_count_limit = 1000;
-    Status status = cache->init(options);
-    ASSERT_TRUE(status.ok());
+    auto cache = TestCacheUtils::create_cache(options);
 
     const size_t cache_size = 1024;
     const std::string cache_key = "test_file";
 
     std::string value(cache_size, 'a');
-    Status st = cache->write(cache_key, 0, cache_size, value.c_str());
-    ASSERT_TRUE(st.ok());
+    ASSERT_OK(cache->write(cache_key, 0, cache_size, value.c_str()));
 
     WriteCacheOptions write_options;
     std::string value2(cache_size, 'b');
-    st = cache->write(cache_key, 0, cache_size, value2.c_str(), &write_options);
+    Status st = cache->write(cache_key, 0, cache_size, value2.c_str(), &write_options);
     ASSERT_TRUE(st.is_already_exist());
 
     write_options.overwrite = true;
-    st = cache->write(cache_key, 0, cache_size, value2.c_str(), &write_options);
-    ASSERT_TRUE(st.ok());
+    ASSERT_OK(cache->write(cache_key, 0, cache_size, value2.c_str(), &write_options));
 
     char rvalue[cache_size] = {0};
     auto res = cache->read(cache_key, 0, cache_size, rvalue);
@@ -169,27 +149,18 @@ TEST_F(BlockCacheTest, write_with_overwrite_option) {
     st = cache->write(cache_key, 0, cache_size, value3.c_str(), &write_options);
     ASSERT_TRUE(st.is_already_exist());
 
-    cache->shutdown();
+    ASSERT_OK(cache->shutdown());
 }
 
 TEST_F(BlockCacheTest, read_cache_with_adaptor) {
     const std::string cache_dir = "./block_disk_cache4";
     ASSERT_TRUE(fs::create_directories(cache_dir).ok());
 
-    std::unique_ptr<BlockCache> cache(new BlockCache);
     const size_t block_size = 1024 * 1024;
-
-    CacheOptions options;
-    options.mem_space_size = 0;
-    size_t quota = 500 * 1024 * 1024;
-    options.disk_spaces.push_back({.path = cache_dir, .size = quota});
-    options.block_size = block_size;
-    options.max_concurrent_inserts = 100000;
-    options.max_flying_memory_mb = 100;
-    options.engine = "starcache";
+    CacheOptions options = TestCacheUtils::create_simple_options(block_size, 0);
+    options.disk_spaces.push_back({.path = cache_dir, .size = 500 * MB});
     options.skip_read_factor = 1;
-    Status status = cache->init(options);
-    ASSERT_TRUE(status.ok());
+    auto cache = TestCacheUtils::create_cache(options);
 
     const size_t batch_size = block_size - 1234;
     const size_t rounds = 20;
@@ -239,8 +210,8 @@ TEST_F(BlockCacheTest, read_cache_with_adaptor) {
         ASSERT_TRUE(res.status().ok());
     }
 
-    cache->shutdown();
-    fs::remove_all(cache_dir);
+    ASSERT_OK(cache->shutdown());
+    ASSERT_OK(fs::remove_all(cache_dir));
 }
 
 TEST_F(BlockCacheTest, update_cache_quota) {
@@ -249,30 +220,22 @@ TEST_F(BlockCacheTest, update_cache_quota) {
 
     std::unique_ptr<BlockCache> block_cache(new BlockCache);
     const size_t block_size = 256 * 1024;
-
-    CacheOptions options;
-    options.mem_space_size = 1 * 1024 * 1024;
-    size_t quota = 50 * 1024 * 1024;
+    size_t quota = 50 * MB;
+    CacheOptions options = TestCacheUtils::create_simple_options(block_size, 1 * MB);
     options.disk_spaces.push_back({.path = cache_dir, .size = quota});
-    options.block_size = block_size;
-    options.max_concurrent_inserts = 100000;
-    options.max_flying_memory_mb = 100;
-    options.enable_direct_io = false;
-    options.engine = "starcache";
-    Status status = block_cache->init(options);
-    ASSERT_TRUE(status.ok());
-    auto cache = block_cache->local_cache();
+    auto cache = TestCacheUtils::create_cache(options);
+    auto local_cache = cache->local_cache();
 
     {
-        auto metrics = cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics(0);
         ASSERT_EQ(metrics.mem_quota_bytes, options.mem_space_size);
         ASSERT_EQ(metrics.disk_quota_bytes, quota);
     }
 
     {
         size_t new_mem_quota = 2 * 1024 * 1024;
-        ASSERT_TRUE(cache->update_mem_quota(new_mem_quota, false).ok());
-        auto metrics = cache->cache_metrics(0);
+        ASSERT_TRUE(local_cache->update_mem_quota(new_mem_quota, false).ok());
+        auto metrics = local_cache->cache_metrics(0);
         ASSERT_EQ(metrics.mem_quota_bytes, new_mem_quota);
     }
 
@@ -280,33 +243,23 @@ TEST_F(BlockCacheTest, update_cache_quota) {
         size_t new_disk_quota = 100 * 1024 * 1024;
         std::vector<DirSpace> dir_spaces;
         dir_spaces.push_back({.path = cache_dir, .size = new_disk_quota});
-        ASSERT_TRUE(cache->update_disk_spaces(dir_spaces).ok());
-        auto metrics = cache->cache_metrics(0);
+        ASSERT_TRUE(local_cache->update_disk_spaces(dir_spaces).ok());
+        auto metrics = local_cache->cache_metrics(0);
         ASSERT_EQ(metrics.disk_quota_bytes, new_disk_quota);
     }
 
-    cache->shutdown();
-    fs::remove_all(cache_dir);
+    ASSERT_OK(cache->shutdown());
+    ASSERT_OK(fs::remove_all(cache_dir));
 }
 
 TEST_F(BlockCacheTest, clear_residual_blockfiles) {
     const std::string cache_dir = "./block_disk_cache6";
     ASSERT_TRUE(fs::create_directories(cache_dir).ok());
 
-    std::unique_ptr<BlockCache> cache(new BlockCache);
     const size_t block_size = 256 * 1024;
-
-    CacheOptions options;
-    options.mem_space_size = 0;
-    size_t quota = 50 * 1024 * 1024;
-    options.disk_spaces.push_back({.path = cache_dir, .size = quota});
-    options.block_size = block_size;
-    options.max_concurrent_inserts = 100000;
-    options.max_flying_memory_mb = 100;
-    options.enable_direct_io = false;
-    options.engine = "starcache";
-    Status status = cache->init(options);
-    ASSERT_TRUE(status.ok());
+    CacheOptions options = TestCacheUtils::create_simple_options(block_size, 0);
+    options.disk_spaces.push_back({.path = cache_dir, .size = 50 * MB});
+    auto cache = TestCacheUtils::create_cache(options);
 
     // write cache
     {
@@ -328,7 +281,7 @@ TEST_F(BlockCacheTest, clear_residual_blockfiles) {
         ASSERT_GT(files.size(), 0);
     }
 
-    cache->shutdown();
+    ASSERT_OK(cache->shutdown());
     DataCacheUtils::clean_residual_datacache(cache_dir);
 
     {
@@ -337,16 +290,12 @@ TEST_F(BlockCacheTest, clear_residual_blockfiles) {
         ASSERT_EQ(files.size(), 0);
     }
 
-    fs::remove_all(cache_dir);
+    ASSERT_OK(fs::remove_all(cache_dir));
 }
 
 TEST_F(BlockCacheTest, read_peer_cache) {
-    std::unique_ptr<BlockCache> cache(new BlockCache);
-    CacheOptions options;
-    options.mem_space_size = 1024 * 1024;
-    options.engine = "starcache";
-    Status status = cache->init(options);
-    ASSERT_TRUE(status.ok());
+    CacheOptions options = TestCacheUtils::create_simple_options(256 * KB, 1 * MB);
+    auto cache = TestCacheUtils::create_cache(options);
 
     IOBuffer iobuf;
     ReadCacheOptions read_options;
@@ -355,6 +304,6 @@ TEST_F(BlockCacheTest, read_peer_cache) {
     auto st = cache->read_buffer_from_remote_cache("test_key", 0, 100, &iobuf, &read_options);
     ASSERT_FALSE(st.ok());
 
-    cache->shutdown();
+    ASSERT_OK(cache->shutdown());
 }
 } // namespace starrocks

--- a/be/test/cache/block_cache/disk_space_monitor_test.cpp
+++ b/be/test/cache/block_cache/disk_space_monitor_test.cpp
@@ -181,6 +181,7 @@ TEST_F(DiskSpaceMonitorTest, auto_increase_cache_quota) {
 
     auto space_monitor = std::make_shared<DiskSpaceMonitor>(local_cache.get(), _mock_fs);
     ASSERT_OK(space_monitor->init(&options.disk_spaces));
+    space_monitor->start();
 
     // Fill cache data
     {
@@ -228,9 +229,8 @@ TEST_F(DiskSpaceMonitorTest, auto_increase_cache_quota_with_limit) {
     auto block_cache = TestCacheUtils::create_cache(options);
     auto local_cache = block_cache->local_cache();
 
-    MockFileSystem* mock_fs = new MockFileSystem;
     SpaceInfo space_info = {.capacity = 500 * MB, .free = 400 * MB, .available = 300 * MB};
-    mock_fs->set_space(1, ".", space_info);
+    _mock_fs->set_space(1, ".", space_info);
 
     auto space_monitor = std::make_shared<DiskSpaceMonitor>(local_cache.get(), _mock_fs);
     ASSERT_OK(space_monitor->init(&options.disk_spaces));

--- a/be/test/cache/block_cache/disk_space_monitor_test.cpp
+++ b/be/test/cache/block_cache/disk_space_monitor_test.cpp
@@ -88,22 +88,16 @@ public:
 
     static void TearDownTestCase() { ASSERT_TRUE(fs::remove_all("./block_disk_cache").ok()); }
 
-    void SetUp() override {}
-    void TearDown() override {
-        if (_cache) {
-            _cache->shutdown();
-        }
-    }
+    void SetUp() override { _mock_fs = std::make_shared<MockFileSystem>(); }
+    void TearDown() override {}
 
     static void insert_to_cache(BlockCache* cache, size_t count);
 
-private:
-    BlockCache* _cache = nullptr;
+protected:
+    std::shared_ptr<MockFileSystem> _mock_fs;
 };
 
 const size_t DiskSpaceMonitorTest::kBlockSize = 256 * KB;
-
-#ifdef WITH_STARCACHE
 
 void DiskSpaceMonitorTest::insert_to_cache(BlockCache* cache, size_t count) {
     size_t batch_size = MB;
@@ -121,12 +115,10 @@ TEST_F(DiskSpaceMonitorTest, adjust_for_empty_cache_dir) {
     SCOPED_UPDATE(int64_t, config::datacache_disk_safe_level, 70);
     SCOPED_UPDATE(int64_t, config::datacache_min_disk_quota_for_adjustment, 0);
 
-    auto mock_fs = std::make_shared<MockFileSystem>();
-    auto space_monitor = std::make_unique<DiskSpaceMonitor>(nullptr, mock_fs);
-
     SpaceInfo space_info = {.capacity = 1000 * GB, .free = 800 * GB, .available = 500 * GB};
-    mock_fs->set_space(1, "disk1", space_info);
-    mock_fs->set_space(2, "disk2", space_info);
+    _mock_fs->set_space(1, "disk1", space_info);
+    _mock_fs->set_space(2, "disk2", space_info);
+    auto space_monitor = std::make_unique<DiskSpaceMonitor>(nullptr, _mock_fs);
 
     std::vector<DirSpace> dir_spaces = {
             {.path = "disk1/dir1", .size = 0}, {.path = "disk1/dir2", .size = 0}, {.path = "disk2/dir2", .size = 0}};
@@ -149,13 +141,11 @@ TEST_F(DiskSpaceMonitorTest, adjust_for_dirty_cache_dir) {
     SCOPED_UPDATE(int64_t, config::datacache_disk_safe_level, 70);
     SCOPED_UPDATE(int64_t, config::datacache_disk_low_level, 60);
 
-    auto mock_fs = std::make_shared<MockFileSystem>();
-    auto space_monitor = std::make_unique<DiskSpaceMonitor>(nullptr, mock_fs);
-
     SpaceInfo space_info = {.capacity = 1000 * GB, .free = 800 * GB, .available = 200 * GB};
-    mock_fs->set_space(1, "disk1", space_info);
-    mock_fs->set_space(2, "disk2", space_info);
-    mock_fs->set_global_directory_capacity(300 * GB);
+    _mock_fs->set_space(1, "disk1", space_info);
+    _mock_fs->set_space(2, "disk2", space_info);
+    _mock_fs->set_global_directory_capacity(300 * GB);
+    auto space_monitor = std::make_unique<DiskSpaceMonitor>(nullptr, _mock_fs);
 
     std::vector<DirSpace> dir_spaces = {
             {.path = "disk1/dir1", .size = 0}, {.path = "disk1/dir2", .size = 0}, {.path = "disk2/dir2", .size = 0}};
@@ -182,48 +172,44 @@ TEST_F(DiskSpaceMonitorTest, auto_increase_cache_quota) {
     SCOPED_UPDATE(int64_t, config::datacache_disk_safe_level, 70);
     SCOPED_UPDATE(int64_t, config::datacache_disk_low_level, 60);
 
-    auto options = create_simple_options(kBlockSize, 0, 20 * MB);
-    auto block_cache = create_cache(options);
-    auto cache = block_cache->local_cache();
+    auto options = TestCacheUtils::create_simple_options(kBlockSize, 0, 20 * MB);
+    auto block_cache = TestCacheUtils::create_cache(options);
+    auto local_cache = block_cache->local_cache();
 
-    MockFileSystem* mock_fs = new MockFileSystem;
     SpaceInfo space_info = {.capacity = 500 * MB, .free = 400 * MB, .available = 300 * MB};
-    mock_fs->set_space(1, ".", space_info);
+    _mock_fs->set_space(1, ".", space_info);
 
-    auto& space_monitor = block_cache->_disk_space_monitor;
-    space_monitor->_fs.reset(mock_fs);
-    space_monitor->init(&options.disk_spaces);
+    auto space_monitor = std::make_shared<DiskSpaceMonitor>(local_cache.get(), _mock_fs);
+    ASSERT_OK(space_monitor->init(&options.disk_spaces));
 
     // Fill cache data
     {
         insert_to_cache(block_cache.get(), 19);
-        auto metrics = cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics(0);
         int64_t used_rate = metrics.disk_used_bytes * 100 / metrics.disk_quota_bytes;
         ASSERT_GT(used_rate, DiskSpace::kAutoIncreaseThreshold);
     }
 
     {
-        auto metrics = cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics(0);
         ASSERT_EQ(metrics.disk_quota_bytes, 20 * MB);
     }
 
     {
         config::datacache_auto_adjust_enable = true;
         sleep(3);
-        auto metrics = cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics(0);
         ASSERT_EQ(metrics.disk_quota_bytes, 20 * MB);
     }
 
     {
         config::datacache_disk_idle_seconds_for_expansion = 1;
         sleep(3);
-        auto metrics = cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics(0);
         // other: 500M - 300M - 19M = 181M
         // new quota: 500 * 0.7 - other = 169M, 169M/10 * 10 = 160M
         ASSERT_EQ(metrics.disk_quota_bytes, 160 * MB);
     }
-
-    cache->shutdown();
 }
 
 TEST_F(DiskSpaceMonitorTest, auto_increase_cache_quota_with_limit) {
@@ -238,50 +224,48 @@ TEST_F(DiskSpaceMonitorTest, auto_increase_cache_quota_with_limit) {
     config::datacache_disk_size = "25%";
     DeferOp defer([]() { config::datacache_disk_size = "100%"; });
 
-    auto options = create_simple_options(kBlockSize, 0, 20 * MB);
-    auto block_cache = create_cache(options);
-    auto cache = block_cache->local_cache();
+    auto options = TestCacheUtils::create_simple_options(kBlockSize, 0, 20 * MB);
+    auto block_cache = TestCacheUtils::create_cache(options);
+    auto local_cache = block_cache->local_cache();
 
     MockFileSystem* mock_fs = new MockFileSystem;
     SpaceInfo space_info = {.capacity = 500 * MB, .free = 400 * MB, .available = 300 * MB};
     mock_fs->set_space(1, ".", space_info);
 
-    auto& space_monitor = block_cache->_disk_space_monitor;
-    space_monitor->_fs.reset(mock_fs);
-    space_monitor->init(&options.disk_spaces);
+    auto space_monitor = std::make_shared<DiskSpaceMonitor>(local_cache.get(), _mock_fs);
+    ASSERT_OK(space_monitor->init(&options.disk_spaces));
+    space_monitor->start();
 
     // Fill cache data
     {
         insert_to_cache(block_cache.get(), 19);
-        auto metrics = cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics(0);
         int64_t used_rate = metrics.disk_used_bytes * 100 / metrics.disk_quota_bytes;
         ASSERT_GT(used_rate, DiskSpace::kAutoIncreaseThreshold);
     }
 
     {
-        auto metrics = cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics(0);
         ASSERT_EQ(metrics.disk_quota_bytes, 20 * MB);
     }
 
     {
         config::datacache_auto_adjust_enable = true;
         sleep(3);
-        auto metrics = cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics(0);
         ASSERT_EQ(metrics.disk_quota_bytes, 20 * MB);
     }
 
     {
         config::datacache_disk_idle_seconds_for_expansion = 1;
         sleep(3);
-        auto metrics = cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics(0);
         // other: 500M - 300M - 19M = 181M
         // new quota: 500 * 0.7 - other = 169M, 169M/10 * 10 = 160M
         // max: 500 * 0.25 = 125M, 125M/10 * 10 = 120M
         // new quota: min(160M, 120M) = 120M
         ASSERT_EQ(metrics.disk_quota_bytes, 120 * MB);
     }
-
-    cache->shutdown();
 }
 
 TEST_F(DiskSpaceMonitorTest, auto_decrease_cache_quota) {
@@ -294,28 +278,27 @@ TEST_F(DiskSpaceMonitorTest, auto_decrease_cache_quota) {
     SCOPED_UPDATE(int64_t, config::datacache_disk_safe_level, 70);
     SCOPED_UPDATE(int64_t, config::datacache_disk_low_level, 60);
 
-    auto options = create_simple_options(kBlockSize, 0, 50 * MB);
-    auto block_cache = create_cache(options);
-    auto cache = block_cache->local_cache();
+    auto options = TestCacheUtils::create_simple_options(kBlockSize, 0, 50 * MB);
+    auto block_cache = TestCacheUtils::create_cache(options);
+    auto local_cache = block_cache->local_cache();
 
-    MockFileSystem* mock_fs = new MockFileSystem;
     SpaceInfo space_info = {.capacity = 100 * MB, .free = 20 * MB, .available = 10 * MB};
-    mock_fs->set_space(1, ".", space_info);
+    _mock_fs->set_space(1, ".", space_info);
 
-    auto& space_monitor = block_cache->_disk_space_monitor;
-    space_monitor->_fs.reset(mock_fs);
-    space_monitor->init(&options.disk_spaces);
+    auto space_monitor = std::make_shared<DiskSpaceMonitor>(local_cache.get(), _mock_fs);
+    ASSERT_OK(space_monitor->init(&options.disk_spaces));
+    space_monitor->start();
 
     // Fill cache data
     {
         insert_to_cache(block_cache.get(), 50);
-        auto metrics = cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics(0);
         int64_t used_rate = metrics.disk_used_bytes * 100 / metrics.disk_quota_bytes;
         ASSERT_GT(used_rate, DiskSpace::kAutoIncreaseThreshold);
     }
 
     {
-        auto metrics = cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics(0);
         ASSERT_EQ(metrics.disk_quota_bytes, 50 * MB);
     }
 
@@ -323,7 +306,7 @@ TEST_F(DiskSpaceMonitorTest, auto_decrease_cache_quota) {
         config::datacache_auto_adjust_enable = true;
         size_t new_quota = 0;
         for (int i = 0; i < 6; ++i) {
-            auto metrics = cache->cache_metrics(0);
+            auto metrics = local_cache->cache_metrics(0);
             if (metrics.disk_quota_bytes > 0 && metrics.disk_quota_bytes != 50 * MB) {
                 config::datacache_auto_adjust_enable = false;
                 new_quota = metrics.disk_quota_bytes;
@@ -335,8 +318,6 @@ TEST_F(DiskSpaceMonitorTest, auto_decrease_cache_quota) {
         // new quota: 100 * 0.7 - other = 30M
         ASSERT_EQ(new_quota, 30 * MB);
     }
-
-    cache->shutdown();
 }
 
 TEST_F(DiskSpaceMonitorTest, auto_decrease_cache_quota_to_zero) {
@@ -349,28 +330,27 @@ TEST_F(DiskSpaceMonitorTest, auto_decrease_cache_quota_to_zero) {
     SCOPED_UPDATE(int64_t, config::datacache_disk_safe_level, 70);
     SCOPED_UPDATE(int64_t, config::datacache_disk_low_level, 60);
 
-    auto options = create_simple_options(kBlockSize, 0, 50 * MB);
-    auto block_cache = create_cache(options);
-    auto cache = block_cache->local_cache();
+    auto options = TestCacheUtils::create_simple_options(kBlockSize, 0, 50 * MB);
+    auto block_cache = TestCacheUtils::create_cache(options);
+    auto local_cache = block_cache->local_cache();
 
-    MockFileSystem* mock_fs = new MockFileSystem;
     SpaceInfo space_info = {.capacity = 100 * MB, .free = 20 * MB, .available = 10 * MB};
-    mock_fs->set_space(1, ".", space_info);
+    _mock_fs->set_space(1, ".", space_info);
 
-    auto& space_monitor = block_cache->_disk_space_monitor;
-    space_monitor->_fs.reset(mock_fs);
-    space_monitor->init(&options.disk_spaces);
+    auto space_monitor = std::make_shared<DiskSpaceMonitor>(local_cache.get(), _mock_fs);
+    ASSERT_OK(space_monitor->init(&options.disk_spaces));
+    space_monitor->start();
 
     // Fill cache data
     {
         insert_to_cache(block_cache.get(), 50);
-        auto metrics = cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics(0);
         int64_t used_rate = metrics.disk_used_bytes * 100 / metrics.disk_quota_bytes;
         ASSERT_GT(used_rate, DiskSpace::kAutoIncreaseThreshold);
     }
 
     {
-        auto metrics = cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics(0);
         ASSERT_EQ(metrics.disk_quota_bytes, 50 * MB);
     }
 
@@ -378,7 +358,7 @@ TEST_F(DiskSpaceMonitorTest, auto_decrease_cache_quota_to_zero) {
         config::datacache_auto_adjust_enable = true;
         size_t new_quota = 0;
         for (int i = 0; i < 6; ++i) {
-            auto metrics = cache->cache_metrics(0);
+            auto metrics = local_cache->cache_metrics(0);
             if (metrics.disk_quota_bytes > 0 && metrics.disk_quota_bytes != 50 * MB) {
                 config::datacache_auto_adjust_enable = false;
                 new_quota = metrics.disk_quota_bytes;
@@ -393,34 +373,28 @@ TEST_F(DiskSpaceMonitorTest, auto_decrease_cache_quota_to_zero) {
         // Adjust to zero again
         ASSERT_EQ(new_quota, 0);
     }
-
-    cache->shutdown();
 }
 
 TEST_F(DiskSpaceMonitorTest, get_directory_capacity) {
     SCOPED_UPDATE(bool, config::datacache_enable, true);
     SCOPED_UPDATE(bool, config::datacache_auto_adjust_enable, false);
 
-    auto options = create_simple_options(kBlockSize, 0, 20 * MB);
-    auto block_cache = create_cache(options);
-    auto cache = block_cache->local_cache();
+    auto options = TestCacheUtils::create_simple_options(kBlockSize, 0, 20 * MB);
+    auto block_cache = TestCacheUtils::create_cache(options);
+    auto local_cache = block_cache->local_cache();
 
     // Fill cache data
     {
         insert_to_cache(block_cache.get(), 20);
 
         auto& disk_spaces = options.disk_spaces;
-        auto& space_monitor = block_cache->_disk_space_monitor;
+        auto space_monitor = std::make_shared<DiskSpaceMonitor>(local_cache.get());
         size_t capacity = 0;
         for (auto& space : disk_spaces) {
-            auto ret = space_monitor->_fs->directory_size(space.path);
-            ASSERT_TRUE(ret.ok());
-            capacity += ret.value();
+            ASSIGN_OR_ASSERT_FAIL(auto value, space_monitor->_fs->directory_size(space.path));
+            capacity += value;
         }
         ASSERT_EQ(capacity, 20 * MB);
     }
 }
-
-#endif
-
 } // namespace starrocks

--- a/be/test/cache/block_cache/test_cache_utils.h
+++ b/be/test/cache/block_cache/test_cache_utils.h
@@ -12,10 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#pragma once
+
 #include <fmt/format.h>
+#include <gtest/gtest.h>
 
 #include "cache/block_cache/block_cache.h"
+#include "cache/block_cache/peer_cache_wrapper.h"
+#include "cache/block_cache/starcache_wrapper.h"
 #include "common/logging.h"
+#include "testutil/assert.h"
 
 namespace starrocks {
 
@@ -23,28 +29,34 @@ constexpr size_t KB = 1024;
 constexpr size_t MB = KB * 1024;
 constexpr size_t GB = MB * 1024;
 
-CacheOptions create_simple_options(size_t block_size, size_t mem_quota, ssize_t disk_quota = -1,
-                                   const std::string& engine = "starcache") {
-    CacheOptions options;
-    options.mem_space_size = mem_quota;
-    if (disk_quota > 0) {
-        options.disk_spaces.push_back({.path = "./block_disk_cache", .size = (size_t)disk_quota});
+class TestCacheUtils {
+public:
+    static CacheOptions create_simple_options(size_t block_size, size_t mem_quota, ssize_t disk_quota = -1,
+                                              const std::string& engine = "starcache") {
+        CacheOptions options;
+        options.mem_space_size = mem_quota;
+        if (disk_quota > 0) {
+            options.disk_spaces.push_back({.path = "./block_disk_cache", .size = (size_t)disk_quota});
+        }
+        options.engine = engine;
+        options.enable_checksum = false;
+        options.max_concurrent_inserts = 1500000;
+        options.max_flying_memory_mb = 100;
+        options.enable_tiered_cache = true;
+        options.block_size = block_size;
+        options.skip_read_factor = 1.0;
+        return options;
     }
-    options.engine = engine;
-    options.enable_checksum = false;
-    options.max_concurrent_inserts = 1500000;
-    options.max_flying_memory_mb = 100;
-    options.enable_tiered_cache = true;
-    options.block_size = block_size;
-    options.skip_read_factor = 1.0;
-    return options;
-}
 
-std::shared_ptr<BlockCache> create_cache(const CacheOptions& options) {
-    std::shared_ptr<BlockCache> cache(new BlockCache);
-    Status status = cache->init(options);
-    EXPECT_TRUE(status.ok());
-    return cache;
-}
+    static std::shared_ptr<BlockCache> create_cache(const CacheOptions& options) {
+        auto local_cache = std::make_shared<StarCacheWrapper>();
+        auto remote_cache = std::make_shared<PeerCacheWrapper>();
+        auto block_cache = std::make_shared<BlockCache>();
+        EXPECT_OK(local_cache->init(options));
+        EXPECT_OK(remote_cache->init(options));
+        EXPECT_OK(block_cache->init(options, local_cache, remote_cache));
+        return block_cache;
+    }
+};
 
 } // namespace starrocks

--- a/be/test/cache/object_cache/starcache_module_test.cpp
+++ b/be/test/cache/object_cache/starcache_module_test.cpp
@@ -16,7 +16,8 @@
 
 #include <gtest/gtest.h>
 
-#include "cache/block_cache/block_cache.h"
+#include "cache/block_cache/starcache_wrapper.h"
+#include "cache/block_cache/test_cache_utils.h"
 #include "fs/fs_util.h"
 #include "testutil/assert.h"
 
@@ -26,17 +27,16 @@ protected:
     void SetUp() override {
         ASSERT_OK(fs::create_directories(cache_dir));
 
-        _init_block_cache();
-        _local_cache = _block_cache->local_cache();
+        _init_local_cache();
         _cache = std::make_shared<StarCacheModule>(_local_cache->starcache_instance());
     }
     void TearDown() override {
-        ASSERT_OK(_block_cache->shutdown());
+        ASSERT_OK(_local_cache->shutdown());
         ASSERT_OK(fs::remove_all(cache_dir));
     }
 
     static void Deleter(const CacheKey& k, void* v) { free(v); }
-    void _init_block_cache();
+    void _init_local_cache();
 
     static std::string int_to_string(size_t length, int num) {
         std::ostringstream oss;
@@ -62,26 +62,19 @@ protected:
     void insert_value(int i);
 
     std::string cache_dir = "./starcache_module_test";
-    std::shared_ptr<BlockCache> _block_cache;
-    std::shared_ptr<LocalCache> _local_cache;
+    std::shared_ptr<StarCacheWrapper> _local_cache;
     std::shared_ptr<ObjectCache> _cache;
     ObjectCacheWriteOptions _write_opt;
     size_t _value_size = 256 * 1024;
     int64_t _mem_quota = 64 * 1024 * 1024;
 };
 
-void StarCacheModuleTest::_init_block_cache() {
-    _block_cache = std::make_shared<BlockCache>();
+void StarCacheModuleTest::_init_local_cache() {
+    CacheOptions options = TestCacheUtils::create_simple_options(256 * KB, _mem_quota);
+    options.disk_spaces.push_back({.path = cache_dir, .size = 50 * MB});
 
-    CacheOptions options;
-    options.mem_space_size = _mem_quota;
-    size_t quota = 50 * 1024 * 1024;
-    options.disk_spaces.push_back({.path = cache_dir, .size = quota});
-    options.block_size = 256 * 1024;
-    options.max_concurrent_inserts = 100000;
-    options.max_flying_memory_mb = 100;
-    options.engine = "starcache";
-    ASSERT_OK(_block_cache->init(options));
+    _local_cache = std::make_shared<StarCacheWrapper>();
+    ASSERT_OK(_local_cache->init(options));
 }
 
 void StarCacheModuleTest::insert_value(int i) {

--- a/be/test/http/action/update_config_action_test.cpp
+++ b/be/test/http/action/update_config_action_test.cpp
@@ -16,7 +16,8 @@
 
 #include <gtest/gtest.h>
 
-#include "cache/block_cache/block_cache.h"
+#include "cache/block_cache/starcache_wrapper.h"
+#include "cache/block_cache/test_cache_utils.h"
 #include "fs/fs_util.h"
 #include "runtime/exec_env.h"
 #include "storage/persistent_index_load_executor.h"
@@ -31,8 +32,6 @@ class UpdateConfigActionTest : public testing::Test {
 public:
     UpdateConfigActionTest() = default;
     ~UpdateConfigActionTest() override = default;
-    static void SetUpTestSuite() {}
-    static void TearDownTestSuite() {}
 
     void SetUp() override {}
     void TearDown() override {}
@@ -43,29 +42,19 @@ TEST_F(UpdateConfigActionTest, update_datacache_disk_size) {
     const std::string cache_dir = "./block_cache_for_update_config";
     ASSERT_TRUE(fs::create_directories(cache_dir).ok());
 
-    auto cache = BlockCache::instance();
-    CacheOptions options;
-    options.mem_space_size = 0;
-    options.disk_spaces.push_back({.path = cache_dir, .size = 50 * 1024 * 1024});
-    options.max_concurrent_inserts = 100000;
-    options.block_size = 256 * 1024;
-    options.enable_checksum = false;
-    options.engine = "starcache";
-    Status st = BlockCache::instance()->init(options);
-    ASSERT_TRUE(st.ok());
-    CacheEnv::GetInstance()->set_local_cache(cache->local_cache());
+    auto cache = std::make_shared<StarCacheWrapper>();
+    CacheOptions options = TestCacheUtils::create_simple_options(256 * KB, 0);
+    options.disk_spaces.push_back({.path = cache_dir, .size = 50 * MB});
+    ASSERT_OK(cache->init(options));
+    CacheEnv::GetInstance()->set_local_cache(cache);
 
     UpdateConfigAction action(ExecEnv::GetInstance());
 
-    st = action.update_config("datacache_disk_size", "-200");
-    ASSERT_TRUE(!st.ok());
+    ASSERT_ERROR(action.update_config("datacache_disk_size", "-200"));
+    ASSERT_OK(action.update_config("datacache_disk_size", "100000000"));
 
-    st = action.update_config("datacache_disk_size", "100000000");
-    ASSERT_TRUE(st.ok());
-
-    auto local_cache = cache->local_cache();
     std::vector<DirSpace> spaces;
-    local_cache->disk_spaces(&spaces);
+    cache->disk_spaces(&spaces);
     ASSERT_EQ(spaces.size(), 1);
     ASSERT_EQ(spaces[0].size, 100000000);
 
@@ -75,8 +64,7 @@ TEST_F(UpdateConfigActionTest, update_datacache_disk_size) {
 TEST_F(UpdateConfigActionTest, test_update_pindex_load_thread_pool_num_max) {
     UpdateConfigAction action(ExecEnv::GetInstance());
 
-    auto st = action.update_config("pindex_load_thread_pool_num_max", "16");
-    CHECK_OK(st);
+    ASSERT_OK(action.update_config("pindex_load_thread_pool_num_max", "16"));
 
     auto* load_pool = StorageEngine::instance()->update_manager()->get_pindex_load_executor()->TEST_get_load_pool();
     ASSERT_EQ(16, load_pool->max_threads());

--- a/be/test/io/cache_input_stream_test.cpp
+++ b/be/test/io/cache_input_stream_test.cpp
@@ -83,9 +83,7 @@ public:
         auto block_cache = TestCacheUtils::create_cache(options);
         CacheEnv::GetInstance()->set_block_cache(block_cache);
     }
-    void TearDown() override {
-        config::datacache_auto_adjust_enable = _saved_enable_auto_adjust;
-    }
+    void TearDown() override { config::datacache_auto_adjust_enable = _saved_enable_auto_adjust; }
 
     static void read_stream_data(io::SeekableInputStream* stream, int64_t offset, int64_t size, char* data) {
         ASSERT_OK(stream->seek(offset));

--- a/be/test/io/cache_input_stream_test.cpp
+++ b/be/test/io/cache_input_stream_test.cpp
@@ -17,7 +17,10 @@
 #include <gtest/gtest.h>
 
 #include "cache/block_cache/block_cache.h"
+#include "cache/block_cache/starcache_wrapper.h"
+#include "cache/block_cache/test_cache_utils.h"
 #include "fs/fs_util.h"
+#include "runtime/exec_env.h"
 #include "testutil/assert.h"
 
 namespace starrocks::io {
@@ -50,9 +53,7 @@ private:
 
 class CacheInputStreamTest : public ::testing::Test {
 public:
-    static void SetUpTestCase() {}
-
-    CacheOptions cache_options() {
+    static CacheOptions cache_options() {
         CacheOptions options;
         options.mem_space_size = 100 * 1024 * 1024;
 #ifdef WITH_STARCACHE
@@ -77,8 +78,14 @@ public:
     void SetUp() override {
         _saved_enable_auto_adjust = config::datacache_auto_adjust_enable;
         config::datacache_auto_adjust_enable = false;
+
+        CacheOptions options = cache_options();
+        auto block_cache = TestCacheUtils::create_cache(options);
+        CacheEnv::GetInstance()->set_block_cache(block_cache);
     }
-    void TearDown() override { config::datacache_auto_adjust_enable = _saved_enable_auto_adjust; }
+    void TearDown() override {
+        config::datacache_auto_adjust_enable = _saved_enable_auto_adjust;
+    }
 
     static void read_stream_data(io::SeekableInputStream* stream, int64_t offset, int64_t size, char* data) {
         ASSERT_OK(stream->seek(offset));
@@ -112,9 +119,6 @@ private:
 const int64_t CacheInputStreamTest::block_size = 256 * 1024;
 
 TEST_F(CacheInputStreamTest, test_aligned_read) {
-    CacheOptions options = cache_options();
-    ASSERT_OK(BlockCache::instance()->init(options));
-
     const int64_t block_count = 3;
 
     int64_t data_size = block_size * block_count;
@@ -148,9 +152,6 @@ TEST_F(CacheInputStreamTest, test_aligned_read) {
 }
 
 TEST_F(CacheInputStreamTest, test_random_read) {
-    CacheOptions options = cache_options();
-    ASSERT_OK(BlockCache::instance()->init(options));
-
     const int64_t block_count = 3;
 
     const int64_t data_size = block_size * block_count;
@@ -190,9 +191,6 @@ TEST_F(CacheInputStreamTest, test_random_read) {
 }
 
 TEST_F(CacheInputStreamTest, test_file_overwrite) {
-    CacheOptions options = cache_options();
-    ASSERT_OK(BlockCache::instance()->init(options));
-
     const int64_t block_count = 3;
 
     int64_t data_size = block_size * block_count;
@@ -237,9 +235,6 @@ TEST_F(CacheInputStreamTest, test_file_overwrite) {
 }
 
 TEST_F(CacheInputStreamTest, test_read_from_io_buffer) {
-    CacheOptions options = cache_options();
-    ASSERT_OK(BlockCache::instance()->init(options));
-
     const int64_t block_count = 1;
 
     int64_t data_size = block_size * block_count;
@@ -274,9 +269,6 @@ TEST_F(CacheInputStreamTest, test_read_from_io_buffer) {
 }
 
 TEST_F(CacheInputStreamTest, test_read_zero_copy) {
-    CacheOptions options = cache_options();
-    ASSERT_OK(BlockCache::instance()->init(options));
-
     int64_t data_size = block_size + 1024;
     char data[data_size + 1];
     gen_test_data(data, data_size, block_size);
@@ -298,9 +290,6 @@ TEST_F(CacheInputStreamTest, test_read_zero_copy) {
 }
 
 TEST_F(CacheInputStreamTest, test_read_with_zero_range) {
-    CacheOptions options = cache_options();
-    ASSERT_OK(BlockCache::instance()->init(options));
-
     const int64_t block_count = 1;
     int64_t data_size = block_size * block_count;
     char data[data_size + 1];
@@ -335,7 +324,8 @@ TEST_F(CacheInputStreamTest, test_read_with_adaptor) {
     // Because the cache adaptor only work for disk cache.
     options.disk_spaces.push_back({.path = cache_dir, .size = 300 * 1024 * 1024});
     options.enable_tiered_cache = false;
-    ASSERT_OK(BlockCache::instance()->init(options));
+    auto block_cache = TestCacheUtils::create_cache(options);
+    CacheEnv::GetInstance()->set_block_cache(block_cache);
 
     const int64_t block_count = 2;
 
@@ -400,9 +390,6 @@ TEST_F(CacheInputStreamTest, test_read_with_adaptor) {
 }
 
 TEST_F(CacheInputStreamTest, test_read_with_shared_buffer) {
-    CacheOptions options = cache_options();
-    ASSERT_OK(BlockCache::instance()->init(options));
-
     const int64_t block_count = 2;
 
     int64_t data_size = block_size * block_count;
@@ -445,9 +432,6 @@ TEST_F(CacheInputStreamTest, test_read_with_shared_buffer) {
 }
 
 TEST_F(CacheInputStreamTest, test_peek) {
-    CacheOptions options = cache_options();
-    ASSERT_OK(BlockCache::instance()->init(options));
-
     const int64_t block_count = 2;
 
     int64_t data_size = block_size * block_count;
@@ -487,9 +471,6 @@ TEST_F(CacheInputStreamTest, test_peek) {
 }
 
 TEST_F(CacheInputStreamTest, test_try_peer_cache) {
-    CacheOptions options = cache_options();
-    ASSERT_OK(BlockCache::instance()->init(options));
-
     const int64_t block_count = 3;
 
     int64_t data_size = block_size * block_count;


### PR DESCRIPTION
## Why I'm doing:

`LocalCache` and `RemoteCache` is the cache engine, `BlockCache` is implemented by `LocalCache` and `RemoteCache`, so   it we should decouple the initialization of `LocalCache`, and `RemoteCache` from the initialization of `BlockCache`.

The function of the `DiskMonitor` is to adjust the disk threshold of the `LocalCache` according to the usage of disk space. Therefore, it should not rely on the `BlockCache` but be bound to the `LocalCache`.

## What I'm doing:

Decouple the initialization of `DiskMonitor`, `LocalCache`, and `RemoteCache` from the initialization of `BlockCache`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
