### PR TITLE
[UT] Fix the compile problem using --without-starcache

### DIFF
--- a/be/src/cache/CMakeLists.txt
+++ b/be/src/cache/CMakeLists.txt
@@ -23,7 +23,6 @@ set(CACHE_FILES
   mem_space_monitor.cpp
   datacache.cpp
   datacache_utils.cpp
-  peer_cache_wrapper.cpp
   block_cache/block_cache.cpp
   block_cache/io_buffer.cpp
   block_cache/block_cache_hit_rate_counter.hpp
@@ -34,6 +33,7 @@ set(CACHE_FILES
 if (${WITH_STARCACHE} STREQUAL "ON")
     list(APPEND CACHE_FILES starcache_wrapper.cpp)
     list(APPEND CACHE_FILES object_cache/starcache_module.cpp)
+    list(APPEND CACHE_FILES peer_cache_wrapper.cpp)
 endif()
 
 add_library(Cache STATIC

--- a/be/src/cache/block_cache/block_cache.cpp
+++ b/be/src/cache/block_cache/block_cache.cpp
@@ -17,7 +17,6 @@
 #include <fmt/format.h>
 
 #include "cache/datacache.h"
-#include "cache/peer_cache_wrapper.h"
 #include "common/statusor.h"
 #include "gutil/strings/substitute.h"
 

--- a/be/src/cache/datacache.cpp
+++ b/be/src/cache/datacache.cpp
@@ -19,7 +19,6 @@
 #include "cache/mem_space_monitor.h"
 #include "cache/object_cache/lrucache_module.h"
 #include "cache/object_cache/page_cache.h"
-#include "cache/peer_cache_wrapper.h"
 #include "common/status.h"
 #include "gutil/strings/split.h"
 #include "gutil/strings/strip.h"
@@ -28,6 +27,7 @@
 
 #ifdef WITH_STARCACHE
 #include "cache/object_cache/starcache_module.h"
+#include "cache/peer_cache_wrapper.h"
 #include "cache/starcache_wrapper.h"
 #endif
 

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -23,7 +23,6 @@
 #include "backend_service.h"
 #include "cache/block_cache/block_cache.h"
 #include "cache/datacache.h"
-#include "cache/starcache_wrapper.h"
 #include "common/config.h"
 #include "common/daemon.h"
 #include "common/process_exit.h"
@@ -48,6 +47,10 @@
 #include "util/mem_info.h"
 #include "util/thrift_rpc_helper.h"
 #include "util/thrift_server.h"
+
+#ifdef WITH_STARCACHE
+#include "cache/starcache_wrapper.h"
+#endif
 
 namespace brpc {
 


### PR DESCRIPTION
## Why I'm doing:

```
/root/starrocks/be/src/cache/starcache_wrapper.h:19:10: fatal error: starcache/star_cache.h: No such file or directory                                                                                             
   19 | #include "starcache/star_cache.h"                                                                                                                                                                          
      |          ^~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                                                          
compilation terminated. 
```

`PeerCache` should also depend on `WITH_STARCACHE`

## What I'm doing:

Fix the compile problem using --without-starcache

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
