### PR TITLE
[Enhancement] Add azure use managed identity property

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureCloudConfigurationProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureCloudConfigurationProvider.java
@@ -39,6 +39,7 @@ import static com.starrocks.connector.share.credential.CloudConfigurationConstan
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_ID;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_SECRET;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_OAUTH2_TENANT_ID;
+import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_OAUTH2_USE_MANAGED_IDENTITY;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_SAS_TOKEN;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_SHARED_KEY;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_STORAGE_ACCOUNT;
@@ -63,6 +64,7 @@ public class AzureCloudConfigurationProvider implements CloudConfigurationProvid
                 properties.getOrDefault(AZURE_BLOB_SHARED_KEY, ""),
                 properties.getOrDefault(AZURE_BLOB_CONTAINER, container),
                 properties.getOrDefault(AZURE_BLOB_SAS_TOKEN, ""),
+                Boolean.parseBoolean(properties.getOrDefault(AZURE_BLOB_OAUTH2_USE_MANAGED_IDENTITY, "false")),
                 properties.getOrDefault(AZURE_BLOB_OAUTH2_CLIENT_ID, ""),
                 properties.getOrDefault(AZURE_BLOB_OAUTH2_CLIENT_SECRET, ""),
                 properties.getOrDefault(AZURE_BLOB_OAUTH2_TENANT_ID, "")

--- a/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureStorageCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureStorageCloudCredential.java
@@ -73,23 +73,27 @@ class AzureBlobCloudCredential extends AzureStorageCloudCredential {
     private final String sharedKey;
     private final String container;
     private final String sasToken;
+    private final boolean useManagedIdentity;
     private final String clientId;
     private final String clientSecret;
     private final String tenantId;
 
     AzureBlobCloudCredential(String endpoint, String storageAccount, String sharedKey, String container, String sasToken,
-                             String clientId, String clientSecret, String tenantId) {
+                             boolean useManagedIdentity, String clientId, String clientSecret, String tenantId) {
         Preconditions.checkNotNull(endpoint);
         Preconditions.checkNotNull(storageAccount);
         Preconditions.checkNotNull(sharedKey);
         Preconditions.checkNotNull(container);
         Preconditions.checkNotNull(sasToken);
         Preconditions.checkNotNull(clientId);
+        Preconditions.checkNotNull(clientSecret);
+        Preconditions.checkNotNull(tenantId);
         this.endpoint = endpoint;
         this.storageAccount = storageAccount;
         this.sharedKey = sharedKey;
         this.container = container;
         this.sasToken = sasToken;
+        this.useManagedIdentity = useManagedIdentity;
         this.clientId = clientId;
         this.clientSecret = clientSecret;
         this.tenantId = tenantId;
@@ -127,14 +131,14 @@ class AzureBlobCloudCredential extends AzureStorageCloudCredential {
             } else if (!sasToken.isEmpty()) {
                 // sas token
                 generatedConfigurationMap.put(CloudConfigurationConstants.AZURE_BLOB_SAS_TOKEN, sasToken);
+            } else if (useManagedIdentity && !clientId.isEmpty()) {
+                // user assigned managed identity
+                generatedConfigurationMap.put(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_ID, clientId);
             } else if (!clientId.isEmpty() && !clientSecret.isEmpty() && !tenantId.isEmpty()) {
                 // client secret service principal
                 generatedConfigurationMap.put(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_ID, clientId);
                 generatedConfigurationMap.put(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_SECRET, clientSecret);
                 generatedConfigurationMap.put(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_TENANT_ID, tenantId);
-            } else if (!clientId.isEmpty()) {
-                // user assigned managed identity
-                generatedConfigurationMap.put(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_ID, clientId);
             }
         }
     }
@@ -147,7 +151,10 @@ class AzureBlobCloudCredential extends AzureStorageCloudCredential {
                 ", sharedKey='" + sharedKey + '\'' +
                 ", container='" + container + '\'' +
                 ", sasToken='" + sasToken + '\'' +
+                ", useManagedIdentity='" + useManagedIdentity + '\'' +
                 ", clientId='" + clientId + '\'' +
+                ", clientSecret='" + clientSecret + '\'' +
+                ", tenantId='" + tenantId + '\'' +
                 '}';
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
@@ -124,7 +124,10 @@ public class CloudConfigurationFactoryTest {
                     put(CloudConfigurationConstants.AZURE_BLOB_SAS_TOKEN, "XX2");
                     put(CloudConfigurationConstants.AZURE_BLOB_STORAGE_ACCOUNT, "XX3");
                     put(CloudConfigurationConstants.AZURE_BLOB_ENDPOINT, "XX4");
+                    put(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_USE_MANAGED_IDENTITY, "true");
                     put(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_ID, "XX5");
+                    put(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_SECRET, "XX6");
+                    put(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_TENANT_ID, "XX7");
                 }
             };
             CloudConfiguration cc = CloudConfigurationFactory.buildCloudConfigurationForStorage(map);
@@ -138,7 +141,8 @@ public class CloudConfigurationFactoryTest {
             cc.toFileStoreInfo();
             Assert.assertEquals(cc.toConfString(),
                     "AzureCloudConfiguration{resources='', jars='', hdpuser='', cred=AzureBlobCloudCredential{endpoint='XX4', " +
-                            "storageAccount='XX3', sharedKey='XX0', container='XX1', sasToken='XX2', clientId='XX5'}}");
+                            "storageAccount='XX3', sharedKey='XX0', container='XX1', sasToken='XX2', " +
+                            "useManagedIdentity='true', clientId='XX5', clientSecret='XX6', tenantId='XX7'}}");
         }
 
         // For azure native sdk
@@ -192,6 +196,7 @@ public class CloudConfigurationFactoryTest {
         {
             Map<String, String> map = new HashMap<String, String>() {
                 {
+                    put(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_USE_MANAGED_IDENTITY, "true");
                     put(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_ID, "client_id_xxx");
                 }
             };

--- a/fe/fe-core/src/test/java/com/starrocks/fs/azure/AzBlobFileSystemTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/fs/azure/AzBlobFileSystemTest.java
@@ -146,6 +146,7 @@ public class AzBlobFileSystemTest {
     @Test
     public void testGlobListWithFilter() throws StarRocksException {
         // Mock
+        properties.put(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_USE_MANAGED_IDENTITY, "true");
         properties.put(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_ID, "client_id_xxx");
         fs = Mockito.spy(new AzBlobFileSystem(properties));
 
@@ -186,6 +187,7 @@ public class AzBlobFileSystemTest {
 
     @Test
     public void testGetCloudConfiguration() throws StarRocksException {
+        properties.put(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_USE_MANAGED_IDENTITY, "true");
         properties.put(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_ID, "client_id_xxx");
         fs = new AzBlobFileSystem(properties);
         String path = "wasbs://container_name@account_name.blob.core.windows.net/blob_name";

--- a/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/credential/CloudConfigurationConstants.java
+++ b/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/credential/CloudConfigurationConstants.java
@@ -87,6 +87,7 @@ public class CloudConfigurationConstants {
     public static final String AZURE_BLOB_SHARED_KEY = "azure.blob.shared_key";
     public static final String AZURE_BLOB_CONTAINER = "azure.blob.container";
     public static final String AZURE_BLOB_SAS_TOKEN = "azure.blob.sas_token";
+    public static final String AZURE_BLOB_OAUTH2_USE_MANAGED_IDENTITY = "azure.blob.oauth2_use_managed_identity";
     public static final String AZURE_BLOB_OAUTH2_CLIENT_ID = "azure.blob.oauth2_client_id";
     public static final String AZURE_BLOB_OAUTH2_CLIENT_SECRET = "azure.blob.oauth2_client_secret";
     public static final String AZURE_BLOB_OAUTH2_TENANT_ID = "azure.blob.oauth2_tenant_id";


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

To distinguish from `client secret service principal` and be compatible with hadoop azure, add `azure.blob.oauth2_use_managed_identity` property to use managed identity if it is set to true.

```
SELECT * FROM FILES(
    "path" = "wasbs://container@account.blob.core.windows.net/path/*",
    "format" = "parquet",
    "azure.blob.oauth2_use_managed_identity" = "true",
    "azure.blob.oauth2_client_id" = "xxx"
)
```

Fixes #59017

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
