### PR TITLE
[BugFix] do not ignore error when starmgr's meta file is corrupted

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/staros/StarMgrServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/staros/StarMgrServer.java
@@ -38,7 +38,6 @@ import org.apache.logging.log4j.Logger;
 import java.io.BufferedInputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
-import java.io.EOFException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -220,8 +219,6 @@ public class StarMgrServer {
         DataInputStream in = new DataInputStream(new BufferedInputStream(new FileInputStream(curFile)));
         try {
             getStarMgr().loadMeta(in);
-        } catch (EOFException eof) {
-            LOG.warn("load star mgr image eof.");
         } finally {
             in.close();
         }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/9569
should throw something like this
```
2025-05-16 14:35:34.904+08:00 WARN (star_os_checkpoint_worker|180) [CheckpointWorker.createImage():97] create image failed
java.io.EOFException: null
	at com.staros.stream.ChunkedInputStream.readNextAvailable(ChunkedInputStream.java:115) ~[starcommon-3.5-rc1.jar:?]
	at com.staros.stream.ChunkedInputStream.read(ChunkedInputStream.java:57) ~[starcommon-3.5-rc1.jar:?]
	at java.security.DigestInputStream.read(DigestInputStream.java:125) ~[?:?]
	at com.staros.stream.ChunkedInputStream.readIntFromParent(ChunkedInputStream.java:141) ~[starcommon-3.5-rc1.jar:?]
	at com.staros.stream.ChunkedInputStream.readNextAvailable(ChunkedInputStream.java:104) ~[starcommon-3.5-rc1.jar:?]
	at com.staros.stream.ChunkedInputStream.read(ChunkedInputStream.java:57) ~[starcommon-3.5-rc1.jar:?]
	at java.security.DigestInputStream.read(DigestInputStream.java:125) ~[?:?]
	at com.google.protobuf.AbstractParser.parsePartialDelimitedFrom(AbstractParser.java:223) ~[protobuf-java-3.25.5.jar:?]
	at com.google.protobuf.AbstractParser.parseDelimitedFrom(AbstractParser.java:244) ~[protobuf-java-3.25.5.jar:?]
	at com.google.protobuf.AbstractParser.parseDelimitedFrom(AbstractParser.java:249) ~[protobuf-java-3.25.5.jar:?]
	at com.google.protobuf.AbstractParser.parseDelimitedFrom(AbstractParser.java:25) ~[protobuf-java-3.25.5.jar:?]
	at com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(GeneratedMessageV3.java:375) ~[protobuf-java-3.25.5.jar:?]
	at com.staros.proto.SectionHeader.parseDelimitedFrom(SectionHeader.java:247) ~[starcommon-3.5-rc1.jar:?]
	at com.staros.section.SectionReader.next(SectionReader.java:59) ~[starcommon-3.5-rc1.jar:?]
	at com.staros.section.SectionReader.forEach(SectionReader.java:96) ~[starcommon-3.5-rc1.jar:?]
	at com.staros.shard.ShardManager.loadMeta(ShardManager.java:1564) ~[starmanager-3.5-rc1.jar:?]
	at com.staros.service.ServiceManager.loadShardManager(ServiceManager.java:589) ~[starmanager-3.5-rc1.jar:?]
	at com.staros.service.ServiceManager.loadMetaFromSection(ServiceManager.java:527) ~[starmanager-3.5-rc1.jar:?]
	at com.staros.service.ServiceManager.lambda$loadMeta$3(ServiceManager.java:512) ~[starmanager-3.5-rc1.jar:?]
	at com.staros.section.SectionReader.forEach(SectionReader.java:95) ~[starcommon-3.5-rc1.jar:?]
	at com.staros.service.ServiceManager.loadMeta(ServiceManager.java:512) ~[starmanager-3.5-rc1.jar:?]
	at com.staros.manager.StarManager.loadSectionMeta(StarManager.java:1273) ~[starmanager-3.5-rc1.jar:?]
	at com.staros.section.SectionReader.forEach(SectionReader.java:95) ~[starcommon-3.5-rc1.jar:?]
	at com.staros.manager.StarManager.loadMeta(StarManager.java:1252) ~[starmanager-3.5-rc1.jar:?]
	at com.starrocks.staros.StarMgrServer.loadImage(StarMgrServer.java:221) ~[starrocks-fe.jar:?]
	at com.starrocks.staros.StarMgrServer.replayAndGenerateImage(StarMgrServer.java:229) ~[starrocks-fe.jar:?]
	at com.starrocks.journal.StarMgrCheckpointWorker.doCheckpoint(StarMgrCheckpointWorker.java:31) ~[starrocks-fe.jar:?]
	at com.starrocks.journal.CheckpointWorker.createImage(CheckpointWorker.java:95) ~[starrocks-fe.jar:?]
	at com.starrocks.journal.CheckpointWorker.runAfterCatalogReady(CheckpointWorker.java:82) ~[starrocks-fe.jar:?]
	at com.starrocks.common.util.FrontendDaemon.runOneCycle(FrontendDaemon.java:72) ~[starrocks-fe.jar:?]
	at com.starrocks.common.util.Daemon.run(Daemon.java:98) ~[starrocks-fe.jar:?]
	Suppressed: java.io.EOFException
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
