### PR TITLE
[BugFix] keep lambdaFunction's isConst as before, array_contains fall back to non-const process when state is nullptr

### DIFF
--- a/be/src/exprs/array_functions.tpp
+++ b/be/src/exprs/array_functions.tpp
@@ -1820,13 +1820,13 @@ public:
                 if (is_const_array) {
                     auto* state = reinterpret_cast<ArrayContainsState*>(
                             context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
-                    if (UNLIKELY(state == nullptr)) {
-                        return Status::InternalError("array_contains get state failed");
+                    // todo: fix LambdaFunction's isConst()
+                    if (state != nullptr) {
+                        return is_nullable_target ? _process_with_hash_table<true>(state, target_data_column,
+                                                                                   target_null_data, is_const_target)
+                                                  : _process_with_hash_table<false>(state, target_data_column,
+                                                                                    target_null_data, is_const_target);
                     }
-                    return is_nullable_target ? _process_with_hash_table<true>(state, target_data_column,
-                                                                               target_null_data, is_const_target)
-                                              : _process_with_hash_table<false>(state, target_data_column,
-                                                                                target_null_data, is_const_target);
                 }
             }
 

--- a/be/src/exprs/lambda_function.h
+++ b/be/src/exprs/lambda_function.h
@@ -64,7 +64,6 @@ public:
 
     bool is_lambda_function() const override { return true; }
     bool is_lambda_expr_independent() const { return _is_lambda_expr_independent; }
-    bool is_constant() const override { return true; }
 
     Expr* get_lambda_expr() const { return _children[0]; }
     std::string debug_string() const override;


### PR DESCRIPTION
## Why I'm doing:
https://github.com/StarRocks/starrocks/pull/59510 is wrong, lambda expr's isConst is difficult to decide, we need a more complete solution  to decide lambda expr's isConst  later
## What I'm doing:
 keep lambdaFunction's isConst as before, array_contains fall back to non-const process when state is nullptr

Fixes [#issue](https://github.com/StarRocks/StarRocksTest/issues/9754)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
