### PR TITLE
[Enhancement] Add sessionId to audit log

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
@@ -151,6 +151,9 @@ public class AuditEvent {
     @AuditField(value = "QueryFEAllocatedMemory")
     public long queryFeMemory = 0;
 
+    @AuditField(value = "SessionId")
+    public String sessionId = "";
+
     public static class AuditEventBuilder {
 
         private AuditEvent auditEvent = new AuditEvent();
@@ -386,6 +389,11 @@ public class AuditEvent {
 
         public AuditEventBuilder setQueryFeMemory(long queryFeMemory) {
             auditEvent.queryFeMemory = queryFeMemory;
+            return this;
+        }
+
+        public AuditEventBuilder setSessionId(String sessionId) {
+            auditEvent.sessionId = sessionId;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -227,7 +227,8 @@ public class ConnectProcessor {
                 .setReturnRows(ctx.getReturnRows())
                 .setStmtId(ctx.getStmtId())
                 .setIsForwardToLeader(isForwardToLeader)
-                .setQueryId(ctx.getQueryId() == null ? "NaN" : ctx.getQueryId().toString());
+                .setQueryId(ctx.getQueryId() == null ? "NaN" : ctx.getQueryId().toString())
+                .setSessionId(ctx.getSessionId().toString());
 
         if (ctx.getState().isQuery()) {
             MetricRepo.COUNTER_QUERY_ALL.increase(1L);

--- a/fe/fe-core/src/test/java/com/starrocks/plugin/AuditEventTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/plugin/AuditEventTest.java
@@ -30,10 +30,14 @@ public class AuditEventTest {
                 .setState("state")
                 .setBigQueryLogCPUSecondThreshold(1)
                 .setCatalog("catalog")
+                .setQueryId("queryId")
+                .setStmtId(123)
+                .setStmt("stmt")
                 .setDigest("digest")
                 .setErrorCode("errorCode")
                 .setIsQuery(true)
-                .setWarehouse("wh");
+                .setWarehouse("wh")
+                .setSessionId("sessionId");
         AuditEvent event = builder.build();
 
         Assert.assertEquals(AuditEvent.EventType.CONNECTION, event.type);
@@ -45,8 +49,13 @@ public class AuditEventTest {
         Assert.assertEquals("state", event.state);
         Assert.assertEquals(1, event.bigQueryLogCPUSecondThreshold);
         Assert.assertEquals("catalog", event.catalog);
+        Assert.assertEquals("queryId", event.queryId);
+        Assert.assertEquals(123, event.stmtId);
+        Assert.assertEquals("stmt", event.stmt);
+        Assert.assertEquals("digest", event.digest);
         Assert.assertEquals("errorCode", event.errorCode);
         Assert.assertEquals(true, event.isQuery);
         Assert.assertEquals("wh", event.warehouse);
+        Assert.assertEquals("sessionId", event.sessionId);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Currently audit log has queryId, statementId and so on. But there is no information if queries were created by the same session or different ones.

## What I'm doing:

Partially solves #58963

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [X] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
