### PR TITLE
[Enhancement] Persistent index support fix length size greater than 128 bytes

### DIFF
--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -893,6 +893,8 @@ private:
     // Calculate total memory usage after index been modified.
     void _calc_memory_usage();
 
+    size_t _get_encoded_fixed_size(const Schema& schema);
+
 protected:
     // index storage directory
     std::string _path;


### PR DESCRIPTION
## Why I'm doing:
If the primary key length of the PK table is fixed and exceeds 128 bytes, the PK table will use an in-memory index instead of a persistent index. This PR enables the creation of persistent indexes for fixed-length keys larger than 128 bytes.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
