### PR TITLE
[BugFix] Fix UnionToValuesRule bug with unligned constant values

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalValuesOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalValuesOperator.java
@@ -70,7 +70,8 @@ public class LogicalValuesOperator extends LogicalOperator {
 
     @Override
     public RowOutputInfo deriveRowOutputInfo(List<OptExpression> inputs) {
-        return new RowOutputInfo(columnRefSet.stream().collect(Collectors.toMap(Function.identity(), Function.identity())));
+        return new RowOutputInfo(columnRefSet.stream().distinct()
+                .collect(Collectors.toMap(Function.identity(), Function.identity())));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalValuesOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalValuesOperator.java
@@ -55,7 +55,8 @@ public class PhysicalValuesOperator extends PhysicalOperator {
 
     @Override
     public RowOutputInfo deriveRowOutputInfo(List<OptExpression> inputs) {
-        return new RowOutputInfo(columnRefSet.stream().collect(Collectors.toMap(Function.identity(), Function.identity())));
+        return new RowOutputInfo(columnRefSet.stream().distinct()
+                .collect(Collectors.toMap(Function.identity(), Function.identity())));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1964,6 +1964,7 @@ public class PlanFragmentBuilder {
             }
             tupleDescriptor.computeMemLayout();
 
+            final int dstSlotCount = tupleDescriptor.getSlots().size();
             if (valuesOperator.getRows().isEmpty()) {
                 EmptySetNode emptyNode = new EmptySetNode(context.getNextNodeId(),
                         Lists.newArrayList(tupleDescriptor.getId()));
@@ -1980,6 +1981,12 @@ public class PlanFragmentBuilder {
 
                 List<List<Expr>> consts = new ArrayList<>();
                 for (List<ScalarOperator> row : valuesOperator.getRows()) {
+                    if (row.size() != dstSlotCount) {
+                        throw new StarRocksPlannerException(
+                                String.format("The number of columns in each row of values %s must be equal to the number of " +
+                                        "slots %s", row.size(), dstSlotCount),
+                                INTERNAL_ERROR);
+                    }
                     List<Expr> exprRow = new ArrayList<>();
                     for (ScalarOperator field : row) {
                         exprRow.add(ScalarOperatorToExpr.buildExecExpression(

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
@@ -640,7 +640,7 @@ public class SetTest extends PlanTestBase {
                 "  |      [11, DOUBLE, true]\n" +
                 "  |  child exprs:\n" +
                 "  |      [10: cast, DOUBLE, true]\n" +
-                "  |      [3: cast, DOUBLE, true]\n");
+                "  |      [12: cast, DOUBLE, true]");
 
         sql = "(select 1 limit 1) UNION ALL select 2;";
         plan = getVerboseExplain(sql);
@@ -656,25 +656,23 @@ public class SetTest extends PlanTestBase {
                 " all select 2 union all select * from (values (3)) t";
         plan = getVerboseExplain(sql);
 
-        assertContains(plan, "  0:UNION\n" +
-                "  |  output exprs:\n" +
+        assertContains(plan, "|  output exprs:\n" +
                 "  |      [13, VARCHAR(32), true]\n" +
                 "  |  child exprs:\n" +
                 "  |      [1: k1, VARCHAR, true]\n" +
                 "  |      [12: cast, VARCHAR(32), false]\n" +
-                "  |      [7: cast, VARCHAR(32), true]\n");
+                "  |      [14: k1, VARCHAR(32), true]\n");
 
         sql = "select k1 from db1.tbl6 union all select 1 union" +
                 " all select 2 union all select * from (values (3)) t";
         plan = getVerboseExplain(sql);
 
-        assertContains(plan, "  0:UNION\n" +
-                "  |  output exprs:\n" +
+        assertContains(plan, "  |  output exprs:\n" +
                 "  |      [13, VARCHAR(32), true]\n" +
                 "  |  child exprs:\n" +
                 "  |      [1: k1, VARCHAR, true]\n" +
                 "  |      [12: cast, VARCHAR(32), false]\n" +
-                "  |      [7: cast, VARCHAR(32), true]\n");
+                "  |      [14: k1, VARCHAR(32), true]");
 
         sql = "select 1 union all select 2 union all select * from (values (1)) t;";
         plan = getVerboseExplain(sql);

--- a/test/sql/test_execute_in_fe/R/test_execute_in_fe
+++ b/test/sql/test_execute_in_fe/R/test_execute_in_fe
@@ -112,3 +112,132 @@ select c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10
 select c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13 from pksk_tbl;
 -- result:
 -- !result
+SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
+UNION ALL
+SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3;
+-- result:
+test	test	test
+test	test	test
+-- !result
+SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
+UNION ALL
+SELECT 'test1' AS c1, 'test1' AS c2, 'test1' AS c3;
+-- result:
+test	test	test
+test1	test1	test1
+-- !result
+SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
+UNION ALL
+SELECT 'test1' AS c1, 'test2' AS c2, 'test3' AS c3;
+-- result:
+test	test	test
+test1	test2	test3
+-- !result
+SELECT 'test1' AS c1, 'test2' AS c2, 'test3' AS c3
+UNION ALL
+SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3;
+-- result:
+test1	test2	test3
+test	test	test
+-- !result
+WITH temp AS (
+		SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
+		UNION ALL
+		SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
+	)
+SELECT DISTINCT c1, c2, c3
+FROM (
+	SELECT c1, c2, c3
+	FROM temp
+	UNION ALL
+	SELECT 'test1' AS c1, 'test1' AS c2, 'test1' AS c3
+	UNION ALL
+	SELECT 'test1' AS c1, 'test1' AS c2, 'test1' AS c3
+	UNION ALL
+	SELECT 'test1' AS c1, 'test2' AS c2, 'test3' AS c3
+) t;
+-- result:
+test	test	test
+test1	test2	test3
+test1	test1	test1
+-- !result
+WITH temp AS (
+		SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
+		UNION ALL
+		SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
+	)
+SELECT c1, c2, c3
+FROM (
+	SELECT c1, c2, c3
+	FROM temp
+	UNION ALL
+	SELECT 'test1' AS c1, 'test1' AS c2, 'test1' AS c3
+	UNION ALL
+	SELECT 'test1' AS c1, 'test2' AS c2, 'test3' AS c3
+) t;
+-- result:
+test1	test1	test1
+test1	test2	test3
+test	test	test
+test	test	test
+-- !result
+WITH temp AS (
+		SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
+		UNION ALL
+		SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
+	)
+SELECT c1, c2, c3
+FROM (
+	SELECT c1, c2, c3
+	FROM temp
+	UNION ALL
+	SELECT 'test1' AS c1, 'test2' AS c2, 'test3' AS c3
+	UNION ALL
+	SELECT 'test1' AS c1, 'test1' AS c2, 'test1' AS c3
+) t;
+-- result:
+test1	test2	test3
+test1	test1	test1
+test	test	test
+test	test	test
+-- !result
+WITH temp AS (
+		SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
+		UNION ALL
+		SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
+	)
+SELECT c1, c2, c3
+FROM (
+	SELECT c1, c2, c3
+	FROM temp
+	UNION ALL
+	SELECT 'test1' AS c1, 'test1' AS c2, 'test1' AS c3
+	UNION ALL
+	SELECT 'test2' AS c1, 'test2' AS c2, 'test2' AS c3
+) t;
+-- result:
+test	test	test
+test	test	test
+test1	test1	test1
+test2	test2	test2
+-- !result
+WITH temp AS (
+		SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
+		UNION ALL
+		SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
+	)
+SELECT c1, c2, c3
+FROM (
+	SELECT c1, c2, c3
+	FROM temp
+	UNION ALL
+	SELECT 'test1' AS c1, 'test1' AS c2, 'test2' AS c3
+	UNION ALL
+	SELECT 'test2' AS c1, 'test2' AS c2, 'test3' AS c3
+) t;
+-- result:
+test	test	test
+test	test	test
+test1	test1	test2
+test2	test2	test3
+-- !result

--- a/test/sql/test_execute_in_fe/T/test_execute_in_fe
+++ b/test/sql/test_execute_in_fe/T/test_execute_in_fe
@@ -55,3 +55,97 @@ ORDER BY(c1,c6,c11,c2);
 select c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13 from pksk_tbl limit 1;
 
 select c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13 from pksk_tbl;
+
+SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
+UNION ALL
+SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3;
+
+SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
+UNION ALL
+SELECT 'test1' AS c1, 'test1' AS c2, 'test1' AS c3;
+
+SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
+UNION ALL
+SELECT 'test1' AS c1, 'test2' AS c2, 'test3' AS c3;
+
+SELECT 'test1' AS c1, 'test2' AS c2, 'test3' AS c3
+UNION ALL
+SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3;
+
+WITH temp AS (
+		SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
+		UNION ALL
+		SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
+	)
+SELECT DISTINCT c1, c2, c3
+FROM (
+	SELECT c1, c2, c3
+	FROM temp
+	UNION ALL
+	SELECT 'test1' AS c1, 'test1' AS c2, 'test1' AS c3
+	UNION ALL
+	SELECT 'test1' AS c1, 'test1' AS c2, 'test1' AS c3
+	UNION ALL
+	SELECT 'test1' AS c1, 'test2' AS c2, 'test3' AS c3
+) t;
+
+WITH temp AS (
+		SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
+		UNION ALL
+		SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
+	)
+SELECT c1, c2, c3
+FROM (
+	SELECT c1, c2, c3
+	FROM temp
+	UNION ALL
+	SELECT 'test1' AS c1, 'test1' AS c2, 'test1' AS c3
+	UNION ALL
+	SELECT 'test1' AS c1, 'test2' AS c2, 'test3' AS c3
+) t;
+
+WITH temp AS (
+		SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
+		UNION ALL
+		SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
+	)
+SELECT c1, c2, c3
+FROM (
+	SELECT c1, c2, c3
+	FROM temp
+	UNION ALL
+	SELECT 'test1' AS c1, 'test2' AS c2, 'test3' AS c3
+	UNION ALL
+	SELECT 'test1' AS c1, 'test1' AS c2, 'test1' AS c3
+) t;
+
+WITH temp AS (
+		SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
+		UNION ALL
+		SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
+	)
+SELECT c1, c2, c3
+FROM (
+	SELECT c1, c2, c3
+	FROM temp
+	UNION ALL
+	SELECT 'test1' AS c1, 'test1' AS c2, 'test1' AS c3
+	UNION ALL
+	SELECT 'test2' AS c1, 'test2' AS c2, 'test2' AS c3
+) t;
+
+
+WITH temp AS (
+		SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
+		UNION ALL
+		SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
+	)
+SELECT c1, c2, c3
+FROM (
+	SELECT c1, c2, c3
+	FROM temp
+	UNION ALL
+	SELECT 'test1' AS c1, 'test1' AS c2, 'test2' AS c3
+	UNION ALL
+	SELECT 'test2' AS c1, 'test2' AS c2, 'test3' AS c3
+) t;


### PR DESCRIPTION
## Why I'm doing:

### Problem1

Exception will be met when execute query as below:

```

WITH temp AS (
		SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
		UNION ALL
		SELECT 'test' AS c1, 'test' AS c2, 'test' AS c3
	)
SELECT c1, c2, c3
FROM (
	SELECT c1, c2, c3
	FROM temp
	UNION ALL
	SELECT 'test1' AS c1, 'test1' AS c2, 'test1' AS c3
	UNION ALL
	SELECT 'test1' AS c1, 'test2' AS c2, 'test3' AS c3
) t;


java.lang.IllegalStateException: Duplicate key 15: expr (attempted merging values 15: expr and 15: expr)
        at java.util.stream.Collectors.duplicateKeyException(Collectors.java:135) ~[?:?]
        at java.util.stream.Collectors.lambda$uniqKeysMapAccumulator$1(Collectors.java:182) ~[?:?]
        at java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169) ~[?:?]
        at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625) ~[?:?]
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921) ~[?:?]
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
        at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682) ~[?:?]
        at com.starrocks.sql.optimizer.operator.logical.LogicalValuesOperator.deriveRowOutputInfo(LogicalValuesOperator.java:73) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.operator.Operator.getRowOutputInfo(Operator.java:203) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.OptExpression.getRowOutputInfo(OptExpression.java:143) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.OptExpression.clearStatsAndInitOutputInfo(OptExpression.java:157) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.OptExpression.clearStatsAndInitOutputInfo(OptExpression.java:152) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.OptExpression.clearStatsAndInitOutputInfo(OptExpression.java:152) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.QueryOptimizer.logicalRuleRewrite(QueryOptimizer.java:730) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.QueryOptimizer.rewriteAndValidatePlan(QueryOptimizer.java:785) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.QueryOptimizer.optimizeByCost(QueryOptimizer.java:241) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.QueryOptimizer.optimize(QueryOptimizer.java:197) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.createQueryPlanWithReTry(StatementPlanner.java:374) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:151) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:105) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:615) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:421) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:631) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:980) ~[starrocks-fe.jar:?]
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:71) ~[starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
```
This is because `LogicalValuesOperator/PhysicalValuesOperator`'s ColumnRefs may contain column refs with the same ids.

NOTE:  The same (constant) expression will use the same column ref which can cause the bug.

### Problem2

After fixing bug above, the result is still wrong:
```
mysql> with temp AS (
    ->         SELECT
    ->             'test' as c1,
    ->             'test'  as c2,
    ->             'test' as c3
    ->         UNION ALL
    ->         SELECT
    ->             'test' as c1,
    ->             'test' as c2,
    ->             'test' as c3
    -> )
    -> SELECT
    ->     c1,
    ->     c2,
    ->     c3
    -> FROM (
    ->         SELECT
    ->             c1,
    ->             c2,
    ->             c3
    ->         from temp
    ->    UNION ALL
    ->         SELECT
    ->             'test1' as c1,
    ->             'test1' as c2,
    ->             'test1' as c3
    ->                     UNION ALL
    ->         SELECT
    ->             'test1' as c1,
    ->             'test2' as c2,
    ->             'test3' as c3
    ->
    ->
    -> ) t;

+-------+-------+-------+
| c1    | c2    | c3    |
+-------+-------+-------+
| test1 | test1 | test1 |
| test1 | test1 | test1 | <- should be test1|test2|test3
| test  | test  | test  |
| test  | test  | test  |
+-------+-------+-------+
4 rows in set (0.12 sec)

```
I found #42915 will merge multi value operators into one, but cannot handle unligned output columnrefs. In `PlanFragmentBuilder`, if ValueOperator's ColumnRefSet's size is not equal to Constant Row's size, BE will generate wrong results.
![image](https://github.com/user-attachments/assets/41ac621e-f0be-4e33-a271-91067d4718ae)

BE has a DCHECK for this:

![image](https://github.com/user-attachments/assets/5c0bf9e1-6fd6-40a2-b05b-79879362fb55)

## What I'm doing:

This pull request introduces several improvements and fixes to the SQL optimizer and planner components, focusing on handling `LogicalValuesOperator` and `UnionToValuesRule`. Key changes include ensuring distinct column references in output, improving row alignment checks, and enhancing test coverage for edge cases involving unions and values. 

### Enhancements to `LogicalValuesOperator` and `UnionToValuesRule`:

* **Distinct Column References in Output**: Updated `deriveRowOutputInfo` methods in both `LogicalValuesOperator` and `PhysicalValuesOperator` to ensure column references are distinct when constructing output mappings. (`fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalValuesOperator.java`, [[1]](diffhunk://#diff-e64cbb262f7435c6485d993a60436d413e16d90e0c00ba274c9e02c3f5607ae6L73-R76); `fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalValuesOperator.java`, [[2]](diffhunk://#diff-8bb9e719ca04b18a0031de28c5b1285f67e2ef588286ba77621408747e075f86L58-R61)
* **Row Alignment Validation**: Added validation in `PlanFragmentBuilder` to ensure the number of columns in each row matches the number of slots in the tuple descriptor, throwing an exception if mismatched. (`fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java`, [fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.javaR1984-R1989](diffhunk://#diff-27efdd598fd6ca13fb864e65ad639e89c5fa2bd7d65c1b91fc354d9bbbf2ba7fR1984-R1989))



Fixes https://github.com/StarRocks/starrocks/issues/59483

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
