### PR TITLE
[BugFix] Fix forgetting to set min version for showing single tablet info in shared-data mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/LakeTabletsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/LakeTabletsProcDir.java
@@ -166,7 +166,8 @@ public class LakeTabletsProcDir implements ProcDirInterface {
                     String.valueOf(tablet.getId()),
                     new Gson().toJson(tablet.getBackendIds(warehouseId)),
                     new ByteSizeValue(tablet.getDataSize(true)).toString(),
-                    String.valueOf(tablet.getRowCount(0L))
+                    String.valueOf(tablet.getRowCount(0L)),
+                    String.valueOf(tablet.getMinVersion())
             );
             result.addRow(row);
 


### PR DESCRIPTION
## Why I'm doing:
https://github.com/StarRocks/starrocks/pull/56244 introduced min_version for tablet in shared-data mode. But it only set min version for showing tablets' detail info within a materialized index and forgets to set min version for showing single tablet info.

## What I'm doing:
Set min version for showing single tablet info in shared-data mode

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
