### PR TITLE
[BugFix] defensive coding against empty partition

### DIFF
--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -559,6 +559,7 @@ Status OlapTablePartitionParam::remove_partitions(const std::vector<int64_t>& pa
 
         _partitions.erase(it);
     }
+    LOG_IF(INFO, _partitions.empty()) << "Empty partitions for db:" << db_id() << ", table_id:" << table_id();
 
     return Status::OK();
 }
@@ -706,6 +707,13 @@ Status OlapTablePartitionParam::find_tablets(Chunk* chunk, std::vector<OlapTable
         auto& part_ids = _partitions_map.begin()->second;
         for (size_t i = 0; i < num_rows; ++i) {
             if ((*selection)[i]) {
+                if (_partitions.empty()) {
+                    // Don't know the reason yet, just defensive coding not crashing the process and possibly for further investigation
+                    LOG(WARNING) << "empty partition for selection[i=" << i << "]=" << (*selection)[i]
+                                 << ", db=" << db_id() << ", table_id=" << table_id();
+                    return Status::InternalError(
+                            fmt::format("empty partitions for db={}, table={}", db_id(), table_id()));
+                }
                 (*partitions)[i] = _partitions[part_ids[(*hashes)[i] % _partitions.size()]];
             }
         }


### PR DESCRIPTION
## Why I'm doing:

`SIGFPE` with the following stack trace.
```
#0  0x00000000040d1efc in starrocks::OlapTablePartitionParam::find_tablets (this=0x146cd7cfde40, chunk=chunk@entry=0x1475a2b13d80, partitions=partitions@entry=0x146e549b61e8, indexes=indexes@entry=0x146e549b6238, selection=selection@entry=0x146e549b61a8, invalid_row_indexs=0x147828e34310, txn_id=930170583, partition_not_exist_row_values=0x0) at be/src/exec/tablet_info.cpp:717
#1  0x00000000040e5d7a in starrocks::OlapTableSink::_send_chunk (this=0x146e549b6000, state=<optimized out>, chunk=0x1475a2b13d80, nonblocking=nonblocking@entry=true) at be/src/exec/tablet_sink.cpp:686
#2  0x00000000040e6bb8 in starrocks::OlapTableSink::send_chunk_nonblocking (this=<optimized out>, state=<optimized out>, chunk=<optimized out>) at be/src/exec/tablet_sink.cpp:592
#3  0x0000000004449b47 in starrocks::pipeline::OlapTableSinkOperator::push_chunk (this=this@entry=0x146c436a0810, state=state@entry=0x146c6041d800, chunk=...) at be/src/exec/pipeline/olap_table_sink_operator.cpp:156
#4  0x00000000044d92c7 in starrocks::pipeline::PipelineDriver::process (this=0x146c60a2a010, runtime_state=0x146c6041d800, worker_id=<optimized out>) at be/src/exec/pipeline/pipeline_driver.cpp:349
#5  0x000000000479b583 in starrocks::pipeline::GlobalDriverExecutor::_worker_thread (this=0x147c5f1eaf00) at be/src/exec/pipeline/pipeline_driver_executor.cpp:154
#6  0x000000000397eab3 in starrocks::ThreadPool::dispatch_thread (this=0x147c49fdf100) at be/src/util/threadpool.cpp:635
#7  0x0000000003976d56 in std::function<void ()>::operator()() const (this=0x147c4a124c18) at /opt/rh/gcc-toolset-10/root/usr/include/c++/10.3.0/bits/std_function.h:622
#8  starrocks::Thread::supervise_thread (arg=0x147c4a124c00) at be/src/util/thread.cpp:366
#9  0x0000147c61089c02 in start_thread () from /lib64/libc.so.6
#10 0x0000147c6110ec40 in clone3 () from /lib64/libc.so.6
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
