### PR TITLE
[BugFix] Primary replica should cancel secondary replica if rpc failed

### DIFF
--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -47,6 +47,7 @@
 #include "storage/txn_manager.h"
 #include "util/brpc_stub_cache.h"
 #include "util/compression/block_compression.h"
+#include "util/disposable_closure.h"
 #include "util/failpoint/fail_point.h"
 #include "util/faststring.h"
 #include "util/starrocks_metrics.h"
@@ -336,9 +337,8 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
     });
     auto finish_wait_writer_ts = watch.elapsed_time();
 
-    // Abort tablets which primary replica already failed
-    if (response->status().status_code() != TStatusCode::OK) {
-        _abort_replica_tablets(request, response->status().error_msgs()[0], node_id_to_abort_tablets);
+    if (!node_id_to_abort_tablets.empty()) {
+        _abort_replica_tablets(request, "primary replica failed to sync data", node_id_to_abort_tablets);
     }
 
     // We need wait all secondary replica commit before we close the channel
@@ -373,7 +373,8 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
                     if (elapse_time_ms > request.timeout_ms()) {
                         LOG(INFO) << "LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(request.id())
                                   << " wait tablet " << tablet_id << " secondary replica finish timeout "
-                                  << request.timeout_ms() << "ms still in state " << state;
+                                  << request.timeout_ms() << "ms still in state " << state
+                                  << ", primary replica: " << delta_writer->replicas()[0].host();
                         timeout = true;
                         break;
                     }
@@ -381,7 +382,8 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
                     if (i % 6000 == 0) {
                         LOG(INFO) << "LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(request.id())
                                   << " wait tablet " << tablet_id << " secondary replica finish already "
-                                  << elapse_time_ms << "ms still in state " << state;
+                                  << elapse_time_ms << "ms still in state " << state
+                                  << ", primary replica: " << delta_writer->replicas()[0].host();
                     }
                 } while (true);
             }
@@ -588,15 +590,36 @@ void LocalTabletsChannel::_abort_replica_tablets(
         cancel_request.set_reason(abort_reason);
         cancel_request.set_sink_id(request.sink_id());
 
-        auto closure = new ReusableClosure<PTabletWriterCancelResult>();
-
-        closure->ref();
-        closure->cntl.set_timeout_ms(request.timeout_ms());
-
         string node_abort_tablet_id_list_str;
         JoinInts(tablet_ids, ",", &node_abort_tablet_id_list_str);
 
+        struct Context {
+            PUniqueId load_id;
+            int64_t txn_id;
+            std::string host;
+            std::string tablets;
+        };
+        auto closure = new DisposableClosure<PTabletWriterCancelResult, Context>(
+                {request.id(), _txn_id, endpoint.host(), node_abort_tablet_id_list_str});
+        closure->cntl.set_timeout_ms(request.timeout_ms());
+        SET_IGNORE_OVERCROWDED(closure->cntl, load);
+        closure->addSuccessHandler([](const Context& ctx, const PTabletWriterCancelResult& result) {
+            VLOG(2) << "Success to cancel secondary replicas, txn_id: " << ctx.txn_id
+                    << ", load_id: " << print_id(ctx.load_id) << ", replica_node: " << ctx.host
+                    << ", tablets: " << ctx.tablets;
+        });
+        closure->addFailedHandler([](const Context& ctx, std::string_view rpc_error_msg) {
+            LOG(ERROR) << "Failed to cancel secondary replicas, txn_id: " << ctx.txn_id
+                       << ", load_id: " << print_id(ctx.load_id) << ", replica_node: " << ctx.host
+                       << ", error: " << rpc_error_msg << ", tablets: " << ctx.tablets;
+        });
+
+#ifndef BE_TEST
         stub->tablet_writer_cancel(&closure->cntl, &cancel_request, &closure->result, closure);
+#else
+        std::pair<PTabletWriterCancelRequest*, google::protobuf::Closure*> rpc_pair{&cancel_request, closure};
+        TEST_SYNC_POINT_CALLBACK("LocalTabletsChannel::rpc::tablet_writer_cancel", &rpc_pair);
+#endif
 
         VLOG(2) << "LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(request.id()) << " Cancel "
                 << tablet_ids.size() << " tablets " << node_abort_tablet_id_list_str << " request to "
@@ -1021,6 +1044,11 @@ void LocalTabletsChannel::WriteCallback::run(const Status& st, const CommittedRo
             const auto replicated_tablet_infos = committed_info->replicate_token->replicated_tablet_infos();
             for (const auto& synced_tablet_info : *replicated_tablet_infos) {
                 _context->add_committed_tablet_info(synced_tablet_info.get());
+            }
+
+            auto failed_replica_node_ids = committed_info->replicate_token->failed_node_ids();
+            for (auto& node_id : failed_replica_node_ids) {
+                _context->add_failed_replica_node_id(node_id, committed_info->tablet->tablet_id());
             }
         }
     }

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -617,8 +617,9 @@ void LocalTabletsChannel::_abort_replica_tablets(
 #ifndef BE_TEST
         stub->tablet_writer_cancel(&closure->cntl, &cancel_request, &closure->result, closure);
 #else
-        std::pair<PTabletWriterCancelRequest*, google::protobuf::Closure*> rpc_pair{&cancel_request, closure};
-        TEST_SYNC_POINT_CALLBACK("LocalTabletsChannel::rpc::tablet_writer_cancel", &rpc_pair);
+        std::tuple<PTabletWriterCancelRequest*, google::protobuf::Closure*, brpc::Controller*> rpc_tuple{
+                &cancel_request, closure, &closure->cntl};
+        TEST_SYNC_POINT_CALLBACK("LocalTabletsChannel::rpc::tablet_writer_cancel", &rpc_tuple);
 #endif
 
         VLOG(2) << "LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(request.id()) << " Cancel "

--- a/be/src/storage/segment_replicate_executor.h
+++ b/be/src/storage/segment_replicate_executor.h
@@ -116,6 +116,8 @@ public:
 
     const std::vector<int64_t> replica_node_ids() const { return _replica_node_ids; }
 
+    const std::set<int64_t> failed_node_ids() const { return _failed_node_id; }
+
     const SegmentReplicateStat& get_stat() const { return _stat; }
 
 private:

--- a/be/test/runtime/local_tablets_channel_test.cpp
+++ b/be/test/runtime/local_tablets_channel_test.cpp
@@ -62,11 +62,12 @@ protected:
         auto load_mem_tracker = std::make_unique<MemTracker>(-1, "", _mem_tracker.get());
         _load_channel = std::make_shared<LoadChannel>(_load_channel_mgr.get(), nullptr, _load_id, _txn_id, string(),
                                                       1000, std::move(load_mem_tracker));
-        _open_primary_request = _create_open_request(ReplicaState::Primary);
-        _open_secondary_request = _create_open_request(ReplicaState::Secondary);
+        _open_single_replica_request = _create_open_request(ReplicaState::Primary, true);
+        _open_primary_request = _create_open_request(ReplicaState::Primary, false);
+        _open_secondary_request = _create_open_request(ReplicaState::Secondary, false);
         TabletsChannelKey key{_load_id, 0, _index_id};
         _schema_param.reset(new OlapTableSchemaParam());
-        ASSERT_OK(_schema_param->init(_open_primary_request.schema()));
+        ASSERT_OK(_schema_param->init(_open_single_replica_request.schema()));
         _tablets_channel =
                 new_local_tablets_channel(_load_channel.get(), key, _load_channel->mem_tracker(), _root_profile.get());
     }
@@ -80,6 +81,8 @@ protected:
             ASSERT_OK(st);
         }
     }
+
+    void test_cancel_secondary_replica_base(bool is_empty_tablet);
 
     TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash) {
         TCreateTabletReq request;
@@ -107,7 +110,7 @@ protected:
         return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
     }
 
-    PTabletWriterOpenRequest _create_open_request(ReplicaState replica_state) {
+    PTabletWriterOpenRequest _create_open_request(ReplicaState replica_state, bool single_replica) {
         PTabletWriterOpenRequest request;
         request.mutable_id()->CopyFrom(_load_id);
         request.set_index_id(_index_id);
@@ -115,7 +118,7 @@ protected:
         request.set_is_lake_tablet(false);
         request.set_is_replicated_storage(true);
         request.set_node_id(replica_state != ReplicaState::Secondary ? _primary_node_id : _secondary_node_id);
-        request.set_write_quorum(WriteQuorumTypePB::MAJORITY);
+        request.set_write_quorum(WriteQuorumTypePB::ONE);
         request.set_miss_auto_increment_column(false);
         request.set_table_id(_table_id);
         request.set_is_incremental(false);
@@ -134,7 +137,7 @@ protected:
         primary_replica->set_host("127.0.0.1");
         primary_replica->set_port(8060);
         primary_replica->set_node_id(_primary_node_id);
-        if (replica_state == ReplicaState::Secondary) {
+        if (!single_replica) {
             auto secondary_replica = tablet->add_replicas();
             secondary_replica->set_host("127.0.0.2");
             secondary_replica->set_port(8060);
@@ -203,6 +206,7 @@ protected:
     std::shared_ptr<Schema> _schema;
     std::shared_ptr<OlapTableSchemaParam> _schema_param;
 
+    PTabletWriterOpenRequest _open_single_replica_request;
     PTabletWriterOpenRequest _open_primary_request;
     PTabletWriterOpenRequest _open_secondary_request;
     PTabletWriterOpenResult _open_response;
@@ -264,7 +268,7 @@ TEST_F(LocalTabletsChannelTest, diagnose_stack_trace) {
 }
 
 TEST_F(LocalTabletsChannelTest, test_primary_replica_profile) {
-    ASSERT_OK(_tablets_channel->open(_open_primary_request, &_open_response, _schema_param, false));
+    ASSERT_OK(_tablets_channel->open(_open_single_replica_request, &_open_response, _schema_param, false));
 
     PTabletWriterAddChunkRequest add_chunk_request;
     add_chunk_request.mutable_id()->CopyFrom(_load_id);
@@ -317,6 +321,68 @@ TEST_F(LocalTabletsChannelTest, test_secondary_replica_profile) {
     auto* secondary_replicas_profile = profile->get_child("SecondaryReplicas");
     ASSERT_NE(nullptr, secondary_replicas_profile);
     ASSERT_EQ(1, secondary_replicas_profile->get_counter("TabletsNum")->value());
+}
+
+using RpcTabletWriterCancelPair = std::pair<PTabletWriterCancelRequest*, google::protobuf::Closure*>;
+
+void LocalTabletsChannelTest::test_cancel_secondary_replica_base(bool is_empty_tablet) {
+    ASSERT_OK(_tablets_channel->open(_open_primary_request, &_open_response, _schema_param, false));
+
+    PTabletWriterAddChunkRequest add_chunk_request;
+    add_chunk_request.mutable_id()->CopyFrom(_load_id);
+    add_chunk_request.set_index_id(_index_id);
+    add_chunk_request.set_sender_id(0);
+    add_chunk_request.set_txn_id(_txn_id);
+    add_chunk_request.set_eos(true);
+    add_chunk_request.set_packet_seq(0);
+    add_chunk_request.set_wait_all_sender_close(true);
+
+    auto chunk = generate_data(1);
+    ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
+    if (!is_empty_tablet) {
+        add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
+        add_chunk_request.add_tablet_ids(_tablet_id);
+        add_chunk_request.add_partition_ids(_partition_id);
+    }
+
+    DeferOp defer([&]() {
+        SyncPoint::GetInstance()->ClearCallBack("LocalTabletsChannel::rpc::tablet_writer_cancel");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    int num_cancel = 0;
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("LocalTabletsChannel::rpc::tablet_writer_cancel", [&](void* arg) {
+        RpcTabletWriterCancelPair* rpc_pair = (RpcTabletWriterCancelPair*)arg;
+        PTabletWriterCancelRequest* request = rpc_pair->first;
+        EXPECT_EQ(print_id(request->id()), print_id(_load_id));
+        EXPECT_EQ(request->index_id(), _index_id);
+        EXPECT_EQ(request->sender_id(), 0);
+        EXPECT_EQ(request->txn_id(), _txn_id);
+        EXPECT_EQ(1, request->tablet_ids().size());
+        EXPECT_EQ(_tablet_id, request->tablet_ids().Get(0));
+        EXPECT_EQ(request->reason(), is_empty_tablet ? "" : "primary replica failed to sync data");
+        google::protobuf::Closure* closure = rpc_pair->second;
+        closure->Run();
+        num_cancel += 1;
+    });
+
+    bool close_channel;
+    PTabletWriterAddBatchResult add_chunk_response;
+    _tablets_channel->add_chunk(is_empty_tablet ? nullptr : &chunk, add_chunk_request, &add_chunk_response,
+                                &close_channel);
+    ASSERT_TRUE(add_chunk_response.status().status_code() == TStatusCode::OK)
+            << add_chunk_response.status().error_msgs(0);
+    ASSERT_TRUE(close_channel);
+    ASSERT_EQ(1, num_cancel);
+}
+
+TEST_F(LocalTabletsChannelTest, test_cancel_empty_secondary_replica) {
+    test_cancel_secondary_replica_base(true);
+}
+
+TEST_F(LocalTabletsChannelTest, test_cancel_failed_secondary_replica) {
+    test_cancel_secondary_replica_base(false);
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
When most replicas success, the primary replica does not cancel those failed secondary replicas which may lead to "Reached timeout" between coordinator BE and executor BE (secondary replica). If replica sync fails because of rpc failure, the secondary replica does not receive the rpc from the primary replica, then continue waiting for the primary replica, so the rpc between coordinator BE and executor BE  can reach timeout

## What I'm doing:
* alway cancel failed secondary replicas no matter the overall successes or fails
* cancel brpc ignores overcrowded
* log the failed cancel brpc for debugging

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
