### PR TITLE
[BugFix] fix shard group id lost when replay DDL from 3.3

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
@@ -463,6 +463,11 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
         Preconditions.checkState(!idToVisibleRollupIndex.containsKey(shadowIndexId), shadowIndexId);
         shadowIdx.setState(IndexState.NORMAL);
         if (isBaseIndex) {
+            // in shared-data cluster, if upgraded from 3.3 or older version, `shardGroupId` will not
+            // be set, so must set it here
+            if (shadowIdx.getShardGroupId() == PhysicalPartition.INVALID_SHARD_GROUP_ID) {
+                shadowIdx.setShardGroupId(shardGroupId);
+            }
             baseIndex = shadowIdx;
         } else {
             idToVisibleRollupIndex.put(shadowIndexId, shadowIdx);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

in 3.3 DDL's shadow index `MaterializedIndex`, shard group is not stored, when replay ddl from 3.3, shard group will not be set, which will cause shard group lost and wrongly deleted by StarMgrMetaSyncer

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
