### PR TITLE
[BugFix] fix invalid json string when parsing PipeFileRecord

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/InvalidOlapTableStateException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/InvalidOlapTableStateException.java
@@ -32,31 +32,31 @@ public class InvalidOlapTableStateException extends DdlException {
         String errorPrompt;
         switch (state) {
             case ROLLUP:
-                errorPrompt = String.format("A materialized view or rollup index is being created on the table \"%s\". " +
-                                "Please wait until the current operation completes.\n" +
+                errorPrompt = String.format("A materialized view or rollup index is being created on the table %s. " +
+                                "Please wait until the current operation completes. " +
                                 "To check the status of the operation, see %s or %s",
                         table,
                         FeConstants.DOCUMENT_SHOW_ALTER_MATERIALIZED_VIEW,
                         FeConstants.DOCUMENT_SHOW_ALTER);
                 break;
             case SCHEMA_CHANGE:
-                errorPrompt = String.format("A schema change operation is in progress on the table \"%s\". " +
-                                "Please wait until the current operation completes.\n" +
+                errorPrompt = String.format("A schema change operation is in progress on the table %s. " +
+                                "Please wait until the current operation completes. " +
                                 "To check the status of the operation, see %s",
                         table,
                         FeConstants.DOCUMENT_SHOW_ALTER);
                 break;
             case BACKUP:
-                errorPrompt = String.format("A backup operation is in progress on the table \"%s\". " +
-                                "Please wait until the current operation completes.\n" +
+                errorPrompt = String.format("A backup operation is in progress on the table %s. " +
+                                "Please wait until the current operation completes. " +
                                 "To check the status of the operation, see %s",
                         table,
                         FeConstants.DOCUMENT_SHOW_BACKUP);
                 break;
             case RESTORE:
             case RESTORE_WITH_LOAD:
-                errorPrompt = String.format("A snapshot restore operation is in progress on the table \"%s\". " +
-                                "Please wait until the current operation completes.\n" +
+                errorPrompt = String.format("A snapshot restore operation is in progress on the table %s. " +
+                                "Please wait until the current operation completes. " +
                                 "To check the status of the operation, see %s",
                         table,
                         FeConstants.DOCUMENT_SHOW_RESTORE);
@@ -67,15 +67,15 @@ public class InvalidOlapTableStateException extends DdlException {
                         "To check the status of the operation, see \n" +
                         FeConstants.DOCUMENT_SHOW_ALTER + " or\n" + FeConstants.DOCUMENT_SHOW_ALTER_MATERIALIZED_VIEW;
 
-                errorPrompt = String.format("The table \"%s\" is being altered or having a materialized view built on it. " +
-                                "Please wait until the current operation completes.\n" +
+                errorPrompt = String.format("The table %s is being altered or having a materialized view built on it. " +
+                                "Please wait until the current operation completes. " +
                                 "To check the status of the operation, see %s or %s",
                         table,
                         FeConstants.DOCUMENT_SHOW_ALTER,
                         FeConstants.DOCUMENT_SHOW_ALTER_MATERIALIZED_VIEW);
                 break;
             default:
-                errorPrompt = String.format("The table \"%s\" is currently in state \"%s\"", table, state.name());
+                errorPrompt = String.format("The table %s is currently in state %s", table, state.name());
                 break;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/PipeFileRecord.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/PipeFileRecord.java
@@ -18,6 +18,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.load.pipe.filelist.FileListRepo;
@@ -53,7 +54,7 @@ public class PipeFileRecord {
     //   "errorCount": 123,
     //   "errorLine": 123
     // }
-    private static final String JSON_FIELD_ERROR_MESSAGE = "errorMessage";
+    public static final String JSON_FIELD_ERROR_MESSAGE = "errorMessage";
     private static final String JSON_FIELD_ERROR_COUNT = "errorCount";
     private static final String JSON_FIELD_ERROR_LINE = "errorLine";
 
@@ -138,12 +139,16 @@ public class PipeFileRecord {
             // Error info are encapsulated in a json object
             if (dataArray.size() > 9) {
                 String errorInfo = dataArray.get(9).getAsString();
-                if (StringUtils.isNotEmpty(errorInfo)) {
-                    JsonObject infoJson = (JsonObject) JsonParser.parseString(errorInfo);
-                    JsonElement errorMessageElement = infoJson.get(JSON_FIELD_ERROR_MESSAGE);
-                    if (errorMessageElement != null && !errorMessageElement.isJsonNull()) {
-                        file.errorMessage = errorMessageElement.getAsString();
+                try {
+                    if (StringUtils.isNotEmpty(errorInfo)) {
+                        JsonObject infoJson = (JsonObject) JsonParser.parseString(errorInfo);
+                        JsonElement errorMessageElement = infoJson.get(JSON_FIELD_ERROR_MESSAGE);
+                        if (errorMessageElement != null && !errorMessageElement.isJsonNull()) {
+                            file.errorMessage = errorMessageElement.getAsString();
+                        }
                     }
+                } catch (JsonSyntaxException e) {
+                    file.errorMessage = "parse json error";
                 }
             }
             if (dataArray.size() > 10) {

--- a/fe/fe-core/src/test/java/com/starrocks/load/pipe/filelist/FileListRepoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/pipe/filelist/FileListRepoTest.java
@@ -16,6 +16,11 @@ package com.starrocks.load.pipe.filelist;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.InvalidOlapTableStateException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.Status;
@@ -48,6 +53,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.starrocks.load.pipe.PipeFileRecord.JSON_FIELD_ERROR_MESSAGE;
 
 public class FileListRepoTest {
 
@@ -120,6 +127,15 @@ public class FileListRepoTest {
                         "NULL, '2023-07-01 01:01:01', " +
                         "'2023-07-01 01:01:01', '2023-07-01 01:01:01', '{\"errorMessage\":null}', '')",
                 valueList);
+
+        // test error message
+        InvalidOlapTableStateException exp = InvalidOlapTableStateException.of(OlapTable.OlapTableState.SCHEMA_CHANGE, "my_tbl");
+        String errorInfo = exp.getMessage();
+        json = "{\"errorMessage\":\"" + errorInfo + "\"}";
+        JsonObject infoJson = (JsonObject) JsonParser.parseString(json);
+        JsonElement errorMessageElement = infoJson.get(JSON_FIELD_ERROR_MESSAGE);
+        Assert.assertTrue(errorMessageElement.getAsString().contains(
+                "A schema change operation is in progress on the table my_tbl"));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
```
"errorMessage":"execution failed: txn_id=6650 failed. A schema change operation is in progress on the table "duplicate_complex_table_200_abnormal_range_partition". Please wait until the current operation completes.
To check the status of the operation, see https://docs.starrocks.io/docs/sql-reference/sql-statements/data-manipulation/SHOW_ALTER: BE:10002"}
```
this is not a valid json string. fe will throw exception when paring this json string. 

1. fix invalid json string
2. catch parse exception

Fixes #issue
https://github.com/StarRocks/StarRocksTest/issues/9789


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
