### PR TITLE
[BugFix] NodeChannel should check the error of eos rpc asap 

### DIFF
--- a/be/src/exec/tablet_sink_index_channel.h
+++ b/be/src/exec/tablet_sink_index_channel.h
@@ -175,6 +175,7 @@ private:
     Status _wait_request(ReusableClosure<PTabletWriterAddBatchResult>* closure);
     Status _wait_all_prev_request();
     Status _wait_one_prev_request();
+    Status _try_send_eos_and_process_all_response();
     bool _check_prev_request_done();
     bool _check_all_prev_request_done();
     Status _serialize_chunk(const Chunk* src, ChunkPB* dst);
@@ -193,6 +194,7 @@ private:
     bool _is_diagnose_done();
     void _wait_diagnose(RuntimeState* state);
     bool _process_diagnose_profile(RuntimeState* state, PLoadDiagnoseResult& result);
+    void _release_diagnose_closure();
 
     std::unique_ptr<MemTracker> _mem_tracker = nullptr;
 
@@ -218,6 +220,7 @@ private:
 
     // channel is closed
     bool _closed{false};
+    bool _all_response_processed{false};
 
     // data sending is finished
     bool _finished{false};

--- a/be/src/exec/tablet_sink_sender.cpp
+++ b/be/src/exec/tablet_sink_sender.cpp
@@ -283,10 +283,10 @@ bool TabletSinkSender::is_close_done() {
 Status TabletSinkSender::close_wait(RuntimeState* state, Status close_status, TabletSinkProfile* ts_profile,
                                     bool write_txn_log) {
     Status status = std::move(close_status);
+    // BE id -> add_batch method counter
+    std::unordered_map<int64_t, AddBatchCounter> node_add_batch_counter_map;
+    int64_t serialize_batch_ns = 0, actual_consume_ns = 0;
     if (status.ok()) {
-        // BE id -> add_batch method counter
-        std::unordered_map<int64_t, AddBatchCounter> node_add_batch_counter_map;
-        int64_t serialize_batch_ns = 0, actual_consume_ns = 0;
         {
             SCOPED_TIMER(ts_profile->close_timer);
             Status err_st = Status::OK();
@@ -324,31 +324,33 @@ Status TabletSinkSender::close_wait(RuntimeState* state, Status close_status, Ta
 
             status.update(_write_combined_txn_log());
         }
-
-        // only if status is ok can we call this _profile->total_time_counter().
-        // if status is not ok, this sink may not be prepared, so that _profile is null
-        SCOPED_TIMER(ts_profile->runtime_profile->total_time_counter());
-        COUNTER_SET(ts_profile->serialize_chunk_timer, serialize_batch_ns);
-        COUNTER_SET(ts_profile->send_rpc_timer, actual_consume_ns);
-
-        int64_t total_server_rpc_time_us = 0;
-        int64_t total_server_wait_memtable_flush_time_us = 0;
-        // print log of add batch time of all node, for tracing load performance easily
-        std::stringstream ss;
-        ss << "Olap table sink statistics. load_id: " << print_id(_load_id) << ", txn_id: " << _txn_id
-           << ", add chunk time(ms)/wait lock time(ms)/num: ";
-        for (auto const& pair : node_add_batch_counter_map) {
-            total_server_rpc_time_us += pair.second.add_batch_execution_time_us;
-            total_server_wait_memtable_flush_time_us += pair.second.add_batch_wait_memtable_flush_time_us;
-            ss << "{" << pair.first << ":(" << (pair.second.add_batch_execution_time_us / 1000) << ")("
-               << (pair.second.add_batch_wait_lock_time_us / 1000) << ")(" << pair.second.add_batch_num << ")} ";
-        }
-        ts_profile->server_rpc_timer->update(total_server_rpc_time_us * 1000);
-        ts_profile->server_wait_flush_timer->update(total_server_wait_memtable_flush_time_us * 1000);
-        LOG(INFO) << ss.str();
     } else {
-        for_each_index_channel([&status](NodeChannel* ch) { ch->cancel(status); });
+        for_each_index_channel(
+                [&status, &node_add_batch_counter_map, &serialize_batch_ns, &actual_consume_ns](NodeChannel* ch) {
+                    ch->cancel(status);
+                    ch->time_report(&node_add_batch_counter_map, &serialize_batch_ns, &actual_consume_ns);
+                });
     }
+
+    SCOPED_TIMER(ts_profile->runtime_profile->total_time_counter());
+    COUNTER_SET(ts_profile->serialize_chunk_timer, serialize_batch_ns);
+    COUNTER_SET(ts_profile->send_rpc_timer, actual_consume_ns);
+
+    int64_t total_server_rpc_time_us = 0;
+    int64_t total_server_wait_memtable_flush_time_us = 0;
+    // print log of add batch time of all node, for tracing load performance easily
+    std::stringstream ss;
+    ss << "Olap table sink statistics. load_id: " << print_id(_load_id) << ", txn_id: " << _txn_id
+       << ", add chunk time(ms)/wait lock time(ms)/num: ";
+    for (auto const& pair : node_add_batch_counter_map) {
+        total_server_rpc_time_us += pair.second.add_batch_execution_time_us;
+        total_server_wait_memtable_flush_time_us += pair.second.add_batch_wait_memtable_flush_time_us;
+        ss << "{" << pair.first << ":(" << (pair.second.add_batch_execution_time_us / 1000) << ")("
+           << (pair.second.add_batch_wait_lock_time_us / 1000) << ")(" << pair.second.add_batch_num << ")} ";
+    }
+    ts_profile->server_rpc_timer->update(total_server_rpc_time_us * 1000);
+    ts_profile->server_wait_flush_timer->update(total_server_wait_memtable_flush_time_us * 1000);
+    LOG(INFO) << ss.str();
 
     Expr::close(_output_expr_ctxs, state);
     if (_partition_params) {

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -440,8 +440,8 @@ void LoadChannel::diagnose(const std::string& remote_ip, const PLoadDiagnoseRequ
         if (!st.ok()) {
             result->clear_profile_data();
         }
-        VLOG(2) << "load channel diagnose profile, load_id: " << print_id(_load_id) << ", txn_id: " << _txn_id
-                << ", status: " << st;
+        LOG(INFO) << "load channel diagnose profile, load_id: " << print_id(_load_id) << ", txn_id: " << _txn_id
+                  << ", status: " << st;
     }
     if (request->has_stack_trace() && request->stack_trace()) {
         DiagnoseRequest stack_trace_request;

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -299,8 +299,8 @@ void LoadChannelMgr::load_diagnose(brpc::Controller* cntl, const PLoadDiagnoseRe
         }
     } else {
         std::string remote_ip = butil::ip2str(cntl->remote_side().ip).c_str();
-        VLOG(2) << "receive load diagnose, load_id: " << load_id << ", txn_id: " << request->txn_id()
-                << ", remote: " << remote_ip;
+        LOG(INFO) << "receive load diagnose, load_id: " << load_id << ", txn_id: " << request->txn_id()
+                  << ", remote: " << remote_ip;
         channel->diagnose(remote_ip, request, response);
     }
 }


### PR DESCRIPTION
## Why I'm doing:
The eos rpc is sent in TabletSinkSender/NodeChannel try_close, and the result is checked in TabletSinkSender/NodeChannel close_wait. When there are many channels. the close_wait is called after all eos rpcs finished (TabletSinkSender/NodeChannel is_close_done). If some rpcs finished earlier with errors, the load still waits for all other rpcs to finish, but the load should fail as soon as possible.
This is a potential cause of `Reached timeout`. Consider the following scenario
1. n1 is the coordinator BE, n2 is primary replica node, n3 is secondary replica node
2. n1 sends eos rpc to n2 and n3, and waits for both rpc to finish
3. n2 is down before sync replica to n3
    * the eos rpc from n1 to n2 should report error "Not connected"
    * n3 continues to wait for the replica sync rpc from n2
4. n1 does not check the rpc error from n2, and still waits for the eos rpc to n3 to finish, but n3 continues waiting for the replica sync from n2, so the  eos rpc from n1 to n3 reaches the timeout finally

## What I'm doing:
try_close is called multiple times when waiting eos rpcs to finish. In each time, should check whether  errors happens on those finished rpcs, and report errors asap

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
