### PR TITLE
[Enhancement] apply the task_runs_max_history_number to task_runs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -400,8 +400,7 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "task run ttl")
     public static int task_runs_ttl_second = 7 * 24 * 3600;     // 7 day
 
-    @Deprecated
-    @ConfField(mutable = true, comment = "[DEPRECATED as enable_task_history_archive] max number of task run history. ")
+    @ConfField(mutable = true, comment = "max number of task run history. ")
     public static int task_runs_max_history_number = 10000;
 
     @ConfField(mutable = true, comment = "Minimum schedule interval of a task")

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
@@ -210,8 +210,11 @@ public class TaskRunHistoryTable {
             predicates.add(" task_state = " + Strings.quote(params.getState()));
         }
         sql += Joiner.on(" AND ").join(predicates);
+        // If user explicitly specify the LIMIT in sql, we don't apply default limit
         if (params.isSetPagination() && params.getPagination().getLimit() > 0) {
             sql += " LIMIT " + params.getPagination().getLimit();
+        } else if (Config.task_runs_max_history_number > 0) {
+            sql += " ORDER BY create_time DESC LIMIT " + Config.task_runs_max_history_number;
         }
 
         List<TResultBatch> batch = SimpleExecutor.getRepoExecutor().executeDQL(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
@@ -102,7 +102,8 @@ public class TaskRunHistoryTest {
         new Expectations() {
             {
                 repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history WHERE TRUE AND  " +
-                        "get_json_string(history_content_json, 'dbName') = 'default_cluster:d1'");
+                        "get_json_string(history_content_json, 'dbName') = 'default_cluster:d1' " +
+                        "ORDER BY create_time DESC LIMIT 10000");
             }
         };
         params.setDb("d1");
@@ -111,7 +112,8 @@ public class TaskRunHistoryTest {
         new Expectations() {
             {
                 repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history WHERE TRUE AND  " +
-                        "task_state = 'SUCCESS'");
+                        "task_state = 'SUCCESS'" +
+                        " ORDER BY create_time DESC LIMIT 10000");
             }
         };
         params.setDb(null);
@@ -121,7 +123,8 @@ public class TaskRunHistoryTest {
         new Expectations() {
             {
                 repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history WHERE TRUE AND  " +
-                        "task_name = 't1'");
+                        "task_name = 't1'" +
+                        " ORDER BY create_time DESC LIMIT 10000");
             }
         };
         params.setDb(null);
@@ -132,7 +135,8 @@ public class TaskRunHistoryTest {
         new Expectations() {
             {
                 repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history WHERE TRUE AND  " +
-                        "task_run_id = 'q1'");
+                        "task_run_id = 'q1'" +
+                        " ORDER BY create_time DESC LIMIT 10000");
             }
         };
         params.setDb(null);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

To apply `config.task_runs_max_history_number` to `information_schema.task_runs`:

1. **Objective**: Limit the number of records retrieved by this view to optimize memory usage effectively.
2. **Impact**: The `task_runs` table will enforce a defined maximum number of records, ensuring controlled resource consumption.

**Behavior change:**
1. Before
    - Before version 3.3, task_runs is stored in memory, which is limited by constraints, `task_runs_ttl_second` and `task_runs_max_history_number`
    -  Starting from version 3.3, the `information_schema.task_runs` table no longer has a limit on the number of records but is instead constrained by a TTL setting, `task_runs_ttl_second=7 days`, provided that the configuration `config.enable_task_history_archive=true` is enabled.  
3. Following this update, the `information_schema.task_runs` table will be subject to two restrictions:  
   - `task_runs_ttl_second`: Defines the maximum time-to-live (TTL) for records.  
   - `task_runs_max_history_number`: Specifies the maximum number of records allowed.  


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
