### PR TITLE
[Refactor] Modify the semantics of the configuration block_cache_enable.

### DIFF
--- a/be/src/bench/object_cache_bench.cpp
+++ b/be/src/bench/object_cache_bench.cpp
@@ -72,6 +72,7 @@ private:
     size_t _page_size = 1024;
 
     std::shared_ptr<StarCacheWrapper> _local_cache;
+    std::shared_ptr<ShardedLRUCache> _shared_lru_cache;
     std::shared_ptr<LRUCacheModule> _lru_cache;
     std::shared_ptr<StarCacheModule> _star_cache;
 };
@@ -112,8 +113,8 @@ ObjectCache* ObjectCacheBench::get_object_cache(CacheType type) {
 
 void ObjectCacheBench::init_cache(CacheType cache_type) {
     if (cache_type == CacheType::LRU) {
-        ObjectCacheOptions opt{.capacity = _capacity};
-        _lru_cache = std::make_shared<LRUCacheModule>(opt);
+        _shared_lru_cache = std::make_shared<ShardedLRUCache>(_capacity);
+        _lru_cache = std::make_shared<LRUCacheModule>(_shared_lru_cache);
         LOG(ERROR) << "init lru cache success";
     } else {
         CacheOptions opt;

--- a/be/src/cache/block_cache/block_cache.h
+++ b/be/src/cache/block_cache/block_cache.h
@@ -16,7 +16,6 @@
 
 #include <atomic>
 
-#include "cache/disk_space_monitor.h"
 #include "cache/local_cache.h"
 #include "cache/remote_cache.h"
 #include "common/status.h"

--- a/be/src/cache/datacache.cpp
+++ b/be/src/cache/datacache.cpp
@@ -42,6 +42,15 @@ Status DataCache::init(const std::vector<StorePath>& store_paths) {
     _global_env = GlobalEnv::GetInstance();
     _store_paths = store_paths;
 
+#if defined(WITH_STARCACHE)
+    if (!config::datacache_enable) {
+        config::block_cache_enable = false;
+    }
+#else
+    config::datacache_enable = false;
+    config::block_cache_enable = false;
+#endif
+
     RETURN_IF_ERROR(_init_datacache());
     RETURN_IF_ERROR(_init_starcache_based_object_cache());
     RETURN_IF_ERROR(_init_lru_base_object_cache());
@@ -78,6 +87,22 @@ void DataCache::destroy() {
     LOG(INFO) << "datacache shutdown successfully";
 }
 
+bool DataCache::adjust_capacity(int64_t delta, size_t min_capacity) {
+    if (_lru_cache != nullptr) {
+        return _lru_cache->adjust_capacity(delta, min_capacity);
+    } else {
+        return false;
+    }
+}
+
+size_t DataCache::get_mem_capacity() const {
+    if (_lru_cache != nullptr) {
+        return _lru_cache->get_capacity();
+    } else {
+        return 0;
+    }
+}
+
 Status DataCache::_init_starcache_based_object_cache() {
 #ifdef WITH_STARCACHE
     if (_local_cache != nullptr && _local_cache->is_initialized()) {
@@ -89,12 +114,11 @@ Status DataCache::_init_starcache_based_object_cache() {
 }
 
 Status DataCache::_init_lru_base_object_cache() {
-    ObjectCacheOptions options;
     ASSIGN_OR_RETURN(int64_t storage_cache_limit, get_storage_page_cache_limit());
     storage_cache_limit = check_storage_page_cache_limit(storage_cache_limit);
-    options.capacity = storage_cache_limit;
 
-    _lru_based_object_cache = std::make_shared<LRUCacheModule>(options);
+    _lru_cache = std::make_shared<ShardedLRUCache>(storage_cache_limit);
+    _lru_based_object_cache = std::make_shared<LRUCacheModule>(_lru_cache);
     LOG(INFO) << "object cache init successfully";
     return Status::OK();
 }
@@ -108,22 +132,6 @@ Status DataCache::_init_page_cache() {
 
 Status DataCache::_init_datacache() {
     _block_cache = std::make_shared<BlockCache>();
-
-    // When configured old `block_cache` configurations, use the old items for compatibility.
-    if (config::block_cache_enable) {
-        config::datacache_enable = true;
-        config::datacache_mem_size = std::to_string(config::block_cache_mem_size);
-        config::datacache_disk_size = std::to_string(config::block_cache_disk_size);
-        LOG(WARNING) << "The configuration items prefixed with `block_cache_` will be deprecated soon"
-                     << ", you'd better use the configuration items prefixed `datacache` instead!";
-    }
-
-#if !defined(WITH_STARCACHE)
-    if (config::datacache_enable) {
-        LOG(WARNING) << "No valid engines supported, skip initializing datacache module";
-        config::datacache_enable = false;
-    }
-#endif
 
     if (config::datacache_enable) {
 #if defined(WITH_STARCACHE)
@@ -140,8 +148,9 @@ Status DataCache::_init_datacache() {
         _remote_cache = std::make_shared<PeerCacheWrapper>();
         RETURN_IF_ERROR(_remote_cache->init(cache_options));
 
-        // init block cache
-        RETURN_IF_ERROR(_block_cache->init(cache_options, _local_cache, _remote_cache));
+        if (config::block_cache_enable) {
+            RETURN_IF_ERROR(_block_cache->init(cache_options, _local_cache, _remote_cache));
+        }
 
         LOG(INFO) << "datacache init successfully";
 #endif

--- a/be/src/cache/datacache.cpp
+++ b/be/src/cache/datacache.cpp
@@ -87,7 +87,7 @@ void DataCache::destroy() {
     LOG(INFO) << "datacache shutdown successfully";
 }
 
-bool DataCache::adjust_capacity(int64_t delta, size_t min_capacity) {
+bool DataCache::adjust_mem_capacity(int64_t delta, size_t min_capacity) {
     if (_lru_cache != nullptr) {
         return _lru_cache->adjust_capacity(delta, min_capacity);
     } else {

--- a/be/src/cache/datacache.h
+++ b/be/src/cache/datacache.h
@@ -29,6 +29,7 @@ class GlobalEnv;
 class DiskSpaceMonitor;
 class MemSpaceMonitor;
 class StoragePageCache;
+class Cache;
 
 class DataCache {
 public:
@@ -51,6 +52,9 @@ public:
     StatusOr<int64_t> get_storage_page_cache_limit();
     int64_t check_storage_page_cache_limit(int64_t storage_cache_limit);
 
+    bool adjust_capacity(int64_t delta, size_t min_capacity);
+    size_t get_mem_capacity() const;
+
 private:
     StatusOr<CacheOptions> _init_cache_options();
     Status _init_datacache();
@@ -61,8 +65,10 @@ private:
     GlobalEnv* _global_env;
     std::vector<StorePath> _store_paths;
 
+    // cache engine
     std::shared_ptr<LocalCache> _local_cache;
     std::shared_ptr<RemoteCache> _remote_cache;
+    std::shared_ptr<Cache> _lru_cache;
 
     std::shared_ptr<BlockCache> _block_cache;
     std::shared_ptr<ObjectCache> _starcache_based_object_cache;

--- a/be/src/cache/datacache.h
+++ b/be/src/cache/datacache.h
@@ -52,7 +52,7 @@ public:
     StatusOr<int64_t> get_storage_page_cache_limit();
     int64_t check_storage_page_cache_limit(int64_t storage_cache_limit);
 
-    bool adjust_capacity(int64_t delta, size_t min_capacity);
+    bool adjust_mem_capacity(int64_t delta, size_t min_capacity);
     size_t get_mem_capacity() const;
 
 private:

--- a/be/src/cache/mem_space_monitor.cpp
+++ b/be/src/cache/mem_space_monitor.cpp
@@ -44,11 +44,11 @@ void MemSpaceMonitor::_evict_datacache(int64_t bytes_to_dec) {
             if (UNLIKELY(_stopped)) {
                 return;
             }
-            _datacache->adjust_capacity(-GCBYTES_ONE_STEP, kcacheMinSize);
+            _datacache->adjust_mem_capacity(-GCBYTES_ONE_STEP, kcacheMinSize);
             bytes -= GCBYTES_ONE_STEP;
         }
         if (bytes > 0) {
-            _datacache->adjust_capacity(-bytes, kcacheMinSize);
+            _datacache->adjust_mem_capacity(-bytes, kcacheMinSize);
         }
     }
 }
@@ -102,7 +102,7 @@ void MemSpaceMonitor::_adjust_datacache_callback() {
         int64_t memory_high = memtracker->limit() * memory_high_level / 100;
         if (delta_urgent > 0) {
             // Memory usage exceeds memory_urgent_level, reduce size immediately.
-            _datacache->adjust_capacity(-delta_urgent, kcacheMinSize);
+            _datacache->adjust_mem_capacity(-delta_urgent, kcacheMinSize);
             size_t bytes_to_dec = dec_advisor->bytes_should_gc(MonoTime::Now(), memory_urgent - memory_high);
             _evict_datacache(static_cast<int64_t>(bytes_to_dec));
             continue;
@@ -126,7 +126,7 @@ void MemSpaceMonitor::_adjust_datacache_callback() {
             int64_t delta_cache = std::min(max_cache_size - cur_cache_size, std::abs(delta_high));
             size_t bytes_to_inc = inc_advisor->bytes_should_gc(MonoTime::Now(), delta_cache);
             if (bytes_to_inc > 0) {
-                _datacache->adjust_capacity(bytes_to_inc, kcacheMinSize);
+                _datacache->adjust_mem_capacity(bytes_to_inc, kcacheMinSize);
             }
         }
     }

--- a/be/src/cache/mem_space_monitor.cpp
+++ b/be/src/cache/mem_space_monitor.cpp
@@ -41,7 +41,7 @@ void MemSpaceMonitor::_evict_datacache(int64_t bytes_to_dec) {
         int64_t bytes = bytes_to_dec;
         while (bytes >= GCBYTES_ONE_STEP) {
             // Evicting 1GB of data takes about 1 second, check if process have been canceled.
-            if (UNLIKELY(_stoped)) {
+            if (UNLIKELY(_stopped)) {
                 return;
             }
             _datacache->adjust_capacity(-GCBYTES_ONE_STEP, kcacheMinSize);

--- a/be/src/cache/mem_space_monitor.cpp
+++ b/be/src/cache/mem_space_monitor.cpp
@@ -36,7 +36,7 @@ void MemSpaceMonitor::stop() {
     }
 }
 
-void evict_pagecache(StoragePageCache* cache, int64_t bytes_to_dec, std::atomic<bool>& stoped) {
+void evict_pagecache(DataCache* cache, int64_t bytes_to_dec, std::atomic<bool>& stoped) {
     if (bytes_to_dec > 0) {
         int64_t bytes = bytes_to_dec;
         while (bytes >= GCBYTES_ONE_STEP) {
@@ -58,7 +58,6 @@ void MemSpaceMonitor::_adjust_datacache_callback() {
     int64_t cur_interval = config::auto_adjust_pagecache_interval_seconds;
     std::unique_ptr<GCHelper> dec_advisor = std::make_unique<GCHelper>(cur_period, cur_interval, MonoTime::Now());
     std::unique_ptr<GCHelper> inc_advisor = std::make_unique<GCHelper>(cur_period, cur_interval, MonoTime::Now());
-    auto* cache = _datacache->page_cache();
     while (!_stopped.load(std::memory_order_consume)) {
         int64_t kWaitTimeout = cur_interval * 1000 * 1000;
         static const int64_t kCheckInterval = 1000 * 1000;
@@ -75,7 +74,7 @@ void MemSpaceMonitor::_adjust_datacache_callback() {
             continue;
         }
         MemTracker* memtracker = GlobalEnv::GetInstance()->process_mem_tracker();
-        if (memtracker == nullptr || !memtracker->has_limit() || cache == nullptr) {
+        if (memtracker == nullptr || !memtracker->has_limit()) {
             continue;
         }
         if (UNLIKELY(cur_period != config::pagecache_adjust_period ||
@@ -103,16 +102,16 @@ void MemSpaceMonitor::_adjust_datacache_callback() {
         int64_t memory_high = memtracker->limit() * memory_high_level / 100;
         if (delta_urgent > 0) {
             // Memory usage exceeds memory_urgent_level, reduce size immediately.
-            cache->adjust_capacity(-delta_urgent, kcacheMinSize);
+            _datacache->adjust_capacity(-delta_urgent, kcacheMinSize);
             size_t bytes_to_dec = dec_advisor->bytes_should_gc(MonoTime::Now(), memory_urgent - memory_high);
-            evict_pagecache(cache, static_cast<int64_t>(bytes_to_dec), _stopped);
+            evict_pagecache(_datacache, static_cast<int64_t>(bytes_to_dec), _stopped);
             continue;
         }
 
         int64_t delta_high = memtracker->consumption() - memory_high;
         if (delta_high > 0) {
             size_t bytes_to_dec = dec_advisor->bytes_should_gc(MonoTime::Now(), delta_high);
-            evict_pagecache(cache, static_cast<int64_t>(bytes_to_dec), _stopped);
+            evict_pagecache(_datacache, static_cast<int64_t>(bytes_to_dec), _stopped);
         } else {
             auto ret = _datacache->get_storage_page_cache_limit();
             if (!ret.ok()) {
@@ -120,14 +119,14 @@ void MemSpaceMonitor::_adjust_datacache_callback() {
                 continue;
             }
             int64_t max_cache_size = std::max(ret.value(), kcacheMinSize);
-            int64_t cur_cache_size = cache->get_capacity();
+            int64_t cur_cache_size = _datacache->get_mem_capacity();
             if (cur_cache_size >= max_cache_size) {
                 continue;
             }
             int64_t delta_cache = std::min(max_cache_size - cur_cache_size, std::abs(delta_high));
             size_t bytes_to_inc = inc_advisor->bytes_should_gc(MonoTime::Now(), delta_cache);
             if (bytes_to_inc > 0) {
-                cache->adjust_capacity(bytes_to_inc);
+                _datacache->adjust_capacity(bytes_to_inc, kcacheMinSize);
             }
         }
     }

--- a/be/src/cache/mem_space_monitor.h
+++ b/be/src/cache/mem_space_monitor.h
@@ -28,7 +28,7 @@ public:
 
 private:
     void _adjust_datacache_callback();
-    void _evict_datacache(int64_t bytes_to_dec) {
+    void _evict_datacache(int64_t bytes_to_dec);
 
     DataCache* _datacache = nullptr;
     std::thread _adjust_datacache_thread;

--- a/be/src/cache/mem_space_monitor.h
+++ b/be/src/cache/mem_space_monitor.h
@@ -28,6 +28,7 @@ public:
 
 private:
     void _adjust_datacache_callback();
+    void _evict_datacache(int64_t bytes_to_dec) {
 
     DataCache* _datacache = nullptr;
     std::thread _adjust_datacache_thread;

--- a/be/src/cache/object_cache/cache_types.h
+++ b/be/src/cache/object_cache/cache_types.h
@@ -25,10 +25,6 @@ namespace starrocks {
 
 enum class ObjectCacheModuleType { LRUCACHE, STARCACHE };
 
-struct ObjectCacheOptions {
-    size_t capacity = 0;
-};
-
 struct ObjectCacheWriteOptions {
     // The priority of the cache object, only support 0 and 1 now.
     int8_t priority = 0;

--- a/be/src/cache/object_cache/lrucache_module.cpp
+++ b/be/src/cache/object_cache/lrucache_module.cpp
@@ -21,15 +21,8 @@
 
 namespace starrocks {
 
-LRUCacheModule::LRUCacheModule(const ObjectCacheOptions& options) : _options(options) {
-    _cache.reset(new_lru_cache(_options.capacity));
+LRUCacheModule::LRUCacheModule(std::shared_ptr<Cache> cache) : _cache(std::move(cache)) {
     _initialized.store(true, std::memory_order_release);
-}
-
-LRUCacheModule::~LRUCacheModule() {
-    if (_cache) {
-        _cache->prune();
-    }
 }
 
 Status LRUCacheModule::insert(const std::string& key, void* value, size_t size, ObjectCacheDeleter deleter,

--- a/be/src/cache/object_cache/lrucache_module.h
+++ b/be/src/cache/object_cache/lrucache_module.h
@@ -24,9 +24,9 @@ class Cache;
 class LRUCacheModule final : public ObjectCache {
 public:
     LRUCacheModule() = delete;
-    LRUCacheModule(const ObjectCacheOptions& options);
+    LRUCacheModule(std::shared_ptr<Cache> cache);
 
-    virtual ~LRUCacheModule();
+    virtual ~LRUCacheModule() = default;
 
     Status insert(const std::string& key, void* value, size_t size, ObjectCacheDeleter deleter,
                   ObjectCacheHandlePtr* handle, ObjectCacheWriteOptions* options) override;
@@ -62,7 +62,6 @@ public:
 private:
     bool _check_write(size_t charge, ObjectCacheWriteOptions* options) const;
 
-    ObjectCacheOptions _options;
     std::shared_ptr<Cache> _cache;
 };
 

--- a/be/src/cache/object_cache/starcache_module.h
+++ b/be/src/cache/object_cache/starcache_module.h
@@ -59,7 +59,6 @@ public:
 private:
     bool _try_release_obj_handle(ObjectCacheHandlePtr handle);
 
-    ObjectCacheOptions _options;
     std::shared_ptr<starcache::StarCache> _cache;
 };
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1259,7 +1259,7 @@ CONF_String(datacache_engine, "");
 CONF_mInt32(report_datacache_metrics_interval_ms, "60000");
 // Whether enable automatically adjust cache space quota.
 // If true, the cache will choose an appropriate quota based on the current remaining space as the quota.
-// and the quota also will be changed dynamiclly.
+// and the quota also will be changed dynamically.
 // Once the disk space usage reach the high level, the quota will be decreased to keep the disk usage
 // around the disk safe level.
 // On the other hand, if the cache is full and the disk usage falls below the disk low level for a long time,
@@ -1281,8 +1281,8 @@ CONF_mInt64(datacache_disk_idle_seconds_for_expansion, "7200");
 // cache quota will be reset to zero to avoid overly frequent population and eviction.
 // Default: 100G
 CONF_mInt64(datacache_min_disk_quota_for_adjustment, "107374182400");
-// The maxmum inline cache item count in datacache.
-// When a cache item has a really small data size, we will try to cache it inline with its metadata
+// The maximum inline cache item count in datacache.
+// When a cache item has a tiny data size, we will try to cache it inline with its metadata
 // to optimize the io performance and reduce disk waste.
 // Set the parameter to `0` will turn off this optimization.
 CONF_Int32(datacache_inline_item_count_limit, "130172");
@@ -1293,12 +1293,14 @@ CONF_Bool(datacache_unified_instance_enable, "true");
 // * slru: segment lru eviction policies, which can better reduce cache pollution problem.
 CONF_String(datacache_eviction_policy, "slru");
 
-// The following configurations will be deprecated, and we use the `datacache` prefix instead.
-// But it is temporarily necessary to keep them for a period of time to be compatible with
-// the old configuration files.
-CONF_Bool(block_cache_enable, "false");
-CONF_Int64(block_cache_disk_size, "0");
-CONF_Int64(block_cache_mem_size, "2147483648"); // 2GB
+// The BlockCache stores the raw data blocks of external tables and shared-data internal tables.
+// It shares the same limit (datacache_disk_size, datacache_mem_size) with the PageCache.
+// Currently, the disk space used by BlockCache cannot be individually configured
+// using block_cache_disk_size and block_cache_mem_size.
+// However, these two configuration items are retained for future support.
+CONF_Bool(block_cache_enable, "true");
+CONF_mString(block_cache_disk_size, "-1");
+CONF_mInt64(block_cache_mem_size, "0");
 CONF_Alias(datacache_block_size, block_cache_block_size);
 CONF_Alias(datacache_max_concurrent_inserts, block_cache_max_concurrent_inserts);
 CONF_Alias(datacache_checksum_enable, block_cache_checksum_enable);

--- a/be/test/cache/disk_space_monitor_test.cpp
+++ b/be/test/cache/disk_space_monitor_test.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "cache/disk_space_monitor.h"
+
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 
@@ -20,7 +22,6 @@
 
 #include "cache/block_cache/block_cache.h"
 #include "cache/block_cache/test_cache_utils.h"
-#include "cache/disk_space_monitor.h"
 #include "common/logging.h"
 #include "common/statusor.h"
 #include "fs/fs_util.h"

--- a/be/test/cache/disk_space_monitor_test.cpp
+++ b/be/test/cache/disk_space_monitor_test.cpp
@@ -20,6 +20,7 @@
 
 #include "cache/block_cache/block_cache.h"
 #include "cache/block_cache/test_cache_utils.h"
+#include "cache/disk_space_monitor.h"
 #include "common/logging.h"
 #include "common/statusor.h"
 #include "fs/fs_util.h"

--- a/be/test/storage/page_cache_test.cpp
+++ b/be/test/storage/page_cache_test.cpp
@@ -49,6 +49,7 @@ protected:
     void SetUp() override;
     void create_obj_cache(size_t capacity);
 
+    std::shared_ptr<Cache> _lru_cache;
     std::shared_ptr<ObjectCache> _obj_cache;
     std::shared_ptr<StoragePageCache> _page_cache;
     size_t _capacity = kNumShards * 2048;
@@ -60,10 +61,8 @@ void StoragePageCacheTest::SetUp() {
 }
 
 void StoragePageCacheTest::create_obj_cache(size_t capacity) {
-    ObjectCacheOptions options;
-    options.capacity = capacity;
-
-    _obj_cache = std::make_shared<LRUCacheModule>(options);
+    _lru_cache = std::make_shared<ShardedLRUCache>(capacity);
+    _obj_cache = std::make_shared<LRUCacheModule>(_lru_cache);
 }
 
 // NOLINTNEXTLINE
@@ -149,7 +148,7 @@ TEST_F(StoragePageCacheTest, normal) {
         ASSERT_FALSE(_page_cache->adjust_capacity(-2 * kNumShards, 0));
     }
 
-    // set capactity = 0
+    // set capacity = 0
     {
         _page_cache->set_capacity(0);
         ASSERT_EQ(_page_cache->get_capacity(), 0);


### PR DESCRIPTION
## Why I'm doing:

The meaning before modification: Configurations for compatibility with version 2.5.
* block_cache_enable: Compatibility with version 2.5, if enabled, `datacache_mem_size=block_cache_mem_size`, `datacache_disk_size=block_cache_disk_size`

After modification:
* `block_cache_enable`: Enable the cache of raw data of external table and shared-data table.
* if `datacache_enable=false`, `block_cache_enable` will be set to false.

`block_cache_disk_size`, `block_cache_mem_size` is ineffective now, will be reserved to config the size of block cache future, currenty the size is uniformly limited by `datacache_disk_size` and `datacache_mem_size`。

![image](https://github.com/user-attachments/assets/9aa7ca33-3b6f-4208-9b5d-0028832eb351)

## What I'm doing:

Modify the semantics of the configuration block_cache_enable.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
