### PR TITLE
[BugFix] fix cache select error after DDL

### DIFF
--- a/be/src/storage/rowset/cast_column_iterator.cpp
+++ b/be/src/storage/rowset/cast_column_iterator.cpp
@@ -77,4 +77,10 @@ Status CastColumnIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t s
     return Status::OK();
 }
 
+StatusOr<std::vector<std::pair<int64_t, int64_t>>> CastColumnIterator::get_io_range_vec(const SparseRange<>& range,
+                                                                                        Column* dst) {
+    auto source_column = _source_chunk.get_column_by_index(0);
+    return _parent->get_io_range_vec(range, source_column.get());
+}
+
 } // namespace starrocks

--- a/be/src/storage/rowset/cast_column_iterator.h
+++ b/be/src/storage/rowset/cast_column_iterator.h
@@ -52,6 +52,9 @@ public:
         return Status::OK();
     }
 
+    StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range,
+                                                                        Column* dst) override;
+
 private:
     void do_cast(Column* target);
 

--- a/be/src/storage/rowset/default_value_column_iterator.h
+++ b/be/src/storage/rowset/default_value_column_iterator.h
@@ -94,6 +94,11 @@ public:
 
     Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) override;
 
+    StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range,
+                                                                        Column* dst) override {
+        return std::vector<std::pair<int64_t, int64_t>>();
+    }
+
 private:
     bool _has_default_value;
     std::string _default_value;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

after doing alter table add column or alter table modify column, cache select might fail with error msg `Not supported: Not Implemented`

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
