### PR TITLE
[Feature] Add result_scan table function

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunction.java
@@ -42,6 +42,8 @@ import java.util.stream.Collectors;
  * Internal representation of a table value function.
  */
 public class TableFunction extends Function {
+    public static final String RESULT_SCAN_FUNCTION = "result_scan";
+
     /**
      * default column name return by table function
      */
@@ -136,6 +138,10 @@ public class TableFunction extends Function {
                 Lists.newArrayList(/*tablet_id*/Type.BIGINT, /*tablet_version*/Type.BIGINT),
                 Lists.newArrayList(Type.BIGINT, Type.BIGINT, Type.BIGINT, Type.BIGINT, Type.BOOLEAN, Type.STRING));
         functionSet.addBuiltin(listRowsets);
+
+        TableFunction resultScan = new TableFunction(new FunctionName(RESULT_SCAN_FUNCTION),
+                null, Lists.newArrayList(Type.VARCHAR), null);
+        functionSet.addBuiltin(resultScan);
     }
 
     public List<Type> getTableFnReturnTypes() {
@@ -152,6 +158,10 @@ public class TableFunction extends Function {
 
     public void setIsLeftJoin(boolean isLeftJoin) {
         this.isLeftJoin = isLeftJoin;
+    }
+
+    public static boolean isResultScanFunction(String functionName) {
+        return functionName.equalsIgnoreCase(RESULT_SCAN_FUNCTION);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -96,6 +96,7 @@ import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.StructField;
 import com.starrocks.catalog.StructType;
+import com.starrocks.catalog.TableFunction;
 import com.starrocks.catalog.Type;
 import com.starrocks.catalog.combinator.AggStateDesc;
 import com.starrocks.catalog.combinator.AggStateUtils;
@@ -6159,6 +6160,10 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             relation.setAlias(new TableName(null, identifier.getValue()));
         }
         relation.setColumnOutputNames(getColumnNames(context.columnAliases()));
+
+        if (functionName.toString().equalsIgnoreCase(TableFunction.RESULT_SCAN_FUNCTION)) {
+            return relation;
+        }
 
         return new NormalizedTableFunctionRelation(relation);
     }


### PR DESCRIPTION
## Why I'm doing:

Some commands do not support filtering results by predicates, such as `show proc "/transactions/"`, it maybe return too many results and it is difficult to find the transaction that you want.

## What I'm doing:

Add a new table function `result_scan` to support filtering `show statement` results.

```
mysql> select * from result_scan('show proc "/transactions/tmp/finished"') where TransactionStatus = "VISIBLE" order by FinishTime desc limit 1;
+---------------+---------------------------------------------+-------------------+-------------------+-------------------+---------------------+---------------------+-------------+---------------------+--------+--------------------+---------------+-----------+--------+
| TransactionId | Label                                       | Coordinator       | TransactionStatus | LoadJobSourceType | PrepareTime         | CommitTime          | PublishTime | FinishTime          | Reason | ErrorReplicasCount | ListenerId    | TimeoutMs | ErrMsg |
+---------------+---------------------------------------------+-------------------+-------------------+-------------------+---------------------+---------------------+-------------+---------------------+--------+--------------------+---------------+-----------+--------+
| 1218209       | insert_dcfdc91b-3c38-11f0-bd70-eace990e052a | FE: 127.0.0.1     | VISIBLE           | INSERT_STREAMING  | 2025-05-29 10:58:57 | 2025-05-29 10:58:57 | \N          | 2025-05-29 10:58:57 |        | 0                  | [-1, 3576107] | 14400000  |        |
+---------------+---------------------------------------------+-------------------+-------------------+-------------------+---------------------+---------------------+-------------+---------------------+--------+--------------------+---------------+-----------+--------+
1 row in set (0.01 sec)
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1