### PR TITLE
[BugFix] Fix the `disk_device_id` function to aquire the device_id of an non-existent entry by its ancestor entries.

### DIFF
--- a/be/src/cache/datacache_utils.cpp
+++ b/be/src/cache/datacache_utils.cpp
@@ -163,8 +163,19 @@ Status DataCacheUtils::change_disk_path(const std::string& old_disk_path, const 
 }
 
 dev_t DataCacheUtils::disk_device_id(const std::string& disk_path) {
+    std::filesystem::path cur_path(disk_path);
+    cur_path = std::filesystem::absolute(cur_path);
+
+    // Traverse from the current path to the ancestor node and find the first existing path
+    while (!cur_path.empty()) {
+        if (std::filesystem::exists(cur_path) || cur_path == cur_path.root_path()) {
+            break;
+        }
+        cur_path = cur_path.parent_path();
+    }
+
     struct stat s;
-    if (stat(disk_path.c_str(), &s) != 0) {
+    if (stat(cur_path.c_str(), &s) != 0) {
         return 0;
     }
     return s.st_dev;

--- a/be/test/cache/datacache_utils_test.cpp
+++ b/be/test/cache/datacache_utils_test.cpp
@@ -134,6 +134,18 @@ TEST_F(DataCacheUtilsTest, parse_cache_space_paths) {
     fs::remove_all(cache_dir).ok();
 }
 
+TEST_F(DataCacheUtilsTest, get_device_id_func) {
+    ASSERT_GT(DataCacheUtils::disk_device_id("/"), 0);
+    ASSERT_GT(DataCacheUtils::disk_device_id("/not_exist1/not_exist2"), 0);
+    ASSERT_EQ(DataCacheUtils::disk_device_id("/"), DataCacheUtils::disk_device_id("/not_exist/not_exist2"));
+
+    // Get the device id for relative path
+    ASSERT_GT(DataCacheUtils::disk_device_id("not_exist"), 0);
+    ASSERT_GT(DataCacheUtils::disk_device_id("./not_exist"), 0);
+    ASSERT_GT(DataCacheUtils::disk_device_id("./not_exist1/not_exist2"), 0);
+    ASSERT_EQ(DataCacheUtils::disk_device_id("./not_exist"), DataCacheUtils::disk_device_id("./not_exist1/not_exist2"));
+}
+
 TEST_F(DataCacheUtilsTest, change_cache_path_suc) {
     const std::string old_dir = "./old_disk_cache_path";
     const std::string new_dir = "./new_disk_cache_path";
@@ -146,15 +158,38 @@ TEST_F(DataCacheUtilsTest, change_cache_path_suc) {
     fs::remove_all(new_dir);
 }
 
-TEST_F(DataCacheUtilsTest, change_cache_path_fail) {
-    const std::string old_dir = "./old_disk_cache_path2";
-    const std::string new_dir = "./old_disk_cache_path2/subdir";
+TEST_F(DataCacheUtilsTest, change_cache_path_to_sub_path) {
+    const std::string old_dir = "./old_disk_cache_path";
+    const std::string new_dir = "./old_disk_cache_path/subdir";
     ASSERT_TRUE(fs::create_directories(old_dir).ok());
     ASSERT_TRUE(fs::create_directories(new_dir).ok());
 
     ASSERT_FALSE(DataCacheUtils::change_disk_path(old_dir, new_dir).ok());
 
     fs::remove_all(old_dir);
+    fs::remove_all(new_dir);
+}
+
+TEST_F(DataCacheUtilsTest, change_cache_path_to_nonexist_dest) {
+    const std::string old_dir = "./old_disk_cache_path";
+    const std::string new_dir = "./new_disk_cache_path";
+    ASSERT_TRUE(fs::create_directories(old_dir).ok());
+
+    ASSERT_TRUE(DataCacheUtils::change_disk_path(old_dir, new_dir).ok());
+
+    fs::remove_all(old_dir);
+    fs::remove_all(new_dir);
+}
+
+TEST_F(DataCacheUtilsTest, change_cache_path_from_nonexist_src) {
+    const std::string old_dir = "./old_disk_cache_path";
+    const std::string new_dir = "./new_disk_cache_path";
+    ASSERT_TRUE(fs::create_directories(new_dir).ok());
+
+    ASSERT_TRUE(DataCacheUtils::change_disk_path(old_dir, new_dir).ok());
+
+    fs::remove_all(old_dir);
+    fs::remove_all(new_dir);
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
We use the `device_id` to identify whether two disk paths locate in same disks. 
The old `disk_device_id` function only aquires stats for the accurate path parameter, which may be not exist and cause the function failed.

## What I'm doing:
Get the `device_id` of the given path from the current entry to its ancestor entries. If the current path does not exist, check its parent and ancestor entries.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
