### PR TITLE
[BugFix] Fix multi partition column mv related bugs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -267,7 +267,7 @@ public class AlterJobMgr {
         List<Column> newColumns = createStmt.getMvColumnItems().stream()
                 .sorted(Comparator.comparing(Column::getName))
                 .collect(Collectors.toList());
-        List<Column> existedColumns = materializedView.getColumns().stream()
+        List<Column> existedColumns = materializedView.getOrderedOutputColumns().stream()
                 .sorted(Comparator.comparing(Column::getName))
                 .collect(Collectors.toList());
         if (newColumns.size() != existedColumns.size()) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -83,6 +83,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.MaterializedViewExceptions;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.NotImplementedException;
 import com.starrocks.common.StarRocksException;
@@ -168,6 +169,10 @@ public class SchemaChangeHandler extends AlterHandler {
         if (olapTable.getState() != OlapTableState.NORMAL) {
             throw new DdlException("Table[" + olapTable.getName() + "]'s is not in NORMAL state");
         }
+
+        // If optimized olap table contains related mvs, set those mv state to inactive.
+        AlterMVJobExecutor.inactiveRelatedMaterializedView(olapTable,
+                MaterializedViewExceptions.inactiveReasonForBaseTableOptimized(olapTable.getName()), false);
 
         long timeoutSecond = PropertyAnalyzer.analyzeTimeout(propertyMap, Config.alter_table_timeout_second);
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
@@ -385,7 +385,7 @@ public class ListPartitionInfo extends PartitionInfo {
         }
         sb.append("(");
         sb.append(MetaUtils.getColumnsByColumnIds(table, partitionColumnIds).stream()
-                .map(item -> "`" + item.getName() + "`")
+                .map(item -> MetaUtils.getPartitionColumnToSql(item))
                 .collect(Collectors.joining(",")));
         sb.append(")");
         if (!isAutomaticPartition) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
@@ -362,7 +362,7 @@ public class ListPartitionInfo extends PartitionInfo {
 
     @Override
     public String toSql(OlapTable table, List<Long> partitionId) {
-        return toSql(table, automaticPartition);
+        return toSql(table, automaticPartition, true);
     }
 
     /**
@@ -370,9 +370,11 @@ public class ListPartitionInfo extends PartitionInfo {
      * @param table : table
      * @param isAutomaticPartition : whether the partition type is automatic or by values. If true, only generate partition-by
      *                             columns without partition values.
+     * @param useGeneratedColumnNameAsExpr : whether to use the generated column name as the expression, if false, use the
+     *                                     generated expression sql as the expression sql rather than the column name.
      * @return : SQL statement for the list partition
      */
-    public String toSql(OlapTable table, boolean isAutomaticPartition) {
+    public String toSql(OlapTable table, boolean isAutomaticPartition, boolean useGeneratedColumnNameAsExpr) {
         String replicationNumStr = table.getTableProperty()
                 .getProperties().get(PROPERTIES_REPLICATION_NUM);
         short tableReplicationNum = replicationNumStr == null ?
@@ -385,7 +387,14 @@ public class ListPartitionInfo extends PartitionInfo {
         }
         sb.append("(");
         sb.append(MetaUtils.getColumnsByColumnIds(table, partitionColumnIds).stream()
-                .map(item -> MetaUtils.getPartitionColumnToSql(item))
+                .map(item -> {
+                    if (useGeneratedColumnNameAsExpr) {
+                        return  "`" + item.getName() + "`";
+                    } else {
+                        // if the column is generated, we need to use the expression sometimes, eg: mv's active/inactive.
+                        return MetaUtils.getPartitionColumnToSql(item);
+                    }
+                })
                 .collect(Collectors.joining(",")));
         sb.append(")");
         if (!isAutomaticPartition) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -111,7 +111,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import static com.starrocks.backup.mv.MVRestoreUpdater.checkMvDefinedQuery;
 import static com.starrocks.backup.mv.MVRestoreUpdater.restoreBaseTableInfoIfNoRestored;
@@ -1348,11 +1347,11 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         StringBuilder sb = new StringBuilder();
         sb.append("CREATE MATERIALIZED VIEW `").append(getName()).append("` (");
         List<String> colDef = Lists.newArrayList();
-        List<Integer> outputIndices =
-                CollectionUtils.isNotEmpty(queryOutputIndices) ? queryOutputIndices :
-                        IntStream.range(0, getBaseSchema().size()).boxed().collect(Collectors.toList());
-        for (int index : outputIndices) {
-            Column column = getBaseSchema().get(index);
+
+        // NOTE: only output non-generated columns
+        // use ordered columns to keep the same order as the original create statement
+        List<Column> orderedColumns = getOrderedOutputColumns();
+        for (Column column : orderedColumns) {
             StringBuilder colSb = new StringBuilder();
             // Since mv supports complex expressions as the output column, add `` to support to replay it.
             colSb.append("`" + column.getName() + "`");

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1383,7 +1383,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             // If isAutoMaticPartition is false, it may generate bad partition sql which will cause error in replay.
             if (partitionInfo instanceof ListPartitionInfo) {
                 ListPartitionInfo listPartitionInfo = (ListPartitionInfo) partitionInfo;
-                String sql = listPartitionInfo.toSql(this, true);
+                String sql = listPartitionInfo.toSql(this, true, false);
                 sb.append("\n").append(sql);
             } else {
                 sb.append("\n").append(partitionInfo.toSql(this, null));

--- a/fe/fe-core/src/main/java/com/starrocks/common/MaterializedViewExceptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/MaterializedViewExceptions.java
@@ -44,6 +44,10 @@ public class MaterializedViewExceptions {
         return "base-table swapped: " + tableName;
     }
 
+    public static String inactiveReasonForBaseTableOptimized(String tableName) {
+        return "base-table optimized: " + tableName;
+    }
+
     public static String inactiveReasonForBaseTableActive(String tableName) {
         return "base-mv inactive: " + tableName;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/HudiPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/HudiPartitionTraits.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.starrocks.connector.partitiontraits;
 
+import com.google.api.client.util.Sets;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.HudiPartitionKey;
 import com.starrocks.catalog.MaterializedView;
@@ -40,8 +41,8 @@ public class HudiPartitionTraits extends DefaultTraits {
     @Override
     public Set<String> getUpdatedPartitionNames(List<BaseTableInfo> baseTables,
                                                 MaterializedView.AsyncRefreshContext context) {
-        // TODO: implement
-        return null;
+        // TODO: Implement Hudi partition update logic, currently we just return empty set which means
+        //  no check updated partitions
+        return Sets.newHashSet();
     }
 }
-

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -587,7 +587,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             mvSessionVariable.setInsertMaxFilterRatio(Config.mv_refresh_fail_on_filter_data ? 0 : 1);
         }
         // enable profile by default for mv refresh task
-        if (!isMVPropertyContains(SessionVariable.ENABLE_PROFILE)) {
+        if (!isMVPropertyContains(SessionVariable.ENABLE_PROFILE) && !mvSessionVariable.isEnableProfile()) {
             mvSessionVariable.setEnableProfile(Config.enable_mv_refresh_collect_profile);
         }
         // set the default new_planner_optimize_timeout for mv refresh

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -1050,13 +1050,6 @@ public class MaterializedViewAnalyzer {
                     statement.setPartitionType(PartitionType.RANGE);
                     checkRangePartitionColumnLimit(mvPartitionByExprs);
                 } else if (refPartitionInfo.isListPartition()) {
-                    ListPartitionInfo listPartitionInfo = (ListPartitionInfo) refPartitionInfo;
-                    // for list partition mv, only 1:1 mapping with ref base table's partition column is supported
-                    if (listPartitionInfo.getPartitionColumnsSize() != 1) {
-                        throw new SemanticException(String.format("Materialized view with list partition column " +
-                                "must be 1:1 mapping with ref base table, but is 1(mv):%d(ref)",
-                                listPartitionInfo.getPartitionColumnsSize()));
-                    }
                     statement.setPartitionType(PartitionType.LIST);
                 }
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -905,18 +905,18 @@ public class MaterializedViewAnalyzer {
                 return changedPartitionByExprs;
             }
             // if expr is generated column expression, replace with generated column
-            OlapTable olapTable = (OlapTable) table;
-            if (!olapTable.getPartitionInfo().isListPartition() || !olapTable.hasGeneratedColumn()) {
+            OlapTable refBaseTable = (OlapTable) table;
+            if (!refBaseTable.getPartitionInfo().isListPartition() || !refBaseTable.hasGeneratedColumn()) {
                 return changedPartitionByExprs;
             }
             TableName tableName = slotRef.getTblNameWithoutAnalyzed();
             Scope scope = new Scope(RelationId.anonymous(), new RelationFields(
-                    olapTable.getBaseSchema().stream()
+                    refBaseTable.getBaseSchema().stream()
                             .map(col -> new Field(col.getName(), col.getType(), tableName, null))
                             .collect(Collectors.toList())));
             Map<Expr, Expr> generatedExprToColumnRef = new HashMap<>();
-            for (Column column : olapTable.getBaseSchema()) {
-                Expr generatedColumnExpression = column.getGeneratedColumnExpr(olapTable.getIdToColumn());
+            for (Column column : refBaseTable.getBaseSchema()) {
+                Expr generatedColumnExpression = column.getGeneratedColumnExpr(refBaseTable.getIdToColumn());
                 if (generatedColumnExpression != null) {
                     SlotRef gcSlotRef = new SlotRef(null, column.getName());
                     ExpressionAnalyzer.analyzeExpression(generatedColumnExpression, new AnalyzeState(),
@@ -927,10 +927,15 @@ public class MaterializedViewAnalyzer {
             }
             for (int i = 0; i < partitionByExprs.size(); i++) {
                 Expr expr = partitionByExprs.get(i);
-                Expr newExpr = substituteExprByGeneratedColumn(session, scope, expr, generatedExprToColumnRef);
-                // record the ith partition expr and its resolved expr
-                if (!expr.equals(newExpr)) {
-                    changedPartitionByExprs.put(i, newExpr);
+                try {
+                    Expr newExpr = substituteExprByGeneratedColumn(session, scope, expr, generatedExprToColumnRef);
+                    // record the ith partition expr and its resolved expr
+                    if (!expr.equals(newExpr)) {
+                        changedPartitionByExprs.put(i, newExpr);
+                    }
+                } catch (Exception e) {
+                    throw new SemanticException("Please check the partition expression %s, " +
+                            "it should refer base table's partition column directly", expr.toSql());
                 }
             }
             return changedPartitionByExprs;
@@ -1045,6 +1050,13 @@ public class MaterializedViewAnalyzer {
                     statement.setPartitionType(PartitionType.RANGE);
                     checkRangePartitionColumnLimit(mvPartitionByExprs);
                 } else if (refPartitionInfo.isListPartition()) {
+                    ListPartitionInfo listPartitionInfo = (ListPartitionInfo) refPartitionInfo;
+                    // for list partition mv, only 1:1 mapping with ref base table's partition column is supported
+                    if (listPartitionInfo.getPartitionColumnsSize() != 1) {
+                        throw new SemanticException(String.format("Materialized view with list partition column " +
+                                "must be 1:1 mapping with ref base table, but is 1(mv):%d(ref)",
+                                listPartitionInfo.getPartitionColumnsSize()));
+                    }
                     statement.setPartitionType(PartitionType.LIST);
                 }
             } else {
@@ -1749,12 +1761,12 @@ public class MaterializedViewAnalyzer {
         } else {
             return partitionByExpr;
         }
-        if (adjustedPartitionByExpr.equals(partitionByExpr)) {
-            return adjustedPartitionByExpr;
+        if (adjustedPartitionByExpr == null) {
+            return partitionByExpr;
         }
         ExpressionAnalyzer.analyzeExpression(adjustedPartitionByExpr, new AnalyzeState(), new Scope(RelationId.anonymous(),
                         new RelationFields(mvColumns.stream().map(col -> new Field(col.getName(),
-                                col.getType(), mvTableName, null)).collect(Collectors.toList()))),
+                                col.getType(), null, null)).collect(Collectors.toList()))),
                 ConnectContext.buildInner());
         // update partitionByExprToAdjustExprMap
         recordPartitionByExprToAdjustExprMap(mvColumns, mvTableName, originalPartitionByExpr, adjustedPartitionByExpr,
@@ -1806,7 +1818,8 @@ public class MaterializedViewAnalyzer {
         slotRef.setNullable(mvPartitionColumn.isAllowNull());
         slotRef.setType(mvPartitionColumn.getType());
         slotRef.setColumnName(mvPartitionColumn.getName());
-        slotRef.setTblName(mvTableName);
+        // set it to null to avoid the slot ref referring to the original base table
+        slotRef.setTblName(null);
     }
 
     public static Map<Expr, Expr> getMVPartitionByExprToAdjustMap(TableName mvTableName,
@@ -1903,7 +1916,7 @@ public class MaterializedViewAnalyzer {
                                                      SlotRef slotRef,
                                                      int zoneHourOffset) {
         if (zoneHourOffset == 0) {
-            return partitionByExpr;
+            return null;
         }
         // date_trunc('day', dt) -> date_trunc('day', date_sub(dt, interval 8 hour))
         {
@@ -1942,7 +1955,7 @@ public class MaterializedViewAnalyzer {
                                                        SlotRef slotRef, IcebergTable icebergTable,
                                                        Expr partitionByExpr) {
         if (!MvUtils.isFuncCallExpr(partitionByExpr, FunctionSet.DATE_TRUNC)) {
-            return partitionByExpr;
+            return null;
         }
         // why resolve slot ref to mv columns?
         // generated column should refer mv's defined column, but partitionByExpr is ref to base table's column,
@@ -1968,7 +1981,7 @@ public class MaterializedViewAnalyzer {
             resolveRefToMVColumns(mvColumns, slotRef, mvTableName);
             return partitionByExpr;
         }
-        return partitionByExpr;
+        return null;
     }
 
     public static Optional<Expr> analyzeMVRetentionCondition(ConnectContext connectContext,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
@@ -283,4 +283,12 @@ public class MetaUtils {
         }
         return columnIds;
     }
+
+    public static String getPartitionColumnToSql(Column column) {
+        if (column.isGeneratedColumn()) {
+            return column.generatedColumnExprToString();
+        } else {
+            return "`" + column.getName() + "`";
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
@@ -25,14 +25,13 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.TimeUtils;
-import com.starrocks.qe.ConnectContext;
 import com.starrocks.scheduler.MVActiveChecker;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AlterMaterializedViewStmt;
 import com.starrocks.sql.ast.RefreshSchemeClause;
-import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
 import org.junit.Before;
@@ -46,12 +45,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase.executeInsertSql;
-
-public class AlterMaterializedViewTest {
-    private static ConnectContext connectContext;
-    private static StarRocksAssert starRocksAssert;
-
+public class AlterMaterializedViewTest extends MVTestBase  {
     private static GlobalStateMgr currentState;
 
     @BeforeClass
@@ -72,6 +66,7 @@ public class AlterMaterializedViewTest {
 
     @Before
     public void before() {
+        super.before();
         connectContext.setThreadLocalInfo();
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -5497,4 +5497,115 @@ public class CreateMaterializedViewTest extends MVTestBase {
         }
         starRocksAssert.dropTable("list_partition_tbl1");
     }
+
+    @Test
+    public void testCreateMaterializedViewOnMultiPartitionColumns1() throws Exception {
+        String createSQL = "CREATE TABLE test.list_partition_tbl1 (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt datetime,\n" +
+                "      province VARCHAR(64) not null\n" +
+                ")\n" +
+                "ENGINE=olap\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY province, date_trunc('day', dt) \n" +
+                "DISTRIBUTED BY HASH(id) BUCKETS 10\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\"\n" +
+                ")";
+        starRocksAssert.withTable(createSQL);
+
+        String sql = "create materialized view list_partition_mv1 " +
+                "PARTITION BY (pr1, date_trunc('day', dt1)) \n" +
+                "distributed by hash(dt, province) buckets 10 " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"" +
+                ") " +
+                "as select dt as dt1, province as pr1, avg(age) from list_partition_tbl1 group by dt, province;";
+        try {
+            starRocksAssert.withMaterializedView(sql);
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Please check the partition expression pr1, " +
+                    "it should refer base table's partition column directly."));
+        }
+        starRocksAssert.dropTable("list_partition_tbl1");
+    }
+
+    @Test
+    public void testCreateMaterializedViewOnMultiPartitionColumns2() throws Exception {
+        String createSQL = "CREATE TABLE test.list_partition_tbl1 (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt datetime,\n" +
+                "      province VARCHAR(64) not null\n" +
+                ")\n" +
+                "ENGINE=olap\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY province, date_trunc('day', dt) \n" +
+                "DISTRIBUTED BY HASH(id) BUCKETS 10\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\"\n" +
+                ")";
+        starRocksAssert.withTable(createSQL);
+
+        String sql = "create materialized view list_partition_mv1 " +
+                "PARTITION BY (date_trunc('day', dt)) \n" +
+                "distributed by hash(dt, province) buckets 10 " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"" +
+                ") " +
+                "as select dt as dt, province , avg(age) from list_partition_tbl1 group by dt, province;";
+        try {
+            starRocksAssert.withMaterializedView(sql);
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Materialized view with list partition column must be 1:1 " +
+                    "mapping with ref base table, but is 1(mv):2(ref)."));
+        }
+        starRocksAssert.dropTable("list_partition_tbl1");
+    }
+
+    @Test
+    public void testCreateMaterializedViewOnMultiPartitionColumnsActive1() throws Exception {
+        String createSQL = "CREATE TABLE test.list_partition_tbl1 (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt datetime,\n" +
+                "      province VARCHAR(64) not null\n" +
+                ")\n" +
+                "ENGINE=olap\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY province, date_trunc('day', dt) \n" +
+                "DISTRIBUTED BY HASH(id) BUCKETS 10\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\"\n" +
+                ")";
+        starRocksAssert.withTable(createSQL);
+
+        String sql = "create materialized view list_partition_mv1 " +
+                "PARTITION BY (province, date_trunc('day', dt)) \n" +
+                "distributed by hash(dt, province) buckets 10 " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"" +
+                ") " +
+                "as select dt, province, avg(age) from list_partition_tbl1 group by dt, province;";
+        starRocksAssert.withMaterializedView(sql);
+        MaterializedView mv = (MaterializedView) starRocksAssert.getTable("test", "list_partition_mv1");
+
+        String result = mv.getMaterializedViewDdlStmt(false, false);
+        System.out.println(result);
+
+        sql = "alter materialized view list_partition_mv1 inactive";
+        starRocksAssert.alterMvProperties(sql);
+
+        sql = "alter materialized view list_partition_mv1 active";
+        starRocksAssert.alterMvProperties(sql);
+
+        mv = (MaterializedView) starRocksAssert.getTable("test", "list_partition_mv1");
+        String result2 = mv.getMaterializedViewDdlStmt(false, false);
+        Assert.assertTrue(result2.equals(result));
+
+        starRocksAssert.dropTable("list_partition_tbl1");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -5558,10 +5558,8 @@ public class CreateMaterializedViewTest extends MVTestBase {
                 "as select dt as dt, province , avg(age) from list_partition_tbl1 group by dt, province;";
         try {
             starRocksAssert.withMaterializedView(sql);
-            Assert.fail();
         } catch (Exception e) {
-            Assert.assertTrue(e.getMessage().contains("Materialized view with list partition column must be 1:1 " +
-                    "mapping with ref base table, but is 1(mv):2(ref)."));
+            Assert.fail();
         }
         starRocksAssert.dropTable("list_partition_tbl1");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ListPartitionInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ListPartitionInfoTest.java
@@ -241,9 +241,9 @@ public class ListPartitionInfoTest {
     }
 
     @Test
-    public void testToSqlWithAutomaticPartition() {
+    public void testToSqlWithAutomaticPartition1() {
         {
-            String sql = this.listPartitionInfo.toSql(this.findTableForSingleListPartition(), false);
+            String sql = this.listPartitionInfo.toSql(this.findTableForSingleListPartition(), false, true);
             String target = "PARTITION BY LIST(`province`)(\n" +
                     "  PARTITION p1 VALUES IN (\'guangdong\', \'tianjin\'),\n" +
                     "  PARTITION p2 VALUES IN (\'shanghai\', \'beijing\')\n" +
@@ -251,7 +251,24 @@ public class ListPartitionInfoTest {
             Assert.assertEquals(sql, target);
         }
         {
-            String sql = this.listPartitionInfo.toSql(this.findTableForSingleListPartition(), true);
+            String sql = this.listPartitionInfo.toSql(this.findTableForSingleListPartition(), true, true);
+            String target = "PARTITION BY (`province`)";
+            Assert.assertEquals(sql, target);
+        }
+    }
+
+    @Test
+    public void testToSqlWithAutomaticPartition2() {
+        {
+            String sql = this.listPartitionInfo.toSql(this.findTableForSingleListPartition(), false, false);
+            String target = "PARTITION BY LIST(`province`)(\n" +
+                    "  PARTITION p1 VALUES IN (\'guangdong\', \'tianjin\'),\n" +
+                    "  PARTITION p2 VALUES IN (\'shanghai\', \'beijing\')\n" +
+                    ")";
+            Assert.assertEquals(sql, target);
+        }
+        {
+            String sql = this.listPartitionInfo.toSql(this.findTableForSingleListPartition(), true, false);
             String target = "PARTITION BY (`province`)";
             Assert.assertEquals(sql, target);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -285,6 +285,10 @@ public class ShowExecutorTest {
                 minTimes = 0;
                 result = Lists.newArrayList(column1, column2);
 
+                mv.getOrderedOutputColumns();
+                minTimes = 0;
+                result = Lists.newArrayList(column1, column2);
+
                 mv.getType();
                 minTimes = 0;
                 result = TableType.MATERIALIZED_VIEW;

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksTestBase.java
@@ -51,7 +51,11 @@ public abstract class StarRocksTestBase {
     @After
     public void after() throws Exception {
         if (starRocksAssert != null) {
-            cleanup(starRocksAssert, existedTables);
+            try {
+                cleanup(starRocksAssert, existedTables);
+            } catch (Exception e) {
+                // ignore exception
+            }
         }
     }
 

--- a/test/sql/test_materialized_view/R/test_mv_with_multi_partition_columns_active
+++ b/test/sql/test_materialized_view/R/test_mv_with_multi_partition_columns_active
@@ -1,0 +1,56 @@
+-- name: test_mv_with_multi_partition_columns_active 
+CREATE TABLE t1 (
+    k1 int,
+    k2 date,
+    k3 string
+)
+DUPLICATE KEY(k1)
+PARTITION BY date_trunc("day", k2), k3;
+-- result:
+-- !result
+INSERT INTO t1 VALUES (1,'2020-06-02','BJ'),(3,'2020-06-02','SZ'),(2,'2020-07-02','SH');
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv1
+partition by (date_trunc("day", k2), k3)
+REFRESH MANUAL
+AS select sum(k1), k2, k3 from t1 group by k2, k3;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv1 with sync mode;
+function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv1")
+-- result:
+True
+-- !result
+select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;
+-- result:
+2020-06-02	BJ	1
+2020-06-02	SZ	3
+2020-07-02	SH	2
+-- !result
+ALTER MATERIALIZED VIEW mv1 INACTIVE;
+-- result:
+-- !result
+function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv1")
+-- result:
+False
+-- !result
+select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;
+-- result:
+2020-06-02	BJ	1
+2020-06-02	SZ	3
+2020-07-02	SH	2
+-- !result
+ALTER MATERIALIZED VIEW mv1 ACTIVE;
+-- result:
+-- !result
+function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv1")
+-- result:
+True
+-- !result
+select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;
+-- result:
+2020-06-02	BJ	1
+2020-06-02	SZ	3
+2020-07-02	SH	2
+-- !result

--- a/test/sql/test_materialized_view/R/test_mv_with_multi_partition_columns_basic
+++ b/test/sql/test_materialized_view/R/test_mv_with_multi_partition_columns_basic
@@ -16,5 +16,15 @@ partition by (date_trunc("day", k2))
 REFRESH MANUAL
 AS select sum(k1), k2, k3 from t1 group by k2, k3;
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Materialized view with list partition column must be 1:1 mapping with ref base table, but is 1(mv):2(ref).')
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("select sum(k1), k2, k3 from t1 group by k2, k3;", "test_mv1")
+-- result:
+True
+-- !result
+select sum(k1), k2, k3 from t1 group by k2, k3;
+-- result:
+1	2020-06-02	BJ
+3	2020-06-02	SZ
+2	2020-07-02	SH
 -- !result

--- a/test/sql/test_materialized_view/R/test_mv_with_multi_partition_columns_basic
+++ b/test/sql/test_materialized_view/R/test_mv_with_multi_partition_columns_basic
@@ -1,0 +1,20 @@
+-- name: test_mv_with_multi_partition_columns_basic 
+CREATE TABLE t1 (
+    k1 int,
+    k2 date,
+    k3 string
+)
+DUPLICATE KEY(k1)
+PARTITION BY date_trunc("day", k2), k3;
+-- result:
+-- !result
+INSERT INTO t1 VALUES (1,'2020-06-02','BJ'),(3,'2020-06-02','SZ'),(2,'2020-07-02','SH');
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1
+partition by (date_trunc("day", k2))
+REFRESH MANUAL
+AS select sum(k1), k2, k3 from t1 group by k2, k3;
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Materialized view with list partition column must be 1:1 mapping with ref base table, but is 1(mv):2(ref).')
+-- !result

--- a/test/sql/test_materialized_view/R/test_mv_with_multi_partition_columns_optimize
+++ b/test/sql/test_materialized_view/R/test_mv_with_multi_partition_columns_optimize
@@ -1,0 +1,47 @@
+-- name: test_mv_with_multi_partition_columns_optimize 
+CREATE TABLE t1 (
+    k1 int,
+    k2 date,
+    k3 string
+)
+DUPLICATE KEY(k1)
+PARTITION BY date_trunc("day", k2);
+-- result:
+-- !result
+INSERT INTO t1 VALUES (1,'2020-06-02','BJ'),(3,'2020-06-02','SZ'),(2,'2020-07-02','SH');
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv1
+partition by (date_trunc("day", k2))
+REFRESH MANUAL
+AS select sum(k1), k2, k3 from t1 group by k2, k3;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv1 with sync mode;
+function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv1")
+-- result:
+True
+-- !result
+select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;
+-- result:
+2020-06-02	BJ	1
+2020-06-02	SZ	3
+2020-07-02	SH	2
+-- !result
+alter table t1 partition by date_trunc("month", k2);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+
+-- !result
+function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv1")
+-- result:
+False
+-- !result
+select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;
+-- result:
+2020-06-02	BJ	1
+2020-06-02	SZ	3
+2020-07-02	SH	2
+-- !result

--- a/test/sql/test_materialized_view/R/test_mv_with_multi_partition_columns_rename
+++ b/test/sql/test_materialized_view/R/test_mv_with_multi_partition_columns_rename
@@ -1,0 +1,53 @@
+-- name: test_mv_with_multi_partition_columns_rename 
+CREATE TABLE t1 (
+    k1 int,
+    k2 date,
+    k3 string
+)
+DUPLICATE KEY(k1)
+PARTITION BY date_trunc("day", k2), k3;
+-- result:
+-- !result
+INSERT INTO t1 VALUES (1,'2020-06-02','BJ'),(3,'2020-06-02','SZ'),(2,'2020-07-02','SH');
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv1
+partition by (date_trunc("day", k2), k3)
+REFRESH MANUAL
+AS select sum(k1), k2, k3 from t1 group by k2, k3;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv1 with sync mode;
+function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv1")
+-- result:
+True
+-- !result
+select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;
+-- result:
+2020-06-02	BJ	1
+2020-06-02	SZ	3
+2020-07-02	SH	2
+-- !result
+ALTER MATERIALIZED VIEW mv1 rename mv2;
+-- result:
+-- !result
+function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv2")
+-- result:
+True
+-- !result
+select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;
+-- result:
+2020-06-02	BJ	1
+2020-06-02	SZ	3
+2020-07-02	SH	2
+-- !result
+select * from mv2 order by 1,2;
+-- result:
+1	2020-06-02	BJ
+2	2020-07-02	SH
+3	2020-06-02	SZ
+-- !result

--- a/test/sql/test_materialized_view/R/test_mv_with_multi_partition_columns_swap
+++ b/test/sql/test_materialized_view/R/test_mv_with_multi_partition_columns_swap
@@ -1,0 +1,70 @@
+-- name: test_mv_with_multi_partition_columns_swap 
+CREATE TABLE t1 (
+    k1 int,
+    k2 date,
+    k3 string
+)
+DUPLICATE KEY(k1)
+PARTITION BY date_trunc("day", k2), k3;
+-- result:
+-- !result
+INSERT INTO t1 VALUES (1,'2020-06-02','BJ'),(3,'2020-06-02','SZ'),(2,'2020-07-02','SH');
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv1
+                partition by (date_trunc("day", k2), k3)
+                REFRESH MANUAL
+                AS select sum(k1), k2, k3 from t1 group by k2, k3;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv1 with sync mode;
+function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv1")
+-- result:
+True
+-- !result
+select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;
+-- result:
+2020-06-02	BJ	1
+2020-06-02	SZ	3
+2020-07-02	SH	2
+-- !result
+CREATE MATERIALIZED VIEW mv2
+                partition by (date_trunc("day", k2), k3)
+                REFRESH MANUAL
+                AS select avg(k1), k2, k3 from t1 group by k2, k3;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv2 with sync mode;
+function: print_hit_materialized_view("select k2, k3, avg(k1) from t1 group by k2, k3 order by 1,2;", "mv2")
+-- result:
+True
+-- !result
+select k2, k3, avg(k1) from t1 group by k2, k3 order by 1,2;
+-- result:
+2020-06-02	BJ	1.0
+2020-06-02	SZ	3.0
+2020-07-02	SH	2.0
+-- !result
+ALTER MATERIALIZED VIEW mv1 SWAP WITH mv2;
+-- result:
+-- !result
+function: print_hit_materialized_view("select k2, k3, avg(k1) from t1 group by k2, k3 order by 1,2;", "mv1")
+-- result:
+True
+-- !result
+select k2, k3, avg(k1) from t1 group by k2, k3 order by 1,2;
+-- result:
+2020-06-02	BJ	1.0
+2020-06-02	SZ	3.0
+2020-07-02	SH	2.0
+-- !result
+function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv2")
+-- result:
+True
+-- !result
+select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;
+-- result:
+2020-06-02	BJ	1
+2020-06-02	SZ	3
+2020-07-02	SH	2
+-- !result

--- a/test/sql/test_materialized_view/T/test_mv_with_multi_partition_columns_active
+++ b/test/sql/test_materialized_view/T/test_mv_with_multi_partition_columns_active
@@ -1,0 +1,30 @@
+-- name: test_mv_with_multi_partition_columns_active 
+CREATE TABLE t1 (
+    k1 int,
+    k2 date,
+    k3 string
+)
+DUPLICATE KEY(k1)
+PARTITION BY date_trunc("day", k2), k3;
+
+INSERT INTO t1 VALUES (1,'2020-06-02','BJ'),(3,'2020-06-02','SZ'),(2,'2020-07-02','SH');
+
+CREATE MATERIALIZED VIEW mv1
+partition by (date_trunc("day", k2), k3)
+REFRESH MANUAL
+AS select sum(k1), k2, k3 from t1 group by k2, k3;
+
+REFRESH MATERIALIZED VIEW mv1 with sync mode;
+
+function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv1")
+select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;
+
+ALTER MATERIALIZED VIEW mv1 INACTIVE;
+
+function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv1")
+select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;
+
+ALTER MATERIALIZED VIEW mv1 ACTIVE;
+
+function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv1")
+select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;

--- a/test/sql/test_materialized_view/T/test_mv_with_multi_partition_columns_basic
+++ b/test/sql/test_materialized_view/T/test_mv_with_multi_partition_columns_basic
@@ -1,0 +1,16 @@
+-- name: test_mv_with_multi_partition_columns_basic 
+CREATE TABLE t1 (
+    k1 int,
+    k2 date,
+    k3 string
+)
+DUPLICATE KEY(k1)
+PARTITION BY date_trunc("day", k2), k3;
+
+INSERT INTO t1 VALUES (1,'2020-06-02','BJ'),(3,'2020-06-02','SZ'),(2,'2020-07-02','SH');
+
+-- Create Fail: mv's partition columns are not the same as table's partition columns
+CREATE MATERIALIZED VIEW test_mv1
+partition by (date_trunc("day", k2))
+REFRESH MANUAL
+AS select sum(k1), k2, k3 from t1 group by k2, k3;

--- a/test/sql/test_materialized_view/T/test_mv_with_multi_partition_columns_basic
+++ b/test/sql/test_materialized_view/T/test_mv_with_multi_partition_columns_basic
@@ -14,3 +14,8 @@ CREATE MATERIALIZED VIEW test_mv1
 partition by (date_trunc("day", k2))
 REFRESH MANUAL
 AS select sum(k1), k2, k3 from t1 group by k2, k3;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: print_hit_materialized_view("select sum(k1), k2, k3 from t1 group by k2, k3;", "test_mv1")
+select sum(k1), k2, k3 from t1 group by k2, k3;

--- a/test/sql/test_materialized_view/T/test_mv_with_multi_partition_columns_optimize
+++ b/test/sql/test_materialized_view/T/test_mv_with_multi_partition_columns_optimize
@@ -1,0 +1,26 @@
+-- name: test_mv_with_multi_partition_columns_optimize 
+
+CREATE TABLE t1 (
+    k1 int,
+    k2 date,
+    k3 string
+)
+DUPLICATE KEY(k1)
+PARTITION BY date_trunc("day", k2);
+
+INSERT INTO t1 VALUES (1,'2020-06-02','BJ'),(3,'2020-06-02','SZ'),(2,'2020-07-02','SH');
+
+CREATE MATERIALIZED VIEW mv1
+partition by (date_trunc("day", k2))
+REFRESH MANUAL
+AS select sum(k1), k2, k3 from t1 group by k2, k3;
+REFRESH MATERIALIZED VIEW mv1 with sync mode;
+
+function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv1")
+select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;
+
+alter table t1 partition by date_trunc("month", k2);
+function: wait_alter_table_finish()
+
+function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv1")
+select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;

--- a/test/sql/test_materialized_view/T/test_mv_with_multi_partition_columns_rename
+++ b/test/sql/test_materialized_view/T/test_mv_with_multi_partition_columns_rename
@@ -1,0 +1,28 @@
+-- name: test_mv_with_multi_partition_columns_rename 
+CREATE TABLE t1 (
+    k1 int,
+    k2 date,
+    k3 string
+)
+DUPLICATE KEY(k1)
+PARTITION BY date_trunc("day", k2), k3;
+
+INSERT INTO t1 VALUES (1,'2020-06-02','BJ'),(3,'2020-06-02','SZ'),(2,'2020-07-02','SH');
+
+CREATE MATERIALIZED VIEW mv1
+partition by (date_trunc("day", k2), k3)
+REFRESH MANUAL
+AS select sum(k1), k2, k3 from t1 group by k2, k3;
+REFRESH MATERIALIZED VIEW mv1 with sync mode;
+
+function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv1")
+select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;
+
+ALTER MATERIALIZED VIEW mv1 rename mv2;
+
+function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv1")
+function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv2")
+select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;
+select * from mv2 order by 1,2;
+
+

--- a/test/sql/test_materialized_view/T/test_mv_with_multi_partition_columns_swap
+++ b/test/sql/test_materialized_view/T/test_mv_with_multi_partition_columns_swap
@@ -1,0 +1,34 @@
+-- name: test_mv_with_multi_partition_columns_swap 
+
+CREATE TABLE t1 (
+    k1 int,
+    k2 date,
+    k3 string
+)
+DUPLICATE KEY(k1)
+PARTITION BY date_trunc("day", k2), k3;
+INSERT INTO t1 VALUES (1,'2020-06-02','BJ'),(3,'2020-06-02','SZ'),(2,'2020-07-02','SH');
+CREATE MATERIALIZED VIEW mv1
+                partition by (date_trunc("day", k2), k3)
+                REFRESH MANUAL
+                AS select sum(k1), k2, k3 from t1 group by k2, k3;
+REFRESH MATERIALIZED VIEW mv1 with sync mode;
+
+function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv1")
+select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;
+
+CREATE MATERIALIZED VIEW mv2
+                partition by (date_trunc("day", k2), k3)
+                REFRESH MANUAL
+                AS select avg(k1), k2, k3 from t1 group by k2, k3;
+REFRESH MATERIALIZED VIEW mv2 with sync mode;
+function: print_hit_materialized_view("select k2, k3, avg(k1) from t1 group by k2, k3 order by 1,2;", "mv2")
+select k2, k3, avg(k1) from t1 group by k2, k3 order by 1,2;
+
+ALTER MATERIALIZED VIEW mv1 SWAP WITH mv2;
+
+function: print_hit_materialized_view("select k2, k3, avg(k1) from t1 group by k2, k3 order by 1,2;", "mv1")
+select k2, k3, avg(k1) from t1 group by k2, k3 order by 1,2;
+
+function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv2")
+select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;


### PR DESCRIPTION
## Why I'm doing:
Since https://github.com/StarRocks/starrocks/issues/48354 has supported multi partition columns for mv. But I found some bugs when using it:
1. `inactive`/`active` /`rename`/`swap` MV with multi partition columns will fail because of the related `generated` columns.
2. MV cannot be refreshed after `Optimize` base table.
3. MV with mutli partition columns for hudi catalog cannot be used rewritten;


## What I'm doing:
#### Problem 1

Use `getPartitionColumnToSql` to generate sql: use generated column's defined sql instead of geneated column name as partition defined expression rather than generated column, otherwise `active/inactive` will fail.


#### Problem 2

If optimized olap table contains related mvs, set those mvs state to inactive since base table's partition struct has been changed.

### Problem 3
Return empty partitions for `getUpdatedPartitionNames` with hudi catalog to support hudi catalog's mv rewrite.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
