### PR TITLE
[BugFix] Fix bugs with partition_condition_retention

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -3598,6 +3598,7 @@ public class OlapTable extends Table {
             properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX, flatJsonColumnMax);
         }
 
+        // partition_retention_condition
         String partitionRetentionCondition = tableProperties.get(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_CONDITION);
         if (!Strings.isNullOrEmpty(partitionRetentionCondition)) {
             properties.put(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_CONDITION, partitionRetentionCondition);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -3598,6 +3598,11 @@ public class OlapTable extends Table {
             properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX, flatJsonColumnMax);
         }
 
+        String partitionRetentionCondition = tableProperties.get(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_CONDITION);
+        if (!Strings.isNullOrEmpty(partitionRetentionCondition)) {
+            properties.put(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_CONDITION, partitionRetentionCondition);
+        }
+
         return properties;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
@@ -467,14 +467,12 @@ public class DynamicPartitionScheduler extends FrontendDaemon {
                 for (Table table : GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(dbId)) {
                     // register dynamic partition table
                     if (DynamicPartitionUtil.isDynamicPartitionTable(table)) {
-                        LOG.info("register table[{}] with dynamic partition", table.getName());
                         registerDynamicPartitionTable(db.getId(), table.getId());
                         dynamicPartitionTables.computeIfAbsent(db.getFullName(), k -> new ArrayList<>())
                                     .add(table.getName());
                     }
                     // register ttl partition table
                     if (DynamicPartitionUtil.isTTLPartitionTable(table)) {
-                        LOG.info("register table[{}] with ttl partition", table.getName());
                         // Table(MV) with dynamic partition enabled should not specify partition_ttl_number(MV) or
                         // partition_live_number property.
                         registerTtlPartitionTable(db.getId(), table.getId());
@@ -503,7 +501,7 @@ public class DynamicPartitionScheduler extends FrontendDaemon {
         // Find all tables that need to be scheduled.
         long now = System.currentTimeMillis();
         long checkIntervalMs = Config.dynamic_partition_check_interval_seconds * 1000L;
-        if ((now - lastFindingTime) > Math.max(300000, checkIntervalMs)) {
+        if ((now - lastFindingTime) > Math.max(60000, checkIntervalMs)) {
             findSchedulableTables();
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -443,7 +443,10 @@ public class PropertyAnalyzer {
         if (properties != null && properties.containsKey(PROPERTIES_PARTITION_RETENTION_CONDITION)) {
             partitionRetentionCondition = properties.get(PROPERTIES_PARTITION_RETENTION_CONDITION);
             if (Strings.isNullOrEmpty(partitionRetentionCondition)) {
-                throw new SemanticException("Illegal partition retention condition: " + partitionRetentionCondition);
+                if (removeProperties) {
+                    properties.remove(PROPERTIES_PARTITION_RETENTION_CONDITION);
+                }
+                return partitionRetentionCondition;
             }
             // parse retention condition
             Expr whereExpr = null;

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3734,9 +3734,6 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             }
             String partitionRetentionCondition = PropertyAnalyzer.analyzePartitionRetentionCondition(
                     db, table, properties, true, null);
-            if (Strings.isNullOrEmpty(partitionRetentionCondition)) {
-                throw new DdlException("Invalid partition retention condition");
-            }
             results.put(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_CONDITION, partitionRetentionCondition);
         }
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_TIME_DRIFT_CONSTRAINT)) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionWithExprListTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionWithExprListTest.java
@@ -686,4 +686,32 @@ public class DropPartitionWithExprListTest extends MVTestBase {
                     });
         }
     }
+
+    @Test
+    public void testPartitionConditionTTL1() throws Exception {
+        starRocksAssert.withTable("create table list_par_int(\n" +
+                " k1 int,\n" +
+                " k2 string)\n" +
+                " partition by list(k1)\n" +
+                " (partition p1 values in('1','2'),\n" +
+                "  partition p2 values in('3','4'),\n" +
+                "  partition p3 values in('5','6'),\n" +
+                "  partition p4 values in('7','8'),\n" +
+                "  partition p5 values in('9','10'),\n" +
+                "  partition p6 values in('11','12'),\n" +
+                "  partition p7 values in('13','14'),\n" +
+                "  partition p8 values in('15','16'),\n" +
+                "  partition p9 values in('17','18'),\n" +
+                "  partition p10 values in('19','20'))\n" +
+                " distributed by hash(k1)\n");
+
+        OlapTable olapTable = (OlapTable) starRocksAssert.getTable("test", "list_par_int");
+        Assert.assertEquals(10, olapTable.getVisiblePartitions().size());
+
+        String sql = "alter table list_par_int drop partitions where k1 > 5";
+        starRocksAssert.alterTable(sql);
+        Assert.assertEquals(3, olapTable.getVisiblePartitions().size());
+        String[] expectedPartitions = {"p1", "p2", "p3"};
+        Assert.assertArrayEquals(expectedPartitions, olapTable.getVisiblePartitionNames().toArray());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/clone/DynamicPartitionSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/DynamicPartitionSchedulerTest.java
@@ -16,6 +16,7 @@ package com.starrocks.clone;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
+import com.google.common.collect.Sets;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.DynamicPartitionProperty;
@@ -49,6 +50,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TimeZone;
 
 import static org.junit.Assert.fail;
@@ -722,5 +724,40 @@ public class DynamicPartitionSchedulerTest {
                         Assert.assertTrue(tbl.getVisiblePartitions().size() == 5);
                     });
         }
+    }
+
+    @Test
+    public void testPartitionConditionTTL1() throws Exception {
+        starRocksAssert.withTable("create table list_par_int(\n" +
+                " k1 int,\n" +
+                " k2 string)\n" +
+                " partition by list(k1)\n" +
+                " (partition p1 values in('1','2'),\n" +
+                "  partition p2 values in('3','4'),\n" +
+                "  partition p3 values in('5','6'),\n" +
+                "  partition p4 values in('7','8'),\n" +
+                "  partition p5 values in('9','10'),\n" +
+                "  partition p6 values in('11','12'),\n" +
+                "  partition p7 values in('13','14'),\n" +
+                "  partition p8 values in('15','16'),\n" +
+                "  partition p9 values in('17','18'),\n" +
+                "  partition p10 values in('19','20'))\n" +
+                " distributed by hash(k1)\n" +
+                "  PROPERTIES (\"partition_retention_condition\" = \"k1 > 5\");");
+
+        final String tableName = "list_par_int";
+        OlapTable olapTable = (OlapTable) starRocksAssert.getTable("test", tableName);
+        Assert.assertEquals(10, olapTable.getVisiblePartitions().size());
+        Assert.assertFalse(DynamicPartitionUtil.isDynamicPartitionTable(olapTable));
+        Assert.assertTrue(DynamicPartitionUtil.isTTLPartitionTable(olapTable));
+
+        DynamicPartitionScheduler scheduler = GlobalStateMgr.getCurrentState()
+                .getDynamicPartitionScheduler();
+        scheduler.runOnceForTest();
+        Set<String> visiblePartitionNames = olapTable.getVisiblePartitionNames();
+        Assert.assertEquals(8, visiblePartitionNames.size());
+        Set<String> expectedPartitionNames = Sets.newHashSet("p3", "p4", "p5", "p6", "p7", "p8", "p9", "p10");
+        System.out.println(visiblePartitionNames);
+        Assert.assertEquals(expectedPartitionNames, visiblePartitionNames);
     }
 }


### PR DESCRIPTION
## Why I'm doing:
https://github.com/StarRocks/starrocks/issues/53117 has supported `partition_condition_retention` property for more generic partition TTL(eg: multi partition columns or more generic partition expressions).

But there are some bugs in using:
1. For `range-partitioned` table, scheduler may fail to drop expired partitions for needs of `ThreadLocal`'s `ConnectContext`;
2. For `list-partitioned` table, it may drop wrong partitions if it's a multi-values partition;
3. `ShowCreateTable` cannot display `partition_condition_retention`;

## What I'm doing:

#### Problem 1

Add a `Guard` to protect this, since connect context is needed sometime, otherwise ConnectContext.get() is null.
```
    public void scheduleTTLPartition() {
        // connect context is needed sometime, otherwise ConnectContext.get() is null.
        ConnectContext connectContext = ConnectContext.buildInner();
        try (var  guard = connectContext.bindScope()) {
            doScheduleTTLPartition();
        } catch (Exception e) {
            LOG.warn("Failed to schedule ttl partition", e);
        }
    }
```
#### Problem 2
Distinguish `drop partition by where` and `partition condition retention` which may cause different selections by `isRecyclingCondition`.

for recycling condition(drop partition with where), keep partitions as less as possible：
```
  // T1, partitions:
  //  p1: [1, 2]
  //  p2: [2, 3]
  // eg: alter table T1 drop partitions where p > 1, only choose p1 when all values are satisfied.
  // p1: [1, 2] is not satisfied, so we need to return p2: [2, 3]
```

for retention condition, keep partitions as much as possible:
```

  // T1, partitions:
  //  p1: [1, 2]
  //  p2: [2, 3]
  // eg: partition_retention_condition = 'p > 1', choose partition if it once is satisfied.
  // p1: [1, 2]/[2, 3] are all satisfied, so we need to return p1/p2 both
```
#### Problem 3

- add  `partition_condition_retention` for  `ShowCreateTable` & support set  `partition_condition_retention` to empty.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
