### PR TITLE
[BugFix] Avoid to reactive the mv if it's inactived by specific reasons

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -3523,6 +3523,12 @@ public class OlapTable extends Table {
         if (!Strings.isNullOrEmpty(timeDriftConstraintSpec)) {
             properties.put(PropertyAnalyzer.PROPERTIES_TIME_DRIFT_CONSTRAINT, timeDriftConstraintSpec);
         }
+
+        // partition_retention_condition
+        String partitionRetentionCondition = tableProperties.get(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_CONDITION);
+        if (!Strings.isNullOrEmpty(partitionRetentionCondition)) {
+            properties.put(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_CONDITION, partitionRetentionCondition);
+        }
         return properties;
     }
 
@@ -3596,12 +3602,6 @@ public class OlapTable extends Table {
         String flatJsonColumnMax = tableProperties.get(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX);
         if (!Strings.isNullOrEmpty(flatJsonColumnMax)) {
             properties.put(PropertyAnalyzer.PROPERTIES_FLAT_JSON_COLUMN_MAX, flatJsonColumnMax);
-        }
-
-        // partition_retention_condition
-        String partitionRetentionCondition = tableProperties.get(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_CONDITION);
-        if (!Strings.isNullOrEmpty(partitionRetentionCondition)) {
-            properties.put(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_CONDITION, partitionRetentionCondition);
         }
 
         return properties;

--- a/fe/fe-core/src/main/java/com/starrocks/common/MaterializedViewExceptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/MaterializedViewExceptions.java
@@ -25,6 +25,9 @@ import java.util.Set;
  */
 public class MaterializedViewExceptions {
 
+    // reason for base table optimized, base table's partition is optimized which mv cannot be actived again.
+    public static final String INACTIVE_REASON_FOR_BASE_TABLE_OPTIMIZED = "base-table optimized:";
+
     /**
      * Create the inactive reason when base table not exists
      */
@@ -45,7 +48,7 @@ public class MaterializedViewExceptions {
     }
 
     public static String inactiveReasonForBaseTableOptimized(String tableName) {
-        return "base-table optimized: " + tableName;
+        return INACTIVE_REASON_FOR_BASE_TABLE_OPTIMIZED + tableName;
     }
 
     public static String inactiveReasonForBaseTableActive(String tableName) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
@@ -42,6 +42,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.starrocks.common.MaterializedViewExceptions.INACTIVE_REASON_FOR_BASE_TABLE_OPTIMIZED;
+
 /**
  * A daemon thread that check the MV active status, try to activate the MV it's inactive.
  */
@@ -59,7 +61,10 @@ public class MVActiveChecker extends FrontendDaemon {
 
     // there are some reasons that we don't active mv automatically, eg: mv backup/restore which may cause to refresh all
     // mv's data behind which is not expected.
-    private static final Set<String> MV_NO_AUTOMATIC_ACTIVE_REASONS = ImmutableSet.of(MV_BACKUP_INACTIVE_REASON);
+    private static final Set<String> MV_NO_AUTOMATIC_ACTIVE_REASONS = ImmutableSet.of(
+            MV_BACKUP_INACTIVE_REASON,
+            INACTIVE_REASON_FOR_BASE_TABLE_OPTIMIZED
+    );
 
     @Override
     protected void runAfterCatalogReady() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
@@ -128,7 +128,7 @@ public class MVActiveChecker extends FrontendDaemon {
         if (mv.isActive() || AlterJobMgr.MANUAL_INACTIVE_MV_REASON.equalsIgnoreCase(reason)) {
             return;
         }
-        if (MV_NO_AUTOMATIC_ACTIVE_REASONS.stream().anyMatch(x -> x.contains(reason))) {
+        if (MV_NO_AUTOMATIC_ACTIVE_REASONS.stream().anyMatch(x -> reason.contains(x))) {
             return;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
@@ -43,6 +43,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -450,5 +451,60 @@ public class CreateLakeTableTest {
                 (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         ShowResultSet resultSet = ShowExecutor.execute(showCreateTableStmt, connectContext);
         Assert.assertFalse(resultSet.getResultRows().isEmpty());
+    }
+
+    @Test
+    public void testRangeTableWithRetentionCondition2() throws Exception {
+        ExceptionChecker.expectThrowsNoException(() -> createTable("CREATE TABLE lake_test.r1 \n" +
+                "(\n" +
+                "    dt date,\n" +
+                "    k2 int,\n" +
+                "    v1 int \n" +
+                ")\n" +
+                "PARTITION BY RANGE(dt)\n" +
+                "(\n" +
+                "    PARTITION p0 values [('2024-01-29'),('2024-01-30')),\n" +
+                "    PARTITION p1 values [('2024-01-30'),('2024-01-31')),\n" +
+                "    PARTITION p2 values [('2024-01-31'),('2024-02-01')),\n" +
+                "    PARTITION p3 values [('2024-02-01'),('2024-02-02')) \n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "'replication_num' = '1',\n" +
+                "'partition_retention_condition' = 'dt > current_date() - interval 1 month'\n" +
+                ")"));
+        LakeTable r1 = getLakeTable("lake_test", "r1");
+        String retentionCondition = r1.getTableProperty().getPartitionRetentionCondition();
+        Assert.assertEquals("dt > current_date() - interval 1 month", retentionCondition);
+
+        String sql = "show create table lake_test.r1";
+        ShowCreateTableStmt showCreateTableStmt =
+                (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        ShowResultSet resultSet = ShowExecutor.execute(showCreateTableStmt, connectContext);
+        List<List<String>> result = resultSet.getResultRows();
+        Assert.assertTrue(result.size() == 1);
+        Assert.assertTrue(result.get(0).size() == 2);
+        final String expect = "CREATE TABLE `r1` (\n" +
+                "  `dt` date NULL COMMENT \"\",\n" +
+                "  `k2` int(11) NULL COMMENT \"\",\n" +
+                "  `v1` int(11) NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP \n" +
+                "DUPLICATE KEY(`dt`, `k2`, `v1`)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "PARTITION BY RANGE(`dt`)\n" +
+                "(PARTITION p0 VALUES [(\"2024-01-29\"), (\"2024-01-30\")),\n" +
+                "PARTITION p1 VALUES [(\"2024-01-30\"), (\"2024-01-31\")),\n" +
+                "PARTITION p2 VALUES [(\"2024-01-31\"), (\"2024-02-01\")),\n" +
+                "PARTITION p3 VALUES [(\"2024-02-01\"), (\"2024-02-02\")))\n" +
+                "DISTRIBUTED BY HASH(`k2`) BUCKETS 3 \n" +
+                "PROPERTIES (\n" +
+                "\"compression\" = \"LZ4\",\n" +
+                "\"datacache.enable\" = \"true\",\n" +
+                "\"enable_async_write_back\" = \"false\",\n" +
+                "\"partition_retention_condition\" = \"dt > current_date() - interval 1 month\",\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"storage_volume\" = \"builtin_storage_volume\"\n" +
+                ");";
+        Assert.assertTrue(result.get(0).get(1).equals(expect));
     }
 }

--- a/test/sql/test_materialized_view/R/test_mv_with_multi_partition_columns_optimize
+++ b/test/sql/test_materialized_view/R/test_mv_with_multi_partition_columns_optimize
@@ -48,7 +48,7 @@ select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;
 INSERT INTO t1 VALUES (1,'2020-06-02','BJ'),(3,'2020-06-02','SZ'),(2,'2020-07-02','SH');
 -- result:
 -- !result
-REFRESH MATERIALIZED VIEW mv1 with sync mode;
+[UC]REFRESH MATERIALIZED VIEW mv1 with sync mode;
 function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv1")
 -- result:
 False

--- a/test/sql/test_materialized_view/R/test_mv_with_multi_partition_columns_optimize
+++ b/test/sql/test_materialized_view/R/test_mv_with_multi_partition_columns_optimize
@@ -45,3 +45,17 @@ select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;
 2020-06-02	SZ	3
 2020-07-02	SH	2
 -- !result
+INSERT INTO t1 VALUES (1,'2020-06-02','BJ'),(3,'2020-06-02','SZ'),(2,'2020-07-02','SH');
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv1 with sync mode;
+function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv1")
+-- result:
+False
+-- !result
+select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;
+-- result:
+2020-06-02	BJ	2
+2020-06-02	SZ	6
+2020-07-02	SH	4
+-- !result

--- a/test/sql/test_materialized_view/T/test_mv_with_multi_partition_columns_optimize
+++ b/test/sql/test_materialized_view/T/test_mv_with_multi_partition_columns_optimize
@@ -24,3 +24,9 @@ function: wait_alter_table_finish()
 
 function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv1")
 select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;
+
+-- refresh should not re-active the materialized view
+INSERT INTO t1 VALUES (1,'2020-06-02','BJ'),(3,'2020-06-02','SZ'),(2,'2020-07-02','SH');
+REFRESH MATERIALIZED VIEW mv1 with sync mode;
+function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv1")
+select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;

--- a/test/sql/test_materialized_view/T/test_mv_with_multi_partition_columns_optimize
+++ b/test/sql/test_materialized_view/T/test_mv_with_multi_partition_columns_optimize
@@ -27,6 +27,7 @@ select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;
 
 -- refresh should not re-active the materialized view
 INSERT INTO t1 VALUES (1,'2020-06-02','BJ'),(3,'2020-06-02','SZ'),(2,'2020-07-02','SH');
-REFRESH MATERIALIZED VIEW mv1 with sync mode;
+[UC]REFRESH MATERIALIZED VIEW mv1 with sync mode;
+
 function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv1")
 select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;


### PR DESCRIPTION
## Why I'm doing:
1. if base table's partition is optimized, the related mv should not  be actived again since refbasetable-mv's mapping is changed.
2. `partition_retention_condition` is missed in `show create table` of cloud env.

## What I'm doing:
1. Disable re-active the mv if base table's partition is optimized which mv cannot be actived again since refbasetable-mv's mapping is changed.
3. Fix `show create table` with `partition_retention_condition` bug in cloud env.

Fixes:
- https://starrocks.atlassian.net/browse/SR-34160
- https://starrocks.atlassian.net/browse/SR-34039

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
