### PR TITLE
[Feature] Distributing data according to virtual buckets for dynamic tablet splitting and merging

### DIFF
--- a/be/src/exec/tablet_info.h
+++ b/be/src/exec/tablet_info.h
@@ -110,7 +110,7 @@ public:
         }
     }
 
-    TabletLocation* find_tablet(int64_t tablet_id) {
+    const TabletLocation* find_tablet(int64_t tablet_id) {
         auto it = _tablets.find(tablet_id);
         if (it != std::end(_tablets)) {
             return &it->second;
@@ -120,8 +120,7 @@ public:
 
     void add_locations(std::vector<TTabletLocation>& locations) {
         for (auto& location : locations) {
-            if (_tablets.count(location.tablet_id) == 0) {
-                _tablets.emplace(location.tablet_id, std::move(location));
+            if (_tablets.try_emplace(location.tablet_id, std::move(location)).second) {
                 VLOG(2) << "add location " << location;
             }
         }
@@ -184,7 +183,6 @@ struct OlapTablePartition {
     ChunkRow start_key;
     ChunkRow end_key;
     std::vector<ChunkRow> in_keys;
-    int64_t num_buckets = 0;
     std::vector<OlapTableIndexTablets> indexes;
 };
 

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -332,20 +332,22 @@ Status OlapTableSink::_init_node_channels(RuntimeState* state, IndexIdToTabletBE
         // collect all tablets belong to this rollup
         std::vector<PTabletWithPartition> tablets;
         auto* index = _schema->indexes()[i];
-        std::unordered_map<int64_t, std::vector<int64_t>> tablet_to_be;
+        auto& tablet_to_be = index_id_to_tablet_be_map[index->index_id];
         for (auto& [id, part] : partitions) {
-            for (auto tablet : part->indexes[i].tablets) {
-                PTabletWithPartition tablet_info;
-                tablet_info.set_tablet_id(tablet);
+            for (auto tablet_id : part->indexes[i].tablets) {
+                auto& tablet_info = tablets.emplace_back();
+                tablet_info.set_tablet_id(tablet_id);
                 tablet_info.set_partition_id(part->id);
 
                 // setup replicas
-                auto* location = _location->find_tablet(tablet);
+                auto* location = _location->find_tablet(tablet_id);
                 if (location == nullptr) {
-                    auto msg = fmt::format("Failed to find tablet {} location info", tablet);
+                    auto msg = fmt::format("Failed to find tablet_id {} location info", tablet_id);
                     return Status::NotFound(msg);
                 }
-                tablet_to_be.emplace(tablet, location->node_ids);
+                if (!tablet_to_be.emplace(tablet_id, location->node_ids).second) {
+                    return Status::InvalidArgument(fmt::format("Duplicated tablet_id: {}", tablet_id));
+                }
 
                 auto node_ids_size = location->node_ids.size();
                 for (size_t i = 0; i < node_ids_size; ++i) {
@@ -379,11 +381,8 @@ Status OlapTableSink::_init_node_channels(RuntimeState* state, IndexIdToTabletBE
                         }
                     }
                 }
-
-                tablets.emplace_back(std::move(tablet_info));
             }
         }
-        index_id_to_tablet_be_map.emplace(index->index_id, std::move(tablet_to_be));
 
         auto channel = std::make_unique<IndexChannel>(this, index->index_id, index->where_clause);
         RETURN_IF_ERROR(channel->init(state, tablets, false));
@@ -534,18 +533,22 @@ Status OlapTableSink::_incremental_open_node_channel(const std::vector<TOlapTabl
     IndexIdToTabletBEMap index_tablet_bes_map;
     for (auto& t_part : partitions) {
         for (auto& index : t_part.indexes) {
-            std::vector<PTabletWithPartition> tablets;
+            auto& tablets = index_tablets_map[index.index_id];
+            auto& tablet_to_be = index_tablet_bes_map[index.index_id];
             // setup new partitions's tablets
-            for (auto tablet : index.tablets) {
-                PTabletWithPartition tablet_info;
-                tablet_info.set_tablet_id(tablet);
+            for (auto tablet_id : index.tablets) {
+                auto& tablet_info = tablets.emplace_back();
+                tablet_info.set_tablet_id(tablet_id);
                 // TODO: support logical materialized views;
                 tablet_info.set_partition_id(t_part.id);
 
-                auto* location = _location->find_tablet(tablet);
+                auto* location = _location->find_tablet(tablet_id);
                 if (location == nullptr) {
-                    auto msg = fmt::format("Failed to find tablet {} location info in incremental open", tablet);
+                    auto msg = fmt::format("Failed to find tablet_id {} location info in incremental open", tablet_id);
                     return Status::NotFound(msg);
+                }
+                if (!tablet_to_be.emplace(tablet_id, location->node_ids).second) {
+                    return Status::InvalidArgument(fmt::format("Duplicated tablet_id: {}", tablet_id));
                 }
 
                 for (auto& node_id : location->node_ids) {
@@ -557,11 +560,7 @@ Status OlapTableSink::_incremental_open_node_channel(const std::vector<TOlapTabl
                     replica->set_host(node_info->host);
                     replica->set_port(node_info->brpc_port);
                     replica->set_node_id(node_id);
-
-                    index_tablet_bes_map[index.index_id][tablet].emplace_back(node_id);
                 }
-
-                index_tablets_map[index.index_id].emplace_back(std::move(tablet_info));
             }
         }
     }

--- a/be/src/exec/tablet_sink_colocate_sender.cpp
+++ b/be/src/exec/tablet_sink_colocate_sender.cpp
@@ -61,9 +61,8 @@ Status TabletSinkColocateSender::send_chunk(const OlapTableSchemaParam* schema,
                 uint16_t selection = validate_select_idx[j];
                 const auto* partition = partitions[selection];
                 index_id_partition_id[index->index_id].emplace(partition->id);
-                const auto& tablets = partition->indexes[i].tablets;
-                // TODO: remove num_buckets
-                _index_tablet_ids[i][selection] = tablets[record_hashes[selection] % partition->num_buckets];
+                const auto& virtual_buckets = partition->indexes[i].virtual_buckets;
+                _index_tablet_ids[i][selection] = virtual_buckets[record_hashes[selection] % virtual_buckets.size()];
             }
         }
         return _send_chunks(schema, chunk, _index_tablet_ids, validate_select_idx);
@@ -76,9 +75,8 @@ Status TabletSinkColocateSender::send_chunk(const OlapTableSchemaParam* schema,
             for (size_t j = 0; j < num_rows; ++j) {
                 const auto* partition = partitions[j];
                 index_id_partition_id[index->index_id].emplace(partition->id);
-                const auto& tablets = partition->indexes[i].tablets;
-                // TODO: remove num_buckets
-                _index_tablet_ids[i][j] = tablets[record_hashes[j] % partition->num_buckets];
+                const auto& virtual_buckets = partition->indexes[i].virtual_buckets;
+                _index_tablet_ids[i][j] = virtual_buckets[record_hashes[j] % virtual_buckets.size()];
             }
         }
         return _send_chunks(schema, chunk, _index_tablet_ids, validate_select_idx);

--- a/be/src/exec/tablet_sink_sender.cpp
+++ b/be/src/exec/tablet_sink_sender.cpp
@@ -60,9 +60,8 @@ Status TabletSinkSender::send_chunk(const OlapTableSchemaParam* schema,
                 uint16_t selection = validate_select_idx[j];
                 const auto* partition = partitions[selection];
                 index_id_partition_id[index->index_id].emplace(partition->id);
-                const auto& tablets = partition->indexes[i].tablets;
-                // TODO: remove num_bucket
-                _tablet_ids[selection] = tablets[record_hashes[selection] % partition->num_buckets];
+                const auto& virtual_buckets = partition->indexes[i].virtual_buckets;
+                _tablet_ids[selection] = virtual_buckets[record_hashes[selection] % virtual_buckets.size()];
             }
             RETURN_IF_ERROR(_send_chunk_by_node(chunk, _channels[i], validate_select_idx));
         }
@@ -73,9 +72,8 @@ Status TabletSinkSender::send_chunk(const OlapTableSchemaParam* schema,
             for (size_t j = 0; j < num_rows; ++j) {
                 const auto* partition = partitions[j];
                 index_id_partition_id[index->index_id].emplace(partition->id);
-                const auto& tablets = partition->indexes[i].tablets;
-                // TODO: remove num_bucket
-                _tablet_ids[j] = tablets[record_hashes[j] % partition->num_buckets];
+                const auto& virtual_buckets = partition->indexes[i].virtual_buckets;
+                _tablet_ids[j] = virtual_buckets[record_hashes[j] % virtual_buckets.size()];
             }
             RETURN_IF_ERROR(_send_chunk_by_node(chunk, _channels[i], validate_select_idx));
         }

--- a/be/src/storage/table_reader.cpp
+++ b/be/src/storage/table_reader.cpp
@@ -131,9 +131,8 @@ Status TableReader::multi_get(Chunk& keys, const std::vector<std::string>& value
     for (size_t i = 0; i < selected_size; ++i) {
         size_t key_index = validate_select_idx[i];
         const auto* partition = partitions[key_index];
-        const auto& tablets = partition->indexes[0].tablets;
-        // TODO: remove num_buckets
-        int64_t tablet_id = tablets[record_hashes[key_index] % partition->num_buckets];
+        const auto& virtual_buckets = partition->indexes[0].virtual_buckets;
+        int64_t tablet_id = virtual_buckets[record_hashes[key_index] % virtual_buckets.size()];
         auto iter = multi_gets_by_tablet.find(tablet_id);
         TabletMultiGet* multi_get = nullptr;
         if (iter == multi_gets_by_tablet.end()) {

--- a/be/test/exec/tablet_info_test.cpp
+++ b/be/test/exec/tablet_info_test.cpp
@@ -110,7 +110,6 @@ TEST_F(OlapTablePartitionParamTest, unknown_distributed_col) {
     t_partition_param.__set_distributed_columns({"c4"});
     t_partition_param.partitions.resize(1);
     t_partition_param.partitions[0].id = 10;
-    t_partition_param.partitions[0].num_buckets = 1;
     t_partition_param.partitions[0].indexes.resize(2);
     t_partition_param.partitions[0].indexes[0].index_id = 4;
     t_partition_param.partitions[0].indexes[0].tablets = {21};
@@ -137,7 +136,6 @@ TEST_F(OlapTablePartitionParamTest, bad_index) {
         t_partition_param.__set_distributed_columns({"c1", "c3"});
         t_partition_param.partitions.resize(1);
         t_partition_param.partitions[0].id = 10;
-        t_partition_param.partitions[0].num_buckets = 1;
         t_partition_param.partitions[0].indexes.resize(1);
         t_partition_param.partitions[0].indexes[0].index_id = 4;
         t_partition_param.partitions[0].indexes[0].tablets = {21};
@@ -156,7 +154,6 @@ TEST_F(OlapTablePartitionParamTest, bad_index) {
         t_partition_param.__set_distributed_columns({"c1", "c3"});
         t_partition_param.partitions.resize(1);
         t_partition_param.partitions[0].id = 10;
-        t_partition_param.partitions[0].num_buckets = 1;
         t_partition_param.partitions[0].indexes.resize(2);
         t_partition_param.partitions[0].indexes[0].index_id = 4;
         t_partition_param.partitions[0].indexes[0].tablets = {21};

--- a/be/test/exec/tablet_sink_index_channel_test.cpp
+++ b/be/test/exec/tablet_sink_index_channel_test.cpp
@@ -88,7 +88,6 @@ protected:
         partition.distributed_columns.push_back("c1");
         partition.partitions.resize(1);
         partition.partitions[0].id = 0;
-        partition.partitions[0].num_buckets = 1;
         partition.partitions[0].indexes.resize(1);
         partition.partitions[0].indexes[0].index_id = 0;
         partition.partitions[0].indexes[0].tablets.push_back(0);

--- a/be/test/storage/table_reader_remote_test.cpp
+++ b/be/test/storage/table_reader_remote_test.cpp
@@ -141,7 +141,6 @@ public:
         params.partition_param.__set_distributed_columns({"pk1"});
         params.partition_param.partitions.resize(1);
         params.partition_param.partitions[0].id = 1;
-        params.partition_param.partitions[0].num_buckets = num_buckets;
         params.partition_param.partitions[0].indexes.resize(1);
         params.partition_param.partitions[0].indexes[0].index_id = 1111;
         params.partition_param.partitions[0].indexes[0].tablets = _tablet_ids;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
@@ -102,7 +102,8 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
     @SerializedName(value = "rowCount")
     private long rowCount;
 
-    // Virtual buckets. Each virtual bucket saves a tablet id.
+    // Virtual buckets. There is a tablet id for each virtual bucket,
+    // which means this virtual bucket's data is stored in this tablet.
     // We divide data into virtual buckets and then arrange these virtual buckets
     // into physical buckets, which are tablets.
     // Each virtual bucket is associated with a tablet. Multiple virtual buckets are

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -743,9 +743,9 @@ public class OlapTableSink extends DataSink {
 
     private static void setIndexAndBucketNums(PhysicalPartition partition, TOlapTablePartition tPartition) {
         for (MaterializedIndex index : partition.getMaterializedIndices(IndexExtState.ALL)) {
-            tPartition.addToIndexes(new TOlapTableIndexTablets(index.getId(), Lists.newArrayList(
-                    index.getTablets().stream().map(Tablet::getId).collect(Collectors.toList()))));
-            tPartition.setNum_buckets(index.getTablets().size());
+            TOlapTableIndexTablets tIndex = new TOlapTableIndexTablets(index.getId(), index.getTabletIdsInOrder());
+            tIndex.setVirtual_buckets(Lists.newArrayList(index.getVirtualBuckets()));
+            tPartition.addToIndexes(tIndex);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -2123,9 +2123,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             }
         }
         for (MaterializedIndex index : physicalPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
-            tPartition.addToIndexes(new TOlapTableIndexTablets(index.getId(), Lists.newArrayList(
-                    index.getTablets().stream().map(Tablet::getId).collect(Collectors.toList()))));
-            tPartition.setNum_buckets(index.getTablets().size());
+            TOlapTableIndexTablets tIndex = new TOlapTableIndexTablets(index.getId(), index.getTabletIdsInOrder());
+            tIndex.setVirtual_buckets(Lists.newArrayList(index.getVirtualBuckets()));
+            tPartition.addToIndexes(tIndex);
         }
         partitions.add(tPartition);
     }
@@ -2535,9 +2535,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         }
         for (MaterializedIndex index : partition.getDefaultPhysicalPartition()
                 .getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
-            tPartition.addToIndexes(new TOlapTableIndexTablets(index.getId(), Lists.newArrayList(
-                    index.getTablets().stream().map(Tablet::getId).collect(Collectors.toList()))));
-            tPartition.setNum_buckets(index.getTablets().size());
+            TOlapTableIndexTablets tIndex = new TOlapTableIndexTablets(index.getId(), index.getTabletIdsInOrder());
+            tIndex.setVirtual_buckets(Lists.newArrayList(index.getVirtualBuckets()));
+            tPartition.addToIndexes(tIndex);
         }
         partitions.add(tPartition);
         txnState.getPartitionNameToTPartition().put(partition.getName(), tPartition);

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -243,6 +243,10 @@ struct TColumn {
 struct TOlapTableIndexTablets {
     1: required i64 index_id
     2: required list<i64> tablets
+
+    // Virtual buckets. There is a tablet id for each virtual bucket,
+    // which means this virtual bucket's data is stored in this tablet.
+    3: optional list<i64> virtual_buckets
 }
 
 // its a closed-open range
@@ -252,8 +256,8 @@ struct TOlapTablePartition {
     2: optional Exprs.TExprNode start_key
     3: optional Exprs.TExprNode end_key
 
-    // how many tablets in one partition
-    4: required i32 num_buckets
+    // Deprecated, different indexes could have different buckets
+    4: optional i32 deprecated_num_buckets = 0
 
     5: required list<TOlapTableIndexTablets> indexes
 


### PR DESCRIPTION
## Why I'm doing:
https://github.com/StarRocks/starrocks/pull/59378 introduced virtual buckets metadata, which has not been used to distribute data.
This pr uses virtual buckets metadata to distribute data.

## What I'm doing:
Distributing data according to virtual buckets for dynamic tablet splitting and merging

Fixes https://github.com/StarRocks/starrocks/issues/59134

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
