### PR TITLE
[BugFix] Fix incorrect txn coordinator for stream load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
@@ -174,7 +174,7 @@ public class StreamLoadMgr implements MemoryTrackable {
             LOG.info(new LogBuilder(LogKey.STREAM_LOAD_TASK, task.getId())
                     .add("msg", "create load task").build());
 
-            task.beginTxnFromBackend(requestId, resp);
+            task.beginTxnFromBackend(requestId, clientIp, resp);
             addLoadTask(task);
         } finally {
             writeUnlock();

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -1265,7 +1265,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         TransactionResult resp = new TransactionResult();
         StreamLoadMgr streamLoadManager = GlobalStateMgr.getCurrentState().getStreamLoadMgr();
         streamLoadManager.beginLoadTaskFromBackend(dbName, table.getName(), request.getLabel(), request.getRequest_id(),
-                request.getUser(), request.getUser_ip(), timeoutSecond * 1000, resp, false, warehouseId);
+                request.getUser(), clientIp, timeoutSecond * 1000, resp, false, warehouseId);
         if (!resp.stateOK()) {
             LOG.warn(resp.msg);
             throw resp.getException();

--- a/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadTaskTest.java
@@ -42,6 +42,7 @@ import org.mockito.Mockito;
 import java.util.Map;
 
 import static com.starrocks.common.ErrorCode.ERR_NO_PARTITIONS_HAVE_DATA_LOAD;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -215,11 +216,13 @@ public class StreamLoadTaskTest {
         TUniqueId requestId = new TUniqueId(100056, 560001);
         StreamLoadTask streamLoadTask1 = Mockito.spy(new StreamLoadTask(0, new Database(), new OlapTable(), 
                                                                         "", "", "", 10, 10, false, 1));
+        TransactionState.TxnCoordinator coordinator =
+                new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.BE, "192.168.1.2");
         doThrow(new DuplicatedRequestException("Duplicate request", 0L, ""))
-                .when(streamLoadTask1).unprotectedBeginTxn(false, true, requestId);
-        streamLoadTask1.beginTxn(0, 1, requestId, true, resp);
+                .when(streamLoadTask1).unprotectedBeginTxn(same(requestId), same(coordinator));
+        streamLoadTask1.beginTxn(0, 1, requestId, coordinator, resp);
         Assert.assertTrue(resp.stateOK());
-        streamLoadTask1.beginTxn(0, 1, requestId, true, resp);
+        streamLoadTask1.beginTxn(0, 1, requestId, coordinator, resp);
         Assert.assertTrue(resp.stateOK());
     }
 }

--- a/test/sql/test_stream_load/R/test_stream_load_txn_coordinator
+++ b/test/sql/test_stream_load/R/test_stream_load_txn_coordinator
@@ -1,0 +1,85 @@
+-- name: test_stream_load_txn_coordinator
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `test` (
+  `id` int
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+-- result:
+-- !result
+shell: curl --location-trusted -u root: -H "Expect:100-continue"  -X PUT -d '1' ${url}/api/db_${uuid0}/test/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+[UC]shell: curl --location-trusted -u root: -H "label:test" -H "db:db_${uuid0}" -H "table:test" -XPOST ${url}/api/transaction/begin
+-- result:
+0
+{
+    "Status": "OK",
+    "Message": "",
+    "Label": "test",
+    "TxnId": 1059,
+    "BeginTxnTimeMs": 0
+}
+-- !result
+[UC]shell: curl --location-trusted -u root: -H "label:test" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:test" -d '1' -X PUT  ${url}/api/transaction/load
+-- result:
+0
+{
+    "Status": "OK",
+    "Message": "",
+    "Label": "test",
+    "TxnId": 1059,
+    "LoadBytes": 1,
+    "StreamLoadPlanTimeMs": 1,
+    "ReceivedDataTimeMs": 0
+}
+-- !result
+[UC]shell: curl --location-trusted -u root: -H "label:test" -H "db:db_${uuid0}" -XPOST ${url}/api/transaction/prepare
+-- result:
+0
+{
+    "Status": "OK",
+    "Message": "",
+    "Label": "test",
+    "TxnId": 1059,
+    "NumberTotalRows": 1,
+    "NumberLoadedRows": 1,
+    "NumberFilteredRows": 0,
+    "NumberUnselectedRows": 0,
+    "LoadBytes": 1,
+    "LoadTimeMs": 74,
+    "StreamLoadPlanTimeMs": 1,
+    "ReceivedDataTimeMs": 0,
+    "WriteDataTimeMs": 60,
+    "CommitAndPublishTimeMs": 3
+}
+-- !result
+[UC]shell: curl --location-trusted -u root: -H "label:test" -H "db:db_${uuid0}" -XPOST ${url}/api/transaction/commit
+-- result:
+0
+{
+  "Label": "test",
+  "Status": "OK",
+  "TxnId": 1059,
+  "Message": ""
+}
+-- !result
+shell: env url="${url}" db="db_${uuid0}" bash ${root_path}/sql/test_stream_load/T/verify_txn_coordinator.sh
+-- result:
+0
+2
+true
+-- !result

--- a/test/sql/test_stream_load/T/test_stream_load_txn_coordinator
+++ b/test/sql/test_stream_load/T/test_stream_load_txn_coordinator
@@ -1,0 +1,21 @@
+-- name: test_stream_load_txn_coordinator
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE `test` (
+  `id` int
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+
+shell: curl --location-trusted -u root: -H "Expect:100-continue"  -X PUT -d '1' ${url}/api/db_${uuid0}/test/_stream_load
+[UC]shell: curl --location-trusted -u root: -H "label:test" -H "db:db_${uuid0}" -H "table:test" -XPOST ${url}/api/transaction/begin
+[UC]shell: curl --location-trusted -u root: -H "label:test" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:test" -d '1' -X PUT  ${url}/api/transaction/load
+[UC]shell: curl --location-trusted -u root: -H "label:test" -H "db:db_${uuid0}" -XPOST ${url}/api/transaction/prepare
+[UC]shell: curl --location-trusted -u root: -H "label:test" -H "db:db_${uuid0}" -XPOST ${url}/api/transaction/commit
+
+shell: env url="${url}" db="db_${uuid0}" bash ${root_path}/sql/test_stream_load/T/verify_txn_coordinator.sh

--- a/test/sql/test_stream_load/T/verify_txn_coordinator.sh
+++ b/test/sql/test_stream_load/T/verify_txn_coordinator.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Step 1: Extract TxnCoordinator IPs
+coordinator_ips=$(curl -s "${url}/system?path=//transactions/${db}/finished" -uroot: |
+  tr -d '\n' |
+  grep -oP '<tr>.*?<td>BE: \K[\d.]+' |
+  sort)
+echo $(wc -l <<< "$coordinator_ips")
+
+# Step 2: Extract Backend IPs
+backend_ips=$(curl -s "${url}/system?path=//backends" -uroot: |
+  tr -d '\n' |
+  sed 's/<tr>/@/g;s/<\/tr>/@/g' |
+  tr '@' '\n' |
+  sed -n '/<td>/p' |
+  while IFS= read -r line; do
+    echo "$line" |
+    grep -oP '<td[^>]*>.*?</td>' |
+    sed -n '2{s/<[^>]*>//g;p}'
+  done |
+  sort -u)
+
+# Step 3: Check if all Coordinator IPs exist in Backend IPs
+all_exist=true
+for ip in $coordinator_ips; do
+    if ! grep -qxF "$ip" <<< "$backend_ips"; then
+        all_exist=false
+        break
+    fi
+done
+
+echo $all_exist


### PR DESCRIPTION
## Why I'm doing:
For (transaction)stream load/routine load, `TxnCoordinator` should be backend, but now it's frontend. The bug is similar to #53893 which only fixed `LoadJobSourceType`. The following txn shows `LoadJobSourceType` is `BACKEND_STREAMING`, but `Coordinator` is FE

```
mysql> show proc '/transactions/test/finished';
+---------------+-------+-------------------+-------------------+-------------------+---------------------+---------------------+---------------------+---------------------+--------+--------------------+------------+-----------+--------+
| TransactionId | Label | Coordinator       | TransactionStatus | LoadJobSourceType | PrepareTime         | CommitTime          | PublishTime         | FinishTime          | Reason | ErrorReplicasCount | ListenerId | TimeoutMs | ErrMsg |
+---------------+-------+-------------------+-------------------+-------------------+---------------------+---------------------+---------------------+---------------------+--------+--------------------+------------+-----------+--------+
| 23            | test  | FE: 172.26.95.206 | VISIBLE           | BACKEND_STREAMING | 2025-05-29 19:07:29 | 2025-05-29 19:07:29 | 2025-05-29 19:07:29 | 2025-05-29 19:07:29 |        | 0                  | [10535]    | 6000000   |        |
+---------------+-------+-------------------+-------------------+-------------------+---------------------+---------------------+---------------------+---------------------+--------+--------------------+------------+-----------+--------+
1 row in set (0.00 sec)
```

## What I'm doing:
Set `TxnCoordinator`  to backend for stream load/routine load

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
