### PR TITLE
[Enhancement] Add version check in shared data

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -2085,6 +2085,58 @@ public class DatabaseTransactionMgr {
             try {
                 writeLock();
                 try {
+                    // check whether version is consistent
+                    Map<Long, PartitionCommitInfo> versions = new HashMap<>();
+                    List<TransactionState> states = stateBatch.getTransactionStates();
+                    long tableId = stateBatch.getTableId();
+                    Table table = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(db.getId(), tableId);
+                    if (table != null) {
+                        for (int i = 0; i < states.size(); i++) {
+                            TransactionState state = states.get(i);
+                            TableCommitInfo tableInfo = state.getTableCommitInfo(tableId);
+                            // TableCommitInfo could be null if the table has been dropped before this transaction is committed.
+                            if (tableInfo == null) {
+                                states = states.subList(0, Math.max(i, 1));
+                                break;
+                            }
+                            Map<Long, PartitionCommitInfo> partitionInfoMap = tableInfo.getIdToPartitionCommitInfo();
+                            for (Map.Entry<Long, PartitionCommitInfo> item : partitionInfoMap.entrySet()) {
+                                PartitionCommitInfo currTxnInfo = item.getValue();
+                                PartitionCommitInfo prevTxnInfo = versions.get(item.getKey());
+                                if (prevTxnInfo != null && prevTxnInfo.getVersion() + 1 != currTxnInfo.getVersion()) {
+                                    // should't happen
+                                    String errMsg =
+                                            String.format(
+                                                    "partition version is inconsistent in transactionStateBatch," +
+                                                            " partition %d, prev version %d, curr version: %d. table %d",
+                                                    item.getKey(), prevTxnInfo.getVersion(), currTxnInfo.getVersion(), tableId);
+                                    LOG.warn(errMsg);
+                                    return;
+
+                                } else if (prevTxnInfo == null) {
+                                    long partitionId = currTxnInfo.getPhysicalPartitionId();
+                                    PhysicalPartition partition = table.getPhysicalPartition(partitionId);
+                                    if (partition == null) {
+                                        continue;
+                                    }
+                                    if (partition.getVisibleVersion() + 1 != currTxnInfo.getVersion()) {
+                                        // should't happen
+                                        String errMsg =
+                                                String.format(
+                                                        "wait for publishing in batch partition %d version %d, " +
+                                                                "self version: %d. table %d",
+                                                        item.getKey(), partition.getVisibleVersion(),
+                                                        currTxnInfo.getVersion(), tableId);
+                                        LOG.warn(errMsg);
+                                        return;
+                                    }
+                                }
+                                versions.put(item.getKey(), currTxnInfo);
+                            }
+                        }
+                    }
+
                     stateBatch.setTransactionVisibleInfo();
                     unprotectSetTransactionStateBatch(stateBatch);
                     txnOperated = true;

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -2049,6 +2049,11 @@ public class DatabaseTransactionMgr {
         updateTransactionMetrics(transactionState);
     }
 
+    // only for test
+    public boolean checkTxnStateBatchConsistent(Database db, TransactionStateBatch stateBatch) {
+        return isTxnStateBatchConsistent(db, stateBatch);
+    }
+
     private boolean isTxnStateBatchConsistent(Database db, TransactionStateBatch stateBatch) {
         Map<Long, PartitionCommitInfo> versions = new HashMap<>();
         List<TransactionState> states = stateBatch.getTransactionStates();

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.transaction;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
@@ -81,12 +82,11 @@ public class LakeTableTxnLogApplier implements TransactionLogApplier {
             long versionTime = partitionCommitInfo.getVersionTime();
             Quantiles compactionScore = partitionCommitInfo.getCompactionScore();
 
-            // lake rollup will lead to version not continuously,
-            // just ingore check for now
-            // or we can persist a mocked transactionState.
             // The version of a replication transaction may not continuously
-            //Preconditions.checkState(txnState.getSourceType() == TransactionState.LoadJobSourceType.REPLICATION
-            //        || version == partition.getVisibleVersion() + 1);
+            Preconditions.checkState(txnState.getSourceType() == TransactionState.LoadJobSourceType.REPLICATION
+                    || txnState.isVersionOverwrite()
+                    || partitionCommitInfo.isDoubleWrite()
+                    || version == partition.getVisibleVersion() + 1);
 
             partition.updateVisibleVersion(version, versionTime);
             if (txnState.getSourceType() != TransactionState.LoadJobSourceType.LAKE_COMPACTION) {


### PR DESCRIPTION
## Why I'm doing:
The version consistency check was removed in this PR #44425 , but it can actually be added back so that we can know the situation when there is a problem.  And to avoid FE crash by unexpected reasons caused by the Inconsistency , add the logic of check  to `publishTransactionBatch` before the check in `TxnLogApplier`.
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
