### PR TITLE
[BugFix] implement hashCode and equalsWithoutChild for InformationFunction

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/InformationFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/InformationFunction.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.analysis;
 
+import com.google.common.base.Objects;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.parser.NodePosition;
@@ -121,5 +122,19 @@ public class InformationFunction extends Expr {
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitInformationFunction(this, context);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(super.hashCode(), funcType);
+    }
+
+    @Override
+    public boolean equalsWithoutChild(Object obj) {
+        if (!super.equalsWithoutChild(obj)) {
+            return false;
+        }
+        InformationFunction o = (InformationFunction) obj;
+        return funcType.equals(o.funcType) && intValue == o.intValue && strValue.equals(o.strValue);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/InformationFunctionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/InformationFunctionTest.java
@@ -1,0 +1,23 @@
+package com.starrocks.analysis;
+
+import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.Test;
+
+import java.util.UUID;
+
+public class InformationFunctionTest extends PlanTestBase {
+    @Test
+    public void testInformationFunction() throws Exception {
+        starRocksAssert.getCtx().setConnectionId(1);
+        starRocksAssert.getCtx().setSessionId(UUID.fromString("436b9df9-5406-4eb7-984e-9d96acedde16"));
+        String sql = "select connection_id(), catalog(), database(), schema(), user(), session_id()";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  1:Project\n" +
+                "  |  <slot 2> : 1\n" +
+                "  |  <slot 3> : 'default_catalog'\n" +
+                "  |  <slot 4> : 'test'\n" +
+                "  |  <slot 5> : 'test'\n" +
+                "  |  <slot 6> : '\\'root\\'@%'\n" +
+                "  |  <slot 7> : '436b9df9-5406-4eb7-984e-9d96acedde16'");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/InformationFunctionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/InformationFunctionTest.java
@@ -10,14 +10,14 @@ public class InformationFunctionTest extends PlanTestBase {
     public void testInformationFunction() throws Exception {
         starRocksAssert.getCtx().setConnectionId(1);
         starRocksAssert.getCtx().setSessionId(UUID.fromString("436b9df9-5406-4eb7-984e-9d96acedde16"));
-        String sql = "select connection_id(), catalog(), database(), schema(), user(), session_id()";
+        String sql = "select connection_id(), catalog(), database(), schema(), user(), session_id(), user()";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "  1:Project\n" +
                 "  |  <slot 2> : 1\n" +
                 "  |  <slot 3> : 'default_catalog'\n" +
                 "  |  <slot 4> : 'test'\n" +
                 "  |  <slot 5> : 'test'\n" +
-                "  |  <slot 6> : '\\'root\\'@%'\n" +
-                "  |  <slot 7> : '436b9df9-5406-4eb7-984e-9d96acedde16'");
+                "  |  <slot 7> : '436b9df9-5406-4eb7-984e-9d96acedde16'\n" +
+                "  |  <slot 8> : '\\'root\\'@%'");
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #59183

root cause:
we didn't implement hashCode and equals method for `InformationFunction`, so it will get wrong result when putting them into outputTranslations in `QueryTransformer`, resulting a wrong outputColumns of the final logical plan.
<img width="959" alt="image" src="https://github.com/user-attachments/assets/867d730c-7295-4983-826e-0dbe093d4d24" />


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1