### PR TITLE
[BugFix] Fix auto increment partial update triggered by error if auto increment column is key when it miss in target columns in insert stmt

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/FileListTableRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/FileListTableRepo.java
@@ -89,7 +89,7 @@ public class FileListTableRepo extends FileListRepo {
             "UPDATE " + FILE_LIST_FULL_NAME + " SET `state` = %s, `finish_load` = now() WHERE ";
 
     protected static final String INSERT_FILES =
-            "INSERT INTO " + FILE_LIST_FULL_NAME + "(" + "`id`, " + ALL_COLUMNS + ")" + " VALUES ";
+            "INSERT INTO " + FILE_LIST_FULL_NAME + "(" + ALL_COLUMNS + ")" + " VALUES ";
 
     protected static final String SELECTED_STAGED_FILES =
             "SELECT " + ALL_COLUMNS + " FROM " + FILE_LIST_FULL_NAME + " WHERE ";

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoAccessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoAccessor.java
@@ -170,9 +170,7 @@ public class RepoAccessor {
     protected String buildSqlAddFiles(List<PipeFileRecord> records) {
         StringBuilder sb = new StringBuilder();
         sb.append(FileListTableRepo.INSERT_FILES);
-        List<String> valueLists = records.stream().map(PipeFileRecord::toValueList).collect(Collectors.toList());
-        sb.append(valueLists.stream().map(
-                        valueList -> "(" + "DEFAULT, " + valueList.substring(1)).collect(Collectors.joining(",")));
+        sb.append(records.stream().map(PipeFileRecord::toValueList).collect(Collectors.joining(",")));
         return sb.toString();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -276,10 +276,17 @@ public class InsertAnalyzer {
                     }
                     if (targetColumns.size() < olapTable.getBaseSchemaWithoutGeneratedColumn().size()) {
                         insertStmt.setUsePartialUpdate();
-                        // mark if partial update for auto increment column
+                        // mark if partial update for auto increment column if and only if:
+                        // 1. There is auto increment defined in base schema
+                        // 2. targetColumns does not contain auto increment column
+                        // 3. auto increment column is not key column
                         if (olapTable.hasAutoIncrementColumn() &&
                                 !targetColumns.stream().anyMatch(col -> col.isAutoIncrement())) {
-                            insertStmt.setAutoIncrementPartialUpdate();
+                            Column autoIncrementColumn =
+                                        table.getBaseSchema().stream().filter(Column::isAutoIncrement).findFirst().get();
+                            if (!autoIncrementColumn.isKey()) {
+                                insertStmt.setAutoIncrementPartialUpdate();
+                            }
                         }
                     }
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/load/pipe/filelist/FileListRepoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/pipe/filelist/FileListRepoTest.java
@@ -149,11 +149,11 @@ public class FileListRepoTest {
         // add files
         sql = RepoAccessor.getInstance().buildSqlAddFiles(records);
         Assert.assertEquals("INSERT INTO _statistics_.pipe_file_list" +
-                        "(`id`, `pipe_id`, `file_name`, `file_version`, `file_size`, `state`, `last_modified`, " +
+                        "(`pipe_id`, `file_name`, `file_version`, `file_size`, `state`, `last_modified`, " +
                         "`staged_time`, `start_load`, `finish_load`, `error_info`, `insert_label`) VALUES " +
-                "(DEFAULT, 1, 'a.parquet', '123asdf', 1024, 'UNLOADED', '2023-07-01 01:01:01', " +
+                "(1, 'a.parquet', '123asdf', 1024, 'UNLOADED', '2023-07-01 01:01:01', " +
                         "'2023-07-01 01:01:01', '2023-07-01 01:01:01', '2023-07-01 01:01:01', '{\"errorMessage\":null}', '')," +
-                "(DEFAULT, 1, 'a.parquet', '123asdf', 1024, 'UNLOADED', '2023-07-01 01:01:01', " +
+                "(1, 'a.parquet', '123asdf', 1024, 'UNLOADED', '2023-07-01 01:01:01', " +
                         "'2023-07-01 01:01:01', '2023-07-01 01:01:01', '2023-07-01 01:01:01', '{\"errorMessage\":null}', '')",
                 sql);
 
@@ -298,10 +298,10 @@ public class FileListRepoTest {
         new Expectations(executor) {
             {
                 executor.executeDML(
-                        "INSERT INTO _statistics_.pipe_file_list(`id`, `pipe_id`, `file_name`, `file_version`, " +
+                        "INSERT INTO _statistics_.pipe_file_list(`pipe_id`, `file_name`, `file_version`, " +
                                 "`file_size`, `state`, `last_modified`, `staged_time`, `start_load`, `finish_load`, " +
                                 "`error_info`, `insert_label`) VALUES " +
-                                "(DEFAULT, 1, 'a.parquet', '1', 0, 'UNLOADED', NULL, NULL, " +
+                                "(1, 'a.parquet', '1', 0, 'UNLOADED', NULL, NULL, " +
                                 "NULL, NULL, '{\"errorMessage\":null}', '')");
                 result = Lists.newArrayList();
             }
@@ -386,11 +386,10 @@ public class FileListRepoTest {
         new Expectations(executor) {
             {
                 executor.executeDML(
-                        String.format("INSERT INTO _statistics_.pipe_file_list(`id`, `pipe_id`, `file_name`, `file_version`, " +
+                    String.format("INSERT INTO _statistics_.pipe_file_list(`pipe_id`, `file_name`, `file_version`, " +
                             "`file_size`, `state`, `last_modified`, `staged_time`, `start_load`, `finish_load`, " +
-                                    "`error_info`, `insert_label`) VALUES (DEFAULT, 1, '%d.parquet', '%d', %d, 'UNLOADED', " +
-                                        "NULL, NULL, NULL, NULL, '{\"errorMessage\":null}', '')",
-                                            recordSize, recordSize, recordSize));
+                            "`error_info`, `insert_label`) VALUES (1, '%d.parquet', '%d', %d, 'UNLOADED', NULL, NULL, " +
+                            "NULL, NULL, '{\"errorMessage\":null}', '')", recordSize, recordSize, recordSize));
                 times = 1;
                 result = null;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/load/pipe/filelist/FileListRepoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/pipe/filelist/FileListRepoTest.java
@@ -386,10 +386,10 @@ public class FileListRepoTest {
         new Expectations(executor) {
             {
                 executor.executeDML(
-                    String.format("INSERT INTO _statistics_.pipe_file_list(`pipe_id`, `file_name`, `file_version`, " +
-                            "`file_size`, `state`, `last_modified`, `staged_time`, `start_load`, `finish_load`, " +
-                            "`error_info`, `insert_label`) VALUES (1, '%d.parquet', '%d', %d, 'UNLOADED', NULL, NULL, " +
-                            "NULL, NULL, '{\"errorMessage\":null}', '')", recordSize, recordSize, recordSize));
+                        String.format("INSERT INTO _statistics_.pipe_file_list(`pipe_id`, `file_name`, `file_version`, " +
+                                "`file_size`, `state`, `last_modified`, `staged_time`, `start_load`, `finish_load`, " +
+                                "`error_info`, `insert_label`) VALUES (1, '%d.parquet', '%d', %d, 'UNLOADED', NULL, NULL, " +
+                                "NULL, NULL, '{\"errorMessage\":null}', '')", recordSize, recordSize, recordSize));
                 times = 1;
                 result = null;
             }

--- a/test/sql/test_auto_increment/R/test_auto_increment
+++ b/test/sql/test_auto_increment/R/test_auto_increment
@@ -687,5 +687,34 @@ SELECT k, v1 from t_auto_increment_insert_partial_update ORDER BY k;
 5	5
 -- !result
 DROP TABLE t_auto_increment_insert_partial_update force;
+CREATE TABLE `t_auto_increment_insert_partial_update` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT "",
+  `ts` bigint(20) NOT NULL COMMENT "",
+  `testString` String NOT NULL COMMENT ""
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `ts`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1 
+PROPERTIES (
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t_auto_increment_insert_partial_update (ts, testString) select 100, "abc";
+-- result:
+-- !result
+insert into t_auto_increment_insert_partial_update (ts, testString) select 100, "abc";
+-- result:
+-- !result
+insert into t_auto_increment_insert_partial_update (ts, testString) select 100, "abc";
+-- result:
+-- !result
+SELECT * FROM t_auto_increment_insert_partial_update order by id;
+-- result:
+1	100	abc
+2	100	abc
+3	100	abc
+-- !result
+DROP TABLE t_auto_increment_insert_partial_update force;
 -- result:
 -- !result

--- a/test/sql/test_auto_increment/T/test_auto_increment
+++ b/test/sql/test_auto_increment/T/test_auto_increment
@@ -299,3 +299,21 @@ insert into t_auto_increment_insert_partial_update (k) values (1),(2),(5);
 
 SELECT k, v1 from t_auto_increment_insert_partial_update ORDER BY k;
 DROP TABLE t_auto_increment_insert_partial_update force;
+
+CREATE TABLE `t_auto_increment_insert_partial_update` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT "",
+  `ts` bigint(20) NOT NULL COMMENT "",
+  `testString` String NOT NULL COMMENT ""
+) ENGINE=OLAP 
+PRIMARY KEY(`id`, `ts`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1 
+PROPERTIES (
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+
+insert into t_auto_increment_insert_partial_update (ts, testString) select 100, "abc";
+insert into t_auto_increment_insert_partial_update (ts, testString) select 100, "abc";
+insert into t_auto_increment_insert_partial_update (ts, testString) select 100, "abc";
+SELECT * FROM t_auto_increment_insert_partial_update order by id;
+DROP TABLE t_auto_increment_insert_partial_update force;


### PR DESCRIPTION
## Why I'm doing:
If a auto increment column is defined as the key column in pk table and it miss in target columns in insert stmt, it will be triggered partial update by error. In this case, partial update flag for auto increment will be set and get analyze exception.

## What I'm doing:
Fix it, do not trigger if column is key.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
