### PR TITLE
[BugFix] Fix result queue capacity of result sink

### DIFF
--- a/be/src/exec/data_sink.cpp
+++ b/be/src/exec/data_sink.cpp
@@ -291,7 +291,7 @@ Status DataSink::decompose_data_sink_to_pipeline(pipeline::PipelineBuilderContex
                                                            result_sink->get_file_opts(), dop, fragment_ctx);
         } else {
             op = std::make_shared<ResultSinkOperatorFactory>(
-                    context->next_operator_id(), result_sink->get_sink_type(), result_sink->isBinaryFormat(),
+                    context->next_operator_id(), dop, result_sink->get_sink_type(), result_sink->isBinaryFormat(),
                     result_sink->get_format_type(), result_sink->get_output_exprs(), fragment_ctx,
                     result_sink->get_row_desc());
         }

--- a/be/src/exec/pipeline/result_sink_operator.cpp
+++ b/be/src/exec/pipeline/result_sink_operator.cpp
@@ -147,9 +147,8 @@ Status ResultSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk
 
 Status ResultSinkOperatorFactory::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(OperatorFactory::prepare(state));
-    auto dop = state->query_options().pipeline_dop;
     RETURN_IF_ERROR(state->exec_env()->result_mgr()->create_sender(state->fragment_instance_id(),
-                                                                   std::min(dop << 1, 1024), &_sender));
+                                                                   std::min<int>(_dop << 1, 1024), &_sender));
 
     RETURN_IF_ERROR(Expr::create_expr_trees(state->obj_pool(), _t_output_expr, &_output_expr_ctxs, state));
 

--- a/be/src/exec/pipeline/result_sink_operator.h
+++ b/be/src/exec/pipeline/result_sink_operator.h
@@ -93,10 +93,11 @@ private:
 
 class ResultSinkOperatorFactory final : public OperatorFactory {
 public:
-    ResultSinkOperatorFactory(int32_t id, TResultSinkType::type sink_type, bool is_binary_format,
+    ResultSinkOperatorFactory(int32_t id, size_t dop, TResultSinkType::type sink_type, bool is_binary_format,
                               TResultSinkFormatType::type format_type, std::vector<TExpr> t_output_expr,
                               FragmentContext* const fragment_ctx, const RowDescriptor& row_desc)
             : OperatorFactory(id, "result_sink", Operator::s_pseudo_plan_node_id_for_final_sink),
+              _dop(dop),
               _sink_type(sink_type),
               _is_binary_format(is_binary_format),
               _format_type(format_type),
@@ -125,6 +126,8 @@ public:
 
 private:
     void _increment_num_sinkers_no_barrier() { _num_sinkers.fetch_add(1, std::memory_order_relaxed); }
+
+    const size_t _dop;
 
     TResultSinkType::type _sink_type;
     bool _is_binary_format;


### PR DESCRIPTION
## Why I'm doing:

Introduced by #30386.

The result queue capacity is `dop*2`. 

However, this dop is get by `state->query_options().pipeline_dop`, which is the raw value of the session variable  `pipeline_dop` (0 by default). 

This results that the queue capacity is 0, which means the queue will be full after putting one result batch. And therefore, result sink can only buffer one chunk.

### Test

16Core 64GB Memory BE.

```sql
select k1,k1,k1,k1,k1,k1,k1,k1,k1,k1,k1,k1,k1,k1,k1,k1,k1,k1,k1,k1,k1,k1,k1,k1 
from d1.__row_util_base 
limit 100000000
```
ResultDeliverTime: 
- Before: 35s139ms
- After:    17s432ms

ResultDeliverTime is decreased, **but the total execution time between these two versions are the same.**


## What I'm doing:

Use actual DOP to set queue capacity.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
