### PR TITLE
[BugFix] Revert PR #59009

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1703,6 +1703,4 @@ CONF_mInt64(split_exchanger_buffer_chunk_num, "1000");
 
 // when to split hashmap/hashset into two level hashmap/hashset, negative number means use default value
 CONF_mInt64(two_level_memory_threshold, "-1");
-
-CONF_mInt32(max_update_tablet_version_internal_ms, "5000");
 } // namespace starrocks::config

--- a/be/src/storage/publish_version_manager.cpp
+++ b/be/src/storage/publish_version_manager.cpp
@@ -15,15 +15,12 @@
 #include "publish_version_manager.h"
 
 #include "agent/finish_task.h"
-#include "agent/master_info.h"
 #include "agent/task_signatures_manager.h"
 #include "common/config.h"
-#include "runtime/client_cache.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet.h"
 #include "storage/tablet_manager.h"
 #include "util/cpu_info.h"
-#include "util/thrift_rpc_helper.h"
 
 namespace starrocks {
 const int MIN_FINISH_PUBLISH_WORKER_COUNT = 8;
@@ -85,8 +82,8 @@ bool PublishVersionManager::_all_task_applied(const TFinishTaskRequest& finish_t
     return all_task_applied;
 }
 
-size_t PublishVersionManager::_left_task_applied(const TFinishTaskRequest& finish_task_request) {
-    size_t unapplied_tablet_num = 0;
+bool PublishVersionManager::_left_task_applied(const TFinishTaskRequest& finish_task_request) {
+    bool applied = true;
     int64_t signature = finish_task_request.signature;
     std::set<std::pair<int64_t, int64_t>> unapplied_tablet;
     auto iter = _unapplied_tablet_by_txn.find(signature);
@@ -103,19 +100,19 @@ size_t PublishVersionManager::_left_task_applied(const TFinishTaskRequest& finis
                 continue;
             }
             if (tablet->max_readable_version() < request_version) {
-                unapplied_tablet_num++;
+                applied = false;
                 unapplied_tablet.insert(std::make_pair(tablet_id, request_version));
             }
             VLOG(2) << "tablet: " << tablet->tablet_id() << " max_readable_version is "
                     << tablet->max_readable_version() << ", request_version is " << request_version;
         }
     }
-    if (unapplied_tablet_num > 0) {
+    if (!applied) {
         iter->second.swap(unapplied_tablet);
     } else {
         _unapplied_tablet_by_txn.erase(signature);
     }
-    return unapplied_tablet_num;
+    return applied;
 }
 
 void PublishVersionManager::wait_publish_task_apply_finish(std::vector<TFinishTaskRequest> finish_task_requests) {
@@ -124,17 +121,14 @@ void PublishVersionManager::wait_publish_task_apply_finish(std::vector<TFinishTa
         if (_all_task_applied(finish_task_requests[i])) {
             _finish_task_requests[finish_task_requests[i].signature] = std::move(finish_task_requests[i]);
         } else {
-            FinishTaskInfo info;
-            info.last_report_time = MonotonicMillis();
-            info.not_report_tablet_num = finish_task_requests[i].tablet_publish_versions.size();
-            info.request = std::move(finish_task_requests[i]);
-            _waitting_finish_task_requests[finish_task_requests[i].signature] = std::move(info);
+            _waitting_finish_task_requests[finish_task_requests[i].signature] = std::move(finish_task_requests[i]);
         }
     }
     DCHECK(has_pending_task());
 }
 
-void PublishVersionManager::update_tablet_version(std::vector<TTabletVersionPair>& tablet_versions) {
+void PublishVersionManager::update_tablet_version(TFinishTaskRequest& finish_task_request) {
+    auto& tablet_versions = finish_task_request.tablet_versions;
     for (int32_t i = 0; i < tablet_versions.size(); i++) {
         int64_t tablet_id = tablet_versions[i].tablet_id;
         TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
@@ -154,7 +148,7 @@ void PublishVersionManager::finish_publish_version_task() {
             // submit finish task
             st = _finish_publish_version_thread_pool->submit_func(
                     [this, finish_request = std::move(finish_task_request)]() mutable {
-                        update_tablet_version(finish_request.tablet_versions);
+                        update_tablet_version(finish_request);
 #ifndef BE_TEST
                         finish_task(finish_request);
 #endif
@@ -166,12 +160,11 @@ void PublishVersionManager::finish_publish_version_task() {
         }
 
         std::vector<int64_t> clear_txn;
-        for (auto& [signature, finish_task_info] : _waitting_finish_task_requests) {
-            size_t unapplied_tablet_num = _left_task_applied(finish_task_info.request);
-            if (unapplied_tablet_num == 0) {
+        for (auto& [signature, finish_task_request] : _waitting_finish_task_requests) {
+            if (_left_task_applied(finish_task_request)) {
                 st = _finish_publish_version_thread_pool->submit_func(
-                        [this, finish_request = std::move(finish_task_info.request)]() mutable {
-                            update_tablet_version(finish_request.tablet_versions);
+                        [this, finish_request = std::move(finish_task_request)]() mutable {
+                            update_tablet_version(finish_request);
 #ifndef BE_TEST
                             finish_task(finish_request);
 #endif
@@ -179,41 +172,6 @@ void PublishVersionManager::finish_publish_version_task() {
                         });
                 if (st.ok()) {
                     erase_waitting_finish_task_signature.emplace_back(signature);
-                }
-            } else {
-                size_t not_report_tablet_num = finish_task_info.not_report_tablet_num;
-                if (unapplied_tablet_num < not_report_tablet_num &&
-                    MonotonicMillis() - finish_task_info.last_report_time >
-                            config::max_update_tablet_version_internal_ms) {
-                    VLOG(2) << "unapplied_tablet_num: " << unapplied_tablet_num
-                            << ", not_report_tablet_num: " << not_report_tablet_num
-                            << ", report_internal_ms: " << MonotonicMillis() - finish_task_info.last_report_time
-                            << ", allow_internla_ms: " << config::max_update_tablet_version_internal_ms;
-
-                    finish_task_info.not_report_tablet_num = unapplied_tablet_num;
-                    finish_task_info.last_report_time = MonotonicMillis();
-                    TUpdateTabletVersionRequest update_request;
-                    update_request.__set_backend(finish_task_info.request.backend);
-                    update_request.__set_signature(signature);
-                    update_request.__set_tablet_versions(finish_task_info.request.tablet_versions);
-                    st = _finish_publish_version_thread_pool->submit_func(
-                            [this, request = std::move(update_request)]() mutable {
-                                update_tablet_version(request.tablet_versions);
-                                TNetworkAddress master_addr = get_master_address();
-                                TUpdateTabletVersionResult result;
-                                auto st = ThriftRpcHelper::rpc<FrontendServiceClient>(
-                                        master_addr.hostname, master_addr.port,
-                                        [&request, &result](FrontendServiceConnection& client) {
-                                            client->updateTabletVersion(result, request);
-                                        });
-                                if (!st.ok()) {
-                                    LOG(WARNING) << "updateTabletVersion failed: " << st
-                                                 << ", signature: " << request.signature;
-                                }
-                            });
-                    if (!st.ok()) {
-                        LOG(WARNING) << "submit report tablet version task failed";
-                    }
                 }
             }
         }

--- a/be/src/storage/publish_version_manager.h
+++ b/be/src/storage/publish_version_manager.h
@@ -27,12 +27,6 @@ namespace starrocks {
 
 using FinishTaskRequestPtr = std::shared_ptr<TFinishTaskRequest>;
 
-struct FinishTaskInfo {
-    TFinishTaskRequest request;
-    int64_t last_report_time;
-    size_t not_report_tablet_num;
-};
-
 class PublishVersionManager {
 public:
     Status init();
@@ -40,20 +34,20 @@ public:
     void wait_publish_task_apply_finish(std::vector<TFinishTaskRequest> finish_task_requests);
     bool has_pending_task() { return !_finish_task_requests.empty() || !_waitting_finish_task_requests.empty(); }
     void finish_publish_version_task();
-    void update_tablet_version(std::vector<TTabletVersionPair>& tablet_versions);
+    void update_tablet_version(TFinishTaskRequest& finish_task_request);
 
     size_t finish_task_requests_size() { return _finish_task_requests.size(); }
     size_t waitting_finish_task_requests_size() { return _waitting_finish_task_requests.size(); }
 
 private:
     bool _all_task_applied(const TFinishTaskRequest& finish_task_request);
-    size_t _left_task_applied(const TFinishTaskRequest& finish_task_request);
+    bool _left_task_applied(const TFinishTaskRequest& finish_task_request);
 
 private:
     mutable std::mutex _lock;
 
     std::map<int64_t, TFinishTaskRequest> _finish_task_requests;
-    std::map<int64_t, FinishTaskInfo> _waitting_finish_task_requests;
+    std::map<int64_t, TFinishTaskRequest> _waitting_finish_task_requests;
     std::map<int64_t, std::set<std::pair<int64_t, int64_t>>> _unapplied_tablet_by_txn;
     std::unique_ptr<ThreadPool> _finish_publish_version_thread_pool;
 };

--- a/be/test/storage/publish_version_manager_test.cpp
+++ b/be/test/storage/publish_version_manager_test.cpp
@@ -237,34 +237,16 @@ TEST_F(PublishVersionManagerTest, test_publish_task) {
     _tablet->updates()->stop_apply(true);
     auto rs1 = create_rowset(_tablet, keys);
     ASSERT_TRUE(_tablet->rowset_commit(3, rs1).ok());
-
-    auto tablet1 = create_tablet(rand(), rand());
-    {
-        auto rs0 = create_rowset(tablet1, keys);
-        ASSERT_TRUE(tablet1->rowset_commit(2, rs0).ok());
-        auto rs1 = create_rowset(tablet1, keys);
-        ASSERT_TRUE(tablet1->rowset_commit(3, rs1).ok());
-    }
-
     std::vector<TFinishTaskRequest> finish_task_requests;
     auto& finish_task_request = finish_task_requests.emplace_back();
     finish_task_request.signature = 2222;
     auto& tablet_publish_versions = finish_task_request.tablet_publish_versions;
-    {
-        auto& pair1 = tablet_publish_versions.emplace_back();
-        pair1.__set_tablet_id(_tablet->tablet_id());
-        pair1.__set_version(3);
-
-        auto& pair2 = tablet_publish_versions.emplace_back();
-        pair2.__set_tablet_id(tablet1->tablet_id());
-        pair2.__set_version(3);
-    }
-
-    config::max_update_tablet_version_internal_ms = 1000;
+    auto& pair = tablet_publish_versions.emplace_back();
+    pair.__set_tablet_id(_tablet->tablet_id());
+    pair.__set_version(3);
     _publish_version_manager->wait_publish_task_apply_finish(std::move(finish_task_requests));
     _finish_publish_version_cv.notify_one();
 
-    std::this_thread::sleep_for(std::chrono::seconds(2));
     ASSERT_EQ(0, _publish_version_manager->finish_task_requests_size());
     ASSERT_EQ(1, _publish_version_manager->waitting_finish_task_requests_size());
     _tablet->updates()->stop_apply(false);

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -357,8 +357,6 @@ import com.starrocks.thrift.TUpdateFailPointRequest;
 import com.starrocks.thrift.TUpdateFailPointResponse;
 import com.starrocks.thrift.TUpdateResourceUsageRequest;
 import com.starrocks.thrift.TUpdateResourceUsageResponse;
-import com.starrocks.thrift.TUpdateTabletVersionRequest;
-import com.starrocks.thrift.TUpdateTabletVersionResult;
 import com.starrocks.thrift.TUserPrivDesc;
 import com.starrocks.thrift.TVerboseVariableRecord;
 import com.starrocks.thrift.TWarehouseInfo;
@@ -3211,11 +3209,6 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         TUpdateFailPointResponse response = new TUpdateFailPointResponse();
         response.setStatus(status);
         return response;
-    }
-
-    @Override
-    public TUpdateTabletVersionResult updateTabletVersion(TUpdateTabletVersionRequest request) {
-        return leaderImpl.updateTabletVersion(request);
     }
 
     @NotNull

--- a/fe/fe-core/src/test/java/com/starrocks/leader/LeaderImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/leader/LeaderImplTest.java
@@ -21,23 +21,9 @@ import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Replica;
-import com.starrocks.catalog.Replica.ReplicaState;
-import com.starrocks.catalog.TabletInvertedIndex;
-import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.jmockit.Deencapsulation;
-import com.starrocks.common.util.concurrent.lock.LockType;
-import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.LakeTablet;
-import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.system.Backend;
-import com.starrocks.system.SystemInfoService;
-import com.starrocks.thrift.TBackend;
-import com.starrocks.thrift.TStatusCode;
-import com.starrocks.thrift.TStorageMedium;
-import com.starrocks.thrift.TTabletVersionPair;
-import com.starrocks.thrift.TUpdateTabletVersionRequest;
-import com.starrocks.thrift.TUpdateTabletVersionResult;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -46,8 +32,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 
 import static com.starrocks.catalog.Replica.ReplicaState.NORMAL;
@@ -115,115 +99,5 @@ public class LeaderImplTest {
 
         Assert.assertEquals(new Replica(tabletId, backendId, -1, NORMAL), Deencapsulation.invoke(leader, "findRelatedReplica",
                 olapTable, physicalPartition, backendId, tabletId, indexId));
-    }
-
-    @Test
-    public void testUpdateTabletVersion() throws Exception {
-        TUpdateTabletVersionRequest request = new TUpdateTabletVersionRequest();
-        TUpdateTabletVersionResult result = new TUpdateTabletVersionResult();
-        result = leader.updateTabletVersion(request);
-        Assert.assertEquals(result.status.getStatus_code(), TStatusCode.CANCELLED);
-        Assert.assertEquals("current fe is not leader", result.status.getError_msgs().get(0));
-
-        new MockUp<GlobalStateMgr>() {
-            @Mock
-            boolean isLeader() {
-                return true;
-            }
-        };
-
-        TBackend tBackend = new TBackend("host2", 8000, 1);
-        request.setBackend(tBackend);
-        result = leader.updateTabletVersion(request);
-        Assert.assertEquals(result.status.getStatus_code(), TStatusCode.CANCELLED);
-        Assert.assertEquals("backend not exist.", result.status.getError_msgs().get(0));
-
-        Backend cn = new Backend(10002, "host2", 8000);
-        new MockUp<SystemInfoService>() {
-            @Mock
-            public Backend getBackendWithBePort(String host, int bePort) {
-                return cn;
-            }
-        };
-
-        List<TTabletVersionPair> tabletVersions = new ArrayList<>();
-        TTabletVersionPair pair1 = new TTabletVersionPair();
-        pair1.setTablet_id(10001L);
-        pair1.setVersion(4L);
-        tabletVersions.add(pair1);
-        
-        TTabletVersionPair pair2 = new TTabletVersionPair();
-        pair2.setTablet_id(10002L);
-        pair2.setVersion(5L);
-        tabletVersions.add(pair2);
-        request.setTablet_versions(tabletVersions);
-
-        result = leader.updateTabletVersion(request);
-        Assert.assertEquals(result.status.getStatus_code(), TStatusCode.CANCELLED);
-        Assert.assertEquals("no replicas on backend", result.status.getError_msgs().get(0));
-
-        List<TabletMeta> metaList = new ArrayList<>();
-        List<Replica> replicas = new ArrayList<>();
-        Replica replica1 = new Replica(1L, cn.getId(), ReplicaState.NORMAL, 3, 0);
-        Replica replica2 = new Replica(2L, cn.getId(), ReplicaState.NORMAL, 3, 0);
-        replicas.add(replica1);
-        replicas.add(replica2);
-
-        new MockUp<TabletInvertedIndex>() {
-            @Mock
-            public List<Replica> getReplicasOnBackendByTabletIds(List<Long> tabletIds, long backendId) {
-                return replicas;
-            }
-        
-            @Mock
-            public List<TabletMeta> getTabletMetaList(List<Long> tabletIds) {
-                return metaList;
-            }
-        };
-
-        result = leader.updateTabletVersion(request);
-        Assert.assertEquals(TStatusCode.CANCELLED, result.status.getStatus_code());
-        Assert.assertEquals("no tabletMeta found", result.status.getError_msgs().get(0));
-
-        TabletMeta meta1 = new TabletMeta(1L, 1L, 1L, 1L, 1, TStorageMedium.HDD, false);
-        TabletMeta meta2 = new TabletMeta(1L, 1L, 1L, 2L, 1, TStorageMedium.HDD, false);
-        metaList.add(meta1);
-        metaList.add(meta2);
-
-        new MockUp<Locker>() {
-            @Mock
-            public void lockTableWithIntensiveDbLock(Long dbId, Long tabletId, LockType lockType) {
-                return;
-            }
-
-            @Mock
-            public void unLockTableWithIntensiveDbLock(Long dbId, Long tabletId, LockType lockType) {
-                return;
-            }
-        };
-
-        result = leader.updateTabletVersion(request);
-        Assert.assertEquals(TStatusCode.OK, result.status.getStatus_code());
-    
-        Assert.assertEquals(4L, replica1.getVersion());
-        Assert.assertEquals(5L, replica2.getVersion());
-
-        TabletMeta wrongMeta = new TabletMeta(2L, 1L, 1L, 1L, 1, TStorageMedium.HDD, false);
-        List<TabletMeta> wrongMetaList = new ArrayList<>();
-        wrongMetaList.add(meta1);
-        wrongMetaList.add(wrongMeta);
-    
-        new MockUp<TabletInvertedIndex>() {
-            @Mock
-            public List<TabletMeta> getTabletMetaList(List<Long> tabletIds) {
-                return wrongMetaList;
-            }
-        };
-    
-        result = leader.updateTabletVersion(request);
-        Assert.assertEquals(TStatusCode.CANCELLED, result.status.getStatus_code());
-        Assert.assertEquals("tablets in request from different db or table", 
-                          result.status.getError_msgs().get(0));
-        
     }
 }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -2127,16 +2127,6 @@ struct TUpdateFailPointResponse {
     1: optional Status.TStatus status;
 }
 
-struct TUpdateTabletVersionRequest {
-    1: optional Types.TBackend backend;
-    2: optional i64 signature;
-    3: optional list<MasterService.TTabletVersionPair> tablet_versions;
-}
-
-struct TUpdateTabletVersionResult {
-    1: optional Status.TStatus status;
-}
-
 service FrontendService {
     TGetDbsResult getDbNames(1:TGetDbsParams params)
     TGetTablesResult getTableNames(1:TGetTablesParams params)
@@ -2278,7 +2268,5 @@ service FrontendService {
     TGetWarehouseQueriesResponse getWarehouseQueries(1: TGetWarehouseQueriesRequest request)
 
     TUpdateFailPointResponse updateFailPointStatus(1: TUpdateFailPointRequest request)
-
-    TUpdateTabletVersionResult updateTabletVersion(1: TUpdateTabletVersionRequest request)
 }
 


### PR DESCRIPTION
## Why I'm doing:
The pr(https://github.com/StarRocks/starrocks/pull/59009) introduce BE report tablet version but not write edit log, so the follower FE maybe lost version update.

One solution is write edit log when update replica version, but writing a large number of edit logs may lead to performance issues. So revert it first and I will find a better way to resolve this issue.

## What I'm doing:

This reverts commit 469ae2a077193e17fdd8b0ac943cb7aa26ef1b52.

Fixes https://github.com/StarRocks/StarRocksTest/issues/9788

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
