### PR TITLE
[BugFix] Fix invalid database id when recycling partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/MergePartitionJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/MergePartitionJob.java
@@ -656,6 +656,7 @@ public class MergePartitionJob extends AlterJobV2 implements GsonPostProcessable
                             + "source partitions:{}, target partition:{}",
                             jobId, dbId, tableId, sourcePartitionNames, tmpPartitionName);
                     targetTable.replaceTempPartitions(
+                            db.getId(),
                             new ArrayList<>(sourcePartitionNames), 
                             Collections.singletonList(tmpPartitionName), 
                             false, true);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
@@ -469,9 +469,9 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 implements GsonPostProcessab
             PartitionInfo partitionInfo = targetTable.getPartitionInfo();
             if (partitionInfo.isRangePartition() || partitionInfo.getType() == PartitionType.LIST) {
                 targetTable.replaceTempPartitions(
-                            Arrays.asList(sourcePartitionName), Arrays.asList(tmpPartitionName), true, false);
+                        db.getId(), Arrays.asList(sourcePartitionName), Arrays.asList(tmpPartitionName), true, false);
             } else if (partitionInfo instanceof SinglePartitionInfo) {
-                targetTable.replacePartition(sourcePartitionName, tmpPartitionName);
+                targetTable.replacePartition(db.getId(), sourcePartitionName, tmpPartitionName);
             } else {
                 throw new AlterCancelException("partition type " + partitionInfo.getType() + " is not supported");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeJobV2.java
@@ -506,10 +506,10 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
 
             PartitionInfo partitionInfo = targetTable.getPartitionInfo();
             if (partitionInfo.isRangePartition() || partitionInfo.getType() == PartitionType.LIST) {
-                targetTable.replaceTempPartitions(sourcePartitionNames, tmpPartitionNames, true, false);
+                targetTable.replaceTempPartitions(db.getId(), sourcePartitionNames, tmpPartitionNames, true, false);
             } else if (partitionInfo instanceof SinglePartitionInfo) {
                 Preconditions.checkState(sourcePartitionNames.size() == 1 && tmpPartitionNames.size() == 1);
-                targetTable.replacePartition(sourcePartitionNames.get(0), tmpPartitionNames.get(0));
+                targetTable.replacePartition(db.getId(), sourcePartitionNames.get(0), tmpPartitionNames.get(0));
             } else {
                 throw new AlterCancelException("partition type " + partitionInfo.getType() + " is not supported");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1501,6 +1501,7 @@ public class OlapTable extends Table {
     }
 
     public void dropPartitionAndReserveTablet(String partitionName) {
+        // reserveTablets is true and partition is not recycled, so dbId -1 is ok.
         dropPartition(-1, partitionName, true, true);
     }
 
@@ -2222,14 +2223,14 @@ public class OlapTable extends Table {
      *
      * return the old partition.
      */
-    public Partition replacePartition(Partition newPartition) {
+    public Partition replacePartition(long dbId, Partition newPartition) {
         Partition oldPartition = nameToPartition.remove(newPartition.getName());
 
         // For cloud native table, add partition into recycle Bin after truncate table.
         // It is no necessary for share nothing mode because file will be deleted throught
         // tablet report in this case.
         if (this.isCloudNativeTableOrMaterializedView()) {
-            RecyclePartitionInfo recyclePartitionInfo = buildRecyclePartitionInfo(-1, oldPartition);
+            RecyclePartitionInfo recyclePartitionInfo = buildRecyclePartitionInfo(dbId, oldPartition);
             recyclePartitionInfo.setRecoverable(false);
             GlobalStateMgr.getCurrentState().getRecycleBin().recyclePartition(recyclePartitionInfo);
         }
@@ -2850,7 +2851,7 @@ public class OlapTable extends Table {
         }
     }
 
-    public void replaceMatchPartitions(List<String> tempPartitionNames) {
+    public void replaceMatchPartitions(long dbId, List<String> tempPartitionNames) {
         for (String partitionName : tempPartitionNames) {
             Partition partition = tempPartitions.getPartition(partitionName);
             if (partition != null) {
@@ -2859,7 +2860,7 @@ public class OlapTable extends Table {
                 Partition oldPartition = nameToPartition.get(oldPartitionName);
                 if (oldPartition != null) {
                     // drop old partition
-                    dropPartition(-1, oldPartitionName, true);
+                    dropPartition(dbId, oldPartitionName, true);
                 }
                 // add new partition
                 addPartition(partition);
@@ -2895,7 +2896,7 @@ public class OlapTable extends Table {
      * names are still p1 and p2.
      *
      */
-    public void replaceTempPartitions(List<String> partitionNames, List<String> tempPartitionNames,
+    public void replaceTempPartitions(long dbId, List<String> partitionNames, List<String> tempPartitionNames,
                                       boolean strictRange, boolean useTempPartitionName) throws DdlException {
         if (partitionInfo instanceof RangePartitionInfo) {
             RangePartitionInfo rangeInfo = (RangePartitionInfo) partitionInfo;
@@ -2958,7 +2959,7 @@ public class OlapTable extends Table {
         // 1. drop old partitions
         for (String partitionName : partitionNames) {
             // This will also drop all tablets of the partition from TabletInvertedIndex
-            dropPartition(-1, partitionName, true);
+            dropPartition(dbId, partitionName, true);
         }
 
         // 2. add temp partitions' range info to rangeInfo, and remove them from
@@ -2987,14 +2988,14 @@ public class OlapTable extends Table {
 
     // used for unpartitioned table in insert overwrite
     // replace partition with temp partition
-    public void replacePartition(String sourcePartitionName, String tempPartitionName) {
+    public void replacePartition(long dbId, String sourcePartitionName, String tempPartitionName) {
         if (partitionInfo.getType() != PartitionType.UNPARTITIONED) {
             return;
         }
         // drop source partition
         Partition srcPartition = nameToPartition.get(sourcePartitionName);
         if (srcPartition != null) {
-            dropPartition(-1, sourcePartitionName, true);
+            dropPartition(dbId, sourcePartitionName, true);
         }
 
         Partition partition = tempPartitions.getPartition(tempPartitionName);

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -553,12 +553,12 @@ public class InsertOverwriteJobRunner {
                                 .collect(Collectors.toList()));
                     }
                     LOG.info("dynamic overwrite job {} replace tmpPartitionNames:{}", job.getJobId(), tmpPartitionNames);
-                    targetTable.replaceMatchPartitions(tmpPartitionNames);
+                    targetTable.replaceMatchPartitions(dbId, tmpPartitionNames);
                 } else {
-                    targetTable.replaceTempPartitions(sourcePartitionNames, tmpPartitionNames, true, false);
+                    targetTable.replaceTempPartitions(dbId, sourcePartitionNames, tmpPartitionNames, true, false);
                 }
             } else if (partitionInfo instanceof SinglePartitionInfo) {
-                targetTable.replacePartition(sourcePartitionNames.get(0), tmpPartitionNames.get(0));
+                targetTable.replacePartition(dbId, sourcePartitionNames.get(0), tmpPartitionNames.get(0));
             } else {
                 throw new DdlException("partition type " + partitionInfo.getType() + " is not supported");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -4526,7 +4526,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             }
 
             // replace
-            truncateTableInternal(olapTable, newPartitions, truncateEntireTable, false);
+            truncateTableInternal(db.getId(), olapTable, newPartitions, truncateEntireTable, false);
 
             try {
                 colocateTableIndex.updateLakeTableColocationInfo(olapTable, true /* isJoin */,
@@ -4575,12 +4575,12 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         }
     }
 
-    private void truncateTableInternal(OlapTable olapTable, List<Partition> newPartitions,
+    private void truncateTableInternal(long dbId, OlapTable olapTable, List<Partition> newPartitions,
                                        boolean isEntireTable, boolean isReplay) {
         // use new partitions to replace the old ones.
         Set<Tablet> oldTablets = Sets.newHashSet();
         for (Partition newPartition : newPartitions) {
-            Partition oldPartition = olapTable.replacePartition(newPartition);
+            Partition oldPartition = olapTable.replacePartition(dbId, newPartition);
             for (PhysicalPartition physicalPartition : oldPartition.getSubPartitions()) {
                 // save old tablets to be removed
                 for (MaterializedIndex index : physicalPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
@@ -4615,7 +4615,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         locker.lockDatabase(db.getId(), LockType.WRITE);
         try {
             OlapTable olapTable = (OlapTable) getTable(db.getId(), info.getTblId());
-            truncateTableInternal(olapTable, info.getPartitions(), info.isEntireTable(), true);
+            truncateTableInternal(info.getDbId(), olapTable, info.getPartitions(), info.isEntireTable(), true);
 
             if (!GlobalStateMgr.isCheckpointThread()) {
                 // add tablet to inverted index
@@ -4764,7 +4764,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
 
             partitionNames.stream().forEach(e ->
                     GlobalStateMgr.getCurrentState().getAnalyzeMgr().recordDropPartition(olapTable.getPartition(e).getId()));
-            olapTable.replaceTempPartitions(partitionNames, tempPartitionNames, isStrictRange, useTempPartitionName);
+            olapTable.replaceTempPartitions(db.getId(), partitionNames, tempPartitionNames, isStrictRange, useTempPartitionName);
 
             // write log
             ReplacePartitionOperationLog info = new ReplacePartitionOperationLog(db.getId(), olapTable.getId(),
@@ -4790,11 +4790,11 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                 return;
             }
             if (replaceTempPartitionLog.isUnPartitionedTable()) {
-                olapTable.replacePartition(replaceTempPartitionLog.getPartitions().get(0),
+                olapTable.replacePartition(db.getId(), replaceTempPartitionLog.getPartitions().get(0),
                         replaceTempPartitionLog.getTempPartitions().get(0));
                 return;
             }
-            olapTable.replaceTempPartitions(replaceTempPartitionLog.getPartitions(),
+            olapTable.replaceTempPartitions(db.getId(), replaceTempPartitionLog.getPartitions(),
                     replaceTempPartitionLog.getTempPartitions(),
                     replaceTempPartitionLog.isStrictRange(),
                     replaceTempPartitionLog.useTempPartitionName());

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ReplaceLakePartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ReplaceLakePartitionTest.java
@@ -170,7 +170,7 @@ public class ReplaceLakePartitionTest {
     @Test
     public void testUnPartitionedLakeTableReplacePartition() {
         LakeTable tbl = buildLakeTableWithTempPartition(PartitionType.UNPARTITIONED);
-        tbl.replacePartition(partitionName, tempPartitionName);
+        tbl.replacePartition(dbId, partitionName, tempPartitionName);
         Assert.assertTrue(GlobalStateMgr.getCurrentState().getRecycleBin().getRecyclePartitionInfo(partitionId) != null);
         erasePartitionOrTableAndUntilFinished(partitionId);
         Assert.assertTrue(GlobalStateMgr.getCurrentState().getRecycleBin().getRecyclePartitionInfo(partitionId) == null);
@@ -180,7 +180,7 @@ public class ReplaceLakePartitionTest {
     public void testUnPartitionedLakeTableReplacePartitionForTruncateTable() {
         LakeTable tbl = buildLakeTableWithTempPartition(PartitionType.UNPARTITIONED);
         Partition newPartition = buildPartitionForTruncateTable();
-        tbl.replacePartition(newPartition);
+        tbl.replacePartition(dbId, newPartition);
         Assert.assertTrue(GlobalStateMgr.getCurrentState().getRecycleBin().getRecyclePartitionInfo(partitionId) != null);
         erasePartitionOrTableAndUntilFinished(partitionId);
         Assert.assertTrue(GlobalStateMgr.getCurrentState().getRecycleBin().getRecyclePartitionInfo(partitionId) == null);
@@ -190,7 +190,7 @@ public class ReplaceLakePartitionTest {
     public void testListPartitionedLakeTableReplacePartitionForTruncateTable() {
         LakeTable tbl = buildLakeTableWithTempPartition(PartitionType.LIST);
         Partition newPartition = buildPartitionForTruncateTable();
-        tbl.replacePartition(newPartition);
+        tbl.replacePartition(dbId, newPartition);
         Assert.assertTrue(GlobalStateMgr.getCurrentState().getRecycleBin().getRecyclePartitionInfo(partitionId) != null);
         erasePartitionOrTableAndUntilFinished(partitionId);
         Assert.assertTrue(GlobalStateMgr.getCurrentState().getRecycleBin().getRecyclePartitionInfo(partitionId) == null);
@@ -200,7 +200,7 @@ public class ReplaceLakePartitionTest {
     public void testRangePartitionedLakeTableReplacePartitionForTruncateTable() {
         LakeTable tbl = buildLakeTableWithTempPartition(PartitionType.RANGE);
         Partition newPartition = buildPartitionForTruncateTable();
-        tbl.replacePartition(newPartition);
+        tbl.replacePartition(dbId, newPartition);
         Assert.assertTrue(GlobalStateMgr.getCurrentState().getRecycleBin().getRecyclePartitionInfo(partitionId) != null);
         erasePartitionOrTableAndUntilFinished(partitionId);
         Assert.assertTrue(GlobalStateMgr.getCurrentState().getRecycleBin().getRecyclePartitionInfo(partitionId) == null);

--- a/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
@@ -113,7 +113,7 @@ public class LocalMetaStoreTest {
         partitionInfo.addPartition(newPartition.getId(), partitionInfo.getDataProperty(sourcePartition.getId()),
                     partitionInfo.getReplicationNum(sourcePartition.getId()),
                     partitionInfo.getIsInMemory(sourcePartition.getId()));
-        olapTable.replacePartition("t1", "t1_100");
+        olapTable.replacePartition(db.getId(), "t1", "t1_100");
 
         Assert.assertEquals(newPartition.getId(), olapTable.getPartition("t1").getId());
     }


### PR DESCRIPTION
## Why I'm doing:

fe starts failed on journal `add replica` replay.

```
2025-06-05 00:00:05.735+08:00 WARN (replayer|115) [GlobalStateMgr.replayJournalInner():2139] catch exception when replaying journal, id: 100001, data: {"ot":"ADD","db":10316,"tb":12391,"pt":269369,"idx":12392,"tbt":269546,"rp":271281,"bc":10003,"vs":2,"minReadableVersion":1,"sh":1744689377,"ds":17827,"rc":264,"lfv":-1,"lsv":2},
com.starrocks.journal.JournalInconsistentException: failed to load journal type 13020
        at com.starrocks.epack.persist.EditLogEPack.loadJournal(EditLogEPack.java:158) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.replayJournalInner(GlobalStateMgr.java:2128) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr$5.runOneCycle(GlobalStateMgr.java:1985) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.Daemon.run(Daemon.java:98) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr$5.run(GlobalStateMgr.java:2050) ~[starrocks-fe.jar:?]
Caused by: com.starrocks.journal.JournalInconsistentException: failed to load journal type 13020
        at com.starrocks.persist.EditLog.loadJournal(EditLog.java:1217) ~[starrocks-fe.jar:?]
        at com.starrocks.epack.persist.EditLogEPack.loadJournal(EditLogEPack.java:154) ~[starrocks-fe.jar:?]
        ... 4 more
Caused by: java.lang.IllegalStateException
        at com.google.common.base.Preconditions.checkState(Preconditions.java:496) ~[spark-dpp-1.0.0.jar:?]
        at com.starrocks.catalog.TabletInvertedIndex.addReplica(TabletInvertedIndex.java:255) ~[starrocks-fe.jar:?]
        at com.starrocks.catalog.LocalTablet.addReplica(LocalTablet.java:177) ~[starrocks-fe.jar:?]
        at com.starrocks.catalog.LocalTablet.addReplica(LocalTablet.java:184) ~[starrocks-fe.jar:?]
        at com.starrocks.server.LocalMetastore.replayAddReplica(LocalMetastore.java:2381) ~[starrocks-fe.jar:?]
        at com.starrocks.persist.EditLog.loadJournal(EditLog.java:434) ~[starrocks-fe.jar:?]
        at com.starrocks.epack.persist.EditLogEPack.loadJournal(EditLogEPack.java:154) ~[starrocks-fe.jar:?]
        ... 4 more
```

## What I'm doing:

tablet meta is failed to added into tablet inverted index because database id is invalid in partition recycle info when loading image.

Fixes https://github.com/StarRocks/StarRocksTest/issues/9764

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
