### PR TITLE
[Enhancement] support more spm function

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -677,7 +677,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_CBO_VIEW_BASED_MV_REWRITE = "enable_cbo_view_based_mv_rewrite";
 
-    public static final String ENABLE_SPM_REWRITE = "enable_sql_plan_manager_rewrite";
+    public static final String ENABLE_SPM_REWRITE = "enable_spm_rewrite";
+    public static final String SPM_REWRITE_TIMEOUT_MS = "spm_rewrite_timeout_ms";
 
     public static final String ENABLE_BIG_QUERY_LOG = "enable_big_query_log";
     public static final String BIG_QUERY_LOG_CPU_SECOND_THRESHOLD = "big_query_log_cpu_second_threshold";
@@ -2196,6 +2197,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_SPM_REWRITE)
     private boolean enableSPMRewrite = false;
+
+    @VarAttr(name = SPM_REWRITE_TIMEOUT_MS, flag = VariableMgr.INVISIBLE)
+    private int spmRewriteTimeoutMs = 1000;
 
     /**
      * Materialized view rewrite rule output limit: how many MVs would be chosen in a Rule for an OptExpr ?
@@ -4981,6 +4985,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableJoinReorderBeforeDeduplicate(boolean enableJoinReorderBeforeDeduplicate) {
         this.enableJoinReorderBeforeDeduplicate = enableJoinReorderBeforeDeduplicate;
+    }
+
+    public int getSpmRewriteTimeoutMs() {
+        return spmRewriteTimeoutMs;
+    }
+
+    public void setSpmRewriteTimeoutMs(int spmRewriteTimeoutMs) {
+        this.spmRewriteTimeoutMs = spmRewriteTimeoutMs;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -734,7 +734,7 @@ public class FunctionAnalyzer {
             return fn;
         }
 
-        fn = SPMFunctions.getSPMFunction(node.getFnName().getFunction());
+        fn = SPMFunctions.getSPMFunction(node, Arrays.stream(argumentTypes).toList());
         if (fn != null) {
             return fn;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
@@ -201,14 +201,16 @@ public class ColumnFilterConverter {
                 return;
             }
             ScalarOperator clone = predicate.clone();
-            clone.getChildren().clear();
+            List<ScalarOperator> newChildren = Lists.newArrayList();
             for (ScalarOperator child : clone.getChildren()) {
                 if (!SPMFunctions.isSPMFunctions(child)) {
-                    clone.getChildren().add(child);
+                    newChildren.add(child);
                 } else {
-                    clone.getChildren().addAll(SPMFunctions.revertSPMFunctions(child));
+                    newChildren.addAll(SPMFunctions.revertSPMFunctions(child));
                 }
             }
+            clone.getChildren().clear();
+            clone.getChildren().addAll(newChildren);
             predicate = clone;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
@@ -201,16 +201,14 @@ public class ColumnFilterConverter {
                 return;
             }
             ScalarOperator clone = predicate.clone();
-            List<ScalarOperator> newChildren = Lists.newArrayList();
+            clone.getChildren().clear();
             for (ScalarOperator child : clone.getChildren()) {
                 if (!SPMFunctions.isSPMFunctions(child)) {
-                    newChildren.add(child);
+                    clone.getChildren().add(child);
                 } else {
-                    newChildren.addAll(SPMFunctions.revertSPMFunctions(child));
+                    clone.getChildren().addAll(SPMFunctions.revertSPMFunctions(child));
                 }
             }
-            clone.getChildren().clear();
-            clone.getChildren().addAll(newChildren);
             predicate = clone;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
@@ -337,7 +337,7 @@ public class SimplifiedPredicateRule extends BottomUpScalarOperatorRewriteRule {
             return predicate;
         }
 
-        if (SPMFunctions.isSPMFunctions(predicate.getChild(1))) {
+        if (SPMFunctions.isSPMFunctions(predicate)) {
             return predicate;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
@@ -313,13 +313,8 @@ public class PredicateStatisticsCalculator {
                 // only columnRefOperator could add column statistic to statistics
                 leftChildOpt = leftChild.isColumnRef() ? Optional.of((ColumnRefOperator) leftChild) : Optional.empty();
 
-                if (rightChild.isConstant()) {
-                    Optional<ConstantOperator> constantOperator;
-                    if (rightChild.isConstantRef()) {
-                        constantOperator = Optional.of((ConstantOperator) rightChild);
-                    } else {
-                        constantOperator = Optional.empty();
-                    }
+                if (rightChild.isConstantRef()) {
+                    Optional<ConstantOperator> constantOperator = Optional.of((ConstantOperator) rightChild);
                     Statistics binaryStats =
                             BinaryPredicateStatisticCalculator.estimateColumnToConstantComparison(leftChildOpt,
                                     leftColumnStatistic, predicate, constantOperator, statistics);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
@@ -125,8 +125,12 @@ public class PredicateStatisticsCalculator {
             if (!checkNeedEvalEstimate(predicate)) {
                 return statistics;
             }
-            if (SPMFunctions.isSPMFunctions(predicate) && SPMFunctions.canRevert2ScalarOperator(predicate)) {
-                predicate = (InPredicateOperator) SPMFunctions.revertSPMFunctions(predicate).get(0);
+            if (SPMFunctions.isSPMFunctions(predicate)) {
+                if (SPMFunctions.canRevert2ScalarOperator(predicate)) {
+                    predicate = (InPredicateOperator) SPMFunctions.revertSPMFunctions(predicate).get(0);
+                } else {
+                    return statistics;
+                }
             }
             double selectivity;
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
@@ -56,6 +56,7 @@ import com.starrocks.analysis.TableName;
 import com.starrocks.analysis.VarBinaryLiteral;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.Type;
+import com.starrocks.common.FeConstants;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.ast.ArrayExpr;
 import com.starrocks.sql.ast.DictionaryGetExpr;
@@ -393,7 +394,7 @@ public class ScalarOperatorToExpr {
         public Expr visitCall(CallOperator call, FormatterContext context) {
             String fnName = call.getFnName();
             Expr callExpr;
-            if (SPMFunctions.isSPMFunctions(call)) {
+            if (!FeConstants.runningUnitTest && SPMFunctions.isSPMFunctions(call)) {
                 throw UnsupportedException.unsupportedException("spm function only used in create baseline stmt");
             }
             switch (fnName.toLowerCase()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMAst2SQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMAst2SQLBuilder.java
@@ -91,7 +91,9 @@ public class SPMAst2SQLBuilder {
 
         @Override
         protected String printWithParentheses(ParseNode node) {
-            if (node instanceof SlotRef || node instanceof LiteralExpr || SPMFunctions.isSPMFunctions((Expr) node)) {
+            if (node instanceof SlotRef || node instanceof LiteralExpr) {
+                return visit(node);
+            } else if (node instanceof FunctionCallExpr && (SPMFunctions.isSPMFunctions((Expr) node))) {
                 return visit(node);
             } else {
                 return "(" + visit(node) + ")";
@@ -170,8 +172,7 @@ public class SPMAst2SQLBuilder {
 
         @Override
         public String visitInPredicate(InPredicate node, Void context) {
-            if ((node.getChildren().stream().skip(1).anyMatch(SPMFunctions::isSPMFunctions) || node.isConstantValues())
-                    && enableDigest) {
+            if ((SPMFunctions.isSPMFunctions(node) || node.isConstantValues()) && enableDigest) {
                 StringBuilder strBuilder = new StringBuilder();
                 String notStr = (node.isNotIn()) ? "NOT " : "";
                 strBuilder.append(printWithParentheses(node.getChild(0))).append(" ").append(notStr).append("IN ");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMFunctions.java
@@ -14,22 +14,30 @@
 
 package com.starrocks.sql.spm;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.starrocks.analysis.BetweenPredicate;
+import com.starrocks.analysis.CompoundPredicate;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.FunctionName;
+import com.starrocks.analysis.InPredicate;
 import com.starrocks.analysis.IntLiteral;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.ScalarFunction;
+import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
+import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 
@@ -42,94 +50,231 @@ public class SPMFunctions {
     // NULL_TYPE _spm_const_var(placeholderID)
     static final String CONST_VAR_FUNC = "_spm_const_var";
 
+    // NULL_TYPE _spm_const_range(placeholderID, min, max)
+    static final String CONST_RANGE_FUNC = "_spm_const_range";
+    // NULL_TYPE _spm_const_enum(placeholderID, enum...)
+    static final String CONST_ENUM_FUNC = "_spm_const_enum";
+
     // for ut test
     public static boolean enableSPMParamsPrint = false;
 
-    private static final Set<String> SPM_FUNCTIONS = Set.of(CONST_LIST_FUNC, CONST_VAR_FUNC);
+    private static final Set<String> SPM_FUNCTIONS =
+            Set.of(CONST_LIST_FUNC, CONST_VAR_FUNC, CONST_RANGE_FUNC, CONST_ENUM_FUNC);
 
-    public static Function getSPMFunction(String fnName) {
-        return getSPMFunction(fnName, Type.NULL);
+    private static final Set<String> CONTAIN_VALUES_FUNCTIONS = Set.of(CONST_LIST_FUNC, CONST_VAR_FUNC);
+
+    public static Function getSPMFunction(FunctionCallExpr expr, List<Type> argsTypes) {
+        if (!SPM_FUNCTIONS.contains(StringUtils.lowerCase(expr.getFnName().getFunction()))) {
+            return null;
+        }
+        if (expr.getChildren().stream().anyMatch(p -> !p.isConstant())) {
+            throw new SemanticException("spm function's parameters must be const");
+        }
+        return getSPMFunction(expr.getFnName().getFunction(), Type.NULL, argsTypes);
     }
 
-    private static Function getSPMFunction(String fnName, Type type) {
+    private static Function getSPMFunction(String fnName, Type type, List<Type> argsTypes) {
         if (!SPM_FUNCTIONS.contains(StringUtils.lowerCase(fnName))) {
             return null;
         }
+        if (argsTypes.isEmpty()) {
+            throw new SemanticException("spm function must have placeholder id");
+        }
+        if (!argsTypes.get(0).isIntegerType()) {
+            throw new SemanticException("spm function placeholder id must be integer");
+        }
 
-        return new ScalarFunction(new FunctionName(StringUtils.lowerCase(fnName)),
-                new Type[] {Type.BIGINT}, type, false);
+        if (CONST_VAR_FUNC.equalsIgnoreCase(fnName)) {
+            if (argsTypes.size() > 2) {
+                throw new SemanticException("spm function _spm_const_var must have at most two parameters");
+            }
+        } else if (CONST_RANGE_FUNC.equalsIgnoreCase(fnName)) {
+            if (argsTypes.size() != 3) {
+                throw new SemanticException("spm function _spm_const_range must have three parameters");
+            }
+            if (!ScalarType.canCastTo(argsTypes.get(1), argsTypes.get(2))) {
+                throw new SemanticException("spm function _spm_const_range min/max type must be same");
+            }
+        } else if (CONST_ENUM_FUNC.equalsIgnoreCase(fnName)) {
+            if (argsTypes.size() < 2) {
+                throw new SemanticException("spm function _spm_const_enum must have at least two parameters");
+            }
+            Type type1 = argsTypes.get(1);
+            for (int i = 2; i < argsTypes.size(); i++) {
+                if (!ScalarType.canCastTo(argsTypes.get(i), type1)) {
+                    throw new SemanticException("spm function _spm_const_enum enum type must be same");
+                }
+            }
+        }
+        return new ScalarFunction(new FunctionName(StringUtils.lowerCase(fnName)), argsTypes, type, false);
     }
 
-    public static FunctionCallExpr newFunc(String func, long placeholderID, List<Expr> children) {
-        FunctionCallExpr expr =
-                new FunctionCallExpr(func, Lists.newArrayList(new IntLiteral(placeholderID, Type.BIGINT)));
-        expr.setFn(getSPMFunction(func, Type.NULL));
+    public static FunctionCallExpr newFunc(String func, long placeholderID, List<Expr> input) {
+        List<Expr> children = Lists.newArrayList(new IntLiteral(placeholderID, Type.BIGINT));
+        children.addAll(input);
+        FunctionCallExpr expr = new FunctionCallExpr(func, children);
+        expr.setFn(getSPMFunction(func, Type.NULL, children.stream().map(Expr::getType).toList()));
         expr.setType(Type.NULL);
-        expr.addChildren(children);
         return expr;
     }
 
     public static boolean isSPMFunctions(Expr expr) {
-        if (!(expr instanceof FunctionCallExpr)) {
-            return false;
+        if ((expr instanceof InPredicate) && expr.getChildren().size() == 2) {
+            expr = expr.getChild(1);
         }
-
-        return SPM_FUNCTIONS.contains(((FunctionCallExpr) expr).getFnName()
-                .getFunction().toLowerCase());
+        return (expr instanceof FunctionCallExpr)
+                && SPM_FUNCTIONS.contains(((FunctionCallExpr) expr).getFnName().getFunction().toLowerCase());
     }
 
     public static boolean isSPMFunctions(ScalarOperator operator) {
-        if (!(operator.getOpType() == OperatorType.CALL)) {
-            return false;
+        if ((operator.getOpType() == OperatorType.IN) && operator.getChildren().size() == 2) {
+            operator = operator.getChild(1);
         }
-
-        return SPM_FUNCTIONS.contains(((CallOperator) operator).getFnName().toLowerCase());
+        return (operator.getOpType() == OperatorType.CALL) && SPM_FUNCTIONS.contains(
+                ((CallOperator) operator).getFnName().toLowerCase());
     }
 
     public static ScalarOperator castSPMFunctions(ScalarOperator operator, Type type) {
+        if (operator.getOpType() == OperatorType.IN) {
+            return operator;
+        }
         CallOperator call = (CallOperator) operator;
         call.setType(type);
-        call.setFunction(getSPMFunction(call.getFunction().functionName(), type));
+        List<Type> argTypes = Lists.newArrayList();
+        argTypes.add(Type.BIGINT);
+        if (!call.getChild(0).getType().equals(Type.BIGINT)) {
+            call.setChild(0, new CastOperator(Type.BIGINT, call.getChild(0)));
+        }
         for (int i = 1; i < call.getChildren().size(); i++) {
             call.setChild(i, new CastOperator(type, call.getChild(i)));
+            // skip placeholder id
+            argTypes.add(type);
         }
+        call.setFunction(getSPMFunction(call.getFunction().functionName(), type, argTypes));
         return call;
     }
 
-    // SPM operator revert to scalar operator
-    public static ScalarOperator revertSPMFunctions(ScalarOperator operator) {
-        ScalarOperator clone = operator.clone();
-        List<ScalarOperator> newChildren = Lists.newArrayList();
-        for (ScalarOperator child : clone.getChildren()) {
-            if (!isSPMFunctions(child)) {
-                newChildren.add(child);
-            } else {
-                CallOperator call = (CallOperator) child;
-                if (call.getChildren().size() <= 1) {
-                    return operator;
-                } else {
-                    call.getChildren().stream().skip(1).forEach(newChildren::add);
-                }
-            }
+    public static boolean canRevert2ScalarOperator(ScalarOperator operator) {
+        if ((operator.getOpType() == OperatorType.IN) && operator.getChildren().size() == 2) {
+            operator = operator.getChild(1);
         }
-        clone.getChildren().clear();
-        clone.getChildren().addAll(newChildren);
-        return clone;
+        return operator.getChildren().size() > 1 && (operator.getOpType() == OperatorType.CALL)
+                && CONTAIN_VALUES_FUNCTIONS.contains(((CallOperator) operator).getFnName().toLowerCase());
+    }
+
+    // SPM operator revert to scalar operator
+    public static List<ScalarOperator> revertSPMFunctions(ScalarOperator operator) {
+        if (operator.getOpType() == OperatorType.CALL) {
+            List<ScalarOperator> newChildren = Lists.newArrayList();
+            operator.getChildren().stream().skip(1).forEach(newChildren::add);
+            return newChildren;
+        } else if (operator instanceof InPredicateOperator in) {
+            List<ScalarOperator> newChildren = Lists.newArrayList();
+            newChildren.add(operator.getChild(0));
+            operator.getChild(1).getChildren().stream().skip(1).forEach(newChildren::add);
+            return List.of(new InPredicateOperator(in.isNotIn(), newChildren));
+        }
+        return List.of(operator);
     }
 
     public static String toSQL(String function, List<String> children) {
         if (enableSPMParamsPrint) {
             return function + "(" + String.join(", ", children) + ")";
         }
-        return function + "(" + children.get(0) + ")";
+        if (CONTAIN_VALUES_FUNCTIONS.contains(function)) {
+            return function + "(" + children.get(0) + ")";
+        } else {
+            return function + "(" + String.join(", ", children) + ")";
+        }
     }
 
     public static List<ColumnStatistic> getSPMFunctionStatistics(CallOperator operator,
                                                                  List<ColumnStatistic> children) {
-        Preconditions.checkState(CONST_VAR_FUNC.equals(operator.getFnName()));
         if (children.size() <= 1) {
             return List.of(ColumnStatistic.unknown());
         }
-        return List.of(children.get(1));
+        if (CONST_VAR_FUNC.equals(operator.getFnName())) {
+            return List.of(children.get(1));
+        } else if (CONST_RANGE_FUNC.equals(operator.getFnName())) {
+            ColumnStatistic min = children.get(1);
+            ColumnStatistic max = children.get(2);
+            ColumnStatistic result = ColumnStatistic.builder()
+                    .setMaxValue(max.getMaxValue()).setMaxString(max.getMaxString())
+                    .setMinValue(min.getMinValue()).setMinString(min.getMinString())
+                    .setDistinctValuesCount(1)
+                    .setNullsFraction(0.0)
+                    .setAverageRowSize(max.getAverageRowSize())
+                    .build();
+            return List.of(result);
+        } else if (CONST_ENUM_FUNC.equals(operator.getFnName())) {
+            ColumnStatistic min = children.stream().skip(1).min(Comparator.comparing(ColumnStatistic::getMinValue))
+                    .orElse(ColumnStatistic.unknown());
+            ColumnStatistic max = children.stream().skip(1).max(Comparator.comparing(ColumnStatistic::getMaxValue))
+                    .orElse(ColumnStatistic.unknown());
+            return List.of(ColumnStatistic.builder()
+                    .setMaxValue(max.getMaxValue()).setMaxString(max.getMaxString())
+                    .setMinValue(min.getMinValue()).setMinString(min.getMinString())
+                    .setDistinctValuesCount(1)
+                    .setNullsFraction(0.0)
+                    .setAverageRowSize(max.getAverageRowSize())
+                    .build());
+        }
+        return List.of(ColumnStatistic.unknown());
+    }
+
+    private static boolean checkParameters(FunctionCallExpr spmExpr, List<Expr> checkParameters) {
+        String fn = spmExpr.getFnName().getFunction();
+        try {
+            Expr checkExpr;
+            if (CONST_RANGE_FUNC.equalsIgnoreCase(fn)) {
+                Expr min = spmExpr.getChild(1);
+                Expr max = spmExpr.getChild(2);
+                List<Expr> values = checkParameters.stream()
+                        .map(p -> (Expr) new BetweenPredicate(p, min, max, false)).toList();
+                checkExpr = CompoundPredicate.compoundAnd(values);
+            } else if (CONST_ENUM_FUNC.equalsIgnoreCase(fn)) {
+                List<Expr> values = spmExpr.getChildren().stream().skip(1).toList();
+                List<Expr> inPredicates = checkParameters.stream()
+                        .map(p -> (Expr) new InPredicate(p, values, false)).toList();
+                checkExpr = CompoundPredicate.compoundAnd(inPredicates);
+            } else {
+                return false;
+            }
+            ScalarOperator p = SqlToScalarOperatorTranslator.translate(checkExpr);
+            ScalarOperatorRewriter rewriter = new ScalarOperatorRewriter();
+            ScalarOperator result = rewriter.rewrite(p, ScalarOperatorRewriter.DEFAULT_REWRITE_RULES);
+            if (result.isConstantTrue()) {
+                return true;
+            }
+        } catch (Exception e) {
+            return false;
+        }
+        return false;
+    }
+
+    public static boolean checkParameters(FunctionCallExpr spmExpr, Expr other) {
+        if (!other.isConstant()) {
+            return false;
+        }
+        String fn = spmExpr.getFnName().getFunction();
+        if (CONTAIN_VALUES_FUNCTIONS.contains(fn)) {
+            return true;
+        }
+        return checkParameters(spmExpr, List.of(other));
+    }
+
+    public static boolean checkParameters(InPredicate spmIn, InPredicate other) {
+        if (other.getChildren().stream().skip(1).anyMatch(p -> !p.isConstant())) {
+            return false;
+        }
+        FunctionCallExpr spmFunc = (FunctionCallExpr) spmIn.getChild(1);
+        String fn = spmFunc.getFnName().getFunction();
+        if (CONST_LIST_FUNC.equalsIgnoreCase(fn)) {
+            return true;
+        }
+        if (CONST_VAR_FUNC.equalsIgnoreCase(fn)) {
+            return other.getChildren().size() == 2;
+        }
+        return checkParameters(spmFunc, other.getChildren().stream().skip(1).toList());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlaceholderBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlaceholderBuilder.java
@@ -122,7 +122,7 @@ public class SPMPlaceholderBuilder {
     private class PlaceholderInserter extends SPMUpdateExprVisitor<Expr> {
         @Override
         public ParseNode visitInPredicate(InPredicate node, Expr root) {
-            if (node.getChildren().stream().skip(1).anyMatch(SPMFunctions::isSPMFunctions)) {
+            if (SPMFunctions.isSPMFunctions(node)) {
                 return visitExpression(node, root);
             }
             if (!node.isConstantValues()) {
@@ -243,7 +243,7 @@ public class SPMPlaceholderBuilder {
 
         @Override
         public ParseNode visitInPredicate(InPredicate node, Expr root) {
-            if (node.getChildren().stream().skip(1).anyMatch(SPMFunctions::isSPMFunctions)) {
+            if (SPMFunctions.isSPMFunctions(node)) {
                 return visitExpression(node, root);
             }
             if (!node.isConstantValues()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlanBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlanBuilder.java
@@ -74,13 +74,6 @@ public class SPMPlanBuilder {
         this.planHints = stmt.getAllQueryScopeHints();
     }
 
-    public SPMPlanBuilder(ConnectContext session, QueryStatement planStmt) {
-        this.session = session;
-        this.planHints = planStmt.getAllQueryScopeHints();
-        this.planStmt = planStmt.getQueryRelation();
-        this.bindStmt = null;
-    }
-
     public BaselinePlan execute() {
         analyze();
         parameterizedStmt();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlanner.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.spm;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.ArithmeticExpr;
@@ -32,13 +33,13 @@ import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.PlannerMetaLocker;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.common.ErrorType;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.parser.SqlParser;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 public class SPMPlanner {
     private final ConnectContext session;
@@ -48,6 +49,8 @@ public class SPMPlanner {
     private final PlaceholderBinder binder = new PlaceholderBinder();
 
     private final PlaceholderReplacer replacer = new PlaceholderReplacer();
+
+    private final Stopwatch watch = Stopwatch.createUnstarted();
 
     private BaselinePlan baseline;
 
@@ -71,40 +74,51 @@ public class SPMPlanner {
             return query;
         }
 
+        watch.start();
         try (Timer ignored = Tracers.watchScope("SPMPlanner")) {
             analyze(query);
+            checkTimeout();
 
-            BaselinePlan base;
+            List<BaselinePlan> plans = Lists.newArrayList();
             try (Timer ignored2 = Tracers.watchScope("foundBaseline")) {
                 SPMAst2SQLBuilder builder = new SPMAst2SQLBuilder(false, true);
                 String digest = builder.build((QueryStatement) query);
                 long hash = builder.buildHash();
-                List<BaselinePlan> plans = Lists.newArrayList();
                 plans.addAll(session.getSqlPlanStorage().findBaselinePlan(digest, hash));
                 plans.addAll(GlobalStateMgr.getCurrentState().getSqlPlanStorage().findBaselinePlan(digest, hash));
-
-                Optional<BaselinePlan> minCosts = plans.stream().filter(BaselinePlan::isEnable)
-                        .min(Comparator.comparingDouble(BaselinePlan::getCosts));
-                Optional<BaselinePlan> minQuery = plans.stream().filter(BaselinePlan::isEnable)
-                        .filter(b -> b.getQueryMs() > 0)
-                        .min(Comparator.comparingDouble(BaselinePlan::getQueryMs));
-
-                if (minQuery.isEmpty() && minCosts.isEmpty()) {
-                    return query;
-                }
-                base = minQuery.orElseGet(minCosts::get);
+                checkTimeout();
+                plans.sort((o1, o2) -> {
+                    if (o1.getQueryMs() > 0 && o2.getQueryMs() > 0) {
+                        return Double.compare(o1.getQueryMs(), o2.getQueryMs());
+                    } else if (o1.getQueryMs() < 0 && o2.getQueryMs() < 0) {
+                        return Double.compare(o1.getCosts(), o2.getCosts());
+                    } else {
+                        return o1.getQueryMs() > 0 ? 1 : -1;
+                    }
+                });
             }
+
             try (Timer ignored3 = Tracers.watchScope("bindBaseline")) {
-                if (!bind(base, query)) {
-                    return query;
+                for (BaselinePlan base : plans) {
+                    checkTimeout();
+                    if (bind(base, query)) {
+                        baseline = base;
+                        return replacePlan(base);
+                    }
                 }
-                baseline = base;
-                return replacePlan(base);
             }
         } catch (Exception e) {
             // fallback to original query
             baseline = null; // clean baseline
             return query;
+        }
+        return query;
+    }
+
+    private void checkTimeout() {
+        if (session.getSessionVariable().getSpmRewriteTimeoutMs() > 0
+                && watch.elapsed().toMillis() > session.getSessionVariable().getSpmRewriteTimeoutMs()) {
+            throw new StarRocksPlannerException("SPM rewrite timeout", ErrorType.INTERNAL_ERROR);
         }
     }
 
@@ -149,7 +163,11 @@ public class SPMPlanner {
         // ----------------- start -----------------
         @Override
         public Boolean visitFunctionCall(FunctionCallExpr node, ParseNode node2) {
-            if (SPMFunctions.isSPMFunctions(node) && ((Expr) node2).isConstant()) {
+            if (SPMFunctions.isSPMFunctions(node)) {
+                if (!SPMFunctions.checkParameters(node, (Expr) node2)) {
+                    return false;
+                }
+
                 Preconditions.checkState(!node.getChildren().isEmpty());
                 Preconditions.checkState(node.getChild(0) instanceof IntLiteral);
                 long spmId = ((IntLiteral) node.getChild(0)).getValue();
@@ -193,7 +211,7 @@ public class SPMPlanner {
 
         @Override
         public Boolean visitInPredicate(InPredicate node, ParseNode context) {
-            if (node.getChildren().stream().skip(1).noneMatch(SPMFunctions::isSPMFunctions)) {
+            if (!SPMFunctions.isSPMFunctions(node)) {
                 return super.visitExpression(node, context);
             }
             InPredicate other = cast(context);
@@ -203,8 +221,10 @@ public class SPMPlanner {
             if (!check(node.getChild(0), other.getChild(0))) {
                 return false;
             }
+            if (!SPMFunctions.checkParameters(node, other)) {
+                return false;
+            }
             Preconditions.checkState(node.getChildren().size() == 2);
-            Preconditions.checkState(SPMFunctions.isSPMFunctions(node.getChild(1)));
             Preconditions.checkState(!node.getChild(1).getChildren().isEmpty());
             Preconditions.checkState(node.getChild(1).getChild(0) instanceof IntLiteral);
             long spmId = ((IntLiteral) node.getChild(1).getChild(0)).getValue();
@@ -231,9 +251,8 @@ public class SPMPlanner {
 
         @Override
         public ParseNode visitInPredicate(InPredicate node, Void context) {
-            if (node.getChildren().stream().skip(1).anyMatch(SPMFunctions::isSPMFunctions)) {
+            if (SPMFunctions.isSPMFunctions(node)) {
                 Preconditions.checkState(node.getChildren().size() == 2);
-                Preconditions.checkState(SPMFunctions.isSPMFunctions(node.getChild(1)));
                 Preconditions.checkState(!node.getChild(1).getChildren().isEmpty());
                 Preconditions.checkState(node.getChild(1).getChild(0) instanceof IntLiteral);
                 long spmId = ((IntLiteral) node.getChild(1).getChild(0)).getValue();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlanner.java
@@ -87,15 +87,16 @@ public class SPMPlanner {
                 plans.addAll(session.getSqlPlanStorage().findBaselinePlan(digest, hash));
                 plans.addAll(GlobalStateMgr.getCurrentState().getSqlPlanStorage().findBaselinePlan(digest, hash));
                 checkTimeout();
-                plans.sort((o1, o2) -> {
-                    if (o1.getQueryMs() > 0 && o2.getQueryMs() > 0) {
-                        return Double.compare(o1.getQueryMs(), o2.getQueryMs());
-                    } else if (o1.getQueryMs() < 0 && o2.getQueryMs() < 0) {
-                        return Double.compare(o1.getCosts(), o2.getCosts());
-                    } else {
-                        return o1.getQueryMs() > 0 ? 1 : -1;
-                    }
-                });
+                plans = plans.stream().filter(BaselinePlan::isEnable)
+                        .sorted((o1, o2) -> {
+                            if (o1.getQueryMs() > 0 && o2.getQueryMs() > 0) {
+                                return Double.compare(o1.getQueryMs(), o2.getQueryMs());
+                            } else if (o1.getQueryMs() < 0 && o2.getQueryMs() < 0) {
+                                return Double.compare(o1.getCosts(), o2.getCosts());
+                            } else {
+                                return o1.getQueryMs() > 0 ? 1 : -1;
+                            }
+                        }).toList();
             }
 
             try (Timer ignored3 = Tracers.watchScope("bindBaseline")) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMStmtExecutor.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 public class SPMStmtExecutor {
-    public static void execute(ConnectContext context, CreateBaselinePlanStmt stmt) {
+    public static BaselinePlan execute(ConnectContext context, CreateBaselinePlanStmt stmt) {
         SPMPlanBuilder builder = new SPMPlanBuilder(context, stmt);
         BaselinePlan plan = builder.execute();
         plan.setEnable(true);
@@ -38,6 +38,7 @@ public class SPMStmtExecutor {
         } else {
             context.getSqlPlanStorage().storeBaselinePlan(List.of(plan));
         }
+        return plan;
     }
 
     public static void execute(ConnectContext context, DropBaselinePlanStmt stmt) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/spm/SPMPlanBindTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/spm/SPMPlanBindTest.java
@@ -78,8 +78,8 @@ public class SPMPlanBindTest extends PlanTestBase {
                 + "FROM `test`.`t0` INNER JOIN `test`.`t1` ON `test`.`t0`.`v3` = `test`.`t1`.`v6` "
                 + "WHERE `test`.`t0`.`v2` = ?");
 
-        assertContains(generator.getPlanStmtSQL(), "SELECT v1, v2, v3, v4, v5, v6 FROM "
-                + "(SELECT * FROM t0 WHERE v2 = _spm_const_var(1)) t_0 INNER JOIN[BROADCAST] t1 ON v3 = v6");
+        assertContains(generator.getPlanStmtSQL(), "SELECT v1, v2, v3, v4, v5, v6 FROM t1 "
+                + "INNER JOIN[BROADCAST] (SELECT * FROM t0 WHERE v2 = _spm_const_var(1)) t_0 ON v3 = v6");
     }
 
     @Test
@@ -94,8 +94,8 @@ public class SPMPlanBindTest extends PlanTestBase {
                 "FROM `test`.`t0` INNER JOIN `test`.`t1` ON `test`.`t0`.`v3` = `test`.`t1`.`v6` " +
                 "WHERE `test`.`t0`.`v2` = ?");
 
-        assertContains(generator.getPlanStmtSQL(), "SELECT v4, v2 FROM (SELECT v2, v4 FROM "
-                + "(SELECT * FROM t0 WHERE v2 = _spm_const_var(1)) t_0 INNER JOIN[BROADCAST] t1 ON v3 = v6) t2");
+        assertContains(generator.getPlanStmtSQL(), "SELECT v4, v2 FROM (SELECT v2, v4 FROM t1 "
+                + "INNER JOIN[BROADCAST] (SELECT * FROM t0 WHERE v2 = _spm_const_var(1)) t_0 ON v3 = v6) t2");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/spm/SPMTPCHBindTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/spm/SPMTPCHBindTest.java
@@ -175,15 +175,12 @@ public class SPMTPCHBindTest extends PlanTestBase {
     }
 
     @Test
-    public void validatePlanSQL() {
-        CreateBaselinePlanStmt stmt = createBaselinePlanStmt(TpchSQL.Q22);
-        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
-        generator.execute();
+    public void validatePlanSQL() throws Exception {
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt(TpchSQL.Q19);
 
-        String bindSQL = generator.getBindSql();
-        String planSQL = generator.getPlanStmtSQL();
-
-        analyzeSuccess(bindSQL);
-        analyzeSuccess(planSQL);
+        SPMStmtExecutor.execute(connectContext, stmt);
+        connectContext.getSessionVariable().setEnableSPMRewrite(true);
+        String s = getFragmentPlan(TpchSQL.Q19);
+        System.out.println(s);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/spm/SPMTPCHBindTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/spm/SPMTPCHBindTest.java
@@ -175,12 +175,15 @@ public class SPMTPCHBindTest extends PlanTestBase {
     }
 
     @Test
-    public void validatePlanSQL() throws Exception {
-        CreateBaselinePlanStmt stmt = createBaselinePlanStmt(TpchSQL.Q19);
+    public void validatePlanSQL() {
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt(TpchSQL.Q22);
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+        generator.execute();
 
-        SPMStmtExecutor.execute(connectContext, stmt);
-        connectContext.getSessionVariable().setEnableSPMRewrite(true);
-        String s = getFragmentPlan(TpchSQL.Q19);
-        System.out.println(s);
+        String bindSQL = generator.getBindSql();
+        String planSQL = generator.getPlanStmtSQL();
+
+        analyzeSuccess(bindSQL);
+        analyzeSuccess(planSQL);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

add more spm function: 
1. `_spm_const_range`: to check const value's range
2. `_spm_const_enum`: to check const value must be one of the enum values

other:
1. refactor `SPMFunction` implements....
2. add spm rewrite timeout check

e.g.

```
MySQL td>
MySQL td> create global baseline using select * from t2 join t1 on t2.v2 = t1.v2 where t2.v3 = _spm_const_range(1, 10, 20);
Query OK, 0 rows affected
Time: 0.061s
MySQL td> show baseline
+--------+--------+--------+----------------------------------------------------------------------------------------------------------+-------------+------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------+---------+--------+---------------------+
| Id     | global | enable | bindSQLDigest                                                                                            | bindSQLHash | bindSQL                                                                                                                            | planSQL                                                                                                                                                                                    | costs             | queryMs | source | updateTime          |
+--------+--------+--------+----------------------------------------------------------------------------------------------------------+-------------+------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------+---------+--------+---------------------+
| 636134 | Y      | Y      | SELECT * FROM `td`.`t2` INNER JOIN `td`.`t1` ON `td`.`t2`.`v2` = `td`.`t1`.`v2` WHERE `td`.`t2`.`v3` = ? | 1085294     | SELECT * FROM `td`.`t2` INNER JOIN `td`.`t1` ON `td`.`t2`.`v2` = `td`.`t1`.`v2` WHERE `td`.`t2`.`v3` = _spm_const_range(1, 10, 20) | SELECT t_0.v1 AS c_1, t_0.v2 AS c_2, t_0.v3 AS c_3, t1.v1 AS c_4, t1.v2 AS c_5 FROM (SELECT * FROM t2 WHERE v3 = _spm_const_range(1, 10, 20)) t_0 INNER JOIN[SHUFFLE] t1 ON t_0.v2 = t1.v2 | 551.0204081632653 | -1.0    | USER   | 2025-05-13 15:29:04 |
+--------+--------+--------+----------------------------------------------------------------------------------------------------------+-------------+------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------+---------+--------+---------------------+
1 row in set
Time: 0.017s
MySQL td> set enable_spm_rewrite=true
Query OK, 0 rows affected
Time: 0.001s
MySQL td> explain select * from t2 join t1 on t2.v2 = t1.v2 where t2.v3 = 14;
+-----------------------------------------------------+
| Explain String                                      |
+-----------------------------------------------------+
| Using baseline plan[636134]                         |
|                                                     |
| PLAN FRAGMENT 0                                     |
|  OUTPUT EXPRS:1: v1 | 2: v2 | 3: v3 | 4: v1 | 5: v2 |
..................................
|      cardinality=1                                  |
|      avgRowSize=11.428572                           |
+-----------------------------------------------------+
63 rows in set
Time: 0.040s
MySQL td>
MySQL td> explain select * from t2 join t1 on t2.v2 = t1.v2 where t2.v3 = 16;
+-----------------------------------------------------+
| Explain String                                      |
+-----------------------------------------------------+
| Using baseline plan[636134]                         |
|                                                     |
| PLAN FRAGMENT 0                                     |
............................
|      avgRowSize=11.428572                           |
+-----------------------------------------------------+
63 rows in set
Time: 0.022s
MySQL td> explain select * from t2 join t1 on t2.v2 = t1.v2 where t2.v3 = 26;
+-----------------------------------------------------+
| Explain String                                      |
+-----------------------------------------------------+
| PLAN FRAGMENT 0                                     |
|  OUTPUT EXPRS:1: v1 | 2: v2 | 3: v3 | 4: v1 | 5: v2 |
|   PARTITION: UNPARTITIONED                          |
.........................
|      tabletList=74058                               |
|      cardinality=5                                  |
|      avgRowSize=8.0                                 |
+-----------------------------------------------------+
61 rows in set
Time: 0.019s
MySQL td>
MySQL td> create baseline using select * from t2 join t1 on t2.v2 = t1.v2 where t2.v3 = _spm_const_var(1);
Query OK, 0 rows affected
Time: 0.017s
MySQL td> show baseline
+--------+--------+--------+----------------------------------------------------------------------------------------------------------+-------------+------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------+---------+--------+---------------------+
| Id     | global | enable | bindSQLDigest                                                                                            | bindSQLHash | bindSQL                                                                                                                            | planSQL                                                                                                                                                                                    | costs             | queryMs | source | updateTime          |
+--------+--------+--------+----------------------------------------------------------------------------------------------------------+-------------+------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------+---------+--------+---------------------+
| 636166 | N      | Y      | SELECT * FROM `td`.`t2` INNER JOIN `td`.`t1` ON `td`.`t2`.`v2` = `td`.`t1`.`v2` WHERE `td`.`t2`.`v3` = ? | 1085294     | SELECT * FROM `td`.`t2` INNER JOIN `td`.`t1` ON `td`.`t2`.`v2` = `td`.`t1`.`v2` WHERE `td`.`t2`.`v3` = _spm_const_var(1)           | SELECT t_0.v1 AS c_1, t_0.v2 AS c_2, t_0.v3 AS c_3, t1.v1 AS c_4, t1.v2 AS c_5 FROM (SELECT * FROM t2 WHERE v3 = _spm_const_var(1)) t_0 INNER JOIN[SHUFFLE] t1 ON t_0.v2 = t1.v2           | 551.0204081632653 | -1.0    | USER   | 2025-05-13 15:43:58 |
| 636134 | Y      | Y      | SELECT * FROM `td`.`t2` INNER JOIN `td`.`t1` ON `td`.`t2`.`v2` = `td`.`t1`.`v2` WHERE `td`.`t2`.`v3` = ? | 1085294     | SELECT * FROM `td`.`t2` INNER JOIN `td`.`t1` ON `td`.`t2`.`v2` = `td`.`t1`.`v2` WHERE `td`.`t2`.`v3` = _spm_const_range(1, 10, 20) | SELECT t_0.v1 AS c_1, t_0.v2 AS c_2, t_0.v3 AS c_3, t1.v1 AS c_4, t1.v2 AS c_5 FROM (SELECT * FROM t2 WHERE v3 = _spm_const_range(1, 10, 20)) t_0 INNER JOIN[SHUFFLE] t1 ON t_0.v2 = t1.v2 | 551.0204081632653 | -1.0    | USER   | 2025-05-13 15:29:04 |
+--------+--------+--------+----------------------------------------------------------------------------------------------------------+-------------+------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------+---------+--------+---------------------+
2 rows in set
Time: 0.020s
MySQL td> explain select * from t2 join t1 on t2.v2 = t1.v2 where t2.v3 = 36;
+-----------------------------------------------------+
| Explain String                                      |
+-----------------------------------------------------+
| Using baseline plan[636166]                         |
|                                                     |
| PLAN FRAGMENT 0                                     |
..............................................
|      avgRowSize=11.428572                           |
+-----------------------------------------------------+
63 rows in set
Time: 0.019s
MySQL td>
```


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
