### PR TITLE
[Enhancement] support read from aggregate tablet meta (backport #58289)

### DIFF
--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -80,6 +80,8 @@ public:
 
     Status put_tablet_metadata(const TabletMetadataPtr& metadata);
 
+    Status cache_tablet_metadata(const TabletMetadataPtr& metadata);
+
     Status put_aggregate_tablet_metadata(std::map<int64_t, TabletMetadataPB>& tablet_metas);
 
     // When using get_tablet_metadata to determine whether a new version exists in publish version,
@@ -93,7 +95,9 @@ public:
                                                     int64_t expected_gtid = 0,
                                                     const std::shared_ptr<FileSystem>& fs = nullptr);
 
-    StatusOr<TabletMetadataPtr> get_single_tablet_metadata(int64_t tablet_id, int64_t version, bool fill_cache = true);
+    StatusOr<TabletMetadataPtr> get_single_tablet_metadata(int64_t tablet_id, int64_t version, bool fill_cache = true,
+                                                           int64_t expected_gtid = 0,
+                                                           const std::shared_ptr<FileSystem>& fs = nullptr);
 
     TabletMetadataPtr get_latest_cached_tablet_metadata(int64_t tablet_id);
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -616,6 +616,13 @@ public class TransactionState implements Writable, GsonPreProcessable {
             txnSpan.end();
         } else if (transactionStatus == TransactionStatus.COMMITTED) {
             txnSpan.addEvent("set_committed");
+            // if this txn is triggered by compaction, and also enable `useCombinedTxnLog`.
+            // That means this txn is downgrade from high version and we should disable
+            // `useCombinedTxnLog`, because we don't support compaction aggregate
+            // in current version.
+            if (sourceType == LoadJobSourceType.LAKE_COMPACTION && useCombinedTxnLog) {
+                useCombinedTxnLog = false;
+            }
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:
Selectively backport the code related to aggregate meta reading from #58289 to version 3.5, so that after the subsequent real-time scenario optimization feature is released, it can also smoothly downgrade to version 3.5.

## What I'm doing:
1. backport aggregate meta reading code.
2. Disable `useCombinedTxnLog` if txn is triggered by compaction. Because this txn is begin on high version which support compaction aggregation, but it doesn't support on v3.5.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1

