### PR TITLE
[Enhancement] Support materialized view concurrent prepare

### DIFF
--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -4841,6 +4841,17 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 -->
 
 <!--
+##### enable_materialized_view_concurrent_prepare
+
+- Default: true
+- Type: Boolean
+- Unit:
+- Is mutable: Yes
+- Description: Prepare materialized view concurrently to improve performance
+- Introduced in: v3.4.4
+-->
+
+<!--
 ##### mv_query_context_cache_max_size
 
 - Default: 1000

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3357,6 +3357,9 @@ public class Config extends ConfigBase {
             "materialized views(>10) or query is complex(multi table joins).")
     public static long mv_query_context_cache_max_size = 1000;
 
+    @ConfField(mutable = true)
+    public static boolean enable_materialized_view_concurrent_prepare = true;
+
     /**
      * Checking the connectivity of port opened by FE,
      * mainly used for checking edit log port currently.

--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
@@ -196,6 +196,13 @@ public class Tracers {
         tracers.tracer(module, Mode.LOGS).log(func, args);
     }
 
+    // lazy log, use it if you want to avoid construct log string when log is disabled
+    public static void log(Tracers tracers, Module module, Function<Object[], String> func, Object... args) {
+        synchronized (tracers) {
+            tracers.tracer(module, Mode.LOGS).log(func, args);
+        }
+    }
+
     public static void log(String log, Object... args) {
         Tracers tracers = THREAD_LOCAL.get();
         tracers.tracer(Module.BASE, Mode.TIMER).log(log, args);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -670,6 +670,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_MATERIALIZED_VIEW_PLAN_CACHE = "enable_materialized_view_plan_cache";
 
+    public static final String ENABLE_MATERIALIZED_VIEW_CONCURRENT_PREPARE =
+            "enable_materialized_view_concurrent_prepare";
+
     public static final String ENABLE_VIEW_BASED_MV_REWRITE = "enable_view_based_mv_rewrite";
 
     public static final String ENABLE_CBO_VIEW_BASED_MV_REWRITE = "enable_cbo_view_based_mv_rewrite";
@@ -2180,6 +2183,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // whether to use materialized view plan context cache to reduce mv rewrite time cost
     @VarAttr(name = ENABLE_MATERIALIZED_VIEW_PLAN_CACHE, flag = VariableMgr.INVISIBLE)
     private boolean enableMaterializedViewPlanCache = true;
+
+    // whether to use materialized view concurrent prepare to reduce mv rewrite time cost
+    @VarAttr(name = ENABLE_MATERIALIZED_VIEW_CONCURRENT_PREPARE)
+    private boolean enableMaterializedViewConcurrentPrepare = true;
 
     @VarAttr(name = ENABLE_VIEW_BASED_MV_REWRITE)
     private boolean enableViewBasedMvRewrite = true;
@@ -4235,6 +4242,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableMaterializedViewPlanCache() {
         return this.enableMaterializedViewPlanCache;
+    }
+
+    public void setEnableMaterializedViewConcurrentPrepare(boolean enableMaterializedViewConcurrentPrepare) {
+        this.enableMaterializedViewConcurrentPrepare = enableMaterializedViewConcurrentPrepare;
+    }
+
+    public boolean isEnableMaterializedViewConcurrentPrepare() {
+        return enableMaterializedViewConcurrentPrepare;
     }
 
     public void setEnableViewBasedMvRewrite(boolean enableViewBasedMvRewrite) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -46,6 +46,7 @@ import com.starrocks.catalog.mv.MVPlanValidationResult;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
+import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.util.DebugUtil;
@@ -98,7 +99,7 @@ public class MvRewritePreprocessor {
     private static final Logger LOG = LogManager.getLogger(MvRewritePreprocessor.class);
 
     private static final Executor MV_PREPARE_EXECUTOR = Executors.newFixedThreadPool(
-            Runtime.getRuntime().availableProcessors(),
+            ThreadPoolManager.cpuIntensiveThreadPoolSize(),
             new ThreadFactoryBuilder().setDaemon(true).setNameFormat("mv-prepare-%d").build());
 
     private final ConnectContext connectContext;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
@@ -44,6 +45,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.mv.MVPlanValidationResult;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
+import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.util.DebugUtil;
@@ -83,12 +85,22 @@ import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
+import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVPrepare;
 
 public class MvRewritePreprocessor {
     private static final Logger LOG = LogManager.getLogger(MvRewritePreprocessor.class);
+
+    private static final Executor MV_PREPARE_EXECUTOR = Executors.newFixedThreadPool(
+            Runtime.getRuntime().availableProcessors(),
+            new ThreadFactoryBuilder().setDaemon(true).setNameFormat("mv-prepare-%d").build());
+
     private final ConnectContext connectContext;
     private final ColumnRefFactory queryColumnRefFactory;
     private final OptimizerContext context;
@@ -661,9 +673,10 @@ public class MvRewritePreprocessor {
             return;
         }
 
+        List<Pair<MaterializedViewWrapper, MvUpdateInfo>> mvInfos =
+                Lists.newArrayListWithExpectedSize(mvWithPlanContexts.size());
         for (MaterializedViewWrapper wrapper : mvWithPlanContexts) {
             MaterializedView mv = wrapper.getMV();
-            MvPlanContext mvPlanContext = wrapper.getMvPlanContext();
             try {
                 // mv's partitions to refresh
                 MvUpdateInfo mvUpdateInfo = queryMaterializationContext.getOrInitMVTimelinessInfos(mv);
@@ -671,25 +684,28 @@ public class MvRewritePreprocessor {
                     OptimizerTraceUtil.logMVRewriteFailReason(mv.getName(), "stale partitions {}", mvUpdateInfo);
                     continue;
                 }
-                Set<String> partitionNamesToRefresh = mvUpdateInfo.getMvToRefreshPartitionNames();
-                if (!checkMvPartitionNamesToRefresh(connectContext, mv, partitionNamesToRefresh, mvPlanContext)) {
-                    continue;
-                }
-                logMVPrepare(mv, "MV' partitions to refresh: {}/{}", partitionNamesToRefresh.size(),
-                        MvUtils.shrinkToSize(partitionNamesToRefresh, Config.max_mv_task_run_meta_message_values_length));
-
-                MaterializationContext materializationContext = buildMaterializationContext(context, mv, mvPlanContext,
-                        mvUpdateInfo, queryTables, wrapper.getLevel());
-                if (materializationContext == null) {
-                    continue;
-                }
-                queryMaterializationContext.addValidCandidateMV(materializationContext);
-                logMVPrepare(connectContext, mv, "Prepare MV {} success", mv.getName());
+                mvInfos.add(Pair.create(wrapper, mvUpdateInfo));
             } catch (Exception e) {
                 List<String> tableNames = queryTables.stream().map(Table::getName).collect(Collectors.toList());
                 logMVPrepare(connectContext, "Preprocess MV {} failed: {}", mv.getName(), DebugUtil.getStackTrace(e));
                 LOG.warn("Preprocess mv {} failed for query tables:{}", mv.getName(), tableNames, e);
             }
+        }
+        Tracers tracers = Tracers.get();
+        List<CompletableFuture<Void>> futures = Lists.newArrayListWithExpectedSize(mvWithPlanContexts.size());
+        Executor exec = Config.enable_materialized_view_concurrent_prepare &&
+                connectContext.getSessionVariable().isEnableMaterializedViewConcurrentPrepare() ? MV_PREPARE_EXECUTOR :
+                newDirectExecutorService();
+        for (Pair<MaterializedViewWrapper, MvUpdateInfo> mvInfo : mvInfos) {
+            futures.add(CompletableFuture.supplyAsync(
+                    () -> prepareMV(tracers, queryTables, mvInfo.first, mvInfo.second), exec)
+            );
+        }
+        try {
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
+        } catch (InterruptedException | ExecutionException e) {
+            LOG.warn("Preprocess mv failed", e);
+            throw new RuntimeException(e);
         }
         // all base table related mvs
         List<String> relatedMvNames = mvWithPlanContexts.stream()
@@ -701,6 +717,29 @@ public class MvRewritePreprocessor {
                 .collect(Collectors.toList());
         logMVPrepare(connectContext, "RelatedMVs: {}, CandidateMVs: {}", relatedMvNames,
                 candidateMvNames);
+    }
+
+    private Void prepareMV(Tracers tracers, Set<Table> queryTables, MaterializedViewWrapper mvWithPlanContext,
+                           MvUpdateInfo mvUpdateInfo) {
+        MaterializedView mv = mvWithPlanContext.getMV();
+        MvPlanContext mvPlanContext = mvWithPlanContext.getMvPlanContext();
+        Set<String> partitionNamesToRefresh = mvUpdateInfo.getMvToRefreshPartitionNames();
+        if (!checkMvPartitionNamesToRefresh(connectContext, mv, partitionNamesToRefresh, mvPlanContext)) {
+            return null;
+        }
+        logMVPrepare(tracers, mv, "MV' partitions to refresh: {}/{}", partitionNamesToRefresh.size(),
+                MvUtils.shrinkToSize(partitionNamesToRefresh, Config.max_mv_task_run_meta_message_values_length));
+
+        MaterializationContext materializationContext = buildMaterializationContext(context, mv, mvPlanContext,
+                mvUpdateInfo, queryTables, mvWithPlanContext.getLevel());
+        if (materializationContext == null) {
+            return null;
+        }
+        synchronized (materializationContext) {
+            queryMaterializationContext.addValidCandidateMV(materializationContext);
+        }
+        logMVPrepare(tracers, connectContext, mv, "Prepare MV {} success", mv.getName());
+        return null;
     }
 
     /**
@@ -777,7 +816,9 @@ public class MvRewritePreprocessor {
         // Add mv info into dump info
         if (context.getDumpInfo() != null) {
             String dbName = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mv.getDbId()).getFullName();
-            context.getDumpInfo().addTable(dbName, mv);
+            synchronized (context) {
+                context.getDumpInfo().addTable(dbName, mv);
+            }
         }
 
         List<Table> baseTables = MvUtils.getAllTables(mvPlan);
@@ -792,8 +833,11 @@ public class MvRewritePreprocessor {
                         mvPlanContext.getRefFactory(), baseTables, intersectingTables,
                         mvUpdateInfo, mvOutputColumns, level);
         // generate scan mv plan here to reuse it in rule applications
-        LogicalOlapScanOperator scanMvOp = createScanMvOperator(mv,
-                materializationContext.getQueryRefFactory(), mvUpdateInfo.getMvToRefreshPartitionNames());
+        LogicalOlapScanOperator scanMvOp;
+        synchronized (materializationContext.getQueryRefFactory()) {
+            scanMvOp = createScanMvOperator(mv, materializationContext.getQueryRefFactory(),
+                    mvUpdateInfo.getMvToRefreshPartitionNames());
+        }
         materializationContext.setScanMvOperator(scanMvOp);
         // should keep the sequence of schema
         List<ColumnRefOperator> scanMvOutputColumns = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
@@ -51,6 +51,15 @@ public class OptimizerTraceUtil {
         });
     }
 
+    public static void logMVPrepare(Tracers tracers, ConnectContext ctx, MaterializedView mv,
+                                    String format, Object... object) {
+        Tracers.log(tracers, Tracers.Module.MV, input -> {
+            String str = MessageFormatter.arrayFormat(format, object).getMessage();
+            Object[] args = new Object[] {mv == null ? "GLOBAL" : mv.getName(), str};
+            return MessageFormatter.arrayFormat("[MV TRACE] [PREPARE {}] {}", args).getMessage();
+        });
+    }
+
     public static void logMVPrepare(String format, Object... object) {
         Tracers.log(Tracers.Module.MV, input -> {
             String str = MessageFormatter.arrayFormat(format, object).getMessage();
@@ -62,6 +71,15 @@ public class OptimizerTraceUtil {
     public static void logMVPrepare(MaterializedView mv,
                                     String format, Object... object) {
         Tracers.log(Tracers.Module.MV, input -> {
+            String str = MessageFormatter.arrayFormat(format, object).getMessage();
+            Object[] args = new Object[] {mv == null ? "GLOBAL" : mv.getName(), str};
+            return MessageFormatter.arrayFormat("[MV TRACE] [PREPARE {}] {}", args).getMessage();
+        });
+    }
+
+    public static void logMVPrepare(Tracers tracers, MaterializedView mv,
+                                    String format, Object... object) {
+        Tracers.log(tracers, Tracers.Module.MV, input -> {
             String str = MessageFormatter.arrayFormat(format, object).getMessage();
             Object[] args = new Object[] {mv == null ? "GLOBAL" : mv.getName(), str};
             return MessageFormatter.arrayFormat("[MV TRACE] [PREPARE {}] {}", args).getMessage();


### PR DESCRIPTION
## Why I'm doing:
mv prepare costs more than 1 seconds where there are lots of mv, we can use threadPool to reduce time costs

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1