### PR TITLE
[Enhancement] Use fastutil to optimize memory usage of HashMap in FE

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -888,6 +888,11 @@ under the License.
             <groupId>com.azure</groupId>
             <artifactId>azure-identity</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -78,6 +78,7 @@ under the License.
         <byteman.version>4.0.24</byteman.version>
         <!-- azure native sdk -->
         <azure.version>1.2.34</azure.version>
+        <fastutil.version>8.5.15</fastutil.version>
     </properties>
 
     <profiles>
@@ -1438,6 +1439,13 @@ under the License.
                 <version>${azure.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <!-- https://mvnrepository.com/artifact/it.unimi.dsi/fastutil -->
+            <dependency>
+                <groupId>it.unimi.dsi</groupId>
+                <artifactId>fastutil</artifactId>
+                <version>${fastutil.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Why I'm doing:
In a cluster with 5 million tablets (3 replicas, 500 tables, each table with 100 partitions, and each partition with 100 buckets), under no load (no checkpoint or tablet reporting), the jmap memory statistics are as follows:

```
$tail -n 10 jmap-raw1.txt
5409:             1             16  sun.reflect.generics.tree.VoidDescriptor (java.base@11.0.23)
5410:             1             16  sun.tools.attach.AttachProviderImpl (jdk.attach@11.0.23)
5411:             1             16  sun.tools.attach.HotSpotVirtualMachine$$Lambda$588/0x00002ad629a7f040 (jdk.attach@11.0.23)
5412:             1             16  sun.util.cldr.CLDRBaseLocaleDataMetaInfo (java.base@11.0.23)
5413:             1             16  sun.util.locale.provider.CalendarDataUtility$CalendarWeekParameterGetter (java.base@11.0.23)
5414:             1             16  sun.util.locale.provider.TimeZoneNameUtility$TimeZoneNameGetter (java.base@11.0.23)
5415:             1             16  sun.util.logging.internal.LoggingProviderImpl (java.logging@11.0.23)
5416:             1             16  sun.util.resources.LocaleData$LocaleDataStrategy (java.base@11.0.23)
5417:             1             16  sun.util.resources.cldr.provider.CLDRLocaleDataMetaInfo (jdk.localedata@11.0.23)
Total     212125537    12211076824


$ grep "java.lang.Long" jmap-raw1.txt
   3:      75453717     1810889208  java.lang.Long (java.base@11.0.23)
 476:             1           2072  [Ljava.lang.Long; (java.base@11.0.23)


$ grep HashMap jmap-raw1.txt | awk '{sum += $3} END {print sum}'
4983183896
Total memory usage is 12,211,076,824 Bytes ≈ 11.37 GB, of which the HashMap data structure itself (excluding stored key-value data) occupies 4,983,183,896 Bytes ≈ 4.64 GB, and Long occupies 1,810,889,208 Bytes ≈ 1.69 GB. This memory can be optimized using specific data structures. 

```
Total memory usage is 12,211,076,824 Bytes ≈ 11.37 GB, of which the HashMap data structure itself (excluding stored key-value data) occupies 4,983,183,896 Bytes ≈ 4.64 GB, and Long occupies 1,810,889,208 Bytes ≈ 1.69 GB. This memory can be optimized using specific data structures. 

After using Fastutil's Long2ObjectOpenHashMap, the total memory usage decreased to 8,621,562,088 Bytes ≈ 8.03 GB, a reduction of 30%. The combined memory usage of HashMap and Long after optimization is 130,886,544 + 998,515,384 = 1,129,401,928 Bytes ≈ 1.05 GB. The effect is quite significant.

```
$ tail -n 10 jmap-fast1.txt
6071:             1             16  sun.reflect.generics.tree.VoidDescriptor (java.base@11.0.23)
6072:             1             16  sun.tools.attach.AttachProviderImpl (jdk.attach@11.0.23)
6073:             1             16  sun.tools.attach.HotSpotVirtualMachine$$Lambda$515/0x00002aef76e4f040 (jdk.attach@11.0.23)
6074:             1             16  sun.util.cldr.CLDRBaseLocaleDataMetaInfo (java.base@11.0.23)
6075:             1             16  sun.util.locale.provider.CalendarDataUtility$CalendarWeekParameterGetter (java.base@11.0.23)
6076:             1             16  sun.util.locale.provider.TimeZoneNameUtility$TimeZoneNameGetter (java.base@11.0.23)
6077:             1             16  sun.util.logging.internal.LoggingProviderImpl (java.logging@11.0.23)
6078:             1             16  sun.util.resources.LocaleData$LocaleDataStrategy (java.base@11.0.23)
6079:             1             16  sun.util.resources.cldr.provider.CLDRLocaleDataMetaInfo (jdk.localedata@11.0.23)
Total      94530553     8621562088


$ grep "java.lang.Long" jmap-fast1.txt
  13:       5453606      130886544  java.lang.Long (java.base@11.0.23)
 520:             1           2072  [Ljava.lang.Long; (java.base@11.0.23)


$ grep HashMap jmap-fast1.txt | awk '{sum += $3} END {print sum}'
998515384
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
