### PR TITLE
[BugFix] Fix query concurrency limit in SlotSelectionStrategyV2

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2.java
@@ -237,7 +237,7 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
         if (queryQueueConcurrencyLimit <= 0) {
             return true;
         }
-        return slotTracker.getCurrentCurrency() <= queryQueueConcurrencyLimit;
+        return slotTracker.getCurrentCurrency() < queryQueueConcurrencyLimit;
     }
 
     private static boolean isSmallSlot(LogicalSlot slot) {


### PR DESCRIPTION
## Why I'm doing:

When I set `query_queue_concurrency_limit` to 1,  it should limit the max concurrency in the QueryQueue is 1 rather than 2.
```
    private boolean isQueryConcurrencyLimitAvailable(BaseSlotTracker slotTracker) {
        // if the query queue limit is not set(by default), return true
        int queryQueueConcurrencyLimit = slotManager.getQueryQueueConcurrencyLimit(warehouseId);
        if (queryQueueConcurrencyLimit <= 0) {
            return true;
        }
-        return slotTracker.getCurrentCurrency() <= queryQueueConcurrencyLimit;
+        return slotTracker.getCurrentCurrency() < queryQueueConcurrencyLimit;
    }

```
## What I'm doing:
- Use `query_queue_concurrency_limit` as the limit rather than +1.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
