### PR TITLE
[Enhancement] Interface of PageCache support options evict_probability

### DIFF
--- a/be/src/bench/object_cache_bench.cpp
+++ b/be/src/bench/object_cache_bench.cpp
@@ -151,7 +151,7 @@ void ObjectCacheBench::prepare_sequence_data(ObjectCache* cache, int64_t count) 
         *(int*)ptr = 1;
         ObjectCacheHandlePtr handle = nullptr;
         ObjectCacheWriteOptions options;
-        Status st = cache->insert(key, ptr, _page_size, deleter, &handle, &options);
+        Status st = cache->insert(key, ptr, _page_size, deleter, &handle, options);
         if (!st.ok()) {
             if (!st.is_already_exist()) {
                 LOG(FATAL) << "insert failed: " << st;

--- a/be/src/cache/object_cache/lrucache_module.cpp
+++ b/be/src/cache/object_cache/lrucache_module.cpp
@@ -123,10 +123,12 @@ bool LRUCacheModule::_check_write(size_t charge, ObjectCacheWriteOptions* option
         return false;
     }
 
+    /*
     // TODO: The cost of this call may be relatively high, and it needs to be optimized later.
     if (_cache->get_memory_usage() + charge <= _cache->get_capacity()) {
         return true;
     }
+    */
 
     if (butil::fast_rand_less_than(100) < options->evict_probability) {
         return true;

--- a/be/src/cache/object_cache/lrucache_module.cpp
+++ b/be/src/cache/object_cache/lrucache_module.cpp
@@ -26,11 +26,11 @@ LRUCacheModule::LRUCacheModule(std::shared_ptr<Cache> cache) : _cache(std::move(
 }
 
 Status LRUCacheModule::insert(const std::string& key, void* value, size_t size, ObjectCacheDeleter deleter,
-                              ObjectCacheHandlePtr* handle, ObjectCacheWriteOptions* options) {
+                              ObjectCacheHandlePtr* handle, const ObjectCacheWriteOptions& options) {
     if (!_check_write(size, options)) {
         return Status::InternalError("cache insertion is rejected");
     }
-    auto* lru_handle = _cache->insert(key, value, size, deleter, static_cast<CachePriority>(options->priority));
+    auto* lru_handle = _cache->insert(key, value, size, deleter, static_cast<CachePriority>(options.priority));
     if (handle) {
         *handle = reinterpret_cast<ObjectCacheHandlePtr>(lru_handle);
     }
@@ -115,11 +115,11 @@ Status LRUCacheModule::shutdown() {
     return Status::OK();
 }
 
-bool LRUCacheModule::_check_write(size_t charge, ObjectCacheWriteOptions* options) const {
-    if (options->evict_probability >= 100) {
+bool LRUCacheModule::_check_write(size_t charge, const ObjectCacheWriteOptions& options) const {
+    if (options.evict_probability >= 100) {
         return true;
     }
-    if (options->evict_probability <= 0) {
+    if (options.evict_probability <= 0) {
         return false;
     }
 
@@ -130,7 +130,7 @@ bool LRUCacheModule::_check_write(size_t charge, ObjectCacheWriteOptions* option
     }
     */
 
-    if (butil::fast_rand_less_than(100) < options->evict_probability) {
+    if (butil::fast_rand_less_than(100) < options.evict_probability) {
         return true;
     }
     return false;

--- a/be/src/cache/object_cache/lrucache_module.h
+++ b/be/src/cache/object_cache/lrucache_module.h
@@ -29,7 +29,7 @@ public:
     virtual ~LRUCacheModule() = default;
 
     Status insert(const std::string& key, void* value, size_t size, ObjectCacheDeleter deleter,
-                  ObjectCacheHandlePtr* handle, ObjectCacheWriteOptions* options) override;
+                  ObjectCacheHandlePtr* handle, const ObjectCacheWriteOptions& options) override;
 
     Status lookup(const std::string& key, ObjectCacheHandlePtr* handle, ObjectCacheReadOptions* options) override;
 
@@ -60,7 +60,7 @@ public:
     Status shutdown() override;
 
 private:
-    bool _check_write(size_t charge, ObjectCacheWriteOptions* options) const;
+    bool _check_write(size_t charge, const ObjectCacheWriteOptions& options) const;
 
     std::shared_ptr<Cache> _cache;
 };

--- a/be/src/cache/object_cache/object_cache.h
+++ b/be/src/cache/object_cache/object_cache.h
@@ -32,7 +32,7 @@ public:
     // size: the size of the value.
     // charge: the actual memory size allocated for this value.
     virtual Status insert(const std::string& key, void* value, size_t size, ObjectCacheDeleter deleter,
-                          ObjectCacheHandlePtr* handle, ObjectCacheWriteOptions* options = nullptr) = 0;
+                          ObjectCacheHandlePtr* handle, const ObjectCacheWriteOptions& options) = 0;
 
     // Lookup object from cache, the `handle` wraps the object pointer.
     // As long as the handle object is not destroyed and the user does not manully call the `handle->release()`

--- a/be/src/cache/object_cache/page_cache.cpp
+++ b/be/src/cache/object_cache/page_cache.cpp
@@ -103,7 +103,7 @@ bool StoragePageCache::lookup(const std::string& key, PageCacheHandle* handle) {
 }
 
 Status StoragePageCache::insert(const std::string& key, std::vector<uint8_t>* data, PageCacheHandle* handle,
-                                bool in_memory) {
+                                const ObjectCacheWriteOptions& opts) {
 #ifndef BE_TEST
     int64_t mem_size = malloc_usable_size(data->data()) + sizeof(*data);
     tls_thread_status.mem_release(mem_size);
@@ -118,8 +118,6 @@ Status StoragePageCache::insert(const std::string& key, std::vector<uint8_t>* da
         delete cache_item;
     };
 
-    ObjectCacheWriteOptions options;
-    options.priority = in_memory ? 1 : 0;
     ObjectCacheHandle* obj_handle = nullptr;
     // Use mem size managed by memory allocator as this record charge size.
     // At the same time, we should record this record size for data fetching when lookup.

--- a/be/src/cache/object_cache/page_cache.cpp
+++ b/be/src/cache/object_cache/page_cache.cpp
@@ -121,7 +121,7 @@ Status StoragePageCache::insert(const std::string& key, std::vector<uint8_t>* da
     ObjectCacheHandle* obj_handle = nullptr;
     // Use mem size managed by memory allocator as this record charge size.
     // At the same time, we should record this record size for data fetching when lookup.
-    Status st = _cache->insert(key, (void*)data, mem_size, deleter, &obj_handle, &options);
+    Status st = _cache->insert(key, (void*)data, mem_size, deleter, &obj_handle, opts);
     if (st.ok()) {
         *handle = PageCacheHandle(_cache, obj_handle);
     }

--- a/be/src/cache/object_cache/page_cache.h
+++ b/be/src/cache/object_cache/page_cache.h
@@ -48,6 +48,7 @@ namespace starrocks {
 
 class PageCacheHandle;
 class MemTracker;
+class ObjectCacheWriteOptions;
 
 // Page cache min size is 256MB
 static constexpr int64_t kcacheMinSize = 268435456;
@@ -80,7 +81,8 @@ public:
     // This function is thread-safe, and when two clients insert two same key
     // concurrently, this function can assure that only one page is cached.
     // The in_memory page will have higher priority.
-    Status insert(const std::string& key, std::vector<uint8_t>* data, PageCacheHandle* handle, bool in_memory = false);
+    Status insert(const std::string& key, std::vector<uint8_t>* data, PageCacheHandle* handle,
+                  const ObjectCacheWriteOptions& opts);
 
     size_t memory_usage() const { return _cache->usage(); }
 

--- a/be/src/cache/object_cache/starcache_module.h
+++ b/be/src/cache/object_cache/starcache_module.h
@@ -26,7 +26,7 @@ public:
     virtual ~StarCacheModule() = default;
 
     Status insert(const std::string& key, void* value, size_t size, ObjectCacheDeleter deleter,
-                  ObjectCacheHandlePtr* handle, ObjectCacheWriteOptions* options) override;
+                  ObjectCacheHandlePtr* handle, const ObjectCacheWriteOptions& options) override;
 
     Status lookup(const std::string& key, ObjectCacheHandlePtr* handle, ObjectCacheReadOptions* options) override;
 

--- a/be/src/formats/parquet/metadata.cpp
+++ b/be/src/formats/parquet/metadata.cpp
@@ -487,7 +487,7 @@ StatusOr<FileMetaDataPtr> FileMetaDataParser::get_file_metadata() {
         auto deleter = [](const CacheKey& key, void* value) { delete (FileMetaDataPtr*)value; };
         ObjectCacheWriteOptions options;
         options.evict_probability = _datacache_options->datacache_evict_probability;
-        st = _cache->insert(metacache_key, capture, file_metadata_size, deleter, &cache_handle, &options);
+        st = _cache->insert(metacache_key, capture, file_metadata_size, deleter, &cache_handle, options);
     } else {
         LOG(ERROR) << "Parsing unexpected parquet file metadata size";
     }

--- a/be/src/formats/parquet/page_reader.cpp
+++ b/be/src/formats/parquet/page_reader.cpp
@@ -92,7 +92,7 @@ Status PageReader::_deal_page_with_cache() {
         }
         RETURN_IF_ERROR(_read_and_decompress_internal(true));
         ObjectCacheWriteOptions opts{.evict_probability = _opts.datacache_options->datacache_evict_probability};
-        auto st = _cache->insert(page_cache_key, _cache_buf, &cache_handle, &opts);
+        auto st = _cache->insert(page_cache_key, _cache_buf, &cache_handle, opts);
         if (st.ok()) {
             _page_handle = PageHandle(std::move(cache_handle));
             _opts.stats->page_cache_write_counter += 1;

--- a/be/src/formats/parquet/page_reader.cpp
+++ b/be/src/formats/parquet/page_reader.cpp
@@ -91,7 +91,8 @@ Status PageReader::_deal_page_with_cache() {
             return Status::OK();
         }
         RETURN_IF_ERROR(_read_and_decompress_internal(true));
-        auto st = _cache->insert(page_cache_key, _cache_buf, &cache_handle, false);
+        ObjectCacheWriteOptions opts{.evict_probability = _opts.datacache_options->datacache_evict_probability};
+        auto st = _cache->insert(page_cache_key, _cache_buf, &cache_handle, &opts);
         if (st.ok()) {
             _page_handle = PageHandle(std::move(cache_handle));
             _opts.stats->page_cache_write_counter += 1;

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -353,7 +353,6 @@ Status ColumnReader::read_page(const ColumnIteratorOptions& iter_opts, const Pag
     opts.verify_checksum = true;
     opts.use_page_cache = iter_opts.use_page_cache;
     opts.encoding_type = _encoding_info->encoding();
-    opts.kept_in_memory = false;
 
     return PageIO::read_and_decompress_page(opts, handle, page_body, footer);
 }

--- a/be/src/storage/rowset/indexed_column_reader.cpp
+++ b/be/src/storage/rowset/indexed_column_reader.cpp
@@ -95,7 +95,6 @@ Status IndexedColumnReader::read_page(const IndexReadOptions& opts, const PagePo
     page_opts.codec = _compress_codec;
     page_opts.stats = opts.stats;
     page_opts.use_page_cache = opts.use_page_cache;
-    page_opts.kept_in_memory = opts.kept_in_memory;
     page_opts.encoding_type = _encoding_info->encoding();
     return PageIO::read_and_decompress_page(page_opts, handle, body, footer);
 }

--- a/be/src/storage/rowset/options.h
+++ b/be/src/storage/rowset/options.h
@@ -55,7 +55,6 @@ public:
 class IndexReadOptions {
 public:
     bool use_page_cache = false;
-    bool kept_in_memory = false;
     // for lake tablet
     LakeIOOptions lake_io_opts{.fill_data_cache = true};
 

--- a/be/src/storage/rowset/ordinal_page_index.cpp
+++ b/be/src/storage/rowset/ordinal_page_index.cpp
@@ -118,7 +118,6 @@ Status OrdinalIndexReader::_do_load(const IndexReadOptions& opts, const OrdinalI
     page_opts.codec = nullptr; // ordinal index page uses NO_COMPRESSION right now
     page_opts.stats = opts.stats;
     page_opts.use_page_cache = opts.use_page_cache;
-    page_opts.kept_in_memory = opts.kept_in_memory;
 
     // read index page
     PageHandle page_handle;

--- a/be/src/storage/rowset/page_io.cpp
+++ b/be/src/storage/rowset/page_io.cpp
@@ -256,7 +256,7 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
     if (opts.use_page_cache) {
         // insert this page into cache and return the cache handle
         ObjectCacheWriteOptions opts;
-        Status st = cache->insert(cache_key, page.get(), &cache_handle, &opts);
+        Status st = cache->insert(cache_key, page.get(), &cache_handle, opts);
         *handle = st.ok() ? PageHandle(std::move(cache_handle)) : PageHandle(page.get());
     } else {
         *handle = PageHandle(page.get());

--- a/be/src/storage/rowset/page_io.cpp
+++ b/be/src/storage/rowset/page_io.cpp
@@ -255,7 +255,8 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
     *body = Slice(page_slice.data, page_slice.size - 4 - footer_size);
     if (opts.use_page_cache) {
         // insert this page into cache and return the cache handle
-        Status st = cache->insert(cache_key, page.get(), &cache_handle, opts.kept_in_memory);
+        ObjectCacheWriteOptions opts;
+        Status st = cache->insert(cache_key, page.get(), &cache_handle, &opts);
         *handle = st.ok() ? PageHandle(std::move(cache_handle)) : PageHandle(page.get());
     } else {
         *handle = PageHandle(page.get());

--- a/be/src/storage/rowset/page_io.h
+++ b/be/src/storage/rowset/page_io.h
@@ -64,9 +64,6 @@ struct PageReadOptions {
     bool verify_checksum = true;
     // whether to use page cache in read path
     bool use_page_cache = true;
-    // if true, use DURABLE CachePriority in page cache
-    // currently used for in memory olap table
-    bool kept_in_memory = false;
     // page encoding type
     EncodingTypePB encoding_type = UNKNOWN_ENCODING;
 

--- a/be/src/storage/rowset/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/scalar_column_iterator.cpp
@@ -461,7 +461,6 @@ Status ScalarColumnIterator::get_row_ranges_by_bloom_filter(const std::vector<co
 
     IndexReadOptions opts;
     opts.use_page_cache = !_opts.temporary_data && !config::disable_storage_page_cache && _opts.use_page_cache;
-    opts.kept_in_memory = false;
     opts.lake_io_opts = _opts.lake_io_opts;
     opts.read_file = _opts.read_file;
     opts.stats = _opts.stats;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2184,7 +2184,6 @@ Status SegmentIterator::_apply_data_sampling() {
 IndexReadOptions SegmentIterator::_index_read_options(ColumnId cid) const {
     IndexReadOptions opts;
     opts.use_page_cache = !_opts.temporary_data && _opts.use_page_cache && !config::disable_storage_page_cache;
-    opts.kept_in_memory = false;
     opts.lake_io_opts = _opts.lake_io_opts;
     opts.read_file = _column_files.at(cid).get();
     opts.stats = _opts.stats;

--- a/be/test/cache/object_cache/lrucache_module_test.cpp
+++ b/be/test/cache/object_cache/lrucache_module_test.cpp
@@ -58,7 +58,7 @@ void LRUCacheModuleTest::_insert_data() {
         *ptr = i;
 
         ObjectCacheHandlePtr handle = nullptr;
-        ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, &Deleter, &handle, &_write_opt));
+        ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, &Deleter, &handle, _write_opt));
         _cache->release(handle);
     }
 }

--- a/be/test/cache/object_cache/object_cache_test.cpp
+++ b/be/test/cache/object_cache/object_cache_test.cpp
@@ -93,7 +93,7 @@ void ObjectCacheTest::_insert_data() {
         *ptr = i;
 
         ObjectCacheHandlePtr handle = nullptr;
-        ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, &Deleter, &handle, &_write_opt));
+        ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, &Deleter, &handle, _write_opt));
         _cache->release(handle);
     }
 }

--- a/be/test/cache/object_cache/page_cache_test.cpp
+++ b/be/test/cache/object_cache/page_cache_test.cpp
@@ -73,7 +73,8 @@ TEST_F(StoragePageCacheTest, normal) {
         auto data = std::make_unique<std::vector<uint8_t>>(1024);
         PageCacheHandle handle;
 
-        ASSERT_OK(_page_cache->insert(key, data.get(), &handle, false));
+        ObjectCacheWriteOptions opts;
+        ASSERT_OK(_page_cache->insert(key, data.get(), &handle, &opts));
         ASSERT_EQ(handle.data(), data.get());
         auto* check_data = data.release();
 
@@ -87,7 +88,8 @@ TEST_F(StoragePageCacheTest, normal) {
         auto data = std::make_unique<std::vector<uint8_t>>(1024);
         PageCacheHandle handle;
 
-        ASSERT_OK(_page_cache->insert(key, data.get(), &handle, true));
+        ObjectCacheWriteOptions opts {.priority = true};
+        ASSERT_OK(_page_cache->insert(key, data.get(), &handle, opts));
         ASSERT_EQ(handle.data(), data.get());
         data.release();
 
@@ -100,7 +102,8 @@ TEST_F(StoragePageCacheTest, normal) {
         key.append(std::to_string(i));
         auto data = std::make_unique<std::vector<uint8_t>>(1024);
         PageCacheHandle handle;
-        ASSERT_OK(_page_cache->insert(key, data.get(), &handle, false));
+        ObjectCacheWriteOptions opts;
+        ASSERT_OK(_page_cache->insert(key, data.get(), &handle, opts));
         data.release();
     }
 
@@ -166,7 +169,8 @@ TEST_F(StoragePageCacheTest, metrics) {
     {
         // Insert a piece of data, but the application layer does not release it.
         auto data = std::make_unique<std::vector<uint8_t>>(1024);
-        ASSERT_OK(_page_cache->insert(key1, data.get(), &handle1, false));
+        ObjectCacheWriteOptions opts;
+        ASSERT_OK(_page_cache->insert(key1, data.get(), &handle1, opts));
         data.release();
     }
 
@@ -174,7 +178,8 @@ TEST_F(StoragePageCacheTest, metrics) {
         // Insert another piece of data and release it from the application layer.
         auto data = std::make_unique<std::vector<uint8_t>>(1024);
         PageCacheHandle handle2;
-        ASSERT_OK(_page_cache->insert(key2, data.get(), &handle2, false));
+        ObjectCacheWriteOptions opts;
+        ASSERT_OK(_page_cache->insert(key2, data.get(), &handle2, opts));
         data.release();
     }
 

--- a/be/test/cache/object_cache/page_cache_test.cpp
+++ b/be/test/cache/object_cache/page_cache_test.cpp
@@ -88,7 +88,7 @@ TEST_F(StoragePageCacheTest, normal) {
         auto data = std::make_unique<std::vector<uint8_t>>(1024);
         PageCacheHandle handle;
 
-        ObjectCacheWriteOptions opts {.priority = true};
+        ObjectCacheWriteOptions opts{.priority = true};
         ASSERT_OK(_page_cache->insert(key, data.get(), &handle, opts));
         ASSERT_EQ(handle.data(), data.get());
         data.release();

--- a/be/test/cache/object_cache/starcache_module_test.cpp
+++ b/be/test/cache/object_cache/starcache_module_test.cpp
@@ -82,7 +82,7 @@ void StarCacheModuleTest::insert_value(int i) {
     int* ptr = (int*)malloc(_value_size);
     *ptr = i;
     ObjectCacheHandlePtr handle = nullptr;
-    ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, &Deleter, &handle, &_write_opt));
+    ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, &Deleter, &handle, _write_opt));
     _cache->release(handle);
 }
 
@@ -102,7 +102,8 @@ TEST_F(StarCacheModuleTest, test_charge_size) {
     int* value = new (ptr) int;
     *value = 10;
     ObjectCacheHandlePtr handle = nullptr;
-    ASSERT_OK(_cache->insert("1", (void*)ptr, mem_size, &Deleter, &handle, nullptr));
+    ObjectCacheWriteOptions opts;
+    ASSERT_OK(_cache->insert("1", (void*)ptr, mem_size, &Deleter, &handle, opts));
     _cache->release(handle);
 
     ObjectCacheHandlePtr lookup_handle = nullptr;
@@ -119,7 +120,7 @@ TEST_F(StarCacheModuleTest, test_charge_size_with_write_option) {
     int* value = new (ptr) int;
     *value = 10;
     ObjectCacheHandlePtr handle = nullptr;
-    ASSERT_OK(_cache->insert("1", (void*)ptr, mem_size, &Deleter, &handle, &_write_opt));
+    ASSERT_OK(_cache->insert("1", (void*)ptr, mem_size, &Deleter, &handle, _write_opt));
     _cache->release(handle);
 
     ObjectCacheHandlePtr lookup_handle = nullptr;
@@ -135,7 +136,8 @@ TEST_F(StarCacheModuleTest, insert_with_null_options) {
     int* ptr = (int*)malloc(_value_size);
     *ptr = 0;
     ObjectCacheHandlePtr handle = nullptr;
-    ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, &Deleter, &handle, nullptr));
+    ObjectCacheWriteOptions opts;
+    ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, &Deleter, &handle, opts));
     _cache->release(handle);
 }
 
@@ -144,12 +146,12 @@ TEST_F(StarCacheModuleTest, insert_and_release_old_handle) {
     int* ptr = (int*)malloc(_value_size);
     *ptr = 0;
     ObjectCacheHandlePtr handle = nullptr;
-    ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, &Deleter, &handle, &_write_opt));
+    ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, &Deleter, &handle, _write_opt));
 
     key = int_to_string(6, 1);
     ptr = (int*)malloc(_value_size);
     *ptr = 1;
-    ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, &Deleter, &handle, &_write_opt));
+    ASSERT_OK(_cache->insert(key, (void*)ptr, _value_size, &Deleter, &handle, _write_opt));
     _cache->release(handle);
 }
 

--- a/be/test/storage/rowset/bitmap_index_test.cpp
+++ b/be/test/storage/rowset/bitmap_index_test.cpp
@@ -61,7 +61,6 @@ protected:
         ASSERT_TRUE(_fs->create_dir(kTestDir).ok());
 
         _opts.use_page_cache = true;
-        _opts.kept_in_memory = false;
         _opts.stats = &_stats;
     }
     void TearDown() override { StoragePageCache::instance()->prune(); }
@@ -261,7 +260,6 @@ TEST_F(BitmapIndexTest, test_concurrent_load) {
     ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(file_name))
     opts.read_file = rfile.get();
     opts.use_page_cache = true;
-    opts.kept_in_memory = false;
     OlapReaderStatistics stats;
     opts.stats = &stats;
     auto reader = std::make_unique<BitmapIndexReader>();

--- a/be/test/storage/rowset/bloom_filter_index_reader_writer_test.cpp
+++ b/be/test/storage/rowset/bloom_filter_index_reader_writer_test.cpp
@@ -56,7 +56,6 @@ protected:
         ASSERT_TRUE(_fs->create_dir(kTestDir).ok());
 
         _opts.use_page_cache = true;
-        _opts.kept_in_memory = false;
         _opts.stats = &_stats;
     }
     void TearDown() override { StoragePageCache::instance()->prune(); }

--- a/be/test/storage/rowset/ordinal_page_index_test.cpp
+++ b/be/test/storage/rowset/ordinal_page_index_test.cpp
@@ -88,7 +88,6 @@ TEST_F(OrdinalPageIndexTest, normal) {
     ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(filename))
     opts.read_file = rfile.get();
     opts.use_page_cache = true;
-    opts.kept_in_memory = false;
     OlapReaderStatistics stats;
     opts.stats = &stats;
     OrdinalIndexReader index;
@@ -149,7 +148,6 @@ TEST_F(OrdinalPageIndexTest, one_data_page) {
     IndexReadOptions opts;
     opts.read_file = nullptr;
     opts.use_page_cache = true;
-    opts.kept_in_memory = false;
     OlapReaderStatistics stats;
     opts.stats = &stats;
     OrdinalIndexReader index;

--- a/be/test/storage/rowset/zone_map_index_test.cpp
+++ b/be/test/storage/rowset/zone_map_index_test.cpp
@@ -92,7 +92,6 @@ protected:
         ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(filename))
         opts.read_file = rfile.get();
         opts.use_page_cache = false;
-        opts.kept_in_memory = false;
         OlapReaderStatistics stats;
         opts.stats = &stats;
         ZoneMapIndexReader column_zone_map;
@@ -146,7 +145,6 @@ void ColumnZoneMapTest::load_zone_map(ZoneMapIndexReader& reader, ColumnIndexMet
     ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(filename))
     opts.read_file = rfile.get();
     opts.use_page_cache = false;
-    opts.kept_in_memory = false;
     OlapReaderStatistics stats;
     opts.stats = &stats;
     ASSERT_TRUE(reader.load(opts, meta.zone_map_index()).value());

--- a/be/test/util/starrocks_metrics_test.cpp
+++ b/be/test/util/starrocks_metrics_test.cpp
@@ -281,7 +281,8 @@ TEST_F(StarRocksMetricsTest, PageCacheMetrics) {
             std::string key("abc0");
             PageCacheHandle handle;
             auto data = std::make_unique<std::vector<uint8_t>>(1024);
-            ASSERT_OK(_page_cache->insert(key, data.get(), &handle, false));
+            ObjectCacheWriteOptions opts;
+            ASSERT_OK(_page_cache->insert(key, data.get(), &handle, opts));
             ASSERT_TRUE(_page_cache->lookup(key, &handle));
             data.release();
         }


### PR DESCRIPTION
## Why I'm doing:

* The interface of PageCache now supports the option evict_probability, which will be used by external tables.
* For shared LRU cache, calculating memory usage is expensive. Temporarily disable the eviction probability's dependency on memory usage.
* Remove the `kept_in_memory option`, which is currently unused. Use priority instead.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
