### PR TITLE
[BugFix] Let submitted tasks without execution can be awared in starrocks::LakeServiceImpl to set a correct response and status

### DIFF
--- a/be/src/exec/write_combined_txn_log.cpp
+++ b/be/src/exec/write_combined_txn_log.cpp
@@ -38,8 +38,8 @@ void mark_failure(const Status& status, std::atomic<bool>* has_error, Status* fi
 }
 
 std::function<void()> create_txn_log_task(const CombinedTxnLogPB* logs, lake::TabletManager* tablet_mgr,
-                                          std::atomic<bool>* has_error, Status* final_status) {
-    return [logs, tablet_mgr, has_error, final_status]() {
+                                          std::atomic<bool>* has_error, Status* final_status, CountDownLatch* latch) {
+    return [logs, tablet_mgr, has_error, final_status, latch]() {
         try {
             Status status = tablet_mgr->put_combined_txn_log(*logs);
             if (!status.ok()) {
@@ -50,6 +50,7 @@ std::function<void()> create_txn_log_task(const CombinedTxnLogPB* logs, lake::Ta
         } catch (...) {
             mark_failure(Status::Unknown("Unknown exception in write combined txn log task"), has_error, final_status);
         }
+        latch->count_down();
     };
 }
 
@@ -58,18 +59,30 @@ Status write_combined_txn_log_parallel(const std::map<int64_t, CombinedTxnLogPB>
     std::atomic<bool> has_error(false);
     Status final_status;
     {
-        std::vector<std::shared_ptr<AutoCleanRunnable>> tasks;
+        std::vector<std::shared_ptr<CancellableRunnable>> tasks;
         for (const auto& [partition_id, logs] : txn_log_map) {
             auto task_logic = create_txn_log_task(&logs, ExecEnv::GetInstance()->lake_tablet_manager(), &has_error,
-                                                  &final_status);
-            auto task = std::make_shared<AutoCleanRunnable>(std::move(task_logic), [&latch]() { latch.count_down(); });
+                                                  &final_status, &latch);
+            auto task =
+                    std::make_shared<CancellableRunnable>(std::move(task_logic), [&latch, &has_error, &final_status]() {
+                        Status st = Status::Cancelled("Task cancelled before execution");
+                        mark_failure(st, &has_error, &final_status);
+                        latch.count_down();
+                    });
             tasks.emplace_back(std::move(task));
         }
+        bool submit_failed = false;
         for (const auto& task : tasks) {
+            if (submit_failed) {
+                latch.count_down(); // Skip further tasks if one has already failed
+                continue;
+            }
+
             Status submit_status = ExecEnv::GetInstance()->put_combined_txn_log_thread_pool()->submit(task);
             if (!submit_status.ok()) {
+                submit_failed = true;
                 mark_failure(submit_status, &has_error, &final_status);
-                break;
+                latch.count_down();
             }
         }
     }

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -61,7 +61,7 @@ public:
 
     ~ChannelOpenTask() override {
         if (!_is_done) {
-            cancel(Status::ServiceUnavailable("Thread pool was shut down"));
+            cancel_task(Status::ServiceUnavailable("Thread pool was shut down"));
         }
     }
 
@@ -71,7 +71,7 @@ public:
         }
     }
 
-    void cancel(const Status& status) {
+    void cancel_task(const Status& status) {
         if (_try_mark_done()) {
             ClosureGuard closure_guard(_open_context.done);
             status.to_protobuf(_open_context.response->mutable_status());
@@ -164,7 +164,7 @@ void LoadChannelMgr::open(brpc::Controller* cntl, const PTabletWriterOpenRequest
     auto task = std::make_shared<ChannelOpenTask>(this, std::move(open_context));
     Status status = _async_rpc_pool->submit(task);
     if (!status.ok()) {
-        task->cancel(status);
+        task->cancel_task(status);
     }
 }
 

--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -735,12 +735,13 @@ Status ConcurrencyLimitedThreadPoolToken::submit(std::shared_ptr<Runnable> task,
         auto t = MilliSecondsSinceEpochFromTimePoint(deadline);
         return Status::TimedOut(fmt::format("acquire semaphore reached deadline={}", t));
     }
+    auto runnable_task = std::move(task); // Disable compilation warnings
     auto token_task = std::make_shared<CancellableRunnable>(
-            [t = task, sem = _sem] {
+            [t = runnable_task, sem = _sem] {
                 t->run();
                 sem->release();
             },
-            [t = task, sem = _sem] {
+            [t = runnable_task, sem = _sem] {
                 t->cancel();
                 sem->release();
             });

--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -44,6 +44,7 @@
 #include "gutil/sysinfo.h"
 #include "testutil/sync_point.h"
 #include "util/cpu_info.h"
+#include "util/defer_op.h"
 #include "util/scoped_cleanup.h"
 #include "util/stack_util.h"
 #include "util/thread.h"
@@ -129,6 +130,12 @@ void ThreadPoolToken::shutdown() {
     // are destructed after the lock is released. This is important because the task's
     // destructors may acquire locks, etc., so this also prevents lock inversions.
     PriorityQueue<ThreadPool::NUM_PRIORITY, ThreadPool::Task> to_release;
+    DeferOp defer([&]() {
+        // PriorityQueue is not iterateable unless we pop the front element.
+        // But it is safe to do that because to_release will be destroyed just
+        // after the defer.
+        ThreadPool::_pop_and_cancel_tasks_in_queue(to_release);
+    });
     std::unique_lock l(_pool->_lock);
     _pool->check_not_pool_thread_unlocked();
 
@@ -296,6 +303,14 @@ void ThreadPool::shutdown() {
     // are destructed after the lock is released. This is important because the task's
     // destructors may acquire locks, etc., so this also prevents lock inversions.
     std::deque<PriorityQueue<NUM_PRIORITY, Task>> to_release;
+    DeferOp defer([&]() {
+        // PriorityQueue is not iterateable unless we pop the front element.
+        // But it is safe to do that because to_release will be destroyed just
+        // after the defer.
+        for (auto& pq : to_release) {
+            ThreadPool::_pop_and_cancel_tasks_in_queue(pq);
+        }
+    });
     std::unique_lock l(_lock);
     check_not_pool_thread_unlocked();
 
@@ -421,6 +436,8 @@ Status ThreadPool::do_submit(std::shared_ptr<Runnable> r, ThreadPoolToken* token
         need_a_thread = true;
         _num_threads_pending_start++;
     }
+
+    TEST_SYNC_POINT_CALLBACK("ThreadPool::do_submit:replace_task", &r);
 
     Task task;
     task.runnable = std::move(r);
@@ -701,15 +718,38 @@ void ThreadPool::check_not_pool_thread_unlocked() {
     }
 }
 
+void ThreadPool::_pop_and_cancel_tasks_in_queue(PriorityQueue<ThreadPool::NUM_PRIORITY, ThreadPool::Task>& pq) {
+    while (!pq.empty()) {
+        try {
+            (pq.front().runnable)->cancel();
+        } catch (...) {
+            LOG(WARNING) << "Exception while cancelling runnable";
+        }
+        pq.pop_front();
+    }
+}
+
 Status ConcurrencyLimitedThreadPoolToken::submit(std::shared_ptr<Runnable> task,
                                                  std::chrono::system_clock::time_point deadline) {
     if (!_sem->try_acquire_until(deadline)) {
         auto t = MilliSecondsSinceEpochFromTimePoint(deadline);
         return Status::TimedOut(fmt::format("acquire semaphore reached deadline={}", t));
     }
-    auto token_task =
-            std::make_shared<AutoCleanRunnable>([t = std::move(task)] { t->run(); }, [sem = _sem] { sem->release(); });
-    return _pool->submit(std::move(token_task));
+    auto token_task = std::make_shared<CancellableRunnable>(
+            [t = task, sem = _sem] {
+                t->run();
+                sem->release();
+            },
+            [t = task, sem = _sem] {
+                t->cancel();
+                sem->release();
+            });
+    auto st = _pool->submit(std::move(token_task));
+    if (!st.ok()) {
+        // handle submit failure manually
+        _sem->release();
+    }
+    return st;
 }
 
 Status ConcurrencyLimitedThreadPoolToken::submit_func(std::function<void()> f,


### PR DESCRIPTION
## Why I'm doing:
Currently, some task submitted by starrocks::LakeServiceImpl can not aware whether the task is executed or not,
which will cause the response or status to be set incorrectly.

## What I'm doing:
Change AutoCleanRunnable to CancellableRunnable, which has a canceller to be called when threadpool is shutdown
to handle the correct response and status. Remove the cleaner and caller should do the proper clean-up work
in run() or when the task submitted failed.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
