### PR TITLE
[Refactor] Rename some config names related to disk watermark.

### DIFF
--- a/be/src/cache/disk_space_monitor.cpp
+++ b/be/src/cache/disk_space_monitor.cpp
@@ -121,9 +121,9 @@ Status DiskSpace::_update_disk_options() {
     ASSIGN_OR_RETURN(_disk_opts.cache_upper_limit,
                      DataCacheUtils::parse_conf_datacache_disk_size(_path, config::datacache_disk_size,
                                                                     _disk_stats.capacity_bytes));
-    _disk_opts.low_level_size = _disk_stats.capacity_bytes * 0.01 * config::datacache_disk_low_level;
-    _disk_opts.safe_level_size = _disk_stats.capacity_bytes * 0.01 * config::datacache_disk_safe_level;
-    _disk_opts.high_level_size = _disk_stats.capacity_bytes * 0.01 * config::datacache_disk_high_level;
+    _disk_opts.low_level_size = _disk_stats.capacity_bytes * 0.01 * config::disk_low_level;
+    _disk_opts.safe_level_size = _disk_stats.capacity_bytes * 0.01 * config::disk_safe_level;
+    _disk_opts.high_level_size = _disk_stats.capacity_bytes * 0.01 * config::disk_high_level;
     _disk_opts.adjust_interval_s = config::datacache_disk_adjust_interval_seconds;
     _disk_opts.idle_for_expansion_s = config::datacache_disk_idle_seconds_for_expansion;
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -50,7 +50,7 @@ CONF_Int32(brpc_port, "8060");
 CONF_Int32(brpc_num_threads, "-1");
 
 // The max number of single connections maintained by the brpc client and each server.
-// Theses connections are created during the first few access and will be used thereafter
+// These connections are created during the first few access and will be used thereafter
 CONF_Int32(brpc_max_connections_per_server, "1");
 
 // Declare a selection strategy for those servers have many ips.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -60,12 +60,22 @@ CONF_Int32(brpc_max_connections_per_server, "1");
 CONF_String(priority_networks, "");
 CONF_Bool(net_use_ipv6_when_priority_networks_empty, "false");
 
-// Memory urget water level, if the memory usage exceeds this level, reduce the size of
-// the Pagecache immediately, it should be between (memory_high_level, 100].
+// Memory urged water level, if the memory usage exceeds this level,
+// be will free up some memory immediately to ensure the system runs smoothly.
+// Currently, only support to release memory of data cache and lake memtable.
 CONF_mInt64(memory_urgent_level, "85");
-// Memory high water level, if the memory usage exceeds this level, reduce the size of
-// the Pagecache slowly, it should be between [1, memory_urgent_level).
+// Memory high water level, if the memory usage exceeds this level, be will free up some memory slowly
+// Currently, only support release memory of data cache.
 CONF_mInt64(memory_high_level, "75");
+
+// The high disk usage level, which trigger to release of disk space immediately to disk_high_level,
+// currently only support release disk space of data cache.
+CONF_mInt64(disk_high_level, "90");
+// The safe disk usage level.
+CONF_mInt64(disk_safe_level, "80");
+// The low disk usage level, which triggers increasing the quota for some components,
+// currently only supports data cache.
+CONF_mInt64(disk_low_level, "60");
 
 // process memory limit specified as number of bytes
 // ('<int>[bB]?'), megabytes ('<float>[mM]'), gigabytes ('<float>[gG]'),
@@ -1262,12 +1272,7 @@ CONF_mInt32(report_datacache_metrics_interval_ms, "60000");
 // which is configured by `datacache_disk_idle_seconds_for_expansion`, the cache quota will be increased to keep the
 // disk usage around the disk safe level.
 CONF_mBool(enable_datacache_disk_auto_adjust, "true");
-// The high disk usage level, which trigger the cache eviction and quota decreased.
-CONF_mInt64(datacache_disk_high_level, "90");
-// The safe disk usage level, the cache quota will be decreased to this level once it reach the high level.
-CONF_mInt64(datacache_disk_safe_level, "80");
-// The low disk usage level, which trigger the cache expansion and quota increased.
-CONF_mInt64(datacache_disk_low_level, "60");
+
 // The interval seconds to check the disk usage and trigger adjustment.
 CONF_mInt64(datacache_disk_adjust_interval_seconds, "10");
 // The silent period, only when the disk usage falls bellow the low level for a time longer than this period,

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -68,7 +68,7 @@ CONF_mInt64(memory_urgent_level, "85");
 // Currently, only support release memory of data cache.
 CONF_mInt64(memory_high_level, "75");
 
-// The high disk usage level, which trigger to release of disk space immediately to disk_high_level,
+// The high disk usage level, which trigger to release of disk space immediately to disk_safe_level,
 // currently only support release disk space of data cache.
 CONF_mInt64(disk_high_level, "90");
 // The safe disk usage level.


### PR DESCRIPTION
## Why I'm doing:

BE should support automatically adjusting the memory or disk quota for some components based on current memory and disk usage. These components we will support include not only data cache but also meta cache, query cache, write buffer, spill space, and some other components. Therefore, we need to define some parameters to set the watermarks for memory and disk.

These parameters are not exposed to users, and users rarely modify them. Therefore, I do not consider using `AliasConfig` to make them compatible.

The doc will be modify in another pr later.

## What I'm doing:

* datacache_disk_high_level -> disk_high_level
* datacache_disk_safe_level -> disk_safe_level
* datacache_disk_low_level ->disk_low_level

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
