### PR TITLE
[BugFix] Use list partitioned mv for iceberg table with partition transforms

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -976,7 +976,7 @@ public class MaterializedViewAnalyzer {
                 } else if (table.isHiveTable() || table.isHudiTable() || table.isOdpsTable()) {
                     checkPartitionColumnWithBaseHMSTable(slotRef, table);
                 } else if (table.isIcebergTable()) {
-                    checkPartitionColumnWithBaseIcebergTable(expr, slotRef, (IcebergTable) table);
+                    checkPartitionColumnWithBaseIcebergTable(statement, expr, slotRef, (IcebergTable) table);
                 } else if (table.isJDBCTable()) {
                     checkPartitionColumnWithBaseJDBCTable(slotRef, (JDBCTable) table);
                 } else if (table.isPaimonTable()) {
@@ -1068,9 +1068,8 @@ public class MaterializedViewAnalyzer {
                 if (Config.enable_mv_list_partition_for_external_table) {
                     statement.setPartitionType(PartitionType.LIST);
                 } else {
-                    if (partitionExprType.isStringType() &&
-                            mvPartitionByExprs.stream().allMatch(t -> t instanceof SlotRef) &&
-                            !(partitionRefTableExpr instanceof FunctionCallExpr)) {
+                    if (shouldMVPartitionByListType(statement, mvPartitionByExprs,
+                            partitionRefTableExpr, refPartitionCol)) {
                         statement.setPartitionType(PartitionType.LIST);
                     } else {
                         statement.setPartitionType(PartitionType.RANGE);
@@ -1078,6 +1077,23 @@ public class MaterializedViewAnalyzer {
                     }
                 }
             }
+        }
+        private boolean shouldMVPartitionByListType(CreateMaterializedViewStatement statement,
+                                                    List<Expr> mvPartitionByExprs,
+                                                    Expr partitionRefTableExpr,
+                                                    Column refPartitionCol) {
+            // for iceberg table with transform, use list partition since it needs to handle the transform with timezone
+            // original range partition mv cannot handle it correctly.
+            if (statement.isRefBaseTablePartitionWithTransform()) {
+                return true;
+            }
+            final Type partitionExprType = refPartitionCol.getType();
+            if (partitionExprType.isStringType() &&
+                    mvPartitionByExprs.stream().allMatch(t -> t instanceof SlotRef) &&
+                    !(partitionRefTableExpr instanceof FunctionCallExpr)) {
+                return true;
+            }
+            return false;
         }
 
         /**
@@ -1293,7 +1309,8 @@ public class MaterializedViewAnalyzer {
             MVPartitionSlotRefResolver.checkWindowFunction(statement, refTablePartitionExprs);
         }
 
-        private void checkPartitionColumnWithBaseIcebergTable(Expr partitionByExpr,
+        private void checkPartitionColumnWithBaseIcebergTable(CreateMaterializedViewStatement statement,
+                                                              Expr partitionByExpr,
                                                               SlotRef slotRef,
                                                               IcebergTable table) {
             org.apache.iceberg.Table icebergTable = table.getNativeTable();
@@ -1325,6 +1342,8 @@ public class MaterializedViewAnalyzer {
                                             "(<transform>, <partition_colum_name>) instead.", partitionByExpr.toSql(),
                                             transform.name());
                                 }
+                                // mark the statement with partition transform to use list partition mv later.
+                                statement.setRefBaseTablePartitionWithTransform(true);
                                 break;
                             case IDENTITY:
                                 if (!(partitionByExpr instanceof SlotRef) && !MvUtils.isStr2Date(partitionByExpr) &&

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
@@ -97,6 +97,10 @@ public class CreateMaterializedViewStatement extends DdlStmt {
     private Map<Integer, Column> generatedPartitionCols = Maps.newHashMap();
     private Map<Expr, Expr> partitionByExprToAdjustExprMap = Maps.newHashMap();
 
+    // Whether the mv is created on a partitioned table with transform function. Use list partition mv if ref base table's
+    // partition contains transform function.
+    private boolean isRefBaseTablePartitionWithTransform = false;
+
     public CreateMaterializedViewStatement(TableName tableName, boolean ifNotExists,
                                            List<ColWithComment> colWithComments,
                                            List<IndexDef> indexDefs,
@@ -328,6 +332,14 @@ public class CreateMaterializedViewStatement extends DdlStmt {
     }
     public String getOriginalDBName() {
         return originalDBName;
+    }
+
+    public boolean isRefBaseTablePartitionWithTransform() {
+        return isRefBaseTablePartitionWithTransform;
+    }
+
+    public void setRefBaseTablePartitionWithTransform(boolean refBaseTablePartitionWithTransform) {
+        isRefBaseTablePartitionWithTransform = refBaseTablePartitionWithTransform;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
@@ -2048,7 +2048,5 @@ public class MvRefreshAndRewriteIcebergTest extends MVTestBase {
                         connectContext);
         MaterializedViewAnalyzer.analyze(stmt, starRocksAssert.getCtx());
         Assert.assertTrue(stmt.isRefBaseTablePartitionWithTransform());
-        final MaterializedView mv = getMv(mvName);
-        Assert.assertTrue(mv.getPartitionInfo().isListPartition());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
@@ -20,6 +20,8 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.common.Config;
 import com.starrocks.connector.iceberg.MockIcebergMetadata;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.MaterializedViewAnalyzer;
+import com.starrocks.sql.ast.CreateMaterializedViewStatement;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.utframe.UtFrameUtils;
@@ -2013,5 +2015,40 @@ public class MvRefreshAndRewriteIcebergTest extends MVTestBase {
         final MaterializedView mv = getMv(mvName);
         Assert.assertTrue(mv.getPartitionInfo().isListPartition());
         Config.enable_mv_list_partition_for_external_table = false;
+    }
+
+    @Test
+    public void testListMVWithIcebergTable4() throws Exception {
+        String mvName = "test_mv1";
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW test_mv1\n" +
+                "PARTITION BY date_trunc('month', ts)\n" +
+                "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")\n" +
+                "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_month` as a;");
+        final MaterializedView mv = getMv(mvName);
+        Assert.assertTrue(mv.getPartitionInfo().isListPartition());
+    }
+
+    @Test
+    public void testRefBaseTablePartitionWithTransform() throws Exception {
+        final String mvName = "test_mv1";
+        final String sql = "CREATE MATERIALIZED VIEW test_mv1\n" +
+                "PARTITION BY date_trunc('month', ts)\n" +
+                "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")\n" +
+                "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_month` as a;";
+        CreateMaterializedViewStatement stmt =
+                (CreateMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql,
+                        connectContext);
+        MaterializedViewAnalyzer.analyze(stmt, starRocksAssert.getCtx());
+        Assert.assertTrue(stmt.isRefBaseTablePartitionWithTransform());
+        final MaterializedView mv = getMv(mvName);
+        Assert.assertTrue(mv.getPartitionInfo().isListPartition());
     }
 }

--- a/test/sql/test_transparent_mv/R/test_mv_with_iceberg_partition_transform
+++ b/test/sql/test_transparent_mv/R/test_mv_with_iceberg_partition_transform
@@ -22,7 +22,7 @@ AS
   SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month;
 -- result:
 -- !result
-REFRESH MATERIALIZED VIEW test_mv1 PARTITION start('2025-01-01') end('2025-01-03') WITH SYNC MODE;
+REFRESH MATERIALIZED VIEW test_mv1 PARTITION (('2025-01-01'), ('2025-01-02'), ('2025-01-03')) WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month order by prcdate;", "test_mv1")
 -- result:
 True
@@ -64,7 +64,7 @@ select * from test_mv1 order by prcdate;
 2025-01-01	b	1.0
 2025-01-02	b	2.0
 -- !result
-REFRESH MATERIALIZED VIEW test_mv1 PARTITION start('2025-01-03') end('2025-01-04') WITH SYNC MODE;
+REFRESH MATERIALIZED VIEW test_mv1 PARTITION (('2025-01-03'), ('2025-01-04')) WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month order by prcdate;", "test_mv1")
 -- result:
 True

--- a/test/sql/test_transparent_mv/R/test_mv_with_iceberg_transforms
+++ b/test/sql/test_transparent_mv/R/test_mv_with_iceberg_transforms
@@ -1,0 +1,91 @@
+-- name: test_mv_with_iceberg_transforms @slow
+set new_planner_optimize_timeout=10000;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_years
+PARTITION BY (date_trunc('year', l_shipdate))
+REFRESH DEFERRED MANUAL
+PROPERTIES ("replication_num" = "1")
+AS
+  SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_years;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_years;
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_years")
+-- result:
+None
+-- !result
+select count(1) from test_years;
+-- result:
+3
+-- !result
+function: print_hit_materialized_views("SELECT * FROM test_years order by l_orderkey;")
+-- result:
+test_years
+-- !result
+function: print_hit_materialized_views("SELECT * FROM test_years where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;")
+-- result:
+test_years
+-- !result
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_years where l_returnflag = 'R' and l_linestatus = 'F' and l_shipdate = '2024-11-13 00:00:00' order by l_orderkey;")
+-- result:
+test_years
+-- !result
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_years where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;")
+-- result:
+test_years
+-- !result
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_years order by l_orderkey;")
+-- result:
+test_years
+-- !result
+SELECT * FROM test_years order by l_orderkey;
+-- result:
+1	1001	5001	1	10.00	1000.00	0.05	0.08	N	O	2024-11-12	2024-11-15 00:00:00	2024-11-20 00:00:00	DELIVER IN PERSON	AIR	Quick delivery required
+2	1002	5002	2	20.00	2000.00	0.10	0.15	R	F	2024-11-13	2024-11-16 00:00:00	2024-11-21 00:00:00	TAKE BACK RETURN	RAIL	Handle with care
+3	1003	5003	3	30.00	3000.00	0.15	0.20	A	P	2024-11-14	2024-11-17 00:00:00	2024-11-22 00:00:00	NONE	SHIP	Fragile item
+-- !result
+SELECT * FROM test_years where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;
+-- result:
+2	1002	5002	2	20.00	2000.00	0.10	0.15	R	F	2024-11-13	2024-11-16 00:00:00	2024-11-21 00:00:00	TAKE BACK RETURN	RAIL	Handle with care
+3	1003	5003	3	30.00	3000.00	0.15	0.20	A	P	2024-11-14	2024-11-17 00:00:00	2024-11-22 00:00:00	NONE	SHIP	Fragile item
+-- !result
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_years where l_returnflag = 'R' and l_linestatus = 'F' and l_shipdate = '2024-11-13 00:00:00' order by l_orderkey;
+-- result:
+2	1002	5002	2	20.00	2000.00	0.10	0.15	R	F	2024-11-13	2024-11-16 00:00:00	2024-11-21 00:00:00	TAKE BACK RETURN	RAIL	Handle with care
+-- !result
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_years where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;
+-- result:
+2	1002	5002	2	20.00	2000.00	0.10	0.15	R	F	2024-11-13	2024-11-16 00:00:00	2024-11-21 00:00:00	TAKE BACK RETURN	RAIL	Handle with care
+3	1003	5003	3	30.00	3000.00	0.15	0.20	A	P	2024-11-14	2024-11-17 00:00:00	2024-11-22 00:00:00	NONE	SHIP	Fragile item
+-- !result
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_years order by l_orderkey;
+-- result:
+1	1001	5001	1	10.00	1000.00	0.05	0.08	N	O	2024-11-12	2024-11-15 00:00:00	2024-11-20 00:00:00	DELIVER IN PERSON	AIR	Quick delivery required
+2	1002	5002	2	20.00	2000.00	0.10	0.15	R	F	2024-11-13	2024-11-16 00:00:00	2024-11-21 00:00:00	TAKE BACK RETURN	RAIL	Handle with care
+3	1003	5003	3	30.00	3000.00	0.15	0.20	A	P	2024-11-14	2024-11-17 00:00:00	2024-11-22 00:00:00	NONE	SHIP	Fragile item
+-- !result
+DROP MATERIALIZED VIEW test_years;
+-- result:
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result
+drop catalog mv_iceberg_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_transparent_mv/T/test_mv_with_iceberg_partition_transform
+++ b/test/sql/test_transparent_mv/T/test_mv_with_iceberg_partition_transform
@@ -21,7 +21,7 @@ AS
   SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month;
 
 -- partial refresh
-REFRESH MATERIALIZED VIEW test_mv1 PARTITION start('2025-01-01') end('2025-01-03') WITH SYNC MODE;
+REFRESH MATERIALIZED VIEW test_mv1 PARTITION (('2025-01-01'), ('2025-01-02'), ('2025-01-03')) WITH SYNC MODE;
 
 function: print_hit_materialized_view("SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month order by prcdate;", "test_mv1")
 function: print_hit_materialized_view("SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month where prcdate < '2025-01-03' order by prcdate;", "test_mv1")
@@ -32,7 +32,7 @@ SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_m
 select distinct prcdate from test_mv1 order by prcdate;
 select * from test_mv1 order by prcdate;
 
-REFRESH MATERIALIZED VIEW test_mv1 PARTITION start('2025-01-03') end('2025-01-04') WITH SYNC MODE;
+REFRESH MATERIALIZED VIEW test_mv1 PARTITION (('2025-01-03'), ('2025-01-04')) WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month order by prcdate;", "test_mv1")
 function: print_hit_materialized_view("SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month where prcdate < '2025-01-03' order by prcdate;", "test_mv1")
 function: print_hit_materialized_view("SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month where prcdate > '2025-01-03' order by prcdate;", "test_mv1")

--- a/test/sql/test_transparent_mv/T/test_mv_with_iceberg_transforms
+++ b/test/sql/test_transparent_mv/T/test_mv_with_iceberg_transforms
@@ -1,0 +1,42 @@
+-- name: test_mv_with_iceberg_transforms @slow
+
+set new_planner_optimize_timeout=10000;
+-- create mv
+create database db_${uuid0};
+use db_${uuid0};
+
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+
+-------------------------------- YEARS --------------------------------
+CREATE MATERIALIZED VIEW test_years
+PARTITION BY (date_trunc('year', l_shipdate))
+REFRESH DEFERRED MANUAL
+PROPERTIES ("replication_num" = "1")
+AS
+  SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_years;
+-- NOT use sync mode since it cannot generate multi task runs for the test.
+REFRESH MATERIALIZED VIEW test_years;
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_years")
+select count(1) from test_years;
+
+function: print_hit_materialized_views("SELECT * FROM test_years order by l_orderkey;")
+function: print_hit_materialized_views("SELECT * FROM test_years where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;")
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_years where l_returnflag = 'R' and l_linestatus = 'F' and l_shipdate = '2024-11-13 00:00:00' order by l_orderkey;")
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_years where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;")
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_years order by l_orderkey;")
+SELECT * FROM test_years order by l_orderkey;
+SELECT * FROM test_years where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_years where l_returnflag = 'R' and l_linestatus = 'F' and l_shipdate = '2024-11-13 00:00:00' order by l_orderkey;
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_years where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_years order by l_orderkey;
+
+DROP MATERIALIZED VIEW test_years;
+
+drop database db_${uuid0} force;
+drop catalog mv_iceberg_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
Before #52966, StarRocks can support to create range mv with one partition column, but it may generate wrong result in mv refreshing for those mvs.

This is because Iceberg transoform's  use `UTC+0` timezone as metadata, but Partition's metadata cannot be aligned with `(date_trunc("year", k1))` (real data has not take care timezone).


eg: 
```
CREATE MATERIALIZED VIEW mv_manual_parkey_single_year9
   DISTRIBUTED BY HASH(k1) BUCKETS 3
   partition by (date_trunc("year", k1))
   REFRESH DEFERRED MANUAL
         PROPERTIES (
      "session.enable_profile" = "true"
  )
   AS SELECT k1, k2, k3, sum(k4)
   FROM iceberg_catalog_9a91a930_2a74_11f0_a0e9_00163e21975a.iceberg_db.parkey_single_year
   GROUP BY 1, 2, 3;

mysql> show partitions from mv_manual_parkey_single_year9;
+-------------+---------------+----------------+---------------------+--------------------+--------+--------------+------------------------------------------------------------------------------------------------------+-----------------+---------+----------------+---------------+---------------------+--------------------------+----------+-------------+-+
| PartitionId | PartitionName | VisibleVersion | VisibleVersionTime  | VisibleVersionHash | State  | PartitionKey | Range                                                                                                | DistributionKey | Buckets | ReplicationNum | StorageMedium | CooldownTime        | LastConsistencyCheckTime | DataSize | StorageSize | |
+-------------+---------------+----------------+---------------------+--------------------+--------+--------------+------------------------------------------------------------------------------------------------------+-----------------+---------+----------------+---------------+---------------------+--------------------------+----------+-------------+-+
| 18336       | p2022_2023    | 2              | 2025-05-12 15:43:11 | 0                  | NORMAL | k1           | [types: [DATETIME]; keys: [2022-01-01 08:00:00]; ..types: [DATETIME]; keys: [2023-01-01 08:00:00]; ) | k1              | 3       | 1              | HDD           | 9999-12-31 23:59:59 | NULL                     | 1.2KB    | 1.2KB       | |
| 18352       | p2023_2024    | 2              | 2025-05-12 15:43:14 | 0                  | NORMAL | k1           | [types: [DATETIME]; keys: [2023-01-01 08:00:00]; ..types: [DATETIME]; keys: [2024-01-01 08:00:00]; ) | k1              | 3       | 1              | HDD           | 9999-12-31 23:59:59 | NULL                     | 1.2KB    | 1.2KB       | |
| 18366       | p2024_2025    | 1              | 2025-05-12 15:43:16 | 0                  | NORMAL | k1           | [types: [DATETIME]; keys: [2024-01-01 08:00:00]; ..types: [DATETIME]; keys: [2025-01-01 08:00:00]; ) | k1              | 3       | 1              | HDD           | 9999-12-31 23:59:59 | NULL                     | 0B       | 0B          | |
+-------------+---------------+----------------+---------------------+--------------------+--------+--------------+------------------------------------------------------------------------------------------------------+-----------------+---------+----------------+---------------+---------------------+--------------------------+----------+-------------+-+
3 rows in set (0.03 sec)

```

## What I'm doing:
- Switch this situation to ListPartition MV which has handle this correctly in #52966.
- Add more tests.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
