### PR TITLE
[Enhancement]Replace exec with ast to load metadata safely

### DIFF
--- a/contrib/datadog-connector/starrocks_be/setup.py
+++ b/contrib/datadog-connector/starrocks_be/setup.py
@@ -1,6 +1,9 @@
 # (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import ast
+
+from ast import literal_eval
 from codecs import open  # To use a consistent encoding
 from os import path
 
@@ -10,8 +13,12 @@ HERE = path.dirname(path.abspath(__file__))
 
 # Get version info
 ABOUT = {}
-with open(path.join(HERE, 'datadog_checks', 'starrocks_be', '__about__.py')) as f:
-    exec(f.read(), ABOUT)
+about_path = path.join(HERE, 'datadog_checks', 'starrocks_be', '__about__.py')
+with open(about_path, 'r', encoding='utf-8') as f:
+    tree = ast.parse(f.read(), filename='__about__.py')
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and isinstance(node.targets[0], ast.Name):
+            ABOUT[node.targets[0].id] = literal_eval(node.value)
 
 # Get the long description from the README file
 with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:

--- a/contrib/datadog-connector/starrocks_fe/setup.py
+++ b/contrib/datadog-connector/starrocks_fe/setup.py
@@ -1,6 +1,9 @@
 # (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import ast
+
+from ast import literal_eval
 from codecs import open  # To use a consistent encoding
 from os import path
 
@@ -10,8 +13,12 @@ HERE = path.dirname(path.abspath(__file__))
 
 # Get version info
 ABOUT = {}
-with open(path.join(HERE, 'datadog_checks', 'starrocks_fe', '__about__.py')) as f:
-    exec(f.read(), ABOUT)
+about_path = path.join(HERE, 'datadog_checks', 'starrocks_be', '__about__.py')
+with open(about_path, 'r', encoding='utf-8') as f:
+    tree = ast.parse(f.read(), filename='__about__.py')
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and isinstance(node.targets[0], ast.Name):
+            ABOUT[node.targets[0].id] = literal_eval(node.value)
 
 # Get the long description from the README file
 with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:


### PR DESCRIPTION
## Why I'm doing:
Replace exec with ast for safely loading metadata from `__about__.py`
## What I'm doing:

Fixes #59376 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
