### PR TITLE
[BugFix]Obtain the real user of the SR process in hadoop_env.sh

### DIFF
--- a/conf/hadoop_env.sh
+++ b/conf/hadoop_env.sh
@@ -13,15 +13,8 @@
 # limitations under the License.
 
 export HADOOP_CLASSPATH=${STARROCKS_HOME}/lib/hadoop/common/*:${STARROCKS_HOME}/lib/hadoop/common/lib/*:${STARROCKS_HOME}/lib/hadoop/hdfs/*:${STARROCKS_HOME}/lib/hadoop/hdfs/lib/*
-if [ -z "${HADOOP_USER_NAME}" ]
-then
-    if [ -z "${USER}" ]
-    then
-        export HADOOP_USER_NAME=$(id -u -n)
-    else
-        export HADOOP_USER_NAME=${USER}
-    fi
-fi
+export HADOOP_USER_NAME=$(ps aux | grep -E 'starrocks_be|StarRocksFE' | grep -v "grep" | awk '{print $1}'| head -n 1)
+echo "HADOOP_USER_NAME:$HADOOP_USER_NAME"
 
 # the purpose is to use local hadoop configuration first.
 # under HADOOP_CONF_DIR(eg. /etc/ecm/hadoop-conf), there are hadoop/hdfs/hbase conf files.


### PR DESCRIPTION
## Why I'm doing:
As shown in the figure, when the USER value is set in advance in the environment variables, the original code in hadoop_env.sh cannot obtain the actual user of the SR process, which will lead to a mismatch of authentication information when accessing the hive catalog or iceberg catalog.
![image](https://github.com/user-attachments/assets/ad90ef0f-607b-45d2-9814-e994fd0fe022)



## What I'm doing:
Modify the hadoop_env.sh file to directly obtain the user of the SR process and assign it to HADOOP_USER_NAME
To test the modification effect, the following command can be executed: sh ${STARROCKS_HOME}/fe/conf/hadoop_env.sh

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1