### PR TITLE
[Feature] adding ADMIN SHOW BACKEND CONFIG command

### DIFF
--- a/be/test/runtime/command_executor_test.cpp
+++ b/be/test/runtime/command_executor_test.cpp
@@ -15,6 +15,7 @@
 #include "runtime/command_executor.h"
 
 #include <gtest/gtest.h>
+#include <rapidjson/document.h>
 
 #include <string>
 
@@ -25,4 +26,45 @@ TEST(CommandExecutorTest, not_support) {
     EXPECT_TRUE(execute_command("set_config_11", "{}", &result).is_not_supported());
 }
 
+TEST(CommandExecutorTest, show_config_basic) {
+    std::string result;
+    Status status = execute_command("show_config", "{}", &result);
+
+    EXPECT_TRUE(status.ok());
+    EXPECT_FALSE(result.empty());
+
+    rapidjson::Document doc;
+    doc.Parse(result.c_str());
+
+    EXPECT_FALSE(doc.HasParseError());
+    EXPECT_TRUE(doc.HasMember("configs"));
+    EXPECT_TRUE(doc["configs"].IsArray());
+    EXPECT_GT(doc["configs"].Size(), 0);
+
+    const auto& config = doc["configs"][0];
+    EXPECT_TRUE(config.HasMember("key"));
+    EXPECT_TRUE(config.HasMember("value"));
+    EXPECT_TRUE(config.HasMember("type"));
+    EXPECT_TRUE(config.HasMember("is_mutable"));
+}
+
+TEST(CommandExecutorTest, show_config_with_pattern) {
+    std::string pattern = "mem";
+    std::string params = "{\"pattern\":\"" + pattern + "\"}";
+    std::string result;
+
+    Status status = execute_command("show_config", params, &result);
+    EXPECT_TRUE(status.ok());
+
+    rapidjson::Document doc;
+    doc.Parse(result.c_str());
+
+    EXPECT_TRUE(doc.HasMember("configs"));
+    const auto& configs = doc["configs"];
+
+    if (configs.Size() > 0) {
+        std::string key = configs[0]["key"].GetString();
+        EXPECT_NE(key.find(pattern), std::string::npos);
+    }
+}
 } // namespace starrocks

--- a/docs/en/sql-reference/sql-statements/cluster-management/config_vars/ADMIN_SHOW_BACKEND_CONFIG.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/config_vars/ADMIN_SHOW_BACKEND_CONFIG.md
@@ -1,0 +1,62 @@
+---
+displayed_sidebar: docs
+---
+
+# ADMIN SHOW BACKEND CONFIG
+
+## Description
+
+Displays the configuration of the backend nodes in the current cluster. This command allows you to view the
+configuration items of all BE (Backend) nodes. For detailed descriptions of BE configuration items,
+see [Configuration](../../../../administration/management/BE_configuration.md).
+
+If you want to set or modify a configuration item, use [ADMIN SET CONFIG](ADMIN_SET_CONFIG.md).
+
+:::tip
+
+This operation requires the SYSTEM-level OPERATE privilege. You can follow the instructions
+in [GRANT](../../account-management/GRANT.md) to grant this privilege.
+
+:::
+
+## Syntax
+
+```sql
+ADMIN SHOW BACKEND CONFIG [LIKE "pattern"]
+```
+
+Note:
+
+Description of the return parameters:
+
+```plain text
+1. Host:       Backend host and port
+2. Key:        Configuration item name
+3. Value:      Configuration item value
+4. Type:       Configuration item type 
+5. IsMutable:  Whether it can be set through the ADMIN SET CONFIG command
+```
+
+## Examples
+
+1. View the configuration of all backend nodes.
+
+    ```sql
+    ADMIN SHOW BACKEND CONFIG;
+    ```
+
+2. Search for the configuration of backend nodes by using the `like` predicate.
+
+    ```plain text
+    mysql> ADMIN SHOW BACKEND CONFIG LIKE 'mem_limit';
+    +-------------------+-----------------------------------------------------+-----------+--------+-----------+
+    | Host              | Key                                                 | Value     | Type   | IsMutable |
+    +-------------------+-----------------------------------------------------+-----------+--------+-----------+
+    | 127.0.0.1:9050    | default_mv_resource_group_spill_mem_limit_threshold | 0.8       | double | false     |
+    | 127.0.0.1:9050    | local_exchange_buffer_mem_limit_per_driver          | 134217728 | int64  | false     |
+    | 127.0.0.1:9050    | mem_limit                                           | 90%       | string | false     |
+    | 127.0.0.1:9050    | mem_limited_chunk_queue_block_size                  | 8388608   | int64  | true      |
+    | 127.0.0.1:9050    | query_pool_spill_mem_limit_threshold                | 1         | double | false     |
+    +-------------------+-----------------------------------------------------+-----------+--------+-----------+
+    5 rows in set (0,13 sec)
+    ``` 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AdminShowBackendConfigStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AdminShowBackendConfigStmt.java
@@ -1,0 +1,65 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.sql.ast;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ScalarType;
+import com.starrocks.qe.ShowResultSetMetaData;
+import com.starrocks.sql.ast.AdminSetConfigStmt.ConfigType;
+import com.starrocks.sql.parser.NodePosition;
+
+// admin show backend config;
+public class AdminShowBackendConfigStmt extends ShowStmt {
+    public static final ImmutableList<String> TITLE_NAMES =
+            new ImmutableList.Builder<String>().add("Host").add("Key").add(
+                    "Value").add("Type").add("IsMutable").build();
+
+    private final ConfigType type;
+    private final String pattern;
+
+    public AdminShowBackendConfigStmt(ConfigType type, String pattern) {
+        this(type, pattern, NodePosition.ZERO);
+    }
+
+    public AdminShowBackendConfigStmt(ConfigType type, String pattern, NodePosition pos) {
+        super(pos);
+        this.type = type;
+        this.pattern = pattern;
+    }
+
+    public ConfigType getType() {
+        return type;
+    }
+
+    public String getPattern() {
+        return pattern;
+    }
+
+    @Override
+    public ShowResultSetMetaData getMetaData() {
+        ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
+        for (String title : TITLE_NAMES) {
+            builder.addColumn(new Column(title, ScalarType.createVarchar(30)));
+        }
+        return builder.build();
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitAdminShowBackendConfigStatement(this, context);
+    }
+} 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -415,6 +415,10 @@ public interface AstVisitor<R, C> {
         return visitShowStatement(statement, context);
     }
 
+    default R visitAdminShowBackendConfigStatement(AdminShowBackendConfigStmt statement, C context) {
+        return visitShowStatement(statement, context);
+    }
+
     default R visitAdminShowReplicaDistributionStatement(AdminShowReplicaDistributionStmt statement, C context) {
         return visitShowStatement(statement, context);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -144,6 +144,7 @@ import com.starrocks.sql.ast.AdminSetAutomatedSnapshotOnStmt;
 import com.starrocks.sql.ast.AdminSetConfigStmt;
 import com.starrocks.sql.ast.AdminSetPartitionVersionStmt;
 import com.starrocks.sql.ast.AdminSetReplicaStatusStmt;
+import com.starrocks.sql.ast.AdminShowBackendConfigStmt;
 import com.starrocks.sql.ast.AdminShowConfigStmt;
 import com.starrocks.sql.ast.AdminShowReplicaDistributionStmt;
 import com.starrocks.sql.ast.AdminShowReplicaStatusStmt;
@@ -2580,6 +2581,16 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             return new AdminShowConfigStmt(AdminSetConfigStmt.ConfigType.FRONTEND, stringLiteral.getValue(), pos);
         }
         return new AdminShowConfigStmt(AdminSetConfigStmt.ConfigType.FRONTEND, null, pos);
+    }
+
+    @Override
+    public ParseNode visitAdminShowBackendConfigStatement(StarRocksParser.AdminShowBackendConfigStatementContext context) {
+        NodePosition pos = createPos(context);
+        if (context.pattern != null) {
+            StringLiteral stringLiteral = (StringLiteral) visit(context.pattern);
+            return new AdminShowBackendConfigStmt(AdminSetConfigStmt.ConfigType.BACKEND, stringLiteral.getValue(), pos);
+        }
+        return new AdminShowBackendConfigStmt(AdminSetConfigStmt.ConfigType.BACKEND, null, pos);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -129,6 +129,7 @@ statement
     | executeScriptStatement
     | adminSetAutomatedSnapshotOnStatement
     | adminSetAutomatedSnapshotOffStatement
+    | adminShowBackendConfigStatement
 
     // Cluster Management Statement
     | alterSystemStatement
@@ -739,6 +740,9 @@ adminSetReplicaStatusStatement
     ;
 adminShowConfigStatement
     : ADMIN SHOW FRONTEND CONFIG (LIKE pattern=string)?
+    ;
+adminShowBackendConfigStatement
+    : ADMIN SHOW BACKEND CONFIG (LIKE pattern=string)?
     ;
 
 adminShowReplicaDistributionStatement

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AdminShowBackendConfigTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AdminShowBackendConfigTest.java
@@ -1,0 +1,65 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.AdminShowBackendConfigStmt;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class AdminShowBackendConfigTest {
+
+    private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+    }
+
+    @Test
+    public void testBasic() throws Exception {
+        String sql = "ADMIN SHOW BACKEND CONFIG";
+        AdminShowBackendConfigStmt stmt
+                = (AdminShowBackendConfigStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+        Assert.assertNotNull(stmt);
+        Assert.assertNull(stmt.getPattern());
+    }
+
+    @Test
+    public void testWithPattern() throws Exception {
+        String sql = "ADMIN SHOW BACKEND CONFIG LIKE 'memory'";
+        AdminShowBackendConfigStmt stmt
+                = (AdminShowBackendConfigStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+        Assert.assertNotNull(stmt);
+        Assert.assertEquals("memory", stmt.getPattern());
+    }
+
+    @Test
+    public void testMetadata() {
+        AdminShowBackendConfigStmt stmt = new AdminShowBackendConfigStmt(null, null);
+        Assert.assertEquals(5, stmt.getMetaData().getColumnCount());
+        Assert.assertEquals("Host", stmt.getMetaData().getColumn(0).getName());
+        Assert.assertEquals("Key", stmt.getMetaData().getColumn(1).getName());
+        Assert.assertEquals("Value", stmt.getMetaData().getColumn(2).getName());
+        Assert.assertEquals("Type", stmt.getMetaData().getColumn(3).getName());
+        Assert.assertEquals("IsMutable", stmt.getMetaData().getColumn(4).getName());
+    }
+} 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AdminShowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AdminShowTest.java
@@ -38,6 +38,12 @@ public class AdminShowTest {
     }
 
     @Test
+    public void testAdminShowBackendConfig() {
+        analyzeSuccess("admin show backend config;");
+        analyzeSuccess("admin show backend config like 'memory';");
+    }
+
+    @Test
     public void testAdminShowReplicaDistribution() {
         analyzeSuccess("ADMIN SHOW REPLICA DISTRIBUTION FROM tbl1;");
         analyzeSuccess("ADMIN SHOW REPLICA DISTRIBUTION FROM db1.tbl1 PARTITION(p1, p2);");


### PR DESCRIPTION
## Why I'm doing:
Sometimes It's hard to obtain BE configs values 
## What I'm doing:
![image](https://github.com/user-attachments/assets/4ac89931-7db8-439e-8c84-b94ae271e1d0)
![image](https://github.com/user-attachments/assets/ed4662d1-b114-4510-87f5-2ea082e4581a)
![image](https://github.com/user-attachments/assets/6aa85115-1133-4e53-bb5a-c2b2031f74d7)
![image](https://github.com/user-attachments/assets/2280bf6e-419e-4d57-bf58-028841863ac5)

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1