### PR TITLE
[Enhancement] Add SignalTimerGuard class for thread stack trace timeout monitoring

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -839,6 +839,8 @@ CONF_mBool(enable_bitmap_union_disk_format_with_set, "false");
 
 // pipeline poller timeout guard
 CONF_mInt64(pipeline_poller_timeout_guard_ms, "-1");
+// pipeline fragment prepare timeout guard
+CONF_mInt64(pipeline_prepare_timeout_guard_ms, "-1");
 // whether to enable large column detection in the pipeline execution framework.
 CONF_mBool(pipeline_enable_large_column_checker, "false");
 

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -51,11 +51,14 @@
 #include "runtime/stream_load/stream_load_context.h"
 #include "runtime/stream_load/transaction_mgr.h"
 #include "util/debug/query_trace.h"
+#include "util/failpoint/fail_point.h"
 #include "util/runtime_profile.h"
 #include "util/time.h"
 #include "util/uid_util.h"
 
 namespace starrocks::pipeline {
+
+DEFINE_FAIL_POINT(fragment_prepare_sleep);
 
 using WorkGroupManager = workgroup::WorkGroupManager;
 using WorkGroup = workgroup::WorkGroup;
@@ -921,6 +924,8 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
         RETURN_IF_ERROR(_prepare_pipeline_driver(exec_env, request));
         RETURN_IF_ERROR(_prepare_stream_load_pipe(exec_env, request));
     }
+
+    FAIL_POINT_TRIGGER_EXECUTE(fragment_prepare_sleep, { sleep(2); });
 
     RETURN_IF_ERROR(_query_ctx->fragment_mgr()->register_ctx(request.fragment_instance_id(), _fragment_ctx));
     _query_ctx->mark_prepared();

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -87,6 +87,7 @@
 #include "util/stopwatch.hpp"
 #include "util/thrift_util.h"
 #include "util/time.h"
+#include "util/time_guard.h"
 #include "util/uid_util.h"
 
 namespace starrocks {
@@ -473,6 +474,7 @@ Status PInternalServiceImplBase<T>::_exec_plan_fragment(brpc::Controller* cntl,
 template <typename T>
 Status PInternalServiceImplBase<T>::_exec_plan_fragment_by_pipeline(const TExecPlanFragmentParams& t_common_param,
                                                                     const TExecPlanFragmentParams& t_unique_request) {
+    SignalTimerGuard guard(config::pipeline_prepare_timeout_guard_ms);
     pipeline::FragmentExecutor fragment_executor;
     auto status = fragment_executor.prepare(_exec_env, t_common_param, t_unique_request);
     if (status.ok()) {

--- a/be/src/util/time_guard.h
+++ b/be/src/util/time_guard.h
@@ -13,9 +13,14 @@
 // limitations under the License.
 
 #pragma once
+#include <csignal>
+#include <thread>
+
+#include "bthread/timer_thread.h"
 #include "common/config.h"
 #include "common/logging.h"
 #include "util/time.h"
+#include "util/unaligned_access.h"
 
 namespace starrocks {
 
@@ -44,6 +49,46 @@ private:
     int64_t _timeout_ms;
     LazyMsgCallBack _callback;
     int64_t _begin_time = 0;
+};
+
+// export from stack_util.h
+std::string get_stack_trace_for_thread(int tid, int timeout_ms);
+
+// SignalTimerGuard class manages a timer to capture and log thread stack traces after a specified timeout.
+// usage:
+// {
+//     SignalTimerGuard guard(100);
+//     monitor_function();
+// }
+class SignalTimerGuard {
+public:
+    using TaskId = bthread::TimerThread::TaskId;
+    SignalTimerGuard(int64_t timeout_ms) {
+        if (timeout_ms > 0) {
+            auto timer_thread = bthread::get_global_timer_thread();
+            timespec tm = butil::milliseconds_from_now(timeout_ms);
+            int lwp_id = syscall(SYS_gettid);
+            void* arg = nullptr;
+            unaligned_store<int>(&arg, lwp_id);
+            _tid = timer_thread->schedule(dump_trace_info, arg, tm);
+        }
+    }
+
+    ~SignalTimerGuard() {
+        if (_tid != bthread::TimerThread::INVALID_TASK_ID) {
+            auto timer_thread = bthread::get_global_timer_thread();
+            timer_thread->unschedule(_tid);
+        }
+    }
+
+private:
+    TaskId _tid = bthread::TimerThread::INVALID_TASK_ID;
+
+    static void dump_trace_info(void* arg) {
+        int tid = unaligned_load<int>(&arg);
+        std::string msg = get_stack_trace_for_thread(tid, 1000);
+        LOG(INFO) << "found slow function:" << msg;
+    }
 };
 
 }; // namespace starrocks

--- a/be/src/util/time_guard.h
+++ b/be/src/util/time_guard.h
@@ -55,6 +55,7 @@ private:
 std::string get_stack_trace_for_thread(int tid, int timeout_ms);
 
 // SignalTimerGuard class manages a timer to capture and log thread stack traces after a specified timeout.
+// Note: If bthread yields. you may not get the expected stacktrace. But it's still safe.
 // usage:
 // {
 //     SignalTimerGuard guard(100);

--- a/test/sql/test_exception/R/test_prepare_slow
+++ b/test/sql/test_exception/R/test_prepare_slow
@@ -1,0 +1,34 @@
+-- name: test_pipeline_operator_failed @sequential
+update default_catalog.information_schema.be_configs set `value` = "1000" where name= "pipeline_prepare_timeout_guard_ms";
+-- result:
+-- !result
+CREATE TABLE `t0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "DEFAULT",
+"enable_persistent_index" = "true",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into t0 SELECT generate_series, generate_series FROM TABLE(generate_series(1,  8192));
+-- result:
+-- !result
+admin enable failpoint 'fragment_prepare_sleep';
+-- result:
+-- !result
+[UC] select count(*) from t0;
+-- result:
+8192
+-- !result
+admin disable failpoint 'fragment_prepare_sleep';
+-- result:
+-- !result

--- a/test/sql/test_exception/T/test_prepare_slow
+++ b/test/sql/test_exception/T/test_prepare_slow
@@ -1,0 +1,24 @@
+-- name: test_pipeline_operator_failed @sequential
+
+update default_catalog.information_schema.be_configs set `value` = "1000" where name= "pipeline_prepare_timeout_guard_ms";
+
+CREATE TABLE `t0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "DEFAULT",
+"enable_persistent_index" = "true",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+insert into t0 SELECT generate_series, generate_series FROM TABLE(generate_series(1,  8192));
+
+admin enable failpoint 'fragment_prepare_sleep';
+[UC] select count(*) from t0;
+admin disable failpoint 'fragment_prepare_sleep';


### PR DESCRIPTION
## Why I'm doing:

Implemented SignalTimerGuard to schedule and manage a timer that captures thread stack traces after a specified timeout. The class uses the global timer thread to schedule a task that logs stack traces for slow functions, with proper cleanup in the destructor.

log example:
```example.txt
I20250527 14:27:59.314656 140273054934592 time_guard.h:84] found slow function:Stack trace id: 6, tid: 492022 cid:140299740018240
    0x7f9c33054520  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x42520)
    0x7f9c330f77f8  clock_nanosleep
    0x7f9c330fc677  __nanosleep
    0x7f9c330fc5ae  sleep
        0x17cb87a3  starrocks::pipeline::FragmentExecutor::_prepare_exec_plan(starrocks::ExecEnv*, starrocks::pipeline::UnifiedExecPlanFragmentParams const&)
        0x17cc42ef  starrocks::pipeline::FragmentExecutor::prepare(starrocks::ExecEnv*, starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&)
        0x223a0125  starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment_by_pipeline(starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&)
        0x2239fab8  starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(brpc::Controller*, starrocks::PExecPlanFragmentRequest const*)
        0x223978cd  starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)
        0x223a865e  starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}::operator()() <8C>^A
        0x223b637e  void std::__invoke_impl<void, starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*<8C>^A
        0x223b3c45  std::enable_if<is_invocable_r_v<void, starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::<8C>^A
        0x223b0681  std::_Function_handler<void (), starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closur<8C>^A
        0x1495e4b0  std::function<void ()>::operator()() const
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
