### PR TITLE
[BugFix] Fix aggregate publish failed when lake table has rollup

### DIFF
--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -293,8 +293,8 @@ Status TabletManager::put_aggregate_tablet_metadata(std::map<int64_t, TabletMeta
     for (auto& [tablet_id, meta] : tablet_metas) {
         (*shared_meta.mutable_tablet_to_schema())[tablet_id] = meta.schema().id();
         unique_schemas.emplace(meta.schema().id(), meta.schema());
-        for (const auto& [ver, schema] : meta.historical_schemas()) {
-            unique_schemas.emplace(ver, schema);
+        for (const auto& [schema_id, schema] : meta.historical_schemas()) {
+            unique_schemas.emplace(schema_id, schema);
         }
     }
 

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -462,6 +462,7 @@ StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(const string& pat
     return metadata_or.value();
 }
 
+DEFINE_FAIL_POINT(tablet_schema_not_found_in_shared_metadata);
 StatusOr<TabletMetadataPtr> TabletManager::get_single_tablet_metadata(int64_t tablet_id, int64_t version,
                                                                       bool fill_cache, int64_t expected_gtid,
                                                                       const std::shared_ptr<FileSystem>& fs) {
@@ -529,6 +530,7 @@ StatusOr<TabletMetadataPtr> TabletManager::get_single_tablet_metadata(int64_t ta
         return Status::Corruption(strings::Substitute("deserialized tablet $0 metadata failed", tablet_id));
     }
 
+    FAIL_POINT_TRIGGER_EXECUTE(tablet_schema_not_found_in_shared_metadata, { tablet_id = 10003; });
     auto schema_id = shared_metadata->tablet_to_schema().find(tablet_id);
     if (schema_id == shared_metadata->tablet_to_schema().end()) {
         return Status::Corruption(

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -292,6 +292,7 @@ Status TabletManager::put_aggregate_tablet_metadata(std::map<int64_t, TabletMeta
     std::unordered_map<int64_t, TabletSchemaPB> unique_schemas;
     for (auto& [tablet_id, meta] : tablet_metas) {
         (*shared_meta.mutable_tablet_to_schema())[tablet_id] = meta.schema().id();
+        unique_schemas.emplace(meta.schema().id(), meta.schema());
         for (const auto& [ver, schema] : meta.historical_schemas()) {
             unique_schemas.emplace(ver, schema);
         }

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -639,6 +639,8 @@ TEST_F(LakeTabletManagerTest, put_aggregate_tablet_metadata) {
         item1.CopyFrom(schema_pb1);
         auto& item2 = (*metadata2.mutable_historical_schemas())[12];
         item2.CopyFrom(schema_pb3);
+        (*metadata2.mutable_rowset_to_schema())[3] = 10;
+        (*metadata2.mutable_rowset_to_schema())[4] = 12;
     }
 
     metadatas.emplace(1, metadata1);
@@ -658,7 +660,7 @@ TEST_F(LakeTabletManagerTest, put_aggregate_tablet_metadata) {
         ASSERT_TRUE(res.ok());
         TabletMetadataPtr metadata = std::move(res).value();
         ASSERT_EQ(metadata->schema().id(), 11);
-        ASSERT_EQ(metadata->historical_schemas_size(), 2);
+        ASSERT_EQ(metadata->historical_schemas_size(), 3);
     }
 
     starrocks::TabletMetadata metadata4;

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -634,7 +634,7 @@ TEST_F(LakeTabletManagerTest, put_aggregate_tablet_metadata) {
     {
         metadata2.set_id(2);
         metadata2.set_version(2);
-        metadata2.mutable_schema()->CopyFrom(schema_pb1);
+        metadata2.mutable_schema()->CopyFrom(schema_pb2);
         auto& item1 = (*metadata2.mutable_historical_schemas())[10];
         item1.CopyFrom(schema_pb1);
         auto& item2 = (*metadata2.mutable_historical_schemas())[12];
@@ -645,11 +645,21 @@ TEST_F(LakeTabletManagerTest, put_aggregate_tablet_metadata) {
     metadatas.emplace(2, metadata2);
     EXPECT_OK(_tablet_manager->put_aggregate_tablet_metadata(metadatas));
 
-    auto res = _tablet_manager->get_tablet_metadata(1, 2);
-    ASSERT_TRUE(res.ok());
-    TabletMetadataPtr metadata3 = std::move(res).value();
-    ASSERT_EQ(metadata3->schema().id(), 10);
-    ASSERT_EQ(metadata3->historical_schemas_size(), 2);
+    {
+        auto res = _tablet_manager->get_tablet_metadata(1, 2);
+        ASSERT_TRUE(res.ok());
+        TabletMetadataPtr metadata = std::move(res).value();
+        ASSERT_EQ(metadata->schema().id(), 10);
+        ASSERT_EQ(metadata->historical_schemas_size(), 2);
+    }
+
+    {
+        auto res = _tablet_manager->get_tablet_metadata(2, 2);
+        ASSERT_TRUE(res.ok());
+        TabletMetadataPtr metadata = std::move(res).value();
+        ASSERT_EQ(metadata->schema().id(), 11);
+        ASSERT_EQ(metadata->historical_schemas_size(), 2);
+    }
 
     starrocks::TabletMetadata metadata4;
     {
@@ -662,7 +672,7 @@ TEST_F(LakeTabletManagerTest, put_aggregate_tablet_metadata) {
         item2.CopyFrom(schema_pb3);
     }
     EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata4));
-    res = _tablet_manager->get_tablet_metadata(3, 3);
+    auto res = _tablet_manager->get_tablet_metadata(3, 3);
     ASSERT_TRUE(res.ok());
 }
 

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -1719,16 +1719,25 @@ TEST_P(LakeVacuumTest, test_vacuum_shared_metadata) {
             }
             )DEL");
 
+    TabletSchemaPB schema_pb1;
+    {
+        schema_pb1.set_id(0);
+        schema_pb1.set_num_short_key_columns(1);
+        schema_pb1.set_keys_type(DUP_KEYS);
+    }
     // create SharedTabletMetadata
     std::map<int64_t, TabletMetadataPB> tablet_metas_v1;
+    t600_v1->mutable_schema()->CopyFrom(schema_pb1);
     tablet_metas_v1[600] = *t600_v1;
     tablet_metas_v1[601] = *t601_v1;
     ASSERT_OK(_tablet_mgr->put_aggregate_tablet_metadata(tablet_metas_v1));
     std::map<int64_t, TabletMetadataPB> tablet_metas_v2;
+    t600_v2->mutable_schema()->CopyFrom(schema_pb1);
     tablet_metas_v2[600] = *t600_v2;
     tablet_metas_v2[601] = *t601_v2;
     ASSERT_OK(_tablet_mgr->put_aggregate_tablet_metadata(tablet_metas_v2));
     std::map<int64_t, TabletMetadataPB> tablet_metas_v3;
+    t600_v3->mutable_schema()->CopyFrom(schema_pb1);
     tablet_metas_v3[600] = *t600_v3;
     tablet_metas_v3[601] = *t601_v3;
     ASSERT_OK(_tablet_mgr->put_aggregate_tablet_metadata(tablet_metas_v3));
@@ -1815,6 +1824,12 @@ TEST_P(LakeVacuumTest, test_vacuum_shared_data_files) {
     create_data_file("00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1e.dat");
     create_data_file("00000000000259e4_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat");
     create_data_file("00000000000259e4_a542395a-bff5-48a7-a3a7-2ed05691b58d.dat");
+    TabletSchemaPB schema_pb1;
+    {
+        schema_pb1.set_id(0);
+        schema_pb1.set_num_short_key_columns(1);
+        schema_pb1.set_keys_type(DUP_KEYS);
+    }
 
     auto t600_v1 = json_to_pb<TabletMetadataPB>(R"DEL(
         {
@@ -1995,14 +2010,17 @@ TEST_P(LakeVacuumTest, test_vacuum_shared_data_files) {
 
     // create SharedTabletMetadata
     std::map<int64_t, TabletMetadataPB> tablet_metas_v1;
+    t600_v1->mutable_schema()->CopyFrom(schema_pb1);
     tablet_metas_v1[600] = *t600_v1;
     tablet_metas_v1[601] = *t601_v1;
     ASSERT_OK(_tablet_mgr->put_aggregate_tablet_metadata(tablet_metas_v1));
     std::map<int64_t, TabletMetadataPB> tablet_metas_v2;
+    t600_v2->mutable_schema()->CopyFrom(schema_pb1);
     tablet_metas_v2[600] = *t600_v2;
     tablet_metas_v2[601] = *t601_v2;
     ASSERT_OK(_tablet_mgr->put_aggregate_tablet_metadata(tablet_metas_v2));
     std::map<int64_t, TabletMetadataPB> tablet_metas_v3;
+    t600_v3->mutable_schema()->CopyFrom(schema_pb1);
     tablet_metas_v3[600] = *t600_v3;
     tablet_metas_v3[601] = *t601_v3;
     ASSERT_OK(_tablet_mgr->put_aggregate_tablet_metadata(tablet_metas_v3));
@@ -2078,6 +2096,7 @@ TEST_P(LakeVacuumTest, test_vacuum_shared_data_files) {
 
     // after compaction
     std::map<int64_t, TabletMetadataPB> tablet_metas_v4;
+    t600_v4->mutable_schema()->CopyFrom(schema_pb1);
     tablet_metas_v4[600] = *t600_v4;
     tablet_metas_v4[601] = *t601_v4;
     ASSERT_OK(_tablet_mgr->put_aggregate_tablet_metadata(tablet_metas_v4));

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -167,7 +167,7 @@ message MetadataUpdateInfoPB {
 }
 
 message SharedTabletMetadataPB {
-    optional int64 schema_id = 1; // the latest schema id of all tablet
+    map<int64, int64> tablet_to_schema = 1; // tablet id -> schema id
     map<int64, TabletSchemaPB> schemas = 2;
     map<int64, PagePointerPB> tablet_meta_pages = 3;
 }


### PR DESCRIPTION
## Why I'm doing:
The `SharedTabletMetadata` aggregates the schemas of all tablets to reduce the size of Protobuf messages, assuming that the schema IDs of all tablets are consistent. However, when a lake table has rollups, the schema IDs of tablets within the same partition may vary, leading to failures in aggregate publishing.

## What I'm doing:
using a map(tablet_id to schema_id) instead of one schema_id

Fixes https://github.com/StarRocks/StarRocksTest/issues/9800,  https://github.com/StarRocks/StarRocksTest/issues/9812

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
