### PR TITLE
[Doc] Use expression partition in the starrocks_audit_tbl__

### DIFF
--- a/docs/en/administration/management/audit_loader.md
+++ b/docs/en/administration/management/audit_loader.md
@@ -51,16 +51,10 @@ CREATE TABLE starrocks_audit_db__.starrocks_audit_tbl__ (
 ) ENGINE = OLAP
 DUPLICATE KEY (`queryId`, `timestamp`, `queryType`)
 COMMENT "Audit log table"
-PARTITION BY RANGE (`timestamp`) ()
-DISTRIBUTED BY HASH (`queryId`) BUCKETS 3 
+PARTITION BY date_trunc('day', timestamp)
 PROPERTIES (
-  "dynamic_partition.time_unit" = "DAY",
-  "dynamic_partition.start" = "-30",       -- Keep the audit logs from the latest 30 days. You can adjust this value based on you business demand.
-  "dynamic_partition.end" = "3",
-  "dynamic_partition.prefix" = "p",
-  "dynamic_partition.buckets" = "3",
-  "dynamic_partition.enable" = "true",
-  "replication_num" = "3"                 -- Keep three replicas of audit logs. It is recommended to keep three replicas in a production environment.
+  "replication_num" = "1",
+  "partition_live_number"="30"
 );
 ```
 

--- a/docs/en/administration/management/audit_loader.md
+++ b/docs/en/administration/management/audit_loader.md
@@ -51,7 +51,7 @@ CREATE TABLE starrocks_audit_db__.starrocks_audit_tbl__ (
 ) ENGINE = OLAP
 DUPLICATE KEY (`queryId`, `timestamp`, `queryType`)
 COMMENT "Audit log table"
-PARTITION BY date_trunc('day', timestamp)
+PARTITION BY date_trunc('day', `timestamp`)
 PROPERTIES (
   "replication_num" = "1",
   "partition_live_number"="30"

--- a/docs/ja/administration/management/audit_loader.md
+++ b/docs/ja/administration/management/audit_loader.md
@@ -51,16 +51,10 @@ CREATE TABLE starrocks_audit_db__.starrocks_audit_tbl__ (
 ) ENGINE = OLAP
 DUPLICATE KEY (`queryId`, `timestamp`, `queryType`)
 COMMENT "監査ログテーブル"
-PARTITION BY RANGE (`timestamp`) ()
-DISTRIBUTED BY HASH (`queryId`) BUCKETS 3 
+PARTITION BY date_trunc('day', timestamp)
 PROPERTIES (
-  "dynamic_partition.time_unit" = "DAY",
-  "dynamic_partition.start" = "-30",       -- 最新の 30 日間の監査ログを保持します。ビジネスの需要に応じてこの値を調整できます。
-  "dynamic_partition.end" = "3",
-  "dynamic_partition.prefix" = "p",
-  "dynamic_partition.buckets" = "3",
-  "dynamic_partition.enable" = "true",
-  "replication_num" = "3"                 -- 監査ログの 3 つのレプリカを保持します。運用環境では 3 つのレプリカを保持することをお勧めします。
+  "replication_num" = "1",
+  "partition_live_number"="30"
 );
 ```
 

--- a/docs/ja/administration/management/audit_loader.md
+++ b/docs/ja/administration/management/audit_loader.md
@@ -51,7 +51,7 @@ CREATE TABLE starrocks_audit_db__.starrocks_audit_tbl__ (
 ) ENGINE = OLAP
 DUPLICATE KEY (`queryId`, `timestamp`, `queryType`)
 COMMENT "監査ログテーブル"
-PARTITION BY date_trunc('day', timestamp)
+PARTITION BY date_trunc('day', `timestamp`)
 PROPERTIES (
   "replication_num" = "1",
   "partition_live_number"="30"

--- a/docs/zh/administration/management/audit_loader.md
+++ b/docs/zh/administration/management/audit_loader.md
@@ -52,7 +52,7 @@ CREATE TABLE starrocks_audit_db__.starrocks_audit_tbl__ (
 ) ENGINE = OLAP
 DUPLICATE KEY (`queryId`, `timestamp`, `queryType`)
 COMMENT "审计日志表"
-PARTITION BY date_trunc('day', timestamp)
+PARTITION BY date_trunc('day', `timestamp`)
 PROPERTIES (
   "replication_num" = "1",
   "partition_live_number"="30"

--- a/docs/zh/administration/management/audit_loader.md
+++ b/docs/zh/administration/management/audit_loader.md
@@ -52,16 +52,10 @@ CREATE TABLE starrocks_audit_db__.starrocks_audit_tbl__ (
 ) ENGINE = OLAP
 DUPLICATE KEY (`queryId`, `timestamp`, `queryType`)
 COMMENT "审计日志表"
-PARTITION BY RANGE (`timestamp`) ()
-DISTRIBUTED BY HASH (`queryId`) BUCKETS 3 
+PARTITION BY date_trunc('day', timestamp)
 PROPERTIES (
-  "dynamic_partition.time_unit" = "DAY",
-  "dynamic_partition.start" = "-30",  --表示只保留最近30天的审计信息，可视需求调整。
-  "dynamic_partition.end" = "3",
-  "dynamic_partition.prefix" = "p",
-  "dynamic_partition.buckets" = "3",
-  "dynamic_partition.enable" = "true",
-  "replication_num" = "3"  --若集群中BE个数不大于3，可调整副本数为1，生产集群不推荐调整。
+  "replication_num" = "1",
+  "partition_live_number"="30"
 );
 ```
 


### PR DESCRIPTION
## Why I'm doing:
Dynamic partition is deprecated. I change the starrocks_audit_tbl__ into expression partition.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1