### PR TITLE
[BugFix] remove CVE-2025-27820 from .trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,3 +1,0 @@
-# https://avd.aquasec.com/nvd/2025/cve-2025-27820/
-# ignore it for now, tracking it in https://github.com/StarRocks/starrocks/issues/58754
-CVE-2025-27820


### PR DESCRIPTION
* should be fixed along with iceberg upgraded to 1.9.0

## Why I'm doing:

## What I'm doing:

Fixes #58754

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
