### PR TITLE
[BugFix] Fix cancel stream load api is not registered correctly

### DIFF
--- a/docs/en/administration/http_interface.md
+++ b/docs/en/administration/http_interface.md
@@ -17,7 +17,7 @@ To facilitate the maintenance of StarRocks clusters, StarRocks provides various 
 | GET                 | `/api/_get_ddl?db={}&tbl={}`                                    | View table DDL statement.                                                                                            |
 | GET                 | `/api/_migration?db={}&tbl={}`                                  | View table tablet information.                                                                                       |
 | GET                 | `/api/_check_storagetype`                                       |
-| POST                | `/api/{db}/{label}/_cancel`                                     |
+| POST                | `/api/{db}/{table}/_cancel?label={}`                            |
 | GET                 | `/api/{db}/get_load_state`                                      |
 | GET                 | `/api/health`                                                   |
 | GET                 | `/metrics?type={core/json}`                                     | View metrics of the current FE.                                                                                      |

--- a/docs/zh/administration/http_interface.md
+++ b/docs/zh/administration/http_interface.md
@@ -17,7 +17,7 @@ displayed_sidebar: docs
 | GET              | `/api/_get_ddl?db={}&tbl={}`                                      | 查看表 DDL 语句。
 | GET              | `/api/_migration?db={}&tbl={}`                                    | 查看表 tablet 信息。                                                                                                    |
 | GET              | `/api/_check_storagetype`
-| POST             | `/api/{db}/{label}/_cancel`
+| POST             | `/api/{db}/{table}/_cancel?label={}`
 | GET              | `/api/{db}/get_load_state`
 | GET              | `/api/health`
 | GET              | `/metrics?type={core/json}`                                       | 查看当前 FE 的 metrics。                                                                                                |

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
@@ -59,7 +59,7 @@ import com.starrocks.http.meta.MetaService.PutAction;
 import com.starrocks.http.meta.MetaService.RoleAction;
 import com.starrocks.http.meta.MetaService.VersionAction;
 import com.starrocks.http.rest.BootstrapFinishAction;
-import com.starrocks.http.rest.CancelStreamLoad;
+import com.starrocks.http.rest.CancelStreamLoadAction;
 import com.starrocks.http.rest.CheckDecommissionAction;
 import com.starrocks.http.rest.ConnectionAction;
 import com.starrocks.http.rest.ExecuteSqlAction;
@@ -159,7 +159,7 @@ public class HttpServer {
         GetDdlStmtAction.registerAction(controller);
         MigrationAction.registerAction(controller);
         StorageTypeCheckAction.registerAction(controller);
-        CancelStreamLoad.registerAction(controller);
+        CancelStreamLoadAction.registerAction(controller);
         GetStreamLoadState.registerAction(controller);
 
         // add web action

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/CancelStreamLoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/CancelStreamLoadAction.java
@@ -45,15 +45,15 @@ import com.starrocks.http.IllegalArgException;
 import com.starrocks.server.GlobalStateMgr;
 import io.netty.handler.codec.http.HttpMethod;
 
-public class CancelStreamLoad extends RestBaseAction {
-    public CancelStreamLoad(ActionController controller) {
+public class CancelStreamLoadAction extends RestBaseAction {
+    public CancelStreamLoadAction(ActionController controller) {
         super(controller);
     }
 
     public static void registerAction(ActionController controller)
             throws IllegalArgException {
-        CancelStreamLoad action = new CancelStreamLoad(controller);
-        controller.registerHandler(HttpMethod.POST, "/api/{" + DB_KEY + "}/{" + LABEL_KEY + "}/_cancel", action);
+        CancelStreamLoadAction action = new CancelStreamLoadAction(controller);
+        controller.registerHandler(HttpMethod.POST, "/api/{" + DB_KEY + "}/{" + TABLE_KEY + "}/_cancel", action);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/http/CancelStreamLoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/CancelStreamLoadActionTest.java
@@ -1,0 +1,88 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.http;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.common.StarRocksException;
+import com.starrocks.http.rest.ActionStatus;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.transaction.GlobalTransactionMgr;
+import mockit.Expectations;
+import mockit.Mocked;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+
+public class CancelStreamLoadActionTest extends StarRocksHttpTestCase {
+
+    private static final String OK = ActionStatus.OK.name();
+    private static final String FAILED = ActionStatus.FAILED.name();
+
+    @Mocked
+    private GlobalTransactionMgr globalTransactionMgr;
+
+    @Test
+    public void testNormal() throws IOException, StarRocksException {
+        // POST /api/{db}/{table}/_cancel?label={label} is working
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        String label = UUID.randomUUID().toString();
+        new Expectations() {
+            {
+                globalTransactionMgr.abortTransaction(anyLong, anyString, anyString);
+                times = 1;
+            }
+        };
+        Request request = new Request.Builder()
+                .post(RequestBody.create(JSON, "[]"))
+                .addHeader("Authorization", rootAuth)
+                .url(BASE_URL + String.format("/api/%s/tbl1/_cancel?label=%s", db.getFullName(), label))
+                .build();
+
+        try (Response response = networkClient.newCall(request).execute()) {
+            Map<String, Object> body = parseResponseBody(response);
+            assertEquals(OK, body.get("status"));
+        }
+    }
+
+    @Test
+    public void testLabelNotExist() throws IOException, StarRocksException {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        String label = UUID.randomUUID().toString();
+        new Expectations() {
+            {
+                globalTransactionMgr.abortTransaction(anyLong, anyString, anyString);
+                times = 1;
+                result = new StarRocksException("label not exist");
+            }
+        };
+        Request request = new Request.Builder()
+                .post(RequestBody.create(JSON, "[]"))
+                .addHeader("Authorization", rootAuth)
+                .url(BASE_URL + String.format("/api/%s/tbl1/_cancel?label=%s", db.getFullName(), label))
+                .build();
+
+        try (Response response = networkClient.newCall(request).execute()) {
+            Map<String, Object> body = parseResponseBody(response);
+            assertEquals(FAILED, body.get("status"));
+            assertEquals("label not exist", body.get("msg"));
+        }
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Current `POST /api/{db}/{label}/_cancel` api to cancel stream load is not working as expected.
`POST /api/{db}/{label}/_cancel` conflicts with `POST /api/{db}/{table}/_query_plan`

Both `{label}` and `{table}`  are wildcard, only **ONE** wildcard's name is sustained in `PathTrie.java`,  the later registery wins. 
In this case, `POST /api/{db}/{table}/_query_plan` is registered after `POST /api/{db}/{label}/_cancel`, then the wildcard's name is `table`.

As the result, `request.getSingleParameter(LABEL_KEY)` in `CancelStreamLoad.java` can't get the actual label from request `POST /api/xx/yy/_cancel`. The params in `request` are {db=xx, table=yy}, not {db=xx, label=yy}


## What I'm doing:

Clarify the correct api is `POST /api/{db}/{table}/_cancel?label={label}` in document and fix the api registery to avoid confliction.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
