### PR TITLE
[BugFix] Fix FeExecuteCoordinator bug for empty table scans 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/FeExecuteCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/FeExecuteCoordinator.java
@@ -336,7 +336,9 @@ public class FeExecuteCoordinator extends Coordinator {
         final List<ByteBuffer> res = Lists.newArrayList();
         if (valueOperatorProjection == null) {
             // Map values operator's output column references to their indices
-            final Map<ColumnRefOperator, Integer> valuesOperatorOutputMap = IntStream.range(0, outputColumnRefs.size())
+            // NOTE: valuesOperatorColumnRefs's length may be different from outputColumnRefs's
+            // length when the query is from an empty table scan.
+            final Map<ColumnRefOperator, Integer> valuesOperatorOutputMap = IntStream.range(0, valuesOperatorColumnRefs.size())
                     .boxed()
                     .collect(Collectors.toMap(valuesOperatorColumnRefs::get, i -> i));
             // Find the indices of the output columns in the values operator's output

--- a/test/sql/test_execute_in_fe/R/test_execute_in_fe
+++ b/test/sql/test_execute_in_fe/R/test_execute_in_fe
@@ -87,3 +87,28 @@ select cast(1.123 as time);
 -- result:
 0:00:01
 -- !result
+CREATE TABLE pksk_tbl (
+    c1 int,
+    c2 date,
+    c3 varchar(10),
+    c4 bigint,
+    c5 varchar(3),
+    c6 datetime,
+    c7 string,
+    c8 decimal(10,5),
+    c9 boolean,
+    c10 largeint,
+    c11 date,
+    c12 float,
+    c13 double)
+PRIMARY KEY(c1,c2)
+DISTRIBUTED BY HASH(c1) BUCKETS 3
+ORDER BY(c1,c6,c11,c2);
+-- result:
+-- !result
+select c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13 from pksk_tbl limit 1;
+-- result:
+-- !result
+select c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13 from pksk_tbl;
+-- result:
+-- !result

--- a/test/sql/test_execute_in_fe/T/test_execute_in_fe
+++ b/test/sql/test_execute_in_fe/T/test_execute_in_fe
@@ -33,3 +33,25 @@ select cast(0.00001 as float), cast(0.00001 as double);
 
 select cast(100 as time);
 select cast(1.123 as time);
+
+CREATE TABLE pksk_tbl (
+    c1 int,
+    c2 date,
+    c3 varchar(10),
+    c4 bigint,
+    c5 varchar(3),
+    c6 datetime,
+    c7 string,
+    c8 decimal(10,5),
+    c9 boolean,
+    c10 largeint,
+    c11 date,
+    c12 float,
+    c13 double)
+PRIMARY KEY(c1,c2)
+DISTRIBUTED BY HASH(c1) BUCKETS 3
+ORDER BY(c1,c6,c11,c2);
+
+select c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13 from pksk_tbl limit 1;
+
+select c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13 from pksk_tbl;


### PR DESCRIPTION
## Why I'm doing:

https://github.com/StarRocks/starrocks/pull/59379 introduces a possible bug for empty plan: 
```
 2025-06-03 14:40:49.739+08:00 WARN (MVActiveChecker|71) [MVActiveChecker.tryToActivate():141] [MVActiveChecker] skip active MV Table [id=37120, name=test_mv1, type=MATERIALIZED_VIEW] since it's in grace-period
 2025-06-03 14:41:39.314+08:00 WARN (starrocks-mysql-nio-pool-18|12944) [StmtExecutor.execute():844] execute Exception, sql select c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13 from pksk_tbl limit 1
 java.lang.IndexOutOfBoundsException: Index 13 out of bounds for length 13
        at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
        at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
        at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
        at java.base/java.util.Objects.checkIndex(Objects.java:359)
        at java.base/java.util.ArrayList.get(ArrayList.java:427)
        at java.base/java.util.stream.Collectors.lambda$uniqKeysMapAccumulator$1(Collectors.java:179)
        at java.base/java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)
        at java.base/java.util.stream.IntPipeline$1$1.accept(IntPipeline.java:180)
        at java.base/java.util.stream.Streams$RangeIntSpliterator.forEachRemaining(Streams.java:104)
        at java.base/java.util.Spliterator$OfInt.forEachRemaining(Spliterator.java:711)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
        at com.starrocks.qe.scheduler.FeExecuteCoordinator.covertToMySQLRowBuffer(FeExecuteCoordinator.java:341)
        at com.starrocks.qe.scheduler.FeExecuteCoordinator.getNext(FeExecuteCoordinator.java:113)
        at com.starrocks.qe.StmtExecutor.handleQueryStmt(StmtExecutor.java:1378)
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:682)
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:421)
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:631)
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:980)
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:71)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
2025-06-03 14:41:49.740+08:00 WARN (MVActiveChecker|71) [MVActiveCh
```

When FeExecuteCoordinator handles all constant expressions(eg: `select 1, 2`), `valuesOperatorColumnRefs`'s length must be plan's `outputColumnRefs`'s length, but this is not correct for pruned table scans.

## What I'm doing:
- use `valuesOperatorColumnRefs` rather than `outputColumnRefs` to construct `valuesOperatorOutputMap`

Fixes https://github.com/StarRocks/StarRocksTest/issues/9741

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
