### PR TITLE
[BugFix] Fix bug of BrokerDesc can not restore from metadb

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/BrokerDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/BrokerDesc.java
@@ -17,6 +17,7 @@
 
 package com.starrocks.analysis;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.io.Text;
@@ -43,7 +44,6 @@ public class BrokerDesc implements ParseNode, Writable {
     private String name;
     @SerializedName("p")
     private Map<String, String> properties;
-    private boolean hasBroker;
 
     private final NodePosition pos;
 
@@ -61,7 +61,6 @@ public class BrokerDesc implements ParseNode, Writable {
     }
     public BrokerDesc(String name, Map<String, String> properties, NodePosition pos) {
         this.pos = pos;
-        this.hasBroker = true;
         this.name = name;
         this.properties = properties;
         if (this.properties == null) {
@@ -71,7 +70,6 @@ public class BrokerDesc implements ParseNode, Writable {
 
     public BrokerDesc(Map<String, String> properties, NodePosition pos) {
         this.pos = pos;
-        this.hasBroker = false;
         this.name = "";
         this.properties = properties;
         if (this.properties == null) {
@@ -80,7 +78,7 @@ public class BrokerDesc implements ParseNode, Writable {
     }
 
     public boolean hasBroker() {
-        return hasBroker;
+        return !Strings.isNullOrEmpty(name);
     }
 
     public String getName() {

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadMgrTest.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.load.loadv2;
 
+import com.starrocks.analysis.BrokerDesc;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
@@ -50,6 +51,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -256,7 +258,7 @@ public class LoadMgrTest {
         loadJob1.id = 1L;
         loadManager.replayCreateLoadJob(loadJob1);
 
-        LoadJob loadJob2 = new BrokerLoadJob(1L, "job1", null, null, null);
+        LoadJob loadJob2 = new BrokerLoadJob(1L, "job1", new BrokerDesc("DUMMY", new HashMap<>()), null, null);
         loadJob2.id = 2L;
         loadManager.replayCreateLoadJob(loadJob2);
 


### PR DESCRIPTION
## Why I'm doing:
To make the field hasBroker in BrokerLoadJob to be Serialized

## What I'm doing:
To make the field hasBroker can restore from metadb

Fixes #59730

[BUG] BrokerLoad Job can not restore from new leader when the old leader crash #59730

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [] This pr needs user documentation (for new or modified features or behaviors)
  - [] I have added documentation for my new feature or new function
- [] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.5
  - [X] 3.4
  - [X] 3.3
