### PR TITLE
[Enhancement] support pagination for information_schema.task_runs

### DIFF
--- a/be/src/exec/schema_scanner/schema_task_runs_scanner.h
+++ b/be/src/exec/schema_scanner/schema_task_runs_scanner.h
@@ -28,7 +28,7 @@ public:
     Status get_next(ChunkPtr* chunk, bool* eos) override;
 
 private:
-    static constexpr int64_t kPaginationBatchSize = 1000;
+    static constexpr int64_t kPaginationBatchSize = DEFAULT_CHUNK_SIZE;
 
     Status fill_chunk(ChunkPtr* chunk);
 

--- a/be/src/exec/schema_scanner/schema_task_runs_scanner.h
+++ b/be/src/exec/schema_scanner/schema_task_runs_scanner.h
@@ -28,9 +28,12 @@ public:
     Status get_next(ChunkPtr* chunk, bool* eos) override;
 
 private:
+    static constexpr int64_t kPaginationBatchSize = 1000;
+
     Status fill_chunk(ChunkPtr* chunk);
 
-    int _task_run_index{0};
+    int _task_run_index = 0;
+    TGetTasksParams _task_params;
     TGetTaskRunInfoResult _task_run_result;
     static SchemaScanner::ColumnDesc _s_tbls_columns[];
 };

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -600,19 +600,23 @@ public class TaskManager implements MemoryTrackable {
 
     public List<TaskRunStatus> getMatchedTaskRunStatus(TGetTasksParams params) {
         List<TaskRunStatus> taskRunList = Lists.newArrayList();
-        // pending task runs
-        List<TaskRun> pendingTaskRuns = taskRunScheduler.getCopiedPendingTaskRuns();
-        pendingTaskRuns.stream()
-                .map(TaskRun::getStatus)
-                .filter(t -> t.match(params))
-                .forEach(taskRunList::add);
+        // only include the RUNNING & PENDING in the first page
+        if (params == null || params.getPagination() == null ||
+                params.isSetPagination() && params.getPagination().getOffset() == 0) {
+            // pending task runs
+            List<TaskRun> pendingTaskRuns = taskRunScheduler.getCopiedPendingTaskRuns();
+            pendingTaskRuns.stream()
+                    .map(TaskRun::getStatus)
+                    .filter(t -> t.match(params))
+                    .forEach(taskRunList::add);
 
-        // running task runs
-        Set<TaskRun> runningTaskRuns = taskRunScheduler.getCopiedRunningTaskRuns();
-        runningTaskRuns.stream()
-                .map(TaskRun::getStatus)
-                .filter(t -> t.match(params))
-                .forEach(taskRunList::add);
+            // running task runs
+            Set<TaskRun> runningTaskRuns = taskRunScheduler.getCopiedRunningTaskRuns();
+            runningTaskRuns.stream()
+                    .map(TaskRun::getStatus)
+                    .filter(t -> t.match(params))
+                    .forEach(taskRunList::add);
+        }
 
         // history task runs
         taskRunList.addAll(taskRunManager.getTaskRunHistory().lookupHistory(params));

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
@@ -210,8 +210,17 @@ public class TaskRunHistoryTable {
             predicates.add(" task_state = " + Strings.quote(params.getState()));
         }
         sql += Joiner.on(" AND ").join(predicates);
-        if (params.isSetPagination() && params.getPagination().getLimit() > 0) {
-            sql += " LIMIT " + params.getPagination().getLimit();
+
+        if (params.isSetPagination()) {
+            if (params.getPagination().getLimit() > 0 || params.getPagination().getOffset() > 0) {
+                sql += " ORDER BY `task_id`, `task_run_id`, `create_time`";
+            }
+            if (params.getPagination().getLimit() > 0) {
+                sql += " LIMIT " + params.getPagination().getLimit();
+            }
+            if (params.getPagination().getOffset() > 0) {
+                sql += " OFFSET " + params.getPagination().getOffset();
+            }
         }
 
         List<TResultBatch> batch = SimpleExecutor.getRepoExecutor().executeDQL(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -72,6 +72,7 @@ import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.statistic.StatisticsMetaManager;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TGetTasksParams;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
@@ -337,7 +338,7 @@ public class CreateMaterializedViewTest extends MVTestBase {
 
     private List<TaskRunStatus> waitingTaskFinish() {
         TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
-        List<TaskRunStatus> taskRuns = taskManager.getMatchedTaskRunStatus(null);
+        List<TaskRunStatus> taskRuns = taskManager.getMatchedTaskRunStatus(new TGetTasksParams());
         int retryCount = 0, maxRetry = 5;
         while (retryCount < maxRetry) {
             ThreadUtil.sleepAtLeastIgnoreInterrupts(2000L);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
@@ -158,7 +158,7 @@ public class TaskRunHistoryTest {
         new Expectations() {
             {
                 repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history WHERE TRUE AND  " +
-                        "task_run_id = 'q1' LIMIT 100");
+                        "task_run_id = 'q1' ORDER BY `task_id`, `task_run_id`, `create_time` LIMIT 100");
             }
         };
         history.lookup(params);

--- a/test/sql/test_information_schema/R/test_task_run_status
+++ b/test/sql/test_information_schema/R/test_task_run_status
@@ -1,4 +1,4 @@
--- name: test_task_run_status
+-- name: test_task_run_status @sequential
 create database db_${uuid0};
 -- result:
 -- !result
@@ -40,7 +40,7 @@ SELECT count(1) FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 
 -- !result
 [UC]task_name=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='mv1';
 -- result:
-mv-28357
+mv-10385348
 -- !result
 SELECT count(1) FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}';
 -- result:
@@ -55,7 +55,7 @@ admin set frontend config('enable_task_run_fe_evaluation'='false');
 -- !result
 [UC]query_id=SELECT `QUERY_ID` FROM information_schema.task_runs WHERE task_name = '${task_name}' limit 1;
 -- result:
-a780f383-44da-11ef-a7c8-e2d8918adc6e
+8a6eba59-3073-11f0-8bba-cec5eca5cdd9
 -- !result
 SELECT count(1) FROM information_schema.task_runs WHERE QUERY_ID = '${query_id}';
 -- result:
@@ -72,6 +72,36 @@ SUCCESS
 SELECT count(1) FROM information_schema.task_runs WHERE `STATE` = '${state}' and task_name = '${task_name}' and QUERY_ID = '${query_id}';
 -- result:
 1
+-- !result
+INSERT INTO _statistics_.task_run_history 
+    (task_id, task_run_id, create_time, task_name, task_state, finish_time, expire_time, history_content_json)
+    SELECT 1, 'fake-query-id' || generate_series, now(), 'fake-name', 'FAILED', now(), now(), 
+        '{"dbName": "default_cluster:sys"}'
+    FROM table(generate_series(1, 10000));
+-- result:
+-- !result
+SELECT (SELECT count(*) FROM information_schema.task_runs) 
+    >= (SELECT count(*) FROM _statistics_.task_run_history);
+-- result:
+1
+-- !result
+SELECT (SELECT count(*) FROM (SELECT * FROM information_schema.task_runs LIMIT 1) r) 
+    >= (SELECT count(*) FROM (SELECT * FROM _statistics_.task_run_history LIMIT 1) r);
+-- result:
+1
+-- !result
+SELECT (SELECT count(*) FROM (SELECT * FROM information_schema.task_runs LIMIT 4096) r) 
+    >= (SELECT count(*) FROM (SELECT * FROM _statistics_.task_run_history LIMIT 4096) r);
+-- result:
+1
+-- !result
+SELECT (SELECT count(*) FROM (SELECT * FROM information_schema.task_runs LIMIT 5000) r) 
+    >= (SELECT count(*) FROM (SELECT * FROM _statistics_.task_run_history LIMIT 5000) r);
+-- result:
+1
+-- !result
+DELETE FROM _statistics_.task_run_history WHERE task_run_id like 'fake-query-id%';
+-- result:
 -- !result
 drop database db_${uuid0};
 -- result:

--- a/test/sql/test_information_schema/T/test_task_run_status
+++ b/test/sql/test_information_schema/T/test_task_run_status
@@ -1,4 +1,4 @@
--- name: test_task_run_status
+-- name: test_task_run_status @sequential
 
 create database db_${uuid0};
 use db_${uuid0};
@@ -28,5 +28,23 @@ SELECT count(1) FROM information_schema.task_runs WHERE query_id= '${query_id}';
 
 [UC]state=SELECT `STATE` FROM information_schema.task_runs WHERE QUERY_ID = '${query_id}';
 SELECT count(1) FROM information_schema.task_runs WHERE `STATE` = '${state}' and task_name = '${task_name}' and QUERY_ID = '${query_id}';
+
+-- Generate a large number of fake task_run_history records for testing purposes
+INSERT INTO _statistics_.task_run_history 
+    (task_id, task_run_id, create_time, task_name, task_state, finish_time, expire_time, history_content_json)
+    SELECT 1, 'fake-query-id' || generate_series, now(), 'fake-name', 'FAILED', now(), now(), 
+        '{"dbName": "default_cluster:sys"}'
+    FROM table(generate_series(1, 10000));
+SELECT (SELECT count(*) FROM information_schema.task_runs) 
+    >= (SELECT count(*) FROM _statistics_.task_run_history);
+SELECT (SELECT count(*) FROM (SELECT * FROM information_schema.task_runs LIMIT 1) r) 
+    >= (SELECT count(*) FROM (SELECT * FROM _statistics_.task_run_history LIMIT 1) r);
+SELECT (SELECT count(*) FROM (SELECT * FROM information_schema.task_runs LIMIT 4096) r) 
+    >= (SELECT count(*) FROM (SELECT * FROM _statistics_.task_run_history LIMIT 4096) r);
+SELECT (SELECT count(*) FROM (SELECT * FROM information_schema.task_runs LIMIT 5000) r) 
+    >= (SELECT count(*) FROM (SELECT * FROM _statistics_.task_run_history LIMIT 5000) r);
+
+DELETE FROM _statistics_.task_run_history WHERE task_run_id like 'fake-query-id%';
+
 
 drop database db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

This view retrieves all historical task run records, which can be substantial. Fetching all records in a single RPC call may result in a large response size, potentially leading to memory issues.

## What I'm doing:

Introduce pagination for the `information_schema.task_runs`, returning 1000 records in each RPC call.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
