### PR TITLE
[Enhancement] Introduce TabletRetainInfo for vaccum

### DIFF
--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -215,6 +215,7 @@ set(STORAGE_FILES
     lake/lake_primary_key_recover.cpp
     lake/load_spill_block_manager.cpp
     lake/spill_mem_table_sink.cpp
+    lake/tablet_retain_info.cpp
     sstable/block_builder.cpp
     sstable/block.cpp
     sstable/coding.cpp

--- a/be/src/storage/lake/tablet_retain_info.cpp
+++ b/be/src/storage/lake/tablet_retain_info.cpp
@@ -1,0 +1,71 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/tablet_retain_info.h"
+
+#include "common/status.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_metadata.h"
+
+namespace starrocks::lake {
+
+Status TabletRetainInfo::build_info(const std::vector<int64_t>& retain_versions, int64_t tablet_id,
+                                    TabletManager* tablet_mgr) {
+    _tablet_id = tablet_id;
+    for (const auto& version : retain_versions) {
+        auto res = tablet_mgr->get_tablet_metadata(tablet_id, version, false);
+        if (!res.status().ok()) {
+            return res.status();
+        }
+        auto metadata = std::move(res).value();
+        for (const auto& rowset : metadata->rowsets()) {
+            _rowset_ids.insert(rowset.id());
+            for (const auto& segment : rowset.segments()) {
+                _files.insert(segment);
+            }
+            for (const auto& del_file : rowset.del_files()) {
+                _files.insert(del_file.name());
+            }
+        }
+
+        for (const auto& [_, dcg] : (*metadata).dcg_meta().dcgs()) {
+            for (const auto& column_file : dcg.column_files()) {
+                _files.insert(column_file);
+            }
+        }
+        for (const auto& [_, file] : (*metadata).delvec_meta().version_to_file()) {
+            _files.insert(file.name());
+        }
+        for (const auto& sstable : (*metadata).sstable_meta().sstables()) {
+            _files.insert(sstable.filename());
+        }
+
+        _versions.insert(version);
+    }
+    return Status::OK();
+}
+
+bool TabletRetainInfo::file_need_to_be_retained(const std::string& file_name) const {
+    return _files.find(file_name) != _files.end();
+}
+
+bool TabletRetainInfo::version_need_to_be_retained(int64_t version) const {
+    return _versions.find(version) != _versions.end();
+}
+
+bool TabletRetainInfo::rowset_need_to_be_retained(uint32_t rowset_id) const {
+    return _rowset_ids.find(rowset_id) != _rowset_ids.end();
+}
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_retain_info.cpp
+++ b/be/src/storage/lake/tablet_retain_info.cpp
@@ -20,8 +20,8 @@
 
 namespace starrocks::lake {
 
-Status TabletRetainInfo::build_info(const std::vector<int64_t>& retain_versions, int64_t tablet_id,
-                                    TabletManager* tablet_mgr) {
+Status TabletRetainInfo::init(const std::vector<int64_t>& retain_versions, int64_t tablet_id,
+                              TabletManager* tablet_mgr) {
     _tablet_id = tablet_id;
     for (const auto& version : retain_versions) {
         auto res = tablet_mgr->get_tablet_metadata(tablet_id, version, false);
@@ -56,15 +56,15 @@ Status TabletRetainInfo::build_info(const std::vector<int64_t>& retain_versions,
     return Status::OK();
 }
 
-bool TabletRetainInfo::file_need_to_be_retained(const std::string& file_name) const {
+bool TabletRetainInfo::contains_file(const std::string& file_name) const {
     return _files.find(file_name) != _files.end();
 }
 
-bool TabletRetainInfo::version_need_to_be_retained(int64_t version) const {
+bool TabletRetainInfo::contains_version(int64_t version) const {
     return _versions.find(version) != _versions.end();
 }
 
-bool TabletRetainInfo::rowset_need_to_be_retained(uint32_t rowset_id) const {
+bool TabletRetainInfo::contains_rowset(uint32_t rowset_id) const {
     return _rowset_ids.find(rowset_id) != _rowset_ids.end();
 }
 

--- a/be/src/storage/lake/tablet_retain_info.cpp
+++ b/be/src/storage/lake/tablet_retain_info.cpp
@@ -20,7 +20,7 @@
 
 namespace starrocks::lake {
 
-Status TabletRetainInfo::init(const std::vector<int64_t>& retain_versions, int64_t tablet_id,
+Status TabletRetainInfo::init(int64_t tablet_id, const std::vector<int64_t>& retain_versions,
                               TabletManager* tablet_mgr) {
     _tablet_id = tablet_id;
     for (const auto& version : retain_versions) {

--- a/be/src/storage/lake/tablet_retain_info.h
+++ b/be/src/storage/lake/tablet_retain_info.h
@@ -28,8 +28,7 @@ class TabletManager;
 
 /*
  * TabletRetainInfo is used to collect all files name, rowsets id for the specifed versions
- * that need to be retained for a tablet. It is used in vacuum process to determine which
- * files(data or meta) can be deleted.
+ * that used in vacuum process to determine which files(data or meta) can be deleted.
 */
 class TabletRetainInfo {
 public:

--- a/be/src/storage/lake/tablet_retain_info.h
+++ b/be/src/storage/lake/tablet_retain_info.h
@@ -35,13 +35,13 @@ public:
     TabletRetainInfo() = default;
     ~TabletRetainInfo() = default;
 
-    Status build_info(const std::vector<int64_t>& retain_versions, int64_t tablet_id, TabletManager* tablet_mgr);
+    Status init(const std::vector<int64_t>& retain_versions, int64_t tablet_id, TabletManager* tablet_mgr);
 
-    bool file_need_to_be_retained(const std::string& file_name) const;
+    bool contains_file(const std::string& file_name) const;
 
-    bool version_need_to_be_retained(int64_t version) const;
+    bool contains_version(int64_t version) const;
 
-    bool rowset_need_to_be_retained(uint32_t rowset_id) const;
+    bool contains_rowset(uint32_t rowset_id) const;
 
     int64_t tablet_id() const { return _tablet_id; }
 

--- a/be/src/storage/lake/tablet_retain_info.h
+++ b/be/src/storage/lake/tablet_retain_info.h
@@ -1,0 +1,56 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace starrocks {
+class Status;
+}
+
+namespace starrocks::lake {
+
+class TabletManager;
+
+/*
+ * TabletRetainInfo is used to collect all files name, rowsets id for the specifed versions
+ * that need to be retained for a tablet. It is used in vacuum process to determine which
+ * files(data or meta) can be deleted.
+*/
+class TabletRetainInfo {
+public:
+    TabletRetainInfo() = default;
+    ~TabletRetainInfo() = default;
+
+    Status build_info(const std::vector<int64_t>& retain_versions, int64_t tablet_id, TabletManager* tablet_mgr);
+
+    bool file_need_to_be_retained(const std::string& file_name) const;
+
+    bool version_need_to_be_retained(int64_t version) const;
+
+    bool rowset_need_to_be_retained(uint32_t rowset_id) const;
+
+    int64_t tablet_id() const { return _tablet_id; }
+
+private:
+    std::unordered_set<int64_t> _versions;
+    std::unordered_set<std::string> _files;
+    std::unordered_set<uint32_t> _rowset_ids;
+    int64_t _tablet_id;
+};
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_retain_info.h
+++ b/be/src/storage/lake/tablet_retain_info.h
@@ -35,7 +35,7 @@ public:
     TabletRetainInfo() = default;
     ~TabletRetainInfo() = default;
 
-    Status init(const std::vector<int64_t>& retain_versions, int64_t tablet_id, TabletManager* tablet_mgr);
+    Status init(int64_t tablet_id, const std::vector<int64_t>& retain_versions, TabletManager* tablet_mgr);
 
     bool contains_file(const std::string& file_name) const;
 
@@ -46,10 +46,10 @@ public:
     int64_t tablet_id() const { return _tablet_id; }
 
 private:
+    int64_t _tablet_id;
     std::unordered_set<int64_t> _versions;
     std::unordered_set<std::string> _files;
     std::unordered_set<uint32_t> _rowset_ids;
-    int64_t _tablet_id;
 };
 
 } // namespace starrocks::lake

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -536,6 +536,7 @@ set(EXEC_FILES
         ./storage/lake/replication_txn_manager_test.cpp
         ./storage/lake/persistent_index_sstable_test.cpp
         ./storage/lake/write_combined_txn_log_test.cpp
+        ./storage/lake/tablet_retain_info_test.cpp
         ./cache/datacache_utils_test.cpp
         ./cache/block_cache/block_cache_hit_rate_counter_test.cpp
         ./cache/peer_cache_test.cpp

--- a/be/test/storage/lake/tablet_retain_info_test.cpp
+++ b/be/test/storage/lake/tablet_retain_info_test.cpp
@@ -160,25 +160,25 @@ TEST_F(LakeTabletRetainInfoTest, test_tablet_retain_info_normal) {
     TabletRetainInfo tablet_retain_info = TabletRetainInfo();
     std::vector<int64_t> vec;
     vec.push_back(2);
-    tablet_retain_info.build_info(vec, 666, _tablet_mgr.get());
+    tablet_retain_info.init(vec, 666, _tablet_mgr.get());
 
     EXPECT_TRUE(
-            tablet_retain_info.file_need_to_be_retained("00000000000159e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e11.dat"));
+            tablet_retain_info.contains_file("00000000000159e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e11.dat"));
     EXPECT_TRUE(
-            tablet_retain_info.file_need_to_be_retained("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b582.dat"));
-    EXPECT_TRUE(tablet_retain_info.file_need_to_be_retained(
+            tablet_retain_info.contains_file("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b582.dat"));
+    EXPECT_TRUE(tablet_retain_info.contains_file(
             "00000000000159e3_3ea06130-ccac-4110-9de8-4813512c60da.delvec"));
     EXPECT_TRUE(
-            tablet_retain_info.file_need_to_be_retained("0000000000011111_9ae981b3-7d4b-49e9-9723-d7f752686155.sst"));
+            tablet_retain_info.contains_file("0000000000011111_9ae981b3-7d4b-49e9-9723-d7f752686155.sst"));
     EXPECT_FALSE(
-            tablet_retain_info.file_need_to_be_retained("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b583.dat"));
+            tablet_retain_info.contains_file("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b583.dat"));
 
-    EXPECT_FALSE(tablet_retain_info.version_need_to_be_retained(1));
-    EXPECT_TRUE(tablet_retain_info.version_need_to_be_retained(2));
-    EXPECT_FALSE(tablet_retain_info.version_need_to_be_retained(3));
+    EXPECT_FALSE(tablet_retain_info.contains_version(1));
+    EXPECT_TRUE(tablet_retain_info.contains_version(2));
+    EXPECT_FALSE(tablet_retain_info.contains_version(3));
 
-    EXPECT_TRUE(tablet_retain_info.rowset_need_to_be_retained(100));
-    EXPECT_FALSE(tablet_retain_info.rowset_need_to_be_retained(101));
+    EXPECT_TRUE(tablet_retain_info.contains_rowset(100));
+    EXPECT_FALSE(tablet_retain_info.contains_rowset(101));
 
     EXPECT_TRUE(tablet_retain_info.tablet_id() == 666);
 }

--- a/be/test/storage/lake/tablet_retain_info_test.cpp
+++ b/be/test/storage/lake/tablet_retain_info_test.cpp
@@ -1,0 +1,183 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/tablet_retain_info.h"
+
+#include <gtest/gtest.h>
+
+#include "json2pb/json_to_pb.h"
+#include "storage/lake/join_path.h"
+#include "storage/lake/metacache.h"
+#include "storage/lake/tablet_metadata.h"
+#include "test_util.h"
+#include "testutil/assert.h"
+
+namespace starrocks::lake {
+
+class LakeTabletRetainInfoTest : public TestBase {
+public:
+    LakeTabletRetainInfoTest() : TestBase(kTestDir) {}
+
+    void SetUp() override {
+        clear_and_init_test_dir();
+    }
+
+    void TearDown() override {
+        remove_test_dir_ignore_error();
+        _tablet_mgr->prune_metacache();
+    }
+
+protected:
+    constexpr static const char* const kTestDir = "./lake_tablet_retain_info_test";
+
+    void create_data_file(const std::string& name) {
+        auto full_path = join_path(join_path(kTestDir, kSegmentDirectoryName), name);
+        ASSIGN_OR_ABORT(auto f, FileSystem::Default()->new_writable_file(full_path));
+        ASSERT_OK(f->append("aaaa"));
+        ASSERT_OK(f->close());
+    }
+
+    template <class ProtobufMessage>
+    std::shared_ptr<ProtobufMessage> json_to_pb(const std::string& json) {
+        auto message = std::make_shared<ProtobufMessage>();
+        std::string error;
+        CHECK(json2pb::JsonToProtoMessage(json, message.get(), &error)) << error;
+        return message;
+    }
+};
+
+// NOLINTNEXTLINE
+TEST_F(LakeTabletRetainInfoTest, test_tablet_retain_info_normal) {
+    create_data_file("00000000000159e3_3ea06130-ccac-4110-9de8-4813512c60da.delvec");
+    create_data_file("00000000000159e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e11.dat");
+    create_data_file("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b582.dat");
+    create_data_file("0000000000011111_9ae981b3-7d4b-49e9-9723-d7f752686155.sst");
+    create_data_file("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b583.dat");
+
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 666,
+        "version": 1
+        }
+        )DEL")));
+
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 666,
+        "version": 2,
+        "rowsets": [
+            {
+                "id" : 100,
+                "segments": [
+                    "00000000000159e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e11.dat",
+                    "00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b582.dat"
+                ],
+                "segment_size": [100, 100],
+                "data_size": 200
+            }
+        ],
+        "delvec_meta": {
+            "version_to_file": [
+                {
+                    "key": 2,
+                    "value": {
+                        "name": "00000000000159e3_3ea06130-ccac-4110-9de8-4813512c60da.delvec",
+                        "size": 23
+                    }
+                }
+            ],
+            "delvecs": [
+                {
+                    "key": 10,
+                    "value": {
+                        "version": 4,
+                        "offset": 0,
+                        "size": 23
+                    }
+                }
+            ]
+        },
+        "sstable_meta": {
+            "sstables": [
+                {
+                    "filename": "0000000000011111_9ae981b3-7d4b-49e9-9723-d7f752686155.sst"
+                }
+            ]
+        },
+        "prev_garbage_version": 0,
+        "commit_time": 2
+        }
+        )DEL")));
+
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 666,
+        "version": 3,
+        "rowsets": [
+            {
+                "id" : 101,
+                "segments": [
+                    "00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b583.dat"
+                ],
+                "segment_size": [100],
+                "data_size": 100
+            }
+        ],
+        "compaction_inputs": [
+            {
+                "segments": [
+                    "00000000000159e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e11.dat",
+                    "00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b582.dat"
+                ],
+                "segment_size": [100, 100],
+                "data_size": 200
+            }
+        ],
+        "orphan_files": [
+            {
+                "name": "00000000000159e3_3ea06130-ccac-4110-9de8-4813512c60da.delvec",
+                "size": 23
+            },
+            {
+                "name": "0000000000011111_9ae981b3-7d4b-49e9-9723-d7f752686155.sst",
+                "size": 24
+            }
+        ],
+        "prev_garbage_version": 0,
+        "commit_time": 3
+        }
+        )DEL")));
+
+        TabletRetainInfo tablet_retain_info = TabletRetainInfo();
+        std::vector<int64_t> vec;
+        vec.push_back(2);
+        tablet_retain_info.build_info(vec, 666, _tablet_mgr.get());
+
+        EXPECT_TRUE(tablet_retain_info.file_need_to_be_retained("00000000000159e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e11.dat"));
+        EXPECT_TRUE(tablet_retain_info.file_need_to_be_retained("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b582.dat"));
+        EXPECT_TRUE(tablet_retain_info.file_need_to_be_retained("00000000000159e3_3ea06130-ccac-4110-9de8-4813512c60da.delvec"));
+        EXPECT_TRUE(tablet_retain_info.file_need_to_be_retained("0000000000011111_9ae981b3-7d4b-49e9-9723-d7f752686155.sst"));
+        EXPECT_FALSE(tablet_retain_info.file_need_to_be_retained("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b583.dat"));
+
+        EXPECT_FALSE(tablet_retain_info.version_need_to_be_retained(1));
+        EXPECT_TRUE(tablet_retain_info.version_need_to_be_retained(2));
+        EXPECT_FALSE(tablet_retain_info.version_need_to_be_retained(3));
+
+        EXPECT_TRUE(tablet_retain_info.rowset_need_to_be_retained(100));
+        EXPECT_FALSE(tablet_retain_info.rowset_need_to_be_retained(101));
+
+        EXPECT_TRUE(tablet_retain_info.tablet_id() == 666);
+}
+
+} // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_retain_info_test.cpp
+++ b/be/test/storage/lake/tablet_retain_info_test.cpp
@@ -29,9 +29,7 @@ class LakeTabletRetainInfoTest : public TestBase {
 public:
     LakeTabletRetainInfoTest() : TestBase(kTestDir) {}
 
-    void SetUp() override {
-        clear_and_init_test_dir();
-    }
+    void SetUp() override { clear_and_init_test_dir(); }
 
     void TearDown() override {
         remove_test_dir_ignore_error();
@@ -159,25 +157,30 @@ TEST_F(LakeTabletRetainInfoTest, test_tablet_retain_info_normal) {
         }
         )DEL")));
 
-        TabletRetainInfo tablet_retain_info = TabletRetainInfo();
-        std::vector<int64_t> vec;
-        vec.push_back(2);
-        tablet_retain_info.build_info(vec, 666, _tablet_mgr.get());
+    TabletRetainInfo tablet_retain_info = TabletRetainInfo();
+    std::vector<int64_t> vec;
+    vec.push_back(2);
+    tablet_retain_info.build_info(vec, 666, _tablet_mgr.get());
 
-        EXPECT_TRUE(tablet_retain_info.file_need_to_be_retained("00000000000159e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e11.dat"));
-        EXPECT_TRUE(tablet_retain_info.file_need_to_be_retained("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b582.dat"));
-        EXPECT_TRUE(tablet_retain_info.file_need_to_be_retained("00000000000159e3_3ea06130-ccac-4110-9de8-4813512c60da.delvec"));
-        EXPECT_TRUE(tablet_retain_info.file_need_to_be_retained("0000000000011111_9ae981b3-7d4b-49e9-9723-d7f752686155.sst"));
-        EXPECT_FALSE(tablet_retain_info.file_need_to_be_retained("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b583.dat"));
+    EXPECT_TRUE(tablet_retain_info.file_need_to_be_retained(
+            "00000000000159e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e11.dat"));
+    EXPECT_TRUE(tablet_retain_info.file_need_to_be_retained(
+            "00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b582.dat"));
+    EXPECT_TRUE(tablet_retain_info.file_need_to_be_retained(
+            "00000000000159e3_3ea06130-ccac-4110-9de8-4813512c60da.delvec"));
+    EXPECT_TRUE(tablet_retain_info.file_need_to_be_retained(
+            "0000000000011111_9ae981b3-7d4b-49e9-9723-d7f752686155.sst"));
+    EXPECT_FALSE(tablet_retain_info.file_need_to_be_retained(
+            "00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b583.dat"));
 
-        EXPECT_FALSE(tablet_retain_info.version_need_to_be_retained(1));
-        EXPECT_TRUE(tablet_retain_info.version_need_to_be_retained(2));
-        EXPECT_FALSE(tablet_retain_info.version_need_to_be_retained(3));
+    EXPECT_FALSE(tablet_retain_info.version_need_to_be_retained(1));
+    EXPECT_TRUE(tablet_retain_info.version_need_to_be_retained(2));
+    EXPECT_FALSE(tablet_retain_info.version_need_to_be_retained(3));
 
-        EXPECT_TRUE(tablet_retain_info.rowset_need_to_be_retained(100));
-        EXPECT_FALSE(tablet_retain_info.rowset_need_to_be_retained(101));
+    EXPECT_TRUE(tablet_retain_info.rowset_need_to_be_retained(100));
+    EXPECT_FALSE(tablet_retain_info.rowset_need_to_be_retained(101));
 
-        EXPECT_TRUE(tablet_retain_info.tablet_id() == 666);
+    EXPECT_TRUE(tablet_retain_info.tablet_id() == 666);
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_retain_info_test.cpp
+++ b/be/test/storage/lake/tablet_retain_info_test.cpp
@@ -160,7 +160,7 @@ TEST_F(LakeTabletRetainInfoTest, test_tablet_retain_info_normal) {
     TabletRetainInfo tablet_retain_info = TabletRetainInfo();
     std::vector<int64_t> vec;
     vec.push_back(2);
-    tablet_retain_info.init(vec, 666, _tablet_mgr.get());
+    tablet_retain_info.init(666, vec, _tablet_mgr.get());
 
     EXPECT_TRUE(
             tablet_retain_info.contains_file("00000000000159e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e11.dat"));

--- a/be/test/storage/lake/tablet_retain_info_test.cpp
+++ b/be/test/storage/lake/tablet_retain_info_test.cpp
@@ -166,8 +166,8 @@ TEST_F(LakeTabletRetainInfoTest, test_tablet_retain_info_normal) {
             tablet_retain_info.file_need_to_be_retained("00000000000159e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e11.dat"));
     EXPECT_TRUE(
             tablet_retain_info.file_need_to_be_retained("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b582.dat"));
-    EXPECT_TRUE(
-            tablet_retain_info.file_need_to_be_retained("00000000000159e3_3ea06130-ccac-4110-9de8-4813512c60da.delvec"));
+    EXPECT_TRUE(tablet_retain_info.file_need_to_be_retained(
+            "00000000000159e3_3ea06130-ccac-4110-9de8-4813512c60da.delvec"));
     EXPECT_TRUE(
             tablet_retain_info.file_need_to_be_retained("0000000000011111_9ae981b3-7d4b-49e9-9723-d7f752686155.sst"));
     EXPECT_FALSE(

--- a/be/test/storage/lake/tablet_retain_info_test.cpp
+++ b/be/test/storage/lake/tablet_retain_info_test.cpp
@@ -162,16 +162,11 @@ TEST_F(LakeTabletRetainInfoTest, test_tablet_retain_info_normal) {
     vec.push_back(2);
     tablet_retain_info.init(666, vec, _tablet_mgr.get());
 
-    EXPECT_TRUE(
-            tablet_retain_info.contains_file("00000000000159e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e11.dat"));
-    EXPECT_TRUE(
-            tablet_retain_info.contains_file("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b582.dat"));
-    EXPECT_TRUE(tablet_retain_info.contains_file(
-            "00000000000159e3_3ea06130-ccac-4110-9de8-4813512c60da.delvec"));
-    EXPECT_TRUE(
-            tablet_retain_info.contains_file("0000000000011111_9ae981b3-7d4b-49e9-9723-d7f752686155.sst"));
-    EXPECT_FALSE(
-            tablet_retain_info.contains_file("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b583.dat"));
+    EXPECT_TRUE(tablet_retain_info.contains_file("00000000000159e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e11.dat"));
+    EXPECT_TRUE(tablet_retain_info.contains_file("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b582.dat"));
+    EXPECT_TRUE(tablet_retain_info.contains_file("00000000000159e3_3ea06130-ccac-4110-9de8-4813512c60da.delvec"));
+    EXPECT_TRUE(tablet_retain_info.contains_file("0000000000011111_9ae981b3-7d4b-49e9-9723-d7f752686155.sst"));
+    EXPECT_FALSE(tablet_retain_info.contains_file("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b583.dat"));
 
     EXPECT_FALSE(tablet_retain_info.contains_version(1));
     EXPECT_TRUE(tablet_retain_info.contains_version(2));

--- a/be/test/storage/lake/tablet_retain_info_test.cpp
+++ b/be/test/storage/lake/tablet_retain_info_test.cpp
@@ -162,16 +162,16 @@ TEST_F(LakeTabletRetainInfoTest, test_tablet_retain_info_normal) {
     vec.push_back(2);
     tablet_retain_info.build_info(vec, 666, _tablet_mgr.get());
 
-    EXPECT_TRUE(tablet_retain_info.file_need_to_be_retained(
-            "00000000000159e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e11.dat"));
-    EXPECT_TRUE(tablet_retain_info.file_need_to_be_retained(
-            "00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b582.dat"));
-    EXPECT_TRUE(tablet_retain_info.file_need_to_be_retained(
-            "00000000000159e3_3ea06130-ccac-4110-9de8-4813512c60da.delvec"));
-    EXPECT_TRUE(tablet_retain_info.file_need_to_be_retained(
-            "0000000000011111_9ae981b3-7d4b-49e9-9723-d7f752686155.sst"));
-    EXPECT_FALSE(tablet_retain_info.file_need_to_be_retained(
-            "00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b583.dat"));
+    EXPECT_TRUE(
+            tablet_retain_info.file_need_to_be_retained("00000000000159e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e11.dat"));
+    EXPECT_TRUE(
+            tablet_retain_info.file_need_to_be_retained("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b582.dat"));
+    EXPECT_TRUE(
+            tablet_retain_info.file_need_to_be_retained("00000000000159e3_3ea06130-ccac-4110-9de8-4813512c60da.delvec"));
+    EXPECT_TRUE(
+            tablet_retain_info.file_need_to_be_retained("0000000000011111_9ae981b3-7d4b-49e9-9723-d7f752686155.sst"));
+    EXPECT_FALSE(
+            tablet_retain_info.file_need_to_be_retained("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b583.dat"));
 
     EXPECT_FALSE(tablet_retain_info.version_need_to_be_retained(1));
     EXPECT_TRUE(tablet_retain_info.version_need_to_be_retained(2));


### PR DESCRIPTION
## What I'm doing:

Introduce TabletRetainInfo class to save the necessary information by the specifed versions that used in vacuum process to determine which files(data or meta) can be deleted.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
