### PR TITLE
[Enhancement] Register pull-hive-remote-files Executor metrics

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorInternalMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorInternalMgr.java
@@ -18,6 +18,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.starrocks.common.Config;
+import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.util.Util;
 import com.starrocks.connector.CachingRemoteFileConf;
 import com.starrocks.connector.CachingRemoteFileIO;
@@ -163,6 +164,9 @@ public class HiveConnectorInternalMgr {
         if (pullRemoteFileExecutor == null) {
             pullRemoteFileExecutor = Executors.newFixedThreadPool(loadRemoteFileMetadataThreadNum,
                     new ThreadFactoryBuilder().setNameFormat("pull-hive-remote-files-%d").build());
+            pullRemoteFileExecutor = ThreadPoolManager.newDaemonFixedThreadPool(
+                    loadRemoteFileMetadataThreadNum, Integer.MAX_VALUE,
+                    "pull-hive-remote-files", true);
         }
 
         return pullRemoteFileExecutor;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Register pull-hive-remote-files executor metrics to explicitly monitor the concurrency of StarRocks reading Hive metadata, enabling clear detection of potential bottlenecks or blocking issues.

Fixes #59705 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1