### PR TITLE
[BugFix] add `numFiles` to hive common stats to avoid hive insert overwrite failure

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveCommitter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveCommitter.java
@@ -120,7 +120,8 @@ public class HiveCommitter {
         List<Pair<PartitionUpdate, HivePartitionStats>> insertExistsPartitions = new ArrayList<>();
         for (PartitionUpdate pu : partitionUpdates) {
             PartitionUpdate.UpdateMode mode = pu.getUpdateMode();
-            HivePartitionStats updateStats = fromCommonStats(pu.getRowCount(), pu.getTotalSizeInBytes());
+            HivePartitionStats updateStats =
+                    fromCommonStats(pu.getRowCount(), pu.getTotalSizeInBytes(), pu.getFileCount());
             if (table.isUnPartitioned()) {
                 if (partitionUpdates.size() != 1) {
                     throw new StarRocksConnectorException("There are multiple updates in the unpartition table: %s.%s",

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveCommonStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveCommonStats.java
@@ -12,29 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector.hive;
 
 public class HiveCommonStats {
-    private static final HiveCommonStats EMPTY = new HiveCommonStats(-1, -1);
+    private static final HiveCommonStats EMPTY = new HiveCommonStats(-1, -1, 0);
 
     // Row num is first obtained from the table or partition's parameters.
     // If the num is null or -1, it will be estimated from total size of the partition or table's files.
     private final long rowNums;
 
-    private long totalFileBytes;
+    private final long totalFileBytes;
 
-    public HiveCommonStats(long rowNums, long totalSize) {
+    private final long numFiles;
+
+    public HiveCommonStats(long rowNums, long totalSize, long numFiles) {
         this.rowNums = rowNums;
         this.totalFileBytes = totalSize;
+        this.numFiles = numFiles;
     }
 
     public static HiveCommonStats empty() {
         return EMPTY;
-    }
-
-    public void setTotalFileBytes(long totalFileBytes) {
-        this.totalFileBytes = totalFileBytes;
     }
 
     public long getRowNums() {
@@ -45,11 +43,16 @@ public class HiveCommonStats {
         return totalFileBytes;
     }
 
+    public long getNumFiles() {
+        return numFiles;
+    }
+
     @Override
     public String toString() {
         final StringBuffer sb = new StringBuffer("HiveCommonStats{");
         sb.append("rowNums=").append(rowNums);
         sb.append(", totalFileBytes=").append(totalFileBytes);
+        sb.append(", numFiles=").append(numFiles);
         sb.append('}');
         return sb.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -630,7 +630,7 @@ public class HiveMetastoreApiConverter {
         }
         long numFiles = getLongParam(NUM_FILES, params);
         if (numFiles < 0) {
-            numFiles = 1;
+            numFiles = 0;
         }
         return new HiveCommonStats(numRows, totalSize, numFiles);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -628,7 +628,11 @@ public class HiveMetastoreApiConverter {
         if (totalSize == -1 && Config.enable_reuse_spark_column_statistics) {
             totalSize = getLongParam("spark.sql.statistics.totalSize", params);
         }
-        return new HiveCommonStats(numRows, totalSize);
+        long numFiles = getLongParam(NUM_FILES, params);
+        if (numFiles < 0) {
+            numFiles = 1;
+        }
+        return new HiveCommonStats(numRows, totalSize, numFiles);
     }
 
     public static Map<String, Map<String, HiveColumnStats>> toPartitionColumnStatistics(
@@ -668,6 +672,7 @@ public class HiveMetastoreApiConverter {
 
         result.put(ROW_COUNT, String.valueOf(statistics.getRowNums()));
         result.put(TOTAL_SIZE, String.valueOf(statistics.getTotalFileBytes()));
+        result.put(NUM_FILES, String.valueOf(statistics.getNumFiles()));
 
         if (!parameters.containsKey("STATS_GENERATED_VIA_STATS_TASK")) {
             result.put("STATS_GENERATED_VIA_STATS_TASK", "workaround for potential lack of HIVE-12730");
@@ -717,7 +722,8 @@ public class HiveMetastoreApiConverter {
     }
 
     /**
-     * Refer to https://github.com/apache/hive/blob/rel/release-3.1.3/ql/src/java/org/apache/hadoop/hive/ql/exec/ColumnStatsUpdateTask.java#L77
+     * Refer to https://github.com/apache/hive/blob/rel/release-3.1
+     * .3/ql/src/java/org/apache/hadoop/hive/ql/exec/ColumnStatsUpdateTask.java#L77
      */
     public static ColumnStatisticsObj convertSparkColumnStatistics(FieldSchema fieldSchema, Map<String, String> parameters) {
 
@@ -805,7 +811,8 @@ public class HiveMetastoreApiConverter {
     }
 
     /**
-     * Refer to https://github.com/apache/hive/blob/rel/release-3.1.3/ql/src/java/org/apache/hadoop/hive/ql/exec/ColumnStatsUpdateTask.java#L318
+     * Refer to https://github.com/apache/hive/blob/rel/release-3.1
+     * .3/ql/src/java/org/apache/hadoop/hive/ql/exec/ColumnStatsUpdateTask.java#L318
      */
     private static Date readDateValue(String dateStr) {
         // try either yyyy-mm-dd, or integer representing days since epoch

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HivePartitionStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HivePartitionStats.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector.hive;
 
 import com.google.common.collect.ImmutableMap;
@@ -29,8 +28,8 @@ public class HivePartitionStats {
         return EMPTY;
     }
 
-    public static HivePartitionStats fromCommonStats(long rowNums, long totalFileBytes) {
-        HiveCommonStats commonStats = new HiveCommonStats(rowNums, totalFileBytes);
+    public static HivePartitionStats fromCommonStats(long rowNums, long totalFileBytes, long numFiles) {
+        HiveCommonStats commonStats = new HiveCommonStats(rowNums, totalFileBytes, numFiles);
         return new HivePartitionStats(commonStats, ImmutableMap.of());
     }
 
@@ -74,13 +73,15 @@ public class HivePartitionStats {
     public static HivePartitionStats reduce(HivePartitionStats first, HivePartitionStats second, ReduceOperator operator) {
         return HivePartitionStats.fromCommonStats(
                 reduce(first.getCommonStats().getRowNums(), second.getCommonStats().getRowNums(), operator),
-                reduce(first.getCommonStats().getTotalFileBytes(), second.getCommonStats().getTotalFileBytes(), operator));
+                reduce(first.getCommonStats().getTotalFileBytes(), second.getCommonStats().getTotalFileBytes(), operator),
+                second.getCommonStats().getNumFiles());
     }
 
     public static HiveCommonStats reduce(HiveCommonStats current, HiveCommonStats update, ReduceOperator operator) {
         return new HiveCommonStats(
                 reduce(current.getRowNums(), update.getRowNums(), operator),
-                reduce(current.getTotalFileBytes(), update.getTotalFileBytes(), operator));
+                reduce(current.getTotalFileBytes(), update.getTotalFileBytes(), operator),
+                update.getNumFiles());
     }
 
     public static long reduce(long current, long update, ReduceOperator operator) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/PartitionUpdate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/PartitionUpdate.java
@@ -67,6 +67,10 @@ public class PartitionUpdate {
         return fileNames;
     }
 
+    public long getFileCount() {
+        return fileNames.size();
+    }
+
     public long getRowCount() {
         return rowCount;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/PartitionUpdate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/PartitionUpdate.java
@@ -68,6 +68,9 @@ public class PartitionUpdate {
     }
 
     public long getFileCount() {
+        if (fileNames == null) {
+            return 0;
+        }
         return fileNames.size();
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
@@ -409,7 +409,7 @@ public class CachingHiveMetastoreTest {
                 metastore, executor, executor,
                 expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
 
-        HiveCommonStats stats = new HiveCommonStats(10, 100);
+        HiveCommonStats stats = new HiveCommonStats(10, 100, 1);
 
         // unpartition
         {
@@ -434,7 +434,7 @@ public class CachingHiveMetastoreTest {
                 metastore, executor, executor,
                 expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
 
-        HiveCommonStats stats = new HiveCommonStats(10, 100);
+        HiveCommonStats stats = new HiveCommonStats(10, 100, 1);
         HivePartitionName hivePartitionName = HivePartitionName.of("db1", "unpartitioned_table", "col1=1");
         Partition partition = cachingHiveMetastore.getPartition(
                 "db1", "unpartitioned_table", Lists.newArrayList("col1"));
@@ -510,9 +510,9 @@ public class CachingHiveMetastoreTest {
         String externalTableMark = externalPartition.getParameters().get(TASK);
         for (int i = 0; i < 5; i++) {
             partition =
-              cachingHiveMetastore.getPartition("db1", "tbl1", Lists.newArrayList("par1"));
+                    cachingHiveMetastore.getPartition("db1", "tbl1", Lists.newArrayList("par1"));
             externalPartition =
-              cachingHiveMetastore.getPartition("db1", "external_table", Lists.newArrayList("par1"));
+                    cachingHiveMetastore.getPartition("db1", "external_table", Lists.newArrayList("par1"));
             Thread.sleep(1000);
         }
         Assert.assertEquals(partition.getParameters().get(TASK), mangedTableMark);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HivePartitionStatsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HivePartitionStatsTest.java
@@ -22,9 +22,10 @@ public class HivePartitionStatsTest {
     public void testFromCommonStats() {
         long rowNums = 5;
         long fileSize = 100;
-        HivePartitionStats hivePartitionStats = HivePartitionStats.fromCommonStats(rowNums, fileSize);
+        HivePartitionStats hivePartitionStats = HivePartitionStats.fromCommonStats(rowNums, fileSize, 1);
         Assert.assertEquals(5, hivePartitionStats.getCommonStats().getRowNums());
         Assert.assertEquals(100, hivePartitionStats.getCommonStats().getTotalFileBytes());
+        Assert.assertEquals(1, hivePartitionStats.getCommonStats().getNumFiles());
         Assert.assertTrue(hivePartitionStats.getColumnStats().isEmpty());
     }
 
@@ -34,17 +35,18 @@ public class HivePartitionStatsTest {
         HivePartitionStats update = HivePartitionStats.empty();
         Assert.assertEquals(current, HivePartitionStats.merge(current, update));
 
-        current = HivePartitionStats.fromCommonStats(5, 100);
+        current = HivePartitionStats.fromCommonStats(5, 100, 1);
         update = HivePartitionStats.empty();
         Assert.assertEquals(current, HivePartitionStats.merge(current, update));
 
-        current = HivePartitionStats.fromCommonStats(0, 0);
-        update = HivePartitionStats.fromCommonStats(5, 100);
+        current = HivePartitionStats.fromCommonStats(0, 0, 1);
+        update = HivePartitionStats.fromCommonStats(5, 100, 1);
         Assert.assertEquals(update, HivePartitionStats.merge(current, update));
 
-        current = HivePartitionStats.fromCommonStats(5, 100);
+        current = HivePartitionStats.fromCommonStats(5, 100, 1);
         Assert.assertEquals(10, HivePartitionStats.merge(current, update).getCommonStats().getRowNums());
         Assert.assertEquals(200, HivePartitionStats.merge(current, update).getCommonStats().getTotalFileBytes());
+        Assert.assertEquals(1, HivePartitionStats.merge(current, update).getCommonStats().getNumFiles());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

We observe a bug that we are unable to `insert into overwrite hive_table partition`.  The stack trace is 

```
2025-05-28T16:36:50,651 ERROR [pool-6-thread-47] metastore.RetryingHMSHandler: MetaException(message:java.lang.NumberFormatException: null)
        at org.apache.hadoop.hive.metastore.HiveMetaStore$HMSHandler.newMetaException(HiveMetaStore.java:6193)
        at org.apache.hadoop.hive.metastore.HiveMetaStore$HMSHandler.rename_partition(HiveMetaStore.java:3853)
        at org.apache.hadoop.hive.metastore.HiveMetaStore$HMSHandler.alter_partition_with_environment_context(HiveMetaStore.java:3779)
        at sun.reflect.GeneratedMethodAccessor50.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.apache.hadoop.hive.metastore.RetryingHMSHandler.invokeInternal(RetryingHMSHandler.java:148)
        at org.apache.hadoop.hive.metastore.RetryingHMSHandler.invoke(RetryingHMSHandler.java:107)
        at com.sun.proxy.$Proxy21.alter_partition_with_environment_context(Unknown Source)
        at org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore$Processor$alter_partition_with_environment_context.getResult(ThriftHiveMetastore.java:12532)
        at org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore$Processor$alter_partition_with_environment_context.getResult(ThriftHiveMetastore.java:12516)
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:39)
        at org.apache.hadoop.hive.metastore.TUGIBasedProcessor$1.run(TUGIBasedProcessor.java:136)
        at org.apache.hadoop.hive.metastore.TUGIBasedProcessor$1.run(TUGIBasedProcessor.java:132)
        at java.security.AccessController.doPrivileged(Native Method)
        at javax.security.auth.Subject.doAs(Subject.java:422)
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1713)
        at org.apache.hadoop.hive.metastore.TUGIBasedProcessor.process(TUGIBasedProcessor.java:144)
        at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:286)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)
Caused by: java.lang.NumberFormatException: null
        at java.lang.Long.parseLong(Long.java:552)
        at java.lang.Long.parseLong(Long.java:631)
        at org.apache.hadoop.hive.metastore.MetaStoreUtils.isFastStatsSame(MetaStoreUtils.java:315)
        at org.apache.hadoop.hive.metastore.HiveAlterHandler.alterPartition(HiveAlterHandler.java:395)
        at org.apache.hadoop.hive.metastore.HiveMetaStore$HMSHandler.rename_partition(HiveMetaStore.java:3823)
```

And we find it's because property `numFiles` is missing when adding and altering partition.  And if we don't write that property, hive will generate a default value(1) for `numFiles`.

```
# Detailed Partition Information
Partition Value:        [2025-05-27]
Database:               zya
Table:                  sr_person_output_partition_parquet
CreateTime:             Wed May 28 15:07:36 CST 2025
LastAccessTime:         UNKNOWN
Location:               hdfs://master-1-1.c-9cc5ed7882ddc60c.cn-zhangjiakou.emr.aliyuncs.com:9000/user/hive/warehouse/zya.db/sr_person_output_partition_parquet/dt=2025-05-27
Partition Parameters:
        STATS_GENERATED_VIA_STATS_TASK  workaround for potential lack of HIVE-12730
        numFiles                1  <--- note that we don't write in starrocks.
        numRows                 10
        starrocks_query_id      6f278417-3b92-11f0-bb47-62fc09c1ac6a
        starrocks_version       [r]?yanz-release-je-starrocks-2f1ec5e
        totalSize               786
        transient_lastDdlTime   1748418775
```
But in the hive code,  it assumes this field existed.  The hive version is 2.3.3, and there is a known bug: 
 https://issues.apache.org/jira/browse/HIVE-18767

![image](https://github.com/user-attachments/assets/0701293e-979d-4d14-bd5f-b68182995fd8)


## What I'm doing:

add `numFiles` property to hive common stats.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
