### PR TITLE
[BugFix] Revert  Reduce the size of data written to edit log when schema changes in shared-data clusters with fast schema evolution enabled. (#55282)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
@@ -81,11 +81,6 @@ public class LakeTableAlterMetaJob extends LakeTableAlterMetaJobBase {
     }
 
     @Override
-    protected LakeTableAlterMetaJob getShadowCopy() {
-        return this;
-    }
-
-    @Override
     protected boolean enableFileBundling() {
         return metaType == TTabletMetaType.ENABLE_FILE_BUNDLING && enableFileBundling;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -112,7 +112,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
             this.watershedTxnId = globalStateMgr.getGlobalTransactionMgr().getTransactionIDGenerator()
                     .getNextTransactionId();
             this.watershedGtid = globalStateMgr.getGtidGenerator().nextGtid();
-            GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this.getShadowCopy());
+            GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this);
         }
 
         try {
@@ -172,7 +172,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
             this.jobState = JobState.FINISHED_REWRITING;
             this.finishedTimeMs = System.currentTimeMillis();
 
-            GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this.getShadowCopy());
+            GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this);
 
             // NOTE: !!! below this point, this update meta job must success unless the database or table been dropped. !!!
             updateNextVersion(table);
@@ -215,7 +215,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
             updateCatalog(db, table);
             this.jobState = JobState.FINISHED;
             this.finishedTimeMs = System.currentTimeMillis();
-            GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this.getShadowCopy());
+            GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this);
             // set visible version
             updateVisibleVersion(table);
             table.setState(OlapTable.OlapTableState.NORMAL);
@@ -443,9 +443,6 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         return watershedTxnId;
     }
 
-    // Only for reducing data writing after the first log, so we don't do deep copy
-    protected abstract LakeTableAlterMetaJobBase getShadowCopy();
-
     @Override
     protected boolean cancelImpl(String errMsg) {
         if (jobState == JobState.CANCELLED || jobState == JobState.FINISHED) {
@@ -542,25 +539,6 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.WRITE);
         }
-    }
-
-    protected void copyOnlyForNonFirstLog(LakeTableAlterMetaJobBase copied) {
-        copied.watershedTxnId = this.watershedTxnId;
-        copied.watershedGtid = this.watershedGtid;
-        copied.physicalPartitionIndexMap = this.physicalPartitionIndexMap;
-        copied.commitVersionMap = this.commitVersionMap;
-
-        copied.type = this.type;
-        copied.jobId = this.jobId;
-        copied.jobState = this.jobState;
-        copied.dbId = this.dbId;
-        copied.tableId = this.tableId;
-        copied.tableName = this.tableName;
-        copied.errMsg = this.errMsg;
-        copied.createTimeMs = this.createTimeMs;
-        copied.finishedTimeMs = this.finishedTimeMs;
-        copied.timeoutMs = this.timeoutMs;
-        copied.warehouseId = this.warehouseId;
     }
 
     // for test

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
@@ -111,13 +111,6 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
     }
 
     @Override
-    protected LakeTableAsyncFastSchemaChangeJob getShadowCopy() {
-        LakeTableAsyncFastSchemaChangeJob copied = new LakeTableAsyncFastSchemaChangeJob();
-        copyOnlyForNonFirstLog(copied);
-        return copied;
-    }
-
-    @Override
     protected void updateCatalog(Database db, LakeTable table) {
         updateCatalogUnprotected(db, table);
     }
@@ -159,6 +152,9 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
 
     @Override
     protected void restoreState(LakeTableAlterMetaJobBase job) {
+        // This PR(#55282) only writes the schemaInfo once in the entire schema change job process, 
+        // but it has compatibility issues with previous versions, so it was reverted.
+        // However, since some versions include this PR, the schemaInfo may be null when upgrading from these versions.
         List<IndexSchemaInfo> jobSchemaInfos = ((LakeTableAsyncFastSchemaChangeJob) job).schemaInfos;
         if (jobSchemaInfos != null && !jobSchemaInfos.isEmpty()) {
             this.schemaInfos = new ArrayList<>(jobSchemaInfos);


### PR DESCRIPTION
This reverts commit 5236f19b6e68644a57a0b191b0feeb425019f736.

## Why I'm doing:
The pr(https://github.com/StarRocks/starrocks/pull/55282) only writes the schemaInfo once in the entire schema change job process. However, if we downgrade to older version, FE maybe crash because the `schemaInfo` is null

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/9763

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
