### PR TITLE
[Enhancement] Remove alias check in subquery

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
@@ -90,8 +90,6 @@ public enum ErrorCode {
     ERR_WRONG_VALUE_FOR_VAR(1231, new byte[] {'4', '2', '0', '0', '0'},
             "Variable '%s' can't be set to the value of '%s'"),
     ERR_WRONG_TYPE_FOR_VAR(1232, new byte[] {'4', '2', '0', '0', '0'}, "Incorrect argument type to variable '%s'"),
-    ERR_DERIVED_MUST_HAVE_ALIAS(1248, new byte[] {'4', '2', '0', '0', '0'},
-            "Every derived table must have its own alias"),
     ERR_NOT_SUPPORTED_AUTH_MODE(1251, new byte[] {'0', '8', '0', '0', '4'},
             "Client does not support authentication protocol requested by server; consider upgrading MySQL client"),
     ERR_UNKNOWN_STORAGE_ENGINE(1286, new byte[] {'4', '2', '0', '0', '0'}, "Unknown storage engine '%s'"),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -990,7 +990,8 @@ public class QueryAnalyzer {
         @Override
         public Scope visitSubqueryRelation(SubqueryRelation subquery, Scope context) {
             if (subquery.getResolveTableName() != null && subquery.getResolveTableName().getTbl() == null) {
-                ErrorReport.reportSemanticException(ErrorCode.ERR_DERIVED_MUST_HAVE_ALIAS);
+                String catalog = ConnectContext.get().getCurrentCatalog();
+                subquery.setAlias(new TableName(catalog, "alias_db", "alias_" + System.nanoTime()));
             }
 
             Scope queryOutputScope = process(subquery.getQueryStatement(), context);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/analyzer/SimpleQueryAnalyzer.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/analyzer/SimpleQueryAnalyzer.java
@@ -28,8 +28,7 @@ import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.TableFunction;
 import com.starrocks.catalog.Type;
-import com.starrocks.common.ErrorCode;
-import com.starrocks.common.ErrorReport;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.AnalyzeState;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.Field;
@@ -196,7 +195,8 @@ public class SimpleQueryAnalyzer {
         @Override
         public Void visitSubqueryRelation(SubqueryRelation subquery, Void context) {
             if (subquery.getResolveTableName() != null && subquery.getResolveTableName().getTbl() == null) {
-                ErrorReport.reportSemanticException(ErrorCode.ERR_DERIVED_MUST_HAVE_ALIAS);
+                String catalog = ConnectContext.get().getCurrentCatalog();
+                subquery.setAlias(new TableName(catalog, "alias_db", "alias_" + System.nanoTime()));
             }
 
             process(subquery.getQueryStatement());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoCtasTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoCtasTest.java
@@ -53,7 +53,7 @@ public class TrinoCtasTest extends TrinoTestBase {
             analyzeSuccess(ctasSql);
 
             connectContext.getSessionVariable().setSqlDialect("starrocks");
-            analyzeFail(ctasSql, "Every derived table must have its own alias");
+            analyzeSuccess(ctasSql);
         } finally {
             connectContext.getSessionVariable().setSqlDialect("trino");
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeJoinTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeFail;
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeSuccess;
+import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeWithoutTestView;
 
 public class AnalyzeJoinTest {
 
@@ -197,7 +198,7 @@ public class AnalyzeJoinTest {
         analyzeFail(sql, "Not unique table/alias: 'a'");
 
         sql = "select * from (t0 a, (select * from t1))";
-        analyzeFail(sql, "Every derived table must have its own alias");
+        analyzeWithoutTestView(sql);
 
         sql = "select * from t0, t0";
         analyzeFail(sql, "Not unique table/alias: 't0'");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSubqueryTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeFail;
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeSuccess;
+import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeWithoutTestView;
 
 public class AnalyzeSubqueryTest {
 
@@ -35,6 +36,7 @@ public class AnalyzeSubqueryTest {
     @Test
     public void testSimple() {
         analyzeSuccess("select k from (select v1 as k from t0) a");
+        analyzeWithoutTestView("select k from (select v1 as k from t0)");
         analyzeSuccess("select k from (select v1 + 1 as k from t0) a");
         analyzeSuccess("select k1, k2 from (select v1 as k1, v2 as k2 from t0) a");
         analyzeSuccess("select * from (select 1 from t0) a");
@@ -46,7 +48,7 @@ public class AnalyzeSubqueryTest {
         analyzeFail("select a.k1 from (select k1, k2 from (select v1 as k1, v2 as k2 from t0) a) b");
 
         analyzeSuccess("select * from (select count(v1) from t0) a");
-        analyzeFail("select * from (select count(v1) from t0)");
+        analyzeWithoutTestView("select * from (select count(v1) from t0)");
 
         analyzeSuccess(
                 "select v1 from t0 where v2 in (select v4 from t1 where v3 = v5) or v2 = (select v4 from t1 where v3 = v5)");


### PR DESCRIPTION
[Enhancement] Remove alias check in subquery
## Why I'm doing:
We can set alias in the subquery relation to make it success when we forget to set alias.
For example in some view, especially hive view.
Users can set SQL like:
select * from (select * from a union all select * from b)
for the view logic.
And here we can add the alias for it, as the alias can be generated by ourselves.
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3