### PR TITLE
[Enhancement] Check duplicate path columns in files table function

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
@@ -80,6 +80,24 @@ public class TableFunctionTableTest {
     }
 
     @Test
+    public void testDuplicateColumnsInSchema() {
+        Map<String, String> properties = newProperties();
+
+        // duplicate with file schema
+        properties.put("columns_from_path", "col_int");
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                "Duplicate column name 'col_int' in files table schema [col_int, col_string, col_int]",
+                () -> new TableFunctionTable(properties));
+
+        // duplicate in columns from path
+        properties.put("columns_from_path", "col_path, col_path");
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                "Duplicate column name 'col_path' in files table schema [col_int, col_string, col_path, col_path]",
+                () -> new TableFunctionTable(properties));
+
+    }
+
+    @Test
     public void testGetFileSchema(@Mocked GlobalStateMgr globalStateMgr,
                                   @Mocked SystemInfoService systemInfoService) throws Exception {
         new Expectations() {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

```
// dt column is also in the parquet file.
mysql> desc files("path" = "hdfs://host/files/dt=2025-04-10/*", "format" = "parquet", "columns_from_path" = "dt");
ERROR 1060 (42S21): Access storage error. Error message: Duplicate column name 'dt' in files table schema [dt, dt]

mysql> select * from files("path" = "hdfs://host/files/date=2025-04-10/*", "format" = "parquet", "columns_from_path" = "date,date");
ERROR 1060 (42S21): Access storage error. Error message: Duplicate column name 'date' in files table schema [dt, date, date]
```
Fixes https://github.com/StarRocks/StarRocksTest/issues/9758

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
