### PR TITLE
[Enhancement] Support changing kafka_broker_list in ALTER ROUTINE LOAD (backport #59787)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -856,6 +856,11 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
             confluentSchemaRegistryUrl = dataSourceProperties.getConfluentSchemaRegistryUrl();
         }
 
+        // modify broker list
+        if (dataSourceProperties.getKafkaBrokerList() != null) {
+            this.brokerList = dataSourceProperties.getKafkaBrokerList();
+        }
+
         LOG.info("modify the data source properties of kafka routine load job: {}, datasource properties: {}",
                 this.id, dataSourceProperties);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
@@ -697,13 +697,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
         if (Strings.isNullOrEmpty(kafkaBrokerList)) {
             throw new AnalysisException(KAFKA_BROKER_LIST_PROPERTY + " is a required property");
         }
-        String[] kafkaBrokerList = this.kafkaBrokerList.split(",");
-        for (String broker : kafkaBrokerList) {
-            if (!Pattern.matches(ENDPOINT_REGEX, broker)) {
-                throw new AnalysisException(KAFKA_BROKER_LIST_PROPERTY + ":" + broker
-                        + " not match pattern " + ENDPOINT_REGEX);
-            }
-        }
+        validateKafkaBrokerList(kafkaBrokerList);
 
         // check topic
         kafkaTopic = Strings.nullToEmpty(dataSourceProperties.get(KAFKA_TOPIC_PROPERTY)).replaceAll(" ", "");
@@ -826,6 +820,23 @@ public class CreateRoutineLoadStmt extends DdlStmt {
         // check kafka_default_offsets
         if (customKafkaProperties.containsKey(KAFKA_DEFAULT_OFFSETS)) {
             getKafkaOffset(customKafkaProperties.get(KAFKA_DEFAULT_OFFSETS));
+        }
+    }
+
+    public static void validateKafkaBrokerList(String brokerList) throws AnalysisException {
+        if (Strings.isNullOrEmpty(brokerList)) {
+            throw new AnalysisException("kafka_broker_list cannot be empty");
+        }
+
+        String cleanBrokerList = brokerList.replaceAll(" ", "");
+        String[] brokers = cleanBrokerList.split(",");
+
+        for (String broker : brokers) {
+            if (!Pattern.matches(ENDPOINT_REGEX, broker)) {
+                throw new AnalysisException(
+                    String.format("%s: %s does not match pattern %s",
+                        KAFKA_BROKER_LIST_PROPERTY, broker, ENDPOINT_REGEX));
+            }
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
@@ -345,7 +345,7 @@ public class RoutineLoadJobTest {
             // The lag [xxx] of partition [0] exceeds Config.routine_load_unstable_threshold_second [3600]
             Assert.assertTrue(showInfo.get(16).contains(
                     "partition [0] exceeds Config.routine_load_unstable_threshold_second [3600]"));
-        
+
             TRoutineLoadJobInfo loadJobInfo = routineLoadJob.toThrift();
             Assert.assertEquals("RUNNING", loadJobInfo.getState());
             Assert.assertEquals("", loadJobInfo.getReasons_of_state_changed());
@@ -635,6 +635,50 @@ public class RoutineLoadJobTest {
         Assert.assertEquals("','", routineLoadJob.getColumnSeparator().toString());
         Assert.assertEquals("'A'", routineLoadJob.getRowDelimiter().toString());
         Assert.assertEquals("p1,p2,p3", Joiner.on(",").join(routineLoadJob.getPartitions().getPartitionNames()));
+    }
+
+    @Test
+    public void testKafkaRoutineLoadJobValidBrokerList() throws Exception {
+        KafkaRoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(1L, "job",
+                2L, 3L, "192.168.1.1:9092", "topic");
+        ConnectContext connectContext = UtFrameUtils.createDefaultCtx();
+
+        String validStmt = "alter routine load for db.job1 " +
+                "FROM KAFKA (\"kafka_broker_list\" = \"192.168.1.2:9092,192.168.1.3:9092\")";
+        routineLoadJob.setOrigStmt(new OriginStatement(validStmt, 0));
+
+        try {
+            AlterRoutineLoadStmt stmt = (AlterRoutineLoadStmt) UtFrameUtils.parseStmtWithNewParser(validStmt, connectContext);
+            routineLoadJob.modifyJob(stmt.getRoutineLoadDesc(), stmt.getAnalyzedJobProperties(),
+                    stmt.getDataSourceProperties(), new OriginStatement(validStmt, 0), true);
+
+            // Verify broker list was updated successfully
+            Assert.assertEquals("192.168.1.2:9092,192.168.1.3:9092", routineLoadJob.getBrokerList());
+        } catch (Exception e) {
+            Assert.fail("Valid broker list should not throw exception");
+        }
+    }
+
+    @Test
+    public void testKafkaRoutineLoadJobInvalidBrokerList() throws Exception {
+        KafkaRoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(1L, "job",
+                2L, 3L, "192.168.1.1:9092", "topic");
+        ConnectContext connectContext = UtFrameUtils.createDefaultCtx();
+
+        String invalidStmt = "alter routine load for db.job1 " +
+                "FROM KAFKA (\"kafka_broker_list\" = \"invalid_broker_format\")";
+        routineLoadJob.setOrigStmt(new OriginStatement(invalidStmt, 0));
+
+        try {
+            AlterRoutineLoadStmt stmt = (AlterRoutineLoadStmt) UtFrameUtils.parseStmtWithNewParser(invalidStmt, connectContext);
+            routineLoadJob.modifyJob(stmt.getRoutineLoadDesc(), stmt.getAnalyzedJobProperties(),
+                    stmt.getDataSourceProperties(), new OriginStatement(invalidStmt, 0), false);
+            Assert.fail("Invalid broker list should throw DdlException");
+        } catch (Exception e) {
+            // This should trigger the catch block on line 841-842
+            Assert.assertTrue("Should contain validation error message",
+                    e.getMessage().contains("does not match pattern"));
+        }
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This change adds support for modifying the kafka_broker_list property in ALTER ROUTINE LOAD statements, allowing users to change Kafka broker endpoints for existing routine load jobs.

Changes:
- Add KAFKA_BROKER_LIST_PROPERTY to configurable properties in RoutineLoadDataSourceProperties
- Add broker list field, getter, and validation support
- Update KafkaRoutineLoadJob.modifyDataSourceProperties() to handle broker list changes
- Centralize broker list validation logic in CreateRoutineLoadStmt.validateKafkaBrokerList()
- Add comprehensive unit tests for both valid and invalid broker list modifications

Usage example:
```
ALTER ROUTINE LOAD FOR example_job
FROM KAFKA
(
"kafka_broker_list" = "127.0.0.1:9092"
);
```

#59874

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

