### PR TITLE
[Enhancement] [BugFix] Optimize warehouse metrics queries

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/SystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/SystemTable.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.catalog.system;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.DescriptorTable.ReferencedPartitionInfo;
@@ -38,17 +39,25 @@ import com.starrocks.catalog.system.information.TemporaryTablesTable;
 import com.starrocks.catalog.system.information.ViewsSystemTable;
 import com.starrocks.catalog.system.information.WarehouseMetricsSystemTable;
 import com.starrocks.catalog.system.information.WarehouseQueriesSystemTable;
+import com.starrocks.common.util.DateUtils;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.thrift.TSchemaTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.NotImplementedException;
+import org.apache.thrift.protocol.TType;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.List;
+import java.util.Set;
 
 import static com.starrocks.catalog.InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
 
@@ -79,6 +88,15 @@ public class SystemTable extends Table {
                     .add(ViewsSystemTable.NAME)
                     .add(WarehouseMetricsSystemTable.NAME)
                     .add(WarehouseQueriesSystemTable.NAME)
+                    .build();
+
+    private static final ImmutableMap<Byte, Type> THRIFT_TO_SCALAR_TYPE_MAPPING =
+            ImmutableMap.<Byte, Type>builder()
+                    .put(TType.I16, Type.SMALLINT)
+                    .put(TType.I32, Type.INT)
+                    .put(TType.I64, Type.BIGINT)
+                    .put(TType.STRING, Type.STRING)
+                    .put(TType.BOOL, Type.BOOLEAN)
                     .build();
 
     private final TSchemaTableType schemaTableType;
@@ -174,12 +192,81 @@ public class SystemTable extends Table {
         return true;
     }
 
+
+    /**
+     * The thrift type may differ from schema-type, for example user a LONG timestamp in thrift, but return a
+     * DATETIME in the schema table.
+     */
+    protected static ConstantOperator mayCast(ConstantOperator value, Type schemaType) {
+        if (value.getType().equals(schemaType)) {
+            return value;
+        }
+        if (value.getType().isStringType() && schemaType.isStringType()) {
+            return value;
+        }
+        // From timestamp to DATETIME
+        if (value.getType().isBigint() && schemaType.isDatetime()) {
+            return ConstantOperator.createDatetime(DateUtils.fromEpochMillis(value.getBigint() * 1000, ZoneId.systemDefault()));
+        }
+        return value.castTo(schemaType)
+                .orElseThrow(() -> new NotImplementedException(String.format("unsupported type cast from %s to %s",
+                        value.getType(), schemaType)));
+    }
+
+    protected static Type thriftToScalarType(byte type) {
+        Type valueType = THRIFT_TO_SCALAR_TYPE_MAPPING.get(type);
+        if (valueType == null) {
+            throw new NotImplementedException("not supported type: " + type);
+        }
+        return valueType;
+    }
+
+    /**
+     * Check if the conjuncts only contains column equal constant operations, eg: c1=v1 AND c2=v2
+     * @param conjuncts: the conjuncts to check
+     * @return: true if all conjuncts are not empty and column equal constant operations
+     */
+    protected boolean isOnlyEqualConstantOps(List<ScalarOperator> conjuncts) {
+        return CollectionUtils.isNotEmpty(conjuncts) &&
+                conjuncts.stream().allMatch(ScalarOperator::isColumnEqualConstant);
+    }
+
+    /**
+     * Check if the conjuncts is empty or only contains column equal constant operations.
+     * @param conjuncts: the conjuncts to check
+     * @return: true if conjuncts is empty or all conjuncts are column equal constant operations
+     */
+    protected boolean isEmptyOrOnlyEqualConstantOps(List<ScalarOperator> conjuncts) {
+        return CollectionUtils.isEmpty(conjuncts) ||
+                conjuncts.stream().allMatch(ScalarOperator::isColumnEqualConstant);
+    }
+
+    /**
+     * Check if the equal predicate columns are supported by this system table.
+     * @param conjuncts: the conjuncts to check
+     * @param supportedColumns: the set of supported columns by this system table
+     * @return: true if all equal predicate columns are supported
+     */
+    protected boolean isSupportedEqualPredicateColumn(List<ScalarOperator> conjuncts,
+                                                      Set<String> supportedColumns) {
+        return conjuncts.stream()
+                .allMatch(conjunct -> {
+                    if (!(conjunct instanceof BinaryPredicateOperator)) {
+                        return false;
+                    }
+                    BinaryPredicateOperator binary = (BinaryPredicateOperator) conjunct;
+                    ColumnRefOperator columnRef = binary.getChild(0).cast();
+                    String name = columnRef.getName().toUpperCase();
+                    return supportedColumns.contains(name);
+                });
+    }
+
     /**
      * Whether this system table supports evaluation in FE
      *
      * @return true if it's supported
      */
-    public boolean supportFeEvaluation() {
+    public boolean supportFeEvaluation(ScalarOperator predicate) {
         return false;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ColumnStatsUsageSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ColumnStatsUsageSystemTable.java
@@ -15,7 +15,6 @@
 package com.starrocks.catalog.system.information;
 
 import com.google.api.client.util.Lists;
-import com.google.common.collect.ImmutableSet;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.InternalCatalog;
@@ -39,9 +38,11 @@ import com.starrocks.thrift.TColumnStatsUsageRes;
 import com.starrocks.thrift.TSchemaTableType;
 import org.apache.commons.lang3.NotImplementedException;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 /**
@@ -72,9 +73,14 @@ public class ColumnStatsUsageSystemTable extends SystemTable {
         return new ColumnStatsUsageSystemTable();
     }
 
-    private static final Set<String> SUPPORTED_EQUAL_COLUMNS = ImmutableSet.of(
-            "TABLE_CATALOG", "TABLE_DATABASE", "TABLE_NAME"
-    );
+    private static final Set<String> SUPPORTED_EQUAL_COLUMNS =
+            Collections.unmodifiableSet(new TreeSet<>(String.CASE_INSENSITIVE_ORDER) {
+                {
+                    add("TABLE_CATALOG");
+                    add("TABLE_DATABASE");
+                    add("TABLE_NAME");
+                }
+            });
 
     @Override
     public boolean supportFeEvaluation(ScalarOperator predicate) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ColumnStatsUsageSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ColumnStatsUsageSystemTable.java
@@ -84,7 +84,8 @@ public class ColumnStatsUsageSystemTable extends SystemTable {
 
     @Override
     public boolean supportFeEvaluation(ScalarOperator predicate) {
-        if (FeConstants.runningUnitTest) {
+        // TODO(FIXME): use it in the non unit test environment
+        if (!FeConstants.runningUnitTest) {
             return false;
         }
         final List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
@@ -13,20 +13,64 @@
 // limitations under the License.
 package com.starrocks.catalog.system.information;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.starrocks.authorization.AccessDeniedException;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndexMeta;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Type;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
+import com.starrocks.common.CaseSensibility;
+import com.starrocks.common.Pair;
+import com.starrocks.common.PatternMatcher;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ShowExecutor;
+import com.starrocks.qe.ShowMaterializedViewStatus;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.Authorizer;
+import com.starrocks.sql.ast.UserIdentity;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.thrift.TGetTablesParams;
+import com.starrocks.thrift.TListMaterializedViewStatusResult;
+import com.starrocks.thrift.TMaterializedViewStatus;
 import com.starrocks.thrift.TSchemaTableType;
+import com.starrocks.thrift.TUserIdentity;
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.thrift.TException;
+import org.apache.thrift.meta_data.FieldValueMetaData;
 
-import static com.starrocks.catalog.system.SystemTable.MAX_FIELD_VARCHAR_LENGTH;
-import static com.starrocks.catalog.system.SystemTable.builder;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
-public class MaterializedViewsSystemTable {
+import static com.starrocks.thrift.TTableType.MATERIALIZED_VIEW;
+
+public class MaterializedViewsSystemTable extends SystemTable {
     public static final String NAME = "materialized_views";
 
-    public static SystemTable create() {
-        return new SystemTable(SystemId.MATERIALIZED_VIEWS_ID,
+    private static final Logger LOG = LogManager.getLogger(MaterializedViewsSystemTable.class);
+    private static final SystemTable INSTANCE = new MaterializedViewsSystemTable();
+
+    public MaterializedViewsSystemTable() {
+        super(SystemId.MATERIALIZED_VIEWS_ID,
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
@@ -57,5 +101,229 @@ public class MaterializedViewsSystemTable {
                         .column("QUERY_REWRITE_STATUS", ScalarType.createVarcharType(64))
                         .column("CREATOR", ScalarType.createVarchar(64))
                         .build(), TSchemaTableType.SCH_MATERIALIZED_VIEWS);
+    }
+
+    public static SystemTable create() {
+        return new MaterializedViewsSystemTable();
+    }
+
+    private static final Set<String> SUPPORTED_EQUAL_COLUMNS =
+            Collections.unmodifiableSet(new TreeSet<>(String.CASE_INSENSITIVE_ORDER) {
+                {
+                    add("TABLE_SCHEMA");
+                    add("TABLE_NAME");
+                }
+            });
+
+    @Override
+    public boolean supportFeEvaluation(ScalarOperator predicate) {
+        final List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);
+        if (conjuncts.isEmpty()) {
+            return true;
+        }
+        if (!isEmptyOrOnlyEqualConstantOps(conjuncts)) {
+            return false;
+        }
+        return isSupportedEqualPredicateColumn(conjuncts, SUPPORTED_EQUAL_COLUMNS);
+    }
+
+    @Override
+    public List<List<ScalarOperator>> evaluate(ScalarOperator predicate) {
+        final List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);
+
+        ConnectContext context = Preconditions.checkNotNull(ConnectContext.get(), "not a valid connection");
+        TUserIdentity userIdentity = context.getCurrentUserIdentity().toThrift();
+        TGetTablesParams params = new TGetTablesParams();
+        params.setCurrent_user_ident(userIdentity);
+        params.setDb(context.getDatabase());
+        params.setType(MATERIALIZED_VIEW);
+        for (ScalarOperator conjunct : conjuncts) {
+            BinaryPredicateOperator binary = (BinaryPredicateOperator) conjunct;
+            ColumnRefOperator columnRef = binary.getChild(0).cast();
+            String name = columnRef.getName();
+            ConstantOperator value = binary.getChild(1).cast();
+            switch (name.toUpperCase()) {
+                case "TABLE_NAME":
+                    params.setTable_name(value.getVarchar());
+                    break;
+                case "TABLE_SCHEMA":
+                    params.setDb(value.getVarchar());
+                    break;
+                default:
+                    throw new NotImplementedException("unsupported column: " + name);
+            }
+        }
+
+        try {
+            TListMaterializedViewStatusResult result = query(params, context);
+            return result.getMaterialized_views().stream().map(this::infoToScalar).collect(Collectors.toList());
+        } catch (Exception e) {
+            LOG.warn("Failed to query materialized views", e);
+            // Return empty result if query failed
+            return Lists.newArrayList();
+        }
+    }
+
+    private static final Map<String, String> ALIAS_MAP = ImmutableMap.of(
+            "materialized_view_id", "id",
+            "table_schema", "database_name",
+            "table_name", "name",
+            "materialized_view_definition", "text",
+            "table_rows", "rows"
+    );
+
+    private List<ScalarOperator> infoToScalar(TMaterializedViewStatus status) {
+        List<ScalarOperator> result = Lists.newArrayList();
+        for (Column column : INSTANCE.getBaseSchema()) {
+            String name = column.getName().toLowerCase();
+            if (ALIAS_MAP.containsKey(name)) {
+                name = ALIAS_MAP.get(name);
+            }
+            TMaterializedViewStatus._Fields field = TMaterializedViewStatus._Fields.findByName(name);
+            Preconditions.checkArgument(field != null, "Unknown field: " + name);
+            FieldValueMetaData meta = TMaterializedViewStatus.metaDataMap.get(field).valueMetaData;
+            Object obj = status.getFieldValue(field);
+            Type valueType = thriftToScalarType(meta.type);
+            ConstantOperator scalar = ConstantOperator.createNullableObject(obj, valueType);
+            scalar = mayCast(scalar, column.getType());
+            result.add(scalar);
+        }
+        return result;
+    }
+
+    public static TListMaterializedViewStatusResult query(TGetTablesParams params,
+                                                          ConnectContext context) throws TException {
+        LOG.debug("get list table request: {}", params);
+        PatternMatcher matcher = null;
+        boolean caseSensitive = CaseSensibility.TABLE.getCaseSensibility();
+        if (params.isSetPattern()) {
+            matcher = PatternMatcher.createMysqlPattern(params.getPattern(), caseSensitive);
+        }
+
+        // database privs should be checked in analysis phrase
+        long limit = params.isSetLimit() ? params.getLimit() : -1;
+        if (params.isSetCurrent_user_ident()) {
+            context.setAuthInfoFromThrift(params.getCurrent_user_ident());
+        } else {
+            UserIdentity currentUser = UserIdentity.createAnalyzedUserIdentWithIp(params.user, params.user_ip);
+            context.setCurrentUserIdentity(currentUser);
+            context.setCurrentRoleIds(currentUser);
+        }
+        Preconditions.checkState(params.isSetType() && MATERIALIZED_VIEW.equals(params.getType()));
+        return listMaterializedViewStatus(limit, matcher, context, params);
+    }
+
+    // list MaterializedView table match pattern
+    private static TListMaterializedViewStatusResult listMaterializedViewStatus(
+            long limit,
+            PatternMatcher matcher,
+            ConnectContext context,
+            TGetTablesParams params) {
+        TListMaterializedViewStatusResult result = new TListMaterializedViewStatusResult();
+        List<TMaterializedViewStatus> tablesResult = Lists.newArrayList();
+        result.setMaterialized_views(tablesResult);
+        String dbName = params.getDb();
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+        if (db == null) {
+            LOG.warn("database not exists: {}", dbName);
+            return result;
+        }
+
+        listMaterializedViews(limit, matcher, context, params).stream()
+                .map(s -> s.toThrift())
+                .forEach(t -> tablesResult.add(t));
+        return result;
+    }
+
+    private static void filterAsynchronousMaterializedView(
+            PatternMatcher matcher,
+            ConnectContext context,
+            String dbName,
+            MaterializedView mv,
+            TGetTablesParams params,
+            List<MaterializedView> result) {
+        // check table name
+        String mvName = params.table_name;
+        if (mvName != null && !mvName.equalsIgnoreCase(mv.getName())) {
+            return;
+        }
+
+        try {
+            Authorizer.checkAnyActionOnTableLikeObject(context, dbName, mv);
+        } catch (AccessDeniedException e) {
+            return;
+        }
+
+        boolean caseSensitive = CaseSensibility.TABLE.getCaseSensibility();
+        if (!PatternMatcher.matchPattern(params.getPattern(), mv.getName(), matcher, caseSensitive)) {
+            return;
+        }
+        result.add(mv);
+    }
+
+    private static void filterSynchronousMaterializedView(
+            OlapTable olapTable,
+            PatternMatcher matcher,
+            TGetTablesParams params,
+            List<Pair<OlapTable, MaterializedIndexMeta>> singleTableMVs) {
+        // synchronized materialized view metadata size should be greater than 1.
+        if (olapTable.getVisibleIndexMetas().size() <= 1) {
+            return;
+        }
+
+        // check table name
+        String mvName = params.table_name;
+        if (mvName != null && !mvName.equalsIgnoreCase(olapTable.getName())) {
+            return;
+        }
+
+        List<MaterializedIndexMeta> visibleMaterializedViews = olapTable.getVisibleIndexMetas();
+        long baseIdx = olapTable.getBaseIndexId();
+        boolean caseSensitive = CaseSensibility.TABLE.getCaseSensibility();
+        for (MaterializedIndexMeta mvMeta : visibleMaterializedViews) {
+            if (baseIdx == mvMeta.getIndexId()) {
+                continue;
+            }
+
+            if (!PatternMatcher.matchPattern(params.getPattern(), olapTable.getIndexNameById(mvMeta.getIndexId()),
+                    matcher, caseSensitive)) {
+                continue;
+            }
+            singleTableMVs.add(Pair.create(olapTable, mvMeta));
+        }
+    }
+
+    private static List<ShowMaterializedViewStatus> listMaterializedViews(
+            long limit,
+            PatternMatcher matcher,
+            ConnectContext context,
+            TGetTablesParams params) {
+        String dbName = params.getDb();
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+        List<MaterializedView> materializedViews = com.google.common.collect.Lists.newArrayList();
+        List<Pair<OlapTable, MaterializedIndexMeta>> singleTableMVs = com.google.common.collect.Lists.newArrayList();
+        Locker locker = new Locker();
+        locker.lockDatabase(db.getId(), LockType.READ);
+        try {
+            for (Table table : GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId())) {
+                if (table.isMaterializedView()) {
+                    filterAsynchronousMaterializedView(matcher, context, dbName,
+                            (MaterializedView) table, params, materializedViews);
+                } else if (table.getType() == Table.TableType.OLAP) {
+                    filterSynchronousMaterializedView((OlapTable) table, matcher, params, singleTableMVs);
+                } else {
+                    // continue
+                }
+
+                // check limit
+                int mvSize = materializedViews.size() + singleTableMVs.size();
+                if (limit > 0 && mvSize >= limit) {
+                    break;
+                }
+            }
+        } finally {
+            locker.unLockDatabase(db.getId(), LockType.READ);
+        }
+        return ShowExecutor.listMaterializedViewStatus(dbName, materializedViews, singleTableMVs);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
@@ -184,6 +184,9 @@ public class MaterializedViewsSystemTable extends SystemTable {
             FieldValueMetaData meta = TMaterializedViewStatus.metaDataMap.get(field).valueMetaData;
             Object obj = status.getFieldValue(field);
             Type valueType = thriftToScalarType(meta.type);
+            if (valueType.isStringType() && obj == null) {
+                obj = ""; // Convert null string to empty string
+            }
             ConstantOperator scalar = ConstantOperator.createNullableObject(obj, valueType);
             scalar = mayCast(scalar, column.getType());
             result.add(scalar);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/WarehouseMetricsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/WarehouseMetricsSystemTable.java
@@ -13,26 +13,44 @@
 // limitations under the License.
 package com.starrocks.catalog.system.information;
 
+import com.google.api.client.util.Lists;
+import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
+import com.starrocks.qe.scheduler.slot.BaseSlotManager;
+import com.starrocks.qe.scheduler.slot.BaseSlotTracker;
+import com.starrocks.qe.scheduler.warehouse.WarehouseMetrics;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.thrift.TSchemaTableType;
+import com.starrocks.warehouse.Warehouse;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.NotImplementedException;
 
-import static com.starrocks.catalog.system.SystemTable.FN_REFLEN;
-import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
-import static com.starrocks.catalog.system.SystemTable.builder;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
-public class WarehouseMetricsSystemTable {
+public class WarehouseMetricsSystemTable extends SystemTable {
     public static final String NAME = "warehouse_metrics";
 
-    public static SystemTable create() {
-        return new SystemTable(
+    public WarehouseMetricsSystemTable() {
+        super(
                 SystemId.WAREHOUSE_METRICS_ID,
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("WAREHOUSE_ID", ScalarType.createVarchar(FN_REFLEN))
+                        .column("WAREHOUSE_ID", ScalarType.createType(PrimitiveType.BIGINT))
                         .column("WAREHOUSE_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .column("QUEUE_PENDING_LENGTH", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .column("QUEUE_RUNNING_LENGTH", ScalarType.createVarchar(NAME_CHAR_LEN))
@@ -45,5 +63,73 @@ public class WarehouseMetricsSystemTable {
                         .column("MAX_SLOTS", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .column("EXTRA_MESSAGE", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .build(), TSchemaTableType.SCH_WAREHOUSE_METRICS);
+    }
+
+    public static SystemTable create() {
+        return new WarehouseMetricsSystemTable();
+    }
+
+    private static final Set<String> SUPPORTED_EQUAL_COLUMNS =
+            Collections.unmodifiableSet(new TreeSet<>(String.CASE_INSENSITIVE_ORDER) {
+                {
+                    add("WAREHOUSE_ID");
+                    add("WAREHOUSE_NAME");
+                }
+            });
+
+    @Override
+    public boolean supportFeEvaluation(ScalarOperator predicate) {
+        final List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);
+        if (conjuncts.isEmpty()) {
+            return true;
+        }
+        if (!isEmptyOrOnlyEqualConstantOps(conjuncts) || conjuncts.size() != 1) {
+            return false;
+        }
+        return isSupportedEqualPredicateColumn(conjuncts, SUPPORTED_EQUAL_COLUMNS);
+    }
+
+    @Override
+    public List<List<ScalarOperator>> evaluate(ScalarOperator predicate) {
+        final BaseSlotManager slotManager = GlobalStateMgr.getCurrentState().getSlotManager();
+        final List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);
+        if (CollectionUtils.isEmpty(conjuncts)) {
+            final Map<Long, BaseSlotTracker> warehouseTrackers = slotManager.getWarehouseIdToSlotTracker();
+            return warehouseTrackers.values().stream()
+                    .map(tracker -> WarehouseMetrics.create(tracker).toConstantOperators())
+                    .collect(Collectors.toUnmodifiableList());
+        } else {
+            List<List<ScalarOperator>> result = Lists.newArrayList();
+            ScalarOperator conjunct = conjuncts.get(0);
+            BinaryPredicateOperator binary = (BinaryPredicateOperator) conjunct;
+            ColumnRefOperator columnRef = binary.getChild(0).cast();
+            String name = columnRef.getName();
+            ConstantOperator value = binary.getChild(1).cast();
+
+            final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+            Warehouse warehouse;
+            switch (name.toUpperCase()) {
+                case "WAREHOUSE_ID": {
+                    long warehouseId = value.getBigint();
+                    warehouse = warehouseManager.getWarehouse(warehouseId);
+                    break;
+                }
+                case "WAREHOUSE_NAME":
+                    String warehouseName = value.getVarchar();
+                    warehouse = warehouseManager.getWarehouse(warehouseName);
+                    break;
+                default:
+                    throw new NotImplementedException("unsupported column: " + name);
+            }
+            if (warehouse == null) {
+                return result; // empty result if warehouse not found
+            } else {
+                BaseSlotTracker tracker = slotManager.getWarehouseIdToSlotTracker().get(warehouse.getId());
+                if (tracker != null) {
+                    result.add(WarehouseMetrics.create(tracker).toConstantOperators());
+                }
+                return result;
+            }
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/WarehouseQueriesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/WarehouseQueriesSystemTable.java
@@ -13,25 +13,42 @@
 // limitations under the License.
 package com.starrocks.catalog.system.information;
 
+import com.google.api.client.util.Lists;
+import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
+import com.starrocks.qe.scheduler.slot.BaseSlotManager;
+import com.starrocks.qe.scheduler.slot.LogicalSlot;
+import com.starrocks.qe.scheduler.warehouse.WarehouseQueryMetrics;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.thrift.TSchemaTableType;
+import com.starrocks.warehouse.Warehouse;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.NotImplementedException;
 
-import static com.starrocks.catalog.system.SystemTable.FN_REFLEN;
-import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
-import static com.starrocks.catalog.system.SystemTable.builder;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
-public class WarehouseQueriesSystemTable {
+public class WarehouseQueriesSystemTable extends SystemTable {
     public static final String NAME = "warehouse_queries";
-    public static SystemTable create() {
-        return new SystemTable(
+    public WarehouseQueriesSystemTable() {
+        super(
                 SystemId.WAREHOUSE_QUERIES_METRICS_ID,
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("WAREHOUSE_ID", ScalarType.createVarchar(FN_REFLEN))
+                        .column("WAREHOUSE_ID", ScalarType.createType(PrimitiveType.BIGINT))
                         .column("WAREHOUSE_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .column("QUERY_ID", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .column("STATE", ScalarType.createVarchar(NAME_CHAR_LEN))
@@ -44,5 +61,74 @@ public class WarehouseQueriesSystemTable {
                         .column("QUERY_DURATION", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .column("EXTRA_MESSAGE", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .build(), TSchemaTableType.SCH_WAREHOUSE_QUERIES);
+    }
+
+    public static SystemTable create() {
+        return new WarehouseQueriesSystemTable();
+    }
+
+    private static final Set<String> SUPPORTED_EQUAL_COLUMNS =
+            Collections.unmodifiableSet(new TreeSet<>(String.CASE_INSENSITIVE_ORDER) {
+                {
+                    add("WAREHOUSE_ID");
+                    add("WAREHOUSE_NAME");
+                }
+            });
+
+    @Override
+    public boolean supportFeEvaluation(ScalarOperator predicate) {
+        final List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);
+        if (conjuncts.isEmpty()) {
+            return true;
+        }
+        if (!isEmptyOrOnlyEqualConstantOps(conjuncts) || conjuncts.size() != 1) {
+            return false;
+        }
+        return isSupportedEqualPredicateColumn(conjuncts, SUPPORTED_EQUAL_COLUMNS);
+    }
+
+    @Override
+    public List<List<ScalarOperator>> evaluate(ScalarOperator predicate) {
+        final BaseSlotManager slotManager = GlobalStateMgr.getCurrentState().getSlotManager();
+        final List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);
+        if (CollectionUtils.isEmpty(conjuncts)) {
+            final List<LogicalSlot> slots = slotManager.getSlots();
+            return slots.stream()
+                    .map(tracker -> WarehouseQueryMetrics.create(tracker).toConstantOperators())
+                    .collect(Collectors.toUnmodifiableList());
+        } else {
+            List<List<ScalarOperator>> result = Lists.newArrayList();
+            ScalarOperator conjunct = conjuncts.get(0);
+            BinaryPredicateOperator binary = (BinaryPredicateOperator) conjunct;
+            ColumnRefOperator columnRef = binary.getChild(0).cast();
+            String name = columnRef.getName();
+            ConstantOperator value = binary.getChild(1).cast();
+
+            final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+            Warehouse warehouse;
+            switch (name.toUpperCase()) {
+                case "WAREHOUSE_ID": {
+                    long warehouseId = value.getBigint();
+                    warehouse = warehouseManager.getWarehouse(warehouseId);
+                    break;
+                }
+                case "WAREHOUSE_NAME":
+                    String warehouseName = value.getVarchar();
+                    warehouse = warehouseManager.getWarehouse(warehouseName);
+                    break;
+                default:
+                    throw new NotImplementedException("unsupported column: " + name);
+            }
+            if (warehouse == null) {
+                return result; // empty result if warehouse not found
+            } else {
+                final List<LogicalSlot> slots = slotManager.getSlots();
+                return slots.stream()
+                        .filter(slot -> slot.getWarehouseId() == warehouse.getId())
+                        .map(slot -> WarehouseQueryMetrics.create(slot))
+                        .map(WarehouseQueryMetrics::toConstantOperators)
+                        .collect(Collectors.toUnmodifiableList());
+            }
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/FeExecuteCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/FeExecuteCoordinator.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.qe.scheduler;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.catalog.ScalarType;
@@ -331,119 +330,29 @@ public class FeExecuteCoordinator extends Coordinator {
         final List<ColumnRefOperator> outputColumnRefs = execPlan.getOutputColumns();
         final Projection valueOperatorProjection = valuesOperator.getProjection();
         final List<ColumnRefOperator> valuesOperatorColumnRefs = valuesOperator.getColumnRefSet();
-        // Map values operator's output column references to their indices
-        final Map<ColumnRefOperator, Integer> valuesOperatorOutputMap = IntStream.range(0, outputColumnRefs.size())
-                .boxed()
-                .collect(Collectors.toMap(valuesOperatorColumnRefs::get, i -> i));
-        // NOTE: this is only used when value operator's projection is null since row will be output by projection mapping if
-        // project exists.
-        // Find the indices of the output columns in the values operator's output
-        final List<Integer> alignedOutputIndexes = valueOperatorProjection == null ?
-                outputColumnRefs.stream()
-                        .map(valuesOperatorOutputMap::get)
-                        .collect(Collectors.toList()) : null;
-        final List<ByteBuffer> res = Lists.newArrayList();
-        for (final List<ScalarOperator> row : valuesOperator.getRows()) {
-            serializer.reset();
-            Preconditions.checkArgument(row.size() == outputColumnRefs.size());
-            List<ScalarOperator> alignedRow = getAlignedRow(valuesOperator, row, alignedOutputIndexes);
-            for (ScalarOperator scalarOperator : alignedRow) {
-                ConstantOperator constantOperator = (ConstantOperator) scalarOperator;
-                if (constantOperator.isNull()) {
-                    serializer.writeNull();
-                } else if (constantOperator.isTrue()) {
-                    serializer.writeLenEncodedString("1");
-                } else if (constantOperator.isFalse()) {
-                    serializer.writeLenEncodedString("0");
-                } else if (constantOperator.getType().getPrimitiveType().isBinaryType()) {
-                    serializer.writeVInt(constantOperator.getBinary().length);
-                    serializer.writeBytes(constantOperator.getBinary());
-                } else {
-                    String value;
-                    switch (constantOperator.getType().getPrimitiveType()) {
-                        case TINYINT:
-                            value = String.valueOf(constantOperator.getTinyInt());
-                            break;
-                        case SMALLINT:
-                            value = String.valueOf(constantOperator.getSmallint());
-                            break;
-                        case INT:
-                            value = String.valueOf(constantOperator.getInt());
-                            break;
-                        case BIGINT:
-                            value = String.valueOf(constantOperator.getBigint());
-                            break;
-                        case LARGEINT:
-                            value = String.valueOf(constantOperator.getLargeInt());
-                            break;
-                        case FLOAT:
-                            value = RyuFloat.floatToString((float) constantOperator.getFloat());
-                            break;
-                        case DOUBLE:
-                            value = RyuDouble.doubleToString(constantOperator.getDouble());
-                            break;
-                        case DECIMALV2:
-                            value = constantOperator.getDecimal().toPlainString();
-                            break;
-                        case DECIMAL32:
-                        case DECIMAL64:
-                        case DECIMAL128:
-                            int scale = ((ScalarType) constantOperator.getType()).getScalarScale();
-                            BigDecimal val1 = constantOperator.getDecimal();
-                            DecimalFormat df = new DecimalFormat((scale == 0 ? "0" : "0.") + StringUtils.repeat("0", scale));
-                            value = df.format(val1);
-                            break;
-                        case CHAR:
-                            value = constantOperator.getChar();
-                            break;
-                        case VARCHAR:
-                            value = constantOperator.getVarchar();
-                            break;
-                        case TIME:
-                            value = convertToTimeString(constantOperator.getTime());
-                            break;
-                        case DATE:
-                            LocalDateTime date = constantOperator.getDate();
-                            value = date.format(DateUtils.DATE_FORMATTER_UNIX);
-                            break;
-                        case DATETIME:
-                            LocalDateTime datetime = constantOperator.getDate();
-                            if (datetime.getNano() != 0) {
-                                value = datetime.format(DateUtils.DATE_TIME_MS_FORMATTER_UNIX);
-                            } else {
-                                value = datetime.format(DateUtils.DATE_TIME_FORMATTER_UNIX);
-                            }
-                            break;
-                        default:
-                            value = constantOperator.toString();
-                    }
-                    serializer.writeLenEncodedString(value);
-                }
-            }
-            res.add(serializer.toByteBuffer());
-        }
-        return res;
-    }
 
-    /**
-     * Align the row with the output indexes of the values operator.
-     * @param valuesOperator: the values operator to get the projection from
-     * @param row: the row to align
-     * @param alignedOutputIndexes: the output indexes of the values operator,
-     *                              if null, will use projection mapping
-     * @return: the aligned row
-     */
-    private List<ScalarOperator> getAlignedRow(PhysicalValuesOperator valuesOperator,
-                                               List<ScalarOperator> row,
-                                               List<Integer> alignedOutputIndexes) {
-        if (alignedOutputIndexes != null) {
-            return alignedOutputIndexes.stream()
-                    .map(i -> row.get(i))
-                    .collect(Collectors.toUnmodifiableList());
+        // NOTE: this is only used when value operator's projection is null since row will be output
+        // by projection mapping if project exists.
+        final List<ByteBuffer> res = Lists.newArrayList();
+        if (valueOperatorProjection == null) {
+            // Map values operator's output column references to their indices
+            final Map<ColumnRefOperator, Integer> valuesOperatorOutputMap = IntStream.range(0, outputColumnRefs.size())
+                    .boxed()
+                    .collect(Collectors.toMap(valuesOperatorColumnRefs::get, i -> i));
+            // Find the indices of the output columns in the values operator's output
+            final List<Integer> alignedOutputIndexes = outputColumnRefs.stream()
+                    .map(valuesOperatorOutputMap::get)
+                    .collect(Collectors.toList());
+            for (final List<ScalarOperator> row : valuesOperator.getRows()) {
+                serializer.reset();
+                final List<ScalarOperator> alignedRow = alignedOutputIndexes.stream()
+                        .map(i -> row.get(i))
+                        .collect(Collectors.toUnmodifiableList());
+                serializeAlignedRow(alignedRow, serializer);
+                res.add(serializer.toByteBuffer());
+            }
         } else {
-            // TODO: add cache for this
-            Preconditions.checkArgument(valuesOperator.getProjection() != null);
-            return execPlan.getOutputExprs().stream()
+            List<ScalarOperator> alignedRow = execPlan.getOutputExprs().stream()
                     .map(expr -> {
                         int slotId = ((SlotRef) expr).getSlotId().asInt();
                         return valuesOperator.getProjection().getColumnRefMap().entrySet().stream()
@@ -453,6 +362,89 @@ public class FeExecuteCoordinator extends Coordinator {
                                 .orElseThrow(() -> new IllegalStateException("No match for slotId: " + slotId));
                     })
                     .collect(Collectors.toList());
+            for (final List<ScalarOperator> row : valuesOperator.getRows()) {
+                serializer.reset();
+                serializeAlignedRow(alignedRow, serializer);
+                res.add(serializer.toByteBuffer());
+            }
+        }
+        return res;
+    }
+
+    private void serializeAlignedRow(List<ScalarOperator> alignedRow,
+                                     MysqlSerializer serializer) {
+        for (ScalarOperator scalarOperator : alignedRow) {
+            ConstantOperator constantOperator = (ConstantOperator) scalarOperator;
+            if (constantOperator.isNull()) {
+                serializer.writeNull();
+            } else if (constantOperator.isTrue()) {
+                serializer.writeLenEncodedString("1");
+            } else if (constantOperator.isFalse()) {
+                serializer.writeLenEncodedString("0");
+            } else if (constantOperator.getType().getPrimitiveType().isBinaryType()) {
+                serializer.writeVInt(constantOperator.getBinary().length);
+                serializer.writeBytes(constantOperator.getBinary());
+            } else {
+                String value;
+                switch (constantOperator.getType().getPrimitiveType()) {
+                    case TINYINT:
+                        value = String.valueOf(constantOperator.getTinyInt());
+                        break;
+                    case SMALLINT:
+                        value = String.valueOf(constantOperator.getSmallint());
+                        break;
+                    case INT:
+                        value = String.valueOf(constantOperator.getInt());
+                        break;
+                    case BIGINT:
+                        value = String.valueOf(constantOperator.getBigint());
+                        break;
+                    case LARGEINT:
+                        value = String.valueOf(constantOperator.getLargeInt());
+                        break;
+                    case FLOAT:
+                        value = RyuFloat.floatToString((float) constantOperator.getFloat());
+                        break;
+                    case DOUBLE:
+                        value = RyuDouble.doubleToString(constantOperator.getDouble());
+                        break;
+                    case DECIMALV2:
+                        value = constantOperator.getDecimal().toPlainString();
+                        break;
+                    case DECIMAL32:
+                    case DECIMAL64:
+                    case DECIMAL128:
+                        int scale = ((ScalarType) constantOperator.getType()).getScalarScale();
+                        BigDecimal val1 = constantOperator.getDecimal();
+                        DecimalFormat df = new DecimalFormat((scale == 0 ? "0" : "0.") + StringUtils.repeat("0", scale));
+                        value = df.format(val1);
+                        break;
+                    case CHAR:
+                        value = constantOperator.getChar();
+                        break;
+                    case VARCHAR:
+                        value = constantOperator.getVarchar();
+                        break;
+                    case TIME:
+                        value = convertToTimeString(constantOperator.getTime());
+                        break;
+                    case DATE:
+                        LocalDateTime date = constantOperator.getDate();
+                        value = date.format(DateUtils.DATE_FORMATTER_UNIX);
+                        break;
+                    case DATETIME:
+                        LocalDateTime datetime = constantOperator.getDate();
+                        if (datetime.getNano() != 0) {
+                            value = datetime.format(DateUtils.DATE_TIME_MS_FORMATTER_UNIX);
+                        } else {
+                            value = datetime.format(DateUtils.DATE_TIME_FORMATTER_UNIX);
+                        }
+                        break;
+                    default:
+                        value = constantOperator.toString();
+                }
+                serializer.writeLenEncodedString(value);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/BaseSlotTracker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/BaseSlotTracker.java
@@ -311,7 +311,10 @@ public abstract class BaseSlotTracker {
     }
 
     public double getEarliestQueryWaitTimeSecond() {
-        return slots.values().stream().map(LogicalSlot::getStartTimeMs).min(Long::compareTo)
+        return slots.values().stream()
+                .filter(slot -> slot.getState() == LogicalSlot.State.REQUIRING) // only consider requiring slots
+                .map(LogicalSlot::getStartTimeMs)
+                .min(Long::compareTo)
                 .map(t -> (System.currentTimeMillis() - t) / 1000.0).orElse(0.0);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/warehouse/WarehouseMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/warehouse/WarehouseMetrics.java
@@ -17,11 +17,15 @@
 
 package com.starrocks.qe.scheduler.warehouse;
 
+import com.google.api.client.util.Lists;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.scheduler.slot.BaseSlotTracker;
 import com.starrocks.qe.scheduler.slot.QueryQueueOptions;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.thrift.TGetWarehouseMetricsResponeItem;
 
+import java.util.List;
 import java.util.Optional;
 
 public class WarehouseMetrics {
@@ -91,5 +95,26 @@ public class WarehouseMetrics {
             item.setExtra_message(GsonUtils.GSON.toJson(extraMessage.get()));
         }
         return item;
+    }
+
+    public List<ScalarOperator> toConstantOperators() {
+        List<ScalarOperator> result = Lists.newArrayList();
+        result.add(ConstantOperator.createVarchar(String.valueOf(warehouseId)));
+        result.add(ConstantOperator.createVarchar(warehouseName));
+        result.add(ConstantOperator.createVarchar(String.valueOf(queuePendingLength)));
+        result.add(ConstantOperator.createVarchar(String.valueOf(queueRunningLength)));
+        result.add(ConstantOperator.createVarchar(String.valueOf(maxQueueQueueLength)));
+        result.add(ConstantOperator.createVarchar(String.valueOf(maxQueuePendingTimeSecond)));
+        result.add(ConstantOperator.createVarchar(String.valueOf(earliestQueryWaitTime)));
+        result.add(ConstantOperator.createVarchar(String.valueOf(maxRequiredSlots)));
+        result.add(ConstantOperator.createVarchar(String.valueOf(sumRequiredSlots)));
+        result.add(ConstantOperator.createVarchar(String.valueOf(remainSlots)));
+        result.add(ConstantOperator.createVarchar(String.valueOf(maxSlots)));
+        if (extraMessage.isPresent()) {
+            result.add(ConstantOperator.createVarchar(GsonUtils.GSON.toJson(extraMessage.get())));
+        } else {
+            result.add(ConstantOperator.createVarchar(""));
+        }
+        return result;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/warehouse/WarehouseQueryMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/warehouse/WarehouseQueryMetrics.java
@@ -17,14 +17,18 @@
 
 package com.starrocks.qe.scheduler.warehouse;
 
+import com.google.common.collect.Lists;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.scheduler.slot.LogicalSlot;
 import com.starrocks.qe.scheduler.slot.QueryQueueOptions;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.thrift.TGetWarehouseQueriesResponseItem;
 import com.starrocks.thrift.TUniqueId;
 
+import java.util.List;
 import java.util.Optional;
 
 public class WarehouseQueryMetrics {
@@ -86,6 +90,31 @@ public class WarehouseQueryMetrics {
             item.setExtra_message(GsonUtils.GSON.toJson(extra));
         }
         return item;
+    }
+
+    public List<ScalarOperator> toConstantOperators() {
+        List<ScalarOperator> result = Lists.newArrayList();
+        result.add(ConstantOperator.createVarchar(String.valueOf(warehouseId)));
+        result.add(ConstantOperator.createVarchar(warehouseName));
+        result.add(ConstantOperator.createVarchar(DebugUtil.printId(queryId)));
+        result.add(ConstantOperator.createVarchar(state.name()));
+        result.add(ConstantOperator.createVarchar(String.valueOf(estCostsSlots)));
+        result.add(ConstantOperator.createVarchar(String.valueOf(allocateSlots)));
+        result.add(ConstantOperator.createDouble(queuedWaitSeconds));
+        result.add(ConstantOperator.createVarchar(query));
+        if (extraMessage.isPresent()) {
+            LogicalSlot.ExtraMessage extra = extraMessage.get();
+            result.add(ConstantOperator.createVarchar(TimeUtils.longToTimeString(extra.getQueryStartTime())));
+            result.add(ConstantOperator.createVarchar(TimeUtils.longToTimeString(extra.getQueryEndTime())));
+            result.add(ConstantOperator.createVarchar(String.valueOf(extra.getQueryDuration())));
+            result.add(ConstantOperator.createVarchar(GsonUtils.GSON.toJson(extra)));
+        } else {
+            result.add(ConstantOperator.createVarchar(""));
+            result.add(ConstantOperator.createVarchar(""));
+            result.add(ConstantOperator.createVarchar(""));
+            result.add(ConstantOperator.createVarchar(""));
+        }
+        return result;
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -60,7 +60,6 @@ import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
-import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
@@ -76,6 +75,7 @@ import com.starrocks.catalog.TabletMeta;
 import com.starrocks.catalog.View;
 import com.starrocks.catalog.system.information.AnalyzeStatusSystemTable;
 import com.starrocks.catalog.system.information.ColumnStatsUsageSystemTable;
+import com.starrocks.catalog.system.information.MaterializedViewsSystemTable;
 import com.starrocks.catalog.system.information.TaskRunsSystemTable;
 import com.starrocks.catalog.system.information.TasksSystemTable;
 import com.starrocks.catalog.system.sys.GrantsTo;
@@ -94,7 +94,6 @@ import com.starrocks.common.DuplicatedRequestException;
 import com.starrocks.common.IdGenerator;
 import com.starrocks.common.LabelAlreadyUsedException;
 import com.starrocks.common.MetaNotFoundException;
-import com.starrocks.common.Pair;
 import com.starrocks.common.PatternMatcher;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.Status;
@@ -149,8 +148,6 @@ import com.starrocks.qe.GlobalVariable;
 import com.starrocks.qe.ProxyContextManager;
 import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.qe.QueryStatisticsInfo;
-import com.starrocks.qe.ShowExecutor;
-import com.starrocks.qe.ShowMaterializedViewStatus;
 import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.qe.scheduler.slot.LogicalSlot;
 import com.starrocks.qe.scheduler.warehouse.WarehouseQueryQueueMetrics;
@@ -303,7 +300,6 @@ import com.starrocks.thrift.TMVReportEpochResponse;
 import com.starrocks.thrift.TMasterOpRequest;
 import com.starrocks.thrift.TMasterOpResult;
 import com.starrocks.thrift.TMasterResult;
-import com.starrocks.thrift.TMaterializedViewStatus;
 import com.starrocks.thrift.TMergeCommitRequest;
 import com.starrocks.thrift.TMergeCommitResult;
 import com.starrocks.thrift.TNetworkAddress;
@@ -639,23 +635,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     @Override
     public TListMaterializedViewStatusResult listMaterializedViewStatus(TGetTablesParams params) throws TException {
         LOG.debug("get list table request: {}", params);
-
-        PatternMatcher matcher = null;
-        boolean caseSensitive = CaseSensibility.TABLE.getCaseSensibility();
-        if (params.isSetPattern()) {
-            matcher = PatternMatcher.createMysqlPattern(params.getPattern(), caseSensitive);
-        }
-
-        // database privs should be checked in analysis phrase
-        long limit = params.isSetLimit() ? params.getLimit() : -1;
-        UserIdentity currentUser;
-        if (params.isSetCurrent_user_ident()) {
-            currentUser = UserIdentity.fromThrift(params.current_user_ident);
-        } else {
-            currentUser = UserIdentity.createAnalyzedUserIdentWithIp(params.user, params.user_ip);
-        }
-        Preconditions.checkState(params.isSetType() && TTableType.MATERIALIZED_VIEW.equals(params.getType()));
-        return listMaterializedViewStatus(limit, matcher, currentUser, params);
+        ConnectContext context = new ConnectContext();
+        return MaterializedViewsSystemTable.query(params, context);
     }
 
     @Override
@@ -801,114 +782,6 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         });
 
         return res;
-    }
-
-    // list MaterializedView table match pattern
-    private TListMaterializedViewStatusResult listMaterializedViewStatus(long limit, PatternMatcher matcher,
-                                                                         UserIdentity currentUser, TGetTablesParams params) {
-        TListMaterializedViewStatusResult result = new TListMaterializedViewStatusResult();
-        List<TMaterializedViewStatus> tablesResult = Lists.newArrayList();
-        result.setMaterialized_views(tablesResult);
-        String dbName = params.getDb();
-        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
-        if (db == null) {
-            LOG.warn("database not exists: {}", dbName);
-            return result;
-        }
-
-        listMaterializedViews(limit, matcher, currentUser, params).stream()
-                .map(s -> s.toThrift())
-                .forEach(t -> tablesResult.add(t));
-        return result;
-    }
-
-    private void filterAsynchronousMaterializedView(PatternMatcher matcher,
-                                                    UserIdentity currentUser,
-                                                    String dbName,
-                                                    MaterializedView mv,
-                                                    TGetTablesParams params,
-                                                    List<MaterializedView> result) {
-        // check table name
-        String mvName = params.table_name;
-        if (mvName != null && !mvName.equalsIgnoreCase(mv.getName())) {
-            return;
-        }
-
-        try {
-            ConnectContext context = new ConnectContext();
-            context.setCurrentUserIdentity(currentUser);
-            context.setCurrentRoleIds(currentUser);
-            Authorizer.checkAnyActionOnTableLikeObject(context, dbName, mv);
-        } catch (AccessDeniedException e) {
-            return;
-        }
-
-        boolean caseSensitive = CaseSensibility.TABLE.getCaseSensibility();
-        if (!PatternMatcher.matchPattern(params.getPattern(), mv.getName(), matcher, caseSensitive)) {
-            return;
-        }
-        result.add(mv);
-    }
-
-    private void filterSynchronousMaterializedView(OlapTable olapTable, PatternMatcher matcher,
-                                                   TGetTablesParams params,
-                                                   List<Pair<OlapTable, MaterializedIndexMeta>> singleTableMVs) {
-        // synchronized materialized view metadata size should be greater than 1.
-        if (olapTable.getVisibleIndexMetas().size() <= 1) {
-            return;
-        }
-
-        // check table name
-        String mvName = params.table_name;
-        if (mvName != null && !mvName.equalsIgnoreCase(olapTable.getName())) {
-            return;
-        }
-
-        List<MaterializedIndexMeta> visibleMaterializedViews = olapTable.getVisibleIndexMetas();
-        long baseIdx = olapTable.getBaseIndexId();
-        boolean caseSensitive = CaseSensibility.TABLE.getCaseSensibility();
-        for (MaterializedIndexMeta mvMeta : visibleMaterializedViews) {
-            if (baseIdx == mvMeta.getIndexId()) {
-                continue;
-            }
-
-            if (!PatternMatcher.matchPattern(params.getPattern(), olapTable.getIndexNameById(mvMeta.getIndexId()),
-                    matcher, caseSensitive)) {
-                continue;
-            }
-            singleTableMVs.add(Pair.create(olapTable, mvMeta));
-        }
-    }
-
-    private List<ShowMaterializedViewStatus> listMaterializedViews(long limit, PatternMatcher matcher,
-                                                                   UserIdentity currentUser, TGetTablesParams params) {
-        String dbName = params.getDb();
-        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
-        List<MaterializedView> materializedViews = Lists.newArrayList();
-        List<Pair<OlapTable, MaterializedIndexMeta>> singleTableMVs = Lists.newArrayList();
-        Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.READ);
-        try {
-            for (Table table : GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId())) {
-                if (table.isMaterializedView()) {
-                    filterAsynchronousMaterializedView(matcher, currentUser, dbName,
-                            (MaterializedView) table, params, materializedViews);
-                } else if (table.getType() == Table.TableType.OLAP) {
-                    filterSynchronousMaterializedView((OlapTable) table, matcher, params, singleTableMVs);
-                } else {
-                    // continue
-                }
-
-                // check limit
-                int mvSize = materializedViews.size() + singleTableMVs.size();
-                if (limit > 0 && mvSize >= limit) {
-                    break;
-                }
-            }
-        } finally {
-            locker.unLockDatabase(db.getId(), LockType.READ);
-        }
-        return ShowExecutor.listMaterializedViewStatus(dbName, materializedViews, singleTableMVs);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
@@ -555,6 +555,12 @@ public class InformationSchemaDataSourceTest {
             }
         };
         // supported
+        starRocksAssert.query("select TABLE_NAME, LAST_REFRESH_STATE,LAST_REFRESH_ERROR_CODE,IS_ACTIVE,INACTIVE_REASON\n" +
+                        "from information_schema.materialized_views where table_name = 'test_mv1")
+                .explainContains(" OUTPUT EXPRS:3: TABLE_NAME | 13: LAST_REFRESH_STATE " +
+                                "| 19: LAST_REFRESH_ERROR_CODE | 5: IS_ACTIVE | 6: INACTIVE_REASON",
+                        "constant exprs: ",
+                        "'test_mv1' | 'true' | '' | 'SUCCESS' | '0'");
         starRocksAssert.query("select count(1) from information_schema.materialized_views")
                 .explainContains("     constant exprs: ");
         starRocksAssert.query("select * from information_schema.materialized_views")

--- a/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
@@ -14,13 +14,26 @@
 
 package com.starrocks.service;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.gson.Gson;
+import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.system.information.InfoSchemaDb;
 import com.starrocks.common.util.DateUtils;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.qe.scheduler.slot.BaseSlotTracker;
+import com.starrocks.qe.scheduler.slot.LogicalSlot;
+import com.starrocks.qe.scheduler.slot.SlotManager;
+import com.starrocks.qe.scheduler.slot.SlotSelectionStrategyV2;
+import com.starrocks.qe.scheduler.slot.SlotTracker;
 import com.starrocks.scheduler.Constants;
+import com.starrocks.scheduler.Task;
+import com.starrocks.scheduler.TaskBuilder;
 import com.starrocks.scheduler.TaskManager;
 import com.starrocks.scheduler.persist.TaskRunStatus;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.thrift.TApplicableRolesInfo;
 import com.starrocks.thrift.TAuthInfo;
@@ -57,6 +70,7 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -507,5 +521,185 @@ public class InformationSchemaDataSourceTest {
                 .explainContains(" OUTPUT EXPRS:1: WAREHOUSE_ID | 2: WAREHOUSE_NAME | 3: QUERY_ID | 4: STATE " +
                         "| 5: EST_COSTS_SLOTS | 6: ALLOCATE_SLOTS | 7: QUEUED_WAIT_SECONDS " +
                         "| 8: QUERY | 9: QUERY_START_TIME | 10: QUERY_END_TIME | 11: QUERY_DURATION | 12: EXTRA_MESSAGE\n");
+    }
+
+    @Test
+    public void testMaterializedViewsEvaluation() throws Exception {
+        starRocksAssert.withDatabase("d1").useDatabase("d1");
+        starRocksAssert.withTable("create table t1 (c1 int, c2 int) properties('replication_num'='1') ");
+        starRocksAssert.withMaterializedView("create materialized view test_mv1 refresh manual as select * from t1");
+
+        MaterializedView mv = starRocksAssert.getMv("d1", "test_mv1");
+        Assert.assertTrue(mv != null);
+        TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
+        String taskName = TaskBuilder.getMvTaskName(mv.getId());
+        Task task = taskManager.getTask(taskName);
+        Assert.assertTrue(task != null);
+
+        TaskRunStatus taskRun = new TaskRunStatus();
+        taskRun.setTaskName(taskName);
+        taskRun.setState(Constants.TaskRunState.SUCCESS);
+        taskRun.setDbName("d1");
+        taskRun.setCreateTime(DateUtils.parseDatTimeString("2024-01-02 03:04:05")
+                .toEpochSecond(offset(ZoneId.systemDefault())) * 1000);
+        taskRun.setFinishTime(DateUtils.parseDatTimeString("2024-01-02 03:04:05")
+                .toEpochSecond(offset(ZoneId.systemDefault())) * 1000);
+        taskRun.setExpireTime(DateUtils.parseDatTimeString("2024-01-02 03:04:05")
+                .toEpochSecond(offset(ZoneId.systemDefault())) * 1000);
+        new MockUp<TaskManager>() {
+            @Mock
+            public Map<String, List<TaskRunStatus>> listMVRefreshedTaskRunStatus(String dbName, Set<String> taskNames) {
+                Map<String, List<TaskRunStatus>> result = Maps.newHashMap();
+                result.put(taskName, Lists.newArrayList(taskRun));
+                return result;
+            }
+        };
+        // supported
+        starRocksAssert.query("select count(1) from information_schema.materialized_views")
+                .explainContains("     constant exprs: ");
+        starRocksAssert.query("select * from information_schema.materialized_views")
+                .explainContains("     constant exprs: ",
+                        "'d1' | 'test_mv1' | 'MANUAL' | 'true' | NULL | 'UNPARTITIONED' | '0'");
+        starRocksAssert.query("select * from information_schema.materialized_views where table_name = 'test_mv1' ")
+                .explainContains("     constant exprs: ",
+                        "'d1' | 'test_mv1' | 'MANUAL' | 'true' | NULL | 'UNPARTITIONED' | '0'");
+        starRocksAssert.query("select * from information_schema.materialized_views " +
+                        "where TABLE_SCHEMA = 'd1' and TABLE_NAME = 'test_mv1'")
+                .explainContains("     constant exprs: ",
+                        "'d1' | 'test_mv1' | 'MANUAL' | 'true' | NULL | 'UNPARTITIONED' | '0'");
+        starRocksAssert.query("select *, TASK_ID + 1 from information_schema.materialized_views " +
+                        "where TABLE_SCHEMA = 'd1' and TABLE_NAME = 'test_mv1'")
+                .explainContains("     constant exprs: ",
+                        "'d1' | 'test_mv1' | 'MANUAL' | 'true' | NULL | 'UNPARTITIONED' | '0'");
+
+        // not supported
+        starRocksAssert.query("select * from information_schema.materialized_views where TABLE_NAME != 'test_mv1' ")
+                .explainContains("SCAN SCHEMA");
+        starRocksAssert.query("select * from information_schema.materialized_views where TABLE_SCHEMA = 'd1' or " +
+                        "TABLE_NAME = 'test_mv1' ")
+                .explainContains("SCAN SCHEMA");
+        starRocksAssert.query("select * from information_schema.materialized_views where TABLE_NAME = 'test_mv1' " +
+                        "or TABLE_NAME = 'test_mv2' ")
+                .explainContains("SCAN SCHEMA");
+        starRocksAssert.query("select * from information_schema.materialized_views where TASK_NAME = 'txxx' ")
+                .explainContains("SCAN SCHEMA");
+    }
+
+    @Test
+    public void testWarehouseMetricsEvaluation() throws Exception {
+        starRocksAssert.withDatabase("d1").useDatabase("d1");
+        SlotSelectionStrategyV2 strategy = new SlotSelectionStrategyV2(WarehouseManager.DEFAULT_WAREHOUSE_ID);
+        SlotTracker slotTracker = new SlotTracker(ImmutableList.of(strategy));
+
+        new MockUp<SlotManager>() {
+            @Mock
+            public Map<Long, BaseSlotTracker> getWarehouseIdToSlotTracker() {
+                Map<Long, BaseSlotTracker> result = Maps.newHashMap();
+                result.put(WarehouseManager.DEFAULT_WAREHOUSE_ID, slotTracker);
+                return result;
+            }
+        };
+        // supported
+        starRocksAssert.query("select count(1) from information_schema.warehouse_metrics")
+                .explainContains("     constant exprs: \n" +
+                        "         '0'");
+        starRocksAssert.query("select * from information_schema.warehouse_metrics")
+                .explainContains("     constant exprs: \n" +
+                        "         '0'");
+        starRocksAssert.query("select WAREHOUSE_NAME, REMAIN_SLOTS from information_schema.warehouse_metrics")
+                .explainContains("constant exprs: \n" +
+                        "         'default_warehouse' | '0'");
+        starRocksAssert.query("select count(1) from information_schema.warehouse_metrics where warehouse_id = '0'")
+                .explainContains("     constant exprs: \n" +
+                        "         '0'");
+        starRocksAssert.query("select * from information_schema.warehouse_metrics where WAREHOUSE_ID = '0'")
+                .explainContains("     constant exprs: \n" +
+                        "         '0'");
+        starRocksAssert.query("select WAREHOUSE_NAME, REMAIN_SLOTS from information_schema.warehouse_metrics " +
+                        "where WAREHOUSE_ID = 0")
+                .explainContains("constant exprs: \n" +
+                        "         'default_warehouse' | '0'");
+        starRocksAssert.query("select count(1) from information_schema.warehouse_metrics where WAREHOUSE_NAME = " +
+                        "'default_warehouse'")
+                .explainContains("     constant exprs: \n" +
+                        "         '0'");
+        starRocksAssert.query("select * from information_schema.warehouse_metrics where WAREHOUSE_NAME= 'default_warehouse'")
+                .explainContains("     constant exprs: \n" +
+                        "         '0'");
+        starRocksAssert.query("select WAREHOUSE_NAME, REMAIN_SLOTS from information_schema.warehouse_metrics " +
+                        "where WAREHOUSE_NAME = 'default_warehouse'")
+                .explainContains("constant exprs: \n" +
+                        "         'default_warehouse' | '0'");
+
+        // not supported
+        starRocksAssert.query("select count(1) from information_schema.warehouse_metrics where WAREHOUSE_ID != '0'")
+                .explainContains("SCAN SCHEMA");
+        starRocksAssert.query("select * from information_schema.warehouse_metrics where WAREHOUSE_ID = 0 and " +
+                        "WAREHOUSE_NAME = 'default_warehouse'")
+                .explainContains("SCAN SCHEMA");
+        starRocksAssert.query("select * from information_schema.warehouse_metrics where WAREHOUSE_ID = 0 or " +
+                        "WAREHOUSE_NAME = 'default_warehouse'")
+                .explainContains("SCAN SCHEMA");
+    }
+
+    private static LogicalSlot generateSlot(int numSlots) {
+        return new LogicalSlot(UUIDUtil.genTUniqueId(), "fe", WarehouseManager.DEFAULT_WAREHOUSE_ID,
+                LogicalSlot.ABSENT_GROUP_ID, numSlots, 0, 0, 0,
+                0, 0);
+    }
+
+    @Test
+    public void testWarehouseQueriesEvaluation() throws Exception {
+        starRocksAssert.withDatabase("d1").useDatabase("d1");
+        LogicalSlot slot1 = generateSlot(1);
+        new MockUp<SlotManager>() {
+            @Mock
+            public List<LogicalSlot> getSlots() {
+                List<LogicalSlot> result = Lists.newArrayList();
+                result.add(slot1);
+                return result;
+            }
+        };
+        // supported
+        starRocksAssert.query("select count(1) from information_schema.warehouse_queries")
+                .explainContains("     constant exprs: \n" +
+                        "         '0'");
+        starRocksAssert.query("select * from information_schema.warehouse_queries")
+                .explainContains("     constant exprs: \n" +
+                        "         '0'");
+        starRocksAssert.query("select WAREHOUSE_NAME, EST_COSTS_SLOTS from information_schema.warehouse_queries")
+                .explainContains("     constant exprs: \n" +
+                        "         'default_warehouse' | '1'");
+        starRocksAssert.query("select count(1) from information_schema.warehouse_queries where warehouse_id = '0'")
+                .explainContains("     constant exprs: \n" +
+                        "         '0'");
+        starRocksAssert.query("select * from information_schema.warehouse_queries where WAREHOUSE_ID = '0'")
+                .explainContains("     constant exprs: \n" +
+                        "         '0'");
+        starRocksAssert.query("select WAREHOUSE_NAME, EST_COSTS_SLOTS from information_schema.warehouse_queries " +
+                        "where WAREHOUSE_ID = 0")
+                .explainContains("     constant exprs: \n" +
+                        "         'default_warehouse' | '1'");
+        starRocksAssert.query("select count(1) from information_schema.warehouse_queries where WAREHOUSE_NAME = " +
+                        "'default_warehouse'")
+                .explainContains("     constant exprs: \n" +
+                        "         '0'");
+        starRocksAssert.query("select * from information_schema.warehouse_queries where WAREHOUSE_NAME= 'default_warehouse'")
+                .explainContains("     constant exprs: \n" +
+                        "         '0'");
+        starRocksAssert.query("select WAREHOUSE_NAME, EST_COSTS_SLOTS from information_schema.warehouse_queries " +
+                        "where WAREHOUSE_NAME = 'default_warehouse'")
+                .explainContains("     constant exprs: \n" +
+                        "         'default_warehouse' | '1'");
+
+        // not supported
+        starRocksAssert.query("select count(1) from information_schema.warehouse_queries where WAREHOUSE_ID != '0'")
+                .explainContains("SCAN SCHEMA");
+        starRocksAssert.query("select * from information_schema.warehouse_queries where WAREHOUSE_ID = 0 and " +
+                        "WAREHOUSE_NAME = 'default_warehouse'")
+                .explainContains("SCAN SCHEMA");
+        starRocksAssert.query("select * from information_schema.warehouse_queries where WAREHOUSE_ID = 0 or " +
+                        "WAREHOUSE_NAME = 'default_warehouse'")
+                .explainContains("SCAN SCHEMA");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
@@ -559,18 +559,18 @@ public class InformationSchemaDataSourceTest {
                 .explainContains("     constant exprs: ");
         starRocksAssert.query("select * from information_schema.materialized_views")
                 .explainContains("     constant exprs: ",
-                        "'d1' | 'test_mv1' | 'MANUAL' | 'true' | NULL | 'UNPARTITIONED' | '0'");
+                        "'d1' | 'test_mv1' | 'MANUAL' | 'true' | '' | 'UNPARTITIONED' | '0'");
         starRocksAssert.query("select * from information_schema.materialized_views where table_name = 'test_mv1' ")
                 .explainContains("     constant exprs: ",
-                        "'d1' | 'test_mv1' | 'MANUAL' | 'true' | NULL | 'UNPARTITIONED' | '0'");
+                        "'d1' | 'test_mv1' | 'MANUAL' | 'true' | '' | 'UNPARTITIONED' | '0'");
         starRocksAssert.query("select * from information_schema.materialized_views " +
                         "where TABLE_SCHEMA = 'd1' and TABLE_NAME = 'test_mv1'")
                 .explainContains("     constant exprs: ",
-                        "'d1' | 'test_mv1' | 'MANUAL' | 'true' | NULL | 'UNPARTITIONED' | '0'");
+                        "'d1' | 'test_mv1' | 'MANUAL' | 'true' | '' | 'UNPARTITIONED' | '0'");
         starRocksAssert.query("select *, TASK_ID + 1 from information_schema.materialized_views " +
                         "where TABLE_SCHEMA = 'd1' and TABLE_NAME = 'test_mv1'")
                 .explainContains("     constant exprs: ",
-                        "'d1' | 'test_mv1' | 'MANUAL' | 'true' | NULL | 'UNPARTITIONED' | '0'");
+                        "'d1' | 'test_mv1' | 'MANUAL' | 'true' | '' | 'UNPARTITIONED' | '0'");
 
         // not supported
         starRocksAssert.query("select * from information_schema.materialized_views where TABLE_NAME != 'test_mv1' ")

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
@@ -216,6 +216,25 @@ public class SelectConstTest extends PlanTestBase {
                 "-78883632:00:01");
     }
 
+    @Test
+    public void testExecuteInFEWithComplexQuery() throws Exception {
+        String sql = "select 1, -1, 1.23456, cast(1.123 as float), cast(1.123 as double), " +
+                "cast(10 as bigint), cast(100 as largeint),\n" +
+                "1000000000000, 1+1, 100 * 100, 'abc', \"中文\", '\"abc\"', " +
+                "\"'abc'\", '\\'abc\\\\', \"\\\"abc\\\\\", cast(1.123000000 as decimalv2),\n" +
+                "cast(1.123 as decimal(10, 7)), date '2021-01-01', " +
+                "datetime '2021-01-01 00:00:00', datetime '2021-01-01 00:00:00.123456',\n" +
+                "timediff('2028-01-01 11:25:36', '2000-11-21 12:12:12'), " +
+                "timediff('2000-11-21 12:12:12', '2028-01-01 11:25:36'), x'123456', x'AABBCC11';";
+        ExecPlan execPlan = getExecPlan(sql);
+        FeExecuteCoordinator coordinator = new FeExecuteCoordinator(connectContext, execPlan);
+        try {
+            RowBatch rowBatch = coordinator.getNext();
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+
     private void assertFeExecuteResult(String sql, String expected) throws Exception {
         ExecPlan execPlan = getExecPlan(sql);
         FeExecuteCoordinator coordinator = new FeExecuteCoordinator(connectContext, execPlan);
@@ -228,6 +247,7 @@ public class SelectConstTest extends PlanTestBase {
         } else {
             value = new String(bytes, lengthOffset, bytes.length - lengthOffset, StandardCharsets.UTF_8);
         }
+        System.out.println(value);
         Assert.assertEquals(expected, value);
     }
 

--- a/test/sql/test_information_schema/R/test_warehouse_metrics
+++ b/test/sql/test_information_schema/R/test_warehouse_metrics
@@ -7,7 +7,7 @@ USE db_${uuid0};
 -- !result
 desc information_schema.warehouse_metrics;
 -- result:
-WAREHOUSE_ID	varchar(512)	YES	false	None	
+WAREHOUSE_ID	bigint	YES	false	None	
 WAREHOUSE_NAME	varchar(2048)	YES	false	None	
 QUEUE_PENDING_LENGTH	varchar(2048)	YES	false	None	
 QUEUE_RUNNING_LENGTH	varchar(2048)	YES	false	None	

--- a/test/sql/test_information_schema/R/test_warehouse_queries
+++ b/test/sql/test_information_schema/R/test_warehouse_queries
@@ -7,7 +7,7 @@ USE db_${uuid0};
 -- !result
 desc information_schema.warehouse_queries;
 -- result:
-WAREHOUSE_ID	varchar(512)	YES	false	None	
+WAREHOUSE_ID	bigint	YES	false	None	
 WAREHOUSE_NAME	varchar(2048)	YES	false	None	
 QUERY_ID	varchar(2048)	YES	false	None	
 STATE	varchar(2048)	YES	false	None	


### PR DESCRIPTION
## Why I'm doing:

### Problem 1: Optimize warehouse metrics queries
Some information_schema tables' query can be slow, or even hanged when BE/CN's load is high, eg: `materialized_views`/`warehouse_metrics`/`warehouse_queries`.

#26341 has supported to evaluate schema scan in the FE to reduce BE-FE's rpc costs, this can be used for all schema scans if query can be evaluated in the FE.

### Problem 2: `getEarliestQueryWaitTimeSecond` should only filter `REQUIRING` slots

## What I'm doing:
1. Support `materialized_views`/`warehouse_metrics`/`warehouse_queries` system tables' FE Evaluations
2. `getEarliestQueryWaitTimeSecond` should only take care `REQUIRING` slots


In CI, I also found an intresting bug introduced by https://github.com/StarRocks/starrocks/pull/44206:
```
mysql> set enable_constant_execute_in_fe=true;
Query OK, 0 rows affected (0.00 sec)

mysql>  select      TABLE_NAME,     LAST_REFRESH_STATE,     LAST_REFRESH_ERROR_CODE,     IS_ACTIVE,     INACTIVE_REASON from information_schema.materialized_views where table_name = 'user_tags_mv1';
+---------------+--------------------+-------------------------+-----------+-----------------+
| TABLE_NAME    | LAST_REFRESH_STATE | LAST_REFRESH_ERROR_CODE | IS_ACTIVE | INACTIVE_REASON |
+---------------+--------------------+-------------------------+-----------+-----------------+
| user_tags_mv1 | true               |                         | SUCCESS   | 0               |
+---------------+--------------------+-------------------------+-----------+-----------------+
1 row in set (1.24 sec)

mysql> set enable_constant_execute_in_fe=false;
Query OK, 0 rows affected (0.00 sec)

mysql>  select      TABLE_NAME,     LAST_REFRESH_STATE,     LAST_REFRESH_ERROR_CODE,     IS_ACTIVE,     INACTIVE_REASON from information_schema.materialized_views where table_name = 'user_tags_mv1';
+---------------+--------------------+-------------------------+-----------+-----------------+
| TABLE_NAME    | LAST_REFRESH_STATE | LAST_REFRESH_ERROR_CODE | IS_ACTIVE | INACTIVE_REASON |
+---------------+--------------------+-------------------------+-----------+-----------------+
| user_tags_mv1 | SUCCESS            | 0                       | true      |                 |
+---------------+--------------------+-------------------------+-----------+-----------------+
1 row in set (1.18 sec)

mysql> explain verbose select      TABLE_NAME,     LAST_REFRESH_STATE,     LAST_REFRESH_ERROR_CODE,     IS_ACTIVE,     INACTIVE_REASON from information_schema.materialized_views where table_name = 'user_tags_mv1';
+-------------------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                          |
+-------------------------------------------------------------------------------------------------------------------------+
| RESOURCE GROUP: default_wg                                                                                              |
|                                                                                                                         |
| PLAN COST                                                                                                               |
|   CPU: 0.0                                                                                                              |
|   Memory: 0.0                                                                                                           |
|                                                                                                                         |
| PLAN FRAGMENT 0(F00)                                                                                                    |
|   Fragment Cost: 0.0                                                                                                    |
|   Output Exprs:3: TABLE_NAME | 13: LAST_REFRESH_STATE | 19: LAST_REFRESH_ERROR_CODE | 5: IS_ACTIVE | 6: INACTIVE_REASON |
|   Input Partition: UNPARTITIONED                                                                                        |
|   RESULT SINK                                                                                                           |
|                                                                                                                         |
|   0:UNION                                                                                                               |
|      constant exprs:                                                                                                    |
|          'user_tags_mv1' | 'true' | '' | 'SUCCESS' | '0'                                                                |
|      cardinality: 1                                                                                                     |
+-------------------------------------------------------------------------------------------------------------------------+
16 rows in set (1.16 sec)


```

This is because `covertToMySQLRowBuffer` ignore's `execPlan.getOutputExprs` when projection is null, we should always try to align `PhysicalValuesOperator`'s output order with `execPlan.getOutputExprs` by PhysicalValuesOperator's `columnRefSet`.
```
    private List<ByteBuffer> covertToMySQLRowBuffer() {
        MysqlSerializer serializer = MysqlSerializer.newInstance();
        PhysicalValuesOperator valuesOperator = (PhysicalValuesOperator) execPlan.getPhysicalPlan().getOp();
        List<ByteBuffer> res = Lists.newArrayList();
        for (List<ScalarOperator> row : valuesOperator.getRows()) {
            serializer.reset();
            if (valuesOperator.getProjection() != null) {
                List<ScalarOperator> alignedOutput = Lists.newArrayList();
                for (Expr expr : execPlan.getOutputExprs()) {
                    SlotRef slotRef = (SlotRef) expr;
                    for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : valuesOperator.getProjection()
                            .getColumnRefMap().entrySet()) {
                        if (slotRef.getSlotId().asInt() == entry.getKey().getId()) {
                            alignedOutput.add(entry.getValue());
                            break;
                        }
                    }
                }
                row = alignedOutput;
            }
```
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
