### PR TITLE
[BugFix] Fix query fail after rename column name if scan node contain unused output column name (backport #59178)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -328,7 +328,7 @@ public class OlapScanNode extends ScanNode {
             }
             if (unUsedOutputColumnIds.contains(slot.getId().asInt()) &&
                     !aggOrPrimaryKeyTableValueColumnNames.contains(slot.getColumn().getName())) {
-                unUsedOutputStringColumns.add(slot.getColumn().getName());
+                unUsedOutputStringColumns.add(slot.getColumn().getColumnId().getId());
             }
         }
     }

--- a/test/sql/test_column_rename/T/test_column_rename
+++ b/test/sql/test_column_rename/T/test_column_rename
@@ -8,73 +8,17 @@ DISTRIBUTED BY HASH(k1)
 PROPERTIES(
     "replication_num" = "1"
 );
--- result:
--- !result
 show create table t1;
--- result:
-t1	CREATE TABLE `t1` (
-  `k1` int(11) NULL COMMENT "",
-  `v1` int(11) NULL COMMENT "",
-  `v2` int(11) NULL COMMENT ""
-) ENGINE=OLAP 
-DUPLICATE KEY(`k1`)
-DISTRIBUTED BY HASH(`k1`)
-PROPERTIES (
-"compression" = "LZ4",
-"fast_schema_evolution" = "true",
-"replicated_storage" = "true",
-"replication_num" = "1"
-);
--- !result
 INSERT INTO t1 VALUES(1, 2, 3);
--- result:
--- !result
 select * from t1;
--- result:
-1	2	3
--- !result
 ALTER TABLE t1 RENAME COLUMN k1 TO k2;
--- result:
--- !result
 ALTER TABLE t1 RENAME COLUMN v1 TO v2;
--- result:
-E: (1060, "Duplicate column name 'v2'")
--- !result
 select * from t1;
--- result:
-1	2	3
--- !result
 select k2 from t1;
--- result:
-1
--- !result
 show create table t1;
--- result:
-t1	CREATE TABLE `t1` (
-  `k2` int(11) NULL COMMENT "",
-  `v1` int(11) NULL COMMENT "",
-  `v2` int(11) NULL COMMENT ""
-) ENGINE=OLAP 
-DUPLICATE KEY(`k2`)
-DISTRIBUTED BY HASH(`k2`)
-PROPERTIES (
-"compression" = "LZ4",
-"fast_schema_evolution" = "true",
-"replicated_storage" = "true",
-"replication_num" = "1"
-);
--- !result
 insert into t1(k2, v1, v2) values(4, 5, 6);
--- result:
--- !result
 select * from t1;
--- result:
-4	5	6
-1	2	3
--- !result
 drop table t1;
--- result:
--- !result
 CREATE TABLE site_access (
     datekey DATE,
     site_id INT,
@@ -91,55 +35,13 @@ DISTRIBUTED BY HASH(site_id)
 PROPERTIES (
     "replication_num" = "1"
 );
--- result:
--- !result
 alter table site_access rename column datekey to dt;
--- result:
--- !result
 show create table site_access;
--- result:
-site_access	CREATE TABLE `site_access` (
-  `dt` date NULL COMMENT "",
-  `site_id` int(11) NULL COMMENT "",
-  `city_code` smallint(6) NULL COMMENT "",
-  `user_name` varchar(32) NULL COMMENT "",
-  `pv` bigint(20) NULL DEFAULT "0" COMMENT ""
-) ENGINE=OLAP 
-DUPLICATE KEY(`dt`, `site_id`, `city_code`, `user_name`)
-PARTITION BY RANGE(`dt`)
-(PARTITION p20210101 VALUES [("2021-01-01"), ("2021-01-02")),
-PARTITION p20210102 VALUES [("2021-01-02"), ("2021-01-03")),
-PARTITION p20210103 VALUES [("2021-01-03"), ("2021-01-04")))
-DISTRIBUTED BY HASH(`site_id`)
-PROPERTIES (
-"compression" = "LZ4",
-"fast_schema_evolution" = "true",
-"replicated_storage" = "true",
-"replication_num" = "1"
-);
--- !result
 insert into site_access values('2021-01-01',1,1,'1',1);
--- result:
--- !result
 insert into site_access(dt,site_id,city_code,user_name,pv) values('2021-01-01',1,1,'1',1);
--- result:
--- !result
 desc site_access;
--- result:
-dt	date	YES	true	None	
-site_id	int	YES	true	None	
-city_code	smallint	YES	true	None	
-user_name	varchar(32)	YES	true	None	
-pv	bigint	YES	false	0	
--- !result
 select * from site_access;
--- result:
-2021-01-01	1	1	1	1
-2021-01-01	1	1	1	1
--- !result
 drop table site_access;
--- result:
--- !result
 CREATE TABLE t_recharge_detail (
     id bigint,
     user_id bigint,
@@ -153,35 +55,13 @@ DISTRIBUTED BY HASH(`id`) BUCKETS 10
 PROPERTIES (
 "replication_num" = "1"
 );
--- result:
--- !result
 alter table t_recharge_detail rename column dt to datekey;
--- result:
--- !result
 insert into t_recharge_detail values(1,1,1,'bj','2020-01-01');
--- result:
--- !result
 insert into t_recharge_detail(id,user_id,recharge_money,province,datekey) values(1,1,1,'bj','2020-01-01');
--- result:
--- !result
 insert overwrite t_recharge_detail PARTITION(datekey='2022-04-02', province='beijing')
 select 2 as id, 2 as user_id, 2 as recharge_money, 'beijing' as province, '2022-04-02' as datekey from dual;
--- result:
--- !result
 desc t_recharge_detail;
--- result:
-id	bigint	YES	true	None	
-user_id	bigint	YES	false	None	
-recharge_money	decimal(32,2)	YES	false	None	
-province	varchar(20)	NO	false	None	
-datekey	varchar(20)	NO	false	None	
--- !result
 select * from t_recharge_detail;
--- result:
-1	1	1.00	bj	2020-01-01
-2	2	2.00	beijing	2022-04-02
-1	1	1.00	bj	2020-01-01
--- !result
 -- name: test_column_rename_insert
 CREATE TABLE t2 (
     k1 INT,
@@ -192,22 +72,10 @@ DISTRIBUTED BY HASH(k1)
 PROPERTIES(
     "replication_num" = "1"
 );
--- result:
--- !result
 alter table t2 rename column k1 to k2;
--- result:
--- !result
 insert into t2(k1,v1,v2) values(4, 5, 6);
--- result:
-E: (1064, "Getting analyzing error. Detail message: Unknown column 'k1' in 't2'.")
--- !result
 insert into t2(k2,v1,v2) values(4, 5, 6);
--- result:
--- !result
 select * from t2;
--- result:
-4	5	6
--- !result
 CREATE TABLE site_access(
     event_day DATE NOT NULL,
     site_id INT DEFAULT '10',
@@ -221,30 +89,8 @@ PARTITION BY date_trunc('day', event_day) (
 )
 DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32
 PROPERTIES("replication_num" = "1");
--- result:
--- !result
 alter table site_access rename column event_day to dt;
--- result:
--- !result
 show create table site_access;
--- result:
-site_access	CREATE TABLE `site_access` (
-  `dt` date NOT NULL COMMENT "",
-  `site_id` int(11) NULL DEFAULT "10" COMMENT "",
-  `city_code` varchar(100) NULL COMMENT "",
-  `user_name` varchar(32) NULL DEFAULT "" COMMENT "",
-  `pv` bigint(20) NULL DEFAULT "0" COMMENT ""
-) ENGINE=OLAP 
-DUPLICATE KEY(`dt`, `site_id`, `city_code`, `user_name`)
-PARTITION BY date_trunc('day', `dt`)
-DISTRIBUTED BY HASH(`dt`, `site_id`) BUCKETS 32 
-PROPERTIES (
-"compression" = "LZ4",
-"fast_schema_evolution" = "true",
-"replicated_storage" = "true",
-"replication_num" = "1"
-);
--- !result
 CREATE TABLE `bill_detail` (
   `bill_code` varchar(200) NOT NULL DEFAULT "" COMMENT "运单号"
 ) ENGINE=OLAP
@@ -260,46 +106,13 @@ PROPERTIES (
 "replication_num" = "1",
 "storage_format" = "DEFAULT"
 );
--- result:
--- !result
 alter table bill_detail rename column bill_code to bill;
--- result:
--- !result
 alter table bill_detail add PARTITION p6 VALUES [('20000000'), ('3021712368984'));
--- result:
--- !result
 insert into bill_detail(bill) values("JT2921712368984");
--- result:
--- !result
 select * from bill_detail;
--- result:
-JT2921712368984
--- !result
 show create table bill_detail;
--- result:
-bill_detail	CREATE TABLE `bill_detail` (
-  `bill` varchar(200) NOT NULL DEFAULT "" COMMENT "运单号"
-) ENGINE=OLAP 
-PRIMARY KEY(`bill`)
-PARTITION BY RANGE(CAST(substr(`bill`, 3, 11) AS BIGINT))
-(PARTITION p1 VALUES [("0"), ("5000000")),
-PARTITION p2 VALUES [("5000000"), ("10000000")),
-PARTITION p3 VALUES [("10000000"), ("15000000")),
-PARTITION p4 VALUES [("15000000"), ("20000000")),
-PARTITION p6 VALUES [("20000000"), ("3021712368984")))
-DISTRIBUTED BY HASH(`bill`) BUCKETS 3 
-PROPERTIES (
-"compression" = "LZ4",
-"enable_persistent_index" = "true",
-"fast_schema_evolution" = "true",
-"replicated_storage" = "true",
-"replication_num" = "1"
-);
--- !result
 select * from bill_detail where bill = "JT2921712368984";
--- result:
-JT2921712368984
--- !result
+
 -- name: test_column_rename_failed_with_unused_output_column
 CREATE TABLE `t_rename_column_unused_output_column_name` (
   `a` bigint(20) NOT NULL COMMENT "",
@@ -317,26 +130,13 @@ PROPERTIES (
 "replicated_storage" = "true",
 "replication_num" = "1"
 );
--- result:
--- !result
+
 insert into t_rename_column_unused_output_column_name values(1, 1, 1, 1, 1, ["1", "1"]);
--- result:
--- !result
+
 alter table t_rename_column_unused_output_column_name rename column d to new_d;
--- result:
--- !result
 SELECT a, e FROM t_rename_column_unused_output_column_name WHERE t_rename_column_unused_output_column_name.new_d IS NOT NULL LIMIT 9;
--- result:
-1	1
--- !result
+
 insert into t_rename_column_unused_output_column_name values(2, 2, 2, 2, 2, ["1", "1"]);
--- result:
--- !result
 SELECT a, e FROM t_rename_column_unused_output_column_name WHERE t_rename_column_unused_output_column_name.new_d IS NOT NULL LIMIT 9;
--- result:
-1	1
-2	2
--- !result
+
 drop table t_rename_column_unused_output_column_name force;
--- result:
--- !result


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1

