### PR TITLE
[Enhancement] Add expiration config for cached starlet filesystem instances

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1102,6 +1102,7 @@ CONF_mInt32(starlet_fslib_s3client_connect_timeout_ms, "1000");
 CONF_Alias(object_storage_request_timeout_ms, starlet_fslib_s3client_request_timeout_ms);
 CONF_mInt32(starlet_delete_files_max_key_in_batch, "1000");
 CONF_mInt32(starlet_filesystem_instance_cache_capacity, "10000");
+CONF_mInt32(starlet_filesystem_instance_cache_ttl_sec, "86400");
 #endif
 
 CONF_mInt64(lake_metadata_cache_limit, /*2GB=*/"2147483648");

--- a/be/src/service/staros_worker.h
+++ b/be/src/service/staros_worker.h
@@ -90,8 +90,10 @@ private:
     struct CacheValue {
         std::weak_ptr<std::string> key;
         std::shared_ptr<FileSystem> fs;
+        int64_t created_time_sec;
 
-        CacheValue(const std::weak_ptr<std::string>& key, const std::shared_ptr<FileSystem>& fs) : key(key), fs(fs) {}
+        CacheValue(const std::weak_ptr<std::string>& key, const std::shared_ptr<FileSystem>& fs)
+                : key(key), fs(fs), created_time_sec(MonotonicSeconds()) {}
     };
 
     // This function can be made static perfectly. The only reason to make it `virtual`

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -3566,6 +3566,24 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Description: An alias of `object_storage_request_timeout_ms`. Refer to [object_storage_request_timeout_ms](#object_storage_request_timeout_ms) for details.
 - Introduced in: v3.3.9
 
+##### starlet_filesystem_instance_cache_capacity
+
+- Default: 10000
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: The cache capacity of starlet filesystem instances.
+- Introduced in: v3.2.16, v3.3.11, v3.4.1
+
+##### starlet_filesystem_instance_cache_ttl_sec
+
+- Default: 86400
+- Type: Int
+- Unit: Seconds
+- Is mutable: Yes
+- Description: The cache expiration time of starlet filesystem instances.
+- Introduced in: v3.3.15, 3.4.5
+
 ##### lake_compaction_stream_buffer_size_bytes
 
 - Default: 1048576

--- a/docs/ja/administration/management/BE_configuration.md
+++ b/docs/ja/administration/management/BE_configuration.md
@@ -1717,6 +1717,24 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 説明: `object_storage_request_timeout_ms` の別名。詳細は [object_storage_request_timeout_ms](#object_storage_request_timeout_ms) を参照してください。
 - 導入バージョン: v3.3.9
 
+##### starlet_filesystem_instance_cache_capacity
+
+- デフォルト: 10000
+- タイプ: Int
+- 単位: 秒
+- 可変: はい
+- 説明: starlet filesystem インスタンスのキャッシュ容量。
+- 導入バージョン: v3.2.16, v3.3.11, v3.4.1
+
+##### starlet_filesystem_instance_cache_ttl_sec
+
+- デフォルト: 86400
+- タイプ: Int
+- 単位: 秒
+- 可変: はい
+- 説明: starlet filesystem インスタンス キャッシュの有効期限。
+- 導入バージョン: v3.3.15, 3.4.5
+
 ##### lake_compaction_stream_buffer_size_bytes
 
 - デフォルト: 1048576

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -3525,6 +3525,24 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 配置项描述: `object_storage_request_timeout_ms` 的别名。详细信息请参考配置项 [object_storage_request_timeout_ms](#object_storage_request_timeout_ms)。
 - 引入版本: v3.3.9
 
+##### starlet_filesystem_instance_cache_capacity
+
+- 默认值：10000
+- 类型：Int
+- 单位：-
+- 是否动态：是
+- 配置项描述: starlet filesystem 实例的缓存容量。
+- 引入版本: v3.2.16, v3.3.11, v3.4.1
+
+##### starlet_filesystem_instance_cache_ttl_sec
+
+- 默认值：86400
+- 类型：Int
+- 单位：秒
+- 是否动态：是
+- 配置项描述: starlet filesystem 实例缓存的过期时间。
+- 引入版本: v3.3.15, 3.4.5
+
 ##### lake_compaction_stream_buffer_size_bytes
 
 - 默认值：1048576


### PR DESCRIPTION
## Why I'm doing:
The fslib::FileSystem instances are cached in memory for reuse among tablets under the same partition, avoiding repeatedly rebuild from ShardInfo.

This is good for most cases. However, in edge cases, the filesystem instances cached contain some info that would be expired after sometime, if the fs instance lives longer than the info, the fs instance will be broken. HDFS kerberos ticket cache is an example, as reported in the github issue https://github.com/StarRocks/starrocks/issues/53097 

## What I'm doing:
Add a configuration item `starlet_filesystem_instance_cache_ttl_sec` to allow forcing rebuilding the fs instance if it lives longer than it. Its default value is 1 day.

Fixes https://github.com/StarRocks/starrocks/issues/53097

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
