### PR TITLE
[BugFix] shared-data stream load filtering out SHUTDOWN node

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -20,6 +20,7 @@ package com.starrocks.planner;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.analysis.SlotDescriptor;
 import com.starrocks.analysis.TupleDescriptor;
@@ -50,7 +51,10 @@ import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.Status;
 import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.lake.LakeTable;
+import com.starrocks.lake.LakeTablet;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.PartitionValue;
 import com.starrocks.system.Backend;
 import com.starrocks.system.BackendHbResponse;
@@ -68,6 +72,7 @@ import com.starrocks.thrift.TTabletLocation;
 import com.starrocks.thrift.TTabletType;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.thrift.TWriteQuorumType;
+import com.starrocks.utframe.MockedWarehouseManager;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
 import mockit.Injectable;
@@ -638,9 +643,100 @@ public class OlapTableSinkTest {
 
         int lowUsageIndex2 = OlapTableSink.findPrimaryReplica(olapTable, bePrimaryMap, infoService,
                 index, selectedBackedIds, singleReplicaList);
-        //note: even though be2 is in shutting down, to ensure the load job could loading normally,
+        //note: even though be2 is in shutting down, to ensure the load job can be loaded normally,
         //      be2 SHUTDOWN status could not be checked, so choose replica4 as primary replica. 
         Assert.assertEquals(singleReplicaList.get(lowUsageIndex2).getId(), replica4.getId());
         Assert.assertEquals(singleReplicaList.get(lowUsageIndex2).getBackendId(), be2.getId());
+    }
+
+    @Test
+    public void testCreateLocationWithSharedDataMode(@Mocked GlobalStateMgr globalStateMgr) throws Exception {
+        SystemInfoService sysInfoService = new SystemInfoService();
+        MockedWarehouseManager warehouseManager = new MockedWarehouseManager();
+
+        new MockUp<RunMode>() {
+            @Mock
+            public RunMode getCurrentRunMode() {
+                return RunMode.SHARED_DATA;
+            }
+        };
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+                result = sysInfoService;
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getNodeMgr().getClusterInfo();
+                result = sysInfoService;
+                GlobalStateMgr.getCurrentState().getWarehouseMgr();
+                result = warehouseManager;
+            }
+        };
+
+        // create two ComputeNodes
+        ComputeNode node1 = new ComputeNode(10001L, "127.0.0.1", 9071);
+        node1.updateOnce(1, 2, 3);
+        BackendHbResponse shutdownResponse =
+                new BackendHbResponse(node1.getId(), TStatusCode.SHUTDOWN, "BE is in shutting down");
+        // Set node1 to status:SHUTDOWN
+        Assert.assertTrue(node1.handleHbResponse(shutdownResponse, false));
+        Assert.assertEquals(node1.getStatus(), ComputeNode.Status.SHUTDOWN);
+        Assert.assertFalse(node1.isAlive());
+
+        ComputeNode node2 = new ComputeNode(10002L, "127.0.0.1", 9072);
+        node2.updateOnce(1, 2, 3);
+
+        warehouseManager.setAllComputeNodeIds(Lists.newArrayList(node1.getId(), node2.getId()));
+        warehouseManager.setAliveComputeNodes(Lists.newArrayList(node2));
+        warehouseManager.setComputeNodesAssignedToTablet(Sets.newHashSet(node1));
+
+        sysInfoService.addComputeNode(node1);
+        sysInfoService.addComputeNode(node2);
+
+        long dbId = 1L;
+        long tableId = 2L;
+        long partitionId = 3L;
+        long indexId = 4L;
+        long tabletId = 5L;
+        long physicalPartitionId = 6L;
+
+        // Columns
+        List<Column> columns = new ArrayList<Column>();
+        Column k1 = new Column("k1", Type.INT, true, null, "", "");
+        columns.add(k1);
+
+        LakeTablet tablet = new LakeTablet(tabletId);
+        // Partition info and distribution info
+        DistributionInfo distributionInfo = new HashDistributionInfo(1, Lists.newArrayList(k1));
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setDataProperty(partitionId, new DataProperty(TStorageMedium.SSD));
+        partitionInfo.setIsInMemory(partitionId, false);
+        partitionInfo.setTabletType(partitionId, TTabletType.TABLET_TYPE_DISK);
+        partitionInfo.setReplicationNum(partitionId, (short) 3);
+        // Index
+        MaterializedIndex index = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
+        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId, indexId, 0, TStorageMedium.SSD);
+        index.addTablet(tablet, tabletMeta);
+        // Partition
+        Partition partition = new Partition(partitionId, physicalPartitionId, "p1", index, distributionInfo);
+        // Table
+        OlapTable table = new LakeTable(tableId, "t1", columns, KeysType.AGG_KEYS, partitionInfo, distributionInfo);
+        Deencapsulation.setField(table, "baseIndexId", indexId);
+        table.addPartition(partition);
+        table.setIndexMeta(indexId, "t1", columns, 0, 0, (short) 3, TStorageType.COLUMN, KeysType.AGG_KEYS);
+
+        TOlapTablePartitionParam partitionParam = new TOlapTablePartitionParam();
+        TOlapTablePartition tPartition = new TOlapTablePartition();
+        tPartition.setId(physicalPartitionId);
+        partitionParam.addToPartitions(tPartition);
+        TOlapTableLocationParam param = OlapTableSink.createLocation(table, partitionParam, false);
+        LOG.warn("TableLocationParam: {}", param);
+        // Check
+        List<TTabletLocation> locations = param.getTablets();
+        Assert.assertEquals(1, locations.size());
+        TTabletLocation location = locations.get(0);
+        List<Long> nodes = location.getNode_ids();
+        Assert.assertEquals(1, nodes.size());
+        Assert.assertEquals((Long) node2.getId(), nodes.get(0));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockedWarehouseManager.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockedWarehouseManager.java
@@ -111,7 +111,20 @@ public class MockedWarehouseManager extends WarehouseManager {
 
     @Override
     public ComputeNode getComputeNodeAssignedToTablet(String warehouseName, LakeTablet tablet) {
-        return computeNodeSetAssignedToTablet.iterator().next();
+        if (computeNodeSetAssignedToTablet.isEmpty()) {
+            return null;
+        } else {
+            return computeNodeSetAssignedToTablet.iterator().next();
+        }
+    }
+
+    @Override
+    public ComputeNode getComputeNodeAssignedToTablet(Long warehouseId, LakeTablet tablet) {
+        if (computeNodeSetAssignedToTablet.isEmpty()) {
+            return null;
+        } else {
+            return computeNodeSetAssignedToTablet.iterator().next();
+        }
     }
 
     public void setComputeNodesAssignedToTablet(Set<ComputeNode> computeNodeSet) {


### PR DESCRIPTION
* use DefaultSharedDataWorkerProvider to replace unavailable workers with its backup node in shared-data mode.

The shared-nothing part is done in #58357
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
