### PR TITLE
[BugFix] Fix check runtime filter version for compatibility

### DIFF
--- a/be/src/exec/pipeline/runtime_filter_types.cpp
+++ b/be/src/exec/pipeline/runtime_filter_types.cpp
@@ -124,7 +124,7 @@ Status PartialRuntimeFilterMerger::merge_singleton_local_bloom_filters() {
     const size_t row_count = std::accumulate(_ht_row_counts.begin(), _ht_row_counts.end(), size_t{0});
 
     const auto join_mode = _bloom_filter_descriptors[0]->join_mode();
-    const bool is_version_v3 = _func_version >= RF_VERSION_V3;
+    const bool is_version_v3 = _func_version >= TFunctionVersion::type::RUNTIME_FILTER_SERIALIZE_VERSION_3;
     const bool maybe_use_bitset_filter =
             _enable_join_runtime_bitset_filter && is_version_v3 && row_count <= _global_rf_limit &&
             join_mode == TRuntimeFilterBuildJoinMode::BORADCAST && _partial_bloom_filter_build_params.size() == 1;
@@ -208,7 +208,7 @@ Status PartialRuntimeFilterMerger::merge_multi_partitioned_local_bloom_filters()
         row_count += count;
     }
 
-    const bool is_version_v3 = _func_version >= RF_VERSION_V3;
+    const bool is_version_v3 = _func_version >= TFunctionVersion::type::RUNTIME_FILTER_SERIALIZE_VERSION_3;
 
     for (auto& desc : _bloom_filter_descriptors) {
         desc->set_is_pipeline(true);


### PR DESCRIPTION
## Why I'm doing:

#57101 introduces a new `func_version` (RUNTIME_FILTER_SERIALIZE_VERSION_3) and `RF_VERSION` (RF_VERSION_V3)

- The `func_version` parameter, transmitted from FE to BE, dictates the function version employed by BE.
- The `RF_VERSION` parameter, utilized during runtime filter exchanges between BE instances, governs the serialization and deserialization formats.


To ensure compatibility during transitional upgrades where BE instances are updated prior to FE, 
- legacy versions of `func_version` (RUNTIME_FILTER_SERIALIZE_VERSION_2) and `RF_VERSION` (RF_VERSION_V2) must be preserved. 
- If FE transmited `func_version` as RUNTIME_FILTER_SERIALIZE_VERSION_2 instead of RUNTIME_FILTER_SERIALIZE_VERSION_3, the preceding RF_VERSION implementation shall be invoked.

However, discrepancies emerge in two code segments where version validation erroneously employs `func_version >= RF_VERSION_V3` rather than the appropriate `func_version >= RUNTIME_FILTER_SERIALIZE_VERSION_3` criterion.


BE crashed
```
==173540==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x503001d23dcf at pc 0x000015d25ed2 bp 0x2b2b4699ba90 sp 0x2b2b4699ba88
READ of size 4 at 0x503001d23dcf thread T642
    #0 0x15d25ed1 in starrocks::SimdBlockFilter::deserialize(unsigned char const*) be/src/exprs/runtime_filter.cpp:78
    #1 0x15d2c653 in starrocks::TRuntimeBloomFilter<(starrocks::LogicalType)5>::deserialize(int, unsigned char const*) be/src/exprs/runtime_filter.cpp:202
    #2 0x15c4e74f in starrocks::ComposedRuntimeFilter<(starrocks::LogicalType)5, starrocks::TRuntimeBloomFilter<(starrocks::LogicalType)5> >::deserialize(int, unsigned char const*) be/src/exprs/runtime_filter.h:1833
    #3 0x15b80928 in starrocks::RuntimeFilterHelper::deserialize_runtime_filter(starrocks::ObjectPool*, starrocks::RuntimeFilter**, unsigned char const*, unsigned long) be/src/exprs/runtime_filter_bank.cpp:292
    #4 0xc6d47a1 in starrocks::RuntimeFilterWorker::_receive_total_runtime_filter(starrocks::PTransmitRuntimeFilterParams&) be/src/runtime/runtime_filter_worker.cpp:921
    #5 0xc6d7e19 in starrocks::RuntimeFilterWorker::_deliver_broadcast_runtime_filter_local(starrocks::PTransmitRuntimeFilterParams&, starrocks::TRuntimeFilterDestination const&) be/src/runtime/runtime_filter_worker.cpp:1105
    #6 0xc6d5e3a in starrocks::RuntimeFilterWorker::_process_send_broadcast_runtime_filter_event(starrocks::PTransmitRuntimeFilterParams&&, std::vector<starrocks::TRuntimeFilterDestination, std::allocator<starrocks::TRuntimeFilterDestination> >&&, int, long) be/src/runtime/runtime_filter_worker.cpp:1010
    #7 0xc6da2db in starrocks::RuntimeFilterWorker::execute() be/src/runtime/runtime_filter_worker.cpp:1204
    #8 0xc6cfd2f in operator() be/src/runtime/runtime_filter_worker.cpp:724
    #9 0xc6dc999 in __invoke_impl<void, starrocks::RuntimeFilterWorker::RuntimeFilterWorker(starrocks::ExecEnv*)::<lambda()> > /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/invoke.h:61
    #10 0xc6dc95c in __invoke<starrocks::RuntimeFilterWorker::RuntimeFilterWorker(starrocks::ExecEnv*)::<lambda()> > /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/invoke.h:96
    #11 0xc6dc909 in _M_invoke<0> /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/std_thread.h:301
    #12 0xc6dc8dd in operator() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/std_thread.h:308
    #13 0xc6dc8c1 in _M_run /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/std_thread.h:253
    #14 0x213fd55f in execute_native_thread_routine ../../../.././libstdc++-v3/src/c++11/[thread.cc:104](http://thread.cc:104/)
    #15 0xc1117d1 in asan_thread_start ../../.././libsanitizer/asan/asan_interceptors.cpp:234
    #16 0x2b29d5977ea4 in start_thread (/lib64/libpthread.so.0+0x7ea4) (BuildId: e10cc8f2b932fc3daeda22f8dac5ebb969524e5b)
    #17 0x2b29d7b1ab0c in clone (/lib64/libc.so.6+0xfeb0c) (BuildId: 1a8fb61bb4614a483833d5334202ab50edda2a25)
```

## What I'm doing:


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
