### PR TITLE
[BugFix]Don't return error when decoding min/max is not supported

### DIFF
--- a/be/src/formats/parquet/scalar_column_reader.cpp
+++ b/be/src/formats/parquet/scalar_column_reader.cpp
@@ -238,10 +238,12 @@ StatusOr<bool> RawColumnReader::_row_group_zone_map_filter(const std::vector<con
                 StatisticsHelper::get_min_max_value(_opts.file_meta_data, col_type, &get_chunk_metadata()->meta_data,
                                                     get_column_parquet_field(), min_values, max_values);
         if (st.ok()) {
-            RETURN_IF_ERROR(StatisticsHelper::decode_value_into_column(min_column, min_values, null_pages, col_type,
-                                                                       get_column_parquet_field(), _opts.timezone));
-            RETURN_IF_ERROR(StatisticsHelper::decode_value_into_column(max_column, max_values, null_pages, col_type,
-                                                                       get_column_parquet_field(), _opts.timezone));
+            st = StatisticsHelper::decode_value_into_column(min_column, min_values, null_pages, col_type,
+                                                            get_column_parquet_field(), _opts.timezone);
+            RETURN_IF(!st.ok(), filtered);
+            st = StatisticsHelper::decode_value_into_column(max_column, max_values, null_pages, col_type,
+                                                            get_column_parquet_field(), _opts.timezone);
+            RETURN_IF(!st.ok(), filtered);
 
             zone_map_detail = ZoneMapDetail{min_column->get(0), max_column->get(0), has_null};
             zone_map_detail->set_num_rows(rg_num_rows);


### PR DESCRIPTION
## Why I'm doing:
we didn't support decoding min/max value of some types, but we shouldn't return
 the error status to users.
On main branch and branch-3.5, there is no bug, we just deal with this error status 
asap to avoid further bug.
On branch-3.4 and branch-3.3, there is bug when the type of predicate is in-filter 
or rf-min-max and the type of data is float/double.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
