### PR TITLE
[BugFix] Fix mv refresh external table error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -76,6 +76,7 @@ import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.StatementPlanner;
+import com.starrocks.sql.analyzer.MaterializedViewAnalyzer;
 import com.starrocks.sql.analyzer.PlannerMetaLocker;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.PartitionNames;
@@ -792,7 +793,9 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
             // refresh old table
             Table table = optTable.get();
-            if (table.isNativeTableOrMaterializedView() || table.isView()) {
+            // if table is native table or materialized view or connector view or external table, no need to refresh
+            if (table.isNativeTableOrMaterializedView() || table.isView()
+                    || MaterializedViewAnalyzer.isExternalTableFromResource(table)) {
                 logger.debug("No need to refresh table:{} because it is native table or mv or connector view",
                         baseTableInfo.getTableInfoStr());
                 continue;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -56,6 +56,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
 import com.starrocks.sql.analyzer.AlterSystemStmtAnalyzer;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
+import com.starrocks.sql.analyzer.MaterializedViewAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AsyncRefreshSchemeDesc;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
@@ -5679,5 +5680,24 @@ public class CreateMaterializedViewTest extends MVTestBase {
         Assert.assertTrue(result2.equals(result));
 
         starRocksAssert.dropTable("list_partition_tbl1");
+    }
+
+    @Test
+    public void testRefreshMVWithExternalTable() throws Exception {
+        new MockUp<MaterializedViewAnalyzer>() {
+            @Mock
+            public static boolean isExternalTableFromResource(Table t) {
+                return true;
+            }
+        };
+        String sql = "create materialized view mv1 " +
+                "distributed by hash(k2) buckets 10 " +
+                "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")" +
+                "as select tbl1.k1 ss, tbl1.k2 from mysql_external_table tbl1;";
+        starRocksAssert.withMaterializedView(sql);
+        starRocksAssert.refreshMV(connectContext, "mv1");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -5683,13 +5683,26 @@ public class CreateMaterializedViewTest extends MVTestBase {
     }
 
     @Test
-    public void testRefreshMVWithExternalTable() throws Exception {
+    public void testRefreshMVWithExternalTable1() throws Exception {
         new MockUp<MaterializedViewAnalyzer>() {
             @Mock
             public static boolean isExternalTableFromResource(Table t) {
                 return true;
             }
         };
+        String sql = "create materialized view mv1 " +
+                "distributed by hash(k2) buckets 10 " +
+                "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")" +
+                "as select tbl1.k1 ss, tbl1.k2 from mysql_external_table tbl1;";
+        starRocksAssert.withMaterializedView(sql);
+        starRocksAssert.refreshMV(connectContext, "mv1");
+    }
+
+    @Test
+    public void testRefreshMVWithExternalTable2() throws Exception {
         String sql = "create materialized view mv1 " +
                 "distributed by hash(k2) buckets 10 " +
                 "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +


### PR DESCRIPTION
## Why I'm doing:
#59287 make it  more strict in mv refreshing when it meets base table's identifier is not the same, but it will break `external tables`.


In the sql tester  case `test_mv_with_external_table` , it will meet exception below:
```
mysql> show materialized views\G:
*************************** 1. row ***************************
                                  id: 25115
                       database_name: db_a69beb0a942746b08dea0d192ac124cb
                                name: test_mv1
                        refresh_type: MANUAL
                           is_active: false
                     inactive_reason: base-table changed: external_mysql_t1
                      partition_type: UNPARTITIONED
                             task_id: 25123
                           task_name: mv-25115
             last_refresh_start_time: 2025-05-27 10:40:36
          last_refresh_finished_time: 2025-05-27 10:40:37
               last_refresh_duration: 1.014
                  last_refresh_state: FAILED
          last_refresh_force_refresh: false
        last_refresh_start_partition: NULL
          last_refresh_end_partition: NULL
last_refresh_base_refresh_partitions: {}
  last_refresh_mv_refresh_partitions: []
             last_refresh_error_code: -1
          last_refresh_error_message: Refresh mv test_mv1 failed after 1 times, try lock failed: 0, error-msg : com.starrocks.sql.common.DmlException: Table external_mysql_t1 is recreated and needed to be repaired, but it is not supported by MVPCTMetaRepairer: default_catalog.25112.25113, set mv test_mv1 inactive
        at com.starrocks.scheduler.mv.MVPCTMetaRepairer.repairMetaIfNeeded(MVPCTMetaRepairer.java:75)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.refreshExternalTable(PartitionBasedMvRefreshProcessor.java:835)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.syncAndCheckPartitions(PartitionBasedMvRefreshProcessor.java:251)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedView(PartitionBasedMvRefreshProcessor.java:454)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedViewWithRetry(PartitionBasedMvRefreshProcessor.java:392)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doMvRefresh(PartitionBasedMvRefreshProcessor.java:353)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.processTaskRun(PartitionBasedMvRefreshProcessor.java:202)
        at com.starrocks.scheduler.TaskRun.executeTaskRun(TaskRun.java:312)
        at com.starrocks.scheduler.TaskRunExecutor.lambda$executeTaskRun$0(TaskRunExecutor.java:60)
        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
                                rows: 0
                                text: CREATE MATERIALIZED VIEW `test_mv1` (`dt`, `num`)
DISTRIBUTED BY RANDOM
REFRESH DEFERRED MANUAL
PROPERTIES (
"replicated_storage" = "true",
"replication_num" = "1",
"storage_medium" = "HDD"
)
AS SELECT `external_mysql_t1`.`dt`, sum(`external_mysql_t1`.`num`) AS `num`
FROM `db_a69beb0a942746b08dea0d192ac124cb`.`external_mysql_t1`
GROUP BY `external_mysql_t1`.`dt`;
                       extra_message: {"queryIds":["f7d643e6-3aa3-11f0-8bcb-765d87dda2da"],"isManual":true,"isSync":false,"isReplay":false,"priority":80,"lastTaskRunState":"FAILED"}
                query_rewrite_status: INVALID: MV is not active
                             creator: 'root'@'%'

```
## What I'm doing:
- Skip to refresh external tables to avoid exceptions above.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
