### PR TITLE
[BugFix] fix object storage dir delete after load spill

### DIFF
--- a/be/src/storage/lake/load_spill_block_manager.h
+++ b/be/src/storage/lake/load_spill_block_manager.h
@@ -63,7 +63,7 @@ public:
     LoadSpillBlockManager(const TUniqueId& load_id, int64_t tablet_id, int64_t txn_id,
                           const std::string& remote_spill_path)
             : _load_id(load_id), _tablet_id(tablet_id), _txn_id(txn_id) {
-        _remote_spill_path = remote_spill_path + "/load_spill/";
+        _remote_spill_path = remote_spill_path + "/load_spill";
     }
 
     // Default destructor.


### PR DESCRIPTION
## Why I'm doing:
In the current implementation of importing spills, the directory structure based on object storage is: /db10200/11096/11098/load_spill//xxxx. Here, there are duplicate slashes (//).

Under the S3 protocol, ​​S3 strictly preserves the number of slashes in the path​​. For example, a/b/c and a/b//c are treated as ​​two different objects​​. As a result, this may lead to ​​deletion failures​​ (e.g., attempting to delete one path while the actual object exists under a slightly different path with extra slashes).

## What I'm doing:
removing redundant slashes


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
