### PR TITLE
[UT] Add more LIKE-predicate tests to demonstrate there is a bug in LIKE

### DIFF
--- a/be/test/exprs/like_test.cpp
+++ b/be/test/exprs/like_test.cpp
@@ -739,7 +739,6 @@ TEST_F(LikeTest, escapeInData) {
     const auto pattern{ColumnHelper::create_const_column<TYPE_VARCHAR>("\\\\", 1)};
     const auto haystack{ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false)};
     haystack->append_datum("Take off");
-    // TODO: The next three rows should assert to true
     haystack->append_datum("Take\\off");
     haystack->append_datum("Take\\off\\");
     haystack->append_datum("Take\\off\\");
@@ -759,6 +758,7 @@ TEST_F(LikeTest, escapeInData) {
 
     ASSERT_EQ(result->size(), 4);
     ASSERT_FALSE(result_viewer.value(0));
+    // TODO: The next three rows should assert to true
     ASSERT_FALSE(result_viewer.value(1));
     ASSERT_FALSE(result_viewer.value(2));
     ASSERT_FALSE(result_viewer.value(3));


### PR DESCRIPTION
## Why I'm doing:

Demonstrate that there is a bug when using backslash characters in LIKE-predicate

## What I'm doing:

Add two new tests for the LIKE operator

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add two unit tests in `be/test/exprs/like_test.cpp` covering LIKE behavior with backslashes and escape sequences.
> 
> - **Tests**:
>   - Add `LikeTest.backslashInData` and `LikeTest.escapeInData` in `be/test/exprs/like_test.cpp` to validate LIKE behavior with backslashes and escape sequences.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a68323ce19c1887d91fe394fef243a9203b1d6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->