### PR TITLE
[BugFix] Fix the hash conflicts for predicate search key

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/PredicateSearchKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PredicateSearchKey.java
@@ -66,7 +66,7 @@ public class PredicateSearchKey {
 
     @Override
     public int hashCode() {
-        return Objects.hash(databaseName, tableName, snapshotId);
+        return Objects.hash(databaseName, tableName, snapshotId, predicate);
     }
 
     @Override


### PR DESCRIPTION
## Why I'm doing:

Fix the issue where hash collisions in the search key lead to incorrect results.

Scope of impact: external table query of iceberg/delta/paimon

validation SQL:
```
select * from xxx where uuid != 2 union all select * from xxx where uuid = 2;
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
