### PR TITLE
[Enhancement]optimize null_column fill when do dict mapping

### DIFF
--- a/be/src/runtime/global_dict/parser.cpp
+++ b/be/src/runtime/global_dict/parser.cpp
@@ -141,8 +141,13 @@ private:
             const auto& container = data_column->get_data();
             auto res = _dict_opt_ctx->convert_column->clone_empty();
 
-            res->append_selective(*_dict_opt_ctx->convert_column,
-                                  _code_convert(container, _dict_opt_ctx->code_convert_map));
+            if (!input->has_null() && _is_strict) {
+                res->append_selective(*_data_column_ptr, code_convert(container, _dict_opt_ctx->code_convert_map));
+            } else {
+                res->append_selective(*_dict_opt_ctx->convert_column,
+                                      _code_convert(container, _dict_opt_ctx->code_convert_map));
+            }
+
             return res;
         } else {
             // is not nullable

--- a/be/src/runtime/global_dict/parser.cpp
+++ b/be/src/runtime/global_dict/parser.cpp
@@ -142,7 +142,7 @@ private:
             auto res = _dict_opt_ctx->convert_column->clone_empty();
 
             if (!input->has_null() && _is_strict) {
-                res->append_selective(*_data_column_ptr, code_convert(container, _dict_opt_ctx->code_convert_map));
+                res->append_selective(*_data_column_ptr, _code_convert(container, _dict_opt_ctx->code_convert_map));
             } else {
                 res->append_selective(*_dict_opt_ctx->convert_column,
                                       _code_convert(container, _dict_opt_ctx->code_convert_map));


### PR DESCRIPTION
## Why I'm doing:
for low cardinality string, we use dict mapping to optimization, but I found NullColumn
append_selective costs a lot even all rows are not null.
before:
<img width="1200" alt="截屏2025-05-15 15 58 36" src="https://github.com/user-attachments/assets/59540703-5f33-4d4c-98a3-5398153d514a" />
after:
<img width="1197" alt="截屏2025-05-15 15 59 34" src="https://github.com/user-attachments/assets/dcac7753-f295-4b80-a367-b2f1adae1cc7" />

and I have a sql 
`SELECT sum(length(p_mfgr)), sum(length(p_category)), sum(length(p_color)), sum(length(p_type)) FROM lineorder_flat;`
Execution time 3.0s->2.3s


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
