### PR TITLE
[Enhancement] Submit write combined_txn_log/aggregate_tablet_metadata to thread pool to avoid block brpc thread

### DIFF
--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -199,9 +199,17 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             return Status::OK();
         });
         _config_callback.emplace("transaction_publish_version_worker_count", [&]() -> Status {
-            auto thread_pool = ExecEnv::GetInstance()->agent_server()->get_thread_pool(TTaskType::PUBLISH_VERSION);
-            return thread_pool->update_max_threads(
+            Status st1 = ExecEnv::GetInstance()
+                                 ->agent_server()
+                                 ->get_thread_pool(TTaskType::PUBLISH_VERSION)
+                                 ->update_max_threads(std::max(MIN_TRANSACTION_PUBLISH_WORKER_COUNT,
+                                                               config::transaction_publish_version_worker_count));
+            Status st2 = ExecEnv::GetInstance()->put_aggregate_metadata_thread_pool()->update_max_threads(
                     std::max(MIN_TRANSACTION_PUBLISH_WORKER_COUNT, config::transaction_publish_version_worker_count));
+            if (!st1.ok() || !st2.ok()) {
+                return Status::InvalidArgument("Failed to update transaction_publish_version_worker_count.");
+            }
+            return st1;
         });
         _config_callback.emplace("transaction_publish_version_thread_pool_num_min", [&]() -> Status {
             auto thread_pool = ExecEnv::GetInstance()->agent_server()->get_thread_pool(TTaskType::PUBLISH_VERSION);

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -575,6 +575,11 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
     _lake_tablet_manager =
             new lake::TabletManager(_lake_location_provider, _lake_update_manager, config::lake_metadata_cache_limit);
     _lake_replication_txn_manager = new lake::ReplicationTxnManager(_lake_tablet_manager);
+    RETURN_IF_ERROR(ThreadPoolBuilder("put_aggregate_metadata_pool")
+                            .set_min_threads(1)
+                            .set_max_threads(1)
+                            .set_max_queue_size(std::numeric_limits<int>::max())
+                            .build(&_put_aggregate_metadata_thread_pool));
 #endif
 
     _agent_server = new AgentServer(this, false);

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -557,7 +557,6 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
     }
     setenv(staros::starlet::fslib::kFslibCacheDir.c_str(), config::starlet_cache_dir.c_str(), 1);
 
-    std::unique_ptr<ThreadPool> put_aggregate_metadata_thread_pool;
     int32_t max_thread_count = config::transaction_publish_version_worker_count;
     if (max_thread_count <= 0) {
         max_thread_count = CpuInfo::num_cores();
@@ -567,6 +566,7 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
                             .set_max_threads(std::max(1, max_thread_count))
                             .set_max_queue_size(std::numeric_limits<int>::max())
                             .build(&_put_aggregate_metadata_thread_pool));
+    REGISTER_THREAD_POOL_METRICS("put_aggregate_metadata_pool", _put_aggregate_metadata_thread_pool);
 
 #elif defined(BE_TEST)
     _lake_location_provider = std::make_shared<lake::FixedLocationProvider>(_store_paths.front().path);

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -561,12 +561,12 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
     if (max_thread_count <= 0) {
         max_thread_count = CpuInfo::num_cores();
     }
-    RETURN_IF_ERROR(ThreadPoolBuilder("put_aggregate_metadata_pool")
+    RETURN_IF_ERROR(ThreadPoolBuilder("put_aggregate_metadata")
                             .set_min_threads(1)
                             .set_max_threads(std::max(1, max_thread_count))
                             .set_max_queue_size(std::numeric_limits<int>::max())
                             .build(&_put_aggregate_metadata_thread_pool));
-    REGISTER_THREAD_POOL_METRICS("put_aggregate_metadata_pool", _put_aggregate_metadata_thread_pool);
+    REGISTER_THREAD_POOL_METRICS(put_aggregate_metadata, _put_aggregate_metadata_thread_pool);
 
 #elif defined(BE_TEST)
     _lake_location_provider = std::make_shared<lake::FixedLocationProvider>(_store_paths.front().path);

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -350,6 +350,8 @@ public:
 
     ThreadPool* delete_file_thread_pool();
 
+    ThreadPool* put_aggregate_metadata_thread_pool() { return _put_aggregate_metadata_thread_pool.get(); }
+
     void try_release_resource_before_core_dump();
 
     DiagnoseDaemon* diagnose_daemon() const { return _diagnose_daemon; }
@@ -419,6 +421,7 @@ private:
     std::shared_ptr<lake::LocationProvider> _lake_location_provider;
     lake::UpdateManager* _lake_update_manager = nullptr;
     lake::ReplicationTxnManager* _lake_replication_txn_manager = nullptr;
+    std::unique_ptr<ThreadPool> _put_aggregate_metadata_thread_pool = nullptr;
 
     AgentServer* _agent_server = nullptr;
     query_cache::CacheManagerRawPtr _cache_mgr;

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -406,8 +406,8 @@ StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(int64_t tablet_id
         } else {
             tablet_metadata_or = get_single_tablet_metadata(tablet_id, version, fill_cache, expected_gtid, fs);
             if (tablet_metadata_or.status().is_not_found()) {
-                tablet_metadata_or =
-                        get_tablet_meta(tablet_metadata_location(tablet_id, version), fill_cache, expected_gtid, fs);
+                tablet_metadata_or = get_tablet_metadata(tablet_metadata_location(tablet_id, version), fill_cache,
+                                                         expected_gtid, fs);
             }
         }
     } else {

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -405,6 +405,10 @@ StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(int64_t tablet_id
                     get_tablet_metadata(tablet_initial_metadata_location(tablet_id), fill_cache, expected_gtid, fs);
         } else {
             tablet_metadata_or = get_single_tablet_metadata(tablet_id, version, fill_cache, expected_gtid, fs);
+            if (tablet_metadata_or.status().is_not_found()) {
+                tablet_metadata_or =
+                        get_tablet_meta(tablet_metadata_location(tablet_id, version), fill_cache, expected_gtid, fs);
+            }
         }
     } else {
         tablet_metadata_or =
@@ -442,6 +446,9 @@ StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(const string& pat
     auto [tablet_id, version] = parse_tablet_metadata_filename(basename(path));
     if (_metacache->lookup_aggregation_partition(tablet_metadata_root_location(tablet_id))) {
         metadata_or = get_single_tablet_metadata(tablet_id, version, fill_cache, expected_gtid, fs);
+        if (metadata_or.status().is_not_found()) {
+            metadata_or = load_tablet_metadata(path, fill_cache, expected_gtid, fs);
+        }
     } else {
         metadata_or = load_tablet_metadata(path, fill_cache, expected_gtid, fs);
         if (metadata_or.status().is_not_found()) {

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -368,6 +368,7 @@ public:
     METRICS_DEFINE_THREAD_POOL(pk_index_compaction);
     METRICS_DEFINE_THREAD_POOL(compact_pool);
     METRICS_DEFINE_THREAD_POOL(pindex_load);
+    METRICS_DEFINE_THREAD_POOL(put_aggregate_metadata);
 
     METRIC_DEFINE_UINT_GAUGE(load_rpc_threadpool_size, MetricUnit::NOUNIT);
 

--- a/be/test/http/action/update_config_action_test.cpp
+++ b/be/test/http/action/update_config_action_test.cpp
@@ -91,4 +91,12 @@ TEST_F(UpdateConfigActionTest, test_update_number_tablet_writer_threads) {
     }
 }
 
+TEST_F(UpdateConfigActionTest, test_update_transaction_publish_version_worker_count) {
+    UpdateConfigAction action(ExecEnv::GetInstance());
+
+    auto st = action.update_config("transaction_publish_version_worker_count", "8");
+    CHECK_OK(st);
+    ASSERT_EQ(8, ExecEnv::GetInstance()->put_aggregate_metadata_thread_pool()->max_threads());
+}
+
 } // namespace starrocks

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -1047,11 +1047,14 @@ TEST_F(LakeServiceTest, test_aggregate_compact) {
                 TxnLogPB txnlog;
                 txnlog.set_tablet_id(100);
                 txnlog.set_txn_id(100);
+                txnlog.set_partition_id(99);
                 resp->add_txn_logs()->CopyFrom(txnlog);
                 TxnLogPB txnlog2;
                 txnlog2.set_tablet_id(101);
                 txnlog2.set_txn_id(100);
+                txnlog2.set_partition_id(99);
                 resp->add_txn_logs()->CopyFrom(txnlog2);
+                resp->mutable_status()->set_status_code(0);
                 done->Run();
             }));
     // compact success - single cn
@@ -1067,6 +1070,7 @@ TEST_F(LakeServiceTest, test_aggregate_compact) {
         request.add_tablet_ids(_tablet_id);
         request.set_txn_id(txn_id);
         request.set_version(1);
+        request.set_timeout_ms(3000);
         // add request to agg_request
         agg_request.add_requests()->CopyFrom(request);
         agg_request.add_compute_nodes()->CopyFrom(cn);
@@ -1087,6 +1091,7 @@ TEST_F(LakeServiceTest, test_aggregate_compact) {
             request.add_tablet_ids(_tablet_id);
             request.set_txn_id(txn_id);
             request.set_version(1);
+            request.set_timeout_ms(3000);
             // add request to agg_request
             agg_request.add_requests()->CopyFrom(request);
             agg_request.add_compute_nodes()->CopyFrom(cn);

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -635,9 +635,9 @@ TEST_F(LakeTabletManagerTest, put_aggregate_tablet_metadata) {
         metadata2.set_id(2);
         metadata2.set_version(2);
         metadata2.mutable_schema()->CopyFrom(schema_pb1);
-        auto& item1 = (*metadata1.mutable_historical_schemas())[10];
+        auto& item1 = (*metadata2.mutable_historical_schemas())[10];
         item1.CopyFrom(schema_pb1);
-        auto& item2 = (*metadata1.mutable_historical_schemas())[12];
+        auto& item2 = (*metadata2.mutable_historical_schemas())[12];
         item2.CopyFrom(schema_pb3);
     }
 
@@ -650,6 +650,20 @@ TEST_F(LakeTabletManagerTest, put_aggregate_tablet_metadata) {
     TabletMetadataPtr metadata3 = std::move(res).value();
     ASSERT_EQ(metadata3->schema().id(), 10);
     ASSERT_EQ(metadata3->historical_schemas_size(), 2);
+
+    starrocks::TabletMetadata metadata4;
+    {
+        metadata4.set_id(3);
+        metadata4.set_version(3);
+        metadata4.mutable_schema()->CopyFrom(schema_pb1);
+        auto& item1 = (*metadata4.mutable_historical_schemas())[10];
+        item1.CopyFrom(schema_pb1);
+        auto& item2 = (*metadata4.mutable_historical_schemas())[12];
+        item2.CopyFrom(schema_pb3);
+    }
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata4));
+    res = _tablet_manager->get_tablet_metadata(3, 3);
+    ASSERT_TRUE(res.ok());
 }
 
 TEST_F(LakeTabletManagerTest, cache_tablet_metadata) {


### PR DESCRIPTION
## Why I'm doing:
The combined_txn_log and aggregated_tablet_metadata are written to remote storage directly in the BRPC threads, which may block the BRPC threads. This PR submits these tasks to a thread pool for execution to avoid blocking BRPC threads.

## What I'm doing:

Fixes #58316

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
