### PR TITLE
[UT] reduce debug info size for unit test under gcov mode

### DIFF
--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -552,7 +552,7 @@ if (USE_AVX2)
 endif ()
 
 add_library(starrocks_test_objs OBJECT ${EXEC_FILES})
-SET_TARGET_PROPERTIES(starrocks_test_objs PROPERTIES COMPILE_FLAGS "-fno-access-control")
+SET_TARGET_PROPERTIES(starrocks_test_objs PROPERTIES COMPILE_FLAGS "-fno-access-control -g1")
 add_executable(starrocks_test test_main.cpp $<TARGET_OBJECTS:starrocks_test_objs>)
 
 TARGET_LINK_LIBRARIES(starrocks_test ${TEST_LINK_LIBS})


### PR DESCRIPTION
* debug info size exceeds 4GB, causes link failure.
* temporarily reduce UT file debug info with `-g1`. Downside: a little bit harder for debugging unit test modules.

## Why I'm doing:

## What I'm doing:

Fixes #issue

before the change
```
$ bloaty be/ut_build_Release/test/starrocks_test
    FILE SIZE        VM SIZE    
 --------------  -------------- 
  47.1%  3.95Gi   0.0%       0    .debug_info
  18.4%  1.54Gi   0.0%       0    .debug_loc
  11.7%  1007Mi   0.0%       0    .debug_str
   4.8%   408Mi   0.0%       0    .strtab
   4.5%   386Mi   0.0%       0    .debug_line
   3.2%   277Mi   0.0%       0    .debug_ranges
   3.1%   270Mi  45.4%   270Mi    .text
   2.5%   214Mi   0.0%       0    .debug_loclists
   0.0%       0  14.9%  88.8Mi    .bss
   1.0%  87.8Mi  14.7%  87.8Mi    .data
   0.9%  75.3Mi   0.0%       0    .symtab
   0.6%  50.7Mi   8.5%  50.7Mi    .rodata
   0.5%  46.6Mi   7.8%  46.6Mi    .dynstr
   0.4%  37.2Mi   0.0%       0    .debug_rnglists
   0.4%  33.3Mi   0.0%       0    .debug_abbrev
   0.2%  18.6Mi   3.1%  18.6Mi    .eh_frame
   0.1%  10.3Mi   1.7%  10.3Mi    .dynsym
   0.1%  9.10Mi   1.5%  9.10Mi    .gcc_except_table
   0.1%  8.02Mi   1.3%  7.64Mi    [32 Others]
   0.1%  7.75Mi   0.0%       0    .debug_aranges
   0.1%  5.70Mi   1.0%  5.69Mi    .data.rel.ro
 100.0%  8.38Gi 100.0%   595Mi    TOTAL
```

After the change
```
$ bloaty be/ut_build_Release/test/starrocks_test
    FILE SIZE        VM SIZE    
 --------------  -------------- 
  45.2%  3.04Gi   0.0%       0    .debug_info
  14.4%   991Mi   0.0%       0    .debug_str
  13.5%   930Mi   0.0%       0    .debug_loc
   6.0%   410Mi   0.0%       0    .strtab
   4.6%   320Mi   0.0%       0    .debug_line
   3.9%   270Mi  45.4%   270Mi    .text
   3.5%   240Mi   0.0%       0    .debug_ranges
   3.3%   225Mi   0.0%       0    .debug_loclists
   0.0%       0  14.9%  89.1Mi    .bss
   1.3%  88.2Mi  14.8%  88.2Mi    .data
   1.1%  75.6Mi   0.0%       0    .symtab
   0.7%  50.7Mi   8.5%  50.7Mi    .rodata
   0.7%  46.7Mi   7.8%  46.7Mi    .dynstr
   0.6%  39.1Mi   0.0%       0    .debug_rnglists
   0.4%  28.4Mi   0.0%       0    .debug_abbrev
   0.3%  18.7Mi   3.1%  18.7Mi    .eh_frame
   0.1%  10.3Mi   1.7%  10.3Mi    .dynsym
   0.1%  9.09Mi   1.5%  9.09Mi    .gcc_except_table
   0.1%  8.06Mi   1.3%  7.66Mi    [32 Others]
   0.1%  7.85Mi   0.0%       0    .debug_aranges
   0.1%  5.73Mi   1.0%  5.72Mi    .data.rel.ro
 100.0%  6.73Gi 100.0%   597Mi    TOTAL
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
