### PR TITLE
[Enhancement] support minimal docker image for FE/BE

### DIFF
--- a/docker/dockerfiles/be/be-ubuntu.Dockerfile
+++ b/docker/dockerfiles/be/be-ubuntu.Dockerfile
@@ -5,6 +5,8 @@
 #     > DOCKER_BUILDKIT=1 docker build --build-arg ARTIFACT_SOURCE=image --build-arg ARTIFACTIMAGE=starrocks/artifacts-ubuntu:latest -f docker/dockerfiles/be/be-ubuntu.Dockerfile -t be-ubuntu:latest .
 #   - Use locally build artifacts to package runtime container:
 #     > DOCKER_BUILDKIT=1 docker build --build-arg ARTIFACT_SOURCE=local --build-arg LOCAL_REPO_PATH=. -f docker/dockerfiles/be/be-ubuntu.Dockerfile -t be-ubuntu:latest .
+#   - Build the minimal version of the image
+#     > DOCKER_BUILDKIT=1 docker build --build-arg ARTIFACT_SOURCE=image --build-arg ARTIFACTIMAGE=starrocks/artifacts-ubuntu:latest --build-arg MINIMAL=true -f docker/dockerfiles/be/be-ubuntu.Dockerfile -t be-ubuntu-mininal:latest .
 #
 # The artifact source used for packing the runtime docker image
 #   image: copy the artifacts from a artifact docker image.
@@ -14,6 +16,11 @@ ARG ARTIFACT_SOURCE=image
 ARG RUN_AS_USER=root
 # The precreated non-privileged user account, the owner of the starrocks assets
 ARG USER=starrocks
+# Build the minimal version of image, MINIMAL={true|false}
+# NOTE:
+# - if MINIMAL=true, RUN_AS_USER parameter will take no effect, the USER for the container will be set to $USER forcibly
+# TODO: make MINIMAL=true as the default behavior
+ARG MINIMAL=false
 
 
 ARG ARTIFACTIMAGE=starrocks/artifacts-ubuntu:latest
@@ -29,14 +36,17 @@ FROM artifacts-from-${ARTIFACT_SOURCE} as artifacts
 RUN rm -f /release/be_artifacts/be/lib/starrocks_be.debuginfo
 
 
-FROM ubuntu:22.04
+FROM ubuntu:22.04 AS base_image
 ARG STARROCKS_ROOT=/opt/starrocks
 ARG USER
 ARG RUN_AS_USER
 ARG GROUP=starrocks
+ARG MINIMAL
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends \
-        binutils-dev openjdk-17-jdk mysql-client curl vim tree net-tools less tzdata locales pigz inotify-tools rclone gdb && \
+# TODO: switch to `openjdk-##-jre` when the starrocks core is ready.
+RUN OPTIONAL_PKGS="" && if [ "x$MINIMAL" = "xfalse" ] ; then OPTIONAL_PKGS="binutils-dev openjdk-17-jdk curl vim tree net-tools less pigz inotify-tools rclone gdb" ; fi && \
+        apt-get update -y && apt-get install -y --no-install-recommends \
+        openjdk-17-jdk mysql-client tzdata locales $OPTIONAL_PKGS && \
         ln -fs /usr/share/zoneinfo/UTC /etc/localtime && \
         dpkg-reconfigure -f noninteractive tzdata && \
         locale-gen en_US.UTF-8 && \
@@ -64,4 +74,14 @@ COPY --chown=$USER:$GROUP docker/dockerfiles/be/*.sh $STARROCKS_ROOT/
 # Create directory for BE storage, create cn symbolic link to be
 RUN mkdir -p $STARROCKS_ROOT/be/storage && ln -sfT be $STARROCKS_ROOT/cn
 
+
+FROM base_image AS runas_minimal_true
+# Nothing to do, the USER is set to $USER in base_image
+
+
+FROM base_image AS runas_minimal_false
+ARG RUN_AS_USER
 USER $RUN_AS_USER
+
+
+FROM runas_minimal_${MINIMAL}


### PR DESCRIPTION
* introduce `MINIMAL={true|false}` build parameter to control the base image installation. Unnecessary tools will not be installed when
* when MINIMAL=true
  - Unnecessary tools will not be installed
  - RUN_AS_USER set to non-root user forcibily

* Fixes #57746

## Why I'm doing:

## What I'm doing:


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
