### PR TITLE
[BugFix] Fix backend hang in fatal log

### DIFF
--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -126,21 +126,33 @@ static void dump_trace_info() {
 
 static void dontdump_unused_pages() {
     static bool start_dump = false;
+    struct timeval tv;
+    gettimeofday(&tv, nullptr);
+    pthread_t tid = pthread_self();
+
     if (!start_dump) {
         std::string purge_msg = "arena." + std::to_string(MALLCTL_ARENAS_ALL) + ".purge";
         int ret = je_mallctl(purge_msg.c_str(), nullptr, nullptr, nullptr, 0);
         if (ret != 0) {
-            LOG(ERROR) << "je_mallctl execute purge failed: " << strerror(ret);
+            std::cerr << "[" << tv.tv_sec << "." << tv.tv_usec / 1000 << "]"
+                      << "[thread:" << tid << "] "
+                      << "je_mallctl execute purge failed: " << strerror(ret) << std::endl;
         } else {
-            LOG(INFO) << "je_mallctl execute purge success";
+            std::cerr << "[" << tv.tv_sec << "." << tv.tv_usec / 1000 << "]"
+                      << "[thread:" << tid << "] "
+                      << "je_mallctl execute purge success" << std::endl;
         }
 
         std::string dontdump_msg = "arena." + std::to_string(MALLCTL_ARENAS_ALL) + ".dontdump";
         ret = je_mallctl(dontdump_msg.c_str(), nullptr, nullptr, nullptr, 0);
         if (ret != 0) {
-            LOG(ERROR) << "je_mallctl execute dontdump failed: " << strerror(ret);
+            std::cerr << "[" << tv.tv_sec << "." << tv.tv_usec / 1000 << "]"
+                      << "[thread:" << tid << "] "
+                      << "je_mallctl execute dontdump failed: " << strerror(ret) << std::endl;
         } else {
-            LOG(INFO) << "je_mallctl execute dontdump success";
+            std::cerr << "[" << tv.tv_sec << "." << tv.tv_usec / 1000 << "]"
+                      << "[thread:" << tid << "] "
+                      << "je_mallctl execute dontdump success" << std::endl;
         }
     }
     start_dump = true;


### PR DESCRIPTION
## Why I'm doing:
**dontdump_unused_pages**() is called back during the execution of FATAL LOG, which does not allow LOG to be used again to print logs, which will cause deadlock.

![image](https://github.com/user-attachments/assets/cabb4548-47d2-42af-920a-ada8841ec084)


## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/9714

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
