### PR TITLE
[Feature] Prune tablets according to virtual bucket for dynamic tablet splitting and merging

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
@@ -102,7 +102,8 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
     @SerializedName(value = "rowCount")
     private long rowCount;
 
-    // Virtual buckets. There is a tablet id for each virtual bucket,
+    // Virtual buckets in order.
+    // There is a tablet id for each virtual bucket,
     // which means this virtual bucket's data is stored in this tablet.
     // We divide data into virtual buckets and then arrange these virtual buckets
     // into physical buckets, which are tablets.
@@ -113,7 +114,7 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
 
     private Map<Long, Tablet> idToTablets;
 
-    // Deprecated, virtual buckets keeps tablet order, keep this for compatibility
+    // Since virtual buckets keeps the order, this can be deprecated if idToTablets persists
     @SerializedName(value = "tablets")
     private List<Tablet> tablets;
 
@@ -195,6 +196,7 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
         return shardGroupId;
     }
 
+    // The virtual buckets are in order
     public List<Long> getVirtualBuckets() {
         return virtualBuckets;
     }
@@ -203,7 +205,8 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
         return tablets;
     }
 
-    public List<Long> getTabletIdsInOrder() {
+    // With virtual buckets, the order of tablets is irrelevant
+    public List<Long> getTabletIds() {
         List<Long> tabletIds = Lists.newArrayListWithCapacity(tablets.size());
         for (Tablet tablet : tablets) {
             tabletIds.add(tablet.getId());
@@ -307,6 +310,9 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
         return virtualBucketIndexes;
     }
 
+    // With virtual buckets, the order index of tablets is irrelevant.
+    // Keep this method only for colocate table in shared-nothing mode,
+    // in which we do not implement tablet split and merge and virtual buckets are the same with tabletIds.
     public int getTabletOrderIdx(long tabletId) {
         int idx = 0;
         for (Tablet tablet : tablets) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MetadataViewer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MetadataViewer.java
@@ -357,7 +357,8 @@ public class MetadataViewer {
                 for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
                     long version = physicalPartition.getVisibleVersion();
                     for (MaterializedIndex index : physicalPartition.getMaterializedIndices(IndexExtState.VISIBLE)) {
-                        List<Long> tabletIds = index.getTabletIdsInOrder();
+                        // TODO(TackY): adapt the modification of bucket number from partition level to materialized index level
+                        List<Long> tabletIds = index.getTabletIds();
                         for (int i = 0; i < tabletIds.size(); i++) {
                             Tablet tablet = index.getTablet(tabletIds.get(i));
                             long rowCount = tablet.getRowCount(version);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2352,7 +2352,7 @@ public class OlapTable extends Table {
 
             short replicationNum = partitionInfo.getReplicationNum(partition.getId());
             MaterializedIndex baseIdx = physicalPartition.getBaseIndex();
-            for (Long tabletId : baseIdx.getTabletIdsInOrder()) {
+            for (Long tabletId : baseIdx.getTabletIds()) {
                 LocalTablet tablet = (LocalTablet) baseIdx.getTablet(tabletId);
                 List<Long> replicaBackendIds = tablet.getNormalReplicaBackendIds();
                 if (replicaBackendIds.size() < replicationNum) {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -798,7 +798,7 @@ public class ColocateTableBalancer extends FrontendDaemon {
                         Preconditions.checkState(backendBucketsSeq.size() == index.getTablets().size(),
                                 backendBucketsSeq.size() + " v.s. " + index.getTablets().size());
                         int idx = 0;
-                        for (Long tabletId : index.getTabletIdsInOrder()) {
+                        for (Long tabletId : index.getTabletIds()) {
                             LocalTablet tablet = (LocalTablet) index.getTablet(tabletId);
                             Set<Long> bucketsSeq = backendBucketsSeq.get(idx);
                             // Tablet has already been scheduled, no need to schedule again

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -553,7 +553,7 @@ public class OlapTableSink extends DataSink {
                         TOlapTablePartition tPartition = new TOlapTablePartition();
                         tPartition.setId(physicalPartition.getId());
                         setRangeKeys(rangePartitionInfo, partition, tPartition);
-                        setIndexAndBucketNums(physicalPartition, tPartition);
+                        setMaterializedIndexes(physicalPartition, tPartition);
                         partitionParam.addToPartitions(tPartition);
                         LOG.debug("add partition: {} physicalPartition: {}", tPartition, physicalPartition);
                     }
@@ -629,7 +629,7 @@ public class OlapTableSink extends DataSink {
                         TOlapTablePartition tPartition = new TOlapTablePartition();
                         tPartition.setId(physicalPartition.getId());
                         setListPartitionValues(listPartitionInfo, partition, tPartition);
-                        setIndexAndBucketNums(physicalPartition, tPartition);
+                        setMaterializedIndexes(physicalPartition, tPartition);
                         partitionParam.addToPartitions(tPartition);
                         LOG.debug("add partition: {} physicalPartition: {}", tPartition, physicalPartition);
                     }
@@ -667,7 +667,7 @@ public class OlapTableSink extends DataSink {
                     TOlapTablePartition tPartition = new TOlapTablePartition();
                     tPartition.setId(physicalPartition.getId());
                     // No lowerBound and upperBound for this range
-                    setIndexAndBucketNums(physicalPartition, tPartition);
+                    setMaterializedIndexes(physicalPartition, tPartition);
                     partitionParam.addToPartitions(tPartition);
                     LOG.debug("add partition: {} physicalPartition: {}", tPartition, physicalPartition);
                 }
@@ -742,9 +742,9 @@ public class OlapTableSink extends DataSink {
         }
     }
 
-    private static void setIndexAndBucketNums(PhysicalPartition partition, TOlapTablePartition tPartition) {
+    private static void setMaterializedIndexes(PhysicalPartition partition, TOlapTablePartition tPartition) {
         for (MaterializedIndex index : partition.getMaterializedIndices(IndexExtState.ALL)) {
-            TOlapTableIndexTablets tIndex = new TOlapTableIndexTablets(index.getId(), index.getTabletIdsInOrder());
+            TOlapTableIndexTablets tIndex = new TOlapTableIndexTablets(index.getId(), index.getTabletIds());
             tIndex.setVirtual_buckets(Lists.newArrayList(index.getVirtualBuckets()));
             tPartition.addToIndexes(tIndex);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -2123,7 +2123,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             }
         }
         for (MaterializedIndex index : physicalPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
-            TOlapTableIndexTablets tIndex = new TOlapTableIndexTablets(index.getId(), index.getTabletIdsInOrder());
+            TOlapTableIndexTablets tIndex = new TOlapTableIndexTablets(index.getId(), index.getTabletIds());
             tIndex.setVirtual_buckets(Lists.newArrayList(index.getVirtualBuckets()));
             tPartition.addToIndexes(tIndex);
         }
@@ -2535,7 +2535,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         }
         for (MaterializedIndex index : partition.getDefaultPhysicalPartition()
                 .getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
-            TOlapTableIndexTablets tIndex = new TOlapTableIndexTablets(index.getId(), index.getTabletIdsInOrder());
+            TOlapTableIndexTablets tIndex = new TOlapTableIndexTablets(index.getId(), index.getTabletIds());
             tIndex.setVirtual_buckets(Lists.newArrayList(index.getVirtualBuckets()));
             tPartition.addToIndexes(tIndex);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -913,7 +913,7 @@ public class MvRewritePreprocessor {
                 selectedPartitionNames.add(p.getName());
                 for (PhysicalPartition physicalPartition : p.getSubPartitions()) {
                     MaterializedIndex materializedIndex = physicalPartition.getIndex(mv.getBaseIndexId());
-                    selectTabletIds.addAll(materializedIndex.getTabletIdsInOrder());
+                    selectTabletIds.addAll(materializedIndex.getTabletIds());
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptDistributionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptDistributionPruner.java
@@ -74,16 +74,16 @@ public class OptDistributionPruner {
                 } else {
                     filters = operator.getColumnFilters();
                 }
-                distributionPruner = new HashDistributionPruner(index.getTabletIdsInOrder(),
+                distributionPruner = new HashDistributionPruner(index.getVirtualBuckets(),
+                        index.getTabletIds(),
                         MetaUtils.getColumnsByColumnIds(idToColumn, info.getDistributionColumns()),
-                        filters,
-                        info.getBucketNum());
+                        filters);
                 return distributionPruner.prune();
             }
         } catch (AnalysisException e) {
             LOG.warn("distribution prune failed. ", e);
         }
 
-        return index.getTabletIdsInOrder();
+        return index.getTabletIds();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -926,16 +926,16 @@ public class PlanFragmentBuilder {
                         selectedNonEmptyPartitionIds.add(partitionId);
                         Map<Long, Integer> tabletId2BucketSeq = Maps.newHashMap();
                         Preconditions.checkState(selectTabletIds != null && !selectTabletIds.isEmpty());
-                        final MaterializedIndex selectedTable = physicalPartition.getIndex(selectedIndexId);
-                        List<Long> allTabletIds = selectedTable.getTabletIdsInOrder();
-                        totalTabletsNum += selectedTable.getTablets().size();
+                        final MaterializedIndex selectedIndex = physicalPartition.getIndex(selectedIndexId);
+                        totalTabletsNum += selectedIndex.getTablets().size();
+                        List<Long> allTabletIds = selectedIndex.getTabletIds();
                         for (int i = 0; i < allTabletIds.size(); i++) {
                             tabletId2BucketSeq.put(allTabletIds.get(i), i);
                         }
                         scanNode.setTabletId2BucketSeq(tabletId2BucketSeq);
                         List<Tablet> tablets =
-                                selectTabletIds.stream().map(selectedTable::getTablet).collect(Collectors.toList());
-                        scanNode.addScanRangeLocations(partition, physicalPartition, selectedTable, tablets, localBeId);
+                                selectTabletIds.stream().map(selectedIndex::getTablet).collect(Collectors.toList());
+                        scanNode.addScanRangeLocations(partition, physicalPartition, selectedIndex, tablets, localBeId);
                     }
                 }
                 scanNode.setSelectedPartitionIds(selectedNonEmptyPartitionIds);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/HashDistributionPrunerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/HashDistributionPrunerTest.java
@@ -55,6 +55,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class HashDistributionPrunerTest extends PlanTestBase {
 
@@ -111,7 +113,9 @@ public class HashDistributionPrunerTest extends PlanTestBase {
         filters.put("channel", channelFilter);
         filters.put("shop_type", shopTypeFilter);
 
-        HashDistributionPruner pruner = new HashDistributionPruner(tabletIds, columns, filters, tabletIds.size());
+        HashDistributionPruner pruner = new HashDistributionPruner(
+                Stream.concat(tabletIds.stream(), tabletIds.stream()).collect(Collectors.toList()),
+                tabletIds, columns, filters);
 
         Collection<Long> results = pruner.prune();
         // 20 = 1 * 5 * 2 * 2 * 1 (element num of each filter)
@@ -190,7 +194,9 @@ public class HashDistributionPrunerTest extends PlanTestBase {
         Map<String, PartitionColumnFilter> filters = Maps.newHashMap();
         filters.put("main_brand_id", mainBrandFilter);
 
-        HashDistributionPruner pruner = new HashDistributionPruner(tabletIds, columns, filters, tabletIds.size());
+        HashDistributionPruner pruner = new HashDistributionPruner(
+                Stream.concat(tabletIds.stream(), tabletIds.stream()).collect(Collectors.toList()),
+                tabletIds, columns, filters);
 
         Collection<Long> results = pruner.prune();
         Assert.assertEquals(tabletIds.size(), results.size());

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
@@ -139,7 +139,7 @@ public class CoordinatorTest extends PlanTestBase {
         OlapTable olapTable = getOlapTable("t0");
         List<Long> olapTableTabletIds =
                 olapTable.getAllPartitions().stream().flatMap(x -> x.getDefaultPhysicalPartition().getBaseIndex()
-                                .getTabletIdsInOrder().stream())
+                                .getTabletIds().stream())
                         .collect(Collectors.toList());
         Assert.assertFalse(olapTableTabletIds.isEmpty());
         tupleDesc.setTable(olapTable);

--- a/fe/fe-core/src/test/java/com/starrocks/server/ConcurrentDDLTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/ConcurrentDDLTest.java
@@ -121,7 +121,7 @@ public class ConcurrentDDLTest {
         for (long threadId : threadIds) {
             table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_tbl_" + threadId);
             List<Long> tablets = table.getPartitions().stream().findFirst().get().getDefaultPhysicalPartition()
-                    .getBaseIndex().getTabletIdsInOrder();
+                    .getBaseIndex().getTabletIds();
             List<Long> backendIdList = tablets.stream()
                         .map(id -> GlobalStateMgr.getCurrentState().getTabletInvertedIndex().getReplicasByTabletId(id))
                         .map(replicaList -> replicaList.get(0).getBackendId())

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/DistributionPrunerRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/DistributionPrunerRuleTest.java
@@ -51,6 +51,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 
@@ -178,7 +179,10 @@ public class DistributionPrunerRuleTest {
                 partition.getDistributionInfo();
                 result = distributionInfo;
 
-                index.getTabletIdsInOrder();
+                index.getVirtualBuckets();
+                result = Stream.concat(tabletIds.stream(), tabletIds.stream()).collect(Collectors.toList());
+
+                index.getTabletIds();
                 result = tabletIds;
 
                 distributionInfo.getDistributionColumns();
@@ -186,9 +190,6 @@ public class DistributionPrunerRuleTest {
 
                 distributionInfo.getType();
                 result = DistributionInfo.DistributionInfoType.HASH;
-
-                distributionInfo.getBucketNum();
-                result = tabletIds.size();
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakeAggregatePublishTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakeAggregatePublishTest.java
@@ -98,7 +98,7 @@ public class LakeAggregatePublishTest {
 
         for (Partition partition : table.getPartitions()) {
             MaterializedIndex baseIndex = partition.getDefaultPhysicalPartition().getBaseIndex();
-            for (Long tabletId : baseIndex.getTabletIdsInOrder()) {
+            for (Long tabletId : baseIndex.getTabletIds()) {
                 for (Long backendId : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds()) {
                     TabletCommitInfo tabletCommitInfo = new TabletCommitInfo(tabletId, backendId);
                     transTablets1.add(tabletCommitInfo);

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
@@ -119,7 +119,7 @@ public class LakePublishBatchTest {
         int num = 0;
         for (Partition partition : table.getPartitions()) {
             MaterializedIndex baseIndex = partition.getDefaultPhysicalPartition().getBaseIndex();
-            for (Long tabletId : baseIndex.getTabletIdsInOrder()) {
+            for (Long tabletId : baseIndex.getTabletIds()) {
                 for (Long backendId : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds()) {
                     TabletCommitInfo tabletCommitInfo = new TabletCommitInfo(tabletId, backendId);
                     if (num % 2 == 0) {
@@ -188,7 +188,7 @@ public class LakePublishBatchTest {
 
         for (Partition partition : table.getPartitions()) {
             MaterializedIndex baseIndex = partition.getDefaultPhysicalPartition().getBaseIndex();
-            for (Long tabletId : baseIndex.getTabletIdsInOrder()) {
+            for (Long tabletId : baseIndex.getTabletIds()) {
                 for (Long backendId : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds()) {
                     TabletCommitInfo tabletCommitInfo = new TabletCommitInfo(tabletId, backendId);
                     transTablets.add(tabletCommitInfo);
@@ -222,7 +222,7 @@ public class LakePublishBatchTest {
         List<TabletCommitInfo> transTablets = Lists.newArrayList();
         for (Partition partition : table.getPartitions()) {
             MaterializedIndex baseIndex = partition.getDefaultPhysicalPartition().getBaseIndex();
-            for (Long tabletId : baseIndex.getTabletIdsInOrder()) {
+            for (Long tabletId : baseIndex.getTabletIds()) {
                 for (Long backendId : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds()) {
                     TabletCommitInfo tabletCommitInfo = new TabletCommitInfo(tabletId, backendId);
                     transTablets.add(tabletCommitInfo);
@@ -280,7 +280,7 @@ public class LakePublishBatchTest {
         List<TabletCommitInfo> transTablets = Lists.newArrayList();
         for (Partition partition : table.getPartitions()) {
             MaterializedIndex baseIndex = partition.getDefaultPhysicalPartition().getBaseIndex();
-            for (Long tabletId : baseIndex.getTabletIdsInOrder()) {
+            for (Long tabletId : baseIndex.getTabletIds()) {
                 for (Long backendId : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds()) {
                     TabletCommitInfo tabletCommitInfo = new TabletCommitInfo(tabletId, backendId);
                     transTablets.add(tabletCommitInfo);
@@ -341,7 +341,7 @@ public class LakePublishBatchTest {
         int num = 0;
         for (Partition partition : table.getPartitions()) {
             MaterializedIndex baseIndex = partition.getDefaultPhysicalPartition().getBaseIndex();
-            for (Long tabletId : baseIndex.getTabletIdsInOrder()) {
+            for (Long tabletId : baseIndex.getTabletIds()) {
                 for (Long backendId : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds()) {
                     TabletCommitInfo tabletCommitInfo = new TabletCommitInfo(tabletId, backendId);
                     if (num % 2 == 0) {


### PR DESCRIPTION
## Why I'm doing:
https://github.com/StarRocks/starrocks/pull/59378 introduced virtual buckets metadata, which has not been used to prune tablets.
This pr uses virtual buckets metadata to prune tablets.

## What I'm doing:
Prune tablets according to virtual bucket for dynamic tablet splitting and merging.

This pr only focus on tablet pruning, and there are 2 more features that need to be adapted with virtual bucket:
- Colocate table
- Show data distribution

These feature will be adapted with virtual bucket in the subsequent pr.

Fixes https://github.com/StarRocks/starrocks/issues/59134

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
