### PR TITLE
[Feature] support FILTER clause for aggregations

### DIFF
--- a/docs/zh/sql-reference/sql-statements/table_bucket_part_index/SELECT.md
+++ b/docs/zh/sql-reference/sql-statements/table_bucket_part_index/SELECT.md
@@ -276,9 +276,9 @@ GROUP BY 子句通常和聚合函数一起使用。GROUP BY 指定的列不会�
 
 - `FILTER` 与聚合函数共同使用，仅有被筛选出来的行才会参与聚合函数的实际运算。
   > 注意：
-  > FILTER 语句仅支持在 AVG, COUNT, MAX, MIN, SUM, AGG_ARRAY, and ARRAY_AGG_DISTINCT 函数后使用。
+  > FILTER 语句仅支持在 AVG, COUNT, MAX, MIN, SUM, ARRAY_AGG, and ARRAY_AGG_DISTINCT 函数后使用。
   > 不支持 COUNT DISTINCT。
-  > AGG_ARRAY 和 ARRAY_AGG_DISTINCT 不支持在函数中使用 ORDER BY。
+  > ARRAY_AGG 和 ARRAY_AGG_DISTINCT 不支持在函数中使用 ORDER BY。
 
 - `GROUPING SETS` ｜ `CUBE` ｜ `ROLLUP` 是对 GROUP BY 子句的扩展，它能够在一个 GROUP BY 子句中实现多个集合的分组的聚合。其结果等价于将多个相应 GROUP BY 子句进行 UNION 操作。
 

--- a/docs/zh/sql-reference/sql-statements/table_bucket_part_index/SELECT.md
+++ b/docs/zh/sql-reference/sql-statements/table_bucket_part_index/SELECT.md
@@ -252,29 +252,15 @@ select  *  from  sales_record  order by  employee_id  nulls first;
 
 ### GROUP BY
 
-GROUP BY 子句通常和聚合函数（例如 COUNT(), SUM(), AVG(), MIN()和 MAX()）一起使用。
+GROUP BY 子句通常和聚合函数一起使用。GROUP BY 指定的列不会参加聚合操作。
 
-GROUP BY 指定的列不会参加聚合操作。GROUP BY 子句可以加入 HAVING 子句来过滤聚合函数产出的结果。例如：
-
-```sql
-select tiny_column, sum(short_column)
-from small_table 
-group by tiny_column;
-```
-
-```sql
-+-------------+---------------------+
-| tiny_column |  sum('short_column')|
-+-------------+---------------------+
-|      1      |        2            |
-|      2      |        1            |
-+-------------+---------------------+
-```
-
-## 语法
+#### 语法
 
   ```sql
-  SELECT ...
+  SELECT
+  ...
+  aggregate_function() [ FILTER ( where boolean_expression ) ]
+  ...
   FROM ...
   [ ... ]
   GROUP BY [
@@ -286,127 +272,118 @@ group by tiny_column;
   [ ... ]
   ```
 
-### Parameters
+#### 参数
 
-- `groupSet` 表示 select list 中的列，别名或者表达式组成的集合 `groupSet ::= { ( expr  [ , expr [ , ... ] ] )}`。
+- `FILTER` 与聚合函数共同使用，仅有被筛选出来的行才会参与聚合函数的实际运算。
+  > 注意：
+  > FILTER 语句仅支持在 AVG, COUNT, MAX, MIN, SUM, AGG_ARRAY, and ARRAY_AGG_DISTINCT 函数后使用。
+  > 不支持 COUNT DISTINCT。
+  > AGG_ARRAY 和 ARRAY_AGG_DISTINCT 不支持在函数中使用 ORDER BY。
 
-- `expr`  表示 select list 中的列，别名或者表达式。
+- `GROUPING SETS` ｜ `CUBE` ｜ `ROLLUP` 是对 GROUP BY 子句的扩展，它能够在一个 GROUP BY 子句中实现多个集合的分组的聚合。其结果等价于将多个相应 GROUP BY 子句进行 UNION 操作。
 
-### Note
+#### 示例
 
-StarRocks 支持类似 PostgreSQL 语法，语法实例如下：
+例1: `FILTER`
 
-  ```sql
-  SELECT a, b, SUM( c ) FROM tab1 GROUP BY GROUPING SETS ( (a, b), (a), (b), ( ) );
-  SELECT a, b,c, SUM( d ) FROM tab1 GROUP BY ROLLUP(a,b,c)
-  SELECT a, b,c, SUM( d ) FROM tab1 GROUP BY CUBE(a,b,c)
-  ```
-
-`ROLLUP(a,b,c)` 等价于如下 `GROUPING SETS` 语句。
+  下述两个查询例子等价。
 
   ```sql
-  GROUPING SETS (
-  (a,b,c),
-  (a,b  ),
-  (a    ),
-  (     )
-  )
+  SELECT
+    COUNT(*) AS total_users,
+    SUM(CASE WHEN gender = 'M' THEN 1 ELSE 0 END) AS male_users,
+    SUM(CASE WHEN gender = 'F' THEN 1 ELSE 0 END) AS female_users
+  FROM users;
   ```
-
-`CUBE (a, b, c)` 等价于如下 `GROUPING SETS` 语句。
-
+  
   ```sql
-  GROUPING SETS (
-  ( a, b, c ),
-  ( a, b    ),
-  ( a,    c ),
-  ( a       ),
-  (    b, c ),
-  (    b    ),
-  (       c ),
-  (         )
-  )
+  SELECT
+    COUNT(*) AS total_users,
+    COUNT(*) FILTER (WHERE gender = 'M') AS male_users,
+    COUNT(*) FILTER (WHERE gender = 'F') AS female_users
+  FROM users;
   ```
 
-## 示例
+例2:  `GROUPING SETS` ｜ `CUBE` ｜ `ROLLUP`
 
-下面是一个实际数据的例子:
-
-  ```sql
-  SELECT * FROM t;
-  +------+------+------+
-  | k1   | k2   | k3   |
-  +------+------+------+
-  | a    | A    |    1 |
-  | a    | A    |    2 |
-  | a    | B    |    1 |
-  | a    | B    |    3 |
-  | b    | A    |    1 |
-  | b    | A    |    4 |
-  | b    | B    |    1 |
-  | b    | B    |    5 |
-  +------+------+------+
-  8 rows in set (0.01 sec)
-
-  SELECT k1, k2, SUM(k3) FROM t
-  GROUP BY GROUPING SETS ( (k1, k2), (k2), (k1), ( ) );
-  +------+------+-----------+
-  | k1   | k2   | sum(`k3`) |
-  +------+------+-----------+
-  | b    | B    |         6 |
-  | a    | B    |         4 |
-  | a    | A    |         3 |
-  | b    | A    |         5 |
-  | NULL | B    |        10 |
-  | NULL | A    |         8 |
-  | a    | NULL |         7 |
-  | b    | NULL |        11 |
-  | NULL | NULL |        18 |
-  +------+------+-----------+
-  9 rows in set (0.06 sec)
-
-  SELECT k1, k2, GROUPING_ID(k1,k2), SUM(k3) FROM t
-  GROUP BY GROUPING SETS ((k1, k2), (k1), (k2), ());
-  +------+------+---------------+----------------+
-  | k1   | k2   | grouping_id(k1,k2) | sum(`k3`) |
-  +------+------+---------------+----------------+
-  | a    | A    |             0 |              3 |
-  | a    | B    |             0 |              4 |
-  | a    | NULL |             1 |              7 |
-  | b    | A    |             0 |              5 |
-  | b    | B    |             0 |              6 |
-  | b    | NULL |             1 |             11 |
-  | NULL | A    |             2 |              8 |
-  | NULL | B    |             2 |             10 |
-  | NULL | NULL |             3 |             18 |
-  +------+------+---------------+----------------+
-  9 rows in set (0.02 sec)
-  ```
-
-GROUP BY `GROUPING SETS` ｜ `CUBE` ｜ `ROLLUP` 是对 GROUP BY 子句的扩展，它能够在一个 GROUP BY 子句中实现多个集合的分组的聚合。其结果等价于将多个相应 GROUP BY 子句进行 UNION 操作。
-
-  GROUP BY 子句是只含有一个元素的 GROUP BY GROUPING SETS 的特例。
-  例如，GROUPING SETS 语句：
-
-  ```sql
-  SELECT a, b, SUM( c ) FROM tab1 GROUP BY GROUPING SETS ( (a, b), (a), (b), ( ) );
-  ```
-
-  其查询结果等价于：
-
-  ```sql
-  SELECT a, b, SUM( c ) FROM tab1 GROUP BY a, b
-  UNION
-  SELECT a, null, SUM( c ) FROM tab1 GROUP BY a
-  UNION
-  SELECT null, b, SUM( c ) FROM tab1 GROUP BY b
-  UNION
-  SELECT null, null, SUM( c ) FROM tab1
-  ```
-
-  `GROUPING(expr)` 指示一个列是否为聚合列，如果是聚合列为 0，否则为 1。
-
-  `GROUPING_ID(expr  [ , expr [ , ... ] ])` 与 GROUPING 类似，GROUPING_ID 根据指定的 column 顺序，计算出一个列列表的 bitmap 值，每一位为 GROUPING 的值. GROUPING_ID()函数返回位向量的十进制值。
+  `ROLLUP(a,b,c)` 等价于如下 `GROUPING SETS` 语句。
+  
+    ```sql
+    GROUPING SETS (
+    (a,b,c),
+    (a,b  ),
+    (a    ),
+    (     )
+    )
+    ```
+  
+  `CUBE (a, b, c)` 等价于如下 `GROUPING SETS` 语句。
+  
+    ```sql
+    GROUPING SETS (
+    ( a, b, c ),
+    ( a, b    ),
+    ( a,    c ),
+    ( a       ),
+    (    b, c ),
+    (    b    ),
+    (       c ),
+    (         )
+    )
+    ```
+  
+  带入实际数据的例子:
+  
+    ```sql
+    SELECT * FROM t;
+    +------+------+------+
+    | k1   | k2   | k3   |
+    +------+------+------+
+    | a    | A    |    1 |
+    | a    | A    |    2 |
+    | a    | B    |    1 |
+    | a    | B    |    3 |
+    | b    | A    |    1 |
+    | b    | A    |    4 |
+    | b    | B    |    1 |
+    | b    | B    |    5 |
+    +------+------+------+
+    8 rows in set (0.01 sec)
+  
+    SELECT k1, k2, SUM(k3) FROM t
+    GROUP BY GROUPING SETS ( (k1, k2), (k2), (k1), ( ) );
+    +------+------+-----------+
+    | k1   | k2   | sum(`k3`) |
+    +------+------+-----------+
+    | b    | B    |         6 |
+    | a    | B    |         4 |
+    | a    | A    |         3 |
+    | b    | A    |         5 |
+    | NULL | B    |        10 |
+    | NULL | A    |         8 |
+    | a    | NULL |         7 |
+    | b    | NULL |        11 |
+    | NULL | NULL |        18 |
+    +------+------+-----------+
+    9 rows in set (0.06 sec)
+  
+    SELECT k1, k2, GROUPING_ID(k1,k2), SUM(k3) FROM t
+    GROUP BY GROUPING SETS ((k1, k2), (k1), (k2), ());
+    +------+------+---------------+----------------+
+    | k1   | k2   | grouping_id(k1,k2) | sum(`k3`) |
+    +------+------+---------------+----------------+
+    | a    | A    |             0 |              3 |
+    | a    | B    |             0 |              4 |
+    | a    | NULL |             1 |              7 |
+    | b    | A    |             0 |              5 |
+    | b    | B    |             0 |              6 |
+    | b    | NULL |             1 |             11 |
+    | NULL | A    |             2 |              8 |
+    | NULL | B    |             2 |             10 |
+    | NULL | NULL |             3 |             18 |
+    +------+------+---------------+----------------+
+    9 rows in set (0.02 sec)
+    ```
 
 ### HAVING
 
@@ -555,7 +532,7 @@ mysql> select varchar_column from big_table order by varchar_column limit 1 offs
 >
 > 在没有 ORDER BY 的情况下使用 OFFSET 语法是允许的，但是此时 OFFSET 无意义。这种情况只取 LIMIT 的值，忽略 OFFSET 的值。因此在没有 ORDER BY 的情况下，OFFSET 超过结果集的最大行数依然是有结果的。**建议使用 OFFSET 时一定带上 ORDER BY。**
 
-### **UNION**
+### UNION
 
 UNION 子句用于合并多个查询的结果，即获取并集。
 
@@ -681,7 +658,7 @@ limit 3;
 3 rows in set (0.01 sec)
 ```
 
-### **INTERSECT**
+### INTERSECT
 
 INTERSECT 子句用于返回多个查询结果之间的交集，即每个结果中都有的数据，并对结果集进行去重。
 
@@ -722,7 +699,7 @@ order by id;
 +------+-------+
 ```
 
-### **EXCEPT/MINUS**
+### EXCEPT/MINUS
 
 EXCEPT/MINUS 子句用于返回多个查询结果之间的补集，即返回左侧查询中在右侧查询中不存在的数据，并对结果集去重。EXCEPT 和 MINUS 功能对等。
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionParams.java
@@ -59,6 +59,7 @@ public class FunctionParams implements Writable {
     private boolean isDistinct;
 
     private List<OrderByElement> orderByElements;
+
     // c'tor for non-star params
     public FunctionParams(boolean isDistinct, List<Expr> exprs) {
         if (exprs != null && exprs.stream().anyMatch(e -> e instanceof NamedArgument)) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -1026,14 +1026,15 @@ public class FunctionSet {
 
         if (AggStateUtils.isSupportedAggStateFunction(aggFunc, false)) {
             // register `_state` combinator
-            AggStateCombinator.of(aggFunc).stream().forEach(this::addBuiltInFunction);
+            AggStateCombinator.of(aggFunc).ifPresent(this::addBuiltInFunction);
             // register `_merge`/`_union` combinator for aggregate functions
-            AggStateUnionCombinator.of(aggFunc).stream().forEach(this::addBuiltInFunction);
-            AggStateMergeCombinator.of(aggFunc).stream().forEach(this::addBuiltInFunction);
+            AggStateUnionCombinator.of(aggFunc).ifPresent(this::addBuiltInFunction);
+            AggStateMergeCombinator.of(aggFunc).ifPresent(this::addBuiltInFunction);
         }
 
         if (AggStateUtils.isSupportedAggStateFunction(aggFunc, true)) {
-            AggStateIf.of(aggFunc).stream().forEach(this::addBuiltInFunction);
+            // register `_if` for aggregate functions
+            AggStateIf.of(aggFunc).ifPresent(this::addBuiltInFunction);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -555,6 +555,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import static com.starrocks.catalog.FunctionSet.ARRAY_AGG_DISTINCT;
 import static com.starrocks.sql.ast.IndexDef.IndexType.getIndexType;
 import static com.starrocks.sql.common.ErrorMsgProxy.PARSER_ERROR_MSG;
 import static java.lang.String.format;
@@ -7525,10 +7526,35 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         if (CollectionUtils.isNotEmpty(orderByElements)) {
             orderByElements.stream().forEach(e -> exprs.add(e.getExpr()));
         }
-        FunctionCallExpr functionCallExpr = new FunctionCallExpr(functionName,
-                context.aggregationFunction().ASTERISK_SYMBOL() == null ?
-                        new FunctionParams(isDistinct, exprs, orderByElements) :
-                        FunctionParams.createStarParam(), pos);
+
+        FunctionCallExpr functionCallExpr;
+        boolean isStar = context.aggregationFunction().ASTERISK_SYMBOL() != null;
+        if (context.filter() == null) {
+            functionCallExpr = new FunctionCallExpr(functionName,
+                    isStar ? FunctionParams.createStarParam() : new FunctionParams(isDistinct, exprs, orderByElements),
+                    pos);
+
+        } else {
+            // convert agg filter to agg_if
+            boolean isCountFunc = functionName.equalsIgnoreCase(FunctionSet.COUNT);
+            if (isCountFunc && isDistinct) {
+                throw new ParsingException("Aggregation filter does not support COUNT DISTINCT");
+            }
+            Expr booleanExpr = (Expr) visit(context.filter().booleanExpression());
+            functionName = functionName + FunctionSet.AGG_STATE_IF_SUFFIX;
+            exprs.add(booleanExpr);
+
+            if (isCountFunc && isStar) {
+                functionCallExpr = new FunctionCallExpr(functionName, new FunctionParams(false, exprs, null, isDistinct, null));
+            } else if (functionName.startsWith(FunctionSet.ARRAY_AGG) && isDistinct) {
+                functionName = ARRAY_AGG_DISTINCT + FunctionSet.AGG_STATE_IF_SUFFIX;
+                functionCallExpr = new FunctionCallExpr(functionName, new FunctionParams(false, exprs, orderByElements), pos);
+            } else {
+                functionCallExpr = new FunctionCallExpr(functionName,
+                        isStar ? FunctionParams.createStarParam() : new FunctionParams(isDistinct, exprs, orderByElements),
+                        pos);
+            }
+        }
 
         functionCallExpr = SyntaxSugars.parse(functionCallExpr);
         functionCallExpr.setHints(hints);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -2607,7 +2607,7 @@ functionCall
     | informationFunctionExpression                                                       #informationFunction
     | specialDateTimeExpression                                                           #specialDateTime
     | specialFunctionExpression                                                           #specialFunction
-    | aggregationFunction over?                                                           #aggregationFunctionCall
+    | aggregationFunction filter? over?                                                   #aggregationFunctionCall
     | windowFunction over                                                                 #windowFunctionCall
     | TRANSLATE '(' (expression (',' expression)*)? ')'                                   #translateFunctionCall
     | qualifiedName '(' (expression (',' expression)*)? ')'  over?                        #simpleFunctionCall
@@ -2695,6 +2695,10 @@ windowFunction
 
 whenClause
     : WHEN condition=expression THEN result=expression
+    ;
+
+filter
+    : FILTER '(' WHERE booleanExpression ')'
     ;
 
 over

--- a/test/sql/test_agg_state/R/test_agg_filter.sql
+++ b/test/sql/test_agg_state/R/test_agg_filter.sql
@@ -1,0 +1,62 @@
+-- name: test_agg_filter
+CREATE TABLE sales (
+    id INT,
+    product VARCHAR(50),
+    amount DECIMAL(10, 2),
+    quantity INT
+) properties ("replication_num"="1");
+-- result:
+-- !result
+INSERT INTO sales (id, product, amount, quantity) VALUES
+(1, 'A', 100.00, 10),
+(2, 'B', 150.00, 20),
+(3, 'A', 200.00, 15),
+(4, 'B', 250.00, 25),
+(5, 'C', 300.00, 30),
+(6, 'Laptop', 500.00, 40);
+-- result:
+-- !result
+CREATE TABLE products (
+    product_id INT,
+    product VARCHAR(50),
+    category VARCHAR(50)
+) properties ("replication_num"="1");
+-- result:
+-- !result
+INSERT INTO products (product_id, product, category) VALUES
+(1, 'Laptop', 'Electronics'),
+(2, 'Smartphone', 'Electronics'),
+(3, 'Desk', 'Furniture'),
+(4, 'Chair', 'Furniture'),
+(5, 'Headphones', 'Electronics');
+-- result:
+-- !result
+SELECT
+AVG(amount) FILTER (WHERE product = 'A') AS avg_amount_a,
+COUNT(*) FILTER (WHERE quantity > 15) AS count_large_quantity,
+MAX(amount) FILTER (WHERE product = 'B') AS max_amount_b,
+MIN(amount) FILTER (WHERE amount > 100) AS min_amount_large,
+SUM(amount) FILTER (WHERE product = 'C') AS sum_amount_c,
+ARRAY_AGG(product) FILTER (WHERE quantity < 20) AS products,
+ARRAY_AGG(DISTINCT product) FILTER (WHERE quantity < 20) AS distinct_products1,
+ARRAY_AGG_DISTINCT(product) FILTER (WHERE quantity < 20) AS distinct_products2,
+COUNT(amount) AS count_amount,
+COUNT(*) FILTER (WHERE amount > (SELECT AVG(amount) FROM sales)) AS count_above_avg,
+SUM(amount) FILTER (WHERE product IN (SELECT product FROM products WHERE category = 'Electronics')) AS sum_electronics
+FROM sales
+group by id
+order by id;
+-- result:
+100.00000000	0	None	None	None	["A"]	["A"]	["A"]	1	0	None
+None	1	150.00	150.00	None	[null]	[null]	[null]	1	0	None
+200.00000000	0	None	200.00	None	["A"]	["A"]	["A"]	1	0	None
+None	1	250.00	250.00	None	[null]	[null]	[null]	1	0	None
+None	1	None	300.00	300.00	[null]	[null]	[null]	1	1	None
+None	1	None	500.00	None	[null]	[null]	[null]	1	1	500.00
+-- !result
+drop table sales;
+-- result:
+-- !result
+drop table products;
+-- result:
+-- !result

--- a/test/sql/test_agg_state/T/test_agg_filter.sql
+++ b/test/sql/test_agg_state/T/test_agg_filter.sql
@@ -1,0 +1,49 @@
+-- name: test_agg_filter
+
+CREATE TABLE sales (
+    id INT,
+    product VARCHAR(50),
+    amount DECIMAL(10, 2),
+    quantity INT
+) properties ("replication_num"="1");
+
+INSERT INTO sales (id, product, amount, quantity) VALUES
+(1, 'A', 100.00, 10),
+(2, 'B', 150.00, 20),
+(3, 'A', 200.00, 15),
+(4, 'B', 250.00, 25),
+(5, 'C', 300.00, 30),
+(6, 'Laptop', 500.00, 40);
+
+CREATE TABLE products (
+    product_id INT,
+    product VARCHAR(50),
+    category VARCHAR(50)
+) properties ("replication_num"="1");
+
+INSERT INTO products (product_id, product, category) VALUES
+(1, 'Laptop', 'Electronics'),
+(2, 'Smartphone', 'Electronics'),
+(3, 'Desk', 'Furniture'),
+(4, 'Chair', 'Furniture'),
+(5, 'Headphones', 'Electronics');
+
+SELECT
+AVG(amount) FILTER (WHERE product = 'A') AS avg_amount_a,
+COUNT(*) FILTER (WHERE quantity > 15) AS count_large_quantity,
+MAX(amount) FILTER (WHERE product = 'B') AS max_amount_b,
+MIN(amount) FILTER (WHERE amount > 100) AS min_amount_large,
+SUM(amount) FILTER (WHERE product = 'C') AS sum_amount_c,
+ARRAY_AGG(product) FILTER (WHERE quantity < 20) AS products,
+ARRAY_AGG(DISTINCT product) FILTER (WHERE quantity < 20) AS distinct_products1,
+ARRAY_AGG_DISTINCT(product) FILTER (WHERE quantity < 20) AS distinct_products2,
+COUNT(amount) AS count_amount,
+COUNT(*) FILTER (WHERE amount > (SELECT AVG(amount) FROM sales)) AS count_above_avg,
+SUM(amount) FILTER (WHERE product IN (SELECT product FROM products WHERE category = 'Electronics')) AS sum_electronics
+FROM sales
+group by id
+order by id;
+
+drop table sales;
+drop table products;
+


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Support filter clause of ansi for common aggregation functions

```
filter
    : FILTER '(' WHERE booleanExpression ')'
    ;
```
This aligns with a standard ANSI SQL syntax, and similar requirements have previously been raised by the community. Given the manageable implementation cost, we believe it's worthwhile to expose this syntax to users.
This syntax enhancement brings real value by improving the usability of aggregate functions. Before this syntax, conditional aggregation was possible but verbose and less readable:
```
SELECT
  COUNT(*) AS total_users,
  SUM(CASE WHEN gender = 'M' THEN 1 ELSE 0 END) AS male_users,
  SUM(CASE WHEN gender = 'F' THEN 1 ELSE 0 END) AS female_users
FROM users;
```

With the agg FILTER syntax, the query becomes much simpler and more readable, with better performance since no unnecessary data copy is needed:
```
SELECT
  COUNT(*) AS total_users,
  COUNT(*) FILTER (WHERE gender = 'M') AS male_users,
  COUNT(*) FILTER (WHERE gender = 'F') AS female_users
FROM users;
```

This pr is mainly to reuse [agg_if](https://github.com/StarRocks/starrocks/pull/58336) feature.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1