### PR TITLE
[BugFix] Fix partition fetching bug with partition_retention_condition

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableWithPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableWithPartitionTest.java
@@ -938,8 +938,8 @@ public class CreateTableWithPartitionTest extends StarRocksTestBase  {
                     "'partition_retention_condition' = 'cast(id as date) > current_date() - interval 1 month'\n" +
                     ")");
         } catch (Exception e) {
-            Assert.assertTrue(e.getMessage().contains("Column is not a partition column which can not be " +
-                    "used in where clause for drop partition"));
+            Assert.assertTrue(e.getMessage().contains("Column `id` in the partition condition is not a table's partition " +
+                    "expression, please use table's partition expressions: `province`/`dt`."));
         }
     }
 
@@ -958,8 +958,8 @@ public class CreateTableWithPartitionTest extends StarRocksTestBase  {
                     "'partition_retention_condition' = 'cast(id as date) > current_date() - interval 1 month'\n" +
                     ")");
         } catch (Exception e) {
-            Assert.assertTrue(e.getMessage().contains("Can't drop partitions with where expression " +
-                    "since it is not partitioned"));
+            Assert.assertTrue(e.getMessage().contains("Partition condition `CAST(id AS DATE) > current_date() - INTERVAL 1 MONTH` " +
+                    "is supported for a partitioned table"));
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionWithExprListTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionWithExprListTest.java
@@ -332,8 +332,9 @@ public class DropPartitionWithExprListTest extends MVTestBase {
                             starRocksAssert.alterTable(dropPartitionSql);
                             Assert.fail();
                         } catch (Exception e) {
-                            Assert.assertTrue(e.getMessage().contains("Column is not a partition column which " +
-                                    "can not be used in where clause for drop partition"));
+                            Assert.assertTrue(e.getMessage().contains("Column `dt` in the partition condition is not " +
+                                    "a table's partition expression, please use table's partition expressions: " +
+                                    "`province`/`str2date(dt, '%Y-%m-%d')`"));
                         }
                         Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
                     }
@@ -487,7 +488,9 @@ public class DropPartitionWithExprListTest extends MVTestBase {
                             starRocksAssert.alterTable(dropPartitionSql);
                             Assert.fail();
                         } catch (Exception e) {
-                            Assert.assertTrue(e.getMessage().contains("Column is not a partition column which can not"));
+                            Assert.assertTrue(e.getMessage().contains("Column `province` in the partition condition is not " +
+                                    "a table's partition expression, please use table's partition expressions: `str2date(dt, " +
+                                    "'%Y-%m-%d')`/`date_trunc('day', dt)`."));
                         }
                     }
                     {

--- a/test/sql/test_drop_partition/R/test_drop_partition_range_table_with_where
+++ b/test/sql/test_drop_partition/R/test_drop_partition_range_table_with_where
@@ -33,7 +33,7 @@ select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uu
 -- !result
 ALTER TABLE t1 DROP PARTITIONS WHERE province like '%a%';
 -- result:
-[REGEX].*Column is not a partition column which can not be used in where clause for drop partition.*
+E: (1064, "Getting analyzing error. Detail message: Column `province` in the partition condition is not a table's partition expression, please use table's partition expressions: `dt`.")
 -- !result
 select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
 -- result:

--- a/test/sql/test_drop_partition/R/test_partition_retention_condition_expr
+++ b/test/sql/test_drop_partition/R/test_partition_retention_condition_expr
@@ -5,13 +5,13 @@ CREATE TABLE t1 (
     num int
 )
 DUPLICATE KEY(dt, province)
-PARTITION BY date_trunc('day', dt)
+PARTITION BY date_trunc('day', dt), province
 PROPERTIES (
     "partition_retention_condition" = "dt >= CURRENT_DATE() - INTERVAL 1 MONTH OR last_day(dt) = date_trunc('day', dt)",
     "replication_num" = "1"
 );
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Retention condition must only contain monotonic functions for range partition tables but contains: last_day.')
+E: (1064, "Getting analyzing error. Detail message: Column `dt` in the partition condition is not a table's partition expression, please use table's partition expressions: date_trunc('day', `dt`)/`province`.")
 -- !result
 CREATE TABLE t1 (
     dt datetime,

--- a/test/sql/test_drop_partition/R/test_partition_retention_condition_expr
+++ b/test/sql/test_drop_partition/R/test_partition_retention_condition_expr
@@ -11,7 +11,7 @@ PROPERTIES (
     "replication_num" = "1"
 );
 -- result:
-E: (1064, "Getting analyzing error. Detail message: Column `dt` in the partition condition is not a table's partition expression, please use table's partition expressions: date_trunc('day', `dt`)/`province`.")
+[REGEX].*Column `dt` in the partition condition is not a table's partition expression.*
 -- !result
 CREATE TABLE t1 (
     dt datetime,
@@ -25,7 +25,7 @@ PROPERTIES (
     "replication_num" = "1"
 );
 -- result:
-E: (1064, "Getting analyzing error. Detail message: Column `dt` in the partition condition is not a table's partition expression, please use table's partition expressions: date_trunc('day', `dt`)/`province`.")
+[REGEX].*Column `dt` in the partition condition is not a table's partition expression.*
 -- !result
 CREATE TABLE tbl_ttl_expr (
     dt datetime,

--- a/test/sql/test_drop_partition/R/test_partition_retention_condition_expr
+++ b/test/sql/test_drop_partition/R/test_partition_retention_condition_expr
@@ -1,0 +1,71 @@
+-- name: test_partition_retention_condition_expr
+CREATE TABLE t1 (
+    dt datetime,
+    province string,
+    num int
+)
+DUPLICATE KEY(dt, province)
+PARTITION BY date_trunc('day', dt)
+PROPERTIES (
+    "partition_retention_condition" = "dt >= CURRENT_DATE() - INTERVAL 1 MONTH OR last_day(dt) = date_trunc('day', dt)",
+    "replication_num" = "1"
+);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Retention condition must only contain monotonic functions for range partition tables but contains: last_day.')
+-- !result
+CREATE TABLE t1 (
+    dt datetime,
+    province string,
+    num int
+)
+DUPLICATE KEY(dt, province)
+PARTITION BY date_trunc('day', dt), province
+PROPERTIES (
+    "partition_retention_condition" = "dt >= CURRENT_DATE() - INTERVAL 1 MONTH OR last_day(dt) = date_trunc('day', dt)",
+    "replication_num" = "1"
+);
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column `dt` in the partition condition is not a table's partition expression, please use table's partition expressions: date_trunc('day', `dt`)/`province`.")
+-- !result
+CREATE TABLE tbl_ttl_expr (
+    dt datetime,
+    province string,
+    num int
+)
+DUPLICATE KEY(dt, province)
+PARTITION BY date_trunc('day', dt), province
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO tbl_ttl_expr (dt, province, num)
+SELECT minutes_add(hours_add(date_add('2025-01-01', x), x%24), x%60), concat('x-', x%3), x
+FROM TABLE(generate_series(0, 200-1)) as t(x);
+-- result:
+-- !result
+function: print_table_partitions_num("tbl_ttl_expr")
+-- result:
+200
+-- !result
+ALTER TABLE tbl_ttl_expr DROP PARTITIONS WHERE date_trunc('day', dt) < CURRENT_DATE() - INTERVAL 3 MONTH;
+-- result:
+-- !result
+function: print_table_partitions_num("tbl_ttl_expr")
+-- result:
+142
+-- !result
+ALTER TABLE tbl_ttl_expr DROP PARTITIONS WHERE last_day(date_trunc('day', dt)) != date_trunc('day', dt);
+-- result:
+-- !result
+function: print_table_partitions_num("tbl_ttl_expr")
+-- result:
+5
+-- !result
+ALTER TABLE tbl_ttl_expr DROP PARTITIONS  WHERE date_trunc('day', dt) < CURRENT_DATE() - INTERVAL 2 MONTH AND last_day(date_trunc('day', dt)) != date_trunc('day', dt);
+-- result:
+-- !result
+function: print_table_partitions_num("tbl_ttl_expr")
+-- result:
+5
+-- !result

--- a/test/sql/test_drop_partition/T/test_partition_retention_condition_expr
+++ b/test/sql/test_drop_partition/T/test_partition_retention_condition_expr
@@ -5,7 +5,7 @@ CREATE TABLE t1 (
     num int
 )
 DUPLICATE KEY(dt, province)
-PARTITION BY date_trunc('day', dt)
+PARTITION BY date_trunc('day', dt), province
 PROPERTIES (
     "partition_retention_condition" = "dt >= CURRENT_DATE() - INTERVAL 1 MONTH OR last_day(dt) = date_trunc('day', dt)",
     "replication_num" = "1"

--- a/test/sql/test_drop_partition/T/test_partition_retention_condition_expr
+++ b/test/sql/test_drop_partition/T/test_partition_retention_condition_expr
@@ -1,0 +1,49 @@
+-- name: test_partition_retention_condition_expr
+CREATE TABLE t1 (
+    dt datetime,
+    province string,
+    num int
+)
+DUPLICATE KEY(dt, province)
+PARTITION BY date_trunc('day', dt)
+PROPERTIES (
+    "partition_retention_condition" = "dt >= CURRENT_DATE() - INTERVAL 1 MONTH OR last_day(dt) = date_trunc('day', dt)",
+    "replication_num" = "1"
+);
+
+CREATE TABLE t1 (
+    dt datetime,
+    province string,
+    num int
+)
+DUPLICATE KEY(dt, province)
+PARTITION BY date_trunc('day', dt), province
+PROPERTIES (
+    "partition_retention_condition" = "dt >= CURRENT_DATE() - INTERVAL 1 MONTH OR last_day(dt) = date_trunc('day', dt)",
+    "replication_num" = "1"
+);
+
+CREATE TABLE tbl_ttl_expr (
+    dt datetime,
+    province string,
+    num int
+)
+DUPLICATE KEY(dt, province)
+PARTITION BY date_trunc('day', dt), province
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO tbl_ttl_expr (dt, province, num)
+SELECT minutes_add(hours_add(date_add('2025-01-01', x), x%24), x%60), concat('x-', x%3), x
+FROM TABLE(generate_series(0, 200-1)) as t(x);
+function: print_table_partitions_num("tbl_ttl_expr")
+
+ALTER TABLE tbl_ttl_expr DROP PARTITIONS WHERE date_trunc('day', dt) < CURRENT_DATE() - INTERVAL 3 MONTH;
+function: print_table_partitions_num("tbl_ttl_expr")
+
+ALTER TABLE tbl_ttl_expr DROP PARTITIONS WHERE last_day(date_trunc('day', dt)) != date_trunc('day', dt);
+function: print_table_partitions_num("tbl_ttl_expr")
+
+ALTER TABLE tbl_ttl_expr DROP PARTITIONS  WHERE date_trunc('day', dt) < CURRENT_DATE() - INTERVAL 2 MONTH AND last_day(date_trunc('day', dt)) != date_trunc('day', dt);
+function: print_table_partitions_num("tbl_ttl_expr")


### PR DESCRIPTION
## Why I'm doing:

```
CREATE TABLE tbl_ttl_expr (
    dt datetime,
    province string,
    num int
)
DUPLICATE KEY(dt, province)
PARTITION BY date_trunc('day', dt), province  -- function not supported
PROPERTIES (

    "partition_retention_condition" = "date_trunc('day', dt) >= CURRENT_DATE() - INTERVAL 1 MONTH OR last_day(date_trunc('day', dt)) = date_trunc('day', dt)",
    "replication_num" = "1"
);

ALTER TABLE tbl_ttl_expr DROP PARTITIONS
WHERE last_day(date_trunc('day', dt)) != date_trunc('day', dt);  -- error

-- Alter table will throw exception below:
ERROR 1064 (HY000): Getting analyzing error. Detail message: Failed to prune partitions with where expression: last_day(CAST(json_query(PARTITION_VALUE, '$[0].[0]') AS DATETIME)) != CAST(json_query(PARTITION_VALUE, '$[0].[0]') AS DATETIME).
```
When `drop partition with expression` is executing, it will try to `constant evaluation` in FE first; if failed, it will generate an executable query (from `information_schema.partition_meta`) to fetch partitions by query executing.

This exception is met when analyzing the generated query, the root cause is `json` to `datetime` is not supported in StarRocks at current:

```
-- cast json to datetime is not supported yet.
mysql> SELECT json_query(PARTITION_VALUE, '$[0].[0]'), CAST(json_query(PARTITION_VALUE, '$[0].[0]') AS DATETIME), PARTITION_NAME, PARTITION_VALUE FROM INFORMATION_SCHEMA.PARTITIONS_META WHERE DB_NAME ='test' and TABLE_NAME='tbl_ttl_expr';
ERROR 1064 (HY000): Getting analyzing error from line 1, column 48 to line 1, column 104. Detail message: Invalid type cast from json to datetime in sql `json_query(INFORMATION_SCHEMA.PARTITIONS_META.PARTITION_VALUE, '$[0].[0]')`.


-- cast json to string first, then cast string to datetime
mysql> SELECT json_query(PARTITION_VALUE, '$[0].[0]'), cast(CAST(json_query(PARTITION_VALUE, '$[0].[0]') AS string) as datetime), PARTITION_NAME, PARTITION_VALUE FROM INFORMATION_SCHEMA.PARTITIONS_META WHERE DB_NAME ='test' and TABLE_NAME='tbl_ttl_expr' limit 1;
+-----------------------------------------+---------------------------------------------------------------------------------------+--------------------+---------------------------------+
| json_query(PARTITION_VALUE, '$[0].[0]') | CAST((CAST((json_query(PARTITION_VALUE, '$[0].[0]')) AS VARCHAR(65533))) AS DATETIME) | PARTITION_NAME | PARTITION_VALUE |
+-----------------------------------------+---------------------------------------------------------------------------------------+--------------------+---------------------------------+
| "2025-05-03 00:00:00" | 2025-05-03 00:00:00 | p20250503000000_x2 | [["2025-05-03 00:00:00","x-2"]] |
+-----------------------------------------+---------------------------------------------------------------------------------------+--------------------+--------------------------
```

## What I'm doing:
1. cast json to string first, then cast string to target type later:
```
    // NOTE: `json` to `datetime` is not supported yet, so we use `string` here.
    private static final String JSON_QUERY_TEMPLATE = "CAST(CAST(JSON_QUERY(%s, '$[0].[%d]') AS STRING) AS %s)";
```
2. optimize error messages for better usage.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
