### PR TITLE
[Enhancement] Introduce catalog HMS metrics entity to monitor HMS API trigger

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeInternalMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeInternalMgr.java
@@ -74,7 +74,7 @@ public class DeltaLakeInternalMgr {
 
     public IDeltaLakeMetastore createHMSBackedDeltaLakeMetastore() {
         HiveMetaClient metaClient = HiveMetaClient.createHiveMetaClient(hdfsEnvironment,
-                deltaLakeCatalogProperties.getProperties());
+                deltaLakeCatalogProperties.getProperties(), catalogName);
         IHiveMetastore hiveMetastore = new HiveMetastore(metaClient, catalogName, metastoreType);
         HMSBackedDeltaMetastore hmsBackedDeltaMetastore = new HMSBackedDeltaMetastore(catalogName, hiveMetastore,
                 hdfsEnvironment.getConfiguration(), deltaLakeCatalogProperties);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorInternalMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorInternalMgr.java
@@ -114,7 +114,7 @@ public class HiveConnectorInternalMgr {
 
     public IHiveMetastore createHiveMetastore() {
         // TODO(stephen): Abstract the creator class to construct hive meta client
-        HiveMetaClient metaClient = HiveMetaClient.createHiveMetaClient(hdfsEnvironment, properties);
+        HiveMetaClient metaClient = HiveMetaClient.createHiveMetaClient(hdfsEnvironment, properties, catalogName);
         IHiveMetastore hiveMetastore = new HiveMetastore(metaClient, catalogName, metastoreType);
         IHiveMetastore baseHiveMetastore;
         if (!enableMetastoreCache) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiConnectorInternalMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiConnectorInternalMgr.java
@@ -108,7 +108,7 @@ public class HudiConnectorInternalMgr {
 
     public IHiveMetastore createHiveMetastore() {
         // TODO(stephen): Abstract the creator class to construct hive meta client
-        HiveMetaClient metaClient = HiveMetaClient.createHiveMetaClient(hdfsEnvironment, properties);
+        HiveMetaClient metaClient = HiveMetaClient.createHiveMetaClient(hdfsEnvironment, properties, catalogName);
         IHiveMetastore hiveMetastore = new HiveMetastore(metaClient, catalogName, metastoreType);
         IHiveMetastore baseHiveMetastore;
         if (!enableMetastoreCache) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/kudu/KuduConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/kudu/KuduConnector.java
@@ -70,7 +70,7 @@ public class KuduConnector implements Connector {
         validateMetastoreUrisIfNecessary(catalogType, metastoreUris);
 
         if (HIVE.equals(catalogType) || GLUE.equals(catalogType)) {
-            HiveMetaClient metaClient = HiveMetaClient.createHiveMetaClient(hdfsEnvironment, properties);
+            HiveMetaClient metaClient = HiveMetaClient.createHiveMetaClient(hdfsEnvironment, properties, catalogName);
             MetastoreType metastoreType = MetastoreType.get(catalogType);
             hiveMetastoreClient = Optional.of(new HiveMetastore(metaClient, catalogName, metastoreType));
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/metric/CatalogHMSMetricsEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/CatalogHMSMetricsEntity.java
@@ -1,0 +1,75 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.metric;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
+import java.util.Set;
+
+public class CatalogHMSMetricsEntity {
+
+    private static final Logger LOG = LogManager.getLogger(CatalogHMSMetricsEntity.class);
+    private static final String GET_PARTITIONS_BY_NAMES = "getPartitionsByNames";
+    private static final String GET_PARTITION_COLUMN_STATS = "getPartitionColumnStats";
+    private final Map<String, HistogramMetric> histogramMetricsMap = Maps.newHashMap();
+
+    // The strings in this array need to strictly match the method name used in callRPC()
+    public static final Set<String> SUPPORTED_RPC_METHODS = Sets.newHashSet(
+            "getAllDatabases", "createDatabase", "dropDatabase", "getAllTables", "createTable", "dropTable",
+            "alter_table", "alter_partition", "listPartitionNames", "getDatabase", "getTable", "tableExists",
+            "getPartition", "add_partitions", "dropPartition", "getTableColumnStatistics"
+    );
+
+    private HistogramMetric getPartitionsByNamesLatency;
+    private HistogramMetric getPartitionColumnStatsLatency;
+
+    public CatalogHMSMetricsEntity() {
+        initCatalogHMSMetrics();
+    }
+
+    protected void initCatalogHMSMetrics() {
+        for (String method : SUPPORTED_RPC_METHODS) {
+            histogramMetricsMap.put(method, new HistogramMetric("hms_" + method + "_latency"));
+        }
+        getPartitionsByNamesLatency = new HistogramMetric("hms_" + GET_PARTITIONS_BY_NAMES + "_latency");
+        histogramMetricsMap.put(GET_PARTITIONS_BY_NAMES, getPartitionsByNamesLatency);
+
+        getPartitionColumnStatsLatency = new HistogramMetric("hms_" + GET_PARTITION_COLUMN_STATS + "_latency");
+        histogramMetricsMap.put(GET_PARTITION_COLUMN_STATS, getPartitionColumnStatsLatency);
+    }
+
+    public Map<String, HistogramMetric> getHistogramMetrics() {
+        return this.histogramMetricsMap;
+    }
+
+    public HistogramMetric getHistogramMetric(String methodName) {
+        if (!SUPPORTED_RPC_METHODS.contains(methodName)) {
+            LOG.warn("Unsupported HMS method: {}", methodName);
+        }
+        return histogramMetricsMap.get(methodName);
+    }
+
+    public void updateGetPartitionsByNamesLatency(long value) {
+        this.getPartitionsByNamesLatency.update(value);
+    }
+
+    public void updateGetPartitionColumnStatsLatency(long value) {
+        this.getPartitionColumnStatsLatency.update(value);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/metric/HistogramMetric.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/HistogramMetric.java
@@ -39,6 +39,19 @@ public final class HistogramMetric extends Histogram {
     }
 
     public void addLabel(MetricLabel label) {
+        if (labels.contains(label)) {
+            return;
+        }
+        for (int i = 0; i < labels.size(); i++) {
+            if (!labels.get(i).getKey().equals(label.getKey())) {
+                continue;
+            }
+            // update the label instead of adding, cuz renaming operations will result in duplicate labels
+            // for instance: after running `alter table t1 rename t2`
+            // labels should change from [{ key: "tbl_name", value: "t1" }] to [{ key: "tbl_name", value: "t2" }]
+            labels.set(i, label);
+            return;
+        }
         labels.add(label);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/metric/HiveMetadataMetricsRegistry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/HiveMetadataMetricsRegistry.java
@@ -1,0 +1,55 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.metric;
+
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+
+public class HiveMetadataMetricsRegistry {
+
+    private final Map<String, CatalogHMSMetricsEntity> nameToHMSMetrics;
+    private static final HiveMetadataMetricsRegistry INSTANCE = new HiveMetadataMetricsRegistry();
+
+    private HiveMetadataMetricsRegistry() {
+        this.nameToHMSMetrics = Maps.newConcurrentMap();
+    }
+
+    public static HiveMetadataMetricsRegistry getInstance() {
+        return INSTANCE;
+    }
+
+    public CatalogHMSMetricsEntity getHMSEntity(String catalogName) {
+        return this.nameToHMSMetrics.computeIfAbsent(catalogName, k -> new CatalogHMSMetricsEntity());
+    }
+
+    public void removeHMSEntity(String catalogName) {
+        this.nameToHMSMetrics.remove(catalogName);
+    }
+
+    public static void collectHiveMetadataMetrics(MetricVisitor visitor) {
+        HiveMetadataMetricsRegistry registry = HiveMetadataMetricsRegistry.getInstance();
+        for (Map.Entry<String, CatalogHMSMetricsEntity> entry : registry.nameToHMSMetrics.entrySet()) {
+            String catalogName = entry.getKey();
+            CatalogHMSMetricsEntity entity = entry.getValue();
+            MetricLabel label = new MetricLabel("catalog", catalogName);
+
+            for (HistogramMetric histogramMetric : entity.getHistogramMetrics().values()) {
+                histogramMetric.addLabel(label);
+                visitor.visitHistogram(histogramMetric);
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -912,6 +912,9 @@ public final class MetricRepo {
             MaterializedViewMetricsRegistry.collectMaterializedViewMetrics(visitor, requestParams.isMinifyMVMetrics());
         }
 
+        // Hive metadata metrics
+        HiveMetadataMetricsRegistry.collectHiveMetadataMetrics(visitor);
+
         // histogram
         SortedMap<String, Histogram> histograms = METRIC_REGISTER.getHistograms();
         for (Map.Entry<String, Histogram> entry : histograms.entrySet()) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
@@ -44,6 +44,7 @@ import com.starrocks.connector.ConnectorMgr;
 import com.starrocks.connector.ConnectorTableId;
 import com.starrocks.connector.ConnectorType;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.metric.HiveMetadataMetricsRegistry;
 import com.starrocks.persist.AlterCatalogLog;
 import com.starrocks.persist.DropCatalogLog;
 import com.starrocks.persist.ImageWriter;
@@ -250,6 +251,7 @@ public class CatalogMgr {
                 GlobalStateMgr.getCurrentState().getEditLog().logDropCatalog(dropCatalogLog);
             }
         } finally {
+            HiveMetadataMetricsRegistry.getInstance().removeHMSEntity(catalogName);
             writeUnLock();
         }
     }
@@ -415,6 +417,7 @@ public class CatalogMgr {
             Authorizer.getInstance().removeAccessControl(catalogName);
             catalogs.remove(catalogName);
         } finally {
+            HiveMetadataMetricsRegistry.getInstance().removeHMSEntity(catalogName);
             writeUnLock();
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/HiveTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/HiveTableTest.java
@@ -42,6 +42,7 @@ import com.starrocks.connector.hive.HiveMetaClient;
 import com.starrocks.connector.hive.HiveMetastoreApiConverter;
 import com.starrocks.connector.hive.HiveMetastoreTest;
 import com.starrocks.connector.hive.HiveStorageFormat;
+import com.starrocks.metric.HiveMetadataMetricsRegistry;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.HiveTableFactory;
@@ -58,6 +59,7 @@ import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -86,6 +88,11 @@ public class HiveTableTest {
                 "\"type\"  =  \"hive\", \"hive.metastore.uris\"  =  \"thrift://127.0.0.1:9083\")");
         starRocksAssert.withDatabase("db");
         hiveClient = new HiveMetastoreTest.MockedHiveMetaClient();
+    }
+
+    @After
+    public void tearDown() {
+        HiveMetadataMetricsRegistry.getInstance().removeHMSEntity("MockedHiveMetastore");
     }
 
     com.starrocks.catalog.Table createTable(CreateTableStmt stmt) throws DdlException {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/HudiTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/HudiTableTest.java
@@ -25,6 +25,7 @@ import com.starrocks.connector.ConnectorMgr;
 import com.starrocks.connector.hive.HiveMetaClient;
 import com.starrocks.connector.hive.HiveMetastoreTest;
 import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.metric.HiveMetadataMetricsRegistry;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.HudiTableFactory;
@@ -40,6 +41,7 @@ import mockit.Mocked;
 import org.apache.avro.Schema;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.exception.HoodieIOException;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -66,6 +68,11 @@ public class HudiTableTest {
                 "\"type\"  =  \"hudi\", \"hive.metastore.uris\"  =  \"thrift://127.0.0.1:9083\")");
         starRocksAssert.withDatabase("db");
         hiveClient = new HiveMetastoreTest.MockedHiveMetaClient();
+    }
+
+    @After
+    public void tearDown() {
+        HiveMetadataMetricsRegistry.getInstance().removeHMSEntity("MockedHiveMetastore");
     }
 
     com.starrocks.catalog.Table createTable(CreateTableStmt stmt) throws DdlException {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/RemoteFileOperationsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/RemoteFileOperationsTest.java
@@ -31,12 +31,14 @@ import com.starrocks.connector.hive.Partition;
 import com.starrocks.connector.hive.RemoteFileInputFormat;
 import com.starrocks.connector.hive.TextFileFormatDesc;
 import com.starrocks.connector.hudi.HudiRemoteFileIO;
+import com.starrocks.metric.HiveMetadataMetricsRegistry;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -55,6 +57,12 @@ import static com.starrocks.connector.hive.MockedRemoteFileSystem.HDFS_HIVE_TABL
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 
 public class RemoteFileOperationsTest {
+
+    @After
+    public void tearDown() {
+        HiveMetadataMetricsRegistry.getInstance().removeHMSEntity("MockedHiveMetastore");
+    }
+
     @Test
     public void testGetHiveRemoteFiles() {
         HiveRemoteFileIO hiveRemoteFileIO = new HiveRemoteFileIO(new Configuration());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/CachingDeltaLakeMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/CachingDeltaLakeMetastoreTest.java
@@ -27,6 +27,7 @@ import com.starrocks.connector.hive.HiveMetastore;
 import com.starrocks.connector.hive.HiveMetastoreTest;
 import com.starrocks.connector.hive.IHiveMetastore;
 import com.starrocks.connector.metastore.MetastoreTable;
+import com.starrocks.metric.HiveMetadataMetricsRegistry;
 import com.starrocks.sql.analyzer.SemanticException;
 import io.delta.kernel.Operation;
 import io.delta.kernel.Snapshot;
@@ -41,6 +42,7 @@ import mockit.Mock;
 import mockit.MockUp;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -69,6 +71,11 @@ public class CachingDeltaLakeMetastoreTest {
         metastore = new HMSBackedDeltaMetastore("delta0", hiveMetastore, new Configuration(),
                 new DeltaLakeCatalogProperties(Maps.newHashMap()));
         executor = Executors.newFixedThreadPool(5);
+    }
+
+    @After
+    public void tearDown() {
+        HiveMetadataMetricsRegistry.getInstance().removeHMSEntity("MockedHiveMetastore");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeCacheUpdateProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeCacheUpdateProcessorTest.java
@@ -25,12 +25,14 @@ import com.starrocks.connector.hive.HiveMetaClient;
 import com.starrocks.connector.hive.HiveMetastore;
 import com.starrocks.connector.hive.HiveMetastoreTest;
 import com.starrocks.connector.hive.IHiveMetastore;
+import com.starrocks.metric.HiveMetadataMetricsRegistry;
 import com.starrocks.mysql.MysqlCommand;
 import com.starrocks.qe.ConnectContext;
 import mockit.Expectations;
 import mockit.MockUp;
 import mockit.Mocked;
 import org.apache.hadoop.conf.Configuration;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,6 +58,11 @@ public class DeltaLakeCacheUpdateProcessorTest {
         cachingDeltaLakeMetastore =
                 CachingDeltaLakeMetastore.createCatalogLevelInstance(metastore, executor, expireAfterWriteSec,
                         refreshAfterWriteSec, 100);
+    }
+
+    @After
+    public void tearDown() {
+        HiveMetadataMetricsRegistry.getInstance().removeHMSEntity("MockedHiveMetastore");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
@@ -28,6 +28,7 @@ import com.starrocks.connector.hive.HiveMetaClient;
 import com.starrocks.connector.hive.HiveMetastore;
 import com.starrocks.connector.hive.HiveMetastoreTest;
 import com.starrocks.connector.hive.IHiveMetastore;
+import com.starrocks.metric.HiveMetadataMetricsRegistry;
 import com.starrocks.qe.ConnectContext;
 import io.delta.kernel.Scan;
 import io.delta.kernel.ScanBuilder;
@@ -52,6 +53,7 @@ import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
 import org.apache.hadoop.conf.Configuration;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -78,6 +80,11 @@ public class DeltaLakeMetadataTest {
 
         deltaLakeMetadata = new DeltaLakeMetadata(hdfsEnvironment, "delta0", deltaOps, null,
                 new ConnectorProperties(ConnectorType.DELTALAKE));
+    }
+
+    @After
+    public void tearDown() {
+        HiveMetadataMetricsRegistry.getInstance().removeHMSEntity("MockedHiveMetastore");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
@@ -28,6 +28,7 @@ import com.starrocks.connector.DatabaseTableName;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.metric.HiveMetadataMetricsRegistry;
 import mockit.Expectations;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.junit.After;
@@ -62,6 +63,7 @@ public class CachingHiveMetastoreTest {
 
     @After
     public void tearDown() {
+        HiveMetadataMetricsRegistry.getInstance().removeHMSEntity("MockedHiveMetastore");
         executor.shutdown();
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveConnectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveConnectorTest.java
@@ -25,6 +25,7 @@ import com.starrocks.connector.CachingRemoteFileIO;
 import com.starrocks.connector.ConnectorContext;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.MetastoreType;
+import com.starrocks.metric.HiveMetadataMetricsRegistry;
 import com.starrocks.qe.ConnectContext;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -71,6 +72,7 @@ public class HiveConnectorTest {
 
     @After
     public void tearDown() {
+        HiveMetadataMetricsRegistry.getInstance().removeHMSEntity("MockedHiveMetastore");
         executorForHmsRefresh.shutdown();
         executorForRemoteFileRefresh.shutdown();
         executorForPullFiles.shutdown();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetaClientTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetaClientTest.java
@@ -15,6 +15,8 @@
 package com.starrocks.connector.hive;
 
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.metric.CatalogHMSMetricsEntity;
+import com.starrocks.metric.HiveMetadataMetricsRegistry;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -70,7 +72,8 @@ public class HiveMetaClientTest {
 
         HiveConf hiveConf = new HiveConf();
         hiveConf.set(MetastoreConf.ConfVars.THRIFT_URIS.getHiveName(), "thrift://127.0.0.1:9030");
-        HiveMetaClient client = new HiveMetaClient(hiveConf);
+        CatalogHMSMetricsEntity entity = HiveMetadataMetricsRegistry.getInstance().getHMSEntity("mock");
+        HiveMetaClient client = new HiveMetaClient(hiveConf, entity);
         // NOTE: this is HiveMetaClient.MAX_HMS_CONNECTION_POOL_SIZE
         int poolSize = 32;
 
@@ -95,18 +98,21 @@ public class HiveMetaClientTest {
 
         Assert.assertTrue(
                 clientNum[0] >= 1 && clientNum[0] <= poolSize);
+        HiveMetadataMetricsRegistry.getInstance().removeHMSEntity("mock");
     }
 
     @Test
     public void testGetHiveClient() {
         HiveConf hiveConf = new HiveConf();
         hiveConf.set(MetastoreConf.ConfVars.THRIFT_URIS.getHiveName(), "thrift://127.0.0.1:90303");
-        HiveMetaClient client = new HiveMetaClient(hiveConf);
+        CatalogHMSMetricsEntity entity = HiveMetadataMetricsRegistry.getInstance().getHMSEntity("mock");
+        HiveMetaClient client = new HiveMetaClient(hiveConf, entity);
         try {
             client.getAllDatabaseNames();
         } catch (Exception e) {
             Assert.assertTrue(e.getMessage().contains("Invalid port 90303"));
         }
+        HiveMetadataMetricsRegistry.getInstance().removeHMSEntity("mock");
     }
 
     @Test
@@ -131,7 +137,8 @@ public class HiveMetaClientTest {
         HiveConf hiveConf = new HiveConf();
         hiveConf.set(HIVE_METASTORE_CONNECTION_POOL_SIZE, "48");
         hiveConf.set(MetastoreConf.ConfVars.THRIFT_URIS.getHiveName(), "thrift://127.0.0.1:90300");
-        HiveMetaClient client = new HiveMetaClient(hiveConf);
+        CatalogHMSMetricsEntity entity = HiveMetadataMetricsRegistry.getInstance().getHMSEntity("mock");
+        HiveMetaClient client = new HiveMetaClient(hiveConf, entity);
         Assert.assertEquals(48, client.getMaxClientPoolSize());
         try {
             client.getTable("db", "tbl");
@@ -153,7 +160,7 @@ public class HiveMetaClientTest {
 
         client.getTable("db", "tbl");
         Assert.assertEquals(1, client.getClientSize());
-
+        HiveMetadataMetricsRegistry.getInstance().removeHMSEntity("mock");
     }
 
     @Test
@@ -216,8 +223,10 @@ public class HiveMetaClientTest {
 
         HiveConf hiveConf = new HiveConf();
         hiveConf.set(MetastoreConf.ConfVars.THRIFT_URIS.getHiveName(), "thrift://127.0.0.1:90300");
-        HiveMetaClient client = new HiveMetaClient(hiveConf);
+        CatalogHMSMetricsEntity entity = HiveMetadataMetricsRegistry.getInstance().getHMSEntity("mock");
+        HiveMetaClient client = new HiveMetaClient(hiveConf, entity);
         client.dropTable("hive_db", "hive_table");
+        HiveMetadataMetricsRegistry.getInstance().removeHMSEntity("mock");
     }
 
     @Test
@@ -230,8 +239,10 @@ public class HiveMetaClientTest {
         };
         HiveConf hiveConf = new HiveConf();
         hiveConf.set(MetastoreConf.ConfVars.THRIFT_URIS.getHiveName(), "thrift://127.0.0.1:90300");
-        HiveMetaClient client = new HiveMetaClient(hiveConf);
+        CatalogHMSMetricsEntity entity = HiveMetadataMetricsRegistry.getInstance().getHMSEntity("mock");
+        HiveMetaClient client = new HiveMetaClient(hiveConf, entity);
         Assert.assertTrue(client.tableExists("hive_db", "hive_table"));
+        HiveMetadataMetricsRegistry.getInstance().removeHMSEntity("mock");
     }
 
     @Test
@@ -272,7 +283,8 @@ public class HiveMetaClientTest {
         };
         HiveConf hiveConf = new HiveConf();
         hiveConf.set(MetastoreConf.ConfVars.THRIFT_URIS.getHiveName(), "thrift://127.0.0.1:90300");
-        HiveMetaClient client = new HiveMetaClient(hiveConf);
+        CatalogHMSMetricsEntity entity = HiveMetadataMetricsRegistry.getInstance().getHMSEntity("mock");
+        HiveMetaClient client = new HiveMetaClient(hiveConf, entity);
         client.alterTable(dbName, tblName, null);
         client.alterPartition("hive_db", "hive_table", partition);
         client.getPartitionKeys(dbName, tblName);
@@ -287,7 +299,7 @@ public class HiveMetaClientTest {
                 () -> client.getPartitionColumnStats(dbName, tblName, new ArrayList<>(), Arrays.asList()));
         client.getTableColumnStats(dbName, tblName, new ArrayList<>());
         client.getNextNotification(0, 0, null);
-
+        HiveMetadataMetricsRegistry.getInstance().removeHMSEntity("mock");
     }
 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
@@ -46,6 +46,7 @@ import com.starrocks.connector.RemoteFileOperations;
 import com.starrocks.connector.RemotePathKey;
 import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.metric.HiveMetadataMetricsRegistry;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.analyzer.AstToStringBuilder;
@@ -141,6 +142,7 @@ public class HiveMetadataTest {
 
     @After
     public void tearDown() {
+        HiveMetadataMetricsRegistry.getInstance().removeHMSEntity("MockedHiveMetastore");
         executorForHmsRefresh.shutdown();
         executorForRemoteFileRefresh.shutdown();
         executorForPullFiles.shutdown();
@@ -250,6 +252,7 @@ public class HiveMetadataTest {
         Assert.assertEquals(0, blockDesc.getOffset());
         Assert.assertEquals(20, blockDesc.getLength());
         Assert.assertEquals(2, blockDesc.getReplicaHostIds().length);
+
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreOperationsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreOperationsTest.java
@@ -32,6 +32,7 @@ import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.metric.HiveMetadataMetricsRegistry;
 import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.CreateTableLikeStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
@@ -79,6 +80,7 @@ public class HiveMetastoreOperationsTest {
 
     @After
     public void tearDown() {
+        HiveMetadataMetricsRegistry.getInstance().removeHMSEntity("MockedHiveMetastore");
         executor.shutdown();
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
@@ -26,6 +26,7 @@ import com.starrocks.connector.DatabaseTableName;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.metric.HiveMetadataMetricsRegistry;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsData;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
@@ -37,6 +38,7 @@ import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -260,10 +262,15 @@ public class HiveMetastoreTest {
         metastore.updatePartitionStatistics("db", "table", "p1=1", ignore -> partitionStats);
     }
 
+    @After
+    public void tearDown() {
+        HiveMetadataMetricsRegistry.getInstance().removeHMSEntity("MockedHiveMetastore");
+    }
+
     public static class MockedHiveMetaClient extends HiveMetaClient {
 
         public MockedHiveMetaClient() {
-            super(new HiveConf());
+            super(new HiveConf(), HiveMetadataMetricsRegistry.getInstance().getHMSEntity("MockedHiveMetaClient"));
         }
 
         public CurrentNotificationEventId getCurrentNotificationEventId() {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveStatisticsProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveStatisticsProviderTest.java
@@ -25,6 +25,7 @@ import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.RemoteFileOperations;
+import com.starrocks.metric.HiveMetadataMetricsRegistry;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.OptimizerFactory;
@@ -103,6 +104,7 @@ public class HiveStatisticsProviderTest {
 
     @After
     public void tearDown() {
+        HiveMetadataMetricsRegistry.getInstance().removeHMSEntity("MockedHiveMetastore");
         executorForHmsRefresh.shutdown();
         executorForRemoteFileRefresh.shutdown();
         executorForPullFiles.shutdown();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
@@ -46,6 +46,7 @@ import com.starrocks.connector.RemoteFileInfoSource;
 import com.starrocks.connector.RemoteFileOperations;
 import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.metric.HiveMetadataMetricsRegistry;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -1720,7 +1721,8 @@ public class MockedHiveMetadata implements ConnectorMetadata {
                                                               List<String> partitionColumnNames,
                                                               Map<String, HivePartitionStats> hivePartitionStatsMap,
                                                               double avgNumPerPartition, double rowCount) {
-        HiveMetaClient metaClient = new HiveMetaClient(new HiveConf());
+        HiveMetaClient metaClient = new HiveMetaClient(new HiveConf(),
+                HiveMetadataMetricsRegistry.getInstance().getHMSEntity("MockedHiveMetastore"));
         HiveMetastore metastore = new HiveMetastore(metaClient, MOCKED_HIVE_CATALOG_NAME, MetastoreType.HMS);
         CachingHiveMetastore cachingHiveMetastore =
                 createCatalogLevelInstance(metastore, Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(),
@@ -1746,6 +1748,8 @@ public class MockedHiveMetadata implements ConnectorMetadata {
                     rowCount);
         } catch (Exception e) {
             throw new StarRocksConnectorException("get partition statistics failed", e);
+        } finally {
+            HiveMetadataMetricsRegistry.getInstance().removeHMSEntity("MockedHiveMetastore");
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hudi/HudiMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hudi/HudiMetadataTest.java
@@ -32,6 +32,7 @@ import com.starrocks.connector.hive.HiveMetastoreTest;
 import com.starrocks.connector.hive.HiveStatisticsProvider;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudType;
+import com.starrocks.metric.HiveMetadataMetricsRegistry;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.utframe.UtFrameUtils;
@@ -95,6 +96,7 @@ public class HudiMetadataTest {
 
     @After
     public void tearDown() {
+        HiveMetadataMetricsRegistry.getInstance().removeHMSEntity("MockedHiveMetastore");
         executorForHmsRefresh.shutdown();
         executorForRemoteFileRefresh.shutdown();
         executorForPullFiles.shutdown();

--- a/fe/fe-core/src/test/java/com/starrocks/metric/MetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/metric/MetricsTest.java
@@ -155,8 +155,25 @@ public class MetricsTest {
                 "sr_duration{quantile=\"0.98\", k1=\"v1\", k2=\"v2\"}",
                 "sr_duration{quantile=\"0.99\", k1=\"v1\", k2=\"v2\"}",
                 "sr_duration{quantile=\"0.999\", k1=\"v1\", k2=\"v2\"}",
-                "sr_duration_sum",
-                "sr_duration_count"
+                "sr_duration_sum{k1=\"v1\", k2=\"v2\"}",
+                "sr_duration_count{k1=\"v1\", k2=\"v2\"}"
+        );
+        for (String metricName : metricNames) {
+            Assert.assertTrue(output.contains(metricName));
+        }
+
+        prometheusMetricVisitor = new PrometheusMetricVisitor("sr_new");
+        histogramMetric.addLabel(new MetricLabel("k2", "v3"));
+        prometheusMetricVisitor.visitHistogram(histogramMetric);
+        output = prometheusMetricVisitor.build();
+        metricNames = Arrays.asList(
+                "sr_new_duration{quantile=\"0.75\", k1=\"v1\", k2=\"v3\"}",
+                "sr_new_duration{quantile=\"0.95\", k1=\"v1\", k2=\"v3\"}",
+                "sr_new_duration{quantile=\"0.98\", k1=\"v1\", k2=\"v3\"}",
+                "sr_new_duration{quantile=\"0.99\", k1=\"v1\", k2=\"v3\"}",
+                "sr_new_duration{quantile=\"0.999\", k1=\"v1\", k2=\"v3\"}",
+                "sr_new_duration_sum{k1=\"v1\", k2=\"v3\"}",
+                "sr_new_duration_count{k1=\"v1\", k2=\"v3\"}"
         );
         for (String metricName : metricNames) {
             Assert.assertTrue(output.contains(metricName));

--- a/fe/fe-core/src/test/java/com/starrocks/server/CatalogLevelTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/CatalogLevelTest.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.Type;
 import com.starrocks.connector.hive.HiveMetaClient;
 import com.starrocks.connector.hive.HiveMetastoreApiConverter;
 import com.starrocks.connector.hive.HiveMetastoreTest;
+import com.starrocks.metric.HiveMetadataMetricsRegistry;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
@@ -40,6 +41,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.iceberg.hive.HiveTableOperations;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -51,6 +53,11 @@ public class CatalogLevelTest {
     public static void beforeClass() throws Exception {
         UtFrameUtils.createMinStarRocksCluster();
         AnalyzeTestUtil.init();
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        HiveMetadataMetricsRegistry.getInstance().removeHMSEntity("MockedHiveMetastore");
     }
 
     @Test


### PR DESCRIPTION
[Enhancement] Introduce catalog HMS metrics entity to monitor HMS API trigger
## Why I'm doing:
There are no monitor for HMS api latency.
So that we can not know the HMS APIs are healthy or not.
Here I add some metrics for HMS API that will make us know the API latency.
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1