### PR TITLE
[Enhancement] Introduce GC control by cluster snapshot info

### DIFF
--- a/be/src/storage/lake/tablet_retain_info.cpp
+++ b/be/src/storage/lake/tablet_retain_info.cpp
@@ -31,12 +31,6 @@ Status TabletRetainInfo::init(int64_t tablet_id, const std::unordered_set<int64_
         auto metadata = std::move(res).value();
         for (const auto& rowset : metadata->rowsets()) {
             _rowset_ids.insert(rowset.id());
-            for (const auto& segment : rowset.segments()) {
-                _files.insert(segment);
-            }
-            for (const auto& del_file : rowset.del_files()) {
-                _files.insert(del_file.name());
-            }
         }
 
         for (const auto& [_, dcg] : (*metadata).dcg_meta().dcgs()) {

--- a/be/src/storage/lake/tablet_retain_info.cpp
+++ b/be/src/storage/lake/tablet_retain_info.cpp
@@ -20,7 +20,7 @@
 
 namespace starrocks::lake {
 
-Status TabletRetainInfo::init(int64_t tablet_id, const std::vector<int64_t>& retain_versions,
+Status TabletRetainInfo::init(int64_t tablet_id, const std::unordered_set<int64_t>& retain_versions,
                               TabletManager* tablet_mgr) {
     _tablet_id = tablet_id;
     for (const auto& version : retain_versions) {

--- a/be/src/storage/lake/tablet_retain_info.h
+++ b/be/src/storage/lake/tablet_retain_info.h
@@ -17,7 +17,6 @@
 #include <cstdint>
 #include <string>
 #include <unordered_set>
-#include <vector>
 
 namespace starrocks {
 class Status;
@@ -36,7 +35,7 @@ public:
     TabletRetainInfo() = default;
     ~TabletRetainInfo() = default;
 
-    Status init(int64_t tablet_id, const std::vector<int64_t>& retain_versions, TabletManager* tablet_mgr);
+    Status init(int64_t tablet_id, const std::unordered_set<int64_t>& retain_versions, TabletManager* tablet_mgr);
 
     bool contains_file(const std::string& file_name) const;
 

--- a/be/test/storage/lake/tablet_retain_info_test.cpp
+++ b/be/test/storage/lake/tablet_retain_info_test.cpp
@@ -158,9 +158,9 @@ TEST_F(LakeTabletRetainInfoTest, test_tablet_retain_info_normal) {
         )DEL")));
 
     TabletRetainInfo tablet_retain_info = TabletRetainInfo();
-    std::vector<int64_t> vec;
-    vec.push_back(2);
-    tablet_retain_info.init(666, vec, _tablet_mgr.get());
+    std::unordered_set<int64_t> set;
+    set.insert(2);
+    tablet_retain_info.init(666, set, _tablet_mgr.get());
 
     EXPECT_TRUE(tablet_retain_info.contains_file("00000000000159e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e11.dat"));
     EXPECT_TRUE(tablet_retain_info.contains_file("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b582.dat"));

--- a/be/test/storage/lake/tablet_retain_info_test.cpp
+++ b/be/test/storage/lake/tablet_retain_info_test.cpp
@@ -162,8 +162,8 @@ TEST_F(LakeTabletRetainInfoTest, test_tablet_retain_info_normal) {
     set.insert(2);
     tablet_retain_info.init(666, set, _tablet_mgr.get());
 
-    EXPECT_TRUE(tablet_retain_info.contains_file("00000000000159e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e11.dat"));
-    EXPECT_TRUE(tablet_retain_info.contains_file("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b582.dat"));
+    EXPECT_FALSE(tablet_retain_info.contains_file("00000000000159e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e11.dat"));
+    EXPECT_FALSE(tablet_retain_info.contains_file("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b582.dat"));
     EXPECT_TRUE(tablet_retain_info.contains_file("00000000000159e3_3ea06130-ccac-4110-9de8-4813512c60da.delvec"));
     EXPECT_TRUE(tablet_retain_info.contains_file("0000000000011111_9ae981b3-7d4b-49e9-9723-d7f752686155.sst"));
     EXPECT_FALSE(tablet_retain_info.contains_file("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b583.dat"));

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -348,6 +348,10 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
     }
 
     private synchronized boolean canEraseDatabase(RecycleDatabaseInfo databaseInfo, long currentTimeMs) {
+        if (GlobalStateMgr.getCurrentState().getClusterSnapshotMgr()
+                            .isDbInClusterSnapshotInfo(databaseInfo.getDb().getId())) {
+            return false;
+        }
         if (!checkValidDeletionByClusterSnapshot(databaseInfo.getDb().getId())) {
             return false;
         }
@@ -360,6 +364,11 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
     }
 
     private synchronized boolean canEraseTable(RecycleTableInfo tableInfo, long currentTimeMs) {
+        if (GlobalStateMgr.getCurrentState().getClusterSnapshotMgr()
+                            .isTableInClusterSnapshotInfo(tableInfo.getDbId(), tableInfo.getTable().getId())) {
+            return false;
+        }
+
         if (!checkValidDeletionByClusterSnapshot(tableInfo.getTable().getId())) {
             return false;
         }
@@ -376,6 +385,12 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
     }
 
     private synchronized boolean canErasePartition(RecyclePartitionInfo partitionInfo, long currentTimeMs) {
+        if (GlobalStateMgr.getCurrentState().getClusterSnapshotMgr()
+                            .isPartitionInClusterSnapshotInfo(partitionInfo.getDbId(),
+                                    partitionInfo.getTableId(), partitionInfo.getPartition().getId())) {
+            return false;
+        }
+
         if (!checkValidDeletionByClusterSnapshot(partitionInfo.getPartition().getId())) {
             return false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
@@ -310,6 +310,27 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
         }
     }
 
+    public boolean isDbInClusterSnapshotInfo(long dbId) {
+        return false;
+    }
+
+    public boolean isTableInClusterSnapshotInfo(long dbId, long tableId) {
+        return false;
+    }
+
+    public boolean isPartitionInClusterSnapshotInfo(long dbId, long tableId, long partId) {
+        return false;
+    }
+
+    public boolean isMaterializedIndexInClusterSnapshotInfo(long dbId, long tableId, long partId, long indexId) {
+        return false;
+    }
+
+    public boolean isMaterializedIndexInClusterSnapshotInfo(
+                   long dbId, long tableId, long partId, long physicalPartId, long indexId) {
+        return false;
+    }
+
     public void start() {
         if (RunMode.isSharedDataMode() && clusterSnapshotCheckpointScheduler == null) {
             clusterSnapshotCheckpointScheduler = new ClusterSnapshotCheckpointScheduler(

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -238,6 +238,7 @@ public class AutovacuumDaemon extends FrontendDaemon {
             vacuumRequest.graceTimestamp = Math.min(vacuumRequest.graceTimestamp,
                     Math.max(GlobalStateMgr.getCurrentState().getClusterSnapshotMgr()
                             .getSafeDeletionTimeMs() / MILLISECONDS_PER_SECOND, 1));
+            vacuumRequest.retainVersions = Lists.newArrayList();
             vacuumRequest.minActiveTxnId = minActiveTxnId;
             vacuumRequest.partitionId = partition.getId();
             vacuumRequest.deleteTxnLog = needDeleteTxnLog;

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -132,6 +132,7 @@ public class StarMgrMetaSyncerTest {
         long tableId = 2L;
         long partitionId = 3L;
         long physicalPartitionId = 4L;
+        long indexId = 5L;
 
 
         new Expectations() {
@@ -246,7 +247,10 @@ public class StarMgrMetaSyncerTest {
         for (long groupId : allShardGroupId) {
             ShardGroupInfo info = ShardGroupInfo.newBuilder()
                     .setGroupId(groupId)
-                    .putLabels("tableId", String.valueOf(tableId))
+                    .putLabels("tableId", String.valueOf(6L))
+                    .putLabels("dbId", String.valueOf(66L))
+                    .putLabels("partitionId", String.valueOf(666L))
+                    .putLabels("indexId", String.valueOf(6666L))
                     .putProperties("createTime", String.valueOf(System.currentTimeMillis()))
                     .build();
             shardGroupInfos.add(info);
@@ -486,7 +490,10 @@ public class StarMgrMetaSyncerTest {
         for (long groupId : allShardGroupId) {
             ShardGroupInfo info = ShardGroupInfo.newBuilder()
                     .setGroupId(groupId)
-                    .putLabels("tableId", String.valueOf(tableId))
+                    .putLabels("tableId", String.valueOf(6L))
+                    .putLabels("dbId", String.valueOf(66L))
+                    .putLabels("partitionId", String.valueOf(666L))
+                    .putLabels("indexId", String.valueOf(6666L))
                     .putProperties("createTime", String.valueOf(System.currentTimeMillis() - 86400 * 1000))
                     .addAllShardIds(allShardIds)
                     .build();
@@ -576,7 +583,10 @@ public class StarMgrMetaSyncerTest {
         List<ShardGroupInfo> shardGroupInfos = new ArrayList<>();
         ShardGroupInfo info = ShardGroupInfo.newBuilder()
                 .setGroupId(groupIdToClear)
-                .putLabels("tableId", String.valueOf(tableId))
+                .putLabels("tableId", String.valueOf(6L))
+                .putLabels("dbId", String.valueOf(66L))
+                .putLabels("partitionId", String.valueOf(666L))
+                .putLabels("indexId", String.valueOf(6666L))
                 .putProperties("createTime", String.valueOf(System.currentTimeMillis() - 86400 * 1000))
                 .addAllShardIds(allShardIds)
                 .build();
@@ -623,7 +633,10 @@ public class StarMgrMetaSyncerTest {
         List<ShardGroupInfo> shardGroupInfos = new ArrayList<>();
         ShardGroupInfo info = ShardGroupInfo.newBuilder()
                 .setGroupId(groupIdToClear)
-                .putLabels("tableId", String.valueOf(tableId))
+                .putLabels("tableId", String.valueOf(6L))
+                .putLabels("dbId", String.valueOf(66L))
+                .putLabels("partitionId", String.valueOf(666L))
+                .putLabels("indexId", String.valueOf(6666L))
                 .putProperties("createTime", String.valueOf(System.currentTimeMillis() - 86400 * 1000))
                 .addAllShardIds(allShardIds)
                 .build();
@@ -688,7 +701,10 @@ public class StarMgrMetaSyncerTest {
         List<ShardGroupInfo> shardGroupInfos = new ArrayList<>();
         ShardGroupInfo info = ShardGroupInfo.newBuilder()
                 .setGroupId(groupIdToClear)
-                .putLabels("tableId", String.valueOf(tableId))
+                .putLabels("tableId", String.valueOf(6L))
+                .putLabels("dbId", String.valueOf(66L))
+                .putLabels("partitionId", String.valueOf(666L))
+                .putLabels("indexId", String.valueOf(6666L))
                 .putProperties("createTime", String.valueOf(System.currentTimeMillis() - 86400 * 1000))
                 .addAllShardIds(allShardIds)
                 .build();
@@ -766,7 +782,10 @@ public class StarMgrMetaSyncerTest {
         List<ShardGroupInfo> shardGroupInfos = new ArrayList<>();
         ShardGroupInfo info = ShardGroupInfo.newBuilder()
                 .setGroupId(groupIdToClear)
-                .putLabels("tableId", String.valueOf(tableId))
+                .putLabels("tableId", String.valueOf(6L))
+                .putLabels("dbId", String.valueOf(66L))
+                .putLabels("partitionId", String.valueOf(666L))
+                .putLabels("indexId", String.valueOf(6666L))
                 .putProperties("createTime", String.valueOf(System.currentTimeMillis() - 86400 * 1000))
                 .addAllShardIds(allShardIds)
                 .build();
@@ -924,8 +943,24 @@ public class StarMgrMetaSyncerTest {
         shards.add(111L);
         shards.add(222L);
         shards.add(333L);
-        starMgrMetaSyncer.syncTableMetaInternal(db, (OlapTable) table, true);
+        shards.add(555L);
+        Assert.assertTrue(starMgrMetaSyncer.syncTableMetaInternal(db, (OlapTable) table, true));
         Assert.assertEquals(3, shards.size());
+
+        shards.clear();
+        shards.add(111L);
+        shards.add(222L);
+        shards.add(333L);
+        shards.add(555L);
+        new MockUp<ClusterSnapshotMgr>() {
+            @Mock
+            public boolean isMaterializedIndexInClusterSnapshotInfo(
+                    long dbId, long tableId, long partId, long physicalPartId, long indexId) {
+                return true;
+            }
+        };
+        Assert.assertTrue(!starMgrMetaSyncer.syncTableMetaInternal(db, (OlapTable) table, true));
+        Assert.assertEquals(4, shards.size());
     }
 
     @Test
@@ -967,12 +1002,18 @@ public class StarMgrMetaSyncerTest {
 
         ShardGroupInfo info1 = ShardGroupInfo.newBuilder()
                 .setGroupId(99L)
-                .putLabels("tableId", String.valueOf(100L))
+                .putLabels("tableId", String.valueOf(6L))
+                .putLabels("dbId", String.valueOf(66L))
+                .putLabels("partitionId", String.valueOf(666L))
+                .putLabels("indexId", String.valueOf(6666L))
                 .putProperties("createTime", String.valueOf(System.currentTimeMillis()))
                 .build();
         ShardGroupInfo info2 = ShardGroupInfo.newBuilder()
                 .setGroupId(100L)
-                .putLabels("tableId", String.valueOf(111L))
+                .putLabels("tableId", String.valueOf(6L))
+                .putLabels("dbId", String.valueOf(66L))
+                .putLabels("partitionId", String.valueOf(666L))
+                .putLabels("indexId", String.valueOf(6666L))
                 .putProperties("createTime", String.valueOf(System.currentTimeMillis()))
                 .build();
         List<ShardGroupInfo> shardGroupsInfo = new ArrayList();
@@ -1057,7 +1098,12 @@ public class StarMgrMetaSyncerTest {
         List<ShardGroupInfo> shardGroupInfos = new ArrayList<>(baseSize + 100);
         for (long i = 1; i <= baseSize; ++i) {
             shardGroupInfos.add(
-                    ShardGroupInfo.newBuilder().setGroupId(i).putProperties("createTime", strNow).build());
+                    ShardGroupInfo.newBuilder().setGroupId(i)
+                    .putLabels("tableId", String.valueOf(6L))
+                    .putLabels("dbId", String.valueOf(66L))
+                    .putLabels("partitionId", String.valueOf(666L))
+                    .putLabels("indexId", String.valueOf(6666L))
+                    .putProperties("createTime", strNow).build());
         }
 
         // 2. add a few numbers in shardGroupInfos but not in groupIdsInFE abd the creation timestamp is NOT expired.
@@ -1066,7 +1112,12 @@ public class StarMgrMetaSyncerTest {
         for (long i = baseSize + offset; i < baseSize + offset + 10; ++i) {
             shardGroupSet1.add(i);
             shardGroupInfos.add(
-                    ShardGroupInfo.newBuilder().setGroupId(i).putProperties("createTime", str4HrsAgo).build());
+                    ShardGroupInfo.newBuilder().setGroupId(i)
+                    .putLabels("tableId", String.valueOf(6L))
+                    .putLabels("dbId", String.valueOf(66L))
+                    .putLabels("partitionId", String.valueOf(666L))
+                    .putLabels("indexId", String.valueOf(6666L))
+                    .putProperties("createTime", str4HrsAgo).build());
         }
 
         // 3. add a few numbers in shardGroupInfos but not in groupIdsInFE and the creation timestamp is expired.
@@ -1075,7 +1126,12 @@ public class StarMgrMetaSyncerTest {
         for (long i = baseSize + offset; i < baseSize + offset + 10; ++i) {
             shardGroupSet2.add(i);
             shardGroupInfos.add(
-                    ShardGroupInfo.newBuilder().setGroupId(i).putProperties("createTime", str2HrsAgo).build());
+                    ShardGroupInfo.newBuilder().setGroupId(i)
+                    .putLabels("tableId", String.valueOf(6L))
+                    .putLabels("dbId", String.valueOf(66L))
+                    .putLabels("partitionId", String.valueOf(666L))
+                    .putLabels("indexId", String.valueOf(6666L))
+                    .putProperties("createTime", str2HrsAgo).build());
         }
 
         List<Long> cleanedGroupIds = new ArrayList<>();
@@ -1083,6 +1139,9 @@ public class StarMgrMetaSyncerTest {
             {
                 GlobalStateMgr.getCurrentState().getStarOSAgent();
                 result = starosAgent;
+
+                GlobalStateMgr.getCurrentState().getClusterSnapshotMgr();
+                result = clusterSnapshotMgr;
             }
         };
 
@@ -1161,7 +1220,12 @@ public class StarMgrMetaSyncerTest {
         for (long i = 1; i <= size; ++i) {
             groupIds.add(i);
             shardGroupInfos.add(
-                    ShardGroupInfo.newBuilder().setGroupId(i).putProperties("createTime", str2secsAgo).build());
+                    ShardGroupInfo.newBuilder().setGroupId(i)
+                    .putLabels("tableId", String.valueOf(6L))
+                    .putLabels("dbId", String.valueOf(66L))
+                    .putLabels("partitionId", String.valueOf(666L))
+                    .putLabels("indexId", String.valueOf(6666L))
+                    .putProperties("createTime", str2secsAgo).build());
         }
 
         AtomicLong delayMs = new AtomicLong();
@@ -1172,6 +1236,9 @@ public class StarMgrMetaSyncerTest {
             {
                 GlobalStateMgr.getCurrentState().getStarOSAgent();
                 result = starosAgent;
+
+                GlobalStateMgr.getCurrentState().getClusterSnapshotMgr();
+                result = clusterSnapshotMgr;
             }
         };
 
@@ -1233,5 +1300,66 @@ public class StarMgrMetaSyncerTest {
             Assert.assertEquals(new HashSet<>(cleanedGroupIds), groupIds);
         }
         Config.shard_group_clean_threshold_sec = oldConfValue;
+    }
+
+    @Test
+    public void testDeleteUnusedShardAndShardGroupWithSnapshotInfo() {
+        boolean oldValue = Config.meta_sync_force_delete_shard_meta;
+        Config.meta_sync_force_delete_shard_meta = false;
+        Config.shard_group_clean_threshold_sec = 0;
+        long groupIdToClear = shardGroupId + 1;
+        // build shardGroupInfos
+        List<Long> allShardIds = Stream.of(1000L, 1001L, 1002L, 1003L).collect(Collectors.toList());
+        int numOfShards = allShardIds.size();
+        List<ShardGroupInfo> shardGroupInfos = new ArrayList<>();
+        ShardGroupInfo info = ShardGroupInfo.newBuilder()
+                .setGroupId(groupIdToClear)
+                .putLabels("tableId", String.valueOf(6L))
+                .putLabels("dbId", String.valueOf(66L))
+                .putLabels("partitionId", String.valueOf(666L))
+                .putLabels("indexId", String.valueOf(6666L))
+                .putProperties("createTime", String.valueOf(System.currentTimeMillis() - 86400 * 1000))
+                .addAllShardIds(allShardIds)
+                .build();
+        shardGroupInfos.add(info);
+
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public void deleteShardGroup(List<Long> groupIds) {
+                for (long groupId : groupIds) {
+                    shardGroupInfos.removeIf(item -> item.getGroupId() == groupId);
+                }
+            }
+            @Mock
+            public List<ShardGroupInfo> listShardGroup() {
+                return shardGroupInfos;
+            }
+
+            @Mock
+            public List<Long> listShard(long groupId) {
+                if (groupId == groupIdToClear) {
+                    return allShardIds;
+                } else {
+                    return Lists.newArrayList();
+                }
+            }
+
+            @Mock
+            public void deleteShards(Set<Long> shardIds) {
+                allShardIds.removeAll(shardIds);
+            }
+        };
+
+        new Expectations(clusterSnapshotMgr) {
+            {
+                clusterSnapshotMgr.isMaterializedIndexInClusterSnapshotInfo(anyLong, anyLong, anyLong, anyLong);
+                minTimes = 1;
+                result = true;
+            }
+        };
+
+        Deencapsulation.invoke(starMgrMetaSyncer, "deleteUnusedShardAndShardGroup");
+
+        Config.meta_sync_force_delete_shard_meta = oldValue;
     }
 }

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -297,6 +297,12 @@ message VacuumRequest {
     repeated TabletInfoPB tablet_infos = 7;
     // Whether enable file bundling
     optional bool enable_file_bundling = 8;
+    // retain version info of tablet metadata
+    // The version here means the version of tablet metadata or the physical partition version
+    // (because vacuun request is send by <node, physical partition>)
+    // All tablet metadata and their data files of these verisons should be retained and can not be
+    // vaccummed.
+    repeated int64 retain_versions = 9;
 }
 
 message VacuumResponse {


### PR DESCRIPTION
## Why I'm doing:
For the GC of cluster snapshot, we retain all version large than latest version of the current cluster snapshot createTime
But the problem is that too many version can not be vaccumed even the files does not contained in the snapshot version.

# What I'm doing:
Introduce cluster snapshot info based GC control for cluster snapshot as following:

1. Can not vacuum all retain versions from the cluster snapshot info.
2. Can not drop the partition/table/db in catalogbin if it is in cluster snapshot info.
3. Can not remove the data when doing StarMgrSyncer::deleteUnusedShardAndShardGroup if the corressponding index id is in cluster snapshot info.
4. Can not remove the data when doing StarMgrSyncer::syncTableMetaInternal if the corressponding index id is in cluster snapshot info.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
