### PR TITLE
[Enhancement] Introduce distribution_key_column_names in TabletSchema

### DIFF
--- a/be/src/storage/metadata_util.cpp
+++ b/be/src/storage/metadata_util.cpp
@@ -399,7 +399,7 @@ Status convert_t_schema_to_pb_schema(const TTabletSchema& tablet_schema, uint32_
         schema->set_bf_fpp(tablet_schema.bloom_filter_fpp);
     }
 
-    if (tablet_schema.__isset.distribution_key_column_ids) {
+    if (tablet_schema.__isset.distribution_key_column_names) {
         for (const auto& col_name : tablet_schema.distribution_key_column_names) {
             schema->add_distribution_key_column_names(col_name);
         }

--- a/be/src/storage/metadata_util.cpp
+++ b/be/src/storage/metadata_util.cpp
@@ -398,6 +398,10 @@ Status convert_t_schema_to_pb_schema(const TTabletSchema& tablet_schema, uint32_
     if (has_bf_columns && tablet_schema.__isset.bloom_filter_fpp) {
         schema->set_bf_fpp(tablet_schema.bloom_filter_fpp);
     }
+
+    for (const auto& col_name : tablet_schema.distribution_key_column_names) {
+        schema->add_distribution_key_column_names(col_name);
+    }
     return validate_tablet_schema(*schema);
 }
 

--- a/be/src/storage/metadata_util.cpp
+++ b/be/src/storage/metadata_util.cpp
@@ -399,8 +399,10 @@ Status convert_t_schema_to_pb_schema(const TTabletSchema& tablet_schema, uint32_
         schema->set_bf_fpp(tablet_schema.bloom_filter_fpp);
     }
 
-    for (const auto& col_name : tablet_schema.distribution_key_column_names) {
-        schema->add_distribution_key_column_names(col_name);
+    if (tablet_schema.__isset.distribution_key_column_ids) {
+        for (const auto& col_name : tablet_schema.distribution_key_column_names) {
+            schema->add_distribution_key_column_names(col_name);
+        }
     }
     return validate_tablet_schema(*schema);
 }

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -297,6 +297,8 @@ public:
     size_t num_key_columns() const { return _num_key_columns; }
     size_t num_short_key_columns() const { return _num_short_key_columns; }
 
+    std::vector<std::string> distribution_key_column_names() const { return _distribution_key_column_names; }
+
     size_t num_rows_per_row_block() const { return _num_rows_per_row_block; }
     KeysType keys_type() const { return static_cast<KeysType>(_keys_type); }
     size_t next_column_unique_id() const { return _next_column_unique_id; }
@@ -382,6 +384,8 @@ private:
     std::vector<ColumnId> _sort_key_idxes;
     std::vector<ColumnUID> _sort_key_uids;
     std::unordered_set<ColumnUID> _sort_key_uids_set;
+
+    std::vector<std::string> _distribution_key_column_names;
 
     uint8_t _keys_type = static_cast<uint8_t>(DUP_KEYS);
     CompressionTypePB _compression_type = CompressionTypePB::LZ4_FRAME;

--- a/be/test/storage/metadata_util_test.cpp
+++ b/be/test/storage/metadata_util_test.cpp
@@ -103,6 +103,9 @@ TEST(MetadataUtilTest, testConvertThriftSchemaToPbSchema) {
         });
     }
 
+    schema.__isset.distribution_key_column_names = true;
+    schema.distribution_key_column_names.emplace_back("c0");
+
     TabletSchemaPB schemaPb;
     ASSERT_TRUE(convert_t_schema_to_pb_schema(schema, TCompressionType::LZ4, &schemaPb).ok());
 
@@ -142,6 +145,9 @@ TEST(MetadataUtilTest, testConvertThriftSchemaToPbSchema) {
     ASSERT_EQ(schemaPb.table_indices(1).col_unique_id_size(), 1);
     ASSERT_EQ(schemaPb.table_indices(1).col_unique_id(0), 1);
     ASSERT_EQ(schemaPb.table_indices(1).index_name(), "vector_index");
+
+    ASSERT_EQ(schemaPb.distribution_key_column_names().size(), 1);
+    ASSERT_EQ(schemaPb.distribution_key_column_names(0), "c0");
 }
 
 } // namespace starrocks

--- a/be/test/storage/tablet_schema_test.cpp
+++ b/be/test/storage/tablet_schema_test.cpp
@@ -170,4 +170,29 @@ TEST(TabletSchemaTest, test_is_support_checksum) {
     ASSERT_FALSE(map_column2.is_support_checksum());
 }
 
+TEST(TabletSchemaTest, test_schema_with_distribution_key) {
+    // init tablet schema
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(DUP_KEYS);
+    schema_pb.set_num_short_key_columns(1);
+
+    auto c1 = schema_pb.add_column();
+    c1->set_unique_id(1);
+    c1->set_name("f1");
+    c1->set_type("VARCHAR");
+    c1->set_is_key(true);
+
+    auto c2 = schema_pb.add_column();
+    c2->set_unique_id(2);
+    c2->set_name("f2");
+    c2->set_type("SMALLINT");
+    c2->set_is_key(false);
+
+    schema_pb.add_distribution_key_column_names("f1");
+    TabletSchema tablet_schema(schema_pb);
+
+    ASSERT_TRUE(tablet_schema.distribution_key_column_names().size() == 1);
+    ASSERT_TRUE(tablet_schema.distribution_key_column_names()[0] == "f1");
+}
+
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
@@ -191,6 +191,7 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
                         .setSortKeyIndexes(null) // Rollup tablets does not have sort key
                         .setSortKeyUniqueIds(null)
                         .addColumns(rollupSchema)
+                        .setDistributionKeyColumnNames(table.getDistributionKeyColumnNames())
                         .build().toTabletSchema();
 
                 boolean createSchemaFile = true;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
@@ -191,7 +191,7 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
                         .setSortKeyIndexes(null) // Rollup tablets does not have sort key
                         .setSortKeyUniqueIds(null)
                         .addColumns(rollupSchema)
-                        .setDistributionKeyColumnNames(table.getDistributionKeyColumnNames())
+                        .setDistributionKeyColumnNames(table.getDistributionKeyColumnIds())
                         .build().toTabletSchema();
 
                 boolean createSchemaFile = true;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -407,6 +407,7 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
                             .setStorageType(TStorageType.COLUMN)
                             .addColumns(shadowSchema)
                             .setSchemaHash(0)
+                            .setDistributionKeyColumnNames(table.getDistributionKeyColumnNames())
                             .build().toTabletSchema();
 
                     boolean createSchemaFile = true;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -407,7 +407,7 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
                             .setStorageType(TStorageType.COLUMN)
                             .addColumns(shadowSchema)
                             .setSchemaHash(0)
-                            .setDistributionKeyColumnNames(table.getDistributionKeyColumnNames())
+                            .setDistributionKeyColumnNames(table.getDistributionKeyColumnIds())
                             .build().toTabletSchema();
 
                     boolean createSchemaFile = true;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -311,7 +311,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                             .setSortKeyIndexes(null) // Rollup tablets does not have sort key
                             .setSortKeyUniqueIds(null)
                             .addColumns(rollupSchema)
-                            .setDistributionKeyColumnNames(tbl.getDistributionKeyColumnNames())
+                            .setDistributionKeyColumnNames(tbl.getDistributionKeyColumnIds())
                             .build().toTabletSchema();
 
                 Map<Long, Long> tabletIdMap = this.physicalPartitionIdToBaseRollupTabletIdMap.get(partitionId);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -311,6 +311,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                             .setSortKeyIndexes(null) // Rollup tablets does not have sort key
                             .setSortKeyUniqueIds(null)
                             .addColumns(rollupSchema)
+                            .setDistributionKeyColumnNames(tbl.getDistributionKeyColumnNames())
                             .build().toTabletSchema();
 
                 Map<Long, Long> tabletIdMap = this.physicalPartitionIdToBaseRollupTabletIdMap.get(partitionId);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -3097,6 +3097,7 @@ public class SchemaChangeHandler extends AlterHandler {
                     .setSortKeyIndexes(schemaChangeData.getSortKeyIdxes())
                     .setSortKeyUniqueIds(schemaChangeData.getSortKeyUniqueIds())
                     .setIndexes(schemaChangeData.getIndexes())
+                    .setDistributionKeyColumnNames(schemaChangeData.getTable().getDistributionKeyColumnNames())
                     .build();
             job.setIndexTabletSchema(indexId, indexName, schemaInfo);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -3097,7 +3097,7 @@ public class SchemaChangeHandler extends AlterHandler {
                     .setSortKeyIndexes(schemaChangeData.getSortKeyIdxes())
                     .setSortKeyUniqueIds(schemaChangeData.getSortKeyUniqueIds())
                     .setIndexes(schemaChangeData.getIndexes())
-                    .setDistributionKeyColumnNames(schemaChangeData.getTable().getDistributionKeyColumnNames())
+                    .setDistributionKeyColumnNames(schemaChangeData.getTable().getDistributionKeyColumnIds())
                     .build();
             job.setIndexTabletSchema(indexId, indexName, schemaInfo);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -357,7 +357,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                             .setSortKeyIndexes(originIndexId == baseIndexId ? sortKeyIdxes : null)
                             .setSortKeyUniqueIds(originIndexId == baseIndexId ? sortKeyUniqueIds : null)
                             .addColumns(shadowSchema)
-                            .setDistributionKeyColumnNames(tbl.getDistributionKeyColumnNames())
+                            .setDistributionKeyColumnNames(tbl.getDistributionKeyColumnIds())
                             .build().toTabletSchema();
                     for (Tablet shadowTablet : shadowIdx.getTablets()) {
                         long shadowTabletId = shadowTablet.getId();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -357,6 +357,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                             .setSortKeyIndexes(originIndexId == baseIndexId ? sortKeyIdxes : null)
                             .setSortKeyUniqueIds(originIndexId == baseIndexId ? sortKeyUniqueIds : null)
                             .addColumns(shadowSchema)
+                            .setDistributionKeyColumnNames(tbl.getDistributionKeyColumnNames())
                             .build().toTabletSchema();
                     for (Tablet shadowTablet : shadowIdx.getTablets()) {
                         long shadowTabletId = shadowTablet.getId();

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -1035,6 +1035,7 @@ public class RestoreJob extends AbstractJob {
                         .setBloomFilterColumnNames(bfColumns)
                         .setBloomFilterFpp(bfFpp)
                         .setIndexes(localTbl.getCopiedIndexes())
+                        .setDistributionKeyColumnNames(localTbl.getDistributionKeyColumnNames())
                         .build().toTabletSchema();
                 for (Tablet restoreTablet : restoredIdx.getTablets()) {
                     globalStateMgr.getTabletInvertedIndex().addTablet(restoreTablet.getId(), tabletMeta);

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -1035,7 +1035,7 @@ public class RestoreJob extends AbstractJob {
                         .setBloomFilterColumnNames(bfColumns)
                         .setBloomFilterFpp(bfFpp)
                         .setIndexes(localTbl.getCopiedIndexes())
-                        .setDistributionKeyColumnNames(localTbl.getDistributionKeyColumnNames())
+                        .setDistributionKeyColumnNames(localTbl.getDistributionKeyColumnIds())
                         .build().toTabletSchema();
                 for (Tablet restoreTablet : restoredIdx.getTablets()) {
                     globalStateMgr.getTabletInvertedIndex().addTablet(restoreTablet.getId(), tabletMeta);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -3821,4 +3821,22 @@ public class OlapTable extends Table {
         }
         return true;
     }
+
+    // Get the column name of the distribution columns when OlapTable supports distribution by hash
+    // return empty list if the table is distributed by random
+    public List<String> getDistributionKeyColumnNames() {
+        List<String> distColumnNames = Lists.newArrayList();
+        switch (defaultDistributionInfo.getType()) {
+            case HASH: {
+                HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) defaultDistributionInfo;
+                for (ColumnId columnId : hashDistributionInfo.getDistributionColumns()) {
+                    distColumnNames.add(columnId.getId());
+                }
+                break;
+            }
+            default:
+                return distColumnNames;
+        }
+        return distColumnNames;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -3822,21 +3822,21 @@ public class OlapTable extends Table {
         return true;
     }
 
-    // Get the column name of the distribution columns when OlapTable supports distribution by hash
+    // Get the physical column name/ColumnId.id of the distribution columns when OlapTable supports distribution by hash
     // return empty list if the table is distributed by random
-    public List<String> getDistributionKeyColumnNames() {
-        List<String> distColumnNames = Lists.newArrayList();
+    public List<String> getDistributionKeyColumnIds() {
+        List<String> distColumnIds = Lists.newArrayList();
         switch (defaultDistributionInfo.getType()) {
             case HASH: {
                 HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) defaultDistributionInfo;
                 for (ColumnId columnId : hashDistributionInfo.getDistributionColumns()) {
-                    distColumnNames.add(columnId.getId());
+                    distColumnIds.add(columnId.getId());
                 }
                 break;
             }
             default:
-                return distColumnNames;
+                return distColumnIds;
         }
-        return distColumnNames;
+        return distColumnIds;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaInfo.java
@@ -54,6 +54,8 @@ public class SchemaInfo {
     private final Set<ColumnId> bloomFilterColumnNames;
     @SerializedName("bfColumnFpp")
     private final double bloomFilterFpp; // false positive probability
+    @SerializedName("distributionKeyColumnNames")
+    private final List<String> distributionKeyColumnNames;
 
     private SchemaInfo(Builder builder) {
         this.id = builder.id;
@@ -68,6 +70,7 @@ public class SchemaInfo {
         this.bloomFilterColumnNames = builder.bloomFilterColumnNames;
         this.bloomFilterFpp = builder.bloomFilterFpp;
         this.schemaHash = builder.schemaHash;
+        this.distributionKeyColumnNames = builder.distributionKeyColumnNames;
     }
 
     public long getId() {
@@ -148,6 +151,10 @@ public class SchemaInfo {
         if (bloomFilterColumnNames != null) {
             tSchema.setBloom_filter_fpp(bloomFilterFpp);
         }
+
+        if (distributionKeyColumnNames != null) {
+            tSchema.setDistribution_key_column_names(distributionKeyColumnNames);
+        }
         return tSchema;
     }
 
@@ -168,6 +175,7 @@ public class SchemaInfo {
         private List<Index> indexes;
         private Set<ColumnId> bloomFilterColumnNames;
         private double bloomFilterFpp; // false positive probability
+        private List<String> distributionKeyColumnNames;
 
         private Builder() {
         }
@@ -246,6 +254,12 @@ public class SchemaInfo {
 
         public Builder setSchemaHash(int schemaHash) {
             this.schemaHash = schemaHash;
+            return this;
+        }
+
+        public Builder setDistributionKeyColumnNames(List<String> distributionKeyColumnNames) {
+            Preconditions.checkState(this.distributionKeyColumnNames == null);
+            this.distributionKeyColumnNames = distributionKeyColumnNames;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -954,7 +954,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                     .setIndexes(olapTable.getCopiedIndexes())
                     .setSortKeyIndexes(indexMeta.getSortKeyIdxes())
                     .setSortKeyUniqueIds(indexMeta.getSortKeyUniqueIds())
-                    .setDistributionKeyColumnNames(olapTable.getDistributionKeyColumnNames())
+                    .setDistributionKeyColumnNames(olapTable.getDistributionKeyColumnIds())
                     .build().toTabletSchema();
 
             CreateReplicaTask task = CreateReplicaTask.newBuilder()

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -954,6 +954,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                     .setIndexes(olapTable.getCopiedIndexes())
                     .setSortKeyIndexes(indexMeta.getSortKeyIdxes())
                     .setSortKeyUniqueIds(indexMeta.getSortKeyUniqueIds())
+                    .setDistributionKeyColumnNames(olapTable.getDistributionKeyColumnNames())
                     .build().toTabletSchema();
 
             CreateReplicaTask task = CreateReplicaTask.newBuilder()

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -1222,7 +1222,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                                                         olapTable.getCopiedIndexes(), indexMeta.getSchema()))
                                             .setSortKeyIndexes(indexMeta.getSortKeyIdxes())
                                             .setSortKeyUniqueIds(indexMeta.getSortKeyUniqueIds())
-                                            .setDistributionKeyColumnNames(olapTable.getDistributionKeyColumnNames())
+                                            .setDistributionKeyColumnNames(olapTable.getDistributionKeyColumnIds())
                                             .build().toTabletSchema();
                                     CreateReplicaTask task = CreateReplicaTask.newBuilder()
                                             .setNodeId(backendId)

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -1222,6 +1222,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                                                         olapTable.getCopiedIndexes(), indexMeta.getSchema()))
                                             .setSortKeyIndexes(indexMeta.getSortKeyIdxes())
                                             .setSortKeyUniqueIds(indexMeta.getSortKeyUniqueIds())
+                                            .setDistributionKeyColumnNames(olapTable.getDistributionKeyColumnNames())
                                             .build().toTabletSchema();
                                     CreateReplicaTask task = CreateReplicaTask.newBuilder()
                                             .setNodeId(backendId)

--- a/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
@@ -248,7 +248,7 @@ public class TabletTaskExecutor {
                 .setBloomFilterColumnNames(table.getBfColumnIds())
                 .setBloomFilterFpp(table.getBfFpp())
                 .addColumns(indexMeta.getSchema())
-                .setDistributionKeyColumnNames(table.getDistributionKeyColumnNames())
+                .setDistributionKeyColumnNames(table.getDistributionKeyColumnIds())
                 .build().toTabletSchema();
 
         final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();

--- a/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
@@ -248,6 +248,7 @@ public class TabletTaskExecutor {
                 .setBloomFilterColumnNames(table.getBfColumnIds())
                 .setBloomFilterFpp(table.getBfFpp())
                 .addColumns(indexMeta.getSchema())
+                .setDistributionKeyColumnNames(table.getDistributionKeyColumnNames())
                 .build().toTabletSchema();
 
         final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/OlapTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/OlapTableTest.java
@@ -436,7 +436,7 @@ public class OlapTableTest {
     }
 
     @Test
-    public void testGetDistributionKeyColumnNames() {
+    public void testGetDistributionKeyColumnIds() {
         GlobalStateMgr.getCurrentState().getTabletInvertedIndex().clear();
 
         Column c0 = new Column("c0", Type.BIGINT, true, null, null, false, null, "cc0", 1);
@@ -456,8 +456,8 @@ public class OlapTableTest {
         );
 
         Assert.assertTrue(olapTable.getDefaultDistributionInfo().getType() == DistributionInfoType.HASH);
-        Assert.assertTrue(olapTable.getDistributionKeyColumnNames().size() == 1);
-        Assert.assertTrue(olapTable.getDistributionKeyColumnNames().get(0).equals("c0"));
+        Assert.assertTrue(olapTable.getDistributionKeyColumnIds().size() == 1);
+        Assert.assertTrue(olapTable.getDistributionKeyColumnIds().get(0).equals("c0"));
 
         new MockUp<DistributionInfo>() {
             @Mock
@@ -465,6 +465,6 @@ public class OlapTableTest {
                 return DistributionInfoType.RANDOM;
             }
         };
-        Assert.assertTrue(olapTable.getDistributionKeyColumnNames().isEmpty());
+        Assert.assertTrue(olapTable.getDistributionKeyColumnIds().isEmpty());
     }
 }

--- a/gensrc/proto/tablet_schema.proto
+++ b/gensrc/proto/tablet_schema.proto
@@ -96,6 +96,7 @@ message TabletSchemaPB {
     repeated uint32 sort_key_unique_ids = 13;
     repeated TabletIndexPB table_indices = 14;
     optional int32 compression_level = 15 [default=-1];
+    // physical column name
     repeated string distribution_key_column_names = 16;
     optional int64 id = 50;
 }

--- a/gensrc/proto/tablet_schema.proto
+++ b/gensrc/proto/tablet_schema.proto
@@ -96,6 +96,7 @@ message TabletSchemaPB {
     repeated uint32 sort_key_unique_ids = 13;
     repeated TabletIndexPB table_indices = 14;
     optional int32 compression_level = 15 [default=-1];
+    repeated string distribution_key_column_names = 16;
     optional int64 id = 50;
 }
 

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -55,6 +55,7 @@ struct TTabletSchema {
     10: optional list<i32> sort_key_idxes
     11: optional list<i32> sort_key_unique_ids
     12: optional i32 schema_version;
+    13: optional list<string> distribution_key_column_names;
 }
 
 // this enum stands for different storage format in src_backends

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -55,6 +55,7 @@ struct TTabletSchema {
     10: optional list<i32> sort_key_idxes
     11: optional list<i32> sort_key_unique_ids
     12: optional i32 schema_version;
+    // physical column name
     13: optional list<string> distribution_key_column_names;
 }
 


### PR DESCRIPTION
## What I'm doing:
This is a prerequisite for tablet spliting. We introduce distribution_key_column_names in TabletSchema to ensure the ability to use them for data filtering base on hash in the future pr.

We choose physical column names instead of column unique id because column names are easier to handle compatibility issues for the tables which create in the older version without unique id in FE.

Fixes #59134 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
