### PR TITLE
[BugFix] fix asan misalignment in avx512

### DIFF
--- a/be/src/simd/delta_decode.h
+++ b/be/src/simd/delta_decode.h
@@ -205,9 +205,31 @@ MFV_AVX2(void delta_decode_chain_int32(int32_t* buf, int n, int32_t min_delta, i
     return delta_decode_chain_int32_avx2(buf, n, min_delta, last_value);
 });
 
+// https://github.com/llvm/llvm-project/issues/91565
+// In ASAN mode, this function will cause SIGSEGV because of touching redzone.
+// But according to ChatGPT's explanation, it's a bug of ASAN. ASAN allocas stack space aligned to 32 bytes not 64 bytes,
+// so when spill zmm registers, it will touch redzone. and assembly code is like following:
+/*
+   0x0000000029b7382e <+331>:   je     0x29b7383d <starrocks::delta_decode_chain_int32_avx512(int32_t*, int, int32_t, int32_t&)+346>
+   0x0000000029b73830 <+333>:   mov    $0x40,%esi
+   0x0000000029b73835 <+338>:   mov    %rax,%rdi
+   0x0000000029b73838 <+341>:   call   0x19824bf0 <__asan_report_store_n>
+=> 0x0000000029b7383d <+346>:   vmovdqa64 %zmm0,-0x180(%r13)
+   0x0000000029b73844 <+353>:   vpxor  %xmm0,%xmm0,%xmm0
+   0x0000000029b73848 <+357>:   lea    -0x100(%r13),%rax
+   0x0000000029b7384f <+364>:   mov    %rax,%rdx
+   0x0000000029b73852 <+367>:   shr    $0x3,%rdx
+   0x0000000029b73856 <+371>:   add    $0x7fff8000,%rdx
+   */
+// to resolve this problem, we have to force stack alignment to 64 bytes, which is not supported in our compiler right now.
+
+#if !defined(ADDRESS_SANITIZER)
+
 MFV_AVX512F(void delta_decode_chain_int32(int32_t* buf, int n, int32_t min_delta, int32_t& last_value) {
     return delta_decode_chain_int32_avx512(buf, n, min_delta, last_value);
 });
+
+#endif
 
 MFV_DEFAULT(void delta_decode_chain_int32(int32_t* buf, int n, int32_t min_delta, int32_t& last_value) {
     return delta_decode_chain_scalar_prefetch<int32_t>(buf, n, min_delta, last_value);
@@ -256,9 +278,13 @@ MFV_AVX512F(void delta_decode_chain_int64_avx512(int64_t* buf, int n, int64_t mi
     }
 });
 
+#if !defined(ADDRESS_SANITIZER)
+
 MFV_AVX512F(void delta_decode_chain_int64(int64_t* buf, int n, int64_t min_delta, int64_t& last_value) {
     return delta_decode_chain_int64_avx512(buf, n, min_delta, last_value);
 });
+
+#endif
 
 MFV_DEFAULT(void delta_decode_chain_int64(int64_t* buf, int n, int64_t min_delta, int64_t& last_value) {
     return delta_decode_chain_scalar_prefetch<int64_t>(buf, n, min_delta, last_value);


### PR DESCRIPTION
## Why I'm doing:

This function crashes occasionlly in ASAN mode in our daily build.  

assembly code is like this

```
   0x0000000029b7382e <+331>:   je     0x29b7383d <starrocks::delta_decode_chain_int32_avx512(int32_t*, int, int32_t, int32_t&)+346>
   0x0000000029b73830 <+333>:   mov    $0x40,%esi
   0x0000000029b73835 <+338>:   mov    %rax,%rdi
   0x0000000029b73838 <+341>:   call   0x19824bf0 <__asan_report_store_n>
=> 0x0000000029b7383d <+346>:   vmovdqa64 %zmm0,-0x180(%r13)
   0x0000000029b73844 <+353>:   vpxor  %xmm0,%xmm0,%xmm0
   0x0000000029b73848 <+357>:   lea    -0x100(%r13),%rax
   0x0000000029b7384f <+364>:   mov    %rax,%rdx
   0x0000000029b73852 <+367>:   shr    $0x3,%rdx
   0x0000000029b73856 <+371>:   add    $0x7fff8000,%rdx
```

## What I'm doing:

This PR is another try following this pr: https://github.com/StarRocks/starrocks/pull/59035

According to gpt's explanation, this could be a bug of ASAN(misalignment for 512 bit-width resgister spilling). https://github.com/llvm/llvm-project/issues/91565

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
