### PR TITLE
[BugFix] Fix compile problem for tablet_retain_info

### DIFF
--- a/be/src/storage/lake/tablet_retain_info.h
+++ b/be/src/storage/lake/tablet_retain_info.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <cstdint>
-
 #include <string>
 #include <unordered_set>
 #include <vector>

--- a/be/src/storage/lake/tablet_retain_info.h
+++ b/be/src/storage/lake/tablet_retain_info.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include <string>
 #include <unordered_set>
 #include <vector>


### PR DESCRIPTION
## What I'm doing:
Fix compile problem for tablet_retain_info in Centos env

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
