### PR TITLE
[BugFix] add escape character in column comment in SHOW CREATE TABLE …

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -767,7 +767,7 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
             }
             sb.append("AS ").append(generatedColumnSql).append(" ");
         }
-        sb.append("COMMENT \"").append(comment).append("\"");
+        sb.append("COMMENT \"").append(getDisplayComment()).append("\"");
 
         return sb.toString();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
@@ -361,4 +361,13 @@ public class ColumnTest {
         Column column = GsonUtils.GSON.fromJson(str, Column.class);
         Assert.assertEquals("test", column.getColumnId().getId());
     }
+
+    @Test
+    public void testToSqlWithoutAggregateTypeName() {
+        String comment = "{\"id\":\"0\",\"value\":\"1\"}";
+        Column column = new Column("col", ScalarType.createType(PrimitiveType.JSON), false, null, true, null, comment);
+        String toSql = column.toSqlWithoutAggregateTypeName(null);
+
+        Assert.assertEquals("`col` json NULL COMMENT \"{\\\"id\\\":\\\"0\\\",\\\"value\\\":\\\"1\\\"}\"", toSql);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableLikeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableLikeTest.java
@@ -284,6 +284,16 @@ public class CreateTableLikeTest {
                     (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(newDbName).getTable("table_like_10");
         Assert.assertEquals(new RandomDistributionInfo(7), table.getDefaultDistributionInfo());
         Assert.assertEquals("1", table.getProperties().get("replication_num"));
+
+        // 11. create table like with primary key and double quotation in column comment
+        String createTableSql11 = "create table test.testTbl11\n" + "(k1 int comment \"xx\\\"xx\", k2 int)\n"
+                + "primary key(k1)\n" + "distributed by hash(k1) buckets 1\n" + "properties('replication_num' = '1'); ";
+        String createTableLikeSql11 = "create table test.testTbl11_like like test.testTbl11";
+        String newDbName11 = "test";
+        String newTblName11 = "testTbl11_like";
+        String existedTblName11 = "testTbl11";
+        checkCreateOlapTableLike(createTableSql11, createTableLikeSql11, newDbName11, newDbName11, newTblName11,
+                existedTblName11);
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
There are no escape characters in the column comments when executing SHOW CREATE TABLE query on a table with Primary Key model. This cause the CREATE TABLE LIKE operation to fail if the comment contains double quotes.
For example: 
```
starrocks> show create table t\G
*************************** 1. row ***************************
       Table: t
Create Table: CREATE TABLE `t` (
 `a` int(11) NOT NULL COMMENT "xx"xx",
 `b` int(11) NULL COMMENT ""
) ENGINE=OLAP 
PRIMARY KEY(`a`)
COMMENT "xx\"xx"
DISTRIBUTED BY HASH(`a`)
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"enable_persistent_index" = "true",
"replicated_storage" = "true",
"compression" = "LZ4"
);
1 row in set (0.00 sec)

starrocks> create table t1 like t;
ERROR 1064 (HY000): Getting syntax error at line 2, column 35. Detail message: Unexpected input 'xx', the most similar input is {',', ')'}.
```
## What I'm doing:
add escape character in column comment in SHOW CREATE TABLE when the table is Primary Key table:

```
starrocks> show create table t\G
*************************** 1. row ***************************
       Table: t
Create Table: CREATE TABLE `t` (
  `a` int(11) NOT NULL COMMENT "xx\"xx",
  `b` int(11) NULL COMMENT ""
) ENGINE=OLAP 
PRIMARY KEY(`a`)
COMMENT "xx\"xx"
DISTRIBUTED BY HASH(`a`)
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"enable_persistent_index" = "true",
"replicated_storage" = "true",
"compression" = "LZ4"
);
1 row in set (0.00 sec)

starrocks> 
starrocks> create table t1 like t;
Query OK, 0 rows affected (0.04 sec)
```
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
