### PR TITLE
[BugFix] Fix invalid connections are fetched in the thrift connection pools

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -648,6 +648,10 @@ CONF_Bool(thrift_rpc_strict_mode, "true");
 // rpc max string body size. 0 means unlimited
 CONF_Int32(thrift_rpc_max_body_size, "0");
 
+// Maximum valid time for a thrift rpc connection. Just be consistent with FE's thrift_client_timeout_ms.
+// The connection will be closed if it has existed in the connection pool for longer than this value.
+CONF_Int32(thrift_rpc_connection_max_valid_time_ms, "5000");
+
 // txn commit rpc timeout
 CONF_mInt32(txn_commit_rpc_timeout_ms, "60000");
 

--- a/be/src/runtime/client_cache.h
+++ b/be/src/runtime/client_cache.h
@@ -135,7 +135,7 @@ private:
 
     // Create a new client for specific host/port in 'client' and put it in _client_map
     Status _create_client(const TNetworkAddress& hostport, const client_factory& factory_method, void** client_key);
-    void _remove_client(void* client_key, ThriftClientImpl* client);
+    void _evict_client(void* client_key, ThriftClientImpl* client);
 };
 
 template <class T>

--- a/be/src/runtime/client_cache.h
+++ b/be/src/runtime/client_cache.h
@@ -101,8 +101,6 @@ public:
     void init_metrics(MetricRegistry* metrics, const std::string& key_prefix);
 
 private:
-    void _remove_client(void* client_key, ThriftClientImpl* client);
-
     template <class T>
     friend class ClientCache;
     // Private constructor so that only ClientCache can instantiate this class.
@@ -136,8 +134,8 @@ private:
     std::unique_ptr<IntGauge> _opened_clients;
 
     // Create a new client for specific host/port in 'client' and put it in _client_map
-    Status create_client(const TNetworkAddress& hostport, const client_factory& factory_method, void** client_key,
-                         int timeout_ms);
+    Status _create_client(const TNetworkAddress& hostport, const client_factory& factory_method, void** client_key);
+    void _remove_client(void* client_key, ThriftClientImpl* client);
 };
 
 template <class T>

--- a/be/src/runtime/client_cache.h
+++ b/be/src/runtime/client_cache.h
@@ -101,6 +101,8 @@ public:
     void init_metrics(MetricRegistry* metrics, const std::string& key_prefix);
 
 private:
+    void _remove_client(void* client_key, ThriftClientImpl* client);
+
     template <class T>
     friend class ClientCache;
     // Private constructor so that only ClientCache can instantiate this class.

--- a/be/src/util/thrift_client.cpp
+++ b/be/src/util/thrift_client.cpp
@@ -17,11 +17,15 @@
 
 #include "util/thrift_client.h"
 
+#include <sys/poll.h>
+#include <sys/types.h>
+
 #include <ostream>
 #include <string>
 
 #include "gutil/strings/substitute.h"
 #include "util/monotime.h"
+#include "util/time.h"
 
 namespace starrocks {
 
@@ -89,6 +93,19 @@ void ThriftClientImpl::close() {
                       << ")";
         }
     }
+}
+
+bool ThriftClientImpl::is_active() {
+    if (MonotonicMillis() - _last_active_time > config::thrift_rpc_connection_max_valid_time_ms) {
+        return false;
+    }
+    // The server side does not actively send requests to the client.
+    // If the POLLIN event is triggered, then the server side is actively disconnecting.
+    pollfd fds[1];
+    fds[0].fd = _socket->getSocketFD();
+    fds[0].events = POLLIN;
+    int ret = poll(fds, 1, 0);
+    return ret == 0;
 }
 
 } // namespace starrocks

--- a/be/src/util/thrift_client.cpp
+++ b/be/src/util/thrift_client.cpp
@@ -95,6 +95,10 @@ void ThriftClientImpl::close() {
     }
 }
 
+void ThriftClientImpl::update_active_time() {
+    _last_active_time = MonotonicMillis();
+}
+
 bool ThriftClientImpl::is_active() {
     if (MonotonicMillis() - _last_active_time > config::thrift_rpc_connection_max_valid_time_ms) {
         return false;

--- a/be/src/util/thrift_client.h
+++ b/be/src/util/thrift_client.h
@@ -35,6 +35,7 @@
 #include "common/status.h"
 #include "gen_cpp/Types_types.h"
 #include "util/thrift_server.h"
+#include "util/time.h"
 
 namespace starrocks {
 
@@ -68,6 +69,10 @@ public:
     // Set the send timeout
     void set_send_timeout(int ms) { _socket->setSendTimeout(ms); }
 
+    void update_active_time() { _last_active_time = MonotonicMillis(); }
+
+    bool is_active();
+
 protected:
     ThriftClientImpl(const std::string& ipaddress, int port)
             : _ipaddress(ipaddress), _port(port), _socket(new apache::thrift::transport::TSocket(ipaddress, port)) {}
@@ -83,6 +88,7 @@ private:
     std::shared_ptr<apache::thrift::transport::TSocket> _socket;
     std::shared_ptr<apache::thrift::transport::TTransport> _transport;
     std::shared_ptr<apache::thrift::protocol::TBinaryProtocol> _protocol;
+    size_t _last_active_time;
 };
 
 // Utility client to a Thrift server. The parameter type is the

--- a/be/src/util/thrift_client.h
+++ b/be/src/util/thrift_client.h
@@ -69,7 +69,7 @@ public:
     // Set the send timeout
     void set_send_timeout(int ms) { _socket->setSendTimeout(ms); }
 
-    void update_active_time() { _last_active_time = MonotonicMillis(); }
+    void update_active_time();
 
     bool is_active();
 
@@ -88,7 +88,7 @@ private:
     std::shared_ptr<apache::thrift::transport::TSocket> _socket;
     std::shared_ptr<apache::thrift::transport::TTransport> _transport;
     std::shared_ptr<apache::thrift::protocol::TBinaryProtocol> _protocol;
-    size_t _last_active_time;
+    size_t _last_active_time{};
 };
 
 // Utility client to a Thrift server. The parameter type is the

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -541,6 +541,7 @@ set(EXEC_FILES
         ./cache/object_cache/lrucache_module_test.cpp
         ./cache/object_cache/object_cache_test.cpp
         ./util/thrift_rpc_helper_test.cpp
+        ./util/thrift_client_test.cpp
         ./udf/java/java_native_method_test.cpp
         ./udf/java/java_data_converter_test.cpp
         )

--- a/be/test/util/thrift_client_test.cpp
+++ b/be/test/util/thrift_client_test.cpp
@@ -1,0 +1,91 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <thrift/concurrency/Thread.h>
+#include <thrift/concurrency/ThreadFactory.h>
+#include <thrift/concurrency/ThreadManager.h>
+#include <thrift/protocol/TBinaryProtocol.h>
+#include <thrift/server/TSimpleServer.h>
+#include <thrift/server/TThreadPoolServer.h>
+#include <thrift/transport/TServerSocket.h>
+#include <thrift/transport/TSocket.h>
+
+#include <memory>
+
+#include "gen_cpp/FrontendService.h"
+#include "runtime/client_cache.h"
+#include "testutil/assert.h"
+#include "util/network_util.h"
+#include "util/thrift_rpc_helper.h"
+
+namespace starrocks {
+
+class MockedThriftService : public FrontendServiceNull {
+public:
+    ~MockedThriftService() override = default;
+};
+
+class MockedFrontendService {
+public:
+    void init();
+
+    ~MockedFrontendService() {
+        _server->stop();
+        _thr->join();
+    }
+
+    static inline const int MOCK_PORT = 18040;
+
+private:
+    std::unique_ptr<std::thread> _thr;
+    std::shared_ptr<FrontendServiceProcessor> _processer;
+    std::unique_ptr<apache::thrift::server::TSimpleServer> _server;
+};
+
+void MockedFrontendService::init() {
+    using namespace apache::thrift::transport;
+    using namespace apache::thrift::protocol;
+    using namespace apache::thrift::server;
+
+    auto service = std::make_shared<MockedThriftService>();
+    _processer = std::make_unique<FrontendServiceProcessor>(service);
+
+    auto serverTransport = std::make_shared<TServerSocket>(MOCK_PORT);
+    auto transportFactory = std::make_shared<TBufferedTransportFactory>();
+    auto protocolFactory = std::make_shared<TBinaryProtocolFactory>();
+    _server = std::make_unique<TSimpleServer>(_processer, serverTransport, transportFactory, protocolFactory);
+    _thr = std::make_unique<std::thread>([this]() { _server->serve(); });
+    // thrift server don't provide a start function
+    // wait server ready
+    sleep(3);
+}
+
+TEST(ThriftRpcClientCacheTest, test_all) {
+    MockedFrontendService service;
+    service.init();
+    TGetProfileResponse rep;
+    TGetProfileRequest req;
+
+    auto client_cache = std::make_unique<FrontendServiceClientCache>(config::max_client_cache_size_per_host);
+    TNetworkAddress address = make_network_address("127.0.0.1", MockedFrontendService::MOCK_PORT);
+    Status status;
+    FrontendServiceConnection client(client_cache.get(), address, 1000, &status);
+    ASSERT_OK(status);
+    client->getQueryProfile(rep, req);
+    ASSERT_OK(client.reopen(100));
+    client->getQueryProfile(rep, req);
+}
+
+} // namespace starrocks

--- a/be/test/util/thrift_rpc_helper_test.cpp
+++ b/be/test/util/thrift_rpc_helper_test.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include "gen_cpp/FrontendService.h"
 #include "runtime/client_cache.h"
 #include "testutil/assert.h"
 #include "util/network_util.h"

--- a/be/test/util/thrift_rpc_helper_test.cpp
+++ b/be/test/util/thrift_rpc_helper_test.cpp
@@ -16,7 +16,6 @@
 
 #include <gtest/gtest.h>
 
-#include "gen_cpp/FrontendService.h"
 #include "runtime/client_cache.h"
 #include "testutil/assert.h"
 #include "util/network_util.h"


### PR DESCRIPTION
This change ensures stale or disconnected Thrift RPC connections are detected and removed, improving reliability and consistency with frontend timeouts.

## Why I'm doing:
I've noticed that our BE's thrift rpc is very ‘unreliable’. One of the logs is shown below.
```
W20250602 13:26:55.698619 139920374855232 thrift_rpc_helper.cpp:118] rpc failed: Rpc error: FE RPC failure, address=TNetworkAddress(hostname=172.17.0.1, port=8505), reason=No more data to read., retry times: 0/2,address=TNetworkAddress(hostname=172.17.0.1, port=8505), timeout_ms=5000
```

`No more data to read` means that FE actively disconnects. I observed FE's thrift rpc execution flow. This one is due to

```
 org.apache.thrift.transport.TTransportException: java.net.SocketTimeoutException: Read timed out
        at org.apache.thrift.transport.TIOStreamTransport.read(TIOStreamTransport.java:172)
        at org.apache.thrift.transport.TTransport.readAll(TTransport.java:100)
        at org.apache.thrift.protocol.TBinaryProtocol.readAll(TBinaryProtocol.java:519)
        at org.apache.thrift.protocol.TBinaryProtocol.readI32(TBinaryProtocol.java:387)
        at org.apache.thrift.protocol.TBinaryProtocol.readMessageBegin(TBinaryProtocol.java:271)
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:27)
        at com.starrocks.common.SRTThreadPoolServer$WorkerProcess.run(SRTThreadPoolServer.java:311)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.net.SocketTimeoutException: Read timed out
        at java.base/sun.nio.ch.NioSocketImpl.timedRead(NioSocketImpl.java:288)
        at java.base/sun.nio.ch.NioSocketImpl.implRead(NioSocketImpl.java:314)
        at java.base/sun.nio.ch.NioSocketImpl.read(NioSocketImpl.java:355)
        at java.base/sun.nio.ch.NioSocketImpl$1.read(NioSocketImpl.java:808)
        at java.base/java.net.Socket$SocketInputStream.read(Socket.java:966)
        at java.base/java.io.BufferedInputStream.fill(BufferedInputStream.java:244)
        at java.base/java.io.BufferedInputStream.read1(BufferedInputStream.java:284)
        at java.base/java.io.BufferedInputStream.read(BufferedInputStream.java:343)
        at org.apache.thrift.transport.TIOStreamTransport.read(TIOStreamTransport.java:170)
        ... 9 more
```

This timeout is controlled by FE config `thrift_client_timeout_ms` for reading data from the socket stream.

Therefore, if more than `thrift_client_timeout_ms` are not active in the thrift rpc connection pool. then the connection is closed by the FE. If the load of the rpc meets this workload, the above error occurs.

## reproduce 
Set the following be config so that the connection times out and closes.
```
report_task_interval_seconds=300
report_disk_state_interval_seconds=300
report_tablet_interval_seconds=300
report_workgroup_interval_seconds=300
report_resource_usage_interval_ms=300000
report_datacache_metrics_interval_ms=3000           
```

We will observe logs in BE:
```
W20250602 13:26:58.799964 139920374855232 thrift_rpc_helper.cpp:118] rpc failed: Rpc error: FE RPC failure, address=TNetworkAddress(hostname=172.17.0.1, port=8505), reason=No more data to read., retry times: 0/2,address=TNetworkAddress(hostname=172.17.0.1, port=8505), timeout_ms=5000
```
## Why wasn't it caught earlier

Because BE regularly reports tablet/cpu/other info to FE. These are reported via thrift rpc and will use connections. But if a large number of thrift connections are generated in a short period of time. At this time the connections in the connection pool are not refreshed by these report tasks and this problem will arise.

## What I'm doing:

- Introduced `thrift_rpc_connection_max_valid_time_ms` config to set a maximum valid time for Thrift RPC connections, aligning with FE's `thrift_client_timeout_ms`.
- Enhanced `ClientCacheHelper`  to check client activity before reuse, removing inactive clients and creating new ones as needed.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
