### PR TITLE
[Enhancement] Enable low cardinality optimization on PRIMARY KEY tables.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -25,7 +25,6 @@ import com.starrocks.catalog.ColumnAccessPath;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.IcebergTable;
-import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -608,9 +608,6 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         long version = table.getPartitions().stream().map(p -> p.getDefaultPhysicalPartition().getVisibleVersionTime())
                 .max(Long::compareTo).orElse(0L);
 
-        if ((table.getKeysType().equals(KeysType.PRIMARY_KEYS))) {
-            return DecodeInfo.EMPTY;
-        }
         if (table.hasForbiddenGlobalDict()) {
             return DecodeInfo.EMPTY;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
@@ -104,12 +104,12 @@ public class LowCardinalityArrayTest extends PlanTestBase {
                 ");");
 
         starRocksAssert.withTable("CREATE TABLE `s4` (    \n" +
-                "  `v1` bigint(20) NULL COMMENT \"\",    \n" +
+                "  `v1` bigint(20) NOT NULL COMMENT \"\",    \n" +
                 "  `v2` int NULL,    \n" +
                 "  `a1` array<string> NULL COMMENT \"\",    \n" +
                 "  `a2` array<string> NULL COMMENT \"\"    \n" +
                 ") ENGINE=OLAP    \n" +
-                "UNIQUE KEY(`v1`)    \n" +
+                "PRIMARY KEY(`v1`)    \n" +
                 "COMMENT \"OLAP\"    \n" +
                 "DISTRIBUTED BY HASH(`v1`) BUCKETS 10    \n" +
                 "PROPERTIES (    \n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -154,7 +154,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "  `c_new` int(11) ,\n" +
                 "  `cpc` int(11)\n" +
                 ") ENGINE=OLAP \n" +
-                "DUPLICATE KEY(`d_date`, `c_mr`)\n" +
+                "PRIMARY KEY(`d_date`, `c_mr`)\n" +
                 "COMMENT \"OLAP\"\n" +
                 "DISTRIBUTED BY HASH(`d_date`, `c_mr`) BUCKETS 16 \n" +
                 "PROPERTIES (\n" +
@@ -2208,7 +2208,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "GROUP BY S_SUPPKEY ";
         String plan = getVerboseExplain(sql);
         assertContains(plan, "17: DictDefine(13: S_ADDRESS, [reverse(<place-holder>)])");
-        assertContains(plan, "15: DictDefine(13: S_ADDRESS, [reverse(<place-holder>)])");
+        assertContains(plan, "15: DictDefine(13: S_ADDRESS, [reverse(<place-holder>)])x");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -2208,7 +2208,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "GROUP BY S_SUPPKEY ";
         String plan = getVerboseExplain(sql);
         assertContains(plan, "17: DictDefine(13: S_ADDRESS, [reverse(<place-holder>)])");
-        assertContains(plan, "15: DictDefine(13: S_ADDRESS, [reverse(<place-holder>)])x");
+        assertContains(plan, "15: DictDefine(13: S_ADDRESS, [reverse(<place-holder>)])");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

To enable low cardinality optimization on PRIMARY KEY tables.

## What I'm doing:

Removes a check restricting the optimization on PRIMARY KEY tables.
The optimization works only when global dictionaries are available. If there is a global dictionary, we don't need to restrict the optimization.

I tested this by changing tables in the unittests(LowCardinalityArrayTest.java and LowCardinalityTest2.java) to PRIMARY KEY tables and confirmed it worked. In the PR, I left 2 of those table changes in unittests.
I also tested this in internal e2e tests of our company.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
