### PR TITLE
[Refactor] Refactor the page cache interface to make it reusable for external tables in the future.

### DIFF
--- a/be/src/cache/datacache.h
+++ b/be/src/cache/datacache.h
@@ -41,6 +41,7 @@ public:
     void try_release_resource_before_core_dump();
 
     void set_local_cache(std::shared_ptr<LocalCache> local_cache) { _local_cache = std::move(local_cache); }
+    void set_page_cache(std::shared_ptr<StoragePageCache> page_cache) { _page_cache = std::move(page_cache); }
 
     LocalCache* local_cache() { return _local_cache.get(); }
     BlockCache* block_cache() const { return _block_cache.get(); }
@@ -48,6 +49,7 @@ public:
     ObjectCache* external_table_meta_cache() const { return _starcache_based_object_cache.get(); }
     ObjectCache* external_table_page_cache() const { return _starcache_based_object_cache.get(); }
     StoragePageCache* page_cache() const { return _page_cache.get(); }
+    std::shared_ptr<StoragePageCache> page_cache_ptr() const { return _page_cache; }
 
     StatusOr<int64_t> get_storage_page_cache_limit();
     int64_t check_storage_page_cache_limit(int64_t storage_cache_limit);

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -18,39 +18,25 @@
 
 #include <cstring>
 #include <iterator>
-#include <map>
-#include <sstream>
 #include <unordered_set>
 #include <utility>
 #include <vector>
 
 #include "cache/datacache.h"
-#include "column/column.h"
-#include "column/column_helper.h"
-#include "column/const_column.h"
 #include "column/vectorized_fwd.h"
 #include "common/compiler_util.h"
 #include "common/config.h"
-#include "common/global_types.h"
 #include "common/logging.h"
 #include "common/status.h"
 #include "exec/hdfs_scanner.h"
-#include "exprs/expr_context.h"
-#include "exprs/runtime_filter.h"
-#include "exprs/runtime_filter_bank.h"
 #include "formats/parquet/metadata.h"
 #include "formats/parquet/predicate_filter_evaluator.h"
-#include "formats/parquet/scalar_column_reader.h"
-#include "formats/parquet/schema.h"
-#include "formats/parquet/statistics_helper.h"
 #include "formats/parquet/utils.h"
 #include "fs/fs.h"
 #include "gen_cpp/parquet_types.h"
 #include "gutil/casts.h"
 #include "gutil/strings/substitute.h"
 #include "io/shared_buffered_input_stream.h"
-#include "runtime/descriptors.h"
-#include "storage/chunk_helper.h"
 
 namespace starrocks::parquet {
 

--- a/be/src/storage/rowset/page_io.cpp
+++ b/be/src/storage/rowset/page_io.cpp
@@ -184,7 +184,7 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
     // hold compressed page at first, reset to decompressed page later
     // Allocate APPEND_OVERFLOW_MAX_SIZE more bytes to make append_strings_overflow work
     std::unique_ptr<std::vector<uint8_t>> page(new std::vector<uint8_t>());
-    raw::stl_vector_resize_uninitialized(page.get(), page_size + Column::APPEND_OVERFLOW_MAX_SIZE, page_size);
+    raw::stl_vector_resize_uninitialized(page.get(), page_size + Column::APPEND_OVERFLOW_MAX_SIZE, page_size - 4);
     Slice page_slice(page->data(), page_size);
     {
         SCOPED_RAW_TIMER(&opts.stats->io_ns);

--- a/be/src/storage/rowset/page_io.cpp
+++ b/be/src/storage/rowset/page_io.cpp
@@ -129,6 +129,20 @@ Status PageIO::write_page(WritableFile* wfile, const std::vector<Slice>& body, c
     return Status::OK();
 }
 
+// The unique key identifying entries in the page cache.
+// Each cached page corresponds to a specific offset within
+// a file.
+//
+// TODO(zc): Now we use file name(std::string) as a part of key,
+//  which is not efficient. We should make it better later
+std::string encode_cache_key(const std::string& fname, int64_t offset) {
+    std::string str;
+    str.reserve(fname.size() + sizeof(offset));
+    str.append(fname);
+    str.append((char*)&offset, sizeof(offset));
+    return str;
+}
+
 Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle* handle, Slice* body,
                                         PageFooterPB* footer) {
     // the function will be used by query or load, current load is not allowed to fail when memory reach the limit,
@@ -140,21 +154,23 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
 
     auto cache = StoragePageCache::instance();
     PageCacheHandle cache_handle;
-    StoragePageCache::CacheKey cache_key(opts.read_file->filename(), opts.page_pointer.offset);
+    std::string cache_key = encode_cache_key(opts.read_file->filename(), opts.page_pointer.offset);
     if (opts.use_page_cache && cache->lookup(cache_key, &cache_handle)) {
         // we find page in cache, use it
         *handle = PageHandle(std::move(cache_handle));
         opts.stats->cached_pages_num++;
         // parse body and footer
-        Slice page_slice = handle->data();
-        uint32_t footer_size = decode_fixed32_le((uint8_t*)page_slice.data + page_slice.size - 4);
-        std::string_view footer_buf{page_slice.data + page_slice.size - 4 - footer_size, footer_size};
+        const auto* page = handle->data();
+        uint32_t footer_length_offset = page->size() - 4;
+        uint32_t footer_size = decode_fixed32_le(page->data() + footer_length_offset);
+        uint32_t footer_offset = footer_length_offset - footer_size;
+        std::string_view footer_buf{(const char*)page->data() + footer_offset, footer_size};
         if (!footer->ParseFromArray(footer_buf.data(), footer_buf.size())) {
             return Status::Corruption(
                     strings::Substitute("Bad page: invalid footer, read from page cache, file=$0, footer_size=$1",
                                         opts.read_file->filename(), footer_size));
         }
-        *body = Slice(page_slice.data, page_slice.size - 4 - footer_size);
+        *body = Slice(page->data(), footer_offset);
         return Status::OK();
     }
 
@@ -167,8 +183,9 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
 
     // hold compressed page at first, reset to decompressed page later
     // Allocate APPEND_OVERFLOW_MAX_SIZE more bytes to make append_strings_overflow work
-    std::unique_ptr<char[]> page(new char[page_size + Column::APPEND_OVERFLOW_MAX_SIZE]);
-    Slice page_slice(page.get(), page_size);
+    std::unique_ptr<std::vector<uint8_t>> page(new std::vector<uint8_t>());
+    raw::stl_vector_resize_uninitialized(page.get(), page_size + Column::APPEND_OVERFLOW_MAX_SIZE, page_size);
+    Slice page_slice(page->data(), page_size);
     {
         SCOPED_RAW_TIMER(&opts.stats->io_ns);
         // todo override is_cache_hit
@@ -208,12 +225,15 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
         }
         SCOPED_RAW_TIMER(&opts.stats->decompress_ns);
         // Allocate APPEND_OVERFLOW_MAX_SIZE more bytes to make append_strings_overflow work
-        std::unique_ptr<char[]> decompressed_page(
-                new char[footer->uncompressed_size() + footer_size + 4 + Column::APPEND_OVERFLOW_MAX_SIZE]);
+        std::unique_ptr<std::vector<uint8_t>> decompressed_page(new std::vector<uint8_t>());
+        uint32_t decompressed_page_size = footer->uncompressed_size() + footer_size + 4;
+        raw::stl_vector_resize_uninitialized(decompressed_page.get(),
+                                             decompressed_page_size + Column::APPEND_OVERFLOW_MAX_SIZE,
+                                             decompressed_page_size);
 
         // decompress page body
         Slice compressed_body(page_slice.data, body_size);
-        Slice decompressed_body(decompressed_page.get(), footer->uncompressed_size());
+        Slice decompressed_body(decompressed_page->data(), footer->uncompressed_size());
         RETURN_IF_ERROR(opts.codec->decompress(compressed_body, &decompressed_body));
         if (decompressed_body.size != footer->uncompressed_size()) {
             return Status::Corruption(strings::Substitute(
@@ -224,10 +244,10 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
         memcpy(decompressed_body.data + decompressed_body.size, page_slice.data + body_size, footer_size + 4);
         // free memory of compressed page
         page = std::move(decompressed_page);
-        page_slice = Slice(page.get(), footer->uncompressed_size() + footer_size + 4);
+        page_slice = Slice(page->data(), decompressed_page_size);
         opts.stats->uncompressed_bytes_read += page_slice.size;
     } else {
-        opts.stats->uncompressed_bytes_read += body_size;
+        opts.stats->uncompressed_bytes_read += page_slice.size;
     }
 
     RETURN_IF_ERROR(StoragePageDecoder::decode_page(footer, footer_size + 4, opts.encoding_type, &page, &page_slice));
@@ -235,10 +255,10 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
     *body = Slice(page_slice.data, page_slice.size - 4 - footer_size);
     if (opts.use_page_cache) {
         // insert this page into cache and return the cache handle
-        Status st = cache->insert(cache_key, page_slice, &cache_handle, opts.kept_in_memory);
-        *handle = st.ok() ? PageHandle(std::move(cache_handle)) : PageHandle(page_slice);
+        Status st = cache->insert(cache_key, page.get(), &cache_handle, opts.kept_in_memory);
+        *handle = st.ok() ? PageHandle(std::move(cache_handle)) : PageHandle(page.get());
     } else {
-        *handle = PageHandle(page_slice);
+        *handle = PageHandle(page.get());
     }
     page.release(); // memory now managed by handle
     return Status::OK();

--- a/be/src/storage/rowset/storage_page_decoder.h
+++ b/be/src/storage/rowset/storage_page_decoder.h
@@ -33,7 +33,7 @@ public:
     virtual void reserve_head(uint8_t head_size) {}
 
     virtual Status decode_page_data(PageFooterPB* footer, uint32_t footer_size, EncodingTypePB encoding,
-                                    std::unique_ptr<char[]>* page, Slice* page_slice) {
+                                    std::unique_ptr<std::vector<uint8_t>>* page, Slice* page_slice) {
         return Status::OK();
     }
 };
@@ -41,7 +41,7 @@ public:
 class StoragePageDecoder {
 public:
     static Status decode_page(PageFooterPB* footer, uint32_t footer_size, EncodingTypePB encoding,
-                              std::unique_ptr<char[]>* page, Slice* page_slice);
+                              std::unique_ptr<std::vector<uint8_t>>* page, Slice* page_slice);
 };
 
 } // namespace starrocks

--- a/be/src/util/raw_container.h
+++ b/be/src/util/raw_container.h
@@ -180,6 +180,15 @@ stl_vector_resize_uninitialized(Container* vec, size_t new_size) {
     ((RawVector<T, typename Container::allocator_type>*)vec)->resize(new_size);
 }
 
+template <typename Container, typename T = typename Container::value_type>
+inline typename std::enable_if<
+        std::is_same<Container, std::vector<typename Container::value_type, typename Container::allocator_type>>::value,
+        void>::type
+stl_vector_resize_uninitialized(Container* vec, size_t reserve_size, size_t new_size) {
+    ((RawVector<T, typename Container::allocator_type>*)vec)->resize(reserve_size);
+    vec->resize(new_size);
+}
+
 inline void stl_string_resize_uninitialized(std::string* str, size_t new_size) {
     ((RawString*)str)->resize(new_size);
 }

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -325,6 +325,7 @@ set(EXEC_FILES
         ./storage/rowset/series_column_iterator_test.cpp
         ./storage/rowset/index_page_test.cpp
         ./storage/rowset/metadata_cache_test.cpp
+        ./storage/rowset/page_io_test.cpp
         ./storage/index/vector_index_test.cpp
         ./storage/index/vector_search_test.cpp
         ./storage/snapshot_meta_test.cpp

--- a/be/test/storage/page_cache_test.cpp
+++ b/be/test/storage/page_cache_test.cpp
@@ -69,48 +69,48 @@ void StoragePageCacheTest::create_obj_cache(size_t capacity) {
 TEST_F(StoragePageCacheTest, normal) {
     {
         // insert normal page
-        StoragePageCache::CacheKey key("abc", 0);
-        Slice data(new char[1024], 1024);
+        std::string key("abc0");
+        auto data = std::make_unique<std::vector<uint8_t>>(1024);
         PageCacheHandle handle;
 
-        ASSERT_OK(_page_cache->insert(key, data, &handle, false));
-        ASSERT_EQ(((Slice*)handle.data().data)->data, data.data);
+        ASSERT_OK(_page_cache->insert(key, data.get(), &handle, false));
+        ASSERT_EQ(handle.data(), data.get());
 
         ASSERT_TRUE(_page_cache->lookup(key, &handle));
-        ASSERT_EQ(data.data, ((Slice*)handle.data().data)->data);
+        ASSERT_EQ(handle.data(), data.get());
     }
 
     {
         // insert in_memory page
-        StoragePageCache::CacheKey memory_key("mem", 0);
-        Slice data(new char[1024], 1024);
+        std::string key("mem0");
+        auto data = std::make_unique<std::vector<uint8_t>>(1024);
         PageCacheHandle handle;
 
-        ASSERT_OK(_page_cache->insert(memory_key, data, &handle, true));
-        ASSERT_EQ(((Slice*)handle.data().data)->data, data.data);
+        ASSERT_OK(_page_cache->insert(key, data.get(), &handle, true));
+        ASSERT_EQ(handle.data(), data.get());
 
-        ASSERT_TRUE(_page_cache->lookup(memory_key, &handle));
+        ASSERT_TRUE(_page_cache->lookup(key, &handle));
     }
 
     // put too many page to eliminate first page
     for (int i = 0; i < 10 * kNumShards; ++i) {
-        StoragePageCache::CacheKey key("bcd", i);
-        Slice data(new char[1024], 1024);
+        std::string key("bcd");
+        key.append(std::to_string(i));
+        auto data = std::make_unique<std::vector<uint8_t>>(1024);
         PageCacheHandle handle;
-        ASSERT_OK(_page_cache->insert(key, data, &handle, false));
+        ASSERT_OK(_page_cache->insert(key, data.get(), &handle, false));
     }
 
     // cache miss
     {
         PageCacheHandle handle;
-        StoragePageCache::CacheKey miss_key("abc", 1);
-        auto found = _page_cache->lookup(miss_key, &handle);
-        ASSERT_FALSE(found);
+        std::string miss_key("abc1");
+        ASSERT_FALSE(_page_cache->lookup(miss_key, &handle));
     }
 
     // cache miss for eliminated key
     {
-        StoragePageCache::CacheKey key("abc", 0);
+        std::string key("abc0");
         PageCacheHandle handle;
         ASSERT_FALSE(_page_cache->lookup(key, &handle));
     }
@@ -156,21 +156,21 @@ TEST_F(StoragePageCacheTest, normal) {
 }
 
 TEST_F(StoragePageCacheTest, metrics) {
-    StoragePageCache::CacheKey key1("abc", 0);
-    StoragePageCache::CacheKey key2("def", 0);
+    std::string key1("abc0");
+    std::string key2("def0");
     PageCacheHandle handle1;
 
     {
         // Insert a piece of data, but the application layer does not release it.
-        Slice data(new char[1024], 1024);
-        ASSERT_OK(_page_cache->insert(key1, data, &handle1, false));
+        auto data = std::make_unique<std::vector<uint8_t>>(1024);
+        ASSERT_OK(_page_cache->insert(key1, data.get(), &handle1, false));
     }
 
     {
         // Insert another piece of data and release it from the application layer.
-        Slice data(new char[1024], 1024);
+        auto data = std::make_unique<std::vector<uint8_t>>(1024);
         PageCacheHandle handle2;
-        ASSERT_OK(_page_cache->insert(key2, data, &handle2, false));
+        ASSERT_OK(_page_cache->insert(key2, data.get(), &handle2, false));
     }
 
     {
@@ -186,7 +186,8 @@ TEST_F(StoragePageCacheTest, metrics) {
         // Test the cache miss
         for (int i = 0; i < 1024; i++) {
             PageCacheHandle handle;
-            StoragePageCache::CacheKey key(std::to_string(i), 0);
+            std::string key(std::to_string(i));
+            key.append("0");
             ASSERT_FALSE(_page_cache->lookup(key, &handle));
         }
 

--- a/be/test/storage/page_cache_test.cpp
+++ b/be/test/storage/page_cache_test.cpp
@@ -75,6 +75,7 @@ TEST_F(StoragePageCacheTest, normal) {
 
         ASSERT_OK(_page_cache->insert(key, data.get(), &handle, false));
         ASSERT_EQ(handle.data(), data.get());
+        data.release();
 
         ASSERT_TRUE(_page_cache->lookup(key, &handle));
         ASSERT_EQ(handle.data(), data.get());
@@ -88,6 +89,7 @@ TEST_F(StoragePageCacheTest, normal) {
 
         ASSERT_OK(_page_cache->insert(key, data.get(), &handle, true));
         ASSERT_EQ(handle.data(), data.get());
+        data.release();
 
         ASSERT_TRUE(_page_cache->lookup(key, &handle));
     }
@@ -99,6 +101,7 @@ TEST_F(StoragePageCacheTest, normal) {
         auto data = std::make_unique<std::vector<uint8_t>>(1024);
         PageCacheHandle handle;
         ASSERT_OK(_page_cache->insert(key, data.get(), &handle, false));
+        data.release();
     }
 
     // cache miss
@@ -164,6 +167,7 @@ TEST_F(StoragePageCacheTest, metrics) {
         // Insert a piece of data, but the application layer does not release it.
         auto data = std::make_unique<std::vector<uint8_t>>(1024);
         ASSERT_OK(_page_cache->insert(key1, data.get(), &handle1, false));
+        data.release();
     }
 
     {
@@ -171,6 +175,7 @@ TEST_F(StoragePageCacheTest, metrics) {
         auto data = std::make_unique<std::vector<uint8_t>>(1024);
         PageCacheHandle handle2;
         ASSERT_OK(_page_cache->insert(key2, data.get(), &handle2, false));
+        data.release();
     }
 
     {

--- a/be/test/storage/page_cache_test.cpp
+++ b/be/test/storage/page_cache_test.cpp
@@ -75,10 +75,10 @@ TEST_F(StoragePageCacheTest, normal) {
 
         ASSERT_OK(_page_cache->insert(key, data.get(), &handle, false));
         ASSERT_EQ(handle.data(), data.get());
-        data.release();
+        auto* check_data = data.release();
 
         ASSERT_TRUE(_page_cache->lookup(key, &handle));
-        ASSERT_EQ(handle.data(), data.get());
+        ASSERT_EQ(handle.data(), check_data);
     }
 
     {

--- a/be/test/storage/rowset/binary_dict_page_test.cpp
+++ b/be/test/storage/rowset/binary_dict_page_test.cpp
@@ -93,7 +93,7 @@ public:
         footer.set_type(DATA_PAGE);
         DataPageFooterPB* data_page_footer = footer.mutable_data_page_footer();
         data_page_footer->set_nullmap_size(0);
-        std::unique_ptr<char[]> page = nullptr;
+        std::unique_ptr<std::vector<uint8_t>> page = nullptr;
 
         Status st = StoragePageDecoder::decode_page(&footer, 0, starrocks::DICT_ENCODING, &page, &encoded_data);
         ASSERT_TRUE(st.ok());
@@ -205,7 +205,7 @@ public:
             footer.set_type(DATA_PAGE);
             DataPageFooterPB* data_page_footer = footer.mutable_data_page_footer();
             data_page_footer->set_nullmap_size(0);
-            std::unique_ptr<char[]> page = nullptr;
+            std::unique_ptr<std::vector<uint8_t>> page = nullptr;
 
             Status st = StoragePageDecoder::decode_page(&footer, 0, starrocks::DICT_ENCODING, &page, &encoded_data);
             ASSERT_TRUE(st.ok());

--- a/be/test/storage/rowset/bitshuffle_page_test.cpp
+++ b/be/test/storage/rowset/bitshuffle_page_test.cpp
@@ -90,7 +90,7 @@ public:
         footer.set_type(starrocks::DATA_PAGE);
         starrocks::DataPageFooterPB* data_page_footer = footer.mutable_data_page_footer();
         data_page_footer->set_nullmap_size(0);
-        std::unique_ptr<char[]> page = nullptr;
+        std::unique_ptr<std::vector<uint8_t>> page = nullptr;
 
         Status st = StoragePageDecoder::decode_page(&footer, 0, starrocks::BIT_SHUFFLE, &page, &encoded_data);
         ASSERT_TRUE(st.ok());
@@ -150,7 +150,7 @@ public:
         OwnedSlice s = page_builder.finish()->build();
 
         Slice encoded_data = s.slice();
-        std::unique_ptr<char[]> page = nullptr;
+        std::unique_ptr<std::vector<uint8_t>> page = nullptr;
         {
             starrocks::PageFooterPB footer;
             footer.set_type(starrocks::DATA_PAGE);
@@ -262,7 +262,7 @@ public:
         footer.set_type(starrocks::DATA_PAGE);
         starrocks::DataPageFooterPB* data_page_footer = footer.mutable_data_page_footer();
         data_page_footer->set_nullmap_size(0);
-        std::unique_ptr<char[]> page = nullptr;
+        std::unique_ptr<std::vector<uint8_t>> page = nullptr;
         Status st = StoragePageDecoder::decode_page(&footer, 0, starrocks::BIT_SHUFFLE, &page, &encoded_data);
         ASSERT_TRUE(st.ok());
 

--- a/be/test/storage/rowset/dict_page_test.cpp
+++ b/be/test/storage/rowset/dict_page_test.cpp
@@ -70,7 +70,7 @@ public:
         dict_footer.set_type(starrocks::DATA_PAGE);
         starrocks::DataPageFooterPB* dict_page_footer = dict_footer.mutable_data_page_footer();
         dict_page_footer->set_nullmap_size(0);
-        std::unique_ptr<char[]> dict_page = nullptr;
+        std::unique_ptr<std::vector<uint8_t>> dict_page = nullptr;
         Status st = StoragePageDecoder::decode_page(&dict_footer, 0, starrocks::BIT_SHUFFLE, &dict_page, &encoded_dict);
         ASSERT_TRUE(st.ok());
 
@@ -85,7 +85,7 @@ public:
         footer_data.set_type(DATA_PAGE);
         starrocks::DataPageFooterPB* data_page_footer = footer_data.mutable_data_page_footer();
         data_page_footer->set_nullmap_size(0);
-        std::unique_ptr<char[]> data_page = nullptr;
+        std::unique_ptr<std::vector<uint8_t>> data_page = nullptr;
         st = StoragePageDecoder::decode_page(&footer_data, 0, starrocks::DICT_ENCODING, &data_page, &encoded_data);
         ASSERT_TRUE(st.ok());
 
@@ -350,7 +350,7 @@ TEST_F(DictPageTest, TestLargeDataSize) {
     dict_footer.set_type(starrocks::DATA_PAGE);
     starrocks::DataPageFooterPB* dict_page_footer = dict_footer.mutable_data_page_footer();
     dict_page_footer->set_nullmap_size(0);
-    std::unique_ptr<char[]> dict_page = nullptr;
+    std::unique_ptr<std::vector<uint8_t>> dict_page = nullptr;
     Status st = StoragePageDecoder::decode_page(&dict_footer, 0, starrocks::BIT_SHUFFLE, &dict_page, &encoded_dict);
     ASSERT_TRUE(st.ok());
     auto dict_page_decoder = std::make_unique<BitShufflePageDecoder<TYPE_BIGINT>>(encoded_dict);
@@ -364,7 +364,7 @@ TEST_F(DictPageTest, TestLargeDataSize) {
         footer.set_type(DATA_PAGE);
         DataPageFooterPB* data_page_footer = footer.mutable_data_page_footer();
         data_page_footer->set_nullmap_size(0);
-        std::unique_ptr<char[]> page = nullptr;
+        std::unique_ptr<std::vector<uint8_t>> page = nullptr;
 
         st = StoragePageDecoder::decode_page(&footer, 0, starrocks::DICT_ENCODING, &page, &encoded_data);
         ASSERT_TRUE(st.ok());

--- a/be/test/storage/rowset/page_io_test.cpp
+++ b/be/test/storage/rowset/page_io_test.cpp
@@ -138,7 +138,6 @@ TEST_F(PageIOTest, test_use_no_cache_compress) {
     PageFooterPB read_footer;
     ASSERT_OK(PageIO::read_and_decompress_page(read_opts, &handle, &body, &read_footer));
     ASSERT_EQ(_stats.uncompressed_bytes_read, uncompressed_size + footer.ByteSizeLong() + 4);
-    LOG(ERROR) << "SIZE: " << _stats.uncompressed_bytes_read;
 
     // check
     BitShufflePageDecoder<TYPE_INT> decoder(body);
@@ -179,7 +178,6 @@ TEST_F(PageIOTest, test_use_no_cache_uncompress) {
     PageFooterPB read_footer;
     ASSERT_OK(PageIO::read_and_decompress_page(read_opts, &handle, &body, &read_footer));
     ASSERT_EQ(_stats.uncompressed_bytes_read, uncompressed_size + footer.ByteSizeLong() + 4);
-    LOG(ERROR) << "SIZE: " << _stats.uncompressed_bytes_read;
 
     // check
     BitShufflePageDecoder<TYPE_INT> decoder(body);
@@ -224,7 +222,6 @@ TEST_F(PageIOTest, test_use_cache_hit) {
         PageFooterPB read_footer;
         ASSERT_OK(PageIO::read_and_decompress_page(read_opts, &handle, &body, &read_footer));
         ASSERT_EQ(_stats.uncompressed_bytes_read, uncompressed_size + footer.ByteSizeLong() + 4);
-        LOG(ERROR) << "SIZE: " << _stats.uncompressed_bytes_read;
         ASSERT_EQ(_stats.cached_pages_num, 0);
     }
 

--- a/be/test/storage/rowset/page_io_test.cpp
+++ b/be/test/storage/rowset/page_io_test.cpp
@@ -1,0 +1,249 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/rowset/page_io.h"
+
+#include <gtest/gtest.h>
+
+#include "cache/object_cache/lrucache_module.h"
+#include "fs/fs_memory.h"
+#include "storage/page_cache.h"
+#include "storage/rowset/binary_plain_page.h"
+#include "storage/rowset/bitshuffle_page.h"
+#include "testutil/assert.h"
+#include "util/compression/block_compression.h"
+
+namespace starrocks {
+
+class PageIOTest : public testing::Test {
+public:
+    void SetUp() override;
+    void TearDown() override;
+
+protected:
+    OwnedSlice _build_data_page(const std::vector<int32_t>& values) const;
+    void _compress_data_page(const Slice& slice, faststring* compressed_body);
+    PageFooterPB _build_page_footer(uint64_t uncompressed_size);
+    PageReadOptions _build_read_options(io::SeekableInputStream*, size_t offset, size_t size, bool use_page_cache);
+
+    size_t _cache_size = 10 * 1024 * 1024;
+    std::shared_ptr<StoragePageCache> _prev_page_cache;
+
+    std::shared_ptr<ShardedLRUCache> _lru_cache;
+    std::shared_ptr<LRUCacheModule> _obj_cache;
+    std::shared_ptr<StoragePageCache> _page_cache;
+
+    std::shared_ptr<MemoryFileSystem> _fs;
+    const BlockCompressionCodec* _codec = nullptr;
+    OlapReaderStatistics _stats;
+};
+
+void PageIOTest::SetUp() {
+    _prev_page_cache = DataCache::GetInstance()->page_cache_ptr();
+    _lru_cache = std::make_shared<ShardedLRUCache>(_cache_size);
+    _obj_cache = std::make_shared<LRUCacheModule>(_lru_cache);
+    _page_cache = std::make_shared<StoragePageCache>(_obj_cache.get());
+    DataCache::GetInstance()->set_page_cache(_page_cache);
+
+    _fs = std::make_shared<MemoryFileSystem>();
+    ASSERT_OK(get_block_compression_codec(CompressionTypePB::LZ4, &_codec));
+}
+
+void PageIOTest::TearDown() {
+    DataCache::GetInstance()->set_page_cache(_prev_page_cache);
+}
+
+OwnedSlice PageIOTest::_build_data_page(const std::vector<int32_t>& values) const {
+    PageBuilderOptions options;
+    options.data_page_size = 256 * 1024;
+    PageBuilderOptions build_opts;
+    BitshufflePageBuilder<TYPE_INT> builder(build_opts);
+    builder.add((const uint8_t*)values.data(), 3);
+    return builder.finish()->build();
+}
+
+void PageIOTest::_compress_data_page(const Slice& slice, faststring* compressed_body) {
+    std::vector<Slice> src_slices{slice};
+    ASSERT_OK(PageIO::compress_page_body(_codec, 0, src_slices, compressed_body));
+    uint64_t uncompressed_size = slice.size;
+    uint64_t compressed_size = compressed_body->size();
+    ASSERT_LT(compressed_size, uncompressed_size);
+}
+
+PageFooterPB PageIOTest::_build_page_footer(uint64_t uncompressed_size) {
+    PageFooterPB footer;
+    footer.set_type(DATA_PAGE);
+    auto* data_page_footer = footer.mutable_data_page_footer();
+    data_page_footer->set_nullmap_size(0);
+    footer.set_uncompressed_size(uncompressed_size);
+
+    return footer;
+}
+
+PageReadOptions PageIOTest::_build_read_options(io::SeekableInputStream* file, size_t offset, size_t size,
+                                                bool use_page_cache) {
+    PageReadOptions read_opts;
+    read_opts.page_pointer.offset = offset;
+    read_opts.page_pointer.size = size;
+    read_opts.codec = _codec;
+    read_opts.stats = &_stats;
+    read_opts.encoding_type = EncodingTypePB::BIT_SHUFFLE;
+    read_opts.use_page_cache = use_page_cache;
+    read_opts.read_file = file;
+
+    return read_opts;
+}
+
+TEST_F(PageIOTest, test_use_no_cache_compress) {
+    std::vector<int32_t> values{1, 2, 3};
+    OwnedSlice page = _build_data_page(values);
+    size_t uncompressed_size = page.slice().size;
+
+    // compress
+    faststring compressed_body;
+    _compress_data_page(page.slice(), &compressed_body);
+
+    // page footer
+    PageFooterPB footer = _build_page_footer(uncompressed_size);
+
+    // write
+    WritableFileOptions write_opts;
+    write_opts.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE;
+    ASSIGN_OR_ASSERT_FAIL(auto write_file, _fs->new_writable_file(write_opts, "/test_use_no_cache_compress"));
+
+    PagePointer result;
+    std::vector<Slice> compressed_page{compressed_body};
+    ASSERT_OK(PageIO::write_page(write_file.get(), compressed_page, footer, &result));
+    ASSERT_OK(write_file->close());
+    uint64_t file_size = write_file->size();
+
+    // read
+    ASSIGN_OR_ASSERT_FAIL(auto read_file, _fs->new_random_access_file("/test_use_no_cache_compress"));
+
+    PageReadOptions read_opts = _build_read_options(read_file.get(), 0, file_size, false);
+
+    PageHandle handle;
+    Slice body;
+    PageFooterPB read_footer;
+    ASSERT_OK(PageIO::read_and_decompress_page(read_opts, &handle, &body, &read_footer));
+    ASSERT_EQ(_stats.uncompressed_bytes_read, uncompressed_size + footer.ByteSizeLong() + 4);
+    LOG(ERROR) << "SIZE: " << _stats.uncompressed_bytes_read;
+
+    // check
+    BitShufflePageDecoder<TYPE_INT> decoder(body);
+    ASSERT_OK(decoder.init());
+
+    size_t size = 10;
+    Int32Column col;
+    ASSERT_OK(decoder.next_batch(&size, &col));
+    ASSERT_EQ(col.debug_string(), "[1, 2, 3]");
+}
+
+TEST_F(PageIOTest, test_use_no_cache_uncompress) {
+    std::vector<int32_t> values{1, 2, 3};
+    OwnedSlice page = _build_data_page(values);
+    size_t uncompressed_size = page.slice().size;
+
+    // page footer
+    PageFooterPB footer = _build_page_footer(uncompressed_size);
+
+    // write
+    WritableFileOptions write_opts;
+    write_opts.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE;
+    ASSIGN_OR_ASSERT_FAIL(auto write_file, _fs->new_writable_file(write_opts, "/test_use_no_cache"));
+
+    PagePointer result;
+    std::vector<Slice> compressed_page{page.slice()};
+    ASSERT_OK(PageIO::write_page(write_file.get(), compressed_page, footer, &result));
+    ASSERT_OK(write_file->close());
+    uint64_t file_size = write_file->size();
+
+    // read
+    ASSIGN_OR_ASSERT_FAIL(auto read_file, _fs->new_random_access_file("/test_use_no_cache"));
+
+    PageReadOptions read_opts = _build_read_options(read_file.get(), 0, file_size, false);
+
+    PageHandle handle;
+    Slice body;
+    PageFooterPB read_footer;
+    ASSERT_OK(PageIO::read_and_decompress_page(read_opts, &handle, &body, &read_footer));
+    ASSERT_EQ(_stats.uncompressed_bytes_read, uncompressed_size + footer.ByteSizeLong() + 4);
+    LOG(ERROR) << "SIZE: " << _stats.uncompressed_bytes_read;
+
+    // check
+    BitShufflePageDecoder<TYPE_INT> decoder(body);
+    ASSERT_OK(decoder.init());
+
+    size_t size = 10;
+    Int32Column col;
+    ASSERT_OK(decoder.next_batch(&size, &col));
+    ASSERT_EQ(col.debug_string(), "[1, 2, 3]");
+}
+
+TEST_F(PageIOTest, test_use_cache_hit) {
+    std::vector<int32_t> values{1, 2, 3};
+    OwnedSlice page = _build_data_page(values);
+    size_t uncompressed_size = page.slice().size;
+
+    // compress
+    faststring compressed_body;
+    _compress_data_page(page.slice(), &compressed_body);
+
+    // page footer
+    PageFooterPB footer = _build_page_footer(uncompressed_size);
+
+    // write
+    WritableFileOptions write_opts;
+    write_opts.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE;
+    ASSIGN_OR_ASSERT_FAIL(auto write_file, _fs->new_writable_file(write_opts, "/test_use_cache_hit"));
+
+    PagePointer result;
+    std::vector<Slice> compressed_page{compressed_body};
+    ASSERT_OK(PageIO::write_page(write_file.get(), compressed_page, footer, &result));
+    ASSERT_OK(write_file->close());
+    uint64_t file_size = write_file->size();
+
+    // read
+    ASSIGN_OR_ASSERT_FAIL(auto read_file, _fs->new_random_access_file("/test_use_cache_hit"));
+    PageReadOptions read_opts = _build_read_options(read_file.get(), 0, file_size, true);
+
+    {
+        PageHandle handle;
+        Slice body;
+        PageFooterPB read_footer;
+        ASSERT_OK(PageIO::read_and_decompress_page(read_opts, &handle, &body, &read_footer));
+        ASSERT_EQ(_stats.uncompressed_bytes_read, uncompressed_size + footer.ByteSizeLong() + 4);
+        LOG(ERROR) << "SIZE: " << _stats.uncompressed_bytes_read;
+        ASSERT_EQ(_stats.cached_pages_num, 0);
+    }
+
+    {
+        PageHandle handle;
+        Slice body;
+        PageFooterPB read_footer;
+        ASSERT_OK(PageIO::read_and_decompress_page(read_opts, &handle, &body, &read_footer));
+        ASSERT_EQ(_stats.uncompressed_bytes_read, uncompressed_size + footer.ByteSizeLong() + 4);
+        ASSERT_EQ(_stats.cached_pages_num, 1);
+
+        // check
+        BitShufflePageDecoder<TYPE_INT> decoder(body);
+        ASSERT_OK(decoder.init());
+
+        size_t size = 10;
+        Int32Column col;
+        ASSERT_OK(decoder.next_batch(&size, &col));
+        ASSERT_EQ(col.debug_string(), "[1, 2, 3]");
+    }
+}
+} // namespace starrocks

--- a/be/test/util/starrocks_metrics_test.cpp
+++ b/be/test/util/starrocks_metrics_test.cpp
@@ -284,6 +284,7 @@ TEST_F(StarRocksMetricsTest, PageCacheMetrics) {
             auto data = std::make_unique<std::vector<uint8_t>>(1024);
             ASSERT_OK(_page_cache->insert(key, data.get(), &handle, false));
             ASSERT_TRUE(_page_cache->lookup(key, &handle));
+            data.release();
         }
         for (int i = 0; i < 1024; i++) {
             PageCacheHandle handle;

--- a/be/test/util/starrocks_metrics_test.cpp
+++ b/be/test/util/starrocks_metrics_test.cpp
@@ -279,15 +279,16 @@ TEST_F(StarRocksMetricsTest, PageCacheMetrics) {
     ASSERT_TRUE(capacity_metric != nullptr);
     {
         {
-            StoragePageCache::CacheKey key("abc", 0);
+            std::string key("abc0");
             PageCacheHandle handle;
-            Slice data(new char[1024], 1024);
-            ASSERT_OK(_page_cache->insert(key, data, &handle, false));
+            auto data = std::make_unique<std::vector<uint8_t>>(1024);
+            ASSERT_OK(_page_cache->insert(key, data.get(), &handle, false));
             ASSERT_TRUE(_page_cache->lookup(key, &handle));
         }
         for (int i = 0; i < 1024; i++) {
             PageCacheHandle handle;
-            StoragePageCache::CacheKey key(std::to_string(i), 0);
+            std::string key(std::to_string(i));
+            key.append("0");
             _page_cache->lookup(key, &handle);
         }
     }


### PR DESCRIPTION
## Why I'm doing:

Currently, both the parquet page reader and internal page reader all use data cache to store decompressed data pages. However, the parquet reader uses object cache to cache data and use `std::vector` as its page buffer, while the internal page reader uses page cache to cache data and use a raw char pointer. In the future, I plan to standardize all readers to use the same page cache interface. Doing this will make the logic more straightforward and unify the metrics framework.

## What I'm doing:

Refactor the page cache interface to make it reusable for external tables in the future.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
