### PR TITLE
[BugFix] Fix mv refresh generate plan for multi tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
@@ -415,6 +415,12 @@ public class ListPartitionInfo extends PartitionInfo {
         return sb.toString();
     }
 
+    /**
+     * Get the partition expression for the partition info
+     * @param tableName: table name of the partitioned table
+     * @param idToColumn: map of column id to column
+     * @return: list of defined partition expressions for the table
+     */
     public List<Expr> getPartitionExprs(TableName tableName, Map<ColumnId, Column> idToColumn) {
         List<Expr> partitionExprs = Lists.newArrayList();
         for (Column column : MetaUtils.getColumnsByColumnIds(idToColumn, partitionColumnIds)) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
@@ -20,7 +20,10 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.LiteralExpr;
+import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.TableName;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
@@ -410,6 +413,18 @@ public class ListPartitionInfo extends PartitionInfo {
             sb.append("\n)");
         }
         return sb.toString();
+    }
+
+    public List<Expr> getPartitionExprs(TableName tableName, Map<ColumnId, Column> idToColumn) {
+        List<Expr> partitionExprs = Lists.newArrayList();
+        for (Column column : MetaUtils.getColumnsByColumnIds(idToColumn, partitionColumnIds)) {
+            if (column.isGeneratedColumn()) {
+                partitionExprs.add(column.getGeneratedColumnExpr(idToColumn));
+            } else {
+                partitionExprs.add(new SlotRef(tableName, column.getName()));
+            }
+        }
+        return partitionExprs;
     }
 
     private String singleListPartitionSql(OlapTable table, List<Long> partitionIds, short tableReplicationNum) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -504,12 +504,13 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             throw new LockTimeoutException("Failed to lock database in prepareRefreshPlan");
         }
 
-        MVPCTRefreshPlanBuilder planBuilder = new MVPCTRefreshPlanBuilder(mv, mvContext, mvRefreshPartitioner);
+        MVPCTRefreshPlanBuilder planBuilder = new MVPCTRefreshPlanBuilder(db, mv, mvContext, mvRefreshPartitioner);
         try {
             // 4. Analyze and prepare a partition & Rebuild insert statement by
             // considering to-refresh partitions of ref tables/ mv
             try (Timer ignored = Tracers.watchScope("MVRefreshAnalyzer")) {
-                insertStmt = planBuilder.analyzeAndBuildInsertPlan(insertStmt, refTablePartitionNames, ctx);
+                insertStmt = planBuilder.analyzeAndBuildInsertPlan(insertStmt,
+                        mvToRefreshedPartitions, refTablePartitionNames, ctx);
                 // Must set execution id before StatementPlanner.plan
                 ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
             }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitioner.java
@@ -17,10 +17,12 @@ package com.starrocks.scheduler.mv;
 
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.AnalysisException;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.scheduler.TableSnapshotInfo;
 import com.starrocks.scheduler.TaskRunContext;
@@ -47,6 +49,13 @@ public final class MVPCTRefreshNonPartitioner extends MVPCTRefreshPartitioner {
     public Expr generatePartitionPredicate(Table table, Set<String> refBaseTablePartitionNames,
                                            List<Expr> mvPartitionSlotRefs) {
         // do nothing
+        return null;
+    }
+
+
+    @Override
+    public Expr generateMVPartitionPredicate(TableName tableName,
+                                             Set<String> mvPartitionNames) throws AnalysisException {
         return null;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
@@ -95,6 +95,13 @@ public abstract class MVPCTRefreshPartitioner {
                                                     Set<String> refBaseTablePartitionNames,
                                                     List<Expr> mvPartitionSlotRefs) throws AnalysisException;
 
+    /**
+     * Generate partition predicate for mv refresh based on the mv partition names.
+     * @param tableName: materialized view table name(db + name)
+     * @param mvPartitionNames: materialized view partition names to check.
+     * @return : partition predicate for mv refresh.
+     * @throws AnalysisException
+     */
     public abstract Expr generateMVPartitionPredicate(TableName tableName,
                                                       Set<String> mvPartitionNames) throws AnalysisException;
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
@@ -17,6 +17,7 @@ package com.starrocks.scheduler.mv;
 import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
@@ -56,6 +57,8 @@ import static com.starrocks.sql.optimizer.rule.transformation.partition.Partitio
  * refresh.
  */
 public abstract class MVPCTRefreshPartitioner {
+    protected  static final int CREATE_PARTITION_BATCH_SIZE = 64;
+
     protected final MvTaskRunContext mvContext;
     protected final TaskRunContext context;
     protected final Database db;
@@ -91,6 +94,9 @@ public abstract class MVPCTRefreshPartitioner {
     public abstract Expr generatePartitionPredicate(Table refBaseTable,
                                                     Set<String> refBaseTablePartitionNames,
                                                     List<Expr> mvPartitionSlotRefs) throws AnalysisException;
+
+    public abstract Expr generateMVPartitionPredicate(TableName tableName,
+                                                      Set<String> mvPartitionNames) throws AnalysisException;
 
     /**
      * Get mv partitions to refresh based on the ref base table partitions.

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPlanBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPlanBuilder.java
@@ -24,6 +24,7 @@ import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.ExpressionRangePartitionInfo;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.ListPartitionInfo;
@@ -45,6 +46,7 @@ import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.SelectList;
 import com.starrocks.sql.ast.SelectListItem;
 import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.SubqueryRelation;
 import com.starrocks.sql.ast.TableRelation;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.Logger;
@@ -58,10 +60,10 @@ import java.util.stream.Collectors;
 
 public class MVPCTRefreshPlanBuilder {
     private final Logger logger;
+    private final Database mvDb;
     private final MaterializedView mv;
     private final MvTaskRunContext mvContext;
     private final MVPCTRefreshPartitioner mvRefreshPartitioner;
-    private final boolean isRefreshFailOnFilterData;
 
     // push down partition predicates into table relation
     private static final String EXTRA_PREDICATE_KEY = "_EXTRA_";
@@ -82,37 +84,43 @@ public class MVPCTRefreshPlanBuilder {
         mvPlanBuildMessage.put(table.getName(), partitionPredicate.toSql());
     }
 
-    private void tracePartitionPredicates(List<Expr> partitionPredicate) {
-        mvPlanBuildMessage.put(EXTRA_PREDICATE_KEY,
-                partitionPredicate.stream().map(Expr::toSql).collect(Collectors.joining(",")));
+    private void tracePartitionPredicates(Expr partitionPredicate) {
+        if (partitionPredicate == null) {
+            return;
+        }
+        mvPlanBuildMessage.put(EXTRA_PREDICATE_KEY, partitionPredicate.toSql());
     }
 
     public Map<String, String> getPlanBuilderMessage() {
         return mvPlanBuildMessage;
     }
 
-    public MVPCTRefreshPlanBuilder(MaterializedView mv,
+    public MVPCTRefreshPlanBuilder(Database mvDb,
+                                   MaterializedView mv,
                                    MvTaskRunContext mvContext,
                                    MVPCTRefreshPartitioner mvRefreshPartitioner) {
+        this.mvDb = mvDb;
         this.mv = mv;
         this.mvContext = mvContext;
         this.mvRefreshPartitioner = mvRefreshPartitioner;
-        this.isRefreshFailOnFilterData = mvContext.getCtx().getSessionVariable().getInsertMaxFilterRatio() == 0;
         this.logger = MVTraceUtils.getLogger(mv, MVPCTRefreshPlanBuilder.class);
     }
 
     public InsertStmt analyzeAndBuildInsertPlan(InsertStmt insertStmt,
+                                                Set<String> mvToRefreshedPartitions,
                                                 Map<String, Set<String>> refTableRefreshPartitions,
                                                 ConnectContext ctx) throws AnalysisException {
         Analyzer.analyze(insertStmt, ctx);
-        InsertStmt newInsertStmt = buildInsertPlan(insertStmt, refTableRefreshPartitions);
+        InsertStmt newInsertStmt = buildInsertPlan(insertStmt, mvToRefreshedPartitions, refTableRefreshPartitions, ctx);
         return newInsertStmt;
     }
 
     private InsertStmt buildInsertPlan(InsertStmt insertStmt,
-                                       Map<String, Set<String>> refTableRefreshPartitions) throws AnalysisException {
+                                       Set<String> mvToRefreshedPartitions,
+                                       Map<String, Set<String>> refTableRefreshPartitions,
+                                       ConnectContext ctx) throws AnalysisException {
         // if the refTableRefreshPartitions is empty(not partitioned mv), no need to generate partition predicate
-        if (refTableRefreshPartitions.isEmpty()) {
+        if (refTableRefreshPartitions.isEmpty() || mvToRefreshedPartitions.isEmpty()) {
             logger.info("There is no ref table partitions to refresh, skip to generate partition predicates");
             return insertStmt;
         }
@@ -209,38 +217,78 @@ public class MVPCTRefreshPlanBuilder {
                 extraPartitionPredicates.add(partitionPredicate);
             }
         }
-        if (extraPartitionPredicates.isEmpty()) {
-            doIfNoPushDownPredicates(numOfPushDownIntoTables, refTableRefreshPartitions);
+
+        if (numOfPushDownIntoTables == tableRelations.size()) {
             logger.info("Generate partition extra predicates empty, mv:{}, numOfPushDownIntoTables:{}",
                     mv.getName(), numOfPushDownIntoTables);
             return insertStmt;
-        }
-        tracePartitionPredicates(extraPartitionPredicates);
-        if (queryRelation instanceof SelectRelation) {
-            SelectRelation selectRelation = (SelectRelation) queryRelation;
-            extraPartitionPredicates.add(selectRelation.getWhereClause());
-            Expr finalPredicate = Expr.compoundAnd(extraPartitionPredicates);
-            selectRelation.setWhereClause(finalPredicate);
-            logger.info("Optimize materialized view {} refresh task, generate insert stmt final " +
-                    "predicate(select relation):{} ", mv.getName(), finalPredicate.toSql());
+        } else if (numOfPushDownIntoTables != uniqueTableNames.size() || extraPartitionPredicates.isEmpty()) {
+            return generateMVPartitionPredicate(mvToRefreshedPartitions, queryStatement, insertStmt);
         } else {
-            // support to generate partition predicate for other query relation types
-            logger.warn("MV Refresh cannot push down partition predicate since " +
-                    "the query relation is not select relation, mv:{}", mv.getName());
-            TableName tableName = queryRelation.getResolveTableName();
-            // use `getColumnOutputNames` rather than `getOutputExpression` to avoid `getOutputExpression` referring original queryStatement's 
-            // output expressions which may cause column missing if the original queryStatement's output contains alias.
-            List<SelectListItem> items = queryRelation.getColumnOutputNames().stream()
-                    .map(x -> new SlotRef(tableName, x))
-                    .map(x -> new SelectListItem(x, null)).collect(Collectors.toList());
-            SelectList selectList = new SelectList(items, false);
-            SelectRelation selectRelation = new SelectRelation(selectList, queryRelation,
-                    Expr.compoundAnd(extraPartitionPredicates), null, null);
-            selectRelation.setWhereClause(Expr.compoundAnd(extraPartitionPredicates));
-            QueryStatement newQueryStatement = new QueryStatement(selectRelation);
-            insertStmt.setQueryStatement(newQueryStatement);
-            new QueryAnalyzer(mvContext.getCtx()).analyze(newQueryStatement);
+            // TODO: merge with above code
+            Expr finalPredicate = Expr.compoundAnd(extraPartitionPredicates);
+            tracePartitionPredicates(finalPredicate);
+            if (queryRelation instanceof SelectRelation) {
+                SelectRelation selectRelation = (SelectRelation) queryRelation;
+                extraPartitionPredicates.add(selectRelation.getWhereClause());
+                selectRelation.setWhereClause(finalPredicate);
+                logger.info("Optimize materialized view {} refresh task, generate insert stmt final " +
+                        "predicate(select relation):{} ", mv.getName(), finalPredicate.toSql());
+            } else {
+                // support to generate partition predicate for other query relation types
+                logger.warn("MV Refresh cannot push down partition predicate since " +
+                        "the query relation is not select relation, mv:{}", mv.getName());
+                TableName tableName = queryRelation.getResolveTableName();
+                // use `getColumnOutputNames` rather than `getOutputExpression` to avoid `getOutputExpression`
+                // referring original queryStatement's
+                // output expressions which may cause column missing if the original queryStatement's output contains alias.
+                List<SelectListItem> items = queryRelation.getColumnOutputNames().stream()
+                        .map(x -> new SlotRef(tableName, x))
+                        .map(x -> new SelectListItem(x, null)).collect(Collectors.toList());
+                SelectList selectList = new SelectList(items, false);
+                SelectRelation selectRelation = new SelectRelation(selectList, queryRelation,
+                        finalPredicate, null, null);
+                QueryStatement newQueryStatement = new QueryStatement(selectRelation);
+                insertStmt.setQueryStatement(newQueryStatement);
+                new QueryAnalyzer(mvContext.getCtx()).analyze(newQueryStatement);
+            }
+            return insertStmt;
         }
+    }
+
+    private InsertStmt generateMVPartitionPredicate(Set<String> mvToRefreshedPartitions,
+                                                    QueryStatement queryStatement,
+                                                    InsertStmt insertStmt)
+            throws AnalysisException {
+        TableName tableName = new TableName(mvDb.getFullName(), mv.getName());
+        Expr mvPartitionPredicate = mvRefreshPartitioner.generateMVPartitionPredicate(tableName, mvToRefreshedPartitions);
+        if (mvPartitionPredicate == null) {
+            logger.warn("Generate mv partition predicate failed, mv:{}", mv.getName());
+            return null;
+        }
+        tracePartitionPredicates(mvPartitionPredicate);
+
+        // support to generate partition predicate for other query relation types
+        logger.warn("Generate mv partition predicate since , mv:{}", mv.getName());
+        SubqueryRelation newRelation = new SubqueryRelation(queryStatement);
+        newRelation.setAlias(tableName);
+
+        // use `getColumnOutputNames` rather than `getOutputExpression` to avoid `getOutputExpression`
+        // referring original queryStatement's
+        // output expressions which may cause column missing if the original queryStatement's output contains alias.
+        QueryRelation queryRelation = queryStatement.getQueryRelation();
+        List<SelectListItem> items = queryRelation.getColumnOutputNames().stream()
+                .map(x -> new SlotRef(tableName, x))
+                .map(x -> new SelectListItem(x, null)).collect(Collectors.toList());
+        SelectList selectList = new SelectList(items, false);
+
+        SelectRelation selectRelation = new SelectRelation(selectList, newRelation,
+                null, null, null);
+        selectRelation.setWhereClause(mvPartitionPredicate);
+
+        QueryStatement newQueryStatement = new QueryStatement(selectRelation);
+        insertStmt.setQueryStatement(newQueryStatement);
+        new QueryAnalyzer(mvContext.getCtx()).analyze(newQueryStatement);
         return insertStmt;
     }
 
@@ -415,21 +463,6 @@ public class MVPCTRefreshPlanBuilder {
             return new BoolLiteral(false);
         }
         return mvRefreshPartitioner.generatePartitionPredicate(table, tablePartitionNames, mvPartitionOutputExprs);
-    }
-
-    private void doIfNoPushDownPredicates(int numOfPushDownIntoTables,
-                                          Map<String, Set<String>> refTableRefreshPartitions) throws AnalysisException {
-        int refBaseTableSize = refTableRefreshPartitions.size();
-        if (numOfPushDownIntoTables == refBaseTableSize) {
-            return;
-        }
-        logger.warn("Cannot generate partition predicate for mv refresh {} and there " +
-                        "are no predicate push down tables, refBaseTableSize:{}, numOfPushDownIntoTables:{}", mv.getName(),
-                refBaseTableSize, numOfPushDownIntoTables);
-        if (isRefreshFailOnFilterData) {
-            throw new AnalysisException(String.format("Cannot generate partition predicate for mv refresh %s",
-                    mv.getName()));
-        }
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
@@ -949,7 +949,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             ExecPlan execPlan = mvContext.getExecPlan();
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
             PlanTestBase.assertContains(plan, "TABLE: t1_par\n" +
-                    "     PARTITION PREDICATES: 9: par_col IS NOT NULL, 10: par_date >= '2020-01-01', " +
+                    "     PARTITION PREDICATES: 10: par_date >= '2020-01-01', " +
                     "10: par_date < '2020-01-05'\n" +
                     "     partitions=6/6");
             PlanTestBase.assertContains(plan, "TABLE: t2_par\n" +
@@ -972,7 +972,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             ExecPlan execPlan = mvContext.getExecPlan();
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
             PlanTestBase.assertContains(plan, "TABLE: t1_par\n" +
-                    "     PARTITION PREDICATES: 9: par_col IS NOT NULL, 10: par_date >= '2020-01-05', " +
+                    "     PARTITION PREDICATES: 10: par_date >= '2020-01-05', " +
                     "10: par_date < '2020-01-06'\n" +
                     "     partitions=1/7");
             // TODO: multi-column partitions cannot prune partitions.
@@ -997,7 +997,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
             // TODO: non-ref base table's update will refresh all the materialized views' partitions.
             PlanTestBase.assertContains(plan, "TABLE: t1_par\n" +
-                    "     PARTITION PREDICATES: 9: par_col IS NOT NULL, 10: par_date >= '2020-01-01', 10: par_date < " +
+                    "     PARTITION PREDICATES: 10: par_date >= '2020-01-01', 10: par_date < " +
                     "'2020-01-06'\n" +
                     "     partitions=7/7");
             // TODO: multi-column partitions cannot prune partitions.
@@ -1085,7 +1085,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
                     "     rollup: test_partition_prune_tbl1");
             PlanTestBase.assertContains(plan, "     TABLE: test_partition_prune_tbl2\n" +
                     "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: 4: k1 IS NOT NULL\n" +
+                    "     PREDICATES: 4: k1 >= '2020-10-01', 4: k1 < '2020-12-15'\n" +
                     "     partitions=1/1");
         }
 
@@ -1103,10 +1103,11 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
             PlanTestBase.assertContains(plan, "     TABLE: test_partition_prune_tbl1\n" +
                     "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: 1: k1 IS NOT NULL");
+                    "     PREDICATES: 1: k1 >= '2020-10-01', 1: k1 < '2020-12-15'\n" +
+                    "     partitions=5/5");
             PlanTestBase.assertContains(plan, "     TABLE: test_partition_prune_tbl2\n" +
                     "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: 4: k1 IS NOT NULL\n" +
+                    "     PREDICATES: 4: k1 >= '2020-10-01', 4: k1 < '2020-12-15'\n" +
                     "     partitions=1/1");
         }
 
@@ -1126,7 +1127,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
                     "     rollup: test_partition_prune_tbl1");
             PlanTestBase.assertContains(plan, "     TABLE: test_partition_prune_tbl2\n" +
                     "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: 4: k1 IS NOT NULL\n" +
+                    "     PREDICATES: 4: k1 >= '2020-10-01', 4: k1 < '2020-12-15'\n" +
                     "     partitions=1/1");
         }
 

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_multi_tables
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_multi_tables
@@ -1,0 +1,415 @@
+-- name: test_range_mv_with_multi_tables1 
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE non_partition_table (dt2 date, int2 int, str2 string);
+-- result:
+-- !result
+INSERT INTO non_partition_table VALUES ("2025-05-16",1, "a"),("2025-05-17",1, "b"),("2025-05-18",1,null),(null,null,null);
+-- result:
+-- !result
+CREATE TABLE partition_table (
+  dt1 date,
+  int1 int(11),
+  str1 string
+) ENGINE=OLAP 
+PARTITION BY date_trunc('day', dt1);
+-- result:
+-- !result
+INSERT INTO partition_table VALUES ("2025-05-16",1, "a"),("2025-05-17",1, "b"),("2025-05-18",1,null),(null,null,null);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY (dt1) 
+REFRESH DEFERRED MANUAL
+PROPERTIES ("partition_refresh_number"="1")
+AS SELECT dt1,sum(int1) from partition_table group by dt1 union all
+SELECT dt2,sum(int2) from non_partition_table group by dt2;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+-- result:
+None
+-- !result
+SELECT COUNT(1) FROM test_mv1;
+-- result:
+8
+-- !result
+SELECT * FROM test_mv1 ORDER BY dt1 LIMIT 5;
+-- result:
+None	None
+None	None
+2025-05-16	1
+2025-05-16	1
+2025-05-17	1
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY (date_trunc('day', dt1))
+REFRESH DEFERRED MANUAL
+PROPERTIES ("partition_refresh_number"="1")
+AS SELECT dt1,sum(int1) from partition_table group by dt1 union all
+SELECT dt2,sum(int2) from non_partition_table group by dt2;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+-- result:
+None
+-- !result
+SELECT COUNT(1) FROM test_mv1;
+-- result:
+8
+-- !result
+SELECT * FROM test_mv1 ORDER BY dt1 LIMIT 5;
+-- result:
+None	None
+None	None
+2025-05-16	1
+2025-05-16	1
+2025-05-17	1
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY (dt1) 
+REFRESH DEFERRED MANUAL
+PROPERTIES ("partition_refresh_number"="1")
+AS 
+SELECT dt1, dt2, sum(int1), sum(int2) 
+from partition_table t1
+join non_partition_table t2 on t1.dt1 = t2.dt2 
+group by dt1, dt2;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+-- result:
+None
+-- !result
+SELECT COUNT(1) FROM test_mv1;
+-- result:
+3
+-- !result
+SELECT * FROM test_mv1 ORDER BY dt1 LIMIT 5;
+-- result:
+2025-05-16	2025-05-16	1	1
+2025-05-17	2025-05-17	1	1
+2025-05-18	2025-05-18	1	1
+-- !result
+DROP database db_${uuid0};
+-- result:
+-- !result
+-- name: test_range_mv_with_multi_tables2
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE non_partition_table (dt2 date, int2 int, str2 string);
+-- result:
+-- !result
+INSERT INTO non_partition_table VALUES ("2025-05-16",1, "a"),("2025-05-17",1, "b"),("2025-05-18",1,null),(null,null,null);
+-- result:
+-- !result
+CREATE TABLE partition_table (
+  dt1 date,
+  int1 int(11),
+  str1  string
+) ENGINE=OLAP 
+PARTITION BY RANGE(dt1)
+(
+  PARTITION p1 VALUES [("2024-03-10"), ("2025-05-16")),
+  PARTITION p2 VALUES [("2025-05-16"), ("2025-05-17")),
+  PARTITION p3 VALUES [("2025-05-17"), ("2025-05-18")),
+  PARTITION p4 VALUES [("2025-05-18"), ("2025-05-19"))
+);
+-- result:
+-- !result
+INSERT INTO partition_table VALUES ("2025-05-16",1, "a"),("2025-05-17",1, "b"),("2025-05-18",1,null);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY (dt1) 
+REFRESH DEFERRED MANUAL
+PROPERTIES ("partition_refresh_number"="1")
+AS SELECT dt1,sum(int1) from partition_table group by dt1 union all
+SELECT dt2,sum(int2) from non_partition_table group by dt2;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+-- result:
+None
+-- !result
+SELECT COUNT(1) FROM test_mv1;
+-- result:
+6
+-- !result
+SELECT * FROM test_mv1 ORDER BY dt1 LIMIT 5;
+-- result:
+2025-05-16	1
+2025-05-16	1
+2025-05-17	1
+2025-05-17	1
+2025-05-18	1
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY (date_trunc('day', dt1))
+REFRESH DEFERRED MANUAL
+PROPERTIES ("partition_refresh_number"="1")
+AS SELECT dt1,sum(int1) from partition_table group by dt1 union all
+SELECT dt2,sum(int2) from non_partition_table group by dt2;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+-- result:
+None
+-- !result
+SELECT COUNT(1) FROM test_mv1;
+-- result:
+6
+-- !result
+SELECT * FROM test_mv1 ORDER BY dt1 LIMIT 5;
+-- result:
+2025-05-16	1
+2025-05-16	1
+2025-05-17	1
+2025-05-17	1
+2025-05-18	1
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY (dt1) 
+REFRESH DEFERRED MANUAL
+PROPERTIES ("partition_refresh_number"="1")
+AS 
+SELECT dt1, dt2, sum(int1), sum(int2) 
+from partition_table t1
+join non_partition_table t2 on t1.dt1 = t2.dt2 
+group by dt1, dt2;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+-- result:
+None
+-- !result
+SELECT COUNT(1) FROM test_mv1;
+-- result:
+3
+-- !result
+SELECT * FROM test_mv1 ORDER BY dt1 LIMIT 5;
+-- result:
+2025-05-16	2025-05-16	1	1
+2025-05-17	2025-05-17	1	1
+2025-05-18	2025-05-18	1	1
+-- !result
+DROP database db_${uuid0};
+-- result:
+-- !result
+-- name: test_range_mv_with_multi_tables3
+create external catalog mv_hive_${uuid0}
+properties
+(
+    "type" = "hive",
+    "hive.catalog.type" = "hive",
+    "hive.metastore.uris" = "${hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_hive_${uuid0};
+-- result:
+-- !result
+create database mv_hive_db_${uuid0};
+-- result:
+-- !result
+use mv_hive_db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE partition_table (
+  int1 int,
+  str1 string,
+  dt1 string
+)
+PARTITION BY (dt1);
+-- result:
+-- !result
+INSERT INTO partition_table VALUES (1, "a", "2025-05-16"),(1, "b","2025-05-17"),(1,null,"2025-05-19");
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE non_partition_table (dt2 date, int2 int, str2 string);
+-- result:
+-- !result
+INSERT INTO non_partition_table VALUES ("2025-05-16",1, "a"),("2025-05-17",1, "b"),("2025-05-18",1,null),(null,null,null);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY str2date(dt1, '%Y-%m-%d')
+REFRESH DEFERRED MANUAL
+PROPERTIES ("partition_refresh_number"="1")
+AS SELECT dt1,sum(int1) from mv_hive_${uuid0}.mv_hive_db_${uuid0}.partition_table group by dt1 union all
+SELECT dt2,sum(int2) from non_partition_table group by dt2;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+-- result:
+None
+-- !result
+SELECT COUNT(1) FROM test_mv1;
+-- result:
+5
+-- !result
+SELECT * FROM test_mv1 ORDER BY dt1 LIMIT 5;
+-- result:
+2025-05-16	1
+2025-05-16	1
+2025-05-17	1
+2025-05-17	1
+2025-05-19	1
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY (date_trunc('day', dt))
+REFRESH DEFERRED MANUAL
+PROPERTIES ("partition_refresh_number"="1")
+AS SELECT str2date(dt1, '%Y-%m-%d') as dt,sum(int1) from mv_hive_${uuid0}.mv_hive_db_${uuid0}.partition_table group by dt1 union all
+SELECT dt2 as dt,sum(int2) from non_partition_table group by dt2;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+-- result:
+None
+-- !result
+SELECT COUNT(1) FROM test_mv1;
+-- result:
+5
+-- !result
+SELECT * FROM test_mv1 ORDER BY dt LIMIT 5;
+-- result:
+2025-05-16	1
+2025-05-16	1
+2025-05-17	1
+2025-05-17	1
+2025-05-19	1
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY (dt1) 
+REFRESH DEFERRED MANUAL
+PROPERTIES ("partition_refresh_number"="1")
+AS 
+SELECT dt1, dt2, sum(int1), sum(int2) 
+from mv_hive_${uuid0}.mv_hive_db_${uuid0}.partition_table t1
+join non_partition_table t2 on t1.dt1 = t2.dt2 
+group by dt1, dt2;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+-- result:
+None
+-- !result
+SELECT COUNT(1) FROM test_mv1;
+-- result:
+2
+-- !result
+SELECT * FROM test_mv1 ORDER BY dt1 LIMIT 5;
+-- result:
+2025-05-16	2025-05-16	1	1
+2025-05-17	2025-05-17	1	1
+-- !result
+DROP database db_${uuid0};
+-- result:
+-- !result
+DROP table mv_hive_${uuid0}.mv_hive_db_${uuid0}.partition_table force;
+-- result:
+-- !result
+DROP database mv_hive_${uuid0}.mv_hive_db_${uuid0} force;
+-- result:
+-- !result
+DROP CATALOG mv_hive_${uuid0};
+-- result:
+-- !result
+-- name: test_range_mv_with_multi_tables4
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE non_partition_table (dt2 date, int2 int, str2 string);
+-- result:
+-- !result
+INSERT INTO non_partition_table VALUES ("2025-05-16",1, "a"),("2025-05-17",1, "b"),("2025-05-18",1,null),(null,null,null);
+-- result:
+-- !result
+CREATE TABLE partition_table (
+  dt1 string,
+  int1 int(11),
+  str1  string
+) ENGINE=OLAP 
+PARTITION BY str2date(dt1, '%Y-%m-%d'), int1;
+-- result:
+-- !result
+INSERT INTO partition_table VALUES ("2025-05-16",1, "a"),("2025-05-17",1, "b"),("2025-05-18",1,null);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY (str2date(dt1, '%Y-%m-%d'), int1)
+REFRESH DEFERRED MANUAL
+PROPERTIES ("partition_refresh_number"="1")
+AS 
+SELECT dt1, int1, sum(int2) 
+from partition_table t1
+join non_partition_table t2 on t1.dt1 = t2.dt2 
+group by dt1, int1;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+-- result:
+None
+-- !result
+SELECT COUNT(1) FROM test_mv1;
+-- result:
+3
+-- !result
+SELECT * FROM test_mv1 ORDER BY dt1 LIMIT 5;
+-- result:
+2025-05-16	1	1
+2025-05-17	1	1
+2025-05-18	1	1
+-- !result
+DROP database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_multi_tables
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_multi_tables
@@ -1,0 +1,221 @@
+
+-- name: test_range_mv_with_multi_tables1 
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE non_partition_table (dt2 date, int2 int, str2 string);
+INSERT INTO non_partition_table VALUES ("2025-05-16",1, "a"),("2025-05-17",1, "b"),("2025-05-18",1,null),(null,null,null);
+CREATE TABLE partition_table (
+  dt1 date,
+  int1 int(11),
+  str1 string
+) ENGINE=OLAP 
+PARTITION BY date_trunc('day', dt1);
+INSERT INTO partition_table VALUES ("2025-05-16",1, "a"),("2025-05-17",1, "b"),("2025-05-18",1,null),(null,null,null);
+
+-- case1: mv1 with union all
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY (dt1) 
+REFRESH DEFERRED MANUAL
+PROPERTIES ("partition_refresh_number"="1")
+AS SELECT dt1,sum(int1) from partition_table group by dt1 union all
+SELECT dt2,sum(int2) from non_partition_table group by dt2;
+REFRESH MATERIALIZED VIEW test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+SELECT COUNT(1) FROM test_mv1;
+SELECT * FROM test_mv1 ORDER BY dt1 LIMIT 5;
+DROP MATERIALIZED VIEW test_mv1;
+
+-- case2: mv1 with union all with date_trunc
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY (date_trunc('day', dt1))
+REFRESH DEFERRED MANUAL
+PROPERTIES ("partition_refresh_number"="1")
+AS SELECT dt1,sum(int1) from partition_table group by dt1 union all
+SELECT dt2,sum(int2) from non_partition_table group by dt2;
+REFRESH MATERIALIZED VIEW test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+SELECT COUNT(1) FROM test_mv1;
+SELECT * FROM test_mv1 ORDER BY dt1 LIMIT 5;
+DROP MATERIALIZED VIEW test_mv1;
+
+-- case3: mv1 with join
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY (dt1) 
+REFRESH DEFERRED MANUAL
+PROPERTIES ("partition_refresh_number"="1")
+AS 
+SELECT dt1, dt2, sum(int1), sum(int2) 
+from partition_table t1
+join non_partition_table t2 on t1.dt1 = t2.dt2 
+group by dt1, dt2;
+REFRESH MATERIALIZED VIEW test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+SELECT COUNT(1) FROM test_mv1;
+SELECT * FROM test_mv1 ORDER BY dt1 LIMIT 5;
+DROP database db_${uuid0};
+
+-- name: test_range_mv_with_multi_tables2
+create database db_${uuid0};
+use db_${uuid0};
+CREATE TABLE non_partition_table (dt2 date, int2 int, str2 string);
+INSERT INTO non_partition_table VALUES ("2025-05-16",1, "a"),("2025-05-17",1, "b"),("2025-05-18",1,null),(null,null,null);
+
+CREATE TABLE partition_table (
+  dt1 date,
+  int1 int(11),
+  str1  string
+) ENGINE=OLAP 
+PARTITION BY RANGE(dt1)
+(
+  PARTITION p1 VALUES [("2024-03-10"), ("2025-05-16")),
+  PARTITION p2 VALUES [("2025-05-16"), ("2025-05-17")),
+  PARTITION p3 VALUES [("2025-05-17"), ("2025-05-18")),
+  PARTITION p4 VALUES [("2025-05-18"), ("2025-05-19"))
+);
+INSERT INTO partition_table VALUES ("2025-05-16",1, "a"),("2025-05-17",1, "b"),("2025-05-18",1,null);
+
+-- case1: mv1 with union all
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY (dt1) 
+REFRESH DEFERRED MANUAL
+PROPERTIES ("partition_refresh_number"="1")
+AS SELECT dt1,sum(int1) from partition_table group by dt1 union all
+SELECT dt2,sum(int2) from non_partition_table group by dt2;
+REFRESH MATERIALIZED VIEW test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+SELECT COUNT(1) FROM test_mv1;
+SELECT * FROM test_mv1 ORDER BY dt1 LIMIT 5;
+DROP MATERIALIZED VIEW test_mv1;
+
+-- case2: mv1 with union all with date_trunc
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY (date_trunc('day', dt1))
+REFRESH DEFERRED MANUAL
+PROPERTIES ("partition_refresh_number"="1")
+AS SELECT dt1,sum(int1) from partition_table group by dt1 union all
+SELECT dt2,sum(int2) from non_partition_table group by dt2;
+REFRESH MATERIALIZED VIEW test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+SELECT COUNT(1) FROM test_mv1;
+SELECT * FROM test_mv1 ORDER BY dt1 LIMIT 5;
+DROP MATERIALIZED VIEW test_mv1;
+
+-- case3: mv1 with join
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY (dt1) 
+REFRESH DEFERRED MANUAL
+PROPERTIES ("partition_refresh_number"="1")
+AS 
+SELECT dt1, dt2, sum(int1), sum(int2) 
+from partition_table t1
+join non_partition_table t2 on t1.dt1 = t2.dt2 
+group by dt1, dt2;
+REFRESH MATERIALIZED VIEW test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+SELECT COUNT(1) FROM test_mv1;
+SELECT * FROM test_mv1 ORDER BY dt1 LIMIT 5;
+
+DROP database db_${uuid0};
+
+-- name: test_range_mv_with_multi_tables3
+create external catalog mv_hive_${uuid0}
+properties
+(
+    "type" = "hive",
+    "hive.catalog.type" = "hive",
+    "hive.metastore.uris" = "${hive_metastore_uris}"
+);
+set catalog mv_hive_${uuid0};
+create database mv_hive_db_${uuid0};
+use mv_hive_db_${uuid0};
+CREATE TABLE partition_table (
+  int1 int,
+  str1 string,
+  dt1 string
+)
+PARTITION BY (dt1);
+INSERT INTO partition_table VALUES (1, "a", "2025-05-16"),(1, "b","2025-05-17"),(1,null,"2025-05-19");
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+CREATE TABLE non_partition_table (dt2 date, int2 int, str2 string);
+INSERT INTO non_partition_table VALUES ("2025-05-16",1, "a"),("2025-05-17",1, "b"),("2025-05-18",1,null),(null,null,null);
+
+-- case1: mv1 with union all
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY str2date(dt1, '%Y-%m-%d')
+REFRESH DEFERRED MANUAL
+PROPERTIES ("partition_refresh_number"="1")
+AS SELECT dt1,sum(int1) from mv_hive_${uuid0}.mv_hive_db_${uuid0}.partition_table group by dt1 union all
+SELECT dt2,sum(int2) from non_partition_table group by dt2;
+REFRESH MATERIALIZED VIEW test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+SELECT COUNT(1) FROM test_mv1;
+SELECT * FROM test_mv1 ORDER BY dt1 LIMIT 5;
+DROP MATERIALIZED VIEW test_mv1;
+
+-- case2: mv1 with union all with date_trunc
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY (date_trunc('day', dt))
+REFRESH DEFERRED MANUAL
+PROPERTIES ("partition_refresh_number"="1")
+AS SELECT str2date(dt1, '%Y-%m-%d') as dt,sum(int1) from mv_hive_${uuid0}.mv_hive_db_${uuid0}.partition_table group by dt1 union all
+SELECT dt2 as dt,sum(int2) from non_partition_table group by dt2;
+REFRESH MATERIALIZED VIEW test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+SELECT COUNT(1) FROM test_mv1;
+SELECT * FROM test_mv1 ORDER BY dt LIMIT 5;
+DROP MATERIALIZED VIEW test_mv1;
+
+-- case3: mv1 with join
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY (dt1) 
+REFRESH DEFERRED MANUAL
+PROPERTIES ("partition_refresh_number"="1")
+AS 
+SELECT dt1, dt2, sum(int1), sum(int2) 
+from mv_hive_${uuid0}.mv_hive_db_${uuid0}.partition_table t1
+join non_partition_table t2 on t1.dt1 = t2.dt2 
+group by dt1, dt2;
+REFRESH MATERIALIZED VIEW test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+SELECT COUNT(1) FROM test_mv1;
+SELECT * FROM test_mv1 ORDER BY dt1 LIMIT 5;
+
+DROP database db_${uuid0};
+DROP table mv_hive_${uuid0}.mv_hive_db_${uuid0}.partition_table force;
+DROP database mv_hive_${uuid0}.mv_hive_db_${uuid0} force;
+DROP CATALOG mv_hive_${uuid0};
+
+-- name: test_range_mv_with_multi_tables4
+create database db_${uuid0};
+use db_${uuid0};
+CREATE TABLE non_partition_table (dt2 date, int2 int, str2 string);
+INSERT INTO non_partition_table VALUES ("2025-05-16",1, "a"),("2025-05-17",1, "b"),("2025-05-18",1,null),(null,null,null);
+
+CREATE TABLE partition_table (
+  dt1 string,
+  int1 int(11),
+  str1  string
+) ENGINE=OLAP 
+PARTITION BY str2date(dt1, '%Y-%m-%d'), int1;
+INSERT INTO partition_table VALUES ("2025-05-16",1, "a"),("2025-05-17",1, "b"),("2025-05-18",1,null);
+
+-- case3: mv1 with join
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY (str2date(dt1, '%Y-%m-%d'), int1)
+REFRESH DEFERRED MANUAL
+PROPERTIES ("partition_refresh_number"="1")
+AS 
+SELECT dt1, int1, sum(int2) 
+from partition_table t1
+join non_partition_table t2 on t1.dt1 = t2.dt2 
+group by dt1, int1;
+
+REFRESH MATERIALIZED VIEW test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}", "test_mv1")
+SELECT COUNT(1) FROM test_mv1;
+SELECT * FROM test_mv1 ORDER BY dt1 LIMIT 5;
+
+DROP database db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
https://github.com/StarRocks/starrocks/pull/58873 enabled  `mv_refresh_fail_on_filter_data` config and failed some tests.

I found [MVPCTRefreshPlanBuilder.java](https://github.com/StarRocks/starrocks/compare/main...LiShuMing:fix_mv_filter_datas?expand=1#diff-9ad14d60b62a3f6b97a1fd963e35b68205651af78f0ede0907cabf373fe9a6ef) is not safe to handle cases like:

```
CREATE TABLE t1 (dt1 date, int1 int)
PARTITION BY RANGE(dt1)
(
PARTITION p202006 VALUES LESS THAN ("2020-07-01"),
PARTITION p202007 VALUES LESS THAN ("2020-08-01"),
PARTITION p202008 VALUES LESS THAN ("2020-09-01")
);
CREATE TABLE t2 (dt2 date, int2 int);
INSERT INTO t1 VALUES ("2020-06-23",1),("2020-07-23",1),("2020-07-23",1),("2020-08-23",1),(null,null);
INSERT INTO t2 VALUES ("2020-06-23",1),("2020-07-23",1),("2020-07-23",1),("2020-08-23",1),(null,null);
CREATE MATERIALIZED VIEW mv2 PARTITION BY dt1 REFRESH MANUAL PROPERTIES ("partition_refresh_number"="3")
AS SELECT dt1,sum(int1) from t1 group by dt1 union all
SELECT dt2,sum(int2) from t2 group by dt2;
REFRESH MATERIALIZED VIEW mv2 WITH SYNC MODE;
INSERT INTO t1 VALUES ("2020-06-23",1);
REFRESH MATERIALIZED VIEW mv2 WITH SYNC MODE;
```
This is because sometime we cannot always generate ref base table's partition predicates by its partitions, sometime
if mv is defined by`partition` ref table and `non-partition` ref base table, we can only generate partitioned ref table's partition predicate, so we need to generate extra mv's partition predicates by to-refresh target partitions to ensure there are no filtered rows in mv refreshing.

## What I'm doing:
- Generate the partition predicates by using mv's target partitions when ref base tables' predicates cannot be pushed down
```
        } else if (numOfPushDownIntoTables != uniqueTableNames.size() || extraPartitionPredicates.isEmpty()) {
            // Only generate partition predicates by mv's target partitions when ref base tables'
            // predicates cannot be pushed down
            return generateMVPartitionPredicate(mvToRefreshedPartitions, queryStatement, insertStmt);
```
Fixes https://github.com/StarRocks/StarRocksTest/issues/9658

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
