### PR TITLE
[Refactor] Use page cache instead of object cache to cache external file footer

### DIFF
--- a/be/src/cache/object_cache/page_cache.cpp
+++ b/be/src/cache/object_cache/page_cache.cpp
@@ -102,8 +102,8 @@ bool StoragePageCache::lookup(const std::string& key, PageCacheHandle* handle) {
     return true;
 }
 
-Status StoragePageCache::insert(const std::string& key, std::vector<uint8_t>* data, PageCacheHandle* handle,
-                                const ObjectCacheWriteOptions& opts) {
+Status StoragePageCache::insert(const std::string& key, std::vector<uint8_t>* data, const ObjectCacheWriteOptions& opts,
+                                PageCacheHandle* handle) {
 #ifndef BE_TEST
     int64_t mem_size = malloc_usable_size(data->data()) + sizeof(*data);
     tls_thread_status.mem_release(mem_size);
@@ -128,8 +128,8 @@ Status StoragePageCache::insert(const std::string& key, std::vector<uint8_t>* da
     return st;
 }
 
-Status StoragePageCache::insert(const std::string& key, void* data, int64_t size, PageCacheHandle* handle,
-                                ObjectCacheDeleter deleter, const ObjectCacheWriteOptions& opts) {
+Status StoragePageCache::insert(const std::string& key, void* data, int64_t size, ObjectCacheDeleter deleter,
+                                const ObjectCacheWriteOptions& opts, PageCacheHandle* handle) {
     ObjectCacheHandle* obj_handle = nullptr;
     Status st = _cache->insert(key, data, size, deleter, &obj_handle, opts);
     if (st.ok()) {

--- a/be/src/cache/object_cache/page_cache.cpp
+++ b/be/src/cache/object_cache/page_cache.cpp
@@ -128,4 +128,14 @@ Status StoragePageCache::insert(const std::string& key, std::vector<uint8_t>* da
     return st;
 }
 
+Status StoragePageCache::insert(const std::string& key, void* data, int64_t size, PageCacheHandle* handle,
+                                ObjectCacheDeleter deleter, const ObjectCacheWriteOptions& opts) {
+    ObjectCacheHandle* obj_handle = nullptr;
+    Status st = _cache->insert(key, data, size, deleter, &obj_handle, opts);
+    if (st.ok()) {
+        *handle = PageCacheHandle(_cache, obj_handle);
+    }
+    return st;
+}
+
 } // namespace starrocks

--- a/be/src/cache/object_cache/page_cache.h
+++ b/be/src/cache/object_cache/page_cache.h
@@ -84,6 +84,9 @@ public:
     Status insert(const std::string& key, std::vector<uint8_t>* data, PageCacheHandle* handle,
                   const ObjectCacheWriteOptions& opts);
 
+    Status insert(const std::string& key, void* data, int64_t size, PageCacheHandle* handle, ObjectCacheDeleter deleter,
+                  const ObjectCacheWriteOptions& opts);
+
     size_t memory_usage() const { return _cache->usage(); }
 
     void set_capacity(size_t capacity);
@@ -128,9 +131,7 @@ public:
     }
 
     ObjectCache* cache() const { return _cache; }
-    const std::vector<uint8_t>* data() const {
-        return reinterpret_cast<const std::vector<uint8_t>*>(_cache->value(_handle));
-    }
+    const void* data() const { return _cache->value(_handle); }
 
 private:
     ObjectCache* _cache = nullptr;

--- a/be/src/cache/object_cache/page_cache.h
+++ b/be/src/cache/object_cache/page_cache.h
@@ -81,11 +81,11 @@ public:
     // This function is thread-safe, and when two clients insert two same key
     // concurrently, this function can assure that only one page is cached.
     // The in_memory page will have higher priority.
-    Status insert(const std::string& key, std::vector<uint8_t>* data, PageCacheHandle* handle,
-                  const ObjectCacheWriteOptions& opts);
+    Status insert(const std::string& key, std::vector<uint8_t>* data, const ObjectCacheWriteOptions& opts,
+                  PageCacheHandle* handle);
 
-    Status insert(const std::string& key, void* data, int64_t size, PageCacheHandle* handle, ObjectCacheDeleter deleter,
-                  const ObjectCacheWriteOptions& opts);
+    Status insert(const std::string& key, void* data, int64_t size, ObjectCacheDeleter deleter,
+                  const ObjectCacheWriteOptions& opts, PageCacheHandle* handle);
 
     size_t memory_usage() const { return _cache->usage(); }
 

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -173,7 +173,7 @@ Status HiveDataSource::open(RuntimeState* state) {
     if (state->query_options().__isset.enable_file_metacache) {
         _use_file_metacache = state->query_options().enable_file_metacache;
     }
-    _use_file_metacache &= BlockCache::instance()->mem_cache_available();
+    _use_file_metacache &= DataCache::GetInstance()->page_cache_available();
 
     if (state->query_options().__isset.enable_file_pagecache) {
         _use_file_pagecache = state->query_options().enable_file_pagecache;

--- a/be/src/formats/parquet/file_reader.h
+++ b/be/src/formats/parquet/file_reader.h
@@ -58,7 +58,7 @@ class ObjectCache;
 namespace starrocks::parquet {
 
 struct SplitContext : public HdfsSplitContext {
-    FileMetaDataPtr file_metadata;
+    const FileMetaData* file_metadata = nullptr;
     SkipRowsContextPtr skip_rows_ctx;
 
     HdfsSplitContextPtr clone() override {
@@ -80,7 +80,7 @@ public:
 
     Status get_next(ChunkPtr* chunk);
 
-    FileMetaData* get_file_metadata();
+    const FileMetaData* get_file_metadata();
 
     Status collect_scan_io_ranges(std::vector<io::SharedBufferedInputStream::IORange>* io_ranges);
 
@@ -102,15 +102,12 @@ private:
     StatusOr<bool> _update_rf_and_filter_group(const GroupReaderPtr& group_reader);
 
     // get row group to read
-    // if scan range conatain the first byte in the row group, will be read
+    // if scan range contain the first byte in the row group, will be read
     // TODO: later modify the larger block should be read
     bool _select_row_group(const tparquet::RowGroup& row_group);
 
     // only scan partition column + not exist column
     Status _exec_no_materialized_column_scan(ChunkPtr* chunk);
-
-    // get partition column idx in param.partition_columns
-    int32_t _get_partition_column_idx(const std::string& col_name) const;
 
     Status _build_split_tasks();
 
@@ -128,8 +125,9 @@ private:
     size_t _scan_row_count = 0;
     bool _no_materialized_column_scan = false;
 
-    ObjectCache* _cache = nullptr;
-    FileMetaDataPtr _file_metadata = nullptr;
+    StoragePageCache* _cache = nullptr;
+    const FileMetaData* _file_metadata = nullptr;
+    FileFooterHandle _file_footer_handle;
 
     // not exist column conjuncts eval false, file can be skipped
     bool _is_file_filtered = false;

--- a/be/src/formats/parquet/file_reader.h
+++ b/be/src/formats/parquet/file_reader.h
@@ -58,7 +58,7 @@ class ObjectCache;
 namespace starrocks::parquet {
 
 struct SplitContext : public HdfsSplitContext {
-    const FileMetaData* file_metadata = nullptr;
+    FileMetaDataPtr file_metadata;
     SkipRowsContextPtr skip_rows_ctx;
 
     HdfsSplitContextPtr clone() override {
@@ -126,8 +126,7 @@ private:
     bool _no_materialized_column_scan = false;
 
     StoragePageCache* _cache = nullptr;
-    const FileMetaData* _file_metadata = nullptr;
-    FileFooterHandle _file_footer_handle;
+    FileMetaDataPtr _file_metadata = nullptr;
 
     // not exist column conjuncts eval false, file can be skipped
     bool _is_file_filtered = false;

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -85,7 +85,7 @@ struct GroupReaderParam {
 
     RandomAccessFile* file = nullptr;
 
-    FileMetaData* file_metadata = nullptr;
+    const FileMetaData* file_metadata = nullptr;
 
     bool case_sensitive = false;
 

--- a/be/src/formats/parquet/meta_helper.h
+++ b/be/src/formats/parquet/meta_helper.h
@@ -44,7 +44,7 @@ namespace starrocks::parquet {
 
 class MetaHelper {
 public:
-    MetaHelper(FileMetaData* file_metadata, bool case_sensitive)
+    MetaHelper(const FileMetaData* file_metadata, bool case_sensitive)
             : _file_metadata(file_metadata), _case_sensitive(case_sensitive) {}
     virtual ~MetaHelper() = default;
 
@@ -65,13 +65,14 @@ protected:
         return column;
     }
 
-    FileMetaData* _file_metadata = nullptr;
+    const FileMetaData* _file_metadata = nullptr;
     bool _case_sensitive = false;
 };
 
 class ParquetMetaHelper : public MetaHelper {
 public:
-    ParquetMetaHelper(FileMetaData* file_metadata, bool case_sensitive) : MetaHelper(file_metadata, case_sensitive) {}
+    ParquetMetaHelper(const FileMetaData* file_metadata, bool case_sensitive)
+            : MetaHelper(file_metadata, case_sensitive) {}
     ~ParquetMetaHelper() override = default;
 
     void prepare_read_columns(const std::vector<HdfsScannerContext::ColumnInfo>& materialized_columns,
@@ -84,7 +85,7 @@ private:
 
 class LakeMetaHelper : public MetaHelper {
 public:
-    LakeMetaHelper(FileMetaData* file_metadata, bool case_sensitive, const TIcebergSchema* t_lake_schema)
+    LakeMetaHelper(const FileMetaData* file_metadata, bool case_sensitive, const TIcebergSchema* t_lake_schema)
             : MetaHelper(file_metadata, case_sensitive) {
         _lake_schema = t_lake_schema;
         DCHECK(_lake_schema != nullptr);

--- a/be/src/formats/parquet/metadata.cpp
+++ b/be/src/formats/parquet/metadata.cpp
@@ -473,8 +473,8 @@ StatusOr<const FileMetaData*> FileMetaDataParser::get_file_metadata(FileFooterHa
         auto deleter = [](const starrocks::CacheKey& key, void* value) { delete (FileMetaData*)value; };
         ObjectCacheWriteOptions options;
         options.evict_probability = _datacache_options->datacache_evict_probability;
-        Status st = _cache->insert(metacache_key, (void*)(file_metadata.get()), file_metadata_size, &cache_handle,
-                                   deleter, options);
+        Status st = _cache->insert(metacache_key, (void*)(file_metadata.get()), file_metadata_size, deleter, options,
+                                   &cache_handle);
         if (st.ok()) {
             _scanner_ctx->stats->footer_cache_write_bytes += file_metadata_size;
             _scanner_ctx->stats->footer_cache_write_count += 1;

--- a/be/src/formats/parquet/metadata.h
+++ b/be/src/formats/parquet/metadata.h
@@ -106,7 +106,7 @@ private:
     ApplicationVersion _writer_version;
 };
 
-using FileMetaDataPtr = std::unique_ptr<FileMetaData>;
+using FileMetaDataPtr = std::shared_ptr<FileMetaData>;
 
 // FileMetaDataParser parse FileMetaData through below way:
 // 1. try to reuse SplitContext's FileMetaData
@@ -120,7 +120,7 @@ public:
               _cache(cache),
               _datacache_options(datacache_options),
               _file_size(file_size) {}
-    StatusOr<const FileMetaData*> get_file_metadata(FileFooterHandle* handle);
+    StatusOr<FileMetaDataPtr> get_file_metadata();
 
 private:
     Status _parse_footer(FileMetaDataPtr* file_metadata_ptr, int64_t* file_metadata_size);

--- a/be/src/formats/parquet/page_reader.cpp
+++ b/be/src/formats/parquet/page_reader.cpp
@@ -93,7 +93,7 @@ Status PageReader::_deal_page_with_cache() {
         }
         RETURN_IF_ERROR(_read_and_decompress_internal(true));
         ObjectCacheWriteOptions opts{.evict_probability = _opts.datacache_options->datacache_evict_probability};
-        auto st = _cache->insert(page_cache_key, _cache_buf, &cache_handle, opts);
+        auto st = _cache->insert(page_cache_key, _cache_buf, opts, &cache_handle);
         if (st.ok()) {
             _page_handle = PageHandle(std::move(cache_handle));
             _opts.stats->page_cache_write_counter += 1;

--- a/be/src/formats/parquet/page_reader.cpp
+++ b/be/src/formats/parquet/page_reader.cpp
@@ -75,7 +75,8 @@ Status PageReader::_deal_page_with_cache() {
         // TODO: This is an ugly implementation. The _cache_buf is used both as a const pointer
         //  retrieved from the cache and as a temporary mutable pointer before insertion into the cache.
         //  Therefore, I must use const_cast here, which will be optimized later.
-        _cache_buf = const_cast<std::vector<uint8_t>*>(cache_handle.data());
+        _cache_buf =
+                const_cast<std::vector<uint8_t>*>(reinterpret_cast<const std::vector<uint8_t>*>(cache_handle.data()));
         _page_handle = PageHandle(std::move(cache_handle));
         _header_length = _cache_buf->size();
         auto st = deserialize_thrift_msg(_cache_buf->data(), &_header_length, TProtocolType::COMPACT, &_cur_header);

--- a/be/src/storage/rowset/page_handle.h
+++ b/be/src/storage/rowset/page_handle.h
@@ -36,6 +36,7 @@
 
 #include "cache/object_cache/page_cache.h"
 #include "gutil/macros.h" // for DISALLOW_COPY
+#include "storage/rowset/page_handle_fwd.h"
 #include "util/slice.h"
 
 namespace starrocks {
@@ -45,32 +46,33 @@ namespace starrocks {
 // class to unify these two cases.
 // If client use this struct to wrap data not in cache, this class
 // will free data's memory when it is destroyed.
-class PageHandle {
+template <class PageType>
+class PageHandleTmpl {
 public:
-    PageHandle() = default;
+    PageHandleTmpl() = default;
 
     // This class will take the ownership of input data's memory. It will
     // free it when deconstructs.
-    explicit PageHandle(std::vector<uint8_t>* data) : _is_data_owner(true), _data(data) {}
+    explicit PageHandleTmpl(PageType* data) : _is_data_owner(true), _data(data) {}
 
     // This class will take the content of cache data, and will make input
     // cache_data to an invalid cache handle.
-    explicit PageHandle(PageCacheHandle&& cache_data) : _cache_data(std::move(cache_data)) {}
+    explicit PageHandleTmpl(PageCacheHandle&& cache_data) : _cache_data(std::move(cache_data)) {}
 
     // Move constructor
-    PageHandle(PageHandle&& other) noexcept : _data(other._data), _cache_data(std::move(other._cache_data)) {
+    PageHandleTmpl(PageHandleTmpl&& other) noexcept : _data(other._data), _cache_data(std::move(other._cache_data)) {
         // we can use std::exchange if we switch c++14 on
         std::swap(_is_data_owner, other._is_data_owner);
     }
 
-    PageHandle& operator=(PageHandle&& other) noexcept {
+    PageHandleTmpl& operator=(PageHandleTmpl&& other) noexcept {
         std::swap(_is_data_owner, other._is_data_owner);
         _data = other._data;
         _cache_data = std::move(other._cache_data);
         return *this;
     }
 
-    ~PageHandle() {
+    ~PageHandleTmpl() {
         if (_is_data_owner) {
             delete _data;
             _data = nullptr;
@@ -86,11 +88,11 @@ public:
     }
 
     // the return slice contains uncompressed page body, page footer, and footer size
-    const std::vector<uint8_t>* data() const {
+    const PageType* data() const {
         if (_is_data_owner) {
             return _data;
         } else {
-            return _cache_data.data();
+            return reinterpret_cast<const PageType*>(_cache_data.data());
         }
     }
 
@@ -106,12 +108,12 @@ private:
     // when this is true, it means this struct own data and _data is valid.
     // otherwise _cache_data is valid, and data is belonged to cache.
     bool _is_data_owner = false;
-    std::vector<uint8_t>* _data = nullptr;
+    PageType* _data = nullptr;
     PageCacheHandle _cache_data;
 
     // Don't allow copy and assign
-    PageHandle(const PageHandle&) = delete;
-    const PageHandle& operator=(const PageHandle&) = delete;
+    PageHandleTmpl(const PageHandleTmpl&) = delete;
+    const PageHandleTmpl& operator=(const PageHandleTmpl&) = delete;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/page_handle_fwd.h
+++ b/be/src/storage/rowset/page_handle_fwd.h
@@ -25,5 +25,5 @@ template <class PageType>
 class PageHandleTmpl;
 
 using PageHandle = PageHandleTmpl<std::vector<uint8_t>>;
-using FileFooterHandle = PageHandleTmpl<parquet::FileMetaData>;
+using FileFooterHandle = PageHandleTmpl<std::shared_ptr<parquet::FileMetaData>*>;
 } // namespace starrocks

--- a/be/src/storage/rowset/page_handle_fwd.h
+++ b/be/src/storage/rowset/page_handle_fwd.h
@@ -1,0 +1,29 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace starrocks {
+namespace parquet {
+class FileMetaData;
+}
+template <class PageType>
+class PageHandleTmpl;
+
+using PageHandle = PageHandleTmpl<std::vector<uint8_t>>;
+using FileFooterHandle = PageHandleTmpl<parquet::FileMetaData>;
+} // namespace starrocks

--- a/be/src/storage/rowset/page_io.cpp
+++ b/be/src/storage/rowset/page_io.cpp
@@ -256,7 +256,7 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
     if (opts.use_page_cache) {
         // insert this page into cache and return the cache handle
         ObjectCacheWriteOptions opts;
-        Status st = cache->insert(cache_key, page.get(), &cache_handle, opts);
+        Status st = cache->insert(cache_key, page.get(), opts, &cache_handle);
         *handle = st.ok() ? PageHandle(std::move(cache_handle)) : PageHandle(page.get());
     } else {
         *handle = PageHandle(page.get());

--- a/be/src/storage/rowset/parsed_page.h
+++ b/be/src/storage/rowset/parsed_page.h
@@ -39,6 +39,7 @@
 #include "storage/range.h"
 #include "storage/rowset/common.h" // ordinal_t
 #include "storage/rowset/page_decoder.h"
+#include "storage/rowset/page_handle_fwd.h"
 #include "storage/rowset/page_pointer.h"
 
 namespace starrocks {
@@ -47,7 +48,6 @@ class Status;
 class Column;
 class DataPageFooterPB;
 class EncodingInfo;
-class PageHandle;
 class PagePointer;
 
 class ParsedPage {

--- a/be/test/cache/object_cache/page_cache_test.cpp
+++ b/be/test/cache/object_cache/page_cache_test.cpp
@@ -78,7 +78,7 @@ TEST_F(StoragePageCacheTest, insert_with_deleter) {
         PageCacheHandle handle;
         ObjectCacheWriteOptions opts;
 
-        ASSERT_OK(_page_cache->insert(key, (void*)value, 15, &handle, deleter, opts));
+        ASSERT_OK(_page_cache->insert(key, (void*)value, 15, deleter, opts, &handle));
         Value* handle_value = (Value*)handle.data();
         ASSERT_EQ(handle_value->value, "value_of_123");
     }
@@ -101,7 +101,7 @@ TEST_F(StoragePageCacheTest, normal) {
         PageCacheHandle handle;
 
         ObjectCacheWriteOptions opts;
-        ASSERT_OK(_page_cache->insert(key, data.get(), &handle, &opts));
+        ASSERT_OK(_page_cache->insert(key, data.get(), &opts, &handle));
         ASSERT_EQ(handle.data(), data.get());
         auto* check_data = data.release();
 
@@ -116,7 +116,7 @@ TEST_F(StoragePageCacheTest, normal) {
         PageCacheHandle handle;
 
         ObjectCacheWriteOptions opts{.priority = true};
-        ASSERT_OK(_page_cache->insert(key, data.get(), &handle, opts));
+        ASSERT_OK(_page_cache->insert(key, data.get(), opts, &handle));
         ASSERT_EQ(handle.data(), data.get());
         data.release();
 
@@ -130,7 +130,7 @@ TEST_F(StoragePageCacheTest, normal) {
         auto data = std::make_unique<std::vector<uint8_t>>(1024);
         PageCacheHandle handle;
         ObjectCacheWriteOptions opts;
-        ASSERT_OK(_page_cache->insert(key, data.get(), &handle, opts));
+        ASSERT_OK(_page_cache->insert(key, data.get(), opts, &handle));
         data.release();
     }
 
@@ -197,7 +197,7 @@ TEST_F(StoragePageCacheTest, metrics) {
         // Insert a piece of data, but the application layer does not release it.
         auto data = std::make_unique<std::vector<uint8_t>>(1024);
         ObjectCacheWriteOptions opts;
-        ASSERT_OK(_page_cache->insert(key1, data.get(), &handle1, opts));
+        ASSERT_OK(_page_cache->insert(key1, data.get(), opts, &handle1));
         data.release();
     }
 
@@ -206,7 +206,7 @@ TEST_F(StoragePageCacheTest, metrics) {
         auto data = std::make_unique<std::vector<uint8_t>>(1024);
         PageCacheHandle handle2;
         ObjectCacheWriteOptions opts;
-        ASSERT_OK(_page_cache->insert(key2, data.get(), &handle2, opts));
+        ASSERT_OK(_page_cache->insert(key2, data.get(), opts, &handle2));
         data.release();
     }
 

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -3351,7 +3351,8 @@ TEST_F(FileReaderTest, TestReadFooterCache) {
     CacheOptions options = TestCacheUtils::create_simple_options(256 * KB, 100 * MB);
     auto local_cache = std::make_shared<StarCacheWrapper>();
     ASSERT_OK(local_cache->init(options));
-    auto cache = std::make_shared<StarCacheModule>(local_cache->starcache_instance());
+    auto starcache_module = std::make_shared<StarCacheModule>(local_cache->starcache_instance());
+    auto cache = std::make_shared<StoragePageCache>(starcache_module.get());
 
     auto file = _create_file(_file1_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),

--- a/be/test/formats/parquet/parquet_cli_reader.h
+++ b/be/test/formats/parquet/parquet_cli_reader.h
@@ -50,7 +50,7 @@ public:
         THdfsScanRange* scan_range = _create_scan_range(_filepath);
 
         // create temporary reader to load schema.
-        FileMetaData* file_metadata = nullptr;
+        const FileMetaData* file_metadata = nullptr;
         HdfsScannerContext ctx;
         HdfsScanStats stats;
         ctx.stats = &stats;

--- a/be/test/util/starrocks_metrics_test.cpp
+++ b/be/test/util/starrocks_metrics_test.cpp
@@ -282,7 +282,7 @@ TEST_F(StarRocksMetricsTest, PageCacheMetrics) {
             PageCacheHandle handle;
             auto data = std::make_unique<std::vector<uint8_t>>(1024);
             ObjectCacheWriteOptions opts;
-            ASSERT_OK(_page_cache->insert(key, data.get(), &handle, opts));
+            ASSERT_OK(_page_cache->insert(key, data.get(), opts, &handle));
             ASSERT_TRUE(_page_cache->lookup(key, &handle));
             data.release();
         }


### PR DESCRIPTION
## Why I'm doing:

`LRUCacheModule` and `StarCacheModule` are only the wrappers of object cache interfaces. `PageCache` is used to cache the decompressed or decoded page, and `BlockCache` is used to cache the raw block of external tables or shared-data tables.

![image](https://github.com/user-attachments/assets/0eac9693-b1db-44ca-925a-99221f2a5cdd)

## What I'm doing:

Use page cache instead of object cache to cache external file footer 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
