### PR TITLE
[BugFix] Fix INSERT OVERWRITE BY NAME Fails with SQL Unknown Error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -242,7 +242,6 @@ public class InsertAnalyzer {
                 }
             }
 
-            Preconditions.checkState(insertStmt.getTargetColumnNames() == null);
             // column name is case insensitive
             insertStmt.setTargetColumnNames(
                     query.getColumnOutputNames().stream().map(String::toLowerCase).collect(Collectors.toList()));

--- a/test/sql/test_insert_overwrite/R/test_insert
+++ b/test/sql/test_insert_overwrite/R/test_insert
@@ -16,3 +16,24 @@ select count(*) from t;
 -- result:
 32
 -- !result
+
+create table t1 (k1 int, k2 varchar(100));
+-- result:
+-- !result
+insert into t1 values(3, "c");
+-- result:
+-- !result
+select * from t1;
+-- result:
+3	c
+-- !result
+create table t2 (k1 int, k2 varchar(100), k3 int default "10");
+-- result:
+-- !result
+insert overwrite t2 by name select k1, k2 from t1;
+-- result:
+-- !result
+select * from t2;
+-- result:
+3	c
+-- !result

--- a/test/sql/test_insert_overwrite/R/test_insert
+++ b/test/sql/test_insert_overwrite/R/test_insert
@@ -35,5 +35,5 @@ insert overwrite t2 by name select k1, k2 from t1;
 -- !result
 select * from t2;
 -- result:
-3	c
+3	c	10
 -- !result

--- a/test/sql/test_insert_overwrite/T/test_insert
+++ b/test/sql/test_insert_overwrite/T/test_insert
@@ -4,3 +4,10 @@ insert into t select * from TABLE(generate_series(0,63));
 select count(*) from t;
 insert overwrite t select * from TABLE(generate_series(0,31));
 select count(*) from t;
+
+create table t1 (k1 int, k2 varchar(100));
+insert into t1 values(3, "c");
+select * from t1;
+create table t2 (k1 int, k2 varchar(100), k3 int default "10");
+insert overwrite t2 by name select k1, k2 from t1;
+select * from t2;


### PR DESCRIPTION
Fixes #58762 

InsertAnalyzer.analyzeWithDeferredLock() is invoked 2 times, on first invocation targetcolumns is null and this check is success; and targetcols is updated with cols specified in select list. When InsertAnalyzer.analyzeWithDeferredLock() is invoked second time for InertOverwriteJob, targetcolumns is not null, it contains the colums from select list. so this check will fail.

mysql> CREATE TABLE my_table (id VARCHAR(64) NOT NULL, uid BIGINT NOT NULL AUTO_INCREMENT) PRIMARY KEY (`id`);
Query OK, 0 rows affected (0.03 sec)

mysql> CREATE TABLE my_other_table (id VARCHAR(64) NOT NULL, uid BIGINT NOT NULL AUTO_INCREMENT) PRIMARY KEY (`id`);
Query OK, 0 rows affected (0.22 sec)

mysql> INSERT INTO my_other_table (id) VALUES ("o1");
Query OK, 1 row affected (0.58 sec)
{'label':'insert_6bb693d9-3897-11f0-8111-fe188ababd24', 'status':'VISIBLE', 'txnId':'23087'}

mysql> INSERT OVERWRITE my_table BY NAME SELECT id FROM my_other_table;
Query OK, 1 row affected (0.27 sec)
{'label':'insert_74dad179-3897-11f0-8111-fe188ababd24', 'status':'VISIBLE', 'txnId':'23089'}

mysql> select * from my_table;
+------+------+
| id   | uid  |
+------+------+
| o1   |    1 |
+------+------+
1 row in set (0.02 sec)


## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.5
  - [X] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
