### PR TITLE
[Enhancement] Support last_day constant evaluation in FE and partition pruning

### DIFF
--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -3310,8 +3310,6 @@ Status TimeFunctions::datediff_close(FunctionContext* context, FunctionContext::
 
 template <LogicalType DATE_TYPE>
 StatusOr<ColumnPtr> TimeFunctions::_last_day(FunctionContext* context, const Columns& columns) {
-    auto input_col = columns[0];
-
     ColumnViewer<DATE_TYPE> data_column(columns[0]);
     auto size = columns[0]->size();
 

--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -3308,9 +3308,11 @@ Status TimeFunctions::datediff_close(FunctionContext* context, FunctionContext::
     return Status::OK();
 }
 
-// last_day
-StatusOr<ColumnPtr> TimeFunctions::last_day(FunctionContext* context, const Columns& columns) {
-    ColumnViewer<TYPE_DATETIME> data_column(columns[0]);
+template <LogicalType DATE_TYPE>
+StatusOr<ColumnPtr> TimeFunctions::_last_day(FunctionContext* context, const Columns& columns) {
+    auto input_col = columns[0];
+
+    ColumnViewer<DATE_TYPE> data_column(columns[0]);
     auto size = columns[0]->size();
 
     ColumnBuilder<TYPE_DATE> result(size);
@@ -3327,13 +3329,24 @@ StatusOr<ColumnPtr> TimeFunctions::last_day(FunctionContext* context, const Colu
     return result.build(ColumnHelper::is_all_const(columns));
 }
 
+// last_day_date
+StatusOr<ColumnPtr> TimeFunctions::last_day_date(FunctionContext* context, const Columns& columns) {
+    return _last_day<TYPE_DATE>(context, columns);
+}
+
+// last_day
+StatusOr<ColumnPtr> TimeFunctions::last_day(FunctionContext* context, const Columns& columns) {
+    return _last_day<TYPE_DATETIME>(context, columns);
+}
+
 Status TimeFunctions::_error_date_part() {
     return Status::InvalidArgument("avaiable data_part parameter is year/month/quarter");
 }
 
+template <LogicalType DATE_TYPE>
 StatusOr<ColumnPtr> TimeFunctions::_last_day_with_format_const(std::string& format_content, FunctionContext* context,
                                                                const Columns& columns) {
-    ColumnViewer<TYPE_DATETIME> data_column(columns[0]);
+    ColumnViewer<DATE_TYPE> data_column(columns[0]);
     auto size = columns[0]->size();
 
     ColumnBuilder<TYPE_DATE> result(size);
@@ -3374,8 +3387,9 @@ StatusOr<ColumnPtr> TimeFunctions::_last_day_with_format_const(std::string& form
     return result.build(ColumnHelper::is_all_const(columns));
 }
 
+template <LogicalType DATE_TYPE>
 StatusOr<ColumnPtr> TimeFunctions::_last_day_with_format(FunctionContext* context, const Columns& columns) {
-    ColumnViewer<TYPE_DATETIME> data_column(columns[0]);
+    ColumnViewer<DATE_TYPE> data_column(columns[0]);
     ColumnViewer<TYPE_VARCHAR> format_column(columns[1]);
     auto size = columns[0]->size();
 
@@ -3405,14 +3419,26 @@ StatusOr<ColumnPtr> TimeFunctions::_last_day_with_format(FunctionContext* contex
     return result.build(ColumnHelper::is_all_const(columns));
 }
 
+// last_day_with_format
 StatusOr<ColumnPtr> TimeFunctions::last_day_with_format(FunctionContext* context, const Columns& columns) {
     DCHECK_EQ(columns.size(), 2);
     auto* state = reinterpret_cast<LastDayCtx*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
     if (state->const_optional) {
         std::string format_content = state->optional_content;
-        return _last_day_with_format_const(format_content, context, columns);
+        return _last_day_with_format_const<TYPE_DATETIME>(format_content, context, columns);
     }
-    return _last_day_with_format(context, columns);
+    return _last_day_with_format<TYPE_DATETIME>(context, columns);
+}
+
+// last_day_date_with_format
+StatusOr<ColumnPtr> TimeFunctions::last_day_date_with_format(FunctionContext* context, const Columns& columns) {
+    DCHECK_EQ(columns.size(), 2);
+    auto* state = reinterpret_cast<LastDayCtx*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
+    if (state->const_optional) {
+        std::string format_content = state->optional_content;
+        return _last_day_with_format_const<TYPE_DATE>(format_content, context, columns);
+    }
+    return _last_day_with_format<TYPE_DATE>(context, columns);
 }
 
 Status TimeFunctions::last_day_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope) {

--- a/be/src/exprs/time_functions.h
+++ b/be/src/exprs/time_functions.h
@@ -772,9 +772,11 @@ public:
      */
     DEFINE_VECTORIZED_FN(last_day);
     DEFINE_VECTORIZED_FN(last_day_with_format);
-
     static Status last_day_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope);
     static Status last_day_close(FunctionContext* context, FunctionContext::FunctionStateScope scope);
+    // last_day with input date type arguments
+    DEFINE_VECTORIZED_FN(last_day_date);
+    DEFINE_VECTORIZED_FN(last_day_date_with_format);
 
     // Following const variables used to obtains number days of year
     constexpr static int NUMBER_OF_LEAP_YEAR = 366;
@@ -853,8 +855,12 @@ private:
 
     static StatusOr<ColumnPtr> convert_tz_const(FunctionContext* context, const Columns& columns,
                                                 const cctz::time_zone& from, const cctz::time_zone& to);
-
+    // last_day
+    template <LogicalType DATE_TYPE>
+    static StatusOr<ColumnPtr> _last_day(FunctionContext* context, const Columns& columns);
+    template <LogicalType DATE_TYPE>
     static StatusOr<ColumnPtr> _last_day_with_format(FunctionContext* context, const Columns& columns);
+    template <LogicalType DATE_TYPE>
     static StatusOr<ColumnPtr> _last_day_with_format_const(std::string& format_content, FunctionContext* context,
                                                            const Columns& columns);
     static Status _error_date_part();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -66,6 +66,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.Month;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -436,6 +437,48 @@ public class ScalarOperatorFunctions {
         return ConstantOperator.createVarchar(jodaDateTime.toString(formatter));
     }
 
+    @ConstantFunction.List(list = {
+            @ConstantFunction(name = "last_day", argTypes = {DATE}, returnType = DATE, isMonotonic = true),
+            @ConstantFunction(name = "last_day", argTypes = {DATETIME}, returnType = DATE, isMonotonic = true),
+            @ConstantFunction(name = "last_day", argTypes = {DATE, VARCHAR}, returnType = DATE, isMonotonic = true),
+            @ConstantFunction(name = "last_day", argTypes = {DATETIME, VARCHAR}, returnType = DATE, isMonotonic = true),
+    })
+    public static ConstantOperator lastDay(ConstantOperator date, ConstantOperator... unitArgs) {
+        if (date.isNull()) {
+            return ConstantOperator.createNull(date.getType());
+        }
+
+        String unit = "month";
+        if (unitArgs.length > 0) {
+            if (unitArgs[0].isNull()) {
+                return ConstantOperator.createNull(date.getType());
+            }
+            unit = unitArgs[0].getVarchar().toLowerCase();
+        }
+
+        LocalDateTime dt = date.getDatetime();
+        LocalDate resultDate;
+
+        switch (unit) {
+            case "month":
+                resultDate = dt.with(TemporalAdjusters.lastDayOfMonth()).toLocalDate();
+                break;
+            case "quarter":
+                int currentQuarter = (dt.getMonthValue() - 1) / 3;
+                Month lastMonthOfQuarter = Month.of((currentQuarter + 1) * 3);
+                LocalDate quarterEnd = LocalDate.of(dt.getYear(), lastMonthOfQuarter, 1)
+                        .with(TemporalAdjusters.lastDayOfMonth());
+                resultDate = quarterEnd;
+                break;
+            case "year":
+                resultDate = LocalDate.of(dt.getYear(), 12, 31);
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid unit for last_day(): " + unit);
+        }
+
+        return ConstantOperator.createDate(resultDate.atStartOfDay());
+    }
 
     @ConstantFunction.List(list = {
             @ConstantFunction(name = "to_iso8601", argTypes = {DATETIME}, returnType = VARCHAR, isMonotonic = true),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -458,7 +458,6 @@ public class ScalarOperatorFunctions {
 
         LocalDateTime dt = date.getDatetime();
         LocalDate resultDate;
-
         switch (unit) {
             case "month":
                 resultDate = dt.with(TemporalAdjusters.lastDayOfMonth()).toLocalDate();
@@ -477,7 +476,7 @@ public class ScalarOperatorFunctions {
                 throw new IllegalArgumentException("Invalid unit for last_day(): " + unit);
         }
 
-        return ConstantOperator.createDate(resultDate.atStartOfDay());
+        return ConstantOperator.createDateOrNull(resultDate.atStartOfDay());
     }
 
     @ConstantFunction.List(list = {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -5350,26 +5350,21 @@ public class CreateMaterializedViewTest extends MVTestBase {
         Assert.assertEquals("dt > current_date() - interval 1 month", retentionCondition);
 
         try {
-            String alterTableSql = "ALTER MATERIALIZED VIEW mv1 SET ('partition_retention_condition' = " +
-                    "'last_day(dt) > current_date() - interval 2 month')";
-            starRocksAssert.alterMvProperties(alterTableSql);
-        } catch (Exception e) {
-            Assert.assertTrue(e.getMessage().contains("Retention condition must only contain monotonic functions for " +
-                    "range partition tables but contains: last_day"));
-        }
-
-        try {
 
             String alterTableSql = "ALTER MATERIALIZED VIEW mv1 SET ('partition_retention_condition' = " +
                     "'date_format(dt, \\'%m月%Y年\\') > current_date() - interval 2 month')";
             starRocksAssert.alterMvProperties(alterTableSql);
+            Assert.fail();
         } catch (Exception e) {
             Assert.assertTrue(e.getMessage().contains("Retention condition must only contain monotonic functions for " +
                     "range partition tables but contains: date_format"));
         }
 
+        String alterTableSql = "ALTER MATERIALIZED VIEW mv1 SET ('partition_retention_condition' = " +
+                "'last_day(dt) > current_date() - interval 2 month')";
+        starRocksAssert.alterMvProperties(alterTableSql);
         retentionCondition = mv.getTableProperty().getPartitionRetentionCondition();
-        Assert.assertEquals("dt > current_date() - interval 1 month", retentionCondition);
+        Assert.assertEquals("last_day(dt) > current_date() - interval 2 month", retentionCondition);
         starRocksAssert.dropMaterializedView("mv1");
         starRocksAssert.dropTable("r1");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableWithPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableWithPartitionTest.java
@@ -1060,26 +1060,9 @@ public class CreateTableWithPartitionTest extends StarRocksTestBase  {
 
         try {
             String alterTableSql = "ALTER TABLE r1 SET ('partition_retention_condition' = " +
-                    "'last_day(dt) > current_date() - interval 2 month')";
-            starRocksAssert.alterTableProperties(alterTableSql);
-        } catch (Exception e) {
-            Assert.assertTrue(e.getMessage().contains("Retention condition must only contain monotonic functions " +
-                    "for range partition tables but contains: last_day"));
-        }
-
-        try {
-            String alterTableSql = "ALTER TABLE r1 SET ('partition_retention_condition' = " +
-                    "'dt > current_date() - interval 1 month or last_day(dt) > current_date() - interval 2 month')";
-            starRocksAssert.alterTableProperties(alterTableSql);
-        } catch (Exception e) {
-            Assert.assertTrue(e.getMessage().contains("Retention condition must only contain monotonic functions " +
-                    "for range partition tables but contains: last_day"));
-        }
-
-        try {
-            String alterTableSql = "ALTER TABLE r1 SET ('partition_retention_condition' = " +
                     "'date_format(dt, \\'%m月%Y年\\') > current_date() - interval 2 month')";
             starRocksAssert.alterTableProperties(alterTableSql);
+            Assert.fail();
         } catch (Exception e) {
             Assert.assertTrue(e.getMessage().contains("Retention condition must only contain monotonic functions " +
                     "for range partition tables but contains: date_format"));
@@ -1089,12 +1072,21 @@ public class CreateTableWithPartitionTest extends StarRocksTestBase  {
             String alterTableSql = "ALTER TABLE r1 SET ('partition_retention_condition' = " +
                     "'date_format(dt, \\'%a-%Y\\') > current_date() - interval 2 month')";
             starRocksAssert.alterTableProperties(alterTableSql);
+            Assert.fail();
         } catch (Exception e) {
             Assert.assertTrue(e.getMessage().contains("Retention condition must only contain monotonic functions " +
                     "for range partition tables but contains: date_format"));
         }
+
+        String alterTableSql = "ALTER TABLE r1 SET ('partition_retention_condition' = " +
+                "'dt > current_date() - interval 1 month or last_day(dt) > current_date() - interval 2 month')";
+        starRocksAssert.alterTableProperties(alterTableSql);
+
+        alterTableSql = "ALTER TABLE r1 SET ('partition_retention_condition' = " +
+                "'last_day(dt) > current_date() - interval 2 month')";
+        starRocksAssert.alterTableProperties(alterTableSql);
         retentionCondition = r1.getTableProperty().getPartitionRetentionCondition();
-        Assert.assertEquals("dt > current_date() - interval 1 month", retentionCondition);
+        Assert.assertEquals("last_day(dt) > current_date() - interval 2 month", retentionCondition);
         starRocksAssert.dropTable("r1");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -116,7 +116,6 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
 
     @Test
     public void testDateFnTransform() throws Exception {
-        connectContext.getSessionVariable().setDisableFunctionFoldConstants(true);
         String sql = "select to_unixtime(TIMESTAMP '2023-04-22 00:00:00');";
         assertPlanContains(sql, "1682092800");
 
@@ -198,11 +197,13 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
         sql = "select parse_datetime('2023-08-02T14:37:02', 'yyyy-MM-dd''T''HH:mm:ss''Z''')";
         assertPlanContains(sql, "str_to_jodatime('2023-08-02T14:37:02', 'yyyy-MM-ddTHH:mm:ss')");
 
+        connectContext.getSessionVariable().setDisableFunctionFoldConstants(true);
         sql = "select last_day_of_month(timestamp '2023-07-01 00:00:00');";
         assertPlanContains(sql, "last_day('2023-07-01 00:00:00', 'month')");
 
         sql = "select last_day_of_month(date '2023-07-01');";
-        assertPlanContains(sql, "last_day('2023-07-01 00:00:00', 'month')");
+        assertPlanContains(sql, "last_day('2023-07-01', 'month')");
+        connectContext.getSessionVariable().setDisableFunctionFoldConstants(false);
 
         sql = "select date_diff('month', timestamp '2023-07-31', timestamp '2023-08-01');";
         assertPlanContains(sql, "date_diff('month', '2023-08-01 00:00:00', '2023-07-31 00:00:00')");
@@ -227,7 +228,6 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
 
         sql = "select from_iso8601_timestamp('2025-02-02')";
         assertPlanContains(sql, "'2025-02-02 00:00:00'");
-        connectContext.getSessionVariable().setDisableFunctionFoldConstants(false);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -116,6 +116,7 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
 
     @Test
     public void testDateFnTransform() throws Exception {
+        connectContext.getSessionVariable().setDisableFunctionFoldConstants(true);
         String sql = "select to_unixtime(TIMESTAMP '2023-04-22 00:00:00');";
         assertPlanContains(sql, "1682092800");
 
@@ -226,6 +227,7 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
 
         sql = "select from_iso8601_timestamp('2025-02-02')";
         assertPlanContains(sql, "'2025-02-02 00:00:00'");
+        connectContext.getSessionVariable().setDisableFunctionFoldConstants(false);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/FurtherPartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/FurtherPartitionPruneTest.java
@@ -474,24 +474,30 @@ class FurtherPartitionPruneTest extends PlanTestBase {
 
     private static Stream<Arguments> partitionPruneWithLastDay() {
         List<Arguments> arguments = Lists.newArrayList();
-        arguments.add(Arguments.of("select * from ptest where last_day(d2) = '2020-04-30'", true));
-        arguments.add(Arguments.of("select * from ptest where last_day(cast(d2 as datetime)) = '2020-04-30'", true));
-        arguments.add(Arguments.of("select * from ptest where last_day(cast(d2 as date)) = '2020-04-30'", true));
-        arguments.add(Arguments.of("select * from ptest where last_day(d2) = cast('2020-04-30' as date)", true));
-        arguments.add(Arguments.of("select * from ptest where last_day(d2) = cast('2020-04-30' as datetime)", true));
-        arguments.add(Arguments.of("select * from ptest where last_day(d2) = date_trunc('day', d2)", false));
+        arguments.add(Arguments.of("select * from less_than_tbl where date_trunc('year', k1) is null",
+                "partitions=1/4"));
+        arguments.add(Arguments.of("select * from less_than_tbl where last_day(k1) is null",
+                "partitions=1/4"));
+        arguments.add(Arguments.of("select * from ptest where last_day(d2) = '2020-04-30'",
+                "partitions=2/4"));
+        arguments.add(Arguments.of("select * from ptest where last_day(cast(d2 as datetime)) = '2020-04-30'",
+                "partitions=2/4"));
+        arguments.add(Arguments.of("select * from ptest where last_day(cast(d2 as date)) = '2020-04-30'",
+                "partitions=2/4"));
+        arguments.add(Arguments.of("select * from ptest where last_day(d2) = cast('2020-04-30' as date)",
+                "partitions=2/4"));
+        arguments.add(Arguments.of("select * from ptest where last_day(d2) = cast('2020-04-30' as datetime)",
+                "partitions=2/4"));
+        arguments.add(Arguments.of("select * from ptest where last_day(d2) = date_trunc('day', d2)",
+                "partitions=4/4"));
         return arguments.stream();
     }
     @ParameterizedTest(name = "sql_{index}: {0}.")
     @MethodSource("partitionPruneWithLastDay")
     @Order(6)
-    void canPrunePredicateSqls2(String sql, boolean pruned) throws Exception {
+    void canPrunePredicateSqls2(String sql, String expect) throws Exception {
         String plan = getFragmentPlan(sql);
-        if (pruned) {
-            PlanTestBase.assertContains(plan, "partitions=2/4");
-        } else {
-            PlanTestBase.assertContains(plan, "PREDICATES: ", "partitions=4/4");
-        }
+        PlanTestBase.assertContains(plan, expect);
     }
 
     private static Stream<Arguments> exprPrunePartitionSqls() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/FurtherPartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/FurtherPartitionPruneTest.java
@@ -472,6 +472,28 @@ class FurtherPartitionPruneTest extends PlanTestBase {
         return sqlList.stream().map(e -> Arguments.of(e));
     }
 
+    private static Stream<Arguments> partitionPruneWithLastDay() {
+        List<Arguments> arguments = Lists.newArrayList();
+        arguments.add(Arguments.of("select * from ptest where last_day(d2) = '2020-04-30'", true));
+        arguments.add(Arguments.of("select * from ptest where last_day(cast(d2 as datetime)) = '2020-04-30'", true));
+        arguments.add(Arguments.of("select * from ptest where last_day(cast(d2 as date)) = '2020-04-30'", true));
+        arguments.add(Arguments.of("select * from ptest where last_day(d2) = cast('2020-04-30' as date)", true));
+        arguments.add(Arguments.of("select * from ptest where last_day(d2) = cast('2020-04-30' as datetime)", true));
+        arguments.add(Arguments.of("select * from ptest where last_day(d2) = date_trunc('day', d2)", false));
+        return arguments.stream();
+    }
+    @ParameterizedTest(name = "sql_{index}: {0}.")
+    @MethodSource("partitionPruneWithLastDay")
+    @Order(6)
+    void canPrunePredicateSqls2(String sql, boolean pruned) throws Exception {
+        String plan = getFragmentPlan(sql);
+        if (pruned) {
+            PlanTestBase.assertContains(plan, "partitions=2/4");
+        } else {
+            PlanTestBase.assertContains(plan, "PREDICATES: ", "partitions=4/4");
+        }
+    }
+
     private static Stream<Arguments> exprPrunePartitionSqls() {
         List<String> sqlList = Lists.newArrayList();
         sqlList.add("select * from less_than_tbl where date_trunc('year', k1) is null");

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -610,6 +610,10 @@ vectorized_functions = [
     [50402, 'last_day', True, False, 'DATE', ['DATETIME'], 'TimeFunctions::last_day'],
     [50403, 'last_day', True, False, 'DATE', ['DATETIME', 'VARCHAR'], 'TimeFunctions::last_day_with_format',
      'TimeFunctions::last_day_prepare', 'TimeFunctions::last_day_close'],
+    [50404, 'last_day', True, False, 'DATE', ['DATE'], 'TimeFunctions::last_day_date'],
+    [50405, 'last_day', True, False, 'DATE', ['DATE', 'VARCHAR'], 'TimeFunctions::last_day_date_with_format',
+     'TimeFunctions::last_day_prepare', 'TimeFunctions::last_day_close'],
+
     [50501, 'makedate', True, False, 'DATE', ['INT', 'INT'], 'TimeFunctions::make_date'],
     [50610, 'time_format', True, False, 'VARCHAR', ['TIME', 'VARCHAR'], 'TimeFunctions::time_format'],
 

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -2783,9 +2783,28 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
 
     def print_table_partitions_num(self, table_name) -> str:
         res = self.execute_sql("SHOW PARTITIONS FROM %s" % table_name, True)
-        tools.assert_true(res["status"], "show schema change task error")
+        tools.assert_true(res["status"], "show table partitions error")
         ans = res["result"]
         return str(len(ans))
+
+    def print_plan_partition_selected_num(self, sql, table_name) -> str:
+        res = self.execute_sql("EXPLAIN %s" % sql, True)
+        tools.assert_true(res["status"], "explain sql error")
+        plan = res["result"]
+        tools.assert_true(len(plan) > 0, "explain sql result is empty")
+
+        lines = str(plan).split('\n')
+        # Search for the table scan node for the specified table
+        for line in lines:
+            if f'TABLE: {table_name}'.lower() in line.lower():
+                # Now look forward in the following lines for the partitions information
+                idx = lines.index(line)
+                for i in range(idx, min(idx + 10, len(lines))):  # Check next 10 lines max
+                    if 'partitions=' in lines[i]:
+                        parts = lines[i].split('partitions=')
+                        if len(parts) > 1:
+                            partition_info = parts[1].split(',')[0].replace('\'', '').strip()
+                            return partition_info
 
     def assert_table_partitions_num(self, table_name, expect_num):
         res = self.execute_sql("SHOW PARTITIONS FROM %s" % table_name, True)

--- a/test/sql/test_automatic_partition/R/test_partition_prune_with_last_day
+++ b/test/sql/test_automatic_partition/R/test_partition_prune_with_last_day
@@ -1,0 +1,22 @@
+-- name: test_partition_prune_with_last_day
+CREATE TABLE t1 (
+    dt datetime,
+    province string,
+    num int
+)
+DUPLICATE KEY(dt, province)
+PARTITION BY date_trunc('day', dt)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t1(dt, province, num)
+SELECT minutes_add(hours_add(date_add('2025-01-01', x), x%24), x%60), concat('x-', x%3), x
+FROM TABLE(generate_series(0, 200-1)) as t(x);
+-- result:
+-- !result
+INSERT INTO t1(dt, province, num) SELECT NULL, NULL, NULL;
+-- result:
+-- !result
+function: print_plan_partition_selected_num("select count(*) from t1 where last_day(dt) = '2025-01-01';", "t1")

--- a/test/sql/test_automatic_partition/R/test_partition_prune_with_last_day
+++ b/test/sql/test_automatic_partition/R/test_partition_prune_with_last_day
@@ -13,10 +13,1042 @@ PROPERTIES (
 -- !result
 INSERT INTO t1(dt, province, num)
 SELECT minutes_add(hours_add(date_add('2025-01-01', x), x%24), x%60), concat('x-', x%3), x
-FROM TABLE(generate_series(0, 200-1)) as t(x);
+FROM TABLE(generate_series(0, 500)) as t(x);
 -- result:
 -- !result
 INSERT INTO t1(dt, province, num) SELECT NULL, NULL, NULL;
 -- result:
 -- !result
 function: print_plan_partition_selected_num("select count(*) from t1 where last_day(dt) = '2025-01-01';", "t1")
+-- result:
+None
+-- !result
+function: print_table_partitions_num("t1")
+-- result:
+502
+-- !result
+select last_day('2025-01-01');
+-- result:
+2025-01-31
+-- !result
+select last_day('2025-01-02');
+-- result:
+2025-01-31
+-- !result
+select last_day('2025-02-28');
+-- result:
+2025-02-28
+-- !result
+select last_day('invalid');
+-- result:
+None
+-- !result
+select last_day(null);
+-- result:
+None
+-- !result
+SELECT dt, last_day(dt) AS last_day_val FROM t1 ORDER BY dt limit 10;
+-- result:
+None	None
+2025-01-01 00:00:00	2025-01-31
+2025-01-02 01:01:00	2025-01-31
+2025-01-03 02:02:00	2025-01-31
+2025-01-04 03:03:00	2025-01-31
+2025-01-05 04:04:00	2025-01-31
+2025-01-06 05:05:00	2025-01-31
+2025-01-07 06:06:00	2025-01-31
+2025-01-08 07:07:00	2025-01-31
+2025-01-09 08:08:00	2025-01-31
+-- !result
+select count(*) from t1 where last_day(dt) = '2025-01-01';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-01-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-02-28';
+-- result:
+28
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-03-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-04-30';
+-- result:
+30
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-05-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-06-30';
+-- result:
+30
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-07-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-08-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-09-30';
+-- result:
+30
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-10-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-11-30';
+-- result:
+30
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-12-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) is NULL;
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-01-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-02-28';
+-- result:
+59
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-09-28';
+-- result:
+243
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-28';
+-- result:
+334
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31';
+-- result:
+365
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt) is NULL;
+-- result:
+365
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('day', dt);
+-- result:
+16
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('month', dt);
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('year', dt);
+-- result:
+0
+-- !result
+select count(*) from t1 where last_day(dt, 'month') = '2025-01-01';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-01-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-02-28';
+-- result:
+28
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-03-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-04-30';
+-- result:
+30
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-05-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-06-30';
+-- result:
+30
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-07-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-08-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-09-30';
+-- result:
+30
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-10-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-11-30';
+-- result:
+30
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-12-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') is NULL;
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-01-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-02-28';
+-- result:
+59
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-09-28';
+-- result:
+243
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-12-28';
+-- result:
+334
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-12-31';
+-- result:
+365
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt, 'month') is NULL;
+-- result:
+365
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = date_trunc('day', dt);
+-- result:
+16
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = date_trunc('month', dt);
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = date_trunc('year', dt);
+-- result:
+0
+-- !result
+select count(*) from t1 where last_day(dt, 'quarter') = '2025-01-01';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-01-31';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-02-28';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-03-31';
+-- result:
+90
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-04-30';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-05-31';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-06-30';
+-- result:
+91
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-07-31';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-08-31';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-09-30';
+-- result:
+92
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-10-31';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-11-30';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-12-31';
+-- result:
+92
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') is NULL;
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-01-31';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-02-28';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-09-28';
+-- result:
+181
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-12-28';
+-- result:
+273
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-12-31';
+-- result:
+365
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt, 'quarter') is NULL;
+-- result:
+365
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = date_trunc('day', dt);
+-- result:
+5
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = date_trunc('month', dt);
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = date_trunc('year', dt);
+-- result:
+0
+-- !result
+select count(*) from t1 where last_day(dt, 'year') = '2025-01-01';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-01-31';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-02-28';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-03-31';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-04-30';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-05-31';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-06-30';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-07-31';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-08-31';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-09-30';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-10-31';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-11-30';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-12-31';
+-- result:
+365
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') is NULL;
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-01-31';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-02-28';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-09-28';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-12-28';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-12-31';
+-- result:
+365
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt, 'year') is NULL;
+-- result:
+365
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = date_trunc('day', dt);
+-- result:
+1
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = date_trunc('month', dt);
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = date_trunc('year', dt);
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-05-30' - INTERVAL 2 MONTH AND last_day(date_trunc('day', dt)) != date_trunc('day', dt);
+-- result:
+86
+-- !result
+SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-12-30' - INTERVAL 2 MONTH AND last_day(date_trunc('day', dt)) != date_trunc('day', dt);
+-- result:
+293
+-- !result
+function: print_plan_partition_selected_num("select count(*) from t1 where last_day(dt) = '2025-01-01';", "t1")
+-- result:
+None
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-01-31';", "t1")
+-- result:
+31/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-02-28';", "t1")
+-- result:
+29/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-03-31';", "t1")
+-- result:
+32/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-04-30';", "t1")
+-- result:
+31/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-05-31';", "t1")
+-- result:
+32/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-06-30';", "t1")
+-- result:
+31/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-07-31';", "t1")
+-- result:
+32/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-08-31';", "t1")
+-- result:
+32/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-09-30';", "t1")
+-- result:
+31/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-10-31';", "t1")
+-- result:
+32/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-11-30';", "t1")
+-- result:
+31/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-12-31';", "t1")
+-- result:
+32/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) is NULL;", "t1")
+-- result:
+None
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-01-31';", "t1")
+-- result:
+31/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-02-28';", "t1")
+-- result:
+59/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-09-28';", "t1")
+-- result:
+243/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-28';", "t1")
+-- result:
+334/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31';", "t1")
+-- result:
+365/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt) is NULL;", "t1")
+-- result:
+365/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('day', dt);", "t1")
+-- result:
+502/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('month', dt);", "t1")
+-- result:
+502/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('year', dt);", "t1")
+-- result:
+502/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-05-30' - INTERVAL 2 MONTH AND last_day(date_trunc('day', dt)) != date_trunc('day', dt);", "t1")
+-- result:
+89/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-12-30' - INTERVAL 2 MONTH AND last_day(date_trunc('day', dt)) != date_trunc('day', dt);", "t1")
+-- result:
+303/502
+-- !result
+drop table if exists t1;
+-- result:
+-- !result
+CREATE TABLE t1 (
+    dt date,
+    province string,
+    num int
+)
+DUPLICATE KEY(dt, province)
+PARTITION BY date_trunc('day', dt)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t1(dt, province, num)
+SELECT minutes_add(hours_add(date_add('2025-01-01', x), x%24), x%60), concat('x-', x%3), x
+FROM TABLE(generate_series(0, 500)) as t(x);
+-- result:
+-- !result
+INSERT INTO t1(dt, province, num) SELECT NULL, NULL, NULL;
+-- result:
+-- !result
+function: print_table_partitions_num("t1")
+-- result:
+502
+-- !result
+SELECT dt, last_day(dt) AS last_day_val FROM t1 ORDER BY dt limit 10;
+-- result:
+None	None
+2025-01-01	2025-01-31
+2025-01-02	2025-01-31
+2025-01-03	2025-01-31
+2025-01-04	2025-01-31
+2025-01-05	2025-01-31
+2025-01-06	2025-01-31
+2025-01-07	2025-01-31
+2025-01-08	2025-01-31
+2025-01-09	2025-01-31
+-- !result
+select count(*) from t1 where last_day(dt) = '2025-01-01';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-01-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-02-28';
+-- result:
+28
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-03-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-04-30';
+-- result:
+30
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-05-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-06-30';
+-- result:
+30
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-07-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-08-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-09-30';
+-- result:
+30
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-10-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-11-30';
+-- result:
+30
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-12-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) is NULL;
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-01-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-02-28';
+-- result:
+59
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-09-28';
+-- result:
+243
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-28';
+-- result:
+334
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31';
+-- result:
+365
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt) is NULL;
+-- result:
+365
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('day', dt);
+-- result:
+16
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('month', dt);
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('year', dt);
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-05-30' - INTERVAL 2 MONTH AND last_day(date_trunc('day', dt)) != date_trunc('day', dt);
+-- result:
+86
+-- !result
+SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-12-30' - INTERVAL 2 MONTH AND last_day(date_trunc('day', dt)) != date_trunc('day', dt);
+-- result:
+293
+-- !result
+function: print_plan_partition_selected_num("select count(*) from t1 where last_day(dt) = '2025-01-01';", "t1")
+-- result:
+None
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-01-31';", "t1")
+-- result:
+31/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-02-28';", "t1")
+-- result:
+29/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-03-31';", "t1")
+-- result:
+32/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-04-30';", "t1")
+-- result:
+31/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-05-31';", "t1")
+-- result:
+32/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-06-30';", "t1")
+-- result:
+31/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-07-31';", "t1")
+-- result:
+32/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-08-31';", "t1")
+-- result:
+32/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-09-30';", "t1")
+-- result:
+31/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-10-31';", "t1")
+-- result:
+32/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-11-30';", "t1")
+-- result:
+31/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-12-31';", "t1")
+-- result:
+32/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) is NULL;", "t1")
+-- result:
+None
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-01-31';", "t1")
+-- result:
+31/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-02-28';", "t1")
+-- result:
+59/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-09-28';", "t1")
+-- result:
+243/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-28';", "t1")
+-- result:
+334/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31';", "t1")
+-- result:
+365/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt) is NULL;", "t1")
+-- result:
+365/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('day', dt);", "t1")
+-- result:
+502/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('month', dt);", "t1")
+-- result:
+502/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('year', dt);", "t1")
+-- result:
+502/502
+-- !result
+select count(*) from t1 where last_day(dt, 'month') = '2025-01-01';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-01-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-02-28';
+-- result:
+28
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-03-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-04-30';
+-- result:
+30
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-05-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-06-30';
+-- result:
+30
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-07-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-08-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-09-30';
+-- result:
+30
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-10-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-11-30';
+-- result:
+30
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-12-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') is NULL;
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-01-31';
+-- result:
+31
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-02-28';
+-- result:
+59
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-09-28';
+-- result:
+243
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-12-28';
+-- result:
+334
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-12-31';
+-- result:
+365
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt, 'month') is NULL;
+-- result:
+365
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = date_trunc('day', dt);
+-- result:
+16
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = date_trunc('month', dt);
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = date_trunc('year', dt);
+-- result:
+0
+-- !result
+select count(*) from t1 where last_day(dt, 'quarter') = '2025-01-01';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-01-31';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-02-28';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-03-31';
+-- result:
+90
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-04-30';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-05-31';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-06-30';
+-- result:
+91
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-07-31';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-08-31';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-09-30';
+-- result:
+92
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-10-31';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-11-30';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-12-31';
+-- result:
+92
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') is NULL;
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-01-31';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-02-28';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-09-28';
+-- result:
+181
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-12-28';
+-- result:
+273
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-12-31';
+-- result:
+365
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt, 'quarter') is NULL;
+-- result:
+365
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = date_trunc('day', dt);
+-- result:
+5
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = date_trunc('month', dt);
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = date_trunc('year', dt);
+-- result:
+0
+-- !result
+select count(*) from t1 where last_day(dt, 'year') = '2025-01-01';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-01-31';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-02-28';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-03-31';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-04-30';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-05-31';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-06-30';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-07-31';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-08-31';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-09-30';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-10-31';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-11-30';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-12-31';
+-- result:
+365
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') is NULL;
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-01-31';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-02-28';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-09-28';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-12-28';
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-12-31';
+-- result:
+365
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt, 'year') is NULL;
+-- result:
+365
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = date_trunc('day', dt);
+-- result:
+1
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = date_trunc('month', dt);
+-- result:
+0
+-- !result
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = date_trunc('year', dt);
+-- result:
+0
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-05-30' - INTERVAL 2 MONTH AND last_day(date_trunc('day', dt)) != date_trunc('day', dt);", "t1")
+-- result:
+89/502
+-- !result
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-12-30' - INTERVAL 2 MONTH AND last_day(date_trunc('day', dt)) != date_trunc('day', dt);", "t1")
+-- result:
+303/502
+-- !result

--- a/test/sql/test_automatic_partition/R/test_partition_prune_with_last_day
+++ b/test/sql/test_automatic_partition/R/test_partition_prune_with_last_day
@@ -1,7 +1,4 @@
 -- name: test_partition_prune_with_last_day
-set disable_function_fold_constants=true;
--- result:
--- !result
 CREATE TABLE t1 (
     dt datetime,
     province string,
@@ -24,7 +21,7 @@ INSERT INTO t1(dt, province, num) SELECT NULL, NULL, NULL;
 -- !result
 function: print_plan_partition_selected_num("select count(*) from t1 where last_day(dt) = '2025-01-01';", "t1")
 -- result:
-502/502
+None
 -- !result
 function: print_table_partitions_num("t1")
 -- result:
@@ -441,83 +438,83 @@ SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-12-30' - INTERVAL 2
 -- !result
 function: print_plan_partition_selected_num("select count(*) from t1 where last_day(dt) = '2025-01-01';", "t1")
 -- result:
-502/502
+None
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-01-31';", "t1")
 -- result:
-502/502
+31/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-02-28';", "t1")
 -- result:
-502/502
+29/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-03-31';", "t1")
 -- result:
-502/502
+32/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-04-30';", "t1")
 -- result:
-502/502
+31/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-05-31';", "t1")
 -- result:
-502/502
+32/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-06-30';", "t1")
 -- result:
-502/502
+31/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-07-31';", "t1")
 -- result:
-502/502
+32/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-08-31';", "t1")
 -- result:
-502/502
+32/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-09-30';", "t1")
 -- result:
-502/502
+31/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-10-31';", "t1")
 -- result:
-502/502
+32/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-11-30';", "t1")
 -- result:
-502/502
+31/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-12-31';", "t1")
 -- result:
-502/502
+32/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) is NULL;", "t1")
 -- result:
-502/502
+1/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-01-31';", "t1")
 -- result:
-502/502
+31/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-02-28';", "t1")
 -- result:
-502/502
+59/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-09-28';", "t1")
 -- result:
-502/502
+243/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-28';", "t1")
 -- result:
-502/502
+334/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31';", "t1")
 -- result:
-502/502
+365/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt) is NULL;", "t1")
 -- result:
-502/502
+366/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('day', dt);", "t1")
 -- result:
@@ -533,11 +530,11 @@ function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-05-30' - INTERVAL 2 MONTH AND last_day(date_trunc('day', dt)) != date_trunc('day', dt);", "t1")
 -- result:
-502/502
+89/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-12-30' - INTERVAL 2 MONTH AND last_day(date_trunc('day', dt)) != date_trunc('day', dt);", "t1")
 -- result:
-502/502
+303/502
 -- !result
 drop table if exists t1;
 -- result:
@@ -681,83 +678,83 @@ SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-12-30' - INTERVAL 2
 -- !result
 function: print_plan_partition_selected_num("select count(*) from t1 where last_day(dt) = '2025-01-01';", "t1")
 -- result:
-502/502
+None
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-01-31';", "t1")
 -- result:
-502/502
+31/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-02-28';", "t1")
 -- result:
-502/502
+29/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-03-31';", "t1")
 -- result:
-502/502
+32/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-04-30';", "t1")
 -- result:
-502/502
+31/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-05-31';", "t1")
 -- result:
-502/502
+32/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-06-30';", "t1")
 -- result:
-502/502
+31/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-07-31';", "t1")
 -- result:
-502/502
+32/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-08-31';", "t1")
 -- result:
-502/502
+32/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-09-30';", "t1")
 -- result:
-502/502
+31/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-10-31';", "t1")
 -- result:
-502/502
+32/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-11-30';", "t1")
 -- result:
-502/502
+31/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-12-31';", "t1")
 -- result:
-502/502
+32/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) is NULL;", "t1")
 -- result:
-502/502
+1/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-01-31';", "t1")
 -- result:
-502/502
+31/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-02-28';", "t1")
 -- result:
-502/502
+59/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-09-28';", "t1")
 -- result:
-502/502
+243/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-28';", "t1")
 -- result:
-502/502
+334/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31';", "t1")
 -- result:
-502/502
+365/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt) is NULL;", "t1")
 -- result:
-502/502
+366/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('day', dt);", "t1")
 -- result:
@@ -1049,9 +1046,9 @@ SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = date_trunc('year', dt);
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-05-30' - INTERVAL 2 MONTH AND last_day(date_trunc('day', dt)) != date_trunc('day', dt);", "t1")
 -- result:
-502/502
+89/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-12-30' - INTERVAL 2 MONTH AND last_day(date_trunc('day', dt)) != date_trunc('day', dt);", "t1")
 -- result:
-502/502
+303/502
 -- !result

--- a/test/sql/test_automatic_partition/R/test_partition_prune_with_last_day
+++ b/test/sql/test_automatic_partition/R/test_partition_prune_with_last_day
@@ -1,4 +1,7 @@
 -- name: test_partition_prune_with_last_day
+set disable_function_fold_constants=true;
+-- result:
+-- !result
 CREATE TABLE t1 (
     dt datetime,
     province string,
@@ -21,7 +24,7 @@ INSERT INTO t1(dt, province, num) SELECT NULL, NULL, NULL;
 -- !result
 function: print_plan_partition_selected_num("select count(*) from t1 where last_day(dt) = '2025-01-01';", "t1")
 -- result:
-None
+502/502
 -- !result
 function: print_table_partitions_num("t1")
 -- result:
@@ -114,7 +117,7 @@ SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-12-31';
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt) is NULL;
 -- result:
-0
+1
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-01-31';
 -- result:
@@ -138,7 +141,7 @@ SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31'
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt) is NULL;
 -- result:
-365
+366
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('day', dt);
 -- result:
@@ -206,7 +209,7 @@ SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-12-31';
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt, 'month') is NULL;
 -- result:
-0
+1
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-01-31';
 -- result:
@@ -230,7 +233,7 @@ SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '20
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt, 'month') is NULL;
 -- result:
-365
+366
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = date_trunc('day', dt);
 -- result:
@@ -298,7 +301,7 @@ SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-12-31';
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') is NULL;
 -- result:
-0
+1
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-01-31';
 -- result:
@@ -322,7 +325,7 @@ SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt, 'quarter') is NULL;
 -- result:
-365
+366
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = date_trunc('day', dt);
 -- result:
@@ -390,7 +393,7 @@ SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-12-31';
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt, 'year') is NULL;
 -- result:
-0
+1
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-01-31';
 -- result:
@@ -414,7 +417,7 @@ SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '202
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt, 'year') is NULL;
 -- result:
-365
+366
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = date_trunc('day', dt);
 -- result:
@@ -438,83 +441,83 @@ SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-12-30' - INTERVAL 2
 -- !result
 function: print_plan_partition_selected_num("select count(*) from t1 where last_day(dt) = '2025-01-01';", "t1")
 -- result:
-None
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-01-31';", "t1")
 -- result:
-31/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-02-28';", "t1")
 -- result:
-29/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-03-31';", "t1")
 -- result:
-32/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-04-30';", "t1")
 -- result:
-31/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-05-31';", "t1")
 -- result:
-32/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-06-30';", "t1")
 -- result:
-31/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-07-31';", "t1")
 -- result:
-32/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-08-31';", "t1")
 -- result:
-32/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-09-30';", "t1")
 -- result:
-31/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-10-31';", "t1")
 -- result:
-32/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-11-30';", "t1")
 -- result:
-31/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-12-31';", "t1")
 -- result:
-32/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) is NULL;", "t1")
 -- result:
-None
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-01-31';", "t1")
 -- result:
-31/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-02-28';", "t1")
 -- result:
-59/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-09-28';", "t1")
 -- result:
-243/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-28';", "t1")
 -- result:
-334/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31';", "t1")
 -- result:
-365/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt) is NULL;", "t1")
 -- result:
-365/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('day', dt);", "t1")
 -- result:
@@ -530,11 +533,11 @@ function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-05-30' - INTERVAL 2 MONTH AND last_day(date_trunc('day', dt)) != date_trunc('day', dt);", "t1")
 -- result:
-89/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-12-30' - INTERVAL 2 MONTH AND last_day(date_trunc('day', dt)) != date_trunc('day', dt);", "t1")
 -- result:
-303/502
+502/502
 -- !result
 drop table if exists t1;
 -- result:
@@ -630,7 +633,7 @@ SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-12-31';
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt) is NULL;
 -- result:
-0
+1
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-01-31';
 -- result:
@@ -654,7 +657,7 @@ SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31'
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt) is NULL;
 -- result:
-365
+366
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('day', dt);
 -- result:
@@ -678,83 +681,83 @@ SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-12-30' - INTERVAL 2
 -- !result
 function: print_plan_partition_selected_num("select count(*) from t1 where last_day(dt) = '2025-01-01';", "t1")
 -- result:
-None
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-01-31';", "t1")
 -- result:
-31/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-02-28';", "t1")
 -- result:
-29/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-03-31';", "t1")
 -- result:
-32/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-04-30';", "t1")
 -- result:
-31/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-05-31';", "t1")
 -- result:
-32/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-06-30';", "t1")
 -- result:
-31/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-07-31';", "t1")
 -- result:
-32/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-08-31';", "t1")
 -- result:
-32/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-09-30';", "t1")
 -- result:
-31/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-10-31';", "t1")
 -- result:
-32/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-11-30';", "t1")
 -- result:
-31/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-12-31';", "t1")
 -- result:
-32/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) is NULL;", "t1")
 -- result:
-None
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-01-31';", "t1")
 -- result:
-31/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-02-28';", "t1")
 -- result:
-59/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-09-28';", "t1")
 -- result:
-243/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-28';", "t1")
 -- result:
-334/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31';", "t1")
 -- result:
-365/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt) is NULL;", "t1")
 -- result:
-365/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('day', dt);", "t1")
 -- result:
@@ -822,7 +825,7 @@ SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-12-31';
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt, 'month') is NULL;
 -- result:
-0
+1
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-01-31';
 -- result:
@@ -846,7 +849,7 @@ SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '20
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt, 'month') is NULL;
 -- result:
-365
+366
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = date_trunc('day', dt);
 -- result:
@@ -914,7 +917,7 @@ SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-12-31';
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') is NULL;
 -- result:
-0
+1
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-01-31';
 -- result:
@@ -938,7 +941,7 @@ SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt, 'quarter') is NULL;
 -- result:
-365
+366
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = date_trunc('day', dt);
 -- result:
@@ -1006,7 +1009,7 @@ SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-12-31';
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt, 'year') is NULL;
 -- result:
-0
+1
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-01-31';
 -- result:
@@ -1030,7 +1033,7 @@ SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '202
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt, 'year') is NULL;
 -- result:
-365
+366
 -- !result
 SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = date_trunc('day', dt);
 -- result:
@@ -1046,9 +1049,9 @@ SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = date_trunc('year', dt);
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-05-30' - INTERVAL 2 MONTH AND last_day(date_trunc('day', dt)) != date_trunc('day', dt);", "t1")
 -- result:
-89/502
+502/502
 -- !result
 function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-12-30' - INTERVAL 2 MONTH AND last_day(date_trunc('day', dt)) != date_trunc('day', dt);", "t1")
 -- result:
-303/502
+502/502
 -- !result

--- a/test/sql/test_automatic_partition/T/test_partition_prune_with_last_day
+++ b/test/sql/test_automatic_partition/T/test_partition_prune_with_last_day
@@ -1,6 +1,6 @@
 -- name: test_partition_prune_with_last_day
 
--- set disable_function_fold_constants=true;
+set disable_function_fold_constants=true;
 
 CREATE TABLE t1 (
     dt datetime,

--- a/test/sql/test_automatic_partition/T/test_partition_prune_with_last_day
+++ b/test/sql/test_automatic_partition/T/test_partition_prune_with_last_day
@@ -1,0 +1,298 @@
+-- name: test_partition_prune_with_last_day
+
+-- set disable_function_fold_constants=true;
+
+CREATE TABLE t1 (
+    dt datetime,
+    province string,
+    num int
+)
+DUPLICATE KEY(dt, province)
+PARTITION BY date_trunc('day', dt)
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t1(dt, province, num)
+SELECT minutes_add(hours_add(date_add('2025-01-01', x), x%24), x%60), concat('x-', x%3), x
+FROM TABLE(generate_series(0, 200-1)) as t(x);
+-- Check the number of partitions
+INSERT INTO t1(dt, province, num) SELECT NULL, NULL, NULL;
+function: print_plan_partition_selected_num("select count(*) from t1 where last_day(dt) = '2025-01-01';", "t1")
+
+function: print_table_partitions_num("t1")
+
+select last_day('2025-01-01');
+select last_day('2025-01-02');
+select last_day('2025-02-28');
+select last_day('invalid');
+select last_day(null);
+
+SELECT dt, last_day(dt) AS last_day_val FROM t1 ORDER BY dt limit 10;
+-- check last_day function
+select count(*) from t1 where last_day(dt) = '2025-01-01';
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-01-31';
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-02-28';
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-03-31';
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-04-30';
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-05-31';
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-06-30';
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-07-31';
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-08-31';
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-09-30';
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-10-31';
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-11-30';
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-12-31';
+SELECT count(*) FROM t1 WHERE last_day(dt) is NULL;
+SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-01-31';
+SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-02-28';
+SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-09-28';
+SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-28';
+SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31';
+SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt) is NULL;
+SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('day', dt);
+SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('month', dt);
+SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('year', dt);
+
+select count(*) from t1 where last_day(dt, 'month') = '2025-01-01';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-01-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-02-28';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-03-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-04-30';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-05-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-06-30';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-07-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-08-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-09-30';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-10-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-11-30';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-12-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') is NULL;
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-01-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-02-28';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-09-28';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-12-28';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-12-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt, 'month') is NULL;
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = date_trunc('day', dt);
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = date_trunc('month', dt);
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = date_trunc('year', dt);
+select count(*) from t1 where last_day(dt, 'quarter') = '2025-01-01';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-01-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-02-28';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-03-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-04-30';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-05-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-06-30';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-07-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-08-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-09-30';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-10-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-11-30';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-12-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') is NULL;
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-01-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-02-28';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-09-28';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-12-28';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-12-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt, 'quarter') is NULL;
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = date_trunc('day', dt);
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = date_trunc('month', dt);
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = date_trunc('year', dt);
+select count(*) from t1 where last_day(dt, 'year') = '2025-01-01';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-01-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-02-28';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-03-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-04-30';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-05-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-06-30';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-07-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-08-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-09-30';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-10-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-11-30';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-12-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') is NULL;
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-01-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-02-28';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-09-28';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-12-28';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-12-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt, 'year') is NULL;
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = date_trunc('day', dt);
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = date_trunc('month', dt);
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = date_trunc('year', dt);
+SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-05-30' - INTERVAL 2 MONTH AND last_day(date_trunc('day', dt)) != date_trunc('day', dt);
+SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-12-30' - INTERVAL 2 MONTH AND last_day(date_trunc('day', dt)) != date_trunc('day', dt);
+
+function: print_plan_partition_selected_num("select count(*) from t1 where last_day(dt) = '2025-01-01';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-01-31';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-02-28';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-03-31';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-04-30';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-05-31';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-06-30';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-07-31';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-08-31';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-09-30';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-10-31';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-11-30';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-12-31';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) is NULL;", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-01-31';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-02-28';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-09-28';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-28';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt) is NULL;", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('day', dt);", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('month', dt);", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('year', dt);", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-05-30' - INTERVAL 2 MONTH AND last_day(date_trunc('day', dt)) != date_trunc('day', dt);", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-12-30' - INTERVAL 2 MONTH AND last_day(date_trunc('day', dt)) != date_trunc('day', dt);", "t1")
+
+
+drop table if exists t1;
+CREATE TABLE t1 (
+    dt date,
+    province string,
+    num int
+)
+DUPLICATE KEY(dt, province)
+PARTITION BY date_trunc('day', dt)
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t1(dt, province, num)
+SELECT minutes_add(hours_add(date_add('2025-01-01', x), x%24), x%60), concat('x-', x%3), x
+FROM TABLE(generate_series(0, 200-1)) as t(x);
+-- Check the number of partitions
+INSERT INTO t1(dt, province, num) SELECT NULL, NULL, NULL;
+
+function: print_table_partitions_num("t1")
+
+SELECT dt, last_day(dt) AS last_day_val FROM t1 ORDER BY dt limit 10;
+-- check last_day function
+select count(*) from t1 where last_day(dt) = '2025-01-01';
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-01-31';
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-02-28';
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-03-31';
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-04-30';
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-05-31';
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-06-30';
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-07-31';
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-08-31';
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-09-30';
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-10-31';
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-11-30';
+SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-12-31';
+SELECT count(*) FROM t1 WHERE last_day(dt) is NULL;
+SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-01-31';
+SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-02-28';
+SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-09-28';
+SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-28';
+SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31';
+SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt) is NULL;
+SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('day', dt);
+SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('month', dt);
+SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('year', dt);
+SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-05-30' - INTERVAL 2 MONTH AND last_day(date_trunc('day', dt)) != date_trunc('day', dt);
+SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-12-30' - INTERVAL 2 MONTH AND last_day(date_trunc('day', dt)) != date_trunc('day', dt);
+
+function: print_plan_partition_selected_num("select count(*) from t1 where last_day(dt) = '2025-01-01';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-01-31';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-02-28';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-03-31';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-04-30';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-05-31';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-06-30';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-07-31';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-08-31';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-09-30';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-10-31';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-11-30';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = '2025-12-31';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) is NULL;", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-01-31';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-02-28';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-09-28';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-28';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31';", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt) is NULL;", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('day', dt);", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('month', dt);", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE last_day(dt) = date_trunc('year', dt);", "t1")
+
+select count(*) from t1 where last_day(dt, 'month') = '2025-01-01';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-01-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-02-28';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-03-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-04-30';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-05-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-06-30';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-07-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-08-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-09-30';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-10-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-11-30';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = '2025-12-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') is NULL;
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-01-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-02-28';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-09-28';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-12-28';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-12-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt, 'month') is NULL;
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = date_trunc('day', dt);
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = date_trunc('month', dt);
+SELECT count(*) FROM t1 WHERE last_day(dt, 'month') = date_trunc('year', dt);
+select count(*) from t1 where last_day(dt, 'quarter') = '2025-01-01';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-01-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-02-28';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-03-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-04-30';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-05-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-06-30';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-07-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-08-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-09-30';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-10-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-11-30';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = '2025-12-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') is NULL;
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-01-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-02-28';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-09-28';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-12-28';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-12-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt, 'quarter') is NULL;
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = date_trunc('day', dt);
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = date_trunc('month', dt);
+SELECT count(*) FROM t1 WHERE last_day(dt, 'quarter') = date_trunc('year', dt);
+select count(*) from t1 where last_day(dt, 'year') = '2025-01-01';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-01-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-02-28';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-03-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-04-30';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-05-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-06-30';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-07-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-08-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-09-30';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-10-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-11-30';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = '2025-12-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') is NULL;
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-01-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-02-28';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-09-28';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-12-28';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-12-31';
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') BETWEEN '2025-01-01' AND '2025-12-31' or last_day(dt, 'year') is NULL;
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = date_trunc('day', dt);
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = date_trunc('month', dt);
+SELECT count(*) FROM t1 WHERE last_day(dt, 'year') = date_trunc('year', dt);
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-05-30' - INTERVAL 2 MONTH AND last_day(date_trunc('day', dt)) != date_trunc('day', dt);", "t1")
+function: print_plan_partition_selected_num("SELECT count(*) FROM t1 WHERE  date_trunc('day', dt) < '2025-12-30' - INTERVAL 2 MONTH AND last_day(date_trunc('day', dt)) != date_trunc('day', dt);", "t1")

--- a/test/sql/test_automatic_partition/T/test_partition_prune_with_last_day
+++ b/test/sql/test_automatic_partition/T/test_partition_prune_with_last_day
@@ -15,7 +15,7 @@ PROPERTIES (
 
 INSERT INTO t1(dt, province, num)
 SELECT minutes_add(hours_add(date_add('2025-01-01', x), x%24), x%60), concat('x-', x%3), x
-FROM TABLE(generate_series(0, 200-1)) as t(x);
+FROM TABLE(generate_series(0, 500)) as t(x);
 -- Check the number of partitions
 INSERT INTO t1(dt, province, num) SELECT NULL, NULL, NULL;
 function: print_plan_partition_selected_num("select count(*) from t1 where last_day(dt) = '2025-01-01';", "t1")
@@ -167,7 +167,7 @@ PROPERTIES (
 
 INSERT INTO t1(dt, province, num)
 SELECT minutes_add(hours_add(date_add('2025-01-01', x), x%24), x%60), concat('x-', x%3), x
-FROM TABLE(generate_series(0, 200-1)) as t(x);
+FROM TABLE(generate_series(0, 500)) as t(x);
 -- Check the number of partitions
 INSERT INTO t1(dt, province, num) SELECT NULL, NULL, NULL;
 

--- a/test/sql/test_automatic_partition/T/test_partition_prune_with_last_day
+++ b/test/sql/test_automatic_partition/T/test_partition_prune_with_last_day
@@ -1,6 +1,6 @@
 -- name: test_partition_prune_with_last_day
 
-set disable_function_fold_constants=true;
+-- set disable_function_fold_constants=true;
 
 CREATE TABLE t1 (
     dt datetime,


### PR DESCRIPTION
## Why I'm doing:
https://github.com/StarRocks/starrocks/pull/23348 has introduced `last_day` function and can be evaluated in `be`. But there are some limitations:

1. `last_day` is monotonic (not strict monotonic) and can be used in the partition prune, but it is not used for now since it cannot be constant evaluated in FE.

2. `last_day` only implements `datetime` input argument in be and will add extra `cast` for `date` type's argument.


## What I'm doing:
1.  Support  `last_day` constant evaluation in FE and partition pruning
2. Support `date` argument in be's implmention.
3. Fix partition pruning bug with inifinity values in testing:
```
        /**
         * Get the infinity range for the given child operator.
         * @param child0: the child operator to evaluate, eg: isNullOperator's first child
         * @return: an Optional containing the infinity range if successful, or empty if it fails
         */
        private Optional<Range<PartitionKey>> getInfinityRange(ScalarOperator child0) {
            Type columnType = child0.getType();
            try {
                if (child0 instanceof CallOperator) {
                    // For CallOperator, we need to evaluate the infinity value as the range bound
                    // to check it with the child0's range bound, otherwise some corner cases may fail.
                    // eg:
                    // partition predicate: last_day(dt) is null
                    // p0: [0000-01-01, 2000-01-01]
                    // old :
                    // check the infinity range(0000-01-01) to child0's range(0000-01-31, 2000-01-31),
                    //  and cause p0 is not interacted with the infinity range which will may p0 will be pruned.
                    // current:
                    // check the infinity range's evaluate result (0000-01-31) to child0's range(0000-01-31, 2000-01-31),
                    // and cause p0 is interacted with the infinity range which will not be pruned.
                    CallOperator callOperator = (CallOperator) child0;
                    LiteralExpr infinityLiteral = createInfinity(columnType, false);
                    Optional<LiteralExpr> newLiteralOpt = mapRangeBoundValue(callOperator, infinityLiteral);
                    if (newLiteralOpt.isEmpty()) {
                        return Optional.empty();
                    }
                    PartitionKey conditionKey = new PartitionKey();
                    conditionKey.pushColumn(newLiteralOpt.get(), columnType.getPrimitiveType());
                    return Optional.of(Range.closed(conditionKey, conditionKey));
                } else {
                    PartitionKey conditionKey = new PartitionKey();
                    conditionKey.pushColumn(LiteralExpr.createInfinity(columnType, false), columnType.getPrimitiveType());
                    return Optional.of(Range.closed(conditionKey, conditionKey));
                }
            } catch (AnalysisException e) {
                return Optional.empty();
            }
        }
```
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
