### PR TITLE
[BugFix] Fix pipe source poll exception causes pipe error state

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/Pipe.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/Pipe.java
@@ -197,7 +197,6 @@ public class Pipe implements GsonPostProcessable {
             pipeSource.poll();
         } catch (Throwable e) {
             recordPipeError("poll from source failed: " + e.getMessage());
-            changeState(State.ERROR, true);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/pipe/PipeManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/pipe/PipeManagerTest.java
@@ -282,7 +282,6 @@ public class PipeManagerTest {
         // Validate pipe execution
         Pipe p2 = follower.mayGetPipe(new PipeName(PIPE_TEST_DB, "p2")).get();
         p2.poll();
-        p2.schedule();
         p1 = follower.mayGetPipe(new PipeName(PIPE_TEST_DB, "p1")).get();
         Assert.assertEquals(Pipe.State.SUSPEND, p1.getState());
     }
@@ -667,9 +666,8 @@ public class PipeManagerTest {
 
         mockPollError(1);
         Pipe p3 = getPipe(pipeName);
-        p3.poll();
-
-        // get error
+        // set error
+        p3.setState(Pipe.State.ERROR);
         Assert.assertEquals(Pipe.State.ERROR, p3.getState());
 
         // resume after error


### PR DESCRIPTION
## Why I'm doing:
![image](https://github.com/user-attachments/assets/122393c3-020b-4697-bd4a-72ba487de793)

pipe state will be set to error when pipe source poll gets exception.

## What I'm doing:

Not set error state and retry.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
