### PR TITLE
[BugFix]fix crash when a subfield of struct appearw in two predicates (backport #59216)

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -407,10 +407,23 @@ Status HiveDataSource::_decompose_conjunct_ctxs(RuntimeState* state) {
                 break;
             }
         }
-        if (!single_slot || slot_ids.empty()) {
+
+        bool single_field = true;
+        if (!slot_ids.empty() && single_slot) {
+            std::vector<std::vector<std::string>> subfields;
+            root_expr->get_subfields(&subfields);
+
+            for (int i = 1; i < subfields.size(); i++) {
+                if (subfields[i] != subfields[0]) {
+                    single_field = false;
+                    break;
+                }
+            }
+        }
+        if (!single_slot || slot_ids.empty() || !single_field) {
             _scanner_conjunct_ctxs.emplace_back(ctx);
             for (SlotId slot_id : slot_ids) {
-                _slots_of_mutli_slot_conjunct.insert(slot_id);
+                _slots_of_multi_field_conjunct.insert(slot_id);
             }
             continue;
         }
@@ -586,7 +599,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     scanner_params.scanner_conjunct_ctxs = _scanner_conjunct_ctxs;
     scanner_params.conjunct_ctxs_by_slot = _conjunct_ctxs_by_slot;
     scanner_params.slots_in_conjunct = _slots_in_conjunct;
-    scanner_params.slots_of_mutli_slot_conjunct = _slots_of_mutli_slot_conjunct;
+    scanner_params.slots_of_multi_field_conjunct = _slots_of_multi_field_conjunct;
     scanner_params.min_max_conjunct_ctxs = _min_max_conjunct_ctxs;
     scanner_params.min_max_tuple_desc = _min_max_tuple_desc;
     scanner_params.hive_column_names = &_hive_column_names;

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -128,7 +128,7 @@ private:
     // used for reader to decide decode or not
     // if only used by filter(not output) and only used in conjunct_ctx_by_slot
     // there is no need to decode.
-    std::unordered_set<SlotId> _slots_of_mutli_slot_conjunct;
+    std::unordered_set<SlotId> _slots_of_multi_field_conjunct;
 
     // partition conjuncts of each partition slot.
     std::vector<ExprContext*> _partition_conjunct_ctxs;

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -119,8 +119,8 @@ Status HdfsScanner::_build_scanner_context() {
             column.slot_desc = slot;
             column.idx_in_chunk = _scanner_params.materialize_index_in_chunk[i];
             column.decode_needed =
-                    slot->is_output_column() || _scanner_params.slots_of_mutli_slot_conjunct.find(slot->id()) !=
-                                                        _scanner_params.slots_of_mutli_slot_conjunct.end();
+                    slot->is_output_column() || _scanner_params.slots_of_multi_field_conjunct.find(slot->id()) !=
+                                                        _scanner_params.slots_of_multi_field_conjunct.end();
             ctx.materialized_columns.emplace_back(std::move(column));
         }
     }

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -163,7 +163,7 @@ struct HdfsScannerParams {
     std::vector<ExprContext*> scanner_conjunct_ctxs;
     std::unordered_set<SlotId> slots_in_conjunct;
     // slot used by conjunct_ctxs
-    std::unordered_set<SlotId> slots_of_mutli_slot_conjunct;
+    std::unordered_set<SlotId> slots_of_multi_field_conjunct;
 
     // conjunct ctxs grouped by slot.
     std::unordered_map<SlotId, std::vector<ExprContext*>> conjunct_ctxs_by_slot;

--- a/test/sql/test_external_file/R/test_parquet_struct_in_struct
+++ b/test/sql/test_external_file/R/test_parquet_struct_in_struct
@@ -65,6 +65,21 @@ select count(*) from struct_in_struct where c_struct_struct.c_struct.c0 in ('55'
 -- result:
 200
 -- !result
+select * from struct_in_struct where (c0 in (101, 1000)) or (c0 > 5000 and c0 < 5005) or (c0 in (9001, 10000));
+-- result:
+101	9900	{"c0":"1","c1":"0"}	{"c0":"1","c_struct":{"c0":"1","c1":"0"}}
+1000	9001	None	None
+5001	5000	{"c0":"1","c1":"0"}	{"c0":"1","c_struct":{"c0":"1","c1":"0"}}
+5002	4999	{"c0":"2","c1":"99"}	{"c0":"2","c_struct":{"c0":"2","c1":"99"}}
+5003	4998	{"c0":"3","c1":"98"}	{"c0":"3","c_struct":{"c0":"3","c1":"98"}}
+5004	4997	{"c0":"4","c1":"97"}	{"c0":"4","c_struct":{"c0":"4","c1":"97"}}
+9001	1000	{"c0":"1","c1":"0"}	{"c0":"1","c_struct":{"c0":"1","c1":"0"}}
+10000	1	None	None
+-- !result
+select count(*) from struct_in_struct where c_struct_struct.c_struct.c0 < '55' and (c_struct_struct.c_struct.c0 > '15' or c_struct_struct.c_struct.c1 = '90');
+-- result:
+4000
+-- !result
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_struct_in_struct/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
 -- result:
 0

--- a/test/sql/test_external_file/T/test_parquet_struct_in_struct
+++ b/test/sql/test_external_file/T/test_parquet_struct_in_struct
@@ -38,4 +38,10 @@ select * from struct_in_struct where c_struct_struct.c_struct.c0 in ('55', '56')
 -- filed is not output column but in conjunct of multi-slot, decode is needed
 select count(*) from struct_in_struct where c_struct_struct.c_struct.c0 in ('55', '56') and c_struct_struct.c_struct.c0 = c_struct.c0;
 
+-- string in struct, lazy_decode -> normal_decode -> lazy_decode
+select * from struct_in_struct where (c0 in (101, 1000)) or (c0 > 5000 and c0 < 5005) or (c0 in (9001, 10000));
+
+-- one subfield appears in two predicates
+select count(*) from struct_in_struct where c_struct_struct.c_struct.c0 < '55' and (c_struct_struct.c_struct.c0 > '15' or c_struct_struct.c_struct.c1 = '90');
+
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_struct_in_struct/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
