### PR TITLE
[Enhancement] Implement missing HDFS filesystem operations for spilling support 

### DIFF
--- a/be/src/fs/hdfs/fs_hdfs.cpp
+++ b/be/src/fs/hdfs/fs_hdfs.cpp
@@ -711,7 +711,7 @@ StatusOr<std::unique_ptr<WritableFile>> HdfsFileSystem::new_writable_file(const 
         hdfs_write_buffer_size = _options.export_sink->hdfs_write_buffer_size_kb;
     }
     if (_options.upload != nullptr && _options.upload->__isset.hdfs_write_buffer_size_kb) {
-        hdfs_write_buffer_size = _options.upload->hdfs_write_buffer_size_kb;
+        hdfs_write_buffer_size = _options.upload->__isset.hdfs_write_buffer_size_kb;
     }
 
     hdfsFile file = hdfsOpenFile(hdfs_client->hdfs_fs, path.c_str(), flags, hdfs_write_buffer_size, 0, 0);

--- a/be/src/fs/hdfs/fs_hdfs.cpp
+++ b/be/src/fs/hdfs/fs_hdfs.cpp
@@ -418,32 +418,135 @@ public:
 
     Status iterate_dir2(const std::string& dir, const std::function<bool(DirEntry)>& cb) override;
 
-    Status delete_file(const std::string& path) override { return Status::NotSupported("HdfsFileSystem::delete_file"); }
+    Status delete_file(const std::string& path) override {
+        std::string namenode;
+        RETURN_IF_ERROR(get_namenode_from_path(path, &namenode));
+        std::shared_ptr<HdfsFsClient> hdfs_client;
+        RETURN_IF_ERROR(HdfsFsCache::instance()->get_connection(namenode, hdfs_client, _options));
+
+        Status exists_status = _path_exists(hdfs_client->hdfs_fs, path);
+        if (!exists_status.ok()) {
+            return exists_status;
+        }
+
+        ASSIGN_OR_RETURN(bool is_dir, _is_directory(hdfs_client->hdfs_fs, path));
+        if (is_dir) {
+            return Status::InvalidArgument(fmt::format("path {} is a directory, not a file", path));
+        }
+
+        if (hdfsDelete(hdfs_client->hdfs_fs, path.c_str(), 0) != 0) {
+            return Status::InternalError(
+                    fmt::format("Failed to delete HDFS file: {}, error: {}", path, get_hdfs_err_msg()));
+        }
+        return Status::OK();
+    }
 
     Status create_dir(const std::string& dirname) override {
-        return Status::NotSupported("HdfsFileSystem::create_dir");
+        std::string namenode;
+        RETURN_IF_ERROR(get_namenode_from_path(dirname, &namenode));
+        std::shared_ptr<HdfsFsClient> hdfs_client;
+        RETURN_IF_ERROR(HdfsFsCache::instance()->get_connection(namenode, hdfs_client, _options));
+        
+        if (hdfsCreateDirectory(hdfs_client->hdfs_fs, dirname.c_str()) != 0) {
+            return Status::InternalError(fmt::format("Failed to create HDFS directory: {}, error: {}", 
+                                                    dirname, get_hdfs_err_msg()));
+        }
+        return Status::OK();
     }
 
     Status create_dir_if_missing(const std::string& dirname, bool* created) override {
-        return Status::NotSupported("HdfsFileSystem::create_dir_if_missing");
+        std::string namenode;
+        RETURN_IF_ERROR(get_namenode_from_path(dirname, &namenode));
+        std::shared_ptr<HdfsFsClient> hdfs_client;
+        RETURN_IF_ERROR(HdfsFsCache::instance()->get_connection(namenode, hdfs_client, _options));
+        
+        // Check if directory already exists
+        Status exists_status = _path_exists(hdfs_client->hdfs_fs, dirname);
+        if (exists_status.ok()) {
+            // Path exists, check if it's a directory
+            ASSIGN_OR_RETURN(bool is_dir, _is_directory(hdfs_client->hdfs_fs, dirname));
+            if (is_dir) {
+                if (created) *created = false;
+                return Status::OK();
+            } else {
+                return Status::InvalidArgument(fmt::format("Path {} exists but is not a directory", dirname));
+            }
+        }
+        
+        // Directory doesn't exist, create it
+        if (hdfsCreateDirectory(hdfs_client->hdfs_fs, dirname.c_str()) != 0) {
+            return Status::InternalError(fmt::format("Failed to create HDFS directory: {}, error: {}", 
+                                                    dirname, get_hdfs_err_msg()));
+        }
+        
+        if (created) *created = true;
+        return Status::OK();
     }
 
     Status create_dir_recursive(const std::string& dirname) override {
-        return Status::NotSupported("HdfsFileSystem::create_dir_recursive");
+        // For HDFS, hdfsCreateDirectory already creates parent directories recursively
+        // This is the default behavior in HDFS - it works like "mkdir -p"
+        return create_dir_if_missing(dirname, nullptr);
     }
 
     Status delete_dir(const std::string& dirname) override {
-        return Status::NotSupported("HdfsFileSystem::delete_dir");
+        std::string namenode;
+        RETURN_IF_ERROR(get_namenode_from_path(dirname, &namenode));
+        std::shared_ptr<HdfsFsClient> hdfs_client;
+        RETURN_IF_ERROR(HdfsFsCache::instance()->get_connection(namenode, hdfs_client, _options));
+
+        Status exists_status = _path_exists(hdfs_client->hdfs_fs, dirname);
+        if (!exists_status.ok()) {
+            return exists_status;
+        }
+
+        ASSIGN_OR_RETURN(bool is_dir, _is_directory(hdfs_client->hdfs_fs, dirname));
+        if (!is_dir) {
+            return Status::InvalidArgument(fmt::format("path {} is not a directory", dirname));
+        }
+
+        if (hdfsDelete(hdfs_client->hdfs_fs, dirname.c_str(), 0) != 0) {
+            return Status::InternalError(
+                    fmt::format("Failed to delete HDFS directory: {}, error: {}", dirname, get_hdfs_err_msg()));
+        }
+        return Status::OK();
     }
 
     Status delete_dir_recursive(const std::string& dirname) override {
-        return Status::NotSupported("HdfsFileSystem::delete_dir_recursive");
+        std::string namenode;
+        RETURN_IF_ERROR(get_namenode_from_path(dirname, &namenode));
+        std::shared_ptr<HdfsFsClient> hdfs_client;
+        RETURN_IF_ERROR(HdfsFsCache::instance()->get_connection(namenode, hdfs_client, _options));
+
+        Status exists_status = _path_exists(hdfs_client->hdfs_fs, dirname);
+        if (exists_status.is_not_found()) {
+            return Status::OK();
+        }
+        if (!exists_status.ok()) {
+            return exists_status;
+        }
+
+        ASSIGN_OR_RETURN(bool is_dir, _is_directory(hdfs_client->hdfs_fs, dirname));
+        if (!is_dir) {
+            return Status::InvalidArgument(fmt::format("path {} is not a directory", dirname));
+        }
+
+        if (hdfsDelete(hdfs_client->hdfs_fs, dirname.c_str(), 1) != 0) {
+            return Status::InternalError(fmt::format("Failed to recursively delete HDFS directory: {}, error: {}",
+                                                     dirname, get_hdfs_err_msg()));
+        }
+        return Status::OK();
     }
 
     Status sync_dir(const std::string& dirname) override { return Status::NotSupported("HdfsFileSystem::sync_dir"); }
 
     StatusOr<bool> is_directory(const std::string& path) override {
-        return Status::NotSupported("HdfsFileSystem::is_directory");
+        std::string namenode;
+        RETURN_IF_ERROR(get_namenode_from_path(path, &namenode));
+        std::shared_ptr<HdfsFsClient> hdfs_client;
+        RETURN_IF_ERROR(HdfsFsCache::instance()->get_connection(namenode, hdfs_client, _options));
+        
+        return _is_directory(hdfs_client->hdfs_fs, path);
     }
 
     Status canonicalize(const std::string& path, std::string* file) override {
@@ -466,6 +569,7 @@ public:
 
 private:
     Status _path_exists(hdfsFS fs, const std::string& path);
+    StatusOr<bool> _is_directory(hdfsFS fs, const std::string& path);
 
     FSOptions _options;
 };
@@ -558,6 +662,18 @@ Status HdfsFileSystem::iterate_dir2(const std::string& dir, const std::function<
 Status HdfsFileSystem::_path_exists(hdfsFS fs, const std::string& path) {
     int status = hdfsExists(fs, path.data());
     return status == 0 ? Status::OK() : Status::NotFound(path);
+}
+
+StatusOr<bool> HdfsFileSystem::_is_directory(hdfsFS fs, const std::string& path) {
+    hdfsFileInfo* file_info = hdfsGetPathInfo(fs, path.c_str());
+    if (file_info == nullptr) {
+        return Status::InternalError(fmt::format("Failed to get HDFS path info: {}, error: {}", 
+                                                path, get_hdfs_err_msg()));
+    }
+    
+    bool is_dir = (file_info->mKind == kObjectKindDirectory);
+    hdfsFreeFileInfo(file_info, 1);
+    return is_dir;
 }
 
 StatusOr<std::unique_ptr<WritableFile>> HdfsFileSystem::new_writable_file(const std::string& path) {

--- a/be/src/fs/hdfs/fs_hdfs.cpp
+++ b/be/src/fs/hdfs/fs_hdfs.cpp
@@ -569,7 +569,7 @@ public:
 
 private:
     Status _path_exists(hdfsFS fs, const std::string& path);
-    StatusOr<bool> _is_directory(hdfsFS fs, const std::string& path);
+    static StatusOr<bool> _is_directory(hdfsFS fs, const std::string& path);
 
     FSOptions _options;
 };

--- a/be/src/util/hdfs_util.h
+++ b/be/src/util/hdfs_util.h
@@ -20,6 +20,11 @@
 
 namespace starrocks {
 
+// Translate hdfs errno to Status
+Status hdfs_error_to_status(const std::string& context, int err_number);
+
+std::string get_hdfs_err_msg(int err);
+
 std::string get_hdfs_err_msg();
 
 Status get_namenode_from_path(const std::string& path, std::string* namenode);

--- a/be/test/fs/fs_hdfs_test.cpp
+++ b/be/test/fs/fs_hdfs_test.cpp
@@ -130,7 +130,7 @@ TEST_F(HdfsFileSystemTest, directory_operations) {
     auto fs = new_fs_hdfs(FSOptions());
     const std::string dirpath = "file://" + _root_path + "/test_directory";
     const std::string nested_dirpath = "file://" + _root_path + "/test_directory/nested";
-    
+
     // Test directory doesn't exist initially
     auto st = fs->path_exists(dirpath);
     EXPECT_TRUE(st.is_not_found());
@@ -187,7 +187,7 @@ TEST_F(HdfsFileSystemTest, directory_operations) {
 TEST_F(HdfsFileSystemTest, create_dir_if_missing_new_directory) {
     auto fs = new_fs_hdfs(FSOptions());
     const std::string dirpath = "file://" + _root_path + "/new_test_directory";
-    
+
     // Test directory doesn't exist initially
     auto st = fs->path_exists(dirpath);
     EXPECT_TRUE(st.is_not_found());
@@ -213,7 +213,7 @@ TEST_F(HdfsFileSystemTest, create_dir_if_missing_new_directory) {
 TEST_F(HdfsFileSystemTest, create_dir_if_missing_on_file) {
     auto fs = new_fs_hdfs(FSOptions());
     const std::string filepath = "file://" + _root_path + "/test_file_not_dir";
-    
+
     // Create a file first
     auto wfile = fs->new_writable_file(filepath);
     EXPECT_TRUE(wfile.ok());
@@ -235,7 +235,7 @@ TEST_F(HdfsFileSystemTest, create_dir_if_missing_on_file) {
 TEST_F(HdfsFileSystemTest, is_directory_on_file) {
     auto fs = new_fs_hdfs(FSOptions());
     const std::string filepath = "file://" + _root_path + "/test_file_for_is_directory";
-    
+
     // Create a file
     auto wfile = fs->new_writable_file(filepath);
     EXPECT_TRUE(wfile.ok());
@@ -256,7 +256,7 @@ TEST_F(HdfsFileSystemTest, is_directory_on_file) {
 TEST_F(HdfsFileSystemTest, delete_empty_directory) {
     auto fs = new_fs_hdfs(FSOptions());
     const std::string dirpath = "file://" + _root_path + "/empty_directory";
-    
+
     // Create directory
     auto st = fs->create_dir(dirpath);
     EXPECT_TRUE(st.ok());
@@ -274,11 +274,11 @@ TEST_F(HdfsFileSystemTest, delete_directory_with_files) {
     auto fs = new_fs_hdfs(FSOptions());
     const std::string dirpath = "file://" + _root_path + "/directory_with_files";
     const std::string filepath = dirpath + "/test_file.txt";
-    
+
     // Create directory and file
     auto st = fs->create_dir(dirpath);
     EXPECT_TRUE(st.ok());
-    
+
     auto wfile = fs->new_writable_file(filepath);
     EXPECT_TRUE(wfile.ok());
     std::string data = "test data";
@@ -373,9 +373,9 @@ TEST_F(HdfsFileSystemTest, spilling_scenario_simulation) {
     const std::string base_spill_dir = "file://" + _root_path + "/spill_base";
     const std::string query_spill_dir = base_spill_dir + "/query_123";
     const std::string container_dir = query_spill_dir + "/container_456";
-    
+
     // Simulate spilling directory creation workflow
-    
+
     // 1. Create base spill directory (create_dir_if_missing in dir_manager.cpp)
     bool created = false;
     auto st = fs->create_dir_if_missing(base_spill_dir, &created);
@@ -416,7 +416,7 @@ TEST_F(HdfsFileSystemTest, spilling_scenario_simulation) {
     // 5. Create some spill files to simulate actual spilling
     const std::string spill_file1 = container_dir + "/spill_block_001.dat";
     const std::string spill_file2 = container_dir + "/spill_block_002.dat";
-    
+
     auto wfile1 = fs->new_writable_file(spill_file1);
     EXPECT_TRUE(wfile1.ok());
     std::string data1 = "spilled data block 1";
@@ -462,18 +462,18 @@ TEST_F(HdfsFileSystemTest, spilling_scenario_simulation) {
 TEST_F(HdfsFileSystemTest, verify_hdfs_create_directory_behavior) {
     auto fs = new_fs_hdfs(FSOptions());
     const std::string deep_nested = "file://" + _root_path + "/level1/level2/level3";
-    
+
     // Test if hdfsCreateDirectory (via create_dir) creates parent directories automatically
     auto st = fs->create_dir(deep_nested);
     if (st.ok()) {
         // hdfsCreateDirectory creates parents automatically
         LOG(INFO) << "hdfsCreateDirectory creates parent directories automatically";
-        
+
         // Verify all levels exist
         EXPECT_TRUE(fs->path_exists("file://" + _root_path + "/level1").ok());
         EXPECT_TRUE(fs->path_exists("file://" + _root_path + "/level1/level2").ok());
         EXPECT_TRUE(fs->path_exists(deep_nested).ok());
-        
+
         // Cleanup
         fs->delete_dir_recursive("file://" + _root_path + "/level1");
     } else {

--- a/be/test/fs/fs_hdfs_test.cpp
+++ b/be/test/fs/fs_hdfs_test.cpp
@@ -126,4 +126,361 @@ TEST_F(HdfsFileSystemTest, create_file_with_open_truncate) {
     (*wfile_2).reset();
 }
 
+TEST_F(HdfsFileSystemTest, directory_operations) {
+    auto fs = new_fs_hdfs(FSOptions());
+    const std::string dirpath = "file://" + _root_path + "/test_directory";
+    const std::string nested_dirpath = "file://" + _root_path + "/test_directory/nested";
+    
+    // Test directory doesn't exist initially
+    auto st = fs->path_exists(dirpath);
+    EXPECT_TRUE(st.is_not_found());
+
+    // Test is_directory on non-existent path
+    auto is_dir_res = fs->is_directory(dirpath);
+    EXPECT_FALSE(is_dir_res.ok());
+
+    // Test create_dir
+    st = fs->create_dir(dirpath);
+    EXPECT_TRUE(st.ok());
+
+    // Test directory now exists
+    st = fs->path_exists(dirpath);
+    EXPECT_TRUE(st.ok());
+
+    // Test is_directory on directory
+    is_dir_res = fs->is_directory(dirpath);
+    EXPECT_TRUE(is_dir_res.ok());
+    EXPECT_TRUE(is_dir_res.value());
+
+    // Test create_dir on existing directory (should fail for basic create_dir)
+    st = fs->create_dir(dirpath);
+    EXPECT_FALSE(st.ok());
+
+    // Test create_dir_if_missing on existing directory
+    bool created = false;
+    st = fs->create_dir_if_missing(dirpath, &created);
+    EXPECT_TRUE(st.ok());
+    EXPECT_FALSE(created);
+
+    // Test create_dir_recursive for nested path
+    st = fs->create_dir_recursive(nested_dirpath);
+    EXPECT_TRUE(st.ok());
+
+    // Test nested directory exists and is a directory
+    st = fs->path_exists(nested_dirpath);
+    EXPECT_TRUE(st.ok());
+    is_dir_res = fs->is_directory(nested_dirpath);
+    EXPECT_TRUE(is_dir_res.ok());
+    EXPECT_TRUE(is_dir_res.value());
+
+    // Test delete_dir_recursive
+    st = fs->delete_dir_recursive(dirpath);
+    EXPECT_TRUE(st.ok());
+
+    // Test directory no longer exists
+    st = fs->path_exists(dirpath);
+    EXPECT_TRUE(st.is_not_found());
+    st = fs->path_exists(nested_dirpath);
+    EXPECT_TRUE(st.is_not_found());
+}
+
+TEST_F(HdfsFileSystemTest, create_dir_if_missing_new_directory) {
+    auto fs = new_fs_hdfs(FSOptions());
+    const std::string dirpath = "file://" + _root_path + "/new_test_directory";
+    
+    // Test directory doesn't exist initially
+    auto st = fs->path_exists(dirpath);
+    EXPECT_TRUE(st.is_not_found());
+
+    // Test create_dir_if_missing on non-existent directory
+    bool created = false;
+    st = fs->create_dir_if_missing(dirpath, &created);
+    EXPECT_TRUE(st.ok());
+    EXPECT_TRUE(created);
+
+    // Test directory now exists and is a directory
+    st = fs->path_exists(dirpath);
+    EXPECT_TRUE(st.ok());
+    auto is_dir_res = fs->is_directory(dirpath);
+    EXPECT_TRUE(is_dir_res.ok());
+    EXPECT_TRUE(is_dir_res.value());
+
+    // Cleanup
+    st = fs->delete_dir_recursive(dirpath);
+    EXPECT_TRUE(st.ok());
+}
+
+TEST_F(HdfsFileSystemTest, create_dir_if_missing_on_file) {
+    auto fs = new_fs_hdfs(FSOptions());
+    const std::string filepath = "file://" + _root_path + "/test_file_not_dir";
+    
+    // Create a file first
+    auto wfile = fs->new_writable_file(filepath);
+    EXPECT_TRUE(wfile.ok());
+    std::string data = "test data";
+    EXPECT_TRUE((*wfile)->append(Slice(data)).ok());
+    (*wfile)->close();
+
+    // Test create_dir_if_missing on existing file (should fail)
+    bool created = false;
+    auto st = fs->create_dir_if_missing(filepath, &created);
+    EXPECT_FALSE(st.ok());
+    EXPECT_TRUE(st.is_invalid_argument());
+
+    // Cleanup
+    st = fs->delete_file(filepath);
+    EXPECT_TRUE(st.ok());
+}
+
+TEST_F(HdfsFileSystemTest, is_directory_on_file) {
+    auto fs = new_fs_hdfs(FSOptions());
+    const std::string filepath = "file://" + _root_path + "/test_file_for_is_directory";
+    
+    // Create a file
+    auto wfile = fs->new_writable_file(filepath);
+    EXPECT_TRUE(wfile.ok());
+    std::string data = "test data";
+    EXPECT_TRUE((*wfile)->append(Slice(data)).ok());
+    (*wfile)->close();
+
+    // Test is_directory on file (should return false)
+    auto is_dir_res = fs->is_directory(filepath);
+    EXPECT_TRUE(is_dir_res.ok());
+    EXPECT_FALSE(is_dir_res.value());
+
+    // Cleanup
+    auto st = fs->delete_file(filepath);
+    EXPECT_TRUE(st.ok());
+}
+
+TEST_F(HdfsFileSystemTest, delete_empty_directory) {
+    auto fs = new_fs_hdfs(FSOptions());
+    const std::string dirpath = "file://" + _root_path + "/empty_directory";
+    
+    // Create directory
+    auto st = fs->create_dir(dirpath);
+    EXPECT_TRUE(st.ok());
+
+    // Test delete_dir on empty directory
+    st = fs->delete_dir(dirpath);
+    EXPECT_TRUE(st.ok());
+
+    // Test directory no longer exists
+    st = fs->path_exists(dirpath);
+    EXPECT_TRUE(st.is_not_found());
+}
+
+TEST_F(HdfsFileSystemTest, delete_directory_with_files) {
+    auto fs = new_fs_hdfs(FSOptions());
+    const std::string dirpath = "file://" + _root_path + "/directory_with_files";
+    const std::string filepath = dirpath + "/test_file.txt";
+    
+    // Create directory and file
+    auto st = fs->create_dir(dirpath);
+    EXPECT_TRUE(st.ok());
+    
+    auto wfile = fs->new_writable_file(filepath);
+    EXPECT_TRUE(wfile.ok());
+    std::string data = "test data";
+    EXPECT_TRUE((*wfile)->append(Slice(data)).ok());
+    (*wfile)->close();
+
+    // Test delete_dir on non-empty directory (should fail)
+    st = fs->delete_dir(dirpath);
+    EXPECT_FALSE(st.ok());
+
+    // Test delete_dir_recursive on non-empty directory (should succeed)
+    st = fs->delete_dir_recursive(dirpath);
+    EXPECT_TRUE(st.ok());
+
+    // Test directory and file no longer exist
+    st = fs->path_exists(dirpath);
+    EXPECT_TRUE(st.is_not_found());
+    st = fs->path_exists(filepath);
+    EXPECT_TRUE(st.is_not_found());
+}
+
+TEST_F(HdfsFileSystemTest, delete_file_on_directory) {
+    auto fs = new_fs_hdfs(FSOptions());
+    const std::string dirpath = "file://" + _root_path + "/dir_for_delete_file_test";
+
+    // Create directory
+    auto st = fs->create_dir(dirpath);
+    EXPECT_TRUE(st.ok());
+
+    // Try to delete directory with delete_file, should fail
+    st = fs->delete_file(dirpath);
+    EXPECT_FALSE(st.ok());
+    EXPECT_TRUE(st.is_invalid_argument());
+
+    // Cleanup
+    st = fs->delete_dir(dirpath);
+    EXPECT_TRUE(st.ok());
+}
+
+TEST_F(HdfsFileSystemTest, delete_dir_on_file) {
+    auto fs = new_fs_hdfs(FSOptions());
+    const std::string filepath = "file://" + _root_path + "/file_for_delete_dir_test";
+
+    // Create file
+    auto wfile = fs->new_writable_file(filepath);
+    EXPECT_TRUE(wfile.ok());
+    EXPECT_TRUE((*wfile)->append(Slice("test")).ok());
+    (*wfile)->close();
+
+    // Try to delete file with delete_dir, should fail
+    auto st = fs->delete_dir(filepath);
+    EXPECT_FALSE(st.ok());
+    EXPECT_TRUE(st.is_invalid_argument());
+
+    // Cleanup
+    st = fs->delete_file(filepath);
+    EXPECT_TRUE(st.ok());
+}
+
+TEST_F(HdfsFileSystemTest, delete_dir_recursive_on_file) {
+    auto fs = new_fs_hdfs(FSOptions());
+    const std::string filepath = "file://" + _root_path + "/file_for_delete_dir_recursive_test";
+
+    // Create file
+    auto wfile = fs->new_writable_file(filepath);
+    EXPECT_TRUE(wfile.ok());
+    EXPECT_TRUE((*wfile)->append(Slice("test")).ok());
+    (*wfile)->close();
+
+    // Try to delete file with delete_dir_recursive, should fail
+    auto st = fs->delete_dir_recursive(filepath);
+    EXPECT_FALSE(st.ok());
+    EXPECT_TRUE(st.is_invalid_argument());
+
+    // Cleanup
+    st = fs->delete_file(filepath);
+    EXPECT_TRUE(st.ok());
+}
+
+TEST_F(HdfsFileSystemTest, delete_dir_recursive_on_non_existent_path) {
+    auto fs = new_fs_hdfs(FSOptions());
+    const std::string dirpath = "file://" + _root_path + "/non_existent_dir";
+
+    // delete_dir_recursive on non-existent path should succeed
+    auto st = fs->delete_dir_recursive(dirpath);
+    EXPECT_TRUE(st.ok());
+}
+
+TEST_F(HdfsFileSystemTest, spilling_scenario_simulation) {
+    // This test simulates the spilling workflow that was failing
+    auto fs = new_fs_hdfs(FSOptions());
+    const std::string base_spill_dir = "file://" + _root_path + "/spill_base";
+    const std::string query_spill_dir = base_spill_dir + "/query_123";
+    const std::string container_dir = query_spill_dir + "/container_456";
+    
+    // Simulate spilling directory creation workflow
+    
+    // 1. Create base spill directory (create_dir_if_missing in dir_manager.cpp)
+    bool created = false;
+    auto st = fs->create_dir_if_missing(base_spill_dir, &created);
+    EXPECT_TRUE(st.ok());
+    EXPECT_TRUE(created);
+
+    // 2. Create query-specific directory (create_dir_if_missing in query_spill_manager.cpp)
+    created = false;
+    st = fs->create_dir_if_missing(query_spill_dir, &created);
+    EXPECT_TRUE(st.ok());
+    EXPECT_TRUE(created);
+
+    // 3. Create container directory (create_dir_if_missing in file_block_manager.cpp)
+    created = false;
+    st = fs->create_dir_if_missing(container_dir, &created);
+    EXPECT_TRUE(st.ok());
+    EXPECT_TRUE(created);
+
+    // 4. Verify all directories exist and are directories
+    st = fs->path_exists(base_spill_dir);
+    EXPECT_TRUE(st.ok());
+    auto is_dir_res = fs->is_directory(base_spill_dir);
+    EXPECT_TRUE(is_dir_res.ok());
+    EXPECT_TRUE(is_dir_res.value());
+
+    st = fs->path_exists(query_spill_dir);
+    EXPECT_TRUE(st.ok());
+    is_dir_res = fs->is_directory(query_spill_dir);
+    EXPECT_TRUE(is_dir_res.ok());
+    EXPECT_TRUE(is_dir_res.value());
+
+    st = fs->path_exists(container_dir);
+    EXPECT_TRUE(st.ok());
+    is_dir_res = fs->is_directory(container_dir);
+    EXPECT_TRUE(is_dir_res.ok());
+    EXPECT_TRUE(is_dir_res.value());
+
+    // 5. Create some spill files to simulate actual spilling
+    const std::string spill_file1 = container_dir + "/spill_block_001.dat";
+    const std::string spill_file2 = container_dir + "/spill_block_002.dat";
+    
+    auto wfile1 = fs->new_writable_file(spill_file1);
+    EXPECT_TRUE(wfile1.ok());
+    std::string data1 = "spilled data block 1";
+    EXPECT_TRUE((*wfile1)->append(Slice(data1)).ok());
+    (*wfile1)->close();
+
+    auto wfile2 = fs->new_writable_file(spill_file2);
+    EXPECT_TRUE(wfile2.ok());
+    std::string data2 = "spilled data block 2";
+    EXPECT_TRUE((*wfile2)->append(Slice(data2)).ok());
+    (*wfile2)->close();
+
+    // 6. Verify files exist and are not directories
+    st = fs->path_exists(spill_file1);
+    EXPECT_TRUE(st.ok());
+    is_dir_res = fs->is_directory(spill_file1);
+    EXPECT_TRUE(is_dir_res.ok());
+    EXPECT_FALSE(is_dir_res.value());
+
+    st = fs->path_exists(spill_file2);
+    EXPECT_TRUE(st.ok());
+    is_dir_res = fs->is_directory(spill_file2);
+    EXPECT_TRUE(is_dir_res.ok());
+    EXPECT_FALSE(is_dir_res.value());
+
+    // 7. Cleanup using recursive delete (simulate cleanup in dir_manager.cpp)
+    st = fs->delete_dir_recursive(base_spill_dir);
+    EXPECT_TRUE(st.ok());
+
+    // 8. Verify everything is cleaned up
+    st = fs->path_exists(base_spill_dir);
+    EXPECT_TRUE(st.is_not_found());
+    st = fs->path_exists(query_spill_dir);
+    EXPECT_TRUE(st.is_not_found());
+    st = fs->path_exists(container_dir);
+    EXPECT_TRUE(st.is_not_found());
+    st = fs->path_exists(spill_file1);
+    EXPECT_TRUE(st.is_not_found());
+    st = fs->path_exists(spill_file2);
+    EXPECT_TRUE(st.is_not_found());
+}
+
+TEST_F(HdfsFileSystemTest, verify_hdfs_create_directory_behavior) {
+    auto fs = new_fs_hdfs(FSOptions());
+    const std::string deep_nested = "file://" + _root_path + "/level1/level2/level3";
+    
+    // Test if hdfsCreateDirectory (via create_dir) creates parent directories automatically
+    auto st = fs->create_dir(deep_nested);
+    if (st.ok()) {
+        // hdfsCreateDirectory creates parents automatically
+        LOG(INFO) << "hdfsCreateDirectory creates parent directories automatically";
+        
+        // Verify all levels exist
+        EXPECT_TRUE(fs->path_exists("file://" + _root_path + "/level1").ok());
+        EXPECT_TRUE(fs->path_exists("file://" + _root_path + "/level1/level2").ok());
+        EXPECT_TRUE(fs->path_exists(deep_nested).ok());
+        
+        // Cleanup
+        fs->delete_dir_recursive("file://" + _root_path + "/level1");
+    } else {
+        // hdfsCreateDirectory does NOT create parents automatically
+        LOG(INFO) << "hdfsCreateDirectory does NOT create parent directories automatically";
+        EXPECT_FALSE(st.ok());
+    }
+}
+
 } // namespace starrocks


### PR DESCRIPTION
Fixes #59757

## Why I'm doing:

When using HDFS as a remote storage volume for spilling, StarRocks fails with `NOT_IMPLEMENTED_ERROR` because several critical filesystem operations were not implemented in the HDFS filesystem wrapper (`HdfsFileSystem` class). These operations are essential for the spilling workflow:

- Creating directories for spill data organization
- Checking if paths are directories vs files  
- Deleting files and directories during cleanup
- Managing directory hierarchy for spill containers

Without these operations, queries that need to spill to HDFS storage volumes cannot function, severely limiting StarRocks' ability to handle large datasets when using HDFS as external storage.

## What I'm doing:

This PR implements the missing HDFS filesystem operations required for spilling functionality:

### Implemented Operations:
- **`delete_file()`** - Delete files from HDFS using `hdfsDelete`
- **`create_dir()`** - Create directories using `hdfsCreateDirectory`
- **`create_dir_if_missing()`** - Create directories if they don't exist (with existence check)
- **`create_dir_recursive()`** - Create directories recursively (leverages HDFS native recursive creation)
- **`delete_dir()`** - Delete empty directories using `hdfsDelete` 
- **`delete_dir_recursive()`** - Delete directories and all contents recursively
- **`is_directory()`** - Check if a path is a directory using `hdfsGetPathInfo`

### Additional Improvements:
- Added private helper method `_is_directory()` for internal directory type checking
- ~~Fixed bug in `hdfs_write_buffer_size` assignment for upload options (was using `__isset` instead of actual value)~~
- Added comprehensive test coverage including realistic spilling workflow simulation

### Implementation Details:
- All operations properly handle HDFS connections through existing `HdfsFsCache` infrastructure
- Robust error handling with meaningful error messages using `get_hdfs_err_msg()`
- Path existence validation before operations to provide clear error messages
- Directory vs file type validation to prevent incorrect operations
- Follows existing code patterns and error handling conventions in the codebase

Fixes #59757

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

Note: This is a bug fix that enables existing functionality. Backporting decisions will be left to the maintainers to determine based on their assessment of stability and compatibility with each version branch. 