### PR TITLE
[BugFix] fix sink decimal bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1168,7 +1168,7 @@ public class IcebergMetadata implements ConnectorMetadata {
 
         PartitionSpec partitionSpec = nativeTbl.spec();
         for (TIcebergDataFile dataFile : dataFiles) {
-            Metrics metrics = IcebergApiConverter.buildDataFileMetrics(dataFile);
+            Metrics metrics = IcebergApiConverter.buildDataFileMetrics(dataFile, nativeTbl);
             DataFiles.Builder builder =
                     DataFiles.builder(partitionSpec)
                             .withMetrics(metrics)

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
@@ -39,6 +39,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.types.Types;
 import org.junit.Test;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -249,6 +250,19 @@ public class IcebergApiConverterTest {
         source = ImmutableMap.of("file_format", "avro", "compression_codec", "zstd");
         target = IcebergApiConverter.rebuildCreateTableProperties(source);
         assertEquals("zstd", target.get(AVRO_COMPRESSION));
+    }
+
+    @Test
+    public void testReverseByteBuffer() {
+        byte[] bytes = new byte[] {1, 2, 3, 4, 5};
+        ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+        IcebergApiConverter.reverseBuffer(byteBuffer);
+        assertEquals(5, byteBuffer.remaining());
+        assertEquals(5, byteBuffer.get(0));
+        assertEquals(4, byteBuffer.get(1));
+        assertEquals(3, byteBuffer.get(2));
+        assertEquals(2, byteBuffer.get(3));
+        assertEquals(1, byteBuffer.get(4));
     }
 
     @Test

--- a/test/sql/test_sink/R/test_iceberg_sink_decimal
+++ b/test/sql/test_sink/R/test_iceberg_sink_decimal
@@ -1,0 +1,43 @@
+-- name: test_iceberg_sink_decimal
+create external catalog iceberg_sink_${uuid0} PROPERTIES (
+    "type"  =  "iceberg",
+    "iceberg.catalog.type"  =  "hive",
+    "iceberg.catalog.hive.metastore.uris"="${hive_metastore_uris}",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}",
+    "enable_iceberg_metadata_cache" = "false"
+);
+-- result:
+-- !result
+create database iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/iceberg_sink_db_${uuid0}/test_iceberg_sink_decimal/${uuid0}"
+);
+-- result:
+-- !result
+create table iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0}.t1 (
+    c1 decimal(10,3)
+);
+-- result:
+-- !result
+insert into iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0}.t1 values(10.23);
+-- result:
+-- !result
+select * from iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0}.t1 where c1=10.23;
+-- result:
+10.230
+-- !result
+drop table iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0}.t1 force;
+-- result:
+-- !result
+drop database iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0};
+-- result:
+-- !result
+drop catalog iceberg_sink_${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/iceberg_sink_db_${uuid0}/test_iceberg_sink_decimal/${uuid0} > /dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_sink/T/test_iceberg_sink_decimal
+++ b/test/sql/test_sink/T/test_iceberg_sink_decimal
@@ -1,0 +1,29 @@
+-- name: test_iceberg_sink_decimal
+
+create external catalog iceberg_sink_${uuid0} PROPERTIES (
+    "type"  =  "iceberg",
+    "iceberg.catalog.type"  =  "hive",
+    "iceberg.catalog.hive.metastore.uris"="${hive_metastore_uris}",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}",
+    "enable_iceberg_metadata_cache" = "false"
+);
+create database iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/iceberg_sink_db_${uuid0}/test_iceberg_sink_decimal/${uuid0}"
+);
+
+create table iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0}.t1 (
+    c1 decimal(10,3)
+);
+
+insert into iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0}.t1 values(10.23);
+
+select * from iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0}.t1 where c1=10.23;
+
+drop table iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0}.t1 force;
+
+drop database iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0};
+drop catalog iceberg_sink_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/iceberg_sink_db_${uuid0}/test_iceberg_sink_decimal/${uuid0} > /dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
## Why I'm doing:
Scenario:
```
##iceberg table:
create table t1(c1 decimal(10,3));
insert into t1 values(10.230);
select * from t1 where c1=10.230;
#get empty set 
```



When reading iceberg manifest to get DataFiles, it will use rowFilter to filter unnecessary dataFiles.
```
return CloseableIterable.filter(
                    content == FileType.DATA_FILES
                            ? scanMetrics.skippedDataFiles()
                            : scanMetrics.skippedDeleteFiles(),
                    onlyLive ? filterLiveEntries(entries) : entries,
                    entry ->
                            entry != null
                                    && evaluator.eval(entry.file().partition())
                                    && metricsEvaluator.eval(entry.file())
                                    && inPartitionSet(entry.file()));
```
the `metricsEvaluator` will do this.

And this will get upperbound and lowerbound from manifest like this
```
private <T> T parseLowerBound(BoundReference<T> ref) {
            Integer id = ref.fieldId();
            return (T)(this.lowerBounds != null && this.lowerBounds.containsKey(id) ? Conversions.fromByteBuffer(ref.ref().type(), (ByteBuffer)this.lowerBounds.get(id)) : null);
        }

        private <T> T parseUpperBound(BoundReference<T> ref) {
            Integer id = ref.fieldId();
            return (T)(this.upperBounds != null && this.upperBounds.containsKey(id) ? Conversions.fromByteBuffer(ref.ref().type(), (ByteBuffer)this.upperBounds.get(id)) : null);
        }

private static Object internalFromByteBuffer(Type type, ByteBuffer buffer) {
        if (buffer == null) {
            return null;
        } else {
            ByteBuffer tmp = buffer.duplicate();
            if (type != UUIDType.get() && !(type instanceof Types.DecimalType)) {
                tmp.order(ByteOrder.LITTLE_ENDIAN);
            } else {
                tmp.order(ByteOrder.BIG_ENDIAN);
            }
```

And the DecimalType, UUIDTYPE should store the bound in bigEndian in manifest files. But now we store them in little endian, this will cause the scenario like above


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
