### PR TITLE
[Enhancement] Fix CVE-2024-13009

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -762,6 +762,10 @@ under the License.
                         <groupId>javax.ws.rs</groupId>
                         <artifactId>jsr311-api</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-server</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -762,10 +762,6 @@ under the License.
                         <groupId>javax.ws.rs</groupId>
                         <artifactId>jsr311-api</artifactId>
                     </exclusion>
-                    <exclusion>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-server</artifactId>
-                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -983,6 +979,10 @@ under the License.
                     <exclusion>
                         <groupId>org.apache.hadoop</groupId>
                         <artifactId>hadoop-hdfs</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.hbase.thirdparty</groupId>
+                        <artifactId>hbase-shaded-jetty</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -18,3 +18,5 @@ scan:
     - "**/paimon-bundle-1.0.1.jar"
     # aws sdk bundle
     - "**/bundle-2.29.52.jar"
+    # spark core
+    - "**/spark-core_2.12-3.5.5.jar"


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
1. Remove the `hbase-shaded-jetty` from `org.apache.hudi:hudi-common`

2. ignore spark-core: Because the jetty-server code is copied in the spark-core package, the jetty-server code version is 9.4.56.v20240826, which has a vulnerability risk: CVE-2024-13009. However, the latest version of spark-core does not update the jetty-server version, so we can only ignore it.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
