### PR TITLE
[Feature] implement iceberg transform functions

### DIFF
--- a/be/src/exprs/binary_functions.h
+++ b/be/src/exprs/binary_functions.h
@@ -55,6 +55,8 @@ public:
     DEFINE_VECTORIZED_FN(from_binary);
     static Status from_binary_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope);
     static Status from_binary_close(FunctionContext* context, FunctionContext::FunctionStateScope scope);
+
+    DEFINE_VECTORIZED_FN(iceberg_truncate_binary);
 };
 
 } // namespace starrocks

--- a/be/src/exprs/function_helper.h
+++ b/be/src/exprs/function_helper.h
@@ -105,4 +105,23 @@ public:
         }                                    \
     } while (false)
 
+#define PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1)     \
+    do {                                                                \
+        if (c0->only_null() || c1->only_null()) {                       \
+            return ColumnHelper::create_const_null_column(c0->size());  \
+        }                                                               \
+        if (c0->has_null() || c1->has_null()) {                         \
+            has_null = true;                                            \
+            null_flags = FunctionHelper::union_nullable_column(c0, c1); \
+        } else {                                                        \
+            null_flags = NullColumn::create();                          \
+            null_flags->reserve(c0->size());                            \
+            null_flags->append_default(c0->size());                     \
+        }                                                               \
+        c0 = FunctionHelper::get_data_column_of_const(c0);              \
+        c1 = FunctionHelper::get_data_column_of_const(c1);              \
+        c0 = FunctionHelper::get_data_column_of_nullable(c0);           \
+        c1 = FunctionHelper::get_data_column_of_nullable(c1);           \
+    } while (0)
+
 } // namespace starrocks

--- a/be/src/exprs/math_functions.h
+++ b/be/src/exprs/math_functions.h
@@ -224,6 +224,18 @@ public:
      */
     DEFINE_VECTORIZED_FN(truncate_decimal128);
 
+    DEFINE_VECTORIZED_FN_TEMPLATE(iceberg_truncate_decimal);
+    DEFINE_VECTORIZED_FN_TEMPLATE(iceberg_truncate_int);
+    //iceberg_truncate_string is defined as StringFunction::left
+
+    DEFINE_VECTORIZED_FN_TEMPLATE(iceberg_bucket_int);
+    DEFINE_VECTORIZED_FN(iceberg_bucket_string);
+    DEFINE_VECTORIZED_FN(iceberg_bucket_date);
+    DEFINE_VECTORIZED_FN(iceberg_bucket_datetime);
+    template <typename T>
+    static vector<uint8_t> int_to_byte_array(T value);
+    DEFINE_VECTORIZED_FN_TEMPLATE(iceberg_bucket_decimal);
+
     /**
     * @param: [DoubleColumn]
     * @return: DoubleColumn

--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -834,7 +834,6 @@ template <TimeUnit UNIT>
 TimestampValue timestamp_add(TimestampValue tsv, int count) {
     return tsv.add<UNIT>(count);
 }
-
 #define DEFINE_TIME_ADD_FN(FN, UNIT)                                                                               \
     DEFINE_BINARY_FUNCTION_WITH_IMPL(FN##Impl, timestamp, value) { return timestamp_add<UNIT>(timestamp, value); } \
                                                                                                                    \
@@ -2898,8 +2897,88 @@ Status TimeFunctions::date_trunc_close(FunctionContext* context, FunctionContext
     return Status::OK();
 }
 
+DEFINE_UNARY_FN_WITH_IMPL(iceberg_years_since_epoch_dateImpl, v) {
+    int y, m, d;
+    ((DateValue)v).to_date(&y, &m, &d);
+    auto ts = TimestampValue::create(y, m, d, 0, 0, 0, 0);
+    return years_diff_v2Impl::apply<TimestampValue, TimestampValue, int64_t>(ts, TimeFunctions::unix_epoch);
+}
+
+DEFINE_UNARY_FN_WITH_IMPL(iceberg_years_since_epoch_datetimeImpl, v) {
+    return years_diff_v2Impl::apply<TimestampValue, TimestampValue, int64_t>(v, TimeFunctions::unix_epoch);
+}
+
+StatusOr<ColumnPtr> TimeFunctions::iceberg_years_since_epoch_date(FunctionContext* context,
+                                                                  const starrocks::Columns& columns) {
+    return VectorizedStrictUnaryFunction<iceberg_years_since_epoch_dateImpl>::evaluate<TYPE_DATE, TYPE_BIGINT>(
+            VECTORIZED_FN_ARGS(0));
+}
+
+StatusOr<ColumnPtr> TimeFunctions::iceberg_years_since_epoch_datetime(FunctionContext* context,
+                                                                      const starrocks::Columns& columns) {
+    return VectorizedStrictUnaryFunction<iceberg_years_since_epoch_datetimeImpl>::evaluate<TYPE_DATETIME, TYPE_BIGINT>(
+            VECTORIZED_FN_ARGS(0));
+}
+
+DEFINE_UNARY_FN_WITH_IMPL(iceberg_months_since_epoch_dateImpl, v) {
+    int y, m, d;
+    ((DateValue)v).to_date(&y, &m, &d);
+    auto ts = TimestampValue::create(y, m, d, 0, 0, 0, 0);
+    return months_diff_v2Impl::apply<TimestampValue, TimestampValue, int64_t>(ts, TimeFunctions::unix_epoch);
+}
+
+DEFINE_UNARY_FN_WITH_IMPL(iceberg_months_since_epoch_datetimeImpl, v) {
+    return months_diff_v2Impl::apply<TimestampValue, TimestampValue, int64_t>(v, TimeFunctions::unix_epoch);
+}
+
+StatusOr<ColumnPtr> TimeFunctions::iceberg_months_since_epoch_date(FunctionContext* context,
+                                                                   const starrocks::Columns& columns) {
+    return VectorizedStrictUnaryFunction<iceberg_months_since_epoch_dateImpl>::evaluate<TYPE_DATE, TYPE_BIGINT>(
+            VECTORIZED_FN_ARGS(0));
+}
+
+StatusOr<ColumnPtr> TimeFunctions::iceberg_months_since_epoch_datetime(FunctionContext* context,
+                                                                       const starrocks::Columns& columns) {
+    return VectorizedStrictUnaryFunction<iceberg_months_since_epoch_datetimeImpl>::evaluate<TYPE_DATETIME, TYPE_BIGINT>(
+            VECTORIZED_FN_ARGS(0));
+}
+
+DEFINE_UNARY_FN_WITH_IMPL(iceberg_days_since_epoch_dateImpl, v) {
+    int y, m, d;
+    ((DateValue)v).to_date(&y, &m, &d);
+    auto ts = TimestampValue::create(y, m, d, 0, 0, 0, 0);
+    return days_diffImpl::apply<TimestampValue, TimestampValue, int64_t>(ts, TimeFunctions::unix_epoch);
+}
+
+DEFINE_UNARY_FN_WITH_IMPL(iceberg_days_since_epoch_datetimeImpl, v) {
+    return days_diffImpl::apply<TimestampValue, TimestampValue, int64_t>(v, TimeFunctions::unix_epoch);
+}
+
+StatusOr<ColumnPtr> TimeFunctions::iceberg_days_since_epoch_date(FunctionContext* context,
+                                                                 const starrocks::Columns& columns) {
+    return VectorizedStrictUnaryFunction<iceberg_days_since_epoch_dateImpl>::evaluate<TYPE_DATE, TYPE_BIGINT>(
+            VECTORIZED_FN_ARGS(0));
+}
+
+StatusOr<ColumnPtr> TimeFunctions::iceberg_days_since_epoch_datetime(FunctionContext* context,
+                                                                     const starrocks::Columns& columns) {
+    return VectorizedStrictUnaryFunction<iceberg_days_since_epoch_datetimeImpl>::evaluate<TYPE_DATETIME, TYPE_BIGINT>(
+            VECTORIZED_FN_ARGS(0));
+}
+
+DEFINE_UNARY_FN_WITH_IMPL(iceberg_hours_since_epoch_datetimeImpl, v) {
+    return hours_diffImpl::apply<TimestampValue, TimestampValue, int64_t>(v, TimeFunctions::unix_epoch);
+}
+
+StatusOr<ColumnPtr> TimeFunctions::iceberg_hours_since_epoch_datetime(FunctionContext* context,
+                                                                      const starrocks::Columns& columns) {
+    return VectorizedStrictUnaryFunction<iceberg_hours_since_epoch_datetimeImpl>::evaluate<TYPE_DATETIME, TYPE_BIGINT>(
+            VECTORIZED_FN_ARGS(0));
+}
+
 // used as start point of time_slice.
 TimestampValue TimeFunctions::start_of_time_slice = TimestampValue::create(1, 1, 1, 0, 0, 0);
+TimestampValue TimeFunctions::unix_epoch = TimestampValue::create(1970, 1, 1, 0, 0, 0);
 std::string TimeFunctions::info_reported_by_time_slice = "time used with time_slice can't before 0001-01-01 00:00:00";
 #undef DEFINE_TIME_UNARY_FN
 #undef DEFINE_TIME_UNARY_FN_WITH_IMPL

--- a/be/src/exprs/time_functions.h
+++ b/be/src/exprs/time_functions.h
@@ -811,6 +811,14 @@ public:
      */
     DEFINE_VECTORIZED_FN(time_format);
 
+    DEFINE_VECTORIZED_FN(iceberg_years_since_epoch_date);
+    DEFINE_VECTORIZED_FN(iceberg_years_since_epoch_datetime);
+    DEFINE_VECTORIZED_FN(iceberg_months_since_epoch_date);
+    DEFINE_VECTORIZED_FN(iceberg_months_since_epoch_datetime);
+    DEFINE_VECTORIZED_FN(iceberg_days_since_epoch_date);
+    DEFINE_VECTORIZED_FN(iceberg_days_since_epoch_datetime);
+    DEFINE_VECTORIZED_FN(iceberg_hours_since_epoch_datetime);
+
 private:
     DEFINE_VECTORIZED_FN_TEMPLATE(_t_from_unix_to_datetime);
 
@@ -853,6 +861,7 @@ private:
 
 public:
     static TimestampValue start_of_time_slice;
+    static TimestampValue unix_epoch;
     static std::string info_reported_by_time_slice;
 
     enum FormatType {

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -4008,4 +4008,99 @@ TEST_F(TimeFunctionsTest, formatTimeTest) {
         EXPECT_EQ("14", std::string(result_viewer.value(3)));
     }
 }
+
+TEST_F(TimeFunctionsTest, IcbergTransTest) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+
+    {
+        Columns columns_const;
+        auto col1 = DateColumn::create();
+        col1->append(DateValue::create(2022, 2, 2));
+        columns_const.emplace_back(std::move(col1));
+
+        ColumnPtr result = TimeFunctions::iceberg_years_since_epoch_date(ctx.get(), columns_const).value();
+        ASSERT_TRUE(result->is_numeric());
+        ASSERT_FALSE(result->is_nullable());
+        auto v = ColumnHelper::as_column<Int64Column>(result);
+        ASSERT_EQ(2022 - 1970, v->get_data()[0]);
+    }
+
+    {
+        Columns columns_const;
+        auto col1 = DateColumn::create();
+        col1->append(DateValue::create(1970, 2, 28));
+        columns_const.emplace_back(std::move(col1));
+
+        ColumnPtr result = TimeFunctions::iceberg_months_since_epoch_date(ctx.get(), columns_const).value();
+        ASSERT_TRUE(result->is_numeric());
+        ASSERT_FALSE(result->is_nullable());
+        auto v = ColumnHelper::as_column<Int64Column>(result);
+        ASSERT_EQ(1, v->get_data()[0]);
+    }
+
+    {
+        Columns columns_const;
+        auto col1 = TimestampColumn::create();
+        col1->append(TimestampValue::create(2022, 2, 2, 12, 22, 22));
+        columns_const.emplace_back(std::move(col1));
+
+        ColumnPtr result = TimeFunctions::iceberg_years_since_epoch_datetime(ctx.get(), columns_const).value();
+        ASSERT_TRUE(result->is_numeric());
+        ASSERT_FALSE(result->is_nullable());
+        auto v = ColumnHelper::as_column<Int64Column>(result);
+        ASSERT_EQ(2022 - 1970, v->get_data()[0]);
+    }
+
+    {
+        Columns columns_const;
+        auto col1 = TimestampColumn::create();
+        col1->append(TimestampValue::create(1970, 2, 2, 12, 22, 22));
+        columns_const.emplace_back(std::move(col1));
+
+        ColumnPtr result = TimeFunctions::iceberg_months_since_epoch_datetime(ctx.get(), columns_const).value();
+        ASSERT_TRUE(result->is_numeric());
+        ASSERT_FALSE(result->is_nullable());
+        auto v = ColumnHelper::as_column<Int64Column>(result);
+        ASSERT_EQ(1, v->get_data()[0]);
+    }
+
+    {
+        Columns columns_const;
+        auto col1 = TimestampColumn::create();
+        col1->append(TimestampValue::create(1970, 1, 2, 23, 22, 22));
+        columns_const.emplace_back(std::move(col1));
+
+        ColumnPtr result = TimeFunctions::iceberg_days_since_epoch_datetime(ctx.get(), columns_const).value();
+        ASSERT_TRUE(result->is_numeric());
+        ASSERT_FALSE(result->is_nullable());
+        auto v = ColumnHelper::as_column<Int64Column>(result);
+        ASSERT_EQ(1, v->get_data()[0]);
+    }
+
+    {
+        Columns columns_const;
+        auto col1 = TimestampColumn::create();
+        col1->append(TimestampValue::create(1970, 1, 1, 23, 22, 22));
+        columns_const.emplace_back(std::move(col1));
+
+        ColumnPtr result = TimeFunctions::iceberg_hours_since_epoch_datetime(ctx.get(), columns_const).value();
+        ASSERT_TRUE(result->is_numeric());
+        ASSERT_FALSE(result->is_nullable());
+        auto v = ColumnHelper::as_column<Int64Column>(result);
+        ASSERT_EQ(23, v->get_data()[0]);
+    }
+
+    {
+        Columns columns_const;
+        auto col1 = DateColumn::create();
+        col1->append(DateValue::create(1970, 1, 2));
+        columns_const.emplace_back(std::move(col1));
+
+        ColumnPtr result = TimeFunctions::iceberg_days_since_epoch_date(ctx.get(), columns_const).value();
+        ASSERT_TRUE(result->is_numeric());
+        ASSERT_FALSE(result->is_nullable());
+        auto v = ColumnHelper::as_column<Int64Column>(result);
+        ASSERT_EQ(1, v->get_data()[0]);
+    }
+}
 } // namespace starrocks

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -197,6 +197,27 @@ vectorized_functions = [
 
     [10330, "cbrt", True, False, "DOUBLE", ["DOUBLE"], "MathFunctions::cbrt"],
 
+    [10340, '__iceberg_transform_truncate', True, False, 'INT', ['INT', 'INT'], 'MathFunctions::iceberg_truncate_int<TYPE_INT>'],
+    [10341, '__iceberg_transform_truncate', True, False, 'BIGINT', ['BIGINT', 'INT'], 'MathFunctions::iceberg_truncate_int<TYPE_BIGINT>'],
+    [10342, '__iceberg_transform_truncate', True, False, 'DECIMAL32', ['DECIMAL32', 'INT'], 'MathFunctions::iceberg_truncate_decimal<TYPE_DECIMAL32>'],
+    [10343, '__iceberg_transform_truncate', True, False, 'DECIMAL64', ['DECIMAL64', 'INT'], 'MathFunctions::iceberg_truncate_decimal<TYPE_DECIMAL64>'],
+    [10344, '__iceberg_transform_truncate', True, False, 'DECIMAL128', ['DECIMAL128', 'INT'], 'MathFunctions::iceberg_truncate_decimal<TYPE_DECIMAL128>'],
+    [10345, '__iceberg_transform_truncate', True, False, 'VARCHAR', ['VARCHAR', 'INT'], 'StringFunctions::left',
+     'StringFunctions::left_or_right_prepare', 'StringFunctions::left_or_right_close'],
+    [10346, '__iceberg_transform_truncate', True, False, 'VARBINARY', ['VARBINARY', 'INT'], 'BinaryFunctions::iceberg_truncate_binary'],
+     
+
+    [10350, '__iceberg_transform_bucket', True, False, 'INT', ['INT', 'INT'], 'MathFunctions::iceberg_bucket_int<TYPE_INT>'],
+    [10351, '__iceberg_transform_bucket', True, False, 'INT', ['BIGINT', 'INT'], 'MathFunctions::iceberg_bucket_int<TYPE_BIGINT>'],
+    [10352, '__iceberg_transform_bucket', True, False, 'INT', ['DATE', 'INT'], 'MathFunctions::iceberg_bucket_date'],
+    [10353, '__iceberg_transform_bucket', True, False, 'INT', ['DATETIME', 'INT'], 'MathFunctions::iceberg_bucket_datetime'],
+    [10354, '__iceberg_transform_bucket', True, False, 'INT', ['VARCHAR', 'INT'], 'MathFunctions::iceberg_bucket_string'],
+    [10355, '__iceberg_transform_bucket', True, False, 'INT', ['VARBINARY', 'INT'], 'MathFunctions::iceberg_bucket_string'],
+    [10356, '__iceberg_transform_bucket', True, False, 'INT', ['DECIMAL32'], 'MathFunctions::iceberg_bucket_decimal<TYPE_DECIMAL32>'],
+    [10357, '__iceberg_transform_bucket', True, False, 'INT', ['DECIMAL64'], 'MathFunctions::iceberg_bucket_decimal<TYPE_DECIMAL64>'],
+    [10358, '__iceberg_transform_bucket', True, False, 'INT', ['DECIMAL128'], 'MathFunctions::iceberg_bucket_decimal<TYPE_DECIMAL128>'],
+
+
     # 20xxx: bit functions
     [20010, 'bitand', True, False, 'TINYINT', ['TINYINT', 'TINYINT'], "BitFunctions::bitAnd<TYPE_TINYINT>"],
     [20011, 'bitand', True, False, 'SMALLINT', ['SMALLINT', 'SMALLINT'], "BitFunctions::bitAnd<TYPE_SMALLINT>"],
@@ -591,6 +612,15 @@ vectorized_functions = [
      'TimeFunctions::last_day_prepare', 'TimeFunctions::last_day_close'],
     [50501, 'makedate', True, False, 'DATE', ['INT', 'INT'], 'TimeFunctions::make_date'],
     [50610, 'time_format', True, False, 'VARCHAR', ['TIME', 'VARCHAR'], 'TimeFunctions::time_format'],
+
+
+    [50620, '__iceberg_transform_year', True, False, 'BIGINT', ['DATE'], 'TimeFunctions::iceberg_years_since_epoch_date'],
+    [50621, '__iceberg_transform_year', True, False, 'BIGINT', ['DATETIME'], 'TimeFunctions::iceberg_years_since_epoch_datetime'],
+    [50630, '__iceberg_transform_month', True, False, 'BIGINT', ['DATE'], 'TimeFunctions::iceberg_months_since_epoch_date'],
+    [50631, '__iceberg_transform_month', True, False, 'BIGINT', ['DATETIME'], 'TimeFunctions::iceberg_months_since_epoch_datetime'],
+    [50640, '__iceberg_transform_day', True, False, 'BIGINT', ['DATE'], 'TimeFunctions::iceberg_days_since_epoch_date'],
+    [50641, '__iceberg_transform_day', True, False, 'BIGINT', ['DATETIME'], 'TimeFunctions::iceberg_days_since_epoch_datetime'],
+    [50650, '__iceberg_transform_hour', True, False, 'BIGINT', ['DATETIME'], 'TimeFunctions::iceberg_hours_since_epoch_datetime'],
 
     # 60xxx: like predicate
     # important ref: LikePredicate.java, must keep name equals LikePredicate.Operator


### PR DESCRIPTION
## Why I'm doing:
This pr is splitted from https://github.com/StarRocks/starrocks/pull/58509, and implement the transform functions in be.
## What I'm doing:

Fixes #58914

Support iceberg partition transform function:
| Transform  | SR Result Type | SR Argument Type   |
|-------|------|--------|
| year  | int   |  date, datetime   |
| month  | int   |  date, datetime  |
| day | int  | date, datetime   |
| hour | int   | datetime   |
| bucket | int   | int, bigint, date, datetime, varchar,  varbinary, decimal32, decimal64, decimal128  |
| truncate | origin column type   |  int, bigint, decimal32, decimal64, decimal128, varchar, varbinary   |


These functions are not for users, and could only be called internally for iceberg table.


## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
