### PR TITLE
[Enhancement] Implement 2 params type regexp_replace function in trino dialect

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
@@ -303,6 +303,12 @@ public class Trino2SRFunctionCallTransformer {
         // regexp_like -> regexp
         registerFunctionTransformer("regexp_like", 2, "regexp",
                 List.of(Expr.class, Expr.class));
+
+        // support regexp_replace with 2 param
+        registerFunctionTransformer("regexp_replace", 2,
+                new FunctionCallExpr("regexp_replace",
+                        List.of(new PlaceholderExpr(1, Expr.class), new PlaceholderExpr(2, Expr.class),
+                                new StringLiteral(""))));
     }
 
     private static void registerURLFunctionTransformer() {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -1257,4 +1257,10 @@ public class TrinoQueryTest extends TrinoTestBase {
         sql = "select null is not distinct from null";
         analyzeSuccess(sql);
     }
+
+    @Test
+    public void testRegexpReplace() throws Exception {
+        String sql = "select regexp_replace('123', '321')";
+        assertPlanContains(sql, "regexp_replace('123', '321', '')");
+    }
 }


### PR DESCRIPTION
[Enhancement] Implement 2 params type regexp_replace function
## Why I'm doing:
In Trino the regexp_replace function can have 2 params type.
Here I also implement it for SR.
<img width="1009" alt="image" src="https://github.com/user-attachments/assets/974ede09-7954-4f9a-9897-32dfbcef9ead" />
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
