### PR TITLE
[Feature] Introduce virtual buckets metadata for dynamic tablet splitting and merging

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
@@ -102,9 +102,18 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
     @SerializedName(value = "rowCount")
     private long rowCount;
 
+    // Virtual buckets. Each virtual bucket saves a tablet id.
+    // We divide data into virtual buckets and then arrange these virtual buckets
+    // into physical buckets, which are tablets.
+    // Each virtual bucket is associated with a tablet. Multiple virtual buckets are
+    // allowed to be associated with the same tablet.
+    @SerializedName(value = "virtualBuckets")
+    private List<Long> virtualBuckets;
+
     private Map<Long, Tablet> idToTablets;
+
+    // Deprecated, virtual buckets keeps tablet order, keep this for compatibility
     @SerializedName(value = "tablets")
-    // this is for keeping tablet order
     private List<Tablet> tablets;
 
     @SerializedName(value = "shardGroupId")
@@ -143,6 +152,7 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
     public MaterializedIndex(long id, @Nullable IndexState state, long visibleTxnId, long shardGroupId) {
         this.id = id;
         this.state = state == null ? IndexState.NORMAL : state;
+        this.virtualBuckets = new ArrayList<>();
         this.idToTablets = new HashMap<>();
         this.tablets = new ArrayList<>();
         this.rowCount = 0;
@@ -184,6 +194,10 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
         return shardGroupId;
     }
 
+    public List<Long> getVirtualBuckets() {
+        return virtualBuckets;
+    }
+
     public List<Tablet> getTablets() {
         return tablets;
     }
@@ -201,6 +215,7 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
     }
 
     public void clearTabletsForRestore() {
+        virtualBuckets.clear();
         idToTablets.clear();
         tablets.clear();
     }
@@ -210,6 +225,7 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
     }
 
     public void addTablet(Tablet tablet, TabletMeta tabletMeta, boolean updateInvertedIndex) {
+        virtualBuckets.add(tablet.getId());
         idToTablets.put(tablet.getId(), tablet);
         tablets.add(tablet);
         if (updateInvertedIndex) {
@@ -280,6 +296,16 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
         }
     }
 
+    public List<Integer> getVirtualBucketsByTabletId(long tabletId) {
+        List<Integer> virtualBucketIndexes = new ArrayList<>();
+        for (int i = 0; i < virtualBuckets.size(); ++i) {
+            if (virtualBuckets.get(i).longValue() == tabletId) {
+                virtualBucketIndexes.add(i);
+            }
+        }
+        return virtualBucketIndexes;
+    }
+
     public int getTabletOrderIdx(long tabletId) {
         int idx = 0;
         for (Tablet tablet : tablets) {
@@ -312,7 +338,7 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(idToTablets);
+        return Objects.hashCode(virtualBuckets, idToTablets);
     }
 
     @Override
@@ -324,8 +350,8 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
             return false;
         }
         MaterializedIndex other = (MaterializedIndex) obj;
-        return idToTablets.equals(other.idToTablets) && state.equals(other.state) && (rowCount == other.rowCount) &&
-                (visibleTxnId == other.visibleTxnId);
+        return virtualBuckets.equals(other.virtualBuckets) && idToTablets.equals(other.idToTablets)
+                && state.equals(other.state) && (rowCount == other.rowCount) && (visibleTxnId == other.visibleTxnId);
     }
 
     @Override
@@ -335,8 +361,10 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
         buffer.append("index state: ").append(state.name()).append("; ");
         buffer.append("shardGroupId: ").append(shardGroupId).append("; ");
         buffer.append("row count: ").append(rowCount).append("; ");
-        buffer.append("tablets size: ").append(tablets.size()).append("; ");
         buffer.append("visibleTxnId: ").append(visibleTxnId).append("; ");
+        buffer.append("virtual buckets size: ").append(virtualBuckets.size()).append("; ");
+        buffer.append("virtual buckets: ").append(virtualBuckets).append("; ");
+        buffer.append("tablets size: ").append(tablets.size()).append("; ");
         buffer.append("tablets: [");
         for (Tablet tablet : tablets) {
             buffer.append("tablet: ").append(tablet.toString()).append(", ");
@@ -351,6 +379,17 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
         // build "idToTablets" from "tablets"
         for (Tablet tablet : tablets) {
             idToTablets.put(tablet.getId(), tablet);
+        }
+
+        // Build "virtualBuckets" from "tablets" when upgrading from old versions
+        // Before StarRocks didn't have virtual buckets, it would be empty when loading
+        // from the previous image.
+        // In this situation, the virtual bucket is equivalent to the physical tablet.
+        // So just fill the virtual buckets with the physical tablets.
+        if (virtualBuckets.isEmpty()) {
+            for (Tablet tablet : tablets) {
+                virtualBuckets.add(tablet.getId());
+            }
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/IndicesProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/IndicesProcDir.java
@@ -59,6 +59,7 @@ import java.util.List;
 public class IndicesProcDir implements ProcDirInterface {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("IndexId").add("IndexName").add("State").add("LastConsistencyCheckTime")
+            .add("VirtualBuckets").add("Tablets")
             .build();
 
     private Database db;
@@ -89,6 +90,8 @@ public class IndicesProcDir implements ProcDirInterface {
                 indexInfo.add(olapTable.getIndexNameById(materializedIndex.getId()));
                 indexInfo.add(materializedIndex.getState());
                 indexInfo.add(TimeUtils.longToTimeString(materializedIndex.getLastCheckTime()));
+                indexInfo.add(materializedIndex.getVirtualBuckets().size());
+                indexInfo.add(materializedIndex.getTablets().size());
 
                 indexInfos.add(indexInfo);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/LakeTabletsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/LakeTabletsProcDir.java
@@ -42,7 +42,8 @@ import java.util.List;
  */
 public class LakeTabletsProcDir implements ProcDirInterface {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
-            .add("TabletId").add("BackendId").add("DataSize").add("RowCount").add("MinVersion")
+            .add("TabletId").add("BackendId").add("DataSize").add("RowCount")
+            .add("MinVersion").add("VirtualBuckets")
             .build();
 
     private final Database db;
@@ -84,6 +85,7 @@ public class LakeTabletsProcDir implements ProcDirInterface {
                 tabletInfo.add(new ByteSizeValue(lakeTablet.getDataSize(true)));
                 tabletInfo.add(lakeTablet.getRowCount(0L));
                 tabletInfo.add(lakeTablet.getMinVersion());
+                tabletInfo.add(index.getVirtualBucketsByTabletId(lakeTablet.getId()).toString());
                 tabletInfos.add(tabletInfo);
             }
         } finally {
@@ -141,7 +143,7 @@ public class LakeTabletsProcDir implements ProcDirInterface {
                 throw new AnalysisException("Can't find tablet id: " + tabletIdStr);
             }
             Preconditions.checkState(tablet instanceof LakeTablet);
-            return new LakeTabletProcNode((LakeTablet) tablet);
+            return new LakeTabletProcNode(index, (LakeTablet) tablet);
         } finally {
             locker.unLockDatabase(db.getId(), LockType.READ);
         }
@@ -149,9 +151,11 @@ public class LakeTabletsProcDir implements ProcDirInterface {
 
     // Handle showing single tablet info
     public static class LakeTabletProcNode implements ProcNodeInterface {
+        private final MaterializedIndex index;
         private final LakeTablet tablet;
 
-        public LakeTabletProcNode(LakeTablet tablet) {
+        public LakeTabletProcNode(MaterializedIndex index, LakeTablet tablet) {
+            this.index = index;
             this.tablet = tablet;
         }
 
@@ -167,7 +171,8 @@ public class LakeTabletsProcDir implements ProcDirInterface {
                     new Gson().toJson(tablet.getBackendIds(warehouseId)),
                     new ByteSizeValue(tablet.getDataSize(true)).toString(),
                     String.valueOf(tablet.getRowCount(0L)),
-                    String.valueOf(tablet.getMinVersion())
+                    String.valueOf(tablet.getMinVersion()),
+                    index.getVirtualBucketsByTabletId(tablet.getId()).toString()
             );
             result.addRow(row);
 


### PR DESCRIPTION
## Why I'm doing:
This pr is a preliminary work for dynamic tablet splitting and merging.
We divide data into virtual buckets and then arrange these virtual buckets into physical buckets, which are tablets. Each virtual bucket is associated with a tablet. Multiple virtual buckets are allowed to be associated with the same tablet.
Before virtual buckets are introduced, logical buckets and physical buckets (tablets) are one-to-one, one bucket corresponds to one tablet, the bucket number is always equal to the tablet number.
After virtual buckets are introduced, logical buckets and physical buckets (tablets) are many-to-one, multiple buckets correspond to one tablet, the bucket number is always greater or equal to the tablet number. When a table or a partition is created, its bucket number and tablet number are the same at the begining, and they may be different after a while.
The concept of bucket number is already exists in starrocks. We keep it as the virtual bucket number. The concept of tablet number needs to be introduced. Users need to understand that bucket number and tablet number are no longer always the same.

## What I'm doing:
Introduce virtual buckets metadata for dynamic tablet splitting and merging.
The virtual buckets is not used in this pr, will be used in next pr.

This pr also add some fields to show virtual buckets.

Fixes https://github.com/StarRocks/starrocks/issues/59134

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
