### PR TITLE
[Feature] Create table supports decimal256 column type

### DIFF
--- a/be/src/types/logical_type.cpp
+++ b/be/src/types/logical_type.cpp
@@ -157,6 +157,9 @@ LogicalType thrift_to_type(TPrimitiveType::type ttype) {
         return TYPE_UNKNOWN;
     case TPrimitiveType::NULL_TYPE:
         return TYPE_NULL;
+    // TODO(stephen): compatibility for this will be in the next patch
+    case TPrimitiveType::DECIMAL256:
+        return TYPE_UNKNOWN;
 #define M(ttype)                \
     case TPrimitiveType::ttype: \
         return TYPE_##ttype;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PrimitiveType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PrimitiveType.java
@@ -76,6 +76,7 @@ public enum PrimitiveType {
     DECIMAL32("DECIMAL32", 4, TPrimitiveType.DECIMAL32),
     DECIMAL64("DECIMAL64", 8, TPrimitiveType.DECIMAL64),
     DECIMAL128("DECIMAL128", 16, TPrimitiveType.DECIMAL128),
+    DECIMAL256("DECIMAL256", 32, TPrimitiveType.DECIMAL256),
 
     JSON("JSON", 16, TPrimitiveType.JSON),
 
@@ -98,7 +99,7 @@ public enum PrimitiveType {
             ImmutableList.of(TINYINT, SMALLINT, INT, BIGINT, LARGEINT);
 
     public static final ImmutableList<PrimitiveType> FLOAT_TYPE_LIST =
-            ImmutableList.of(FLOAT, DOUBLE, DECIMALV2, DECIMAL32, DECIMAL64, DECIMAL128);
+            ImmutableList.of(FLOAT, DOUBLE, DECIMALV2, DECIMAL32, DECIMAL64, DECIMAL128, DECIMAL256);
 
     public static final ImmutableList<PrimitiveType> NUMBER_TYPE_LIST =
             ImmutableList.<PrimitiveType>builder()
@@ -180,7 +181,7 @@ public enum PrimitiveType {
         builder.putAll(CHAR, BASIC_TYPE_LIST);
 
         // Decimal
-        for (PrimitiveType decimalType : Arrays.asList(DECIMALV2, DECIMAL32, DECIMAL64, DECIMAL128)) {
+        for (PrimitiveType decimalType : Arrays.asList(DECIMALV2, DECIMAL32, DECIMAL64, DECIMAL128, DECIMAL256)) {
             builder.putAll(decimalType, BOOLEAN);
             builder.putAll(decimalType, NUMBER_TYPE_LIST);
             builder.putAll(decimalType, STRING_TYPE_LIST);
@@ -270,6 +271,8 @@ public enum PrimitiveType {
                 return DECIMAL64;
             case DECIMAL128:
                 return DECIMAL128;
+            case DECIMAL256:
+                return DECIMAL256;
             case DATE:
                 return DATE;
             case DATETIME:
@@ -321,6 +324,19 @@ public enum PrimitiveType {
         }
     }
 
+    /**
+     * Returns the maximum precision (total number of digits) supported by the specified decimal type.
+     * Different bit widths correspond to different decimal ranges due to storage limitations.
+     *
+     * @param t The decimal primitive type to check
+     * @return The maximum precision for the given decimal type:
+     *         - DECIMALV2: 27 digits
+     *         - DECIMAL32: 9 digits
+     *         - DECIMAL64: 18 digits
+     *         - DECIMAL128: 38 digits
+     *         - DECIMAL256: 76 digits
+     * @throws IllegalStateException if the input type is not a decimal type
+     */
     public static int getMaxPrecisionOfDecimal(PrimitiveType t) {
         switch (t) {
             case DECIMALV2:
@@ -331,6 +347,8 @@ public enum PrimitiveType {
                 return 18;
             case DECIMAL128:
                 return 38;
+            case DECIMAL256:
+                return 76;
             default:
                 Preconditions.checkState(t.isDecimalOfAnyVersion());
                 return -1;
@@ -347,6 +365,8 @@ public enum PrimitiveType {
                 return 18;
             case DECIMAL128:
                 return 38;
+            case DECIMAL256:
+                return 76;
             default:
                 Preconditions.checkState(t.isDecimalOfAnyVersion());
                 return -1;
@@ -364,10 +384,6 @@ public enum PrimitiveType {
         }
         Preconditions.checkState(type.isDecimalOfAnyVersion());
         return type;
-    }
-
-    public void setTimeType() {
-        isTimeType = true;
     }
 
     @Override
@@ -420,6 +436,9 @@ public enum PrimitiveType {
             case DECIMALV2:
             case DECIMAL128:
                 typeSize = 16;
+                break;
+            case DECIMAL256:
+                typeSize = 32;
                 break;
             case CHAR:
             case VARCHAR:
@@ -477,7 +496,7 @@ public enum PrimitiveType {
     }
 
     public boolean isDecimalV3Type() {
-        return this == DECIMAL32 || this == DECIMAL64 || this == DECIMAL128;
+        return this == DECIMAL32 || this == DECIMAL64 || this == DECIMAL128 || this == DECIMAL256;
     }
 
     public boolean isNumericType() {
@@ -553,6 +572,7 @@ public enum PrimitiveType {
             case DECIMAL32:
             case DECIMAL64:
             case DECIMAL128:
+            case DECIMAL256:
                 return MysqlColType.MYSQL_TYPE_NEWDECIMAL;
             case VARCHAR:
                 return MysqlColType.MYSQL_TYPE_VAR_STRING;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -103,7 +103,7 @@ public abstract class Type implements Cloneable {
     // DECIMAL, NULL, and INVALID_TYPE  are handled separately.
     private static final List<PrimitiveType> SKIP_COMPARE_TYPES = Arrays.asList(
             PrimitiveType.INVALID_TYPE, PrimitiveType.NULL_TYPE, PrimitiveType.DECIMALV2,
-            PrimitiveType.DECIMAL32, PrimitiveType.DECIMAL64, PrimitiveType.DECIMAL128,
+            PrimitiveType.DECIMAL32, PrimitiveType.DECIMAL64, PrimitiveType.DECIMAL128, PrimitiveType.DECIMAL256,
             PrimitiveType.TIME, PrimitiveType.JSON, PrimitiveType.FUNCTION,
             PrimitiveType.BINARY, PrimitiveType.VARBINARY);
 
@@ -129,11 +129,15 @@ public abstract class Type implements Cloneable {
             ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 6);
     public static final ScalarType DEFAULT_DECIMAL128 =
             ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 9);
+    public static final ScalarType DEFAULT_DECIMAL256 =
+            ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL256, 76, 12);
+
     public static final ScalarType DECIMALV2 = DEFAULT_DECIMALV2;
 
     public static final ScalarType DECIMAL32 = ScalarType.createWildcardDecimalV3Type(PrimitiveType.DECIMAL32);
     public static final ScalarType DECIMAL64 = ScalarType.createWildcardDecimalV3Type(PrimitiveType.DECIMAL64);
     public static final ScalarType DECIMAL128 = ScalarType.createWildcardDecimalV3Type(PrimitiveType.DECIMAL128);
+    public static final ScalarType DECIMAL256 = ScalarType.createWildcardDecimalV3Type(PrimitiveType.DECIMAL256);
 
     // DECIMAL64_INT and DECIMAL128_INT for integer casting to decimal
     public static final ScalarType DECIMAL_ZERO =
@@ -192,7 +196,7 @@ public abstract class Type implements Cloneable {
 
     // NOTE: DECIMAL_TYPES not contain DECIMALV2
     public static final ImmutableList<ScalarType> DECIMAL_TYPES =
-            ImmutableList.of(DECIMAL32, DECIMAL64, DECIMAL128);
+            ImmutableList.of(DECIMAL32, DECIMAL64, DECIMAL128, DECIMAL256);
 
     public static final ImmutableList<ScalarType> DATE_TYPES =
             ImmutableList.of(Type.DATE, Type.DATETIME);

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/Util.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/Util.java
@@ -101,6 +101,7 @@ public class Util {
         TYPE_STRING_MAP.put(PrimitiveType.DECIMAL32, "decimal(%d,%d)");
         TYPE_STRING_MAP.put(PrimitiveType.DECIMAL64, "decimal(%d,%d)");
         TYPE_STRING_MAP.put(PrimitiveType.DECIMAL128, "decimal(%d,%d)");
+        TYPE_STRING_MAP.put(PrimitiveType.DECIMAL256, "decimal(%d,%d)");
         TYPE_STRING_MAP.put(PrimitiveType.HLL, "varchar(%d)");
         TYPE_STRING_MAP.put(PrimitiveType.BOOLEAN, "bool");
         TYPE_STRING_MAP.put(PrimitiveType.BITMAP, "bitmap");
@@ -259,6 +260,7 @@ public class Util {
                 case DECIMAL32:
                 case DECIMAL64:
                 case DECIMAL128:
+                case DECIMAL256:
                     return String.format(
                             TYPE_STRING_MAP.get(primitiveType), 
                             ((ScalarType) type).getScalarPrecision(),

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ScalarTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ScalarTypeTest.java
@@ -78,7 +78,7 @@ public class ScalarTypeTest {
                 ScalarType.createUnifiedDecimalType(38, 38),
                 ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 38));
 
-        Assert.assertThrows(Throwable.class, () -> ScalarType.createUnifiedDecimalType(39, 38));
+        Assert.assertThrows(Throwable.class, () -> ScalarType.createUnifiedDecimalType(79, 38));
         Assert.assertThrows(Throwable.class, () -> ScalarType.createUnifiedDecimalType(10, 11));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/combinator/AggStateCombinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/combinator/AggStateCombinatorTest.java
@@ -792,28 +792,30 @@ public class AggStateCombinatorTest extends MVTestBase {
             String sql1 = "select k1, " + Joiner.on(", ").join(unionColumns)
                     + " from test_agg_state_table group by k1;";
             String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql1);
-            PlanTestBase.assertContains(plan, "|  aggregate: multi_distinct_sum_union[([6: v4, VARBINARY, true]); " +
-                    "args: VARBINARY; result: VARBINARY; args nullable: true; " +
-                    "result nullable: true], multi_distinct_sum_union[([7: v5, VARBINARY, true]); args: VARBINARY; " +
-                    "result: VARBINARY; args nullable: true; result nullable: true], " +
-                    "multi_distinct_sum_union[([8: v6, VARBINARY, true]); args: VARBINARY; " +
-                    "result: VARBINARY; args nullable: true; result nullable: true], " +
-                    "multi_distinct_sum_union[([9: v7, VARBINARY, true]); args: VARBINARY; " +
-                    "result: VARBINARY; args nullable: true; result nullable: true], " +
-                    "multi_distinct_sum_union[([10: v8, VARBINARY, true]); args: VARBINARY; " +
-                    "result: VARBINARY; args nullable: true; result nullable: true], " +
-                    "multi_distinct_sum_union[([11: v9, VARBINARY, true]); args: VARBINARY; " +
-                    "result: VARBINARY; args nullable: true; result nullable: true], " +
-                    "multi_distinct_sum_union[([12: v10, VARBINARY, true]); args: VARBINARY; " +
-                    "result: VARBINARY; args nullable: true; result nullable: true], " +
-                    "multi_distinct_sum_union[([2: v0, VARBINARY, true]); args: VARBINARY; " +
-                    "result: VARBINARY; args nullable: true; result nullable: true], " +
-                    "multi_distinct_sum_union[([3: v1, VARBINARY, true]); args: VARBINARY; " +
-                    "result: VARBINARY; args nullable: true; result nullable: true], " +
-                    "multi_distinct_sum_union[([4: v2, VARBINARY, true]); args: VARBINARY; " +
-                    "result: VARBINARY; args nullable: true; result nullable: true], " +
-                    "multi_distinct_sum_union[([5: v3, VARBINARY, true]); args: VARBINARY; " +
-                    "result: VARBINARY; args nullable: true; result nullable: true]");
+            PlanTestBase.assertContains(plan, "aggregate: multi_distinct_sum_union[([5: v3, VARBINARY, true]);" +
+                    " args: VARBINARY; result: VARBINARY; args nullable: true; result nullable: true]," +
+                    " multi_distinct_sum_union[([6: v4, VARBINARY, true]); args: VARBINARY; result: VARBINARY; " +
+                    "args nullable: true; result nullable: true], " +
+                    "multi_distinct_sum_union[([7: v5, VARBINARY, true]);" +
+                    " args: VARBINARY; result: VARBINARY; args nullable: true; result nullable: true]," +
+                    " multi_distinct_sum_union[([8: v6, VARBINARY, true]);" +
+                    " args: VARBINARY; result: VARBINARY; args nullable: true; result nullable: true], " +
+                    "multi_distinct_sum_union[([9: v7, VARBINARY, true]);" +
+                    " args: VARBINARY; result: VARBINARY; args nullable: true; result nullable: true]," +
+                    " multi_distinct_sum_union[([10: v8, VARBINARY, true]); " +
+                    "args: VARBINARY; result: VARBINARY; args nullable: true; result nullable: true]," +
+                    " multi_distinct_sum_union[([11: v9, VARBINARY, true]);" +
+                    " args: VARBINARY; result: VARBINARY; args nullable: true; result nullable: true]," +
+                    " multi_distinct_sum_union[([12: v10, VARBINARY, true]);" +
+                    " args: VARBINARY; result: VARBINARY; args nullable: true; result nullable: true]," +
+                    " multi_distinct_sum_union[([13: v11, VARBINARY, true]);" +
+                    " args: VARBINARY; result: VARBINARY; args nullable: true; result nullable: true]," +
+                    " multi_distinct_sum_union[([2: v0, VARBINARY, true]);" +
+                    " args: VARBINARY; result: VARBINARY; args nullable: true; result nullable: true]," +
+                    " multi_distinct_sum_union[([3: v1, VARBINARY, true]);" +
+                    " args: VARBINARY; result: VARBINARY; args nullable: true; result nullable: true]," +
+                    " multi_distinct_sum_union[([4: v2, VARBINARY, true]);" +
+                    " args: VARBINARY; result: VARBINARY; args nullable: true; result nullable: true");
             PlanTestBase.assertContains(plan, " 0:OlapScanNode\n" +
                     "     table: test_agg_state_table, rollup: test_agg_state_table");
         }
@@ -823,28 +825,29 @@ public class AggStateCombinatorTest extends MVTestBase {
             String sql1 = "select k1, " + Joiner.on(", ").join(mergeColumns)
                     + " from test_agg_state_table group by k1;";
             String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql1);
-            PlanTestBase.assertContains(plan, "|  aggregate: multi_distinct_sum_merge[([6: v4, VARBINARY, true]); " +
-                    "args: VARBINARY; result: BIGINT; args nullable: true; result nullable: true], " +
-                    "multi_distinct_sum_merge[([7: v5, VARBINARY, true]); args: VARBINARY; " +
-                    "result: BIGINT; args nullable: true; result nullable: true], " +
-                    "multi_distinct_sum_merge[([8: v6, VARBINARY, true]); args: VARBINARY; " +
-                    "result: BIGINT; args nullable: true; result nullable: true], " +
-                    "multi_distinct_sum_merge[([9: v7, VARBINARY, true]); args: VARBINARY; " +
-                    "result: LARGEINT; args nullable: true; result nullable: true], " +
-                    "multi_distinct_sum_merge[([10: v8, VARBINARY, true]); args: VARBINARY; " +
-                    "result: DECIMAL128(38,2); args nullable: true; result nullable: true], " +
-                    "multi_distinct_sum_merge[([11: v9, VARBINARY, true]); args: VARBINARY; " +
-                    "result: DECIMAL128(38,2); args nullable: true; result nullable: true], " +
-                    "multi_distinct_sum_merge[([12: v10, VARBINARY, true]); args: VARBINARY; " +
-                    "result: DECIMAL128(38,2); args nullable: true; result nullable: true], " +
-                    "multi_distinct_sum_merge[([2: v0, VARBINARY, true]); args: VARBINARY; " +
-                    "result: DOUBLE; args nullable: true; result nullable: true], " +
-                    "multi_distinct_sum_merge[([3: v1, VARBINARY, true]); args: VARBINARY; " +
-                    "result: DOUBLE; args nullable: true; result nullable: true], " +
-                    "multi_distinct_sum_merge[([4: v2, VARBINARY, true]); args: VARBINARY; " +
-                    "result: BIGINT; args nullable: true; result nullable: true], " +
-                    "multi_distinct_sum_merge[([5: v3, VARBINARY, true]); args: VARBINARY; " +
-                    "result: BIGINT; args nullable: true; result nullable: true]");
+            PlanTestBase.assertContains(plan, "|  aggregate: multi_distinct_sum_merge[([5: v3, VARBINARY, true]);" +
+                    " args: VARBINARY; result: BIGINT; args nullable: true; result nullable: true]," +
+                    " multi_distinct_sum_merge[([6: v4, VARBINARY, true]); args: VARBINARY; result: BIGINT;" +
+                    " args nullable: true; result nullable: true], multi_distinct_sum_merge[([7: v5, VARBINARY, true]);" +
+                    " args: VARBINARY; result: BIGINT; args nullable: true; result nullable: true]," +
+                    " multi_distinct_sum_merge[([8: v6, VARBINARY, true]);" +
+                    " args: VARBINARY; result: BIGINT; args nullable: true; result nullable: true]," +
+                    " multi_distinct_sum_merge[([9: v7, VARBINARY, true]);" +
+                    " args: VARBINARY; result: LARGEINT; args nullable: true; result nullable: true]," +
+                    " multi_distinct_sum_merge[([10: v8, VARBINARY, true]);" +
+                    " args: VARBINARY; result: DECIMAL128(38,2); args nullable: true; result nullable: true]," +
+                    " multi_distinct_sum_merge[([11: v9, VARBINARY, true]);" +
+                    " args: VARBINARY; result: DECIMAL128(38,2); args nullable: true; result nullable: true]," +
+                    " multi_distinct_sum_merge[([12: v10, VARBINARY, true]);" +
+                    " args: VARBINARY; result: DECIMAL128(38,2); args nullable: true; result nullable: true]," +
+                    " multi_distinct_sum_merge[([13: v11, VARBINARY, true]);" +
+                    " args: VARBINARY; result: DECIMAL128(38,2); args nullable: true; result nullable: true]," +
+                    " multi_distinct_sum_merge[([2: v0, VARBINARY, true]);" +
+                    " args: VARBINARY; result: DOUBLE; args nullable: true; result nullable: true]," +
+                    " multi_distinct_sum_merge[([3: v1, VARBINARY, true]);" +
+                    " args: VARBINARY; result: DOUBLE; args nullable: true; result nullable: true]," +
+                    " multi_distinct_sum_merge[([4: v2, VARBINARY, true]);" +
+                    " args: VARBINARY; result: BIGINT; args nullable: true; result nullable: true]");
             PlanTestBase.assertContains(plan, " 0:OlapScanNode\n" +
                     "     table: test_agg_state_table, rollup: test_agg_state_table");
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
@@ -180,7 +180,7 @@ class ParserTest {
 
     @Test
     void testParseLargeDecimal() {
-        String sql = "select cast(1 as decimal(65,0))";
+        String sql = "select cast(1 as decimal(85,0))";
         ConnectContext ctx = UtFrameUtils.createDefaultCtx();
         ctx.setThreadLocalInfo();
         SessionVariable sessionVariable = ctx.getSessionVariable();
@@ -189,7 +189,7 @@ class ParserTest {
             QueryStatement stmt = (QueryStatement) SqlParser.parse(sql, sessionVariable).get(0);
             Assert.fail();
         } catch (Throwable err) {
-            Assert.assertTrue(err.getMessage().contains("DECIMAL's precision should range from 1 to 38"));
+            Assert.assertTrue(err.getMessage().contains("DECIMAL's precision should range from 1 to 76"));
         }
 
         try {
@@ -197,7 +197,7 @@ class ParserTest {
             QueryStatement stmt = (QueryStatement) SqlParser.parse(sql, sessionVariable).get(0);
             Assert.fail();
         } catch (Throwable err) {
-            Assert.assertTrue(err.getMessage().contains("DECIMAL's precision should range from 1 to 38"));
+            Assert.assertTrue(err.getMessage().contains("DECIMAL's precision should range from 1 to 76"));
         }
 
         try {
@@ -228,7 +228,7 @@ class ParserTest {
             QueryStatement stmt = (QueryStatement) SqlParser.parse(sql, sessionVariable).get(0);
             Analyzer.analyze(stmt, ctx);
             Type type = stmt.getQueryRelation().getOutputExpression().get(0).getType();
-            Assert.assertEquals(type, ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 0));
+            Assert.assertEquals(type, ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL256, 76, 0));
         } catch (Throwable err) {
             Assert.fail(err.getMessage());
         }
@@ -239,7 +239,7 @@ class ParserTest {
             QueryStatement stmt = (QueryStatement) SqlParser.parse(sql, sessionVariable).get(0);
             Analyzer.analyze(stmt, ctx);
             Type type = stmt.getQueryRelation().getOutputExpression().get(0).getType();
-            Assert.assertEquals(type, ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 0));
+            Assert.assertEquals(type, ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL256, 76, 0));
         } catch (Throwable err) {
             Assert.fail(err.getMessage());
         }
@@ -263,7 +263,7 @@ class ParserTest {
         Analyzer.analyze(stmt, ctx);
         Type type1 = stmt.getQueryRelation().getOutputExpression().get(0).getType();
         Type type2 = stmt.getQueryRelation().getOutputExpression().get(1).getType();
-        Assert.assertEquals(type1, ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 0));
+        Assert.assertEquals(type1, ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL256, 65, 0));
         Assert.assertEquals(type2, ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 0));
     }
 

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -100,7 +100,8 @@ enum TPrimitiveType {
   DECIMAL128,
   JSON,
   FUNCTION,
-  VARBINARY
+  VARBINARY,
+  DECIMAL256
 }
 
 enum TTypeNodeType {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
support create table with decimal precision in the range (38, 76]. 
eg:
```
CREATE TABLE test_decimal (k1 int, k2 int, k3 int , d1 decimal(50, 24));
```
now, we can support decimal's precision in the range [1, 76]. decimal's scale in the range [0, 76]. 
Also, this patch removes some unused code.

Fixes #issue
https://github.com/StarRocks/starrocks/issues/59645

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
