### PR TITLE
[Enhancement] Rename oidc to jwt

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authentication/JWTAuthenticationProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/JWTAuthenticationProvider.java
@@ -22,19 +22,19 @@ import com.starrocks.sql.ast.UserIdentity;
 
 import java.nio.ByteBuffer;
 
-public class OpenIdConnectAuthenticationProvider implements AuthenticationProvider {
-    public static final String OIDC_JWKS_URL = "jwks_url";
-    public static final String OIDC_PRINCIPAL_FIELD = "principal_field";
-    public static final String OIDC_REQUIRED_ISSUER = "required_issuer";
-    public static final String OIDC_REQUIRED_AUDIENCE = "required_audience";
+public class JWTAuthenticationProvider implements AuthenticationProvider {
+    public static final String JWT_JWKS_URL = "jwks_url";
+    public static final String JWT_PRINCIPAL_FIELD = "principal_field";
+    public static final String JWT_REQUIRED_ISSUER = "required_issuer";
+    public static final String JWT_REQUIRED_AUDIENCE = "required_audience";
 
     private final String jwksUrl;
     private final String principalFiled;
     private final String[] requiredIssuer;
     private final String[] requiredAudience;
 
-    public OpenIdConnectAuthenticationProvider(String jwksUrl, String principalFiled,
-                                               String[] requiredIssuer, String[] requiredAudience) {
+    public JWTAuthenticationProvider(String jwksUrl, String principalFiled,
+                                     String[] requiredIssuer, String[] requiredAudience) {
         this.jwksUrl = jwksUrl;
         this.principalFiled = principalFiled;
         this.requiredIssuer = requiredIssuer;

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/JWTSecurityIntegration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/JWTSecurityIntegration.java
@@ -22,30 +22,30 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-public class OIDCSecurityIntegration extends SecurityIntegration {
+public class JWTSecurityIntegration extends SecurityIntegration {
 
     public static final Set<String> REQUIRED_PROPERTIES = new HashSet<>(Arrays.asList(
             SecurityIntegration.SECURITY_INTEGRATION_PROPERTY_TYPE_KEY,
-            OpenIdConnectAuthenticationProvider.OIDC_JWKS_URL,
-            OpenIdConnectAuthenticationProvider.OIDC_PRINCIPAL_FIELD));
+            JWTAuthenticationProvider.JWT_JWKS_URL,
+            JWTAuthenticationProvider.JWT_PRINCIPAL_FIELD));
 
     private static final Pattern COMMA_SPLIT = Pattern.compile("\\s*,\\s*");
 
-    public OIDCSecurityIntegration(String name, Map<String, String> propertyMap) {
+    public JWTSecurityIntegration(String name, Map<String, String> propertyMap) {
         super(name, propertyMap);
     }
 
     @Override
     public AuthenticationProvider getAuthenticationProvider() {
-        String jwksUrl = propertyMap.get(OpenIdConnectAuthenticationProvider.OIDC_JWKS_URL);
-        String principalFiled = propertyMap.get(OpenIdConnectAuthenticationProvider.OIDC_PRINCIPAL_FIELD);
-        String commaSeparatedIssuer = propertyMap.get(OpenIdConnectAuthenticationProvider.OIDC_REQUIRED_ISSUER);
+        String jwksUrl = propertyMap.get(JWTAuthenticationProvider.JWT_JWKS_URL);
+        String principalFiled = propertyMap.get(JWTAuthenticationProvider.JWT_PRINCIPAL_FIELD);
+        String commaSeparatedIssuer = propertyMap.get(JWTAuthenticationProvider.JWT_REQUIRED_ISSUER);
         String[] requireIssuer = commaSeparatedIssuer == null ?
                 new String[0] : COMMA_SPLIT.split(commaSeparatedIssuer);
-        String commaSeperatedRequireAudiences = propertyMap.get(OpenIdConnectAuthenticationProvider.OIDC_REQUIRED_AUDIENCE);
+        String commaSeperatedRequireAudiences = propertyMap.get(JWTAuthenticationProvider.JWT_REQUIRED_AUDIENCE);
         String[] requireAudiences = commaSeperatedRequireAudiences == null ?
                 new String[0] : COMMA_SPLIT.split(commaSeperatedRequireAudiences.trim());
-        return new OpenIdConnectAuthenticationProvider(jwksUrl, principalFiled, requireIssuer, requireAudiences);
+        return new JWTAuthenticationProvider(jwksUrl, principalFiled, requireIssuer, requireAudiences);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/SecurityIntegrationFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/SecurityIntegrationFactory.java
@@ -25,7 +25,7 @@ public class SecurityIntegrationFactory {
     private static final ImmutableSortedSet<String> SUPPORTED_AUTH_MECHANISM =
             ImmutableSortedSet.orderedBy(String.CASE_INSENSITIVE_ORDER)
                     .add(AuthPlugin.Server.AUTHENTICATION_LDAP_SIMPLE.name())
-                    .add(AuthPlugin.Server.AUTHENTICATION_OPENID_CONNECT.name())
+                    .add(AuthPlugin.Server.AUTHENTICATION_JWT.name())
                     .add(AuthPlugin.Server.AUTHENTICATION_OAUTH2.name())
                     .build();
 
@@ -42,8 +42,8 @@ public class SecurityIntegrationFactory {
         SecurityIntegration securityIntegration = null;
         if (type.equalsIgnoreCase(AuthPlugin.Server.AUTHENTICATION_LDAP_SIMPLE.name())) {
             securityIntegration = new SimpleLDAPSecurityIntegration(name, propertyMap);
-        } else if (type.equalsIgnoreCase(AuthPlugin.Server.AUTHENTICATION_OPENID_CONNECT.name())) {
-            securityIntegration = new OIDCSecurityIntegration(name, propertyMap);
+        } else if (type.equalsIgnoreCase(AuthPlugin.Server.AUTHENTICATION_JWT.name())) {
+            securityIntegration = new JWTSecurityIntegration(name, propertyMap);
         } else if (type.equalsIgnoreCase(AuthPlugin.Server.AUTHENTICATION_OAUTH2.name())) {
             securityIntegration = new OAuth2SecurityIntegration(name, propertyMap);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3552,7 +3552,7 @@ public class Config extends ConfigBase {
      * The URL to a JWKS service or a local file in the conf dir
      */
     @ConfField(mutable = false)
-    public static String oidc_jwks_url = "";
+    public static String jwt_jwks_url = "";
 
     /**
      * String to identify the field in the JWT that identifies the subject of the JWT.
@@ -3560,21 +3560,21 @@ public class Config extends ConfigBase {
      * The value of this field must be the same as the user specified when logging into StarRocks.
      */
     @ConfField(mutable = false)
-    public static String oidc_principal_field = "sub";
+    public static String jwt_principal_field = "sub";
 
     /**
      * Specifies a list of string. One of that must match the value of the JWT’s issuer (iss) field in order to consider
      * this JWT valid. The iss field in the JWT identifies the principal that issued the JWT.
      */
     @ConfField(mutable = false)
-    public static String[] oidc_required_issuer = {};
+    public static String[] jwt_required_issuer = {};
 
     /**
      * Specifies a list of strings. For a JWT to be considered valid, the value of its 'aud' (Audience) field must match
      * at least one of these strings.
      */
     @ConfField(mutable = false)
-    public static String[] oidc_required_audience = {};
+    public static String[] jwt_required_audience = {};
 
     /**
      * The authorization URL. The URL a user’s browser will be redirected to in order to begin the OAuth2 authorization process

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
@@ -73,9 +73,9 @@ import com.starrocks.alter.RollupJobV2;
 import com.starrocks.alter.SchemaChangeJobV2;
 import com.starrocks.authentication.FileGroupProvider;
 import com.starrocks.authentication.GroupProvider;
+import com.starrocks.authentication.JWTSecurityIntegration;
 import com.starrocks.authentication.LDAPGroupProvider;
 import com.starrocks.authentication.OAuth2SecurityIntegration;
-import com.starrocks.authentication.OIDCSecurityIntegration;
 import com.starrocks.authentication.SecurityIntegration;
 import com.starrocks.authentication.SimpleLDAPSecurityIntegration;
 import com.starrocks.authentication.UnixGroupProvider;
@@ -354,7 +354,7 @@ public class GsonUtils {
 
     private static final RuntimeTypeAdapterFactory<SecurityIntegration> SEC_INTEGRATION_RUNTIME_TYPE_ADAPTER_FACTORY =
             RuntimeTypeAdapterFactory.of(SecurityIntegration.class, "clazz")
-                    .registerSubtype(OIDCSecurityIntegration.class, "OIDCSecurityIntegration")
+                    .registerSubtype(JWTSecurityIntegration.class, "JWTSecurityIntegration")
                     .registerSubtype(SimpleLDAPSecurityIntegration.class, "SimpleLDAPSecurityIntegration")
                     .registerSubtype(OAuth2SecurityIntegration.class, "OAuth2SecurityIntegration");
 

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/OpenIdConnectAuthenticationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/OpenIdConnectAuthenticationTest.java
@@ -35,8 +35,8 @@ public class OpenIdConnectAuthenticationTest {
     public void testAuthentication() throws Exception {
         GlobalStateMgr.getCurrentState().setJwkMgr(new MockTokenUtils.MockJwkMgr());
 
-        OpenIdConnectAuthenticationProvider provider =
-                new OpenIdConnectAuthenticationProvider("jwks.json", "preferred_username", emptyIssuer, emptyAudience);
+        JWTAuthenticationProvider provider =
+                new JWTAuthenticationProvider("jwks.json", "preferred_username", emptyIssuer, emptyAudience);
         UserAuthOptionAnalyzer.analyzeAuthOption(new UserIdentity("harbor", "%"),
                 new UserAuthOption(null, "", true, NodePosition.ZERO));
         String openIdConnectJson = mockTokenUtils.generateTestOIDCToken(3600 * 1000);

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/SecurityIntegrationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/SecurityIntegrationTest.java
@@ -55,8 +55,8 @@ public class SecurityIntegrationTest {
         properties.put("group_provider", "A, B, C");
         properties.put("permitted_groups", "B");
 
-        OIDCSecurityIntegration oidcSecurityIntegration =
-                new OIDCSecurityIntegration("oidc", properties);
+        JWTSecurityIntegration oidcSecurityIntegration =
+                new JWTSecurityIntegration("oidc", properties);
 
         List<String> groupProviderNameList = oidcSecurityIntegration.getGroupProviderName();
         Assert.assertEquals("A,B,C", Joiner.on(",").join(groupProviderNameList));
@@ -64,14 +64,14 @@ public class SecurityIntegrationTest {
         List<String> permittedGroups = oidcSecurityIntegration.getGroupAllowedLoginList();
         Assert.assertEquals("B", Joiner.on(",").join(permittedGroups));
 
-        oidcSecurityIntegration = new OIDCSecurityIntegration("oidc", new HashMap<>());
+        oidcSecurityIntegration = new JWTSecurityIntegration("oidc", new HashMap<>());
         Assert.assertTrue(oidcSecurityIntegration.getGroupProviderName().isEmpty());
         Assert.assertTrue(oidcSecurityIntegration.getGroupAllowedLoginList().isEmpty());
 
         properties = new HashMap<>();
         properties.put("group_provider", "");
         properties.put("permitted_groups", "");
-        oidcSecurityIntegration = new OIDCSecurityIntegration("oidc", properties);
+        oidcSecurityIntegration = new JWTSecurityIntegration("oidc", properties);
         Assert.assertTrue(oidcSecurityIntegration.getGroupProviderName().isEmpty());
         Assert.assertTrue(oidcSecurityIntegration.getGroupAllowedLoginList().isEmpty());
     }
@@ -81,9 +81,9 @@ public class SecurityIntegrationTest {
         GlobalStateMgr.getCurrentState().setJwkMgr(new MockTokenUtils.MockJwkMgr());
 
         Map<String, String> properties = new HashMap<>();
-        properties.put(SecurityIntegration.SECURITY_INTEGRATION_PROPERTY_TYPE_KEY, "authentication_openid_connect");
-        properties.put(OpenIdConnectAuthenticationProvider.OIDC_JWKS_URL, "jwks.json");
-        properties.put(OpenIdConnectAuthenticationProvider.OIDC_PRINCIPAL_FIELD, "preferred_username");
+        properties.put(SecurityIntegration.SECURITY_INTEGRATION_PROPERTY_TYPE_KEY, "authentication_jwt");
+        properties.put(JWTAuthenticationProvider.JWT_JWKS_URL, "jwks.json");
+        properties.put(JWTAuthenticationProvider.JWT_PRINCIPAL_FIELD, "preferred_username");
 
         AuthenticationMgr authenticationMgr = GlobalStateMgr.getCurrentState().getAuthenticationMgr();
         authenticationMgr.createSecurityIntegration("oidc2", properties, true);
@@ -141,9 +141,9 @@ public class SecurityIntegrationTest {
         GlobalStateMgr.getCurrentState().setJwkMgr(new MockTokenUtils.MockJwkMgr());
 
         Map<String, String> properties = new HashMap<>();
-        properties.put(OIDCSecurityIntegration.SECURITY_INTEGRATION_PROPERTY_TYPE_KEY, "authentication_openid_connect");
-        properties.put(OpenIdConnectAuthenticationProvider.OIDC_JWKS_URL, "jwks.json");
-        properties.put(OpenIdConnectAuthenticationProvider.OIDC_PRINCIPAL_FIELD, "preferred_username");
+        properties.put(JWTSecurityIntegration.SECURITY_INTEGRATION_PROPERTY_TYPE_KEY, "authentication_jwt");
+        properties.put(JWTAuthenticationProvider.JWT_JWKS_URL, "jwks.json");
+        properties.put(JWTAuthenticationProvider.JWT_PRINCIPAL_FIELD, "preferred_username");
         properties.put(SecurityIntegration.SECURITY_INTEGRATION_PROPERTY_GROUP_PROVIDER, "file_group_provider");
         properties.put(SecurityIntegration.SECURITY_INTEGRATION_GROUP_ALLOWED_LOGIN, "group1");
 

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlAuthPacketTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlAuthPacketTest.java
@@ -19,8 +19,8 @@ package com.starrocks.mysql;
 
 import com.starrocks.authentication.AuthenticationException;
 import com.starrocks.authentication.AuthenticationMgr;
-import com.starrocks.authentication.OIDCSecurityIntegration;
-import com.starrocks.authentication.OpenIdConnectAuthenticationProvider;
+import com.starrocks.authentication.JWTAuthenticationProvider;
+import com.starrocks.authentication.JWTSecurityIntegration;
 import com.starrocks.authentication.SecurityIntegration;
 import com.starrocks.common.Config;
 import com.starrocks.mysql.privilege.AuthPlugin;
@@ -142,7 +142,7 @@ public class MysqlAuthPacketTest {
         AuthenticationMgr authenticationMgr = new AuthenticationMgr();
         GlobalStateMgr.getCurrentState().setAuthenticationMgr(authenticationMgr);
         CreateUserStmt createUserStmt = (CreateUserStmt) SqlParser
-                .parse("create user harbor identified with authentication_openid_connect", 32).get(0);
+                .parse("create user harbor identified with authentication_jwt", 32).get(0);
         Analyzer.analyze(createUserStmt, ctx);
         authenticationMgr.createUser(createUserStmt);
 
@@ -157,9 +157,9 @@ public class MysqlAuthPacketTest {
 
         //test security integration
         Map<String, String> properties = new HashMap<>();
-        properties.put(OIDCSecurityIntegration.SECURITY_INTEGRATION_PROPERTY_TYPE_KEY, "authentication_openid_connect");
-        properties.put(OpenIdConnectAuthenticationProvider.OIDC_JWKS_URL, "jwks.json");
-        properties.put(OpenIdConnectAuthenticationProvider.OIDC_PRINCIPAL_FIELD, "preferred_username");
+        properties.put(JWTSecurityIntegration.SECURITY_INTEGRATION_PROPERTY_TYPE_KEY, "authentication_jwt");
+        properties.put(JWTAuthenticationProvider.JWT_JWKS_URL, "jwks.json");
+        properties.put(JWTAuthenticationProvider.JWT_PRINCIPAL_FIELD, "preferred_username");
         properties.put(SecurityIntegration.SECURITY_INTEGRATION_PROPERTY_GROUP_PROVIDER, "file_group_provider");
         properties.put(SecurityIntegration.SECURITY_INTEGRATION_GROUP_ALLOWED_LOGIN, "group1");
         authenticationMgr.createSecurityIntegration("oidc", properties, true);
@@ -187,7 +187,7 @@ public class MysqlAuthPacketTest {
         AuthenticationMgr authenticationMgr = new AuthenticationMgr();
         GlobalStateMgr.getCurrentState().setAuthenticationMgr(authenticationMgr);
         CreateUserStmt createUserStmt = (CreateUserStmt) SqlParser
-                .parse("create user harbor identified with authentication_openid_connect", 32).get(0);
+                .parse("create user harbor identified with authentication_jwt", 32).get(0);
         Analyzer.analyze(createUserStmt, ctx);
         authenticationMgr.createUser(createUserStmt);
 
@@ -210,6 +210,6 @@ public class MysqlAuthPacketTest {
         Assert.assertEquals("mysql_native_password", AuthPlugin.covertFromServerToClient("MYSQL_NATIVE_PASSWORD"));
         Assert.assertEquals("mysql_clear_password", AuthPlugin.covertFromServerToClient("authentication_ldap_simple"));
         Assert.assertEquals("authentication_openid_connect_client",
-                AuthPlugin.covertFromServerToClient("authentication_openid_connect"));
+                AuthPlugin.covertFromServerToClient("authentication_jwt"));
     }
 }

--- a/test/sql/test_security_integration/R/test_security_integration
+++ b/test/sql/test_security_integration/R/test_security_integration
@@ -12,13 +12,13 @@ create security integration oidc properties("jwks_url"="jwks.json", "principal_f
 -- result:
 E: (1064, 'Getting analyzing error. Detail message: missing required property: type.')
 -- !result
-create security integration oidc properties("type"="authentication_openid_connect", "jwks_url"="jwks.json", "principal_field"="sub");
+create security integration oidc properties("type"="authentication_jwt", "jwks_url"="jwks.json", "principal_field"="sub");
 -- result:
 -- !result
 show create security integration oidc;
 -- result:
 oidc	CREATE SECURITY INTEGRATION `oidc` PROPERTIES (
-"type" = "authentication_openid_connect",
+"type" = "authentication_jwt",
 "principal_field" = "sub",
 "jwks_url" = "jwks.json"
 )
@@ -29,7 +29,7 @@ alter security integration oidc set ("principal_field"="preferred_name");
 show create security integration oidc;
 -- result:
 oidc	CREATE SECURITY INTEGRATION `oidc` PROPERTIES (
-"type" = "authentication_openid_connect",
+"type" = "authentication_jwt",
 "principal_field" = "preferred_name",
 "jwks_url" = "jwks.json"
 )
@@ -53,7 +53,7 @@ alter security integration oidc set ("principal_field"="preferred_name");
 -- result:
 E: (5203, 'Access denied; you need (at least one of) the SECURITY privilege(s) on SYSTEM for this operation. Please ask the admin to grant permission(s) or try activating existing roles using <set [default] role>. Current role(s): NONE. Inactivated role(s): NONE.')
 -- !result
-create security integration oidc2 properties("type"="authentication_openid_connect", "jwks_url"="jwks.json", "principal_field"="sub");
+create security integration oidc2 properties("type"="authentication_jwt", "jwks_url"="jwks.json", "principal_field"="sub");
 -- result:
 E: (5203, 'Access denied; you need (at least one of) the SECURITY privilege(s) on SYSTEM for this operation. Please ask the admin to grant permission(s) or try activating existing roles using <set [default] role>. Current role(s): NONE. Inactivated role(s): NONE.')
 -- !result

--- a/test/sql/test_security_integration/T/test_security_integration
+++ b/test/sql/test_security_integration/T/test_security_integration
@@ -6,7 +6,7 @@ grant impersonate on user root to u1;
 
 create security integration oidc properties("jwks_url"="jwks.json", "principal_field"="sub");
 
-create security integration oidc properties("type"="authentication_openid_connect", "jwks_url"="jwks.json", "principal_field"="sub");
+create security integration oidc properties("type"="authentication_jwt", "jwks_url"="jwks.json", "principal_field"="sub");
 show create security integration oidc;
 alter security integration oidc set ("principal_field"="preferred_name");
 show create security integration oidc;
@@ -16,7 +16,7 @@ show security integrations;
 show create security integration oidc;
 drop security integration oidc;
 alter security integration oidc set ("principal_field"="preferred_name");
-create security integration oidc2 properties("type"="authentication_openid_connect", "jwks_url"="jwks.json", "principal_field"="sub");
+create security integration oidc2 properties("type"="authentication_jwt", "jwks_url"="jwks.json", "principal_field"="sub");
 
 execute as root with no revert;
 drop user u1;


### PR DESCRIPTION
## Why I'm doing:
Because we use the mysql client, in order to correspond to the naming of mysql, we divide the authentication methods into OAuth and OIDC. But in fact, in the OIDC authentication method of mysql, what needs to be provided by the client is access token or id token (choose 1 from 2), not the complete OIDC token (access token + id token), which is also confusing in the design and naming of mysql.
And in StarRocks' complete lake authentication solution, iceberg needs access token, so in the current OIDC authentication method, users should provide access token for authentication and login, which is not the concept of complete OIDC token.
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
