### PR TITLE
[Feature] support int256 data type

### DIFF
--- a/be/src/types/CMakeLists.txt
+++ b/be/src/types/CMakeLists.txt
@@ -27,4 +27,5 @@ add_library(Types STATIC
     timestamp_value.cpp
     checker/type_checker.cpp
     type_checker_manager.cpp
+    int256.cpp
 )

--- a/be/src/types/int256.cpp
+++ b/be/src/types/int256.cpp
@@ -1,0 +1,174 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "types/int256.h"
+
+#include <glog/logging.h>
+
+#include <algorithm>
+
+namespace starrocks {
+
+// =============================================================================
+// Division Implementation
+// =============================================================================
+
+// TODO(stephen): optimize this operator in the next patch
+int256_t int256_t::operator/(const int256_t& other) const {
+    if (other.high == 0 && other.low == 0) {
+        throw std::domain_error("Division by zero");
+    }
+
+    if (high == 0 && low == 0) return int256_t(0);
+    if (*this == other) return int256_t(1);
+
+    bool negative = (high < 0) != (other.high < 0);
+    int256_t dividend = (high < 0) ? -*this : *this;
+    int256_t divisor = (other.high < 0) ? -other : other;
+
+    if (dividend < divisor) return int256_t(0);
+
+    if (divisor.high == 0 && divisor.low == 1) {
+        return negative ? -dividend : dividend;
+    }
+
+    int256_t quotient(0);
+    int256_t remainder(0);
+
+    for (int i = 255; i >= 0; i--) {
+        remainder = remainder << 1;
+
+        if (i >= 128) {
+            if ((dividend.high >> (i - 128)) & 1) {
+                remainder.low |= 1;
+            }
+        } else {
+            if ((dividend.low >> i) & 1) {
+                remainder.low |= 1;
+            }
+        }
+
+        if (remainder >= divisor) {
+            remainder = remainder - divisor;
+            if (i >= 128) {
+                quotient.high |= (static_cast<int128_t>(1) << (i - 128));
+            } else {
+                quotient.low |= (static_cast<uint128_t>(1) << i);
+            }
+        }
+    }
+
+    return negative ? -quotient : quotient;
+}
+
+// =============================================================================
+// Modulo Implementation
+// =============================================================================
+
+int256_t int256_t::operator%(const int256_t& other) const {
+    if (other.high == 0 && other.low == 0) {
+        throw std::domain_error("Division by zero");
+    }
+
+    if (high == 0 && low == 0) return int256_t(0);
+    if (*this == other) return int256_t(0);
+
+    int256_t quotient = *this / other;
+    int256_t remainder = *this - (quotient * other);
+    return remainder;
+}
+
+// =============================================================================
+// Utility Functions Implementation
+// =============================================================================
+
+std::string int256_t::to_string() const {
+    if (high == 0 && low == 0) {
+        return "0";
+    }
+    int256_t temp = *this;
+    bool negative = false;
+    if (temp.high < 0) {
+        negative = true;
+        temp = -temp;
+    }
+    std::string result;
+    while (temp.high != 0 || temp.low != 0) {
+        uint32_t rem;
+        int256_t quot;
+        divmod_u32(temp, 10, &quot, &rem);
+        result.push_back('0' + rem);
+        temp = quot;
+    }
+    if (negative) result.push_back('-');
+    std::reverse(result.begin(), result.end());
+    return result;
+}
+
+void divmod_u32(const int256_t& value, uint32_t divisor, int256_t* quotient, uint32_t* remainder) {
+    uint64_t parts[4];
+    parts[0] = static_cast<uint64_t>(value.low);
+    parts[1] = static_cast<uint64_t>(value.low >> 64);
+    parts[2] = static_cast<uint64_t>(value.high);
+    parts[3] = static_cast<uint64_t>(value.high >> 64);
+
+    uint64_t q[4] = {0, 0, 0, 0};
+    uint64_t r = 0;
+    for (int i = 3; i >= 0; --i) {
+        __uint128_t acc = (static_cast<__uint128_t>(r) << 64) | parts[i];
+        q[i] = static_cast<uint64_t>(acc / divisor);
+        r = static_cast<uint64_t>(acc % divisor);
+    }
+    *quotient = int256_t((static_cast<__int128_t>(q[3]) << 64) | q[2], (static_cast<__uint128_t>(q[1]) << 64) | q[0]);
+    *remainder = r;
+}
+
+int256_t parse_int256(const std::string& str) {
+    if (str.empty()) {
+        throw std::invalid_argument("empty string");
+    }
+
+    int256_t result = 0;
+    bool negative = false;
+    size_t i = 0;
+
+    if (str[0] == '-') {
+        negative = true;
+        i = 1;
+        if (i >= str.size()) {
+            throw std::invalid_argument("only minus sign");
+        }
+    }
+
+    bool has_digits = false;
+
+    for (; i < str.size(); ++i) {
+        if (str[i] < '0' || str[i] > '9') {
+            throw std::invalid_argument("invalid digit");
+        }
+        has_digits = true;
+        result = result * 10 + (str[i] - '0');
+    }
+
+    if (!has_digits) {
+        throw std::invalid_argument("no valid digits");
+    }
+
+    return negative ? -result : result;
+}
+
+} // namespace starrocks

--- a/be/src/types/int256.cpp
+++ b/be/src/types/int256.cpp
@@ -1,19 +1,16 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include "types/int256.h"
 

--- a/be/src/types/int256.cpp
+++ b/be/src/types/int256.cpp
@@ -24,6 +24,42 @@
 namespace starrocks {
 
 // =============================================================================
+// Type Conversion Operators Implementation
+// =============================================================================
+
+int256_t::operator double() const {
+    if (*this == 0) return 0.0;
+
+    bool negative = (high < 0);
+    int256_t abs_val = negative ? -*this : *this;
+
+    // Find the position of the most significant bit
+    int bit_count = 0;
+    int256_t temp = abs_val;
+    while (temp > 0) {
+        temp >>= 1;
+        bit_count++;
+    }
+
+    if (bit_count <= 53) {
+        // Can represent exactly in double
+        double result = static_cast<double>(static_cast<uint64_t>(abs_val.low));
+        if (abs_val.high != 0) {
+            result += static_cast<double>(static_cast<uint64_t>(abs_val.high)) * (1ULL << 32) * (1ULL << 32) *
+                      (1ULL << 32) * (1ULL << 32);
+        }
+        return negative ? -result : result;
+    } else {
+        // Need to round to fit in double precision
+        int shift = bit_count - 53;
+        int256_t rounded = (abs_val + (int256_t(1) << (shift - 1))) >> shift;
+        double mantissa = static_cast<double>(static_cast<uint64_t>(rounded.low));
+        double result = mantissa * pow(2.0, shift);
+        return negative ? -result : result;
+    }
+}
+
+// =============================================================================
 // Division Implementation
 // =============================================================================
 

--- a/be/src/types/int256.h
+++ b/be/src/types/int256.h
@@ -1,19 +1,17 @@
 // Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #pragma once
 
@@ -30,30 +28,25 @@ typedef unsigned __int128 uint128_t;
 
 /**
 *
-* This file implements a 256-bit signed integer type int256_t for high-precision integer arithmetic.
+* This file implements a 256-bit signed integer type using two 128-bit components.
 *
-* ## Storage Format
+* ## Memory Layout
 *
-* int256_t uses two 128-bit integers to represent 256-bit data:
-* - high: Upper 128 bits (int128_t, signed)
-* - low:  Lower 128 bits (uint128_t, unsigned)
-*
-* **Structure Member Layout**:
-* The order of members in memory is determined by the conditional compilation:
+* Structure member layout in memory depends on CPU endianness:
 * - On little-endian systems: low member declared first, high member declared second
 * - On big-endian systems: high member declared first, low member declared second
 *
-* ## Storage Example (Little Endian)
-*
-* Consider a 256-bit hexadecimal value:
-* 0x123456789ABCDEF0FEDCBA0987654321_0123456789ABCDEFEDCBA09876543210
-*
-* This breaks down as:
-* - high (upper 128 bits): 0x123456789ABCDEF0FEDCBA0987654321
+* For a 256-bit value 0x123456789ABCDEF0FEDCBA0987654321_0123456789ABCDEFEDCBA09876543210:
 * - low (lower 128 bits):  0x0123456789ABCDEFEDCBA09876543210
+* - high (upper 128 bits): 0x123456789ABCDEF0FEDCBA0987654321
 *
-* ## Memory Layout (Little Endian)
+* Little-endian CPU memory layout:
+* Address   | Content
+* ----------|-----------
+* 0x00-0x0F | low member
+* 0x10-0x1F | high member
 *
+* ### Examples:
 * ```
 * Memory grows from LEFT to RIGHT →
 *
@@ -70,7 +63,7 @@ typedef unsigned __int128 uint128_t;
 *
 * **Address Space Breakdown**:
 * - 0x1000 - 0x100F: First 128-bit member (16 bytes) - low part
-* - 0x1010 - 0x101F: Second 128-bit member (16 bytes) - high part
+* - 0x1010 - 0x101F: Second 128-bit member (16 bytes)- high part
 * - Total: 32 bytes (256 bits) for complete int256_t
 *
 * **Address Calculation**:

--- a/be/src/types/int256.h
+++ b/be/src/types/int256.h
@@ -148,37 +148,7 @@ public:
     operator bool() const { return high != 0 || low != 0; }
 
     /// High precision conversion using bit manipulation
-    operator double() const {
-        if (*this == 0) return 0.0;
-
-        bool negative = (high < 0);
-        int256_t abs_val = negative ? -*this : *this;
-
-        // Find the position of the most significant bit
-        int bit_count = 0;
-        int256_t temp = abs_val;
-        while (temp > 0) {
-            temp >>= 1;
-            bit_count++;
-        }
-
-        if (bit_count <= 53) {
-            // Can represent exactly in double
-            double result = static_cast<double>(static_cast<uint64_t>(abs_val.low));
-            if (abs_val.high != 0) {
-                result += static_cast<double>(static_cast<uint64_t>(abs_val.high)) * (1ULL << 32) * (1ULL << 32) *
-                          (1ULL << 32) * (1ULL << 32);
-            }
-            return negative ? -result : result;
-        } else {
-            // Need to round to fit in double precision
-            int shift = bit_count - 53;
-            int256_t rounded = (abs_val + (int256_t(1) << (shift - 1))) >> shift;
-            double mantissa = static_cast<double>(static_cast<uint64_t>(rounded.low));
-            double result = mantissa * pow(2.0, shift);
-            return negative ? -result : result;
-        }
-    }
+    operator double() const;
 
     // =============================================================================
     // Unary Operators

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -404,7 +404,6 @@ set(EXEC_FILES
         ./runtime/fragment_mgr_test.cpp
         ./runtime/http_result_writer_test.cpp
         ./runtime/int128_arithmetic_ops_test.cpp
-        types/int256_test.cpp
         ./runtime/kafka_consumer_pipe_test.cpp
         ./runtime/local_tablets_channel_test.cpp
         ./runtime/lake_tablets_channel_test.cpp
@@ -441,6 +440,7 @@ set(EXEC_FILES
         ./serde/column_array_serde_test.cpp
         ./serde/protobuf_serde_test.cpp
         ./types/bitmap_value_test.cpp
+        ./types/int256_test.cpp
         ./types/type_checker_test.cpp
         ./simd/batch_run_counter_test.cpp
         ./simd/simd_test.cpp

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -404,7 +404,7 @@ set(EXEC_FILES
         ./runtime/fragment_mgr_test.cpp
         ./runtime/http_result_writer_test.cpp
         ./runtime/int128_arithmetic_ops_test.cpp
-        ./runtime/int256_test.cpp
+        types/int256_test.cpp
         ./runtime/kafka_consumer_pipe_test.cpp
         ./runtime/local_tablets_channel_test.cpp
         ./runtime/lake_tablets_channel_test.cpp

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -404,6 +404,7 @@ set(EXEC_FILES
         ./runtime/fragment_mgr_test.cpp
         ./runtime/http_result_writer_test.cpp
         ./runtime/int128_arithmetic_ops_test.cpp
+        ./runtime/int256_test.cpp
         ./runtime/kafka_consumer_pipe_test.cpp
         ./runtime/local_tablets_channel_test.cpp
         ./runtime/lake_tablets_channel_test.cpp

--- a/be/test/runtime/int256_test.cpp
+++ b/be/test/runtime/int256_test.cpp
@@ -1,0 +1,1079 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "types/int256.h"
+
+#include <gtest/gtest.h>
+
+#include <limits>
+#include <sstream>
+#include <string>
+
+namespace starrocks {
+
+class Int256Test : public testing::Test {
+public:
+    Int256Test() = default;
+
+protected:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+// =============================================================================
+// Constructor Tests
+// =============================================================================
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, default_constructor) {
+    int256_t value;
+    ASSERT_EQ(0, value.high);
+    ASSERT_EQ(0, value.low);
+    ASSERT_EQ("0", value.to_string());
+    ASSERT_FALSE(static_cast<bool>(value));
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, constructor_from_high_low) {
+    int256_t value(1, 0);
+    ASSERT_EQ(1, value.high);
+    ASSERT_EQ(0, value.low);
+
+    int256_t value2(-1, static_cast<uint128_t>(-1));
+    ASSERT_EQ(-1, value2.high);
+    ASSERT_EQ(static_cast<uint128_t>(-1), value2.low);
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, constructor_from_int) {
+    {
+        int256_t value(42);
+        ASSERT_EQ(0, value.high);
+        ASSERT_EQ(42, value.low);
+        ASSERT_EQ("42", value.to_string());
+    }
+
+    {
+        int256_t value(-42);
+        ASSERT_EQ(-1, value.high);
+        ASSERT_EQ(static_cast<uint128_t>(-42), value.low);
+        ASSERT_EQ("-42", value.to_string());
+    }
+
+    {
+        int256_t value(0);
+        ASSERT_EQ(0, value.high);
+        ASSERT_EQ(0, value.low);
+        ASSERT_EQ("0", value.to_string());
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, constructor_from_long) {
+    {
+        long val = 1234567890L;
+        int256_t value(val);
+        ASSERT_EQ(0, value.high);
+        ASSERT_EQ(static_cast<uint128_t>(val), value.low);
+        ASSERT_EQ("1234567890", value.to_string());
+    }
+
+    {
+        long val = -1234567890L;
+        int256_t value(val);
+        ASSERT_EQ(-1, value.high);
+        ASSERT_EQ(static_cast<uint128_t>(val), value.low);
+        ASSERT_EQ("-1234567890", value.to_string());
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, constructor_from_int128) {
+    {
+        __int128 val = static_cast<__int128>(1) << 100;
+        int256_t value(val);
+        ASSERT_EQ(0, value.high);
+        ASSERT_EQ(static_cast<uint128_t>(val), value.low);
+    }
+
+    {
+        __int128 val = -(static_cast<__int128>(1) << 100);
+        int256_t value(val);
+        ASSERT_EQ(-1, value.high);
+        ASSERT_EQ(static_cast<uint128_t>(val), value.low);
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, constructor_from_float) {
+    {
+        float val = 123.456f;
+        int256_t value(val);
+        ASSERT_EQ("123", value.to_string());
+    }
+
+    {
+        float val = -123.456f;
+        int256_t value(val);
+        ASSERT_EQ("-123", value.to_string());
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, constructor_from_double) {
+    {
+        double val = 123456.789;
+        int256_t value(val);
+        ASSERT_EQ("123456", value.to_string());
+    }
+
+    {
+        double val = -123456.789;
+        int256_t value(val);
+        ASSERT_EQ("-123456", value.to_string());
+    }
+}
+
+// =============================================================================
+// Type Conversion Tests
+// =============================================================================
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, bool_conversion) {
+    ASSERT_FALSE(static_cast<bool>(int256_t(0)));
+    ASSERT_TRUE(static_cast<bool>(int256_t(1)));
+    ASSERT_TRUE(static_cast<bool>(int256_t(-1)));
+    ASSERT_TRUE(static_cast<bool>(int256_t(1, 0)));
+    ASSERT_TRUE(static_cast<bool>(int256_t(0, 1)));
+}
+
+// =============================================================================
+// Unary Operator Tests
+// =============================================================================
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, unary_negation) {
+    {
+        int256_t value(42);
+        int256_t neg_value = -value;
+        ASSERT_EQ("-42", neg_value.to_string());
+        ASSERT_EQ("42", (-neg_value).to_string());
+    }
+
+    {
+        int256_t value(0);
+        int256_t neg_value = -value;
+        ASSERT_EQ("0", neg_value.to_string());
+    }
+
+    {
+        int256_t value(1, 0); // 2^128
+        int256_t neg_value = -value;
+        ASSERT_EQ(-1, neg_value.high);
+        ASSERT_EQ(0, neg_value.low);
+    }
+
+    {
+        int256_t value(0, 1);
+        int256_t neg_value = -value;
+        ASSERT_EQ(-1, neg_value.high);
+        ASSERT_EQ(static_cast<uint128_t>(-1), neg_value.low);
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, unary_plus) {
+    int256_t value(42);
+    int256_t plus_value = +value;
+    ASSERT_EQ(value, plus_value);
+    ASSERT_EQ("42", plus_value.to_string());
+}
+
+// =============================================================================
+// Comparison Operator Tests
+// =============================================================================
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, equality_comparison) {
+    int256_t value1(42);
+    int256_t value2(42);
+    int256_t value3(43);
+
+    ASSERT_TRUE(value1 == value2);
+    ASSERT_FALSE(value1 == value3);
+    ASSERT_FALSE(value1 != value2);
+    ASSERT_TRUE(value1 != value3);
+
+    // Test with int
+    ASSERT_TRUE(value1 == 42);
+    ASSERT_FALSE(value1 == 43);
+    ASSERT_FALSE(value1 != 42);
+    ASSERT_TRUE(value1 != 43);
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, ordering_comparison) {
+    int256_t small(10);
+    int256_t medium(20);
+    int256_t large(30);
+    int256_t negative(-10);
+
+    // Less than
+    ASSERT_TRUE(small < medium);
+    ASSERT_TRUE(medium < large);
+    ASSERT_TRUE(negative < small);
+    ASSERT_FALSE(medium < small);
+
+    // Less than or equal
+    ASSERT_TRUE(small <= medium);
+    ASSERT_TRUE(small <= int256_t(10));
+    ASSERT_FALSE(medium <= small);
+
+    // Greater than
+    ASSERT_TRUE(large > medium);
+    ASSERT_TRUE(medium > small);
+    ASSERT_TRUE(small > negative);
+    ASSERT_FALSE(small > medium);
+
+    // Greater than or equal
+    ASSERT_TRUE(large >= medium);
+    ASSERT_TRUE(medium >= int256_t(20));
+    ASSERT_FALSE(small >= medium);
+
+    // Test with int
+    ASSERT_TRUE(small < 15);
+    ASSERT_TRUE(small <= 10);
+    ASSERT_TRUE(large > 25);
+    ASSERT_TRUE(large >= 30);
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, comparison_with_high_bits) {
+    int256_t value1(1, 0);                          // 2^128
+    int256_t value2(2, 0);                          // 2 * 2^128
+    int256_t value3(0, static_cast<uint128_t>(-1)); // 2^128 - 1
+
+    ASSERT_TRUE(value1 > value3);
+    ASSERT_TRUE(value2 > value1);
+    ASSERT_TRUE(value3 < value1);
+
+    // Negative high bits
+    int256_t neg_value(-1, 0);
+    ASSERT_TRUE(neg_value < value3);
+    ASSERT_TRUE(neg_value < value1);
+}
+
+// =============================================================================
+// Addition Tests
+// =============================================================================
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, addition_basic) {
+    {
+        int256_t a(10);
+        int256_t b(20);
+        int256_t result = a + b;
+        ASSERT_EQ("30", result.to_string());
+    }
+
+    {
+        int256_t a(-10);
+        int256_t b(20);
+        int256_t result = a + b;
+        ASSERT_EQ("10", result.to_string());
+    }
+
+    {
+        int256_t a(-10);
+        int256_t b(-20);
+        int256_t result = a + b;
+        ASSERT_EQ("-30", result.to_string());
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, addition_with_overflow) {
+    {
+        int256_t a(0, static_cast<uint128_t>(-1)); // 2^128 - 1
+        int256_t b(0, 1);
+        int256_t result = a + b;
+        ASSERT_EQ(1, result.high);
+        ASSERT_EQ(0, result.low);
+    }
+
+    {
+        int256_t a(0, static_cast<uint128_t>(-2)); // 2^128 - 2
+        int256_t b(0, 3);
+        int256_t result = a + b;
+        ASSERT_EQ(1, result.high);
+        ASSERT_EQ(1, result.low);
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, addition_with_int) {
+    int256_t a(100);
+    int256_t result = a + 50;
+    ASSERT_EQ("150", result.to_string());
+
+    int256_t result2 = a + (-150);
+    ASSERT_EQ("-50", result2.to_string());
+}
+
+// =============================================================================
+// Addition Overflow Tests
+// =============================================================================
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, addition_positive_overflow) {
+    // Test case 1: INT256_MAX + 1 should overflow
+    {
+        int256_t max_val = INT256_MAX; // 2^255 - 1
+        int256_t one(1);
+        int256_t result = max_val + one;
+
+        // After overflow, should wrap to INT256_MIN
+        ASSERT_EQ(INT256_MIN, result);
+    }
+
+    // Test case 2: INT256_MAX + INT256_MAX should overflow significantly
+    {
+        int256_t max_val = INT256_MAX;
+        int256_t result = max_val + max_val;
+
+        // 2 * (2^255 - 1) = 2^256 - 2, which overflows to -2 in two's complement
+        int256_t expected(-1, static_cast<uint128_t>(-2));
+        ASSERT_EQ(expected, result);
+        ASSERT_EQ("-2", result.to_string());
+    }
+
+    // Test case 3: Near maximum values
+    {
+        int256_t near_max(INT256_MAX.high, INT256_MAX.low - 100); // INT256_MAX - 100
+        int256_t large_positive(200);
+        int256_t result = near_max + large_positive;
+
+        // Should overflow by 100
+        int256_t expected(INT256_MIN.high, INT256_MIN.low + 99); // INT256_MIN + 99
+        ASSERT_EQ(expected, result);
+    }
+
+    // Test case 4: Large positive numbers causing overflow
+    {
+        // Create two large positive numbers that sum > INT256_MAX
+        int256_t large1(static_cast<int128_t>((static_cast<uint128_t>(1) << 126)), 0); // 2^254
+        int256_t large2(static_cast<int128_t>((static_cast<uint128_t>(1) << 126)), 0); // 2^254
+        int256_t result = large1 + large2;
+
+        // 2^254 + 2^254 = 2^255, which equals INT256_MIN (since it's the sign bit)
+        ASSERT_EQ(INT256_MIN, result);
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, addition_negative_overflow) {
+    // Test case 1: INT256_MIN + (-1) should underflow
+    {
+        int256_t min_val = INT256_MIN; // -2^255
+        int256_t neg_one(-1);
+        int256_t result = min_val + neg_one;
+
+        // After underflow, should wrap to INT256_MAX
+        ASSERT_EQ(INT256_MAX, result);
+    }
+
+    // Test case 2: INT256_MIN + INT256_MIN should underflow significantly
+    {
+        int256_t min_val = INT256_MIN;
+        int256_t result = min_val + min_val;
+
+        // 2 * (-2^255) = -2^256, which wraps to 0 in 256-bit arithmetic
+        int256_t expected(0, 0);
+        ASSERT_EQ(expected, result);
+        ASSERT_EQ("0", result.to_string());
+    }
+
+    // Test case 3: Near minimum values
+    {
+        int256_t near_min(INT256_MIN.high, INT256_MIN.low + 50); // INT256_MIN + 50
+        int256_t large_negative(-100);
+        int256_t result = near_min + large_negative;
+
+        // Should underflow by 50
+        int256_t expected(INT256_MAX.high, INT256_MAX.low - 49); // INT256_MAX - 49
+        ASSERT_EQ(expected, result);
+    }
+
+    // Test case 4: Large negative numbers causing underflow
+    {
+        int256_t large_neg1(-1, static_cast<uint128_t>(1) << 126); // Very large negative
+        int256_t large_neg2(-1, static_cast<uint128_t>(1) << 126); // Very large negative
+        int256_t result = large_neg1 + large_neg2;
+
+        std::cout << "Large negative + Large negative = " << result.to_string() << std::endl;
+        ASSERT_TRUE(result < int256_t(0));
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, addition_mixed_overflow_cases) {
+    // Test case 1: Positive + Negative near boundaries
+    {
+        int256_t max_val = INT256_MAX;
+        int256_t small_neg(-10);
+        int256_t result = max_val + small_neg;
+
+        // Should not overflow, just subtract
+        int256_t expected(INT256_MAX.high, INT256_MAX.low - 10);
+        ASSERT_EQ(expected, result);
+    }
+
+    // Test case 2: Very large positive + very large negative (no overflow)
+    {
+        int256_t large_pos = INT256_MAX;
+        int256_t large_neg = INT256_MIN;
+        int256_t result = large_pos + large_neg;
+
+        // INT256_MAX + INT256_MIN = -1
+        ASSERT_EQ("-1", result.to_string());
+    }
+
+    // Test case 3: Overflow detection in low part affecting high part
+    {
+        int256_t value1(0, static_cast<uint128_t>(-1)); // high=0, low=2^128-1
+        int256_t value2(0, 2);                          // high=0, low=2
+        int256_t result = value1 + value2;
+
+        // Low part overflows, should increment high part
+        ASSERT_EQ(1, result.high);
+        ASSERT_EQ(1, result.low);
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, addition_boundary_values) {
+    // Test exact boundary conditions
+    {
+        // Test adding 1 to various boundary values
+        std::vector<int256_t> boundary_values = {
+                INT256_MAX,      INT256_MIN, int256_t(0, static_cast<uint128_t>(-1)), // 2^128 - 1
+                int256_t(1, 0),                                                       // 2^128
+                int256_t(-1, 0),                                                      // -2^128
+        };
+
+        for (const auto& boundary : boundary_values) {
+            boundary + int256_t(1);
+
+            // Verify the operation completed (no exceptions)
+            ASSERT_TRUE(true); // Just ensure we reach this point
+        }
+    }
+
+    // Test subtracting 1 from boundary values
+    {
+        std::vector<int256_t> boundary_values = {
+                INT256_MAX, INT256_MIN, int256_t(0, 0), // Zero
+                int256_t(1, 0),                         // 2^128
+        };
+
+        for (const auto& boundary : boundary_values) {
+            boundary + int256_t(-1);
+
+            // Verify the operation completed (no exceptions)
+            ASSERT_TRUE(true);
+        }
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, addition_performance_with_overflow) {
+    // Test that overflow handling doesn't cause performance issues
+    {
+        int256_t accumulator(0);
+        int256_t increment = INT256_MAX;
+
+        // Perform multiple additions that will cause overflows
+        for (int i = 0; i < 10; ++i) {
+            accumulator += increment;
+        }
+
+        // Just verify we completed without issues
+        ASSERT_TRUE(true);
+    }
+}
+
+// =============================================================================
+// Subtraction Tests
+// =============================================================================
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, subtraction_basic) {
+    {
+        int256_t a(30);
+        int256_t b(10);
+        int256_t result = a - b;
+        ASSERT_EQ("20", result.to_string());
+    }
+
+    {
+        int256_t a(10);
+        int256_t b(30);
+        int256_t result = a - b;
+        ASSERT_EQ("-20", result.to_string());
+    }
+
+    {
+        int256_t a(-10);
+        int256_t b(-30);
+        int256_t result = a - b;
+        ASSERT_EQ("20", result.to_string());
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, subtraction_with_different_types) {
+    int256_t a(100);
+
+    {
+        int256_t result = a - 50;
+        ASSERT_EQ("50", result.to_string());
+    }
+
+    {
+        __int128 val = 25;
+        int256_t result = a - val;
+        ASSERT_EQ("75", result.to_string());
+    }
+
+    {
+        double val = 25.0;
+        double result = a - val;
+        ASSERT_DOUBLE_EQ(75.0, result);
+    }
+}
+
+// =============================================================================
+// Multiplication Tests
+// =============================================================================
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, multiplication_basic) {
+    {
+        int256_t a(10);
+        int256_t b(20);
+        int256_t result = a * b;
+        ASSERT_EQ("200", result.to_string());
+    }
+
+    {
+        int256_t a(-10);
+        int256_t b(20);
+        int256_t result = a * b;
+        ASSERT_EQ("-200", result.to_string());
+    }
+
+    {
+        int256_t a(-10);
+        int256_t b(-20);
+        int256_t result = a * b;
+        ASSERT_EQ("200", result.to_string());
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, multiplication_edge_cases) {
+    {
+        int256_t a(100);
+        int256_t b(0);
+        int256_t result = a * b;
+        ASSERT_EQ("0", result.to_string());
+    }
+
+    {
+        int256_t a(100);
+        int256_t b(1);
+        int256_t result = a * b;
+        ASSERT_EQ("100", result.to_string());
+    }
+
+    {
+        int256_t a(1);
+        int256_t b(100);
+        int256_t result = a * b;
+        ASSERT_EQ("100", result.to_string());
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, multiplication_with_int) {
+    int256_t a(50);
+    int256_t result = a * 4;
+    ASSERT_EQ("200", result.to_string());
+
+    int256_t result2 = a * (-3);
+    ASSERT_EQ("-150", result2.to_string());
+}
+
+// =============================================================================
+// Division Tests
+// =============================================================================
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, division_basic) {
+    {
+        int256_t a(100);
+        int256_t b(10);
+        int256_t result = a / b;
+        ASSERT_EQ("10", result.to_string());
+    }
+
+    {
+        int256_t a(-100);
+        int256_t b(10);
+        int256_t result = a / b;
+        ASSERT_EQ("-10", result.to_string());
+    }
+
+    {
+        int256_t a(100);
+        int256_t b(-10);
+        int256_t result = a / b;
+        ASSERT_EQ("-10", result.to_string());
+    }
+
+    {
+        int256_t a(-100);
+        int256_t b(-10);
+        int256_t result = a / b;
+        ASSERT_EQ("10", result.to_string());
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, division_edge_cases) {
+    {
+        int256_t a(100);
+        int256_t b(1);
+        int256_t result = a / b;
+        ASSERT_EQ("100", result.to_string());
+    }
+
+    {
+        int256_t a(100);
+        int256_t b(100);
+        int256_t result = a / b;
+        ASSERT_EQ("1", result.to_string());
+    }
+
+    {
+        int256_t a(50);
+        int256_t b(100);
+        int256_t result = a / b;
+        ASSERT_EQ("0", result.to_string());
+    }
+
+    {
+        int256_t a(0);
+        int256_t b(100);
+        int256_t result = a / b;
+        ASSERT_EQ("0", result.to_string());
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, division_by_zero) {
+    int256_t a(100);
+    int256_t b(0);
+    ASSERT_THROW(a / b, std::domain_error);
+}
+
+// =============================================================================
+// Modulo Tests
+// =============================================================================
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, modulo_basic) {
+    {
+        int256_t a(100);
+        int256_t b(30);
+        int256_t result = a % b;
+        ASSERT_EQ("10", result.to_string());
+    }
+
+    {
+        int256_t a(100);
+        int256_t b(25);
+        int256_t result = a % b;
+        ASSERT_EQ("0", result.to_string());
+    }
+
+    {
+        int256_t a(-100);
+        int256_t b(30);
+        int256_t result = a % b;
+        ASSERT_EQ("-10", result.to_string());
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, modulo_by_zero) {
+    int256_t a(100);
+    int256_t b(0);
+    ASSERT_THROW(a % b, std::domain_error);
+}
+
+// =============================================================================
+// Assignment Operator Tests
+// =============================================================================
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, assignment_operators) {
+    {
+        int256_t a(10);
+        int256_t b(20);
+        a += b;
+        ASSERT_EQ("30", a.to_string());
+    }
+
+    {
+        int256_t a(30);
+        int256_t b(10);
+        a -= b;
+        ASSERT_EQ("20", a.to_string());
+    }
+
+    {
+        int256_t a(10);
+        int256_t b(5);
+        a *= b;
+        ASSERT_EQ("50", a.to_string());
+    }
+
+    {
+        int256_t a(50);
+        int256_t b(10);
+        a /= b;
+        ASSERT_EQ("5", a.to_string());
+    }
+
+    {
+        int256_t a(50);
+        int256_t b(12);
+        a %= b;
+        ASSERT_EQ("2", a.to_string());
+    }
+}
+
+// =============================================================================
+// Increment/Decrement Tests
+// =============================================================================
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, increment_operators) {
+    {
+        int256_t a(10);
+        int256_t result = ++a;
+        ASSERT_EQ("11", a.to_string());
+        ASSERT_EQ("11", result.to_string());
+    }
+
+    {
+        int256_t a(10);
+        int256_t result = a++;
+        ASSERT_EQ("11", a.to_string());
+        ASSERT_EQ("10", result.to_string());
+    }
+
+    {
+        int256_t a(0, static_cast<uint128_t>(-1)); // 2^128 - 1
+        ++a;
+        ASSERT_EQ(1, a.high);
+        ASSERT_EQ(0, a.low);
+    }
+}
+
+// =============================================================================
+// Bit Shift Tests
+// =============================================================================
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, left_shift) {
+    {
+        int256_t a(1);
+        int256_t result = a << 1;
+        ASSERT_EQ("2", result.to_string());
+    }
+
+    {
+        int256_t a(1);
+        int256_t result = a << 10;
+        ASSERT_EQ("1024", result.to_string());
+    }
+
+    {
+        int256_t a(1);
+        int256_t result = a << 128;
+        ASSERT_EQ(1, result.high);
+        ASSERT_EQ(0, result.low);
+    }
+
+    {
+        int256_t a(1);
+        int256_t result = a << 256;
+        ASSERT_EQ("0", result.to_string());
+    }
+
+    {
+        int256_t a(1);
+        a <<= 5;
+        ASSERT_EQ("32", a.to_string());
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, right_shift) {
+    {
+        int256_t a(8);
+        int256_t result = a >> 1;
+        ASSERT_EQ("4", result.to_string());
+    }
+
+    {
+        int256_t a(1024);
+        int256_t result = a >> 10;
+        ASSERT_EQ("1", result.to_string());
+    }
+
+    {
+        int256_t a(1, 0); // 2^128
+        int256_t result = a >> 128;
+        ASSERT_EQ("1", result.to_string());
+    }
+
+    // Arithmetic right shift for negative numbers
+    {
+        int256_t a(-8);
+        int256_t result = a >> 1;
+        ASSERT_EQ("-4", result.to_string());
+    }
+
+    {
+        int256_t a(-1);
+        int256_t result = a >> 100;
+        ASSERT_EQ("-1", result.to_string());
+    }
+
+    {
+        int256_t a(32);
+        a >>= 2;
+        ASSERT_EQ("8", a.to_string());
+    }
+}
+
+// =============================================================================
+// String Conversion Tests
+// =============================================================================
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, to_string) {
+    ASSERT_EQ("0", int256_t(0).to_string());
+    ASSERT_EQ("1", int256_t(1).to_string());
+    ASSERT_EQ("-1", int256_t(-1).to_string());
+    ASSERT_EQ("123456789", int256_t(123456789).to_string());
+    ASSERT_EQ("-123456789", int256_t(-123456789).to_string());
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, parse_from_string) {
+    {
+        int256_t result = parse_int256("0");
+        ASSERT_EQ("0", result.to_string());
+    }
+
+    {
+        int256_t result = parse_int256("123456789");
+        ASSERT_EQ("123456789", result.to_string());
+    }
+
+    {
+        int256_t result = parse_int256("-123456789");
+        ASSERT_EQ("-123456789", result.to_string());
+    }
+
+    { ASSERT_THROW(parse_int256("12a34"), std::invalid_argument); }
+
+    { ASSERT_THROW(parse_int256(""), std::invalid_argument); }
+}
+
+// =============================================================================
+// Utility Function Tests
+// =============================================================================
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, abs_function) {
+    ASSERT_EQ("0", abs(int256_t(0)).to_string());
+    ASSERT_EQ("42", abs(int256_t(42)).to_string());
+    ASSERT_EQ("42", abs(int256_t(-42)).to_string());
+
+    int256_t large_negative(-1, 0);
+    int256_t abs_result = abs(large_negative);
+    ASSERT_EQ(1, abs_result.high);
+    ASSERT_EQ(0, abs_result.low);
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, divmod_u32) {
+    {
+        int256_t dividend(100);
+        uint32_t divisor = 7;
+        int256_t quotient;
+        uint32_t remainder;
+
+        divmod_u32(dividend, divisor, &quotient, &remainder);
+
+        ASSERT_EQ("14", quotient.to_string());
+        ASSERT_EQ(2, remainder);
+    }
+
+    {
+        int256_t dividend(1000000);
+        uint32_t divisor = 1000;
+        int256_t quotient;
+        uint32_t remainder;
+
+        divmod_u32(dividend, divisor, &quotient, &remainder);
+
+        ASSERT_EQ("1000", quotient.to_string());
+        ASSERT_EQ(0, remainder);
+    }
+}
+
+// =============================================================================
+// Constant Tests
+// =============================================================================
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, constants) {
+    // Test INT256_MAX
+    ASSERT_TRUE(INT256_MAX > int256_t(0));
+    ASSERT_EQ(static_cast<int128_t>((static_cast<uint128_t>(1) << 127) - 1), INT256_MAX.high);
+    ASSERT_EQ(static_cast<uint128_t>(-1), INT256_MAX.low);
+
+    // Test INT256_MIN
+    ASSERT_TRUE(INT256_MIN < int256_t(0));
+    ASSERT_EQ(static_cast<int128_t>(static_cast<uint128_t>(1) << 127), INT256_MIN.high);
+    ASSERT_EQ(static_cast<uint128_t>(0), INT256_MIN.low);
+
+    // Test relationship
+    ASSERT_TRUE(INT256_MIN < INT256_MAX);
+    ASSERT_EQ("-1", (INT256_MIN + INT256_MAX).to_string());
+}
+
+// =============================================================================
+// Hash Function Tests
+// =============================================================================
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, hash_function) {
+    std::hash<int256_t> hasher;
+
+    int256_t a(42);
+    int256_t b(42);
+    int256_t c(43);
+
+    ASSERT_EQ(hasher(a), hasher(b));
+    ASSERT_NE(hasher(a), hasher(c));
+}
+
+// =============================================================================
+// Stream Output Tests
+// =============================================================================
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, stream_output) {
+    std::ostringstream oss;
+    int256_t value(12345);
+    oss << value;
+    ASSERT_EQ("12345", oss.str());
+
+    std::ostringstream oss2;
+    int256_t negative_value(-12345);
+    oss2 << negative_value;
+    ASSERT_EQ("-12345", oss2.str());
+}
+
+// =============================================================================
+// Large Number Tests
+// =============================================================================
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, large_number_operations) {
+    // Test with numbers that require high bits
+    int256_t large1(1, 0); // 2^128
+    int256_t large2(2, 0); // 2 * 2^128
+
+    {
+        int256_t sum = large1 + large1;
+        ASSERT_EQ(large2, sum);
+    }
+
+    {
+        int256_t diff = large2 - large1;
+        ASSERT_EQ(large1, diff);
+    }
+
+    {
+        int256_t product = large1 * int256_t(2);
+        ASSERT_EQ(large2, product);
+    }
+
+    {
+        int256_t quotient = large2 / int256_t(2);
+        ASSERT_EQ(large1, quotient);
+    }
+}
+
+// =============================================================================
+// Edge Case Tests
+// =============================================================================
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, edge_cases) {
+    // Test operations near overflow boundaries
+    {
+        int256_t max_low(0, static_cast<uint128_t>(-1));
+        int256_t one(1);
+        int256_t result = max_low + one;
+        ASSERT_EQ(1, result.high);
+        ASSERT_EQ(0, result.low);
+    }
+
+    // Test negative zero handling
+    {
+        int256_t pos_zero(0);
+        int256_t neg_zero = -pos_zero;
+        ASSERT_EQ(pos_zero, neg_zero);
+        ASSERT_EQ("0", neg_zero.to_string());
+    }
+
+    // Test self-operations
+    {
+        int256_t value(42);
+        ASSERT_EQ("0", (value - value).to_string());
+        ASSERT_EQ("1", (value / value).to_string());
+        ASSERT_EQ("0", (value % value).to_string());
+    }
+}
+
+} // end namespace starrocks

--- a/be/test/types/int256_test.cpp
+++ b/be/test/types/int256_test.cpp
@@ -16,7 +16,6 @@
 
 #include <gtest/gtest.h>
 
-#include <limits>
 #include <sstream>
 #include <string>
 


### PR DESCRIPTION
## Why I'm doing:
int256 is only used for decimal256 storage, this is a split patch of https://github.com/StarRocks/starrocks/pull/59778
## What I'm doing:
This PR is only the simplest version for int256 four arithmetic operations. We will optimize it in the subsequent PR.
int256_t uses two 128-bit integers to represent 256-bit data. Default Little Endian Storage
- high: Upper 128 bits (int128_t, signed)
- low:  Lower 128 bits (uint128_t, unsigned)

**256-bit hex value**: `0x123456789ABCDEF0FEDCBA0987654321_0123456789ABCDEFEDCBA09876543210`
- high: `0x123456789ABCDEF0FEDCBA0987654321`
- low: `0x0123456789ABCDEFEDCBA09876543210`

**Common values**:
- Zero: `high = 0, low = 0`
- One: `high = 0, low = 1`
- 2^128: `high = 1, low = 0`
- -1: `high = -1, low = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF`

**Boundary values**:
- Max (2^255-1): `high = 0x7FFF..., low = 0xFFFF...`
- Min (-2^255): `high = 0x8000..., low = 0x0000...`

Fixes #issue
https://github.com/StarRocks/starrocks/issues/59645

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
