### PR TITLE
[Enhancement] Change bucket number from physical partition level to materialized index level

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableRollupBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableRollupBuilder.java
@@ -76,18 +76,18 @@ public class LakeTableRollupBuilder extends AlterJobV2Builder {
                 // create shard group
                 long shardGroupId = GlobalStateMgr.getCurrentState().getStarOSAgent().
                         createShardGroup(dbId, olapTable.getId(), partitionId, rollupIndexId);
+                MaterializedIndex baseIndex = physicalPartition.getIndex(baseIndexId);
                 // index state is SHADOW
                 MaterializedIndex mvIndex = new MaterializedIndex(rollupIndexId,
-                        MaterializedIndex.IndexState.SHADOW, shardGroupId);
-                MaterializedIndex baseIndex = physicalPartition.getIndex(baseIndexId);
-
+                        MaterializedIndex.IndexState.SHADOW, shardGroupId, baseIndex.getBucketNum());
+                
                 // create shard
                 Map<String, String> shardProperties = new HashMap<>();
                 shardProperties.put(LakeTablet.PROPERTY_KEY_TABLE_ID, Long.toString(olapTable.getId()));
                 shardProperties.put(LakeTablet.PROPERTY_KEY_PARTITION_ID, Long.toString(physicalPartitionId));
                 shardProperties.put(LakeTablet.PROPERTY_KEY_INDEX_ID, Long.toString(rollupIndexId));
 
-                List<Tablet> originTablets = physicalPartition.getIndex(baseIndexId).getTablets();
+                List<Tablet> originTablets = baseIndex.getTablets();
                 WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
                 Optional<Long> workerGroupId = warehouseManager.selectWorkerGroupByWarehouseId(
                         ConnectContext.get().getCurrentWarehouseId());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableAlterJobV2Builder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableAlterJobV2Builder.java
@@ -89,9 +89,12 @@ public class OlapTableAlterJobV2Builder extends AlterJobV2Builder {
                 long partitionId = partition.getParentId();
                 TStorageMedium medium = table.getPartitionInfo().getDataProperty(partitionId).getStorageMedium();
                 short replicationNum = table.getPartitionInfo().getReplicationNum(partitionId);
-                // index state is SHADOW
-                MaterializedIndex shadowIndex = new MaterializedIndex(shadowIndexId, MaterializedIndex.IndexState.SHADOW);
                 MaterializedIndex originIndex = partition.getIndex(originIndexId);
+                // index state is SHADOW
+                MaterializedIndex shadowIndex = new MaterializedIndex(shadowIndexId,
+                        MaterializedIndex.IndexState.SHADOW,
+                        PhysicalPartition.INVALID_SHARD_GROUP_ID,
+                        originIndex.getBucketNum());
                 TabletMeta shadowTabletMeta = new TabletMeta(
                         dbId, tableId, physicalPartitionId, shadowIndexId, newSchemaHash, medium);
                 for (Tablet originTablet : originIndex.getTablets()) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableRollupJobBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableRollupJobBuilder.java
@@ -64,9 +64,12 @@ public class OlapTableRollupJobBuilder extends AlterJobV2Builder {
 
             for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
                 long physicalPartitionId = physicalPartition.getId();
-                // index state is SHADOW
-                MaterializedIndex mvIndex = new MaterializedIndex(rollupIndexId, MaterializedIndex.IndexState.SHADOW);
                 MaterializedIndex baseIndex = physicalPartition.getIndex(baseIndexId);
+                // index state is SHADOW
+                MaterializedIndex mvIndex = new MaterializedIndex(rollupIndexId,
+                        MaterializedIndex.IndexState.SHADOW,
+                        PhysicalPartition.INVALID_SHARD_GROUP_ID,
+                        baseIndex.getBucketNum());
                 TabletMeta mvTabletMeta = new TabletMeta(dbId, olapTable.getId(),
                         physicalPartitionId, rollupIndexId, mvSchemaHash, medium);
                 for (Tablet baseTablet : baseIndex.getTablets()) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
@@ -470,8 +470,9 @@ public class ExternalOlapTable extends OlapTable {
             PhysicalPartition physicalPartition = new PhysicalPartition(GlobalStateMgr.getCurrentState().getNextId(),
                     partitionMeta.getPartition_name(),
                     partitionMeta.getPartition_id(), // TODO(wulei): fix it
+                    PhysicalPartition.INVALID_SHARD_GROUP_ID,
+                    partitionMeta.getBucket_num(),
                     null);
-            physicalPartition.setBucketNum(defaultDistributionInfo.getBucketNum());
 
             logicalPartition.addSubPartition(physicalPartition);
 
@@ -480,7 +481,9 @@ public class ExternalOlapTable extends OlapTable {
                     partitionMeta.getVisible_time());
             for (TIndexMeta indexMeta : meta.getIndexes()) {
                 MaterializedIndex index = new MaterializedIndex(indexMeta.getIndex_id(),
-                        IndexState.fromThrift(indexMeta.getIndex_state()));
+                        IndexState.fromThrift(indexMeta.getIndex_state()),
+                        PhysicalPartition.INVALID_SHARD_GROUP_ID,
+                        indexMeta.getBucket_num());
                 index.setRowCount(indexMeta.getRow_count());
                 for (TTabletMeta tTabletMeta : indexMeta.getTablets()) {
                     LocalTablet tablet = new LocalTablet(tTabletMeta.getTablet_id());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
@@ -110,13 +110,16 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
     @SerializedName(value = "shardGroupId")
     private long shardGroupId = PhysicalPartition.INVALID_SHARD_GROUP_ID;
 
+    @SerializedName(value = "bucketNum")
+    private int bucketNum = 0;
+
     // If this is an index of LakeTable and the index state is SHADOW, all transactions
     // whose txn id is less than 'visibleTxnId' will ignore this index when sending
     // PublishVersionRequest requests to BE nodes.
     private long visibleTxnId;
 
     public MaterializedIndex() {
-        this(0, IndexState.NORMAL, PhysicalPartition.INVALID_SHARD_GROUP_ID);
+        this(0);
     }
 
     public MaterializedIndex(long id) {
@@ -124,11 +127,11 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
     }
 
     public MaterializedIndex(long id, @Nullable IndexState state) {
-        this(id, state, 0, PhysicalPartition.INVALID_SHARD_GROUP_ID);
+        this(id, state, 0, PhysicalPartition.INVALID_SHARD_GROUP_ID, 0);
     }
 
-    public MaterializedIndex(long id, @Nullable IndexState state, long shardGroupId) {
-        this(id, state, 0, shardGroupId);
+    public MaterializedIndex(long id, @Nullable IndexState state, long shardGroupId, int bucketNum) {
+        this(id, state, 0, shardGroupId, bucketNum);
     }
 
     /**
@@ -140,7 +143,7 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
      * @param state        the state of the index
      * @param visibleTxnId the minimum transaction id that can see this index.
      */
-    public MaterializedIndex(long id, @Nullable IndexState state, long visibleTxnId, long shardGroupId) {
+    public MaterializedIndex(long id, @Nullable IndexState state, long visibleTxnId, long shardGroupId, int bucketNum) {
         this.id = id;
         this.state = state == null ? IndexState.NORMAL : state;
         this.idToTablets = new HashMap<>();
@@ -148,6 +151,7 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
         this.rowCount = 0;
         this.visibleTxnId = (this.state == IndexState.SHADOW) ? visibleTxnId : 0;
         this.shardGroupId = shardGroupId;
+        this.bucketNum = bucketNum;
     }
 
     /**
@@ -182,6 +186,14 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
 
     public long getShardGroupId() {
         return shardGroupId;
+    }
+
+    public int getBucketNum() {
+        return bucketNum;
+    }
+
+    public void setBucketNum(int bucketNum) {
+        this.bucketNum = bucketNum;
     }
 
     public List<Tablet> getTablets() {
@@ -334,6 +346,7 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
         buffer.append("index id: ").append(id).append("; ");
         buffer.append("index state: ").append(state.name()).append("; ");
         buffer.append("shardGroupId: ").append(shardGroupId).append("; ");
+        buffer.append("bucket num: ").append(bucketNum).append("; ");
         buffer.append("row count: ").append(rowCount).append("; ");
         buffer.append("tablets size: ").append(tablets.size()).append("; ");
         buffer.append("visibleTxnId: ").append(visibleTxnId).append("; ");

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
@@ -123,10 +123,13 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
 
     }
 
-    public PhysicalPartition(long id, String name, long parentId, MaterializedIndex baseIndex) {
+    public PhysicalPartition(long id, String name, long parentId, long shardGroupId, int bucketNum,
+            MaterializedIndex baseIndex) {
         this.id = id;
         this.name = name;
         this.parentId = parentId;
+        this.shardGroupId = shardGroupId;
+        this.bucketNum = bucketNum;
         this.baseIndex = baseIndex;
         this.visibleVersion = PARTITION_INIT_VERSION;
         this.visibleVersionTime = System.currentTimeMillis();

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/IndicesProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/IndicesProcDir.java
@@ -58,7 +58,7 @@ import java.util.List;
  */
 public class IndicesProcDir implements ProcDirInterface {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
-            .add("IndexId").add("IndexName").add("State").add("LastConsistencyCheckTime")
+            .add("IndexId").add("IndexName").add("State").add("LastConsistencyCheckTime").add("Buckets")
             .build();
 
     private Database db;
@@ -89,6 +89,7 @@ public class IndicesProcDir implements ProcDirInterface {
                 indexInfo.add(olapTable.getIndexNameById(materializedIndex.getId()));
                 indexInfo.add(materializedIndex.getState());
                 indexInfo.add(TimeUtils.longToTimeString(materializedIndex.getLastCheckTime()));
+                indexInfo.add(materializedIndex.getBucketNum());
 
                 indexInfos.add(indexInfo);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
@@ -357,8 +357,7 @@ public class PartitionsProcDir implements ProcDirInterface {
         partitionInfo.add(findRangeOrListValues(tblPartitionInfo, partition.getId()));
         DistributionInfo distributionInfo = partition.getDistributionInfo();
         partitionInfo.add(distributionKeyAsString(table, distributionInfo));
-        partitionInfo.add(physicalPartition.getBucketNum() > 0 ?
-                physicalPartition.getBucketNum() : distributionInfo.getBucketNum());
+        partitionInfo.add(physicalPartition.getBucketNum());
 
         short replicationNum = tblPartitionInfo.getReplicationNum(partition.getId());
         partitionInfo.add(String.valueOf(replicationNum));
@@ -400,7 +399,7 @@ public class PartitionsProcDir implements ProcDirInterface {
                 .stream().map(Column::getName).collect(Collectors.toList()))); // Partition key
         partitionInfo.add(findRangeOrListValues(tblPartitionInfo, partition.getId())); // List or Range
         partitionInfo.add(distributionKeyAsString(table, partition.getDistributionInfo())); // DistributionKey
-        partitionInfo.add(partition.getDistributionInfo().getBucketNum()); // Buckets
+        partitionInfo.add(physicalPartition.getBucketNum()); // Buckets
         partitionInfo.add(new ByteSizeValue(physicalPartition.storageDataSize())); // DataSize
         long storageSize = physicalPartition.storageDataSize() + physicalPartition.getExtraFileSize();
         partitionInfo.add(new ByteSizeValue(storageSize)); // StorageSize

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -990,6 +990,7 @@ public class LeaderImpl {
                 partitionMeta.setVisible_time(physicalPartition.getVisibleVersionTime());
                 partitionMeta.setNext_version(physicalPartition.getNextVersion());
                 partitionMeta.setIs_temp(olapTable.getPartition(partition.getName(), true) != null);
+                partitionMeta.setBucket_num(physicalPartition.getBucketNum());
                 tableMeta.addToPartitions(partitionMeta);
                 short replicaNum = partitionInfo.getReplicationNum(partition.getId());
                 boolean inMemory = partitionInfo.getIsInMemory(partition.getId());
@@ -1126,6 +1127,7 @@ public class LeaderImpl {
                             throw new NotImplementedException(tablet.getClass().getName() + " is not implemented");
                         }
                         indexMeta.addToTablets(tTabletMeta);
+                        indexMeta.setBucket_num(index.getBucketNum());
                     }
                     tableMeta.addToIndexes(indexMeta);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -3239,6 +3239,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                 partitionMeta.setVisible_time(physicalPartition.getVisibleVersionTime());
                 partitionMeta.setNext_version(physicalPartition.getNextVersion());
                 partitionMeta.setIs_temp(olapTable.isTempPartition(parentPartitionId));
+                partitionMeta.setBucket_num(physicalPartition.getBucketNum());
                 result.add(partitionMeta);
                 donePartitionIds.add(partitionId);
             } finally {

--- a/fe/fe-core/src/test/java/com/starrocks/backup/CatalogMocker.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/CatalogMocker.java
@@ -493,9 +493,13 @@ public class CatalogMocker {
                             TEST_PARTITION1_NAME, baseIndexP1, distributionInfo4);
 
             PhysicalPartition physicalPartition2 = new PhysicalPartition(
-                        TEST_PARTITION2_ID, "pp2", TEST_PARTITION1_ID, baseIndexP2);
+                    TEST_PARTITION2_ID, "pp2", TEST_PARTITION1_ID,
+                    PhysicalPartition.INVALID_SHARD_GROUP_ID, 0,
+                    baseIndexP2);
             PhysicalPartition physicalPartition3 = new PhysicalPartition(
-                        TEST_PARTITION3_ID, "pp3", TEST_PARTITION1_ID, baseIndexP3);
+                        TEST_PARTITION3_ID, "pp3", TEST_PARTITION1_ID,
+                        PhysicalPartition.INVALID_SHARD_GROUP_ID, 0, 
+                        baseIndexP3);
             partition1.addSubPartition(physicalPartition2);
             partition1.addSubPartition(physicalPartition3);
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedIndexTest.java
@@ -84,14 +84,14 @@ public class MaterializedIndexTest {
         Assert.assertTrue(index.visibleForTransaction(10));
 
         index = new MaterializedIndex(10, IndexState.NORMAL, 10,
-                PhysicalPartition.INVALID_SHARD_GROUP_ID);
+                PhysicalPartition.INVALID_SHARD_GROUP_ID, 0);
         Assert.assertTrue(index.visibleForTransaction(0));
         Assert.assertTrue(index.visibleForTransaction(9));
         Assert.assertTrue(index.visibleForTransaction(10));
         Assert.assertTrue(index.visibleForTransaction(11));
 
         index = new MaterializedIndex(10, IndexState.SHADOW, 10,
-                PhysicalPartition.INVALID_SHARD_GROUP_ID);
+                PhysicalPartition.INVALID_SHARD_GROUP_ID, 0);
         Assert.assertFalse(index.visibleForTransaction(0));
         Assert.assertFalse(index.visibleForTransaction(9));
         Assert.assertTrue(index.visibleForTransaction(10));

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/PhysicalPartitionImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/PhysicalPartitionImplTest.java
@@ -40,7 +40,9 @@ public class PhysicalPartitionImplTest {
 
     @Test
     public void testPhysicalPartition() throws Exception {
-        PhysicalPartition p = new PhysicalPartition(1, "", 1, new MaterializedIndex());
+        PhysicalPartition p = new PhysicalPartition(1, "", 1,
+                PhysicalPartition.INVALID_SHARD_GROUP_ID, 0,
+                new MaterializedIndex());
         Assert.assertEquals(1, p.getId());
         Assert.assertEquals(1, p.getParentId());
         Assert.assertFalse(p.isImmutable());
@@ -106,7 +108,9 @@ public class PhysicalPartitionImplTest {
         Assert.assertTrue(p.equals(p));
         Assert.assertFalse(p.equals(new Partition(0, 11, "", null, null)));
 
-        PhysicalPartition p2 = new PhysicalPartition(1, "", 1, new MaterializedIndex());
+        PhysicalPartition p2 = new PhysicalPartition(1, "", 1,
+                PhysicalPartition.INVALID_SHARD_GROUP_ID, 0,
+                new MaterializedIndex());
         Assert.assertFalse(p.equals(p2));
         p2.setBaseIndex(new MaterializedIndex(1));
 
@@ -143,8 +147,12 @@ public class PhysicalPartitionImplTest {
 
     @Test
     public void testPhysicalPartitionEqual() throws Exception {
-        PhysicalPartition p1 = new PhysicalPartition(1, "", 1, new MaterializedIndex());
-        PhysicalPartition p2 = new PhysicalPartition(1, "", 1, new MaterializedIndex());
+        PhysicalPartition p1 = new PhysicalPartition(1, "", 1,
+                PhysicalPartition.INVALID_SHARD_GROUP_ID, 0,
+                new MaterializedIndex());
+        PhysicalPartition p2 = new PhysicalPartition(1, "", 1,
+                PhysicalPartition.INVALID_SHARD_GROUP_ID, 0,
+                new MaterializedIndex());
         Assert.assertTrue(p1.equals(p2));
 
         p1.createRollupIndex(new MaterializedIndex());

--- a/fe/fe-core/src/test/java/com/starrocks/clone/DiskAndTabletLoadReBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/DiskAndTabletLoadReBalancerTest.java
@@ -131,7 +131,7 @@ public class DiskAndTabletLoadReBalancerTest {
         database.registerTableUnlocked(table);
 
         PhysicalPartition physicalPartition = new PhysicalPartition(physicalPartitionId, "partition", partitionId,
-                materializedIndex);
+                PhysicalPartition.INVALID_SHARD_GROUP_ID, 0, materializedIndex);
 
         new Expectations() {
             {
@@ -299,7 +299,7 @@ public class DiskAndTabletLoadReBalancerTest {
         database.registerTableUnlocked(table);
 
         PhysicalPartition physicalPartition = new PhysicalPartition(physicalPartitionId, "partition", partitionId,
-                materializedIndex);
+                PhysicalPartition.INVALID_SHARD_GROUP_ID, 0, materializedIndex);
 
         new Expectations() {
             {
@@ -490,9 +490,9 @@ public class DiskAndTabletLoadReBalancerTest {
         database.registerTableUnlocked(table);
 
         PhysicalPartition physicalPartition1 = new PhysicalPartition(physicalPartitionId1, "partition1", partitionId1,
-                materializedIndex);
+                PhysicalPartition.INVALID_SHARD_GROUP_ID, 0, materializedIndex);
         PhysicalPartition physicalPartition2 = new PhysicalPartition(physicalPartitionId2, "partition2", partitionId2,
-                materializedIndex);
+                PhysicalPartition.INVALID_SHARD_GROUP_ID, 0, materializedIndex);
 
         new Expectations() {
             {
@@ -690,7 +690,7 @@ public class DiskAndTabletLoadReBalancerTest {
         database.registerTableUnlocked(table);
 
         PhysicalPartition physicalPartition = new PhysicalPartition(physicalPartitionId, "partition", partitionId,
-                materializedIndex);
+                PhysicalPartition.INVALID_SHARD_GROUP_ID, 0, materializedIndex);
 
         new Expectations() {
             {

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionJobTest.java
@@ -33,7 +33,8 @@ public class CompactionJobTest {
     public void testGetResult() {
         Database db = new Database();
         Table table = new Table(Table.TableType.CLOUD_NATIVE);
-        PhysicalPartition partition = new PhysicalPartition(0, "", 1, null);
+        PhysicalPartition partition = new PhysicalPartition(0, "", 1,
+                PhysicalPartition.INVALID_SHARD_GROUP_ID, 0, null);
         CompactionJob job = new CompactionJob(db, table, partition, 10010, true);
 
         Assert.assertTrue(job.getAllowPartialSuccess());
@@ -78,7 +79,8 @@ public class CompactionJobTest {
     public void testBuildTabletCommitInfo() {
         Database db = new Database();
         Table table = new Table(Table.TableType.CLOUD_NATIVE);
-        PhysicalPartition partition = new PhysicalPartition(0, "", 1, null);
+        PhysicalPartition partition = new PhysicalPartition(0, "", 1,
+                PhysicalPartition.INVALID_SHARD_GROUP_ID, 0, null);
         CompactionJob job = new CompactionJob(db, table, partition, 10010, false);
         assertDoesNotThrow(() -> {
             job.buildTabletCommitInfo();
@@ -89,7 +91,8 @@ public class CompactionJobTest {
     public void testGetExecutionProfile() {
         Database db = new Database();
         Table table = new Table(Table.TableType.CLOUD_NATIVE);
-        PhysicalPartition partition = new PhysicalPartition(0, "", 1, null);
+        PhysicalPartition partition = new PhysicalPartition(0, "", 1,
+                PhysicalPartition.INVALID_SHARD_GROUP_ID, 0, null);
         CompactionJob job = new CompactionJob(db, table, partition, 10010, true);
 
         Assert.assertTrue(job.getExecutionProfile().isEmpty());
@@ -122,7 +125,8 @@ public class CompactionJobTest {
     public void testSuccessCompactInputFIleSize() {
         Database db = new Database();
         Table table = new Table(Table.TableType.CLOUD_NATIVE);
-        PhysicalPartition partition = new PhysicalPartition(0, "", 1, null);
+        PhysicalPartition partition = new PhysicalPartition(0, "", 1,
+                PhysicalPartition.INVALID_SHARD_GROUP_ID, 0, null);
         CompactionJob job = new CompactionJob(db, table, partition, 10010, true);
 
         Assert.assertTrue(job.getAllowPartialSuccess());

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionMgrTest.java
@@ -213,7 +213,8 @@ public class CompactionMgrTest {
                 PartitionIdentifier partitionIdentifier = new PartitionIdentifier(1, 2, 3);
                 Database db = new Database();
                 Table table = new LakeTable();
-                PhysicalPartition partition = new PhysicalPartition(123, "aaa", 123,  null);
+                PhysicalPartition partition = new PhysicalPartition(123, "aaa", 123,
+                        PhysicalPartition.INVALID_SHARD_GROUP_ID, 0, null);
                 CompactionJob job = new CompactionJob(db, table, partition, txnId, false);
                 r.put(partitionIdentifier, job);
                 return r;

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
@@ -106,8 +106,10 @@ public class CompactionSchedulerTest {
                 Table table = new LakeTable();
                 PartitionIdentifier partitionIdentifier1 = new PartitionIdentifier(1, 2, 3);
                 PartitionIdentifier partitionIdentifier2 = new PartitionIdentifier(1, 2, 4);
-                PhysicalPartition partition1 = new PhysicalPartition(123, "aaa", 123, null);
-                PhysicalPartition partition2 = new PhysicalPartition(124, "bbb", 124, null);
+                PhysicalPartition partition1 = new PhysicalPartition(123, "aaa", 123,
+                        PhysicalPartition.INVALID_SHARD_GROUP_ID, 0, null);
+                PhysicalPartition partition2 = new PhysicalPartition(124, "bbb", 124,
+                        PhysicalPartition.INVALID_SHARD_GROUP_ID, 0, null);
                 CompactionJob job1 = new CompactionJob(db, table, partition1, 100, false);
                 try {
                     Thread.sleep(10);
@@ -193,7 +195,8 @@ public class CompactionSchedulerTest {
                 Database db = new Database();
                 Table table = new LakeTable();
                 long partitionId = partitionStatisticsSnapshot.getPartition().getPartitionId();
-                PhysicalPartition partition = new PhysicalPartition(partitionId, "aaa", partitionId, null);
+                PhysicalPartition partition = new PhysicalPartition(partitionId, "aaa", partitionId,
+                        PhysicalPartition.INVALID_SHARD_GROUP_ID, 0, null);
                 return new CompactionJob(db, table, partition, 100, false);
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -464,10 +464,12 @@ public class OlapTableSinkTest {
         RandomDistributionInfo distInfo = new RandomDistributionInfo(3);
         Partition partition = new Partition(2, 22, "p1", index, distInfo);
 
-        PhysicalPartition physicalPartition = new PhysicalPartition(3, "", 2, index);
+        PhysicalPartition physicalPartition = new PhysicalPartition(3, "", 2,
+                PhysicalPartition.INVALID_SHARD_GROUP_ID, 0, index);
         partition.addSubPartition(physicalPartition);
 
-        physicalPartition = new PhysicalPartition(4, "", 2, index);
+        physicalPartition = new PhysicalPartition(4, "", 2,
+                PhysicalPartition.INVALID_SHARD_GROUP_ID, 0, index);
         physicalPartition.setImmutable(true);
         partition.addSubPartition(physicalPartition);
 
@@ -504,10 +506,12 @@ public class OlapTableSinkTest {
         RandomDistributionInfo distInfo = new RandomDistributionInfo(3);
         Partition partition = new Partition(2, 22, "p1", index, distInfo);
 
-        PhysicalPartition physicalPartition = new PhysicalPartition(3, "", 2, index);
+        PhysicalPartition physicalPartition = new PhysicalPartition(3, "", 2,
+                PhysicalPartition.INVALID_SHARD_GROUP_ID, 0, index);
         partition.addSubPartition(physicalPartition);
 
-        physicalPartition = new PhysicalPartition(4, "", 2, index);
+        physicalPartition = new PhysicalPartition(4, "", 2,
+                PhysicalPartition.INVALID_SHARD_GROUP_ID, 0, index);
         physicalPartition.setImmutable(true);
         partition.addSubPartition(physicalPartition);
 
@@ -548,10 +552,12 @@ public class OlapTableSinkTest {
         RandomDistributionInfo distInfo = new RandomDistributionInfo(3);
         Partition partition = new Partition(2, 22, "p1", index, distInfo);
 
-        PhysicalPartition physicalPartition = new PhysicalPartition(3, "", 2, index);
+        PhysicalPartition physicalPartition = new PhysicalPartition(3, "", 2,
+                PhysicalPartition.INVALID_SHARD_GROUP_ID, 0, index);
         partition.addSubPartition(physicalPartition);
 
-        physicalPartition = new PhysicalPartition(4, "", 2, index);
+        physicalPartition = new PhysicalPartition(4, "", 2,
+                PhysicalPartition.INVALID_SHARD_GROUP_ID, 0, index);
         physicalPartition.setImmutable(true);
         partition.addSubPartition(physicalPartition);
 

--- a/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
@@ -183,7 +183,9 @@ public class LocalMetaStoreTest {
                     index.getId(), schemaHash, table.getPartitionInfo().getDataProperty(p.getParentId()).getStorageMedium());
         index.addTablet(new LocalTablet(0), tabletMeta);
         PhysicalPartitionPersistInfoV2 info = new PhysicalPartitionPersistInfoV2(
-                    db.getId(), table.getId(), p.getParentId(), new PhysicalPartition(123, "", p.getId(), index));
+                    db.getId(), table.getId(), p.getParentId(),
+                    new PhysicalPartition(123, "", p.getId(),
+                        PhysicalPartition.INVALID_SHARD_GROUP_ID, 0, index));
 
         LocalMetastore localMetastore = connectContext.getGlobalStateMgr().getLocalMetastore();
         localMetastore.replayAddSubPartition(info);

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/MockedLocalMetaStore.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/MockedLocalMetaStore.java
@@ -150,6 +150,8 @@ public class MockedLocalMetaStore extends LocalMetastore {
                 physicalPartitionId,
                 logicalPartition.generatePhysicalPartitionName(physicalPartitionId),
                 partitionId,
+                PhysicalPartition.INVALID_SHARD_GROUP_ID,
+                0,
                 null);
         physicalPartition.setBucketNum(distributionInfo.getBucketNum());
 

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1259,6 +1259,7 @@ struct TIndexMeta {
     6: optional i64 rollup_finished_version
     7: optional TSchemaMeta schema_meta
     8: optional list<TTabletMeta> tablets
+    9: optional i32 bucket_num
 }
 
 struct TDataProperty {
@@ -1309,6 +1310,7 @@ struct TPartitionMeta {
     8: optional i64 next_version
     9: optional i64 next_version_hash // Deprecated
     10: optional bool is_temp
+    11: optional i32 bucket_num
 }
 
 struct THashDistributionInfo {


### PR DESCRIPTION
## Why I'm doing:
This is a preliminary work of tablet splitting.
Previously, bucket number is at physical partition level. All materialized indexes in a physical partition must have the same bucket number. But after tablet splitting, different materialized index in a physical partition could has different bucket number.

## What I'm doing:
Change bucket number from physical partition level to materialized index level.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
