### PR TITLE
[BugFix] Deletion task failed when using datetime as a deletion predicate

### DIFF
--- a/be/src/storage/utils.cpp
+++ b/be/src/storage/utils.cpp
@@ -365,14 +365,6 @@ bool valid_datetime(const string& value_str) {
             }
         }
 
-        if (what[8].length()) {
-            const string& ms_str = what[9].str();
-            if (ms_str.empty() || ms_str.size() > 6) {
-                LOG(WARNING) << "invalid milliseconds length " << ms_str.size();
-                return false;
-            }
-        }
-
         return true;
     } else {
         LOG(WARNING) << "datetime string does not match";

--- a/be/src/storage/utils.cpp
+++ b/be/src/storage/utils.cpp
@@ -321,9 +321,12 @@ bool valid_decimal(const string& value_str, uint32_t precision, uint32_t frac) {
 }
 
 bool valid_datetime(const string& value_str) {
+    //const char* datetime_pattern =
+    //        "((?:\\d){4})-((?:\\d){2})-((?:\\d){2})[ ]*"
+    //        "(((?:\\d){2}):((?:\\d){2}):((?:\\d){2}))?";
     const char* datetime_pattern =
             "((?:\\d){4})-((?:\\d){2})-((?:\\d){2})[ ]*"
-            "(((?:\\d){2}):((?:\\d){2}):((?:\\d){2}))?";
+            "(((?:\\d){2}):((?:\\d){2}):((?:\\d){2})(\\.(\\d{1,6}))?)?";
     boost::regex e(datetime_pattern);
     boost::smatch what;
 
@@ -361,6 +364,14 @@ bool valid_datetime(const string& value_str) {
             int second = strtol(what[7].str().c_str(), nullptr, 10);
             if (second < 0 || second > 59) {
                 LOG(WARNING) << "invalid second " << second;
+                return false;
+            }
+        }
+
+        if (what[8].length()) {
+            const string& ms_str = what[9].str();
+            if (ms_str.empty() || ms_str.size() > 6) {
+                LOG(WARNING) << "invalid milliseconds length " << ms_str.size();
                 return false;
             }
         }

--- a/be/src/storage/utils.cpp
+++ b/be/src/storage/utils.cpp
@@ -321,9 +321,6 @@ bool valid_decimal(const string& value_str, uint32_t precision, uint32_t frac) {
 }
 
 bool valid_datetime(const string& value_str) {
-    //const char* datetime_pattern =
-    //        "((?:\\d){4})-((?:\\d){2})-((?:\\d){2})[ ]*"
-    //        "(((?:\\d){2}):((?:\\d){2}):((?:\\d){2}))?";
     const char* datetime_pattern =
             "((?:\\d){4})-((?:\\d){2})-((?:\\d){2})[ ]*"
             "(((?:\\d){2}):((?:\\d){2}):((?:\\d){2})(\\.(\\d{1,6}))?)?";

--- a/be/test/storage/utils_test.cpp
+++ b/be/test/storage/utils_test.cpp
@@ -57,4 +57,13 @@ TEST_F(TestUtils, test_is_tracker_hit_hard_limit) {
     ASSERT_TRUE(!is_tracker_hit_hard_limit(tracker.get(), 4));
 }
 
+TEST_F(TestUtils, test_valid_datetime) {
+    ASSERT_TRUE(valid_datetime("2020-01-01 00:00:00"));
+    ASSERT_TRUE(valid_datetime("2020-01-01 00:00:00.0"));
+    ASSERT_TRUE(valid_datetime("2020-01-01 00:00:00.01"));
+    ASSERT_TRUE(valid_datetime("2020-01-01 00:00:00.012345"));
+    ASSERT_TRUE(valid_datetime("2020-01-01 00:00:00.1230"));
+    ASSERT_FALSE(valid_datetime("2020-01-01 00:00:00.0123456"));
+}
+
 } // namespace starrocks

--- a/test/sql/test_datetime/R/test_datetime
+++ b/test/sql/test_datetime/R/test_datetime
@@ -40,3 +40,43 @@ select * from test_datetime order by c1;
 12	2020-01-01 00:00:00.123450
 13	2020-01-01 00:00:00.123450
 -- !result
+delete from test_datetime where c2 = '2020-01-01 00:00:00';
+-- result:
+-- !result
+delete from test_datetime where c2 = '2020-01-01 00:00:00.0';
+-- result:
+-- !result
+delete from test_datetime where c2 = '2020-01-01 00:00:00.012';
+-- result:
+-- !result
+select * from test_datetime order by c1;
+-- result:
+3	2020-01-01 00:00:00.010000
+5	2020-01-01 00:00:00.012300
+6	2020-01-01 00:00:00.012340
+7	2020-01-01 00:00:00.012345
+8	2020-01-01 00:00:00.100000
+9	2020-01-01 00:00:00.120000
+10	2020-01-01 00:00:00.123000
+11	2020-01-01 00:00:00.123400
+12	2020-01-01 00:00:00.123450
+13	2020-01-01 00:00:00.123450
+-- !result
+delete from test_datetime where c2 = '2020-01-01 00:00:00.1';
+-- result:
+-- !result
+delete from test_datetime where c2 = '2020-01-01 00:00:00.123';
+-- result:
+-- !result
+delete from test_datetime where c2 = '2020-01-01 00:00:00.123450';
+-- result:
+-- !result
+select * from test_datetime order by c1;
+-- result:
+3	2020-01-01 00:00:00.010000
+5	2020-01-01 00:00:00.012300
+6	2020-01-01 00:00:00.012340
+7	2020-01-01 00:00:00.012345
+9	2020-01-01 00:00:00.120000
+11	2020-01-01 00:00:00.123400
+-- !result

--- a/test/sql/test_datetime/T/test_datetime
+++ b/test/sql/test_datetime/T/test_datetime
@@ -23,3 +23,15 @@ insert into test_datetime values
 (13, '2020-01-01 00:00:00.123450');
 
 select * from test_datetime order by c1;
+
+delete from test_datetime where c2 = '2020-01-01 00:00:00';
+delete from test_datetime where c2 = '2020-01-01 00:00:00.0';
+delete from test_datetime where c2 = '2020-01-01 00:00:00.012';
+
+select * from test_datetime order by c1;
+
+delete from test_datetime where c2 = '2020-01-01 00:00:00.1';
+delete from test_datetime where c2 = '2020-01-01 00:00:00.123';
+delete from test_datetime where c2 = '2020-01-01 00:00:00.123450';
+
+select * from test_datetime order by c1;


### PR DESCRIPTION
## Why I'm doing:
Since version 3.3.5, the datetime type supports millisecond precision, but deletion operations fail when using datetime values with millisecond precision as deletion predicates.
The reason is that BE doesn't support millisecond precision when validating datetime legality.


## What I'm doing:
BE support millisecond precision for datetime legality

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
