### PR TITLE
[BugFix] Fix string to infinity float bug

### DIFF
--- a/be/src/util/string_parser.hpp
+++ b/be/src/util/string_parser.hpp
@@ -490,6 +490,8 @@ inline T StringParser::string_to_float_internal(const char* s, int len, ParseRes
                 *result = PARSE_FAILURE;
                 return 0;
             }
+        } else {
+            break;
         }
     }
 

--- a/be/test/util/string_parser_test.cpp
+++ b/be/test/util/string_parser_test.cpp
@@ -485,6 +485,11 @@ TEST(StringToFloat, Basic) {
     test_all_float_variants("INFinity", StringParser::PARSE_SUCCESS);
     test_all_float_variants("infinity", StringParser::PARSE_SUCCESS);
     test_all_float_variants("inf", StringParser::PARSE_SUCCESS);
+    test_all_float_variants("Inf", StringParser::PARSE_SUCCESS);
+
+    test_all_float_variants("xinf", StringParser::PARSE_FAILURE);
+    test_all_float_variants("innf", StringParser::PARSE_FAILURE);
+    test_all_float_variants("ErrorInfo", StringParser::PARSE_FAILURE);
 
     test_float_value_is_nan<float>("nan", StringParser::PARSE_SUCCESS);
     test_float_value_is_nan<double>("nan", StringParser::PARSE_SUCCESS);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

`xinf and ErrorInfo` are not `float` values, should not be converted to `float infinity`.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
