### PR TITLE
[Enhancement] Support using native sdk to access azure blob storage in files() table function

### DIFF
--- a/be/src/fs/fs.cpp
+++ b/be/src/fs/fs.cpp
@@ -16,6 +16,7 @@
 
 #include <fmt/format.h>
 
+#include "fs/azure/fs_azblob.h"
 #include "fs/encrypt_file.h"
 #include "fs/fs_posix.h"
 #include "fs/fs_s3.h"
@@ -105,6 +106,9 @@ StatusOr<std::unique_ptr<FileSystem>> FileSystem::CreateUniqueFromString(std::st
     if (fs::is_s3_uri(uri)) {
         return new_fs_s3(options);
     }
+    if (options.azure_use_native_sdk() && fs::is_azblob_uri(uri)) {
+        return new_fs_azblob(options);
+    }
     if (fs::is_azure_uri(uri) || fs::is_gcs_uri(uri)) {
         // TODO(SmithCruise):
         // Now Azure storage and Google Cloud Storage both are using LibHdfs, we can use cpp sdk instead in the future.
@@ -166,6 +170,15 @@ const TCloudConfiguration* FSOptions::get_cloud_configuration() const {
     }
 
     return nullptr;
+}
+
+bool FSOptions::azure_use_native_sdk() const {
+    const auto* t_cloud_configuration = get_cloud_configuration();
+    if (t_cloud_configuration == nullptr) {
+        return false;
+    }
+
+    return t_cloud_configuration->__isset.azure_use_native_sdk && t_cloud_configuration->azure_use_native_sdk;
 }
 
 static std::deque<FileWriteStat> file_write_history;

--- a/be/src/fs/fs.h
+++ b/be/src/fs/fs.h
@@ -81,6 +81,7 @@ public:
 
     const THdfsProperties* hdfs_properties() const;
     const TCloudConfiguration* get_cloud_configuration() const;
+    bool azure_use_native_sdk() const;
 
     const TBrokerScanRangeParams* scan_range_params;
     const TExportSink* export_sink;

--- a/be/src/fs/fs_util.h
+++ b/be/src/fs/fs_util.h
@@ -214,6 +214,10 @@ inline bool is_s3_uri(std::string_view uri) {
     return is_in_list(uri, config::s3_compatible_fs_list);
 }
 
+inline bool is_azblob_uri(std::string_view uri) {
+    return starts_with(uri, "wasb://") || starts_with(uri, "wasbs://");
+}
+
 inline bool is_azure_uri(std::string_view uri) {
     return starts_with(uri, "wasb://") || starts_with(uri, "wasbs://") || starts_with(uri, "adl://") ||
            starts_with(uri, "abfs://") || starts_with(uri, "abfss://");

--- a/be/test/fs/fs_test.cpp
+++ b/be/test/fs/fs_test.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include "testutil/assert.h"
+
 namespace starrocks {
 
 TEST(FileSystemTest, test_good_construction) {
@@ -67,6 +68,23 @@ TEST(FileSystemTest, test_good_construction) {
         std::unique_ptr<FSOptions> fs_options = std::make_unique<FSOptions>(params);
         ASSIGN_OR_ABORT(auto fs, FileSystem::Create("unknown2://", *fs_options));
         ASSERT_EQ(fs->type(), FileSystem::S3);
+    }
+
+    {
+        std::string uri = "wasbs://container_name@account_name.blob.core.windows.net/blob_name";
+
+        TCloudConfiguration cloud_configuration;
+        cloud_configuration.__set_cloud_type(TCloudType::AZURE);
+        cloud_configuration.__set_cloud_properties({});
+        cloud_configuration.__set_azure_use_native_sdk(true);
+        THdfsProperties hdfs_properties;
+        hdfs_properties.__set_cloud_configuration(cloud_configuration);
+        TBrokerScanRangeParams scan_range_params;
+        scan_range_params.__set_hdfs_properties(hdfs_properties);
+        FSOptions options(&scan_range_params);
+
+        ASSIGN_OR_ABORT(auto fs, FileSystem::CreateUniqueFromString(uri, options));
+        ASSERT_EQ(fs->type(), FileSystem::AZBLOB);
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -19,7 +19,6 @@ import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import com.starrocks.analysis.BrokerDesc;
 import com.starrocks.analysis.Delimiter;
 import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.common.CsvFormat;
@@ -29,7 +28,7 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.CompressionUtils;
 import com.starrocks.common.util.ParseUtil;
-import com.starrocks.fs.HdfsUtil;
+import com.starrocks.fs.FileSystem;
 import com.starrocks.load.Load;
 import com.starrocks.proto.PGetFileSchemaResult;
 import com.starrocks.proto.PSlotDescriptor;
@@ -323,7 +322,8 @@ public class TableFunctionTable extends Table {
         }
 
         List<FileStatus> files = Lists.newArrayList();
-        for (FileStatus fStatus : HdfsUtil.listFileMeta(uri.normalize().toString(), new BrokerDesc(properties), false)) {
+        String normalizedPath = uri.normalize().toString();
+        for (FileStatus fStatus : FileSystem.getFileSystem(normalizedPath, properties).globList(normalizedPath, false)) {
             files.add(fStatus);
             if (listRecursively && fStatus.isDirectory()) {
                 files.addAll(listFilesAndDirs(fStatus.getPath().toString() + "/*", true, properties));
@@ -541,7 +541,15 @@ public class TableFunctionTable extends Table {
             }
             List<String> pieces = Splitter.on(",").trimResults().omitEmptyStrings().splitToList(path);
             for (String piece : ListUtils.emptyIfNull(pieces)) {
-                HdfsUtil.parseFile(piece, new BrokerDesc(properties), fileStatuses);
+                List<FileStatus> fileStatusList = FileSystem.getFileSystem(piece, properties).globList(piece, true);
+                for (FileStatus fileStatus : fileStatusList) {
+                    TBrokerFileStatus brokerFileStatus = new TBrokerFileStatus();
+                    brokerFileStatus.setPath(fileStatus.getPath().toString());
+                    brokerFileStatus.setIsDir(fileStatus.isDirectory());
+                    brokerFileStatus.setSize(fileStatus.getLen());
+                    brokerFileStatus.setIsSplitable(true);
+                    fileStatuses.add(brokerFileStatus);
+                }
             }
         } catch (StarRocksException e) {
             LOG.error("parse files error", e);
@@ -578,8 +586,8 @@ public class TableFunctionTable extends Table {
         }
 
         try {
-            THdfsProperties hdfsProperties = new THdfsProperties();
-            HdfsUtil.getTProperties(filelist.get(0).path, new BrokerDesc(properties), hdfsProperties);
+            String path = filelist.get(0).path;
+            THdfsProperties hdfsProperties = FileSystem.getFileSystem(path, properties).getHdfsProperties(path);
             params.setHdfs_properties(hdfsProperties);
         } catch (StarRocksException e) {
             throw new TException("failed to parse files: " + e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2746,6 +2746,14 @@ public class Config extends ConfigBase {
     // * END: of Cloud native meta server related configurations
     // ***********************************************************
 
+    /**
+     * Whether to use Azure Native SDK (FE java and BE c++) to access Azure Storage.
+     * Default is true. If set to false, use Hadoop Azure.
+     * Currently only supported for Azure Blob Storage in files() table function.
+     */
+    @ConfField(mutable = true)
+    public static boolean azure_use_native_sdk = true;
+
     @ConfField(mutable = true)
     public static boolean enable_experimental_rowstore = false;
 

--- a/fe/fe-core/src/main/java/com/starrocks/fs/azure/AzBlobFileSystem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/azure/AzBlobFileSystem.java
@@ -34,6 +34,7 @@ import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.azure.AzureCloudConfigurationProvider;
 import com.starrocks.fs.FileSystem;
 import com.starrocks.thrift.TCloudConfiguration;
+import com.starrocks.thrift.THdfsProperties;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.GlobFilter;
 import org.apache.hadoop.fs.Path;
@@ -205,7 +206,7 @@ public class AzBlobFileSystem implements FileSystem {
     }
 
     @Override
-    public TCloudConfiguration getCloudConfiguration(String path) throws StarRocksException {
+    public THdfsProperties getHdfsProperties(String path) throws StarRocksException {
         Map<String, String> copied = Maps.newHashMap(properties);
 
         // Put path into properties, so that we can get storage account and container from path
@@ -222,7 +223,12 @@ public class AzBlobFileSystem implements FileSystem {
         TCloudConfiguration tCloudConfiguration = new TCloudConfiguration();
         cloudConfiguration.toThrift(tCloudConfiguration);
 
-        return tCloudConfiguration;
+        // Set use azure native sdk as true
+        tCloudConfiguration.setAzure_use_native_sdk(true);
+
+        THdfsProperties hdfsProperties = new THdfsProperties();
+        hdfsProperties.setCloud_configuration(tCloudConfiguration);
+        return hdfsProperties;
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFileSystemWrap.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFileSystemWrap.java
@@ -18,7 +18,6 @@ import com.starrocks.analysis.BrokerDesc;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.fs.FileSystem;
 import com.starrocks.fs.HdfsUtil;
-import com.starrocks.thrift.TCloudConfiguration;
 import com.starrocks.thrift.THdfsProperties;
 import org.apache.hadoop.fs.FileStatus;
 
@@ -38,9 +37,9 @@ public class HdfsFileSystemWrap implements FileSystem {
     }
 
     @Override
-    public TCloudConfiguration getCloudConfiguration(String path) throws StarRocksException {
+    public THdfsProperties getHdfsProperties(String path) throws StarRocksException {
         THdfsProperties hdfsProperties = new THdfsProperties();
         HdfsUtil.getTProperties(path, new BrokerDesc(properties), hdfsProperties);
-        return hdfsProperties.getCloud_configuration();
+        return hdfsProperties;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/TableFunctionTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/TableFunctionTableSink.java
@@ -15,6 +15,7 @@
 package com.starrocks.planner;
 
 import com.starrocks.catalog.TableFunctionTable;
+import com.starrocks.common.Config;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationFactory;
 import com.starrocks.thrift.TCloudConfiguration;
@@ -50,6 +51,8 @@ public class TableFunctionTableSink extends DataSink {
         tTableFunctionTableSink.setTarget_table(table.toTTableFunctionTable());
         TCloudConfiguration tCloudConfiguration = new TCloudConfiguration();
         cloudConfiguration.toThrift(tCloudConfiguration);
+        // Set use azure native sdk
+        tCloudConfiguration.setAzure_use_native_sdk(Config.azure_use_native_sdk);
         tTableFunctionTableSink.setCloud_configuration(tCloudConfiguration);
         TDataSink tDataSink = new TDataSink(TDataSinkType.TABLE_FUNCTION_TABLE_SINK);
         tDataSink.setTable_function_table_sink(tTableFunctionTableSink);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.collect.Lists;
 import com.starrocks.analysis.BrokerDesc;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker;
@@ -30,11 +31,11 @@ import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
-import com.starrocks.thrift.TBrokerFileStatus;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
+import org.apache.hadoop.fs.FileStatus;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
@@ -45,6 +46,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 public class TableFunctionTableTest {
 
     Map<String, String> newProperties() {
@@ -194,8 +196,8 @@ public class TableFunctionTableTest {
     public void testNoFilesFound() throws DdlException {
         new MockUp<HdfsUtil>() {
             @Mock
-            public void parseFile(String path, BrokerDesc brokerDesc, List<TBrokerFileStatus> fileStatuses) throws
-                    StarRocksException {
+            public List<FileStatus> listFileMeta(String path, BrokerDesc brokerDesc, boolean skipDir) throws StarRocksException {
+                return Lists.newArrayList();
             }
         };
 
@@ -242,8 +244,8 @@ public class TableFunctionTableTest {
     public void testIllegalCSVTrimSpace() throws DdlException {
         new MockUp<HdfsUtil>() {
             @Mock
-            public void parseFile(String path, BrokerDesc brokerDesc, List<TBrokerFileStatus> fileStatuses) throws
-                    StarRocksException {
+            public List<FileStatus> listFileMeta(String path, BrokerDesc brokerDesc, boolean skipDir) throws StarRocksException {
+                return Lists.newArrayList();
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/fs/azure/AzBlobFileSystemTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/fs/azure/AzBlobFileSystemTest.java
@@ -26,6 +26,7 @@ import com.starrocks.common.StarRocksException;
 import com.starrocks.connector.share.credential.CloudConfigurationConstants;
 import com.starrocks.thrift.TCloudConfiguration;
 import com.starrocks.thrift.TCloudType;
+import com.starrocks.thrift.THdfsProperties;
 import org.apache.hadoop.fs.FileStatus;
 import org.junit.Assert;
 import org.junit.Before;
@@ -188,8 +189,10 @@ public class AzBlobFileSystemTest {
         String path = "wasbs://container_name@account_name.blob.core.windows.net/blob_name";
 
         // Check TCloudConfiguration
-        TCloudConfiguration cc = fs.getCloudConfiguration(path);
+        THdfsProperties hdfsProperties = fs.getHdfsProperties(path);
+        TCloudConfiguration cc = hdfsProperties.getCloud_configuration();
         Assert.assertEquals(TCloudType.AZURE, cc.getCloud_type());
+        Assert.assertTrue(cc.isAzure_use_native_sdk());
         Map<String, String> cloudProperties = cc.getCloud_properties();
         Assert.assertEquals("client_id_xxx", cloudProperties.get(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_ID));
     }

--- a/gensrc/thrift/CloudConfiguration.thrift
+++ b/gensrc/thrift/CloudConfiguration.thrift
@@ -34,4 +34,5 @@ struct TCloudConfiguration {
     1: optional TCloudType cloud_type;
     2: optional list<TCloudProperty> deprecated_cloud_properties; // Deprecated
     3: optional map<string, string> cloud_properties;
+    4: optional bool azure_use_native_sdk;
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:


1. Support for using the Azure native SDK for accessing Azure Blob Storage in both the backend (BE) and frontend (FE) components of the system in files() table function.
```
SELECT * FROM FILES(
    "path" = "wasbs://container@account.blob.core.windows.net/path/*",
    "format" = "parquet",
    "azure.blob.oauth2_client_id" = "xxx"
)

INSERT INTO FILES(
    "path" = "wasbs://container@account.blob.core.windows.net/path/",
    "format" = "parquet",
    "azure.blob.oauth2_client_id" = "xxx"
) SELECT * FROM SR;
```

2. Add a new configuration property `azure_use_native_sdk` (default: true) to toggle the use of the Azure native SDK.
3. `Azure Data Lake Storage Gen2 and Gen1` still use Hadoop Azure.

Fixes #59017

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
