### PR TITLE
[BugFix] Fix multiple issues with bundled data file reading failures

### DIFF
--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -238,7 +238,7 @@ private:
     std::unordered_map<int64_t, uint32_t> _tablet_id_to_sorted_indexes;
     std::unordered_map<int64_t, std::unique_ptr<AsyncDeltaWriter>> _delta_writers;
     // Partition id -> BundleWritableFileContext
-    std::unordered_map<int64_t, std::unique_ptr<BundleWritableFileContext>> _bwfile_ctxs_by_partition;
+    std::unordered_map<int64_t, std::unique_ptr<BundleWritableFileContext>> _bundle_wfile_ctx_by_partition;
 
     GlobalDictByNameMaps _global_dicts;
     std::unique_ptr<MemPool> _mem_pool;
@@ -709,10 +709,10 @@ Status LakeTabletsChannel::_create_delta_writers(const PTabletWriterOpenRequest&
     for (const PTabletWithPartition& tablet : params.tablets()) {
         BundleWritableFileContext* bundle_writable_file_context = nullptr;
         if (_is_data_file_bundle_enabled(params)) {
-            if (_bwfile_ctxs_by_partition.count(tablet.partition_id()) == 0) {
-                _bwfile_ctxs_by_partition[tablet.partition_id()] = std::make_unique<BundleWritableFileContext>();
+            if (_bundle_wfile_ctx_by_partition.count(tablet.partition_id()) == 0) {
+                _bundle_wfile_ctx_by_partition[tablet.partition_id()] = std::make_unique<BundleWritableFileContext>();
             }
-            bundle_writable_file_context = _bwfile_ctxs_by_partition[tablet.partition_id()].get();
+            bundle_writable_file_context = _bundle_wfile_ctx_by_partition[tablet.partition_id()].get();
         }
         if (_delta_writers.count(tablet.tablet_id()) != 0) {
             // already created for the tablet, usually in incremental open case

--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -235,7 +235,8 @@ private:
     mutable bthreads::BThreadSharedMutex _rw_mtx;
     std::unordered_map<int64_t, uint32_t> _tablet_id_to_sorted_indexes;
     std::unordered_map<int64_t, std::unique_ptr<AsyncDeltaWriter>> _delta_writers;
-    std::unique_ptr<BundleWritableFileContext> _bundle_writable_file_context;
+    // Partition id -> BundleWritableFileContext
+    std::unordered_map<int64_t, std::unique_ptr<BundleWritableFileContext>> _bundle_writable_file_contexts;
 
     GlobalDictByNameMaps _global_dicts;
     std::unique_ptr<MemPool> _mem_pool;
@@ -331,10 +332,6 @@ Status LakeTabletsChannel::open(const PTabletWriterOpenRequest& params, PTabletW
         }
     }
 
-    if (params.has_lake_tablet_params() && params.lake_tablet_params().has_enable_data_file_bundling() &&
-        params.lake_tablet_params().enable_data_file_bundling()) {
-        _bundle_writable_file_context = std::make_unique<BundleWritableFileContext>();
-    }
     RETURN_IF_ERROR(_create_delta_writers(params, false));
 
     for (auto& [id, writer] : _delta_writers) {
@@ -700,9 +697,21 @@ Status LakeTabletsChannel::_create_delta_writers(const PTabletWriterOpenRequest&
         }
     }
 
+    bool enable_data_file_bundling = false;
+    if (params.has_lake_tablet_params() && params.lake_tablet_params().has_enable_data_file_bundling() &&
+        params.lake_tablet_params().enable_data_file_bundling()) {
+        enable_data_file_bundling = true;
+    }
     std::vector<int64_t> tablet_ids;
     tablet_ids.reserve(params.tablets_size());
     for (const PTabletWithPartition& tablet : params.tablets()) {
+        BundleWritableFileContext* bundle_writable_file_context = nullptr;
+        if (enable_data_file_bundling) {
+            if (_bundle_writable_file_contexts.count(tablet.partition_id()) == 0) {
+                _bundle_writable_file_contexts[tablet.partition_id()] = std::make_unique<BundleWritableFileContext>();
+            }
+            bundle_writable_file_context = _bundle_writable_file_contexts[tablet.partition_id()].get();
+        }
         if (_delta_writers.count(tablet.tablet_id()) != 0) {
             // already created for the tablet, usually in incremental open case
             continue;
@@ -723,7 +732,7 @@ Status LakeTabletsChannel::_create_delta_writers(const PTabletWriterOpenRequest&
                                               .set_column_to_expr_value(&_column_to_expr_value)
                                               .set_load_id(params.id())
                                               .set_profile(_profile)
-                                              .set_bundle_writable_file_context(_bundle_writable_file_context.get())
+                                              .set_bundle_writable_file_context(bundle_writable_file_context)
                                               .build());
         _delta_writers.emplace(tablet.tablet_id(), std::move(writer));
         tablet_ids.emplace_back(tablet.tablet_id());

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -613,7 +613,9 @@ StatusOr<TxnLogPtr> DeltaWriterImpl::finish_with_txnlog(DeltaWriterFinishMode mo
     }
 
     // handle partial update
-    bool skip_pk_preload = config::skip_pk_preload;
+    // If there is bundle data file, we will skip preload pk state, because the bundle data file hasn't been
+    // flushed to storage yet.
+    bool skip_pk_preload = config::skip_pk_preload || op_write->rowset().bundle_file_offsets_size() > 0;
     RowsetTxnMetaPB* rowset_txn_meta = _tablet_writer->rowset_txn_meta();
     if (rowset_txn_meta != nullptr) {
         if (is_partial_update()) {

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -129,7 +129,7 @@ Status HorizontalGeneralTabletWriter::flush_segment_writer(SegmentPB* segment) {
         std::string segment_name = std::string(basename(segment_path));
         auto file_info = FileInfo{segment_name, segment_size, _seg_writer->encryption_meta()};
         if (_seg_writer->bundle_file_offset() >= 0) {
-            // This is a shared data file.
+            // This is a bundle data file.
             file_info.bundle_file_offset = _seg_writer->bundle_file_offset();
         }
         _files.emplace_back(file_info);

--- a/be/src/storage/lake/tablet_retain_info.h
+++ b/be/src/storage/lake/tablet_retain_info.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <unordered_set>
 #include <vector>

--- a/be/src/storage/meta_reader.cpp
+++ b/be/src/storage/meta_reader.cpp
@@ -189,7 +189,7 @@ Status SegmentMetaCollecter::_init_return_column_iterators() {
     if (_segment->encryption_info()) {
         ropts.encryption_info = *_segment->encryption_info();
     }
-    ASSIGN_OR_RETURN(_read_file, fs->new_random_access_file(ropts, _segment->file_name()));
+    ASSIGN_OR_RETURN(_read_file, fs->new_random_access_file_with_bundling(ropts, _segment->file_info()));
 
     auto max_cid = _params->cids.empty() ? 0 : *std::max_element(_params->cids.begin(), _params->cids.end());
     _column_iterators.resize(max_cid + 1);

--- a/be/src/storage/rowset/segment_rewriter.cpp
+++ b/be/src/storage/rowset/segment_rewriter.cpp
@@ -40,7 +40,7 @@ Status SegmentRewriter::rewrite_partial_update(const FileInfo& src, FileInfo* de
         wopts.encryption_info = ropts.encryption_info;
         dest->encryption_meta = src.encryption_meta;
     }
-    ASSIGN_OR_RETURN(auto rfile, fs->new_random_access_file(ropts, src));
+    ASSIGN_OR_RETURN(auto rfile, fs->new_random_access_file_with_bundling(ropts, src));
     ASSIGN_OR_RETURN(auto wfile, fs->new_writable_file(wopts, dest->path));
 
     SegmentFooterPB footer;


### PR DESCRIPTION
## Why I'm doing:
In previous PR #58923 , we introduced bundle data file feature.
And in the current implementation, there are several issues that may cause bundled data file reading failures:
1. During multi-partition imports, bundled data files may be shared across partitions. Since data files cannot exist across partition directories, this causes the system to fail locating the bundled files.
2. Preloading initiated before bundled data files are fully persisted results in "file not found" errors.
3. Incorrect usage of bundled data file reading APIs in multiple code paths leads to data reading anomalies.

## What I'm doing:
Fix #58316
This PR fixes the aforementioned issues. 

### Enhancements for Bundling Data Files:

* **New Method for Checking Bundling Status**: Added `_is_data_file_bundle_enabled` method in `LakeTabletsChannel` to encapsulate logic for determining whether data file bundling is enabled based on request parameters. (`[[1]](diffhunk://#diff-cb0fbac7cd7174aa5fccc214e7e862f79a8e11a9666c0fa36a8205ab4d09fcb5R209-R210)`, `[[2]](diffhunk://#diff-cb0fbac7cd7174aa5fccc214e7e862f79a8e11a9666c0fa36a8205ab4d09fcb5R668-R672)`)
* **Partition-Based Bundling Context**: Replaced the single `BundleWritableFileContext` with a partition-based mapping (`_bwfile_ctxs_by_partition`) to manage bundled files more effectively. (`[[1]](diffhunk://#diff-cb0fbac7cd7174aa5fccc214e7e862f79a8e11a9666c0fa36a8205ab4d09fcb5L238-R241)`, `[[2]](diffhunk://#diff-cb0fbac7cd7174aa5fccc214e7e862f79a8e11a9666c0fa36a8205ab4d09fcb5R710-R716)`)
* **Delta Writer Updates**: Modified `_create_delta_writers` to use partition-specific bundling contexts and updated the `DeltaWriter` builder to support bundled files. (`[[1]](diffhunk://#diff-cb0fbac7cd7174aa5fccc214e7e862f79a8e11a9666c0fa36a8205ab4d09fcb5R710-R716)`, `[[2]](diffhunk://#diff-cb0fbac7cd7174aa5fccc214e7e862f79a8e11a9666c0fa36a8205ab4d09fcb5L726-R737)`)

### File Handling Improvements:

* **File Access Updates**: Replaced `new_random_access_file` with `new_random_access_file_with_bundling` in multiple locations to accommodate bundled file handling. (`[[1]](diffhunk://#diff-a5433fc4c5ee849e918b1c2eb9974d5aecc02b3903155ed745b7c7ce6fa42461L192-R192)`, `[[2]](diffhunk://#diff-3c073f242259e54f685bafc4fd19da86b21969be5de8ae5b81ca0a4ee451c325L43-R43)`)
* **Skip Preload Logic**: Enhanced `DeltaWriterImpl` to skip primary key preload when bundled files are present, ensuring correct handling of unflushed data. (`[be/src/storage/lake/delta_writer.cppL616-R618](diffhunk://#diff-24e44403f5e4c75144f9645f2fcff77dcdd9269836bafd5b79d5b2d6589e49fdL616-R618)`)

### Testing:

* **New Test Case**: Added `test_write_bundling_file` in `LakeTabletsChannelTest` to validate the functionality of data file bundling, including partition handling and transaction log verification. (`[be/test/runtime/lake_tablets_channel_test.cppR444-R508](diffhunk://#diff-24bc5f1765c03c495d5cd72f1dff37877249a0f187b1b608e1010e3284b460a0R444-R508)`)

### Miscellaneous:

* **Comment Updates**: Updated comments to reflect the new bundling terminology, replacing "shared data file" with "bundle data file." (`[be/src/storage/lake/general_tablet_writer.cppL132-R132](diffhunk://#diff-3dc155c1f66ca23166df68c90b2dd007553dcdb5614809d09dc669af8d406593L132-R132)`)
* **Additional Includes**: Included `<cstdint>` in `tablet_retain_info.h` for consistency and completeness. (`[be/src/storage/lake/tablet_retain_info.hR17](diffhunk://#diff-1249fb64d433d33db81344d35f81ac9e5d933a5151bf1dc2af76bb0152163b39R17)`)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
