### PR TITLE
[Enhancement] MV support self-union-join

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPlanBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPlanBuilder.java
@@ -46,6 +46,7 @@ import com.starrocks.sql.ast.SelectList;
 import com.starrocks.sql.ast.SelectListItem;
 import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.TableRelation;
+import com.starrocks.sql.ast.UnionRelation;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.Logger;
 
@@ -171,7 +172,8 @@ public class MVPCTRefreshPlanBuilder {
             // since it will deduce `hasTableHints` to true and causes rewrite failed.
             boolean isSameTable = relations.stream().allMatch(e ->
                     e.getName().equals(relations.iterator().next().getName()));
-            boolean isPushDownBelowTable = (relations.size() == 1 || isSameTable);
+            // If the query relation is a union relation and the table relation is the same table, need to push down.
+            boolean isPushDownBelowTable = (relations.size() == 1 || (isSameTable && queryRelation instanceof UnionRelation));
             if (isPushDownBelowTable) {
                 boolean ret = pushDownPartitionPredicates(table, tableRelation, refTablePartitionSlotRefs,
                         tablePartitionNames, isEnableMVRefreshQueryRewrite);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPlanBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPlanBuilder.java
@@ -169,7 +169,9 @@ public class MVPCTRefreshPlanBuilder {
             // If there are multiple table relations, don't push down partition predicate into table relation
             // If `enable_mv_refresh_query_rewrite` is enabled, table relation should not set partition names
             // since it will deduce `hasTableHints` to true and causes rewrite failed.
-            boolean isPushDownBelowTable = (relations.size() == 1);
+            boolean isSameTable = relations.stream().allMatch(e ->
+                    e.getName().equals(relations.iterator().next().getName()));
+            boolean isPushDownBelowTable = (relations.size() == 1 || isSameTable);
             if (isPushDownBelowTable) {
                 boolean ret = pushDownPartitionPredicates(table, tableRelation, refTablePartitionSlotRefs,
                         tablePartitionNames, isEnableMVRefreshQueryRewrite);


### PR DESCRIPTION

## Why I'm doing:

Refer to this #58919  ; the current MV does not support self-join.

## What I'm doing:

When the join table is the same table, continue executing the `com.starrocks.scheduler.mv.MVPCTRefreshPlanBuilder#pushDownPartitionPredicates` function.

Fixes #58919

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
