### PR TITLE
[Doc] remove description heading

### DIFF
--- a/docs/en/sql-reference/How_to_Write_Functions_Documentation.md
+++ b/docs/en/sql-reference/How_to_Write_Functions_Documentation.md
@@ -8,8 +8,6 @@ unlisted: true
 > *- When you write new function docs, please provide complete example data so users can test it, including the CREATE TABLE, INSERT/LOAD data examples.*
 > *- This article uses `CONVERT_TZ` as an example to illustrate the requirements for writing function documentation.*
 
-## Description
-
 Converts a datetime value from one time zone to another.
 
 This function is supported from v2.0.

--- a/docs/en/sql-reference/data-types/numeric/BIGINT.md
+++ b/docs/en/sql-reference/data-types/numeric/BIGINT.md
@@ -4,8 +4,4 @@ displayed_sidebar: docs
 
 # BIGINT
 
-## Description
-
-BIGINT
-
-8-byte signed integer. The value range is [-9223372036854775808, 9223372036854775807].
+BIGINT is an 8-byte signed integer. The value range is [-9223372036854775808, 9223372036854775807].

--- a/docs/en/sql-reference/data-types/numeric/BOOLEAN.md
+++ b/docs/en/sql-reference/data-types/numeric/BOOLEAN.md
@@ -4,8 +4,6 @@ displayed_sidebar: docs
 
 # BOOLEAN
 
-## Description
-
 BOOL, BOOLEAN
 
 Like TINYINT, 0 stands for false and 1 for true.

--- a/docs/en/sql-reference/data-types/numeric/DECIMAL.md
+++ b/docs/en/sql-reference/data-types/numeric/DECIMAL.md
@@ -4,11 +4,7 @@ displayed_sidebar: docs
 
 # DECIMAL
 
-## Description
-
-DECIMAL(P[,S])
-
-High-precision fixed-point value. `P` stands for the total number of significant numbers (precision). `S` stands for the maximum number of decimal points (scale).
+DECIMAL(P[,S]) is a high-precision fixed-point value. `P` stands for the total number of significant numbers (precision). `S` stands for the maximum number of decimal points (scale).
 
 If `P` is omitted, the default is 10. If `S` is omitted, the default is 0.
 

--- a/docs/en/sql-reference/data-types/numeric/DOUBLE.md
+++ b/docs/en/sql-reference/data-types/numeric/DOUBLE.md
@@ -4,8 +4,4 @@ displayed_sidebar: docs
 
 # DOUBLE
 
-## Description
-
-DOUBLE
-
-8-byte floating point number
+DOUBLE is an 8-byte floating point number

--- a/docs/en/sql-reference/data-types/numeric/FLOAT.md
+++ b/docs/en/sql-reference/data-types/numeric/FLOAT.md
@@ -4,8 +4,6 @@ displayed_sidebar: docs
 
 # FLOAT
 
-## Description
-
 FLOAT
 
 4-byte floating point number

--- a/docs/en/sql-reference/data-types/numeric/INT.md
+++ b/docs/en/sql-reference/data-types/numeric/INT.md
@@ -4,8 +4,4 @@ displayed_sidebar: docs
 
 # INT
 
-## Description
-
-INT
-
-4-byte signed integer. The value range is [-2147483648, 2147483647].
+INT is a 4-byte signed integer. The value range is [-2147483648, 2147483647].

--- a/docs/en/sql-reference/data-types/numeric/LARGEINT.md
+++ b/docs/en/sql-reference/data-types/numeric/LARGEINT.md
@@ -4,8 +4,4 @@ displayed_sidebar: docs
 
 # LARGEINT
 
-## Description
-
-LARGEINT
-
-16-byte signed integer. The value range is [-2^127 + 1, 2^127 - 1].
+LARGEINT is a 16-byte signed integer. The value range is [-2^127 + 1, 2^127 - 1].

--- a/docs/en/sql-reference/data-types/numeric/SMALLINT.md
+++ b/docs/en/sql-reference/data-types/numeric/SMALLINT.md
@@ -4,8 +4,4 @@ displayed_sidebar: docs
 
 # SMALLINT
 
-## Description
-
-SMALLINT
-
-2-byte signed integer. The value range is [-32768, 32767].
+SMALLINT is a 2-byte signed integer. The value range is [-32768, 32767].

--- a/docs/en/sql-reference/data-types/numeric/TINYINT.md
+++ b/docs/en/sql-reference/data-types/numeric/TINYINT.md
@@ -4,8 +4,4 @@ displayed_sidebar: docs
 
 # TINYINT
 
-## Description
-
-TINYINT
-
-1-byte signed integer. The value range is [-128, 127].
+TINYINT is a 1-byte signed integer. The value range is [-128, 127].

--- a/docs/en/sql-reference/data-types/other-data-types/HLL.md
+++ b/docs/en/sql-reference/data-types/other-data-types/HLL.md
@@ -4,8 +4,6 @@ displayed_sidebar: docs
 
 # HLL (HyperLogLog)
 
-## Description
-
 HLL is used for [approximate count distinct](../../../using_starrocks/distinct_values/Using_HLL.md).
 
 HLL enables the development of programmes based on the HyperLogLog algorithm. It is used to store intermediate results of the HyperLogLog calculation process. It can only be used as the value column type of the table. HLL reduces the amount of data through aggregation to speed up the query process. There may be a 1% deviation in the estimated results.

--- a/docs/en/sql-reference/data-types/semi_structured/Map.md
+++ b/docs/en/sql-reference/data-types/semi_structured/Map.md
@@ -4,8 +4,6 @@ displayed_sidebar: docs
 
 # MAP
 
-## Description
-
 MAP is a complex data type that stores a set of key-value pairs, for example, `{a:1, b:2, c:3}`. Keys in a map must be unique. A nested map can contain up to 14 levels of nesting.
 
 The MAP data type is supported from v3.1 onwards. In v3.1, you can define MAP columns when you create a StarRocks table, load MAP data into that table, and query MAP data.

--- a/docs/en/sql-reference/data-types/semi_structured/STRUCT.md
+++ b/docs/en/sql-reference/data-types/semi_structured/STRUCT.md
@@ -4,8 +4,6 @@ displayed_sidebar: docs
 
 # STRUCT
 
-## Description
-
 STRUCT is widely used to express complex data types. It represents a collection of elements (also called fields) with different data types, for example, `<a INT, b STRING>`.
 
 Field names in a struct must be unique. Fields can be of primitive data types (such as numeric, string, or date) or complex data types (such as ARRAY or MAP).

--- a/docs/en/sql-reference/data-types/string-type/BINARY.md
+++ b/docs/en/sql-reference/data-types/string-type/BINARY.md
@@ -4,8 +4,6 @@ displayed_sidebar: docs
 
 # BINARY/VARBINARY
 
-## Description
-
 BINARY(M)
 
 VARBINARY(M)

--- a/docs/en/sql-reference/data-types/string-type/CHAR.md
+++ b/docs/en/sql-reference/data-types/string-type/CHAR.md
@@ -4,8 +4,6 @@ displayed_sidebar: docs
 
 # CHAR
 
-## Description
-
 CHAR(M)
 
 A fixed-length string, `M` represents the length of a fixed-length string. Unit: bytes. The range of `M` is [1, 255].

--- a/docs/en/sql-reference/data-types/string-type/STRING.md
+++ b/docs/en/sql-reference/data-types/string-type/STRING.md
@@ -4,8 +4,6 @@ displayed_sidebar: docs
 
 # STRING
 
-## Description
-
 STRING
 
 A variable length string. The maximum length is 65533 bytes.

--- a/docs/en/sql-reference/data-types/string-type/VARCHAR.md
+++ b/docs/en/sql-reference/data-types/string-type/VARCHAR.md
@@ -4,8 +4,6 @@ displayed_sidebar: docs
 
 # VARCHAR
 
-## Description
-
 VARCHAR(M)
 
 A variable-length string. `M` indicates the length of the string. The default value is `1`. Unit: bytes.

--- a/docs/en/sql-reference/http_sql_api.md
+++ b/docs/en/sql-reference/http_sql_api.md
@@ -4,8 +4,6 @@ displayed_sidebar: docs
 
 # HTTP SQL API
 
-## Description
-
 StarRocks v3.2.0 introduces the HTTP SQL API for users to perform various types of queries using HTTP. Currently, this API supports SELECT, SHOW, EXPLAIN, and KILL statements.
 
 Syntax using the curl command:

--- a/docs/en/sql-reference/sql-functions/aggregate-functions/mann_whitney_u_test.md
+++ b/docs/en/sql-reference/sql-functions/aggregate-functions/mann_whitney_u_test.md
@@ -4,9 +4,7 @@ displayed_sidebar: "docs"
 
 # mann_whitney_u_test
 
-## Description
-
-Performs the Mann-Whitney rank test on samples derived from two populations. The Mann-Whitney U test is a non-parametric test that can be used to determine if two populations were selected from the same distribution.
+`mann_whitney_u_test` performs the Mann-Whitney rank test on samples derived from two populations. The Mann-Whitney U test is a non-parametric test that can be used to determine if two populations were selected from the same distribution.
 
 ## Syntax
 

--- a/docs/en/sql-reference/sql-functions/array-functions/array_flatten.md
+++ b/docs/en/sql-reference/sql-functions/array-functions/array_flatten.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # array_flatten
 
-## Description
-
-Flatten one layer of nested arrays.
+`array_flatten` flattens one layer of nested arrays.
 
 ## Syntax
 

--- a/docs/en/sql-reference/sql-functions/array-functions/array_repeat.md
+++ b/docs/en/sql-reference/sql-functions/array-functions/array_repeat.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # array_repeat
 
-## Description
-
-Returns an array containing a given element repeated a specified number of times.
+`array_repeat` returns an array containing a given element repeated a specified number of times.
 
 ## Syntax
 

--- a/docs/en/sql-reference/sql-statements/Catalog/CREATE_EXTERNAL_CATALOG.md
+++ b/docs/en/sql-reference/sql-statements/Catalog/CREATE_EXTERNAL_CATALOG.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # CREATE EXTERNAL CATALOG
 
-## Description
-
-Creates an external catalog. You can use external catalogs to query data in external data sources without loading data into StarRocks or creating external tables. Currently, you can create the following types of external catalogs:
+CREATE EXTERNAL CATALOG creates an external catalog. You can use external catalogs to query data in external data sources without loading data into StarRocks or creating external tables. Currently, you can create the following types of external catalogs:
 
 - [Hive catalog](../../../data_source/catalog/hive_catalog.md): used for querying data from Apache Hive™.
 - [Iceberg catalog](../../../data_source/catalog/iceberg/iceberg_catalog.md): used for querying data from Apache Iceberg.

--- a/docs/en/sql-reference/sql-statements/Catalog/DROP_CATALOG.md
+++ b/docs/en/sql-reference/sql-statements/Catalog/DROP_CATALOG.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # DROP CATALOG
 
-## Description
-
-Deletes an external catalog. The internal catalog cannot be deleted. A StarRocks cluster has only one internal catalog named `default_catalog`.
+DROP CATALOG deletes an external catalog. The internal catalog cannot be deleted. A StarRocks cluster has only one internal catalog named `default_catalog`.
 
 ## Syntax
 

--- a/docs/en/sql-reference/sql-statements/Catalog/SHOW_CATALOGS.md
+++ b/docs/en/sql-reference/sql-statements/Catalog/SHOW_CATALOGS.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW CATALOGS
 
-## Description
-
-Query all catalogs in the current StarRocks cluster, including the internal catalog and external catalogs.
+SHOW CATALOGS queries all catalogs in the current StarRocks cluster, including the internal catalog and external catalogs.
 
 > **NOTE**
 >

--- a/docs/en/sql-reference/sql-statements/Catalog/SHOW_CREATE_CATALOG.md
+++ b/docs/en/sql-reference/sql-statements/Catalog/SHOW_CREATE_CATALOG.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW CREATE CATALOG
 
-## Description
-
-Queries the creation statement of an [external catalog](../../../data_source/catalog/catalog_overview.md).
+SHOW CREATE CATALOG queries the creation statement of an [external catalog](../../../data_source/catalog/catalog_overview.md).
 
 Note that authentication-related information in the return result will be anonymized.
 

--- a/docs/en/sql-reference/sql-statements/Database/ALTER_DATABASE.md
+++ b/docs/en/sql-reference/sql-statements/Database/ALTER_DATABASE.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # ALTER DATABASE
 
-## Description
-
-Configures the properties of the specified database.
+ALTER DATABASE configures the properties of the specified database.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/Database/CREATE_DATABASE.md
+++ b/docs/en/sql-reference/sql-statements/Database/CREATE_DATABASE.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # CREATE DATABASE
 
-## Description
-
-This statement is used to create databases.
+CREATE DATABASE is used to create databases.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/Database/DROP_DATABASE.md
+++ b/docs/en/sql-reference/sql-statements/Database/DROP_DATABASE.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # DROP DATABASE
 
-## Description
-
-Drops a database in StarRocks.
+DROP DATABASE is used to delete a database in StarRocks.
 
 > **NOTE**
 >

--- a/docs/en/sql-reference/sql-statements/Database/SHOW_DATA.md
+++ b/docs/en/sql-reference/sql-statements/Database/SHOW_DATA.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW DATA
 
-## Description
-
-This statement is used to display the amount of data, the number of copies, and the number of statistical rows in a database or a database table.
+SHOW DATA is used to display the amount of data, the number of copies, and the number of statistical rows in a database or a database table.
 
 Syntax:
 

--- a/docs/en/sql-reference/sql-statements/Database/SHOW_DATABASES.md
+++ b/docs/en/sql-reference/sql-statements/Database/SHOW_DATABASES.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW DATABASES
 
-## Description
-
-Views databases in your current StarRocks cluster or an external data source. StarRocks supports viewing databases of an external data source from v2.3 onwards.
+SHOW DATABASES lists databases in your current StarRocks cluster or an external data source. StarRocks supports viewing databases of an external data source from v2.3 onwards.
 
 ## Syntax
 

--- a/docs/en/sql-reference/sql-statements/Database/USE.md
+++ b/docs/en/sql-reference/sql-statements/Database/USE.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # USE
 
-## Description
-
-Specifies the active database for your session. You can then perform operations, such as creating tables and executing queries.
+USE specifies the active database for your session. You can then perform operations, such as creating tables and executing queries.
 
 ## Syntax
 

--- a/docs/en/sql-reference/sql-statements/Function/CREATE_FUNCTION.md
+++ b/docs/en/sql-reference/sql-statements/Function/CREATE_FUNCTION.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # CREATE FUNCTION
 
-## Description
-
-Creates a user-defined function (UDF). Currently, you can only create Java UDFs, including Scalar functions, user-defined aggregate functions (UDAFs), user-defined window functions (UDWFs), and user-defined table functions (UDTFs).
+CREATE FUNCTION creates a user-defined function (UDF). Currently, you can only create Java UDFs, including Scalar functions, user-defined aggregate functions (UDAFs), user-defined window functions (UDWFs), and user-defined table functions (UDTFs).
 
 **For details about how to compile, create, and use a Java UDF, see [Java UDF](../../sql-functions/JAVA_UDF.md).**
 

--- a/docs/en/sql-reference/sql-statements/Function/DROP_FUNCTION.md
+++ b/docs/en/sql-reference/sql-statements/Function/DROP_FUNCTION.md
@@ -6,7 +6,7 @@ displayed_sidebar: docs
 
 ## Description
 
-Deletes a custom function. The function can only be deleted when its name and parameter type are consistent.
+DROP FUNCTION deletes a custom function. The function can only be deleted when its name and parameter type are consistent.
 
 Only the owner of the custom function have the permissions to delete the function.
 

--- a/docs/en/sql-reference/sql-statements/Function/SHOW_FUNCTIONS.md
+++ b/docs/en/sql-reference/sql-statements/Function/SHOW_FUNCTIONS.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW FUNCTIONS
 
-## Description
-
-Queries all the custom (or built-in) functions under a database. If no database is specified, the current database is used by default.
+SHOW FUNCTIONS queries all the custom (or built-in) functions under a database. If no database is specified, the current database is used by default.
 
 ## Syntax
 

--- a/docs/en/sql-reference/sql-statements/Resource/ALTER_RESOURCE.md
+++ b/docs/en/sql-reference/sql-statements/Resource/ALTER_RESOURCE.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # ALTER RESOURCE
 
-## Description
-
-You can use the ALTER RESOURCE statement to modify the properties of a resource.
+Use the ALTER RESOURCE statement to modify the properties of a resource.
 
 ## Syntax
 

--- a/docs/en/sql-reference/sql-statements/Resource/CREATE_RESOURCE.md
+++ b/docs/en/sql-reference/sql-statements/Resource/CREATE_RESOURCE.md
@@ -4,8 +4,6 @@ displayed_sidebar: docs
 
 # CREATE RESOURCE
 
-## Description
-
 Creates resources. The following types of resources can be created: Apache Spark™, Apache Hive™, Apache Iceberg, Apache Hudi, and JDBC. Spark resources are used in Spark Load to manage loading information, such as YARN configurations, storage path of intermediate data, and Broker configurations. Hive, Iceberg, Hudi, and JDBC resources are used for managing data source access information involved in querying [External tables](../../../data_source/External_table.md).
 
 :::tip

--- a/docs/en/sql-reference/sql-statements/Resource/DROP_RESOURCE.md
+++ b/docs/en/sql-reference/sql-statements/Resource/DROP_RESOURCE.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # DROP RESOURCE
 
-## Description
-
-This statement is used to drop an existing resource. Only root or superuser can drop resources.
+Use DROP RESOURCE to drop an existing resource. Only root or superuser can drop resources.
 
 Syntax:
 

--- a/docs/en/sql-reference/sql-statements/Resource/SHOW_RESOURCES.md
+++ b/docs/en/sql-reference/sql-statements/Resource/SHOW_RESOURCES.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW RESOURCES
 
-## Description
-
-This statement is used to show the resources that the users have permissions to use. Ordinary users can only use the resources they have permission to use, while root or admin users can show all resources.
+SHOW RESOURCES shows the resources that the users have permissions to use. Ordinary users can only use the resources they have permission to use, while root or admin users can show all resources.
 
 Syntax:
 

--- a/docs/en/sql-reference/sql-statements/View/ALTER_VIEW.md
+++ b/docs/en/sql-reference/sql-statements/View/ALTER_VIEW.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # ALTER VIEW
 
-## Description
-
-Modifies the definition of a view.
+ALTER VIEW Modifies the definition of a view.
 
 ## Syntax
 

--- a/docs/en/sql-reference/sql-statements/View/CREATE_VIEW.md
+++ b/docs/en/sql-reference/sql-statements/View/CREATE_VIEW.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # CREATE VIEW
 
-## Description
-
-Creates a view.
+CREATE VIEW creates a logical view.
 
 A view, or a logical view, is a virtual table whose data is derived from a query against other existing physical tables. Therefore, a view uses no physical storage, and all queries against the view are equivalent to sub-queries of the query statement used to build the view.
 

--- a/docs/en/sql-reference/sql-statements/View/DROP_VIEW.md
+++ b/docs/en/sql-reference/sql-statements/View/DROP_VIEW.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # DROP VIEW
 
-## Description
-
-This statement is used to drop a logical view VIEW
+DROP VIEW is used to drop a logical view VIEW
 
 ## Syntax
 

--- a/docs/en/sql-reference/sql-statements/account-management/ALTER_USER.md
+++ b/docs/en/sql-reference/sql-statements/account-management/ALTER_USER.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # ALTER USER
 
-## Description
-
-Modifies user information, including password, authentication method, default roles, and user properties (supported from v3.3.3 onwards).
+ALTER USER modifies user information, including password, authentication method, default roles, and user properties (supported from v3.3.3 onwards).
 
 :::tip
 Common users can use this command to modify information for themselves. Only users with the `user_admin` role can modify information for other users.

--- a/docs/en/sql-reference/sql-statements/account-management/CREATE_ROLE.md
+++ b/docs/en/sql-reference/sql-statements/account-management/CREATE_ROLE.md
@@ -6,9 +6,7 @@ displayed_sidebar: docs
 
 import UserManagementPriv from '../../../_assets/commonMarkdown/userManagementPriv.md'
 
-## Description
-
-Creates a role. After a role is created, you can grant privileges to the role and then assign this role to a user or another role. This way, the privileges associated with this role are passed on to users or roles.
+CREATE ROLE creates a role. After a role is created, you can grant privileges to the role and then assign this role to a user or another role. This way, the privileges associated with this role are passed on to users or roles.
 
 <UserManagementPriv />
 

--- a/docs/en/sql-reference/sql-statements/account-management/CREATE_USER.md
+++ b/docs/en/sql-reference/sql-statements/account-management/CREATE_USER.md
@@ -6,9 +6,7 @@ displayed_sidebar: docs
 
 import UserManagementPriv from '../../../_assets/commonMarkdown/userManagementPriv.md'
 
-## Description
-
-Creates a StarRocks user. In StarRocks, a "user_identity" uniquely identifies a user. From v3.3.3, StarRocks supports setting user properties when creating a user.
+CREATE USER creates a StarRocks user. In StarRocks, a "user_identity" uniquely identifies a user. From v3.3.3, StarRocks supports setting user properties when creating a user.
 
 <UserManagementPriv />
 

--- a/docs/en/sql-reference/sql-statements/account-management/DROP_ROLE.md
+++ b/docs/en/sql-reference/sql-statements/account-management/DROP_ROLE.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # DROP ROLE
 
-## Description
-
-Drops a role. If a role has been granted to a user, the user still has the privileges associated with this role even after the role is dropped.
+DROP ROLE drops a role. If a role has been granted to a user, the user still has the privileges associated with this role even after the role is dropped.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/account-management/DROP_USER.md
+++ b/docs/en/sql-reference/sql-statements/account-management/DROP_USER.md
@@ -6,9 +6,7 @@ displayed_sidebar: docs
 
 import UserManagementPriv from '../../../_assets/commonMarkdown/userManagementPriv.md'
 
-## Description
-
-Drops a specified user identity.
+DROP USER drops a specified user identity.
 
 <UserManagementPriv />
 

--- a/docs/en/sql-reference/sql-statements/account-management/EXECUTE_AS.md
+++ b/docs/en/sql-reference/sql-statements/account-management/EXECUTE_AS.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # EXECUTE AS
 
-## Description
-
-After you obtain the privilege to impersonate a user (IMPERSONATE), you can use the EXECUTE AS statement to switch the execution context of the current session to the user.
+Use the IMPERSONATE privilege with EXECUTE AS statements to switch the execution context of the current session to the impersonated user.
 
 This command is supported from v2.4.
 

--- a/docs/en/sql-reference/sql-statements/account-management/GRANT.md
+++ b/docs/en/sql-reference/sql-statements/account-management/GRANT.md
@@ -8,9 +8,7 @@ toc_max_heading_level: 4
 import UserPrivilegeCase from '../../../_assets/commonMarkdown/userPrivilegeCase.md'
 import MultiServiceAccess from '../../../_assets/commonMarkdown/multi-service-access.mdx'
 
-## Description
-
-Grants one or more privileges on specific objects to a user or a role.
+GRANT grants one or more privileges on specific objects to a user or a role.
 
 Grants roles to users or other roles.
 

--- a/docs/en/sql-reference/sql-statements/account-management/REVOKE.md
+++ b/docs/en/sql-reference/sql-statements/account-management/REVOKE.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # REVOKE
 
-## Description
-
-Revokes specific privileges or roles from a user or a role. For the privileges supported by StarRocks, see [Privileges supported by StarRocks](../../../administration/user_privs/authorization/user_privs.md).
+Use REVOKE to remove specific privileges or roles from a user or a role. For the privileges supported by StarRocks, see [Privileges supported by StarRocks](../../../administration/user_privs/authorization/user_privs.md).
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/account-management/SET_DEFAULT_ROLE.md
+++ b/docs/en/sql-reference/sql-statements/account-management/SET_DEFAULT_ROLE.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SET DEFAULT ROLE
 
-## Description
-
-Sets the roles that are activated by default when the user connects to the server.
+SET DEFAULT ROLE sets the roles that are activated by default when the user connects to the server.
 
 This command is supported from v3.0.
 

--- a/docs/en/sql-reference/sql-statements/account-management/SET_PASSWORD.md
+++ b/docs/en/sql-reference/sql-statements/account-management/SET_PASSWORD.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SET PASSWORD
 
-## Description
-
-Changes login password for users. The [ALTER USER](ALTER_USER.md) command can also be used to change a password.
+SET PASSWORD changes the login password for users. The [ALTER USER](ALTER_USER.md) command can also be used to change a password.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/account-management/SET_ROLE.md
+++ b/docs/en/sql-reference/sql-statements/account-management/SET_ROLE.md
@@ -4,11 +4,10 @@ displayed_sidebar: docs
 
 # SET ROLE
 
-## Description
 
-Activates roles, along with all of its associated privileges and nested roles, for the current session. After the role is activated, users can use this role to perform operations.
+SET ROLE activates roles, along with all of its associated privileges and nested roles, for the current session. After the role is activated, users can use this role to perform operations.
 
- After running this command, you can run `select is_role_in_session("<role_name>");` to verify whether this role is active in the current session.
+After running this command, you can run `select is_role_in_session("<role_name>");` to verify whether this role is active in the current session.
 
 This command is supported from v3.0.
 

--- a/docs/en/sql-reference/sql-statements/account-management/SHOW_AUTHENTICATION.md
+++ b/docs/en/sql-reference/sql-statements/account-management/SHOW_AUTHENTICATION.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW AUTHENTICATION
 
-## Description
-
-Displays the authentication information of the current user or all users in the current cluster.
+SHOW AUTHENTICATION displays the authentication information of the current user or all users in the current cluster.
 
 :::tip
 All users have the privilege to view their own authentication information. Only users with the `user_admin` role can view the authentication information of all users or the authentication information of specified users.

--- a/docs/en/sql-reference/sql-statements/account-management/SHOW_GRANTS.md
+++ b/docs/en/sql-reference/sql-statements/account-management/SHOW_GRANTS.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW GRANTS
 
-## Description
-
-Displays all the privileges that have been granted to a user or role.
+SHOW GRANTS displays all the privileges that have been granted to a user or role.
 
 For more information about roles and privileges, see [Overview of privileges](../../../administration/user_privs/authorization/user_privs.md).
 

--- a/docs/en/sql-reference/sql-statements/account-management/SHOW_PROPERTY.md
+++ b/docs/en/sql-reference/sql-statements/account-management/SHOW_PROPERTY.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW PROPERTY
 
-## Description
-
-Views the properties of a user. Currently, only the maximum number of connections can be viewed using this command.
+SHOW PROPERTY displays properties of a user. Currently, only the maximum number of connections can be viewed using this command.
 
 :::tip
 The current user can view its own property. Only users with the `user_admin` role can view the property of other users.

--- a/docs/en/sql-reference/sql-statements/account-management/SHOW_ROLES.md
+++ b/docs/en/sql-reference/sql-statements/account-management/SHOW_ROLES.md
@@ -6,9 +6,7 @@ displayed_sidebar: docs
 
 import UserManagementPriv from '../../../_assets/commonMarkdown/userManagementPriv.md'
 
-## Description
-
-Displays all roles in the system. You can use `SHOW GRANTS FOR ROLE <role_name>;` to view the privileges of a specific role. For more information, see [SHOW GRANTS](SHOW_GRANTS.md).
+SHOW ROLES displays all roles in the system. You can use `SHOW GRANTS FOR ROLE <role_name>;` to view the privileges of a specific role. For more information, see [SHOW GRANTS](SHOW_GRANTS.md).
 
 This command is supported from v3.0.
 

--- a/docs/en/sql-reference/sql-statements/account-management/SHOW_USERS.md
+++ b/docs/en/sql-reference/sql-statements/account-management/SHOW_USERS.md
@@ -6,9 +6,7 @@ displayed_sidebar: docs
 
 import UserManagementPriv from '../../../_assets/commonMarkdown/userManagementPriv.md'
 
-## Description
-
-Displays all users in the system. Users mentioned here are user identities, not user names. For more information about user identities, see [CREATE USER](CREATE_USER.md). This command is supported from v3.0.
+SHOW USERS displays all users in the system. Users mentioned here are user identities, not user names. For more information about user identities, see [CREATE USER](CREATE_USER.md). This command is supported from v3.0.
 
 You can use `SHOW GRANTS FOR <user_identity>;` to view the privileges of a specific user. For more information, see [SHOW GRANTS](SHOW_GRANTS.md).
 

--- a/docs/en/sql-reference/sql-statements/cbo_stats/ANALYZE_TABLE.md
+++ b/docs/en/sql-reference/sql-statements/cbo_stats/ANALYZE_TABLE.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # ANALYZE TABLE
 
-## Description
-
-Creates a manual collection task for collecting CBO statistics. By default, manual collection is a synchronous operation. You can also set it to an asynchronous operation. In asynchronous mode, after you run ANALYZE TABLE, the system immediately returns whether this statement is successful. However, the collection task will be running in the background and you do not have to wait for the result. You can check the status of the task by running SHOW ANALYZE STATUS. Asynchronous collection is suitable for tables with large data volume, whereas synchronous collection is suitable for tables with small data volume.
+ANALYZE TABLE creates a manual collection task for collecting CBO statistics. By default, manual collection is a synchronous operation. You can also set it to an asynchronous operation. In asynchronous mode, after you run ANALYZE TABLE, the system immediately returns whether this statement is successful. However, the collection task will be running in the background and you do not have to wait for the result. You can check the status of the task by running SHOW ANALYZE STATUS. Asynchronous collection is suitable for tables with large data volume, whereas synchronous collection is suitable for tables with small data volume.
 
 **Manual collection tasks are run only once after creation. You do not need to delete manual collection tasks.**
 

--- a/docs/en/sql-reference/sql-statements/cbo_stats/CREATE_ANALYZE.md
+++ b/docs/en/sql-reference/sql-statements/cbo_stats/CREATE_ANALYZE.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # CREATE ANALYZE
 
-## Description
-
-Customizes an automatic collection task for collecting CBO statistics.
+CREATE ANALYZE customizes an automatic collection task for collecting CBO statistics.
 
 By default, StarRocks automatically collects full statistics of a table. It checks for any data updates every 5 minutes. If data change is detected, data collection will be automatically triggered. If you do not want to use automatic full collection, you can set the FE configuration item `enable_collect_full_statistic` to `false` and customize a collection task.
 

--- a/docs/en/sql-reference/sql-statements/cbo_stats/DROP_ANALYZE.md
+++ b/docs/en/sql-reference/sql-statements/cbo_stats/DROP_ANALYZE.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # DROP ANALYZE
 
-## Description
-
-Deletes a custom collection task.
+DROP ANALYZE deletes a custom collection task.
 
 By default, StarRocks automatically collects full statistics of a table. It checks for any data updates every 5 minutes. If data change is detected, data collection will be automatically triggered. If you do not want to use automatic full collection, you can set the FE configuration item `enable_collect_full_statistic` to `false` and customize a collection task.
 

--- a/docs/en/sql-reference/sql-statements/cbo_stats/DROP_STATS.md
+++ b/docs/en/sql-reference/sql-statements/cbo_stats/DROP_STATS.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # DROP STATS
 
-## Description
-
-Deletes CBO statistics, which include basic statistics and histograms. For more information, see [Gather statistics for CBO](../../../using_starrocks/Cost_based_optimizer.md#basic-statistics).
+DROP STATS deletes CBO statistics, which include basic statistics and histograms. For more information, see [Gather statistics for CBO](../../../using_starrocks/Cost_based_optimizer.md#basic-statistics).
 
 You can delete statistical information you do not need. When you delete statistics, both the data and metadata of the statistics are deleted, as well as the statistics in expired cache. Note that if an automatic collection task is ongoing, previously deleted statistics may be collected again. You can use `SHOW ANALYZE STATUS` to view the history of collection tasks.
 

--- a/docs/en/sql-reference/sql-statements/cbo_stats/KILL_ANALYZE.md
+++ b/docs/en/sql-reference/sql-statements/cbo_stats/KILL_ANALYZE.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # KILL ANALYZE
 
-## Description
-
-Cancels a **running** collection task, including manual and custom automatic tasks.
+KILL ANALYZE cancels a **running** collection task, including manual and custom automatic tasks.
 
 This statement is supported from v2.4.
 

--- a/docs/en/sql-reference/sql-statements/cbo_stats/SHOW_ANALYZE_JOB.md
+++ b/docs/en/sql-reference/sql-statements/cbo_stats/SHOW_ANALYZE_JOB.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW ANALYZE JOB
 
-## Description
-
-Views the information and status of custom collection tasks.
+SHOW ANALYZE JOB views the information and status of custom collection tasks.
 
 By default, StarRocks automatically collects full statistics of a table. It checks for any data updates every 5 minutes. If data change is detected, data collection will be automatically triggered. If you do not want to use automatic full collection, you can set the FE configuration item `enable_collect_full_statistic` to `false` and customize a collection task.
 

--- a/docs/en/sql-reference/sql-statements/cbo_stats/SHOW_ANALYZE_STATUS.md
+++ b/docs/en/sql-reference/sql-statements/cbo_stats/SHOW_ANALYZE_STATUS.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW ANALYZE STATUS
 
-## Description
-
-Views the status of collection tasks.
+SHOW ANALYZE STATUS views the status of collection tasks.
 
 This statement cannot be used to view the status of custom collection tasks. To view the status of custom collection tasks, use SHOW ANALYZE JOB.
 

--- a/docs/en/sql-reference/sql-statements/cbo_stats/SHOW_META.md
+++ b/docs/en/sql-reference/sql-statements/cbo_stats/SHOW_META.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW META
 
-## Description
-
-Views metadata of CBO statistics, including basic statistics and histograms.
+SHOW META views metadata of CBO statistics, including basic statistics and histograms.
 
 This statement is supported from v2.4.
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/config_vars/ADMIN_SET_CONFIG.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/config_vars/ADMIN_SET_CONFIG.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # ADMIN SET CONFIG
 
-## Description
-
-This statement is used to set configuration items for the cluster (Currently, only FE dynamic configuration items can be set using this command). You can view these configuration items using the [ADMIN SHOW FRONTEND CONFIG](ADMIN_SET_CONFIG.md) command.
+ADMIN SET CONFIG is used to set configuration items for the cluster (Currently, only FE dynamic configuration items can be set using this command). You can view these configuration items using the [ADMIN SHOW FRONTEND CONFIG](ADMIN_SET_CONFIG.md) command.
 
 The configurations will be restored to the default values in the `fe.conf` file after the FE restarts. Therefore, we recommend that you also modify the configuration items in `fe.conf` to prevent the loss of modifications.
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/config_vars/ADMIN_SHOW_CONFIG.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/config_vars/ADMIN_SHOW_CONFIG.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # ADMIN SHOW CONFIG
 
-## Description
-
-Displays the configuration of the current cluster (Currently, only FE configuration items can be displayed). For detailed description of these configuration items, see [Configuration](../../../../administration/management/FE_configuration.md).
+ADMIN SHOW CONFIG displays the configuration of the current cluster (Currently, only FE configuration items can be displayed). For detailed description of these configuration items, see [Configuration](../../../../administration/management/FE_configuration.md).
 
 If you want to set or modify a configuration item, use [ADMIN SET CONFIG](ADMIN_SET_CONFIG.md).
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/config_vars/SET.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/config_vars/SET.md
@@ -4,8 +4,6 @@ displayed_sidebar: docs
 
 # SET
 
-## Description
-
 Sets the specified system variables or user-defined variables for StarRocks. You can view the system variables of StarRocks using [SHOW VARIABLES](./SHOW_VARIABLES.md). For details about system variables, see [System Variables](../../../System_variable.md). For details about user-defined variables, see [User-defined variables](../../../user_defined_variables.md).
 
 :::tip

--- a/docs/en/sql-reference/sql-statements/cluster-management/config_vars/SHOW_VARIABLES.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/config_vars/SHOW_VARIABLES.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW VARIABLES
 
-## Description
-
-Shows the system variables of StarRocks. For details about system variables, see [System Variables](../../../System_variable.md).
+SHOW VARIABLES shows the system variables of StarRocks. For details about system variables, see [System Variables](../../../System_variable.md).
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/file/DROP_FILE.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/file/DROP_FILE.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # DROP FILE
 
-## Description
-
-You can execute the DROP FILE statement to delete a file. When you use this statement to delete a file, the file is deleted both in frontend (FE) memory and in Berkeley DB Java Edition (BDBJE).
+Use the DROP FILE statement to delete a file. When you use this statement to delete a file, the file is deleted both in frontend (FE) memory and in Berkeley DB Java Edition (BDBJE).
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/ADD_BACKEND_BLACKLIST.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/ADD_BACKEND_BLACKLIST.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # ADD BACKEND BLACKLIST
 
-## Description
-
-Adds a BE node to the BE Blacklist. You can manually add BE nodes to the blacklist to forbid the usage of the nodes in query execution, thereby avoiding frequent query failures or other unexpected behaviors caused by failed connections to the BE nodes.
+ADD BACKEND BLACKLIST adds a BE node to the BE Blacklist. You can manually add BE nodes to the blacklist to forbid the usage of the nodes in query execution, thereby avoiding frequent query failures or other unexpected behaviors caused by failed connections to the BE nodes.
 
 This feature is supported from v3.3.0 onwards. For more information, see [Manage BE Blacklist](../../../../administration/management/BE_blacklist.md).
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/ALTER_SYSTEM.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/ALTER_SYSTEM.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # ALTER SYSTEM
 
-## Description
-
-Manages FE, BE, CN, Broker nodes, and metadata snapshots in a cluster.
+ALTER SYSTEM Manages FE, BE, CN, Broker nodes, and metadata snapshots in a cluster.
 
 > **NOTE**
 >

--- a/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/CANCEL_DECOMMISSION.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/CANCEL_DECOMMISSION.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # CANCEL DECOMMISSION
 
-## Description
-
-This statement is used to undo a node decommission.
+CANCEL DECOMMISSION is used to undo a node decommission.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/DELETE_BACKEND_BLACKLIST.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/DELETE_BACKEND_BLACKLIST.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # DELETE BACKEND BLACKLIST
 
-## Description
-
-Removes a BE node from the BE Blacklist. Please note that StarRocks will not remove the BE nodes that are manually blacklisted by users.
+DELETE BACKEND BLACKLIST removes a BE node from the BE Blacklist. Please note that StarRocks will not remove the BE nodes that are manually blacklisted by users.
 
 This feature is supported from v3.3.0 onwards. For more information, see [Manage BE Blacklist](../../../../administration/management/BE_blacklist.md).
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/KILL.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/KILL.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # KILL
 
-## Description
-
-Terminates a connection or a query currently being performed by threads executing within StarRocks.
+Kill terminates a connection or a query currently being performed by threads executing within StarRocks.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/SHOW_BACKENDS.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/SHOW_BACKENDS.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW BACKENDS
 
-## Description
-
-Shows the information of all BE nodes in the cluster.
+SHOW BACKENDS shows the information of all BE nodes in the cluster.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/SHOW_BACKEND_BLACKLIST.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/SHOW_BACKEND_BLACKLIST.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW BACKEND BLACKLIST
 
-## Description
-
-Shows the BE nodes in the BE Blacklist.
+SHOW BACKEND BLACKLIST shows the BE nodes in the BE Blacklist.
 
 This feature is supported from v3.3.0 onwards. For more information, see [Manage BE Blacklist](../../../../administration/management/BE_blacklist.md).
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/SHOW_BROKER.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/SHOW_BROKER.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW BROKER
 
-## Description
-
-This statement is used to view broker that currently exists.
+SHOW BROKER is used to view a broker that currently exists.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/SHOW_COMPUTE_NODES.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/SHOW_COMPUTE_NODES.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW COMPUTE NODES
 
-## Description
-
-Shows the information of all CN nodes in the cluster.
+SHOW COMPUTE NODES shows the information of all CN nodes in the cluster.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/SHOW_FRONTENDS.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/SHOW_FRONTENDS.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW FRONTENDS
 
-## Description
-
-This statement is used to view FE nodes.
+SHOW FRONTENDS is used to view FE nodes.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/SHOW_PROC.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/SHOW_PROC.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW PROC
 
-## Description
-
-Shows certain indicators of the StarRocks cluster.
+SHOW PROC shows certain indicators of the StarRocks cluster.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/SHOW_PROCESSLIST.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/SHOW_PROCESSLIST.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW PROCESSLIST
 
-## Description
-
-Lists the operations currently being performed by threads executing within the server. The current version of StarRocks only supports listing queries.
+SHOW PROCESSLIST lists the operations currently being performed by threads executing within the server. The current version of StarRocks only supports listing queries.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/SHOW_RUNNING_QUERIES.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/nodes_processes/SHOW_RUNNING_QUERIES.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW RUNNING QUERIES
 
-## Description
-
-Shows the information of all queries that are running or pending in the query queue. This feature is supported from v3.1.4 onwards.
+SHOW RUNNING QUERIES displays information of all queries that are running or pending in the query queue. This feature is supported from v3.1.4 onwards.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/plan_profile/ANALYZE_PROFILE.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/plan_profile/ANALYZE_PROFILE.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # ANALYZE PROFILE
 
-## Description
-
-Analyzes a specific query profile on a per-fragment basis, and displays it in a tree structure. For more information about query profile, see [Query Profile Overview](../../../../administration/query_profile_overview.md).
+ANALYZE PROFILE analyzes a specific query profile on a per-fragment basis, and displays it in a tree structure. For more information about query profile, see [Query Profile Overview](../../../../administration/query_profile_overview.md).
 
 This feature is supported from v3.1 onwards.
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/plan_profile/EXPLAIN.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/plan_profile/EXPLAIN.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # EXPLAIN
 
-## Description
-
-Shows the logical or physical execution plans for a query statement. For instructions on how to analyze a query plan, refer to [Plan analysis](../../../../administration/Query_planning.md#plan-analysis).
+EXPLAIN shows the logical or physical execution plans for a query statement. For instructions on how to analyze a query plan, refer to [Plan analysis](../../../../administration/Query_planning.md#plan-analysis).
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/plan_profile/EXPLAIN_ANALYZE.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/plan_profile/EXPLAIN_ANALYZE.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # EXPLAIN ANALYZE
 
-## Description
-
-Executes the specified SQL statement, and shows the query profile of this statement. For more information about query profile, see [Query Profile Overview](../../../../administration/query_profile_overview.md).
+EXPLAIN ANALYZE executes the specified SQL statement, and shows the query profile of this statement. For more information about query profile, see [Query Profile Overview](../../../../administration/query_profile_overview.md).
 
 This feature is supported from v3.1 onwards.
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/plan_profile/SHOW_PROFILELIST.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/plan_profile/SHOW_PROFILELIST.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW PROFILELIST
 
-## Description
-
-Lists the query profile records cached in your StarRocks cluster. For more information about query profile, see [Query Profile Overview](../../../../administration/query_profile_overview.md).
+SHOW PROFILELIST lists the query profile records cached in your StarRocks cluster. For more information about query profile, see [Query Profile Overview](../../../../administration/query_profile_overview.md).
 
 This feature is supported from v3.1 onwards.
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/plugin/INSTALL_PLUGIN.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/plugin/INSTALL_PLUGIN.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # INSTALL PLUGIN
 
-## Description
-
-This statement is used to install a plugin.
+INSTALL PLUGIN is used to install a plugin.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/plugin/SHOW_PLUGINS.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/plugin/SHOW_PLUGINS.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW PLUGINS
 
-## Description
-
-This statement is used to view the installed plugins.
+SHOW PLUGINS is used to view the installed plugins.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/plugin/UNINSTALL_PLUGIN.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/plugin/UNINSTALL_PLUGIN.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # UNINSTALL PLUGIN
 
-## Description
-
-This statement is used to uninstall a plugin.
+UNINSTALL PLUGIN is used to uninstall a plugin.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/resource_group/ALTER_RESOURCE_GROUP.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/resource_group/ALTER_RESOURCE_GROUP.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # ALTER RESOURCE GROUP
 
-## Description
-
-Alters the configuration of a resource group.
+ALTER RESOURCE GROUP alters the configuration of a resource group.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/resource_group/CREATE_RESOURCE_GROUP.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/resource_group/CREATE_RESOURCE_GROUP.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # CREATE RESOURCE GROUP
 
-## Description
-
-Creates a resource group.
+CREATE RESOURCE GROUP creates a resource group.
 
 For more information, see [Resource group](../../../../administration/management/resource_management/resource_group.md).
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/resource_group/DROP_RESOURCE_GROUP.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/resource_group/DROP_RESOURCE_GROUP.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # DROP RESOURCE GROUP
 
-## Description
-
-Drops the specified resource group.
+DROP RESOURCE GROUP drops the specified resource group.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/resource_group/SHOW_RESOURCE_GROUP.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/resource_group/SHOW_RESOURCE_GROUP.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW RESOURCE GROUP
 
-## Description
-
-Shows the information of resource groups.
+SHOW RESOURCE GROUP shows the information of resource groups.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/resource_group/SHOW_USAGE_RESOURCE_GROUPS.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/resource_group/SHOW_USAGE_RESOURCE_GROUPS.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW USAGE RESOURCE GROUPS
 
-## Description
-
-Shows the usage information of resource groups. This feature is supported from v3.1.4 onwards.
+SHOW USAGE RESOURCE GROUPS shows the usage information of resource groups. This feature is supported from v3.1.4 onwards.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/sql_blacklist/ADD_SQLBLACKLIST.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/sql_blacklist/ADD_SQLBLACKLIST.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # ADD SQLBLACKLIST
 
-## Description
-
-Adds a regular expression to the SQL blacklist to forbid certain SQL patterns. When the SQL Blacklist feature is enabled, StarRocks compares all SQL statements to be executed against the SQL regular expressions in the blacklist. StarRocks does not execute SQLs that match any regular expression in the blacklist and returns an error. This prevents certain SQLs from triggering cluster crashes or unexpected behavior.
+ADD SQLBLACKLIST adds a regular expression to the SQL blacklist to forbid certain SQL patterns. When the SQL Blacklist feature is enabled, StarRocks compares all SQL statements to be executed against the SQL regular expressions in the blacklist. StarRocks does not execute SQLs that match any regular expression in the blacklist and returns an error. This prevents certain SQLs from triggering cluster crashes or unexpected behavior.
 
 For more about SQL Blacklist, see [Manage SQL Blacklist](../../../../administration/management/resource_management/Blacklist.md).
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/sql_blacklist/DELETE_SQLBLACKLIST.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/sql_blacklist/DELETE_SQLBLACKLIST.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # DELETE SQLBLACKLIST
 
-## Description
-
-Deletes an SQL regular expression from the SQL blacklist.
+DELETE SQLBLACKLIST deletes an SQL regular expression from the SQL blacklist.
 
 For more about SQL Blacklist, see [Manage SQL Blacklist](../../../../administration/management/resource_management/Blacklist.md).
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/sql_blacklist/SHOW_SQLBLACKLIST.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/sql_blacklist/SHOW_SQLBLACKLIST.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW SQLBLACKLIST
 
-## Description
-
-Shows the SQL regular expressions in the SQL blacklist.
+SHOW SQLBLACKLIST shows the SQL regular expressions in the SQL blacklist.
 
 For more about SQL Blacklist, see [Manage SQL Blacklist](../../../../administration/management/resource_management/Blacklist.md).
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/storage_volume/ALTER_STORAGE_VOLUME.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/storage_volume/ALTER_STORAGE_VOLUME.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # ALTER STORAGE VOLUME
 
-## Description
-
-Alters the credential properties, comment, or status (`enabled`) of a storage volume. For more about the properties of a storage volume, see [CREATE STORAGE VOLUME](CREATE_STORAGE_VOLUME.md). This feature is supported from v3.1.
+ALTER STORAGE VOLUME alters the credential properties, comment, or status (`enabled`) of a storage volume. For more about the properties of a storage volume, see [CREATE STORAGE VOLUME](CREATE_STORAGE_VOLUME.md). This feature is supported from v3.1.
 
 > **CAUTION**
 >

--- a/docs/en/sql-reference/sql-statements/cluster-management/storage_volume/CREATE_STORAGE_VOLUME.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/storage_volume/CREATE_STORAGE_VOLUME.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # CREATE STORAGE VOLUME
 
-## Description
-
-Creates a storage volume for a remote storage system. This feature is supported from v3.1.
+CREATE STORAGE VOLUME creates a storage volume for a remote storage system. This feature is supported from v3.1.
 
 A storage volume consists of the properties and credential information of the remote data storage. You can reference a storage volume when you create databases and cloud-native tables in a shared-data StarRocks cluster.
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/storage_volume/DESC_STORAGE_VOLUME.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/storage_volume/DESC_STORAGE_VOLUME.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # DESC STORAGE VOLUME
 
-## Description
-
-Describes a storage volume. This feature is supported from v3.1.
+DESC STORAGE VOLUME describes a storage volume. This feature is supported from v3.1.
 
 > **CAUTION**
 >

--- a/docs/en/sql-reference/sql-statements/cluster-management/storage_volume/DROP_STORAGE_VOLUME.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/storage_volume/DROP_STORAGE_VOLUME.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # DROP STORAGE VOLUME
 
-## Description
-
-Drops a storage volume. Dropped storage volumes cannot be referenced anymore. This feature is supported from v3.1.
+DROP STORAGE VOLUME drops a storage volume. Dropped storage volumes cannot be referenced anymore. This feature is supported from v3.1.
 
 > **CAUTION**
 >

--- a/docs/en/sql-reference/sql-statements/cluster-management/storage_volume/SET_DEFAULT_STORAGE_VOLUME.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/storage_volume/SET_DEFAULT_STORAGE_VOLUME.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SET DEFAULT STORAGE VOLUME
 
-## Description
-
-Sets a storage volume as the default storage volume. After creating a storage volume for an external data source, you can set it as the default storage volume of your StarRocks cluster. This feature is supported from v3.1.
+SET DEFAULT STORAGE VOLUME sets a storage volume as the default storage volume. After creating a storage volume for an external data source, you can set it as the default storage volume of your StarRocks cluster. This feature is supported from v3.1.
 
 > **CAUTION**
 >

--- a/docs/en/sql-reference/sql-statements/cluster-management/storage_volume/SHOW_STORAGE_VOLUMES.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/storage_volume/SHOW_STORAGE_VOLUMES.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW STORAGE VOLUMES
 
-## Description
-
-Shows the storage volumes in your StarRocks cluster. This feature is supported from v3.1.
+SHOW STORAGE VOLUMES shows the storage volumes in your StarRocks cluster. This feature is supported from v3.1.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/tablet_replica/ADMIN_CANCEL_REPAIR.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/tablet_replica/ADMIN_CANCEL_REPAIR.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # ADMIN CANCEL REPAIR
 
-## Description
-
-This statement is used to cancel repairing specified tables or partitions with high priority.
+ADMIN CANCEL REPAIR is used to cancel repairing specified tables or partitions with high priority.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/tablet_replica/ADMIN_CHECK_TABLET.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/tablet_replica/ADMIN_CHECK_TABLET.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # ADMIN CHECK TABLET
 
-## Description
-
-This statement is used to check a group of tablets.
+ADMIN CHECK TABLET is used to check a group of tablets.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/tablet_replica/ADMIN_REPAIR.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/tablet_replica/ADMIN_REPAIR.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # ADMIN REPAIR
 
-## Description
-
-This statement is used to try and fix the specified tables or partitions first.
+ADMIN REPAIR is used to try and fix the specified tables or partitions first.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/tablet_replica/ADMIN_SET_PARTITION_VERSION.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/tablet_replica/ADMIN_SET_PARTITION_VERSION.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # ADMIN SET PARTITION VERSION
 
-## Description
-
-Sets a partition to a specific data version.
+ADMIN SET PARTITION VERSION sets a partition to a specific data version.
 
 Note that manually setting the partition version is a high-risk operation and is recommended only when problems occur in the cluster metadata. In normal circumstances, the version of a partition is consistent with that of the tablets within.
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/tablet_replica/ADMIN_SET_REPLICA_STATUS.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/tablet_replica/ADMIN_SET_REPLICA_STATUS.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # ADMIN SET REPLICA STATUS
 
-## Description
-
-This statement is used to set the status of the specified replicas.
+ADMIN SET REPLICA STATUS is used to set the status of the specified replicas.
 
 This command currently only used to manually set the status of some replicas to BAD or OK, allowing the system to automatically repair these replicas.
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/tablet_replica/ADMIN_SHOW_REPLICA_DISTRIBUTION.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/tablet_replica/ADMIN_SHOW_REPLICA_DISTRIBUTION.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # ADMIN SHOW REPLICA DISTRIBUTION
 
-## Description
-
-This statement is used to show the distribution status of a table or a partition replica.
+ADMIN SHOW REPLICA DISTRIBUTION is used to show the distribution status of a table or a partition replica.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/tablet_replica/ADMIN_SHOW_REPLICA_STATUS.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/tablet_replica/ADMIN_SHOW_REPLICA_STATUS.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # ADMIN SHOW REPLICA STATUS
 
-## Description
-
-This statement is used to show the status of replicas for a table or a partition.
+ADMIN SHOW REPLICA STATUS is used to show the status of replicas for a table or a partition.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/tablet_replica/SHOW_TABLE_STATUS.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/tablet_replica/SHOW_TABLE_STATUS.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW TABLE STATUS
 
-## Description
-
-This statement is used to view some of the information in Table.
+SHOW TABLE STATUS is used to view some of the information in Table.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/loading_unloading/ALTER_LOAD.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/ALTER_LOAD.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # ALTER LOAD
 
-## Description
-
-Changes the priority of a Broker Load job that is in the **QUEUEING** or **LOADING** state. This statement is supported since v2.5.
+ALTER LOAD changes the priority of a Broker Load job that is in the **QUEUEING** or **LOADING** state. This statement is supported since v2.5.
 
 > **NOTE**
 >

--- a/docs/en/sql-reference/sql-statements/loading_unloading/BROKER_LOAD.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/BROKER_LOAD.md
@@ -13,8 +13,6 @@ keywords:
 
 import InsertPrivNote from '../../../_assets/commonMarkdown/insertPrivNote.md'
 
-## Description
-
 StarRocks provides the MySQL-based loading method Broker Load. After you submit a load job, StarRocks asynchronously runs the job. You can use `SELECT * FROM information_schema.loads` to query the job result. This feature is supported from v3.1 onwards. For more information about the background information, principles, supported data file formats, how to perform single-table loads and multi-table loads, and how to view job results, see [loading overview](../../../loading/Loading_intro.md).
 
 <InsertPrivNote />

--- a/docs/en/sql-reference/sql-statements/loading_unloading/CANCEL_LOAD.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/CANCEL_LOAD.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # CANCEL LOAD
 
-## Description
-
-Cancels a given load job: [Broker Load](BROKER_LOAD.md), [Spark Load](SPARK_LOAD.md), or [INSERT](INSERT.md). A load job in the `PREPARED`, `CANCELLED` or `FINISHED` state cannot be canceled.
+CANCEL LOAD cancels a given load job: [Broker Load](BROKER_LOAD.md), [Spark Load](SPARK_LOAD.md), or [INSERT](INSERT.md). A load job in the `PREPARED`, `CANCELLED` or `FINISHED` state cannot be canceled.
 
 Canceling a load job is an asynchronous process. You can use the [SHOW LOAD](SHOW_LOAD.md) statement to check whether a load job is successfully canceled. The load job is successfully canceled if the value of `State` is `CANCELLED` and the value of `type` (displayed in `ErrorMsg`) is `USER_CANCEL`.
 

--- a/docs/en/sql-reference/sql-statements/loading_unloading/ETL/DROP_TASK.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/ETL/DROP_TASK.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # DROP TASK
 
-## Description
-
-Drops an asynchronous ETL task submitted using [SUBMIT TASK](SUBMIT_TASK.md). This feature has been supported since StarRocks v2.5.7.
+DROP TASK drops an asynchronous ETL task submitted using [SUBMIT TASK](SUBMIT_TASK.md). This feature has been supported since StarRocks v2.5.7.
 
 > **NOTE**
 >

--- a/docs/en/sql-reference/sql-statements/loading_unloading/ETL/SUBMIT_TASK.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/ETL/SUBMIT_TASK.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SUBMIT TASK
 
-## Description
-
-Submits an ETL statement as an asynchronous task.
+SUBMIT TASK submits an ETL statement as an asynchronous task.
 
 You can use this statement to:
 

--- a/docs/en/sql-reference/sql-statements/loading_unloading/INSERT.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/INSERT.md
@@ -4,8 +4,6 @@ displayed_sidebar: docs
 
 # INSERT
 
-## Description
-
 Inserts data into a specific table or overwrites a specific table with data. From v3.2.0 onwards, INSERT supports writing data into files in remote storage. You can use INSERT INTO FILES() to unload data from StarRocks to remote storage.
 
 You can submit an asynchronous INSERT task using [SUBMIT TASK](ETL/SUBMIT_TASK.md).

--- a/docs/en/sql-reference/sql-statements/loading_unloading/SHOW_LOAD.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/SHOW_LOAD.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW LOAD
 
-## Description
-
-Displays information of all load jobs or given load jobs in a database. This statement can only display load jobs that are created by using Broker Load, INSERT, and SPARK_LOAD. You can also view load job information via the `curl` command. From v3.1 onwards, we recommend that you use the SELECT statement to query the results of Broker Load or Insert jobs from the `loads` table in the `information_schema` database. For more information, see [Loading](../../../loading/Loading_intro.md).
+SHOW LOAD displays information of all load jobs or given load jobs in a database. This statement can only display load jobs that are created by using Broker Load, INSERT, and SPARK_LOAD. You can also view load job information via the `curl` command. From v3.1 onwards, we recommend that you use the SELECT statement to query the results of Broker Load or Insert jobs from the `loads` table in the `information_schema` database. For more information, see [Loading](../../../loading/Loading_intro.md).
 
 In addition to the preceding loading methods, StarRocks supports using Stream Load and Routine Load to load data. Stream Load is a synchronous operation and will directly return information of Stream Load jobs. Routine Load is an asynchronous operation where you can use the [SHOW ROUTINE LOAD](routine_load/SHOW_ROUTINE_LOAD.md) statement to display information of Routine Load jobs.
 

--- a/docs/en/sql-reference/sql-statements/loading_unloading/SHOW_TRANSACTION.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/SHOW_TRANSACTION.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW TRANSACTION
 
-## Description
-
-This syntax is used to view the transaction details of the specified transaction id.
+SHOW TRANSACTION is used to view the transaction details of the specified transaction id.
 
 Syntax:
 

--- a/docs/en/sql-reference/sql-statements/loading_unloading/SPARK_LOAD.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/SPARK_LOAD.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SPARK LOAD
 
-## Description
-
-Spark load preprocesses the imported data through external spark resources, improves the import performance of a large amount of StarRocks data, and saves the computing resources of StarRocks cluster. It is mainly used in the scenario of initial migration and large amount of data import into StarRocks.
+SPARK LOAD preprocesses the imported data through external spark resources, improves the import performance of a large amount of StarRocks data, and saves the computing resources of StarRocks cluster. It is mainly used in the scenario of initial migration and large amount of data import into StarRocks.
 
 Spark load is an asynchronous import method. Users need to create Spark type import tasks through MySQL protocol and view the import results through`SHOW LOAD`.
 

--- a/docs/en/sql-reference/sql-statements/loading_unloading/STREAM_LOAD.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/STREAM_LOAD.md
@@ -6,11 +6,9 @@ import Tip from '../../../_assets/commonMarkdown/quickstart-shared-nothing-tip.m
 
 # STREAM LOAD
 
+StarRocks provides the loading method HTTP-based STREAM LOAD to help you load data from a local file system or a streaming data source. After you submit a load job, StarRocks synchronously runs the job, and returns the result of the job after the job finishes. You can determine whether the job is successful based on the job result. For information about the application scenarios, limits, principles, and supported data file formats of Stream Load, see [Loading from a local file system via Stream Load](../../../loading/StreamLoad.md#loading-from-a-local-file-system-via-stream-load).
+
 <Tip />
-
-## Description
-
-StarRocks provides the loading method HTTP-based Stream Load to help you load data from a local file system or a streaming data source. After you submit a load job, StarRocks synchronously runs the job, and returns the result of the job after the job finishes. You can determine whether the job is successful based on the job result. For information about the application scenarios, limits, principles, and supported data file formats of Stream Load, see [Loading from a local file system via Stream Load](../../../loading/StreamLoad.md#loading-from-a-local-file-system-via-stream-load).
 
 Since v3.2.7, Stream Load supports compressing JSON data during transmission, reducing network bandwidth overhead. Users can specify different compression algorithms using parameters `compression` and `Content-Encoding`. Supported compression algorithms including GZIP, BZIP2, LZ4_FRAME, and ZSTD. For more information, see [data_desc](#data_desc).
 

--- a/docs/en/sql-reference/sql-statements/loading_unloading/pipe/ALTER_PIPE.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/pipe/ALTER_PIPE.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # ALTER PIPE
 
-## Description
-
-Alters the settings of the properties of a pipe. This command is supported from v3.2 onwards.
+ALTER PIPE alters the settings of the properties of a pipe. This command is supported from v3.2 onwards.
 
 ## Syntax
 

--- a/docs/en/sql-reference/sql-statements/loading_unloading/pipe/CREATE_PIPE.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/pipe/CREATE_PIPE.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # CREATE PIPE
 
-## Description
-
-Creates a new pipe for defining the INSERT INTO SELECT FROM FILES statement used by the system to load data from a specified source data file to a destination table. This command is supported from v3.2 onwards.
+CREATE PIPE creates a new pipe for defining the INSERT INTO SELECT FROM FILES statement used by the system to load data from a specified source data file to a destination table. This command is supported from v3.2 onwards.
 
 ## Syntax
 

--- a/docs/en/sql-reference/sql-statements/loading_unloading/pipe/DROP_PIPE.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/pipe/DROP_PIPE.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # DROP PIPE
 
-## Description
-
-Drops a pipe and the related jobs and metadata. Executing this statement on a pipe does not revoke the data that has been loaded via this pipe. This command is supported from v3.2 onwards.
+DROP PIPE drops a pipe and the related jobs and metadata. Executing this statement on a pipe does not revoke the data that has been loaded via this pipe. This command is supported from v3.2 onwards.
 
 ## Syntax
 

--- a/docs/en/sql-reference/sql-statements/loading_unloading/pipe/RETRY_FILE.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/pipe/RETRY_FILE.md
@@ -1,8 +1,10 @@
+---
+displayed_sidebar: docs
+---
+
 # RETRY FILE
 
-## Description
-
-Retries to load all data files or a specific data file in a pipe. This command is supported from v3.2 onwards.
+RETRY FILE retries to load all data files or a specific data file in a pipe. This command is supported from v3.2 onwards.
 
 ## Syntax
 

--- a/docs/en/sql-reference/sql-statements/loading_unloading/pipe/SHOW_PIPES.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/pipe/SHOW_PIPES.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW PIPES
 
-## Description
-
-Lists the pipes stored in a specified database or in the current database in use. This command is supported from v3.2 onwards.
+SHOW PIPES lists the pipes stored in a specified database or in the current database in use. This command is supported from v3.2 onwards.
 
 ## Syntax
 

--- a/docs/en/sql-reference/sql-statements/loading_unloading/pipe/SUSPEND_or_RESUME_PIPE.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/pipe/SUSPEND_or_RESUME_PIPE.md
@@ -4,8 +4,6 @@ displayed_sidebar: docs
 
 # SUSPEND or RESUME PIPE
 
-## Description
-
 Suspends or resumes a pipe:
 
 - When a load job is in progress (namely, in the `RUNNING` state), suspending (`SUSPEND`) the pipe for the job interrupts the job.

--- a/docs/en/sql-reference/sql-statements/loading_unloading/routine_load/ALTER_ROUTINE_LOAD.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/routine_load/ALTER_ROUTINE_LOAD.md
@@ -6,9 +6,7 @@ displayed_sidebar: docs
 
 import RoutineLoadPrivNote from '../../../../_assets/commonMarkdown/RoutineLoadPrivNote.md'
 
-## Description
-
-Alters a Routine Load job that is in the `PAUSED` state. You can execute PAUSE ROUTINE LOAD to pause a Routine Load job.
+ALTER ROUTINE LOAD alters a Routine Load job that is in the `PAUSED` state. You can execute PAUSE ROUTINE LOAD to pause a Routine Load job.
 
 After successfully altering a Routine Load job, you can:
 

--- a/docs/en/sql-reference/sql-statements/loading_unloading/routine_load/PAUSE_ROUTINE_LOAD.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/routine_load/PAUSE_ROUTINE_LOAD.md
@@ -6,9 +6,7 @@ displayed_sidebar: docs
 
 import RoutineLoadPrivNote from '../../../../_assets/commonMarkdown/RoutineLoadPrivNote.md'
 
-## Description
-
-Pauses a Routine Load job but does not terminate this job. You can execute [RESUME ROUTINE LOAD](RESUME_ROUTINE_LOAD.md) to resume it. After the load job is paused, you can execute [SHOW ROUTINE LOAD](SHOW_ROUTINE_LOAD.md) and [ALTER ROUTINE LOAD](./ALTER_ROUTINE_LOAD.md) to view and modify information ../../data-manipulation/ALTER_ROUTINE_LOAD.mdob.
+PAUSE ROUTINE LOAD pauses a Routine Load job but does not terminate this job. You can execute [RESUME ROUTINE LOAD](RESUME_ROUTINE_LOAD.md) to resume it. After the load job is paused, you can execute [SHOW ROUTINE LOAD](SHOW_ROUTINE_LOAD.md) and [ALTER ROUTINE LOAD](./ALTER_ROUTINE_LOAD.md) to view and modify information ../../data-manipulation/ALTER_ROUTINE_LOAD.mdob.
 
 <RoutineLoadPrivNote />
 

--- a/docs/en/sql-reference/sql-statements/loading_unloading/routine_load/RESUME_ROUTINE_LOAD.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/routine_load/RESUME_ROUTINE_LOAD.md
@@ -6,9 +6,7 @@ displayed_sidebar: docs
 
 import RoutineLoadPrivNote from '../../../../_assets/commonMarkdown/RoutineLoadPrivNote.md'
 
-## Description
-
-Resumes a Routine load job. The job will temporarily enter **NEED_SCHEDULE** state because the job is being re-scheduled. And after some time, the job will be resumed to **RUNNING** state, continuing consuming messages from the data source and loading data. You can check the job's information using the [SHOW ROUTINE LOAD](SHOW_ROUTINE_LOAD.md) statement.
+RESUME ROUTINE LOAD resumes a Routine load job. The job will temporarily enter **NEED_SCHEDULE** state because the job is being re-scheduled. And after some time, the job will be resumed to **RUNNING** state, continuing consuming messages from the data source and loading data. You can check the job's information using the [SHOW ROUTINE LOAD](SHOW_ROUTINE_LOAD.md) statement.
 
 <RoutineLoadPrivNote />
 

--- a/docs/en/sql-reference/sql-statements/loading_unloading/routine_load/SHOW_ROUTINE_LOAD.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/routine_load/SHOW_ROUTINE_LOAD.md
@@ -6,9 +6,7 @@ displayed_sidebar: docs
 
 import RoutineLoadPrivNote from '../../../../_assets/commonMarkdown/RoutineLoadPrivNote.md'
 
-## Description
-
-Shows the execution information of Routine Load jobs.
+SHOW ROUTINE LOAD shows the execution information of Routine Load jobs.
 
 <RoutineLoadPrivNote />
 

--- a/docs/en/sql-reference/sql-statements/loading_unloading/routine_load/SHOW_ROUTINE_LOAD_TASK.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/routine_load/SHOW_ROUTINE_LOAD_TASK.md
@@ -6,9 +6,7 @@ displayed_sidebar: docs
 
 import RoutineLoadPrivNote from '../../../../_assets/commonMarkdown/RoutineLoadPrivNote.md'
 
-## Description
-
-Shows the execution information of load tasks within a Routine Load job.
+SHOW ROUTINE LOAD TASK shows the execution information of load tasks within a Routine Load job.
 
 :::note
 

--- a/docs/en/sql-reference/sql-statements/loading_unloading/routine_load/STOP_ROUTINE_LOAD.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/routine_load/STOP_ROUTINE_LOAD.md
@@ -6,9 +6,7 @@ displayed_sidebar: docs
 
 import RoutineLoadPrivNote from '../../../../_assets/commonMarkdown/RoutineLoadPrivNote.md'
 
-## Description
-
-Stops a Routine Load job.
+STOP ROUTINE LOAD stops a Routine Load job.
 
 <RoutineLoadPrivNote />
 

--- a/docs/en/sql-reference/sql-statements/loading_unloading/unloading/CANCEL_EXPORT.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/unloading/CANCEL_EXPORT.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # CANCEL EXPORT
 
-## Description
-
-Cancels a given data unloading job. Unloading jobs with the state `CANCELLED` or `FINISHED` cannot be canceled. Canceling an unloading job is an asynchronous process. You can use the [SHOW EXPORT](SHOW_EXPORT.md) statement to check whether an unloading job is successfully canceled. The unloading job is successfully canceled if the value of `State` is `CANCELLED`.
+CANCEL EXPORT cancels a given data unloading job. Unloading jobs with the state `CANCELLED` or `FINISHED` cannot be canceled. Canceling an unloading job is an asynchronous process. You can use the [SHOW EXPORT](SHOW_EXPORT.md) statement to check whether an unloading job is successfully canceled. The unloading job is successfully canceled if the value of `State` is `CANCELLED`.
 
 The CANCEL EXPORT statement requires that you have at least one of the following privileges on the database to which the given unloading job belongs: `SELECT_PRIV`, `LOAD_PRIV`, `ALTER_PRIV`, `CREATE_PRIV`, `DROP_PRIV`, and `USAGE_PRIV`. For more information about privilege descriptions, see [GRANT](../../account-management/GRANT.md).
 

--- a/docs/en/sql-reference/sql-statements/loading_unloading/unloading/EXPORT.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/unloading/EXPORT.md
@@ -4,8 +4,6 @@ displayed_sidebar: docs
 
 # EXPORT
 
-## Description
-
 Exports the data of a table to a specified location.
 
 This is an asynchronous operation. The export result is returned after you submit the export task. You can use [SHOW EXPORT](SHOW_EXPORT.md) to view the progress of the export task.

--- a/docs/en/sql-reference/sql-statements/loading_unloading/unloading/SHOW_EXPORT.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/unloading/SHOW_EXPORT.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW EXPORT
 
-## Description
-
-Queries the execution information of export jobs that meet the specified conditions.
+SHOW EXPORT queries the execution information of export jobs that meet the specified conditions.
 
 ## Syntax
 

--- a/docs/en/sql-reference/sql-statements/materialized_view/ALTER_MATERIALIZED_VIEW.md
+++ b/docs/en/sql-reference/sql-statements/materialized_view/ALTER_MATERIALIZED_VIEW.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # ALTER MATERIALIZED VIEW
 
-## Description
-
-This SQL statement can:
+ALTER MATERIALIZED VIEW can:
 
 - Alter the name of an asynchronous materialized view.
 - Alter the refresh strategy of an asynchronous materialized view.

--- a/docs/en/sql-reference/sql-statements/materialized_view/CANCEL_REFRESH_MATERIALIZED_VIEW.md
+++ b/docs/en/sql-reference/sql-statements/materialized_view/CANCEL_REFRESH_MATERIALIZED_VIEW.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # CANCEL REFRESH MATERIALIZED VIEW
 
-## Description
-
-Cancels a refresh task for an asynchronous materialized view.
+CANCEL REFRESH MATERIALIZED VIEW cancels a refresh task for an asynchronous materialized view.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md
+++ b/docs/en/sql-reference/sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # CREATE MATERIALIZED VIEW
 
-## Description
-
-Creates a materialized view. For usage information about materialized views, see [Synchronous materialized view](../../../using_starrocks/Materialized_view-single_table.md) and [Asynchronous materialized view](../../../using_starrocks/async_mv/Materialized_view.md).
+CREATE MATERIALIZED VIEW creates a materialized view. For usage information about materialized views, see [Synchronous materialized view](../../../using_starrocks/Materialized_view-single_table.md) and [Asynchronous materialized view](../../../using_starrocks/async_mv/Materialized_view.md).
 
 > **CAUTION**
 >

--- a/docs/en/sql-reference/sql-statements/materialized_view/DROP_MATERIALIZED_VIEW.md
+++ b/docs/en/sql-reference/sql-statements/materialized_view/DROP_MATERIALIZED_VIEW.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # DROP MATERIALIZED VIEW
 
-## Description
-
-Drops a materialized view.
+DROP MATERIALIZED VIEW drops a materialized view.
 
 You cannot drop a synchronous materialized view that is being created in process with this command. To drop a synchronous materialized view that is being created in process, see [Synchronous materialized View - Drop an unfinished materialized view](../../../using_starrocks/Materialized_view-single_table.md#drop-an-unfinished-synchronous-materialized-view) for further instructions.
 

--- a/docs/en/sql-reference/sql-statements/materialized_view/REFRESH_MATERIALIZED_VIEW.md
+++ b/docs/en/sql-reference/sql-statements/materialized_view/REFRESH_MATERIALIZED_VIEW.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # REFRESH MATERIALIZED VIEW
 
-## Description
-
-Manually refresh a specific asynchronous materialized view or partitions within.
+REFRESH MATERIALIZED VIEW manually refreshes a specific asynchronous materialized view or partitions within.
 
 > **CAUTION**
 >

--- a/docs/en/sql-reference/sql-statements/materialized_view/SHOW_ALTER_MATERIALIZED_VIEW.md
+++ b/docs/en/sql-reference/sql-statements/materialized_view/SHOW_ALTER_MATERIALIZED_VIEW.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW ALTER MATERIALIZED VIEW
 
-## Description
-
-Shows the building status of synchronous materialized views.
+SHOW ALTER MATERIALIZED VIEW shows the building status of synchronous materialized views.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/materialized_view/SHOW_CREATE_MATERIALIZED_VIEW.md
+++ b/docs/en/sql-reference/sql-statements/materialized_view/SHOW_CREATE_MATERIALIZED_VIEW.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW CREATE MATERIALIZED VIEW
 
-## Description
-
-Shows the definition of a specific asynchronous materialized view.
+SHOW CREATE MATERIALIZED VIEW shows the definition of a specific asynchronous materialized view.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/materialized_view/SHOW_MATERIALIZED_VIEW.md
+++ b/docs/en/sql-reference/sql-statements/materialized_view/SHOW_MATERIALIZED_VIEW.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW MATERIALIZED VIEWS
 
-## Description
-
-Shows all or one specific asynchronous materialized view.
+SHOW MATERIALIZED VIEWS shows all or one specific asynchronous materialized view.
 
 Since v3.0, the name of this statement is changed from SHOW MATERIALIZED VIEW to SHOW MATERIALIZED VIEWS.
 

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # ALTER TABLE
 
-## Description
-
-Modifies an existing table, including:
+ALTER TABLE Modifies an existing table, including:
 
 - [Rename table, partition, index, or column](#rename)
 - [Modify table comment](#alter-table-comment-from-v31)

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/CANCEL_ALTER_TABLE.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/CANCEL_ALTER_TABLE.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # CANCEL ALTER TABLE
 
-## Description
-
-Cancels the execution of the ongoing ALTER TABLE operation, including:
+CANCEL ALTER TABLE cancels the execution of the ongoing ALTER TABLE operation, including:
 
 - Modify columns.
 - Optimize table schema (from v3.2), including modifying the bucketing method and the number of buckets.

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_INDEX.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_INDEX.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # CREATE INDEX
 
-## Description
-
-This statement is used to create indexes. You can use this statement to create only Bitmap indexes. For usage notes and scenarios of Bitmap indexes, see [Bitmap index](../../../table_design/indexes/Bitmap_index.md).
+CREATE INDEX is used to create only Bitmap indexes. For usage notes and scenarios of Bitmap indexes, see [Bitmap index](../../../table_design/indexes/Bitmap_index.md).
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE_AS_SELECT.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE_AS_SELECT.md
@@ -5,9 +5,7 @@ keywords: ['CTAS']
 
 # CREATE TABLE AS SELECT
 
-## Description
-
-You can use the CREATE TABLE AS SELECT (CTAS) statement to synchronously or asynchronously query a table and create a new table based on the query result, and then insert the query result into the new table.
+Use the CREATE TABLE AS SELECT (CTAS) statement to synchronously or asynchronously query a table and create a new table based on the query result, and then insert the query result into the new table.
 
 You can submit an asynchronous CTAS task using [SUBMIT TASK](../loading_unloading/ETL/SUBMIT_TASK.md).
 

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE_LIKE.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE_LIKE.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # CREATE TABLE LIKE
 
-## Description
-
-Creates an identical empty table based on the definition of another table. The definition includes column definition, partitions, and table properties. You can copy an external table such as MySQL.
+CREATE TABLE LIKE creates an identical empty table based on the definition of another table. The definition includes column definition, partitions, and table properties. You can copy an external table such as MySQL.
 
 v3.2 allows you to specify a different partitioning method, bucketing method, and properties for the new table than the source table.
 

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/DESCRIBE.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/DESCRIBE.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # DESC
 
-## Description
-
-You can use the statement to perform the following operations:
+DESC is used to view table schemas:
 
 - View the schema of a table stored in your StarRocks cluster, along with the type of the [sort key](../../../table_design/indexes/Prefix_index_sort_key.md) and [materialized view](../../../using_starrocks/async_mv/Materialized_view.md) of the table.
 - View the schema of a table stored in the following external data sources, such as Apache Hive™. Note that you can perform this operation only in StarRocks 2.4 and later versions.

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/DROP_INDEX.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/DROP_INDEX.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # DROP INDEX
 
-## Description
-
-This statement is used to drop a specified index on a table. Currently, only bitmap index is supported in this version.
+DROP INDEX is used to drop a specified index on a table. Currently, only bitmap index is supported in this version.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/DROP_TABLE.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/DROP_TABLE.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # DROP TABLE
 
-## Description
-
-This statement is used to delete a table.
+DROP TABLE is used to delete a table.
 
 ## Syntax
 

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/REFRESH_EXTERNAL_TABLE.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/REFRESH_EXTERNAL_TABLE.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # REFRESH EXTERNAL TABLE
 
-## Description
-
-Updates metadata cached in StarRocks. The metadata is from tables in data lakes. This statement is used in the following scenarios:
+REFRESH EXTERNAL TABLE metadata cached in StarRocks. The metadata is from tables in data lakes. This statement is used in the following scenarios:
 
 - **External table**: When using a Hive external table or Hudi external table to query data in Apache Hive™ or Apache Hudi, you can execute this statement to update the metadata of a Hive table or Hudi table cached in StarRocks.
 - **External catalog**: When using an [external catalog](../../../data_source/catalog/catalog_overview.md) to query data in the corresponding data source, you can execute this statement to update the metadata cached in StarRocks.

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/SELECT.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/SELECT.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SELECT
 
-## Description
-
-Queries data from one or more tables, views, or materialized views. The SELECT statement generally consists of the following clauses:
+SELECT queries data from one or more tables, views, or materialized views. The SELECT statement generally consists of the following clauses:
 
 - [WITH](#with)
 - [WHERE and operators](#where-and-operators)

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/SHOW_ALTER.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/SHOW_ALTER.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW ALTER TABLE
 
-## Description
-
-Shows the execution of the ongoing ALTER TABLE operations, including:
+SHOW ALTER TABLE shows the execution of the ongoing ALTER TABLE operations, including:
 
 - Modify columns.
 - Optimize table schema (from v3.2), including modifying the bucketing method and the number of buckets.

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/SHOW_DELETE.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/SHOW_DELETE.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW DELETE
 
-## Description
-
-Queries historical DELETE operations that were successfully performed on Duplicate Key, Unique Key, and Aggregate tables in a specified database. For more information about data deletion, see [DELETE](DELETE.md).
+SHOW DELETE queries historical DELETE operations that were successfully performed on Duplicate Key, Unique Key, and Aggregate tables in a specified database. For more information about data deletion, see [DELETE](DELETE.md).
 
 Note that this command cannot be used to query DELETE operations that were performed on Primary Key tables.
 

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/SHOW_DYNAMIC_PARTITION_TABLES.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/SHOW_DYNAMIC_PARTITION_TABLES.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW DYNAMIC PARTITION TABLES
 
-## Description
-
-This statement is used to display the status of all the partitioned tables for which dynamic partitioning properties are configured in a database.
+SHOW DYNAMIC PARTITION TABLES is used to display the status of all the partitioned tables for which dynamic partitioning properties are configured in a database.
 
 ## Syntax
 

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/SHOW_FULL_COLUMNS.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/SHOW_FULL_COLUMNS.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW FULL COLUMNS
 
-## Description
-
-This statement is used to show content in columns from specified tables.
+SHOW FULL COLUMNS is used to show content in columns from specified tables.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/SHOW_INDEX.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/SHOW_INDEX.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW INDEX
 
-## Description
-
-This statement is used to show information related to index in a table. It currently only supports bitmap index.
+SHOW INDEX is used to show information related to index in a table. It currently only supports bitmap index.
 
 :::tip
 

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/SHOW_PARTITIONS.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/SHOW_PARTITIONS.md
@@ -1,5 +1,7 @@
 ---
 displayed_sidebar: docs
+keywords:
+  - SHOW PARTITIONS
 ---
 
 # SHOW PARTITIONS

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/SHOW_PARTITIONS.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/SHOW_PARTITIONS.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW PARTITIONS
 
-## Description
-
-Displays partition information, including common partitions and [temporary partitions](../../../table_design/data_distribution/Temporary_partition.md).
+SHOW PARTITIONS displays partition information, including common partitions and [temporary partitions](../../../table_design/data_distribution/Temporary_partition.md).
 
 ## Syntax
 

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/SHOW_TABLES.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/SHOW_TABLES.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW TABLES
 
-## Description
-
-Displays all tables in a StarRocks database or a database in an external data source, for example, Hive, Iceberg, Hudi, or Delta Lake.
+SHOW TABLES displays all tables in a StarRocks database or a database in an external data source, for example, Hive, Iceberg, Hudi, or Delta Lake.
 
 > **NOTE**
 >

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/SHOW_TABLET.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/SHOW_TABLET.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # SHOW TABLET
 
-## Description
-
-Displays tablet related information.
+SHOW TABLET displays tablet related information.
 
 > **NOTE**
 >

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/TRUNCATE_TABLE.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/TRUNCATE_TABLE.md
@@ -4,9 +4,7 @@ displayed_sidebar: docs
 
 # TRUNCATE TABLE
 
-## Description
-
-This statement is used to truncate the specified table and partition data.
+TRUNCATE TABLE is used to truncate the specified table and partition data.
 
 Syntax:
 

--- a/docs/en/table_design/indexes/Prefix_index_sort_key.md
+++ b/docs/en/table_design/indexes/Prefix_index_sort_key.md
@@ -5,8 +5,6 @@ sidebar_position: 10
 
 # Prefix indexes
 
-## Description
-
 Specify one or more columns to comprise the sort key at table creation. The data rows in the table will be sorted based on the sort key and then stored on the disk.
 
 **During data writing, the Prefix index is automatically generated. After the data is sorted according to the specified sort key, every 1024 rows of data are included in one logical data block. An index entry that consists of the values of sort key columns of the first data row in that logical data block is added to the Prefix index table.**


### PR DESCRIPTION
## Why I'm doing:

Having:

```md
## Description

text that describes the function
```

results in this in the index pages:

<img width="942" alt="image" src="https://github.com/user-attachments/assets/86091d79-ebb6-4af2-963e-9cd24b7b38e2" />

## What I'm doing:

This PR removes the `## Description` line and sets a short description of the statement or function.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1