### PR TITLE
[Feature] Adapt show data distribution sql command for virtual buckets

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowDataDistributionStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowDataDistributionStmt.java
@@ -25,7 +25,9 @@ public class ShowDataDistributionStmt extends ShowStmt {
     private static final ShowResultSetMetaData SHOW_DATA_DISTRIBUTION_META_DATA =
             ShowResultSetMetaData.builder()
                     .addColumn(new Column("PartitionName", ScalarType.createVarchar(30)))
-                    .addColumn(new Column("BucketId", ScalarType.createVarchar(10)))
+                    .addColumn(new Column("SubPartitionId", ScalarType.createVarchar(30)))
+                    .addColumn(new Column("MaterializedIndexName", ScalarType.createVarchar(30)))
+                    .addColumn(new Column("VirtualBuckets", ScalarType.createVarchar(30)))
                     .addColumn(new Column("RowCount", ScalarType.createVarchar(30)))
                     .addColumn(new Column("RowCount%", ScalarType.createVarchar(10)))
                     .addColumn(new Column("DataSize", ScalarType.createVarchar(30)))


### PR DESCRIPTION
## Why I'm doing:
The sql command `show data distribution` introduced by https://github.com/StarRocks/starrocks/pull/57819 assumes that all materialized indexes in a partition have the same bucket number, and then merges the statistics of all materialized indexes with the same bucket sequence number to show.
This assumption is no longer true since we changed the bucket number from partition level to materialized index level.
So we need to adapt show data distribution sql command for virtual buckets.

## What I'm doing:
Adapt `show data distribution` sql command for virtual buckets.

Do not assume that all materialized indexes in a partition have the same bucket number, and do not merge the statistics of all materialized indexes to show, just show data distribution at materialized index level.

![image](https://github.com/user-attachments/assets/b225922d-135f-4e40-a25f-1b86be3b8b69)


Fixes https://github.com/StarRocks/starrocks/issues/59134

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
