### PR TITLE
[Enhancement] Support service principal authentication in azure blob file system

### DIFF
--- a/be/src/fs/credential/cloud_configuration.h
+++ b/be/src/fs/credential/cloud_configuration.h
@@ -64,16 +64,12 @@ public:
     std::string shared_key;
     std::string sas_token;
     std::string client_id;
-
-    Status validate() const {
-        if (shared_key.empty() && sas_token.empty() && client_id.empty()) {
-            return Status::InvalidArgument("Azure credential invalid: all fields are empty");
-        }
-        return Status::OK();
-    }
+    std::string client_secret;
+    std::string tenant_id;
 
     bool operator==(const AzureCloudCredential& rhs) const {
-        return shared_key == rhs.shared_key && sas_token == rhs.sas_token && client_id == rhs.client_id;
+        return shared_key == rhs.shared_key && sas_token == rhs.sas_token && client_id == rhs.client_id &&
+               client_secret == rhs.client_secret && tenant_id == rhs.tenant_id;
     }
 };
 

--- a/be/src/fs/credential/cloud_configuration_factory.cpp
+++ b/be/src/fs/credential/cloud_configuration_factory.cpp
@@ -88,6 +88,8 @@ const AzureCloudConfiguration CloudConfigurationFactory::create_azure(
     azure_cloud_credential.shared_key = get_or_default(properties, AZURE_BLOB_SHARED_KEY, std::string());
     azure_cloud_credential.sas_token = get_or_default(properties, AZURE_BLOB_SAS_TOKEN, std::string());
     azure_cloud_credential.client_id = get_or_default(properties, AZURE_BLOB_OAUTH2_CLIENT_ID, std::string());
+    azure_cloud_credential.client_secret = get_or_default(properties, AZURE_BLOB_OAUTH2_CLIENT_SECRET, std::string());
+    azure_cloud_credential.tenant_id = get_or_default(properties, AZURE_BLOB_OAUTH2_TENANT_ID, std::string());
 
     AzureCloudConfiguration azure_cloud_configuration{};
     azure_cloud_configuration.azure_cloud_credential = azure_cloud_credential;

--- a/be/src/fs/credential/cloud_configuration_factory.h
+++ b/be/src/fs/credential/cloud_configuration_factory.h
@@ -59,6 +59,8 @@ static const std::string ALIYUN_OSS_ENDPOINT = "aliyun.oss.endpoint";
 static const std::string AZURE_BLOB_SHARED_KEY = "azure.blob.shared_key";
 static const std::string AZURE_BLOB_SAS_TOKEN = "azure.blob.sas_token";
 static const std::string AZURE_BLOB_OAUTH2_CLIENT_ID = "azure.blob.oauth2_client_id";
+static const std::string AZURE_BLOB_OAUTH2_CLIENT_SECRET = "azure.blob.oauth2_client_secret";
+static const std::string AZURE_BLOB_OAUTH2_TENANT_ID = "azure.blob.oauth2_tenant_id";
 
 class CloudConfigurationFactory {
 public:

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -34,6 +34,7 @@ set(EXEC_FILES
         ./connector_sink/file_chunk_sink_test.cpp
         ./connector_sink/async_flush_output_stream_test.cpp
         ./fs/azure/azblob_uri_test.cpp
+        ./fs/azure/fs_azblob_test.cpp
         ./fs/azure/utils_test.cpp
         ./fs/credential/cloud_configuration_factory_test.cpp
         ./fs/fs_broker_test.cpp

--- a/be/test/fs/azure/fs_azblob_test.cpp
+++ b/be/test/fs/azure/fs_azblob_test.cpp
@@ -1,0 +1,74 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "fs/azure/fs_azblob.h"
+
+#include <gtest/gtest.h>
+
+#include "fs/credential/cloud_configuration_factory.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+class AzBlobFileSystemTest : public ::testing::Test {};
+
+TEST_F(AzBlobFileSystemTest, test_new_random_access_file) {
+    std::string uri = "wasbs://container_name@account_name.blob.core.windows.net/blob_name";
+
+    {
+        std::map<std::string, std::string> properties;
+        properties.emplace(AZURE_BLOB_OAUTH2_CLIENT_ID, "client_id_xxx");
+
+        TCloudConfiguration cloud_configuration;
+        cloud_configuration.__set_cloud_type(TCloudType::AZURE);
+        cloud_configuration.__set_cloud_properties(properties);
+        cloud_configuration.__set_azure_use_native_sdk(true);
+        THdfsProperties hdfs_properties;
+        hdfs_properties.__set_cloud_configuration(cloud_configuration);
+        TBrokerScanRangeParams scan_range_params;
+        scan_range_params.__set_hdfs_properties(hdfs_properties);
+        FSOptions options(&scan_range_params);
+
+        ASSIGN_OR_ABORT(auto fs, FileSystem::CreateUniqueFromString(uri, options));
+        ASSERT_EQ(fs->type(), FileSystem::AZBLOB);
+
+        ASSIGN_OR_ABORT(auto file, fs->new_random_access_file(uri));
+        EXPECT_TRUE(dynamic_cast<RandomAccessFile*>(file.get()) != nullptr);
+    }
+
+    {
+        std::map<std::string, std::string> properties;
+        properties.emplace(AZURE_BLOB_OAUTH2_CLIENT_ID, "client_id_yyy");
+        properties.emplace(AZURE_BLOB_OAUTH2_CLIENT_SECRET, "client_secret_yyy");
+        properties.emplace(AZURE_BLOB_OAUTH2_TENANT_ID, "11111111-2222-3333-4444-555555555555");
+
+        TCloudConfiguration cloud_configuration;
+        cloud_configuration.__set_cloud_type(TCloudType::AZURE);
+        cloud_configuration.__set_cloud_properties(properties);
+        cloud_configuration.__set_azure_use_native_sdk(true);
+        THdfsProperties hdfs_properties;
+        hdfs_properties.__set_cloud_configuration(cloud_configuration);
+        TBrokerScanRangeParams scan_range_params;
+        scan_range_params.__set_hdfs_properties(hdfs_properties);
+        FSOptions options(&scan_range_params);
+
+        ASSIGN_OR_ABORT(auto fs, FileSystem::CreateUniqueFromString(uri, options));
+        ASSERT_EQ(fs->type(), FileSystem::AZBLOB);
+
+        ASSIGN_OR_ABORT(auto file, fs->new_random_access_file(uri));
+        EXPECT_TRUE(dynamic_cast<RandomAccessFile*>(file.get()) != nullptr);
+    }
+}
+
+} // namespace starrocks

--- a/be/test/fs/credential/cloud_configuration_factory_test.cpp
+++ b/be/test/fs/credential/cloud_configuration_factory_test.cpp
@@ -34,7 +34,6 @@ TEST_F(CloudConfigurationFactoryTest, test_create_azure) {
         const auto& cloud_configuration = CloudConfigurationFactory::create_azure(t_cloud_configuration);
         const auto& azure_cloud_credential = cloud_configuration.azure_cloud_credential;
 
-        EXPECT_OK(azure_cloud_credential.validate());
         EXPECT_STREQ(azure_cloud_credential.shared_key.c_str(), "shared_key");
     }
 
@@ -46,8 +45,22 @@ TEST_F(CloudConfigurationFactoryTest, test_create_azure) {
         const auto& cloud_configuration = CloudConfigurationFactory::create_azure(t_cloud_configuration);
         const auto& azure_cloud_credential = cloud_configuration.azure_cloud_credential;
 
-        EXPECT_OK(azure_cloud_credential.validate());
         EXPECT_STREQ(azure_cloud_credential.sas_token.c_str(), "sas_token");
+    }
+
+    {
+        std::map<std::string, std::string> properties;
+        properties.emplace(AZURE_BLOB_OAUTH2_CLIENT_ID, "client_id");
+        properties.emplace(AZURE_BLOB_OAUTH2_CLIENT_SECRET, "client_secret");
+        properties.emplace(AZURE_BLOB_OAUTH2_TENANT_ID, "tenant_id");
+        t_cloud_configuration.__set_cloud_properties(properties);
+
+        const auto& cloud_configuration = CloudConfigurationFactory::create_azure(t_cloud_configuration);
+        const auto& azure_cloud_credential = cloud_configuration.azure_cloud_credential;
+
+        EXPECT_STREQ(azure_cloud_credential.client_id.c_str(), "client_id");
+        EXPECT_STREQ(azure_cloud_credential.client_secret.c_str(), "client_secret");
+        EXPECT_STREQ(azure_cloud_credential.tenant_id.c_str(), "tenant_id");
     }
 
     {
@@ -58,18 +71,7 @@ TEST_F(CloudConfigurationFactoryTest, test_create_azure) {
         const auto& cloud_configuration = CloudConfigurationFactory::create_azure(t_cloud_configuration);
         const auto& azure_cloud_credential = cloud_configuration.azure_cloud_credential;
 
-        EXPECT_OK(azure_cloud_credential.validate());
         EXPECT_STREQ(azure_cloud_credential.client_id.c_str(), "client_id");
-    }
-
-    {
-        std::map<std::string, std::string> properties;
-        t_cloud_configuration.__set_cloud_properties(properties);
-
-        const auto& cloud_configuration = CloudConfigurationFactory::create_azure(t_cloud_configuration);
-        const auto& azure_cloud_credential = cloud_configuration.azure_cloud_credential;
-
-        ASSERT_ERROR(azure_cloud_credential.validate());
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureCloudConfigurationProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureCloudConfigurationProvider.java
@@ -37,6 +37,8 @@ import static com.starrocks.connector.share.credential.CloudConfigurationConstan
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_CONTAINER;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_ENDPOINT;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_ID;
+import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_SECRET;
+import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_OAUTH2_TENANT_ID;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_SAS_TOKEN;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_SHARED_KEY;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_STORAGE_ACCOUNT;
@@ -61,7 +63,9 @@ public class AzureCloudConfigurationProvider implements CloudConfigurationProvid
                 properties.getOrDefault(AZURE_BLOB_SHARED_KEY, ""),
                 properties.getOrDefault(AZURE_BLOB_CONTAINER, container),
                 properties.getOrDefault(AZURE_BLOB_SAS_TOKEN, ""),
-                properties.getOrDefault(AZURE_BLOB_OAUTH2_CLIENT_ID, "")
+                properties.getOrDefault(AZURE_BLOB_OAUTH2_CLIENT_ID, ""),
+                properties.getOrDefault(AZURE_BLOB_OAUTH2_CLIENT_SECRET, ""),
+                properties.getOrDefault(AZURE_BLOB_OAUTH2_TENANT_ID, "")
         );
         if (blob.validate()) {
             return new AzureCloudConfiguration(blob);

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
@@ -174,6 +174,25 @@ public class CloudConfigurationFactoryTest {
             Map<String, String> map = new HashMap<String, String>() {
                 {
                     put(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_ID, "client_id_xxx");
+                    put(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_SECRET, "client_secret_xxx");
+                    put(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_TENANT_ID, "tenant_id_xxx");
+                }
+            };
+
+            CloudConfiguration cc = CloudConfigurationFactory.buildCloudConfigurationForStorage(map);
+            TCloudConfiguration tc = new TCloudConfiguration();
+            cc.toThrift(tc);
+            Map<String, String> cloudProperties = tc.getCloud_properties();
+            Assert.assertEquals("client_id_xxx", cloudProperties.get(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_ID));
+            Assert.assertEquals("client_secret_xxx",
+                    cloudProperties.get(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_SECRET));
+            Assert.assertEquals("tenant_id_xxx", cloudProperties.get(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_TENANT_ID));
+        }
+
+        {
+            Map<String, String> map = new HashMap<String, String>() {
+                {
+                    put(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_ID, "client_id_xxx");
                 }
             };
 

--- a/fe/fe-core/src/test/java/com/starrocks/fs/azure/AzBlobFileSystemTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/fs/azure/AzBlobFileSystemTest.java
@@ -94,7 +94,9 @@ public class AzBlobFileSystemTest {
     @Test
     public void testGlobListWithWildcard() throws StarRocksException {
         // Mock
-        properties.put(CloudConfigurationConstants.AZURE_BLOB_SHARED_KEY, "shared_key_xxx");
+        properties.put(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_ID, "client_id_xxx");
+        properties.put(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_SECRET, "client_secret_xxx");
+        properties.put(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_TENANT_ID, "11111111-2222-3333-4444-555555555555");
         fs = Mockito.spy(new AzBlobFileSystem(properties));
 
         String path = "wasbs://testcontainer@testaccount.blob.core.windows.net/data";

--- a/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/credential/CloudConfigurationConstants.java
+++ b/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/credential/CloudConfigurationConstants.java
@@ -85,6 +85,8 @@ public class CloudConfigurationConstants {
     public static final String AZURE_BLOB_CONTAINER = "azure.blob.container";
     public static final String AZURE_BLOB_SAS_TOKEN = "azure.blob.sas_token";
     public static final String AZURE_BLOB_OAUTH2_CLIENT_ID = "azure.blob.oauth2_client_id";
+    public static final String AZURE_BLOB_OAUTH2_CLIENT_SECRET = "azure.blob.oauth2_client_secret";
+    public static final String AZURE_BLOB_OAUTH2_TENANT_ID = "azure.blob.oauth2_tenant_id";
     // For Azure Data Lake Storage Gen1 (ADLS1)
     public static final String AZURE_ADLS1_USE_MANAGED_SERVICE_IDENTITY = "azure.adls1.use_managed_service_identity";
     public static final String AZURE_ADLS1_OAUTH2_CLIENT_ID = "azure.adls1.oauth2_client_id";


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Support using `client id, tenant id and client secret` as `service principal credential` to authenticate to azure blob storage.

```
SELECT * FROM FILES(
    "path" = "wasbs://container@account.blob.core.windows.net/path/*",
    "format" = "parquet",
    "azure.blob.oauth2_client_id" = "xxx",
    "azure.blob.oauth2_client_secret" = "yyy",
    "azure.blob.oauth2_tenant_id" = "zzz"
)
```

Fixes #59017

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
