### PR TITLE
[BugFix] Fix mv refresh when iceberg base table is recreated

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/MaterializedViewExceptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/MaterializedViewExceptions.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.common;
 
-import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.sql.analyzer.SemanticException;
 import org.apache.commons.lang3.StringUtils;
 
@@ -33,6 +32,13 @@ public class MaterializedViewExceptions {
      */
     public static String inactiveReasonForBaseTableNotExists(String tableName) {
         return "base-table dropped: " + tableName;
+    }
+
+    /**
+     * Create the inactive reason when base table changed, eg: drop & recreated
+     */
+    public static String inactiveReasonForBaseTableChanged(String tableName) {
+        return "base-table changed: " + tableName;
     }
 
     public static String inactiveReasonForBaseTableNotExists(long tableId) {
@@ -75,7 +81,7 @@ public class MaterializedViewExceptions {
         return "base table schema changed for columns: " + StringUtils.join(columns, ",");
     }
 
-    public static SemanticException reportBaseTableNotExists(BaseTableInfo baseTableInfo) {
-        return new SemanticException(inactiveReasonForBaseTableNotExists(baseTableInfo.getTableName()));
+    public static SemanticException reportBaseTableNotExists(String tableName) {
+        return new SemanticException(inactiveReasonForBaseTableNotExists(tableName));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
@@ -120,9 +120,6 @@ public class MVActiveChecker extends FrontendDaemon {
      *                         job doesn't
      */
     public static void tryToActivate(MaterializedView mv, boolean checkGracePeriod) {
-        if (!Config.enable_mv_automatic_active_check) {
-            return;
-        }
         // if the mv is set to inactive manually, we don't activate it
         String reason = mv.getInactiveReason();
         if (mv.isActive() || AlterJobMgr.MANUAL_INACTIVE_MV_REASON.equalsIgnoreCase(reason)) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -788,7 +788,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
             // refresh old table
             Table table = optTable.get();
-            if (table.isNativeTableOrMaterializedView() || table.isConnectorView()) {
+            if (table.isNativeTableOrMaterializedView() || table.isView()) {
                 logger.debug("No need to refresh table:{} because it is native table or mv or connector view",
                         baseTableInfo.getTableInfoStr());
                 continue;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -820,20 +820,15 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             }
 
             Table newTable = optNewTable.get();
-            if ((newTable instanceof HiveTable)
-                    && ((HiveTable) newTable).getHiveTableType() == HiveTable.HiveTableType.EXTERNAL_TABLE) {
+            // only collect to-repair tables when the table is not the same as the old one by checking the table identifier
+            if (!baseTableInfo.getTableIdentifier().equals(table.getTableIdentifier())) {
                 toRepairTables.add(Pair.create(newTable, baseTableInfo));
-            } else {
-                logger.info("Table:{} is not an hive external table, no need to repair", baseTableInfo.getTableInfoStr());
             }
         }
 
         // do repair if needed
         if (!toRepairTables.isEmpty()) {
-            MVPCTMetaRepairer repairer = new MVPCTMetaRepairer(db, mv);
-            for (Pair<Table, BaseTableInfo> pair : toRepairTables) {
-                repairer.repairTableIfNeeded(pair.first, pair.second);
-            }
+            MVPCTMetaRepairer.repairMetaIfNeeded(db, mv, toRepairTables);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -407,7 +407,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
         // throw the last exception if all retries failed
         String errorMsg = MvUtils.shrinkToSize(DebugUtil.getRootStackTrace(lastException), MAX_FIELD_VARCHAR_LENGTH);
-        throw new DmlException("Refresh mv %s failed after %s/%s times, error-msg : " +
+        throw new DmlException("Refresh mv %s failed after %s times, try lock failed: %s, error-msg : " +
                 "%s", lastException, mv.getName(), refreshFailedTimes, lockFailedTimes, errorMsg);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTMetaRepairer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTMetaRepairer.java
@@ -13,11 +13,15 @@
 // limitations under the License.
 package com.starrocks.scheduler.mv;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.MaterializedViewExceptions;
+import com.starrocks.common.Pair;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.connector.HivePartitionDataInfo;
@@ -47,6 +51,60 @@ public class MVPCTMetaRepairer {
     public MVPCTMetaRepairer(Database db, MaterializedView mv) {
         this.db = db;
         this.mv = mv;
+    }
+
+    /**
+     * Repair the base table's meta info of the materialized view if needed. For example, if the base external table is dropped
+     * and recreated, the table identifier may change.
+     * @param db: the database of the materialized view
+     * @param mv: the materialized view to repair
+     * @param toRepairTables: the list of tables to repair
+     * @throws DmlException when the table is not supported by MVPCTMetaRepairer, and the mv will be set inactive.
+     */
+    public static void repairMetaIfNeeded(Database db, MaterializedView mv,
+                                          List<Pair<Table, BaseTableInfo>> toRepairTables) throws DmlException {
+        if (toRepairTables.isEmpty()) {
+            return;
+        }
+        Optional<Pair<Table, BaseTableInfo>> nonSupportedTableOpt =
+                toRepairTables.stream().filter(p -> !isSupportedPCTRepairer(p.first, p.second)).findFirst();
+        if (nonSupportedTableOpt.isPresent()) {
+            Pair<Table, BaseTableInfo> nonSupportedTable = nonSupportedTableOpt.get();
+            mv.setInactiveAndReason(
+                    MaterializedViewExceptions.inactiveReasonForBaseTableNotExists(nonSupportedTable.second.getTableName()));
+            throw new DmlException(String.format("Table %s is recreated and needed to be repaired, but it is not supported " +
+                            "by MVPCTMetaRepairer: %s, set mv %s inactive",
+                    nonSupportedTable.first.getName(), nonSupportedTable.second, mv.getName()));
+        }
+        final MVPCTMetaRepairer repairer = new MVPCTMetaRepairer(db, mv);
+        for (Pair<Table, BaseTableInfo> pair : toRepairTables) {
+            Table newTable = pair.first;
+            BaseTableInfo baseTableInfo = pair.second;
+            repairer.repairTableIfNeeded(newTable, baseTableInfo);
+        }
+    }
+
+    /**
+     * Check whether the base table is supported by MVPCTMetaRepairer.
+     * - Only table identifier change is needed to repair.
+     * - Only Hive table is supported if it is external table.
+     * @param baseTable: the base table of materialized view
+     * @param baseTableInfo: the base table info of the materialized view
+     * @return: true if the base table is supported by MVPCTMetaRepairer, false otherwise
+     */
+    @VisibleForTesting
+    public static boolean isSupportedPCTRepairer(Table baseTable, BaseTableInfo baseTableInfo) {
+        if (baseTable == null) {
+            return false;
+        }
+        if (baseTable.getTableIdentifier().equals(baseTableInfo.getTableIdentifier())) {
+            return true;
+        }
+        if (!(baseTable instanceof HiveTable)) {
+            return false;
+        }
+        HiveTable hiveTable = (HiveTable) baseTable;
+        return hiveTable.getHiveTableType() == HiveTable.HiveTableType.EXTERNAL_TABLE;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTMetaRepairer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTMetaRepairer.java
@@ -71,7 +71,7 @@ public class MVPCTMetaRepairer {
         if (nonSupportedTableOpt.isPresent()) {
             Pair<Table, BaseTableInfo> nonSupportedTable = nonSupportedTableOpt.get();
             mv.setInactiveAndReason(
-                    MaterializedViewExceptions.inactiveReasonForBaseTableNotExists(nonSupportedTable.second.getTableName()));
+                    MaterializedViewExceptions.inactiveReasonForBaseTableChanged(nonSupportedTable.second.getTableName()));
             throw new DmlException(String.format("Table %s is recreated and needed to be repaired, but it is not supported " +
                             "by MVPCTMetaRepairer: %s, set mv %s inactive",
                     nonSupportedTable.first.getName(), nonSupportedTable.second, mv.getName()));

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTMetaRepairer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTMetaRepairer.java
@@ -94,7 +94,7 @@ public class MVPCTMetaRepairer {
      */
     @VisibleForTesting
     public static boolean isSupportedPCTRepairer(Table baseTable, BaseTableInfo baseTableInfo) {
-        if (baseTable == null) {
+        if (baseTable == null || baseTableInfo == null) {
             return false;
         }
         if (baseTable.getTableIdentifier().equals(baseTableInfo.getTableIdentifier())) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -563,7 +563,7 @@ public class MetadataMgr {
         if (tableOpt.isPresent()) {
             return tableOpt.get();
         }
-        throw MaterializedViewExceptions.reportBaseTableNotExists(baseTableInfo);
+        throw MaterializedViewExceptions.reportBaseTableNotExists(baseTableInfo.getTableName());
     }
 
     public Table getTemporaryTable(UUID sessionId, String catalogName, Long databaseId, String tblName) {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/MVPCTMetaRepairerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/MVPCTMetaRepairerTest.java
@@ -102,6 +102,7 @@ public class MVPCTMetaRepairerTest extends MVTestBase {
         starRocksAssert.useDatabase("test")
                 .withMaterializedView("CREATE MATERIALIZED VIEW `iceberg_mv1` " +
                         "REFRESH DEFERRED MANUAL\n" +
+                        "PROPERTIES (\n" +
                         "\"replication_num\" = \"1\"" +
                         ")\n" +
                         "AS SELECT id, data, date  FROM `iceberg0`.`partitioned_db`.`t1` as a;");
@@ -135,7 +136,7 @@ public class MVPCTMetaRepairerTest extends MVTestBase {
                         "but it is not supported by MVPCTMetaRepairer");
             }
             assertThat(mv.isActive()).isFalse();
-            assertThat(mv.getInactiveReason().equals("base-table dropped: t1"));
+            assertThat(mv.getInactiveReason().equals("base-table changed: t1")).isTrue();
         }
 
         {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/MVPCTMetaRepairerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/MVPCTMetaRepairerTest.java
@@ -1,0 +1,214 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.scheduler;
+
+import com.starrocks.catalog.BaseTableInfo;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.Table;
+import com.starrocks.scheduler.mv.MVPCTMetaRepairer;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.MetadataMgr;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+import java.util.List;
+
+import static com.starrocks.connector.iceberg.MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class MVPCTMetaRepairerTest extends MVTestBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        MVTestBase.beforeClass();
+    }
+
+    @Test
+    public void testIsSupportedPCTRepairerIceberg() throws Exception {
+        // iceberg catalog
+        ConnectorPlanTestBase.mockCatalog(connectContext, MOCKED_ICEBERG_CATALOG_NAME);
+
+        MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
+        Table t1 =  metadataMgr.getTable(connectContext, MOCKED_ICEBERG_CATALOG_NAME, "partitioned_db", "t1");
+        assertThat(t1).isNotNull();
+
+        {
+            BaseTableInfo baseTableInfo = new BaseTableInfo(MOCKED_ICEBERG_CATALOG_NAME, t1.getCatalogDBName(),
+                    t1.getName(), t1.getTableIdentifier());
+            assertThat(MVPCTMetaRepairer.isSupportedPCTRepairer(t1, baseTableInfo)).isTrue();
+        }
+        {
+            BaseTableInfo baseTableInfo = new BaseTableInfo(MOCKED_ICEBERG_CATALOG_NAME, t1.getCatalogDBName(),
+                    t1.getName(), "t1:0");
+            assertThat(MVPCTMetaRepairer.isSupportedPCTRepairer(t1, baseTableInfo)).isFalse();
+        }
+
+        ConnectorPlanTestBase.dropCatalog(MOCKED_ICEBERG_CATALOG_NAME);
+    }
+
+    @Test
+    public void testIsSupportedPCTRepairerHive() throws Exception {
+        // hive catalog
+        ConnectorPlanTestBase.mockHiveCatalog(connectContext);
+
+        MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
+        Table t1 =  metadataMgr.getTable(connectContext, "hive0", "tpch", "supplier");
+        assertThat(t1).isNotNull();
+
+        {
+            BaseTableInfo baseTableInfo = new BaseTableInfo("hive0", t1.getCatalogDBName(),
+                    t1.getName(), t1.getTableIdentifier());
+            assertThat(MVPCTMetaRepairer.isSupportedPCTRepairer(t1, baseTableInfo)).isTrue();
+        }
+        {
+            BaseTableInfo baseTableInfo = new BaseTableInfo("hive0", t1.getCatalogDBName(),
+                    t1.getName(), "supplier:0");
+            assertThat(MVPCTMetaRepairer.isSupportedPCTRepairer(t1, baseTableInfo)).isTrue();
+        }
+
+        ConnectorPlanTestBase.dropCatalog("hive0");
+    }
+
+    @Test
+    public void testPCTRepairerWithIceberg() throws Exception {
+        // iceberg catalog
+        ConnectorPlanTestBase.mockCatalog(connectContext, MOCKED_ICEBERG_CATALOG_NAME);
+
+        MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
+        Table t1 =  metadataMgr.getTable(connectContext, MOCKED_ICEBERG_CATALOG_NAME, "partitioned_db", "t1");
+        assertThat(t1).isNotNull();
+
+        starRocksAssert.useDatabase("test")
+                .withMaterializedView("CREATE MATERIALIZED VIEW `iceberg_mv1` " +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "\"replication_num\" = \"1\"" +
+                        ")\n" +
+                        "AS SELECT id, data, date  FROM `iceberg0`.`partitioned_db`.`t1` as a;");
+
+        MaterializedView mv = getMv("iceberg_mv1");
+        assertThat(mv).isNotNull();
+        assertThat(mv.isActive()).isTrue();
+        List<BaseTableInfo> baseTableInfos = mv.getBaseTableInfos();
+        assertThat(baseTableInfos.size()).isEqualTo(1);
+        BaseTableInfo baseTableInfo = baseTableInfos.get(0);
+        assertThat(baseTableInfo.getTableIdentifier()).isEqualTo(t1.getTableIdentifier());
+        // it's fine to refresh
+        {
+            refreshMaterializedView("test", "iceberg_mv1");
+            assertThat(mv.isActive()).isTrue();
+        }
+
+        // it will inactive after refresh
+        {
+            new MockUp<BaseTableInfo>() {
+                @Mock
+                public String getTableIdentifier() {
+                    return "xxx:0";
+                }
+            };
+            try {
+                refreshMaterializedView("test", "iceberg_mv1");
+                Assert.fail();
+            } catch (Exception e) {
+                assertThat(e.getMessage()).contains(" Table t1 is recreated and needed to be repaired, " +
+                        "but it is not supported by MVPCTMetaRepairer");
+            }
+            assertThat(mv.isActive()).isFalse();
+            assertThat(mv.getInactiveReason().equals("base-table dropped: t1"));
+        }
+
+        {
+            new MockUp<BaseTableInfo>() {
+                @Mock
+                public String getTableIdentifier() {
+                    return t1.getTableIdentifier();
+                }
+            };
+            refreshMaterializedView("test", "iceberg_mv1");
+            assertThat(mv.isActive()).isTrue();
+        }
+
+        ConnectorPlanTestBase.dropCatalog(MOCKED_ICEBERG_CATALOG_NAME);
+    }
+
+    @Test
+    public void testPCTRepairerWithHive() throws Exception {
+        // hive catalog
+        ConnectorPlanTestBase.mockHiveCatalog(connectContext);
+
+        MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
+        Table t1 =  metadataMgr.getTable(connectContext, "hive0", "tpch", "supplier");
+        assertThat(t1).isNotNull();
+
+        starRocksAssert.useDatabase("test")
+                .withMaterializedView("CREATE MATERIALIZED VIEW `hive_mv1` " +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\"" +
+                        ")\n" +
+                        " as select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier");
+
+        MaterializedView mv = getMv("hive_mv1");
+        assertThat(mv).isNotNull();
+        assertThat(mv.isActive()).isTrue();
+        List<BaseTableInfo> baseTableInfos = mv.getBaseTableInfos();
+        assertThat(baseTableInfos.size()).isEqualTo(1);
+        BaseTableInfo baseTableInfo = baseTableInfos.get(0);
+        assertThat(baseTableInfo.getTableIdentifier()).isEqualTo(t1.getTableIdentifier());
+        // it's fine to refresh
+        {
+            refreshMaterializedView("test", "hive_mv1");
+            assertThat(mv.isActive()).isTrue();
+        }
+
+        // it will inactive after refresh
+        {
+            new MockUp<BaseTableInfo>() {
+                @Mock
+                public String getTableIdentifier() {
+                    return "xxx:0";
+                }
+            };
+            try {
+                refreshMaterializedView("test", "hive_mv1");
+            } catch (Exception e) {
+                Assert.fail();
+            }
+            assertThat(mv.isActive()).isTrue();
+        }
+
+        {
+            new MockUp<BaseTableInfo>() {
+                @Mock
+                public String getTableIdentifier() {
+                    return t1.getTableIdentifier();
+                }
+            };
+            refreshMaterializedView("test", "hive_mv1");
+            assertThat(mv.isActive()).isTrue();
+        }
+
+        ConnectorPlanTestBase.dropCatalog("hive0");
+    }
+}

--- a/test/sql/test_materialized_view/R/test_mv_with_iceberg_recreate
+++ b/test/sql/test_materialized_view/R/test_mv_with_iceberg_recreate
@@ -1,0 +1,188 @@
+-- name: test_mv_with_iceberg_recreate
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_ice_db_${uuid0};
+-- result:
+-- !result
+use mv_ice_db_${uuid0};
+-- result:
+-- !result
+create table mv_ice_tbl_${uuid0} (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt);
+-- result:
+-- !result
+insert into mv_ice_tbl_${uuid0} values 
+  ('1d8cf2a2c0e14fa89d8117792be6eb6f', 2000, '2023-12-01'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2000, '2023-12-01'),
+  ('abc', 2000, '2023-12-02'),
+  (NULL, 2000, '2023-12-02'),
+  ('ab1d8cf2a2c0e14fa89d8117792be6eb6f', 2001, '2023-12-03'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2001, '2023-12-03'),
+  ('abc', 2001, '2023-12-04'),
+  (NULL, 2001, '2023-12-04');
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt 
+REFRESH DEFERRED MANUAL AS SELECT dt,sum(col_int) 
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-01' GROUP BY dt", "test_mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-02' GROUP BY dt", "test_mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-03' GROUP BY dt", "test_mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt", "test_mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-03' GROUP BY dt", "test_mv1")
+-- result:
+True
+-- !result
+SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt>='2023-12-03' GROUP BY dt order by dt;
+-- result:
+2023-12-03	4002
+2023-12-04	4002
+-- !result
+SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} GROUP BY dt order by dt;
+-- result:
+2023-12-01	4000
+2023-12-02	4000
+2023-12-03	4002
+2023-12-04	4002
+-- !result
+admin set frontend config('enable_mv_automatic_active_check'='false');
+-- result:
+-- !result
+use mv_iceberg_${uuid0}.mv_ice_db_${uuid0};
+-- result:
+-- !result
+DROP TABLE mv_ice_tbl_${uuid0};
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+use mv_iceberg_${uuid0}.mv_ice_db_${uuid0};
+-- result:
+-- !result
+create table mv_ice_tbl_${uuid0} (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt);
+-- result:
+-- !result
+insert into mv_ice_tbl_${uuid0} values 
+  ('1d8cf2a2c0e14fa89d8117792be6eb6f', 2000, '2023-12-01'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2000, '2023-12-01');
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+[UC] REFRESH MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1 WITH SYNC MODE;
+-- result:
+E: (1064, 'execute task mv-13011 failed: Refresh mv test_mv1 failed after 1 times, try lock failed: 0, error-msg : com.starrocks.sql.common.DmlException: Table mv_ice_tbl_fcb3eae133304a57b1a9c4c039f5fbe9 is recreated and needed to be repaired, but it is not supported by MVPCTMetaRepairer: mv_iceberg_fcb3eae133304a57b1a9c4c039f5fbe9.mv_ice_db_fcb3eae133304a57b1a9c4c039f5fbe9.mv_ice_tbl_fcb3eae133304a57b1a9c4c039f5fbe9:bf52406e-9d77-4861-afdc-f5cc3a8a3fb2, set mv test_mv1 inactive\n\tat com.starrocks.scheduler.mv.MVPCTMetaRepairer.repairMetaIfNeeded(MVPCTMetaRepairer.java:75)\n\tat com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.refreshExternalTable(PartitionBasedMvRefreshProcessor.java:831)\n\tat com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.syncAndCheckPartitions(PartitionBasedMvRefreshProcessor.java:250)\n\tat com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedView(PartitionBasedMvRefreshProcessor.java:453)\n\tat com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedViewWithRetry(PartitionBasedMvRefreshProcessor.java:391)\n\tat com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doMvRefresh(PartitionBasedMvRefreshProcessor.java:352)\n\tat com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.processTaskRun(PartitionBasedMvRefreshProcessor.java:201)\n\tat com.starrocks.scheduler.TaskRun.executeTaskRun(TaskRun.java:292)\n\tat com.starrocks.scheduler.TaskRunExecutor.lambda$executeTaskRun$0(TaskRunExecutor.java:60)\n\tat java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)\n\tat java.base/java.lang.Thread.run(Thread.java:833)')
+-- !result
+select is_active, inactive_reason from information_schema.materialized_views where TABLE_NAME = 'test_mv1' and table_schema = 'db_${uuid0}';
+-- result:
+[REGEX]false	base-table changed: .*
+-- !result
+function: print_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-01' GROUP BY dt", "test_mv1")
+-- result:
+False
+-- !result
+SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt>='2023-12-03' GROUP BY dt order by dt;
+-- result:
+-- !result
+select * from default_catalog.db_${uuid0}.test_mv1 order by 1, 2;
+-- result:
+2023-12-01	4000
+2023-12-02	4000
+2023-12-03	4002
+2023-12-04	4002
+-- !result
+[UC] REFRESH MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1 WITH SYNC MODE;
+-- result:
+e4847828-37aa-11f0-aa1c-2e3e098d43f4
+-- !result
+SELECT is_active, inactive_reason from information_schema.materialized_views where TABLE_NAME = 'test_mv1' and table_schema = 'db_${uuid0}';
+-- result:
+true	
+-- !result
+function: print_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-01' GROUP BY dt", "test_mv1")
+-- result:
+True
+-- !result
+SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt>='2023-12-03' GROUP BY dt order by dt;
+-- result:
+-- !result
+select * from default_catalog.db_${uuid0}.test_mv1 order by 1, 2;
+-- result:
+2023-12-01	4000
+-- !result
+ALTER MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1 INACTIVE;
+-- result:
+-- !result
+select is_active, inactive_reason from information_schema.materialized_views
+  where TABLE_NAME = 'test_mv1' and table_schema = 'db_${uuid0}';
+-- result:
+false	user use alter materialized view set status to inactive
+-- !result
+ALTER MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1 ACTIVE;
+-- result:
+-- !result
+select is_active, inactive_reason from information_schema.materialized_views
+  where TABLE_NAME = 'test_mv1' and table_schema = 'db_${uuid0}';
+-- result:
+true	
+-- !result
+REFRESH MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1 WITH SYNC MODE;
+select * from default_catalog.db_${uuid0}.test_mv1 order by 1, 2;
+-- result:
+2023-12-01	4000
+-- !result
+admin set frontend config('enable_mv_automatic_active_check'='true');
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} force;
+-- result:
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/T/test_mv_with_iceberg_recreate
+++ b/test/sql/test_materialized_view/T/test_mv_with_iceberg_recreate
@@ -1,0 +1,95 @@
+-- name: test_mv_with_iceberg_recreate
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog mv_iceberg_${uuid0};
+create database mv_ice_db_${uuid0};
+use mv_ice_db_${uuid0};
+create table mv_ice_tbl_${uuid0} (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt);
+insert into mv_ice_tbl_${uuid0} values 
+  ('1d8cf2a2c0e14fa89d8117792be6eb6f', 2000, '2023-12-01'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2000, '2023-12-01'),
+  ('abc', 2000, '2023-12-02'),
+  (NULL, 2000, '2023-12-02'),
+  ('ab1d8cf2a2c0e14fa89d8117792be6eb6f', 2001, '2023-12-03'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2001, '2023-12-03'),
+  ('abc', 2001, '2023-12-04'),
+  (NULL, 2001, '2023-12-04');
+
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt 
+REFRESH DEFERRED MANUAL AS SELECT dt,sum(col_int) 
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: print_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-01' GROUP BY dt", "test_mv1")
+function: print_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-02' GROUP BY dt", "test_mv1")
+function: print_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-03' GROUP BY dt", "test_mv1")
+function: print_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt", "test_mv1")
+function: print_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-03' GROUP BY dt", "test_mv1")
+
+SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt>='2023-12-03' GROUP BY dt order by dt;
+SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} GROUP BY dt order by dt;
+
+admin set frontend config('enable_mv_automatic_active_check'='false');
+-- drop base table
+use mv_iceberg_${uuid0}.mv_ice_db_${uuid0};
+DROP TABLE mv_ice_tbl_${uuid0};
+set catalog default_catalog;
+use db_${uuid0};
+
+-- recreate it
+use mv_iceberg_${uuid0}.mv_ice_db_${uuid0};
+create table mv_ice_tbl_${uuid0} (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt);
+insert into mv_ice_tbl_${uuid0} values 
+  ('1d8cf2a2c0e14fa89d8117792be6eb6f', 2000, '2023-12-01'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2000, '2023-12-01');
+set catalog default_catalog;
+
+[UC] REFRESH MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1 WITH SYNC MODE;
+
+select is_active, inactive_reason from information_schema.materialized_views where TABLE_NAME = 'test_mv1' and table_schema = 'db_${uuid0}';
+function: print_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-01' GROUP BY dt", "test_mv1")
+SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt>='2023-12-03' GROUP BY dt order by dt;
+select * from default_catalog.db_${uuid0}.test_mv1 order by 1, 2;
+
+[UC] REFRESH MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1 WITH SYNC MODE;
+
+SELECT is_active, inactive_reason from information_schema.materialized_views where TABLE_NAME = 'test_mv1' and table_schema = 'db_${uuid0}';
+
+function: print_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-01' GROUP BY dt", "test_mv1")
+
+SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt>='2023-12-03' GROUP BY dt order by dt;
+select * from default_catalog.db_${uuid0}.test_mv1 order by 1, 2;
+
+-- manually inactive and active
+ALTER MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1 INACTIVE;
+select is_active, inactive_reason from information_schema.materialized_views
+  where TABLE_NAME = 'test_mv1' and table_schema = 'db_${uuid0}';
+ALTER MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1 ACTIVE;
+select is_active, inactive_reason from information_schema.materialized_views
+  where TABLE_NAME = 'test_mv1' and table_schema = 'db_${uuid0}';
+  
+REFRESH MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1 WITH SYNC MODE;
+
+select * from default_catalog.db_${uuid0}.test_mv1 order by 1, 2;
+
+admin set frontend config('enable_mv_automatic_active_check'='true');
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} force;
+drop materialized view default_catalog.db_${uuid0}.test_mv1;


### PR DESCRIPTION
## Why I'm doing:
If the base table (eg: iceberg table) has been dropped and re-created,  associated mvs should be set inactive rather than refreshing success without any changes. More details you can see: https://github.com/StarRocks/starrocks/issues/59149

The main reason for this is https://github.com/StarRocks/starrocks/pull/45118 can handle Hive's re-created situations but leaving other external catalog's recreating refresh wrong.

Exceptions should be thrown here and mv should be set inactive:

![image](https://github.com/user-attachments/assets/3f5ce147-568e-44ee-94c5-7bea936258a1)


## What I'm doing:
1. Throw exceptions when MVPCTMetaRepairer meets un-supported base tables to be repaired & set the mv inactive, and add a  new inactive reason (inactiveReasonForBaseTableChanged) to mark this.
2. In MaterializedView#refreshBaseTable, use `getTable` rather than `getTableChecked` to avoid throw exceptions before MVPCTMetaRepairer.

Fixes  https://github.com/StarRocks/starrocks/issues/59149

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
