### PR TITLE
[BugFix] Fix short circuit not work when table has global dict columns

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ShortCircuitPlannerHybrid.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ShortCircuitPlannerHybrid.java
@@ -25,7 +25,6 @@ import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
-import com.starrocks.sql.optimizer.statistics.IDictManager;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ShortCircuitPlannerHybrid.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ShortCircuitPlannerHybrid.java
@@ -47,12 +47,6 @@ public class ShortCircuitPlannerHybrid {
                 return false;
             }
 
-            for (Column column : table.getFullSchema()) {
-                if (IDictManager.getInstance().hasGlobalDict(table.getId(), column.getColumnId())) {
-                    return false;
-                }
-            }
-
             List<String> keyColumns = ((OlapTable) table).getKeyColumns().stream().map(Column::getName).collect(
                     Collectors.toList());
             List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -2237,4 +2237,12 @@ public class LowCardinalityTest2 extends PlanTestBase {
         Assert.assertFalse("table doesn't contain global dict, we can change its distribution",
                 execPlan.getOptExpression(1).isExistRequiredDistribution());
     }
+
+    @Test
+    public void testShortCircuitQuery() throws Exception {
+        connectContext.getSessionVariable().setEnableShortCircuit(true);
+        String sql = "select * from low_card_t2 where d_date='20160404' and c_mr = '12'";
+        final String plan = getFragmentPlan(sql);
+        assertContains(plan, "Short Circuit Scan: true");
+    }
 }


### PR DESCRIPTION

## Why I'm doing:

Our global dictionary is not optimized for point query, and our short-circuits only work for point query. So we don't have to check whether we store a global dictionary in whether we enable short path optimization.

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/9779

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
