### PR TITLE
[BugFix] fix LambdaFunction's isConst always return false

### DIFF
--- a/be/src/exprs/lambda_function.h
+++ b/be/src/exprs/lambda_function.h
@@ -64,7 +64,7 @@ public:
 
     bool is_lambda_function() const override { return true; }
     bool is_lambda_expr_independent() const { return _is_lambda_expr_independent; }
-    bool is_constant() const {return true;}
+    bool is_constant() const { return true; }
 
     Expr* get_lambda_expr() const { return _children[0]; }
     std::string debug_string() const override;

--- a/be/src/exprs/lambda_function.h
+++ b/be/src/exprs/lambda_function.h
@@ -64,7 +64,7 @@ public:
 
     bool is_lambda_function() const override { return true; }
     bool is_lambda_expr_independent() const { return _is_lambda_expr_independent; }
-    bool is_constant() const { return true; }
+    bool is_constant() const override { return true; }
 
     Expr* get_lambda_expr() const { return _children[0]; }
     std::string debug_string() const override;

--- a/be/src/exprs/lambda_function.h
+++ b/be/src/exprs/lambda_function.h
@@ -64,6 +64,7 @@ public:
 
     bool is_lambda_function() const override { return true; }
     bool is_lambda_expr_independent() const { return _is_lambda_expr_independent; }
+    bool is_constant() const {return true;}
 
     Expr* get_lambda_expr() const { return _children[0]; }
     std::string debug_string() const override;

--- a/test/sql/test_array/R/test_array_map
+++ b/test/sql/test_array/R/test_array_map
@@ -125,3 +125,14 @@ WITH `CTE` AS (
 [1]	[1]
 [1]	[1]
 -- !result
+with t1 as (
+ select parse_json('[{"open_id": "aaa", "num": 1},{"open_id": "bbb", "num": 2},{"open_id": "ccc", "num": 3}]') as price_list
+),t2 as (
+ select price_list,array_map(x -> get_json_string(x,'$.open_id'), cast(price_list as array<json>)  ) as  fields
+ from t1  
+)
+select * from t2 
+where  array_contains(fields,'bbb')
+-- result:
+[{"num": 1, "open_id": "aaa"}, {"num": 2, "open_id": "bbb"}, {"num": 3, "open_id": "ccc"}]	["aaa","bbb","ccc"]
+-- !result

--- a/test/sql/test_array/R/test_array_map
+++ b/test/sql/test_array/R/test_array_map
@@ -132,7 +132,7 @@ with t1 as (
  from t1  
 )
 select * from t2 
-where  array_contains(fields,'bbb')
+where  array_contains(fields,'bbb');
 -- result:
 [{"num": 1, "open_id": "aaa"}, {"num": 2, "open_id": "bbb"}, {"num": 3, "open_id": "ccc"}]	["aaa","bbb","ccc"]
 -- !result

--- a/test/sql/test_array/T/test_array_map
+++ b/test/sql/test_array/T/test_array_map
@@ -112,3 +112,14 @@ WITH `CTE` AS (
     UNION ALL
     SELECT TRUE AS bool_1, TRUE AS bool_2, TRUE AS bool_3, ["a"] AS arr
 ) SELECT ARRAY_MAP((arg)->`bool_1` AND `bool_2` AND `bool_3`, arr), ARRAY_MAP((arg)->`bool_1` AND `bool_3` AND `bool_2`, arr) FROM `CTE`;
+
+
+-- test array_map with const child
+with t1 as (
+ select parse_json('[{"open_id": "aaa", "num": 1},{"open_id": "bbb", "num": 2},{"open_id": "ccc", "num": 3}]') as price_list
+),t2 as (
+ select price_list,array_map(x -> get_json_string(x,'$.open_id'), cast(price_list as array<json>)  ) as  fields
+ from t1  
+)
+select * from t2 
+where  array_contains(fields,'bbb')

--- a/test/sql/test_array/T/test_array_map
+++ b/test/sql/test_array/T/test_array_map
@@ -122,4 +122,4 @@ with t1 as (
  from t1  
 )
 select * from t2 
-where  array_contains(fields,'bbb')
+where  array_contains(fields,'bbb');


### PR DESCRIPTION
## Why I'm doing:
 lambda exp like array_map's isConst() always return false, but actually lambda expr's isConst should rely only on childs except first one: LambdaFunction which always return false right now because it has fake ColumnRef

## What I'm doing:
LambdaFunction's isConst can return ture.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
