### PR TITLE
[Enhancement] pk compaction should not retry when apply timeout

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2104,9 +2104,11 @@ Status TabletUpdates::_do_compaction(std::unique_ptr<CompactionInfo>* pinfo, con
     EditVersion version;
     RETURN_IF_ERROR(_commit_compaction(pinfo, *output_rowset, &version));
     {
-        // already committed, so we can ignore timeout error here
         std::unique_lock<std::mutex> ul(_lock);
-        RETURN_IF_ERROR(_wait_for_version(version, 120000, ul, true));
+        auto st = _wait_for_version(version, 120000, ul, true);
+        // apply timeout doesn't mean compaction failed, we shouldn't return error,
+        // apply task will success later.
+        RETURN_IF(!st.ok() && !st.is_timeout(), st);
     }
     // Release metadata memory after rowsets have been compacted.
     Rowset::close_rowsets(input_rowsets);

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2108,7 +2108,7 @@ Status TabletUpdates::_do_compaction(std::unique_ptr<CompactionInfo>* pinfo, con
         auto st = _wait_for_version(version, 120000, ul, true);
         // apply timeout doesn't mean compaction failed, we shouldn't return error,
         // apply task will success later.
-        RETURN_IF(!st.ok() && !st.is_timeout(), st);
+        RETURN_IF(!st.ok() && !st.is_time_out(), st);
     }
     // Release metadata memory after rowsets have been compacted.
     Rowset::close_rowsets(input_rowsets);


### PR DESCRIPTION
## Why I'm doing:
In the current implementation, during the final stage of `_do_compaction`,  it waits for the apply operation to complete with a maximum timeout of 120 seconds. If a timeout occurs here, it will lead to:

1. Continuous retries of the compaction process
2. Failure to promptly close the rowset

## What I'm doing:
This pull request includes a change in the `_do_compaction` method in `tablet_updates.cpp` to improve error handling for version application timeouts during compaction. The most significant change ensures that a timeout during `_wait_for_version` does not incorrectly propagate as a failure, allowing the apply task to succeed later.

Error handling improvement:

* [`be/src/storage/tablet_updates.cpp`](diffhunk://#diff-269b48b8e08e9d0910eef0c84ae94a418eb2c7780b2dae5817badbea2a77102cL2107-R2111): Modified `_do_compaction` to handle `_wait_for_version` timeouts more gracefully by checking the status and only returning an error if it is not a timeout. This prevents unnecessary error propagation and ensures the apply task can complete successfully later.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
