### PR TITLE
[BugFix] Fix miss update job state when replaying restore log may cause restored table lost after FE restart

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -812,10 +812,6 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
             // for example: In restore job, PENDING will transfer to SNAPSHOTING, not DOWNLOAD.
             job.replayRun();
         }
-        if (isJobExpired(job, System.currentTimeMillis())) {
-            LOG.warn("skip expired job {}", job);
-            return;
-        }
         dbIdToBackupOrRestoreJob.put(job.getDbId(), job);
         mvRestoreContext.addIntoMvBaseTableBackupInfo(job);
     }


### PR DESCRIPTION
## Why I'm doing:
If we set history_job_keep_max_second < checkpoint time interval (no matter by background daemon
or manlly create image). When we replay the log for the restore job, the final FINISHED state log
will be skipped to update the state job state in BackupHandler because this job is considered
as a expired job controlled by history_job_keep_max_second.

But the point here is that, Only FINISHED state is skipped to update but not other state log, the BackupHandler
will persistent the unfinished state for this job even the job is actually finished now.

When we restart FE in this case, we will get a unfinished restore job in FE and if the restart time is far away
from the restore job start time, the job will be cancelled uncorrectly(because FE treat it as a unfinished job)
and remove all table restored successfully before FE restart.

## What I'm doing:
Skip to check expire or not in replay.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
