### PR TITLE
[Feature] Change bucket number from physical partition level to materialized index level

### DIFF
--- a/be/src/exec/tablet_info.h
+++ b/be/src/exec/tablet_info.h
@@ -171,11 +171,11 @@ private:
 
 struct ChunkRow {
     ChunkRow() = default;
-    ChunkRow(Columns* columns_, uint32_t index_) : columns(columns_), index(index_) {}
+    ChunkRow(const Columns* columns_, uint32_t index_) : columns(columns_), index(index_) {}
 
     std::string debug_string();
 
-    Columns* columns = nullptr;
+    const Columns* columns = nullptr;
     uint32_t index = 0;
 };
 
@@ -258,7 +258,7 @@ public:
     // `invalid_row_index` stores index that chunk[index]
     // has been filtered out for not being able to find tablet.
     // it could be any row, becauset it's just for outputing error message for user to diagnose.
-    Status find_tablets(Chunk* chunk, std::vector<OlapTablePartition*>* partitions, std::vector<uint32_t>* indexes,
+    Status find_tablets(Chunk* chunk, std::vector<OlapTablePartition*>* partitions, std::vector<uint32_t>* hashes,
                         std::vector<uint8_t>* selection, std::vector<int>* invalid_row_indexs, int64_t txn_id,
                         std::vector<std::vector<std::string>>* partition_not_exist_row_values);
 
@@ -276,40 +276,40 @@ private:
     /**
      * @brief  find tablets with range partition table
      * @param chunk  input chunk
-     * @param partition_columns input partition columns 
+     * @param partition_columns input partition columns
+     * @param hashes  input row hashes
      * @param partitions  output partitions
-     * @param indexes  output partition indexes
      * @param selection  chunk's selection
      * @param invalid_row_indexs output invalid row indexs
      * @param partition_not_exist_row_values  output partition not exist row values
      * @return Status 
      */
-    Status _find_tablets_with_range_partition(Chunk* chunk, Columns partition_columns,
+    Status _find_tablets_with_range_partition(Chunk* chunk, const Columns& partition_columns,
+                                              const std::vector<uint32_t>& hashes,
                                               std::vector<OlapTablePartition*>* partitions,
-                                              std::vector<uint32_t>* indexes, std::vector<uint8_t>* selection,
-                                              std::vector<int>* invalid_row_indexs,
+                                              std::vector<uint8_t>* selection, std::vector<int>* invalid_row_indexs,
                                               std::vector<std::vector<std::string>>* partition_not_exist_row_values);
 
     /**
      * @brief  find tablets with list partition table
      * @param chunk  input chunk
-     * @param partition_columns input partition columns 
+     * @param partition_columns input partition columns
+     * @param hashes  input row hashes
      * @param partitions  output partitions
-     * @param indexes  output partition indexes
      * @param selection  chunk's selection
      * @param invalid_row_indexs output invalid row indexs
      * @param partition_not_exist_row_values  output partition not exist row values
      * @return Status 
      */
-    Status _find_tablets_with_list_partition(Chunk* chunk, Columns partition_columns,
+    Status _find_tablets_with_list_partition(Chunk* chunk, const Columns& partition_columns,
+                                             const std::vector<uint32_t>& hashes,
                                              std::vector<OlapTablePartition*>* partitions,
-                                             std::vector<uint32_t>* indexes, std::vector<uint8_t>* selection,
-                                             std::vector<int>* invalid_row_indexs,
+                                             std::vector<uint8_t>* selection, std::vector<int>* invalid_row_indexs,
                                              std::vector<std::vector<std::string>>* partition_not_exist_row_values);
 
     Status _create_partition_keys(const std::vector<TExprNode>& t_exprs, ChunkRow* part_key);
 
-    void _compute_hashes(Chunk* chunk, std::vector<uint32_t>* indexes);
+    void _compute_hashes(const Chunk* chunk, std::vector<uint32_t>* hashes);
 
     // check if this partition contain this key
     bool _part_contains(OlapTablePartition* part, ChunkRow* key) const {
@@ -327,7 +327,7 @@ private:
     std::vector<SlotDescriptor*> _partition_slot_descs;
     std::vector<SlotDescriptor*> _distributed_slot_descs;
     Columns _partition_columns;
-    std::vector<Column*> _distributed_columns;
+    std::vector<const Column*> _distributed_columns;
     std::vector<ExprContext*> _partitions_expr_ctxs;
 
     ObjectPool _obj_pool;

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -211,7 +211,7 @@ private:
     std::vector<std::unique_ptr<IndexChannel>> _channels;
     std::vector<OlapTablePartition*> _partitions;
     std::unordered_map<int64_t, std::set<int64_t>> _index_id_partition_ids;
-    std::vector<uint32_t> _tablet_indexes;
+    std::vector<uint32_t> _record_hashes;
     // Store the output expr comput result column
     std::unique_ptr<Chunk> _output_chunk;
     bool _open_done{false};

--- a/be/src/exec/tablet_sink_colocate_sender.h
+++ b/be/src/exec/tablet_sink_colocate_sender.h
@@ -31,7 +31,7 @@ public:
 
 public:
     Status send_chunk(const OlapTableSchemaParam* schema, const std::vector<OlapTablePartition*>& partitions,
-                      const std::vector<uint32_t>& tablet_indexes, const std::vector<uint16_t>& validate_select_idx,
+                      const std::vector<uint32_t>& record_hashes, const std::vector<uint16_t>& validate_select_idx,
                       std::unordered_map<int64_t, std::set<int64_t>>& index_id_partition_id, Chunk* chunkk) override;
 
     Status try_open(RuntimeState* state) override;

--- a/be/src/exec/tablet_sink_sender.cpp
+++ b/be/src/exec/tablet_sink_sender.cpp
@@ -42,7 +42,7 @@ TabletSinkSender::TabletSinkSender(PUniqueId load_id, int64_t txn_id, IndexIdToT
 
 Status TabletSinkSender::send_chunk(const OlapTableSchemaParam* schema,
                                     const std::vector<OlapTablePartition*>& partitions,
-                                    const std::vector<uint32_t>& tablet_indexes,
+                                    const std::vector<uint32_t>& record_hashes,
                                     const std::vector<uint16_t>& validate_select_idx,
                                     std::unordered_map<int64_t, std::set<int64_t>>& index_id_partition_id,
                                     Chunk* chunk) {
@@ -58,8 +58,11 @@ Status TabletSinkSender::send_chunk(const OlapTableSchemaParam* schema,
             auto* index = schema->indexes()[i];
             for (size_t j = 0; j < selection_size; ++j) {
                 uint16_t selection = validate_select_idx[j];
-                index_id_partition_id[index->index_id].emplace(partitions[selection]->id);
-                _tablet_ids[selection] = partitions[selection]->indexes[i].tablets[tablet_indexes[selection]];
+                const auto* partition = partitions[selection];
+                index_id_partition_id[index->index_id].emplace(partition->id);
+                const auto& tablets = partition->indexes[i].tablets;
+                // TODO: remove num_bucket
+                _tablet_ids[selection] = tablets[record_hashes[selection] % partition->num_buckets];
             }
             RETURN_IF_ERROR(_send_chunk_by_node(chunk, _channels[i], validate_select_idx));
         }
@@ -68,8 +71,11 @@ Status TabletSinkSender::send_chunk(const OlapTableSchemaParam* schema,
         for (size_t i = 0; i < index_size; ++i) {
             auto* index = schema->indexes()[i];
             for (size_t j = 0; j < num_rows; ++j) {
-                index_id_partition_id[index->index_id].emplace(partitions[j]->id);
-                _tablet_ids[j] = partitions[j]->indexes[i].tablets[tablet_indexes[j]];
+                const auto* partition = partitions[j];
+                index_id_partition_id[index->index_id].emplace(partition->id);
+                const auto& tablets = partition->indexes[i].tablets;
+                // TODO: remove num_bucket
+                _tablet_ids[j] = tablets[record_hashes[j] % partition->num_buckets];
             }
             RETURN_IF_ERROR(_send_chunk_by_node(chunk, _channels[i], validate_select_idx));
         }

--- a/be/src/exec/tablet_sink_sender.h
+++ b/be/src/exec/tablet_sink_sender.h
@@ -33,7 +33,7 @@ public:
 
 public:
     virtual Status send_chunk(const OlapTableSchemaParam* schema, const std::vector<OlapTablePartition*>& partitions,
-                              const std::vector<uint32_t>& tablet_indexes,
+                              const std::vector<uint32_t>& record_hashes,
                               const std::vector<uint16_t>& validate_select_idx,
                               std::unordered_map<int64_t, std::set<int64_t>>& index_id_partition_id, Chunk* chunk);
 


### PR DESCRIPTION
## Why I'm doing:
This is a preliminary work of tablet splitting and merging.
Previously, bucket number is at physical partition level. All materialized indexes in a physical partition must have the same bucket number. But after tablet splitting, different materialized index in a physical partition could have different bucket number. We need to change bucket number from physical partition level to materialized index level. 

## What I'm doing:
Change bucket number from physical partition level to materialized index level.

Because different materialized index in a physical partition could have different bucket number. Tablet sink cannot calculate a unified tablet index for each record of data to be distributed to different materialized index. 
To solve the problem, we refactor the code of tablet sink. Now tablet sink calculate a unified hash value for each record of data to be distributed to different materialized index, then the tablet index for each record of data will be calculated according to the hash value and the tablet size of a materialized index when the record of data is distributed to the materialized index.

This pr just refactor the code. Next pr will remove `num_bucket` in `OlapTablePartition` and use `tablets.size()` in each `OlapTableIndexTablets` instead.

Fixes https://github.com/StarRocks/starrocks/issues/59134

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
