### PR TITLE
[Enhancement] Support changing kafka_broker_list in ALTER ROUTINE LOAD

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/RoutineLoadDataSourceProperties.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/RoutineLoadDataSourceProperties.java
@@ -197,6 +197,12 @@ public class RoutineLoadDataSourceProperties implements ParseNode {
 
         if (properties.containsKey(CreateRoutineLoadStmt.KAFKA_BROKER_LIST_PROPERTY)) {
             kafkaBrokerList = properties.get(CreateRoutineLoadStmt.KAFKA_BROKER_LIST_PROPERTY);
+            // validate broker list if provided
+            try {
+                CreateRoutineLoadStmt.validateKafkaBrokerList(kafkaBrokerList);
+            } catch (AnalysisException e) {
+                throw new AnalysisException(e.getMessage(), e);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/RoutineLoadDataSourceProperties.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/RoutineLoadDataSourceProperties.java
@@ -51,6 +51,7 @@ import java.util.Optional;
 public class RoutineLoadDataSourceProperties implements ParseNode {
 
     private static final ImmutableSet<String> CONFIGURABLE_KAFKA_PROPERTIES_SET = new ImmutableSet.Builder<String>()
+            .add(CreateRoutineLoadStmt.KAFKA_BROKER_LIST_PROPERTY)
             .add(CreateRoutineLoadStmt.KAFKA_PARTITIONS_PROPERTY)
             .add(CreateRoutineLoadStmt.KAFKA_OFFSETS_PROPERTY)
             .add(CreateRoutineLoadStmt.CONFLUENT_SCHEMA_REGISTRY_URL)
@@ -70,6 +71,8 @@ public class RoutineLoadDataSourceProperties implements ParseNode {
     private List<Pair<Integer, Long>> kafkaPartitionOffsets = Lists.newArrayList();
     @SerializedName(value = "customKafkaProperties")
     private Map<String, String> customKafkaProperties = Maps.newHashMap();
+    @SerializedName(value = "kafkaBrokerList")
+    private String kafkaBrokerList;
 
     @SerializedName(value = "pulsarPartitionInitialPositions")
     private List<Pair<String, Long>> pulsarPartitionInitialPositions = Lists.newArrayList();
@@ -101,7 +104,7 @@ public class RoutineLoadDataSourceProperties implements ParseNode {
 
     public boolean hasAnalyzedProperties() {
         if (type.equals("KAFKA")) {
-            return !kafkaPartitionOffsets.isEmpty() || !customKafkaProperties.isEmpty();
+            return !kafkaPartitionOffsets.isEmpty() || !customKafkaProperties.isEmpty() || kafkaBrokerList != null;
         } else if (type.equals("PULSAR")) {
             return !pulsarPartitionInitialPositions.isEmpty() || !customPulsarProperties.isEmpty();
         } else {
@@ -123,6 +126,10 @@ public class RoutineLoadDataSourceProperties implements ParseNode {
 
     public Map<String, String> getCustomKafkaProperties() {
         return customKafkaProperties;
+    }
+
+    public String getKafkaBrokerList() {
+        return kafkaBrokerList;
     }
 
     public List<Pair<String, Long>> getPulsarPartitionInitialPositions() {
@@ -187,6 +194,10 @@ public class RoutineLoadDataSourceProperties implements ParseNode {
         if (properties.containsKey(CreateRoutineLoadStmt.CONFLUENT_SCHEMA_REGISTRY_URL)) {
             confluentSchemaRegistryUrl = properties.get(CreateRoutineLoadStmt.CONFLUENT_SCHEMA_REGISTRY_URL);
         }
+
+        if (properties.containsKey(CreateRoutineLoadStmt.KAFKA_BROKER_LIST_PROPERTY)) {
+            kafkaBrokerList = properties.get(CreateRoutineLoadStmt.KAFKA_BROKER_LIST_PROPERTY);
+        }
     }
 
     private void checkPulsarProperties() throws AnalysisException {
@@ -235,6 +246,9 @@ public class RoutineLoadDataSourceProperties implements ParseNode {
         if (type.equals("KAFKA")) {
             sb.append(", kafka partition offsets: ").append(kafkaPartitionOffsets);
             sb.append(", custom properties: ").append(customKafkaProperties);
+            if (kafkaBrokerList != null) {
+                sb.append(", kafka_broker_list: ").append(kafkaBrokerList);
+            }
         } else if (type.equals("PULSAR")) {
             if (!pulsarPartitionInitialPositions.isEmpty()) {
                 sb.append(", pulsar partition initial positions: ").append(pulsarPartitionInitialPositions);

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -831,13 +831,6 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
                     throw new DdlException("The specified partition is not in the consumed partitions ", e);
                 }
             }
-
-            // validate broker list if provided
-            try {
-                CreateRoutineLoadStmt.validateKafkaBrokerList(dataSourceProperties.getKafkaBrokerList());
-            } catch (AnalysisException e) {
-                throw new DdlException(e.getMessage(), e);
-            }
         }
         super.modifyJob(routineLoadDesc, jobProperties, dataSourceProperties, originStatement, isReplay);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -831,6 +831,13 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
                     throw new DdlException("The specified partition is not in the consumed partitions ", e);
                 }
             }
+
+            // validate broker list if provided
+            try {
+                CreateRoutineLoadStmt.validateKafkaBrokerList(dataSourceProperties.getKafkaBrokerList());
+            } catch (AnalysisException e) {
+                throw new DdlException(e.getMessage(), e);
+            }
         }
         super.modifyJob(routineLoadDesc, jobProperties, dataSourceProperties, originStatement, isReplay);
     }
@@ -858,6 +865,11 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
 
         if (dataSourceProperties.getConfluentSchemaRegistryUrl() != null) {
             confluentSchemaRegistryUrl = dataSourceProperties.getConfluentSchemaRegistryUrl();
+        }
+
+        // modify broker list
+        if (dataSourceProperties.getKafkaBrokerList() != null) {
+            this.brokerList = dataSourceProperties.getKafkaBrokerList();
         }
 
         LOG.info("modify the data source properties of kafka routine load job: {}, datasource properties: {}",

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
@@ -833,7 +833,9 @@ public class CreateRoutineLoadStmt extends DdlStmt {
 
         for (String broker : brokers) {
             if (!Pattern.matches(ENDPOINT_REGEX, broker)) {
-                throw new AnalysisException("kafka_broker_list: " + broker + " does not match pattern " + ENDPOINT_REGEX);
+                throw new AnalysisException(
+                    String.format("%s: %s does not match pattern %s",
+                        KAFKA_BROKER_LIST_PROPERTY, broker, ENDPOINT_REGEX));
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
@@ -697,13 +697,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
         if (Strings.isNullOrEmpty(kafkaBrokerList)) {
             throw new AnalysisException(KAFKA_BROKER_LIST_PROPERTY + " is a required property");
         }
-        String[] kafkaBrokerList = this.kafkaBrokerList.split(",");
-        for (String broker : kafkaBrokerList) {
-            if (!Pattern.matches(ENDPOINT_REGEX, broker)) {
-                throw new AnalysisException(KAFKA_BROKER_LIST_PROPERTY + ":" + broker
-                        + " not match pattern " + ENDPOINT_REGEX);
-            }
-        }
+        validateKafkaBrokerList(kafkaBrokerList);
 
         // check topic
         kafkaTopic = Strings.nullToEmpty(dataSourceProperties.get(KAFKA_TOPIC_PROPERTY)).replaceAll(" ", "");
@@ -826,6 +820,21 @@ public class CreateRoutineLoadStmt extends DdlStmt {
         // check kafka_default_offsets
         if (customKafkaProperties.containsKey(KAFKA_DEFAULT_OFFSETS)) {
             getKafkaOffset(customKafkaProperties.get(KAFKA_DEFAULT_OFFSETS));
+        }
+    }
+
+    public static void validateKafkaBrokerList(String brokerList) throws AnalysisException {
+        if (Strings.isNullOrEmpty(brokerList)) {
+            throw new AnalysisException("kafka_broker_list cannot be empty");
+        }
+
+        String cleanBrokerList = brokerList.replaceAll(" ", "");
+        String[] brokers = cleanBrokerList.split(",");
+
+        for (String broker : brokers) {
+            if (!Pattern.matches(ENDPOINT_REGEX, broker)) {
+                throw new AnalysisException("kafka_broker_list: " + broker + " does not match pattern " + ENDPOINT_REGEX);
+            }
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
@@ -320,7 +320,7 @@ public class RoutineLoadJobTest {
             Assert.assertEquals("{\"0\":\"1701411708409\"}", showInfo.get(15));
             Assert.assertTrue(showInfo.get(10).contains("\"pause_on_fatal_parse_error\":\"true\""));
 
-            
+
             TRoutineLoadJobInfo loadJobInfo = routineLoadJob.toThrift();
             Assert.assertEquals("{\"0\":\"12345\"}", loadJobInfo.getLatest_source_position());
             //The displayed value is the actual value - 1
@@ -348,7 +348,7 @@ public class RoutineLoadJobTest {
             // The lag [xxx] of partition [0] exceeds Config.routine_load_unstable_threshold_second [3600]
             Assert.assertTrue(showInfo.get(16).contains(
                     "partition [0] exceeds Config.routine_load_unstable_threshold_second [3600]"));
-        
+
             TRoutineLoadJobInfo loadJobInfo = routineLoadJob.toThrift();
             Assert.assertEquals("RUNNING", loadJobInfo.getState());
             Assert.assertEquals("", loadJobInfo.getReasons_of_state_changed());
@@ -636,6 +636,50 @@ public class RoutineLoadJobTest {
         Assert.assertEquals("','", routineLoadJob.getColumnSeparator().toString());
         Assert.assertEquals("'A'", routineLoadJob.getRowDelimiter().toString());
         Assert.assertEquals("p1,p2,p3", Joiner.on(",").join(routineLoadJob.getPartitions().getPartitionNames()));
+    }
+
+    @Test
+    public void testKafkaRoutineLoadJobValidBrokerList() throws Exception {
+        KafkaRoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(1L, "job",
+                2L, 3L, "192.168.1.1:9092", "topic");
+        ConnectContext connectContext = UtFrameUtils.createDefaultCtx();
+
+        String validStmt = "alter routine load for db.job1 " +
+                "FROM KAFKA (\"kafka_broker_list\" = \"192.168.1.2:9092,192.168.1.3:9092\")";
+        routineLoadJob.setOrigStmt(new OriginStatement(validStmt, 0));
+
+        try {
+            AlterRoutineLoadStmt stmt = (AlterRoutineLoadStmt) UtFrameUtils.parseStmtWithNewParser(validStmt, connectContext);
+            routineLoadJob.modifyJob(stmt.getRoutineLoadDesc(), stmt.getAnalyzedJobProperties(),
+                    stmt.getDataSourceProperties(), new OriginStatement(validStmt, 0), true);
+
+            // Verify broker list was updated successfully
+            Assert.assertEquals("192.168.1.2:9092,192.168.1.3:9092", routineLoadJob.getBrokerList());
+        } catch (Exception e) {
+            Assert.fail("Valid broker list should not throw exception");
+        }
+    }
+
+    @Test
+    public void testKafkaRoutineLoadJobInvalidBrokerList() throws Exception {
+        KafkaRoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(1L, "job",
+                2L, 3L, "192.168.1.1:9092", "topic");
+        ConnectContext connectContext = UtFrameUtils.createDefaultCtx();
+
+        String invalidStmt = "alter routine load for db.job1 " +
+                "FROM KAFKA (\"kafka_broker_list\" = \"invalid_broker_format\")";
+        routineLoadJob.setOrigStmt(new OriginStatement(invalidStmt, 0));
+
+        try {
+            AlterRoutineLoadStmt stmt = (AlterRoutineLoadStmt) UtFrameUtils.parseStmtWithNewParser(invalidStmt, connectContext);
+            routineLoadJob.modifyJob(stmt.getRoutineLoadDesc(), stmt.getAnalyzedJobProperties(),
+                    stmt.getDataSourceProperties(), new OriginStatement(invalidStmt, 0), false);
+            Assert.fail("Invalid broker list should throw DdlException");
+        } catch (Exception e) {
+            // This should trigger the catch block on line 841-842
+            Assert.assertTrue("Should contain validation error message",
+                    e.getMessage().contains("does not match pattern"));
+        }
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This change adds support for modifying the kafka_broker_list property in ALTER ROUTINE LOAD statements, allowing users to change Kafka broker endpoints for existing routine load jobs.

Changes:
- Add KAFKA_BROKER_LIST_PROPERTY to configurable properties in RoutineLoadDataSourceProperties
- Add broker list field, getter, and validation support
- Update KafkaRoutineLoadJob.modifyDataSourceProperties() to handle broker list changes
- Centralize broker list validation logic in CreateRoutineLoadStmt.validateKafkaBrokerList()
- Add comprehensive unit tests for both valid and invalid broker list modifications

Usage example:
```
ALTER ROUTINE LOAD FOR example_job
FROM KAFKA
(
"kafka_broker_list" = "127.0.0.1:9092"
);
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
