### PR TITLE
[BugFix] Fix query fail after rename column name if scan node contain unused output column name

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -329,8 +329,7 @@ public class OlapScanNode extends ScanNode {
                 continue;
             }
             if (unUsedOutputColumnIds.contains(slot.getId().asInt())) {
-                Column col = slot.getColumn();
-                unUsedOutputStringColumns.add(col.isShadowColumn() ? col.getName() : col.getColumnId().getId());
+                unUsedOutputStringColumns.add(slot.getColumn().getColumnId().getId());
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -329,7 +329,8 @@ public class OlapScanNode extends ScanNode {
                 continue;
             }
             if (unUsedOutputColumnIds.contains(slot.getId().asInt())) {
-                unUsedOutputStringColumns.add(slot.getColumn().getName());
+                Column col = slot.getColumn();
+                unUsedOutputStringColumns.add(col.isShadowColumn() ? col.getName() : col.getColumnId().getId());
             }
         }
     }

--- a/test/sql/test_column_rename/R/test_column_rename
+++ b/test/sql/test_column_rename/R/test_column_rename
@@ -300,3 +300,43 @@ select * from bill_detail where bill = "JT2921712368984";
 -- result:
 JT2921712368984
 -- !result
+-- name: test_column_rename_failed_with_unused_output_column
+CREATE TABLE `t_rename_column_unused_output_column_name` (
+  `a` bigint(20) NOT NULL COMMENT "",
+  `b` varchar(20) NULL COMMENT "",
+  `c` boolean NULL COMMENT "",
+  `d` varchar(255) NULL COMMENT "",
+  `e` varchar(255) NULL COMMENT "",
+  `f` array<varchar(255)> NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`a`)
+DISTRIBUTED BY HASH(`a`) BUCKETS 1
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t_rename_column_unused_output_column_name values(1, 1, 1, 1, 1, ["1", "1"]);
+-- result:
+-- !result
+alter table t_rename_column_unused_output_column_name rename column d to new_d;
+-- result:
+-- !result
+SELECT a, e FROM t_rename_column_unused_output_column_name WHERE t_rename_column_unused_output_column_name.new_d IS NOT NULL LIMIT 9;
+-- result:
+1	1
+-- result:
+insert into t_rename_column_unused_output_column_name values(2, 2, 2, 2, 2, ["1", "1"]);
+-- result:
+-- !result
+SELECT a, e FROM t_rename_column_unused_output_column_name WHERE t_rename_column_unused_output_column_name.new_d IS NOT NULL LIMIT 9;
+-- result:
+1	1
+2	2
+-- result:
+drop table t_rename_column_unused_output_column_name force;
+-- result:
+-- !result

--- a/test/sql/test_column_rename/R/test_column_rename
+++ b/test/sql/test_column_rename/R/test_column_rename
@@ -328,7 +328,7 @@ alter table t_rename_column_unused_output_column_name rename column d to new_d;
 SELECT a, e FROM t_rename_column_unused_output_column_name WHERE t_rename_column_unused_output_column_name.new_d IS NOT NULL LIMIT 9;
 -- result:
 1	1
--- result:
+-- !result
 insert into t_rename_column_unused_output_column_name values(2, 2, 2, 2, 2, ["1", "1"]);
 -- result:
 -- !result
@@ -336,7 +336,7 @@ SELECT a, e FROM t_rename_column_unused_output_column_name WHERE t_rename_column
 -- result:
 1	1
 2	2
--- result:
+-- !result
 drop table t_rename_column_unused_output_column_name force;
 -- result:
 -- !result

--- a/test/sql/test_column_rename/T/test_column_rename
+++ b/test/sql/test_column_rename/T/test_column_rename
@@ -112,3 +112,31 @@ insert into bill_detail(bill) values("JT2921712368984");
 select * from bill_detail;
 show create table bill_detail;
 select * from bill_detail where bill = "JT2921712368984";
+
+-- name: test_column_rename_failed_with_unused_output_column
+CREATE TABLE `t_rename_column_unused_output_column_name` (
+  `a` bigint(20) NOT NULL COMMENT "",
+  `b` varchar(20) NULL COMMENT "",
+  `c` boolean NULL COMMENT "",
+  `d` varchar(255) NULL COMMENT "",
+  `e` varchar(255) NULL COMMENT "",
+  `f` array<varchar(255)> NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`a`)
+DISTRIBUTED BY HASH(`a`) BUCKETS 1
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+
+insert into t_rename_column_unused_output_column_name values(1, 1, 1, 1, 1, ["1", "1"]);
+
+alter table t_rename_column_unused_output_column_name rename column d to new_d;
+SELECT a, e FROM t_rename_column_unused_output_column_name WHERE t_rename_column_unused_output_column_name.new_d IS NOT NULL LIMIT 9;
+
+insert into t_rename_column_unused_output_column_name values(2, 2, 2, 2, 2, ["1", "1"]);
+SELECT a, e FROM t_rename_column_unused_output_column_name WHERE t_rename_column_unused_output_column_name.new_d IS NOT NULL LIMIT 9;
+
+drop table t_rename_column_unused_output_column_name force;


### PR DESCRIPTION
## Why I'm doing:
Query fail after rename column name if scan node contain unused output column name because the unused output column name use the new column name instead of the base name(old name) and fail in BE side.

## What I'm doing:
Set base column name(old name) for unused output column name in scan node.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
