### PR TITLE
[Enhancement] Add azure blob credential in backend

### DIFF
--- a/be/src/fs/CMakeLists.txt
+++ b/be/src/fs/CMakeLists.txt
@@ -26,6 +26,7 @@ set(EXEC_FILES
     fs_broker.cpp
     fs_memory.cpp
     fs_s3.cpp
+    credential/cloud_configuration_factory.cpp
     hdfs/fs_hdfs.cpp
     hdfs/hdfs_fs_cache.cpp
     s3/poco_http_client_factory.cpp

--- a/be/src/fs/credential/cloud_configuration.h
+++ b/be/src/fs/credential/cloud_configuration.h
@@ -16,6 +16,8 @@
 
 #include <string>
 
+#include "common/status.h"
+
 namespace starrocks {
 class CloudCredential {
 public:
@@ -56,6 +58,25 @@ public:
     }
 };
 
+// Currently only supported for Azure Blob Storage
+class AzureCloudCredential final : public CloudCredential {
+public:
+    std::string shared_key;
+    std::string sas_token;
+    std::string client_id;
+
+    Status validate() const {
+        if (shared_key.empty() && sas_token.empty() && client_id.empty()) {
+            return Status::InvalidArgument("Azure credential invalid: all fields are empty");
+        }
+        return Status::OK();
+    }
+
+    bool operator==(const AzureCloudCredential& rhs) const {
+        return shared_key == rhs.shared_key && sas_token == rhs.sas_token && client_id == rhs.client_id;
+    }
+};
+
 class CloudConfiguration {
 public:
     virtual ~CloudConfiguration() = default;
@@ -79,4 +100,14 @@ public:
     }
     AliyunCloudCredential aliyun_cloud_credential;
 };
+
+class AzureCloudConfiguration final : public CloudConfiguration {
+public:
+    bool operator==(const AzureCloudConfiguration& rhs) const {
+        return azure_cloud_credential == rhs.azure_cloud_credential;
+    }
+
+    AzureCloudCredential azure_cloud_credential;
+};
+
 } // namespace starrocks

--- a/be/src/fs/credential/cloud_configuration_factory.cpp
+++ b/be/src/fs/credential/cloud_configuration_factory.cpp
@@ -1,0 +1,113 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "fs/credential/cloud_configuration_factory.h"
+
+#include <glog/logging.h>
+
+#include <boost/lexical_cast.hpp>
+
+namespace starrocks {
+
+const AWSCloudConfiguration CloudConfigurationFactory::create_aws(const TCloudConfiguration& t_cloud_configuration) {
+    DCHECK(t_cloud_configuration.__isset.cloud_type);
+    DCHECK(t_cloud_configuration.cloud_type == TCloudType::AWS);
+    std::map<std::string, std::string> properties{};
+    if (t_cloud_configuration.__isset.cloud_properties) {
+        properties = t_cloud_configuration.cloud_properties;
+    }
+
+    AWSCloudConfiguration aws_cloud_configuration{};
+    AWSCloudCredential aws_cloud_credential{};
+
+    // Set aws cloud configuration first
+    aws_cloud_configuration.enable_path_style_access =
+            get_or_default(properties, AWS_S3_ENABLE_PATH_STYLE_ACCESS, false);
+    aws_cloud_configuration.enable_ssl = get_or_default(properties, AWS_S3_ENABLE_SSL, true);
+
+    // Set aws cloud credential next
+    aws_cloud_credential.use_aws_sdk_default_behavior =
+            get_or_default(properties, AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR, false);
+    aws_cloud_credential.use_instance_profile = get_or_default(properties, AWS_S3_USE_INSTANCE_PROFILE, false);
+    aws_cloud_credential.access_key = get_or_default(properties, AWS_S3_ACCESS_KEY, std::string());
+    aws_cloud_credential.secret_key = get_or_default(properties, AWS_S3_SECRET_KEY, std::string());
+    aws_cloud_credential.session_token = get_or_default(properties, AWS_S3_SESSION_TOKEN, std::string());
+    aws_cloud_credential.iam_role_arn = get_or_default(properties, AWS_S3_IAM_ROLE_ARN, std::string());
+    aws_cloud_credential.sts_region = get_or_default(properties, AWS_S3_STS_REGION, std::string());
+    aws_cloud_credential.sts_endpoint = get_or_default(properties, AWS_S3_STS_ENDPOINT, std::string());
+    aws_cloud_credential.external_id = get_or_default(properties, AWS_S3_EXTERNAL_ID, std::string());
+    aws_cloud_credential.region = get_or_default(properties, AWS_S3_REGION, std::string());
+    aws_cloud_credential.endpoint = get_or_default(properties, AWS_S3_ENDPOINT, std::string());
+
+    aws_cloud_configuration.aws_cloud_credential = aws_cloud_credential;
+    return aws_cloud_configuration;
+}
+
+const AliyunCloudConfiguration CloudConfigurationFactory::create_aliyun(
+        const TCloudConfiguration& t_cloud_configuration) {
+    DCHECK(t_cloud_configuration.__isset.cloud_type);
+    DCHECK(t_cloud_configuration.cloud_type == TCloudType::ALIYUN);
+    std::map<std::string, std::string> properties{};
+    if (t_cloud_configuration.__isset.cloud_properties) {
+        properties = t_cloud_configuration.cloud_properties;
+    }
+
+    AliyunCloudConfiguration aliyun_cloud_configuration{};
+    AliyunCloudCredential aliyun_cloud_credential{};
+
+    aliyun_cloud_credential.access_key = get_or_default(properties, ALIYUN_OSS_ACCESS_KEY, std::string());
+    aliyun_cloud_credential.secret_key = get_or_default(properties, ALIYUN_OSS_SECRET_KEY, std::string());
+    aliyun_cloud_credential.endpoint = get_or_default(properties, ALIYUN_OSS_ENDPOINT, std::string());
+
+    aliyun_cloud_configuration.aliyun_cloud_credential = aliyun_cloud_credential;
+    return aliyun_cloud_configuration;
+}
+
+const AzureCloudConfiguration CloudConfigurationFactory::create_azure(
+        const TCloudConfiguration& t_cloud_configuration) {
+    DCHECK(t_cloud_configuration.__isset.cloud_type);
+    DCHECK(t_cloud_configuration.cloud_type == TCloudType::AZURE);
+
+    std::map<std::string, std::string> properties{};
+    if (t_cloud_configuration.__isset.cloud_properties) {
+        properties = t_cloud_configuration.cloud_properties;
+    }
+
+    AzureCloudCredential azure_cloud_credential{};
+    azure_cloud_credential.shared_key = get_or_default(properties, AZURE_BLOB_SHARED_KEY, std::string());
+    azure_cloud_credential.sas_token = get_or_default(properties, AZURE_BLOB_SAS_TOKEN, std::string());
+    azure_cloud_credential.client_id = get_or_default(properties, AZURE_BLOB_OAUTH2_CLIENT_ID, std::string());
+
+    AzureCloudConfiguration azure_cloud_configuration{};
+    azure_cloud_configuration.azure_cloud_credential = azure_cloud_credential;
+    return azure_cloud_configuration;
+}
+
+template <typename ReturnType>
+ReturnType CloudConfigurationFactory::get_or_default(const std::map<std::string, std::string>& properties,
+                                                     const std::string& key, ReturnType default_value) {
+    auto it = properties.find(key);
+    if (it != properties.end()) {
+        std::string value = it->second;
+        if (std::is_same<bool, ReturnType>::value) {
+            // Change value to "0" or "1" before use boost::lexical_cast()
+            value = (value == "true") ? "1" : "0";
+        }
+        return boost::lexical_cast<ReturnType>(value);
+    } else {
+        return default_value;
+    }
+}
+
+} // namespace starrocks

--- a/be/src/fs/credential/cloud_configuration_factory.h
+++ b/be/src/fs/credential/cloud_configuration_factory.h
@@ -14,13 +14,11 @@
 
 #pragma once
 
-#include <boost/lexical_cast.hpp>
 #include <string>
 #include <unordered_map>
 
 #include "fs/credential/cloud_configuration.h"
 #include "gen_cpp/CloudConfiguration_types.h"
-#include "glog/logging.h"
 
 namespace starrocks {
 // The same as CloudConfiguration.java in FE
@@ -56,77 +54,24 @@ static const std::string ALIYUN_OSS_ACCESS_KEY = "aliyun.oss.access_key";
 static const std::string ALIYUN_OSS_SECRET_KEY = "aliyun.oss.secret_key";
 static const std::string ALIYUN_OSS_ENDPOINT = "aliyun.oss.endpoint";
 
+// Configuration for Azure
+// Currently only supported for Azure Blob Storage
+static const std::string AZURE_BLOB_SHARED_KEY = "azure.blob.shared_key";
+static const std::string AZURE_BLOB_SAS_TOKEN = "azure.blob.sas_token";
+static const std::string AZURE_BLOB_OAUTH2_CLIENT_ID = "azure.blob.oauth2_client_id";
+
 class CloudConfigurationFactory {
 public:
-    static const AWSCloudConfiguration create_aws(const TCloudConfiguration& t_cloud_configuration) {
-        DCHECK(t_cloud_configuration.__isset.cloud_type);
-        DCHECK(t_cloud_configuration.cloud_type == TCloudType::AWS);
-        std::map<std::string, std::string> properties{};
-        if (t_cloud_configuration.__isset.cloud_properties) {
-            properties = t_cloud_configuration.cloud_properties;
-        }
-
-        AWSCloudConfiguration aws_cloud_configuration{};
-        AWSCloudCredential aws_cloud_credential{};
-
-        // Set aws cloud configuration first
-        aws_cloud_configuration.enable_path_style_access =
-                get_or_default(properties, AWS_S3_ENABLE_PATH_STYLE_ACCESS, false);
-        aws_cloud_configuration.enable_ssl = get_or_default(properties, AWS_S3_ENABLE_SSL, true);
-
-        // Set aws cloud credential next
-        aws_cloud_credential.use_aws_sdk_default_behavior =
-                get_or_default(properties, AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR, false);
-        aws_cloud_credential.use_instance_profile = get_or_default(properties, AWS_S3_USE_INSTANCE_PROFILE, false);
-        aws_cloud_credential.access_key = get_or_default(properties, AWS_S3_ACCESS_KEY, std::string());
-        aws_cloud_credential.secret_key = get_or_default(properties, AWS_S3_SECRET_KEY, std::string());
-        aws_cloud_credential.session_token = get_or_default(properties, AWS_S3_SESSION_TOKEN, std::string());
-        aws_cloud_credential.iam_role_arn = get_or_default(properties, AWS_S3_IAM_ROLE_ARN, std::string());
-        aws_cloud_credential.sts_region = get_or_default(properties, AWS_S3_STS_REGION, std::string());
-        aws_cloud_credential.sts_endpoint = get_or_default(properties, AWS_S3_STS_ENDPOINT, std::string());
-        aws_cloud_credential.external_id = get_or_default(properties, AWS_S3_EXTERNAL_ID, std::string());
-        aws_cloud_credential.region = get_or_default(properties, AWS_S3_REGION, std::string());
-        aws_cloud_credential.endpoint = get_or_default(properties, AWS_S3_ENDPOINT, std::string());
-
-        aws_cloud_configuration.aws_cloud_credential = aws_cloud_credential;
-        return aws_cloud_configuration;
-    }
+    static const AWSCloudConfiguration create_aws(const TCloudConfiguration& t_cloud_configuration);
 
     // This is a reserved interface for aliyun EMR starrocks, and cannot be deleted
-    static const AliyunCloudConfiguration create_aliyun(const TCloudConfiguration& t_cloud_configuration) {
-        DCHECK(t_cloud_configuration.__isset.cloud_type);
-        DCHECK(t_cloud_configuration.cloud_type == TCloudType::ALIYUN);
-        std::map<std::string, std::string> properties{};
-        if (t_cloud_configuration.__isset.cloud_properties) {
-            properties = t_cloud_configuration.cloud_properties;
-        }
+    static const AliyunCloudConfiguration create_aliyun(const TCloudConfiguration& t_cloud_configuration);
 
-        AliyunCloudConfiguration aliyun_cloud_configuration{};
-        AliyunCloudCredential aliyun_cloud_credential{};
-
-        aliyun_cloud_credential.access_key = get_or_default(properties, ALIYUN_OSS_ACCESS_KEY, std::string());
-        aliyun_cloud_credential.secret_key = get_or_default(properties, ALIYUN_OSS_SECRET_KEY, std::string());
-        aliyun_cloud_credential.endpoint = get_or_default(properties, ALIYUN_OSS_ENDPOINT, std::string());
-
-        aliyun_cloud_configuration.aliyun_cloud_credential = aliyun_cloud_credential;
-        return aliyun_cloud_configuration;
-    }
+    static const AzureCloudConfiguration create_azure(const TCloudConfiguration& t_cloud_configuration);
 
 private:
     template <typename ReturnType>
     static ReturnType get_or_default(const std::map<std::string, std::string>& properties, const std::string& key,
-                                     ReturnType default_value) {
-        auto it = properties.find(key);
-        if (it != properties.end()) {
-            std::string value = it->second;
-            if (std::is_same<bool, ReturnType>::value) {
-                // Change value to "0" or "1" before use boost::lexical_cast()
-                value = (value == "true") ? "1" : "0";
-            }
-            return boost::lexical_cast<ReturnType>(value);
-        } else {
-            return default_value;
-        }
-    }
+                                     ReturnType default_value);
 };
 } // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -33,6 +33,7 @@ set(EXEC_FILES
         ./connector_sink/iceberg_chunk_sink_test.cpp
         ./connector_sink/file_chunk_sink_test.cpp
         ./connector_sink/async_flush_output_stream_test.cpp
+        ./fs/credential/cloud_configuration_factory_test.cpp
         ./fs/fs_broker_test.cpp
         ./fs/fs_hdfs_test.cpp
         ./fs/fs_posix_test.cpp

--- a/be/test/fs/credential/cloud_configuration_factory_test.cpp
+++ b/be/test/fs/credential/cloud_configuration_factory_test.cpp
@@ -1,0 +1,76 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "fs/credential/cloud_configuration_factory.h"
+
+#include <gtest/gtest.h>
+
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+class CloudConfigurationFactoryTest : public ::testing::Test {};
+
+TEST_F(CloudConfigurationFactoryTest, test_create_azure) {
+    TCloudConfiguration t_cloud_configuration;
+    t_cloud_configuration.__set_cloud_type(TCloudType::AZURE);
+
+    {
+        std::map<std::string, std::string> properties;
+        properties.emplace(AZURE_BLOB_SHARED_KEY, "shared_key");
+        t_cloud_configuration.__set_cloud_properties(properties);
+
+        const auto& cloud_configuration = CloudConfigurationFactory::create_azure(t_cloud_configuration);
+        const auto& azure_cloud_credential = cloud_configuration.azure_cloud_credential;
+
+        EXPECT_OK(azure_cloud_credential.validate());
+        EXPECT_STREQ(azure_cloud_credential.shared_key.c_str(), "shared_key");
+    }
+
+    {
+        std::map<std::string, std::string> properties;
+        properties.emplace(AZURE_BLOB_SAS_TOKEN, "sas_token");
+        t_cloud_configuration.__set_cloud_properties(properties);
+
+        const auto& cloud_configuration = CloudConfigurationFactory::create_azure(t_cloud_configuration);
+        const auto& azure_cloud_credential = cloud_configuration.azure_cloud_credential;
+
+        EXPECT_OK(azure_cloud_credential.validate());
+        EXPECT_STREQ(azure_cloud_credential.sas_token.c_str(), "sas_token");
+    }
+
+    {
+        std::map<std::string, std::string> properties;
+        properties.emplace(AZURE_BLOB_OAUTH2_CLIENT_ID, "client_id");
+        t_cloud_configuration.__set_cloud_properties(properties);
+
+        const auto& cloud_configuration = CloudConfigurationFactory::create_azure(t_cloud_configuration);
+        const auto& azure_cloud_credential = cloud_configuration.azure_cloud_credential;
+
+        EXPECT_OK(azure_cloud_credential.validate());
+        EXPECT_STREQ(azure_cloud_credential.client_id.c_str(), "client_id");
+    }
+
+    {
+        std::map<std::string, std::string> properties;
+        t_cloud_configuration.__set_cloud_properties(properties);
+
+        const auto& cloud_configuration = CloudConfigurationFactory::create_azure(t_cloud_configuration);
+        const auto& azure_cloud_credential = cloud_configuration.azure_cloud_credential;
+
+        ASSERT_ERROR(azure_cloud_credential.validate());
+    }
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

1. Add `AzureCloudCredential` and `AzureCloudConfiguration` classes to represent Azure-specific credentials and configurations. These include fields for `shared_key`, `sas_token`, and `client_id`. Currently only supported for Azure Blob Storage.
2. Refactor cloud configuration factory.

Fixes #59017

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
