### PR TITLE
[Enhancement] Fix the cache select behavior when datacache is disabled

### DIFF
--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -101,12 +101,6 @@ private:
     Status _init_extended_values();
     Status _init_global_dicts(HdfsScannerParams* params);
     Status _init_scanner(RuntimeState* state);
-    HdfsScanner* _create_hudi_jni_scanner(const FSOptions& options);
-    HdfsScanner* _create_paimon_jni_scanner(const FSOptions& options);
-    // for hiveTable/fileTable with avro/rcfile/sequence format
-    HdfsScanner* _create_hive_jni_scanner(const FSOptions& options);
-    HdfsScanner* _create_odps_jni_scanner(const FSOptions& options);
-    HdfsScanner* _create_kudu_jni_scanner(const FSOptions& options);
     Status _check_all_slots_nullable();
 
     // =====================================


### PR DESCRIPTION
## Why I'm doing:

Previous behavior: When the data cache is disabled, `cache select xxx` would select all data and decode it, which consumed a significant amount of CPU resources.
Behavior after modification: When the data cache is disabled, the `cache select xxx` will selects no data and returns success immediately.

## What I'm doing:

Fix the cache select behavior when datacache is disable

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
