### PR TITLE
[Enhancement] Optimize the disk cache space monitor to simplify the logic of automatic capacity adjustment for datacache. (backport #57452)

### DIFF
--- a/be/src/cache/block_cache/datacache_utils.cpp
+++ b/be/src/cache/block_cache/datacache_utils.cpp
@@ -15,6 +15,7 @@
 #include "cache/block_cache/datacache_utils.h"
 
 #include <fmt/format.h>
+#include <sys/stat.h>
 
 #include <filesystem>
 
@@ -145,7 +146,7 @@ Status DataCacheUtils::change_disk_path(const std::string& old_disk_path, const 
     std::filesystem::path old_path(old_disk_path);
     std::filesystem::path new_path(new_disk_path);
     if (std::filesystem::exists(old_path)) {
-        if (DiskInfo::disk_id(old_path.c_str()) != DiskInfo::disk_id(new_path.c_str())) {
+        if (disk_device_id(old_path.c_str()) != disk_device_id(new_path.c_str())) {
             LOG(ERROR) << "fail to rename the old datacache directory [" << old_path.string() << "] to the new one ["
                        << new_path.string() << "] because they are located on different disks.";
             return Status::InternalError("The old datacache directory is different from the new one");
@@ -162,6 +163,14 @@ Status DataCacheUtils::change_disk_path(const std::string& old_disk_path, const 
         }
     }
     return Status::OK();
+}
+
+dev_t DataCacheUtils::disk_device_id(const std::string& disk_path) {
+    struct stat s;
+    if (stat(disk_path.c_str(), &s) != 0) {
+        return 0;
+    }
+    return s.st_dev;
 }
 
 } // namespace starrocks

--- a/be/src/cache/block_cache/datacache_utils.h
+++ b/be/src/cache/block_cache/datacache_utils.h
@@ -35,6 +35,8 @@ public:
     static void clean_residual_datacache(const std::string& disk_path);
 
     static Status change_disk_path(const std::string& old_disk_path, const std::string& new_disk_path);
+
+    static dev_t disk_device_id(const std::string& disk_path);
 };
 
 } // namespace starrocks

--- a/be/src/cache/block_cache/disk_space_monitor.h
+++ b/be/src/cache/block_cache/disk_space_monitor.h
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <sys/stat.h>
-
 #include <atomic>
 #include <mutex>
 #include <thread>
@@ -48,6 +46,7 @@ public:
         int64_t capacity_bytes = 0;
         int64_t available_bytes = 0;
 
+        int64_t used_bytes() { return capacity_bytes - available_bytes; }
         double used_rate() { return static_cast<double>(capacity_bytes - available_bytes) / capacity_bytes; }
     };
 
@@ -65,7 +64,7 @@ public:
 
     std::vector<DirSpace>& dir_spaces() { return _dir_spaces; }
 
-    size_t total_cache_quota();
+    size_t cache_quota();
 
     // The align unit when adjusting cache disk quota. We set it to 10G to keep consistent with underlying cache file size,
     // which can help reduce processing the specail tail files.
@@ -81,13 +80,17 @@ private:
 
     void _revise_disk_stats_by_cache_dir();
 
-    void _update_spaces_by_cache_usage(const AdjustContext& ctx);
-
     void _update_spaces_by_cache_quota(size_t cache_avalil_bytes);
 
     bool _allow_expansion(const AdjustContext& ctx);
 
+    size_t _cache_usage(const AdjustContext& ctx);
+
+    size_t _check_cache_limit(int64_t cache_quota);
+
     size_t _check_cache_low_limit(int64_t cache_quota);
+
+    size_t _check_cache_high_limit(int64_t cache_quota);
 
     dev_t _device_id = 0;
     std::string _path;

--- a/be/src/cache/block_cache/starcache_wrapper.cpp
+++ b/be/src/cache/block_cache/starcache_wrapper.cpp
@@ -54,7 +54,7 @@ Status StarCacheWrapper::init(const CacheOptions& options) {
 
     _enable_tiered_cache = options.enable_tiered_cache;
     _enable_datacache_persistence = options.enable_datacache_persistence;
-    _cache = std::make_unique<starcache::StarCache>();
+    _cache = std::make_shared<starcache::StarCache>();
     return to_status(_cache->init(opt));
 }
 


### PR DESCRIPTION
## Why I'm doing:
Now we calculate the target cache quota based on the delta used rate, which make it complex and is prone to errors.

## What I'm doing:
* Optimize the disk cache space monitor to calculate the target cache based on the current disk usage, to simplify the logic of automatic capacity adjustment for datacache.

* Compare disk instances by disk device id instead of disk id because the DiskInfo::disk_id() may return -1 in some virtualization environments.

* Fix the unmatched starcache instance pointers.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1

