### PR TITLE
[Enhancement] Adding catalog level access manager for external catalogs to allow operations on DB and tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authorization/AllowAllAccessController.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/AllowAllAccessController.java
@@ -17,7 +17,7 @@ package com.starrocks.authorization;
 import com.starrocks.analysis.TableName;
 import com.starrocks.qe.ConnectContext;
 
-public class AllowAllHiveAccessController extends ExternalAccessController {
+public class AllowAllAccessController extends ExternalAccessController {
     @Override
     public void checkDbAction(ConnectContext context, String catalogName, String db, PrivilegeType privilegeType) {
         // Allow all DB actions

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/AllowAllHiveAccessController.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/AllowAllHiveAccessController.java
@@ -1,0 +1,70 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.authorization;
+
+import com.starrocks.analysis.TableName;
+import com.starrocks.qe.ConnectContext;
+
+public class AllowAllHiveAccessController extends ExternalAccessController {
+    @Override
+    public void checkDbAction(ConnectContext context, String catalogName, String db, PrivilegeType privilegeType) {
+        // Allow all DB actions
+    }
+
+    @Override
+    public void checkAnyActionOnDb(ConnectContext context, String catalogName, String db) {
+        // Allow any action on any DB
+    }
+
+    @Override
+    public void checkTableAction(ConnectContext context, TableName tableName, PrivilegeType privilegeType) {
+        // Allow all table actions
+    }
+
+    @Override
+    public void checkAnyActionOnTable(ConnectContext context, TableName tableName) {
+        // Allow any action on any table
+    }
+
+    @Override
+    public void checkAnyActionOnAnyTable(ConnectContext context, String catalog, String db) {
+        // Allow any action on any table in any DB
+    }
+
+    @Override
+    public void checkColumnAction(ConnectContext context, TableName tableName, String column, PrivilegeType privilegeType) {
+        // Allow all column actions
+    }
+
+    @Override
+    public void checkViewAction(ConnectContext context, TableName tableName, PrivilegeType privilegeType) {
+        // Allow all view actions
+    }
+
+    @Override
+    public void checkAnyActionOnView(ConnectContext context, TableName tableName) {
+        // Allow any action on any view
+    }
+
+    @Override
+    public void checkAnyActionOnAnyView(ConnectContext context, String db) {
+        // Allow any action on any view in DB
+    }
+
+    @Override
+    public void checkActionInDb(ConnectContext context, String db, PrivilegeType privilegeType) {
+        // Allow any action in DB
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
@@ -20,6 +20,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.starrocks.authorization.AllowAllHiveAccessController;
 import com.starrocks.authorization.NativeAccessController;
 import com.starrocks.authorization.ranger.hive.RangerHiveAccessController;
 import com.starrocks.authorization.ranger.starrocks.RangerStarRocksAccessController;
@@ -117,10 +118,13 @@ public class CatalogMgr {
 
             try {
                 Preconditions.checkState(!catalogs.containsKey(catalogName), "Catalog '%s' already exists", catalogName);
+                String accessControl = properties.getOrDefault("catalog.access.control", Config.access_control);
                 String serviceName = properties.get("ranger.plugin.hive.service.name");
                 if (serviceName == null || serviceName.isEmpty()) {
-                    if (Config.access_control.equals("ranger")) {
+                    if (accessControl.equals("ranger")) {
                         Authorizer.getInstance().setAccessControl(catalogName, new RangerStarRocksAccessController());
+                    } else if (accessControl.equals("allowall")) {
+                        Authorizer.getInstance().setAccessControl(catalogName, new AllowAllHiveAccessController());
                     } else {
                         Authorizer.getInstance().setAccessControl(catalogName, new NativeAccessController());
                     }
@@ -188,10 +192,13 @@ public class CatalogMgr {
             connectorMgr.addConnector(catalogName, newConnector);
 
             if (newProperties.containsKey("ranger.plugin.hive.service.name")) {
+                String accessControl = newProperties.getOrDefault("catalog.access.control", Config.access_control);
                 String serviceName = newProperties.get("ranger.plugin.hive.service.name");
                 if (StringUtils.isEmpty(serviceName)) {
-                    if ("ranger".equals(Config.access_control)) {
+                    if ("ranger".equals(accessControl)) {
                         Authorizer.getInstance().setAccessControl(catalogName, new RangerStarRocksAccessController());
+                    } else if ("allowall".equals(accessControl)) {
+                        Authorizer.getInstance().setAccessControl(catalogName, new AllowAllHiveAccessController());
                     } else {
                         Authorizer.getInstance().setAccessControl(catalogName, new NativeAccessController());
                     }
@@ -349,9 +356,12 @@ public class CatalogMgr {
             }
 
             String serviceName = config.get("ranger.plugin.hive.service.name");
+            String accessControl = config.getOrDefault("catalog.access.control", Config.access_control);
             if (serviceName == null || serviceName.isEmpty()) {
-                if (Config.access_control.equals("ranger")) {
+                if (accessControl.equals("ranger")) {
                     Authorizer.getInstance().setAccessControl(catalogName, new RangerStarRocksAccessController());
+                } else if (accessControl.equals("allowall")) {
+                    Authorizer.getInstance().setAccessControl(catalogName, new AllowAllHiveAccessController());
                 } else {
                     Authorizer.getInstance().setAccessControl(catalogName, new NativeAccessController());
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
@@ -20,7 +20,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.starrocks.authorization.AllowAllHiveAccessController;
+import com.starrocks.authorization.AllowAllAccessController;
 import com.starrocks.authorization.NativeAccessController;
 import com.starrocks.authorization.ranger.hive.RangerHiveAccessController;
 import com.starrocks.authorization.ranger.starrocks.RangerStarRocksAccessController;
@@ -124,7 +124,7 @@ public class CatalogMgr {
                     if (accessControl.equals("ranger")) {
                         Authorizer.getInstance().setAccessControl(catalogName, new RangerStarRocksAccessController());
                     } else if (accessControl.equals("allowall")) {
-                        Authorizer.getInstance().setAccessControl(catalogName, new AllowAllHiveAccessController());
+                        Authorizer.getInstance().setAccessControl(catalogName, new AllowAllAccessController());
                     } else {
                         Authorizer.getInstance().setAccessControl(catalogName, new NativeAccessController());
                     }
@@ -198,7 +198,7 @@ public class CatalogMgr {
                     if ("ranger".equals(accessControl)) {
                         Authorizer.getInstance().setAccessControl(catalogName, new RangerStarRocksAccessController());
                     } else if ("allowall".equals(accessControl)) {
-                        Authorizer.getInstance().setAccessControl(catalogName, new AllowAllHiveAccessController());
+                        Authorizer.getInstance().setAccessControl(catalogName, new AllowAllAccessController());
                     } else {
                         Authorizer.getInstance().setAccessControl(catalogName, new NativeAccessController());
                     }
@@ -361,7 +361,7 @@ public class CatalogMgr {
                 if (accessControl.equals("ranger")) {
                     Authorizer.getInstance().setAccessControl(catalogName, new RangerStarRocksAccessController());
                 } else if (accessControl.equals("allowall")) {
-                    Authorizer.getInstance().setAccessControl(catalogName, new AllowAllHiveAccessController());
+                    Authorizer.getInstance().setAccessControl(catalogName, new AllowAllAccessController());
                 } else {
                     Authorizer.getInstance().setAccessControl(catalogName, new NativeAccessController());
                 }


### PR DESCRIPTION
## Why I'm doing:
When we have external systems like Hive which are already doing authorization and access control we donot have to rely on Starrocks native access control. Also with Ouath and OIDC we can have users that are not registered with Starrocks and NativeAccessControl will fail with them. 

## What I'm doing:
Added AllowAllHiveAccessControl to allow operations on Hive tables for DB and tables.

Fixes #59612 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
