### PR TITLE
[BugFix] Don't archive task run history on fe follower

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -857,8 +857,8 @@ public class TaskManager implements MemoryTrackable {
         dropTasks(taskIdToDelete, true);
     }
 
-    public void removeExpiredTaskRuns() {
-        taskRunManager.getTaskRunHistory().vacuum();
+    public void removeExpiredTaskRuns(boolean archiveHistory) {
+        taskRunManager.getTaskRunHistory().vacuum(archiveHistory);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
@@ -130,16 +130,20 @@ public class TaskRunHistory {
 
     // TODO: make it thread safe
     /**
-     * Remove expired task runs, would be called in regular daemon thread, and also in checkpoint
+     * Remove expired task runs, would be called in regular daemon thread, and also in checkpoint.
+     *
+     * @param archiveHistory Controls historical task run archiving behavior.
+     *         - When `false`: Performs cleanup of expired task runs and garbage collection only.
+     *         - When `true`: Also persists historical task runs, but must only be executed on the FE leader.
      */
-    public void vacuum() {
+    public void vacuum(boolean archiveHistory) {
         removeExpiredRuns();
 
         // trigger to force gc to avoid too many history task runs.
         forceGC();
 
         // archive histories
-        if (!GlobalStateMgr.isCheckpointThread()) {
+        if (archiveHistory && !GlobalStateMgr.isCheckpointThread()) {
             archiveHistory();
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -2658,7 +2658,7 @@ public class GlobalStateMgr {
             LOG.warn("task manager clean expire tasks failed", t);
         }
         try {
-            taskManager.removeExpiredTaskRuns();
+            taskManager.removeExpiredTaskRuns(false);
         } catch (Throwable t) {
             LOG.warn("task manager clean expire task runs history failed", t);
         }
@@ -2671,7 +2671,7 @@ public class GlobalStateMgr {
             LOG.warn("task manager clean expire tasks failed", t);
         }
         try {
-            taskManager.removeExpiredTaskRuns();
+            taskManager.removeExpiredTaskRuns(true);
         } catch (Throwable t) {
             LOG.warn("task manager clean expire task runs history failed", t);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
@@ -238,7 +238,7 @@ public class TaskRunHistoryTest {
         history.addHistory(run2);
         assertEquals(2, history.getInMemoryHistory().size());
 
-        history.vacuum();
+        history.vacuum(true);
         assertEquals(1, history.getInMemoryHistory().size());
 
         // vacuum failed
@@ -254,8 +254,28 @@ public class TaskRunHistoryTest {
         run3.setTaskName("t3");
         run3.setState(Constants.TaskRunState.SUCCESS);
         history.addHistory(run3);
-        history.vacuum();
+        history.vacuum(true);
         assertEquals(2, history.getInMemoryHistory().size());
+    }
+
+    @Test
+    public void testHistoryVacuumSkipArchive(@Mocked SimpleExecutor repo) {
+        new MockUp<TableKeeper>() {
+            @Mock
+            public boolean isReady() {
+                return true;
+            }
+        };
+
+        TaskRunHistory history = new TaskRunHistory();
+        TaskRunStatus run = new TaskRunStatus();
+        run.setExpireTime(System.currentTimeMillis() + 10000);
+        run.setQueryId("q3");
+        run.setTaskName("t3");
+        run.setState(Constants.TaskRunState.SUCCESS);
+        history.addHistory(run);
+        history.vacuum(false);
+        assertEquals(1, history.getInMemoryHistory().size());
     }
 
     @Test
@@ -280,7 +300,7 @@ public class TaskRunHistoryTest {
         assertEquals(2, history.getInMemoryHistory().size());
 
         // run, trigger the expiration
-        history.vacuum();
+        history.vacuum(true);
         Assert.assertEquals(0, history.getInMemoryHistory().size());
 
         Config.enable_task_history_archive = true;


### PR DESCRIPTION
## Why I'm doing:
`LoadLabelCleaner` can trigger TaskRunHistory.archiveHistory which executes load  on FE follower. This will result txn inconsistency between leader and follower, such as txn id resue

```
2025-05-27 05:42:59.313+08:00 WARN (LoadLabelCleaner|109) [TaskRunHistory.archiveHistory():210] archive task-run history failed:
com.starrocks.sql.analyzer.SemanticException: Getting analyzing error. Detail message: execute sql failed: Current node is not leader, but FOLLOWER, submit log is not allowed.
        at com.starrocks.load.pipe.filelist.RepoExecutor.executeDML(RepoExecutor.java:77) ~[starrocks-fe.jar:?]
        at com.starrocks.scheduler.history.TaskRunHistoryTable.addHistories(TaskRunHistoryTable.java:155) ~[starrocks-fe.jar:?]
        at com.starrocks.scheduler.history.TaskRunHistory.archiveHistory(TaskRunHistory.java:196) ~[starrocks-fe.jar:?]
        at com.starrocks.scheduler.history.TaskRunHistory.vacuum(TaskRunHistory.java:143) ~[starrocks-fe.jar:?]
        at com.starrocks.scheduler.TaskManager.removeExpiredTaskRuns(TaskManager.java:861) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.clearExpiredJobs(GlobalStateMgr.java:2757) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr$2.runAfterCatalogReady(GlobalStateMgr.java:1936) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.FrontendDaemon.runOneCycle(FrontendDaemon.java:72) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.Daemon.run(Daemon.java:98) ~[starrocks-fe.jar:?]
Caused by: java.lang.IllegalStateException: Current node is not leader, but FOLLOWER, submit log is not allowed
        at com.google.common.base.Preconditions.checkState(Preconditions.java:512) ~[spark-dpp-1.0.0.jar:?]
        at com.starrocks.persist.EditLog.submitLog(EditLog.java:1252) ~[starrocks-fe.jar:?]
        at com.starrocks.persist.EditLog.logEdit(EditLog.java:1233) ~[starrocks-fe.jar:?]
        at com.starrocks.persist.EditLog.logJsonObject(EditLog.java:2052) ~[starrocks-fe.jar:?]
        at com.starrocks.persist.EditLog.logSaveTransactionId(EditLog.java:1334) ~[starrocks-fe.jar:?]
        at com.starrocks.transaction.TransactionIdGenerator.getNextTransactionId(TransactionIdGenerator.java:48) ~[starrocks-fe.jar:?]
        at com.starrocks.transaction.DatabaseTransactionMgr.beginTransaction(DatabaseTransactionMgr.java:185) ~[starrocks-fe.jar:?]
        at com.starrocks.transaction.GlobalTransactionMgr.beginTransaction(GlobalTransactionMgr.java:183) ~[starrocks-fe.jar:?]
        at com.starrocks.transaction.GlobalTransactionMgr.beginTransaction(GlobalTransactionMgr.java:198) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.beginTransaction(StatementPlanner.java:536) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:110) ~[starrocks-fe.jar:?]
        at com.starrocks.load.pipe.filelist.RepoExecutor.executeDML(RepoExecutor.java:68) ~[starrocks-fe.jar:?]
        ... 8 more

```


## What I'm doing:
The daemon `LoadLabelCleaner` will start on all FE nodes, so should not archive history in it. Only archive the history in the daemon `TaskCleaner` which only starts on FE leader


Fixes #https://github.com/StarRocks/StarRocksTest/issues/9718

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
