### PR TITLE
[BugFix] fix getting hive partition bug when using escaped string 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -45,12 +45,14 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.starrocks.common.profile.Tracers.Module.EXTERNAL;
 import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_CONNECTION_POOL_SIZE;
 import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_TIMEOUT;
 import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_TYPE;
 import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_URIS;
+import static org.apache.hadoop.hive.common.FileUtils.unescapePathName;
 
 public class HiveMetaClient {
     private static final Logger LOG = LogManager.getLogger(HiveMetaClient.class);
@@ -315,8 +317,10 @@ public class HiveMetaClient {
             RecyclableClient client = null;
             StarRocksConnectorException connectionException = null;
             try {
+                List<String> decodedPartitionNames = partitionNames.stream().
+                        map(name -> unescapePathName(name)).collect(Collectors.toList());
                 client = getClient();
-                partitions = client.hiveClient.getPartitionsByNames(dbName, tblName, partitionNames);
+                partitions = client.hiveClient.getPartitionsByNames(dbName, tblName, decodedPartitionNames);
                 if (partitions.size() != partitionNames.size()) {
                     LOG.warn("Expect to fetch {} partition on [{}.{}], but actually fetched {} partition",
                             partitionNames.size(), dbName, tblName, partitions.size());

--- a/test/sql/test_dml/R/test_escape
+++ b/test/sql/test_dml/R/test_escape
@@ -1,0 +1,34 @@
+-- name: test_escape
+create external catalog hive_catalog_${uuid0} PROPERTIES ("type"="hive", 
+    "hive.metastore.uris"="${hive_metastore_uris}",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}");
+-- result:
+-- !result
+create database hive_catalog_${uuid0}.hive_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/hive_db_${uuid0}/test_escape/${uuid0}"
+);
+-- result:
+-- !result
+CREATE TABLE hive_catalog_${uuid0}.hive_db_${uuid0}.hive_lineorder_par(
+      lo_orderkey int,
+       lo_orderpriority varchar(16))
+       partition by(lo_orderpriority);
+-- result:
+-- !result
+insert into hive_catalog_${uuid0}.hive_db_${uuid0}.hive_lineorder_par values(1, "4-NOT SPECI");
+-- result:
+-- !result
+insert into hive_catalog_${uuid0}.hive_db_${uuid0}.hive_lineorder_par values(2, "4-NOT SPECI");
+-- result:
+-- !result
+drop table hive_catalog_${uuid0}.hive_db_${uuid0}.hive_lineorder_par force;
+-- result:
+-- !result
+drop database hive_catalog_${uuid0}.hive_db_${uuid0};
+-- result:
+-- !result
+drop catalog hive_catalog_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_dml/T/test_escape
+++ b/test/sql/test_dml/T/test_escape
@@ -1,0 +1,24 @@
+-- name: test_escape 
+
+create external catalog hive_catalog_${uuid0} PROPERTIES ("type"="hive", 
+    "hive.metastore.uris"="${hive_metastore_uris}",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}");
+create database hive_catalog_${uuid0}.hive_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/hive_db_${uuid0}/test_escape/${uuid0}"
+);
+
+CREATE TABLE hive_catalog_${uuid0}.hive_db_${uuid0}.hive_lineorder_par(
+      lo_orderkey int,
+       lo_orderpriority varchar(16))
+       partition by(lo_orderpriority);
+
+insert into hive_catalog_${uuid0}.hive_db_${uuid0}.hive_lineorder_par values(1, "4-NOT SPECI");
+
+insert into hive_catalog_${uuid0}.hive_db_${uuid0}.hive_lineorder_par values(2, "4-NOT SPECI");
+
+drop table hive_catalog_${uuid0}.hive_db_${uuid0}.hive_lineorder_par force;
+
+drop database hive_catalog_${uuid0}.hive_db_${uuid0};
+drop catalog hive_catalog_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
insert a value like "a b" into hive table partition column c1, we will get the path like "c1=a%20b".

and if we use the path to get partition, we will get no result. we should unescape the path before get partition.
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
