### PR TITLE
[Enhancement] Skip compressed data cache

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -976,6 +976,7 @@ CONF_mBool(parquet_cache_aware_dict_decoder_enable, "true");
 
 CONF_mBool(parquet_reader_enable_adpative_bloom_filter, "true");
 CONF_Double(parquet_page_cache_decompress_threshold, "2.0");
+CONF_mBool(parquet_page_cache_skip_over_threshold, "true");
 
 CONF_Int32(io_coalesce_read_max_buffer_size, "8388608");
 CONF_Int32(io_coalesce_read_max_distance_size, "1048576");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -976,7 +976,7 @@ CONF_mBool(parquet_cache_aware_dict_decoder_enable, "true");
 
 CONF_mBool(parquet_reader_enable_adpative_bloom_filter, "true");
 CONF_Double(parquet_page_cache_decompress_threshold, "1.5");
-CONF_mBool(parquet_page_cache_skip_over_threshold, "true");
+CONF_mBool(enable_adjustment_page_cache_skip, "true");
 
 CONF_Int32(io_coalesce_read_max_buffer_size, "8388608");
 CONF_Int32(io_coalesce_read_max_distance_size, "1048576");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -975,7 +975,7 @@ CONF_mBool(parquet_push_down_filter_to_decoder_enable, "true");
 CONF_mBool(parquet_cache_aware_dict_decoder_enable, "true");
 
 CONF_mBool(parquet_reader_enable_adpative_bloom_filter, "true");
-CONF_Double(parquet_page_cache_decompress_threshold, "2.0");
+CONF_Double(parquet_page_cache_decompress_threshold, "1.5");
 CONF_mBool(parquet_page_cache_skip_over_threshold, "true");
 
 CONF_Int32(io_coalesce_read_max_buffer_size, "8388608");

--- a/be/src/formats/parquet/page_reader.cpp
+++ b/be/src/formats/parquet/page_reader.cpp
@@ -24,6 +24,7 @@
 #include "cache/datacache.h"
 #include "cache/object_cache/object_cache.h"
 #include "common/compiler_util.h"
+#include "common/config.h"
 #include "common/status.h"
 #include "exec/hdfs_scanner.h"
 #include "formats/parquet/column_reader.h"
@@ -82,7 +83,7 @@ Status PageReader::_deal_page_with_cache() {
     } else {
         _cache_buf = std::make_shared<std::vector<uint8_t>>();
         RETURN_IF_ERROR(_read_and_deserialize_header(true));
-        if (config::parquet_page_cache_skip_over_threshold && !_cache_decompressed_data()) {
+        if (config::enable_adjustment_page_cache_skip && !_cache_decompressed_data()) {
             _skip_page_cache = true;
             return Status::OK();
         }

--- a/be/src/formats/parquet/page_reader.cpp
+++ b/be/src/formats/parquet/page_reader.cpp
@@ -24,6 +24,7 @@
 #include "cache/datacache.h"
 #include "cache/object_cache/object_cache.h"
 #include "common/compiler_util.h"
+#include "common/status.h"
 #include "exec/hdfs_scanner.h"
 #include "formats/parquet/column_reader.h"
 #include "formats/parquet/utils.h"
@@ -59,6 +60,7 @@ Status PageReader::next_page() {
     if (_opts.use_file_pagecache) {
         _cache_buf.reset();
         _hit_cache = false;
+        _skip_page_cache = false;
     }
     return seek_to_offset(_next_header_pos);
 }
@@ -80,6 +82,10 @@ Status PageReader::_deal_page_with_cache() {
     } else {
         _cache_buf = std::make_shared<std::vector<uint8_t>>();
         RETURN_IF_ERROR(_read_and_deserialize_header(true));
+        if (config::parquet_page_cache_skip_over_threshold && !_cache_decompressed_data()) {
+            _skip_page_cache = true;
+            return Status::OK();
+        }
         RETURN_IF_ERROR(_read_and_decompress_internal(true));
         BufferPtr* capture = new BufferPtr(_cache_buf);
         Status st = Status::InternalError("write file page cache failed");
@@ -241,7 +247,7 @@ std::string& PageReader::_current_page_cache_key() {
 
 StatusOr<Slice> PageReader::read_and_decompress_page_data() {
     _opts.stats->page_read_counter += 1;
-    if (!_opts.use_file_pagecache) {
+    if (!_opts.use_file_pagecache || _skip_page_cache) {
         RETURN_IF_ERROR(_read_and_decompress_internal(false));
         return _uncompressed_data;
     } else {

--- a/be/src/formats/parquet/page_reader.h
+++ b/be/src/formats/parquet/page_reader.h
@@ -114,7 +114,8 @@ private:
     BufferPtr _compressed_buf;
     BufferPtr _uncompressed_buf;
     BufferPtr _cache_buf;
-    bool _hit_cache;
+    bool _hit_cache = false;
+    bool _skip_page_cache = false;
 
     Slice _uncompressed_data;
 };

--- a/be/src/formats/parquet/stored_column_reader.cpp
+++ b/be/src/formats/parquet/stored_column_reader.cpp
@@ -530,6 +530,7 @@ bool RepeatedStoredColumnReader::_cur_page_selected(size_t row_readed, const Fil
 Status StoredColumnReaderImpl::load_specific_page(size_t cur_page_idx, uint64_t offset, uint64_t first_row) {
     _reader->set_next_read_page_idx(cur_page_idx);
     RETURN_IF_ERROR(_reader->seek_to_offset(offset));
+    RETURN_IF_ERROR(_reader->next_page());
     RETURN_IF_ERROR(_reader->load_header());
     _cur_page_loaded = false;
     _num_values_left_in_cur_page = _reader->num_values();


### PR DESCRIPTION
## Why I'm doing:
In some scenarios, pagecache of os is affected by decompresed page cache, 
Lower the decompression threshold and skip caching data with high compression ratios, 
so that the decompressed page cache can cache as many pages as possible and 
reduce the overlap with the OS page cache.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
