### PR TITLE
[BugFix] Fix case-insensitive column alias conflicts in SELECT queries with ORDER BY clauses

### DIFF
--- a/test/sql/test_select_column_alias_case_insensitive/R/test_select_column_alias_case_insensitive
+++ b/test/sql/test_select_column_alias_case_insensitive/R/test_select_column_alias_case_insensitive
@@ -1,0 +1,84 @@
+-- name: test_select_column_alias_case_insensitive
+CREATE DATABASE IF NOT EXISTS test_alias_case;
+-- result:
+-- !result
+USE test_alias_case;
+-- result:
+-- !result
+
+-- Create test table
+CREATE TABLE IF NOT EXISTS test_case_sensitive (
+    foo INT,
+    bar INT,
+    baz INT
+) DISTRIBUTED BY HASH(foo) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+
+-- Insert test data
+INSERT INTO test_case_sensitive VALUES (1, 2, 3);
+-- result:
+-- !result
+
+-- Test case 1: Basic select with case-different aliases (should fail with ambiguous error)
+SELECT foo AS foo, bar AS FOO FROM test_case_sensitive;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column 'foo' is ambiguous.")
+-- !result
+
+-- Test case 2: Select with ORDER BY using case-insensitive column name (should fail with ambiguous error)
+SELECT foo AS foo, bar AS FOO FROM test_case_sensitive ORDER BY baz;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column 'foo' is ambiguous.")
+-- !result
+
+-- Test case 3: Select with ORDER BY using aliased column (should fail with ambiguous error)
+SELECT foo AS foo, bar AS FOO FROM test_case_sensitive ORDER BY foo;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column 'foo' is ambiguous.")
+-- !result
+
+-- Test case 4: Select with ORDER BY using upper case alias (should fail with ambiguous error)
+SELECT foo AS foo, bar AS FOO FROM test_case_sensitive ORDER BY FOO;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column 'foo' is ambiguous.")
+-- !result
+
+-- Test case 5: Select with WHERE clause and ORDER BY (should fail with ambiguous error)
+SELECT foo AS foo, bar AS FOO FROM test_case_sensitive WHERE baz > 0 ORDER BY baz;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column 'foo' is ambiguous.")
+-- !result
+
+-- Test case 6: Select with multiple case variations (should fail with ambiguous error)
+SELECT foo as Foo, bar as FOO, baz as fOO FROM test_case_sensitive ORDER BY Foo;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column 'Foo' is ambiguous.")
+-- !result
+
+-- Test case 7: Select with unique aliases (should work)
+SELECT foo AS col1, bar AS col2, SUM(baz) as sum_baz FROM test_case_sensitive GROUP BY foo, bar ORDER BY col1;
+-- result:
+1	2	3
+-- !result
+
+-- Test case 8: Select with DISTINCT and unique aliases (should work)
+SELECT DISTINCT foo AS col1, bar AS col2 FROM test_case_sensitive ORDER BY col1;
+-- result:
+1	2
+-- !result
+
+-- Test case 9: Select without ambiguous aliases (should work)
+SELECT foo, bar, baz FROM test_case_sensitive ORDER BY foo;
+-- result:
+1	2	3
+-- !result
+
+-- Cleanup
+DROP TABLE test_case_sensitive;
+-- result:
+-- !result
+DROP DATABASE test_alias_case;
+-- result:
+-- !result

--- a/test/sql/test_select_column_alias_case_insensitive/T/test_select_column_alias_case_insensitive
+++ b/test/sql/test_select_column_alias_case_insensitive/T/test_select_column_alias_case_insensitive
@@ -1,0 +1,45 @@
+-- name: test_select_column_alias_case_insensitive
+CREATE DATABASE IF NOT EXISTS test_alias_case;
+USE test_alias_case;
+
+-- Create test table
+CREATE TABLE IF NOT EXISTS test_case_sensitive (
+    foo INT,
+    bar INT,
+    baz INT
+) DISTRIBUTED BY HASH(foo) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+-- Insert test data
+INSERT INTO test_case_sensitive VALUES (1, 2, 3);
+
+-- Test case 1: Basic select with case-different aliases (should fail with ambiguous error)
+SELECT foo AS foo, bar AS FOO FROM test_case_sensitive;
+
+-- Test case 2: Select with ORDER BY using case-insensitive column name (should fail with ambiguous error)
+SELECT foo AS foo, bar AS FOO FROM test_case_sensitive ORDER BY baz;
+
+-- Test case 3: Select with ORDER BY using aliased column (should fail with ambiguous error)
+SELECT foo AS foo, bar AS FOO FROM test_case_sensitive ORDER BY foo;
+
+-- Test case 4: Select with ORDER BY using upper case alias (should fail with ambiguous error)
+SELECT foo AS foo, bar AS FOO FROM test_case_sensitive ORDER BY FOO;
+
+-- Test case 5: Select with WHERE clause and ORDER BY (should fail with ambiguous error)
+SELECT foo AS foo, bar AS FOO FROM test_case_sensitive WHERE baz > 0 ORDER BY baz;
+
+-- Test case 6: Select with multiple case variations (should fail with ambiguous error)
+SELECT foo as Foo, bar as FOO, baz as fOO FROM test_case_sensitive ORDER BY Foo;
+
+-- Test case 7: Select with unique aliases (should work)
+SELECT foo AS col1, bar AS col2, SUM(baz) as sum_baz FROM test_case_sensitive GROUP BY foo, bar ORDER BY col1;
+
+-- Test case 8: Select with DISTINCT and unique aliases (should work)
+SELECT DISTINCT foo AS col1, bar AS col2 FROM test_case_sensitive ORDER BY col1;
+
+-- Test case 9: Select without ambiguous aliases (should work)
+SELECT foo, bar, baz FROM test_case_sensitive ORDER BY foo;
+
+-- Cleanup
+DROP TABLE test_case_sensitive;
+DROP DATABASE test_alias_case;


### PR DESCRIPTION
## Why I'm doing:
The column alias has conflicts in SELECT and ORDER BY statements.

## What I'm doing:
- Fix issue where ORDER BY incorrectly reported ambiguous column errors when using column aliases
- Handle case-insensitive column name resolution in SelectAnalyzer to avoid false conflicts
- Add comprehensive test cases for column alias case sensitivity scenarios

Fixes #59670

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
