### PR TITLE
[Enhancement] Support load persistent index after clone new tablet

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1662,4 +1662,6 @@ CONF_mInt64(split_exchanger_buffer_chunk_num, "1000");
 
 // when to split hashmap/hashset into two level hashmap/hashset, negative number means use default value
 CONF_mInt64(two_level_memory_threshold, "-1");
+
+CONF_mBool(load_persistent_index_after_clone_new_tablet, "false");
 } // namespace starrocks::config

--- a/be/src/storage/task/engine_clone_task.h
+++ b/be/src/storage/task/engine_clone_task.h
@@ -88,6 +88,8 @@ private:
 
     Status _finish_clone_primary(Tablet* tablet, const std::string& clone_dir);
 
+    void _load_persistent_index(TTableId tablet_id);
+
 private:
     std::unique_ptr<MemTracker> _mem_tracker;
     const TCloneReq& _clone_req;


### PR DESCRIPTION
## Why I'm doing:
When writing data to a newly cloned primary key tablet, the BE must first build the primary key index. This time-consuming operation blocks write operations, which increases stream load latency.
 
## What I'm doing:
For persistent primary key indexes, we aim to load the persistent index immediately after cloning a new tablet, eliminating the need to build the index during read/write operations.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
