### PR TITLE
[Enhancement] Optimize int256 multiplication implement

### DIFF
--- a/be/src/types/int256.cpp
+++ b/be/src/types/int256.cpp
@@ -27,8 +27,8 @@ namespace starrocks {
 int256_t::operator double() const {
     if (*this == 0) return 0.0;
 
-    bool negative = (high < 0);
-    int256_t abs_val = negative ? -*this : *this;
+    const bool negative = (high < 0);
+    const int256_t abs_val = negative ? -*this : *this;
 
     // Find the position of the most significant bit
     int bit_count = 0;
@@ -48,12 +48,226 @@ int256_t::operator double() const {
         return negative ? -result : result;
     } else {
         // Need to round to fit in double precision
-        int shift = bit_count - 53;
-        int256_t rounded = (abs_val + (int256_t(1) << (shift - 1))) >> shift;
-        double mantissa = static_cast<double>(static_cast<uint64_t>(rounded.low));
-        double result = mantissa * pow(2.0, shift);
+        const int shift = bit_count - 53;
+        const int256_t rounded = (abs_val + (int256_t(1) << (shift - 1))) >> shift;
+        const double mantissa = static_cast<double>(static_cast<uint64_t>(rounded.low));
+        const double result = mantissa * pow(2.0, shift);
         return negative ? -result : result;
     }
+}
+
+// =============================================================================
+// Multiplication Runtime Implementation - Helper Functions
+// =============================================================================
+
+/**
+ * @brief Multiply two 64-bit unsigned integers to produce a 256-bit result
+ *
+ * This is the simplest case where both operands fit in 64 bits.
+ * The mathematical result is at most 128 bits, which easily fits in int256_t.
+ *
+ * Mathematical formula: result = a × b (where a, b ≤ 2^64 - 1)
+ * Maximum result: (2^64 - 1)² = 2^128 - 2^65 + 1 < 2^128
+ *
+ * @param a First 64-bit operand
+ * @param b Second 64-bit operand
+ * @param is_negative Whether the final result should be negative
+ * @return Product as int256_t with high=0 and low containing the 128-bit result
+ */
+int256_t int256_t::multiply_64x64(const uint64_t a, const uint64_t b, const bool is_negative) {
+    const uint128_t product = static_cast<uint128_t>(a) * static_cast<uint128_t>(b);
+    const int256_t result(0, product);
+    return is_negative ? -result : result;
+};
+
+/**
+ * @brief Multiply two 128-bit unsigned integers to produce a 256-bit result
+ *
+ * This implements the classic "long multiplication" algorithm by breaking each
+ * 128-bit number into two 64-bit parts and performing four 64×64 multiplications.
+ *
+ * Algorithm breakdown:
+ * Let a = a_high × 2^64 + a_low, b = b_high × 2^64 + b_low
+ * Then: a × b = (a_high × 2^64 + a_low) × (b_high × 2^64 + b_low)
+ *             = a_high × b_high × 2^128     (p3 × 2^128)
+ *             + a_high × b_low × 2^64       (p2 × 2^64)
+ *             + a_low × b_high × 2^64       (p1 × 2^64)
+ *             + a_low × b_low               (p0)
+ *
+ * Position mapping in 256-bit result:
+ * ┌─────────────┬─────────────┬─────────────┬─────────────┐
+ * │   255-192   │   191-128   │   127-64    │    63-0     │
+ * ├─────────────┼─────────────┼─────────────┼─────────────┤
+ * │     p3      │             │             │     p0      │ ← Direct placement
+ * │             │ middle>>64  │ middle<<64  │             │ ← Middle terms
+ * └─────────────┴─────────────┴─────────────┴─────────────┘
+ *              result_high                result_low
+ *
+ * @param a First 128-bit operand
+ * @param b Second 128-bit operand
+ * @param is_negative Whether the final result should be negative
+ * @return Product as int256_t containing the full 256-bit result
+ */
+int256_t int256_t::multiply_128x128(const uint128_t a, const uint128_t b, const bool is_negative) {
+    const uint64_t a_low = static_cast<uint64_t>(a);
+    const uint64_t a_high = static_cast<uint64_t>(a >> 64);
+    const uint64_t b_low = static_cast<uint64_t>(b);
+    const uint64_t b_high = static_cast<uint64_t>(b >> 64);
+
+    const uint128_t p0 = static_cast<uint128_t>(a_low) * static_cast<uint128_t>(b_low);   // low × low
+    const uint128_t p1 = static_cast<uint128_t>(a_low) * static_cast<uint128_t>(b_high);  // low × high
+    const uint128_t p2 = static_cast<uint128_t>(a_high) * static_cast<uint128_t>(b_low);  // high × low
+    const uint128_t p3 = static_cast<uint128_t>(a_high) * static_cast<uint128_t>(b_high); // high × high
+
+    uint128_t result_low = p0;
+    uint128_t result_high = p3;
+
+    const uint128_t middle = p1 + p2;
+
+    result_low += (middle << 64);
+    result_high += (middle >> 64);
+
+    if (result_low < p0) {
+        result_high++;
+    }
+
+    const int256_t result(static_cast<int128_t>(result_high), result_low);
+    return is_negative ? -result : result;
+}
+
+/**
+ * @brief Multiply a 64-bit integer by a 256-bit integer
+ *
+ * This function implements multiplication of a small (64-bit) value with a large
+ * (256-bit) value using the distributive property. The 256-bit number is treated
+ * as an array of four 64-bit parts, and we multiply each part by the small value.
+ *
+ * Algorithm:
+ * 1. Break large number into four 64-bit parts: [p3, p2, p1, p0]
+ * 2. Multiply each part by small: small × p_i
+ * 3. Handle carries between parts to prevent overflow
+ * 4. Reconstruct 256-bit result from the four 64-bit results
+ *
+ * Mathematical representation:
+ * large = p3×2^192 + p2×2^128 + p1×2^64 + p0
+ * result = small × (p3×2^192 + p2×2^128 + p1×2^64 + p0)
+ *        = (small×p3)×2^192 + (small×p2)×2^128 + (small×p1)×2^64 + (small×p0)
+ *
+ * @param small 64-bit operand (multiplicand)
+ * @param large 256-bit operand (multiplier)
+ * @param is_negative Whether the final result should be negative
+ * @return Product as int256_t
+ */
+int256_t int256_t::multiply_64x256(const uint64_t small, const int256_t& large, const bool is_negative) {
+    uint64_t large_parts[4];
+    large_parts[0] = static_cast<uint64_t>(large.low);
+    large_parts[1] = static_cast<uint64_t>(large.low >> 64);
+    large_parts[2] = static_cast<uint64_t>(large.high);
+    large_parts[3] = static_cast<uint64_t>(large.high >> 64);
+
+    uint64_t result[4] = {0, 0, 0, 0};
+    uint64_t carry = 0;
+
+    for (int i = 0; i < 4; i++) {
+        const uint128_t product = static_cast<uint128_t>(small) * static_cast<uint128_t>(large_parts[i]) + carry;
+        result[i] = static_cast<uint64_t>(product);
+        carry = static_cast<uint64_t>(product >> 64);
+    }
+
+    const uint128_t result_low = static_cast<uint128_t>(result[0]) | (static_cast<uint128_t>(result[1]) << 64);
+    const int128_t result_high =
+            static_cast<int128_t>(static_cast<uint128_t>(result[2]) | (static_cast<uint128_t>(result[3]) << 64));
+
+    const int256_t final_result(result_high, result_low);
+    return is_negative ? -final_result : final_result;
+}
+
+/**
+ * @brief Multiply a 128-bit integer by a 256-bit integer
+ *
+ * This function breaks down the 128-bit operand into two 64-bit parts and
+ * uses the 64×256 multiplication function twice, then combines the results
+ * with appropriate bit shifting.
+ *
+ * Algorithm:
+ * 1. Split 128-bit number: small = small_high×2^64 + small_low
+ * 2. Compute: small × large = (small_high×2^64 + small_low) × large
+ *                           = small_high×large×2^64 + small_low×large
+ * 3. Use 64×256 multiplication for each term
+ * 4. Shift and add results
+ *
+ * @param small 128-bit operand
+ * @param large 256-bit operand
+ * @param is_negative Whether the final result should be negative
+ * @return Product as int256_t
+ */
+int256_t int256_t::multiply_128x256(const uint128_t small, const int256_t& large, const bool is_negative) {
+    const uint64_t small_low = static_cast<uint64_t>(small);
+    const uint64_t small_high = static_cast<uint64_t>(small >> 64);
+
+    const int256_t product_low = multiply_64x256(small_low, large, false);
+    int256_t product_high = multiply_64x256(small_high, large, false);
+
+    product_high = product_high << 64;
+
+    const int256_t result = product_low + product_high;
+    return is_negative ? -result : result;
+}
+
+// =============================================================================
+// Multiplication Runtime Implementation
+// =============================================================================
+
+int256_t int256_t::multiply_runtime(const int256_t& other) const {
+    if ((*this == int256_t(0)) || (other == int256_t(0))) {
+        return int256_t(0);
+    }
+    if (other == int256_t(1)) {
+        return *this;
+    }
+    if (*this == int256_t(1)) {
+        return other;
+    }
+
+    if (*this == INT256_MIN && other == int256_t(-1)) {
+        return INT256_MIN;
+    }
+    if (other == INT256_MIN && *this == int256_t(-1)) {
+        return INT256_MIN;
+    }
+
+    const bool is_negative = (high < 0) != (other.high < 0);
+    const int256_t lhs = (high < 0) ? -*this : *this;
+    const int256_t rhs = (other.high < 0) ? -other : other;
+
+    const bool lhs_is_64bit = (lhs.high == 0) && (static_cast<uint64_t>(lhs.low >> 64) == 0);
+    const bool rhs_is_64bit = (rhs.high == 0) && (static_cast<uint64_t>(rhs.low >> 64) == 0);
+    const bool lhs_is_128bit = (lhs.high == 0);
+    const bool rhs_is_128bit = (rhs.high == 0);
+
+    if (lhs_is_64bit && rhs_is_64bit) {
+        return multiply_64x64(static_cast<uint64_t>(lhs.low), static_cast<uint64_t>(rhs.low), is_negative);
+    }
+
+    if (lhs_is_128bit && rhs_is_128bit) {
+        return multiply_128x128(lhs.low, rhs.low, is_negative);
+    }
+
+    if (lhs_is_64bit) {
+        return multiply_64x256(static_cast<uint64_t>(lhs.low), rhs, is_negative);
+    }
+    if (rhs_is_64bit) {
+        return multiply_64x256(static_cast<uint64_t>(rhs.low), lhs, is_negative);
+    }
+
+    if (lhs_is_128bit) {
+        return multiply_128x256(lhs.low, rhs, is_negative);
+    }
+    if (rhs_is_128bit) {
+        return multiply_128x256(rhs.low, lhs, is_negative);
+    }
+
+    return multiply_core_256bit(lhs, rhs, is_negative);
 }
 
 // =============================================================================

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -442,6 +442,7 @@ set(EXEC_FILES
         ./serde/protobuf_serde_test.cpp
         ./types/bitmap_value_test.cpp
         ./types/int256_test.cpp
+        ./types/int256_arithmetic_test.cpp
         ./types/type_checker_test.cpp
         ./simd/batch_run_counter_test.cpp
         ./simd/simd_test.cpp

--- a/be/test/types/int256_arithmetic_test.cpp
+++ b/be/test/types/int256_arithmetic_test.cpp
@@ -1,0 +1,325 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <limits>
+#include <random>
+#include <vector>
+
+#include "types/int256.h"
+#include "types/large_int_value.h"
+
+namespace starrocks {
+
+class Int256ArithmeticTest : public testing::Test {
+public:
+    Int256ArithmeticTest() = default;
+
+protected:
+    void SetUp() override {}
+    void TearDown() override {}
+
+    static std::vector<int256_t> getTestValues() {
+        return {
+                int256_t(0),                                   // Zero
+                int256_t(1),                                   // One
+                int256_t(-1),                                  // Negative one
+                int256_t(42),                                  // Small positive
+                int256_t(-42),                                 // Small negative
+                int256_t(0x7FFFFFFF),                          // 32-bit max
+                int256_t(-0x80000000),                         // 32-bit min
+                int256_t(0x7FFFFFFFFFFFFFFFLL),                // 64-bit max
+                int256_t(-0x8000000000000000LL),               // 64-bit min
+                int256_t(static_cast<__int128>(1) << 100),     // Large 128-bit
+                int256_t(-(static_cast<__int128>(1) << 100)),  // Large negative 128-bit
+                int256_t(1, 0),                                // 2^128
+                int256_t(-1, 0),                               // -2^128
+                int256_t(0, static_cast<uint128_t>(-1)),       // 2^128 - 1
+                INT256_MAX,                                    // Maximum value
+                INT256_MIN,                                    // Minimum value
+                int256_t(INT256_MAX.high, INT256_MAX.low - 1), // Near maximum
+                int256_t(INT256_MIN.high, INT256_MIN.low + 1), // Near minimum
+        };
+    }
+};
+
+// =============================================================================
+// Multiplication Edge Cases and Overflow Tests
+// =============================================================================
+
+// NOLINTNEXTLINE
+TEST_F(Int256ArithmeticTest, multiplication_zero_cases) {
+    auto test_values = getTestValues();
+
+    for (const auto& value : test_values) {
+        // Any number multiplied by zero should be zero
+        ASSERT_EQ(int256_t(0), value * int256_t(0)) << "Failed for value: " << value.to_string();
+        ASSERT_EQ(int256_t(0), int256_t(0) * value) << "Failed for value: " << value.to_string();
+
+        // Any number multiplied by one should be itself
+        ASSERT_EQ(value, value * int256_t(1)) << "Failed for value: " << value.to_string();
+        ASSERT_EQ(value, int256_t(1) * value) << "Failed for value: " << value.to_string();
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256ArithmeticTest, multiplication_sign_handling) {
+    std::vector<std::pair<int256_t, int256_t>> sign_test_cases = {
+            {int256_t(42), int256_t(13)},   // positive × positive = positive
+            {int256_t(-42), int256_t(13)},  // negative × positive = negative
+            {int256_t(42), int256_t(-13)},  // positive × negative = negative
+            {int256_t(-42), int256_t(-13)}, // negative × negative = positive
+    };
+
+    for (const auto& [a, b] : sign_test_cases) {
+        const int256_t result = a * b;
+
+        if ((a.high < 0) != (b.high < 0)) {
+            ASSERT_TRUE(result.high < 0) << "Expected negative result for " << a.to_string() << " × " << b.to_string()
+                                         << " = " << result.to_string();
+        } else {
+            ASSERT_TRUE(result.high >= 0) << "Expected positive result for " << a.to_string() << " × " << b.to_string()
+                                          << " = " << result.to_string();
+        }
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256ArithmeticTest, multiplication_64bit_optimization) {
+    const uint64_t a = 0xFFFFFFFF; // 2^32 - 1
+    const uint64_t b = 0xFFFFFFFF; // 2^32 - 1
+
+    const int256_t val_a(static_cast<long long>(a));
+    const int256_t val_b(static_cast<long long>(b));
+    const int256_t result = val_a * val_b;
+
+    const uint128_t expected_low = static_cast<uint128_t>(a) * static_cast<uint128_t>(b);
+    ASSERT_EQ(0, result.high);
+    ASSERT_EQ(expected_low, result.low);
+
+    const int256_t a_dec(1000000); // 10^6
+    const int256_t b_dec(2000000); // 2×10^6
+    const int256_t result_dec = a_dec * b_dec;
+    const int256_t expected_dec = parse_int256("2000000000000"); // 2×10^12
+    ASSERT_EQ(expected_dec, result_dec);
+
+    const int256_t a_large(123456789);
+    const int256_t b_large(987654321);
+    const int256_t result_large = a_large * b_large;
+    const int256_t expected_large = parse_int256("121932631112635269");
+    ASSERT_EQ(expected_large, result_large);
+
+    const int256_t near_max(9223372036854775807LL); // 2^63 - 1
+    const int256_t small_mult(2);
+    const int256_t result_boundary = near_max * small_mult;
+    const int256_t expected_boundary = parse_int256("18446744073709551614");
+    ASSERT_EQ(expected_boundary, result_boundary);
+
+    const int256_t neg_a(-123456789);
+    const int256_t pos_b(1000000);
+    const int256_t result_neg = neg_a * pos_b;
+    const int256_t expected_neg = parse_int256("-123456789000000");
+    ASSERT_EQ(expected_neg, result_neg) << "Failed negative 64-bit multiplication";
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256ArithmeticTest, multiplication_128bit_optimization) {
+    // Test the 128×128 multiplication path
+    const uint128_t a = (static_cast<uint128_t>(1) << 64) + 1; // 2^64 + 1
+    const uint128_t b = (static_cast<uint128_t>(1) << 64) - 1; // 2^64 - 1
+
+    const int256_t val_a(0, a);
+    const int256_t val_b(0, b);
+    const int256_t result = val_a * val_b;
+
+    // Expected: (2^64 + 1)(2^64 - 1) = 2^128 - 1
+    ASSERT_EQ(0, result.high);
+    ASSERT_EQ(static_cast<uint128_t>(-1), result.low);
+
+    const int256_t a_128 = parse_int256("340282366920938463463374607431768211456"); // 2^128
+    const int256_t b_128(2);
+    const int256_t result_128 = a_128 * b_128;
+    const int256_t expected_128 = parse_int256("680564733841876926926749214863536422912"); // 2^129
+    ASSERT_EQ(expected_128, result_128);
+
+    const int256_t big_a = parse_int256("123456789012345678901234567890");
+    const int256_t big_b = parse_int256("987654321098765432109876543210");
+    const int256_t result_big = big_a * big_b;
+    const int256_t expected_big = parse_int256("121932631137021795226185032733622923332237463801111263526900");
+    ASSERT_EQ(expected_big, result_big);
+
+    const int256_t prime_a = parse_int256("170141183460469231731687303715884105727");
+    const int256_t prime_b(3);
+    const int256_t result_prime = prime_a * prime_b;
+    const int256_t expected_prime = parse_int256("510423550381407695195061911147652317181");
+    ASSERT_EQ(expected_prime, result_prime);
+
+    const int256_t boundary_a = parse_int256("18446744073709551616"); // 2^64
+    const int256_t boundary_b = parse_int256("18446744073709551615"); // 2^64 - 1
+    const int256_t result_boundary = boundary_a * boundary_b;
+    const int256_t expected_boundary = parse_int256("340282366920938463444927863358058659840");
+    ASSERT_EQ(expected_boundary, result_boundary);
+
+    const int256_t neg_128 = parse_int256("-123456789012345678901234567890");
+    const int256_t pos_small(12345);
+    const int256_t result_neg_128 = neg_128 * pos_small;
+    const int256_t expected_neg_128 = parse_int256("-1524074060357407406035740740602050");
+    ASSERT_EQ(expected_neg_128, result_neg_128);
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256ArithmeticTest, multiplication_64x256_optimization) {
+    {
+        constexpr uint64_t small = 1000000;
+        const int256_t large(0x123456789ABCDEF0LL, 0xFEDCBA9876543210ULL);
+
+        const int256_t result = int256_t(static_cast<long long>(small)) * large;
+
+        ASSERT_NE(int256_t(0), result);
+        ASSERT_TRUE(abs(result) > abs(large));
+    }
+
+    {
+        const int256_t large_base = parse_int256("12345678901234567890123456789012345678901234567890");
+        const int256_t multiplier(12345);
+        const int256_t result = large_base * multiplier;
+        const int256_t expected = parse_int256("152407406035740740603574074060357407406035740740602050");
+        ASSERT_EQ(expected, result);
+    }
+
+    {
+        const int256_t big_a = parse_int256("12345678901234567890123456789012345678");
+        const int256_t big_b = parse_int256("98765432109876543210987654321098765432");
+        const int256_t result = big_a * big_b;
+        const int256_t expected =
+                parse_int256("1219326311370217952261850327338667885854747751864349946654322511812221002896");
+        ASSERT_EQ(expected, result);
+    }
+
+    {
+        const int256_t scientific_a = parse_int256("602214076000000000000000000");
+        const int256_t scientific_b = parse_int256("299792458000000000");
+        const int256_t result = scientific_a * scientific_b;
+        const int256_t expected = parse_int256("180539238086238808000000000000000000000000000");
+        ASSERT_EQ(expected, result);
+    }
+
+    {
+        const int256_t mersenne_like = parse_int256("2305843009213693951");
+        const int256_t large_prime = parse_int256("1000000000000000000000000000057");
+        const int256_t result = mersenne_like * large_prime;
+        const int256_t expected = parse_int256("2305843009213693951000000000131433051525180555207");
+        ASSERT_EQ(expected, result);
+    }
+
+    {
+        const int256_t power_base = parse_int256("340282366920938463463374607431768211456"); // 2^128
+        const int256_t small_factor(255);                                                    // 2^8 - 1
+        const int256_t result = power_base * small_factor;
+        const int256_t expected = parse_int256("86772003564839308183160524895100893921280");
+        ASSERT_EQ(expected, result);
+    }
+
+    {
+        const int256_t neg_large = parse_int256("-123456789012345678901234567890123456789");
+        const int256_t pos_medium = parse_int256("987654321098765432109876543");
+        const int256_t result = neg_large * pos_medium;
+        const int256_t expected = parse_int256("-121932631137021795226185032707818930270769699763964487123185200427");
+        ASSERT_EQ(expected, result);
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256ArithmeticTest, multiplication_128x256_optimization) {
+    {
+        const uint128_t small = (static_cast<uint128_t>(1) << 100); // 2^100
+        const int256_t large(1, 0);                                 // 2^128
+
+        const int256_t val_small(0, small);
+        const int256_t result = val_small * large;
+
+        // Expected: 2^100 × 2^128 = 2^228
+        // This should fit in 256 bits since 228 < 256
+        ASSERT_NE(int256_t(0), result);
+        ASSERT_TRUE(result.high > 0);
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256ArithmeticTest, multiplication_overflow_detection) {
+    // Case 1: Maximum positive × 2 should overflow to negative
+    {
+        const int256_t max_val = INT256_MAX;
+        const int256_t two(2);
+        const int256_t result = max_val * two;
+
+        // Should overflow and become negative
+        ASSERT_TRUE(result.high < 0);
+    }
+
+    // Case 2: Large positive numbers causing overflow
+    {
+        const int256_t large1(static_cast<int128_t>((static_cast<uint128_t>(1) << 126)), 0); // 2^254
+        const int256_t large2(4);
+        const int256_t result = large1 * large2;
+
+        ASSERT_EQ(int256_t(0), result);
+    }
+
+    // Case 3: Critical overflow case: -1 × INT256_MIN
+    {
+        int256_t neg_one(-1);
+        int256_t min_val = INT256_MIN;
+        int256_t result = neg_one * min_val;
+
+        // This is a critical overflow case in signed arithmetic
+        // -1 × (-2^255) = 2^255, which cannot be represented in signed 256-bit
+        ASSERT_EQ(INT256_MIN, result);
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256ArithmeticTest, multiplication_boundary_values) {
+    ASSERT_EQ(0, int256_t(1, 0) * int256_t(1, 0));
+    ASSERT_EQ(parse_int256("340282366920938463463374607431768211456"),
+              int256_t(0, static_cast<uint128_t>(1) << 127) * int256_t(2));
+    ASSERT_EQ(INT256_MAX, INT256_MAX * int256_t(1));
+    ASSERT_EQ(parse_int256("-340282366920938463463374607431768211458"),
+              int256_t(INT256_MAX.high, INT256_MAX.low / 2) * int256_t(2));
+    ASSERT_EQ(INT256_MIN, INT256_MIN * int256_t(1));
+    ASSERT_EQ(INT256_MIN, INT256_MIN * int256_t(-1));
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256ArithmeticTest, multiplication_correctness) {
+    EXPECT_EQ(int256_t(0), int256_t(123456) * int256_t(0));
+    EXPECT_EQ(int256_t(42), int256_t(21) * int256_t(2));
+    EXPECT_EQ(int256_t(-100), int256_t(10) * int256_t(-10));
+
+    const int256_t big1 = parse_int256("123456789012345678901");
+    const int256_t big2 = parse_int256("987654321098765432109");
+    const int256_t expected = parse_int256("121932631137021795225845145533336229232209");
+    EXPECT_EQ(expected, big1 * big2);
+
+    EXPECT_EQ(parse_int256("-121932631137021795225845145533336229232209"), big1 * -big2);
+    EXPECT_EQ(parse_int256("-121932631137021795225845145533336229232209"), -big1 * big2);
+    EXPECT_EQ(expected, -big1 * -big2);
+
+    const int256_t max_times_2 = INT256_MAX * int256_t(2);
+    EXPECT_TRUE(max_times_2.high < 0);
+}
+
+} // end namespace starrocks

--- a/be/test/types/int256_test.cpp
+++ b/be/test/types/int256_test.cpp
@@ -145,6 +145,254 @@ TEST_F(Int256Test, constructor_from_double) {
     }
 }
 
+// NOLINTNEXTLINE
+TEST_F(Int256Test, constructor_from_unsigned_int) {
+    {
+        unsigned int val = 42U;
+        int256_t value(val);
+        ASSERT_EQ(0, value.high);
+        ASSERT_EQ(static_cast<uint128_t>(val), value.low);
+        ASSERT_EQ("42", value.to_string());
+    }
+
+    {
+        unsigned int val = 0U;
+        int256_t value(val);
+        ASSERT_EQ(0, value.high);
+        ASSERT_EQ(0, value.low);
+        ASSERT_EQ("0", value.to_string());
+    }
+
+    {
+        unsigned int val = 0xFFFFFFFFU; // 2^32 - 1
+        int256_t value(val);
+        ASSERT_EQ(0, value.high);
+        ASSERT_EQ(static_cast<uint128_t>(val), value.low);
+        ASSERT_EQ("4294967295", value.to_string());
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, constructor_from_unsigned_long) {
+    {
+        unsigned long val = 1234567890UL;
+        int256_t value(val);
+        ASSERT_EQ(0, value.high);
+        ASSERT_EQ(static_cast<uint128_t>(val), value.low);
+        ASSERT_EQ("1234567890", value.to_string());
+    }
+
+    {
+        unsigned long val = 0UL;
+        int256_t value(val);
+        ASSERT_EQ(0, value.high);
+        ASSERT_EQ(0, value.low);
+        ASSERT_EQ("0", value.to_string());
+    }
+
+    {
+        unsigned long val = 0xFFFFFFFFFFFFFFFFUL;
+        int256_t value(val);
+        ASSERT_EQ(0, value.high);
+        ASSERT_EQ(static_cast<uint128_t>(val), value.low);
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, constructor_from_unsigned_long_long) {
+    {
+        unsigned long long val = 9876543210ULL;
+        int256_t value(val);
+        ASSERT_EQ(0, value.high);
+        ASSERT_EQ(static_cast<uint128_t>(val), value.low);
+        ASSERT_EQ("9876543210", value.to_string());
+    }
+
+    {
+        unsigned long long val = 0ULL;
+        int256_t value(val);
+        ASSERT_EQ(0, value.high);
+        ASSERT_EQ(0, value.low);
+        ASSERT_EQ("0", value.to_string());
+    }
+
+    {
+        unsigned long long val = 0xFFFFFFFFFFFFFFFFULL;
+        int256_t value(val);
+        ASSERT_EQ(0, value.high);
+        ASSERT_EQ(static_cast<uint128_t>(val), value.low);
+        ASSERT_EQ("18446744073709551615", value.to_string()); // 2^64 - 1
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, constructor_from_size_t) {
+    {
+        size_t val = 999999;
+        int256_t value(val);
+        ASSERT_EQ(0, value.high);
+        ASSERT_EQ(static_cast<uint128_t>(val), value.low);
+        ASSERT_EQ("999999", value.to_string());
+    }
+
+    {
+        size_t val = 0;
+        int256_t value(val);
+        ASSERT_EQ(0, value.high);
+        ASSERT_EQ(0, value.low);
+        ASSERT_EQ("0", value.to_string());
+    }
+
+    {
+        size_t val = static_cast<size_t>(-1);
+        int256_t value(val);
+        ASSERT_EQ(0, value.high);
+        ASSERT_EQ(static_cast<uint128_t>(val), value.low);
+        ASSERT_TRUE(value > int256_t(0));
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, constructor_from_uint32_t) {
+    {
+        uint32_t val = 42;
+        int256_t value(val);
+        ASSERT_EQ(0, value.high);
+        ASSERT_EQ(static_cast<uint128_t>(val), value.low);
+        ASSERT_EQ("42", value.to_string());
+    }
+
+    {
+        uint32_t val = 0;
+        int256_t value(val);
+        ASSERT_EQ(0, value.high);
+        ASSERT_EQ(0, value.low);
+        ASSERT_EQ("0", value.to_string());
+    }
+
+    {
+        uint32_t val = 0xFFFFFFFF; // 2^32 - 1
+        int256_t value(val);
+        ASSERT_EQ(0, value.high);
+        ASSERT_EQ(static_cast<uint128_t>(val), value.low);
+        ASSERT_EQ("4294967295", value.to_string());
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, constructor_from_uint64_t) {
+    {
+        uint64_t val = 1234567890123456789ULL;
+        int256_t value(val);
+        ASSERT_EQ(0, value.high);
+        ASSERT_EQ(static_cast<uint128_t>(val), value.low);
+        ASSERT_EQ("1234567890123456789", value.to_string());
+    }
+
+    {
+        uint64_t val = 0;
+        int256_t value(val);
+        ASSERT_EQ(0, value.high);
+        ASSERT_EQ(0, value.low);
+        ASSERT_EQ("0", value.to_string());
+    }
+
+    {
+        uint64_t val = 0xFFFFFFFFFFFFFFFF; // 2^64 - 1
+        int256_t value(val);
+        ASSERT_EQ(0, value.high);
+        ASSERT_EQ(static_cast<uint128_t>(val), value.low);
+        ASSERT_EQ("18446744073709551615", value.to_string());
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, constructor_from_uint128_t) {
+    {
+        uint128_t val = static_cast<uint128_t>(42);
+        int256_t value(val);
+        ASSERT_EQ(0, value.high);
+        ASSERT_EQ(val, value.low);
+        ASSERT_EQ("42", value.to_string());
+    }
+
+    {
+        uint128_t val = 0;
+        int256_t value(val);
+        ASSERT_EQ(0, value.high);
+        ASSERT_EQ(0, value.low);
+        ASSERT_EQ("0", value.to_string());
+    }
+
+    {
+        uint128_t val = static_cast<uint128_t>(-1);
+        int256_t value(val);
+        ASSERT_EQ(0, value.high);
+        ASSERT_EQ(val, value.low);
+        ASSERT_TRUE(value > int256_t(0));
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, unsigned_constructor_consistency) {
+    {
+        unsigned int uint_val = 12345U;
+        unsigned long ulong_val = 12345UL;
+        unsigned long long ulonglong_val = 12345ULL;
+        uint32_t uint32_val = 12345;
+        uint64_t uint64_val = 12345;
+        size_t size_val = 12345;
+
+        int256_t from_uint(uint_val);
+        int256_t from_ulong(ulong_val);
+        int256_t from_ulonglong(ulonglong_val);
+        int256_t from_uint32(uint32_val);
+        int256_t from_uint64(uint64_val);
+        int256_t from_size(size_val);
+
+        ASSERT_EQ(from_uint, from_ulong);
+        ASSERT_EQ(from_uint, from_ulonglong);
+        ASSERT_EQ(from_uint, from_uint32);
+        ASSERT_EQ(from_uint, from_uint64);
+        ASSERT_EQ(from_uint, from_size);
+
+        ASSERT_EQ("12345", from_uint.to_string());
+        ASSERT_EQ("12345", from_ulong.to_string());
+        ASSERT_EQ("12345", from_ulonglong.to_string());
+        ASSERT_EQ("12345", from_uint32.to_string());
+        ASSERT_EQ("12345", from_uint64.to_string());
+        ASSERT_EQ("12345", from_size.to_string());
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(Int256Test, unsigned_vs_signed_constructor) {
+    {
+        int signed_val = 42;
+        unsigned int unsigned_val = 42U;
+
+        int256_t from_signed(signed_val);
+        int256_t from_unsigned(unsigned_val);
+
+        ASSERT_EQ(from_signed, from_unsigned);
+        ASSERT_EQ(from_signed.to_string(), from_unsigned.to_string());
+        ASSERT_EQ("42", from_signed.to_string());
+        ASSERT_EQ("42", from_unsigned.to_string());
+    }
+
+    {
+        long long signed_val = 1234567890LL;
+        unsigned long long unsigned_val = 1234567890ULL;
+
+        int256_t from_signed(signed_val);
+        int256_t from_unsigned(unsigned_val);
+
+        ASSERT_EQ(from_signed, from_unsigned);
+        ASSERT_EQ("1234567890", from_signed.to_string());
+        ASSERT_EQ("1234567890", from_unsigned.to_string());
+    }
+}
+
 // =============================================================================
 // Type Conversion Tests
 // =============================================================================


### PR DESCRIPTION
## Why I'm doing:
The current implementation of int256 multiplication is relatively simple. This pr makes some simple optimizations for implementation. This PR only optimizes the multiplication `operator*` for int256. The overflow check and assembly optimization will be routed at the upper layer. I will submit some patches for improvement later.
## What I'm doing:
this pr is based on https://github.com/StarRocks/starrocks/pull/59808. 
main changes
1. Adaptive Algorithm Selection 
- Automatically selects optimal multiplication algorithm based on operand bit width
- Routes to specialized functions for different size combinations (64×64, 128×128, 64×256, 128×256)
2. Specialized Multiplication Functions 
- multiply_64x64(): Direct 128-bit multiplication for small operands
- multiply_128x128(): Classic "schoolbook" with four 64×64 operations
- multiply_64x256(): Distributive multiplication for mixed sizes
- multiply_128x256(): Decomposed multiplication using 64×256 operations
- multiply_256x256(): Blocked, short-circuited "schoolbook" algorithm

Fixes #issue
https://github.com/StarRocks/starrocks/issues/59645

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
