### PR TITLE
[BugFix] Fix the OAuth2.0 where arbitrary parameter from redirect_uri is removed.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/OAuth2Action.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/OAuth2Action.java
@@ -56,7 +56,7 @@ public class OAuth2Action extends RestBaseAction {
     @Override
     public void execute(BaseRequest request, BaseResponse response) {
         String authorizationCode = getSingleParameter(request, "code", r -> r);
-        String connectionIdStr = getSingleParameter(request, "connectionId", r -> r);
+        String connectionIdStr = getSingleParameter(request, "state", r -> r);
         long connectionId = Long.parseLong(connectionIdStr);
 
         NodeMgr nodeMgr = GlobalStateMgr.getCurrentState().getNodeMgr();
@@ -112,7 +112,8 @@ public class OAuth2Action extends RestBaseAction {
         Map<Object, Object> postParams = Map.of(
                 "grant_type", "authorization_code",
                 "code", authorizationCode,
-                "redirect_uri", oAuth2Context.redirectUrl() + "?connectionId=" + connectionId,
+                "redirect_uri", oAuth2Context.redirectUrl(),
+                "state=", connectionId,
                 "client_id", oAuth2Context.clientId(),
                 "client_secret", oAuth2Context.clientSecret()
         );

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -391,7 +391,7 @@ public class ConnectProcessor {
                             "?response_type=code" +
                             "&client_id=" + URLEncoder.encode(oAuth2Context.clientId(), StandardCharsets.UTF_8) +
                             "&redirect_uri=" + URLEncoder.encode(oAuth2Context.redirectUrl(), StandardCharsets.UTF_8) +
-                            "?connectionId=" + ctx.getConnectionId() +
+                            "&state=" + ctx.getConnectionId() +
                             "&scope=openid";
 
                     ErrorReport.report(ErrorCode.ERR_OAUTH2_NOT_AUTHENTICATED, authUrl);


### PR DESCRIPTION
## Why I'm doing:
OAuth servers require exact string matching of registered redirect_uri values (per RFC 6749 §4.1.3), prohibiting dynamic parameters in this field.  

Current implementation appends `connection_id=<value>` to the redirect_uri, causing authentication failures when servers validate against static URIs.  

## What I'm doing:
Move connection ID to state parameter, which OAuth spec §4.1.1 designates for client context preservation.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
