### PR TITLE
[Enhancement] fix unexpected function call in fill_dst_column

### DIFF
--- a/be/src/formats/parquet/scalar_column_reader.cpp
+++ b/be/src/formats/parquet/scalar_column_reader.cpp
@@ -634,6 +634,7 @@ bool LowCardColumnReader::try_to_use_dict_filter(ExprContext* ctx, bool is_decod
 }
 
 Status LowCardColumnReader::fill_dst_column(ColumnPtr& dst, ColumnPtr& src) {
+    size_t num_rows = src->size();
     if (!_code_convert_map.has_value()) {
         RETURN_IF_ERROR(_check_current_dict());
     }
@@ -647,7 +648,7 @@ Status LowCardColumnReader::fill_dst_column(ColumnPtr& dst, ColumnPtr& src) {
 
     auto& codes = codes_column->get_data();
     if (codes_nullable_column->has_null()) {
-        for (size_t i = 0; i < src->size(); i++) {
+        for (size_t i = 0; i < num_rows; i++) {
             // if null, we assign dict code 0
             // null = 0, mask = 0xffffffff
             // null = 1, mask = 0x00000000
@@ -658,7 +659,7 @@ Status LowCardColumnReader::fill_dst_column(ColumnPtr& dst, ColumnPtr& src) {
 
     auto* dst_data_column = down_cast<LowCardDictColumn*>(ColumnHelper::get_data_column(dst.get()));
     SIMDGather::gather(dst_data_column->get_data().data(), _code_convert_map->data(), codes.data(),
-                       _code_convert_map->size(), src->size());
+                       _code_convert_map->size(), num_rows);
 
     if (dst->is_nullable()) {
         auto* nullable_dst = down_cast<NullableColumn*>(dst.get());


### PR DESCRIPTION
## Why I'm doing:

baseline in fill_dst_column
```
 19.18 │ a0:┌─→mov        0x10(%r15),%rax                                                                                                                                                   ▒
  0.10 │    │  mov        0x10(%r13),%rcx                                                                                                                                                   ▒
  0.16 │    │  movzbl     (%rax,%r12,1),%eax                                                                                                                                                ▒
  0.75 │    │  sub        $0x1,%eax                                                                                                                                                         ▒
 19.34 │    │  and        %eax,(%rcx,%r12,4)                                                                                                                                                ▒
  3.86 │    │  add        $0x1,%r12                                                                                                                                                         ▒
 18.97 │ b8:│  mov        (%rbx),%rdi                                                                                                                                                       ▒
  0.06 │    │  mov        (%rdi),%rax                                                                                                                                                       ▒
  1.48 │    │→ call       *0xe0(%rax)                                                                                                                                                       ▒
 19.51 │    ├──cmp        %rax,%r12                                                                                                                                                         ▒
       │    └──jb         a0        
```

patched:
```
  3.02 │118:   vmovdqu      (%rdi),%ymm7                                                                                                                                                    ▒
  1.72 │       vpmovzxbw    (%rdi),%ymm1                                                                                                                                                    ▒
  0.36 │       add          $0x20,%rdi                                                                                                                                                      ▒
  2.73 │       sub          $0xffffffffffffff80,%rax                                                                                                                                        ▒
       │       vextracti128 $0x1,%ymm7,%xmm0                                                                                                                                                ▒
  0.11 │       vpaddw       %ymm3,%ymm1,%ymm1                                                                                                                                               ▒
  0.14 │       vpmovzxbw    %xmm0,%ymm0                                                                                                                                                     ▒
  2.59 │       vextracti128 $0x1,%ymm1,%xmm4                                                                                                                                                ▒
  0.14 │       vpmovsxwd    %xmm1,%ymm1                                                                                                                                                     ▒
  0.07 │       vpaddw       %ymm3,%ymm0,%ymm0                                                                                                                                               ▒
  0.14 │       vpand        -0x80(%rax),%ymm1,%ymm1                                                                                                                                         ▒
  6.36 │       vpmovsxwd    %xmm4,%ymm4                                                                                                                                                     ▒
  0.11 │       vpmovsxwd    %xmm0,%ymm2                                                                                                                                                     ▒
  0.04 │       vextracti128 $0x1,%ymm0,%xmm0                                                                                                                                                ▒
  0.07 │       vpand        -0x60(%rax),%ymm4,%ymm4                                                                                                                                         ▒
  3.55 │       vpand        -0x40(%rax),%ymm2,%ymm2                                                                                                                                         ▒
  4.09 │       vpmovsxwd    %xmm0,%ymm0                                                                                                                                                     ▒
  0.54 │       vpand        -0x20(%rax),%ymm0,%ymm0                                                                                                                                         ▒
  1.87 │       vmovdqu      %ymm1,-0x80(%rax)                                                                                                                                               ▒
  3.20 │       vmovdqu      %ymm4,-0x60(%rax)                                                                                                                                               ▒
  1.90 │       vmovdqu      %ymm2,-0x40(%rax)                                                                                                                                               ▒
       │       vmovdqu      %ymm0,-0x20(%rax)                                                                                                                                               ▒
  0.57 │       cmp          %rdi,%r9  
```

## What I'm doing:

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
