### PR TITLE
[BugFix] Fix flat json set child encoding error

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1514,6 +1514,9 @@ CONF_mBool(enable_json_flat_remain_filter, "true");
 // enable flat complex type (/array/object/hyper type), diables for save storage
 CONF_mBool(enable_json_flat_complex_type, "false");
 
+// flat json use dict-encoding
+CONF_mBool(json_flat_use_dict_encoding, "true");
+
 // if disable flat complex type, check complex type rate in hyper-type column
 CONF_mDouble(json_flat_complex_type_factor, "0.3");
 

--- a/be/src/storage/rowset/json_column_writer.cpp
+++ b/be/src/storage/rowset/json_column_writer.cpp
@@ -174,12 +174,13 @@ Status FlatJsonColumnWriter::_init_flat_writers() {
             opts.meta->set_is_nullable(true);
         }
 
-        if (_flat_types[i] == TYPE_JSON && (!_has_remain || i != _flat_paths.size() - 1)) {
+        if (config::json_flat_use_dict_encoding && _flat_types[i] == TYPE_JSON &&
+            (!_has_remain || i != _flat_paths.size() - 1)) {
             // try to use dict encoding for flat json
             opts.meta->set_encoding(EncodingTypePB::DICT_ENCODING);
             opts.meta->set_compression(_json_meta->compression());
         } else {
-            opts.meta->set_encoding(_json_meta->encoding());
+            opts.meta->set_encoding(EncodingTypePB::DEFAULT_ENCODING);
             opts.meta->set_compression(_json_meta->compression());
         }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
1. SegementWriter will set default encoding
2. `FlatJsonColumnWriter::init()` will update encoding to json's default encoding(PLAIN)
3. update the encoding of the chlidren in flat json (ERROR, the except is set default encoding, not json's encoding)

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
