### PR TITLE
[BugFix] fix iceberg eq delete bugs

### DIFF
--- a/test/sql/test_iceberg/R/test_iceberg_eq_delete_table
+++ b/test/sql/test_iceberg/R/test_iceberg_eq_delete_table
@@ -1,0 +1,18 @@
+-- name: testIcebergEqDeleteTable
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_oss_db.eq_del_tbl;
+-- result:
+0	0	0
+2	2	2
+3	3	3
+4	4	4
+5	5	5
+6	6	6
+7	7	7
+8	8	8
+-- !result
+drop catalog iceberg_sql_test_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_eq_delete_table
+++ b/test/sql/test_iceberg/T/test_iceberg_eq_delete_table
@@ -1,0 +1,6 @@
+-- name: testIcebergEqDeleteTable
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+
+select * from iceberg_sql_test_${uuid0}.iceberg_oss_db.eq_del_tbl;
+
+drop catalog iceberg_sql_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
With a table like t1(id, name, age), the table has ten records at first, from (0,0,0), (1,1,1),...(9,9,9).

and the we use equal delete to delete the data id = 9, and age=1.

then we query the table:
```
mysql> select * from t1;
+------+------+------+
| id   | name | age  |
+------+------+------+
|    0 | 0    |    0 |
|    1 | 1    |    1 |
|    2 | 2    |    2 |
|    3 | 3    |    3 |
|    4 | 4    |    4 |
|    5 | 5    |    5 |
|    6 | 6    |    6 |
|    7 | 7    |    7 |
|    8 | 8    |    8 |
+------+------+------+
9 rows in set (1.95 sec)
```

the age=1 record are not correctly deleted.


## What I'm doing:

a data file can have multiple eq delete files, and the delete files may have different eq ids. 

the remoteFileInfoSource queue will be distinguished by the eq ids. And now the queue is not filled correctly.

fix the bug.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
