### PR TITLE
[Refactor] Refactor cache metrics

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -841,7 +841,7 @@ void* ReportDataCacheMetricsTaskWorkerPool::_worker_thread_callback(void* arg_th
         TDataCacheMetrics t_metrics{};
         const LocalCache* cache = DataCache::GetInstance()->local_cache();
         if (cache != nullptr && cache->is_initialized()) {
-            const DataCacheMetrics& metrics = cache->cache_metrics(0);
+            const auto metrics = cache->cache_metrics();
             DataCacheUtils::set_metrics_from_thrift(t_metrics, metrics);
         } else {
             t_metrics.__set_status(TDataCacheStatus::DISABLED);

--- a/be/src/cache/cache_options.h
+++ b/be/src/cache/cache_options.h
@@ -22,10 +22,6 @@
 #include "cache/dummy_types.h"
 #include "common/status.h"
 
-#ifdef WITH_STARCACHE
-#include "starcache/star_cache.h"
-#endif
-
 namespace starrocks {
 
 // Options to control how to create DataCache instance
@@ -75,7 +71,7 @@ struct WriteCacheOptions {
     bool overwrite = false;
     bool async = false;
     // When allow_zero_copy=true, it means the caller can ensure the target buffer not be released before
-    // the write finish. So the cache library can use the buffer directly without copying it to another buffer.
+    // to write finish. So the cache library can use the buffer directly without copying it to another buffer.
     bool allow_zero_copy = false;
     std::function<void(int, const std::string&)> callback = nullptr;
 
@@ -107,17 +103,5 @@ struct ReadCacheOptions {
         int64_t read_disk_bytes = 0;
     } stats;
 };
-
-// We use the `starcache::ObjectHandle` directly because implementing a new one seems unnecessary.
-// Importing the starcache headers here is not graceful, but the `cachelib` doesn't support
-// object cache and we'll deprecate it for some performance reasons. Now there is no need to
-// pay too much attention to the compatibility and upper-level abstraction of the cachelib interface.
-#ifdef WITH_STARCACHE
-using DataCacheMetrics = starcache::CacheMetrics;
-using DataCacheStatus = starcache::CacheStatus;
-#else
-using DataCacheMetrics = DummyCacheMetrics;
-using DataCacheStatus = DummyCacheStatus;
-#endif
 
 } // namespace starrocks

--- a/be/src/cache/datacache_utils.cpp
+++ b/be/src/cache/datacache_utils.cpp
@@ -32,6 +32,16 @@ void DataCacheUtils::set_metrics_from_thrift(TDataCacheMetrics& t_metrics, const
     t_metrics.__set_mem_used_bytes(metrics.mem_used_bytes);
 }
 
+#ifdef WITH_STARCACHE
+void DataCacheUtils::set_metrics_from_thrift(TDataCacheMetrics& t_metrics, const StarCacheMetrics& metrics) {
+    t_metrics.__set_status(DataCacheStatusUtils::to_thrift(static_cast<DataCacheStatus>(metrics.status)));
+    t_metrics.__set_disk_quota_bytes(metrics.disk_quota_bytes);
+    t_metrics.__set_disk_used_bytes(metrics.disk_used_bytes);
+    t_metrics.__set_mem_quota_bytes(metrics.mem_quota_bytes);
+    t_metrics.__set_mem_used_bytes(metrics.mem_used_bytes);
+}
+#endif
+
 Status DataCacheUtils::parse_conf_datacache_mem_size(const std::string& conf_mem_size_str, int64_t mem_limit,
                                                      size_t* mem_size) {
     ASSIGN_OR_RETURN(int64_t parsed_mem_size, ParseUtil::parse_mem_spec(conf_mem_size_str, mem_limit));

--- a/be/src/cache/datacache_utils.cpp
+++ b/be/src/cache/datacache_utils.cpp
@@ -21,25 +21,11 @@
 
 #include "fs/fs.h"
 #include "gutil/strings/split.h"
-#include "util/disk_info.h"
 #include "util/parse_util.h"
 
 namespace starrocks {
 void DataCacheUtils::set_metrics_from_thrift(TDataCacheMetrics& t_metrics, const DataCacheMetrics& metrics) {
-    switch (metrics.status) {
-    case DataCacheStatus::NORMAL:
-        t_metrics.__set_status(TDataCacheStatus::NORMAL);
-        break;
-    case DataCacheStatus::UPDATING:
-        t_metrics.__set_status(TDataCacheStatus::UPDATING);
-        break;
-    case DataCacheStatus::LOADING:
-        t_metrics.__set_status(TDataCacheStatus::LOADING);
-        break;
-    default:
-        t_metrics.__set_status(TDataCacheStatus::ABNORMAL);
-    }
-
+    t_metrics.__set_status(DataCacheStatusUtils::to_thrift(metrics.status));
     t_metrics.__set_disk_quota_bytes(metrics.disk_quota_bytes);
     t_metrics.__set_disk_used_bytes(metrics.disk_used_bytes);
     t_metrics.__set_mem_quota_bytes(metrics.mem_quota_bytes);

--- a/be/src/cache/datacache_utils.h
+++ b/be/src/cache/datacache_utils.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "cache/dummy_types.h"
 #include "cache/local_cache.h"
 #include "gen_cpp/DataCache_types.h"
 
@@ -22,6 +23,10 @@ namespace starrocks {
 class DataCacheUtils {
 public:
     static void set_metrics_from_thrift(TDataCacheMetrics& t_metrics, const DataCacheMetrics& metrics);
+
+#ifdef WITH_STARCACHE
+    static void set_metrics_from_thrift(TDataCacheMetrics& t_metrics, const StarCacheMetrics& metrics);
+#endif
 
     static Status parse_conf_datacache_mem_size(const std::string& conf_mem_size_str, int64_t mem_limit,
                                                 size_t* mem_size);

--- a/be/src/cache/disk_space_monitor.cpp
+++ b/be/src/cache/disk_space_monitor.cpp
@@ -353,7 +353,7 @@ std::string DiskSpaceMonitor::to_string(const std::vector<DirSpace>& dir_spaces)
 }
 
 void DiskSpaceMonitor::_update_cache_stats() {
-    const auto metrics = _cache->cache_metrics(0);
+    const auto metrics = _cache->cache_metrics();
     _total_cache_usage = metrics.disk_used_bytes;
     _total_cache_quota = metrics.disk_quota_bytes;
 }

--- a/be/src/cache/dummy_types.h
+++ b/be/src/cache/dummy_types.h
@@ -15,23 +15,59 @@
 #pragma once
 
 #include "common/status.h"
+#include "gen_cpp/DataCache_types.h"
+
+#ifdef WITH_STARCACHE
+#include "starcache/star_cache.h"
+#endif
 
 namespace starrocks {
 
-enum class DummyCacheStatus { NORMAL, UPDATING, ABNORMAL, LOADING };
+enum class DataCacheStatus { NORMAL, UPDATING, ABNORMAL, LOADING };
 
-struct DummyCacheMetrics {
-    struct DirSpace {
-        std::string path;
-        size_t quota_bytes;
-    };
-    DummyCacheStatus status;
-    int64_t mem_quota_bytes;
+struct DataCacheStatusUtils {
+    static std::string to_string(DataCacheStatus status) {
+        switch (status) {
+        case DataCacheStatus::NORMAL:
+            return "NORMAL";
+        case DataCacheStatus::UPDATING:
+            return "UPDATING";
+        case DataCacheStatus::ABNORMAL:
+            return "ABNORMAL";
+        case DataCacheStatus::LOADING:
+            return "LOADING";
+        default:
+            return "UNKNOWN";
+        }
+    }
+
+    static TDataCacheStatus::type to_thrift(DataCacheStatus status) {
+        switch (status) {
+        case DataCacheStatus::NORMAL:
+            return TDataCacheStatus::NORMAL;
+        case DataCacheStatus::UPDATING:
+            return TDataCacheStatus::UPDATING;
+        case DataCacheStatus::LOADING:
+            return TDataCacheStatus::LOADING;
+        default:
+            return TDataCacheStatus::ABNORMAL;
+        }
+    }
+};
+
+struct DataCacheMetrics {
+    DataCacheStatus status;
+
+    size_t mem_quota_bytes;
     size_t mem_used_bytes;
     size_t disk_quota_bytes;
     size_t disk_used_bytes;
-    std::vector<DirSpace> disk_dir_spaces;
     size_t meta_used_bytes = 0;
 };
+
+#ifdef WITH_STARCACHE
+using StarCacheMetrics = starcache::CacheMetrics;
+using StarCacheStatus = starcache::CacheStatus;
+#endif
 
 } // namespace starrocks

--- a/be/src/cache/local_cache.h
+++ b/be/src/cache/local_cache.h
@@ -49,7 +49,7 @@ public:
     // Update the datacache disk space information, such as disk quota or disk path.
     virtual Status update_disk_spaces(const std::vector<DirSpace>& spaces) = 0;
 
-    virtual const DataCacheMetrics cache_metrics(int level) const = 0;
+    virtual const DataCacheMetrics cache_metrics() const = 0;
 
     virtual void record_read_remote(size_t size, int64_t latency_us) = 0;
 

--- a/be/src/cache/starcache_wrapper.cpp
+++ b/be/src/cache/starcache_wrapper.cpp
@@ -17,6 +17,7 @@
 #include <filesystem>
 
 #include "cache/disk_space_monitor.h"
+#include "cache/dummy_types.h"
 #include "cache/status.h"
 #include "common/logging.h"
 #include "common/statusor.h"
@@ -144,16 +145,19 @@ Status StarCacheWrapper::update_disk_spaces(const std::vector<DirSpace>& spaces)
     return st;
 }
 
-const DataCacheMetrics StarCacheWrapper::cache_metrics(int level) const {
-    auto metrics = _cache->metrics(level);
-    // Now the EEXIST is treated as a failed status in starcache, which will cause the write_fail_count too large
-    // in many cases because we write cache with `overwrite=false` now. It makes users confused.
-    // As real writing failure rarely occur currently, so we temporarily adjust it here.
-    // Once the starcache library is update, the following lines will be removed.
-    if (metrics.detail_l2) {
-        metrics.detail_l2->write_success_count += metrics.detail_l2->write_fail_count;
-        metrics.detail_l2->write_fail_count = 0;
-    }
+const StarCacheMetrics StarCacheWrapper::starcache_metrics(int level) const {
+    return _cache->metrics(level);
+}
+
+const DataCacheMetrics StarCacheWrapper::cache_metrics() const {
+    auto starcache_metrics = _cache->metrics(0);
+    DataCacheMetrics metrics = {
+            .status = static_cast<DataCacheStatus>(starcache_metrics.status),
+            .mem_quota_bytes = starcache_metrics.mem_quota_bytes,
+            .mem_used_bytes = starcache_metrics.mem_used_bytes,
+            .disk_quota_bytes = starcache_metrics.disk_quota_bytes,
+            .disk_used_bytes = starcache_metrics.disk_used_bytes,
+            .meta_used_bytes = starcache_metrics.meta_used_bytes};
     return metrics;
 }
 
@@ -175,14 +179,14 @@ Status StarCacheWrapper::shutdown() {
 }
 
 void StarCacheWrapper::_refresh_quota() {
-    auto metrics = cache_metrics(0);
+    auto metrics = starcache_metrics(0);
     _mem_quota.store(metrics.mem_quota_bytes, std::memory_order_relaxed);
     _disk_quota.store(metrics.disk_quota_bytes, std::memory_order_relaxed);
 }
 
 void StarCacheWrapper::disk_spaces(std::vector<DirSpace>* spaces) const {
     spaces->clear();
-    auto metrics = cache_metrics(0);
+    auto metrics = starcache_metrics(0);
     for (auto& dir : metrics.disk_dir_spaces) {
         spaces->push_back({.path = dir.path, .size = dir.quota_bytes});
     }

--- a/be/src/cache/starcache_wrapper.cpp
+++ b/be/src/cache/starcache_wrapper.cpp
@@ -151,13 +151,12 @@ const StarCacheMetrics StarCacheWrapper::starcache_metrics(int level) const {
 
 const DataCacheMetrics StarCacheWrapper::cache_metrics() const {
     auto starcache_metrics = _cache->metrics(0);
-    DataCacheMetrics metrics = {
-            .status = static_cast<DataCacheStatus>(starcache_metrics.status),
-            .mem_quota_bytes = starcache_metrics.mem_quota_bytes,
-            .mem_used_bytes = starcache_metrics.mem_used_bytes,
-            .disk_quota_bytes = starcache_metrics.disk_quota_bytes,
-            .disk_used_bytes = starcache_metrics.disk_used_bytes,
-            .meta_used_bytes = starcache_metrics.meta_used_bytes};
+    DataCacheMetrics metrics = {.status = static_cast<DataCacheStatus>(starcache_metrics.status),
+                                .mem_quota_bytes = starcache_metrics.mem_quota_bytes,
+                                .mem_used_bytes = starcache_metrics.mem_used_bytes,
+                                .disk_quota_bytes = starcache_metrics.disk_quota_bytes,
+                                .disk_used_bytes = starcache_metrics.disk_used_bytes,
+                                .meta_used_bytes = starcache_metrics.meta_used_bytes};
     return metrics;
 }
 

--- a/be/src/cache/starcache_wrapper.h
+++ b/be/src/cache/starcache_wrapper.h
@@ -41,7 +41,9 @@ public:
 
     Status update_disk_spaces(const std::vector<DirSpace>& spaces) override;
 
-    const DataCacheMetrics cache_metrics(int level) const override;
+    const StarCacheMetrics starcache_metrics(int level) const;
+
+    const DataCacheMetrics cache_metrics() const override;
 
     void record_read_remote(size_t size, int64_t latency_us) override;
 

--- a/be/src/exec/schema_scanner/schema_be_datacache_metrics_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_datacache_metrics_scanner.cpp
@@ -16,6 +16,7 @@
 
 #include "agent/master_info.h"
 #include "cache/datacache.h"
+#include "cache/starcache_wrapper.h"
 #include "column/datum.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/exec_env.h"
@@ -60,25 +61,16 @@ Status SchemaBeDataCacheMetricsScanner::get_next(ChunkPtr* chunk, bool* eos) {
 
     DatumArray row{};
     std::string status{};
-    DataCacheMetrics metrics{};
+    StarCacheMetrics metrics{};
 
     row.emplace_back(_be_id);
 
-    const LocalCache* cache = DataCache::GetInstance()->local_cache();
+    const auto* cache = reinterpret_cast<StarCacheWrapper*>(DataCache::GetInstance()->local_cache());
     if (cache != nullptr && cache->is_initialized()) {
         // retrieve different priority's used bytes from level = 2 metrics
-        metrics = cache->cache_metrics(2);
+        metrics = cache->starcache_metrics(2);
 
-        switch (metrics.status) {
-        case DataCacheStatus::NORMAL:
-            status = "Normal";
-            break;
-        case DataCacheStatus::UPDATING:
-            status = "Updating";
-            break;
-        default:
-            status = "Abnormal";
-        }
+        status = DataCacheStatusUtils::to_string(static_cast<DataCacheStatus>(metrics.status));
 
         row.emplace_back(Slice(status));
         row.emplace_back(metrics.disk_quota_bytes);

--- a/be/src/exec/schema_scanner/schema_be_datacache_metrics_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_datacache_metrics_scanner.cpp
@@ -16,11 +16,14 @@
 
 #include "agent/master_info.h"
 #include "cache/datacache.h"
-#include "cache/starcache_wrapper.h"
 #include "column/datum.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/exec_env.h"
 #include "runtime/string_value.h"
+
+#ifdef WITH_STARCACHE
+#include "cache/starcache_wrapper.h"
+#endif
 
 namespace starrocks {
 

--- a/be/src/http/action/datacache_action.cpp
+++ b/be/src/http/action/datacache_action.cpp
@@ -23,11 +23,14 @@
 
 #include "cache/block_cache/block_cache_hit_rate_counter.hpp"
 #include "cache/local_cache.h"
-#include "cache/starcache_wrapper.h"
 #include "http/http_channel.h"
 #include "http/http_headers.h"
 #include "http/http_request.h"
 #include "http/http_status.h"
+
+#ifdef WITH_STARCACHE
+#include "cache/starcache_wrapper.h"
+#endif
 
 namespace starrocks {
 

--- a/be/src/http/action/datacache_action.cpp
+++ b/be/src/http/action/datacache_action.cpp
@@ -23,6 +23,7 @@
 
 #include "cache/block_cache/block_cache_hit_rate_counter.hpp"
 #include "cache/local_cache.h"
+#include "cache/starcache_wrapper.h"
 #include "http/http_channel.h"
 #include "http/http_headers.h"
 #include "http/http_request.h"
@@ -34,25 +35,6 @@ const static std::string HEADER_JSON = "application/json";
 const static std::string ACTION_KEY = "action";
 const static std::string ACTION_STAT = "stat";
 const static std::string ACTION_APP_STAT = "app_stat";
-
-std::string cache_status_str(const DataCacheStatus& status) {
-    std::string str_status;
-    switch (status) {
-    case DataCacheStatus::NORMAL:
-        str_status = "NORMAL";
-        break;
-    case DataCacheStatus::UPDATING:
-        str_status = "UPDATING";
-        break;
-    case DataCacheStatus::ABNORMAL:
-        str_status = "ABNORMAL";
-        break;
-    case DataCacheStatus::LOADING:
-        str_status = "LOADING";
-        break;
-    }
-    return str_status;
-}
 
 bool DataCacheAction::_check_request(HttpRequest* req) {
     if (req->method() != HttpMethod::GET) {
@@ -97,8 +79,9 @@ void DataCacheAction::_handle_stat(HttpRequest* req) {
     _handle(req, [=](rapidjson::Document& root) {
 #ifdef WITH_STARCACHE
         auto& allocator = root.GetAllocator();
-        auto&& metrics = _local_cache->cache_metrics(2);
-        std::string status = cache_status_str(metrics.status);
+        auto* starcache = reinterpret_cast<StarCacheWrapper*>(_local_cache);
+        auto&& metrics = starcache->starcache_metrics(2);
+        std::string status = DataCacheStatusUtils::to_string(static_cast<DataCacheStatus>(metrics.status));
 
         rapidjson::Value status_value;
         status_value.SetString(status.c_str(), status.length(), allocator);

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -517,7 +517,7 @@ void RuntimeState::update_load_datacache_metrics(TReportExecStatusParams* load_p
         const LocalCache* cache = DataCache::GetInstance()->local_cache();
         if (cache != nullptr && cache->is_initialized()) {
             TDataCacheMetrics t_metrics{};
-            DataCacheUtils::set_metrics_from_thrift(t_metrics, cache->cache_metrics(0));
+            DataCacheUtils::set_metrics_from_thrift(t_metrics, cache->cache_metrics());
             metrics.__set_metrics(t_metrics);
             load_params->__set_load_datacache_metrics(metrics);
         }

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -304,7 +304,7 @@ void SystemMetrics::_update_datacache_mem_tracker() {
     if (datacache_mem_tracker) {
         LocalCache* local_cache = DataCache::GetInstance()->local_cache();
         if (local_cache != nullptr && local_cache->is_initialized()) {
-            auto datacache_metrics = local_cache->cache_metrics(0);
+            auto datacache_metrics = local_cache->cache_metrics();
             datacache_mem_bytes = datacache_metrics.mem_used_bytes + datacache_metrics.meta_used_bytes;
         }
 #ifdef USE_STAROS

--- a/be/test/cache/block_cache/block_cache_test.cpp
+++ b/be/test/cache/block_cache/block_cache_test.cpp
@@ -227,7 +227,7 @@ TEST_F(BlockCacheTest, update_cache_quota) {
     auto local_cache = cache->local_cache();
 
     {
-        auto metrics = local_cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics();
         ASSERT_EQ(metrics.mem_quota_bytes, options.mem_space_size);
         ASSERT_EQ(metrics.disk_quota_bytes, quota);
     }
@@ -235,7 +235,7 @@ TEST_F(BlockCacheTest, update_cache_quota) {
     {
         size_t new_mem_quota = 2 * 1024 * 1024;
         ASSERT_TRUE(local_cache->update_mem_quota(new_mem_quota, false).ok());
-        auto metrics = local_cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics();
         ASSERT_EQ(metrics.mem_quota_bytes, new_mem_quota);
     }
 
@@ -244,7 +244,7 @@ TEST_F(BlockCacheTest, update_cache_quota) {
         std::vector<DirSpace> dir_spaces;
         dir_spaces.push_back({.path = cache_dir, .size = new_disk_quota});
         ASSERT_TRUE(local_cache->update_disk_spaces(dir_spaces).ok());
-        auto metrics = local_cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics();
         ASSERT_EQ(metrics.disk_quota_bytes, new_disk_quota);
     }
 

--- a/be/test/cache/disk_space_monitor_test.cpp
+++ b/be/test/cache/disk_space_monitor_test.cpp
@@ -193,27 +193,27 @@ TEST_F(DiskSpaceMonitorTest, auto_increase_cache_quota) {
     // Fill cache data
     {
         insert_to_cache(block_cache.get(), 19);
-        auto metrics = local_cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics();
         int64_t used_rate = metrics.disk_used_bytes * 100 / metrics.disk_quota_bytes;
         ASSERT_GT(used_rate, DiskSpace::kAutoIncreaseThreshold);
     }
 
     {
-        auto metrics = local_cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics();
         ASSERT_EQ(metrics.disk_quota_bytes, 20 * MB);
     }
 
     {
         config::enable_datacache_disk_auto_adjust = true;
         sleep(3);
-        auto metrics = local_cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics();
         ASSERT_EQ(metrics.disk_quota_bytes, 20 * MB);
     }
 
     {
         config::datacache_disk_idle_seconds_for_expansion = 1;
         sleep(3);
-        auto metrics = local_cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics();
         // other: 500M - 300M - 19M = 181M
         // new quota: 500 * 0.7 - other = 169M, 169M/10 * 10 = 160M
         ASSERT_EQ(metrics.disk_quota_bytes, 160 * MB);
@@ -243,27 +243,27 @@ TEST_F(DiskSpaceMonitorTest, auto_increase_cache_quota_with_limit) {
     // Fill cache data
     {
         insert_to_cache(block_cache.get(), 19);
-        auto metrics = local_cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics();
         int64_t used_rate = metrics.disk_used_bytes * 100 / metrics.disk_quota_bytes;
         ASSERT_GT(used_rate, DiskSpace::kAutoIncreaseThreshold);
     }
 
     {
-        auto metrics = local_cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics();
         ASSERT_EQ(metrics.disk_quota_bytes, 20 * MB);
     }
 
     {
         config::enable_datacache_disk_auto_adjust = true;
         sleep(3);
-        auto metrics = local_cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics();
         ASSERT_EQ(metrics.disk_quota_bytes, 20 * MB);
     }
 
     {
         config::datacache_disk_idle_seconds_for_expansion = 1;
         sleep(3);
-        auto metrics = local_cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics();
         // other: 500M - 300M - 19M = 181M
         // new quota: 500 * 0.7 - other = 169M, 169M/10 * 10 = 160M
         // max: 500 * 0.25 = 125M, 125M/10 * 10 = 120M
@@ -293,13 +293,13 @@ TEST_F(DiskSpaceMonitorTest, auto_decrease_cache_quota) {
     // Fill cache data
     {
         insert_to_cache(block_cache.get(), 50);
-        auto metrics = local_cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics();
         int64_t used_rate = metrics.disk_used_bytes * 100 / metrics.disk_quota_bytes;
         ASSERT_GT(used_rate, DiskSpace::kAutoIncreaseThreshold);
     }
 
     {
-        auto metrics = local_cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics();
         ASSERT_EQ(metrics.disk_quota_bytes, 50 * MB);
     }
 
@@ -307,7 +307,7 @@ TEST_F(DiskSpaceMonitorTest, auto_decrease_cache_quota) {
         config::enable_datacache_disk_auto_adjust = true;
         size_t new_quota = 0;
         for (int i = 0; i < 6; ++i) {
-            auto metrics = local_cache->cache_metrics(0);
+            auto metrics = local_cache->cache_metrics();
             if (metrics.disk_quota_bytes > 0 && metrics.disk_quota_bytes != 50 * MB) {
                 config::enable_datacache_disk_auto_adjust = false;
                 new_quota = metrics.disk_quota_bytes;
@@ -342,13 +342,13 @@ TEST_F(DiskSpaceMonitorTest, auto_decrease_cache_quota_to_zero) {
     // Fill cache data
     {
         insert_to_cache(block_cache.get(), 50);
-        auto metrics = local_cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics();
         int64_t used_rate = metrics.disk_used_bytes * 100 / metrics.disk_quota_bytes;
         ASSERT_GT(used_rate, DiskSpace::kAutoIncreaseThreshold);
     }
 
     {
-        auto metrics = local_cache->cache_metrics(0);
+        auto metrics = local_cache->cache_metrics();
         ASSERT_EQ(metrics.disk_quota_bytes, 50 * MB);
     }
 
@@ -356,7 +356,7 @@ TEST_F(DiskSpaceMonitorTest, auto_decrease_cache_quota_to_zero) {
         config::enable_datacache_disk_auto_adjust = true;
         size_t new_quota = 0;
         for (int i = 0; i < 6; ++i) {
-            auto metrics = local_cache->cache_metrics(0);
+            auto metrics = local_cache->cache_metrics();
             if (metrics.disk_quota_bytes > 0 && metrics.disk_quota_bytes != 50 * MB) {
                 config::enable_datacache_disk_auto_adjust = false;
                 new_quota = metrics.disk_quota_bytes;

--- a/test/sql/test_datacache/R/test_datacache_metrics
+++ b/test/sql/test_datacache/R/test_datacache_metrics
@@ -1,5 +1,5 @@
 -- name: test_datacache_metrics
 select STATUS from default_catalog.information_schema.be_datacache_metrics limit 1;
 -- result:
-Normal
+NORMAL
 -- !result


### PR DESCRIPTION
## Why I'm doing:

Cache metrics are the statistics of local cache engine. I split cache metrics into two parts:
* Universal cache metrics, such as mem usage, which all types of cache engines have.
* Proprietary metrics, which only one type of engine has.

`LocalCache` should be used as the cache engine interface, so it should not use the structure of `StarCache` lib as the return parameter for interfaces of cache engine.

## What I'm doing:

* Remove DummyCacheMetrics
* Add an interface to convert DataCacheStatus to either string or Thrift format.
* Modify the metrics interface of `LocalCache`.
* Remove code that was compatible with bugs in older versions.
* Fix the bug of `SchemaBeDataCacheMetricsScanner` not support `DataCacheStatus::LOADING`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
