### PR TITLE
[BugFix] Fix invalid max column unique id introduced by version compatibility for cloud-native table

### DIFF
--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -58,6 +58,7 @@
 #include "storage/type_utils.h"
 #include "storage/utils.h"
 #include "util/crc32c.h"
+#include "util/failpoint/fail_point.h"
 #include "util/slice.h"
 
 bvar::Adder<int> g_open_segments;    // NOLINT
@@ -411,6 +412,7 @@ Status Segment::_create_column_readers(SegmentFooterPB* footer) {
     return Status::OK();
 }
 
+DEFINE_FAIL_POINT(ingest_duplicate_column_unique_id);
 Status Segment::_check_column_unique_id_uniqueness(
         SegmentFooterPB* footer, std::unordered_map<uint32_t, uint32_t>& column_id_to_footer_ordinal) {
     // check uniqueness of column ids in footer
@@ -418,20 +420,24 @@ Status Segment::_check_column_unique_id_uniqueness(
         const auto& column_pb = footer->columns(ordinal);
         auto [it, ok] = column_id_to_footer_ordinal.emplace(column_pb.unique_id(), ordinal);
         if (UNLIKELY(!ok)) {
-            LOG(ERROR) << "Duplicate column id=" << column_pb.unique_id() << " found in segment footer between column '"
+            LOG(ERROR) << "Duplicate column id=" << column_pb.unique_id() << " found between column '"
                        << footer->columns(it->second).name() << "' and column '" << column_pb.name() << "'";
-            return Status::InternalError("Duplicate column id found in segment footer");
+            return Status::InternalError("Duplicate column id");
         }
     }
 
     // check uniqueness of column ids in tablet schema
     std::unordered_map<uint32_t, uint32_t> column_id_to_tablet_schema_ordinal;
+    FAIL_POINT_TRIGGER_EXECUTE(ingest_duplicate_column_unique_id,
+                               { column_id_to_tablet_schema_ordinal.emplace(1, 2); });
+
     for (uint32_t ordinal = 0, sz = _tablet_schema->num_columns(); ordinal < sz; ++ordinal) {
         const auto& column = _tablet_schema->column(ordinal);
         auto [it, ok] = column_id_to_tablet_schema_ordinal.emplace(column.unique_id(), ordinal);
         if (UNLIKELY(!ok)) {
-            LOG(ERROR) << "Duplicate column id=" << column.unique_id() << " found in tablet schema between column '"
-                       << footer->columns(it->second).name() << "' and column '" << column.name() << "'";
+            LOG(ERROR) << "Duplicate column id=" << column.unique_id() << " found between column '"
+                       << _tablet_schema->column(it->second).name() << "' and column '" << column.name()
+                       << "' in tablet schema";
             return Status::InternalError("Duplicate column id found in tablet schema");
         }
     }

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -276,6 +276,9 @@ private:
                  const LakeIOOptions& lake_io_opts);
     Status _create_column_readers(SegmentFooterPB* footer);
 
+    Status _check_column_unique_id_uniqueness(SegmentFooterPB* footer,
+                                              std::unordered_map<uint32_t, uint32_t>& column_id_to_footer_ordinal);
+
     StatusOr<ChunkIteratorPtr> _new_iterator(const Schema& schema, const SegmentReadOptions& read_options);
 
     bool _use_segment_zone_map_filter(const SegmentReadOptions& read_options);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
@@ -38,6 +38,7 @@ import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
+import com.starrocks.lake.LakeTableHelper;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.Utils;
 import com.starrocks.proto.TxnInfoPB;
@@ -621,7 +622,11 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
         // If upgraded from an old version and do roll up,
         // the schema saved in indexSchemaMap is the schema in the old version, whose uniqueId is -1,
         // so here we initialize column uniqueId here.
-        restoreColumnUniqueIdIfNeed(rollupSchema);
+        boolean restored = LakeTableHelper.restoreColumnUniqueId(rollupSchema);
+        if (restored) {
+            LOG.info("Columns of rollup index {} in table {} has reset all unique ids, column size: {}", rollupIndexId,
+                    tableName, rollupSchema.size());
+        }
 
         tbl.setIndexMeta(rollupIndexId, rollupIndexName, rollupSchema, rollupSchemaVersion /* initial schema version */,
                 rollupSchemaHash, rollupShortKeyColumnCount, TStorageType.COLUMN, rollupKeysType, origStmt);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -55,6 +55,7 @@ import com.starrocks.common.io.Text;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.journal.JournalTask;
+import com.starrocks.lake.LakeTableHelper;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.Utils;
 import com.starrocks.persist.EditLog;
@@ -245,7 +246,7 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
             // If upgraded from an old version and do schema change,
             // the schema saved in indexSchemaMap is the schema in the old version, whose uniqueId is -1,
             // so here we initialize column uniqueId here.
-            restoreColumnUniqueIdIfNeed(indexSchemaMap.get(shadowIdxId));
+            LakeTableHelper.restoreColumnUniqueId(table.getName(), shadowIdxId, indexSchemaMap.get(shadowIdxId));
 
             table.setIndexMeta(shadowIdxId, indexIdToName.get(shadowIdxId), indexSchemaMap.get(shadowIdxId), 0, 0,
                     indexShortKeyMap.get(shadowIdxId), TStorageType.COLUMN,

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -247,7 +247,7 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
             // the schema saved in indexSchemaMap is the schema in the old version, whose uniqueId is -1,
             // so here we initialize column uniqueId here.
             List<Column> columns = indexSchemaMap.get(shadowIdxId);
-            boolean restored = LakeTableHelper.restoreColumnUniqueIdIfNeeded(columns);
+            boolean restored = LakeTableHelper.restoreColumnUniqueId(columns);
             if (restored) {
                 LOG.info("Columns of index {} in table {} has reset all unique ids, column size: {}", shadowIdxId,
                         tableName, columns.size());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -246,9 +246,14 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
             // If upgraded from an old version and do schema change,
             // the schema saved in indexSchemaMap is the schema in the old version, whose uniqueId is -1,
             // so here we initialize column uniqueId here.
-            LakeTableHelper.restoreColumnUniqueId(table.getName(), shadowIdxId, indexSchemaMap.get(shadowIdxId));
+            List<Column> columns = indexSchemaMap.get(shadowIdxId);
+            boolean restored = LakeTableHelper.restoreColumnUniqueIdIfNeeded(columns);
+            if (restored) {
+                LOG.info("Columns of index {} in table {} has reset all unique ids, column size: {}", shadowIdxId,
+                        tableName, columns.size());
+            }
 
-            table.setIndexMeta(shadowIdxId, indexIdToName.get(shadowIdxId), indexSchemaMap.get(shadowIdxId), 0, 0,
+            table.setIndexMeta(shadowIdxId, indexIdToName.get(shadowIdxId), columns, 0, 0,
                     indexShortKeyMap.get(shadowIdxId), TStorageType.COLUMN,
                     table.getKeysTypeByIndexId(indexIdMap.get(shadowIdxId)), null, sortKeyColumnIndexes,
                     sortKeyColumnUniqueIds);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJobBase.java
@@ -16,10 +16,8 @@
 package com.starrocks.alter;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
-import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.AnalysisException;
@@ -37,7 +35,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
@@ -58,17 +55,6 @@ public abstract class LakeTableSchemaChangeJobBase extends AlterJobV2 {
 
     public LakeTableSchemaChangeJobBase(JobType jobType) {
         super(jobType);
-    }
-
-    protected void restoreColumnUniqueIdIfNeed(List<Column> columns) {
-        boolean needRestoreColumnUniqueId = (columns.get(0).getUniqueId() < 0);
-        if (needRestoreColumnUniqueId) {
-            for (int i = 0; i < columns.size(); i++) {
-                Column col = columns.get(i);
-                Preconditions.checkState(col.getUniqueId() <= 0, col.getUniqueId());
-                col.setUniqueId(i);
-            }
-        }
     }
 
     @Nullable

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -90,7 +90,6 @@ import com.starrocks.common.util.Util;
 import com.starrocks.common.util.WriteQuorum;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.lake.DataCacheInfo;
-import com.starrocks.lake.LakeTableHelper;
 import com.starrocks.lake.StarOSAgent;
 import com.starrocks.lake.StorageInfo;
 import com.starrocks.persist.ColocatePersistInfo;
@@ -447,14 +446,6 @@ public class OlapTable extends Table {
             olapTable.curBinlogConfig = new BinlogConfig(this.curBinlogConfig);
         }
         olapTable.dbName = this.dbName;
-    }
-
-    protected void restoreColumnUniqueIdIfNeed() {
-        boolean needRestoreColumnUniqueId = (indexIdToMeta.values().stream().findFirst().
-                get().getSchema().get(0).getUniqueId() < 0);
-        if (needRestoreColumnUniqueId) {
-            setMaxColUniqueId(LakeTableHelper.restoreColumnUniqueId(this));
-        }
     }
 
     public void addDoubleWritePartition(long sourcePartitionId, long tempPartitionId) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeMaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeMaterializedView.java
@@ -219,8 +219,9 @@ public class LakeMaterializedView extends MaterializedView {
 
     @Override
     public void gsonPostProcess() throws IOException {
-        // We should restore column unique id before calling super.gsonPostProcess(), which will rebuild full schema there
-        LakeTableHelper.restoreColumnUniqueIdPostLoadImage(this);
+        // We should restore column unique id before calling super.gsonPostProcess(), which will rebuild full schema there.
+        // And the max unique id will be reset while rebuilding full schema.
+        LakeTableHelper.restoreColumnUniqueIdIfNeeded(this);
         super.gsonPostProcess();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeMaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeMaterializedView.java
@@ -219,7 +219,8 @@ public class LakeMaterializedView extends MaterializedView {
 
     @Override
     public void gsonPostProcess() throws IOException {
+        // We should restore column unique id before calling super.gsonPostProcess(), which will rebuild full schema there
+        LakeTableHelper.restoreColumnUniqueIdPostLoadImage(this);
         super.gsonPostProcess();
-        restoreColumnUniqueIdIfNeed();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
@@ -264,8 +264,9 @@ public class LakeTable extends OlapTable {
 
     @Override
     public void gsonPostProcess() throws IOException {
-        // We should restore column unique id before calling super.gsonPostProcess(), which will rebuild full schema there
-        LakeTableHelper.restoreColumnUniqueIdPostLoadImage(this);
+        // We should restore column unique id before calling super.gsonPostProcess(), which will rebuild full schema there.
+        // And the max unique id will be reset while rebuilding full schema.
+        LakeTableHelper.restoreColumnUniqueIdIfNeeded(this);
         super.gsonPostProcess();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
@@ -264,8 +264,9 @@ public class LakeTable extends OlapTable {
 
     @Override
     public void gsonPostProcess() throws IOException {
+        // We should restore column unique id before calling super.gsonPostProcess(), which will rebuild full schema there
+        LakeTableHelper.restoreColumnUniqueIdPostLoadImage(this);
         super.gsonPostProcess();
-        restoreColumnUniqueIdIfNeed();
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeRollupJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeRollupJobTest.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.alter;
 
-import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.FeConstants;
@@ -200,16 +199,5 @@ public class LakeRollupJobTest {
         });
         Assert.assertTrue(exception.getMessage().contains("No alive backend"));
         Assert.assertEquals(AlterJobV2.JobState.PENDING, lakeRollupJob3.getJobState());
-    }
-
-    @Test
-    public void testRestoreColumnUniqueIdIfNeed() {
-        Column a = new Column();
-        Column b = new Column();
-        List<Column> columns = List.of(a, b);
-
-        lakeRollupJob.restoreColumnUniqueIdIfNeed(columns);
-        Assert.assertEquals(a.getUniqueId(), 0);
-        Assert.assertEquals(b.getUniqueId(), 1);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
@@ -388,17 +388,38 @@ public class CreateLakeTableTest {
                         "distributed by hash(c0) buckets 2\n" +
                         "properties('enable_persistent_index' = 'true', 'persistent_index_type' = 'cloud_native');"));
         LakeTable lakeTable = getLakeTable("lake_test", "test_unique_id");
-        // Clear unique id first
-        lakeTable.setMaxColUniqueId(-1);
-        for (Column column : lakeTable.getColumns()) {
-            column.setUniqueId(-1);
+        {
+            // case 1:
+            // table created on version v3.2, then upgraded to v3.3 upwards,
+            // all unique ids include max unique id is -1
+            lakeTable.setMaxColUniqueId(-1);
+            for (Column column : lakeTable.getColumns()) {
+                column.setUniqueId(-1);
+            }
+            lakeTable.gsonPostProcess();
+            Assert.assertEquals(3, lakeTable.getMaxColUniqueId());
+            Assert.assertEquals(0, lakeTable.getColumn("c0").getUniqueId());
+            Assert.assertEquals(1, lakeTable.getColumn("c1").getUniqueId());
+            Assert.assertEquals(2, lakeTable.getColumn("c2").getUniqueId());
+            Assert.assertEquals(3, lakeTable.getColumn("c3").getUniqueId());
         }
-        lakeTable.gsonPostProcess();
-        Assert.assertEquals(3, lakeTable.getMaxColUniqueId());
-        Assert.assertEquals(0, lakeTable.getColumn("c0").getUniqueId());
-        Assert.assertEquals(1, lakeTable.getColumn("c1").getUniqueId());
-        Assert.assertEquals(2, lakeTable.getColumn("c2").getUniqueId());
-        Assert.assertEquals(3, lakeTable.getColumn("c3").getUniqueId());
+
+        {
+            // case 1:
+            // 1. table created on version v3.3
+            // 2. cluster downgraded to v3.2
+            // 3. add one column on version v3.2, the column's unique id is -1
+            // 4. cluster upgraded to v3.3
+            lakeTable.setMaxColUniqueId(2);
+            lakeTable.getColumns().get(3).setUniqueId(-1);
+
+            lakeTable.gsonPostProcess();
+            Assert.assertEquals(3, lakeTable.getMaxColUniqueId());
+            Assert.assertEquals(0, lakeTable.getColumn("c0").getUniqueId());
+            Assert.assertEquals(1, lakeTable.getColumn("c1").getUniqueId());
+            Assert.assertEquals(2, lakeTable.getColumn("c2").getUniqueId());
+            Assert.assertEquals(3, lakeTable.getColumn("c3").getUniqueId());
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
@@ -16,21 +16,29 @@ package com.starrocks.lake;
 
 import com.google.common.collect.Lists;
 import com.staros.proto.ShardGroupInfo;
+import com.starrocks.catalog.AggregateType;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.CreateDbStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.thrift.TStorageType;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
@@ -42,6 +50,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -147,5 +156,84 @@ public class LakeTableHelperTest {
 
         LakeTableHelper.deleteShardGroupMeta(partition);
         Assert.assertEquals(0, shardGroupInfos.size());
+    }
+
+    @Test
+    public void testRestoreColumnUniqueIdIfNeeded() throws Exception {
+        String sql = "create table test_lake_table_helper.test_tb (k1 int, k2 int, k3 varchar)";
+        LakeTable table = createTable(sql);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+
+        // add one more index meta
+        long indexId = 1000L;
+        long partitionId = 1001L;
+        KeysType keysType = KeysType.DUP_KEYS;
+        Column c0 = new Column("c0", Type.INT, true, AggregateType.NONE, false, null, null);
+        Column c1 = new Column("c1", Type.INT, true, AggregateType.NONE, false, null, null);
+
+        DistributionInfo dist = new HashDistributionInfo(10, Arrays.asList(c0, c1));
+        MaterializedIndex index = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
+        Partition partition = new Partition(partitionId, partitionId + 100, "t0", index, dist);
+        TStorageMedium storage = TStorageMedium.HDD;
+        TabletMeta tabletMeta =
+                new TabletMeta(db.getId(), table.getId(), partition.getId(), index.getId(), 0, storage, true);
+        for (int i = 0; i < 10; i++) {
+            Tablet tablet = new LakeTablet(GlobalStateMgr.getCurrentState().getNextId());
+            index.addTablet(tablet, tabletMeta);
+        }
+        table.addPartition(partition);
+        table.setIndexMeta(index.getId(), "t0", Arrays.asList(c0, c1), 0, 0, (short) 1, TStorageType.COLUMN,
+                keysType);
+        List<Column> newIndexSchema = table.getSchemaByIndexId(indexId);
+        List<Column> baseSchema = table.getBaseSchema();
+
+        {
+            // reset column unique id to invalid value
+            c0.setUniqueId(-1);
+            c1.setUniqueId(0);
+            Assert.assertEquals(2, table.getIndexIdToSchema().size());
+
+            // base schema is fine
+            Assert.assertFalse(LakeTableHelper.restoreColumnUniqueId(baseSchema));
+            // index schema needs to be restored
+            Assert.assertTrue(LakeTableHelper.restoreColumnUniqueId(newIndexSchema));
+            Assert.assertEquals(0, c0.getUniqueId());
+            Assert.assertEquals(1, c1.getUniqueId());
+            for (int ordinal = 0; ordinal < baseSchema.size(); ordinal++) {
+                Column column = baseSchema.get(ordinal);
+                Assert.assertEquals(ordinal, column.getUniqueId());
+            }
+        }
+
+        {
+            // reset column unique id to invalid value
+            c0.setUniqueId(-1);
+            c1.setUniqueId(0);
+            // case for restoring table
+            LakeTableHelper.restoreColumnUniqueIdIfNeeded(table);
+            Assert.assertEquals(0, c0.getUniqueId());
+            Assert.assertEquals(1, c1.getUniqueId());
+            baseSchema = table.getBaseSchema();
+            for (int ordinal = 0; ordinal < baseSchema.size(); ordinal++) {
+                Column column = baseSchema.get(ordinal);
+                Assert.assertEquals(ordinal, column.getUniqueId());
+            }
+        }
+
+        {
+            // reset column unique id to invalid value
+            c0.setUniqueId(-1);
+            c1.setUniqueId(0);
+            baseSchema.get(2).setUniqueId(-1);
+            // case for restoring table
+            LakeTableHelper.restoreColumnUniqueIdIfNeeded(table);
+            Assert.assertEquals(0, c0.getUniqueId());
+            Assert.assertEquals(1, c1.getUniqueId());
+            baseSchema = table.getBaseSchema();
+            for (int ordinal = 0; ordinal < baseSchema.size(); ordinal++) {
+                Column column = baseSchema.get(ordinal);
+                Assert.assertEquals(ordinal, column.getUniqueId());
+            }
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

When upgrade and downgrade between  v3.2 and v3.3, there are chances column unique id has unexpected values. Some efforts have been tried to solve those problems, such as #48628 #47826 #58164 .

Bad luck, there are still other bad cases relative to column unique id. Issue #57850 mentioned a CN crash issue.

The direct reason for that crash is duplicate unique id found in tablet meta, looks like this one (omitted unrelated properties here).
```json
 {
         [
           {
                "unique_id": 5,
                "name": "t_col_329",
                "type": "BIGINT"
            },
            {
                "unique_id": 6,
                "name": "t_col_329_1",
                "type": "BIGINT"
            },
            {
                "unique_id": 6,
                "name": "t_col_329_2",
                "type": "BIGINT"
            }
        ],
        "next_column_unique_id": 8,
    },
```

We can see that last two columns have same unique ids. 

Further investigation revealed that the cause of the duplicate unique ID issue is related to version upgrades and downgrades. And The problem can be reproduced in the following way:

1. Create a table on v3.3 cluster
```sql
create database test;
use test;
CREATE TABLE `t_user` (
  `id` bigint(20) NOT NULL COMMENT "",
  `name` varchar(765) NULL COMMENT "",
  `age` tinyint(4) NULL COMMENT "",
  `create_time` datetime NULL COMMENT "",
  `update_time` datetime NULL COMMENT ""
) ENGINE=OLAP 
PRIMARY KEY(`id`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`id`)
PROPERTIES (
"compression" = "LZ4",
"datacache.enable" = "true",
"enable_async_write_back" = "false",
"enable_persistent_index" = "true",
"persistent_index_type" = "CLOUD_NATIVE",
"replication_num" = "1",
"fast_schema_evolution"="false",
"storage_volume" = "builtin_storage_volume"
);
```

2. Downgrade the cluster from v3.3 to v3.2, then do alter statement.
```sql
alter table t_user add column (`t_col` bigint(20));
```
3. Upgrade from v3.2 to v3.3 again, the max unique id is wrong
4. Do alter statement again, then table meta will have duplicate unique ids.


## What I'm doing:

Fixes #57850

1. Prevent CN crash by adding tablet meta column uniqueness check in BE, if duplicate id found, we will stop user from query this tablet.
```sql
select * from t_user;
ERROR 1064 (HY000): load_segments failed tablet:15023 rowset:1 segid:0: Duplicate column id found in tablet schema: BE:10001`
```

2. Try to restore column unique id while upgrading and downgrading version happend.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
