### PR TITLE
[Refactor] Refactor AlterMVJobExecutor to make it more clear

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -791,6 +791,10 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
             mv.getTableProperty().getProperties()
                     .put(PropertyAnalyzer.PROPERTIES_AUTO_REFRESH_PARTITIONS_LIMIT, String.valueOf(limit));
             mv.getTableProperty().setAutoRefreshPartitionsLimit(limit);
+            if (isNonPartitioned) {
+                throw new AnalysisException(PropertyAnalyzer.PROPERTIES_AUTO_REFRESH_PARTITIONS_LIMIT
+                        + " does not support non-range-partitioned materialized view.");
+            }
         }
         // partition refresh number
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER)) {
@@ -809,10 +813,6 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
             mv.getTableProperty().getProperties()
                     .put(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_STRATEGY, strategy);
             mv.getTableProperty().setPartitionRefreshStrategy(strategy);
-            if (isNonPartitioned) {
-                throw new AnalysisException(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_STRATEGY
-                        + " does not support non-partitioned materialized view.");
-            }
         }
         // exclude trigger tables
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_EXCLUDED_TRIGGER_TABLES)) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1542,19 +1542,15 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         return sb.toString();
     }
 
-    private static final ImmutableSet<String> NEED_SHOW_PROPS;
-
-    static {
-        NEED_SHOW_PROPS = new ImmutableSet.Builder<String>()
-                .add(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME)
-                .add(PropertyAnalyzer.PROPERTIES_PARTITION_TTL_NUMBER)
-                .add(PropertyAnalyzer.PROPERTIES_PARTITION_TTL)
-                .add(PropertyAnalyzer.PROPERTIES_AUTO_REFRESH_PARTITIONS_LIMIT)
-                .add(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER)
-                .add(PropertyAnalyzer.PROPERTIES_EXCLUDED_TRIGGER_TABLES)
-                .add(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_STRATEGY)
-                .build();
-    }
+    private static final ImmutableSet<String> NEED_SHOW_PROPS = ImmutableSet.of(
+            PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME,
+            PropertyAnalyzer.PROPERTIES_PARTITION_TTL_NUMBER,
+            PropertyAnalyzer.PROPERTIES_PARTITION_TTL,
+            PropertyAnalyzer.PROPERTIES_AUTO_REFRESH_PARTITIONS_LIMIT,
+            PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER,
+            PropertyAnalyzer.PROPERTIES_EXCLUDED_TRIGGER_TABLES,
+            PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_STRATEGY
+    );
 
     public Map<String, String> getMaterializedViewPropMap() {
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3063,7 +3063,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
 
         boolean isNonPartitioned = partitionInfo.isUnPartitioned();
         DataProperty dataProperty = PropertyAnalyzer.analyzeMVDataProperty(materializedView, properties);
-        PropertyAnalyzer.analyzeMVProperties(db, materializedView, properties, isNonPartitioned,
+        AlterMVJobExecutor.analyzeMVProperties(db, materializedView, properties, isNonPartitioned,
                 stmt.getPartitionByExprToAdjustExprMap());
         final long warehouseId = materializedView.getWarehouseId();
         try {


### PR DESCRIPTION
## Why I'm doing:

There are a lot of duplicate codes in AlterMVJobExecutor which is hard to maintain any more.

## What I'm doing:
- This pull request refactors the handling of materialized view properties in`visitModifyTablePropertiesClause ` method, focusing on simplifying code and improving maintainability. 
-  Deleted the `analyzeMVProperties` method from `PropertyAnalyzer.java` and moved its functionality to `AlterMVJobExecutor`, centralizing materialized view property analysis logic. [[1]](diffhunk://#diff-61be4f97e7d1b1a47bd2246fa0a233592132c888cebba90077216db336661ba1L1562-R1553) [[2]](diffhunk://#diff-1b0d077c3f2a45922be5fa50d2221e0e7cb4883e224636656434d449ef37ea9cL3062-R3062)


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
