### PR TITLE
[Enhancement] Fully support aggregate publish version for lake table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
@@ -690,13 +690,8 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
                 rollUpTxnInfo.txnType = TxnTypePB.TXN_NORMAL;
                 rollUpTxnInfo.gtid = watershedGtid;
                 // publish rollup tablets
-                if (!enablePartitionAggregation) {
-                    Utils.publishVersion(physicalPartitionIdToRollupIndex.get(partitionId).getTablets(), rollUpTxnInfo,
-                            1, commitVersion, warehouseId);
-                } else {
-                    Utils.aggregatePublishVersion(physicalPartitionIdToRollupIndex.get(partitionId).getTablets(), 
-                            Lists.newArrayList(rollUpTxnInfo), 1, commitVersion, null, null, warehouseId, null);
-                }
+                Utils.publishVersion(physicalPartitionIdToRollupIndex.get(partitionId).getTablets(), rollUpTxnInfo,
+                        1, commitVersion, warehouseId, enablePartitionAggregation);
 
                 TxnInfoPB originTxnInfo = new TxnInfoPB();
                 originTxnInfo.txnId = -1L;
@@ -705,13 +700,8 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
                 originTxnInfo.txnType = TxnTypePB.TXN_EMPTY;
                 originTxnInfo.gtid = watershedGtid;
                 // publish origin tablets
-                if (!enablePartitionAggregation) {
-                    Utils.publishVersion(allOtherPartitionTablets, originTxnInfo, commitVersion - 1,
-                            commitVersion, warehouseId);
-                } else {
-                    Utils.aggregatePublishVersion(allOtherPartitionTablets, Lists.newArrayList(originTxnInfo),
-                            commitVersion - 1, commitVersion, null, null, warehouseId, null);
-                }
+                Utils.publishVersion(allOtherPartitionTablets, originTxnInfo, commitVersion - 1,
+                        commitVersion, warehouseId, enablePartitionAggregation);
 
             }
             return true;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
@@ -671,6 +671,7 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
     protected boolean lakePublishVersion() {
         try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
             OlapTable table = getTableOrThrow(db, tableId);
+            boolean enablePartitionAggregation = table.enablePartitionAggregation();
             for (long partitionId : physicalPartitionIdToRollupIndex.keySet()) {
                 PhysicalPartition physicalPartition = table.getPhysicalPartition(partitionId);
                 Preconditions.checkState(physicalPartition != null, partitionId);
@@ -689,8 +690,13 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
                 rollUpTxnInfo.txnType = TxnTypePB.TXN_NORMAL;
                 rollUpTxnInfo.gtid = watershedGtid;
                 // publish rollup tablets
-                Utils.publishVersion(physicalPartitionIdToRollupIndex.get(partitionId).getTablets(), rollUpTxnInfo,
-                        1, commitVersion, warehouseId);
+                if (!enablePartitionAggregation) {
+                    Utils.publishVersion(physicalPartitionIdToRollupIndex.get(partitionId).getTablets(), rollUpTxnInfo,
+                            1, commitVersion, warehouseId);
+                } else {
+                    Utils.aggregatePublishVersion(physicalPartitionIdToRollupIndex.get(partitionId).getTablets(), 
+                            Lists.newArrayList(rollUpTxnInfo), 1, commitVersion, null, null, warehouseId, null);
+                }
 
                 TxnInfoPB originTxnInfo = new TxnInfoPB();
                 originTxnInfo.txnId = -1L;
@@ -699,8 +705,13 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
                 originTxnInfo.txnType = TxnTypePB.TXN_EMPTY;
                 originTxnInfo.gtid = watershedGtid;
                 // publish origin tablets
-                Utils.publishVersion(allOtherPartitionTablets, originTxnInfo, commitVersion - 1,
-                        commitVersion, warehouseId);
+                if (!enablePartitionAggregation) {
+                    Utils.publishVersion(allOtherPartitionTablets, originTxnInfo, commitVersion - 1,
+                            commitVersion, warehouseId);
+                } else {
+                    Utils.aggregatePublishVersion(allOtherPartitionTablets, Lists.newArrayList(originTxnInfo),
+                            commitVersion - 1, commitVersion, null, null, warehouseId, null);
+                }
 
             }
             return true;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -272,7 +272,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
                 for (MaterializedIndex index : dirtyIndexMap.values()) {
                     if (!enablePartitionAggregation) {
                         Utils.publishVersion(index.getTablets(), txnInfo, commitVersion - 1, commitVersion,
-                                warehouseId);
+                                warehouseId, enablePartitionAggregation);
                     } else {
                         tablets.addAll(index.getTablets());
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -799,7 +799,8 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
                 Map<Long, MaterializedIndex> shadowIndexMap = physicalPartitionIndexMap.row(partitionId);
                 for (MaterializedIndex shadowIndex : shadowIndexMap.values()) {
                     if (!enablePartitionAggregation) {
-                        Utils.publishVersion(shadowIndex.getTablets(), txnInfo, 1, commitVersion, warehouseId);
+                        Utils.publishVersion(shadowIndex.getTablets(), txnInfo, 1, commitVersion, warehouseId,
+                                enablePartitionAggregation);
                     } else {
                         tablets.addAll(shadowIndex.getTablets());
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
@@ -103,9 +103,9 @@ public class Utils {
     }
 
     public static void publishVersion(@NotNull List<Tablet> tablets, TxnInfoPB txnInfo, long baseVersion,
-                                      long newVersion, long warehouseId)
+                                      long newVersion, long warehouseId, boolean enablePartitionAggregation)
             throws NoAliveBackendException, RpcException {
-        publishVersion(tablets, txnInfo, baseVersion, newVersion, null, warehouseId, null);
+        publishVersion(tablets, txnInfo, baseVersion, newVersion, null, warehouseId, null, enablePartitionAggregation);
     }
 
     public static void publishVersionBatch(@NotNull List<Tablet> tablets, List<TxnInfoPB> txnInfos,
@@ -185,10 +185,17 @@ public class Utils {
 
     public static void publishVersion(@NotNull List<Tablet> tablets, TxnInfoPB txnInfo, long baseVersion,
                                       long newVersion, Map<Long, Double> compactionScores,
-                                      long warehouseId, Map<Long, Long> tabletRowNums)
+                                      long warehouseId, Map<Long, Long> tabletRowNums,
+                                      boolean enablePartitionAggregation)
             throws NoAliveBackendException, RpcException {
         List<TxnInfoPB> txnInfos = Lists.newArrayList(txnInfo);
-        publishVersionBatch(tablets, txnInfos, baseVersion, newVersion, compactionScores, null, warehouseId, tabletRowNums);
+        if (enablePartitionAggregation) {
+            publishVersionBatch(tablets, txnInfos, baseVersion, newVersion, compactionScores, null, 
+                    warehouseId, tabletRowNums);
+        } else {
+            aggregatePublishVersion(tablets, txnInfos, baseVersion, newVersion, compactionScores, 
+                    null, warehouseId, tabletRowNums);
+        }
     }
 
     public static boolean processTablets(List<Tablet> tablets, long warehouseId,

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -479,6 +479,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tableId), LockType.READ);
         // version -> shadowTablets
         long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
+        boolean enablePartitionAggregation = Config.enable_partition_aggregation;
         try {
             OlapTable table =
                     (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
@@ -498,6 +499,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
                 return false;
             }
 
+            enablePartitionAggregation = table.enablePartitionAggregation();
             for (int i = 0; i < transactionStates.size(); i++) {
                 TransactionState txnState = transactionStates.get(i);
                 warehouseId = txnState.getWarehouseId();
@@ -544,9 +546,14 @@ public class PublishVersionDaemon extends FrontendDaemon {
 
                 // used to delete txnLog when publish success
                 Map<ComputeNode, List<Long>> nodeToTablets = new HashMap<>();
-                Utils.publishVersionBatch(publishTablets, txnInfos,
-                        startVersion - 1, endVersion, compactionScores, nodeToTablets,
-                        warehouseId, null);
+                if (!enablePartitionAggregation) {
+                    Utils.publishVersionBatch(publishTablets, txnInfos,
+                            startVersion - 1, endVersion, compactionScores, nodeToTablets,
+                            warehouseId, null);
+                } else {
+                    Utils.aggregatePublishVersion(publishTablets, txnInfos, startVersion - 1, endVersion, 
+                            compactionScores, nodeToTablets, warehouseId, null);
+                }
 
                 Quantiles quantiles = Quantiles.compute(compactionScores.values());
                 stateBatch.setCompactionScore(tableId, partitionId, quantiles);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -828,13 +828,8 @@ public class PublishVersionDaemon extends FrontendDaemon {
                 Map<Long, Double> compactionScores = new HashMap<>();
                 // Used to collect statistics when the partition is first imported
                 Map<Long, Long> tabletRowNums = new HashMap<>();
-                if (!enablePartitionAggregation) {
-                    Utils.publishVersion(normalTablets, txnInfo, baseVersion, txnVersion, compactionScores,
-                            warehouseId, tabletRowNums);
-                } else {
-                    Utils.aggregatePublishVersion(normalTablets, Lists.newArrayList(txnInfo), baseVersion, txnVersion, 
-                            compactionScores, null, warehouseId, tabletRowNums);
-                }
+                Utils.publishVersion(normalTablets, txnInfo, baseVersion, txnVersion, compactionScores,
+                        warehouseId, tabletRowNums, enablePartitionAggregation);
 
                 Quantiles quantiles = Quantiles.compute(compactionScores.values());
                 partitionCommitInfo.setCompactionScore(quantiles);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeRollupJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeRollupJobTest.java
@@ -50,6 +50,7 @@ public class LakeRollupJobTest {
     private static LakeRollupJob lakeRollupJob;
     private static LakeRollupJob lakeRollupJob2;
     private static LakeRollupJob lakeRollupJob3;
+    private static LakeRollupJob lakeRollupJob4;
 
     private static Database db;
     private static Table table;
@@ -97,7 +98,22 @@ public class LakeRollupJobTest {
                         "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
                         "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
                         ")\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3");
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3")
+                .withTable("CREATE TABLE base_table4\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    k3 int\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                        "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES(\n" +
+                        "    \"enable_partition_aggregation\" = \"true\"\n" +
+                        ");");
 
         String sql = "create materialized view mv1 as\n" +
                 "select k2, k1 from base_table order by k2;";
@@ -105,6 +121,8 @@ public class LakeRollupJobTest {
                 "select k2, k1 from base_table2 order by k2;";
         String sql3 = "create materialized view mv3 as\n" +
                 "select k2, k1 from base_table3 order by k2;";
+        String sql4 = "create materialized view mv4 as\n" +
+                "select k2, k1 from base_table4 order by k2;";
         StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         Assert.assertTrue(stmt instanceof CreateMaterializedViewStmt);
         CreateMaterializedViewStmt createMaterializedViewStmt = (CreateMaterializedViewStmt) stmt;
@@ -120,15 +138,21 @@ public class LakeRollupJobTest {
         CreateMaterializedViewStmt createMaterializedViewStmt3 = (CreateMaterializedViewStmt) stmt3;
         GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createMaterializedViewStmt3);
 
+        StatementBase stmt4 = UtFrameUtils.parseStmtWithNewParser(sql4, connectContext);
+        Assert.assertTrue(stmt4 instanceof CreateMaterializedViewStmt);
+        CreateMaterializedViewStmt createMaterializedViewStmt4 = (CreateMaterializedViewStmt) stmt4;
+        GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createMaterializedViewStmt4);
+
         db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
         table = db.getTable("base_table");
 
         Map<Long, AlterJobV2> alterJobV2Map = GlobalStateMgr.getCurrentState().getRollupHandler().getAlterJobsV2();
-        Assert.assertEquals(3, alterJobV2Map.size());
+        Assert.assertEquals(4, alterJobV2Map.size());
         List<AlterJobV2> alterJobV2List = alterJobV2Map.values().stream().collect(Collectors.toList());
         lakeRollupJob = (LakeRollupJob) alterJobV2List.get(0);
         lakeRollupJob2 = (LakeRollupJob) alterJobV2List.get(1);
         lakeRollupJob3 = (LakeRollupJob) alterJobV2List.get(2);
+        lakeRollupJob4 = (LakeRollupJob) alterJobV2List.get(3);
     }
 
     @AfterClass
@@ -165,6 +189,37 @@ public class LakeRollupJobTest {
             Thread.sleep(100);
         }
         Assert.assertEquals(AlterJobV2.JobState.FINISHED, lakeRollupJob.getJobState());
+    }
+
+    @Test
+    public void testCreateSyncMvWithEnablePartitionAggregation() throws Exception {
+        new MockUp<LakeRollupJob>() {
+            @Mock
+            public void sendAgentTask(AgentBatchTask batchTask) {
+                batchTask.getAllTasks().forEach(t -> t.setFinished(true));
+            }
+        };
+
+        lakeRollupJob4.runPendingJob();
+        Assert.assertEquals(AlterJobV2.JobState.WAITING_TXN, lakeRollupJob4.getJobState());
+
+        lakeRollupJob4.runWaitingTxnJob();
+        Assert.assertEquals(AlterJobV2.JobState.RUNNING, lakeRollupJob4.getJobState());
+
+        List<List<Comparable>> infos = new ArrayList<>();
+        lakeRollupJob4.getInfo(infos);
+        Assert.assertEquals(1, infos.size());
+        Assert.assertTrue(!infos.get(0).get(10).equals(FeConstants.NULL_STRING));
+
+        Assert.assertEquals(1, infos.size());
+        lakeRollupJob4.runRunningJob();
+        Assert.assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, lakeRollupJob4.getJobState());
+
+        while (lakeRollupJob4.getJobState() != AlterJobV2.JobState.FINISHED) {
+            lakeRollupJob4.runFinishedRewritingJob();
+            Thread.sleep(100);
+        }
+        Assert.assertEquals(AlterJobV2.JobState.FINISHED, lakeRollupJob4.getJobState());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakeAggregatePublishTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakeAggregatePublishTest.java
@@ -47,7 +47,6 @@ import java.util.concurrent.TimeUnit;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
-//import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
@@ -32,8 +33,11 @@ import mockit.Mock;
 import mockit.MockUp;
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+//import org.junit.BeforeClass;
+//import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -43,14 +47,15 @@ public class LakePublishBatchTest {
     private static StarRocksAssert starRocksAssert;
 
     private static final String DB = "db_for_test";
-    private static final String TABLE = "table_for_test";
+    private static final String TABLE_AGG_ON = "table_for_test_agg_on";
+    private static final String TABLE_AGG_OFF = "table_for_test_agg_off";
     private TransactionState.TxnCoordinator transactionSource =
             new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE, "localfe");
 
     private static boolean enable_batch_publish_version;
     private static int batch_publish_min_version_num;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         enable_batch_publish_version = Config.lake_enable_batch_publish_version;
         batch_publish_min_version_num = Config.lake_batch_publish_min_version_num;
@@ -69,7 +74,7 @@ public class LakePublishBatchTest {
         starRocksAssert = new StarRocksAssert(connectContext);
         starRocksAssert.withDatabase(DB).useDatabase(DB);
 
-        String sql = "create table " + TABLE +
+        String sql1 = "create table " + TABLE_AGG_OFF +
                 " (dt date NOT NULL, pk bigint NOT NULL, v0 string not null) primary KEY (dt, pk) " +
                 "PARTITION BY RANGE(`dt`) (\n" +
                 "    PARTITION p20210820 VALUES [('2021-08-20'), ('2021-08-21')),\n" +
@@ -79,8 +84,21 @@ public class LakePublishBatchTest {
                 ")" +
                 "DISTRIBUTED BY HASH(pk) BUCKETS 3" +
                 " PROPERTIES(\"replication_num\" = \"" + 3 +
-                "\", \"storage_medium\" = \"SSD\")";
-        starRocksAssert.withTable(sql);
+                "\", \"storage_medium\" = \"SSD\", \"enable_partition_aggregation\" = \"false\")";
+        starRocksAssert.withTable(sql1);
+
+        String sql2 = "create table " + TABLE_AGG_ON +
+                " (dt date NOT NULL, pk bigint NOT NULL, v0 string not null) primary KEY (dt, pk) " +
+                "PARTITION BY RANGE(`dt`) (\n" +
+                "    PARTITION p20210820 VALUES [('2021-08-20'), ('2021-08-21')),\n" +
+                "    PARTITION p20210821 VALUES [('2021-08-21'), ('2021-08-22')),\n" +
+                "    PARTITION p20210929 VALUES [('2021-09-29'), ('2021-09-30')),\n" +
+                "    PARTITION p20210930 VALUES [('2021-09-30'), ('2021-10-01'))\n" +
+                ")" +
+                "DISTRIBUTED BY HASH(pk) BUCKETS 3" +
+                " PROPERTIES(\"replication_num\" = \"" + 3 +
+                "\", \"storage_medium\" = \"SSD\", \"enable_partition_aggregation\" = \"true\")";
+        starRocksAssert.withTable(sql2);
     }
 
     @AfterClass
@@ -89,10 +107,12 @@ public class LakePublishBatchTest {
         Config.lake_batch_publish_min_version_num = batch_publish_min_version_num;
     }
 
-    @Test
-    public void testNormal() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testNormal(boolean enableAggregation) throws Exception {
+        String tableName = enableAggregation ? TABLE_AGG_ON : TABLE_AGG_OFF;
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
-        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), TABLE);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
         List<TabletCommitInfo> transTablets1 = Lists.newArrayList();
         List<TabletCommitInfo> transTablets2 = Lists.newArrayList();
 
@@ -115,7 +135,7 @@ public class LakePublishBatchTest {
         GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
         long transactionId1 = globalTransactionMgr.
                 beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
-                        GlobalStateMgrTestUtil.testTxnLable1,
+                        GlobalStateMgrTestUtil.testTxnLable1 + "_" + UUIDUtil.genUUID().toString(),
                         transactionSource,
                         TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         // commit a transaction
@@ -124,7 +144,7 @@ public class LakePublishBatchTest {
 
         long transactionId2 = globalTransactionMgr.
                 beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
-                        GlobalStateMgrTestUtil.testTxnLable2,
+                        GlobalStateMgrTestUtil.testTxnLable2 + "_" + UUIDUtil.genUUID().toString(),
                         transactionSource,
                         TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         // commit a transaction
@@ -133,7 +153,7 @@ public class LakePublishBatchTest {
 
         long transactionId3 = globalTransactionMgr.
                 beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
-                        GlobalStateMgrTestUtil.testTxnLable3,
+                        GlobalStateMgrTestUtil.testTxnLable3 + "_" + UUIDUtil.genUUID().toString(),
                         transactionSource,
                         TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         // commit a transaction
@@ -142,7 +162,7 @@ public class LakePublishBatchTest {
 
         long transactionId4 = globalTransactionMgr.
                 beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
-                        GlobalStateMgrTestUtil.testTxnLable4,
+                        GlobalStateMgrTestUtil.testTxnLable4 + "_" + UUIDUtil.genUUID().toString(),
                         transactionSource,
                         TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         // commit a transaction
@@ -158,10 +178,12 @@ public class LakePublishBatchTest {
         Assert.assertTrue(waiter4.await(10, TimeUnit.SECONDS));
     }
 
-    @Test
-    public void testPublishTransactionState() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testPublishTransactionState(boolean enableAggregation) throws Exception {
+        String tableName = enableAggregation ? TABLE_AGG_ON : TABLE_AGG_OFF;
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
-        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), TABLE);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
         List<TabletCommitInfo> transTablets = Lists.newArrayList();
 
         for (Partition partition : table.getPartitions()) {
@@ -179,7 +201,7 @@ public class LakePublishBatchTest {
         Config.lake_batch_publish_min_version_num = 1;
         long transactionId9 = globalTransactionMgr.
                 beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
-                        GlobalStateMgrTestUtil.testTxnLable9,
+                        GlobalStateMgrTestUtil.testTxnLable9 + "_" + UUIDUtil.genUUID().toString(),
                         transactionSource,
                         TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         // commit a transaction
@@ -191,10 +213,12 @@ public class LakePublishBatchTest {
         Assert.assertTrue(waiter9.await(10, TimeUnit.SECONDS));
     }
 
-    @Test
-    public void testPublishDbDroped() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testPublishDbDroped(boolean enableAggregation) throws Exception {
+        String tableName = enableAggregation ? TABLE_AGG_ON : TABLE_AGG_OFF;
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
-        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), TABLE);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
         List<TabletCommitInfo> transTablets = Lists.newArrayList();
         for (Partition partition : table.getPartitions()) {
             MaterializedIndex baseIndex = partition.getDefaultPhysicalPartition().getBaseIndex();
@@ -210,7 +234,7 @@ public class LakePublishBatchTest {
 
         long transactionId5 = globalTransactionMgr.
                 beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
-                        GlobalStateMgrTestUtil.testTxnLable5,
+                        GlobalStateMgrTestUtil.testTxnLable5 + "_" + UUIDUtil.genUUID().toString(),
                         transactionSource,
                         TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         // commit a transaction
@@ -219,7 +243,7 @@ public class LakePublishBatchTest {
 
         long transactionId6 = globalTransactionMgr.
                 beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
-                        GlobalStateMgrTestUtil.testTxnLable6,
+                        GlobalStateMgrTestUtil.testTxnLable6 + "_" + UUIDUtil.genUUID().toString(),
                         transactionSource,
                         TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         // commit a transaction
@@ -247,10 +271,12 @@ public class LakePublishBatchTest {
         Assert.assertEquals(transactionState2.getTransactionStatus(), TransactionStatus.ABORTED);
     }
 
-    @Test
-    public void testPublishTableDropped() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testPublishTableDropped(boolean enableAggregation) throws Exception {
+        String tableName = enableAggregation ? TABLE_AGG_ON : TABLE_AGG_OFF;
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
-        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), TABLE);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
         List<TabletCommitInfo> transTablets = Lists.newArrayList();
         for (Partition partition : table.getPartitions()) {
             MaterializedIndex baseIndex = partition.getDefaultPhysicalPartition().getBaseIndex();
@@ -266,7 +292,7 @@ public class LakePublishBatchTest {
 
         long transactionId7 = globalTransactionMgr.
                 beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
-                        GlobalStateMgrTestUtil.testTxnLable7,
+                        GlobalStateMgrTestUtil.testTxnLable7 + "_" + UUIDUtil.genUUID().toString(),
                         transactionSource,
                         TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         // commit a transaction
@@ -275,7 +301,7 @@ public class LakePublishBatchTest {
 
         long transactionId8 = globalTransactionMgr.
                 beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
-                        GlobalStateMgrTestUtil.testTxnLable8,
+                        GlobalStateMgrTestUtil.testTxnLable8 + "_" + UUIDUtil.genUUID().toString(),
                         transactionSource,
                         TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         // commit a transaction
@@ -303,10 +329,12 @@ public class LakePublishBatchTest {
         Assert.assertEquals(transactionState2.getTransactionStatus(), TransactionStatus.VISIBLE);
     }
 
-    @Test
-    public void testTransformBatchToSingle() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testTransformBatchToSingle(boolean enableAggregation) throws Exception {
+        String tableName = enableAggregation ? TABLE_AGG_ON : TABLE_AGG_OFF;
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
-        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), TABLE);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
         List<TabletCommitInfo> transTablets1 = Lists.newArrayList();
         List<TabletCommitInfo> transTablets2 = Lists.newArrayList();
 
@@ -329,7 +357,7 @@ public class LakePublishBatchTest {
         GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
         long transactionId1 = globalTransactionMgr.
                 beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
-                        "label1",
+                        "label1" + "_" + UUIDUtil.genUUID().toString(),
                         transactionSource,
                         TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         // commit a transaction
@@ -338,7 +366,7 @@ public class LakePublishBatchTest {
 
         long transactionId2 = globalTransactionMgr.
                 beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
-                        "label2",
+                        "label2" + "_" + UUIDUtil.genUUID().toString(),
                         transactionSource,
                         TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         // commit a transaction
@@ -357,7 +385,7 @@ public class LakePublishBatchTest {
         Config.lake_enable_batch_publish_version = false;
         long transactionId3 = globalTransactionMgr.
                 beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
-                        "label3",
+                        "label3" + "_" + UUIDUtil.genUUID().toString(),
                         transactionSource,
                         TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         // commit a transaction


### PR DESCRIPTION
## Why I'm doing:
In previous PRs, we support aggregate publish for lake table. But there are some job not support aggregate publish yet:
1. batch publish
2. alter job

## What I'm doing:
enable aggregate publish for those jobs.

Fixes https://github.com/StarRocks/starrocks/issues/58316

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
