### PR TITLE
[BugFix] fix partial compaction's segment deleted by abort transaction (backport #58737)

### DIFF
--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -412,8 +412,7 @@ Status publish_log_version(TabletManager* tablet_mgr, int64_t tablet_id, const i
     return Status::OK();
 }
 
-static void collect_files_in_log(TabletManager* tablet_mgr, const TxnLog& txn_log,
-                                 std::vector<std::string>* files_to_delete) {
+void collect_files_in_log(TabletManager* tablet_mgr, const TxnLog& txn_log, std::vector<std::string>* files_to_delete) {
     auto tablet_id = txn_log.tablet_id();
     if (txn_log.has_op_write()) {
         for (const auto& segment : txn_log.op_write().rowset().segments()) {
@@ -424,8 +423,12 @@ static void collect_files_in_log(TabletManager* tablet_mgr, const TxnLog& txn_lo
         }
     }
     if (txn_log.has_op_compaction()) {
-        for (const auto& segment : txn_log.op_compaction().output_rowset().segments()) {
-            files_to_delete->emplace_back(tablet_mgr->segment_location(tablet_id, segment));
+        // only delete actual new segments
+        size_t new_segment_offset = txn_log.op_compaction().new_segment_offset();
+        size_t new_segment_count = txn_log.op_compaction().new_segment_count();
+        const auto& segments = txn_log.op_compaction().output_rowset().segments();
+        for (size_t idx = new_segment_offset, cnt = 0; idx < segments.size() && cnt < new_segment_count; ++idx, ++cnt) {
+            files_to_delete->emplace_back(tablet_mgr->segment_location(tablet_id, segments[idx]));
         }
     }
     if (txn_log.has_op_schema_change() && !txn_log.op_schema_change().linked_segment()) {

--- a/be/src/storage/lake/transactions.h
+++ b/be/src/storage/lake/transactions.h
@@ -21,7 +21,8 @@
 
 namespace starrocks {
 class TxnInfoPB;
-}
+class TxnLogPB;
+} // namespace starrocks
 
 namespace starrocks::lake {
 
@@ -81,5 +82,9 @@ Status publish_log_version(TabletManager* tablet_mgr, int64_t tablet_id, const i
 // - txns A `std::span` of `TxnInfoPB` containing information of the transactions to be aborted.
 //
 void abort_txn(TabletManager* tablet_mgr, int64_t tablet_id, std::span<const TxnInfoPB> txns);
+
+// Collect files to delete for `abort_txn` in transaction log
+void collect_files_in_log(TabletManager* tablet_mgr, const TxnLogPB& txn_log,
+                          std::vector<std::string>* files_to_delete);
 
 } // namespace starrocks::lake

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -691,6 +691,8 @@ TEST_F(LakeServiceTest, test_abort) {
         log.mutable_op_compaction()->mutable_output_rowset()->set_data_size(4096);
         log.mutable_op_compaction()->mutable_output_rowset()->add_segments(generate_segment_file(txn_id));
         log.mutable_op_compaction()->mutable_output_rowset()->add_segments(generate_segment_file(txn_id));
+        log.mutable_op_compaction()->set_new_segment_offset(0);
+        log.mutable_op_compaction()->set_new_segment_count(2);
         ASSERT_OK(_tablet_mgr->put_txn_log(log));
 
         logs.emplace_back(log);

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -180,6 +180,14 @@ message TxnLogPB {
         optional PersistentIndexSstablePB output_sstable = 4;
         // Base version of compaction task, used for conflict check with partial update
         optional int64 compact_version = 5;
+        // For normal compaction, all segments in `output_rowset` will be new segments.
+        // For partial compaction, we put compacted segments and uncompacted segments
+        // together, and when compaction is aborted, we need to avoid uncompacted segments
+        // being deleted.
+        // e.g., a b x y e f, in `output_rowset`, a,b,e,f might be uncompacted segments,
+        // x and y might be new segments
+        optional int32 new_segment_offset = 6;
+        optional int32 new_segment_count = 7;
     }
 
     message OpSchemaChange {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1

