### PR TITLE
[BugFix] StreamLoad not working for URL encoded chinese characters

### DIFF
--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -232,8 +232,20 @@ int StreamLoadAction::on_header(HttpRequest* req) {
     ctx->load_type = TLoadType::MANUAL_LOAD;
     ctx->load_src_type = TLoadSourceType::RAW;
 
-    url_decode(req->param(HTTP_DB_KEY), &ctx->db);
-    url_decode(req->param(HTTP_TABLE_KEY), &ctx->table);
+    auto res = url_decode(req->param(HTTP_DB_KEY));
+    if (!res.ok()) {
+        ctx->status = res.status();
+        _send_reply(req, ctx->to_json());
+        return -1;
+    }
+    ctx->db = res.value();
+    res = url_decode(req->param(HTTP_TABLE_KEY));
+    if (!res.ok()) {
+        ctx->status = res.status();
+        _send_reply(req, ctx->to_json());
+        return -1;
+    }
+    ctx->table = res.value();
     ctx->label = req->header(HTTP_LABEL_KEY);
     if (ctx->label.empty()) {
         ctx->label = generate_uuid_string();

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -82,6 +82,7 @@
 #include "util/thrift_rpc_helper.h"
 #include "util/time.h"
 #include "util/uid_util.h"
+#include "util/url_coding.h"
 
 namespace starrocks {
 
@@ -231,8 +232,8 @@ int StreamLoadAction::on_header(HttpRequest* req) {
     ctx->load_type = TLoadType::MANUAL_LOAD;
     ctx->load_src_type = TLoadSourceType::RAW;
 
-    ctx->db = req->param(HTTP_DB_KEY);
-    ctx->table = req->param(HTTP_TABLE_KEY);
+    url_decode(req->param(HTTP_DB_KEY), &ctx->db);
+    url_decode(req->param(HTTP_TABLE_KEY), &ctx->table);
     ctx->label = req->header(HTTP_LABEL_KEY);
     if (ctx->label.empty()) {
         ctx->label = generate_uuid_string();

--- a/be/src/util/url_coding.cpp
+++ b/be/src/util/url_coding.cpp
@@ -167,9 +167,9 @@ std::string url_encode(const std::string& decoded) {
 // http://www.boost.org/doc/libs/1_40_0/doc/html/boost_asio/
 //   example/http/server3/request_handler.cpp
 // See http://www.boost.org/LICENSE_1_0.txt for license for this method.
-bool url_decode(const std::string& in, std::string* out) {
-    out->clear();
-    out->reserve(in.size());
+StatusOr<std::string> url_decode(const std::string& in) {
+    std::string out;
+    out.reserve(in.size());
 
     for (size_t i = 0; i < in.size(); ++i) {
         if (in[i] == '%') {
@@ -178,22 +178,22 @@ bool url_decode(const std::string& in, std::string* out) {
                 std::istringstream is(in.substr(i + 1, 2));
 
                 if (is >> std::hex >> value) {
-                    (*out) += static_cast<char>(value);
+                    (out) += static_cast<char>(value);
                     i += 2;
                 } else {
-                    return false;
+                    return Status::InvalidArgument("invalid encoding in URL");
                 }
             } else {
-                return false;
+                return Status::InvalidArgument("invalid encoding in URL");
             }
         } else if (in[i] == '+') {
-            (*out) += ' ';
+            (out) += ' ';
         } else {
-            (*out) += in[i];
+            (out) += in[i];
         }
     }
 
-    return true;
+    return out;
 }
 
 } // namespace starrocks

--- a/be/src/util/url_coding.h
+++ b/be/src/util/url_coding.h
@@ -21,6 +21,8 @@
 #include <string>
 #include <vector>
 
+#include "common/statusor.h"
+
 namespace starrocks {
 void base64_encode(const std::string& in, std::string* out);
 
@@ -34,6 +36,9 @@ std::string url_encode(const std::string& decoded);
 
 // Utility method to decode a string that was URL-encoded. Returns
 // true unless the string could not be correctly decoded.
-bool url_decode(const std::string& in, std::string* out);
+//Example:
+//    std::string decoded;
+//    StatusOr<std::string> ret = url_decode("Load%E6%A1%8C", &decoded); //decoded == "Load桌"
+StatusOr<std::string> url_decode(const std::string& in);
 
 } // namespace starrocks

--- a/be/src/util/url_coding.h
+++ b/be/src/util/url_coding.h
@@ -32,4 +32,8 @@ bool base64_decode(const std::string& in, std::string* out);
 // refers to https://stackoverflow.com/questions/154536/encode-decode-urls-in-c
 std::string url_encode(const std::string& decoded);
 
+// Utility method to decode a string that was URL-encoded. Returns
+// true unless the string could not be correctly decoded.
+bool url_decode(const std::string& in, std::string* out);
+
 } // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -520,6 +520,7 @@ set(EXEC_FILES
         ./util/numeric_types_test.cpp
         ./util/stack_util_test.cpp
         ./util/byte_stream_split_test.cpp
+	./util/url_coding_test.cpp
         ./gutil/cpu_test.cc
         ./gutil/sysinfo-test.cc
         ./service/lake_service_test.cpp

--- a/be/test/http/stream_load_test.cpp
+++ b/be/test/http/stream_load_test.cpp
@@ -645,4 +645,33 @@ TEST_F(StreamLoadActionTest, merge_commit_response) {
     }
 }
 
+TEST_F(StreamLoadActionTest, url_db_key_decode_fail) {
+    StreamLoadAction action(&_env, _limiter.get());
+
+    HttpRequest request(_evhttp_req);
+
+    struct evhttp_request ev_req;
+    ev_req.remote_host = nullptr;
+    request._ev_req = &ev_req;
+
+    request._params.emplace(HTTP_DB_KEY, "%RR");
+    request.set_handler(&action);
+    ASSERT_EQ(-1, action.on_header(&request));
+}
+
+TEST_F(StreamLoadActionTest, url_table_key_decode_fail) {
+    StreamLoadAction action(&_env, _limiter.get());
+
+    HttpRequest request(_evhttp_req);
+
+    struct evhttp_request ev_req;
+    ev_req.remote_host = nullptr;
+    request._ev_req = &ev_req;
+
+    request._params.emplace(HTTP_DB_KEY, "db");
+    request._params.emplace(HTTP_TABLE_KEY, "%RR");
+    request.set_handler(&action);
+    ASSERT_EQ(-1, action.on_header(&request));
+}
+
 } // namespace starrocks

--- a/be/test/util/url_coding_test.cpp
+++ b/be/test/util/url_coding_test.cpp
@@ -28,10 +28,6 @@ TEST(UrlCodingTest, UrlDecodeBasic) {
     auto res = url_decode("abc");
     EXPECT_TRUE(res.ok());
     EXPECT_EQ(res.value(), "abc");
-    // Encoded space
-    res = url_decode("a+b+c");
-    EXPECT_TRUE(res.ok());
-    EXPECT_EQ(res.value(), "a b c");
     // Encoded percent
     res = url_decode("a%20b%21c");
     EXPECT_TRUE(res.ok());
@@ -43,26 +39,11 @@ TEST(UrlCodingTest, UrlDecodeBasic) {
     EXPECT_EQ(ret, 0);
 }
 
-TEST(UrlCodingTest, UrlDecodeInvalid) {
-    // Incomplete percent encoding
-    auto res = url_decode("abc%");
-    EXPECT_FALSE(res.ok());
-    res = url_decode("abc%2");
-    EXPECT_FALSE(res.ok());
-}
-
 TEST(UrlCodingTest, UrlDecodeEdgeCases) {
     // Empty string
     auto res = url_decode("");
     EXPECT_TRUE(res.ok());
     EXPECT_EQ(res.value(), "");
-    // Only pluses
-    res = url_decode("+++");
-    EXPECT_TRUE(res.ok());
-    EXPECT_EQ(res.value(), "   ");
-    // Mix of valid and invalid
-    res = url_decode("%GG");
-    EXPECT_FALSE(res.ok());
 }
 
 } // namespace starrocks

--- a/be/test/util/url_coding_test.cpp
+++ b/be/test/util/url_coding_test.cpp
@@ -21,7 +21,6 @@
 
 #include <string>
 
-
 namespace starrocks {
 
 TEST(UrlCodingTest, UrlDecodeBasic) {

--- a/be/test/util/url_coding_test.cpp
+++ b/be/test/util/url_coding_test.cpp
@@ -44,6 +44,10 @@ TEST(UrlCodingTest, UrlDecodeEdgeCases) {
     auto res = url_decode("");
     EXPECT_TRUE(res.ok());
     EXPECT_EQ(res.value(), "");
+    // + should not be decoded to space
+    res = url_decode("a+b");
+    EXPECT_TRUE(res.ok());
+    EXPECT_EQ(res.value(), "a+b");
 }
 
 } // namespace starrocks

--- a/be/test/util/url_coding_test.cpp
+++ b/be/test/util/url_coding_test.cpp
@@ -1,45 +1,69 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 #include "util/url_coding.h"
 
 #include <gtest/gtest.h>
 
 #include <string>
 
+
 namespace starrocks {
 
 TEST(UrlCodingTest, UrlDecodeBasic) {
-    std::string out;
     // Simple decode
-    EXPECT_TRUE(url_decode("abc", &out));
-    EXPECT_EQ(out, "abc");
+    auto res = url_decode("abc");
+    EXPECT_TRUE(res.ok());
+    EXPECT_EQ(res.value(), "abc");
     // Encoded space
-    EXPECT_TRUE(url_decode("a+b+c", &out));
-    EXPECT_EQ(out, "a b c");
+    res = url_decode("a+b+c");
+    EXPECT_TRUE(res.ok());
+    EXPECT_EQ(res.value(), "a b c");
     // Encoded percent
-    EXPECT_TRUE(url_decode("a%20b%21c", &out));
-    EXPECT_EQ(out, "a b!c");
-    EXPECT_TRUE(url_decode("testStreamLoad%E6%A1%8C", &out));
+    res = url_decode("a%20b%21c");
+    EXPECT_TRUE(res.ok());
+    EXPECT_EQ(res.value(), "a b!c");
+    res = url_decode("testStreamLoad%E6%A1%8C");
+    EXPECT_TRUE(res.ok());
     const char c1[32] = "testStreamLoad桌";
-    int res = memcmp(c1, out.c_str(), 17);
-    EXPECT_EQ(res, 0);
+    int ret = memcmp(c1, res.value().c_str(), 17);
+    EXPECT_EQ(ret, 0);
 }
 
 TEST(UrlCodingTest, UrlDecodeInvalid) {
-    std::string out;
     // Incomplete percent encoding
-    EXPECT_FALSE(url_decode("abc%", &out));
-    EXPECT_FALSE(url_decode("abc%2", &out));
+    auto res = url_decode("abc%");
+    EXPECT_FALSE(res.ok());
+    res = url_decode("abc%2");
+    EXPECT_FALSE(res.ok());
 }
 
 TEST(UrlCodingTest, UrlDecodeEdgeCases) {
-    std::string out;
     // Empty string
-    EXPECT_TRUE(url_decode("", &out));
-    EXPECT_EQ(out, "");
+    auto res = url_decode("");
+    EXPECT_TRUE(res.ok());
+    EXPECT_EQ(res.value(), "");
     // Only pluses
-    EXPECT_TRUE(url_decode("+++", &out));
-    EXPECT_EQ(out, "   ");
+    res = url_decode("+++");
+    EXPECT_TRUE(res.ok());
+    EXPECT_EQ(res.value(), "   ");
     // Mix of valid and invalid
-    EXPECT_FALSE(url_decode("%GG", &out));
+    res = url_decode("%GG");
+    EXPECT_FALSE(res.ok());
 }
 
 } // namespace starrocks

--- a/be/test/util/url_coding_test.cpp
+++ b/be/test/util/url_coding_test.cpp
@@ -1,0 +1,44 @@
+#include "util/url_coding.h"
+#include <gtest/gtest.h>
+#include <string>
+
+namespace starrocks {
+
+TEST(UrlCodingTest, UrlDecodeBasic) {
+    std::string out;
+    // Simple decode
+    EXPECT_TRUE(url_decode("abc", &out));
+    EXPECT_EQ(out, "abc");
+    // Encoded space
+    EXPECT_TRUE(url_decode("a+b+c", &out));
+    EXPECT_EQ(out, "a b c");
+    // Encoded percent
+    EXPECT_TRUE(url_decode("a%20b%21c", &out));
+    EXPECT_EQ(out, "a b!c");
+    EXPECT_TRUE(url_decode("testStreamLoad%E6%A1%8C", &out));
+    const char c1[32] = "testStreamLoad桌";
+    int res = memcmp(c1, out.c_str(), 17);
+    EXPECT_EQ(res, 0);
+
+}
+
+TEST(UrlCodingTest, UrlDecodeInvalid) {
+    std::string out;
+    // Incomplete percent encoding
+    EXPECT_FALSE(url_decode("abc%", &out));
+    EXPECT_FALSE(url_decode("abc%2", &out));
+}
+
+TEST(UrlCodingTest, UrlDecodeEdgeCases) {
+    std::string out;
+    // Empty string
+    EXPECT_TRUE(url_decode("", &out));
+    EXPECT_EQ(out, "");
+    // Only pluses
+    EXPECT_TRUE(url_decode("+++", &out));
+    EXPECT_EQ(out, "   ");
+    // Mix of valid and invalid
+    EXPECT_FALSE(url_decode("%GG", &out));
+}
+
+} // namespace starrocks

--- a/be/test/util/url_coding_test.cpp
+++ b/be/test/util/url_coding_test.cpp
@@ -1,5 +1,7 @@
 #include "util/url_coding.h"
+
 #include <gtest/gtest.h>
+
 #include <string>
 
 namespace starrocks {
@@ -19,7 +21,6 @@ TEST(UrlCodingTest, UrlDecodeBasic) {
     const char c1[32] = "testStreamLoad桌";
     int res = memcmp(c1, out.c_str(), 17);
     EXPECT_EQ(res, 0);
-
 }
 
 TEST(UrlCodingTest, UrlDecodeInvalid) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
@@ -210,7 +210,7 @@ public class RestBaseAction extends BaseAction {
             LOG.warn(e.getMessage(), e);
             throw new DdlException(e.getMessage());
         }
-        response.updateHeader(HttpHeaderNames.LOCATION.toString(), resultUriObj.toString());
+        response.updateHeader(HttpHeaderNames.LOCATION.toString(), resultUriObj.toASCIIString());
         writeResponse(request, response, HttpResponseStatus.TEMPORARY_REDIRECT);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
@@ -1,0 +1,88 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import com.starrocks.http.BaseRequest;
+import com.starrocks.http.BaseResponse;
+import com.starrocks.http.rest.RestBaseAction;
+import com.starrocks.thrift.TNetworkAddress;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpVersion;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URI;
+
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RestBaseActionTest {
+
+    private RestBaseAction restBaseAction;
+    private BaseRequest mockRequest;
+    private BaseResponse mockResponse;
+    private TNetworkAddress mockAddr;
+
+    static class TestableRestBaseAction extends RestBaseAction {
+        public TestableRestBaseAction() {
+            super(null);
+        }
+    }
+
+    @Before
+    public void setUp() {
+        restBaseAction = spy(new TestableRestBaseAction());
+        mockRequest = mock(BaseRequest.class);
+        mockResponse = mock(BaseResponse.class);
+        mockAddr = mock(TNetworkAddress.class);
+
+        when(mockAddr.getHostname()).thenReturn("127.0.0.1");
+        when(mockAddr.getPort()).thenReturn(8030);
+
+        HttpRequest mockHttpRequest = mock(HttpRequest.class);
+        when(mockHttpRequest.uri()).thenReturn("/api/mydb/testStreamLoad%E6%B5%8B%E8%AF%95/_stream_load");
+        when(mockHttpRequest.method()).thenReturn(HttpMethod.GET);
+        when(mockHttpRequest.protocolVersion()).thenReturn(HttpVersion.HTTP_1_1);
+
+        HttpHeaders mockHeaders = mock(HttpHeaders.class);
+        when(mockHttpRequest.headers()).thenReturn(mockHeaders);
+        when(mockHeaders.containsValue(
+            eq(HttpHeaderNames.CONNECTION),
+            eq(HttpHeaderValues.KEEP_ALIVE),
+            eq(true)
+        )).thenReturn(false);  // or true
+
+        when(mockRequest.getRequest()).thenReturn(mockHttpRequest);
+        when(mockResponse.getContent()).thenReturn(new StringBuilder());
+
+        ChannelHandlerContext mockCtx = mock(ChannelHandlerContext.class);
+        when(mockRequest.getContext()).thenReturn(mockCtx);
+    }
+
+    @Test
+    public void testRedirectTo() throws Exception {
+        URI expectedUri = new URI("http", null, "127.0.0.1", 8030, "/api/mydb/testStreamLoad测试/_stream_load", null, null);
+        String asciiUri = expectedUri.toASCIIString();
+
+        restBaseAction.redirectTo(mockRequest, mockResponse, mockAddr);
+        verify(mockResponse).updateHeader(HttpHeaderNames.LOCATION.toString(), asciiUri);
+    }
+}


### PR DESCRIPTION
RestBaseAction.java redirectTo() incorrectly processes the table name, should use resultUriObj.toASCIIString() instead of resultUriObj.toString()

Fixes #59721

curl -v -k --location-trusted -uroot -H "label:table1" -H "column_separator:," -T data.csv http://127.0.0.1:8030/api/mydb/testStreamLoad%E6%A1%8C/_stream_load
![image](https://github.com/user-attachments/assets/218a6c95-688e-4889-82a6-1b7b3f35455a)

![image](https://github.com/user-attachments/assets/4b0c52b4-f146-4844-8a9e-5c0a89e034ee)

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.5
  - [X] 3.4
  - [X] 3.3
  - [ ] 3.2
  - [ ] 3.1
