### PR TITLE
[BugFix] Fix query version not found error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1251,6 +1251,23 @@ public class DatabaseTransactionMgr {
                                     transactionState.setErrorMsg(errMsg);
                                     hasError = true;
                                 }
+
+                                // collect unknown replicas
+                                long tabletId = tablet.getId();
+                                for (Replica replica : ((LocalTablet) tablet).getImmutableReplicas()) {
+                                    long replicaId = replica.getId();
+                                    long backendId = replica.getBackendId();
+
+                                    if (errorReplicaIds.contains(replicaId)) {
+                                        continue;
+                                    }
+
+                                    if (transactionState.tabletCommitInfosContainsReplica(tabletId, backendId, replicaId)) {
+                                        continue;
+                                    }
+
+                                    transactionState.addUnknownReplica(replicaId);
+                                }
                             }
                         }
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
@@ -121,7 +121,7 @@ public class OlapTableTxnLogApplier implements TransactionLogApplier {
                         }
                         long lastFailedVersion = replica.getLastFailedVersion();
                         long newVersion = version;
-                        long lastSucessVersion = replica.getLastSuccessVersion();
+                        long lastSuccessVersion = replica.getLastSuccessVersion();
                         if (txnState.checkReplicaNeedSkip(tablet, replica, partitionCommitInfo)
                                 || errorReplicaIds.contains(replica.getId())) {
                             // There are 2 cases that we can't update version to visible version and need to
@@ -160,9 +160,9 @@ public class OlapTableTxnLogApplier implements TransactionLogApplier {
                             }
 
                             // success version always move forward
-                            lastSucessVersion = version;
+                            lastSuccessVersion = version;
                         }
-                        replica.updateVersionInfo(newVersion, lastFailedVersion, lastSucessVersion);
+                        replica.updateVersionInfo(newVersion, lastFailedVersion, lastSuccessVersion);
                     } // end for replicas
 
                     if (hasFailedVersion && replicationNum == 1) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -229,6 +229,17 @@ public class TransactionState implements Writable, GsonPreProcessable {
     @SerializedName("er")
     private Set<Long> errorReplicas;
 
+    private Set<TabletCommitInfo> tabletCommitInfos = null;
+
+    // tabletCommitInfos is not persistent because it is very large, and it is null in follower FE.
+    // 'OlapTableTxnLogApplier.applyVisibleLog' uses tabletCommitInfos to check whether replica need update version.
+    // null tabletCommitInfos will cause follower wrong version update, and query failed from follower
+    // with version not found error.
+    // so add persistent unknownReplicas to fix this issue, unknownReplicas is much less than tabletCommitInfos.
+    // unknownReplicas = total replicas - tabletCommitInfos - errorReplicas
+    @SerializedName("ur")
+    private Set<Long> unknownReplicas;
+
     @SerializedName("ctl")
     private boolean useCombinedTxnLog;
 
@@ -307,8 +318,6 @@ public class TransactionState implements Writable, GsonPreProcessable {
     private Span txnSpan = null;
     private String traceParent = null;
 
-    private Set<TabletCommitInfo> tabletCommitInfos = null;
-
     // For a transaction, we need to ensure that different clients obtain consistent partition information,
     // to avoid inconsistencies caused by replica migration and other operations during the transaction process.
     // Therefore, a snapshot of this information is maintained here.
@@ -342,6 +351,7 @@ public class TransactionState implements Writable, GsonPreProcessable {
         this.finishTime = -1;
         this.reason = "";
         this.errorReplicas = Sets.newHashSet();
+        this.unknownReplicas = Sets.newHashSet();
         this.publishVersionTasks = Maps.newHashMap();
         this.hasSendTask = false;
         this.latch = new CountDownLatch(1);
@@ -368,6 +378,7 @@ public class TransactionState implements Writable, GsonPreProcessable {
         this.finishTime = -1;
         this.reason = "";
         this.errorReplicas = Sets.newHashSet();
+        this.unknownReplicas = Sets.newHashSet();
         this.publishVersionTasks = Maps.newHashMap();
         this.hasSendTask = false;
         this.latch = new CountDownLatch(1);
@@ -399,6 +410,7 @@ public class TransactionState implements Writable, GsonPreProcessable {
         this.finishTime = -1;
         this.reason = "";
         this.errorReplicas = Sets.newHashSet();
+        this.unknownReplicas = Sets.newHashSet();
         this.publishVersionTasks = Maps.newHashMap();
         this.hasSendTask = false;
         this.latch = new CountDownLatch(1);
@@ -419,6 +431,10 @@ public class TransactionState implements Writable, GsonPreProcessable {
         this.errorReplicas = newErrorReplicas;
     }
 
+    public void addUnknownReplica(long replicaId) {
+        unknownReplicas.add(replicaId);
+    }
+
     public boolean isRunning() {
         return transactionStatus == TransactionStatus.PREPARE || transactionStatus == TransactionStatus.PREPARED ||
                 transactionStatus == TransactionStatus.COMMITTED;
@@ -436,15 +452,33 @@ public class TransactionState implements Writable, GsonPreProcessable {
         this.tabletCommitInfos.addAll(infos);
     }
 
+    // Not skip check replica version
+    // 1. replica state is not normal and clone
+    // 2. replica is in tabletCommitInfos in leader (or not in errorReplicas and unknownReplicas in follower)
+    // 3. replica current version >= commit version
     public boolean checkReplicaNeedSkip(Tablet tablet, Replica replica, PartitionCommitInfo partitionCommitInfo) {
-        boolean isContain = tabletCommitInfosContainsReplica(tablet.getId(), replica.getBackendId(), replica.getState());
+        ReplicaState state = replica.getState();
+        if (state != ReplicaState.NORMAL && state != ReplicaState.CLONE) {
+            // Not skip check when replica is ALTER or SCHEMA CHANGE.
+            // Should not return false if the state is CLONE, because lastSuccessVersion will be updated incorrectly
+            // in 'OlapTableTxnLogApplier.applyVisibleLog'.
+            if (LOG.isDebugEnabled()) {
+                Backend backend =
+                        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackend(replica.getBackendId());
+                LOG.debug("skip replica version check because tablet {} backend {} is in state {}",
+                        tablet.getId(), backend != null ? backend.toString() : "", state);
+            }
+            return false;
+        }
+
+        boolean isContain = tabletCommitInfosContainsReplica(tablet.getId(), replica.getBackendId(), replica.getId());
         if (isContain) {
             return false;
         }
 
         // In order for the transaction to complete in time for this scenario: the server machine is not recovered.
         // 1. Transaction TA writes to a two-replicas tablet and enters the committed state.
-        //    The tablet's repliace are replicaA, replicaB.
+        //    The tablet's replicas are replicaA, replicaB.
         // 2. replicaA, replicaB generate tasks: PublishVersionTaskA, PublishVersionTaskB.
         //    PublishVersionTaskA/PublishVersionTaskB successfully submitted to the beA/beB via RPC.
         // 3. The machine where beB is located hangs and is not recoverable.
@@ -464,29 +498,13 @@ public class TransactionState implements Writable, GsonPreProcessable {
         tabletCommitInfos = null;
     }
 
-    public boolean tabletCommitInfosContainsReplica(long tabletId, long backendId, ReplicaState state) {
-        TabletCommitInfo info = new TabletCommitInfo(tabletId, backendId);
-        if (this.tabletCommitInfos == null) {
-            if (LOG.isDebugEnabled()) {
-                Backend backend = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackend(backendId);
-                // if tabletCommitInfos is null, skip this check and return true
-                LOG.debug("tabletCommitInfos is null in TransactionState, tablet {} backend {} txn {}",
-                        tabletId, backend != null ? backend.toString() : "", transactionId);
-            }
-            return true;
+    public boolean tabletCommitInfosContainsReplica(long tabletId, long backendId, long replicaId) {
+        if (tabletCommitInfos != null) {
+            return tabletCommitInfos.contains(new TabletCommitInfo(tabletId, backendId));
+        } else {
+            // tabletCommitInfos is not persistent and is null in follower fe
+            return !errorReplicas.contains(replicaId) && !unknownReplicas.contains(replicaId);
         }
-        if (state != ReplicaState.NORMAL && state != ReplicaState.CLONE) {
-            // Skip check when replica is ALTER or SCHEMA CHANGE.
-            // Should not return true if the state is CLONE, because lastSuccessVersion will be updated incorrectly
-            // in 'OlapTableTxnLogApplier.applyVisibleLog'.
-            if (LOG.isDebugEnabled()) {
-                Backend backend = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackend(backendId);
-                LOG.debug("skip tabletCommitInfos check because tablet {} backend {} is in state {}",
-                        tabletId, backend != null ? backend.toString() : "", state);
-            }
-            return true;
-        }
-        return this.tabletCommitInfos.contains(info);
     }
 
     // Only for OlapTable
@@ -821,7 +839,13 @@ public class TransactionState implements Writable, GsonPreProcessable {
         sb.append(", coordinator: ").append(txnCoordinator.toString());
         sb.append(", transaction status: ").append(transactionStatus);
         sb.append(", error replicas num: ").append(errorReplicas.size());
-        sb.append(", replica ids: ").append(Joiner.on(",").join(errorReplicas.stream().limit(5).toArray()));
+        if (!errorReplicas.isEmpty()) {
+            sb.append(", error replica ids: ").append(Joiner.on(",").join(errorReplicas.stream().limit(5).toArray()));
+        }
+        sb.append(", unknown replicas num: ").append(unknownReplicas.size());
+        if (!unknownReplicas.isEmpty()) {
+            sb.append(", unknown replica ids: ").append(Joiner.on(",").join(unknownReplicas.stream().limit(5).toArray()));
+        }
         sb.append(", prepare time: ").append(prepareTime);
         sb.append(", write end time: ").append(writeEndTimeMs);
         sb.append(", allow commit time: ").append(allowCommitTimeMs);
@@ -877,7 +901,13 @@ public class TransactionState implements Writable, GsonPreProcessable {
         sb.append(", db id: ").append(dbId);
         sb.append(", table id list: ").append(StringUtils.join(tableIdList, ","));
         sb.append(", error replicas num: ").append(errorReplicas.size());
-        sb.append(", replica ids: ").append(Joiner.on(",").join(errorReplicas.stream().limit(5).toArray()));
+        if (!errorReplicas.isEmpty()) {
+            sb.append(", error replica ids: ").append(Joiner.on(",").join(errorReplicas.stream().limit(5).toArray()));
+        }
+        sb.append(", unknown replicas num: ").append(unknownReplicas.size());
+        if (!unknownReplicas.isEmpty()) {
+            sb.append(", unknown replica ids: ").append(Joiner.on(",").join(unknownReplicas.stream().limit(5).toArray()));
+        }
         if (commitTime > prepareTime) {
             sb.append(", write cost: ").append(commitTime - prepareTime).append("ms");
         }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateTest.java
@@ -21,7 +21,11 @@ import com.baidu.bjf.remoting.protobuf.Codec;
 import com.baidu.bjf.remoting.protobuf.ProtobufProxy;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Replica.ReplicaState;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.proto.TxnFinishStatePB;
@@ -140,26 +144,46 @@ public class TransactionStateTest {
     }
 
     @Test
-    public void testCommitInfos() {
-        TransactionState transactionState = new TransactionState(1000L, Lists.newArrayList(20000L, 20001L),
-                3000, "label123", UUIDUtil.genTUniqueId(),
-                LoadJobSourceType.BACKEND_STREAMING, new TxnCoordinator(TxnSourceType.BE, "127.0.0.1"), 50000L,
-                60 * 1000L);
-        Assert.assertTrue(transactionState.tabletCommitInfosContainsReplica(1001, 1001, ReplicaState.NORMAL));
-        TabletCommitInfo info1 = new TabletCommitInfo(10001, 10001);
-        TabletCommitInfo info2 = new TabletCommitInfo(10001, 10002);
-        TabletCommitInfo info3 = new TabletCommitInfo(10002, 10002);
+    public void testCheckReplicaNeedSkip() {
+        TransactionState state = new TransactionState(1000L, Lists.newArrayList(20000L, 20001L), 3000, "label123",
+                UUIDUtil.genTUniqueId(), LoadJobSourceType.BACKEND_STREAMING, new TxnCoordinator(TxnSourceType.BE, "127.0.0.1"),
+                50000L, 60 * 1000L);
+
+        PartitionCommitInfo pcInfo = new PartitionCommitInfo(1L, 100L, 1L);
+
+        Tablet tablet0 = new LocalTablet(1001L);
+        Tablet tablet1 = new LocalTablet(10001L);
+        Tablet tablet2 = new LocalTablet(10002L);
+
+        TabletCommitInfo info1 = new TabletCommitInfo(10001L, 10001L);
+        TabletCommitInfo info2 = new TabletCommitInfo(10001L, 10002L);
+        TabletCommitInfo info3 = new TabletCommitInfo(10002L, 10002L);
         List<TabletCommitInfo> infos = new ArrayList<>();
         infos.add(info1);
         infos.add(info2);
         infos.add(info3);
-        transactionState.setTabletCommitInfos(infos);
-        Assert.assertFalse(transactionState.tabletCommitInfosContainsReplica(1001, 1001, ReplicaState.NORMAL));
-        Assert.assertTrue(transactionState.tabletCommitInfosContainsReplica(10001, 10001, ReplicaState.NORMAL));
-        Assert.assertTrue(transactionState.tabletCommitInfosContainsReplica(10001, 10002, ReplicaState.NORMAL));
-        Assert.assertTrue(transactionState.tabletCommitInfosContainsReplica(10002, 10002, ReplicaState.NORMAL));
-        Assert.assertTrue(transactionState.tabletCommitInfosContainsReplica(1001, 1001, ReplicaState.ALTER));
-        Assert.assertTrue(transactionState.tabletCommitInfosContainsReplica(1001, 1001, ReplicaState.SCHEMA_CHANGE));
-        Assert.assertFalse(transactionState.tabletCommitInfosContainsReplica(1001, 1001, ReplicaState.CLONE));
+        state.setTabletCommitInfos(infos);
+
+        // replica state is not normal and clone
+        Assert.assertFalse(state.checkReplicaNeedSkip(tablet0, new Replica(1L, 1L, ReplicaState.ALTER, 1L, 0), pcInfo));
+        Assert.assertFalse(state.checkReplicaNeedSkip(tablet0, new Replica(1L, 1L, ReplicaState.SCHEMA_CHANGE, 1L, 0), pcInfo));
+        Assert.assertTrue(state.checkReplicaNeedSkip(tablet0, new Replica(1L, 1L, ReplicaState.NORMAL, 1L, 0), pcInfo));
+        Assert.assertTrue(state.checkReplicaNeedSkip(tablet0, new Replica(1L, 1L, ReplicaState.CLONE, 1L, 0), pcInfo));
+
+        // replica is in tabletCommitInfos
+        Assert.assertFalse(state.checkReplicaNeedSkip(tablet1, new Replica(2L, 10001L, ReplicaState.NORMAL, 99L, 0), pcInfo));
+        Assert.assertFalse(state.checkReplicaNeedSkip(tablet1, new Replica(3L, 10002L, ReplicaState.NORMAL, 99L, 0), pcInfo));
+        Assert.assertFalse(state.checkReplicaNeedSkip(tablet2, new Replica(4L, 10002L, ReplicaState.NORMAL, 99L, 0), pcInfo));
+
+        // replica current version >= commit version
+        Assert.assertFalse(state.checkReplicaNeedSkip(tablet0, new Replica(1L, 1L, ReplicaState.NORMAL, 100L, 0), pcInfo));
+
+        // follower tabletCommitInfos is null
+        Deencapsulation.setField(state, "tabletCommitInfos", null);
+        Assert.assertFalse(state.checkReplicaNeedSkip(tablet0, new Replica(5L, 1L, ReplicaState.NORMAL, 1L, 0), pcInfo));
+
+        // follower tabletCommitInfos is null and unknownReplicas contains the replica
+        state.addUnknownReplica(5L);
+        Assert.assertTrue(state.checkReplicaNeedSkip(tablet0, new Replica(5L, 1L, ReplicaState.NORMAL, 1L, 0), pcInfo));
     }
 }


### PR DESCRIPTION
## Why I'm doing:

`tabletCommitInfos` in `TransactionState` is not persistent because it is very large, and it is null in follower FE.
`OlapTableTxnLogApplier.applyVisibleLog` uses tabletCommitInfos to check whether replica need update version.
`null tabletCommitInfos` will cause follower wrong version update, and query failed from follower with version not found error.

## What I'm doing:
so add persistent `unknownReplicas` to fix this issue, `unknownReplicas` is much less than `tabletCommitInfos`.

`unknownReplicas = total replicas - tabletCommitInfos - errorReplicas`

Fixes https://github.com/StarRocks/StarRocksTest/issues/9360

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
