### PR TITLE
[Feature] implement insert into iceberg partition transform table

### DIFF
--- a/be/src/connector/async_flush_stream_poller.h
+++ b/be/src/connector/async_flush_stream_poller.h
@@ -32,7 +32,9 @@ public:
 
     AsyncFlushStreamPoller() = default;
 
-    void enqueue(std::unique_ptr<Stream> stream);
+    virtual ~AsyncFlushStreamPoller() = default;
+
+    virtual void enqueue(std::unique_ptr<Stream> stream);
 
     // return a pair of
     // 1. io status

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -234,7 +234,6 @@ Status HiveDataSource::_init_conjunct_ctxs(RuntimeState* state) {
 
 Status HiveDataSource::_init_partition_values() {
     if (!(_hive_table != nullptr && _has_partition_columns)) return Status::OK();
-
     auto* partition_desc = _hive_table->get_partition(_scan_range.partition_id);
     if (partition_desc == nullptr) {
         return Status::InternalError(

--- a/be/src/connector/iceberg_chunk_sink.h
+++ b/be/src/connector/iceberg_chunk_sink.h
@@ -35,7 +35,7 @@ namespace starrocks::connector {
 
 class IcebergChunkSink : public ConnectorChunkSink {
 public:
-    IcebergChunkSink(std::vector<std::string> partition_columns,
+    IcebergChunkSink(std::vector<std::string> partition_columns, std::vector<std::string> transform_exprs,
                      std::vector<std::unique_ptr<ColumnEvaluator>>&& partition_column_evaluators,
                      std::unique_ptr<LocationProvider> location_provider,
                      std::unique_ptr<formats::FileWriterFactory> file_writer_factory, int64_t max_file_size,
@@ -44,6 +44,13 @@ public:
     ~IcebergChunkSink() override = default;
 
     void callback_on_commit(const CommitResult& result) override;
+
+    const std::vector<std::string>& transform_expr() const { return _transform_exprs; }
+
+    Status add(Chunk* chunk) override;
+
+private:
+    std::vector<std::string> _transform_exprs;
 };
 
 struct IcebergChunkSinkContext : public ConnectorChunkSinkContext {
@@ -51,8 +58,10 @@ struct IcebergChunkSinkContext : public ConnectorChunkSinkContext {
 
     std::string path;
     std::vector<std::string> column_names;
+    std::vector<std::string> partition_column_names;
+    std::vector<std::string> transform_exprs;
     std::vector<std::unique_ptr<ColumnEvaluator>> column_evaluators;
-    std::vector<int32_t> partition_column_indices;
+    std::vector<std::unique_ptr<ColumnEvaluator>> partition_evaluators;
     int64_t max_file_size = 128L * 1024 * 1024;
     std::string format;
     TCompressionType::type compression_type = TCompressionType::UNKNOWN_COMPRESSION;

--- a/be/src/connector/sink_memory_manager.cpp
+++ b/be/src/connector/sink_memory_manager.cpp
@@ -18,7 +18,7 @@
 
 namespace starrocks::connector {
 
-void SinkOperatorMemoryManager::init(std::unordered_map<std::string, WriterStreamPair>* writer_stream_pairs,
+void SinkOperatorMemoryManager::init(std::map<PartitionKey, WriterStreamPair>* writer_stream_pairs,
                                      AsyncFlushStreamPoller* io_poller, CommitFunc commit_func) {
     _candidates = writer_stream_pairs;
     _commit_func = std::move(commit_func);
@@ -31,7 +31,7 @@ bool SinkOperatorMemoryManager::kill_victim() {
     }
 
     // find file writer with the largest file size
-    std::string partition;
+    PartitionKey partition;
     WriterStreamPair* victim = nullptr;
     for (auto& [key, writer_and_stream] : *_candidates) {
         if (victim && victim->first->get_written_bytes() > writer_and_stream.first->get_written_bytes()) {

--- a/be/src/connector/sink_memory_manager.h
+++ b/be/src/connector/sink_memory_manager.h
@@ -28,7 +28,7 @@ class SinkOperatorMemoryManager {
 public:
     SinkOperatorMemoryManager() = default;
 
-    void init(std::unordered_map<std::string, WriterStreamPair>* writer_stream_pairs, AsyncFlushStreamPoller* io_poller,
+    void init(std::map<PartitionKey, WriterStreamPair>* writer_stream_pairs, AsyncFlushStreamPoller* io_poller,
               CommitFunc commit_func);
 
     // return true if a victim is found and killed, otherwise return false
@@ -45,7 +45,7 @@ public:
     int64_t writer_occupied_memory() { return _writer_occupied_memory.load(); }
 
 private:
-    std::unordered_map<std::string, WriterStreamPair>* _candidates = nullptr; // reference, owned by sink operator
+    std::map<PartitionKey, WriterStreamPair>* _candidates = nullptr; // reference, owned by sink operator
     CommitFunc _commit_func;
     AsyncFlushStreamPoller* _io_poller;
     std::atomic_int64_t _releasable_memory{0};

--- a/be/src/connector/utils.h
+++ b/be/src/connector/utils.h
@@ -37,7 +37,19 @@ public:
             const std::vector<std::unique_ptr<ColumnEvaluator>>& column_evaluators, Chunk* chunk,
             bool support_null_partition);
 
+    static StatusOr<std::string> iceberg_make_partition_name(
+            const std::vector<std::string>& partition_column_names,
+            const std::vector<std::unique_ptr<ColumnEvaluator>>& column_evaluators,
+            const std::vector<std::string>& transform_exprs, Chunk* chunk, bool support_null_partition,
+            std::vector<int8_t>& field_is_null);
+
     static StatusOr<std::string> column_value(const TypeDescriptor& type_desc, const ColumnPtr& column, int idx);
+
+    static StatusOr<std::string> iceberg_column_value(const TypeDescriptor& type_desc, const ColumnPtr& column,
+                                                      const std::string& transform_expr, int8_t& is_null);
+
+    template <typename T>
+    static StatusOr<std::string> format_decimal_value(T value, int scale);
 };
 
 class IcebergUtils {

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
@@ -49,6 +49,7 @@ class LocalExchangeSourceOperator final : public SourceOperator {
         std::queue<std::unique_ptr<Chunk>> queue;
         int64_t num_rows{0};
         size_t memory_usage{0};
+        std::vector<std::pair<TypeDescriptor, ColumnPtr>> partition_key_datum;
     };
 
 public:
@@ -64,7 +65,9 @@ public:
     Status add_chunk(ChunkPtr chunk, const std::shared_ptr<std::vector<uint32_t>>& indexes, uint32_t from,
                      uint32_t size, size_t memory_bytes);
 
-    Status add_chunk(const std::vector<std::string>& partition_key, std::unique_ptr<Chunk> chunk);
+    Status add_chunk(const std::vector<std::string>& partition_key,
+                     const std::vector<std::pair<TypeDescriptor, ColumnPtr>>& partition_datum,
+                     std::unique_ptr<Chunk> chunk);
 
     bool has_output() const override;
 
@@ -111,7 +114,8 @@ private:
 
     int64_t _key_partition_max_rows() const;
 
-    PartialChunks& _max_row_partition_chunks();
+    std::unordered_map<std::vector<std::string>, LocalExchangeSourceOperator::PartialChunks>::iterator
+    _max_row_partition_chunks();
 
     bool _local_buffer_almost_full() const { return _local_memory_usage >= _local_memory_limit; }
 

--- a/be/src/exec/pipeline/sink/table_function_table_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/table_function_table_sink_operator.cpp
@@ -65,7 +65,8 @@ StatusOr<std::string> column_to_string(const TypeDescriptor& type_desc, const Co
         return url_encode(datum.get_slice().to_string());
     }
     default: {
-        return Status::InvalidArgument("unsupported partition column type" + type_desc.debug_string());
+        return Status::InvalidArgument("unsupported partition column type in table function sink" +
+                                       type_desc.debug_string());
     }
     }
 }

--- a/be/src/formats/file_writer.h
+++ b/be/src/formats/file_writer.h
@@ -49,6 +49,11 @@ public:
         FileStatistics file_statistics;
         std::string location;
         std::function<void()> rollback_action;
+        std::string extra_data;
+        CommitResult& set_extra_data(std::string extra_data) {
+            this->extra_data = std::move(extra_data);
+            return *this;
+        }
     };
 
     virtual ~FileWriter() = default;

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -229,19 +229,33 @@ IcebergTableDescriptor::IcebergTableDescriptor(const TTableDescriptor& tdesc, Ob
     _table_location = tdesc.icebergTable.location;
     _columns = tdesc.icebergTable.columns;
     _t_iceberg_schema = tdesc.icebergTable.iceberg_schema;
-    _partition_column_names = tdesc.icebergTable.partition_column_names;
+    if (tdesc.icebergTable.__isset.partition_info) {
+        for (const auto& part_info : tdesc.icebergTable.partition_info) {
+            _source_column_names.push_back(part_info.source_column_name);
+            _partition_column_names.push_back(part_info.partition_column_name);
+            _transform_exprs.push_back(part_info.transform_expr);
+            _partition_exprs.push_back(part_info.partition_expr);
+        }
+    } else {
+        _source_column_names = tdesc.icebergTable.partition_column_names; //to compat with lower fe, set this also
+        _partition_column_names = tdesc.icebergTable.partition_column_names;
+    }
 }
 
-std::vector<int32_t> IcebergTableDescriptor::partition_index_in_schema() {
+std::vector<int32_t> IcebergTableDescriptor::partition_source_index_in_schema() {
     std::vector<int32_t> indexes;
-    indexes.reserve(_partition_column_names.size());
+    indexes.reserve(_source_column_names.size());
 
-    for (const auto& name : _partition_column_names) {
-        for (int i = 0; i < _columns.size(); ++i) {
+    for (const auto& name : _source_column_names) {
+        bool found = false;
+        for (int i = 0; !found && i < _columns.size(); ++i) {
             if (_columns[i].column_name == name) {
                 indexes.emplace_back(i);
-                break;
+                found = true;
             }
+        }
+        if (!found) {
+            indexes.emplace_back(-1);
         }
     }
 

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -246,15 +246,20 @@ public:
     const TIcebergSchema* get_iceberg_schema() const { return &_t_iceberg_schema; }
     bool is_unpartitioned_table() { return _partition_column_names.empty(); }
     const std::vector<std::string>& partition_column_names() { return _partition_column_names; }
+    const std::vector<TExpr>& get_partition_exprs() { return _partition_exprs; }
+    const std::vector<std::string>& get_transform_exprs() { return _transform_exprs; }
     const std::vector<std::string> full_column_names();
-    std::vector<int32_t> partition_index_in_schema();
+    std::vector<int32_t> partition_source_index_in_schema();
     bool has_base_path() const override { return true; }
 
     Status set_partition_desc_map(const TIcebergTable& thrift_table, ObjectPool* pool);
 
 private:
     TIcebergSchema _t_iceberg_schema;
+    std::vector<std::string> _source_column_names; // partition transform column's source column name
     std::vector<std::string> _partition_column_names;
+    std::vector<std::string> _transform_exprs;
+    std::vector<TExpr> _partition_exprs;
 };
 
 class FileTableDescriptor : public HiveTableDescriptor {

--- a/be/test/connector_sink/iceberg_chunk_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_chunk_sink_test.cpp
@@ -28,6 +28,7 @@
 #include "formats/utils.h"
 #include "testutil/assert.h"
 #include "util/defer_op.h"
+#include "util/integer_util.h"
 
 namespace starrocks::connector {
 namespace {
@@ -59,16 +60,68 @@ public:
     MOCK_METHOD(StatusOr<WriterAndStream>, create, (const std::string&), (const override));
 };
 
+class MockWriter : public formats::FileWriter {
+public:
+    MOCK_METHOD(Status, init, (), (override));
+    MOCK_METHOD(int64_t, get_written_bytes, (), (override));
+    MOCK_METHOD(int64_t, get_allocated_bytes, (), (override));
+    MOCK_METHOD(Status, write, (Chunk * chunk), (override));
+    MOCK_METHOD(CommitResult, commit, (), (override));
+};
+
+class MockFile : public WritableFile {
+public:
+    MOCK_METHOD(Status, append, (const Slice& data), (override));
+    MOCK_METHOD(Status, appendv, (const Slice* data, size_t cnt), (override));
+    MOCK_METHOD(Status, pre_allocate, (uint64_t size), (override));
+    MOCK_METHOD(Status, close, (), (override));
+    MOCK_METHOD(Status, flush, (FlushMode mode), (override));
+    MOCK_METHOD(Status, sync, (), (override));
+    MOCK_METHOD(uint64_t, size, (), (const, override));
+    MOCK_METHOD(const std::string&, filename, (), (const, override));
+};
+
+class MockPoller : public AsyncFlushStreamPoller {
+public:
+    MOCK_METHOD(void, enqueue, (std::unique_ptr<Stream> stream), (override));
+};
+
 TEST_F(IcebergChunkSinkTest, test_callback) {
     {
         std::vector<std::string> partition_column_names = {"k1"};
+        std::vector<std::string> transform = {"identity"};
         std::vector<std::unique_ptr<ColumnEvaluator>> partition_column_evaluators =
                 ColumnSlotIdEvaluator::from_types({TypeDescriptor::from_logical_type(TYPE_VARCHAR)});
         auto mock_writer_factory = std::make_unique<MockFileWriterFactory>();
         auto location_provider = std::make_unique<LocationProvider>("base_path", "ffffff", 0, 0, "parquet");
-        auto sink = std::make_unique<IcebergChunkSink>(partition_column_names, std::move(partition_column_evaluators),
-                                                       std::move(location_provider), std::move(mock_writer_factory),
-                                                       100, _runtime_state);
+        WriterAndStream ws;
+        ws.writer = std::make_unique<MockWriter>();
+        ws.stream = std::make_unique<io::AsyncFlushOutputStream>(std::make_unique<MockFile>(), nullptr, nullptr);
+        EXPECT_CALL(*mock_writer_factory, create(::testing::_))
+                .WillRepeatedly(::testing::Return(ByMove(StatusOr<WriterAndStream>(std::move(ws)))));
+        auto sink = std::make_unique<IcebergChunkSink>(
+                partition_column_names, transform, std::move(partition_column_evaluators), std::move(location_provider),
+                std::move(mock_writer_factory), 100, _runtime_state);
+        auto poller = MockPoller();
+        sink->set_io_poller(&poller);
+        Columns partition_key_columns;
+        ChunkPtr chunk = std::make_shared<Chunk>();
+        std::vector<ChunkExtraColumnsMeta> extra_metas;
+        std::string tmp = "abc";
+        Datum datum;
+        datum.set_slice(tmp);
+        auto res = ColumnHelper::create_column(TYPE_VARCHAR_DESC, true);
+        res->append_datum(datum);
+        auto ptr = ConstColumn::create(std::move(res), 1);
+        partition_key_columns.emplace_back(ptr);
+        extra_metas.push_back(ChunkExtraColumnsMeta{TYPE_VARCHAR_DESC, true /*useless*/, true /*useless*/});
+
+        auto chunk_extra_data = std::make_shared<ChunkExtraColumnsData>(extra_metas, std::move(partition_key_columns));
+        // Unlock during merging partition chunks into a full chunk.
+        chunk->set_extra_data(chunk_extra_data);
+        Chunk* raw_chunk_ptr = chunk.get();
+        auto ret = sink->add(raw_chunk_ptr);
+        EXPECT_EQ(ret.ok(), true);
         sink->callback_on_commit(CommitResult{
                 .io_status = Status::OK(),
                 .format = formats::PARQUET,
@@ -77,7 +130,8 @@ TEST_F(IcebergChunkSinkTest, test_callback) {
                                 .record_count = 100,
                         },
                 .location = "path/to/directory/data.parquet",
-        });
+        }
+                                         .set_extra_data("0"));
 
         EXPECT_EQ(_runtime_state->num_rows_load_sink(), 100);
     }
@@ -90,7 +144,6 @@ TEST_F(IcebergChunkSinkTest, test_factory) {
         auto sink_ctx = std::make_shared<connector::IcebergChunkSinkContext>();
         sink_ctx->path = "/path/to/directory/";
         sink_ctx->column_names = {"k1", "k2"};
-        sink_ctx->partition_column_indices = {0};
         sink_ctx->executor = nullptr;
         sink_ctx->format = formats::PARQUET; // iceberg sink only supports parquet
         sink_ctx->compression_type = TCompressionType::NO_COMPRESSION;
@@ -110,7 +163,6 @@ TEST_F(IcebergChunkSinkTest, test_factory) {
         auto sink_ctx = std::make_shared<connector::IcebergChunkSinkContext>();
         sink_ctx->path = "/path/to/directory/";
         sink_ctx->column_names = {"k1", "k2"};
-        sink_ctx->partition_column_indices = {0};
         sink_ctx->executor = nullptr;
         sink_ctx->format = "unknown";
         sink_ctx->compression_type = TCompressionType::NO_COMPRESSION;
@@ -124,6 +176,242 @@ TEST_F(IcebergChunkSinkTest, test_factory) {
         SinkOperatorMemoryManager mm;
         sink->set_operator_mem_mgr(&mm);
         EXPECT_ERROR(sink->init()); // format is not supported
+    }
+}
+
+TEST_F(IcebergChunkSinkTest, test_utils) {
+    int128_t val = 123;
+    std::string str128 = integer_to_string(val);
+    EXPECT_EQ("123", str128);
+    str128 = integer_to_string(-val);
+    EXPECT_EQ("-123", str128);
+
+    auto format_dec = HiveUtils::format_decimal_value<int32_t>(123, 2);
+    EXPECT_EQ("1.23", format_dec.value());
+    format_dec = HiveUtils::format_decimal_value<int32_t>(123, 4);
+    EXPECT_EQ("0.0123", format_dec.value());
+    EXPECT_ERROR(HiveUtils::format_decimal_value<int32_t>(123, -1));
+
+    {
+        Columns partition_key_columns;
+        ChunkPtr chunk = std::make_shared<Chunk>();
+        std::vector<ChunkExtraColumnsMeta> extra_metas;
+        {
+            Datum datum;
+            datum.set_int64(23);
+            auto res = ColumnHelper::create_column(TYPE_BIGINT_DESC, true);
+            res->append_datum(datum);
+            auto ptr = ConstColumn::create(std::move(res), 1);
+            partition_key_columns.emplace_back(ptr);
+            extra_metas.push_back(ChunkExtraColumnsMeta{TYPE_BIGINT_DESC, true /*useless*/, true /*useless*/});
+        }
+
+        {
+            Datum datum;
+            datum.set_int64(40);
+            auto res = ColumnHelper::create_column(TYPE_BIGINT_DESC, true);
+            res->append_datum(datum);
+            auto ptr = ConstColumn::create(std::move(res), 1);
+            partition_key_columns.emplace_back(ptr);
+            extra_metas.push_back(ChunkExtraColumnsMeta{TYPE_BIGINT_DESC, true /*useless*/, true /*useless*/});
+        }
+        std::vector<std::unique_ptr<ColumnEvaluator>> partition_column_evaluators = ColumnSlotIdEvaluator::from_types(
+                {TypeDescriptor::from_logical_type(TYPE_BIGINT), TypeDescriptor::from_logical_type(TYPE_VARCHAR)});
+        auto chunk_extra_data = std::make_shared<ChunkExtraColumnsData>(extra_metas, std::move(partition_key_columns));
+        // Unlock during merging partition chunks into a full chunk.
+        chunk->set_extra_data(chunk_extra_data);
+        std::vector<int8_t> field_is_null;
+        auto ret = HiveUtils::iceberg_make_partition_name({"k1", "k2"}, partition_column_evaluators, {"day", "hour"},
+                                                          chunk.get(), true, field_is_null);
+
+        EXPECT_EQ("k1=1970-01-24/k2=1970-01-02-16/", ret.value());
+        ret = HiveUtils::iceberg_make_partition_name({"k1", "k2"}, partition_column_evaluators, {"year", "month"},
+                                                     chunk.get(), true, field_is_null);
+        EXPECT_EQ("k1=1993/k2=1973-05/", ret.value());
+    }
+
+    {
+        Columns partition_key_columns;
+        ChunkPtr chunk = std::make_shared<Chunk>();
+        std::string tmp = "abc";
+        std::vector<ChunkExtraColumnsMeta> extra_metas;
+        {
+            Datum datum;
+            datum.set_slice(tmp);
+            auto res = ColumnHelper::create_column(TYPE_VARCHAR_DESC, true);
+            res->append_datum(datum);
+            auto ptr = ConstColumn::create(std::move(res), 1);
+            partition_key_columns.emplace_back(ptr);
+            extra_metas.push_back(ChunkExtraColumnsMeta{TYPE_VARCHAR_DESC, true /*useless*/, true /*useless*/});
+        }
+
+        {
+            Datum datum;
+            datum.set_date(DateValue::create(1999, 12, 31));
+            auto res = ColumnHelper::create_column(TYPE_DATE_DESC, true);
+            res->append_datum(datum);
+            auto ptr = ConstColumn::create(std::move(res), 1);
+            partition_key_columns.emplace_back(ptr);
+            extra_metas.push_back(ChunkExtraColumnsMeta{TYPE_DATE_DESC, true /*useless*/, true /*useless*/});
+        }
+
+        std::vector<std::unique_ptr<ColumnEvaluator>> partition_column_evaluators = ColumnSlotIdEvaluator::from_types(
+                {TypeDescriptor::from_logical_type(TYPE_VARCHAR), TypeDescriptor::from_logical_type(TYPE_DATE)});
+
+        auto chunk_extra_data = std::make_shared<ChunkExtraColumnsData>(extra_metas, std::move(partition_key_columns));
+        // Unlock during merging partition chunks into a full chunk.
+        chunk->set_extra_data(chunk_extra_data);
+        std::vector<int8_t> field_is_null;
+        auto ret = HiveUtils::iceberg_make_partition_name({"k1", "k2"}, partition_column_evaluators,
+                                                          {"identity", "truncate"}, chunk.get(), true, field_is_null);
+        EXPECT_EQ("k1=abc/k2=1999-12-31/", ret.value());
+    }
+
+    {
+        Columns partition_key_columns;
+        ChunkPtr chunk = std::make_shared<Chunk>();
+        std::string tmp = "abc";
+        auto time = TimestampValue::create(2023, 10, 31, 12, 0, 0);
+        std::vector<ChunkExtraColumnsMeta> extra_metas;
+        {
+            Datum datum;
+            datum.set_slice(tmp);
+            auto res = ColumnHelper::create_column(TYPE_VARBINARY_DESC, true);
+            res->append_datum(datum);
+            auto ptr = ConstColumn::create(std::move(res), 1);
+            partition_key_columns.emplace_back(ptr);
+            extra_metas.push_back(ChunkExtraColumnsMeta{TYPE_VARBINARY_DESC, true /*useless*/, true /*useless*/});
+        }
+
+        {
+            Datum datum;
+            datum.set_slice(tmp);
+            auto res = ColumnHelper::create_column(TypeDescriptor::create_char_type(10), true);
+            res->append_datum(datum);
+            auto ptr = ConstColumn::create(std::move(res), 1);
+            partition_key_columns.emplace_back(ptr);
+            extra_metas.push_back(
+                    ChunkExtraColumnsMeta{TypeDescriptor::create_char_type(10), true /*useless*/, true /*useless*/});
+        }
+
+        {
+            Datum datum;
+            datum.set_timestamp(time);
+            auto res = ColumnHelper::create_column(TYPE_DATETIME_DESC, true);
+            res->append_datum(datum);
+            auto ptr = ConstColumn::create(std::move(res), 1);
+            partition_key_columns.emplace_back(ptr);
+            extra_metas.push_back(ChunkExtraColumnsMeta{TYPE_DATETIME_DESC, true /*useless*/, true /*useless*/});
+        }
+
+        {
+            Datum datum;
+            datum.set_int8(12);
+            auto res = ColumnHelper::create_column(TypeDescriptor(LogicalType::TYPE_TINYINT), true);
+            res->append_datum(datum);
+            auto ptr = ConstColumn::create(std::move(res), 1);
+            partition_key_columns.emplace_back(ptr);
+            extra_metas.push_back(ChunkExtraColumnsMeta{TypeDescriptor(LogicalType::TYPE_TINYINT), true /*useless*/,
+                                                        true /*useless*/});
+        }
+
+        {
+            Datum datum;
+            datum.set_int16(33);
+            auto res = ColumnHelper::create_column(TypeDescriptor(LogicalType::TYPE_SMALLINT), true);
+            res->append_datum(datum);
+            auto ptr = ConstColumn::create(std::move(res), 1);
+            partition_key_columns.emplace_back(ptr);
+            extra_metas.push_back(ChunkExtraColumnsMeta{TypeDescriptor(LogicalType::TYPE_SMALLINT), true /*useless*/,
+                                                        true /*useless*/});
+        }
+
+        {
+            Datum datum;
+            datum.set_int32(33);
+            auto res = ColumnHelper::create_column(TypeDescriptor(LogicalType::TYPE_INT), true);
+            res->append_datum(datum);
+            auto ptr = ConstColumn::create(std::move(res), 1);
+            partition_key_columns.emplace_back(ptr);
+            extra_metas.push_back(
+                    ChunkExtraColumnsMeta{TypeDescriptor(LogicalType::TYPE_INT), true /*useless*/, true /*useless*/});
+        }
+
+        {
+            Datum datum;
+            datum.set_int64(33);
+            auto res = ColumnHelper::create_column(TypeDescriptor(LogicalType::TYPE_BIGINT), true);
+            res->append_datum(datum);
+            auto ptr = ConstColumn::create(std::move(res), 1);
+            partition_key_columns.emplace_back(ptr);
+            extra_metas.push_back(ChunkExtraColumnsMeta{TypeDescriptor(LogicalType::TYPE_BIGINT), true /*useless*/,
+                                                        true /*useless*/});
+        }
+
+        auto chunk_extra_data = std::make_shared<ChunkExtraColumnsData>(extra_metas, std::move(partition_key_columns));
+        // Unlock during merging partition chunks into a full chunk.
+        chunk->set_extra_data(chunk_extra_data);
+        std::vector<int8_t> field_is_null;
+        std::vector<std::unique_ptr<ColumnEvaluator>> partition_column_evaluators = ColumnSlotIdEvaluator::from_types(
+                {TypeDescriptor::from_logical_type(TYPE_VARBINARY), TypeDescriptor::from_logical_type(TYPE_CHAR),
+                 TypeDescriptor::from_logical_type(TYPE_DATETIME), TypeDescriptor::from_logical_type(TYPE_TINYINT),
+                 TypeDescriptor::from_logical_type(TYPE_INT), TypeDescriptor::from_logical_type(TYPE_BIGINT)});
+        auto ret = HiveUtils::iceberg_make_partition_name(
+                {"k1", "k2", "k3", "k4", "k5", "k6", "k7"}, partition_column_evaluators,
+                {"bucket", "identity", "truncate", "truncate", "truncate", "truncate", "truncate"}, chunk.get(), true,
+                field_is_null);
+        EXPECT_EQ("k1=YWJj/k2=abc%20%20%20%20%20%20%20/k3=2023-10-31%2012%3A00%3A00/k4=12/k5=33/k6=33/k7=33/",
+                  ret.value());
+    }
+
+    {
+        Columns partition_key_columns;
+        ChunkPtr chunk = std::make_shared<Chunk>();
+        std::vector<ChunkExtraColumnsMeta> extra_metas;
+        {
+            Datum datum;
+            datum.set_int32(1234);
+            auto res = ColumnHelper::create_column(TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL32, 7, 2), true);
+            res->append_datum(datum);
+            auto ptr = ConstColumn::create(std::move(res), 1);
+            partition_key_columns.emplace_back(ptr);
+            extra_metas.push_back(ChunkExtraColumnsMeta{TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL32, 7, 2),
+                                                        true /*useless*/, true /*useless*/});
+        }
+
+        {
+            Datum datum;
+            datum.set_int64(3344);
+            auto res = ColumnHelper::create_column(TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL64, 10, 2), true);
+            res->append_datum(datum);
+            auto ptr = ConstColumn::create(std::move(res), 1);
+            partition_key_columns.emplace_back(ptr);
+            extra_metas.push_back(ChunkExtraColumnsMeta{TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL64, 10, 2),
+                                                        true /*useless*/, true /*useless*/});
+        }
+
+        {
+            Datum datum;
+            datum.set_int128(7893);
+            auto res = ColumnHelper::create_column(TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL128, 20, 2), true);
+            res->append_datum(datum);
+            auto ptr = ConstColumn::create(std::move(res), 1);
+            partition_key_columns.emplace_back(ptr);
+            extra_metas.push_back(ChunkExtraColumnsMeta{TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL128, 20, 2),
+                                                        true /*useless*/, true /*useless*/});
+        }
+
+        auto chunk_extra_data = std::make_shared<ChunkExtraColumnsData>(extra_metas, std::move(partition_key_columns));
+        // Unlock during merging partition chunks into a full chunk.
+        std::vector<std::unique_ptr<ColumnEvaluator>> partition_column_evaluators = ColumnSlotIdEvaluator::from_types(
+                {TypeDescriptor::from_logical_type(TYPE_DECIMAL32), TypeDescriptor::from_logical_type(TYPE_DECIMAL64),
+                 TypeDescriptor::from_logical_type(TYPE_DECIMAL128)});
+        chunk->set_extra_data(chunk_extra_data);
+        std::vector<int8_t> field_is_null;
+        auto ret = HiveUtils::iceberg_make_partition_name({"k1", "k2", "k3"}, partition_column_evaluators,
+                                                          {"identity", "truncate", "bucket"}, chunk.get(), true,
+                                                          field_is_null);
+        EXPECT_EQ("k1=12.34/k2=33.44/k3=78.93/", ret.value());
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
@@ -672,7 +672,13 @@ public class ColumnTypeConverter {
             case DECIMAL:
                 int precision = ((Types.DecimalType) icebergType).precision();
                 int scale = ((Types.DecimalType) icebergType).scale();
-                return ScalarType.createUnifiedDecimalType(precision, scale);
+                if (precision <= 9) {
+                    return ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, precision, scale);
+                } else if (precision <= 18) {
+                    return ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, precision, scale);
+                } else {
+                    return ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, precision, scale);
+                }
             case LIST:
                 Type type = convertToArrayTypeForIceberg(icebergType);
                 if (type.isArrayType()) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -73,6 +73,7 @@ import com.starrocks.sql.ast.CreateViewStmt;
 import com.starrocks.sql.ast.DropTableStmt;
 import com.starrocks.sql.ast.ListPartitionDesc;
 import com.starrocks.sql.ast.PartitionDesc;
+import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -133,8 +134,10 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1177,14 +1180,19 @@ public class IcebergMetadata implements ConnectorMetadata {
                             .withRecordCount(dataFile.record_count)
                             .withFileSizeInBytes(dataFile.file_size_in_bytes)
                             .withSplitOffsets(dataFile.split_offsets);
-
+            String nullFingerprint = "";
+            if (!dataFile.isSetPartition_null_fingerprint()) {
+                nullFingerprint = "0".repeat(partitionSpec.fields().size());
+            } else {
+                nullFingerprint = dataFile.getPartition_null_fingerprint();
+            }
             if (partitionSpec.isPartitioned()) {
                 String relativePartitionLocation = getIcebergRelativePartitionPath(
                         nativeTbl.location(), dataFile.partition_path);
-
                 PartitionData partitionData = partitionDataFromPath(
-                        relativePartitionLocation, partitionSpec);
+                        relativePartitionLocation, nullFingerprint, partitionSpec, nativeTbl);
                 builder.withPartition(partitionData);
+                // builder.withPartitionPath(relativePartitionLocation);
             }
             batchWrite.addFile(builder.build());
         }
@@ -1226,27 +1234,100 @@ public class IcebergMetadata implements ConnectorMetadata {
         return isOverwrite ? new DynamicOverwrite(transaction) : new Append(transaction);
     }
 
-    public static PartitionData partitionDataFromPath(String relativePartitionPath, PartitionSpec spec) {
+    public PartitionData partitionDataFromPath(String relativePartitionPath, 
+            String partitionNullFingerprint, PartitionSpec spec, org.apache.iceberg.Table table) {
         PartitionData data = new PartitionData(spec.fields().size());
         String[] partitions = relativePartitionPath.split("/", -1);
         List<PartitionField> partitionFields = spec.fields();
-
+        if (partitions.length != partitionNullFingerprint.length()) {
+            throw new InternalError("Invalid partition and fingerprint size, partition:" + relativePartitionPath + 
+                    " partition size:" + String.valueOf(partitions.length) + " fingerprint:" + partitionNullFingerprint);
+        }
         for (int i = 0; i < partitions.length; i++) {
             PartitionField field = partitionFields.get(i);
             String[] parts = partitions[i].split("=", 2);
             Preconditions.checkArgument(parts.length == 2 && parts[0] != null &&
                     field.name().equals(parts[0]), "Invalid partition: %s", partitions[i]);
-
-            org.apache.iceberg.types.Type sourceType = spec.partitionType().fields().get(i).type();
-            // apply url decoding for string/fixed type
-            if (sourceType.typeId() == Type.TypeID.STRING || sourceType.typeId() == Type.TypeID.FIXED) {
-                parts[1] = URLDecoder.decode(parts[1], StandardCharsets.UTF_8);
+            org.apache.iceberg.types.Type resultType = spec.partitionType().fields().get(i).type();
+            // org.apache.iceberg.types.Type sourceType = table.schema().findType(field.sourceId());
+            // NOTICE:
+            // The behavior here should match the make_partition_path method in be, 
+            // and revert the String path value to the origin value and type of transform expr for the metastore.
+            // otherwise, if we use the api of iceberg to filter the scan files, the result may be incorrect!
+            if (partitionNullFingerprint.charAt(i) == '0') { //'0' means not null, '1' means null
+                // apply date decoding for date type
+                String transform = field.transform().toString();
+                if (transform.equals("year") || transform.equals("month") 
+                        || transform.equals("day") || transform.equals("hour")) {
+                    Integer year = org.apache.iceberg.util.DateTimeUtil.EPOCH.getYear();
+                    Integer month = org.apache.iceberg.util.DateTimeUtil.EPOCH.getMonthValue();
+                    Integer day = org.apache.iceberg.util.DateTimeUtil.EPOCH.getDayOfMonth();
+                    Integer hour = org.apache.iceberg.util.DateTimeUtil.EPOCH.getHour();
+                    String[] dateParts = parts[1].split("-");
+                    if (dateParts.length > 0) {
+                        year = Integer.parseInt(dateParts[0]);
+                    }
+                    if (dateParts.length > 1) {
+                        month = Integer.parseInt(dateParts[1]);
+                    }
+                    if (dateParts.length > 2) {
+                        day = Integer.parseInt(dateParts[2]);
+                    }
+                    if (dateParts.length > 3) {
+                        hour = Integer.parseInt(dateParts[3]);
+                    }
+                    LocalDateTime target = LocalDateTime.of(year, month, day, hour, 0);
+                    if (transform.equals("year")) {
+                        //iceberg stores the result of transform as metadata.
+                        parts[1] = String.valueOf(
+                                ChronoUnit.YEARS.between(org.apache.iceberg.util.DateTimeUtil.EPOCH_DAY, target));
+                    } else if (transform.equals("month")) {
+                        parts[1] = String.valueOf(
+                                ChronoUnit.MONTHS.between(org.apache.iceberg.util.DateTimeUtil.EPOCH_DAY, target));
+                    } else if (transform.equals("day")) {
+                        //The reuslt of day transform is a date type.
+                        //It is diffrent from other date transform exprs, however other's result is a integer.
+                        //do nothing
+                    } else if (transform.equals("hour")) {
+                        parts[1] = String.valueOf(
+                                ChronoUnit.HOURS.between(org.apache.iceberg.util.DateTimeUtil.EPOCH_DAY.atTime(0, 0), target));
+                    }
+                } else if (transform.startsWith("truncate")) {
+                    //the result type of truncate is the same as the truncate column
+                    if (parts[1].length() == 0) {
+                        //do nothing
+                    } else if (resultType.typeId() == Type.TypeID.STRING || resultType.typeId() == Type.TypeID.FIXED) {
+                        parts[1] = URLDecoder.decode(parts[1], StandardCharsets.UTF_8);
+                    } else if (resultType.typeId() == Type.TypeID.BINARY) {
+                        parts[1] = URLDecoder.decode(parts[1], StandardCharsets.UTF_8);
+                        //Do not convert the byte array to utf-8, because some byte is not valid in utf-8.
+                        //like 0xE6 is not valid in utf8. If the convert failed, utf-8 will transfer the byte to 0xFFFD as default
+                        //we should just read and store the byte in latin, and thus not change the byte array value.
+                        parts[1] = new String(Base64.getDecoder().decode(parts[1]), StandardCharsets.ISO_8859_1);
+                    }
+                } else if (transform.startsWith("bucket")) {
+                    //the result type of bucket is integer.
+                    //do nothing
+                } else if (transform.equals("identity")) {
+                    if (parts[1].length() == 0) {
+                        //do nothing
+                    } else if (resultType.typeId() == Type.TypeID.STRING || resultType.typeId() == Type.TypeID.FIXED) {
+                        parts[1] = URLDecoder.decode(parts[1], StandardCharsets.UTF_8);
+                    } else if (resultType.typeId() == Type.TypeID.BINARY) {
+                        parts[1] = URLDecoder.decode(parts[1], StandardCharsets.UTF_8);
+                        parts[1] = new String(Base64.getDecoder().decode(parts[1]), StandardCharsets.ISO_8859_1);
+                    }
+                } else {
+                    throw new DmlException("Unsupported partition transform: %s", transform);
+                }
             }
 
-            if (parts[1].equals("null")) {
+            if (partitionNullFingerprint.charAt(i) == '1') {
                 data.set(i, null);
+            } else if (resultType.typeId() == Type.TypeID.BINARY) {
+                data.set(i, parts[1].getBytes(StandardCharsets.ISO_8859_1));
             } else {
-                data.set(i, Conversions.fromPartitionString(sourceType, parts[1]));
+                data.set(i, Conversions.fromPartitionString(resultType, parts[1]));
             }
         }
         return data;
@@ -1367,7 +1448,11 @@ public class IcebergMetadata implements ConnectorMetadata {
 
         @Override
         public <T> T get(int pos, Class<T> javaClass) {
-            return javaClass.cast(values[pos]);
+            Object value = values[pos];
+            if (javaClass == ByteBuffer.class && value instanceof byte[]) {
+                value = ByteBuffer.wrap((byte[]) value);
+            }
+            return javaClass.cast(value);
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -662,7 +662,7 @@ public class CreateTableAnalyzer {
                 boolean isMatched = desc.getPartitionColNames().stream()
                         .anyMatch(partitionColName -> partitionColName.equalsIgnoreCase(column.getName()));
                 if (!isMatched) {
-                    throw new SemanticException("Iceberg generated column are not illegal");
+                    throw new SemanticException("Iceberg generated column are illegal");
                 }
                 Expr expr = column.getGeneratedColumnExpr(columns);
                 if (expr instanceof FunctionCallExpr) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
@@ -273,6 +273,8 @@ public class TypeManager {
         } else if ((type2.isBoolean() && type1.isNumericType()) ||
                 (type2.isFixedPointType() && type1.isFloatingPointType())) {
             return type1;
+        } else if (type1.isBinaryType() && type2.isVarchar()) {
+            return type1;
         }
 
         return Type.DOUBLE;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
@@ -602,6 +602,8 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
 
             } else if (desc.isChar() || desc.isVarchar()) {
                 res =  ConstantOperator.createChar(childString, desc);
+            } else if (desc.isScalarType(PrimitiveType.BINARY) || desc.isScalarType(PrimitiveType.VARBINARY)) {
+                res = ConstantOperator.createBinary(childString.getBytes(), desc);
             }
         } catch (Exception e) {
             return Optional.empty();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
@@ -16,10 +16,12 @@ package com.starrocks.catalog;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.catalog.constraint.UniqueConstraint;
 import com.starrocks.common.DdlException;
 import com.starrocks.connector.iceberg.TableTestBase;
 import com.starrocks.server.IcebergTableFactory;
+import com.starrocks.thrift.TTableDescriptor;
 import mockit.Mocked;
 import org.apache.iceberg.Table;
 import org.junit.Assert;
@@ -102,5 +104,30 @@ public class IcebergTableTest extends TableTestBase {
             Column c = table.getPresentivateColumn();
             Assert.assertEquals(c.getName(), "k3");
         }
+    }
+
+    @Test
+    public void testIcebergTableRToThrift(@Mocked Table icebergNativeTable) {
+        List<Column> columns = Lists.newArrayList(
+                new Column("k1", INT),
+                new Column("k2", STRING),
+                new Column("k3", ARRAY_BIGINT));
+        IcebergTable.Builder tableBuilder = IcebergTable.builder()
+                .setId(1000)
+                .setSrTableName("supplier")
+                .setCatalogName("iceberg_catalog")
+                .setCatalogDBName("iceberg_oss_tpch_1g_parquet_gzip")
+                .setCatalogTableName("supplier")
+                .setFullSchema(columns)
+                .setNativeTable(icebergNativeTable)
+                .setIcebergProperties(new HashMap<>());
+        // by default use k1 as column
+        IcebergTable table = tableBuilder.build();
+        {
+            Column c = table.getPresentivateColumn();
+            Assert.assertEquals(c.getName(), "k1");
+        }
+
+        TTableDescriptor tds = table.toThrift(new ArrayList<DescriptorTable.ReferencedPartitionInfo>());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
@@ -71,10 +71,13 @@ public class IcebergApiConverterTest {
     public void testDecimal() {
         int precision = 9;
         int scale = 5;
-        Type decimalType = ScalarType.createUnifiedDecimalType(precision, scale);
         org.apache.iceberg.types.Type icebergType = Types.DecimalType.of(precision, scale);
         Type resType = fromIcebergType(icebergType);
-        assertEquals(resType, decimalType);
+        assertEquals(resType, ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, scale));
+        resType = fromIcebergType(Types.DecimalType.of(10, scale));
+        assertEquals(resType, ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, scale));
+        resType = fromIcebergType(Types.DecimalType.of(19, scale));
+        assertEquals(resType, ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 19, scale));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -620,6 +620,7 @@ public class IcebergMetadataTest extends TableTestBase {
         tIcebergDataFile.setSplit_offsets(splitOffsets);
         tIcebergDataFile.setPartition_path(partitionPath);
         tIcebergDataFile.setFile_size_in_bytes(fileSize);
+        tIcebergDataFile.setPartition_null_fingerprint("0");
 
         tSinkCommitInfo.setIs_overwrite(false);
         tSinkCommitInfo.setIceberg_data_file(tIcebergDataFile);
@@ -671,6 +672,251 @@ public class IcebergMetadataTest extends TableTestBase {
         Assert.assertEquals(fileSize, dataFile.fileSizeInBytes());
         Assert.assertEquals(4, dataFile.splitOffsets().get(0).longValue());
         Assert.assertEquals(111L, dataFile.valueCounts().get(1).longValue());
+    }
+
+    @Test
+    public void testFinishSink2() {
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", Lists.newArrayList(), mockedNativeTableJ, Maps.newHashMap());
+
+        new Expectations(metadata) {
+            {
+                metadata.getTable((ConnectContext) any, anyString, anyString);
+                result = icebergTable;
+                minTimes = 0;
+            }
+        };
+
+        TSinkCommitInfo tSinkCommitInfo = new TSinkCommitInfo();
+        TIcebergDataFile tIcebergDataFile = new TIcebergDataFile();
+        String path = mockedNativeTableJ.location() + "/data/ts_month=2022-01/c.parquet";
+        String format = "parquet";
+        long recordCount = 10;
+        long fileSize = 2000;
+        String partitionPath = mockedNativeTableJ.location() + "/data/ts_month=2022-01/";
+        List<Long> splitOffsets = Lists.newArrayList(4L);
+        tIcebergDataFile.setPath(path);
+        tIcebergDataFile.setFormat(format);
+        tIcebergDataFile.setRecord_count(recordCount);
+        tIcebergDataFile.setSplit_offsets(splitOffsets);
+        tIcebergDataFile.setPartition_path(partitionPath);
+        tIcebergDataFile.setFile_size_in_bytes(fileSize);
+        tIcebergDataFile.setPartition_null_fingerprint("0");
+
+        tSinkCommitInfo.setIs_overwrite(false);
+        tSinkCommitInfo.setIceberg_data_file(tIcebergDataFile);
+
+        metadata.finishSink("iceberg_db", "iceberg_table", Lists.newArrayList(tSinkCommitInfo), null);
+
+        List<FileScanTask> fileScanTasks = Lists.newArrayList(mockedNativeTableJ.newScan().planFiles());
+        Assert.assertEquals(1, fileScanTasks.size());
+        FileScanTask task = fileScanTasks.get(0);
+        Assert.assertEquals(0, task.deletes().size());
+        DataFile dataFile = task.file();
+        Assert.assertEquals(path, dataFile.path());
+        Assert.assertEquals(format, dataFile.format().name().toLowerCase(Locale.ROOT));
+        Assert.assertEquals(1, dataFile.partition().size());
+        Assert.assertEquals(recordCount, dataFile.recordCount());
+        Assert.assertEquals(fileSize, dataFile.fileSizeInBytes());
+        Assert.assertEquals(4, dataFile.splitOffsets().get(0).longValue());
+
+        tSinkCommitInfo.setIs_overwrite(true);
+        recordCount = 22;
+        fileSize = 3333;
+        tIcebergDataFile.setRecord_count(recordCount);
+        tIcebergDataFile.setFile_size_in_bytes(fileSize);
+        Map<Integer, Long> valueCounts = new HashMap<>();
+        valueCounts.put(1, 111L);
+        TIcebergColumnStats columnStats = new TIcebergColumnStats();
+        columnStats.setColumn_sizes(new HashMap<>());
+        columnStats.setValue_counts(valueCounts);
+        columnStats.setNull_value_counts(new HashMap<>());
+        columnStats.setLower_bounds(new HashMap<>());
+        columnStats.setUpper_bounds(new HashMap<>());
+        tIcebergDataFile.setColumn_stats(columnStats);
+
+        tSinkCommitInfo.setIceberg_data_file(tIcebergDataFile);
+
+        metadata.finishSink("iceberg_db", "iceberg_table", Lists.newArrayList(tSinkCommitInfo), null);
+        mockedNativeTableJ.refresh();
+        TableScan scan = mockedNativeTableJ.newScan().includeColumnStats();
+        fileScanTasks = Lists.newArrayList(scan.planFiles());
+
+        Assert.assertEquals(1, fileScanTasks.size());
+        task = fileScanTasks.get(0);
+        Assert.assertEquals(0, task.deletes().size());
+        dataFile = task.file();
+        Assert.assertEquals(path, dataFile.path());
+        Assert.assertEquals(format, dataFile.format().name().toLowerCase(Locale.ROOT));
+        Assert.assertEquals(1, dataFile.partition().size());
+        Assert.assertEquals(recordCount, dataFile.recordCount());
+        Assert.assertEquals(fileSize, dataFile.fileSizeInBytes());
+        Assert.assertEquals(4, dataFile.splitOffsets().get(0).longValue());
+        Assert.assertEquals(111L, dataFile.valueCounts().get(1).longValue());
+    }
+
+    @Test
+    public void testFinishSink3() {
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", Lists.newArrayList(), mockedNativeTableJ, Maps.newHashMap());
+
+        new Expectations(metadata) {
+            {
+                metadata.getTable((ConnectContext) any, anyString, anyString);
+                result = icebergTable;
+                minTimes = 0;
+            }
+        };
+
+        TSinkCommitInfo tSinkCommitInfo = new TSinkCommitInfo();
+        TIcebergDataFile tIcebergDataFile = new TIcebergDataFile();
+        String path = mockedNativeTableJ.location() + "/data/ts_month=2022-01/c.parquet";
+        String format = "parquet";
+        long recordCount = 10;
+        long fileSize = 2000;
+        String partitionPath = mockedNativeTableJ.location() + "/data/ts_month=2022-01/";
+        List<Long> splitOffsets = Lists.newArrayList(4L);
+        tIcebergDataFile.setPath(path);
+        tIcebergDataFile.setFormat(format);
+        tIcebergDataFile.setRecord_count(recordCount);
+        tIcebergDataFile.setSplit_offsets(splitOffsets);
+        tIcebergDataFile.setPartition_path(partitionPath);
+        tIcebergDataFile.setFile_size_in_bytes(fileSize);
+        tIcebergDataFile.setPartition_null_fingerprint("1234124");
+
+        tSinkCommitInfo.setIs_overwrite(false);
+        tSinkCommitInfo.setIceberg_data_file(tIcebergDataFile);
+
+        ExceptionChecker.expectThrowsWithMsg(InternalError.class,
+                "Invalid partition and fingerprint size",
+                () -> metadata.finishSink("iceberg_db", "iceberg_table", Lists.newArrayList(tSinkCommitInfo), null));
+
+    }
+
+    @Test
+    public void testFinishSink4() {
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", Lists.newArrayList(), mockedNativeTableF, Maps.newHashMap());
+
+        new Expectations(metadata) {
+            {
+                metadata.getTable((ConnectContext) any, anyString, anyString);
+                result = icebergTable;
+                minTimes = 0;
+            }
+        };
+
+        TSinkCommitInfo tSinkCommitInfo = new TSinkCommitInfo();
+        TIcebergDataFile tIcebergDataFile = new TIcebergDataFile();
+        String path = mockedNativeTableF.location() + "/data/dt_day=2022-01-02/c.parquet";
+        String format = "parquet";
+        long recordCount = 10;
+        long fileSize = 2000;
+        String partitionPath = mockedNativeTableF.location() + "/data/dt_day=2022-01-02/";
+        List<Long> splitOffsets = Lists.newArrayList(4L);
+        tIcebergDataFile.setPath(path);
+        tIcebergDataFile.setFormat(format);
+        tIcebergDataFile.setRecord_count(recordCount);
+        tIcebergDataFile.setSplit_offsets(splitOffsets);
+        tIcebergDataFile.setPartition_path(partitionPath);
+        tIcebergDataFile.setFile_size_in_bytes(fileSize);
+        tIcebergDataFile.setPartition_null_fingerprint("0");
+
+        tSinkCommitInfo.setIs_overwrite(false);
+        tSinkCommitInfo.setIceberg_data_file(tIcebergDataFile);
+        metadata.finishSink("iceberg_db", "iceberg_table", Lists.newArrayList(tSinkCommitInfo), null);
+    }
+
+    @Test
+    public void testFinishSink5() {
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", Lists.newArrayList(), mockedNativeTableD, Maps.newHashMap());
+
+        new Expectations(metadata) {
+            {
+                metadata.getTable((ConnectContext) any, anyString, anyString);
+                result = icebergTable;
+                minTimes = 0;
+            }
+        };
+
+        TSinkCommitInfo tSinkCommitInfo = new TSinkCommitInfo();
+        TIcebergDataFile tIcebergDataFile = new TIcebergDataFile();
+        String path = mockedNativeTableD.location() + "/data/ts_hour=2022-01-02-11/c.parquet";
+        String format = "parquet";
+        long recordCount = 10;
+        long fileSize = 2000;
+        String partitionPath = mockedNativeTableD.location() + "/data/ts_hour=2022-01-02-11/";
+        List<Long> splitOffsets = Lists.newArrayList(4L);
+        tIcebergDataFile.setPath(path);
+        tIcebergDataFile.setFormat(format);
+        tIcebergDataFile.setRecord_count(recordCount);
+        tIcebergDataFile.setSplit_offsets(splitOffsets);
+        tIcebergDataFile.setPartition_path(partitionPath);
+        tIcebergDataFile.setFile_size_in_bytes(fileSize);
+        tIcebergDataFile.setPartition_null_fingerprint("0");
+
+        tSinkCommitInfo.setIs_overwrite(false);
+        tSinkCommitInfo.setIceberg_data_file(tIcebergDataFile);
+        metadata.finishSink("iceberg_db", "iceberg_table", Lists.newArrayList(tSinkCommitInfo), null);
+        tIcebergDataFile.setPartition_null_fingerprint("1");
+        metadata.finishSink("iceberg_db", "iceberg_table", Lists.newArrayList(tSinkCommitInfo), null);
+    }
+
+    @Test
+    public void testFinishSink6() {
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", Lists.newArrayList(), mockedNativeTableK, Maps.newHashMap());
+
+        new Expectations(metadata) {
+            {
+                metadata.getTable((ConnectContext) any, anyString, anyString);
+                result = icebergTable;
+                minTimes = 0;
+            }
+        };
+
+        TSinkCommitInfo tSinkCommitInfo = new TSinkCommitInfo();
+        TIcebergDataFile tIcebergDataFile = new TIcebergDataFile();
+        String path = mockedNativeTableK.location() + "/data/ts_year=2022/c.parquet";
+        String format = "parquet";
+        long recordCount = 10;
+        long fileSize = 2000;
+        String partitionPath = mockedNativeTableK.location() + "/data/ts_year=2022/";
+        List<Long> splitOffsets = Lists.newArrayList(4L);
+        tIcebergDataFile.setPath(path);
+        tIcebergDataFile.setFormat(format);
+        tIcebergDataFile.setRecord_count(recordCount);
+        tIcebergDataFile.setSplit_offsets(splitOffsets);
+        tIcebergDataFile.setPartition_path(partitionPath);
+        tIcebergDataFile.setFile_size_in_bytes(fileSize);
+        tIcebergDataFile.setPartition_null_fingerprint("0");
+
+        tSinkCommitInfo.setIs_overwrite(false);
+        tSinkCommitInfo.setIceberg_data_file(tIcebergDataFile);
+        metadata.finishSink("iceberg_db", "iceberg_table", Lists.newArrayList(tSinkCommitInfo), null);
+        tIcebergDataFile.setPartition_null_fingerprint("1");
+        metadata.finishSink("iceberg_db", "iceberg_table", Lists.newArrayList(tSinkCommitInfo), null);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/TableTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/TableTestBase.java
@@ -224,6 +224,8 @@ public class TableTestBase {
     public TestTables.TestTable mockedNativeTableG = null;
     public TestTables.TestTable mockedNativeTableH = null;
     public TestTables.TestTable mockedNativeTableI = null;
+    public TestTables.TestTable mockedNativeTableJ = null;
+    public TestTables.TestTable mockedNativeTableK = null;
 
     protected final int formatVersion = 1;
 
@@ -242,6 +244,8 @@ public class TableTestBase {
         this.mockedNativeTableG = create(SCHEMA_B, SPEC_B_1, "tg", 1);
         this.mockedNativeTableH = create(SCHEMA_H, PartitionSpec.unpartitioned(), "th", 1);
         this.mockedNativeTableI = create(SCHEMA_F, SPEC_F_1, "ti", 1);
+        this.mockedNativeTableJ = create(SCHEMA_E, SPEC_E_3, "tj", 1);
+        this.mockedNativeTableK = create(SCHEMA_E, SPEC_E_2, "tk", 1);
     }
 
     @After

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
@@ -160,6 +160,10 @@ public class AnalyzeInsertTest {
                 icebergTable.getBaseSchema();
                 result = ImmutableList.of(new Column("c1", Type.INT));
                 minTimes = 0;
+
+                icebergTable.getFullSchema();
+                result = ImmutableList.of(new Column("c1", Type.INT));
+                minTimes = 0;
             }
         };
         analyzeSuccess("insert into iceberg_catalog.db.iceberg_tbl values (1)");
@@ -219,6 +223,10 @@ public class AnalyzeInsertTest {
                 result = ImmutableList.of(new Column("c1", Type.INT), new Column("p1", Type.INT), new Column("p2", Type.INT));
                 minTimes = 0;
 
+                icebergTable.getFullSchema();
+                result = ImmutableList.of(new Column("c1", Type.INT), new Column("p1", Type.INT), new Column("p2", Type.INT));
+                minTimes = 0;
+
                 icebergTable.getColumn(anyString);
                 result = ImmutableList.of(new Column("p1", Type.INT), new Column("p2", Type.INT));
                 minTimes = 0;
@@ -239,6 +247,11 @@ public class AnalyzeInsertTest {
                         new Column("p2", Type.INT));
                 minTimes = 0;
 
+                icebergTable.getFullSchema();
+                result = ImmutableList.of(new Column("c1", Type.INT), new Column("p1", Type.DATETIME),
+                        new Column("p2", Type.INT));
+                minTimes = 0;
+
                 icebergTable.getColumn(anyString);
                 result = ImmutableList.of(new Column("p1", Type.INT), new Column("p2", Type.DATETIME));
                 minTimes = 0;
@@ -249,12 +262,11 @@ public class AnalyzeInsertTest {
 
                 icebergTable.getType();
                 result = Table.TableType.ICEBERG;
-                minTimes = 1;
+                minTimes = 0;
             }
         };
 
-        analyzeFail("insert into iceberg_catalog.db.tbl select 1, 2, \"2023-01-01 12:34:45\"",
-                "Unsupported partition column type [DATETIME] for ICEBERG table sink.");
+        analyzeSuccess("insert into iceberg_catalog.db.tbl select 1, 2, \"2023-01-01 12:34:45\"");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -40,6 +40,7 @@ import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.hadoop.HadoopFileIO;
@@ -847,6 +848,9 @@ public class InsertPlanTest extends PlanTestBase {
                 nativeTable.io();
                 result = new HadoopFileIO();
                 minTimes = 0;
+
+                nativeTable.spec();
+                result = PartitionSpec.unpartitioned();
             }
         };
 

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -514,6 +514,13 @@ struct TCompressedPartitionMap {
     3: optional string compressed_serialized_partitions
 }
 
+struct TIcebergPartitionInfo {
+    1: optional string source_column_name
+    2: optional string partition_column_name
+    3: optional string transform_expr
+    4: optional Exprs.TExpr partition_expr
+}
+
 struct TIcebergTable {
     // table location
     1: optional string location
@@ -525,7 +532,7 @@ struct TIcebergTable {
     3: optional TIcebergSchema iceberg_schema
 
     // partition column names
-    4: optional list<string> partition_column_names
+    4: optional list<string> partition_column_names //Deprecated, move to TIcebergPartitionInfo
 
     // partition map may be very big, serialize costs too much, just use serialized byte[]
     5: optional TCompressedPartitionMap compressed_partitions
@@ -535,6 +542,8 @@ struct TIcebergTable {
 
     // Iceberg equality delete schema, used to support schema evolution
     7: optional TIcebergSchema iceberg_equal_delete_schema
+
+    8: optional list<TIcebergPartitionInfo> partition_info
 }
 
 struct THudiTable {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -581,6 +581,7 @@ struct TIcebergDataFile {
     5: optional string partition_path;
     6: optional list<i64> split_offsets;
     7: optional TIcebergColumnStats column_stats;
+    8: optional string partition_null_fingerprint;
 }
 
 struct THiveFileInfo {


### PR DESCRIPTION
## Why I'm doing:
This pr is splitted from https://github.com/StarRocks/starrocks/pull/58509, and implement inserting data into  partition transform iceberg table based on https://github.com/StarRocks/starrocks/pull/58912.

## What I'm doing:

After implementing the transform functions and enabling the creation of Iceberg tables with partition transforms, the next step is to support data insertion into such tables.

Since partition values for transform expressions (other than identity) are computed dynamically at runtime, static partition inserts are not supported. Only dynamic partition inserts are valid for Iceberg tables with partition transforms.

Fixes https://github.com/StarRocks/starrocks/issues/58914

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
