### PR TITLE
[BugFix] Avoid polluting task run properties in multi task runs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -105,6 +105,7 @@ import java.util.stream.Collectors;
 
 import static com.starrocks.catalog.system.SystemTable.MAX_FIELD_VARCHAR_LENGTH;
 import static com.starrocks.scheduler.TaskRun.MV_ID;
+import static com.starrocks.scheduler.TaskRun.MV_UNCOPYABLE_PROPERTIES;
 
 /**
  * Core logic of mv refresh task run
@@ -671,9 +672,12 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         String taskName = TaskBuilder.getMvTaskName(mvId);
         Map<String, String> newProperties = Maps.newHashMap();
         for (Map.Entry<String, String> proEntry : properties.entrySet()) {
-            if (proEntry.getValue() != null) {
-                newProperties.put(proEntry.getKey(), proEntry.getValue());
+            // skip uncopyable properties: force/partition_values/... which only can be set specifically.
+            if (proEntry.getKey() == null || proEntry.getValue() == null
+                    || MV_UNCOPYABLE_PROPERTIES.contains(proEntry.getKey())) {
+                continue;
             }
+            newProperties.put(proEntry.getKey(), proEntry.getValue());
         }
         PartitionInfo partitionInfo = mv.getPartitionInfo();
         if (partitionInfo.isListPartition()) {
@@ -703,8 +707,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 mvContext.executeOption.getPriority() : Constants.TaskRunPriority.HIGHER.value();
         ExecuteOption option = new ExecuteOption(priority, true, newProperties);
         logger.info("[MV] Generate a task to refresh next batches of partitions for MV {}-{}, start={}, end={}, " +
-                        "priority={}", mv.getName(), mv.getId(),
-                mvContext.getNextPartitionStart(), mvContext.getNextPartitionEnd(), priority);
+                        "priority={}, properties={}", mv.getName(), mv.getId(),
+                mvContext.getNextPartitionStart(), mvContext.getNextPartitionEnd(), priority, properties);
 
         if (properties.containsKey(TaskRun.IS_TEST) && properties.get(TaskRun.IS_TEST).equalsIgnoreCase("true")) {
             // for testing

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -56,6 +56,8 @@ public class TaskRun implements Comparable<TaskRun> {
 
     private static final Logger LOG = LogManager.getLogger(TaskRun.class);
 
+    // NOTE: ALL task run properties should be defined here, and the associated properties configuration below should be
+    // added carefully.
     public static final String MV_ID = "mvId";
     public static final String PARTITION_START = "PARTITION_START";
     public static final String PARTITION_END = "PARTITION_END";
@@ -63,14 +65,32 @@ public class TaskRun implements Comparable<TaskRun> {
     public static final String PARTITION_VALUES = "PARTITION_VALUES";
     public static final String FORCE = "FORCE";
     public static final String START_TASK_RUN_ID = "START_TASK_RUN_ID";
-    // All properties that can be set in TaskRun
-    public static final Set<String> TASK_RUN_PROPERTIES = ImmutableSet.of(
-            MV_ID, PARTITION_START, PARTITION_END, FORCE, START_TASK_RUN_ID, PARTITION_VALUES, PROPERTIES_WAREHOUSE);
+    // Only used in FE's UT
+    public static final String IS_TEST = "__IS_TEST__";
+
+    // TODO: Refactor this for better extensibility later by using a class rather than a map.
+    // MV's task run can be generated from the last task run, those properties are not allowed to be copied from one task run
+    // to another and must be only set specifically for each run but cannot be extended from the last task run.
+    // eg: `FORCE` is only allowed to set in the first task run and cannot be copied into the following task run.
+    public static final Set<String> MV_UNCOPYABLE_PROPERTIES = ImmutableSet.of(
+            PARTITION_START, PARTITION_END, PARTITION_VALUES, FORCE);
+    // If there are many pending mv task runs, we can merge some of them by comparing the properties, those properties that are
+    // used to check equality of task runs and we can ignore the other properties.
+    // eg:
+    // - `FORCE` is used to check equality of task runs because the refresh partitions are different for each task run.
+    // - `PROPERTIES_WAREHOUSE`/`START_TASK_RUN_ID` is no need to check equality of task runs because they will not affect
+    //  the task run's result.
+    public static final Set<String> MV_COMPARABLE_PROPERTIES = ImmutableSet.of(
+            MV_ID, PARTITION_START, PARTITION_END, PARTITION_VALUES, FORCE);
+    // Properties that can be set in TaskRun which are used to distinguish other noisy properties from users' defined properties.
+    // and will ignore other properties in the task run history.
+    // This should be only used in the task run history table and should not used for checking task run's real properties
+    // because this is not a complete list of task run properties.
+    public static final Set<String> RESERVED_HISTORY_TASK_RUN_PROPERTIES = ImmutableSet.of(
+            MV_ID, PARTITION_START, PARTITION_END, FORCE, START_TASK_RUN_ID, PARTITION_VALUES, PROPERTIES_WAREHOUSE, IS_TEST);
 
     public static final int INVALID_TASK_PROGRESS = -1;
 
-    // Only used in FE's UT
-    public static final String IS_TEST = "__IS_TEST__";
     private boolean isKilled = false;
 
     @SerializedName("taskId")

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -141,7 +141,6 @@ public class TaskRunManager implements MemoryTrackable {
             // If the task run is sync-mode, it will hang forever if the task run is merged because
             // user's using `future.get()` to wait and the future will not be set forever.
             ExecuteOption executeOption = taskRun.getExecuteOption();
-            boolean isTaskRunContainsToMergeProperties = executeOption.containsToMergeProperties();
             if (taskRuns != null && executeOption.isMergeRedundant()) {
                 for (TaskRun oldTaskRun : taskRuns) {
                     if (oldTaskRun == null) {
@@ -168,16 +167,11 @@ public class TaskRunManager implements MemoryTrackable {
                     // TODO: Here we always merge the older task run to the newer task run which it can
                     // record the history of the task run. But we can also reject the newer task run directly to
                     // avoid the merge operation later.
-                    boolean isOldTaskRunContainsToMergeProperties = oldExecuteOption.containsToMergeProperties();
-                    // this should not happen since one task only can one task run in the running queue
-                    if (isTaskRunContainsToMergeProperties && isOldTaskRunContainsToMergeProperties) {
-                        LOG.warn("failed to merge TaskRun, both TaskRun contains toMergeProperties, " +
-                                        "oldTaskRun: {}, taskRun: {}", oldTaskRun, taskRun);
-                        continue;
-                    }
                     // merge the old execution option into the new task run
-                    if (isOldTaskRunContainsToMergeProperties && !isTaskRunContainsToMergeProperties) {
-                        executeOption.mergeProperties(oldExecuteOption);
+                    if (!executeOption.isMergeableWith(oldExecuteOption)) {
+                        LOG.warn("failed to merge TaskRun, both TaskRun contains toMergeProperties, " +
+                                "oldTaskRun: {}, taskRun: {}", oldTaskRun, taskRun);
+                        continue;
                     }
 
                     // prefer higher priority to be better scheduler

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
@@ -184,7 +184,7 @@ public class TaskRunHistoryTable {
         }
         Iterator<Map.Entry<String, String>> iterator = properties.entrySet().iterator();
         while (iterator.hasNext()) {
-            if (!TaskRun.TASK_RUN_PROPERTIES.contains(iterator.next().getKey())) {
+            if (!TaskRun.RESERVED_HISTORY_TASK_RUN_PROPERTIES.contains(iterator.next().getKey())) {
                 iterator.remove();
             }
         }


### PR DESCRIPTION
## Why I'm doing:
it's weird to find that TaskRun's properties can be polluted sometimes.

```
2025-05-15 16:48:43.837-04:00 INFO (starrocks-taskrun-pool-1839|26764776) [TaskRunManager.submitTaskRun():56] submit task run:TaskRun{taskId=982129, type=PERIODICAL, uuid=fd6dbef0-31cd-11f0-a9ef-0affeef69e79, task_state=, properties={PARTITION_START=2025-03-18, query_mem_limit32212254720, FORCE=true, query_timeout=240000, mvId=982127, replication_num=1, enable_spill=false, PARTITION_END=2025-04-16, in_memory=false, warehouse_id=0, START_TASK_RUN_ID=94925bde-1b18-11f0-a9ef-0affeef69e79}, extra_message =}
```

For MV's task, `force` property should be only set in the command  and should not be for many task runs :
```
refresh materialized view xxx force;
```
which means `force` property maybe polluted by some codes.



In `Task`'s properties,  
- I found there's no way to change it since we always use `copy` rather changing it directly.

In `TaskRun`'s properties, There are some codes that are not safe:
1. `generateNextTaskRun` will always copy previous `force` properties:  If the base table's partitions always changed, it may always refresh(force property will refresh all the partitions)
```
    private void generateNextTaskRun() {
        TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
        Map<String, String> properties = mvContext.getProperties();
        long mvId = Long.parseLong(properties.get(MV_ID));
        String taskName = TaskBuilder.getMvTaskName(mvId);
        Map<String, String> newProperties = Maps.newHashMap();
        for (Map.Entry<String, String> proEntry : properties.entrySet()) {
            if (proEntry.getValue() != null) {
                newProperties.put(proEntry.getKey(), proEntry.getValue());
            }
        }

}
```

2. Where there are many pending task runs to merge, it's not safe to copy properties directly. 

```
    public void mergeProperties(ExecuteOption option) {
        if (option.taskRunProperties != null) {
            if (taskRunProperties == null) {
                taskRunProperties = Maps.newHashMap();
            }
            taskRunProperties.putAll(option.taskRunProperties);
        }
    }
```
## What I'm doing:
To avoid this:
1. When mv generates the next task run, skip to copy some uncopyable properties.
2. When merge pending task runs, skip to merge task runs if theirs properties are not the same.

Fixes 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
