### PR TITLE
[Enhancement] Change proc_profile collect time to 2min

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1418,22 +1418,16 @@ public class Config extends ConfigBase {
     public static boolean proc_profile_cpu_enable = true;
 
     /**
-     * The number of seconds between proc profile collections
-     */
-    @ConfField(mutable = true, comment = "The number of seconds between proc profile collections")
-    public static long proc_profile_collect_interval_s = 600;
-
-    /**
      * The number of seconds it takes to collect single proc profile
      */
     @ConfField(mutable = true, comment = "The number of seconds it takes to collect single proc profile")
-    public static long proc_profile_collect_time_s = 300;
+    public static long proc_profile_collect_time_s = 120;
 
     /**
      * The number of days to retain profile files
      */
     @ConfField(mutable = true, comment = "The number of days to retain profile files")
-    public static int proc_profile_file_retained_days = 2;
+    public static int proc_profile_file_retained_days = 1;
 
     /**
      * The number of bytes to retain profile files

--- a/fe/fe-core/src/main/java/com/starrocks/memory/ProcProfileCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/ProcProfileCollector.java
@@ -47,7 +47,6 @@ public class ProcProfileCollector extends FrontendDaemon {
     private final SimpleDateFormat profileTimeFormat = new SimpleDateFormat("yyyyMMdd-HHmmss");
     private final String profileLogDir;
 
-    private long lastCollectTime = -1;
     private long lastLogTime = -1;
 
     public ProcProfileCollector() {
@@ -60,18 +59,12 @@ public class ProcProfileCollector extends FrontendDaemon {
         File file = new File(profileLogDir);
         file.mkdirs();
 
-        if (lastCollectTime == -1L
-                || (System.currentTimeMillis() - lastCollectTime > Config.proc_profile_collect_interval_s * 1000)) {
+        if (Config.proc_profile_cpu_enable) {
+            collectCPUProfile();
+        }
 
-            lastCollectTime = System.currentTimeMillis();
-
-            if (Config.proc_profile_cpu_enable) {
-                collectCPUProfile();
-            }
-
-            if (Config.proc_profile_mem_enable) {
-                collectMemProfile();
-            }
+        if (Config.proc_profile_mem_enable) {
+            collectMemProfile();
         }
 
         deleteExpiredFiles();


### PR DESCRIPTION
## Why I'm doing:

Some cluster memory usage spikes suddenly, and it may take only 1–2 minutes from the start of the memory spike to the process getting stuck. If the profile collection time is too long, it can cause the collected process to also get stuck, resulting in no output.

## What I'm doing:
Change the default collect time to 2min.
Remove `proc_profile_collect_interval_s` param. In actual scenarios, profile collection must not have intervals. If users feel that collecting profiles affects performance, they can simply disable this function.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
