### PR TITLE
[Enhancement] Optimize and refine the tablet health check logic

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
@@ -36,6 +36,7 @@ package com.starrocks.clone;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
@@ -73,6 +74,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -858,7 +860,8 @@ public class TabletChecker extends FrontendDaemon {
     private static LocalTabletHealthStats collectLocalTabletHealthStats(LocalTablet localTablet,
                                                                         SystemInfoService systemInfoService,
                                                                         long visibleVersion,
-                                                                        Multimap<String, String> requiredLocation) {
+                                                                        Multimap<String, String> requiredLocation,
+                                                                        boolean ensureReplicaHA) {
         LocalTabletHealthStats stats = new LocalTabletHealthStats();
         Set<Pair<String, String>> uniqueReplicaLocations = Sets.newHashSet();
         Set<String> hosts = Sets.newHashSet();
@@ -902,9 +905,10 @@ public class TabletChecker extends FrontendDaemon {
                 stats.incrLocationMatchCnt();
             } else {
                 Pair<String, String> backendLocKV = backend.getSingleLevelLocationKV();
-                if (backendLocKV != null) {
-                    if (!uniqueReplicaLocations.contains(backendLocKV) &&
-                            isLocationMatch(backendLocKV.first, backendLocKV.second, requiredLocation)) {
+                if (backendLocKV != null && isLocationMatch(backendLocKV.first, backendLocKV.second, requiredLocation)) {
+                    if (!ensureReplicaHA) {
+                        stats.incrLocationMatchCnt();
+                    } else if (!uniqueReplicaLocations.contains(backendLocKV)) {
                         stats.incrLocationMatchCnt();
                         uniqueReplicaLocations.add(backendLocKV);
                     }
@@ -1027,8 +1031,9 @@ public class TabletChecker extends FrontendDaemon {
             List<Long> aliveBeIdsInCluster,
             Multimap<String, String> requiredLocation) {
         List<Replica> replicas = localTablet.getImmutableReplicas();
+        boolean ensureReplicaHA = shouldEnsureReplicaHA(replicationNum, requiredLocation, systemInfoService);
         LocalTabletHealthStats stats = collectLocalTabletHealthStats(localTablet, systemInfoService,
-                visibleVersion, requiredLocation);
+                visibleVersion, requiredLocation, ensureReplicaHA);
 
         // The priority of handling different unhealthy situations should be:
         // FORCE_REDUNDANT > REPLICA_MISSING > VERSION_INCOMPLETE >
@@ -1086,6 +1091,70 @@ public class TabletChecker extends FrontendDaemon {
         try (CloseableLock ignored = CloseableLock.lock(localTablet.getReadLock())) {
             return getColocateTabletHealthStatusUnlocked(localTablet, visibleVersion, replicationNum, backendsSet);
         }
+    }
+
+    /**
+     * Determines whether high availability (HA) should be ensured for replica placement,
+     * based on the number of replicas and the required location mapping.
+     *
+     * <p>High availability is considered to be required only when the number of
+     * specified locations matches the number of replicas. This typically implies that
+     * multiple racks are assigned during table creation, which helps prevent replica
+     * co-location on the same rack and improves fault tolerance.</p>
+     *
+     * <p>In contrast, if only a single rack is assigned (even if different tables use different racks),
+     * the requirement is typically for physical isolation rather than availability.</p>
+     *
+     * @param replicationNum   the number of replicas configured for the table
+     * @param requiredLocation the mapping of location requirements (e.g., rack assignments)
+     * @return true if high availability should be enforced based on the location configuration; false otherwise
+     */
+    public static boolean shouldEnsureReplicaHA(int replicationNum,
+                                                 Multimap<String, String> requiredLocation,
+                                                 SystemInfoService systemInfoService) {
+        if (requiredLocation == null || requiredLocation.isEmpty()) {
+            return false;
+        }
+
+        // Collect all backend locations into a multimap
+        Multimap<String, String> allLocations = collectDistinctBackendLocations(systemInfoService);
+
+        int requiredUniqueLocationCount = 0;
+
+        // Case 1: requiredLocation contains wildcard '*'
+        if (requiredLocation.keySet().contains("*")) {
+            // Count all unique key:value combinations
+            requiredUniqueLocationCount = allLocations.size();
+        } else {
+            // Case 2: specific keys, e.g., rack:*, zone:zone01
+            for (String locKey : requiredLocation.keySet()) {
+                Collection<String> values = requiredLocation.get(locKey);
+                if (values.contains("*")) {
+                    // If value is '*', count all values under this key
+                    requiredUniqueLocationCount += allLocations.get(locKey).size();
+                } else {
+                    // Otherwise, just count the number of required key-value entries
+                    // assuming all required locations are already validated and present
+                    requiredUniqueLocationCount += values.size();
+                }
+            }
+        }
+
+        // Return whether we have enough distinct location matches to meet the replication requirement
+        return requiredUniqueLocationCount >= replicationNum;
+    }
+
+    public static Multimap<String, String> collectDistinctBackendLocations(SystemInfoService systemInfoService) {
+        HashMultimap<String, String> allLocations = HashMultimap.create();
+        for (Backend backend : systemInfoService.getBackends()) {
+            Map<String, String> location = backend.getLocation();
+            if (location != null && !location.isEmpty()) {
+                for (Map.Entry<String, String> entry : location.entrySet()) {
+                    allLocations.put(entry.getKey(), entry.getValue());
+                }
+            }
+        }
+        return allLocations;
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletCheckerTest.java
@@ -1,0 +1,134 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.clone;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.starrocks.system.Backend;
+import com.starrocks.system.SystemInfoService;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+public class TabletCheckerTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        systemInfoService = Mockito.mock(SystemInfoService.class);
+    }
+
+    private Backend mockBackend(String locationLabel) {
+        Backend mockBackend = Mockito.mock(Backend.class);
+        Map<String, String> location = new HashMap<>();
+        if (locationLabel.isEmpty()) {
+            mockBackend.setLocation(null);
+            Mockito.when(mockBackend.getLocation()).thenReturn(null);
+        } else {
+            String[] locKV = locationLabel.split(":");
+            location.put(locKV[0].trim(), locKV[1].trim());
+            Mockito.when(mockBackend.getLocation()).thenReturn(location);
+        }
+
+        return mockBackend;
+    }
+
+    private SystemInfoService mockSystemInfoService(String... locationLabel) {
+        SystemInfoService mockSystemInfoService = Mockito.mock(SystemInfoService.class);
+        List<Backend> backends = new ArrayList<>();
+        for (String location : locationLabel) {
+            backends.add(mockBackend(location));
+        }
+        Mockito.when(mockSystemInfoService.getBackends()).thenReturn(backends);
+
+        return mockSystemInfoService;
+    }
+
+    @Test
+    public void testCollectBackendWithLocation() {
+
+        systemInfoService = mockSystemInfoService("", "", "");
+        Multimap<String, String> backendLocations = TabletChecker.collectDistinctBackendLocations(systemInfoService);
+        Assert.assertEquals(0, backendLocations.size());
+
+        systemInfoService = mockSystemInfoService(
+                "rack:rack1",
+                "rack:rack1",
+                "rack:rack1",
+                "");
+        backendLocations = TabletChecker.collectDistinctBackendLocations(systemInfoService);
+        Assert.assertEquals(1, backendLocations.size());
+
+        systemInfoService = mockSystemInfoService(
+                "rack:rack1",
+                "rack:rack1",
+                "rack:rack1",
+                "rack:rack2",
+                "rack:rack3",
+                "region:region1",
+                "region:region2");
+        backendLocations = TabletChecker.collectDistinctBackendLocations(systemInfoService);
+        Assert.assertEquals(5, backendLocations.size());
+    }
+
+    @Test
+    public void testShouldEnsureReplicaHA() {
+        systemInfoService = mockSystemInfoService(
+                "rack:rack1",
+                "rack:rack1",
+                "rack:rack1",
+                "rack:rack2",
+                "rack:rack2",
+                "rack:rack3",
+                "region:region1",
+                "region:region2");
+
+        Multimap<String, String> requiredLocation = ArrayListMultimap.create();
+        Assert.assertFalse(TabletChecker.shouldEnsureReplicaHA(1, null, systemInfoService));
+        Assert.assertFalse(TabletChecker.shouldEnsureReplicaHA(2, requiredLocation, systemInfoService));
+
+        requiredLocation.put("rack", "rack2");
+        Assert.assertTrue(TabletChecker.shouldEnsureReplicaHA(1, requiredLocation, systemInfoService));
+        Assert.assertFalse(TabletChecker.shouldEnsureReplicaHA(2, requiredLocation, systemInfoService));
+        requiredLocation.clear();
+
+        requiredLocation.put("rack", "rack2");
+        requiredLocation.put("rack", "rack3");
+        Assert.assertTrue(TabletChecker.shouldEnsureReplicaHA(2, requiredLocation, systemInfoService));
+        Assert.assertFalse(TabletChecker.shouldEnsureReplicaHA(3, requiredLocation, systemInfoService));
+        requiredLocation.clear();
+
+        requiredLocation.put("rack", "*");
+        Assert.assertTrue(TabletChecker.shouldEnsureReplicaHA(3, requiredLocation, systemInfoService));
+        requiredLocation.clear();
+
+        requiredLocation.put("rack", "rack3");
+        requiredLocation.put("region", "*");
+        Assert.assertTrue(TabletChecker.shouldEnsureReplicaHA(3, requiredLocation, systemInfoService));
+        requiredLocation.clear();
+
+        requiredLocation.put("*", "");
+        Assert.assertTrue(TabletChecker.shouldEnsureReplicaHA(3, requiredLocation, systemInfoService));
+        requiredLocation.clear();
+    }
+
+    private static SystemInfoService systemInfoService;
+}


### PR DESCRIPTION
## Why I'm doing:

There is an issue with the current tablet health check logic. For example, a tablet may have three replicas located on different BEs, but all of these BEs share the same label, such as rack:rack1. In this case, the system incorrectly marks the tablet as being in a **LOCATION_MISMATCH** state.

This judgment is unreasonable because it affects operations that rely on the tablet's health status, such as tablet scheduling and index creation. If all nodes in the cluster have the same label, it is effectively equivalent to having no label at all. However, StarRocks behaves inconsistently between these two cases.

Moreover, the current design explicitly allows multiple replicas of the same tablet to reside within the same rack. Therefore, it is not appropriate to consider a tablet unhealthy just because its replicas share the same label.

## What I'm doing:

Remove the redundant validation logic.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
