### PR TITLE
[BugFix] Fix compilation errors in centos7

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1410,7 +1410,8 @@ build_libxml2() {
         -DLIBXML2_WITH_LZMA=OFF \
         -DLIBXML2_WITH_PYTHON=OFF \
         -DLIBXML2_WITH_ZLIB=OFF \
-        -DLIBXML2_WITH_TESTS=OFF
+        -DLIBXML2_WITH_TESTS=OFF \
+        -DCMAKE_INSTALL_LIBDIR=lib
 
     ${BUILD_SYSTEM} -j "${PARALLEL}"
     ${BUILD_SYSTEM} install


### PR DESCRIPTION


## Why I'm doing:

fix below CE
```
make[2]: *** No rule to make target
`/var/local/thirdparty/installed//lib/libxml2.a', needed by
`../output/lib/starrocks_be'.  Stop.
make[2]: *** Waiting for unfinished jobs....
[ 99%] Building CXX object
src/service/CMakeFiles/starrocks_be.dir/starrocks_main.cpp.o
make[1]: *** [src/service/CMakeFiles/starrocks_be.dir/all] Error 2
```

## What I'm doing:

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
