### PR TITLE
[BugFix] Fix avx512 unaligned store

### DIFF
--- a/be/src/simd/delta_decode.h
+++ b/be/src/simd/delta_decode.h
@@ -145,7 +145,7 @@ MFV_AVX512F(__m512i prefix_and_accumulate_int32_avx512(int32_t* p, __m512i s, co
     x = _mm512_add_epi32(x, _mm512_alignr_epi32(x, v_zero, 16 - 8));
     // accumulate
     x = _mm512_add_epi32(s, x);
-    _mm512_storeu_si512((__m512i*)p, x);
+    _mm512_storeu_si512(p, x);
     // return last value.
     return _mm512_permutexvar_epi32(v_perm15, x);
 });


### PR DESCRIPTION
## Why I'm doing:

Got several crashes in BE-UT ASAN Mode. Debug it and find the assembly code like

```
   0x0000000029b7382e <+331>:   je     0x29b7383d <starrocks::delta_decode_chain_int32_avx512(int32_t*, int, int32_t, int32_t&)+346>
   0x0000000029b73830 <+333>:   mov    $0x40,%esi
   0x0000000029b73835 <+338>:   mov    %rax,%rdi
   0x0000000029b73838 <+341>:   call   0x19824bf0 <__asan_report_store_n>
=> 0x0000000029b7383d <+346>:   vmovdqa64 %zmm0,-0x180(%r13)
   0x0000000029b73844 <+353>:   vpxor  %xmm0,%xmm0,%xmm0
   0x0000000029b73848 <+357>:   lea    -0x100(%r13),%rax
   0x0000000029b7384f <+364>:   mov    %rax,%rdx
   0x0000000029b73852 <+367>:   shr    $0x3,%rdx
   0x0000000029b73856 <+371>:   add    $0x7fff8000,%rdx

```

And according to ChatGpt explanation that if you write 
> _mm512_storeu_si512((__m512i*)p, x);

Compiler could think the p is 64B aligned and generate aligned instruction, because  definition of `__m512i` is
> typedef long long __m512i __attribute__((__vector_size__(64), __aligned__(64)));

## What I'm doing:

Don't use cast right here. Force compiler to generate unaligned store.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
