### PR TITLE
[Enhancement] Push down limit to multi cast sink

### DIFF
--- a/be/src/exec/data_sink.cpp
+++ b/be/src/exec/data_sink.cpp
@@ -359,12 +359,13 @@ Status DataSink::decompose_data_sink_to_pipeline(pipeline::PipelineBuilderContex
                     context->next_operator_id(), upstream_plan_node_id, i, mcast_local_exchanger);
             context->inherit_upstream_source_properties(source_op.get(), upstream_source);
             source_op->set_degree_of_parallelism(dop);
+            ops.emplace_back(source_op);
 
             // limit op
-            if (t_stream_sink.limit != -1) {
+            auto limit = t_stream_sink.limit;
+            if (limit != -1) {
                 ops.emplace_back(std::make_shared<LimitOperatorFactory>(
-                        context->next_operator_id(), upstream_plan_node_id, t_stream_sink.limit,
-                        true /*no_chunk_mutation*/));
+                        context->next_operator_id(), upstream_plan_node_id, limit, false /*limit_chunk_in_place*/));
             }
 
             // sink op

--- a/be/src/exec/data_sink.cpp
+++ b/be/src/exec/data_sink.cpp
@@ -53,6 +53,7 @@
 #include "exec/pipeline/exchange/multi_cast_local_exchange_source_operator.h"
 #include "exec/pipeline/exchange/sink_buffer.h"
 #include "exec/pipeline/fragment_executor.h"
+#include "exec/pipeline/limit_operator.h"
 #include "exec/pipeline/olap_table_sink_operator.h"
 #include "exec/pipeline/result_sink_operator.h"
 #include "exec/pipeline/sink/blackhole_table_sink_operator.h"
@@ -315,10 +316,10 @@ Status DataSink::decompose_data_sink_to_pipeline(pipeline::PipelineBuilderContex
         // note(yan): steps are:
         // 1. create exchange[EX]
         // 2. create sink[A] at the end of current pipeline
-        // 3. create source[B]/sink[C] pipelines.
-        // A -> EX -> B0/C0
-        //       | -> B1/C1
-        //       | -> B2/C2
+        // 3. create source[B]/limit[C]/sink[D] pipelines.
+        // A -> EX -> B0/C0/D0
+        //       | -> B1/C1/D1
+        //       | -> B2/C2/D2
         // sink[A] will push chunk to exchanger
         // and source[B] will pull chunk from exchanger
         // so basically you can think exchanger is a chunk repository.
@@ -345,11 +346,11 @@ Status DataSink::decompose_data_sink_to_pipeline(pipeline::PipelineBuilderContex
         prev_operators.emplace_back(sink_op);
         context->add_pipeline(std::move(prev_operators));
 
-        // ==== create source/sink pipelines ====
+        // ==== create source/limit/sink pipelines ====
         for (size_t i = 0; i < sinks.size(); i++) {
             const auto& sender = sinks[i];
             OpFactories ops;
-            // it's okary to set arbitrary dop.
+            // it's okay to set arbitrary dop.
             const size_t dop = 1;
             auto& t_stream_sink = t_multi_case_stream_sink.sinks[i];
 
@@ -359,11 +360,15 @@ Status DataSink::decompose_data_sink_to_pipeline(pipeline::PipelineBuilderContex
             context->inherit_upstream_source_properties(source_op.get(), upstream_source);
             source_op->set_degree_of_parallelism(dop);
 
-            // sink op
-            auto sink_op = _create_exchange_sink_operator(context, t_stream_sink, sender.get());
+            // limit op
+            if (t_stream_sink.limit != -1) {
+                ops.emplace_back(std::make_shared<LimitOperatorFactory>(
+                        context->next_operator_id(), upstream_plan_node_id, t_stream_sink.limit));
+            }
 
-            ops.emplace_back(source_op);
-            ops.emplace_back(sink_op);
+            // sink op
+            ops.emplace_back(_create_exchange_sink_operator(context, t_stream_sink, sender.get()));
+
             context->add_pipeline(std::move(ops));
         }
     } else if (typeid(*this) == typeid(starrocks::SplitDataStreamSink)) {

--- a/be/src/exec/data_sink.cpp
+++ b/be/src/exec/data_sink.cpp
@@ -363,8 +363,9 @@ Status DataSink::decompose_data_sink_to_pipeline(pipeline::PipelineBuilderContex
 
             // limit op
             if (t_stream_sink.__isset.limit && t_stream_sink.limit != -1) {
-                ops.emplace_back(std::make_shared<LimitOperatorFactory>(
-                        context->next_operator_id(), upstream_plan_node_id, t_stream_sink.limit, false /*limit_chunk_in_place*/));
+                ops.emplace_back(std::make_shared<LimitOperatorFactory>(context->next_operator_id(),
+                                                                        upstream_plan_node_id, t_stream_sink.limit,
+                                                                        false /*limit_chunk_in_place*/));
             }
 
             // sink op

--- a/be/src/exec/data_sink.cpp
+++ b/be/src/exec/data_sink.cpp
@@ -362,10 +362,9 @@ Status DataSink::decompose_data_sink_to_pipeline(pipeline::PipelineBuilderContex
             ops.emplace_back(source_op);
 
             // limit op
-            auto limit = t_stream_sink.limit;
-            if (limit != -1) {
+            if (t_stream_sink.__isset.limit && t_stream_sink.limit != -1) {
                 ops.emplace_back(std::make_shared<LimitOperatorFactory>(
-                        context->next_operator_id(), upstream_plan_node_id, limit, false /*limit_chunk_in_place*/));
+                        context->next_operator_id(), upstream_plan_node_id, t_stream_sink.limit, false /*limit_chunk_in_place*/));
             }
 
             // sink op

--- a/be/src/exec/data_sink.cpp
+++ b/be/src/exec/data_sink.cpp
@@ -363,7 +363,8 @@ Status DataSink::decompose_data_sink_to_pipeline(pipeline::PipelineBuilderContex
             // limit op
             if (t_stream_sink.limit != -1) {
                 ops.emplace_back(std::make_shared<LimitOperatorFactory>(
-                        context->next_operator_id(), upstream_plan_node_id, t_stream_sink.limit));
+                        context->next_operator_id(), upstream_plan_node_id, t_stream_sink.limit,
+                        true /*no_chunk_mutation*/));
             }
 
             // sink op

--- a/be/src/exec/pipeline/limit_operator.cpp
+++ b/be/src/exec/pipeline/limit_operator.cpp
@@ -35,6 +35,11 @@ Status LimitOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
     } while (num_consume_rows && !_limit.compare_exchange_strong(old_limit, old_limit - num_consume_rows));
 
     if (num_consume_rows != chunk->num_rows()) {
+        // In case of multi cast exchange chunks could be used in multiple pipelines with different limits and should
+        // not be updated in place.
+        if (_no_chunk_mutation) {
+            _cur_chunk = chunk->clone_unique();
+        }
         _cur_chunk->set_num_rows(num_consume_rows);
     }
 

--- a/be/src/exec/pipeline/limit_operator.cpp
+++ b/be/src/exec/pipeline/limit_operator.cpp
@@ -37,7 +37,7 @@ Status LimitOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
     if (num_consume_rows != chunk->num_rows()) {
         // In case of multi cast exchange chunks could be used in multiple pipelines with different limits and should
         // not be updated in place.
-        if (_no_chunk_mutation) {
+        if (!_limit_chunk_in_place) {
             _cur_chunk = chunk->clone_unique();
         }
         _cur_chunk->set_num_rows(num_consume_rows);

--- a/be/src/exec/pipeline/limit_operator.h
+++ b/be/src/exec/pipeline/limit_operator.h
@@ -23,7 +23,7 @@ public:
                   std::atomic<int64_t>& limit, bool limit_chunk_in_place = true)
             : Operator(factory, id, "limit", plan_node_id, false, driver_sequence),
               _limit(limit),
-              _limit_chunk_in_place(limit_chunk_in_place)  {}
+              _limit_chunk_in_place(limit_chunk_in_place) {}
 
     ~LimitOperator() override = default;
 
@@ -50,7 +50,7 @@ private:
     bool _is_finished = false;
     std::atomic<int64_t>& _limit;
     ChunkPtr _cur_chunk = nullptr;
-	// determines whether the limit can be use to update the columns of the chunk in place, or the chunk should be
+    // determines whether the limit can be use to update the columns of the chunk in place, or the chunk should be
     // cloned beforehand. This is relevant in the case of multi cast exchange where chunks could be used in multiple
     // pipelines with different limits.
     bool _limit_chunk_in_place;
@@ -65,7 +65,7 @@ public:
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
         return std::make_shared<LimitOperator>(this, _id, _plan_node_id, driver_sequence, _limit,
-                _limit_chunk_in_place);
+                                               _limit_chunk_in_place);
     }
 
     int64_t limit() const { return _limit; }

--- a/be/src/exec/pipeline/limit_operator.h
+++ b/be/src/exec/pipeline/limit_operator.h
@@ -50,6 +50,9 @@ private:
     bool _is_finished = false;
     std::atomic<int64_t>& _limit;
     ChunkPtr _cur_chunk = nullptr;
+	// determines whether the limit can be use to update the columns of the chunk in place, or the chunk should be
+    // cloned beforehand. This is relevant in the case of multi cast exchange where chunks could be used in multiple
+    // pipelines with different limits.
     bool _limit_chunk_in_place;
 };
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -63,6 +63,7 @@ set(EXEC_FILES
         ./exec/pipeline/table_function_operator_test.cpp
         ./exec/pipeline/sink/export_sink_operator_test.cpp
         ./exec/pipeline/sink/table_function_table_sink_operator_test.cpp
+        ./exec/pipeline/limit_operator_test.cpp
         ./exec/pipeline/mem_limited_chunk_queue_test.cpp
         ./exec/query_cache/query_cache_test.cpp
         ./exec/query_cache/transform_operator.cpp

--- a/be/test/exec/pipeline/limit_operator_test.cpp
+++ b/be/test/exec/pipeline/limit_operator_test.cpp
@@ -1,0 +1,97 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/pipeline/limit_operator.h"
+
+#include <gtest/gtest.h>
+
+#include "runtime/runtime_state.h"
+#include "testutil/assert.h"
+
+namespace starrocks::pipeline {
+
+class AutoIncChunkBuilder {
+public:
+    AutoIncChunkBuilder(size_t chunk_size = 4096) : _chunk_size(chunk_size) {}
+
+    ChunkPtr get_next() {
+        ChunkPtr chunk = std::make_shared<Chunk>();
+        auto col = ColumnHelper::create_column(TypeDescriptor(TYPE_BIGINT), false);
+        for (size_t i = 0; i < _chunk_size; i++) {
+            col->append_datum(Datum(_next_value++));
+        }
+        chunk->append_column(std::move(col), 0);
+        return chunk;
+    }
+    size_t _next_value = 0;
+    size_t _chunk_size;
+};
+
+class LimitOperatorTest : public ::testing::Test {
+public:
+    void SetUp() override { dummy_runtime_state.set_chunk_size(chunk_size); }
+
+    void TearDown() override {}
+
+protected:
+    RuntimeState dummy_runtime_state;
+    int limit = 6000;
+    size_t chunk_size = 4096;
+    AutoIncChunkBuilder builder{chunk_size};
+};
+
+TEST_F(LimitOperatorTest, test_limit_chunk_in_place) {
+    LimitOperatorFactory factory(1, 1, limit, true /*limit_chunk_in_place*/);
+    auto limit_op = factory.create(1, 1);
+
+    auto first_pushed_chunk = builder.get_next();
+    EXPECT_TRUE(limit_op->push_chunk(&dummy_runtime_state, first_pushed_chunk).ok());
+    auto first_pulled_chunk_or_status = limit_op->pull_chunk(&dummy_runtime_state);
+    ASSERT_OK(first_pulled_chunk_or_status.status());
+    auto first_pulled_chunk = first_pulled_chunk_or_status.value();
+    EXPECT_TRUE(first_pushed_chunk == first_pulled_chunk);
+    EXPECT_TRUE(first_pulled_chunk->num_rows() == chunk_size);
+
+    auto second_pushed_chunk = builder.get_next();
+    EXPECT_TRUE(limit_op->push_chunk(&dummy_runtime_state, second_pushed_chunk).ok());
+    auto second_pulled_chunk_or_status = limit_op->pull_chunk(&dummy_runtime_state);
+    ASSERT_OK(second_pulled_chunk_or_status.status());
+    auto second_pulled_chunk = second_pulled_chunk_or_status.value();
+    EXPECT_TRUE(second_pushed_chunk == second_pulled_chunk);
+    EXPECT_TRUE(second_pulled_chunk->num_rows() == limit - chunk_size);
+}
+
+TEST_F(LimitOperatorTest, test_limit_chunk_clone_on_update) {
+    LimitOperatorFactory factory(1, 1, limit, false /*limit_chunk_in_place*/);
+    auto limit_op = factory.create(1, 1);
+
+    auto first_pushed_chunk = builder.get_next();
+    EXPECT_TRUE(limit_op->push_chunk(&dummy_runtime_state, first_pushed_chunk).ok());
+    auto first_pulled_chunk_or_status = limit_op->pull_chunk(&dummy_runtime_state);
+    ASSERT_OK(first_pulled_chunk_or_status.status());
+    auto first_pulled_chunk = first_pulled_chunk_or_status.value();
+    EXPECT_TRUE(first_pushed_chunk == first_pulled_chunk);
+    EXPECT_TRUE(first_pulled_chunk->num_rows() == chunk_size);
+
+    auto second_pushed_chunk = builder.get_next();
+    EXPECT_TRUE(limit_op->push_chunk(&dummy_runtime_state, second_pushed_chunk).ok());
+    auto second_pulled_chunk_or_status = limit_op->pull_chunk(&dummy_runtime_state);
+    ASSERT_OK(second_pulled_chunk_or_status.status());
+    auto second_pulled_chunk = second_pulled_chunk_or_status.value();
+    EXPECT_TRUE(second_pushed_chunk != second_pulled_chunk);
+    EXPECT_TRUE(second_pushed_chunk->num_rows() == chunk_size);
+    EXPECT_TRUE(second_pulled_chunk->num_rows() == limit - chunk_size);
+}
+
+} // namespace starrocks::pipeline

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DataStreamSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DataStreamSink.java
@@ -40,6 +40,7 @@ import com.starrocks.thrift.TDataStreamSink;
 import com.starrocks.thrift.TExplainLevel;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Data sink that forwards data to an exchange node.
@@ -50,6 +51,8 @@ public class DataStreamSink extends DataSink {
 
     private DataPartition outputPartition;
 
+    private long limit;
+
     private boolean isMerge;
 
     // Specify the columns which need to send, used on MultiCastSink
@@ -57,6 +60,7 @@ public class DataStreamSink extends DataSink {
 
     public DataStreamSink(PlanNodeId exchNodeId) {
         this.exchNodeId = exchNodeId;
+        this.limit = -1;
     }
 
     @Override
@@ -85,6 +89,8 @@ public class DataStreamSink extends DataSink {
         this.outputColumnIds = outputColumnIds;
     }
 
+    public void setLimit(long limit) { this.limit = limit; }
+
     @Override
     public String getExplainString(String prefix, TExplainLevel explainLevel) {
         StringBuilder strBuilder = new StringBuilder();
@@ -111,12 +117,13 @@ public class DataStreamSink extends DataSink {
     protected TDataSink toThrift() {
         TDataSink result = new TDataSink(TDataSinkType.DATA_STREAM_SINK);
         TDataStreamSink tStreamSink =
-                new TDataStreamSink(exchNodeId.asInt(), outputPartition.toThrift());
+                new TDataStreamSink(exchNodeId.asInt(), outputPartition.toThrift(), limit);
         tStreamSink.setIs_merge(isMerge);
         tStreamSink.setDest_dop(exchDop);
         if (outputColumnIds != null && !outputColumnIds.isEmpty()) {
             tStreamSink.setOutput_columns(outputColumnIds);
         }
+        tStreamSink.setLimit(limit);
         result.setStream_sink(tStreamSink);
         return result;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DataStreamSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DataStreamSink.java
@@ -40,7 +40,6 @@ import com.starrocks.thrift.TDataStreamSink;
 import com.starrocks.thrift.TExplainLevel;
 
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Data sink that forwards data to an exchange node.
@@ -51,12 +50,13 @@ public class DataStreamSink extends DataSink {
 
     private DataPartition outputPartition;
 
-    private long limit;
-
     private boolean isMerge;
 
     // Specify the columns which need to send, used on MultiCastSink
     private List<Integer> outputColumnIds;
+
+    // Specify the limit on output columns, used on MultiCastSink
+    private long limit;
 
     public DataStreamSink(PlanNodeId exchNodeId) {
         this.exchNodeId = exchNodeId;
@@ -117,13 +117,15 @@ public class DataStreamSink extends DataSink {
     protected TDataSink toThrift() {
         TDataSink result = new TDataSink(TDataSinkType.DATA_STREAM_SINK);
         TDataStreamSink tStreamSink =
-                new TDataStreamSink(exchNodeId.asInt(), outputPartition.toThrift(), limit);
+                new TDataStreamSink(exchNodeId.asInt(), outputPartition.toThrift());
         tStreamSink.setIs_merge(isMerge);
         tStreamSink.setDest_dop(exchDop);
         if (outputColumnIds != null && !outputColumnIds.isEmpty()) {
             tStreamSink.setOutput_columns(outputColumnIds);
         }
-        tStreamSink.setLimit(limit);
+        if (limit == -1) {
+            tStreamSink.setLimit(limit);
+        }
         result.setStream_sink(tStreamSink);
         return result;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DataStreamSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DataStreamSink.java
@@ -123,7 +123,7 @@ public class DataStreamSink extends DataSink {
         if (outputColumnIds != null && !outputColumnIds.isEmpty()) {
             tStreamSink.setOutput_columns(outputColumnIds);
         }
-        if (limit == -1) {
+        if (limit != -1) {
             tStreamSink.setLimit(limit);
         }
         result.setStream_sink(tStreamSink);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ExchangeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ExchangeNode.java
@@ -165,8 +165,10 @@ public class ExchangeNode extends PlanNode {
 
     @Override
     public final void setLimit(long limit) {
-        super.setLimit(limit);
-        cardinality = Math.min(limit, cardinality);
+        if (limit != -1) {
+            super.setLimit(limit);
+            cardinality = Math.min(limit, cardinality);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ExchangeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ExchangeNode.java
@@ -164,6 +164,12 @@ public class ExchangeNode extends PlanNode {
     }
 
     @Override
+    public final void setLimit(long limit) {
+        super.setLimit(limit);
+        cardinality = Math.min(limit, cardinality);
+    }
+
+    @Override
     public final void computeTupleIds() {
         clearTupleIds();
         tupleIds.addAll(getChild(0).getTupleIds());

--- a/fe/fe-core/src/main/java/com/starrocks/planner/MultiCastPlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/MultiCastPlanFragment.java
@@ -19,7 +19,6 @@ import com.google.common.collect.Lists;
 import com.starrocks.thrift.TResultSinkType;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 /*

--- a/fe/fe-core/src/main/java/com/starrocks/planner/MultiCastPlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/MultiCastPlanFragment.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.thrift.TResultSinkType;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /*
@@ -72,6 +73,7 @@ public class MultiCastPlanFragment extends PlanFragment {
             streamSink.setPartition(DataPartition.RANDOM);
             streamSink.setFragment(this);
             streamSink.setOutputColumnIds(f.getReceiveColumns());
+            streamSink.setLimit(f.getLimit());
             multiCastDataSink.getDataStreamSinks().add(streamSink);
             multiCastDataSink.getDestinations().add(Lists.newArrayList());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -914,6 +914,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String COLUMN_VIEW_CONCAT_BYTES_LIMIT = "column_view_concat_bytes_limit";
     public static final String ENABLE_DEFER_PROJECT_AFTER_TOPN = "enable_defer_project_after_topn";
 
+    public static final String ENABLE_MULTI_CAST_LIMIT_PUSH_DOWN = "enable_multi_cast_limit_push_down";
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(MAX_EXECUTION_TIME)
@@ -1506,7 +1508,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = NEW_PLANER_AGG_STAGE)
     private int newPlannerAggStage = SessionVariableConstants.AggregationStage.AUTO.ordinal();
 
-    @VariableMgr.VarAttr(name = TRANSMISSION_COMPRESSION_TYPE) 
+    @VariableMgr.VarAttr(name = TRANSMISSION_COMPRESSION_TYPE)
     private String transmissionCompressionType = "AUTO";
 
     // if a packet's size is larger than RPC_HTTP_MIN_SIZE, it will use RPC via http, as the std rpc has 2GB size limit.
@@ -1840,6 +1842,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_DEFER_PROJECT_AFTER_TOPN)
     private boolean enableDeferProjectAfterTopN = true;
+
+    @VarAttr(name = ENABLE_MULTI_CAST_LIMIT_PUSH_DOWN, flag = VariableMgr.INVISIBLE)
+    private boolean enableMultiCastLimitPushDown = true;
 
     public int getCboPruneJsonSubfieldDepth() {
         return cboPruneJsonSubfieldDepth;
@@ -5004,6 +5009,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setSpmRewriteTimeoutMs(int spmRewriteTimeoutMs) {
         this.spmRewriteTimeoutMs = spmRewriteTimeoutMs;
+    }
+
+    public void setEnableMultiCastLimitPushDown(boolean enableMultiCastLimitPushDown) {
+        this.enableMultiCastLimitPushDown = enableMultiCastLimitPushDown;
+    }
+
+    public boolean isEnableMultiCastLimitPushDown() {
+        return enableMultiCastLimitPushDown;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1843,6 +1843,17 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_DEFER_PROJECT_AFTER_TOPN)
     private boolean enableDeferProjectAfterTopN = true;
 
+    // When this variable is enabled, the limits of consumers a CTE are pushed down to the producer of the CTE.
+    // The limits can then be applied before the exchange.
+    // For example:
+    //
+    //   Fragment-2              Fragment-3            Fragment-2              Fragment-3
+    //        \                       /                      \                    /
+    //       limit-1              limit-2                shuffle by v1       shuffle by v2
+    //           \                 /              ==>           \               /
+    //    shuffle by v1      shuffle by v2                    limit-1        limit-2
+    //              \           /                                 \           /
+    //                Fragment-1                                    Fragment-1
     @VarAttr(name = ENABLE_MULTI_CAST_LIMIT_PUSH_DOWN, flag = VariableMgr.INVISIBLE)
     private boolean enableMultiCastLimitPushDown = true;
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -3531,6 +3531,9 @@ public class PlanFragmentBuilder {
                     .map(ColumnRefOperator::getId).distinct().collect(Collectors.toList()));
             exchangeNode.setDataPartition(cteFragment.getDataPartition());
             exchangeNode.forceCollectExecStats();
+            if (consume.hasLimit()) {
+                exchangeNode.setLimit(consume.getLimit());
+            }
 
             PlanFragment consumeFragment = new PlanFragment(context.getNextFragmentId(), exchangeNode,
                     cteFragment.getDataPartition());
@@ -3553,11 +3556,6 @@ public class PlanFragmentBuilder {
                 this.currentExecGroup.add(selectNode, true);
                 selectNode.computeStatistics(optExpression.getStatistics());
                 consumeFragment.setPlanRoot(selectNode);
-            }
-
-            // set limit
-            if (consume.hasLimit()) {
-                consumeFragment.getPlanRoot().setLimit(consume.getLimit());
             }
 
             cteFragment.getDestNodeList().add(exchangeNode);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -3557,7 +3557,10 @@ public class PlanFragmentBuilder {
                 consumeFragment.setPlanRoot(selectNode);
             }
 
-            // set limit
+            // if multi cast limit push down is enabled and there is no predicate, the limit can be added at the source of the
+            // CTE consume fragment, the exchange operator. The limit will be then propagated to the sink of the CTE produce
+            // fragment. Otherwise, especially if there is a predicate, limit push down can not be performed and the limit will
+            // be applied after the predicate.
             if (consume.hasLimit()) {
                 if (ConnectContext.get().getSessionVariable().isEnableMultiCastLimitPushDown()
                         && consume.getPredicate() == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -3531,7 +3531,7 @@ public class PlanFragmentBuilder {
                     .map(ColumnRefOperator::getId).distinct().collect(Collectors.toList()));
             exchangeNode.setDataPartition(cteFragment.getDataPartition());
             exchangeNode.forceCollectExecStats();
-            if (consume.hasLimit()) {
+            if (ConnectContext.get().getSessionVariable().isEnableMultiCastLimitPushDown() && consume.hasLimit()) {
                 exchangeNode.setLimit(consume.getLimit());
             }
 
@@ -3556,6 +3556,11 @@ public class PlanFragmentBuilder {
                 this.currentExecGroup.add(selectNode, true);
                 selectNode.computeStatistics(optExpression.getStatistics());
                 consumeFragment.setPlanRoot(selectNode);
+            }
+
+            // set limit
+            if (!ConnectContext.get().getSessionVariable().isEnableMultiCastLimitPushDown() && consume.hasLimit()) {
+                consumeFragment.getPlanRoot().setLimit(consume.getLimit());
             }
 
             cteFragment.getDestNodeList().add(exchangeNode);

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -134,21 +134,23 @@ struct TDataStreamSink {
   // to each destination host.
   2: required Partitions.TDataPartition output_partition
 
-  3: optional bool ignore_not_found
+  3: required i64 limit
+
+  4: optional bool ignore_not_found
 
   // Only useful in pipeline mode
   // If receiver side is ExchangeMergeSortSourceOperator, then all the
   // packets should be kept in order (according sequence), so the sender
   // side need to maintain a send window in order to avoiding the receiver
   // buffer too many out-of-order packets
-  4: optional bool is_merge
+  5: optional bool is_merge
 
   // degree of paralleliasm of destination
   // only used in pipeline engine
-  5: optional i32 dest_dop
+  6: optional i32 dest_dop
 
   // Specify the columns which need to send
-  6: optional list<i32> output_columns;
+  7: optional list<i32> output_columns;
 }
 
 struct TMultiCastDataStreamSink {

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -134,23 +134,24 @@ struct TDataStreamSink {
   // to each destination host.
   2: required Partitions.TDataPartition output_partition
 
-  3: required i64 limit
-
-  4: optional bool ignore_not_found
+  3: optional bool ignore_not_found
 
   // Only useful in pipeline mode
   // If receiver side is ExchangeMergeSortSourceOperator, then all the
   // packets should be kept in order (according sequence), so the sender
   // side need to maintain a send window in order to avoiding the receiver
   // buffer too many out-of-order packets
-  5: optional bool is_merge
+  4: optional bool is_merge
 
   // degree of paralleliasm of destination
   // only used in pipeline engine
-  6: optional i32 dest_dop
+  5: optional i32 dest_dop
 
   // Specify the columns which need to send
-  7: optional list<i32> output_columns;
+  6: optional list<i32> output_columns
+
+  // Specify limit on output columns
+  7: optional i64 limit;
 }
 
 struct TMultiCastDataStreamSink {

--- a/test/sql/test_limit/R/test_limit
+++ b/test/sql/test_limit/R/test_limit
@@ -1,10 +1,10 @@
 -- name: test_limit
- CREATE TABLE `t0` (
-  `region` varchar(128) NOT NULL COMMENT "",
-  `order_date` date NOT NULL COMMENT "",
-  `income` decimal(7, 0) NOT NULL COMMENT "",
-  `ship_mode` int NOT NULL COMMENT "",
-  `ship_code` int) ENGINE=OLAP
+CREATE TABLE `t0` (
+ `region` varchar(128) NOT NULL COMMENT "",
+ `order_date` date NOT NULL COMMENT "",
+ `income` decimal(7, 0) NOT NULL COMMENT "",
+ `ship_mode` int NOT NULL COMMENT "",
+ `ship_code` int) ENGINE=OLAP
 DUPLICATE KEY(`region`, `order_date`)
 COMMENT "OLAP"
 DISTRIBUTED BY HASH(`region`, `order_date`) BUCKETS 10
@@ -123,4 +123,24 @@ select count(*) from (select * from TABLE(generate_series(1, 100000)) limit 9000
 select count(*) from (select * from TABLE(generate_series(1, 100000)) limit 1, 1000) x;
 -- result:
 1000
+-- !result
+set enable_multi_cast_limit_push_down = false;
+-- result:
+-- !result
+with C as (select region, sum(income) as total from t0 group by 1), 
+     L as (select total from C limit 3), 
+     R as (select total from C limit 4)
+select count(*) from ( select * from L union all select * from R ) as U;
+-- result:
+7
+-- !result
+set enable_multi_cast_limit_push_down = true;
+-- result:
+-- !result
+with C as (select region, sum(income) as total from t0 group by 1), 
+     L as (select total from C limit 3), 
+     R as (select total from C limit 4)
+select count(*) from ( select * from L union all select * from R ) as U;
+-- result:
+7
 -- !result

--- a/test/sql/test_limit/R/test_limit
+++ b/test/sql/test_limit/R/test_limit
@@ -134,6 +134,10 @@ select count(*) from ( select * from L union all select * from R ) as U;
 -- result:
 7
 -- !result
+function: assert_explain_verbose_contains('with C as (select region, sum(income) as total from t0 group by 1), L as (select total from C limit 3),  R as (select total from C limit 4) select count(*) from ( select * from L union all select * from R ) as U;', '  6:EXCHANGE\n     distribution type: SHUFFLE\n     partition exprs: [21: region, INT, false]\n     limit: 4\n     cardinality: 4', '  10:EXCHANGE\n     distribution type: SHUFFLE\n     partition exprs: [21: region, INT, false]\n     limit: 4\n     cardinality: 4')
+-- result:
+None
+-- !result
 set enable_multi_cast_limit_push_down = true;
 -- result:
 -- !result
@@ -143,4 +147,8 @@ with C as (select region, sum(income) as total from t0 group by 1),
 select count(*) from ( select * from L union all select * from R ) as U;
 -- result:
 7
+-- !result
+function: assert_explain_verbose_contains('with C as (select region, sum(income) as total from t0 group by 1), L as (select total from C limit 3),  R as (select total from C limit 4) select count(*) from ( select * from L union all select * from R ) as U;', '  6:EXCHANGE\n     distribution type: SHUFFLE\n     partition exprs: [21: region, INT, false]\n     limit: 3\n     cardinality: 3', '  10:EXCHANGE\n     distribution type: SHUFFLE\n     partition exprs: [21: region, INT, false]\n     limit: 4\n     cardinality: 4')
+-- result:
+None
 -- !result

--- a/test/sql/test_limit/T/test_limit
+++ b/test/sql/test_limit/T/test_limit
@@ -70,3 +70,17 @@ select COUNT(*) from (select * from (select * from t0 limit 30) x limit 50, 10) 
 select count(*) from (select * from TABLE(generate_series(1, 100000)) limit 50000, 10) x;
 select count(*) from (select * from TABLE(generate_series(1, 100000)) limit 90000, 20000) x;
 select count(*) from (select * from TABLE(generate_series(1, 100000)) limit 1, 1000) x;
+
+set enable_multi_cast_limit_push_down = false;
+
+with C as (select region, sum(income) as total from t0 group by 1), 
+     L as (select total from C limit 3), 
+     R as (select total from C limit 4)
+select count(*) from ( select * from L union all select * from R ) as U;
+
+set enable_multi_cast_limit_push_down = true;
+
+with C as (select region, sum(income) as total from t0 group by 1), 
+     L as (select total from C limit 3), 
+     R as (select total from C limit 4)
+select count(*) from ( select * from L union all select * from R ) as U;

--- a/test/sql/test_limit/T/test_limit
+++ b/test/sql/test_limit/T/test_limit
@@ -78,9 +78,14 @@ with C as (select region, sum(income) as total from t0 group by 1),
      R as (select total from C limit 4)
 select count(*) from ( select * from L union all select * from R ) as U;
 
+function: assert_explain_verbose_contains('with C as (select region, sum(income) as total from t0 group by 1), L as (select total from C limit 3),  R as (select total from C limit 4) select count(*) from ( select * from L union all select * from R ) as U;', '  6:EXCHANGE\n     distribution type: SHUFFLE\n     partition exprs: [21: region, INT, false]\n     limit: 4\n     cardinality: 4', '  10:EXCHANGE\n     distribution type: SHUFFLE\n     partition exprs: [21: region, INT, false]\n     limit: 4\n     cardinality: 4')
+
 set enable_multi_cast_limit_push_down = true;
 
 with C as (select region, sum(income) as total from t0 group by 1), 
      L as (select total from C limit 3), 
      R as (select total from C limit 4)
 select count(*) from ( select * from L union all select * from R ) as U;
+
+
+function: assert_explain_verbose_contains('with C as (select region, sum(income) as total from t0 group by 1), L as (select total from C limit 3),  R as (select total from C limit 4) select count(*) from ( select * from L union all select * from R ) as U;', '  6:EXCHANGE\n     distribution type: SHUFFLE\n     partition exprs: [21: region, INT, false]\n     limit: 3\n     cardinality: 3', '  10:EXCHANGE\n     distribution type: SHUFFLE\n     partition exprs: [21: region, INT, false]\n     limit: 4\n     cardinality: 4')


### PR DESCRIPTION
## Why I'm doing:

When a CTE producer is used by multiple consumers that have different limits (including not having a limit at all), only the maximum limit can be pushed down to the CTE. However, currently the limits are applied on the consumer side after the exchange. This change is for appling the limit on the producer side to avoid unnecessary exchange costs.
![image](https://github.com/user-attachments/assets/2a398df2-5ce2-4ee3-8f23-3d8911664577)

## What I'm doing:

This change passes the limits from CTE consumers into the DataStreamSinks of the MultiCastDataSink and applies and inserts corresponding limit operators after the MultiCastLocalExchanger.

**Example profile part:**
before
```
EXCHANGE_SINK (plan_node_id=5):
  CommonMetrics:
     - OperatorTotalTime: 704.278ms
     - PullChunkNum: 0
     - PullRowNum: 0
     - PullTotalTime: 0ns
     - PushChunkNum: 29.502K (29502)
     - PushRowNum: 120.840M (120840192)
     - PushTotalTime: 704.159ms
MULTI_CAST_LOCAL_EXCHANGE_SOURCE (plan_node_id=3):
          ...
```
after
```
EXCHANGE_SINK (plan_node_id=5):
  CommonMetrics:
     - OperatorTotalTime: 141.332us
     - PullChunkNum: 0
     - PullRowNum: 0
     - PullTotalTime: 0ns
     - PushChunkNum: 10
     - PushRowNum: 100
     - PushTotalTime: 44.299us
LIMIT (plan_node_id=3) (operator id=5):
  CommonMetrics:
     - OperatorTotalTime: 241.399us
     - PullChunkNum: 10
     - PullRowNum: 100
     - PullTotalTime: 301ns
     - PushChunkNum: 10
     - PushRowNum: 40.960K (40960)
     - PushTotalTime: 240.424us
MULTI_CAST_LOCAL_EXCHANGE_SOURCE (plan_node_id=3):
          ...
```

Testing showed the cost of exchange operator can be reduced to almost 0 depending on the used limits.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
