### PR TITLE
[BugFix] disable ASAN build when gcov is enabled to avoid link failure

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -298,6 +298,11 @@ else
     done
 fi
 
+if [[ "${BUILD_TYPE}" == "ASAN" && "${WITH_GCOV}" == "ON" ]]; then
+    echo "Error: ASAN and gcov cannot be enabled at the same time. Please disable one of them."
+    exit 1
+fi
+
 if [[ ${HELP} -eq 1 ]]; then
     usage
     exit

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -141,6 +141,11 @@ while true; do
     esac
 done
 
+if [[ "${BUILD_TYPE}" == "ASAN" && "${WITH_GCOV}" == "ON" ]]; then
+    echo "Error: ASAN and gcov cannot be enabled at the same time. Please disable one of them."
+    exit 1
+fi
+
 if [ ${HELP} -eq 1 ]; then
     usage
     exit 0


### PR DESCRIPTION
## Why I'm doing:

When building StarRocks with both AddressSanitizer (ASAN) and gcov enabled, the resulting binary can exceed the ELF format’s 2GB size limit, leading to link-time failures. This is because both ASAN and gcov insert additional code, greatly increasing binary size. To avoid this issue and improve the developer experience, we should prevent these two options from being enabled at the same time.

## What I'm doing:

Add checks in the build scripts (‎`run-be-ut.sh`) to detect when both ASAN and gcov are enabled. If both are set, the script will exit early with a clear error message, instructing the user to disable one of them. This prevents build failures and wasted compilation time.

Fixes #58220

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
