### PR TITLE
[BugFix] some Range (e.g. (+∞, +∞))can be constructed during canonicalizing range (backport #58869)

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/ColumnRangePredicateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/ColumnRangePredicateTest.java
@@ -17,8 +17,10 @@ package com.starrocks.sql.optimizer.rule.transformation.materialization;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import com.google.common.collect.TreeRangeSet;
+import com.starrocks.analysis.BinaryType;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Type;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -208,5 +210,17 @@ public class ColumnRangePredicateTest {
             ScalarOperator ret = columnRangePredicate.simplify(result);
             Assert.assertEquals(ConstantOperator.TRUE, ret);
         }
+    }
+
+    @Test
+    public void testNonCanonicalBigintRangePredicate() {
+        ColumnRefOperator columnRef = new ColumnRefOperator(1, Type.BIGINT, "col", true);
+        ConstantOperator maxValue = ConstantOperator.createBigint(9223372036854775807L);
+        BinaryPredicateOperator pred = new BinaryPredicateOperator(BinaryType.GT, columnRef, maxValue);
+        PredicateExtractor extractor = new PredicateExtractor();
+        PredicateExtractor.PredicateExtractorContext context = new PredicateExtractor.PredicateExtractorContext();
+        RangePredicate rangePredicate = extractor.visitBinaryPredicate(pred, context);
+        String s  = rangePredicate.toScalarOperator().toString();
+        Assert.assertEquals(s, "1: col > 9223372036854775807", s);
     }
 }


### PR DESCRIPTION
## Why I'm doing:
https://github.com/StarRocks/StarRocksTest/issues/9573

for open range (+∞, +∞), it can not be canonicalized into a close-open range and IllegalArgumentException/AssertionError is thrown. open range (+∞, +∞) is generated when trying to canonicalize the range (MAX_VALUE, +∞) yielded by column > MAX_VALUE. for an example: col > 9223372036854775807 (col is bigint type)
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
<hr>This is an automatic backport of pull request #58869 done by [Mergify](https://mergify.com).

