### PR TITLE
[BugFix] Fix storage_size lost in partitions_meta table

### DIFF
--- a/be/src/exec/schema_scanner/schema_partitions_meta_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_partitions_meta_scanner.cpp
@@ -54,6 +54,7 @@ SchemaScanner::ColumnDesc SchemaPartitionsMetaScanner::_s_columns[] = {
         {"P50_CS", TypeDescriptor::from_logical_type(TYPE_DOUBLE), sizeof(double), false},
         {"MAX_CS", TypeDescriptor::from_logical_type(TYPE_DOUBLE), sizeof(double), false},
         {"STORAGE_PATH", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), false},
+        {"STORAGE_SIZE", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
 };
 
 SchemaPartitionsMetaScanner::SchemaPartitionsMetaScanner()
@@ -295,6 +296,12 @@ Status SchemaPartitionsMetaScanner::fill_chunk(ChunkPtr* chunk) {
             fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&storage_path);
             break;
         }
+        case 29: {
+            // STORAGE_SIZE
+            fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.storage_size);
+            break;
+        }
+
         default:
             break;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -492,6 +492,8 @@ public class InformationSchemaDataSource {
         partitionMetaInfo.setData_version(physicalPartition.getDataVersion());
         partitionMetaInfo.setVersion_epoch(physicalPartition.getVersionEpoch());
         partitionMetaInfo.setVersion_txn_type(physicalPartition.getVersionTxnType().toThrift());
+        // STORAGE_SIZE
+        partitionMetaInfo.setStorage_size(physicalPartition.storageDataSize() + physicalPartition.getExtraFileSize());
     }
 
     // tables

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1511,6 +1511,7 @@ struct TPartitionMetaInfo {
     26: optional i64 data_version
     27: optional i64 version_epoch
     28: optional Types.TTxnType version_txn_type = Types.TTxnType.TXN_NORMAL
+    29: optional i64 storage_size
 }
 
 struct TGetPartitionsMetaResponse {

--- a/test/sql/test_information_schema/R/test_partitions_meta
+++ b/test/sql/test_information_schema/R/test_partitions_meta
@@ -14,7 +14,7 @@ PARTITION BY RANGE(`v`)
 (PARTITION p1 VALUES [("-2147483648"), ("0")),
 PARTITION p2 VALUES [("0"), ("10")),
 PARTITION p3 VALUES [("10"), ("2147483647")))
-DISTRIBUTED BY HASH(`k`) BUCKETS 2
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
 PROPERTIES (
 "replication_num" = "1"
 );
@@ -38,14 +38,14 @@ PROPERTIES (
 admin set frontend config("max_get_partitions_meta_result_count"="1");
 -- result:
 -- !result
-select TABLE_NAME, PARTITION_NAME, DATA_VERSION, VERSION_TXN_TYPE from INFORMATION_SCHEMA.PARTITIONS_META where table_name like '%partitions_meta_test%' order by table_name asc, partition_name asc;
+select TABLE_NAME, PARTITION_NAME, DATA_VERSION, VERSION_TXN_TYPE, STORAGE_SIZE from INFORMATION_SCHEMA.PARTITIONS_META where table_name like '%partitions_meta_test%' order by table_name asc, partition_name asc;
 -- result:
-partitions_meta_test1	p1	1	TXN_NORMAL
-partitions_meta_test1	p2	1	TXN_NORMAL
-partitions_meta_test1	p3	1	TXN_NORMAL
-partitions_meta_test2	p1	1	TXN_NORMAL
-partitions_meta_test2	p2	1	TXN_NORMAL
-partitions_meta_test2	p3	1	TXN_NORMAL
+partitions_meta_test1	p1	1	TXN_NORMAL	0
+partitions_meta_test1	p2	1	TXN_NORMAL	0
+partitions_meta_test1	p3	1	TXN_NORMAL	0
+partitions_meta_test2	p1	1	TXN_NORMAL	0
+partitions_meta_test2	p2	1	TXN_NORMAL	0
+partitions_meta_test2	p3	1	TXN_NORMAL	0
 -- !result
 admin set frontend config("max_get_partitions_meta_result_count"="100000");
 -- result:

--- a/test/sql/test_information_schema/T/test_partitions_meta
+++ b/test/sql/test_information_schema/T/test_partitions_meta
@@ -28,6 +28,6 @@ PROPERTIES (
 "replication_num" = "1"
 );
 admin set frontend config("max_get_partitions_meta_result_count"="1");
-select TABLE_NAME, PARTITION_NAME, DATA_VERSION, VERSION_TXN_TYPE from INFORMATION_SCHEMA.PARTITIONS_META where table_name like '%partitions_meta_test%' order by table_name asc, partition_name asc;
+select TABLE_NAME, PARTITION_NAME, DATA_VERSION, VERSION_TXN_TYPE, STORAGE_SIZE from INFORMATION_SCHEMA.PARTITIONS_META where table_name like '%partitions_meta_test%' order by table_name asc, partition_name asc;
 admin set frontend config("max_get_partitions_meta_result_count"="100000");
 drop database db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
This pr(https://github.com/StarRocks/starrocks/pull/56234) add storage_size for lake table and add it to partition proc, but storage size does not added to table `partitions_meta`.

## What I'm doing:
Add storage_size to table `partitions_meta`

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
