### PR TITLE
[Feature] Support more intelligent/adaptive MV Refresh phrase2

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVAdaptiveRefreshException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVAdaptiveRefreshException.java
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.scheduler.mv;
+
+
+import com.starrocks.common.StarRocksException;
+
+public class MVAdaptiveRefreshException extends StarRocksException {
+
+    public MVAdaptiveRefreshException(String msg) {
+        super(msg);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
@@ -430,66 +430,23 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
     }
 
     @Override
-    public void filterPartitionByRefreshNumber(Set<String> mvPartitionsToRefresh,
-                                               Set<String> mvPotentialPartitionNames, boolean tentative) {
-        Map<String, PCell> partitionToCells = Maps.newHashMap();
-        Map<String, PListCell> listPartitionMap = mv.getListPartitionItems();
-        for (String partitionName : mvPartitionsToRefresh) {
-            PListCell listCell = listPartitionMap.get(partitionName);
-            if (listCell == null) {
-                logger.warn("Partition {} is not found in materialized view {}", partitionName, mv.getName());
-                continue;
-            }
-            partitionToCells.put(partitionName, listCell);
-        }
-
-        // filter by partition ttl
-        filterPartitionsByTTL(partitionToCells, false);
-        if (CollectionUtils.sizeIsEmpty(partitionToCells)) {
-            return;
-        }
-        Map<String, PListCell> toRefreshPartitions = partitionToCells.entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> (PListCell) e.getValue()));
-
-        // filter by partition refresh number
-        int filterNumber = mv.getTableProperty().getPartitionRefreshNumber();
-        // TODO: Sort by List Partition's value is weird because there maybe meaningless or un-sortable,
-        // users should take care of `partition_ttl_number` for list partition.
-        LinkedHashMap<String, PListCell> sortedPartition = toRefreshPartitions.entrySet().stream()
-                .sorted((e1, e2) -> e2.getValue().compareTo(e1.getValue())) // reverse order(max heap)
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
-        Iterator<Map.Entry<String, PListCell>> iter = sortedPartition.entrySet().iterator();
-        // iterate partition_ttl_number times
-        for (int i = 0; i < filterNumber; i++) {
-            if (iter.hasNext()) {
-                iter.next();
-            }
-        }
-        // compute next partition list cells in the next task run
-        Set<PListCell> nextPartitionValues = Sets.newHashSet();
-        while (iter.hasNext()) {
-            Map.Entry<String, PListCell> entry = iter.next();
-            nextPartitionValues.add(entry.getValue());
-            // remove the partition which is not reserved
-            toRefreshPartitions.remove(entry.getKey());
-        }
-        logger.info("Filter partitions by partition_ttl_number, ttl_number:{}, result:{}, remains:{}",
-                filterNumber, toRefreshPartitions, nextPartitionValues);
-        // do filter input mvPartitionsToRefresh since it's a reference
-        mvPartitionsToRefresh.retainAll(toRefreshPartitions.keySet());
-        if (CollectionUtils.isEmpty(nextPartitionValues)) {
-            return;
-        }
-        if (!tentative) {
-            // partitionNameIter has just been traversed, and endPartitionName is not updated
-            // will cause endPartitionName == null
-            mvContext.setNextPartitionValues(PListCell.batchSerialize(nextPartitionValues));
-        }
+    public void filterPartitionByRefreshNumber(Set<String> mvPartitionsToRefresh, Set<String> mvPotentialPartitionNames,
+                                               boolean tentative) {
+        filterPartitionByRefreshNumberInternal(mvPartitionsToRefresh, mvPotentialPartitionNames, tentative,
+                MaterializedView.PartitionRefreshStrategy.STRICT);
     }
 
-    public void filterPartitionByAdaptiveRefreshNumber(Set<String> mvPartitionsToRefresh,
-                                                       Set<String> mvPotentialPartitionNames,
+    @Override
+    public void filterPartitionByAdaptiveRefreshNumber(Set<String> mvPartitionsToRefresh, Set<String> mvPotentialPartitionNames,
                                                        boolean tentative) {
+        filterPartitionByRefreshNumberInternal(mvPartitionsToRefresh, mvPotentialPartitionNames, tentative,
+                MaterializedView.PartitionRefreshStrategy.ADAPTIVE);
+    }
+
+    public void filterPartitionByRefreshNumberInternal(Set<String> mvPartitionsToRefresh,
+                                                       Set<String> mvPotentialPartitionNames,
+                                                       boolean tentative,
+                                                       MaterializedView.PartitionRefreshStrategy refreshStrategy) {
         Map<String, PCell> partitionToCells = Maps.newHashMap();
         Map<String, PListCell> listPartitionMap = mv.getListPartitionItems();
         for (String partitionName : mvPartitionsToRefresh) {
@@ -508,8 +465,6 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
         }
         Map<String, PListCell> toRefreshPartitions = partitionToCells.entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getKey, e -> (PListCell) e.getValue()));
-
-        Map<String, Map<Table, Set<String>>> mvToBaseNameRefs = mvContext.getMvRefBaseTableIntersectedPartitions();
 
         // TODO: Sort by List Partition's value is weird because there maybe meaningless or un-sortable,
         // users should take care of `partition_ttl_number` for list partition.
@@ -519,15 +474,15 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
         Iterator<String> toSelectedPartitionNameIter = sortedPartition.keySet().iterator();
 
         // dynamically obtain the number of partitions to be refreshed this time
-        int adaptivePartitionRefreshNumber = getAdaptivePartitionRefreshNumber(toSelectedPartitionNameIter);
+        int refreshNumber = getRefreshNumberByMode(toSelectedPartitionNameIter, refreshStrategy);
         Iterator<Map.Entry<String, PListCell>> iter = sortedPartition.entrySet().iterator();
-        // iterate adaptivePartitionRefreshNumber times
-        for (int i = 0; i < adaptivePartitionRefreshNumber; i++) {
+
+        // iterate refreshNumber times
+        for (int i = 0; i < refreshNumber; i++) {
             if (iter.hasNext()) {
                 iter.next();
             }
         }
-
         // compute next partition list cells in the next task run
         Set<PListCell> nextPartitionValues = Sets.newHashSet();
         while (iter.hasNext()) {
@@ -536,8 +491,8 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
             // remove the partition which is not reserved
             toRefreshPartitions.remove(entry.getKey());
         }
-        logger.info("Filter partitions by adaptive_partition_number, ttl_number:{}, result:{}, remains:{}",
-                adaptivePartitionRefreshNumber, toRefreshPartitions, nextPartitionValues);
+        logger.info("Filter partitions by refresh number, ttl_number:{}, result:{}, remains:{}",
+                refreshNumber, toRefreshPartitions, nextPartitionValues);
         // do filter input mvPartitionsToRefresh since it's a reference
         mvPartitionsToRefresh.retainAll(toRefreshPartitions.keySet());
         if (CollectionUtils.isEmpty(nextPartitionValues)) {
@@ -550,13 +505,11 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
         }
     }
 
-    private int getAdaptivePartitionRefreshNumber(Iterator<String> partitionNameIter) {
-
+    public int getAdaptivePartitionRefreshNumber(Iterator<String> partitionNameIter) throws MVAdaptiveRefreshException {
         Map<String, Map<Table, Set<String>>> mvToBaseNameRefs = mvContext.getMvRefBaseTableIntersectedPartitions();
         MVRefreshPartitionSelector mvRefreshPartitionSelector =
                 new MVRefreshPartitionSelector(Config.mv_max_rows_per_refresh, Config.mv_max_bytes_per_refresh,
-                        Config.mv_max_partitions_num_per_refresh);
-
+                        Config.mv_max_partitions_num_per_refresh, mvContext.getExternalRefBaseTableMVPartitionMap());
         int adaptiveRefreshNumber = 0;
         while (partitionNameIter.hasNext()) {
             String partitionName = partitionNameIter.next();

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitioner.java
@@ -27,6 +27,7 @@ import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.scheduler.TableSnapshotInfo;
 import com.starrocks.scheduler.TaskRunContext;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -92,5 +93,10 @@ public final class MVPCTRefreshNonPartitioner extends MVPCTRefreshPartitioner {
     public void filterPartitionByAdaptiveRefreshNumber(Set<String> mvPartitionsToRefresh,
                                                        Set<String> mvPotentialPartitionNames, boolean tentative) {
         // do nothing
+    }
+
+    @Override
+    protected int getAdaptivePartitionRefreshNumber(Iterator<String> partitionNameIter) throws MVAdaptiveRefreshException {
+        return 0;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
@@ -396,6 +396,22 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
     public void filterPartitionByRefreshNumber(Set<String> mvPartitionsToRefresh,
                                                Set<String> mvPotentialPartitionNames,
                                                boolean tentative) {
+        filterPartitionByRefreshNumberInternal(mvPartitionsToRefresh, mvPotentialPartitionNames, tentative,
+                MaterializedView.PartitionRefreshStrategy.STRICT);
+    }
+
+    @Override
+    public void filterPartitionByAdaptiveRefreshNumber(Set<String> mvPartitionsToRefresh,
+                                                       Set<String> mvPotentialPartitionNames,
+                                                       boolean tentative) {
+        filterPartitionByRefreshNumberInternal(mvPartitionsToRefresh, mvPotentialPartitionNames, tentative,
+                MaterializedView.PartitionRefreshStrategy.ADAPTIVE);
+    }
+
+    public void filterPartitionByRefreshNumberInternal(Set<String> mvPartitionsToRefresh,
+                                                       Set<String> mvPotentialPartitionNames,
+                                                       boolean tentative,
+                                                       MaterializedView.PartitionRefreshStrategy refreshStrategy) {
         int partitionRefreshNumber = mv.getTableProperty().getPartitionRefreshNumber();
         Map<String, Range<PartitionKey>> mvRangePartitionMap = mv.getRangePartitionMap();
         if (partitionRefreshNumber <= 0 || partitionRefreshNumber >= mvRangePartitionMap.size()) {
@@ -419,9 +435,13 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toCollection(LinkedList::new));
 
-        Iterator<String> partitionNameIter = Config.materialized_view_refresh_ascending
+        Iterator<String> toSelectedPartitionNameIter = Config.materialized_view_refresh_ascending
                 ? sortedPartition.iterator() : sortedPartition.descendingIterator();
         String mvRefreshPartition = "";
+        // dynamically obtain the number of partitions to be refreshed this time
+        partitionRefreshNumber = getRefreshNumberByMode(toSelectedPartitionNameIter, refreshStrategy);
+        Iterator<String> partitionNameIter = Config.materialized_view_refresh_ascending
+                ? sortedPartition.iterator() : sortedPartition.descendingIterator();
         for (int i = 0; i < partitionRefreshNumber; i++) {
             if (partitionNameIter.hasNext()) {
                 mvRefreshPartition = partitionNameIter.next();
@@ -457,52 +477,26 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
         setNextPartitionStartAndEnd(mvPartitionsToRefresh, mappedPartitionsToRefresh, partitionNameIter, tentative);
     }
 
-    public void filterPartitionByAdaptiveRefreshNumber(Set<String> mvPartitionsToRefresh,
-                                                       Set<String> mvPotentialPartitionNames,
-                                                       boolean tentative) {
-        Map<String, Range<PartitionKey>> mvRangePartitionMap = mv.getRangePartitionMap();
+    public int getAdaptivePartitionRefreshNumber(Iterator<String> partitionNameIter) throws MVAdaptiveRefreshException {
 
-        Map<String, Range<PartitionKey>> mappedPartitionsToRefresh = Maps.newHashMap();
-        Iterator<String> mvToRefreshPartitionsIter = mvPartitionsToRefresh.iterator();
-        while (mvToRefreshPartitionsIter.hasNext()) {
-            String mvPartitionName = mvToRefreshPartitionsIter.next();
-            // skip if partition is not in the mv's partition range map
-            if (!mvRangePartitionMap.containsKey(mvPartitionName)) {
-                logger.warn("Partition {} is not in the materialized view's partition range map, " +
-                        "remove it from refresh list", mvPartitionName);
-                mvToRefreshPartitionsIter.remove();
-                continue;
-            }
-            mappedPartitionsToRefresh.put(mvPartitionName, mvRangePartitionMap.get(mvPartitionName));
-        }
-        LinkedList<String> sortedPartition = mappedPartitionsToRefresh.entrySet().stream()
-                .sorted(Map.Entry.comparingByValue(RangeUtils.RANGE_COMPARATOR))
-                .map(Map.Entry::getKey)
-                .collect(Collectors.toCollection(LinkedList::new));
+        Map<String, Map<Table, Set<String>>> mvToBaseNameRefs = mvContext.getMvRefBaseTableIntersectedPartitions();
+        MVRefreshPartitionSelector mvRefreshPartitionSelector =
+                new MVRefreshPartitionSelector(Config.mv_max_rows_per_refresh, Config.mv_max_bytes_per_refresh,
+                        Config.mv_max_partitions_num_per_refresh, mvContext.getExternalRefBaseTableMVPartitionMap());
 
-        Iterator<String> toSelectedPartitionNameIter = Config.materialized_view_refresh_ascending
-                ? sortedPartition.iterator() : sortedPartition.descendingIterator();
-        String mvRefreshPartition = "";
-        // dynamically obtain the number of partitions to be refreshed this time
-        int adaptivePartitionRefreshNumber = getAdaptivePartitionRefreshNumber(toSelectedPartitionNameIter);
-        Iterator<String> partitionNameIter = Config.materialized_view_refresh_ascending
-                ? sortedPartition.iterator() : sortedPartition.descendingIterator();
-
-        for (int i = 0; i < adaptivePartitionRefreshNumber; i++) {
-            if (partitionNameIter.hasNext()) {
-                mvRefreshPartition = partitionNameIter.next();
+        int adaptiveRefreshNumber = 0;
+        while (partitionNameIter.hasNext()) {
+            String mvRefreshPartition = partitionNameIter.next();
+            Map<Table, Set<String>> refBaseTablesPartitions = mvToBaseNameRefs.get(mvRefreshPartition);
+            if (mvRefreshPartitionSelector.canAddPartition(refBaseTablesPartitions)) {
+                mvRefreshPartitionSelector.addPartition(refBaseTablesPartitions);
                 partitionNameIter.remove();
-            }
-            if (!mvPotentialPartitionNames.isEmpty() && mvPotentialPartitionNames.contains(mvRefreshPartition)) {
-                return;
+                adaptiveRefreshNumber++;
+            } else {
+                break;
             }
         }
-
-
-        if (!Config.materialized_view_refresh_ascending) {
-            partitionNameIter = sortedPartition.iterator();
-        }
-        setNextPartitionStartAndEnd(mvPartitionsToRefresh, mappedPartitionsToRefresh, partitionNameIter, tentative);
+        return adaptiveRefreshNumber;
     }
 
     private void setNextPartitionStartAndEnd(Set<String> partitionsToRefresh,
@@ -535,28 +529,6 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
                 mvContext.setNextPartitionEnd(null);
             }
         }
-    }
-
-    private int getAdaptivePartitionRefreshNumber(Iterator<String> partitionNameIter) {
-
-        Map<String, Map<Table, Set<String>>> mvToBaseNameRefs = mvContext.getMvRefBaseTableIntersectedPartitions();
-        MVRefreshPartitionSelector mvRefreshPartitionSelector =
-                new MVRefreshPartitionSelector(Config.mv_max_rows_per_refresh, Config.mv_max_bytes_per_refresh,
-                        Config.mv_max_partitions_num_per_refresh);
-
-        int adaptiveRefreshNumber = 0;
-        while (partitionNameIter.hasNext()) {
-            String mvRefreshPartition = partitionNameIter.next();
-            Map<Table, Set<String>> refBaseTablesPartitions = mvToBaseNameRefs.get(mvRefreshPartition);
-            if (mvRefreshPartitionSelector.canAddPartition(refBaseTablesPartitions)) {
-                mvRefreshPartitionSelector.addPartition(refBaseTablesPartitions);
-                partitionNameIter.remove();
-                adaptiveRefreshNumber++;
-            } else {
-                break;
-            }
-        }
-        return adaptiveRefreshNumber;
     }
 
     private void addRangePartitions(Database database, MaterializedView materializedView,

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshPartitionSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshPartitionSelector.java
@@ -14,11 +14,18 @@
 
 package com.starrocks.scheduler.mv;
 
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Pair;
+import com.starrocks.sql.optimizer.rule.transformation.partition.PartitionSelector;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class MVRefreshPartitionSelector {
 
@@ -30,20 +37,37 @@ public class MVRefreshPartitionSelector {
     private final long maxBytesThreshold;
     private final int maxSelectedPartitions;
 
+    private final Map<Table, Map<String, Set<String>>> externalPartitionMap;
+    /**
+     * Minimum required ratio of collected partition statistics.
+     * If the collected stats are less than this ratio compared to the expected partitions,
+     * the adaptive refresh will be considered unreliable and fallback will be triggered.
+     */
+    private static final double MIN_COLLECTED_PARTITION_STATS_RATIO = 0.9;
+
+
     // ensure that at least one partition is selected
     private boolean isFirstPartition = true;
 
     public MVRefreshPartitionSelector(long maxRowsThreshold, long maxBytesThreshold, int maxPartitionNum) {
+        this(maxRowsThreshold, maxBytesThreshold, maxPartitionNum, Collections.emptyMap());
+    }
+
+    public MVRefreshPartitionSelector(long maxRowsThreshold,
+                                      long maxBytesThreshold,
+                                      int maxPartitionNum,
+                                      Map<Table, Map<String, Set<String>>> externalPartitionMap) {
         this.maxRowsThreshold = maxRowsThreshold;
         this.maxBytesThreshold = maxBytesThreshold;
         this.maxSelectedPartitions = maxPartitionNum;
+        this.externalPartitionMap = externalPartitionMap != null ? externalPartitionMap : Collections.emptyMap();
     }
 
     /**
      * Check if the incoming partition set can be added based on current total usage and thresholds.
      * Always allows the first partition.
      */
-    public boolean canAddPartition(Map<Table, Set<String>> partitionSet) {
+    public boolean canAddPartition(Map<Table, Set<String>> partitionSet) throws MVAdaptiveRefreshException {
         if (isFirstPartition) {
             return true;
         }
@@ -64,7 +88,7 @@ public class MVRefreshPartitionSelector {
      * Actually add the given partition set to the total usage.
      * This should be called after canAddPartitionSet() returns true.
      */
-    public void addPartition(Map<Table, Set<String>> partitionSet) {
+    public void addPartition(Map<Table, Set<String>> partitionSet) throws MVAdaptiveRefreshException {
         long[] usage = estimatePartitionUsage(partitionSet);
         currentTotalRows += usage[0];
         currentTotalBytes += usage[1];
@@ -77,18 +101,91 @@ public class MVRefreshPartitionSelector {
      *
      * @return array of [rows, bytes]
      */
-    private long[] estimatePartitionUsage(Map<Table, Set<String>> partitionSet) {
+    private long[] estimatePartitionUsage(Map<Table, Set<String>> partitionSet) throws MVAdaptiveRefreshException {
         long totalRows = 0;
         long totalBytes = 0;
 
         for (Map.Entry<Table, Set<String>> entry : partitionSet.entrySet()) {
             Table table = entry.getKey();
-            for (String partitionName : entry.getValue()) {
-                Partition partition = table.getPartition(partitionName);
-                totalRows += partition.getRowCount();
-                totalBytes += partition.getDataSize();
+            Set<String> refBaseTablePartitions = entry.getValue();
+            Set<String> finalPartitionNames = refBaseTablePartitions.stream()
+                    .map(p -> resolveFinalPartitionNames(table, p))
+                    .flatMap(Collection::stream)
+                    .collect(Collectors.toSet());
+            Map<String, Pair<Long, Long>> partitionStats = collectSelectedPartitionStats(table, finalPartitionNames);
+
+            int expectedCount = finalPartitionNames.size();
+            int actualCount = partitionStats.size();
+
+            if (actualCount == 0 || actualCount < expectedCount * MIN_COLLECTED_PARTITION_STATS_RATIO) {
+                throw new MVAdaptiveRefreshException(
+                        String.format("Missing too many partition stats for table %s: expected %d, got %d",
+                                table.getName(), expectedCount, actualCount));
+            }
+
+            for (String partitionName : finalPartitionNames) {
+                Pair<Long, Long> stats = partitionStats.get(partitionName);
+                if (stats != null) {
+                    totalRows += stats.first;
+                    totalBytes += stats.second;
+                }
             }
         }
+
         return new long[] {totalRows, totalBytes};
+    }
+
+    /**
+     * Resolves the final set of partition names for a given table and logical partition name.
+     * <p>
+     * For OLAP tables, the mapping is one-to-one, so the original partition name is returned as a singleton set.
+     * For external tables (e.g., Hive, Iceberg), the logical partition name may map to multiple actual partitions,
+     * and the method returns all corresponding partition names from the precomputed external partition mapping.
+     *
+     * @param table the table from which to resolve the partition names
+     * @param logicalPartitionNames the logical partition name used in the materialized view
+     * @return a set of actual partition names in the base table corresponding to the given logical partition name
+     */
+    private Set<String> resolveFinalPartitionNames(Table table, String logicalPartitionNames) {
+        if (table instanceof OlapTable) {
+            return Collections.singleton(logicalPartitionNames);
+        }
+        Map<String, Set<String>> mapping = externalPartitionMap.get(table);
+        return mapping != null
+                ? mapping.getOrDefault(logicalPartitionNames, Collections.emptySet())
+                : Collections.emptySet();
+    }
+
+    /**
+     * Returns a map of partition statistics for the given table.
+     * Each entry in the map represents a partition, with the key being the partition name,
+     * and the value being a pair of (rowCount, dataSize).
+     * For internal OLAP tables, statistics are retrieved directly from the partition metadata.
+     * For external tables, only Hive, Iceberg, Hudi, and Delta Lake are currently supported for statistics collection.
+     * Statistics for these external tables are retrieved via the statistic executor and may be partial.
+     * Note: For external tables, statistics are aggregated by partition name,
+     * since there may be multiple statistic records for the same partition.
+     *
+     * @param table the table to collect statistics from
+     * @return a map of partition name to (rowCount, dataSize)
+     */
+    private Map<String, Pair<Long, Long>> collectSelectedPartitionStats(Table table, Set<String> selectedPartitions) {
+        Map<String, Pair<Long, Long>> result = new HashMap<>();
+
+        if (table instanceof OlapTable) {
+            OlapTable olapTable = (OlapTable) table;
+            for (String partitionName : selectedPartitions) {
+                Partition partition = olapTable.getPartition(partitionName);
+                if (partition != null) {
+                    long rowCount = partition.getRowCount();
+                    long dataSize = partition.getDataSize();
+                    result.put(partitionName, Pair.create(rowCount, dataSize));
+                }
+            }
+        } else {
+            result = PartitionSelector.getExternalTablePartitionStats(table, selectedPartitions);
+        }
+
+        return result;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/partition/PartitionSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/partition/PartitionSelector.java
@@ -84,6 +84,8 @@ import org.apache.parquet.Strings;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -103,6 +105,9 @@ public class PartitionSelector {
     // why not use `PARTITION_ID` here? because partition_id in partitions_meta is physical partition id which may be confused.
     private static final String PARTITIONS_META_TEMPLATE = "SELECT PARTITION_NAME FROM INFORMATION_SCHEMA.PARTITIONS_META " +
             "WHERE DB_NAME ='%s' and TABLE_NAME='%s' AND %s;";
+    private static final String EXTERNAL_TABLE_PARTITION_META_TEMPLATE = "SELECT PARTITION_NAME, SUM(ROW_COUNT) as ROW_COUNT," +
+            "CAST(SUM(DATA_SIZE) AS BIGINT) as DATA_SIZE FROM _statistics_.external_column_statistics " +
+            "WHERE TABLE_UUID = '%s' AND PARTITION_NAME in ('%s') GROUP BY PARTITION_NAME;";
     // NOTE: `json` to `datetime` is not supported yet, so we use `string` here.
     private static final String JSON_QUERY_TEMPLATE = "CAST(CAST(JSON_QUERY(%s, '$[0].[%d]') AS STRING) AS %s)";
 
@@ -794,6 +799,38 @@ public class PartitionSelector {
             }
         }
         return selectedPartitionIds;
+    }
+
+    /**
+     * Use `_statistics_.external_column_statistics` to get partition statistics for an external table
+     * such as Iceberg/Hudi by its table UUID.
+     */
+    public static Map<String, Pair<Long, Long>> getExternalTablePartitionStats(Table table, Set<String> needPartitionNames) {
+        String sql = String.format(EXTERNAL_TABLE_PARTITION_META_TEMPLATE, table.getUUID(),
+                String.join(",", needPartitionNames));
+        LOG.info("Get external table partition stats by sql: {}", sql);
+        List<TResultBatch> batch = SimpleExecutor.getRepoExecutor().executeDQL(sql);
+        return deserializeExternalStatisticsResult(batch);
+    }
+
+    private static Map<String, Pair<Long, Long>> deserializeExternalStatisticsResult(
+            List<TResultBatch> batches) {
+        Map<String, Pair<Long, Long>> result = new HashMap<>();
+        for (TResultBatch batch : ListUtils.emptyIfNull(batches)) {
+            for (ByteBuffer buffer : batch.getRows()) {
+                ByteBuf copied = Unpooled.copiedBuffer(buffer);
+                String jsonString = copied.toString(StandardCharsets.UTF_8);
+                List<String> data = MetaFunctions.LookupRecord.fromJson(jsonString).data;
+
+                if (data != null && data.size() >= 3) {
+                    String partitionName = data.get(0);
+                    long rowCount = Long.parseLong(data.get(1));
+                    long dataSize = Long.parseLong(data.get(2));
+                    result.put(partitionName, Pair.create(rowCount, dataSize));
+                }
+            }
+        }
+        return result;
     }
 
     private static String buildPartitionSelectQuery(String dbName,

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/MVAdaptiveRefreshExceptionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/MVAdaptiveRefreshExceptionTest.java
@@ -1,0 +1,29 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler;
+
+import com.starrocks.scheduler.mv.MVAdaptiveRefreshException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MVAdaptiveRefreshExceptionTest {
+
+    @Test
+    public void testConstructor() {
+        MVAdaptiveRefreshException ex = new MVAdaptiveRefreshException("error");
+        assertEquals("error", ex.getMessage());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/MVAdaptiveRefreshExceptionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/MVAdaptiveRefreshExceptionTest.java
@@ -15,15 +15,14 @@
 package com.starrocks.scheduler;
 
 import com.starrocks.scheduler.mv.MVAdaptiveRefreshException;
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class MVAdaptiveRefreshExceptionTest {
 
     @Test
     public void testConstructor() {
         MVAdaptiveRefreshException ex = new MVAdaptiveRefreshException("error");
-        assertEquals("error", ex.getMessage());
+        Assertions.assertEquals("error", ex.getMessage());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitionerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitionerTest.java
@@ -1,0 +1,44 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.mv;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.scheduler.MvTaskRunContext;
+import com.starrocks.scheduler.TaskRunContext;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.Iterator;
+
+import static org.junit.Assert.assertEquals;
+
+public class MVPCTRefreshNonPartitionerTest {
+
+    @Test
+    public void testGetAdaptivePartitionRefreshNumber() throws MVAdaptiveRefreshException {
+        MvTaskRunContext mvTaskRunContext = Mockito.mock(MvTaskRunContext.class);
+        TaskRunContext taskRunContext = Mockito.mock(TaskRunContext.class);
+        Database database = Mockito.mock(Database.class);
+        MaterializedView mv = Mockito.mock(MaterializedView.class);
+        MVPCTRefreshNonPartitioner job = new MVPCTRefreshNonPartitioner(mvTaskRunContext, taskRunContext,
+                database, mv);
+        Iterator<String> dummyIter = Collections.emptyIterator();
+
+        int result = job.getAdaptivePartitionRefreshNumber(dummyIter);
+        assertEquals(0, result);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitionerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitionerTest.java
@@ -18,13 +18,12 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.scheduler.TaskRunContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.Iterator;
-
-import static org.junit.Assert.assertEquals;
 
 public class MVPCTRefreshNonPartitionerTest {
 
@@ -39,6 +38,6 @@ public class MVPCTRefreshNonPartitionerTest {
         Iterator<String> dummyIter = Collections.emptyIterator();
 
         int result = job.getAdaptivePartitionRefreshNumber(dummyIter);
-        assertEquals(0, result);
+        Assertions.assertEquals(0, result);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitionerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitionerTest.java
@@ -15,20 +15,63 @@
 package com.starrocks.scheduler.mv;
 
 import com.google.common.collect.Maps;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.sql.common.PCell;
+import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class MVPCTRefreshRangePartitionerTest {
+
+    @Test
+    public void testGetAdaptivePartitionRefreshNumber() {
+        MvTaskRunContext mvContext = mock(MvTaskRunContext.class);
+        MaterializedView mv = mock(MaterializedView.class);
+        when(mv.getTableProperty()).thenReturn(mock(TableProperty.class));
+        when(mv.getPartitionInfo()).thenReturn(mock(PartitionInfo.class));
+
+        OlapTable refTable1 = Mockito.mock(OlapTable.class);
+        Set<String> refTablePartition1 = Set.of("partition1", "partition2");
+        Map<Table, Set<String>> ref1 = new HashMap<>();
+        ref1.put(refTable1, refTablePartition1);
+
+        IcebergTable refTable2 = Mockito.mock(IcebergTable.class);
+        Set<String> refTablePartition2 = Set.of("partition1", "partition2");
+        Map<Table, Set<String>> ref2 = new HashMap<>();
+        ref2.put(refTable2, refTablePartition2);
+
+        Map<String, Map<Table, Set<String>>> mvToBaseNameRefs = Maps.newHashMap();
+        mvToBaseNameRefs.put("mv_p1", ref1);
+        mvToBaseNameRefs.put("mv_p2", ref2);
+
+        Mockito.when(mvContext.getMvRefBaseTableIntersectedPartitions()).thenReturn(mvToBaseNameRefs);
+        Mockito.when(mvContext.getExternalRefBaseTableMVPartitionMap()).thenReturn(new HashMap<>());
+
+        List<String> partitions = Arrays.asList("mv_p1", "mv_p2");
+        Iterator<String> iter = partitions.iterator();
+
+        MVPCTRefreshRangePartitioner partitioner = new MVPCTRefreshRangePartitioner(mvContext, null, null, mv);
+        MVAdaptiveRefreshException exception = Assert.assertThrows(MVAdaptiveRefreshException.class,
+                () -> partitioner.getAdaptivePartitionRefreshNumber(iter));
+        Assertions.assertTrue(exception.getMessage().contains("Missing too many partition stats"));
+    }
 
     @Test
     public void testFilterPartitionsByTTL() {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitionerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitionerTest.java
@@ -23,7 +23,6 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.sql.common.PCell;
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -68,7 +67,7 @@ public class MVPCTRefreshRangePartitionerTest {
         Iterator<String> iter = partitions.iterator();
 
         MVPCTRefreshRangePartitioner partitioner = new MVPCTRefreshRangePartitioner(mvContext, null, null, mv);
-        MVAdaptiveRefreshException exception = Assert.assertThrows(MVAdaptiveRefreshException.class,
+        MVAdaptiveRefreshException exception = Assertions.assertThrows(MVAdaptiveRefreshException.class,
                 () -> partitioner.getAdaptivePartitionRefreshNumber(iter));
         Assertions.assertTrue(exception.getMessage().contains("Missing too many partition stats"));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVRefreshPartitionSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVRefreshPartitionSelectorTest.java
@@ -14,8 +14,11 @@
 
 package com.starrocks.scheduler.mv;
 
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
+import org.junit.BeforeClass;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -25,13 +28,18 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.anyString;
 
 public class MVRefreshPartitionSelectorTest {
 
+    @BeforeClass
+    public static void setUp() throws Exception {
+    }
+
     private Map<Table, Set<String>> mockPartitionSet(long rows, long bytes) {
-        Table table = Mockito.mock(Table.class);
+        OlapTable table = Mockito.mock(OlapTable.class);
         Partition partition = Mockito.mock(Partition.class);
 
         Mockito.when(partition.getRowCount()).thenReturn(rows);
@@ -43,14 +51,20 @@ public class MVRefreshPartitionSelectorTest {
         return map;
     }
 
+    private Table mockExternalTable() {
+        IcebergTable table = Mockito.mock(IcebergTable.class);
+        Mockito.when(table.getUUID()).thenReturn(UUID.randomUUID().toString());
+        return table;
+    }
+
     @Test
-    public void testFirstPartitionAlwaysAllowed() {
+    public void testFirstPartitionAlwaysAllowed() throws Exception {
         MVRefreshPartitionSelector selector = new MVRefreshPartitionSelector(1000, 10000, 10);
         Assertions.assertTrue(selector.canAddPartition(mockPartitionSet(2000, 20000)));
     }
 
     @Test
-    public void testCanAddWithinThreshold() {
+    public void testCanAddWithinThreshold() throws Exception {
         MVRefreshPartitionSelector selector = new MVRefreshPartitionSelector(1000, 10000, 10);
         selector.addPartition(mockPartitionSet(500, 5000)); // First one always allowed
 
@@ -58,7 +72,7 @@ public class MVRefreshPartitionSelectorTest {
     }
 
     @Test
-    public void testExceedRowLimit() {
+    public void testExceedRowLimit() throws Exception {
         MVRefreshPartitionSelector selector = new MVRefreshPartitionSelector(1000, 10000, 10);
         selector.addPartition(mockPartitionSet(900, 5000));
 
@@ -66,7 +80,7 @@ public class MVRefreshPartitionSelectorTest {
     }
 
     @Test
-    public void testExceedByteLimit() {
+    public void testExceedByteLimit() throws Exception {
         MVRefreshPartitionSelector selector = new MVRefreshPartitionSelector(1000, 10000, 10);
         selector.addPartition(mockPartitionSet(800, 9000));
 
@@ -74,7 +88,7 @@ public class MVRefreshPartitionSelectorTest {
     }
 
     @Test
-    public void testExceedPartitionLimit() {
+    public void testExceedPartitionLimit() throws Exception {
         MVRefreshPartitionSelector selector = new MVRefreshPartitionSelector(1000, 10000, 10);
         selector.addPartition(mockPartitionSet(10, 200));
         selector.addPartition(mockPartitionSet(10, 200));
@@ -91,11 +105,30 @@ public class MVRefreshPartitionSelectorTest {
     }
 
     @Test
-    public void testAddPartitionAccumulatesUsage() {
+    public void testAddPartitionAccumulatesUsage() throws Exception {
         MVRefreshPartitionSelector selector = new MVRefreshPartitionSelector(1000, 10000, 10);
         selector.addPartition(mockPartitionSet(300, 3000));
         selector.addPartition(mockPartitionSet(400, 4000));
 
         Assertions.assertFalse(selector.canAddPartition(mockPartitionSet(400, 4000)));
+    }
+
+    @Test
+    public void testExternalTablePartitionsStatistics() throws Exception {
+        Map<Table, Map<String, Set<String>>> externalPartitionMap = new HashMap<>();
+        HashMap<String, Set<String>> partitionMap1 = new HashMap<>();
+        partitionMap1.put("p1", Set.of("dt=p1"));
+        partitionMap1.put("p2", Set.of("dt=p2", "dt=p3"));
+        externalPartitionMap.put(mockExternalTable(), partitionMap1);
+        HashMap<String, Set<String>> partitionMap2 = new HashMap<>();
+        partitionMap2.put("p1", Set.of("dt=p1"));
+        partitionMap2.put("p2", Set.of("dt=p2"));
+        externalPartitionMap.put(mockExternalTable(), partitionMap2);
+
+        MVRefreshPartitionSelector selector = new MVRefreshPartitionSelector(1000, 10000,
+                10, externalPartitionMap);
+        HashMap<Table, Set<String>> toSelectedPartitionMap = new HashMap<>();
+        toSelectedPartitionMap.put(mockExternalTable(), Set.of("p1"));
+        Assertions.assertTrue(selector.canAddPartition(toSelectedPartitionMap));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVRefreshPartitionSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVRefreshPartitionSelectorTest.java
@@ -18,8 +18,8 @@ import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
-import org.junit.BeforeClass;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -34,7 +34,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 
 public class MVRefreshPartitionSelectorTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
@@ -224,6 +224,27 @@ public class MaterializedViewAnalyzerTest {
     }
 
     @Test
+    public void testCreateIcebergTable2WithAdaptive() throws Exception {
+        String mvName = "iceberg_parttbl_mv1";
+        starRocksAssert.useDatabase("test")
+                .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_parttbl_mv1`\n" +
+                        "PARTITION BY date \n" +
+                        "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "properties (\n" +
+                        "'replication_num' = '1',\n" +
+                        "'partition_refresh_strategy' = 'adaptive'" +
+                        ") \n" +
+                        "AS SELECT id, data, date  FROM `iceberg0`.`partitioned_db`.`t1` as a;");
+        Table mv = starRocksAssert.getTable("test", mvName);
+        Assertions.assertTrue(mv != null);
+        Assertions.assertTrue(mv instanceof MaterializedView);
+        PartitionInfo partitionInfo = ((MaterializedView) mv).getPartitionInfo();
+        Assertions.assertTrue(partitionInfo.isListPartition());
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+
+    @Test
     public void testCreateIcebergTable3() {
         try {
             starRocksAssert.useDatabase("test")

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_with_smart_refresh
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_with_smart_refresh
@@ -929,3 +929,75 @@ drop materialized view test_mv12;
 drop materialized view test_mv13;
 -- result:
 -- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_iceberg_db_${uuid0};
+-- result:
+-- !result
+use mv_iceberg_db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t1 (
+   `id` varchar(36),
+   `location_id` varchar(36),
+   `location_id_hash` int,
+   `source_id` varchar(36),
+   `person_id` varchar(36)
+)
+PARTITION BY (person_id);
+-- result:
+-- !result
+INSERT INTO t1 VALUES (1, 'beijing', 20, 'a', 'a1'), (2, 'guangdong', 30, 'b', 'b1'), (3, 'guangdong', 20, 'c', 'c1');
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database if not exists db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create materialized view test_mv1
+PARTITION BY `person_id`
+DISTRIBUTED BY HASH(`id`) BUCKETS 3
+PROPERTIES (
+    "replication_num" = "1",
+    "partition_refresh_strategy" = "adaptive"
+)
+as select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1;
+-- result:
+-- !result
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2, 3;
+-- result:
+1	beijing	a1
+2	guangdong	b1
+3	guangdong	c1
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+drop database default_catalog.db_${uuid0} force;
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 force;
+-- result:
+-- !result
+drop database mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_with_smart_refresh
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_with_smart_refresh
@@ -445,3 +445,52 @@ drop materialized view test_mv7;
 drop materialized view test_mv11;
 drop materialized view test_mv12;
 drop materialized view test_mv13;
+
+drop database db_${uuid0};
+
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${hive_metastore_uris}"
+);
+
+-- create iceberg table
+set catalog mv_iceberg_${uuid0};
+create database mv_iceberg_db_${uuid0};
+use mv_iceberg_db_${uuid0};
+
+CREATE TABLE t1 (
+   `id` varchar(36),
+   `location_id` varchar(36),
+   `location_id_hash` int,
+   `source_id` varchar(36),
+   `person_id` varchar(36)
+)
+PARTITION BY (person_id);
+INSERT INTO t1 VALUES (1, 'beijing', 20, 'a', 'a1'), (2, 'guangdong', 30, 'b', 'b1'), (3, 'guangdong', 20, 'c', 'c1');
+
+set catalog default_catalog;
+create database if not exists db_${uuid0};
+use db_${uuid0};
+
+create materialized view test_mv1
+PARTITION BY `person_id`
+DISTRIBUTED BY HASH(`id`) BUCKETS 3
+PROPERTIES (
+    "replication_num" = "1",
+    "partition_refresh_strategy" = "adaptive"
+)
+as select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1;
+
+refresh materialized view  test_mv1 with sync mode;
+
+select * from test_mv1 order by 1, 2, 3;
+
+drop materialized view test_mv1;
+drop database default_catalog.db_${uuid0} force;
+drop table mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 force;
+drop database mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0} force;
+
+


### PR DESCRIPTION
## Why I'm doing:
[#58351](https://github.com/StarRocks/starrocks/pull/58351) proposes introducing a more adaptive method to adjust this based on base table data info. However, it does not handle non-OLAP tables when collecting related partition information.

## What I'm doing:
The "Gather statistics for CBO about external tables" mechanism records partition information of external tables in _statistics_.external_column_statistics. When refreshing materialized views involving external tables, these statistics can be used as a reference to compute relevant partition data.


Fixes [#56973](https://github.com/StarRocks/starrocks/issues/56973)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
