### PR TITLE
[BugFix] persistent index will lost data when load snapshot fail

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -963,7 +963,9 @@ public:
     }
 
     Status load_snapshot(phmap::BinaryInputArchive& ar) override {
-        TRY_CATCH_BAD_ALLOC(_map.load(ar));
+        bool succ = false;
+        TRY_CATCH_BAD_ALLOC(succ = _map.load(ar));
+        RETURN_IF(!succ, Status::InternalError("load snapshot failed"));
         return Status::OK();
     }
 

--- a/be/src/util/phmap/phmap_dump.h
+++ b/be/src/util/phmap/phmap_dump.h
@@ -284,7 +284,7 @@ public:
         TEST_SYNC_POINT_CALLBACK("BinaryInputArchive::load::1", &ret);
         if (!ret) return ret;
         ifs_.read(p, sz);
-        return true;
+        return !ifs_.fail();
     }
 
     template <typename V>
@@ -293,7 +293,7 @@ public:
         TEST_SYNC_POINT_CALLBACK("BinaryInputArchive::load::2", &ret);
         if (!ret) return ret;
         ifs_.read(reinterpret_cast<char*>(v), sizeof(V));
-        return true;
+        return !ifs_.fail();
     }
 
 private:

--- a/be/src/util/phmap/phmap_dump.h
+++ b/be/src/util/phmap/phmap_dump.h
@@ -280,12 +280,18 @@ public:
     explicit BinaryInputArchive(const char* file_path) { ifs_.open(file_path, std::ios_base::binary); }
 
     bool load(char* p, size_t sz) {
+        bool ret = true;
+        TEST_SYNC_POINT_CALLBACK("BinaryInputArchive::load::1", &ret);
+        if (!ret) return ret;
         ifs_.read(p, sz);
         return true;
     }
 
     template <typename V>
     typename std::enable_if<type_traits_internal::IsTriviallyCopyable<V>::value, bool>::type load(V* v) {
+        bool ret = true;
+        TEST_SYNC_POINT_CALLBACK("BinaryInputArchive::load::2", &ret);
+        if (!ret) return ret;
         ifs_.read(reinterpret_cast<char*>(v), sizeof(V));
         return true;
     }


### PR DESCRIPTION
## Why I'm doing:
In `FixedMutableIndex::load_snapshot`, we doesn't check whether map load from snapshot success or not, it will lead to data lost when read file fail.

## What I'm doing:
Fix it.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
