### PR TITLE
[BugFix] Redact credentials in audit log when SQL parsing fails

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/SqlCredentialRedactor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/SqlCredentialRedactor.java
@@ -1,0 +1,100 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import com.google.common.collect.ImmutableSet;
+import com.starrocks.connector.share.credential.CloudConfigurationConstants;
+
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Utility class to redact sensitive credentials from SQL strings.
+ * This is primarily used when SQL parsing fails and we need to log the original SQL statement
+ * without exposing credentials in audit logs.
+ */
+public class SqlCredentialRedactor {
+
+    // Set of credential keys that should be redacted
+    private static final Set<String> CREDENTIAL_KEYS = ImmutableSet.<String>builder()
+            .add(CloudConfigurationConstants.AWS_S3_ACCESS_KEY)
+            .add(CloudConfigurationConstants.AWS_S3_SECRET_KEY)
+            .add(CloudConfigurationConstants.AWS_S3_SESSION_TOKEN)
+            .add(CloudConfigurationConstants.AWS_GLUE_ACCESS_KEY)
+            .add(CloudConfigurationConstants.AWS_GLUE_SECRET_KEY)
+            .add(CloudConfigurationConstants.AWS_GLUE_SESSION_TOKEN)
+            .add(CloudConfigurationConstants.AZURE_BLOB_SHARED_KEY)
+            .add(CloudConfigurationConstants.AZURE_BLOB_SAS_TOKEN)
+            .add(CloudConfigurationConstants.AZURE_ADLS1_OAUTH2_CREDENTIAL)
+            .add(CloudConfigurationConstants.AZURE_ADLS2_SHARED_KEY)
+            .add(CloudConfigurationConstants.AZURE_ADLS2_SAS_TOKEN)
+            .add(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_SECRET)
+            .add(CloudConfigurationConstants.GCP_GCS_SERVICE_ACCOUNT_PRIVATE_KEY)
+            .add(CloudConfigurationConstants.GCP_GCS_SERVICE_ACCOUNT_PRIVATE_KEY_ID)
+            .add(CloudConfigurationConstants.HDFS_PASSWORD)
+            .add(CloudConfigurationConstants.HDFS_PASSWORD_DEPRECATED)
+            .add(CloudConfigurationConstants.HDFS_KERBEROS_KEYTAB_DEPRECATED)
+            .add(CloudConfigurationConstants.HADOOP_KERBEROS_KEYTAB)
+            .add(CloudConfigurationConstants.HDFS_KERBEROS_KEYTAB_CONTENT_DEPRECATED)
+            .add(CloudConfigurationConstants.HADOOP_KERBEROS_KEYTAB_CONTENT)
+            .add(CloudConfigurationConstants.ALIYUN_OSS_ACCESS_KEY)
+            .add(CloudConfigurationConstants.ALIYUN_OSS_SECRET_KEY)
+            .add(CloudConfigurationConstants.TENCENT_COS_ACCESS_KEY)
+            .add(CloudConfigurationConstants.TENCENT_COS_SECRET_KEY)
+            .add("password")
+            .add("passwd")
+            .add("pwd")
+            .build();
+
+    // Pattern to match key-value pairs in SQL
+    // This pattern handles cases like:
+    // "key" = "value"
+    // "key"="value"
+    // key = "value"
+    // key="value"
+    private static final Pattern KEY_VALUE_PATTERN = Pattern.compile(
+            "\"?(" + String.join("|", CREDENTIAL_KEYS.stream()
+                    .map(Pattern::quote)
+                    .toArray(String[]::new)) + ")\"?\\s*=\\s*\"([^\"]+)\"",
+            Pattern.CASE_INSENSITIVE
+    );
+
+    private static final String REDACTED_VALUE = "***";
+
+    /**
+     * Redact sensitive credentials from SQL string.
+     *
+     * @param sql the SQL string that may contain credentials
+     * @return the SQL string with credentials redacted
+     */
+    public static String redact(String sql) {
+        if (sql == null || sql.isEmpty()) {
+            return sql;
+        }
+
+        Matcher matcher = KEY_VALUE_PATTERN.matcher(sql);
+        StringBuffer result = new StringBuffer();
+
+        while (matcher.find()) {
+            String key = matcher.group(1);
+            String replacement = "\"" + key + "\" = \"" + REDACTED_VALUE + "\"";
+            matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
+        }
+
+        matcher.appendTail(result);
+        return result.toString();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -51,6 +51,7 @@ import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.util.AuditStatisticsUtil;
 import com.starrocks.common.util.LogUtil;
+import com.starrocks.common.util.SqlCredentialRedactor;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
@@ -283,7 +284,8 @@ public class ConnectProcessor {
             ctx.getAuditEventBuilder().setStmt(AstToSQLBuilder.toSQLOrDefault(parsedStmt, origStmt));
         } else if (parsedStmt == null) {
             // invalid sql, record the original statement to avoid audit log can't replay
-            ctx.getAuditEventBuilder().setStmt(origStmt);
+            // but redact sensitive credentials first
+            ctx.getAuditEventBuilder().setStmt(SqlCredentialRedactor.redact(origStmt));
         } else {
             ctx.getAuditEventBuilder().setStmt(LogUtil.removeLineSeparator(origStmt));
         }

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/SqlCredentialRedactorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/SqlCredentialRedactorTest.java
@@ -79,9 +79,9 @@ public class SqlCredentialRedactorTest {
                 ")\n" +
                 "WITH BROKER hdfs_broker\n" +
                 "(\n" +
-                "    \"hadoop.username\" = \"hdfs_user\",\n" +
-                "    \"hadoop.password\" = \"hdfs_password123\",\n" +
-                "    \"password\" = \"broker_password456\"\n" +
+                "    \"hadoop.security.authentication\" = \"simple\",\n" +
+                "    \"username\" = \"hdfs_user\",\n" +
+                "    \"password\" = \"hdfs_password123\"\n" +
                 ")";
 
         String redacted = SqlCredentialRedactor.redact(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/SqlCredentialRedactorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/SqlCredentialRedactorTest.java
@@ -1,0 +1,160 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SqlCredentialRedactorTest {
+
+    @Test
+    public void testRedactAwsCredentials() {
+        String sql = "select * from FILES(\n" +
+                "        \"path\" = \"s3://chaoyli/people.parquet\",\n" +
+                "        \"format\" = \"parquet\"\n" +
+                "        \"aws.s3.access_key\" = \"AKIA3NNAD3JMMNRBH\",\n" +
+                "        \"aws.s3.secret_key\" = \"KnJRWyHrQP0aN4B8Wo3X5hlcIIhU9q+Zxc\",\n" +
+                "        \"aws.s3.region\" = \"us-east-1\"\n" +
+                ")";
+
+        String redacted = SqlCredentialRedactor.redact(sql);
+        Assert.assertFalse("Access key should be redacted", redacted.contains("AKIA3NNAD3JMMNRBH"));
+        Assert.assertFalse("Secret key should be redacted", redacted.contains("KnJRWyHrQP0aN4B8Wo3X5hlcIIhU9q+Zxc"));
+        Assert.assertTrue("Non-sensitive values should remain", redacted.contains("us-east-1"));
+        Assert.assertTrue("Should contain redacted marker", redacted.contains("***"));
+    }
+
+    @Test
+    public void testRedactAzureCredentials() {
+        String sql = "CREATE EXTERNAL TABLE test (\n" +
+                "    id INT\n" +
+                ") ENGINE=file\n" +
+                "PROPERTIES (\n" +
+                "    \"path\" = \"abfs://container@account.dfs.core.windows.net/path\",\n" +
+                "    \"azure.blob.shared_key\" = \"base64encodedkey==\",\n" +
+                "    \"azure.blob.sas_token\" = \"?sv=2020-08-04&ss=bfqt&srt=sco&sp=rwdlacupx\"\n" +
+                ")";
+
+        String redacted = SqlCredentialRedactor.redact(sql);
+        Assert.assertFalse("Shared key should be redacted", redacted.contains("base64encodedkey=="));
+        Assert.assertFalse("SAS token should be redacted", redacted.contains("sv=2020-08-04"));
+        Assert.assertTrue("Path should remain", redacted.contains("abfs://container@account.dfs.core.windows.net/path"));
+    }
+
+    @Test
+    public void testRedactGcpCredentials() {
+        String sql = "CREATE EXTERNAL CATALOG gcs_catalog\n" +
+                "PROPERTIES (\n" +
+                " \"type\" = \"hive\",\n" +
+                " \"gcp.gcs.service_account_private_key\" = " +
+                "   \"-----BEGIN PRIVATE KEY-----\\nMIIEvQIBADANBgkqh\\n" +
+                "     -----END PRIVATE KEY-----\",\n" +
+                " \"gcp.gcs.service_account_private_key_id\" = \"key123456789\"\n" +
+                ")";
+
+        String redacted = SqlCredentialRedactor.redact(sql);
+        Assert.assertFalse("Private key should be redacted", redacted.contains("BEGIN PRIVATE KEY"));
+        Assert.assertFalse("Private key ID should be redacted", redacted.contains("key123456789"));
+        Assert.assertTrue("Type should remain", redacted.contains("hive"));
+    }
+
+    @Test
+    public void testRedactHdfsCredentials() {
+        String sql = "LOAD LABEL test_load\n" +
+                "(\n" +
+                "    DATA INFILE(\"hdfs://namenode:9000/path/to/file\")\n" +
+                "    INTO TABLE test_table\n" +
+                ")\n" +
+                "WITH BROKER hdfs_broker\n" +
+                "(\n" +
+                "    \"hadoop.username\" = \"hdfs_user\",\n" +
+                "    \"hadoop.password\" = \"hdfs_password123\",\n" +
+                "    \"password\" = \"broker_password456\"\n" +
+                ")";
+
+        String redacted = SqlCredentialRedactor.redact(sql);
+        Assert.assertFalse("Hadoop password should be redacted", redacted.contains("hdfs_password123"));
+        Assert.assertFalse("Broker password should be redacted", redacted.contains("broker_password456"));
+        Assert.assertTrue("Username can remain", redacted.contains("hdfs_user"));
+    }
+
+    @Test
+    public void testRedactWithDifferentFormats() {
+        // Test without spaces around equals
+        String sql1 = "\"aws.s3.access_key\"=\"AKIAIOSFODNN7EXAMPLE\"";
+        String redacted1 = SqlCredentialRedactor.redact(sql1);
+        Assert.assertFalse(redacted1.contains("AKIAIOSFODNN7EXAMPLE"));
+
+        // Test without quotes on key
+        String sql2 = "aws.s3.secret_key = \"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\"";
+        String redacted2 = SqlCredentialRedactor.redact(sql2);
+        Assert.assertFalse(redacted2.contains("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"));
+
+        // Test with extra spaces
+        String sql3 = "\"aws.s3.access_key\"   =   \"AKIAIOSFODNN7EXAMPLE\"";
+        String redacted3 = SqlCredentialRedactor.redact(sql3);
+        Assert.assertFalse(redacted3.contains("AKIAIOSFODNN7EXAMPLE"));
+    }
+
+    @Test
+    public void testCaseInsensitive() {
+        String sql = "\"AWS.S3.ACCESS_KEY\" = \"AKIAIOSFODNN7EXAMPLE\",\n" +
+                "\"aws.s3.SECRET_key\" = \"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\"";
+
+        String redacted = SqlCredentialRedactor.redact(sql);
+        Assert.assertFalse("Should redact case-insensitive", redacted.contains("AKIAIOSFODNN7EXAMPLE"));
+        Assert.assertFalse("Should redact case-insensitive", redacted.contains("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"));
+    }
+
+    @Test
+    public void testNullAndEmptySql() {
+        Assert.assertNull(SqlCredentialRedactor.redact(null));
+        Assert.assertEquals("", SqlCredentialRedactor.redact(""));
+    }
+
+    @Test
+    public void testNoCredentials() {
+        String sql = "SELECT * FROM table WHERE id = 1";
+        Assert.assertEquals(sql, SqlCredentialRedactor.redact(sql));
+    }
+
+    @Test
+    public void testMultipleCredentials() {
+        String sql = "CREATE STORAGE VOLUME test_volume\n" +
+                "TYPE = S3\n" +
+                "LOCATIONS = ('s3://bucket/path')\n" +
+                "PROPERTIES (\n" +
+                "    \"aws.s3.access_key\" = \"AKIAIOSFODNN7EXAMPLE\",\n" +
+                "    \"aws.s3.secret_key\" = \"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\",\n" +
+                "    \"aws.s3.region\" = \"us-west-2\",\n" +
+                "    \"aws.s3.endpoint\" = \"s3.us-west-2.amazonaws.com\"\n" +
+                ")";
+
+        String redacted = SqlCredentialRedactor.redact(sql);
+        Assert.assertFalse("Access key should be redacted", redacted.contains("AKIAIOSFODNN7EXAMPLE"));
+        Assert.assertFalse("Secret key should be redacted", redacted.contains("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"));
+        Assert.assertTrue("Region should remain", redacted.contains("us-west-2"));
+        Assert.assertTrue("Endpoint should remain", redacted.contains("s3.us-west-2.amazonaws.com"));
+
+        // Count occurrences of ***
+        int count = 0;
+        int index = 0;
+        while ((index = redacted.indexOf("***", index)) != -1) {
+            count++;
+            index += 3;
+        }
+        Assert.assertEquals("Should have exactly 2 redacted values", 2, count);
+    }
+}


### PR DESCRIPTION
When SQL parsing fails due to syntax errors, credentials in the original SQL statement are exposed in the audit log. This fix adds credential redaction for unparsed SQL statements to prevent security information leakage.

Changes:
- Add SqlCredentialRedactor utility to redact sensitive credentials from SQL strings
- Update ConnectProcessor.auditAfterExec to use redaction when parsedStmt is null
- Add comprehensive unit tests for credential redaction

The fix ensures that credentials like aws.s3.access_key, aws.s3.secret_key, and other sensitive keys are replaced with *** in audit logs when SQL parsing fails.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
