### PR TITLE
[Feature] Support enabling partition aggregation for tables created in older versions

### DIFF
--- a/be/src/exec/schema_scanner/schema_partitions_meta_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_partitions_meta_scanner.cpp
@@ -55,6 +55,7 @@ SchemaScanner::ColumnDesc SchemaPartitionsMetaScanner::_s_columns[] = {
         {"MAX_CS", TypeDescriptor::from_logical_type(TYPE_DOUBLE), sizeof(double), false},
         {"STORAGE_PATH", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
         {"STORAGE_SIZE", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
+        {"METADATA_SWITCH_VERSION", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
 };
 
 SchemaPartitionsMetaScanner::SchemaPartitionsMetaScanner()
@@ -299,6 +300,11 @@ Status SchemaPartitionsMetaScanner::fill_chunk(ChunkPtr* chunk) {
         case 29: {
             // STORAGE_SIZE
             fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.storage_size);
+            break;
+        }
+        case 30: {
+            // METADATA_SWITCH_VERSION
+            fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.metadata_switch_version);
             break;
         }
 

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -468,6 +468,12 @@ Status SchemaChangeHandler::do_process_update_tablet_meta(const TTabletMetaInfo&
         }
     }
 
+    // TODO(zhangqiang)
+    // aggregate alter txn log
+    if (tablet_meta_info.__isset.aggregate_tablet_metadata) {
+        metadata_update_info->set_aggregate_tablet_metadata(tablet_meta_info.aggregate_tablet_metadata);
+    }
+
     RETURN_IF_ERROR(tablet.put_txn_log(std::move(txn_log)));
     return Status::OK();
 }

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -324,8 +324,8 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, int64_t t
                 new_metadata->mutable_orphan_files()->Clear();
             }
 
-            // 1. force update prev_garbage_version at most config::lake_max_garbage_version_distance,
-            //    prevent prev_garbage_version from not being updated for a long time and affecting tablet meta vacuum
+            // force update prev_garbage_version at most config::lake_max_garbage_version_distance,
+            // prevent prev_garbage_version from not being updated for a long time and affecting tablet meta vacuum
             if (base_metadata->compaction_inputs_size() > 0 || base_metadata->orphan_files_size() > 0 ||
                 base_metadata->version() - base_metadata->prev_garbage_version() >=
                         config::lake_max_garbage_version_distance) {

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -324,8 +324,8 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, int64_t t
                 new_metadata->mutable_orphan_files()->Clear();
             }
 
-            // force update prev_garbage_version at most config::lake_max_garbage_version_distance,
-            // prevent prev_garbage_version from not being updated for a long time and affecting tablet meta vacuum
+            // 1. force update prev_garbage_version at most config::lake_max_garbage_version_distance,
+            //    prevent prev_garbage_version from not being updated for a long time and affecting tablet meta vacuum
             if (base_metadata->compaction_inputs_size() > 0 || base_metadata->orphan_files_size() > 0 ||
                 base_metadata->version() - base_metadata->prev_garbage_version() >=
                         config::lake_max_garbage_version_distance) {

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -85,7 +85,6 @@ Status apply_alter_meta_log(TabletMetadataPB* metadata, const TxnLogPB_OpAlterMe
             metadata->mutable_schema()->CopyFrom(alter_meta.tablet_schema());
         }
 
-        // TODO(zhangqiang)
         if (alter_meta.has_aggregate_tablet_metadata()) {
             // do nothing
         }

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -84,6 +84,11 @@ Status apply_alter_meta_log(TabletMetadataPB* metadata, const TxnLogPB_OpAlterMe
             }
             metadata->mutable_schema()->CopyFrom(alter_meta.tablet_schema());
         }
+
+        // TODO(zhangqiang)
+        if (alter_meta.has_aggregate_tablet_metadata()) {
+            // do nothing
+        }
     }
     return Status::OK();
 }

--- a/be/test/storage/lake/alter_tablet_meta_test.cpp
+++ b/be/test/storage/lake/alter_tablet_meta_test.cpp
@@ -609,4 +609,28 @@ TEST_F(AlterTabletMetaTest, test_skip_load_pindex) {
     }
 }
 
+TEST_F(AlterTabletMetaTest, test_enable_partition_aggregation) {
+    lake::SchemaChangeHandler handler(_tablet_mgr.get());
+    TUpdateTabletMetaInfoReq update_tablet_meta_req;
+    int64_t txn_id = next_id();
+    update_tablet_meta_req.__set_txn_id(txn_id);
+
+    TTabletMetaInfo tablet_meta_info;
+    auto tablet_id = _tablet_metadata->id();
+    tablet_meta_info.__set_tablet_id(tablet_id);
+    tablet_meta_info.__set_aggregate_tablet_metadata(true);
+
+    update_tablet_meta_req.tabletMetaInfos.push_back(tablet_meta_info);
+    ASSERT_OK(handler.process_update_tablet_meta(update_tablet_meta_req));
+
+    ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_log(tablet_id, txn_id));
+    ASSERT_TRUE(txn_log->has_op_alter_metadata());
+    for (const auto& alter_meta : txn_log->op_alter_metadata().metadata_update_infos()) {
+        ASSERT_TRUE(alter_meta.has_aggregate_tablet_metadata());
+        ASSERT_TRUE(alter_meta.aggregate_tablet_metadata());
+    }
+    auto new_tablet_meta = publish_single_version(tablet_id, 2, txn_id);
+    ASSERT_OK(new_tablet_meta.status());
+}
+
 } // namespace starrocks::lake

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -434,7 +434,8 @@ public class AlterJobExecutor implements AstVisitor<Void, ConnectContext> {
                 schemaChangeHandler.updateTableMeta(db, tableName.getTbl(), properties,
                         TTabletMetaType.PRIMARY_INDEX_CACHE_EXPIRE_SEC);
             } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX)
-                    || properties.containsKey(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE)) {
+                    || properties.containsKey(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE)
+                    || properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_PARTITION_AGGREGATION)) {
                 if (table.isCloudNativeTable()) {
                     Locker locker = new Locker();
                     locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.WRITE);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
@@ -49,15 +49,15 @@ public class LakeTableAlterMetaJob extends LakeTableAlterMetaJobBase {
                                  long timeoutMs, TTabletMetaType metaType, boolean metaValue,
                                  String persistentIndexType) {
         this(jobId, dbId, tableId, tableName, timeoutMs, metaType, metaValue, persistentIndexType,
-                false, false);
+                MetadataOp.NO_OPERATION);
     }
 
     public LakeTableAlterMetaJob(long jobId, long dbId, long tableId, String tableName,
                                  long timeoutMs, TTabletMetaType metaType, boolean metaValue,
                                  String persistentIndexType,
-                                 boolean aggregateTabletMetadata, boolean splitTabletMetadata) {
+                                 MetadataOp metadataOp) {
         super(jobId, JobType.SCHEMA_CHANGE, dbId, tableId, tableName, timeoutMs, 
-                aggregateTabletMetadata, splitTabletMetadata);
+                metadataOp);
         this.metaType = metaType;
         this.metaValue = metaValue;
         this.persistentIndexType = persistentIndexType;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
@@ -72,7 +72,7 @@ public class LakeTableAlterMetaJob extends LakeTableAlterMetaJobBase {
         }
         if (metaType == TTabletMetaType.ENABLE_PARTITION_AGGREGATION) {
             return TabletMetadataUpdateAgentTaskFactory.createUpdatePartitionAggregationTask(nodeId, tablets,
-                        getAggregateTabletMetadata());
+                        isAggregateTabletMetadata());
         }
         return null;
     }
@@ -94,7 +94,7 @@ public class LakeTableAlterMetaJob extends LakeTableAlterMetaJobBase {
             table.getTableProperty().buildPersistentIndexType();
         }
         if (metaType == TTabletMetaType.ENABLE_PARTITION_AGGREGATION) {
-            table.setEnablePartitionAggregation(getAggregateTabletMetadata());
+            table.setEnablePartitionAggregation(isAggregateTabletMetadata());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -623,7 +623,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         GlobalStateMgr.getCurrentState().getLocalMetastore().handleMVRepair(db, table, partitionRepairInfos);
     }
 
-    public boolean getAggregateTabletMetadata() {
+    public boolean isAggregateTabletMetadata() {
         return metadataOp == MetadataOp.AGGREGATE;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -273,7 +273,6 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
             boolean isEnablePartitionAggregation = isEnablePartitionAggregation();
             for (long partitionId : physicalPartitionIndexMap.rowKeySet()) {
                 long commitVersion = commitVersionMap.get(partitionId);
-                tablets.clear();
                 Map<Long, MaterializedIndex> dirtyIndexMap = physicalPartitionIndexMap.row(partitionId);
                 List<Tablet> tablets = new ArrayList<>();
                 for (MaterializedIndex index : dirtyIndexMap.values()) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -437,7 +437,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
                     "partitionVisitionVersion=" + partition.getVisibleVersion() + " commitVersion=" + commitVersion);
             partition.updateVisibleVersion(commitVersion, finishedTimeMs);
             if (metadataOp == MetadataOp.AGGREGATE || metadataOp == MetadataOp.SPLIT) {
-                partition.setMetadataSwitchVersion(commitVersion - 1);
+                partition.setMetadataSwitchVersion(commitVersion);
             }
             LOG.info("partitionVisibleVersion=" + partition.getVisibleVersion() + " commitVersion=" + commitVersion);
             LOG.info("LakeTableAlterMetaJob id: {} update visible version of partition: {}, visible Version: {}",

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
@@ -166,12 +166,12 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
     }
 
     @Override
-    protected boolean isEnablePartitionAggregation() {
+    protected boolean isAggregateMetadata() {
         return false;
     }
 
     @Override
-    protected boolean isDisablePartitionAggregation() {
+    protected boolean isSplitMetadata() {
         return false;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
@@ -165,6 +165,16 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
         }
     }
 
+    @Override
+    protected boolean isEnablePartitionAggregation() {
+        return false;
+    }
+
+    @Override
+    protected boolean isDisablePartitionAggregation() {
+        return false;
+    }
+
     private static class IndexSchemaInfo {
         @SerializedName("indexId")
         private final long indexId;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2114,7 +2114,6 @@ public class SchemaChangeHandler extends AlterHandler {
             boolean enablePersistentIndex = false;
             String persistentIndexType = "";
             boolean aggregateTabletMetadata = false;
-            LakeTableAlterMetaJob.MetadataOp metadataOp = LakeTableAlterMetaJob.MetadataOp.NO_OPERATION;
             TTabletMetaType metaType = TTabletMetaType.ENABLE_PERSISTENT_INDEX;
             if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX)) {
                 enablePersistentIndex = PropertyAnalyzer.analyzeBooleanProp(properties,
@@ -2157,11 +2156,6 @@ public class SchemaChangeHandler extends AlterHandler {
                             olapTable.getName(), aggregateTabletMetadata));
                     return null;
                 }
-                if (aggregateTabletMetadata) {
-                    metadataOp = LakeTableAlterMetaJob.MetadataOp.ENABLE_PARTITION_AGGREGATE;
-                } else {
-                    metadataOp = LakeTableAlterMetaJob.MetadataOp.DISABLE_PARTITION_AGGREGATE;
-                }
                 metaType = TTabletMetaType.ENABLE_PARTITION_AGGREGATION;
             } else {
                 throw new DdlException("does not support alter " + properties.entrySet().iterator().next().getKey() +
@@ -2172,7 +2166,7 @@ public class SchemaChangeHandler extends AlterHandler {
             alterMetaJob = new LakeTableAlterMetaJob(GlobalStateMgr.getCurrentState().getNextId(),
                     db.getId(),
                     olapTable.getId(), olapTable.getName(), timeoutSecond * 1000 /* should be ms*/,
-                    metaType, enablePersistentIndex, persistentIndexType, metadataOp);
+                    metaType, enablePersistentIndex, persistentIndexType, aggregateTabletMetadata);
         } else {
             // shouldn't happen
             throw new DdlException("only support alter enable_persistent_index in shared_data mode");

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2114,7 +2114,7 @@ public class SchemaChangeHandler extends AlterHandler {
             boolean enablePersistentIndex = false;
             String persistentIndexType = "";
             boolean aggregateTabletMetadata = false;
-            LakeTableAlterMetaJobBase.MetadataOp metadataOp = LakeTableAlterMetaJobBase.MetadataOp.NO_OPERATION;
+            LakeTableAlterMetaJob.MetadataOp metadataOp = LakeTableAlterMetaJob.MetadataOp.NO_OPERATION;
             TTabletMetaType metaType = TTabletMetaType.ENABLE_PERSISTENT_INDEX;
             if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX)) {
                 enablePersistentIndex = PropertyAnalyzer.analyzeBooleanProp(properties,
@@ -2158,9 +2158,9 @@ public class SchemaChangeHandler extends AlterHandler {
                     return null;
                 }
                 if (aggregateTabletMetadata) {
-                    metadataOp = LakeTableAlterMetaJobBase.MetadataOp.AGGREGATE;
+                    metadataOp = LakeTableAlterMetaJob.MetadataOp.ENABLE_PARTITION_AGGREGATE;
                 } else {
-                    metadataOp = LakeTableAlterMetaJobBase.MetadataOp.SPLIT;
+                    metadataOp = LakeTableAlterMetaJob.MetadataOp.DISABLE_PARTITION_AGGREGATE;
                 }
                 metaType = TTabletMetaType.ENABLE_PARTITION_AGGREGATION;
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -3809,4 +3809,15 @@ public class OlapTable extends Table {
         }
         return null;
     }
+
+    public boolean allowUpdatePartitionAggregation() {
+        for (Partition partition : getPartitions()) {
+            for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
+                if (physicalPartition.getMetadataSwitchVersion() != 0) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
@@ -103,6 +103,18 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
     @SerializedName(value = "versionTxnType")
     private TransactionType versionTxnType;
     /**
+     * if splitMetadataVersion is not 0, it means the tablet data before splitMetadataVersion will keep its own
+     * metadata
+     */
+    @SerializedName(value = "splitMetadataVersion")
+    private long splitMetadataVersion;
+    /**
+     * if aggregateMetadataVersion is not 0, it means the tablet data before aggregateMetadataVersion will keep a
+     * shared metadata
+     */
+    @SerializedName(value = "aggregateMetadataVersion")
+    private long aggregateMetadataVersion;
+    /**
      * ID of the transaction that has committed current visible version.
      * Just for tracing the txn log, no need to persist.
      */
@@ -342,6 +354,14 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
 
     public void setVersionTxnType(TransactionType versionTxnType) {
         this.versionTxnType = versionTxnType;
+    }
+
+    public void setSplitMetadataVersion(long splitMetadataVersion) {
+        this.splitMetadataVersion = splitMetadataVersion;
+    }
+
+    public void setAggregateMetadataVersion(long aggregateMetadataVersion) {
+        this.aggregateMetadataVersion = aggregateMetadataVersion;
     }
 
     public MaterializedIndex getIndex(long indexId) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
@@ -104,7 +104,15 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
     private TransactionType versionTxnType;
 
     /**
-     * metadataSwitchVersion is non-zero: Tablets with versions below this value maintain independent metadata.
+     * metadataSwitchVersion is non-zero: The metadata format differs before and after this version.
+     * Therefore, vacuum operations cannot be executed across `metadataSwitchVersion`
+     * e.g.
+     *  the tablet under this partition has five versions: 1, 2, 3, 4, 5 and the metadataSwitchVersion is 3
+     *  the vacuum is run as the following:
+     *      1. Set minRetainVersion to 3 in the vacuumRequest.
+     *      2. The BE will delete tablet metadata where the version is less than 3.
+     *      3. If all tablets execute successfully and there are no metadata entries in two different formats, 
+     *      set metadataSwitchVersion to 0.
      */
     @SerializedName(value = "metadataSwitchVersion")
     private long metadataSwitchVersion;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PartitionsMetaSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PartitionsMetaSystemTable.java
@@ -61,6 +61,7 @@ public class PartitionsMetaSystemTable {
                         .column("MAX_CS", ScalarType.createType(PrimitiveType.DOUBLE))
                         .column("STORAGE_PATH", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .column("STORAGE_SIZE", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("METADATA_SWITCH_VERSION", ScalarType.createType(PrimitiveType.BIGINT))
                         .build(), TSchemaTableType.SCH_PARTITIONS_META);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
@@ -114,7 +114,6 @@ public class PartitionsProcDir implements ProcDirInterface {
                     .add("PartitionName")
                     .add("CompactVersion")
                     .add("VisibleVersion")
-                    .add("MetaSwitchVersion")
                     .add("NextVersion")
                     .add("State")
                     .add("PartitionKey")
@@ -132,6 +131,7 @@ public class PartitionsProcDir implements ProcDirInterface {
                     .add("DataVersion")
                     .add("VersionEpoch")
                     .add("VersionTxnType");
+                    .add("MetaSwitchVersion")
             this.titleNames = builder.build();
         } else {
             ImmutableList.Builder<String> builder = new ImmutableList.Builder<String>()
@@ -395,7 +395,6 @@ public class PartitionsProcDir implements ProcDirInterface {
         partitionInfo.add(partition.getName()); // PartitionName
         partitionInfo.add(statistics != null ? statistics.getCompactionVersion().getVersion() : 0); // CompactVersion
         partitionInfo.add(physicalPartition.getVisibleVersion()); // VisibleVersion
-        partitionInfo.add(physicalPartition.getMetadataSwitchVersion()); // MetaSwitchVersion
         partitionInfo.add(physicalPartition.getNextVersion()); // NextVersion
         partitionInfo.add(partition.getState()); // State
         partitionInfo.add(Joiner.on(", ").join(tblPartitionInfo.getPartitionColumns(table.getIdToColumn())
@@ -416,6 +415,7 @@ public class PartitionsProcDir implements ProcDirInterface {
         partitionInfo.add(physicalPartition.getDataVersion()); // DataVersion
         partitionInfo.add(physicalPartition.getVersionEpoch()); // VersionEpoch
         partitionInfo.add(physicalPartition.getVersionTxnType()); // VersionTxnType
+        partitionInfo.add(physicalPartition.getMetadataSwitchVersion()); // MetaSwitchVersion
         return partitionInfo;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
@@ -114,6 +114,7 @@ public class PartitionsProcDir implements ProcDirInterface {
                     .add("PartitionName")
                     .add("CompactVersion")
                     .add("VisibleVersion")
+                    .add("MetaSwitchVersion")
                     .add("NextVersion")
                     .add("State")
                     .add("PartitionKey")
@@ -394,6 +395,7 @@ public class PartitionsProcDir implements ProcDirInterface {
         partitionInfo.add(partition.getName()); // PartitionName
         partitionInfo.add(statistics != null ? statistics.getCompactionVersion().getVersion() : 0); // CompactVersion
         partitionInfo.add(physicalPartition.getVisibleVersion()); // VisibleVersion
+        partitionInfo.add(physicalPartition.getMetadataSwitchVersion()); // MetaSwitchVersion
         partitionInfo.add(physicalPartition.getNextVersion()); // NextVersion
         partitionInfo.add(partition.getState()); // State
         partitionInfo.add(Joiner.on(", ").join(tblPartitionInfo.getPartitionColumns(table.getIdToColumn())
@@ -414,7 +416,6 @@ public class PartitionsProcDir implements ProcDirInterface {
         partitionInfo.add(physicalPartition.getDataVersion()); // DataVersion
         partitionInfo.add(physicalPartition.getVersionEpoch()); // VersionEpoch
         partitionInfo.add(physicalPartition.getVersionTxnType()); // VersionTxnType
-
         return partitionInfo;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
@@ -130,8 +130,8 @@ public class PartitionsProcDir implements ProcDirInterface {
                     .add("MaxCS") // Maximum compaction score
                     .add("DataVersion")
                     .add("VersionEpoch")
-                    .add("VersionTxnType");
-                    .add("MetaSwitchVersion")
+                    .add("VersionTxnType")
+                    .add("MetaSwitchVersion");
             this.titleNames = builder.build();
         } else {
             ImmutableList.Builder<String> builder = new ImmutableList.Builder<String>()

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -113,6 +113,11 @@ public class AutovacuumDaemon extends FrontendDaemon {
         if (current < partition.getLastVacuumTime() + Config.lake_autovacuum_partition_naptime_seconds * 1000) {
             return false;
         }
+
+        if (partition.getMetadataSwitchVersion() > 0) {
+            return true;
+        }
+
         if (Config.lake_autovacuum_detect_vaccumed_version) {
             long minRetainVersion = partition.getMinRetainVersion();
             if (minRetainVersion <= 0) {
@@ -169,6 +174,7 @@ public class AutovacuumDaemon extends FrontendDaemon {
 
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
+        boolean enablePartitionAggregation = table.enablePartitionAggregation();
         try {
             for (MaterializedIndex index : partition.getMaterializedIndices(IndexExtState.VISIBLE)) {
                 tablets.addAll(index.getTablets());
@@ -179,6 +185,12 @@ public class AutovacuumDaemon extends FrontendDaemon {
                 minRetainVersion = Math.max(1, visibleVersion - Config.lake_autovacuum_max_previous_versions);
             }
             preExtraFileSize = partition.getExtraFileSize();
+            if (partition.getMetadataSwitchVersion() != 0) {
+                // If metadataSwitchVersion is not 0, it means that for versions prior to this, the value of 
+                // enablePartitionAggregation should be the ​​opposite​​ of the current value.
+                enablePartitionAggregation = !enablePartitionAggregation;
+            }
+
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
         }
@@ -189,7 +201,7 @@ public class AutovacuumDaemon extends FrontendDaemon {
         for (Tablet tablet : tablets) {
             LakeTablet lakeTablet = (LakeTablet) tablet;
 
-            if (table.enablePartitionAggregation()) {
+            if (enablePartitionAggregation) {
                 // if enable partition aggregation, there will be only one node.
                 if (pickNode == null) {
                     pickNode = LakeAggregator.chooseAggregatorNode(warehouse.getId());
@@ -227,7 +239,7 @@ public class AutovacuumDaemon extends FrontendDaemon {
             vacuumRequest.minActiveTxnId = minActiveTxnId;
             vacuumRequest.partitionId = partition.getId();
             vacuumRequest.deleteTxnLog = needDeleteTxnLog;
-            vacuumRequest.enablePartitionAggregation = table.enablePartitionAggregation();
+            vacuumRequest.enablePartitionAggregation = enablePartitionAggregation;
             // Perform deletion of txn log on the first node only.
             needDeleteTxnLog = false;
             try {
@@ -289,6 +301,9 @@ public class AutovacuumDaemon extends FrontendDaemon {
             // the vacuumedVersion isthe minimum success vacuum version among all tablets within the partition which
             // means that all the garbage files before the vacuumVersion have been deleted.
             partition.setLastSuccVacuumVersion(vacuumedVersion);
+            if (partition.getMetadataSwitchVersion() != 0 && vacuumedVersion > partition.getMetadataSwitchVersion()) {
+                partition.setMetadataSwitchVersion(0);
+            }
             long incrementExtraFileSize = partition.getExtraFileSize() - preExtraFileSize;
             partition.setExtraFileSize(extraFileSize + incrementExtraFileSize);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -487,6 +487,8 @@ public class InformationSchemaDataSource {
             // STORAGE_PATH
             partitionMetaInfo.setStorage_path(
                     table.getPartitionFilePathInfo(physicalPartition.getId()).getFullPath());
+            // METADATA_SWITCH_VERSION
+            partitionMetaInfo.setMetadata_switch_version(physicalPartition.getMetadataSwitchVersion());
         }
 
         partitionMetaInfo.setData_version(physicalPartition.getDataVersion());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -269,6 +269,20 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
                         "Property " + PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE +
                                 " must be CLOUD_NATIVE or LOCAL");
             }
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_PARTITION_AGGREGATION)) {
+            if (!properties.get(PropertyAnalyzer.PROPERTIES_ENABLE_PARTITION_AGGREGATION).equalsIgnoreCase("true") &&
+                    !properties.get(PropertyAnalyzer.PROPERTIES_ENABLE_PARTITION_AGGREGATION).equalsIgnoreCase("false")) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                        "Property " + PropertyAnalyzer.PROPERTIES_ENABLE_PARTITION_AGGREGATION +
+                                " must be bool type(false/true)");
+            }
+            if (!table.isCloudNativeTable()) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                            "Property " + PropertyAnalyzer.PROPERTIES_ENABLE_PARTITION_AGGREGATION +
+                                    " only support cloud native table");
+            }
+            // TODO(zhangqiang)
+            // reject alter partition_aggregate request if the table contains metadata with two different types
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE)) {
             if (!properties.get(PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE).equalsIgnoreCase("true") &&
                     !properties.get(PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE).equalsIgnoreCase("false")) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -276,6 +276,7 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
                         "Property " + PropertyAnalyzer.PROPERTIES_ENABLE_PARTITION_AGGREGATION +
                                 " must be bool type(false/true)");
             }
+
             if (!table.isCloudNativeTable()) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
                             "Property " + PropertyAnalyzer.PROPERTIES_ENABLE_PARTITION_AGGREGATION +
@@ -283,6 +284,13 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
             }
             // TODO(zhangqiang)
             // reject alter partition_aggregate request if the table contains metadata with two different types
+            OlapTable olapTable = (OlapTable) table;
+            if (!olapTable.allowUpdatePartitionAggregation()) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                            "Property " + PropertyAnalyzer.PROPERTIES_ENABLE_PARTITION_AGGREGATION +
+                                    " cannot be updated now because this table contains mixed metadata types "  + 
+                                    "(both split and aggregate). Please wait until old metadata versions are vacuumed");
+            }
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE)) {
             if (!properties.get(PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE).equalsIgnoreCase("true") &&
                     !properties.get(PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE).equalsIgnoreCase("false")) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -282,9 +282,16 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
                             "Property " + PropertyAnalyzer.PROPERTIES_ENABLE_PARTITION_AGGREGATION +
                                     " only support cloud native table");
             }
-            // TODO(zhangqiang)
-            // reject alter partition_aggregate request if the table contains metadata with two different types
+
+            boolean enablePartitionAggregation = properties.get(
+                            PropertyAnalyzer.PROPERTIES_ENABLE_PARTITION_AGGREGATION).equalsIgnoreCase("true");
             OlapTable olapTable = (OlapTable) table;
+            if (enablePartitionAggregation == olapTable.enablePartitionAggregation()) {
+                String msg = String.format("table: %s enable_partition_aggregation is %s, nothing need to do",
+                        olapTable.getName(), enablePartitionAggregation);
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, msg);
+            }
+            
             if (!olapTable.allowUpdatePartitionAggregation()) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
                             "Property " + PropertyAnalyzer.PROPERTIES_ENABLE_PARTITION_AGGREGATION +

--- a/fe/fe-core/src/main/java/com/starrocks/task/TabletMetadataUpdateAgentTaskFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/TabletMetadataUpdateAgentTaskFactory.java
@@ -72,6 +72,12 @@ public class TabletMetadataUpdateAgentTaskFactory {
         return new UpdateLakePersistentIndexTask(backendId, tablets, enablePersistentIndex, persistentIndexType);
     }
 
+    public static TabletMetadataUpdateAgentTask createUpdatePartitionAggregationTask(long backendId, Set<Long> tablets,
+                                                                                     boolean aggregateTabletMetadata) {
+        requireNonNull(tablets, "tablets is null");
+        return new UpdatePartitionAggregationTask(backendId, tablets, aggregateTabletMetadata);
+    }
+
     public static TabletMetadataUpdateAgentTask createEnablePersistentIndexUpdateTask(long backend, Set<Long> tablets,
                                                                                       Boolean value) {
         requireNonNull(tablets, "tablets is null");
@@ -245,6 +251,35 @@ public class TabletMetadataUpdateAgentTaskFactory {
                     throw new IllegalArgumentException("Unknown persistent index type: " + persistentIndexType);
                 }
                 metaInfo.setMeta_type(TTabletMetaType.ENABLE_PERSISTENT_INDEX);
+                metaInfos.add(metaInfo);
+            }
+            return metaInfos;
+        }
+    }
+
+    private static class UpdatePartitionAggregationTask extends TabletMetadataUpdateAgentTask {
+        private final Set<Long> tablets;
+        private boolean aggregateTabletMetadata;
+
+        private UpdatePartitionAggregationTask(long backendId, Set<Long> tablets, 
+                                               boolean aggregateTabletMetadata) {
+            super(backendId, tablets.hashCode());
+            this.tablets = tablets;
+            this.aggregateTabletMetadata = aggregateTabletMetadata;
+        }
+
+        @Override
+        public Set<Long> getTablets() {
+            return tablets;
+        }
+
+        @Override
+        public List<TTabletMetaInfo> getTTabletMetaInfoList() {
+            List<TTabletMetaInfo> metaInfos = Lists.newArrayList();
+            for (Long tabletId : tablets) {
+                TTabletMetaInfo metaInfo = new TTabletMetaInfo();
+                metaInfo.setTablet_id(tabletId);
+                metaInfo.setAggregate_tablet_metadata(aggregateTabletMetadata);
                 metaInfos.add(metaInfo);
             }
             return metaInfos;

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeSyncMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeSyncMaterializedViewTest.java
@@ -232,19 +232,19 @@ public class LakeSyncMaterializedViewTest {
     @Test
     public void testSelectFromSyncMV() throws Exception {
         // `tbl1`'s distribution keys is k2, sync_mv1 no `k2` in its outputs.
-        String sql = "create materialized view sync_mv as select k1, sum(v1) from tbl1 group by k1;";
+        String sql = "create materialized view sync_mv1 as select k1, sum(v1) from tbl1 group by k1;";
         CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
                 parseStmtWithNewParser(sql, connectContext);
         GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createTableStmt);
 
         waitingRollupJobV2Finish();
-        sql = "select * from sync_mv [_SYNC_MV_];";
+        sql = "select * from sync_mv1 [_SYNC_MV_];";
         Pair<String, ExecPlan> pair = UtFrameUtils.getPlanAndFragment(connectContext, sql);
         String explainString = pair.second.getExplainString(StatementBase.ExplainLevel.NORMAL);
         Assert.assertTrue(explainString.contains("partitions=2/2\n" +
-                "     rollup: sync_mv\n" +
+                "     rollup: sync_mv1\n" +
                 "     tabletRatio=6/6"));
-        starRocksAssert.dropMaterializedView("sync_mv");
+        starRocksAssert.dropMaterializedView("sync_mv1");
     }
 
     // create sync mv that mv's name already existed in the db
@@ -265,7 +265,7 @@ public class LakeSyncMaterializedViewTest {
     // create sync mv that mv's name already existed in the same table
     @Test
     public void testCreateSyncMV2() throws Exception {
-        String sql = "create materialized view sync_mv2 as select k1, sum(v1) from tbl1 group by k1;";
+        String sql = "create materialized view sync_mv1 as select k1, sum(v1) from tbl1 group by k1;";
         CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
                 parseStmtWithNewParser(sql, connectContext);
         GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createTableStmt);
@@ -273,26 +273,26 @@ public class LakeSyncMaterializedViewTest {
         waitingRollupJobV2Finish();
         OlapTable tbl1 = (OlapTable) (getTable("test", "tbl1"));
         Assert.assertTrue(tbl1 != null);
-        Assert.assertTrue(tbl1.hasMaterializedIndex("sync_mv2"));
+        Assert.assertTrue(tbl1.hasMaterializedIndex("sync_mv1"));
 
         // sync_mv1 already existed in the tbl1
-        sql = "create materialized view sync_mv2 as select k1, sum(v1) from tbl1 group by k1;";
+        sql = "create materialized view sync_mv1 as select k1, sum(v1) from tbl1 group by k1;";
         createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
                 parseStmtWithNewParser(sql, connectContext);
         try {
             GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createTableStmt);
             Assert.fail();
         } catch (Throwable e) {
-            Assert.assertTrue(e.getMessage().contains("Materialized view[sync_mv2] already exists in " +
+            Assert.assertTrue(e.getMessage().contains("Materialized view[sync_mv1] already exists in " +
                     "the table tbl1"));
         }
-        starRocksAssert.dropMaterializedView("sync_mv2");
+        starRocksAssert.dropMaterializedView("sync_mv1");
     }
 
     // create sync mv that mv's name already existed in other table
     @Test
     public void testCreateSyncMV3() throws Exception {
-        String sql = "create materialized view sync_mv3 as select k1, sum(v1) from tbl1 group by k1;";
+        String sql = "create materialized view sync_mv1 as select k1, sum(v1) from tbl1 group by k1;";
         CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
                 parseStmtWithNewParser(sql, connectContext);
         GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createTableStmt);
@@ -300,19 +300,19 @@ public class LakeSyncMaterializedViewTest {
         waitingRollupJobV2Finish();
         OlapTable tbl1 = (OlapTable) (getTable("test", "tbl1"));
         Assert.assertTrue(tbl1 != null);
-        Assert.assertTrue(tbl1.hasMaterializedIndex("sync_mv3"));
+        Assert.assertTrue(tbl1.hasMaterializedIndex("sync_mv1"));
         // sync_mv1 already existed in tbl1
-        sql = "create materialized view sync_mv3 as select k1, sum(v1) from tbl3 group by k1;";
+        sql = "create materialized view sync_mv1 as select k1, sum(v1) from tbl3 group by k1;";
         createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
                 parseStmtWithNewParser(sql, connectContext);
         try {
             GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createTableStmt);
             Assert.fail();
         } catch (Throwable e) {
-            Assert.assertTrue(e.getMessage().contains("Materialized view[sync_mv3] already exists " +
+            Assert.assertTrue(e.getMessage().contains("Materialized view[sync_mv1] already exists " +
                     "in table tbl1"));
         }
-        starRocksAssert.dropMaterializedView("sync_mv3");
+        starRocksAssert.dropMaterializedView("sync_mv1");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
@@ -26,9 +26,11 @@ import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
+import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.CreateDbStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.ModifyTablePropertiesClause;
@@ -402,5 +404,55 @@ public class LakeTableAlterMetaJobTest {
         ExceptionChecker.expectThrows(DdlException.class,
                 () -> schemaChangeHandler.createAlterMetaJob(modify, db, table2));
 
+    }
+
+    @Test
+    public void testModifyPropertyEnablePartitionAggregation() throws Exception {
+        LakeTable table2 = createTable(connectContext,
+                    "CREATE TABLE t12(c0 INT) PRIMARY KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 " +
+                                "PROPERTIES('enable_partition_aggregation'='false')");
+        Assert.assertFalse(table2.enablePartitionAggregation());
+        Map<String, String> properties = new HashMap<>();
+        properties.put("enable_partition_aggregation", "true");
+        ModifyTablePropertiesClause modify = new ModifyTablePropertiesClause(properties);
+        SchemaChangeHandler schemaChangeHandler = new SchemaChangeHandler();
+        AlterJobV2 job = schemaChangeHandler.createAlterMetaJob(modify, db, table2);
+        Assert.assertNotNull(job);
+        Assert.assertEquals(AlterJobV2.JobState.PENDING, job.getJobState());
+        job.runPendingJob();
+        Assert.assertEquals(AlterJobV2.JobState.RUNNING, job.getJobState());
+        Assert.assertNotEquals(-1L, job.getTransactionId().orElse(-1L).longValue());
+        job.runRunningJob();
+        Assert.assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, job.getJobState());
+        while (job.getJobState() != AlterJobV2.JobState.FINISHED) {
+            job.runFinishedRewritingJob();
+            Thread.sleep(100);
+        }
+        Assert.assertEquals(AlterJobV2.JobState.FINISHED, job.getJobState());
+        Assert.assertTrue(table2.enablePartitionAggregation());
+        Assert.assertFalse(table2.allowUpdatePartitionAggregation());
+
+        properties.put("enable_partition_aggregation", "true");
+        ModifyTablePropertiesClause modify1 = new ModifyTablePropertiesClause(properties);
+        AlterJobV2 job1 = schemaChangeHandler.createAlterMetaJob(modify1, db, table2);
+        Assert.assertNull(job1);
+        Assert.assertFalse(table2.allowUpdatePartitionAggregation());
+
+        try {
+            String alterStmtStr = "alter table test.t12 set ('enable_partition_aggregation'='true')";
+            AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterStmtStr, connectContext);
+            DDLStmtExecutor.execute(alterTableStmt, connectContext);
+        } catch (Exception e) {
+            Assert.assertTrue(table2.enablePartitionAggregation());
+        }
+
+        try {
+            String alterStmtStr = "alter table test.t12 set ('enable_partition_aggregation'='false')";
+            AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterStmtStr, connectContext);
+            DDLStmtExecutor.execute(alterTableStmt, connectContext);
+        } catch (Exception e) {
+            Assert.assertFalse(table2.allowUpdatePartitionAggregation());
+            Assert.assertTrue(table2.enablePartitionAggregation());
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/PhysicalPartitionImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/PhysicalPartitionImplTest.java
@@ -130,6 +130,12 @@ public class PhysicalPartitionImplTest {
         p.setLastVacuumTime(1);
         Assert.assertEquals(1, p.getLastVacuumTime());
 
+        p.setMinRetainVersion(3);
+        p.setMetadataSwitchVersion(1);
+        Assert.assertEquals(1, p.getMinRetainVersion());
+        p.setMetadataSwitchVersion(0);
+        Assert.assertEquals(3, p.getMinRetainVersion());
+
         p.setDataVersion(0);
         p.setNextDataVersion(0);
         p.setVersionEpoch(0);

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/PartitionsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/PartitionsProcDirTest.java
@@ -71,8 +71,9 @@ public class PartitionsProcDirTest {
         Assert.assertEquals("p1", list1.get(1));
         Assert.assertEquals("0", list1.get(2));
         Assert.assertEquals("1", list1.get(3));
-        Assert.assertEquals("2", list1.get(4));
-        Assert.assertEquals("NORMAL", list1.get(5));
-        Assert.assertEquals("province", list1.get(6));
+        Assert.assertEquals("0", list1.get(4));
+        Assert.assertEquals("2", list1.get(5));
+        Assert.assertEquals("NORMAL", list1.get(6));
+        Assert.assertEquals("province", list1.get(7));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/PartitionsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/PartitionsProcDirTest.java
@@ -71,9 +71,9 @@ public class PartitionsProcDirTest {
         Assert.assertEquals("p1", list1.get(1));
         Assert.assertEquals("0", list1.get(2));
         Assert.assertEquals("1", list1.get(3));
-        Assert.assertEquals("0", list1.get(4));
-        Assert.assertEquals("2", list1.get(5));
-        Assert.assertEquals("NORMAL", list1.get(6));
-        Assert.assertEquals("province", list1.get(7));
+        Assert.assertEquals("2", list1.get(4));
+        Assert.assertEquals("NORMAL", list1.get(5));
+        Assert.assertEquals("province", list1.get(6));
+        Assert.assertEquals("0", list1.get(7));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/PartitionsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/PartitionsProcDirTest.java
@@ -74,6 +74,6 @@ public class PartitionsProcDirTest {
         Assert.assertEquals("2", list1.get(4));
         Assert.assertEquals("NORMAL", list1.get(5));
         Assert.assertEquals("province", list1.get(6));
-        Assert.assertEquals("0", list1.get(7));
+        Assert.assertEquals("0", list1.get(21));
     }
 }

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -162,6 +162,8 @@ message MetadataUpdateInfoPB {
     optional bool enable_persistent_index = 1;
     optional TabletSchemaPB tablet_schema = 2;
     optional PersistentIndexTypePB persistent_index_type = 3;
+    optional bool aggregate_tablet_metadata = 4;
+    optional bool split_tablet_metadata = 5;
 }
 
 message SharedTabletMetadataPB {

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -163,7 +163,6 @@ message MetadataUpdateInfoPB {
     optional TabletSchemaPB tablet_schema = 2;
     optional PersistentIndexTypePB persistent_index_type = 3;
     optional bool aggregate_tablet_metadata = 4;
-    optional bool split_tablet_metadata = 5;
 }
 
 message SharedTabletMetadataPB {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -437,7 +437,8 @@ enum TTabletMetaType {
     MUTABLE_BUCKET_NUM,
     ENABLE_LOAD_PROFILE,
     BASE_COMPACTION_FORBIDDEN_TIME_RANGES,
-    FLAT_JSON_CONFIG
+    FLAT_JSON_CONFIG,
+    ENABLE_PARTITION_AGGREGATION
 }
 
 struct TTabletMetaInfo {
@@ -454,6 +455,7 @@ struct TTabletMetaInfo {
     10: optional bool create_schema_file;
     11: optional TPersistentIndexType persistent_index_type;
     12: optional TFlatJsonConfig flat_json_config;
+    13: optional bool aggregate_tablet_metadata;
 }
 
 struct TUpdateTabletMetaInfoReq {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1512,6 +1512,7 @@ struct TPartitionMetaInfo {
     27: optional i64 version_epoch
     28: optional Types.TTxnType version_txn_type = Types.TTxnType.TXN_NORMAL
     29: optional i64 storage_size
+    30: optional i64 metadata_switch_version
 }
 
 struct TGetPartitionsMetaResponse {

--- a/test/sql/test_information_schema/R/test_partitions_meta
+++ b/test/sql/test_information_schema/R/test_partitions_meta
@@ -38,14 +38,14 @@ PROPERTIES (
 admin set frontend config("max_get_partitions_meta_result_count"="1");
 -- result:
 -- !result
-select TABLE_NAME, PARTITION_NAME, DATA_VERSION, VERSION_TXN_TYPE, STORAGE_SIZE from INFORMATION_SCHEMA.PARTITIONS_META where table_name like '%partitions_meta_test%' order by table_name asc, partition_name asc;
+select TABLE_NAME, PARTITION_NAME, DATA_VERSION, VERSION_TXN_TYPE, STORAGE_SIZE, METADATA_SWITCH_VERSION from INFORMATION_SCHEMA.PARTITIONS_META where table_name like '%partitions_meta_test%' order by table_name asc, partition_name asc;
 -- result:
-partitions_meta_test1	p1	1	TXN_NORMAL	0
-partitions_meta_test1	p2	1	TXN_NORMAL	0
-partitions_meta_test1	p3	1	TXN_NORMAL	0
-partitions_meta_test2	p1	1	TXN_NORMAL	0
-partitions_meta_test2	p2	1	TXN_NORMAL	0
-partitions_meta_test2	p3	1	TXN_NORMAL	0
+partitions_meta_test1	p1	1	TXN_NORMAL	0	0
+partitions_meta_test1	p2	1	TXN_NORMAL	0	0
+partitions_meta_test1	p3	1	TXN_NORMAL	0	0
+partitions_meta_test2	p1	1	TXN_NORMAL	0	0
+partitions_meta_test2	p2	1	TXN_NORMAL	0	0
+partitions_meta_test2	p3	1	TXN_NORMAL	0	0
 -- !result
 admin set frontend config("max_get_partitions_meta_result_count"="100000");
 -- result:

--- a/test/sql/test_information_schema/T/test_partitions_meta
+++ b/test/sql/test_information_schema/T/test_partitions_meta
@@ -28,6 +28,6 @@ PROPERTIES (
 "replication_num" = "1"
 );
 admin set frontend config("max_get_partitions_meta_result_count"="1");
-select TABLE_NAME, PARTITION_NAME, DATA_VERSION, VERSION_TXN_TYPE, STORAGE_SIZE from INFORMATION_SCHEMA.PARTITIONS_META where table_name like '%partitions_meta_test%' order by table_name asc, partition_name asc;
+select TABLE_NAME, PARTITION_NAME, DATA_VERSION, VERSION_TXN_TYPE, STORAGE_SIZE, METADATA_SWITCH_VERSION from INFORMATION_SCHEMA.PARTITIONS_META where table_name like '%partitions_meta_test%' order by table_name asc, partition_name asc;
 admin set frontend config("max_get_partitions_meta_result_count"="100000");
 drop database db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
In previous PRs, we implemented table-level `enable_partition_aggregation` property to reduce API calls in StarRocks shared-data mode. However, this property currently can only be specified during table creation. As a result, even after users upgrade to the latest version, they cannot enable this feature for existing tables unless they create new ones.

Therefore, we need to develop a method to activate this functionality for historical tables.

## What I'm doing:
Users can enable/disable this feature using the following SQL command when they upgrade to new version:
```sql
Alter table $table_name set ('enable_partition_property' = 'true');
Alter table $table_name set ('enable_partition_property' = 'false');
```

But there is one critical limitation:**consecutive modifications to enable_partition_aggregation are prohibited.**

e.g.
1. If you successfully execute:  
   ```sql
   ALTER TABLE test_tbl SET ('enable_partition_aggregation' = 'true');
2. You cannot immediately follow it with:
    ```sql
    ALTER TABLE test_tbl SET ('enable_partition_aggregation' = 'false');
    ```
   Otherwise, you may encounter errors like:
   ```
    Property enable_partition_aggregation cannot be updated now because this table contains mixed metadata types (both split and aggregate). Please wait until old metadata versions are vacuumed);
    ```

**Why:**
1.  `enable_partition_aggregation` is designed as a non-frequently toggled property. Modification support is primarily intended to allow enabling the feature on tables created in old version.
2. Modify `enable_partition_aggregation` will ​​modify the table's metadata storage format​​. So the system must support ​​coexistence of both metadata formats​​ during the transition period. After modify `enable_partition_aggregation`, the table metadata will keep a `metadataSwitchVersion` field to track the version of the format change. Frequent modifications will increased complexity in compatibility logic, So the modification is prohibited​​ when `metadataSwitchVersion` is not 0.

**When we can do the next modification of `enable_partition_aggregation property`?**

If you want to modify `enable_partition_aggregation`, you can check the `metadataSwitchVersion` first. You can run  `show '/proc/dbs/$db/$table/partitions' ` to check the `metadataSwitchVersion`.

**How can we efficiently reset the metadataSwitchVersion to 0 after completing the metadata format transition?**

​​`metadataSwitchVersion` is reset to 0 when the version before `metadataSwitchVersion` is vacuumed. So we can decrease `lake_autovacuum_grace_period_minutes` to speed up vacuum.


Fixes https://github.com/StarRocks/starrocks/issues/58316

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
