### PR TITLE
[Enhancement] Add failpoints for load

### DIFF
--- a/be/src/exec/tablet_sink_index_channel.cpp
+++ b/be/src/exec/tablet_sink_index_channel.cpp
@@ -28,6 +28,7 @@
 #include "gutil/strings/fastmem.h"
 #include "gutil/strings/join.h"
 #include "runtime/current_thread.h"
+#include "runtime/load_fail_point.h"
 #include "runtime/runtime_state.h"
 #include "serde/protobuf_serde.h"
 #include "testutil/sync_point.h"
@@ -249,10 +250,12 @@ void NodeChannel::_open(int64_t index_id, RefCountClosure<PTabletWriterOpenResul
             LOG(ERROR) << res.status().message();
             return;
         }
+        FAIL_POINT_TRIGGER_EXECUTE(load_tablet_writer_open, TABLET_WRITER_OPEN_FP_ACTION(open_closure, request));
         res.value()->tablet_writer_open(&open_closure->cntl, &request, &open_closure->result, open_closure);
         VLOG(2) << "NodeChannel::_open() issue a http rpc, request size = " << request.ByteSizeLong();
     } else {
 #ifndef BE_TEST
+        FAIL_POINT_TRIGGER_EXECUTE(load_tablet_writer_open, TABLET_WRITER_OPEN_FP_ACTION(open_closure, request));
         _stub->tablet_writer_open(&open_closure->cntl, &request, &open_closure->result, open_closure);
 #else
         std::pair<PTabletWriterOpenRequest*, RefCountClosure<PTabletWriterOpenResult>*> rpc_pair{&request,
@@ -723,10 +726,15 @@ Status NodeChannel::_send_request(bool eos, bool finished) {
             }
             auto closure = _add_batch_closures[_current_request_index];
             serialize_to_iobuf<PTabletWriterAddChunksRequest>(request, &closure->cntl.request_attachment());
+            FAIL_POINT_TRIGGER_EXECUTE(load_tablet_writer_add_chunks,
+                                       TABLET_WRITER_ADD_CHUNKS_FP_ACTION(closure, request));
             res.value()->tablet_writer_add_chunks_via_http(&closure->cntl, nullptr, &closure->result, closure);
             VLOG(2) << "NodeChannel::_send_request() issue a http rpc, request size = "
                     << closure->cntl.request_attachment().size();
         } else {
+            FAIL_POINT_TRIGGER_EXECUTE(
+                    load_tablet_writer_add_chunks,
+                    TABLET_WRITER_ADD_CHUNKS_FP_ACTION(_add_batch_closures[_current_request_index], request));
             _stub->tablet_writer_add_chunks(&_add_batch_closures[_current_request_index]->cntl, &request,
                                             &_add_batch_closures[_current_request_index]->result,
                                             _add_batch_closures[_current_request_index]);
@@ -745,11 +753,16 @@ Status NodeChannel::_send_request(bool eos, bool finished) {
             auto closure = _add_batch_closures[_current_request_index];
             serialize_to_iobuf<PTabletWriterAddChunkRequest>(*request.mutable_requests(0),
                                                              &closure->cntl.request_attachment());
+            FAIL_POINT_TRIGGER_EXECUTE(load_tablet_writer_add_chunks,
+                                       TABLET_WRITER_ADD_CHUNKS_FP_ACTION(closure, request));
             res.value()->tablet_writer_add_chunk_via_http(&closure->cntl, nullptr, &closure->result, closure);
             VLOG(2) << "NodeChannel::_send_request() issue a http rpc, request size = "
                     << closure->cntl.request_attachment().size();
         } else {
 #ifndef BE_TEST
+            FAIL_POINT_TRIGGER_EXECUTE(
+                    load_tablet_writer_add_chunks,
+                    TABLET_WRITER_ADD_CHUNKS_FP_ACTION(_add_batch_closures[_current_request_index], request));
             _stub->tablet_writer_add_chunk(
                     &_add_batch_closures[_current_request_index]->cntl, request.mutable_requests(0),
                     &_add_batch_closures[_current_request_index]->result, _add_batch_closures[_current_request_index]);
@@ -1095,6 +1108,8 @@ void NodeChannel::_cancel(int64_t index_id, const Status& err_st) {
     closure->ref();
     closure->cntl.set_timeout_ms(_rpc_timeout_ms);
     SET_IGNORE_OVERCROWDED(closure->cntl, load);
+    FAIL_POINT_TRIGGER_EXECUTE(load_tablet_writer_cancel,
+                               TABLET_WRITER_CANCEL_FP_ACTION(closure, closure->cntl, request));
     _stub->tablet_writer_cancel(&closure->cntl, &request, &closure->result, closure);
     request.release_id();
 }

--- a/be/src/exec/tablet_sink_index_channel.cpp
+++ b/be/src/exec/tablet_sink_index_channel.cpp
@@ -250,12 +250,14 @@ void NodeChannel::_open(int64_t index_id, RefCountClosure<PTabletWriterOpenResul
             LOG(ERROR) << res.status().message();
             return;
         }
-        FAIL_POINT_TRIGGER_EXECUTE(load_tablet_writer_open, TABLET_WRITER_OPEN_FP_ACTION(open_closure, request));
+        FAIL_POINT_TRIGGER_EXECUTE(load_tablet_writer_open,
+                                   TABLET_WRITER_OPEN_FP_ACTION(_node_info->host, open_closure, request));
         res.value()->tablet_writer_open(&open_closure->cntl, &request, &open_closure->result, open_closure);
         VLOG(2) << "NodeChannel::_open() issue a http rpc, request size = " << request.ByteSizeLong();
     } else {
 #ifndef BE_TEST
-        FAIL_POINT_TRIGGER_EXECUTE(load_tablet_writer_open, TABLET_WRITER_OPEN_FP_ACTION(open_closure, request));
+        FAIL_POINT_TRIGGER_EXECUTE(load_tablet_writer_open,
+                                   TABLET_WRITER_OPEN_FP_ACTION(_node_info->host, open_closure, request));
         _stub->tablet_writer_open(&open_closure->cntl, &request, &open_closure->result, open_closure);
 #else
         std::pair<PTabletWriterOpenRequest*, RefCountClosure<PTabletWriterOpenResult>*> rpc_pair{&request,
@@ -727,14 +729,14 @@ Status NodeChannel::_send_request(bool eos, bool finished) {
             auto closure = _add_batch_closures[_current_request_index];
             serialize_to_iobuf<PTabletWriterAddChunksRequest>(request, &closure->cntl.request_attachment());
             FAIL_POINT_TRIGGER_EXECUTE(load_tablet_writer_add_chunks,
-                                       TABLET_WRITER_ADD_CHUNKS_FP_ACTION(closure, request));
+                                       TABLET_WRITER_ADD_CHUNKS_FP_ACTION(_node_info->host, closure, request));
             res.value()->tablet_writer_add_chunks_via_http(&closure->cntl, nullptr, &closure->result, closure);
             VLOG(2) << "NodeChannel::_send_request() issue a http rpc, request size = "
                     << closure->cntl.request_attachment().size();
         } else {
-            FAIL_POINT_TRIGGER_EXECUTE(
-                    load_tablet_writer_add_chunks,
-                    TABLET_WRITER_ADD_CHUNKS_FP_ACTION(_add_batch_closures[_current_request_index], request));
+            FAIL_POINT_TRIGGER_EXECUTE(load_tablet_writer_add_chunks,
+                                       TABLET_WRITER_ADD_CHUNKS_FP_ACTION(
+                                               _node_info->host, _add_batch_closures[_current_request_index], request));
             _stub->tablet_writer_add_chunks(&_add_batch_closures[_current_request_index]->cntl, &request,
                                             &_add_batch_closures[_current_request_index]->result,
                                             _add_batch_closures[_current_request_index]);
@@ -754,15 +756,15 @@ Status NodeChannel::_send_request(bool eos, bool finished) {
             serialize_to_iobuf<PTabletWriterAddChunkRequest>(*request.mutable_requests(0),
                                                              &closure->cntl.request_attachment());
             FAIL_POINT_TRIGGER_EXECUTE(load_tablet_writer_add_chunks,
-                                       TABLET_WRITER_ADD_CHUNKS_FP_ACTION(closure, request));
+                                       TABLET_WRITER_ADD_CHUNKS_FP_ACTION(_node_info->host, closure, request));
             res.value()->tablet_writer_add_chunk_via_http(&closure->cntl, nullptr, &closure->result, closure);
             VLOG(2) << "NodeChannel::_send_request() issue a http rpc, request size = "
                     << closure->cntl.request_attachment().size();
         } else {
 #ifndef BE_TEST
-            FAIL_POINT_TRIGGER_EXECUTE(
-                    load_tablet_writer_add_chunks,
-                    TABLET_WRITER_ADD_CHUNKS_FP_ACTION(_add_batch_closures[_current_request_index], request));
+            FAIL_POINT_TRIGGER_EXECUTE(load_tablet_writer_add_chunks,
+                                       TABLET_WRITER_ADD_CHUNKS_FP_ACTION(
+                                               _node_info->host, _add_batch_closures[_current_request_index], request));
             _stub->tablet_writer_add_chunk(
                     &_add_batch_closures[_current_request_index]->cntl, request.mutable_requests(0),
                     &_add_batch_closures[_current_request_index]->result, _add_batch_closures[_current_request_index]);
@@ -1109,7 +1111,7 @@ void NodeChannel::_cancel(int64_t index_id, const Status& err_st) {
     closure->cntl.set_timeout_ms(_rpc_timeout_ms);
     SET_IGNORE_OVERCROWDED(closure->cntl, load);
     FAIL_POINT_TRIGGER_EXECUTE(load_tablet_writer_cancel,
-                               TABLET_WRITER_CANCEL_FP_ACTION(closure, closure->cntl, request));
+                               TABLET_WRITER_CANCEL_FP_ACTION(_node_info->host, closure, closure->cntl, request));
     _stub->tablet_writer_cancel(&closure->cntl, &request, &closure->result, closure);
     request.release_id();
 }

--- a/be/src/runtime/CMakeLists.txt
+++ b/be/src/runtime/CMakeLists.txt
@@ -108,6 +108,7 @@ set(RUNTIME_FILES
     customized_result_writer.cpp
     int128_to_double.cpp
     diagnose_daemon.cpp
+    load_fail_point.cpp
 )
 
 set(RUNTIME_FILES ${RUNTIME_FILES}

--- a/be/src/runtime/load_fail_point.cpp
+++ b/be/src/runtime/load_fail_point.cpp
@@ -1,0 +1,113 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runtime/load_fail_point.h"
+
+#ifdef FIU_ENABLE
+#include "gutil/strings/join.h"
+#include "service/backend_options.h"
+#include "util/uid_util.h"
+#endif
+
+namespace starrocks::load::failpoint {
+
+DEFINE_FAIL_POINT(load_tablet_writer_open);
+DEFINE_FAIL_POINT(load_tablet_writer_add_chunks);
+DEFINE_FAIL_POINT(load_tablet_writer_add_segment);
+DEFINE_FAIL_POINT(load_tablet_writer_cancel);
+DEFINE_FAIL_POINT(load_commit_txn);
+DEFINE_FAIL_POINT(load_memtable_flush);
+DEFINE_FAIL_POINT(load_segment_flush);
+DEFINE_FAIL_POINT(load_pk_preload);
+
+#ifdef FIU_ENABLE
+
+#define LOG_FP(name) LOG(INFO) << "load_failpoint: " << #name
+#define LOG_BRPC_FP(name, cntl, request)                                                        \
+    LOG_FP(name) << ", remote_ip: " << get_remote_ip(cntl) << ", txn_id: " << request->txn_id() \
+                 << ", load_id: " << print_id(request->id())
+
+#define BRPC_ERROR_MSG(name, txn_id) \
+    fmt::format("{} failpoint triggered failure, be: {}, txn_id: {}", #name, BackendOptions::get_localhost(), txn_id)
+#define IO_ERROR_MSG(name, txn_id, tablet_id) \
+    fmt::format("{} failpoint triggered failure, txn_id: {}, tablet_id: {}", #name, txn_id, tablet_id)
+
+std::string get_remote_ip(const brpc::Controller& cntl) {
+    return butil::ip2str(cntl.remote_side().ip).c_str();
+}
+
+void tablet_writer_open_fp_action(RefCountClosure<PTabletWriterOpenResult>* closure,
+                                  PTabletWriterOpenRequest* request) {
+    std::string tablet_ids = JoinMapped(
+            request->tablets(), [](const PTabletWithPartition& tablet) { return std::to_string(tablet.tablet_id()); },
+            ",");
+    LOG_BRPC_FP(load_tablet_writer_open, closure->cntl, request)
+            << ", send_id: " << request->sender_id() << ", tablet_ids: " << tablet_ids;
+    closure->cntl.SetFailed(BRPC_ERROR_MSG(load_tablet_writer_open, request->txn_id()));
+    brpc::StartCancel(closure->cntl.call_id());
+}
+
+void tablet_writer_add_chunks_fp_action(ReusableClosure<PTabletWriterAddBatchResult>* closure,
+                                        PTabletWriterAddChunksRequest* request) {
+    CHECK(request->requests().size() > 0);
+    LOG_BRPC_FP(load_tablet_writer_add_chunks, closure->cntl, request->mutable_requests(0))
+            << ", send_id: " << request->mutable_requests(0)->sender_id();
+    closure->cntl.SetFailed(BRPC_ERROR_MSG(load_tablet_writer_add_chunks, request->mutable_requests(0)->txn_id()));
+    closure->cancel();
+}
+
+void tablet_writer_add_segment_fp_action(ReusableClosure<PTabletWriterAddSegmentResult>* closure,
+                                         PTabletWriterAddSegmentRequest* request) {
+    LOG_BRPC_FP(load_tablet_writer_add_segment, closure->cntl, request) << ", tablet_id: " << request->tablet_id();
+    closure->cntl.SetFailed(BRPC_ERROR_MSG(load_tablet_writer_add_segment, request->txn_id()));
+    closure->cancel();
+}
+
+void tablet_writer_cancel_fp_action(::google::protobuf::Closure* closure, brpc::Controller* cntl,
+                                    PTabletWriterCancelRequest* request) {
+    std::string tablet_ids;
+    if (request->has_tablet_id()) {
+        tablet_ids = std::to_string(request->tablet_id());
+    } else if (!request->tablet_ids().empty()) {
+        tablet_ids = JoinElements(request->tablet_ids(), ",");
+    }
+    LOG_BRPC_FP(load_tablet_writer_cancel, *cntl, request) << ", send_id: " << request->sender_id() << ", tablet_ids: ("
+                                                           << tablet_ids << "), reason: " << request->reason();
+    cntl->SetFailed(BRPC_ERROR_MSG(load_tablet_writer_cancel, request->txn_id()));
+    brpc::StartCancel(cntl->call_id());
+}
+
+Status memtable_flush_fp_action(int64_t txn_id, int64_t tablet_id) {
+    LOG_FP(load_memtable_flush) << ", txn_id: " << txn_id << ", tablet_id: " << tablet_id;
+    return Status::IOError(IO_ERROR_MSG(load_memtable_flush, txn_id, tablet_id));
+}
+
+Status segment_flush_fp_action(int64_t txn_id, int64_t tablet_id) {
+    LOG_FP(load_segment_flush) << ", txn_id: " << txn_id << ", tablet_id: " << tablet_id;
+    return Status::IOError(IO_ERROR_MSG(load_segment_flush, txn_id, tablet_id));
+}
+
+Status pk_preload_fp_action(int64_t txn_id, int64_t tablet_id) {
+    LOG_FP(load_pk_preload) << ", txn_id: " << txn_id << ", tablet_id: " << tablet_id;
+    return Status::IOError(IO_ERROR_MSG(load_pk_preload, txn_id, tablet_id));
+}
+
+Status commit_txn_fp_action(int64_t txn_id, int64_t tablet_id) {
+    LOG_FP(load_commit_txn) << ", txn_id: " << txn_id << ", tablet_id: " << tablet_id;
+    return Status::IOError(IO_ERROR_MSG(load_commit_txn, txn_id, tablet_id));
+}
+
+#endif
+
+} // namespace starrocks::load::failpoint

--- a/be/src/runtime/load_fail_point.cpp
+++ b/be/src/runtime/load_fail_point.cpp
@@ -34,53 +34,55 @@ DEFINE_FAIL_POINT(load_pk_preload);
 #ifdef FIU_ENABLE
 
 #define LOG_FP(name) LOG(INFO) << "load_failpoint: " << #name
-#define LOG_BRPC_FP(name, cntl, request)                                                        \
-    LOG_FP(name) << ", remote_ip: " << get_remote_ip(cntl) << ", txn_id: " << request->txn_id() \
+#define LOG_BRPC_FP(name, remote_host, request)                                         \
+    LOG_FP(name) << ", remote_ip: " << remote_host << ", txn_id: " << request->txn_id() \
                  << ", load_id: " << print_id(request->id())
 
-#define BRPC_ERROR_MSG(name, txn_id) \
-    fmt::format("{} failpoint triggered failure, be: {}, txn_id: {}", #name, BackendOptions::get_localhost(), txn_id)
+#define BRPC_ERROR_MSG(name, remote_host, txn_id)                                                                    \
+    fmt::format("{} failpoint triggered failure, rpc: {} -> {}, txn_id: {}", #name, BackendOptions::get_localhost(), \
+                remote_host, txn_id)
 #define IO_ERROR_MSG(name, txn_id, tablet_id)                                               \
     fmt::format("{} failpoint triggered failure, be: {}, txn_id: {}, tablet_id: {}", #name, \
                 BackendOptions::get_localhost(), txn_id, tablet_id)
 
-std::string get_remote_ip(const brpc::Controller& cntl) {
-    return butil::ip2str(cntl.remote_side().ip).c_str();
-}
-
-void tablet_writer_open_fp_action(RefCountClosure<PTabletWriterOpenResult>* closure,
+void tablet_writer_open_fp_action(const std::string& remote_host, RefCountClosure<PTabletWriterOpenResult>* closure,
                                   PTabletWriterOpenRequest* request) {
     std::string tablet_ids = JoinMapped(
             request->tablets(), [](const PTabletWithPartition& tablet) { return std::to_string(tablet.tablet_id()); },
             ",");
-    LOG_BRPC_FP(load_tablet_writer_open, closure->cntl, request)
+    LOG_BRPC_FP(load_tablet_writer_open, remote_host, request)
             << ", send_id: " << request->sender_id() << ", tablet_ids: " << tablet_ids;
-    closure->cntl.SetFailed(BRPC_ERROR_MSG(load_tablet_writer_open, request->txn_id()));
+    closure->cntl.SetFailed(BRPC_ERROR_MSG(load_tablet_writer_open, remote_host, request->txn_id()));
 }
 
-void tablet_writer_add_chunks_fp_action(ReusableClosure<PTabletWriterAddBatchResult>* closure,
+void tablet_writer_add_chunks_fp_action(const std::string& remote_host,
+                                        ReusableClosure<PTabletWriterAddBatchResult>* closure,
                                         PTabletWriterAddChunksRequest* request) {
     CHECK(request->requests().size() > 0);
-    LOG_BRPC_FP(load_tablet_writer_add_chunks, closure->cntl, request->mutable_requests(0))
+    LOG_BRPC_FP(load_tablet_writer_add_chunks, remote_host, request->mutable_requests(0))
             << ", send_id: " << request->mutable_requests(0)->sender_id();
-    closure->cntl.SetFailed(BRPC_ERROR_MSG(load_tablet_writer_add_chunks, request->mutable_requests(0)->txn_id()));
+    closure->cntl.SetFailed(
+            BRPC_ERROR_MSG(load_tablet_writer_add_chunks, remote_host, request->mutable_requests(0)->txn_id()));
 }
 
-void tablet_writer_add_segment_fp_action(ReusableClosure<PTabletWriterAddSegmentResult>* closure,
+void tablet_writer_add_segment_fp_action(const std::string& remote_host,
+                                         ReusableClosure<PTabletWriterAddSegmentResult>* closure,
                                          PTabletWriterAddSegmentRequest* request) {
-    LOG_BRPC_FP(load_tablet_writer_add_segment, closure->cntl, request) << ", tablet_id: " << request->tablet_id();
-    closure->cntl.SetFailed(BRPC_ERROR_MSG(load_tablet_writer_add_segment, request->txn_id()));
+    LOG_BRPC_FP(load_tablet_writer_add_segment, remote_host, request) << ", tablet_id: " << request->tablet_id();
+    closure->cntl.SetFailed(BRPC_ERROR_MSG(load_tablet_writer_add_segment, remote_host, request->txn_id()) +
+                            ", tablet_id: " + std::to_string(request->tablet_id()));
 }
 
-void tablet_writer_cancel_fp_action(::google::protobuf::Closure* closure, brpc::Controller* cntl,
-                                    PTabletWriterCancelRequest* request) {
+void tablet_writer_cancel_fp_action(const std::string& remote_host, ::google::protobuf::Closure* closure,
+                                    brpc::Controller* cntl, PTabletWriterCancelRequest* request) {
     std::string tablet_ids;
     if (!request->tablet_ids().empty()) {
         tablet_ids = JoinElements(request->tablet_ids(), ",");
     }
-    LOG_BRPC_FP(load_tablet_writer_cancel, *cntl, request) << ", send_id: " << request->sender_id() << ", tablet_ids: ("
-                                                           << tablet_ids << "), reason: " << request->reason();
-    cntl->SetFailed(BRPC_ERROR_MSG(load_tablet_writer_cancel, request->txn_id()));
+    LOG_BRPC_FP(load_tablet_writer_cancel, remote_host, request)
+            << ", send_id: " << request->sender_id() << ", tablet_ids: (" << tablet_ids
+            << "), reason: " << request->reason();
+    cntl->SetFailed(BRPC_ERROR_MSG(load_tablet_writer_cancel, remote_host, request->txn_id()));
 }
 
 Status memtable_flush_fp_action(int64_t txn_id, int64_t tablet_id) {

--- a/be/src/runtime/load_fail_point.cpp
+++ b/be/src/runtime/load_fail_point.cpp
@@ -40,8 +40,9 @@ DEFINE_FAIL_POINT(load_pk_preload);
 
 #define BRPC_ERROR_MSG(name, txn_id) \
     fmt::format("{} failpoint triggered failure, be: {}, txn_id: {}", #name, BackendOptions::get_localhost(), txn_id)
-#define IO_ERROR_MSG(name, txn_id, tablet_id) \
-    fmt::format("{} failpoint triggered failure, txn_id: {}, tablet_id: {}", #name, txn_id, tablet_id)
+#define IO_ERROR_MSG(name, txn_id, tablet_id)                                               \
+    fmt::format("{} failpoint triggered failure, be: {}, txn_id: {}, tablet_id: {}", #name, \
+                BackendOptions::get_localhost(), txn_id, tablet_id)
 
 std::string get_remote_ip(const brpc::Controller& cntl) {
     return butil::ip2str(cntl.remote_side().ip).c_str();

--- a/be/src/runtime/load_fail_point.cpp
+++ b/be/src/runtime/load_fail_point.cpp
@@ -55,7 +55,6 @@ void tablet_writer_open_fp_action(RefCountClosure<PTabletWriterOpenResult>* clos
     LOG_BRPC_FP(load_tablet_writer_open, closure->cntl, request)
             << ", send_id: " << request->sender_id() << ", tablet_ids: " << tablet_ids;
     closure->cntl.SetFailed(BRPC_ERROR_MSG(load_tablet_writer_open, request->txn_id()));
-    brpc::StartCancel(closure->cntl.call_id());
 }
 
 void tablet_writer_add_chunks_fp_action(ReusableClosure<PTabletWriterAddBatchResult>* closure,
@@ -64,14 +63,12 @@ void tablet_writer_add_chunks_fp_action(ReusableClosure<PTabletWriterAddBatchRes
     LOG_BRPC_FP(load_tablet_writer_add_chunks, closure->cntl, request->mutable_requests(0))
             << ", send_id: " << request->mutable_requests(0)->sender_id();
     closure->cntl.SetFailed(BRPC_ERROR_MSG(load_tablet_writer_add_chunks, request->mutable_requests(0)->txn_id()));
-    closure->cancel();
 }
 
 void tablet_writer_add_segment_fp_action(ReusableClosure<PTabletWriterAddSegmentResult>* closure,
                                          PTabletWriterAddSegmentRequest* request) {
     LOG_BRPC_FP(load_tablet_writer_add_segment, closure->cntl, request) << ", tablet_id: " << request->tablet_id();
     closure->cntl.SetFailed(BRPC_ERROR_MSG(load_tablet_writer_add_segment, request->txn_id()));
-    closure->cancel();
 }
 
 void tablet_writer_cancel_fp_action(::google::protobuf::Closure* closure, brpc::Controller* cntl,
@@ -85,7 +82,6 @@ void tablet_writer_cancel_fp_action(::google::protobuf::Closure* closure, brpc::
     LOG_BRPC_FP(load_tablet_writer_cancel, *cntl, request) << ", send_id: " << request->sender_id() << ", tablet_ids: ("
                                                            << tablet_ids << "), reason: " << request->reason();
     cntl->SetFailed(BRPC_ERROR_MSG(load_tablet_writer_cancel, request->txn_id()));
-    brpc::StartCancel(cntl->call_id());
 }
 
 Status memtable_flush_fp_action(int64_t txn_id, int64_t tablet_id) {

--- a/be/src/runtime/load_fail_point.cpp
+++ b/be/src/runtime/load_fail_point.cpp
@@ -75,9 +75,7 @@ void tablet_writer_add_segment_fp_action(ReusableClosure<PTabletWriterAddSegment
 void tablet_writer_cancel_fp_action(::google::protobuf::Closure* closure, brpc::Controller* cntl,
                                     PTabletWriterCancelRequest* request) {
     std::string tablet_ids;
-    if (request->has_tablet_id()) {
-        tablet_ids = std::to_string(request->tablet_id());
-    } else if (!request->tablet_ids().empty()) {
+    if (!request->tablet_ids().empty()) {
         tablet_ids = JoinElements(request->tablet_ids(), ",");
     }
     LOG_BRPC_FP(load_tablet_writer_cancel, *cntl, request) << ", send_id: " << request->sender_id() << ", tablet_ids: ("

--- a/be/src/runtime/load_fail_point.h
+++ b/be/src/runtime/load_fail_point.h
@@ -25,27 +25,30 @@
 namespace starrocks::load::failpoint {
 
 #ifdef FIU_ENABLE
-void tablet_writer_open_fp_action(RefCountClosure<PTabletWriterOpenResult>* closure, PTabletWriterOpenRequest* request);
-void tablet_writer_add_chunks_fp_action(ReusableClosure<PTabletWriterAddBatchResult>* closure,
+void tablet_writer_open_fp_action(const std::string& remote_host, RefCountClosure<PTabletWriterOpenResult>* closure,
+                                  PTabletWriterOpenRequest* request);
+void tablet_writer_add_chunks_fp_action(const std::string& remote_host,
+                                        ReusableClosure<PTabletWriterAddBatchResult>* closure,
                                         PTabletWriterAddChunksRequest* request);
-void tablet_writer_add_segment_fp_action(ReusableClosure<PTabletWriterAddSegmentResult>* closure,
+void tablet_writer_add_segment_fp_action(const std::string& remote_host,
+                                         ReusableClosure<PTabletWriterAddSegmentResult>* closure,
                                          PTabletWriterAddSegmentRequest* request);
-void tablet_writer_cancel_fp_action(::google::protobuf::Closure* closure, brpc::Controller* cntl,
-                                    PTabletWriterCancelRequest* request);
+void tablet_writer_cancel_fp_action(const std::string& remote_host, ::google::protobuf::Closure* closure,
+                                    brpc::Controller* cntl, PTabletWriterCancelRequest* request);
 
 Status memtable_flush_fp_action(int64_t txn_id, int64_t tablet_id);
 Status segment_flush_fp_action(int64_t txn_id, int64_t tablet_id);
 Status pk_preload_fp_action(int64_t txn_id, int64_t tablet_id);
 Status commit_txn_fp_action(int64_t txn_id, int64_t tablet_id);
 
-#define TABLET_WRITER_OPEN_FP_ACTION(closure, request) \
-    ::starrocks::load::failpoint::tablet_writer_open_fp_action(closure, &request)
-#define TABLET_WRITER_ADD_CHUNKS_FP_ACTION(closure, request) \
-    ::starrocks::load::failpoint::tablet_writer_add_chunks_fp_action(closure, &request)
-#define TABLET_WRITER_ADD_SEGMENT_FP_ACTION(closure, request) \
-    ::starrocks::load::failpoint::tablet_writer_add_segment_fp_action(closure, &request)
-#define TABLET_WRITER_CANCEL_FP_ACTION(closure, cntl, request) \
-    ::starrocks::load::failpoint::tablet_writer_cancel_fp_action(closure, &cntl, &request)
+#define TABLET_WRITER_OPEN_FP_ACTION(remote_host, closure, request) \
+    ::starrocks::load::failpoint::tablet_writer_open_fp_action(remote_host, closure, &request)
+#define TABLET_WRITER_ADD_CHUNKS_FP_ACTION(remote_host, closure, request) \
+    ::starrocks::load::failpoint::tablet_writer_add_chunks_fp_action(remote_host, closure, &request)
+#define TABLET_WRITER_ADD_SEGMENT_FP_ACTION(remote_host, closure, request) \
+    ::starrocks::load::failpoint::tablet_writer_add_segment_fp_action(remote_host, closure, &request)
+#define TABLET_WRITER_CANCEL_FP_ACTION(remote_host, closure, cntl, request) \
+    ::starrocks::load::failpoint::tablet_writer_cancel_fp_action(remote_host, closure, &cntl, &request)
 #define MEMTABLE_FLUSH_FP_ACTION(txn_id, tablet_id) \
     return ::starrocks::load::failpoint::memtable_flush_fp_action(txn_id, tablet_id)
 #define SEGMENT_FLUSH_FP_ACTION(txn_id, tablet_id) \
@@ -53,10 +56,10 @@ Status commit_txn_fp_action(int64_t txn_id, int64_t tablet_id);
 #define PK_PRELOAD_FP_ACTION(txn_id, tablet_id) ::starrocks::load::failpoint::pk_preload_fp_action(txn_id, tablet_id)
 #define COMMIT_TXN_FP_ACTION(txn_id, tablet_id) ::starrocks::load::failpoint::commit_txn_fp_action(txn_id, tablet_id)
 #else
-#define TABLET_WRITER_OPEN_FP_ACTION(closure, request)
-#define TABLET_WRITER_ADD_CHUNKS_FP_ACTION(closure, request)
-#define TABLET_WRITER_ADD_SEGMENT_FP_ACTION(closure, request)
-#define TABLET_WRITER_CANCEL_FP_ACTION(closure, request)
+#define TABLET_WRITER_OPEN_FP_ACTION(remote_host, closure, request)
+#define TABLET_WRITER_ADD_CHUNKS_FP_ACTION(remote_host, closure, request)
+#define TABLET_WRITER_ADD_SEGMENT_FP_ACTION(remote_host, closure, request)
+#define TABLET_WRITER_CANCEL_FP_ACTION(remote_host, closure, request)
 #define MEMTABLE_FLUSH_FP_ACTION(txn_id, tablet_id)
 #define SEGMENT_FLUSH_FP_ACTION(txn_id, tablet_id)
 #define PK_PRELOAD_FP_ACTION(txn_id, tablet_id)

--- a/be/src/runtime/load_fail_point.h
+++ b/be/src/runtime/load_fail_point.h
@@ -1,0 +1,66 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "util/failpoint/fail_point.h"
+
+#ifdef FIU_ENABLE
+#include "gen_cpp/internal_service.pb.h"
+#include "util/ref_count_closure.h"
+#include "util/reusable_closure.h"
+#endif
+
+namespace starrocks::load::failpoint {
+
+#ifdef FIU_ENABLE
+void tablet_writer_open_fp_action(RefCountClosure<PTabletWriterOpenResult>* closure, PTabletWriterOpenRequest* request);
+void tablet_writer_add_chunks_fp_action(ReusableClosure<PTabletWriterAddBatchResult>* closure,
+                                        PTabletWriterAddChunksRequest* request);
+void tablet_writer_add_segment_fp_action(ReusableClosure<PTabletWriterAddSegmentResult>* closure,
+                                         PTabletWriterAddSegmentRequest* request);
+void tablet_writer_cancel_fp_action(::google::protobuf::Closure* closure, brpc::Controller* cntl,
+                                    PTabletWriterCancelRequest* request);
+
+Status memtable_flush_fp_action(int64_t txn_id, int64_t tablet_id);
+Status segment_flush_fp_action(int64_t txn_id, int64_t tablet_id);
+Status pk_preload_fp_action(int64_t txn_id, int64_t tablet_id);
+Status commit_txn_fp_action(int64_t txn_id, int64_t tablet_id);
+
+#define TABLET_WRITER_OPEN_FP_ACTION(closure, request) \
+    ::starrocks::load::failpoint::tablet_writer_open_fp_action(closure, &request)
+#define TABLET_WRITER_ADD_CHUNKS_FP_ACTION(closure, request) \
+    ::starrocks::load::failpoint::tablet_writer_add_chunks_fp_action(closure, &request)
+#define TABLET_WRITER_ADD_SEGMENT_FP_ACTION(closure, request) \
+    ::starrocks::load::failpoint::tablet_writer_add_segment_fp_action(closure, &request)
+#define TABLET_WRITER_CANCEL_FP_ACTION(closure, cntl, request) \
+    ::starrocks::load::failpoint::tablet_writer_cancel_fp_action(closure, &cntl, &request)
+#define MEMTABLE_FLUSH_FP_ACTION(txn_id, tablet_id) \
+    return ::starrocks::load::failpoint::memtable_flush_fp_action(txn_id, tablet_id)
+#define SEGMENT_FLUSH_FP_ACTION(txn_id, tablet_id) \
+    return ::starrocks::load::failpoint::segment_flush_fp_action(txn_id, tablet_id)
+#define PK_PRELOAD_FP_ACTION(txn_id, tablet_id) ::starrocks::load::failpoint::pk_preload_fp_action(txn_id, tablet_id)
+#define COMMIT_TXN_FP_ACTION(txn_id, tablet_id) ::starrocks::load::failpoint::commit_txn_fp_action(txn_id, tablet_id)
+#else
+#define TABLET_WRITER_OPEN_FP_ACTION(closure, request)
+#define TABLET_WRITER_ADD_CHUNKS_FP_ACTION(closure, request)
+#define TABLET_WRITER_ADD_SEGMENT_FP_ACTION(closure, request)
+#define TABLET_WRITER_CANCEL_FP_ACTION(closure, request)
+#define MEMTABLE_FLUSH_FP_ACTION(txn_id, tablet_id)
+#define SEGMENT_FLUSH_FP_ACTION(txn_id, tablet_id)
+#define PK_PRELOAD_FP_ACTION(txn_id, tablet_id)
+#define COMMIT_TXN_FP_ACTION(txn_id, tablet_id)
+#endif
+
+} // namespace starrocks::load::failpoint

--- a/be/src/runtime/load_fail_point.h
+++ b/be/src/runtime/load_fail_point.h
@@ -24,6 +24,14 @@
 
 namespace starrocks::load::failpoint {
 
+// All fail points are defined as global variables in load_fail_point.cpp. Each fail point
+// represents a specific failure scenario that can be triggered during data loading operations.
+// The file contains detailed documentation for each fail point's purpose.
+//
+// Below are the action handlers for each fail point. Each handler is named after its
+// corresponding fail point with an "_fp_action" suffix. These handlers implement the
+// specific failure behavior when a fail point is triggered.
+
 #ifdef FIU_ENABLE
 void tablet_writer_open_fp_action(const std::string& remote_host, RefCountClosure<PTabletWriterOpenResult>* closure,
                                   PTabletWriterOpenRequest* request);

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -34,6 +34,7 @@
 #include "runtime/global_dict/types.h"
 #include "runtime/global_dict/types_fwd_decl.h"
 #include "runtime/load_channel.h"
+#include "runtime/load_fail_point.h"
 #include "runtime/mem_pool.h"
 #include "runtime/mem_tracker.h"
 #include "runtime/tablets_channel.h"
@@ -593,6 +594,8 @@ void LocalTabletsChannel::_abort_replica_tablets(
         });
 
 #ifndef BE_TEST
+        FAIL_POINT_TRIGGER_EXECUTE(load_tablet_writer_cancel,
+                                   TABLET_WRITER_CANCEL_FP_ACTION(closure, closure->cntl, cancel_request));
         stub->tablet_writer_cancel(&closure->cntl, &cancel_request, &closure->result, closure);
 #else
         std::tuple<PTabletWriterCancelRequest*, google::protobuf::Closure*, brpc::Controller*> rpc_tuple{

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -594,8 +594,9 @@ void LocalTabletsChannel::_abort_replica_tablets(
         });
 
 #ifndef BE_TEST
-        FAIL_POINT_TRIGGER_EXECUTE(load_tablet_writer_cancel,
-                                   TABLET_WRITER_CANCEL_FP_ACTION(closure, closure->cntl, cancel_request));
+        FAIL_POINT_TRIGGER_EXECUTE(
+                load_tablet_writer_cancel,
+                TABLET_WRITER_CANCEL_FP_ACTION(endpoint.host(), closure, closure->cntl, cancel_request));
         stub->tablet_writer_cancel(&closure->cntl, &cancel_request, &closure->result, closure);
 #else
         std::tuple<PTabletWriterCancelRequest*, google::protobuf::Closure*, brpc::Controller*> rpc_tuple{

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -20,6 +20,7 @@
 #include "io/io_profiler.h"
 #include "runtime/current_thread.h"
 #include "runtime/descriptors.h"
+#include "runtime/load_fail_point.h"
 #include "storage/compaction_manager.h"
 #include "storage/memtable.h"
 #include "storage/memtable_flush_executor.h"
@@ -750,7 +751,10 @@ Status DeltaWriter::commit() {
     if (_tablet->keys_type() == KeysType::PRIMARY_KEYS && !config::skip_pk_preload &&
         !_storage_engine->update_manager()->mem_tracker()->limit_exceeded_by_ratio(config::memory_high_level) &&
         !_storage_engine->update_manager()->update_state_mem_tracker()->any_limit_exceeded()) {
-        auto st = _storage_engine->update_manager()->on_rowset_finished(_tablet.get(), _cur_rowset.get());
+        Status st;
+        FAIL_POINT_TRIGGER_ASSIGN_STATUS_OR_DEFAULT(
+                load_pk_preload, st, PK_PRELOAD_FP_ACTION(_opt.txn_id, _opt.tablet_id),
+                _storage_engine->update_manager()->on_rowset_finished(_tablet.get(), _cur_rowset.get()));
         if (!st.ok() && !st.is_uninitialized()) {
             _set_state(kAborted, st);
             return st;
@@ -766,9 +770,11 @@ Status DeltaWriter::commit() {
         }
     }
     auto replica_ts = watch.elapsed_time();
-
-    auto res = _storage_engine->txn_manager()->commit_txn(_opt.partition_id, _tablet, _opt.txn_id, _opt.load_id,
-                                                          _cur_rowset, false);
+    Status res;
+    FAIL_POINT_TRIGGER_ASSIGN_STATUS_OR_DEFAULT(
+            load_commit_txn, res, COMMIT_TXN_FP_ACTION(_opt.txn_id, _opt.tablet_id),
+            _storage_engine->txn_manager()->commit_txn(_opt.partition_id, _tablet, _opt.txn_id, _opt.load_id,
+                                                       _cur_rowset, false));
     auto commit_txn_ts = watch.elapsed_time();
 
     if (!res.ok()) {

--- a/be/src/storage/lake/spill_mem_table_sink.cpp
+++ b/be/src/storage/lake/spill_mem_table_sink.cpp
@@ -313,4 +313,12 @@ Status SpillMemTableSink::merge_blocks_to_segments() {
     return Status::OK();
 }
 
+int64_t SpillMemTableSink::txn_id() {
+    return _writer->txn_id();
+}
+
+int64_t SpillMemTableSink::tablet_id() {
+    return _writer->tablet_id();
+}
+
 } // namespace starrocks::lake

--- a/be/src/storage/lake/spill_mem_table_sink.h
+++ b/be/src/storage/lake/spill_mem_table_sink.h
@@ -73,6 +73,9 @@ public:
 
     spill::Spiller* get_spiller() { return _spiller.get(); }
 
+    int64_t txn_id() override;
+    int64_t tablet_id() override;
+
 private:
     Status _prepare(const ChunkPtr& chunk_ptr);
     Status _do_spill(const Chunk& chunk, const spill::SpillOutputDataStreamPtr& output);

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -24,6 +24,7 @@
 #include "io/io_profiler.h"
 #include "runtime/current_thread.h"
 #include "runtime/descriptors.h"
+#include "runtime/load_fail_point.h"
 #include "storage/chunk_helper.h"
 #include "storage/memtable_sink.h"
 #include "storage/primary_key_encoder.h"
@@ -327,6 +328,7 @@ Status MemTable::finalize() {
 }
 
 Status MemTable::flush(SegmentPB* seg_info, bool eos, int64_t* flush_data_size) {
+    FAIL_POINT_TRIGGER_EXECUTE(load_memtable_flush, MEMTABLE_FLUSH_FP_ACTION(_sink->txn_id(), _sink->tablet_id()));
     if (UNLIKELY(_result_chunk == nullptr)) {
         return Status::OK();
     }

--- a/be/src/storage/memtable_rowset_writer_sink.h
+++ b/be/src/storage/memtable_rowset_writer_sink.h
@@ -38,6 +38,9 @@ public:
         return _rowset_writer->flush_chunk_with_deletes(upserts, deletes, seg_info);
     }
 
+    int64_t txn_id() override { return _rowset_writer->context().txn_id; }
+    int64_t tablet_id() override { return _rowset_writer->context().tablet_id; }
+
 private:
     RowsetWriter* _rowset_writer;
 };

--- a/be/src/storage/memtable_sink.h
+++ b/be/src/storage/memtable_sink.h
@@ -33,6 +33,9 @@ public:
                                int64_t* flush_data_size = nullptr) = 0;
     virtual Status flush_chunk_with_deletes(const Chunk& upserts, const Column& deletes, SegmentPB* seg_info = nullptr,
                                             bool eos = false, int64_t* flush_data_size = nullptr) = 0;
+
+    virtual int64_t txn_id() = 0;
+    virtual int64_t tablet_id() = 0;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -48,7 +48,7 @@
 #include "fs/fs.h"
 #include "fs/key_cache.h"
 #include "io/io_error.h"
-#include "runtime/exec_env.h"
+#include "runtime/load_fail_point.h"
 #include "segment_options.h"
 #include "serde/column_array_serde.h"
 #include "storage/aggregate_iterator.h"
@@ -470,6 +470,7 @@ Status RowsetWriter::_flush_update_file(const SegmentPB& segment_pb, butil::IOBu
 }
 
 Status RowsetWriter::flush_segment(const SegmentPB& segment_pb, butil::IOBuf& data) {
+    FAIL_POINT_TRIGGER_EXECUTE(load_segment_flush, SEGMENT_FLUSH_FP_ACTION(_context.txn_id, _context.tablet_id));
     if (data.size() != segment_pb.data_size() + segment_pb.delete_data_size() + segment_pb.update_data_size() +
                                segment_pb.seg_index_data_size()) {
         return Status::InternalError(fmt::format(

--- a/be/src/storage/rowset/rowset_writer.h
+++ b/be/src/storage/rowset/rowset_writer.h
@@ -170,6 +170,8 @@ public:
 
     const GlobalDictByNameMaps* rowset_global_dicts() const { return _writer_options.global_dicts; }
 
+    const RowsetWriterContext& context() const { return _context; }
+
 private:
     Status _flush_segment(const SegmentPB& segment_pb, butil::IOBuf& data);
 

--- a/be/src/storage/segment_replicate_executor.cpp
+++ b/be/src/storage/segment_replicate_executor.cpp
@@ -23,6 +23,7 @@
 #include "gen_cpp/data.pb.h"
 #include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
+#include "runtime/load_fail_point.h"
 #include "runtime/mem_tracker.h"
 #include "storage/delta_writer.h"
 #include "util/brpc_stub_cache.h"
@@ -165,6 +166,7 @@ void ReplicateChannel::_send_request(SegmentPB* segment, butil::IOBuf& data, boo
     // brpc send buffer is also considered as part of the memory used by load
     _mem_tracker->consume_without_root(_closure->request_size);
 
+    FAIL_POINT_TRIGGER_EXECUTE(load_tablet_writer_add_segment, TABLET_WRITER_ADD_SEGMENT_FP_ACTION(_closure, request));
     _stub->tablet_writer_add_segment(&_closure->cntl, &request, &_closure->result, _closure);
 
     request.release_id();

--- a/be/src/storage/segment_replicate_executor.cpp
+++ b/be/src/storage/segment_replicate_executor.cpp
@@ -166,7 +166,8 @@ void ReplicateChannel::_send_request(SegmentPB* segment, butil::IOBuf& data, boo
     // brpc send buffer is also considered as part of the memory used by load
     _mem_tracker->consume_without_root(_closure->request_size);
 
-    FAIL_POINT_TRIGGER_EXECUTE(load_tablet_writer_add_segment, TABLET_WRITER_ADD_SEGMENT_FP_ACTION(_closure, request));
+    FAIL_POINT_TRIGGER_EXECUTE(load_tablet_writer_add_segment,
+                               TABLET_WRITER_ADD_SEGMENT_FP_ACTION(_host, _closure, request));
     _stub->tablet_writer_add_segment(&_closure->cntl, &request, &_closure->result, _closure);
 
     request.release_id();

--- a/be/src/util/failpoint/fail_point.h
+++ b/be/src/util/failpoint/fail_point.h
@@ -81,24 +81,51 @@ public:
 #ifdef FIU_ENABLE
 // Use this macro to define failpoint
 // NOTE: it can only be used in cpp files, the name of failpoint must be globally unique
-#define DEFINE_FAIL_POINT(NAME)                      \
-    starrocks::failpoint::FailPoint fp##NAME(#NAME); \
-    starrocks::failpoint::FailPointRegisterer fpr##NAME(&fp##NAME);
-#define DEFINE_SCOPED_FAIL_POINT(NAME)                      \
-    starrocks::failpoint::ScopedFailPoint sfp##NAME(#NAME); \
-    starrocks::failpoint::FailPointRegisterer fpr##NAME(&sfp##NAME);
-#define FAIL_POINT_SCOPE(NAME) starrocks::failpoint::ScopedFailPointGuard sfpg##NAME(#NAME);
+#define DEFINE_FAIL_POINT(NAME)                       \
+    starrocks::failpoint::FailPoint fp_##NAME(#NAME); \
+    starrocks::failpoint::FailPointRegisterer fpr_##NAME(&fp_##NAME);
+#define DEFINE_SCOPED_FAIL_POINT(NAME)                       \
+    starrocks::failpoint::ScopedFailPoint sfp_##NAME(#NAME); \
+    starrocks::failpoint::FailPointRegisterer fpr_##NAME(&sfp_##NAME);
+#define FAIL_POINT_SCOPE(NAME) starrocks::failpoint::ScopedFailPointGuard sfpg_##NAME(#NAME);
 #define FAIL_POINT_TRIGGER_EXECUTE(NAME, stmt) fiu_do_on(#NAME, stmt)
+// Execute stmt if the failpoint is triggered, otherwise execute default_stmt
+#define FAIL_POINT_TRIGGER_EXECUTE_OR_DEFAULT(NAME, stmt, default_stmt) \
+    do {                                                                \
+        bool fp_triggered__ = false;                                    \
+        fiu_do_on(#NAME, {                                              \
+            fp_triggered__ = true;                                      \
+            { stmt; }                                                   \
+        });                                                             \
+        if (!fp_triggered__) {                                          \
+            default_stmt;                                               \
+        }                                                               \
+    } while (false)
 #define FAIL_POINT_TRIGGER_RETURN(NAME, retVal) fiu_return_on(#NAME, retVal)
 #define FAIL_POINT_TRIGGER_RETURN_ERROR(NAME) \
     fiu_return_on(#NAME, Status::InternalError(fmt::format("inject error {} at {}:{}", #NAME, __FILE__, __LINE__)))
+// Execute the stmt, and assign the result to the status if the failpoint is triggered,
+// otherwise assign the result of default_stmt to the status
+#define FAIL_POINT_TRIGGER_ASSIGN_STATUS_OR_DEFAULT(NAME, status, stmt, default_stmt) \
+    do {                                                                              \
+        bool fp_triggered__ = false;                                                  \
+        fiu_do_on(#NAME, {                                                            \
+            fp_triggered__ = true;                                                    \
+            { status = stmt; }                                                        \
+        });                                                                           \
+        if (!fp_triggered__) {                                                        \
+            status = default_stmt;                                                    \
+        }                                                                             \
+    } while (false)
 #else
 #define DEFINE_FAIL_POINT(NAME)
 #define DEFINE_SCOPED_FAIL_POINT(NAME)
 #define FAIL_POINT_SCOPE(NAME)
 #define FAIL_POINT_TRIGGER_EXECUTE(NAME, stmt)
+#define FAIL_POINT_TRIGGER_EXECUTE_OR_DEFAULT(NAME, stmt, default_stmt) default_stmt
 #define FAIL_POINT_TRIGGER_RETURN(NAME, retVal)
 #define FAIL_POINT_TRIGGER_RETURN_ERROR(NAME)
+#define FAIL_POINT_TRIGGER_ASSIGN_STATUS_OR_DEFAULT(NAME, status, stmt, default_stmt) status = default_stmt
 #endif
 
 bool init_failpoint_from_conf(const std::string& conf_file);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -436,6 +436,7 @@ set(EXEC_FILES
         ./runtime/memory_scratch_sink_test.cpp
         ./runtime/command_executor_test.cpp
         ./runtime/exec_env_test.cpp
+        ./runtime/load_fail_point_test.cpp
         ./serde/column_array_serde_test.cpp
         ./serde/protobuf_serde_test.cpp
         ./types/bitmap_value_test.cpp

--- a/be/test/runtime/load_fail_point_test.cpp
+++ b/be/test/runtime/load_fail_point_test.cpp
@@ -1,0 +1,100 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runtime/load_fail_point.h"
+
+#include <gtest/gtest.h>
+
+namespace starrocks::load::failpoint {
+
+TEST(LoadFailPointTest, tablet_writer_open) {
+    RefCountClosure<PTabletWriterOpenResult> closure;
+    PTabletWriterOpenRequest request;
+    request.mutable_id()->set_hi(9382);
+    request.mutable_id()->set_lo(482323);
+    request.set_txn_id(123456);
+    request.set_sender_id(1);
+    tablet_writer_open_fp_action(&closure, &request);
+    ASSERT_TRUE(closure.cntl.Failed());
+    ASSERT_EQ(closure.cntl.ErrorText(), "load_tablet_writer_open failpoint triggered failure, be: , txn_id: 123456");
+}
+
+TEST(LoadFailPointTest, tablet_writer_add_chunks) {
+    ReusableClosure<PTabletWriterAddBatchResult> closure;
+    PTabletWriterAddChunksRequest request;
+    request.mutable_id()->set_hi(9382);
+    request.mutable_id()->set_lo(482323);
+    auto sub_request = request.add_requests();
+    sub_request->mutable_id()->set_hi(9382);
+    sub_request->mutable_id()->set_lo(482323);
+    sub_request->set_txn_id(123456);
+    sub_request->set_sender_id(1);
+    tablet_writer_add_chunks_fp_action(&closure, &request);
+    ASSERT_TRUE(closure.cntl.Failed());
+    ASSERT_EQ(closure.cntl.ErrorText(),
+              "load_tablet_writer_add_chunks failpoint triggered failure, be: , txn_id: 123456");
+}
+
+TEST(LoadFailPointTest, tablet_writer_add_segment) {
+    ReusableClosure<PTabletWriterAddSegmentResult> closure;
+    PTabletWriterAddSegmentRequest request;
+    request.mutable_id()->set_hi(9382);
+    request.mutable_id()->set_lo(482323);
+    request.set_txn_id(123456);
+    tablet_writer_add_segment_fp_action(&closure, &request);
+    ASSERT_TRUE(closure.cntl.Failed());
+    ASSERT_EQ(closure.cntl.ErrorText(),
+              "load_tablet_writer_add_segment failpoint triggered failure, be: , txn_id: 123456");
+}
+
+TEST(LoadFailPointTest, tablet_writer_cancel) {
+    RefCountClosure<PTabletWriterCancelResult> closure;
+    PTabletWriterCancelRequest request;
+    request.mutable_id()->set_hi(9382);
+    request.mutable_id()->set_lo(482323);
+    request.set_txn_id(123456);
+    request.add_tablet_ids(1);
+    request.add_tablet_ids(2);
+    tablet_writer_cancel_fp_action(&closure, &closure.cntl, &request);
+    ASSERT_TRUE(closure.cntl.Failed());
+    ASSERT_EQ(closure.cntl.ErrorText(), "load_tablet_writer_cancel failpoint triggered failure, be: , txn_id: 123456");
+}
+
+TEST(LoadFailPointTest, memtable_flush) {
+    auto status = memtable_flush_fp_action(123456, 7890);
+    ASSERT_TRUE(status.is_io_error());
+    ASSERT_EQ(status.message(),
+              "load_memtable_flush failpoint triggered failure, be: , txn_id: 123456, tablet_id: 7890");
+}
+
+TEST(LoadFailPointTest, segment_flush) {
+    auto status = segment_flush_fp_action(123456, 7890);
+    ASSERT_TRUE(status.is_io_error());
+    ASSERT_EQ(status.message(),
+              "load_segment_flush failpoint triggered failure, be: , txn_id: 123456, tablet_id: 7890");
+}
+
+TEST(LoadFailPointTest, pk_preload) {
+    auto status = pk_preload_fp_action(123456, 7890);
+    ASSERT_TRUE(status.is_io_error());
+    ASSERT_EQ(status.message(), "load_pk_preload failpoint triggered failure, be: , txn_id: 123456, tablet_id: 7890");
+}
+
+TEST(LoadFailPointTest, commit_txn) {
+    auto status = commit_txn_fp_action(123456, 7890);
+    ASSERT_TRUE(status.is_io_error());
+    ASSERT_EQ(status.message(), "load_commit_txn failpoint triggered failure, be: , txn_id: 123456, tablet_id: 7890");
+}
+
+} // namespace starrocks::load::failpoint

--- a/be/test/runtime/load_fail_point_test.cpp
+++ b/be/test/runtime/load_fail_point_test.cpp
@@ -27,9 +27,10 @@ TEST(LoadFailPointTest, tablet_writer_open) {
     request.set_sender_id(1);
     auto tablet = request.add_tablets();
     tablet->set_tablet_id(1);
-    tablet_writer_open_fp_action(&closure, &request);
+    tablet_writer_open_fp_action("127.0.0.1", &closure, &request);
     ASSERT_TRUE(closure.cntl.Failed());
-    ASSERT_EQ(closure.cntl.ErrorText(), "load_tablet_writer_open failpoint triggered failure, be: , txn_id: 123456");
+    ASSERT_EQ(closure.cntl.ErrorText(),
+              "load_tablet_writer_open failpoint triggered failure, rpc: 127.0.0.1 -> , txn_id: 123456");
 }
 
 TEST(LoadFailPointTest, tablet_writer_add_chunks) {
@@ -42,10 +43,10 @@ TEST(LoadFailPointTest, tablet_writer_add_chunks) {
     sub_request->mutable_id()->set_lo(482323);
     sub_request->set_txn_id(123456);
     sub_request->set_sender_id(1);
-    tablet_writer_add_chunks_fp_action(&closure, &request);
+    tablet_writer_add_chunks_fp_action("127.0.0.1", &closure, &request);
     ASSERT_TRUE(closure.cntl.Failed());
     ASSERT_EQ(closure.cntl.ErrorText(),
-              "load_tablet_writer_add_chunks failpoint triggered failure, be: , txn_id: 123456");
+              "load_tablet_writer_add_chunks failpoint triggered failure, rpc: 127.0.0.1 -> , txn_id: 123456");
 }
 
 TEST(LoadFailPointTest, tablet_writer_add_segment) {
@@ -54,10 +55,10 @@ TEST(LoadFailPointTest, tablet_writer_add_segment) {
     request.mutable_id()->set_hi(9382);
     request.mutable_id()->set_lo(482323);
     request.set_txn_id(123456);
-    tablet_writer_add_segment_fp_action(&closure, &request);
+    tablet_writer_add_segment_fp_action("127.0.0.1", &closure, &request);
     ASSERT_TRUE(closure.cntl.Failed());
     ASSERT_EQ(closure.cntl.ErrorText(),
-              "load_tablet_writer_add_segment failpoint triggered failure, be: , txn_id: 123456");
+              "load_tablet_writer_add_segment failpoint triggered failure, rpc: 127.0.0.1 -> , txn_id: 123456");
 }
 
 TEST(LoadFailPointTest, tablet_writer_cancel) {
@@ -68,9 +69,10 @@ TEST(LoadFailPointTest, tablet_writer_cancel) {
     request.set_txn_id(123456);
     request.add_tablet_ids(1);
     request.add_tablet_ids(2);
-    tablet_writer_cancel_fp_action(&closure, &closure.cntl, &request);
+    tablet_writer_cancel_fp_action("127.0.0.1", &closure, &closure.cntl, &request);
     ASSERT_TRUE(closure.cntl.Failed());
-    ASSERT_EQ(closure.cntl.ErrorText(), "load_tablet_writer_cancel failpoint triggered failure, be: , txn_id: 123456");
+    ASSERT_EQ(closure.cntl.ErrorText(),
+              "load_tablet_writer_cancel failpoint triggered failure, rpc: 127.0.0.1 -> , txn_id: 123456");
 }
 
 TEST(LoadFailPointTest, memtable_flush) {

--- a/be/test/runtime/load_fail_point_test.cpp
+++ b/be/test/runtime/load_fail_point_test.cpp
@@ -25,6 +25,8 @@ TEST(LoadFailPointTest, tablet_writer_open) {
     request.mutable_id()->set_lo(482323);
     request.set_txn_id(123456);
     request.set_sender_id(1);
+    auto tablet = request.add_tablets();
+    tablet->set_tablet_id(1);
     tablet_writer_open_fp_action(&closure, &request);
     ASSERT_TRUE(closure.cntl.Failed());
     ASSERT_EQ(closure.cntl.ErrorText(), "load_tablet_writer_open failpoint triggered failure, be: , txn_id: 123456");

--- a/be/test/runtime/load_fail_point_test.cpp
+++ b/be/test/runtime/load_fail_point_test.cpp
@@ -30,7 +30,7 @@ TEST(LoadFailPointTest, tablet_writer_open) {
     tablet_writer_open_fp_action("127.0.0.1", &closure, &request);
     ASSERT_TRUE(closure.cntl.Failed());
     ASSERT_EQ(closure.cntl.ErrorText(),
-              "load_tablet_writer_open failpoint triggered failure, rpc: 127.0.0.1 -> , txn_id: 123456");
+              "load_tablet_writer_open failpoint triggered failure, rpc:  -> 127.0.0.1, txn_id: 123456");
 }
 
 TEST(LoadFailPointTest, tablet_writer_add_chunks) {
@@ -46,7 +46,7 @@ TEST(LoadFailPointTest, tablet_writer_add_chunks) {
     tablet_writer_add_chunks_fp_action("127.0.0.1", &closure, &request);
     ASSERT_TRUE(closure.cntl.Failed());
     ASSERT_EQ(closure.cntl.ErrorText(),
-              "load_tablet_writer_add_chunks failpoint triggered failure, rpc: 127.0.0.1 -> , txn_id: 123456");
+              "load_tablet_writer_add_chunks failpoint triggered failure, rpc:  -> 127.0.0.1, txn_id: 123456");
 }
 
 TEST(LoadFailPointTest, tablet_writer_add_segment) {
@@ -55,10 +55,12 @@ TEST(LoadFailPointTest, tablet_writer_add_segment) {
     request.mutable_id()->set_hi(9382);
     request.mutable_id()->set_lo(482323);
     request.set_txn_id(123456);
+    request.set_tablet_id(7890);
     tablet_writer_add_segment_fp_action("127.0.0.1", &closure, &request);
     ASSERT_TRUE(closure.cntl.Failed());
     ASSERT_EQ(closure.cntl.ErrorText(),
-              "load_tablet_writer_add_segment failpoint triggered failure, rpc: 127.0.0.1 -> , txn_id: 123456");
+              "load_tablet_writer_add_segment failpoint triggered failure, rpc:  -> 127.0.0.1, txn_id: 123456, "
+              "tablet_id: 7890");
 }
 
 TEST(LoadFailPointTest, tablet_writer_cancel) {
@@ -72,7 +74,7 @@ TEST(LoadFailPointTest, tablet_writer_cancel) {
     tablet_writer_cancel_fp_action("127.0.0.1", &closure, &closure.cntl, &request);
     ASSERT_TRUE(closure.cntl.Failed());
     ASSERT_EQ(closure.cntl.ErrorText(),
-              "load_tablet_writer_cancel failpoint triggered failure, rpc: 127.0.0.1 -> , txn_id: 123456");
+              "load_tablet_writer_cancel failpoint triggered failure, rpc:  -> 127.0.0.1, txn_id: 123456");
 }
 
 TEST(LoadFailPointTest, memtable_flush) {

--- a/be/test/util/fail_point_test.cpp
+++ b/be/test/util/fail_point_test.cpp
@@ -93,7 +93,7 @@ TEST(FailPointTest, fp_demo) {
 
     PFailPointTriggerMode trigger_mode;
     trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);
-    fpfp_test.setMode(trigger_mode);
+    fp_fp_test.setMode(trigger_mode);
 
     ASSERT_FALSE(test_func());
 }
@@ -110,7 +110,7 @@ TEST(FailPointTest, sfp_demo) {
 
     PFailPointTriggerMode trigger_mode;
     trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);
-    sfpsfp_test.setMode(trigger_mode);
+    sfp_sfp_test.setMode(trigger_mode);
 
     ASSERT_TRUE(test_func());
 

--- a/test/sql/test_load/R/test_load_ha
+++ b/test/sql/test_load/R/test_load_ha
@@ -20,7 +20,7 @@ PROPERTIES (
 );
 -- result:
 -- !result
-[UC]ADMIN ENABLE FAILPOINT 'load_memtable_flush';
+ADMIN ENABLE FAILPOINT 'load_memtable_flush';
 -- result:
 -- !result
 [UC]shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue" -H "label:${uuid1}" -H "format:json" -d '{"id":1,"name":"n1","score":1}' ${url}/api/db_${uuid0}/t/_stream_load
@@ -31,23 +31,23 @@ PROPERTIES (
     "Message": "172.26.80.6: load_memtable_flush failpoint triggered failure, be: 172.26.80.6, txn_id: 78, tablet_id: 10925"
 }
 -- !result
-[UC]ADMIN DISABLE FAILPOINT 'load_memtable_flush';
+ADMIN DISABLE FAILPOINT 'load_memtable_flush';
 -- result:
 -- !result
 sync;
 -- result:
 -- !result
-[UC]select state, instr(error_msg, 'load_memtable_flush failpoint triggered failure') > 0 from information_schema.loads where label='${uuid1}';
+select state, instr(error_msg, 'load_memtable_flush failpoint triggered failure') > 0 from information_schema.loads where label='${uuid1}';
 -- result:
 CANCELLED	1
 -- !result
-[UC]select * from t;
+select * from t;
 -- result:
 -- !result
-[UC]ADMIN ENABLE FAILPOINT 'load_segment_flush';
+ADMIN ENABLE FAILPOINT 'load_segment_flush';
 -- result:
 -- !result
-[UC]shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue" -H "label:${uuid2}" -H "format:json" -d '{"id":2,"name":"n2","score":2}' ${url}/api/db_${uuid0}/t/_stream_load
+shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue" -H "label:${uuid2}" -H "format:json" -d '{"id":2,"name":"n2","score":2}' ${url}/api/db_${uuid0}/t/_stream_load
 -- result:
 0
 {
@@ -55,17 +55,17 @@ CANCELLED	1
     "Message": "OK"
 }
 -- !result
-[UC]ADMIN DISABLE FAILPOINT 'load_segment_flush';
+ADMIN DISABLE FAILPOINT 'load_segment_flush';
 -- result:
 -- !result
 sync;
 -- result:
 -- !result
-[UC]select state, error_msg from information_schema.loads where label='${uuid2}';
+select state, error_msg from information_schema.loads where label='${uuid2}';
 -- result:
 FINISHED	
 -- !result
-[UC]select * from t;
+select * from t;
 -- result:
 2	n2	2
 -- !result

--- a/test/sql/test_load/T/test_load_ha
+++ b/test/sql/test_load/T/test_load_ha
@@ -17,16 +17,16 @@ PROPERTIES (
  "replication_num" = "3"
 );
 
-[UC]ADMIN ENABLE FAILPOINT 'load_memtable_flush';
+ADMIN ENABLE FAILPOINT 'load_memtable_flush';
 [UC]shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue" -H "label:${uuid1}" -H "format:json" -d '{"id":1,"name":"n1","score":1}' ${url}/api/db_${uuid0}/t/_stream_load
-[UC]ADMIN DISABLE FAILPOINT 'load_memtable_flush';
+ADMIN DISABLE FAILPOINT 'load_memtable_flush';
 sync;
-[UC]select state, instr(error_msg, 'load_memtable_flush failpoint triggered failure') > 0 from information_schema.loads where label='${uuid1}';
-[UC]select * from t;
+select state, instr(error_msg, 'load_memtable_flush failpoint triggered failure') > 0 from information_schema.loads where label='${uuid1}';
+select * from t;
 
-[UC]ADMIN ENABLE FAILPOINT 'load_segment_flush';
-[UC]shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue" -H "label:${uuid2}" -H "format:json" -d '{"id":2,"name":"n2","score":2}' ${url}/api/db_${uuid0}/t/_stream_load
-[UC]ADMIN DISABLE FAILPOINT 'load_segment_flush';
+ADMIN ENABLE FAILPOINT 'load_segment_flush';
+shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue" -H "label:${uuid2}" -H "format:json" -d '{"id":2,"name":"n2","score":2}' ${url}/api/db_${uuid0}/t/_stream_load
+ADMIN DISABLE FAILPOINT 'load_segment_flush';
 sync;
-[UC]select state, error_msg from information_schema.loads where label='${uuid2}';
-[UC]select * from t;
+select state, error_msg from information_schema.loads where label='${uuid2}';
+select * from t;


### PR DESCRIPTION
## Why I'm doing:
We have met some load issues caused by network/disk failures, see https://github.com/StarRocks/starrocks/pull/57539 for details. To detect and defend against these issues early, introduce some failpoints to easily inject network/disk failures when running tests.​​

## What I'm doing:
The following diagram illustrates the key components of the load process that are impacted by network and disk, along with their corresponding APIs. What we do is to add failpoints to mock those APIs for failure.  
![image](https://github.com/user-attachments/assets/b7d09bb9-85d0-4228-89ab-9e860f55318c)

The failpoins added are
| Name                             | Category | Description                                                                                             | Architecture                   | API                                                                                              |
| :------------------------------- | :------- | :------------------------------------------------------------------------------------------------------ | :----------------------------- | :----------------------------------------------------------------------------------------------- |
| ​**load_tablet_writer_open**​      | Network  | Inject failure during brpc tablet_writer_open calls                                                    | shared-nothing<br>shared-data  | brpc tablet_writer_open (NodeChannel)                                                           |
| ​**load_tablet_writer_add_chunks**​ | Network  | Inject failure during brpc tablet_writer_add_chunks                                                    | shared-nothing<br>shared-data  | brpc tablet_writer_add_chuncks (NodeChannel)                                                     |
| ​**load_tablet_writer_add_segment**​ | Network  | Inject failure during brpc tablet_writer_add_segment                                                   | shared-nothing<br>shared-data  | brpc tablet_writer_add_segment (ReplicateChannel)                                               |
| ​**load_tablet_writer_cancel**​    | Network  | Inject failure during brpc tablet_writer_cancel calls                                                  | shared-nothing<br>shared-data  | shared-nothing:<br>- Brpc tablet_writer_cancel (NodeChannel)<br>- Bpc tablet_writer_cancel (LocalTabletsChannel)<br><br>shared-data:<br>- Brpc tablet_writer_cancel (NodeChannel) |
| ​**load_memtable_flush**​          | I/O      | Inject failure during memtable flush                                                                    | shared-nothing<br>shared-data  | Memtable::flush                                                                                  |
| ​**load_segment_flush**​           | I/O      | Inject failure during segment flush which only happens on secondary replicas under shared-nothing       | shared-nothing                 | RowsetWriter::flush_segment                                                                      |
| ​**load_pk_preload**​              | I/O      | Inject failure when primary key table preloads index                                                   | shared-nothing<br>shared-data  | shared-nothing:<br>- UpdateManager::on_rowset_finished<br><br>shared-data:<br>- UpdateManager::preload_update_state |
| ​**load_commit_txn**​              | I/O      | Injects failure during transaction commit                                                              | shared-nothing<br>shared-data  | shared-nothing:<br>- TxnManager::commit_txn<br><br>shared-data:<br>- Tablet::put_txn_log                 |

To use failpoint
* compile be with `ENABLE_FAULT_INJECTION=ON`
* enable failpoints by
```
ADMIN ENABLE FAILPOINT 'load_tablet_writer_open';
ADMIN ENABLE FAILPOINT 'load_tablet_writer_open' WITH 0.1 PROBABILITY;

mysql> insert into t values (1);
ERROR 5609 (22000): load_tablet_writer_open failpoint triggered failure, rpc: 172.26.80.18 -> 172.26.80.17, txn_id: 23038:  be:172.26.80.18
```


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
