### PR TITLE
[Refactor] Use UUIDUtil to generate queryId/loadId/executionId

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TableQueryPlanAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TableQueryPlanAction.java
@@ -45,6 +45,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.StarRocksHttpException;
 import com.starrocks.common.util.NetUtils;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.http.ActionController;
@@ -75,7 +76,6 @@ import com.starrocks.thrift.TPlanFragment;
 import com.starrocks.thrift.TQueryPlanInfo;
 import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.thrift.TTabletVersionInfo;
-import com.starrocks.thrift.TUniqueId;
 import com.starrocks.warehouse.Warehouse;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -91,7 +91,6 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 /**
  * This class responsible for parse the sql and generate the query plan fragment for a (only one) table{@see OlapTable}
@@ -317,8 +316,7 @@ public class TableQueryPlanAction extends RestBaseAction {
         tQueryPlanInfo.plan_fragment = tPlanFragment;
         tQueryPlanInfo.desc_tbl = execPlan.getDescTbl().toThrift();
         // set query_id
-        UUID uuid = UUID.randomUUID();
-        tQueryPlanInfo.query_id = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+        tQueryPlanInfo.query_id = UUIDUtil.genTUniqueId();
 
         Map<Long, TTabletVersionInfo> tabletInfo = new HashMap<>();
         // acquire resolved tablet distribution

--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteMgr.java
@@ -74,6 +74,7 @@ import com.starrocks.common.Pair;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.ListComparator;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.lake.delete.LakeDeleteJob;
@@ -117,7 +118,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
@@ -259,7 +259,7 @@ public class DeleteMgr implements Writable, MemoryTrackable {
         }
 
         // generate label
-        String label = "delete_" + UUID.randomUUID();
+        String label = "delete_" + UUIDUtil.genUUID().toString();
         long jobId = GlobalStateMgr.getCurrentState().getNextId();
         stmt.setJobId(jobId);
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
@@ -73,6 +73,7 @@ import com.starrocks.common.util.BrokerUtil;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.NetUtils;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
@@ -484,7 +485,7 @@ public class ExportJob implements Writable, GsonPostProcessable {
     }
 
     private void genCoordinators(ExportStmt stmt, List<PlanFragment> fragments, List<ScanNode> nodes) {
-        UUID uuid = UUID.randomUUID();
+        UUID uuid = UUIDUtil.genUUID();
         for (int i = 0; i < fragments.size(); ++i) {
             PlanFragment fragment = fragments.get(i);
             ScanNode scanNode = nodes.get(i);

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/MergeCommitJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/MergeCommitJob.java
@@ -34,7 +34,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicLong;
@@ -221,8 +220,8 @@ public class MergeCommitJob implements MergeCommitTaskCallback {
                 backendIds.add(backendId);
             }
 
-            String label = LABEL_PREFIX + DebugUtil.printId(UUIDUtil.toTUniqueId(UUID.randomUUID()));
-            TUniqueId loadId = UUIDUtil.toTUniqueId(UUID.randomUUID());
+            TUniqueId loadId = UUIDUtil.genTUniqueId();
+            String label = LABEL_PREFIX + DebugUtil.printId(loadId);
             MergeCommitTask mergeCommitTask = new MergeCommitTask(
                     tableId, label, loadId, streamLoadInfo, batchWriteIntervalMs, loadParameters,
                     backendIds, queryCoordinatorFactory, this);

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -54,6 +54,7 @@ import com.starrocks.common.util.LoadPriority;
 import com.starrocks.common.util.LogBuilder;
 import com.starrocks.common.util.LogKey;
 import com.starrocks.common.util.ThreadUtil;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.load.BrokerFileGroup;
@@ -89,7 +90,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 /**
  * There are 3 steps in BrokerLoadJob: BrokerPendingTask, LoadLoadingTask, CommitAndPublishTxn.
@@ -283,8 +283,7 @@ public class BrokerLoadJob extends BulkLoadJob {
                 } else if (partialUpdateMode.equals("row")) {
                     mode = TPartialUpdateMode.ROW_MODE;
                 }
-                UUID uuid = UUID.randomUUID();
-                TUniqueId loadId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+                TUniqueId loadId = UUIDUtil.genTUniqueId();
 
                 LoadLoadingTask task = new LoadLoadingTask.Builder()
                         .setDb(db)

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -64,6 +64,7 @@ import com.starrocks.common.util.LogBuilder;
 import com.starrocks.common.util.LogKey;
 import com.starrocks.common.util.SmallFileMgr;
 import com.starrocks.common.util.SmallFileMgr.SmallFile;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.load.Load;
@@ -292,7 +293,7 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
                         }
                     }
                     long timeToExecuteMs = System.currentTimeMillis() + taskSchedIntervalS * 1000;
-                    KafkaTaskInfo kafkaTaskInfo = new KafkaTaskInfo(UUID.randomUUID(), this,
+                    KafkaTaskInfo kafkaTaskInfo = new KafkaTaskInfo(UUIDUtil.genUUID(), this,
                             taskSchedIntervalS * 1000,
                             timeToExecuteMs, taskKafkaProgress, taskTimeoutSecond * 1000);
                     kafkaTaskInfo.setWarehouseId(warehouseId);

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
@@ -42,6 +42,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.KafkaUtil;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.load.streamload.StreamLoadTask;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TExecPlanFragmentParams;
@@ -86,7 +87,7 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
 
     public KafkaTaskInfo(long timeToExecuteMs, KafkaTaskInfo kafkaTaskInfo, Map<Integer, Long> partitionIdToOffset,
                          long tastTimeoutMs) {
-        super(UUID.randomUUID(), kafkaTaskInfo.getJob(), kafkaTaskInfo.getTaskScheduleIntervalMs(), timeToExecuteMs,
+        super(UUIDUtil.genUUID(), kafkaTaskInfo.getJob(), kafkaTaskInfo.getTaskScheduleIntervalMs(), timeToExecuteMs,
                 kafkaTaskInfo.getBeId(), tastTimeoutMs);
         this.partitionIdToOffset = partitionIdToOffset;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarRoutineLoadJob.java
@@ -44,6 +44,7 @@ import com.starrocks.common.util.LogKey;
 import com.starrocks.common.util.PulsarUtil;
 import com.starrocks.common.util.SmallFileMgr;
 import com.starrocks.common.util.SmallFileMgr.SmallFile;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.load.Load;
@@ -64,7 +65,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 /**
  * PulsarRoutineLoadJob is a kind of RoutineLoadJob which fetch data from pulsar.
@@ -208,7 +208,7 @@ public class PulsarRoutineLoadJob extends RoutineLoadJob {
                         }
                     }
                     long timeToExecuteMs = System.currentTimeMillis() + taskSchedIntervalS * 1000;
-                    PulsarTaskInfo pulsarTaskInfo = new PulsarTaskInfo(UUID.randomUUID(), this,
+                    PulsarTaskInfo pulsarTaskInfo = new PulsarTaskInfo(UUIDUtil.genUUID(), this,
                             taskSchedIntervalS * 1000, timeToExecuteMs, partitions,
                             initialPositions, getTaskTimeoutSecond() * 1000);
                     pulsarTaskInfo.setWarehouseId(warehouseId);

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarTaskInfo.java
@@ -24,6 +24,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.PulsarUtil;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TExecPlanFragmentParams;
 import com.starrocks.thrift.TFileFormatType;
@@ -50,7 +51,7 @@ public class PulsarTaskInfo extends RoutineLoadTaskInfo {
     }
 
     public PulsarTaskInfo(long timeToExecuteMs, PulsarTaskInfo pulsarTaskInfo, Map<String, Long> initialPositions) {
-        super(UUID.randomUUID(), pulsarTaskInfo.getJob(), pulsarTaskInfo.getTaskScheduleIntervalMs(),
+        super(UUIDUtil.genUUID(), pulsarTaskInfo.getJob(), pulsarTaskInfo.getTaskScheduleIntervalMs(),
                 timeToExecuteMs, pulsarTaskInfo.getBeId(), pulsarTaskInfo.getTimeoutMs());
         this.partitions = pulsarTaskInfo.getPartitions();
         this.initialPositions.putAll(initialPositions);

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -38,6 +38,7 @@ import com.starrocks.common.util.LogKey;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
@@ -87,7 +88,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
-import java.util.UUID;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static com.starrocks.common.ErrorCode.ERR_NO_PARTITIONS_HAVE_DATA_LOAD;
@@ -229,8 +229,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
     public StreamLoadTask(long id, Database db, OlapTable table, String label, String user, String clientIp,
                           long timeoutMs, int channelNum, int channelId, long createTimeMs, long warehouseId) {
         this.id = id;
-        UUID uuid = UUID.randomUUID();
-        this.loadId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+        this.loadId = UUIDUtil.genTUniqueId();
         this.dbId = db.getId();
         this.dbName = db.getFullName();
         this.tableId = table.getId();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
@@ -59,6 +59,7 @@ import com.starrocks.common.CsvFormat;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.load.Load;
 import com.starrocks.load.streamload.StreamLoadInfo;
 import com.starrocks.server.GlobalStateMgr;
@@ -86,7 +87,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
-import java.util.UUID;
 
 import static com.starrocks.catalog.DefaultExpr.SUPPORTED_DEFAULT_FNS;
 
@@ -408,8 +408,7 @@ public class StreamLoadScanNode extends LoadScanNode {
                 case FILE_STREAM:
                     rangeDesc.setPath("Invalid Path");
                     if (needAssignBE) {
-                        UUID uuid = UUID.randomUUID();
-                        rangeDesc.setLoad_id(new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits()));
+                        rangeDesc.setLoad_id(UUIDUtil.genTUniqueId());
                     } else {
                         rangeDesc.setLoad_id(loadId);
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -673,11 +673,10 @@ public class StmtExecutor {
                     try {
                         //reset query id for each retry
                         if (i > 0) {
-                            uuid = UUID.randomUUID();
+                            uuid = UUIDUtil.genUUID();
                             LOG.info("transfer QueryId: {} to {}", DebugUtil.printId(context.getQueryId()),
                                     DebugUtil.printId(uuid));
-                            context.setExecutionId(
-                                    new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits()));
+                            context.setExecutionId(UUIDUtil.toTUniqueId(uuid));
                         }
 
                         handleQueryStmt(retryContext.getExecPlan());

--- a/fe/fe-core/src/main/java/com/starrocks/task/ExportExportingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/ExportExportingTask.java
@@ -44,6 +44,7 @@ import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.fs.HdfsUtil;
 import com.starrocks.load.ExportChecker;
@@ -341,7 +342,7 @@ public class ExportExportingTask extends PriorityLeaderTask {
 
                 if (i < RETRY_NUM - 1) {
                     TUniqueId oldQueryId = coord.getQueryId();
-                    UUID uuid = UUID.randomUUID();
+                    UUID uuid = UUIDUtil.genUUID();
                     // generate one new queryId here, to avoid being rejected by BE,
                     // because the request is considered as a repeat request.
                     // we make the high part of query id unchanged to facilitate tracing problem by log.

--- a/fe/fe-core/src/test/java/com/starrocks/http/GetStreamLoadStateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/GetStreamLoadStateTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.http;
 
 import com.starrocks.catalog.Database;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.TransactionStateSnapshot;
@@ -27,7 +28,6 @@ import okhttp3.Response;
 import org.junit.Test;
 
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
@@ -45,7 +45,7 @@ public class GetStreamLoadStateTest  extends StarRocksHttpTestCase {
     @Test
     public void testSuccessLoad() throws Exception {
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
-        String label = UUID.randomUUID().toString();
+        String label = UUIDUtil.genUUID().toString();
         new Expectations() {
             {
                 globalTransactionMgr.getLabelStatus(db.getId(), label);
@@ -86,7 +86,7 @@ public class GetStreamLoadStateTest  extends StarRocksHttpTestCase {
     @Test
     public void testAbortedState() throws Exception {
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
-        String label = UUID.randomUUID().toString();
+        String label = UUIDUtil.genUUID().toString();
         new Expectations() {
             {
                 globalTransactionMgr.getLabelStatus(db.getId(), label);
@@ -100,7 +100,7 @@ public class GetStreamLoadStateTest  extends StarRocksHttpTestCase {
     @Test
     public void testUnknownState() throws Exception {
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
-        String label = UUID.randomUUID().toString();
+        String label = UUIDUtil.genUUID().toString();
         new Expectations() {
             {
                 globalTransactionMgr.getLabelStatus(db.getId(), label);

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/MergeCommitTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/MergeCommitTaskTest.java
@@ -55,7 +55,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -93,8 +92,8 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
 
     @Before
     public void setup() throws Exception {
-        label = "batch_write_" + DebugUtil.printId(UUIDUtil.toTUniqueId(UUID.randomUUID()));
-        loadId = UUIDUtil.toTUniqueId(UUID.randomUUID());
+        loadId = UUIDUtil.genTUniqueId();
+        label = "batch_write_" + DebugUtil.printId(loadId);
 
         Map<String, String> map = new HashMap<>();
         map.put(StreamLoadHttpHeader.HTTP_FORMAT, "json");

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaTaskInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaTaskInfoTest.java
@@ -22,6 +22,7 @@ import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.KafkaUtil;
+import com.starrocks.common.util.UUIDUtil;
 import mockit.Injectable;
 import mockit.Mock;
 import mockit.MockUp;
@@ -30,7 +31,6 @@ import org.junit.Test;
 
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 public class KafkaTaskInfoTest {
 
@@ -58,7 +58,7 @@ public class KafkaTaskInfoTest {
 
         Map<Integer, Long> offset1 = Maps.newHashMap();
         offset1.put(0, 99L);
-        KafkaTaskInfo kafkaTaskInfo1 = new KafkaTaskInfo(UUID.randomUUID(),
+        KafkaTaskInfo kafkaTaskInfo1 = new KafkaTaskInfo(UUIDUtil.genUUID(),
                 kafkaRoutineLoadJob,
                 System.currentTimeMillis(),
                 System.currentTimeMillis(),
@@ -69,7 +69,7 @@ public class KafkaTaskInfoTest {
 
         Map<Integer, Long> offset2 = Maps.newHashMap();
         offset2.put(0, 100L);
-        KafkaTaskInfo kafkaTaskInfo2 = new KafkaTaskInfo(UUID.randomUUID(),
+        KafkaTaskInfo kafkaTaskInfo2 = new KafkaTaskInfo(UUIDUtil.genUUID(),
                 kafkaRoutineLoadJob,
                 System.currentTimeMillis(),
                 System.currentTimeMillis(),
@@ -80,7 +80,7 @@ public class KafkaTaskInfoTest {
         // consume offset > latest offset
         Map<Integer, Long> offset3 = Maps.newHashMap();
         offset3.put(0, 101L);
-        KafkaTaskInfo kafkaTaskInfo3 = new KafkaTaskInfo(UUID.randomUUID(),
+        KafkaTaskInfo kafkaTaskInfo3 = new KafkaTaskInfo(UUIDUtil.genUUID(),
                 kafkaRoutineLoadJob,
                 System.currentTimeMillis(),
                 System.currentTimeMillis(),
@@ -106,7 +106,7 @@ public class KafkaTaskInfoTest {
 
         Map<Integer, Long> offset1 = Maps.newHashMap();
         offset1.put(0, 100L);
-        KafkaTaskInfo kafkaTaskInfo = new KafkaTaskInfo(UUID.randomUUID(),
+        KafkaTaskInfo kafkaTaskInfo = new KafkaTaskInfo(UUIDUtil.genUUID(),
                 kafkaRoutineLoadJob,
                 System.currentTimeMillis(),
                 System.currentTimeMillis(),
@@ -140,7 +140,7 @@ public class KafkaTaskInfoTest {
 
         Map<Integer, Long> offset = Maps.newHashMap();
         offset.put(0, 99L);
-        KafkaTaskInfo kafkaTaskInfo = new KafkaTaskInfo(UUID.randomUUID(),
+        KafkaTaskInfo kafkaTaskInfo = new KafkaTaskInfo(UUIDUtil.genUUID(),
                 kafkaRoutineLoadJob,
                 System.currentTimeMillis(),
                 System.currentTimeMillis(),

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/PulsarTaskInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/PulsarTaskInfoTest.java
@@ -15,12 +15,12 @@
 package com.starrocks.load.routineload;
 
 import com.google.common.collect.Maps;
+import com.starrocks.common.util.UUIDUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Map;
-import java.util.UUID;
 
 public class PulsarTaskInfoTest {
 
@@ -31,7 +31,7 @@ public class PulsarTaskInfoTest {
         Map<String, Long> offsets1 = Maps.newHashMap();
         offsets1.put("0", 101L);
         offsets1.put("1", 102L);
-        PulsarTaskInfo task1 = new PulsarTaskInfo(UUID.randomUUID(), routineLoadJob, 1000,
+        PulsarTaskInfo task1 = new PulsarTaskInfo(UUIDUtil.genUUID(), routineLoadJob, 1000,
                 2000, Arrays.asList("0", "1"), offsets1, 3000);
 
         Map<String, Long> offsets2 = Maps.newHashMap();

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
@@ -45,6 +45,7 @@ import com.starrocks.common.InternalErrorCode;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.KafkaUtil;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.load.RoutineLoadDesc;
 import com.starrocks.metric.TableMetricsEntity;
 import com.starrocks.metric.TableMetricsRegistry;
@@ -72,7 +73,6 @@ import org.junit.Test;
 
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 public class RoutineLoadJobTest {
     @Test
@@ -145,7 +145,7 @@ public class RoutineLoadJobTest {
                 result = Lists.newArrayList();
                 routineLoadTaskInfo.getId();
                 minTimes = 0;
-                result = UUID.randomUUID();
+                result = UUIDUtil.genUUID();
                 routineLoadMgr.getJob(anyLong);
                 minTimes = 0;
                 result = routineLoadJob;
@@ -214,7 +214,7 @@ public class RoutineLoadJobTest {
                 result = Lists.newArrayList();
                 routineLoadTaskInfo.getId();
                 minTimes = 0;
-                result = UUID.randomUUID();
+                result = UUIDUtil.genUUID();
                 routineLoadMgr.getJob(anyLong);
                 minTimes = 0;
                 result = routineLoadJob;
@@ -811,7 +811,7 @@ public class RoutineLoadJobTest {
                 result = txnId;
                 routineLoadTaskInfo.getId();
                 minTimes = 0;
-                result = UUID.randomUUID();
+                result = UUIDUtil.genUUID();
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadManagerTest.java
@@ -48,6 +48,7 @@ import com.starrocks.common.LoadException;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.RoutineLoadOperation;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
@@ -266,7 +267,7 @@ public class RoutineLoadManagerTest {
         nameToRoutineLoadJob.put(jobName, routineLoadJobList);
         dbToNameToRoutineLoadJob.put(1L, nameToRoutineLoadJob);
         Map<String, RoutineLoadJob> idToRoutineLoadJob = Maps.newConcurrentMap();
-        idToRoutineLoadJob.put(UUID.randomUUID().toString(), kafkaRoutineLoadJobWithSameName);
+        idToRoutineLoadJob.put(UUIDUtil.genUUID().toString(), kafkaRoutineLoadJobWithSameName);
 
         Deencapsulation.setField(routineLoadManager, "dbToNameToRoutineLoadJob", dbToNameToRoutineLoadJob);
         Deencapsulation.setField(routineLoadManager, "idToRoutineLoadJob", idToRoutineLoadJob);

--- a/fe/fe-core/src/test/java/com/starrocks/load/streamload/ShowStreamLoadTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/streamload/ShowStreamLoadTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.load.streamload;
 
 import com.starrocks.common.Config;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.http.rest.TransactionResult;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ShowExecutor;
@@ -33,8 +34,6 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.UUID;
-
 public class ShowStreamLoadTest {
     private static final Logger LOG = LogManager.getLogger(ShowStreamLoadTest.class);
     private static ConnectContext connectContext;
@@ -52,7 +51,7 @@ public class ShowStreamLoadTest {
         // create connect context
         connectContext = UtFrameUtils.createDefaultCtx();
         connectContext.setDatabase("test_db");
-        connectContext.setQueryId(UUID.randomUUID());
+        connectContext.setQueryId(UUIDUtil.genUUID());
 
         // create database
         String createDbStmtStr = "create database test_db;";

--- a/fe/fe-core/src/test/java/com/starrocks/planner/StreamLoadPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/StreamLoadPlannerTest.java
@@ -45,6 +45,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.load.routineload.KafkaRoutineLoadJob;
 import com.starrocks.load.routineload.RoutineLoadJob;
 import com.starrocks.load.streamload.StreamLoadInfo;
@@ -67,7 +68,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_PARTIAL_UPDATE_MODE;
 
@@ -180,8 +180,7 @@ public class StreamLoadPlannerTest {
     public void testPartialUpdateMode() throws StarRocksException {
         StreamLoadKvParams param = new StreamLoadKvParams(
                 Collections.singletonMap(HTTP_PARTIAL_UPDATE_MODE, "column"));
-        UUID uuid = UUID.randomUUID();
-        TUniqueId loadId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+        TUniqueId loadId = UUIDUtil.genTUniqueId();
         StreamLoadInfo.fromHttpStreamLoadRequest(loadId, 100, Optional.of(100), param);
         RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
         StreamLoadInfo.fromRoutineLoadJob(routineLoadJob);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/KillQueryHandleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/KillQueryHandleTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.qe;
 
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.rpc.ThriftConnectionPool;
 import com.starrocks.rpc.ThriftRPCRequestExecutor;
 import com.starrocks.server.GlobalStateMgr;
@@ -32,8 +33,6 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.xnio.StreamConnection;
-
-import java.util.UUID;
 
 public class KillQueryHandleTest {
 
@@ -196,7 +195,7 @@ public class KillQueryHandleTest {
         ctx1.setQualifiedUser("root");
         ctx1.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
         ctx1.setConnectionId(1);
-        ctx1.setQueryId(UUID.randomUUID());
+        ctx1.setQueryId(UUIDUtil.genUUID());
 
         ExecuteEnv.getInstance().getScheduler().registerConnection(ctx1);
         return ctx1;

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/SchedulerTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/SchedulerTestNoneDBBase.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Multimap;
 import com.starrocks.catalog.CatalogIdGenerator;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.PBackendService;
@@ -26,7 +27,6 @@ import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.NodeSelector;
 import com.starrocks.thrift.TNetworkAddress;
-import com.starrocks.thrift.TUniqueId;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
@@ -40,7 +40,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Random;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
@@ -107,8 +106,7 @@ public class SchedulerTestNoneDBBase extends PlanTestNoneDBBase {
 
     public DefaultCoordinator getSchedulerWithQueryId(String sql) throws Exception {
         DefaultCoordinator coordinator = getScheduler(sql);
-        UUID uuid = UUID.randomUUID();
-        coordinator.setQueryId(new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits()));
+        coordinator.setQueryId(UUIDUtil.genTUniqueId());
         return coordinator;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -470,8 +470,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         new MockUp<StmtExecutor>() {
             @Mock
             public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
-                UUID uuid = UUID.randomUUID();
-                TUniqueId loadId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+                TUniqueId loadId = UUIDUtil.genTUniqueId();
                 TUniqueId queryId = UUIDUtil.toTUniqueId(execPlan.getConnectContext().getQueryId());
                 System.out.println("register query id: " + DebugUtil.printId(queryId));
                 LoadPlanner loadPlanner = new LoadPlanner(1, loadId, 1, 1, materializedView,

--- a/fe/fe-core/src/test/java/com/starrocks/server/SqlBlacklistTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/SqlBlacklistTest.java
@@ -16,6 +16,7 @@ package com.starrocks.server;
 
 import com.starrocks.analysis.RedirectStatus;
 import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.meta.BlackListSql;
 import com.starrocks.meta.SqlBlackList;
 import com.starrocks.persist.DeleteSqlBlackLists;
@@ -40,7 +41,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.util.List;
-import java.util.UUID;
 import java.util.regex.Pattern;
 
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.parseSql;
@@ -62,7 +62,7 @@ public class SqlBlacklistTest {
         sqlBlackList = new SqlBlackList();
         connectContext = UtFrameUtils.createDefaultCtx();
         editLog = Mockito.mock(EditLog.class);
-        connectContext.setQueryId(UUID.randomUUID());
+        connectContext.setQueryId(UUIDUtil.genUUID());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -30,6 +30,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.PatternMatcher;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
 import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.load.batchwrite.BatchWriteMgr;
@@ -109,7 +110,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -1092,8 +1092,7 @@ public class FrontendServiceImplTest {
     public void testGetLoadTxnStatus() throws Exception {
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "site_access_day");
-        UUID uuid = UUID.randomUUID();
-        TUniqueId requestId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+        TUniqueId requestId = UUIDUtil.genTUniqueId();
         long transactionId = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().beginTransaction(db.getId(),
                     Lists.newArrayList(table.getId()), "1jdc689-xd232", requestId,
                     new TxnCoordinator(TxnSourceType.BE, "1.1.1.1"),

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/AnalyzeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/AnalyzeMgrTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.journal.JournalEntity;
 import com.starrocks.persist.OperationType;
 import com.starrocks.qe.ConnectContext;
@@ -42,7 +43,6 @@ import org.junit.Test;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
-import java.util.UUID;
 
 public class AnalyzeMgrTest {
     public static ConnectContext connectContext;
@@ -333,8 +333,7 @@ public class AnalyzeMgrTest {
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().addBasicStatsMeta(new BasicStatsMeta(dbId, tableId,
                 Lists.newArrayList("c1"), StatsConstants.AnalyzeType.FULL, LocalDateTime.now(), new HashMap<>()));
 
-        UUID uuid = UUID.randomUUID();
-        TUniqueId requestId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+        TUniqueId requestId = UUIDUtil.genTUniqueId();
         TransactionState transactionState = new TransactionState(dbId, Lists.newArrayList(tableId), 33333L, "xxx",
                 requestId, TransactionState.LoadJobSourceType.INSERT_STREAMING, null, 44444L, 10000);
         transactionState.setTxnCommitAttachment(new InsertTxnCommitAttachment(0));

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
@@ -54,6 +54,7 @@ import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.LabelAlreadyUsedException;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
 import com.starrocks.load.loadv2.ManualLoadTxnCommitAttachment;
 import com.starrocks.load.routineload.KafkaProgress;
@@ -99,7 +100,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -384,7 +384,7 @@ public class GlobalTransactionMgrTest {
         Map<Integer, Long> partitionIdToOffset = Maps.newHashMap();
         partitionIdToOffset.put(1, 0L);
         KafkaTaskInfo routineLoadTaskInfo =
-                new KafkaTaskInfo(UUID.randomUUID(), routineLoadJob, 20000, System.currentTimeMillis(),
+                new KafkaTaskInfo(UUIDUtil.genUUID(), routineLoadJob, 20000, System.currentTimeMillis(),
                         partitionIdToOffset, Config.routine_load_task_timeout_second);
         Deencapsulation.setField(routineLoadTaskInfo, "txnId", 1L);
         routineLoadTaskInfoList.add(routineLoadTaskInfo);
@@ -487,7 +487,7 @@ public class GlobalTransactionMgrTest {
         Map<Integer, Long> partitionIdToOffset = Maps.newHashMap();
         partitionIdToOffset.put(1, 0L);
         KafkaTaskInfo routineLoadTaskInfo =
-                new KafkaTaskInfo(UUID.randomUUID(), routineLoadJob, 20000, System.currentTimeMillis(),
+                new KafkaTaskInfo(UUIDUtil.genUUID(), routineLoadJob, 20000, System.currentTimeMillis(),
                         partitionIdToOffset, Config.routine_load_task_timeout_second);
         Deencapsulation.setField(routineLoadTaskInfo, "txnId", 1L);
         routineLoadTaskInfoList.add(routineLoadTaskInfo);
@@ -1060,7 +1060,7 @@ public class GlobalTransactionMgrTest {
     @Test
     public void testGetLabelStatus() throws Exception {
         FakeGlobalStateMgr.setGlobalStateMgr(masterGlobalStateMgr);
-        String label = UUID.randomUUID().toString();
+        String label = UUIDUtil.genUUID().toString();
         TransactionStateSnapshot state1 = masterTransMgr.getLabelStatus(GlobalStateMgrTestUtil.testDbId1, label);
         Assert.assertNotNull(state1);
         Assert.assertEquals(TransactionStatus.UNKNOWN, state1.getStatus());

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateBatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateBatchTest.java
@@ -16,8 +16,8 @@ package com.starrocks.transaction;
 
 import com.google.common.collect.Lists;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.system.ComputeNode;
-import com.starrocks.thrift.TUniqueId;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -32,7 +32,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 public class TransactionStateBatchTest {
     private static String fileName = "./TransactionStateBatchTest";
@@ -52,16 +51,14 @@ public class TransactionStateBatchTest {
 
         Long dbId = 1000L;
         Long tableId = 20000L;
-        UUID uuid = UUID.randomUUID();
         List<TransactionState> transactionStateList = new ArrayList<TransactionState>();
         TransactionState transactionState1 = new TransactionState(dbId, Lists.newArrayList(tableId),
-                3000, "label1", new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits()),
+                3000, "label1", UUIDUtil.genTUniqueId(),
                 TransactionState.LoadJobSourceType.BACKEND_STREAMING,
                 new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.BE, "127.0.0.1"), 50000L,
                 60 * 1000L);
-        uuid = UUID.randomUUID();
         TransactionState transactionState2 = new TransactionState(dbId, Lists.newArrayList(tableId),
-                3001, "label2", new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits()),
+                3001, "label2", UUIDUtil.genTUniqueId(),
                 TransactionState.LoadJobSourceType.BACKEND_STREAMING,
                 new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.BE, "127.0.0.1"), 50000L,
                 60 * 1000L);
@@ -95,16 +92,14 @@ public class TransactionStateBatchTest {
     public void testPutBeTablets() {
         Long dbId = 1000L;
         Long tableId = 20000L;
-        UUID uuid = UUID.randomUUID();
         List<TransactionState> transactionStateList = new ArrayList<TransactionState>();
         TransactionState transactionState1 = new TransactionState(dbId, Lists.newArrayList(tableId),
-                3000, "label1", new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits()),
+                3000, "label1", UUIDUtil.genTUniqueId(),
                 TransactionState.LoadJobSourceType.BACKEND_STREAMING,
                 new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.BE, "127.0.0.1"), 50000L,
                 60 * 1000L);
-        uuid = UUID.randomUUID();
         TransactionState transactionState2 = new TransactionState(dbId, Lists.newArrayList(tableId),
-                3001, "label2", new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits()),
+                3001, "label2", UUIDUtil.genTUniqueId(),
                 TransactionState.LoadJobSourceType.BACKEND_STREAMING,
                 new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.BE, "127.0.0.1"), 50000L,
                 60 * 1000L);

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateTest.java
@@ -22,9 +22,9 @@ import com.baidu.bjf.remoting.protobuf.ProtobufProxy;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.Replica.ReplicaState;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.proto.TxnFinishStatePB;
-import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.TransactionState.LoadJobSourceType;
 import com.starrocks.transaction.TransactionState.TxnCoordinator;
 import com.starrocks.transaction.TransactionState.TxnSourceType;
@@ -40,7 +40,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 
 public class TransactionStateTest {
 
@@ -54,9 +53,8 @@ public class TransactionStateTest {
 
     @Test
     public void testSerDe() {
-        UUID uuid = UUID.randomUUID();
         TransactionState transactionState = new TransactionState(1000L, Lists.newArrayList(20000L, 20001L),
-                3000, "label123", new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits()),
+                3000, "label123", UUIDUtil.genTUniqueId(),
                 LoadJobSourceType.BACKEND_STREAMING, new TxnCoordinator(TxnSourceType.BE, "127.0.0.1"), 50000L,
                 60 * 1000L);
 
@@ -107,9 +105,8 @@ public class TransactionStateTest {
 
     @Test
     public void testSerDeTxnStateNewFinish() {
-        UUID uuid = UUID.randomUUID();
         TransactionState transactionState = new TransactionState(1000L, Lists.newArrayList(20000L, 20001L),
-                3000, "label123", new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits()),
+                3000, "label123", UUIDUtil.genTUniqueId(),
                 LoadJobSourceType.BACKEND_STREAMING, new TxnCoordinator(TxnSourceType.BE, "127.0.0.1"), 50000L,
                 60 * 1000L);
 
@@ -132,10 +129,9 @@ public class TransactionStateTest {
         nonRunningStatus.add(TransactionStatus.VISIBLE);
         nonRunningStatus.add(TransactionStatus.ABORTED);
 
-        UUID uuid = UUID.randomUUID();
         for (TransactionStatus status : TransactionStatus.values()) {
             TransactionState transactionState = new TransactionState(1000L, Lists.newArrayList(20000L, 20001L),
-                    3000, "label123", new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits()),
+                    3000, "label123", UUIDUtil.genTUniqueId(),
                     LoadJobSourceType.BACKEND_STREAMING, new TxnCoordinator(TxnSourceType.BE, "127.0.0.1"), 50000L,
                     60 * 1000L);
             transactionState.setTransactionStatus(status);
@@ -145,9 +141,8 @@ public class TransactionStateTest {
 
     @Test
     public void testCommitInfos() {
-        UUID uuid = UUID.randomUUID();
         TransactionState transactionState = new TransactionState(1000L, Lists.newArrayList(20000L, 20001L),
-                3000, "label123", new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits()),
+                3000, "label123", UUIDUtil.genTUniqueId(),
                 LoadJobSourceType.BACKEND_STREAMING, new TxnCoordinator(TxnSourceType.BE, "127.0.0.1"), 50000L,
                 60 * 1000L);
         Assert.assertTrue(transactionState.tabletCommitInfosContainsReplica(1001, 1001, ReplicaState.NORMAL));


### PR DESCRIPTION
## Why I'm doing:

Preparation for changing UUID generation algorithm in #58962.

## What I'm doing:

For code related to queryId/loadId/executionId generation:
* Replace `UUID.randomUUID()` calls with `UUIDUtil.genUUID()`.
* Replace `new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits())` with `UUIDUtil.genTUniqueId()`

There are other places there `UUID.randomUUID()` is used (e.g. in FileSystem temp paths, in AWS secret handling and so on), which I left intact.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [X] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
