### PR TITLE
[Enhancement] Support merge partitions with distribution

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -504,8 +504,20 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
                         ErrorCode.ERR_COMMON_ERROR, functionName);
             }
             if (clause.getDistributionDesc() != null) {
-                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
-                        "Unsupported change distribution type when merge partitions");
+                DistributionDesc defaultDistributionInfo = olapTable.getDefaultDistributionInfo()
+                        .toDistributionDesc(olapTable.getIdToColumn());
+                if (clause.getDistributionDesc().getType() != defaultDistributionInfo.getType()) {
+                    ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                            "Unsupported change distribution type when merge partitions");
+                }
+                if (defaultDistributionInfo instanceof HashDistributionDesc) {
+                    HashDistributionDesc hashDistributionDesc = (HashDistributionDesc) defaultDistributionInfo;
+                    if (!hashDistributionDesc.getDistributionColumnNames().equals(
+                            ((HashDistributionDesc) clause.getDistributionDesc()).getDistributionColumnNames())) {
+                        ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                                "Unsupported change distribution column when merge partitions");
+                    }
+                }
             }
             if (clause.getPartitionNames() != null) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -1370,6 +1370,7 @@ public class AnalyzerUtils {
 
     public static AddPartitionClause getAddPartitionClauseFromPartitionValues(OlapTable olapTable,
                                                                               PartitionDesc partitionDesc,
+                                                                              DistributionDesc distributionDesc,
                                                                               List<List<String>> partitionValues,
                                                                               boolean isTemp,
                                                                               String partitionNamePrefix)
@@ -1379,7 +1380,7 @@ public class AnalyzerUtils {
             PartitionMeasure measure = checkAndGetPartitionMeasure(expressionPartitionDesc.getExpr());
             PartitionInfo partitionInfo = olapTable.getPartitionInfo();
             return getAddPartitionClauseForRangePartition(olapTable, partitionValues, isTemp, partitionNamePrefix, measure,
-                    (ExpressionRangePartitionInfo) partitionInfo);
+                    distributionDesc, (ExpressionRangePartitionInfo) partitionInfo);
         } else {
             throw new AnalysisException("Unsupported partition type " + partitionDesc.getType());
         }
@@ -1400,7 +1401,7 @@ public class AnalyzerUtils {
             Expr expr = partitionExprs.get(0);
             PartitionMeasure measure = checkAndGetPartitionMeasure(expr);
             return getAddPartitionClauseForRangePartition(olapTable, partitionValues, isTemp, partitionNamePrefix, measure,
-                    expressionRangePartitionInfo);
+                    null, expressionRangePartitionInfo);
         } else if (partitionInfo instanceof ListPartitionInfo) {
             Short replicationNum = olapTable.getTableProperty().getReplicationNum();
             DistributionDesc distributionDesc = olapTable.getDefaultDistributionInfo()
@@ -1507,14 +1508,16 @@ public class AnalyzerUtils {
             boolean isTemp,
             String partitionPrefix,
             PartitionMeasure measure,
+            DistributionDesc distributionDesc,
             ExpressionRangePartitionInfo expressionRangePartitionInfo) throws AnalysisException {
         String granularity = measure.getGranularity();
         long interval = measure.getInterval();
         Type firstPartitionColumnType = expressionRangePartitionInfo.getPartitionColumns(olapTable.getIdToColumn())
                 .get(0).getType();
         Short replicationNum = olapTable.getTableProperty().getReplicationNum();
-        DistributionDesc distributionDesc = olapTable.getDefaultDistributionInfo()
-                .toDistributionDesc(olapTable.getIdToColumn());
+        if (distributionDesc == null) {
+            distributionDesc = olapTable.getDefaultDistributionInfo().toDistributionDesc(olapTable.getIdToColumn());
+        }
         Map<String, String> partitionProperties = ImmutableMap.of("replication_num", String.valueOf(replicationNum));
 
         List<PartitionDesc> partitionDescs = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AddPartitionClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AddPartitionClause.java
@@ -25,7 +25,7 @@ import java.util.Map;
 public class AddPartitionClause extends AlterTableClause {
 
     private PartitionDesc partitionDesc;
-    private final DistributionDesc distributionDesc;
+    private DistributionDesc distributionDesc;
     private final Map<String, String> properties;
     // true if this is to add a temporary partition
     private final boolean isTempPartition;
@@ -43,6 +43,10 @@ public class AddPartitionClause extends AlterTableClause {
 
     public DistributionDesc getDistributionDesc() {
         return distributionDesc;
+    }
+
+    public void setDistributionDesc(DistributionDesc distributionDesc) {
+        this.distributionDesc = distributionDesc;
     }
 
     public boolean isTempPartition() {

--- a/test/sql/test_optimize_table/R/test_merge_partitions
+++ b/test/sql/test_optimize_table/R/test_merge_partitions
@@ -180,3 +180,68 @@ alter table t partition by date_trunc('day',b);
 -- result:
 E: (5064, 'Getting analyzing error. Detail message: Unsupported from granularity month to granularity day when merge partitions.')
 -- !result
+
+-- name: test_merge_partitions_infer_distributition
+create table t(k date) partition by date_trunc('day', k) distributed by hash(k) buckets 3;
+-- result:
+-- !result
+insert into t values('2020-01-01'),('2020-02-01'),('2020-02-02');
+-- result:
+-- !result
+show partitions from t;
+-- result:
+[REGEX].*p20200101.*
+.*p20200201.*
+.*p20200202.*
+-- !result
+alter table t partition by date_trunc('month',k) between '2020-02-01' and '2020-02-28';
+-- result:
+-- !result
+function: wait_optimize_table_finish()
+-- result:
+None
+-- !result
+show partitions from t;
+-- result:
+[REGEX].*p20200101.*
+.*p202002.*k	1	3.*
+-- !result
+
+-- name: test_merge_partitions_specify_distributition
+create table t(k date) partition by date_trunc('day', k) distributed by hash(k) buckets 3;
+-- result:
+-- !result
+insert into t values('2020-01-01'),('2020-02-01'),('2020-02-02');
+-- result:
+-- !result
+show partitions from t;
+-- result:
+[REGEX].*p20200101.*
+.*p20200201.*
+.*p20200202.*
+-- !result
+alter table t partition by date_trunc('month',k) distributed by hash(k) buckets 4 between '2020-02-01' and '2020-02-28';
+-- result:
+-- !result
+function: wait_optimize_table_finish()
+-- result:
+None
+-- !result
+show partitions from t;
+-- result:
+[REGEX].*p20200101.*
+.*p202002.*k	4	3.*
+-- !result
+
+-- name: test_merge_partitions_specify_distributition_fail
+create table t(k date, v int) partition by date_trunc('day', k) distributed by hash(k) buckets 3;
+-- result:
+-- !result
+alter table t partition by date_trunc('month',k) distributed by hash(v) buckets 4 between '2020-02-01' and '2020-02-28';
+-- result:
+E: (5064, 'Getting analyzing error. Detail message: Unsupported change distribution column when merge partitions.')
+-- !result
+alter table t partition by date_trunc('month',k) distributed by random between '2020-02-01' and '2020-02-28';
+-- result:
+E: (5064, 'Getting analyzing error. Detail message: Unsupported change distribution type when merge partitions.')
+-- !result

--- a/test/sql/test_optimize_table/T/test_merge_partitions
+++ b/test/sql/test_optimize_table/T/test_merge_partitions
@@ -55,3 +55,24 @@ insert into t values
 alter table t partition by date_trunc('month',b);
 alter table t partition by date_trunc('day',b);
 
+-- name: test_merge_partitions_infer_distributition
+create table t(k date) partition by date_trunc('day', k) distributed by hash(k) buckets 3;
+insert into t values('2020-01-01'),('2020-02-01'),('2020-02-02');
+show partitions from t;
+alter table t partition by date_trunc('month',k) between '2020-02-01' and '2020-02-28';
+function: wait_optimize_table_finish()
+show partitions from t;
+
+
+-- name: test_merge_partitions_specify_distributition
+create table t(k date) partition by date_trunc('day', k) distributed by hash(k) buckets 3;
+insert into t values('2020-01-01'),('2020-02-01'),('2020-02-02');
+show partitions from t;
+alter table t partition by date_trunc('month',k) distributed by hash(k) buckets 4 between '2020-02-01' and '2020-02-28';
+function: wait_optimize_table_finish()
+show partitions from t;
+
+-- name: test_merge_partitions_specify_distributition_fail
+create table t(k date, v int) partition by date_trunc('day', k) distributed by hash(k) buckets 3;
+alter table t partition by date_trunc('month',k) distributed by hash(v) buckets 4 between '2020-02-01' and '2020-02-28';
+alter table t partition by date_trunc('month',k) distributed by random between '2020-02-01' and '2020-02-28';


### PR DESCRIPTION
## Why I'm doing:

Within merging partitions, usually users want to shrink the total bucket number, but also want to get a good performance over the newly merged partitions.

So, setting proper bucket number is a MUST features. (we won’t support to change bucketing method now)


## What I'm doing:

We need to support the syntax to set buckets number, the ALTER TABLE command should be:

```
ALTER TABLE tbl
PARTITION BY xxx 
[ DISTRIBUTED BY HASH(x) BUCKET y ]
[ partition_condition ]
```
The DISTRIBUTED BY HASH(x) must be the same as table’s.

If users have set the bucket number like: ALTER TABLE tbl PARTITION BY xxx DISTRIBUTED BY HASH(x) BUCKET y:

Just use the bucket number.

If users have not set the bucket number for ALTER TABLE commands

For RANDOM bucketing, system will auto set physical partitions according to the data size.

For other bucketing, system will estimate the bucket number according to the merged data size, the same algorithm as estimating bucket number for new partitions according to the historical partition data size.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
