### PR TITLE
[UT] Fix flaky ThreadPool tests

### DIFF
--- a/be/test/util/threadpool_test.cpp
+++ b/be/test/util/threadpool_test.cpp
@@ -68,6 +68,8 @@ static const char* kDefaultPoolName = "test";
 
 class ThreadPoolTest : public ::testing::Test {
 public:
+    static constexpr int64_t kThreadIdleTimeoutMs = 500; // 500ms
+
     void SetUp() override { ASSERT_TRUE(ThreadPoolBuilder(kDefaultPoolName).build(&_pool).ok()); }
 
     Status rebuild_pool_with_builder(const ThreadPoolBuilder& builder) { return builder.build(&_pool); }
@@ -137,7 +139,7 @@ TEST_F(ThreadPoolTest, TestThreadPoolWithNoMinimum) {
     ASSERT_TRUE(rebuild_pool_with_builder(ThreadPoolBuilder(kDefaultPoolName)
                                                   .set_min_threads(0)
                                                   .set_max_threads(3)
-                                                  .set_idle_timeout(MonoDelta::FromMilliseconds(1)))
+                                                  .set_idle_timeout(MonoDelta::FromMilliseconds(kThreadIdleTimeoutMs)))
                         .ok());
 
     // There are no threads to start with.
@@ -210,7 +212,7 @@ TEST_F(ThreadPoolTest, TestRace) {
     ASSERT_TRUE(rebuild_pool_with_builder(ThreadPoolBuilder(kDefaultPoolName)
                                                   .set_min_threads(0)
                                                   .set_max_threads(1)
-                                                  .set_idle_timeout(MonoDelta::FromMicroseconds(1)))
+                                                  .set_idle_timeout(MonoDelta::FromMicroseconds(kThreadIdleTimeoutMs)))
                         .ok());
 
     for (int i = 0; i < 500; i++) {
@@ -229,7 +231,7 @@ TEST_F(ThreadPoolTest, TestVariableSizeThreadPool) {
     ASSERT_TRUE(rebuild_pool_with_builder(ThreadPoolBuilder(kDefaultPoolName)
                                                   .set_min_threads(1)
                                                   .set_max_threads(4)
-                                                  .set_idle_timeout(MonoDelta::FromMilliseconds(1)))
+                                                  .set_idle_timeout(MonoDelta::FromMilliseconds(kThreadIdleTimeoutMs)))
                         .ok());
 
     // There is 1 thread to start with.
@@ -259,7 +261,7 @@ TEST_F(ThreadPoolTest, TestIncMaxThreadPool) {
     ASSERT_TRUE(rebuild_pool_with_builder(ThreadPoolBuilder(kDefaultPoolName)
                                                   .set_min_threads(1)
                                                   .set_max_threads(4)
-                                                  .set_idle_timeout(MonoDelta::FromMilliseconds(1)))
+                                                  .set_idle_timeout(MonoDelta::FromMilliseconds(kThreadIdleTimeoutMs)))
                         .ok());
 
     // There is 1 thread to start with.
@@ -312,7 +314,7 @@ TEST_F(ThreadPoolTest, TestIncMinThreadPool) {
     ASSERT_TRUE(rebuild_pool_with_builder(ThreadPoolBuilder(kDefaultPoolName)
                                                   .set_min_threads(0)
                                                   .set_max_threads(4)
-                                                  .set_idle_timeout(MonoDelta::FromMilliseconds(1)))
+                                                  .set_idle_timeout(MonoDelta::FromMilliseconds(kThreadIdleTimeoutMs)))
                         .ok());
     // There is 0 thread to start with.
     ASSERT_EQ(0, _pool->num_threads());


### PR DESCRIPTION
## Why I'm doing:

We found that some ThreadPool tests are flaky.

## What I'm doing:

This PR fixes the flaky tests by increasing the idle_timeout. Ran presubmit-tests 5 times, all passed.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
