### PR TITLE
[BugFix] fix skip write txnlog when compaction fail

### DIFF
--- a/be/src/storage/lake/cloud_native_index_compaction_task.cpp
+++ b/be/src/storage/lake/cloud_native_index_compaction_task.cpp
@@ -28,6 +28,7 @@ Status CloudNativeIndexCompactionTask::execute(CancelFunc cancel_func, ThreadPoo
     RETURN_IF_ERROR(cancel_func());
     RETURN_IF_ERROR(execute_index_major_compaction(txn_log.get()));
     _context->progress.update(100);
+    TEST_ERROR_POINT("CloudNativeIndexCompactionTask::execute::1");
     if (_context->skip_write_txnlog) {
         // return txn_log to caller later
         _context->txn_log = txn_log;

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -126,7 +126,8 @@ void CompactionTaskCallback::finish_task(std::unique_ptr<CompactionTaskContext>&
     compact_stat->set_in_queue_time_sec(context->stats->in_queue_time_sec);
     compact_stat->set_sub_task_count(_request->tablet_ids_size());
     compact_stat->set_total_compact_input_file_size(context->stats->input_file_size);
-    if (context->skip_write_txnlog) {
+    if (context->skip_write_txnlog && context->txn_log != nullptr) {
+        // context->txn_log could be nullptr if the task is failed before writing txn log.
         _response->add_txn_logs()->CopyFrom(*context->txn_log);
     }
     DCHECK(_request != nullptr);

--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -121,6 +121,7 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
     RETURN_IF_ERROR(fill_compaction_segment_info(op_compaction, writer.get()));
     op_compaction->set_compact_version(_tablet.metadata()->version());
     RETURN_IF_ERROR(execute_index_major_compaction(txn_log.get()));
+    TEST_ERROR_POINT("HorizontalCompactionTask::execute::1");
     if (_context->skip_write_txnlog) {
         // return txn_log to caller later
         _context->txn_log = txn_log;

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -92,6 +92,7 @@ Status VerticalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush
     RETURN_IF_ERROR(fill_compaction_segment_info(op_compaction, writer.get()));
     op_compaction->set_compact_version(_tablet.metadata()->version());
     RETURN_IF_ERROR(execute_index_major_compaction(txn_log.get()));
+    TEST_ERROR_POINT("VerticalCompactionTask::execute::1");
     if (_context->skip_write_txnlog) {
         // return txn_log to caller later
         _context->txn_log = txn_log;


### PR DESCRIPTION
## Why I'm doing:
After this pr #58441, we introduce compaction txnlog aggregation. And after that if compaction task run fail, and `txn_log` in compaction context will be nullptr, and it will lead to BE crash:
```
*** Aborted at 1748517018 (unix time) try "date -d @1748517018" if you are using GNU date ***
PC: @          0x45c8113 starrocks::TxnLogPB::MergeFrom(starrocks::TxnLogPB const&)
*** SIGSEGV (@0x8) received by PID 2951 (TID 0x2ae430401700) LWP(3307) from PID 8; stack trace: ***
    @     0x2ae3f813020b __pthread_once_slow
    @          0xb74cc14 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x2ae3f90d1999 PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0]
    @     0x2ae3f90d23ee JVM_handle_linux_signal
    @     0x2ae3f8139630 (/usr/lib64/libpthread-2.17.so+0xf62f)
    @          0x45c8113 starrocks::TxnLogPB::MergeFrom(starrocks::TxnLogPB const&)
    @          0x74beac6 starrocks::lake::CompactionTaskCallback::finish_task(std::unique_ptr<starrocks::lake::CompactionTaskContext, std::default_delete<starrocks::lake::CompactionTaskContext> >&&)
    @          0x74bf32b starrocks::lake::CompactionScheduler::do_compaction(std::unique_ptr<starrocks::lake::CompactionTaskContext, std::default_delete<starrocks::lake::CompactionTaskContext> >)
    @          0x74c0301 starrocks::lake::CompactionScheduler::thread_task(int)
    @          0x409b21f starrocks::ThreadPool::dispatch_thread()
    @          0x40927f0 starrocks::Thread::supervise_thread(void*)
    @     0x2ae3f8131ea5 start_thread
```

## What I'm doing:
This pull request introduces error injection points for testing and enhances the robustness of compaction task handling. It also adds a new test case to validate behavior when transaction logs are not written due to errors.

### Enhancements for Error Injection and Testing:

* Added `TEST_ERROR_POINT` injection points in the `execute` methods of `CloudNativeIndexCompactionTask`, `HorizontalCompactionTask`, and `VerticalCompactionTask` to simulate errors during execution. (`be/src/storage/lake/cloud_native_index_compaction_task.cpp` [[1]](diffhunk://#diff-c98fc4171f3b904cf4f550faa5f045aa4345effaf0a13a910da5834b7c99c377R31) `be/src/storage/lake/horizontal_compaction_task.cpp` [[2]](diffhunk://#diff-f7fd3e76508b60fb1199994d6d4d507b253a851a7a0083b296176481905d0ef6R124) `be/src/storage/lake/vertical_compaction_task.cpp` [[3]](diffhunk://#diff-a1ab8c006c1ef5ff09f84e1efb5bc6a947967bc096730c0be13884068a8071dfR95)

* Introduced a new test case `test_abort_with_not_write_txnlog` in `LakeCompactionSchedulerTest` to ensure proper handling of scenarios where transaction logs are not written due to simulated errors. (`be/test/storage/lake/compaction_scheduler_test.cpp` [be/test/storage/lake/compaction_scheduler_test.cppR278-R300](diffhunk://#diff-8507a12783ef3aad5e84e1b5f50500070432485ce39af651c0d9631f94a20a16R278-R300))

### Improvements to Compaction Task Handling:

* Updated the `finish_task` method in `CompactionTaskCallback` to check for `nullptr` before accessing `txn_log`, ensuring robustness when the task fails before writing a transaction log. (`be/src/storage/lake/compaction_scheduler.cpp` [be/src/storage/lake/compaction_scheduler.cppL129-R130](diffhunk://#diff-b7596da4b0efc7497bb03b532a6c06fa793ae1165161ed5f9d91a12320ee0519L129-R130))

Fix #58316

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
