### PR TITLE
[Refactor] Use the storage page cache instead of the object cache to cache the decompressed data of external tables

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -178,7 +178,7 @@ Status HiveDataSource::open(RuntimeState* state) {
     if (state->query_options().__isset.enable_file_pagecache) {
         _use_file_pagecache = state->query_options().enable_file_pagecache;
     }
-    _use_file_pagecache &= BlockCache::instance()->mem_cache_available();
+    _use_file_pagecache &= !config::disable_storage_page_cache;
 #endif
 
     if (state->query_options().__isset.enable_dynamic_prune_scan_range) {

--- a/be/src/formats/parquet/page_reader.cpp
+++ b/be/src/formats/parquet/page_reader.cpp
@@ -107,7 +107,7 @@ Status PageReader::_read_and_deserialize_header(bool need_fill_cache) {
 
     RETURN_IF_ERROR(_stream->seek(_offset));
     BufferPtr tmp_page_buffer;
-    Buffer* page_buffer;
+    std::vector<uint8_t>* page_buffer;
     if (need_fill_cache) {
         DCHECK(_cache_buf);
         page_buffer = _cache_buf.get();

--- a/be/src/formats/parquet/page_reader.cpp
+++ b/be/src/formats/parquet/page_reader.cpp
@@ -16,7 +16,6 @@
 
 #include <glog/logging.h>
 
-#include <algorithm>
 #include <memory>
 #include <ostream>
 #include <vector>
@@ -50,11 +49,11 @@ PageReader::PageReader(io::SeekableInputStream* stream, uint64_t start_offset, u
           _opts(opts),
           _codec(codec) {
     if (_opts.use_file_pagecache) {
-        _cache = DataCache::GetInstance()->external_table_page_cache();
+        _cache = DataCache::GetInstance()->page_cache();
         _init_page_cache_key();
     }
-    _compressed_buf = std::make_shared<std::vector<uint8_t>>();
-    _uncompressed_buf = std::make_shared<std::vector<uint8_t>>();
+    _compressed_buf = std::make_unique<std::vector<uint8_t>>();
+    _uncompressed_buf = std::make_unique<std::vector<uint8_t>>();
 }
 
 Status PageReader::next_page() {
@@ -68,41 +67,28 @@ Status PageReader::next_page() {
 
 Status PageReader::_deal_page_with_cache() {
     std::string& page_cache_key = _current_page_cache_key();
-    ObjectCacheHandle* cache_handle = nullptr;
-    Status st = _cache->lookup(page_cache_key, &cache_handle);
-    if (st.ok()) {
+    PageCacheHandle cache_handle;
+    bool ret = _cache->lookup(page_cache_key, &cache_handle);
+    if (ret) {
         _hit_cache = true;
-        _opts.stats->page_cache_read_counter += 1;
-        _cache_buf = *(static_cast<const BufferPtr*>(_cache->value(cache_handle)));
-        _cache->release(cache_handle);
+        auto* cache_buf = cache_handle.data();
+        _page_handle = PageHandle(std::move(cache_handle));
         _header_length = _cache_buf->size();
-        auto st = deserialize_thrift_msg(_cache_buf->data(), &_header_length, TProtocolType::COMPACT, &_cur_header);
+        auto st = deserialize_thrift_msg(cache_buf->data(), &_header_length, TProtocolType::COMPACT, &_cur_header);
         DCHECK(st.ok());
         _next_header_pos = _offset + _header_length + _data_length();
         RETURN_IF_ERROR(_skip_bytes(_header_length + _data_length()));
     } else {
-        _cache_buf = std::make_shared<std::vector<uint8_t>>();
+        _cache_buf = std::make_unique<std::vector<uint8_t>>();
         RETURN_IF_ERROR(_read_and_deserialize_header(true));
         if (config::enable_adjustment_page_cache_skip && !_cache_decompressed_data()) {
             _skip_page_cache = true;
             return Status::OK();
         }
         RETURN_IF_ERROR(_read_and_decompress_internal(true));
-        BufferPtr* capture = new BufferPtr(_cache_buf);
-        Status st = Status::InternalError("write file page cache failed");
-        int64_t page_cache_size = sizeof(BufferPtr) + sizeof(*_cache_buf) + _cache_buf->size();
-        DeferOp op([&st, this, capture, &cache_handle]() {
-            if (st.ok()) {
-                _opts.stats->page_cache_write_counter += 1;
-                _cache->release(cache_handle);
-            } else {
-                delete capture;
-            }
-        });
-        auto deleter = [](const CacheKey& key, void* value) { delete (BufferPtr*)value; };
-        ObjectCacheWriteOptions options;
-        options.evict_probability = _opts.datacache_options->datacache_evict_probability;
-        st = _cache->insert(page_cache_key, capture, page_cache_size, deleter, &cache_handle, &options);
+        auto st = _cache->insert(page_cache_key, _cache_buf.get(), &cache_handle, false);
+        _page_handle = st.ok() ? PageHandle(std::move(cache_handle)) : PageHandle(_cache_buf.get());
+        _cache_buf.release();
     }
 
     return Status::OK();
@@ -114,12 +100,14 @@ Status PageReader::_read_and_deserialize_header(bool need_fill_cache) {
     _header_length = 0;
 
     RETURN_IF_ERROR(_stream->seek(_offset));
-    BufferPtr page_buffer;
+    BufferPtr tmp_page_buffer;
+    Buffer* page_buffer;
     if (need_fill_cache) {
         DCHECK(_cache_buf);
-        page_buffer = _cache_buf;
+        page_buffer = _cache_buf.get();
     } else {
-        page_buffer = std::make_shared<std::vector<uint8_t>>();
+        tmp_page_buffer = std::make_unique<std::vector<uint8_t>>();
+        page_buffer = tmp_page_buffer.get();
     }
 
     do {
@@ -134,7 +122,7 @@ Status PageReader::_read_and_deserialize_header(bool need_fill_cache) {
                 page_buf = (const uint8_t*)st.value().data();
                 peek_mode = true;
             } else {
-                TRY_CATCH_BAD_ALLOC(raw::stl_vector_resize_uninitialized(page_buffer.get(), allowed_page_size));
+                TRY_CATCH_BAD_ALLOC(raw::stl_vector_resize_uninitialized(page_buffer, allowed_page_size));
                 RETURN_IF_ERROR(_stream->read_at_fully(_offset, page_buffer->data(), allowed_page_size));
                 page_buf = page_buffer->data();
                 auto st = _stream->peek(allowed_page_size);

--- a/be/src/formats/parquet/page_reader.cpp
+++ b/be/src/formats/parquet/page_reader.cpp
@@ -354,8 +354,7 @@ Status PageReader::_read_and_decompress_internal(bool need_fill_cache) {
             return _decompress_page(read_data, &_uncompressed_data);
         } else if (_cache_decompressed_data()) {
             auto original_size = _cache_buf->size();
-            TRY_CATCH_BAD_ALLOC(
-                    raw::stl_vector_resize_uninitialized(_cache_buf, uncompressed_size + original_size));
+            TRY_CATCH_BAD_ALLOC(raw::stl_vector_resize_uninitialized(_cache_buf, uncompressed_size + original_size));
             _uncompressed_data = Slice(_cache_buf->data() + original_size, uncompressed_size);
             return _decompress_page(read_data, &_uncompressed_data);
         }

--- a/be/src/formats/parquet/page_reader.h
+++ b/be/src/formats/parquet/page_reader.h
@@ -23,10 +23,12 @@
 #include "common/statusor.h"
 #include "gen_cpp/parquet_types.h"
 #include "io/seekable_input_stream.h"
+#include "storage/rowset/page_handle.h"
 #include "util/slice.h"
 
 namespace starrocks {
 class ObjectCache;
+class StoragePageCache;
 class BlockCompressionCodec;
 } // namespace starrocks
 
@@ -104,16 +106,17 @@ private:
     size_t _page_num = 0xffffffff;
     size_t _next_read_page_idx = 0;
 
-    ObjectCache* _cache = nullptr;
+    StoragePageCache* _cache = nullptr;
     std::string _page_cache_key;
 
     const tparquet::CompressionCodec::type _codec;
     const BlockCompressionCodec* _compress_codec = nullptr;
 
-    using BufferPtr = std::shared_ptr<std::vector<uint8_t>>;
+    using BufferPtr = std::unique_ptr<std::vector<uint8_t>>;
     BufferPtr _compressed_buf;
     BufferPtr _uncompressed_buf;
     BufferPtr _cache_buf;
+    PageHandle _page_handle;
     bool _hit_cache = false;
     bool _skip_page_cache = false;
 

--- a/be/src/formats/parquet/page_reader.h
+++ b/be/src/formats/parquet/page_reader.h
@@ -115,7 +115,7 @@ private:
     using BufferPtr = std::unique_ptr<std::vector<uint8_t>>;
     BufferPtr _compressed_buf;
     BufferPtr _uncompressed_buf;
-    BufferPtr _cache_buf;
+    std::vector<uint8_t>* _cache_buf = nullptr;
     PageHandle _page_handle;
     bool _hit_cache = false;
     bool _skip_page_cache = false;

--- a/be/test/util/starrocks_metrics_test.cpp
+++ b/be/test/util/starrocks_metrics_test.cpp
@@ -105,7 +105,6 @@ TEST_F(StarRocksMetricsTest, Normal) {
     auto instance = StarRocksMetrics::instance();
     auto metrics = instance->metrics();
     metrics->collect(&visitor);
-    LOG(INFO) << "\n" << visitor.to_string();
     // check metric
     {
         instance->fragment_requests_total.increment(12);


### PR DESCRIPTION
## Why I'm doing:

We use page cache to storage all the decompressed data of internal and external table, so we  Use the storage page cache instead of the object cache to cache the decompressed data of external tables, this pr also fix the memory statistic problem of query external table.

## What I'm doing:

Use the storage page cache instead of the object cache to cache the decompressed data of external tables

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
