### PR TITLE
[Feature] Introduce customSessionName

### DIFF
--- a/docs/en/sql-reference/System_variable.md
+++ b/docs/en/sql-reference/System_variable.md
@@ -408,6 +408,13 @@ Used for MySQL client compatibility. No practical usage.
 * **Data type**: String
 * **Introduced in**: v3.4.0
 
+### custom_session_name (session)
+
+* **Description**: Used to specify custom name of current session, analog of `applicationName` or `program_name` in DMBS like MySQL or PostgreSQL. Can be set using `SET SESSION custom_session_name = 'my session name';`. Value can be found in audit logs in `customSessionName` field.
+* **Default**: ""
+* **Data type**: String
+* **Introduced in**: v4.0.0
+
 ### datacache_sharing_work_period
 
 * **Description**: The period of time that Cache Sharing takes effect. After each cluster scaling operation, only the requests within this period of time will try to access the cache data from other nodes if the Cache Sharing feature is enabled.

--- a/docs/en/sql-reference/System_variable.md
+++ b/docs/en/sql-reference/System_variable.md
@@ -413,7 +413,7 @@ Used for MySQL client compatibility. No practical usage.
 * **Description**: Used to specify custom name of current session, analog of `applicationName` or `program_name` in DMBS like MySQL or PostgreSQL. Can be set using `SET SESSION custom_session_name = 'my session name';`. Value can be found in audit logs in `customSessionName` field.
 * **Default**: ""
 * **Data type**: String
-* **Introduced in**: v4.0.0
+* **Introduced in**: v4.1.0
 
 ### datacache_sharing_work_period
 

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
@@ -160,6 +160,7 @@ public class AuditEvent {
     @AuditField(value = "SessionId")
     public String sessionId = "";
     
+<<<<<<< HEAD
     @AuditField(value = "CustomQueryId")
     public String customQueryId = "";
 
@@ -201,6 +202,10 @@ public class AuditEvent {
             return 0;
         }
     }
+=======
+    @AuditField(value = "CustomSessionName")
+    public String customSessionName = "";
+>>>>>>> d97d1ac4998 ([Enhancement] Introduce customSessionName)
 
     public static class AuditEventBuilder {
 
@@ -465,6 +470,7 @@ public class AuditEvent {
             return this;
         }
 
+<<<<<<< HEAD
         public AuditEventBuilder setCustomQueryId(String customQueryId) {
             auditEvent.customQueryId = customQueryId;
             return this;
@@ -491,6 +497,10 @@ public class AuditEvent {
 
         public AuditEventBuilder setPreparedStmtId(String preparedStmtId) {
             auditEvent.preparedStmtId = preparedStmtId;
+=======
+        public AuditEventBuilder setCustomSessionName(String customSessionName) {
+            auditEvent.customSessionName = customSessionName;
+>>>>>>> d97d1ac4998 ([Enhancement] Introduce customSessionName)
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
@@ -160,9 +160,11 @@ public class AuditEvent {
     @AuditField(value = "SessionId")
     public String sessionId = "";
     
-<<<<<<< HEAD
     @AuditField(value = "CustomQueryId")
     public String customQueryId = "";
+
+    @AuditField(value = "CustomSessionName")
+    public String customSessionName = "";
 
     @AuditField(value = "TransmittedBytes")
     public long transmittedBytes = -1;
@@ -202,10 +204,6 @@ public class AuditEvent {
             return 0;
         }
     }
-=======
-    @AuditField(value = "CustomSessionName")
-    public String customSessionName = "";
->>>>>>> d97d1ac4998 ([Enhancement] Introduce customSessionName)
 
     public static class AuditEventBuilder {
 
@@ -470,9 +468,13 @@ public class AuditEvent {
             return this;
         }
 
-<<<<<<< HEAD
         public AuditEventBuilder setCustomQueryId(String customQueryId) {
             auditEvent.customQueryId = customQueryId;
+            return this;
+        }
+
+        public AuditEventBuilder setCustomSessionName(String customSessionName) {
+            auditEvent.customSessionName = customSessionName;
             return this;
         }
 
@@ -497,10 +499,6 @@ public class AuditEvent {
 
         public AuditEventBuilder setPreparedStmtId(String preparedStmtId) {
             auditEvent.preparedStmtId = preparedStmtId;
-=======
-        public AuditEventBuilder setCustomSessionName(String customSessionName) {
-            auditEvent.customSessionName = customSessionName;
->>>>>>> d97d1ac4998 ([Enhancement] Introduce customSessionName)
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/AuditLogBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/AuditLogBuilder.java
@@ -70,19 +70,20 @@ public class AuditLogBuilder extends Plugin implements AuditPlugin {
                 if (af == null) {
                     continue;
                 }
+                String fieldName = af.value();
 
                 // fields related to big queries are not written into audit log by default,
                 // they will be written into big query log.
-                if (af.value().equals("BigQueryLogCPUSecondThreshold") ||
-                        af.value().equals("BigQueryLogScanBytesThreshold") ||
-                        af.value().equals("BigQueryLogScanRowsThreshold")) {
+                if (fieldName.equals("BigQueryLogCPUSecondThreshold") ||
+                        fieldName.equals("BigQueryLogScanBytesThreshold") ||
+                        fieldName.equals("BigQueryLogScanRowsThreshold")) {
                     continue;
                 }
-                if (af.value().equalsIgnoreCase("features")) {
+                if (fieldName.equalsIgnoreCase("features")) {
                     continue;
                 }
 
-                if (af.value().equals("Time")) {
+                if (fieldName.equals("Time")) {
                     queryTime = (long) f.get(event);
                 }
 
@@ -117,9 +118,15 @@ public class AuditLogBuilder extends Plugin implements AuditPlugin {
                 }
 
                 if (Config.audit_log_json_format) {
-                    logMap.put(af.value(), value);
+                    logMap.put(fieldName, value);
                 } else {
-                    sb.append("|").append(af.value()).append("=").append(value);
+                    // Prevent inserting strings which may break log format
+                    String strValue = value == null ? "null" : value.toString();
+                    strValue = strValue.replace("\n", "\\n")
+                                    .replace("\r", "\\r")
+                                    .replace("|", "")
+                                    .replace("=", "");
+                    sb.append("|").append(fieldName).append("=").append(strValue);
                 }
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/AuditLogBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/AuditLogBuilder.java
@@ -120,13 +120,7 @@ public class AuditLogBuilder extends Plugin implements AuditPlugin {
                 if (Config.audit_log_json_format) {
                     logMap.put(fieldName, value);
                 } else {
-                    // Prevent inserting strings which may break log format
-                    String strValue = value == null ? "null" : value.toString();
-                    strValue = strValue.replace("\n", "\\n")
-                                    .replace("\r", "\\r")
-                                    .replace("|", "")
-                                    .replace("=", "");
-                    sb.append("|").append(fieldName).append("=").append(strValue);
+                    sb.append("|").append(af.value()).append("=").append(value);
                 }
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -932,6 +932,10 @@ public class ConnectContext {
         return sessionVariable != null ? sessionVariable.getCustomQueryId() : "";
     }
 
+    public String getCustomSessionName() {
+        return sessionVariable != null ? sessionVariable.getCustomSessionName() : "";
+    }
+
     public boolean isProfileEnabled() {
         if (sessionVariable == null) {
             return false;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -375,7 +375,7 @@ public class ConnectProcessor {
                 .setCatalog(ctx.getCurrentCatalog())
                 .setWarehouse(ctx.getCurrentWarehouseName())
                 .setCustomQueryId(ctx.getCustomQueryId())
-                .setCustomSessionName(ctx.getCustomSessionName());``
+                .setCustomSessionName(ctx.getCustomSessionName())
                 .setCNGroup(ctx.getCurrentComputeResourceName());
         Tracers.register(ctx);
         // set isQuery before `forwardToLeader` to make it right for audit log.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -375,6 +375,7 @@ public class ConnectProcessor {
                 .setCatalog(ctx.getCurrentCatalog())
                 .setWarehouse(ctx.getCurrentWarehouseName())
                 .setCustomQueryId(ctx.getCustomQueryId())
+                .setCustomSessionName(ctx.getCustomSessionName());``
                 .setCNGroup(ctx.getCurrentComputeResourceName());
         Tracers.register(ctx);
         // set isQuery before `forwardToLeader` to make it right for audit log.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -734,6 +734,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String OPTIMIZE_DISTINCT_AGG_OVER_FRAMED_WINDOW =
             "optimize_distinct_agg_over_framed_window";
 
+    public static final String CUSTOM_SESSION_NAME = "custom_session_name";
+    public static final int CUSTOM_SESSION_NAME_MAX_LENGTH = 64;
+
     // Flag to control whether to proxy follower's query statement to leader/follower.
     public enum FollowerQueryForwardMode {
         DEFAULT,    // proxy queries by the follower's replay progress (default)
@@ -3263,6 +3266,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = CUSTOM_QUERY_ID, flag = VariableMgr.SESSION_ONLY)
     private String customQueryId = "";
 
+    @VarAttr(name = CUSTOM_SESSION_NAME, flag = VariableMgr.SESSION_ONLY)
+    private String customSessionName = "";
+
     @VarAttr(name = ENABLE_REWRITE_UNNEST_BITMAP_TO_ARRAY)
     private boolean enableRewriteUnnestBitmapToArray = true;
 
@@ -5536,6 +5542,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setCustomQueryId(String customQueryId) {
         this.customQueryId = customQueryId;
+    }
+
+    public String getCustomSessionName() {
+        return customSessionName;
+    }
+
+    public void setCustomSessionName(String customSessionName) {
+        this.customSessionName = customSessionName;
     }
 
     public int getConnectorRemoteFileAsyncQueueSize() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/VariableVarConverters.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/VariableVarConverters.java
@@ -38,6 +38,7 @@ public class VariableVarConverters {
         PartialUpdateModeConverter partialUpdateModeConverter = new PartialUpdateModeConverter();
         CONVERTERS.put(SessionVariable.PARTIAL_UPDATE_MODE, partialUpdateModeConverter);
         CONVERTERS.put(SessionVariable.INSERT_MAX_FILTER_RATIO, new InsertMaxFilterRatioConverter());
+        CONVERTERS.put(SessionVariable.CUSTOM_SESSION_NAME, new CustomSessionNameConverter());
     }
 
     public static String convert(String varName, String value) throws DdlException {
@@ -82,6 +83,21 @@ public class VariableVarConverters {
             } catch (NumberFormatException e) {
                 ErrorReport.reportDdlException(
                         ErrorCode.ERR_INVALID_VALUE, SessionVariable.INSERT_MAX_FILTER_RATIO, value, "between 0.0 and 1.0");
+            }
+            return value;
+        }
+    }
+
+    // check var `custom_session_name`
+    public static class CustomSessionNameConverter implements VariableVarConverterI {
+        @Override
+        public String convert(String value) throws DdlException {
+            if (value.length() > 64) {
+                throw new DdlException("custom_session_name length can not exceed 64 characters");
+            }
+            // check invalid characters
+            if (!value.matches("^[a-zA-Z0-9_\\-]*$")) {
+                throw new DdlException("custom_session_name can only contain letters, digits, hyhens and underscores");
             }
             return value;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/plugin/AuditEventTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/plugin/AuditEventTest.java
@@ -43,6 +43,7 @@ public class AuditEventTest {
                 .setWarehouse("wh")
                 .setSessionId("sessionId")
                 .setCustomQueryId("customQueryId")
+                .setCustomSessionName("customSessionName")
                 .setCNGroup("test_cngroup")
                 .addReadLocalCnt(100)
                 .addReadRemoteCnt(100);
@@ -73,6 +74,7 @@ public class AuditEventTest {
         Assertions.assertEquals("wh", event.warehouse);
         Assertions.assertEquals("sessionId", event.sessionId);
         Assertions.assertEquals("customQueryId", event.customQueryId);
+        Assertions.assertEquals("customSessionName", event.customSessionName);
         Assertions.assertEquals("test_cngroup", event.cnGroup);
         Assertions.assertEquals("50.0%", event.cacheHitRatio);
         Assertions.assertEquals(100, event.writeClientTimeMs);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -653,12 +653,12 @@ public class ConnectProcessorTest extends DDLTestBase {
             }
         };
         processor.processOnce();
-        Assert.assertEquals(MysqlCommand.COM_QUERY, myContext.getCommand());
+        Assertions.assertEquals(MysqlCommand.COM_QUERY, myContext.getCommand());
         // verify customSessionName is set during query execution
-        Assert.assertEquals("session_name", customSessionName.get());
+        Assertions.assertEquals("session_name", customSessionName.get());
         // customSessionName is NOT cleared after query finished
-        Assert.assertEquals("session_name", ctx.getCustomSessionName());
-        Assert.assertEquals("session_name", ctx.getSessionVariable().getCustomSessionName());
+        Assertions.assertEquals("session_name", ctx.getCustomSessionName());
+        Assertions.assertEquals("session_name", ctx.getSessionVariable().getCustomSessionName());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -639,7 +639,7 @@ public class ConnectProcessorTest extends DDLTestBase {
     }
 
     @Test
-    public void testQueryWithCustomSessionName(@Mocked StmtExecutor executor) throws Exception {
+    public void testQueryWithCustomSessionName() throws Exception {
         ConnectContext ctx = initMockContext(mockChannel(queryPacket), GlobalStateMgr.getCurrentState());
         ctx.getSessionVariable().setCustomSessionName("session_name");
 
@@ -650,6 +650,11 @@ public class ConnectProcessorTest extends DDLTestBase {
             @Mock
             public void execute() throws Exception {
                 customSessionName.set(ctx.getCustomSessionName());
+            }
+            
+            @Mock
+            public PQueryStatistics getQueryStatisticsForAuditLog() {
+                return null;
             }
         };
         processor.processOnce();


### PR DESCRIPTION
## Why I'm doing:

In #59563 I've added `sessionId` field to AuditEvent, so audit plugins can understand that some queries were executed within the same session. But there is no session name concept, which may be beneficial for some integrations to track user-defined session name, like `applicatioName` in Postgres.

## What I'm doing:

Introduce `custom_session_name` session variable which can be set like this:

```sql
SET SESSION custom_session_name = 'my_session';
```

It works similar to `custom_query_id`, but `custom_session_name` doesn't reset after query is finished. For now, this value is added only to AuditEvent, but it also can be added to various logs within StarRocks.

This partially solves #58963.

## What type of PR is this:

- [ ] BugFix
- [X] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [X] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
