### PR TITLE
[BugFix] Fix deadlock introduced by streamLoadTask

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -329,18 +329,7 @@ public class GlobalTransactionMgr implements MemoryTrackable {
         TransactionState transactionState = getTransactionState(db.getId(), transactionId);
         List<Long> tableIdList = transactionState.getTableIdList();
 
-        Locker locker = new Locker();
-        if (!locker.tryLockTablesWithIntensiveDbLock(db.getId(), tableIdList, LockType.WRITE,
-                timeoutMillis, TimeUnit.MILLISECONDS)) {
-            String errMsg = String.format("get database write lock timeout, transactionId=%d, database=%s, timeoutMillis=%d",
-                    transactionId, db.getFullName(), timeoutMillis);
-            throw new StarRocksException(errMsg);
-        }
-        try {
-            waiter = getDatabaseTransactionMgr(db.getId()).commitPreparedTransaction(transactionId);
-        } finally {
-            locker.unLockTablesWithIntensiveDbLock(db.getId(), tableIdList, LockType.WRITE);
-        }
+        waiter = getDatabaseTransactionMgr(db.getId()).commitPreparedTransaction(transactionId);
         if (waiter == null) {
             throw new TransactionCommitFailedException(String.format("transaction fail to commit, %s",
                     transactionState.toString()));


### PR DESCRIPTION
## Why I'm doing:
![image](https://github.com/user-attachments/assets/a3d9677e-af51-4614-a51c-f3f285c5a736)

The locking order during the routine load phase is dbIX -> streamLoadManager#writeLock, but the locking order of transaction commit is streamLoadManager#readLock -> dbIX lock. This may causes a deadlock for the locking order is inconsistent.
![image](https://github.com/user-attachments/assets/c9cd007a-6e93-489c-aa7f-6e55c0dd2502)

![image](https://github.com/user-attachments/assets/9d243c3d-b05a-4a63-90e0-c2caba31ec10)

## What I'm doing:
The db lock during transaction commit seems unnecessary, so delete it
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
