### PR TITLE
[BugFix] Transform all exception for some operation in HdfsFsMgr into StarRocksException to prevent Exception leak for the caller

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
@@ -1311,9 +1311,6 @@ public class HdfsFsManager {
             Thread.interrupted(); // clear interrupted flag
             LOG.error("Interrupted while delete path: " + path, e);
             throw new StarRocksException("Failed to delete path: " + path, e); // throw unified user exception
-        } catch (IOException e) {
-            LOG.error("errors while delete path " + path, e);
-            throw new StarRocksException("delete path " + path + "error", e);
         } catch (Exception e) {
             LOG.error("errors while delete path " + path, e);
             throw new StarRocksException("delete path " + path + "error", e);
@@ -1349,9 +1346,6 @@ public class HdfsFsManager {
             LOG.error("Interrupted while rename path from " + srcPath + " to " + destPath, e);
             // throw unified user exception
             throw new StarRocksException("Failed to rename path from " + srcPath + " to " + destPath, e);
-        } catch (IOException e) {
-            LOG.error("errors while rename path from " + srcPath + " to " + destPath, e);
-            throw new StarRocksException("errors while rename " + srcPath + "to " + destPath, e);
         } catch (Exception e) {
             LOG.error("errors while rename path from " + srcPath + " to " + destPath, e);
             throw new StarRocksException("errors while rename " + srcPath + "to " + destPath, e);
@@ -1368,9 +1362,6 @@ public class HdfsFsManager {
             Thread.interrupted(); // clear interrupted flag
             LOG.error("Interrupted while check path exist: " + path, e);
             throw new StarRocksException("Failed to check path exist: " + path, e); // throw unified user exception
-        } catch (IOException e) {
-            LOG.error("errors while check path exist: " + path, e);
-            throw new StarRocksException("errors while check if path " + path + " exist", e);
         } catch (Exception e) {
             LOG.error("errors while check path exist: " + path, e);
             throw new StarRocksException("errors while check if path " + path + " exist", e);
@@ -1393,9 +1384,6 @@ public class HdfsFsManager {
             Thread.interrupted(); // clear interrupted flag
             LOG.error("Interrupted while open file " + path, e);
             throw new StarRocksException("Failed to open file " + path, e); // throw unified user exception
-        } catch (IOException e) {
-            LOG.error("errors while open path", e);
-            throw new StarRocksException("could not open file " + path, e);
         } catch (Exception e) {
             LOG.error("errors while open path", e);
             throw new StarRocksException("could not open file " + path, e);
@@ -1505,9 +1493,6 @@ public class HdfsFsManager {
             Thread.interrupted(); // clear interrupted flag
             LOG.error("Interrupted while open file " + path, e);
             throw new StarRocksException("Failed to open file " + path, e); // throw unified user exception
-        } catch (IOException e) {
-            LOG.error("errors while open path", e);
-            throw new StarRocksException("could not open file " + path, e);
         } catch (Exception e) {
             LOG.error("errors while open path", e);
             throw new StarRocksException("could not open file " + path, e);

--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
@@ -1314,6 +1314,9 @@ public class HdfsFsManager {
         } catch (IOException e) {
             LOG.error("errors while delete path " + path, e);
             throw new StarRocksException("delete path " + path + "error", e);
+        } catch (Exception e) {
+            LOG.error("errors while delete path " + path, e);
+            throw new StarRocksException("delete path " + path + "error", e);
         }
     }
 
@@ -1349,6 +1352,9 @@ public class HdfsFsManager {
         } catch (IOException e) {
             LOG.error("errors while rename path from " + srcPath + " to " + destPath, e);
             throw new StarRocksException("errors while rename " + srcPath + "to " + destPath, e);
+        } catch (Exception e) {
+            LOG.error("errors while rename path from " + srcPath + " to " + destPath, e);
+            throw new StarRocksException("errors while rename " + srcPath + "to " + destPath, e);
         }
     }
 
@@ -1363,6 +1369,9 @@ public class HdfsFsManager {
             LOG.error("Interrupted while check path exist: " + path, e);
             throw new StarRocksException("Failed to check path exist: " + path, e); // throw unified user exception
         } catch (IOException e) {
+            LOG.error("errors while check path exist: " + path, e);
+            throw new StarRocksException("errors while check if path " + path + " exist", e);
+        } catch (Exception e) {
             LOG.error("errors while check path exist: " + path, e);
             throw new StarRocksException("errors while check if path " + path + " exist", e);
         }
@@ -1385,6 +1394,9 @@ public class HdfsFsManager {
             LOG.error("Interrupted while open file " + path, e);
             throw new StarRocksException("Failed to open file " + path, e); // throw unified user exception
         } catch (IOException e) {
+            LOG.error("errors while open path", e);
+            throw new StarRocksException("could not open file " + path, e);
+        } catch (Exception e) {
             LOG.error("errors while open path", e);
             throw new StarRocksException("could not open file " + path, e);
         }
@@ -1494,6 +1506,9 @@ public class HdfsFsManager {
             LOG.error("Interrupted while open file " + path, e);
             throw new StarRocksException("Failed to open file " + path, e); // throw unified user exception
         } catch (IOException e) {
+            LOG.error("errors while open path", e);
+            throw new StarRocksException("could not open file " + path, e);
+        } catch (Exception e) {
             LOG.error("errors while open path", e);
             throw new StarRocksException("could not open file " + path, e);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/fs/HdfsUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/fs/HdfsUtilTest.java
@@ -17,12 +17,20 @@
 
 package com.starrocks.fs;
 
+import com.starrocks.analysis.BrokerDesc;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.fs.hdfs.HdfsFs;
+import com.starrocks.fs.hdfs.HdfsFsManager;
+import com.starrocks.thrift.THdfsProperties;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class HdfsUtilTest {
     @Test
@@ -45,5 +53,32 @@ public class HdfsUtilTest {
         } catch (StarRocksException e) {
             Assert.fail(e.getMessage());
         }
+    }
+
+    @Test
+    public void testException() {
+        new MockUp<HdfsFsManager>() {
+            @Mock
+            public HdfsFs getFileSystem(String path, Map<String, String> loadProperties, THdfsProperties tProperties)
+                                        throws StarRocksException {
+                return null;
+            }
+        };
+
+        Assert.assertThrows(StarRocksException.class, () ->
+                HdfsUtil.deletePath("hdfs://abc/dbf", new BrokerDesc(new HashMap<>())));
+
+        Assert.assertThrows(StarRocksException.class, () ->
+                HdfsUtil.rename("hdfs://abc/dbf", "hdfs://abc/dba", new BrokerDesc(new HashMap<>()), 1000));
+
+        Assert.assertThrows(StarRocksException.class, () ->
+                HdfsUtil.checkPathExist("hdfs://abc/dbf", new BrokerDesc(new HashMap<>())));
+
+        HdfsFsManager fileSystemManager = new HdfsFsManager();
+        Assert.assertThrows(StarRocksException.class, () ->
+                fileSystemManager.openReader("hdfs://abc/dbf", 0, new HashMap<>()));
+
+        Assert.assertThrows(StarRocksException.class, () ->
+                fileSystemManager.openWriter("hdfs://abc/dbf", new HashMap<>()));
     }
 }


### PR DESCRIPTION
## Why I'm doing:
Some operation in HdfsFsMgr does not catch all kinds of exception which cause some non-StarRocksException will be throw for the caller. But the caller usually only catch StarRocksException and lead Exception leak

## What I'm doing:
Make sure all exception will be transformed into StarRocksException

Fixes #59770

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
