### PR TITLE
[Enhancement] Add SKIPPED State for task run

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/WarehouseMetricsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/WarehouseMetricsSystemTable.java
@@ -13,7 +13,7 @@
 // limitations under the License.
 package com.starrocks.catalog.system.information;
 
-import com.google.api.client.util.Lists;
+import com.google.common.collect.Lists;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;

--- a/fe/fe-core/src/main/java/com/starrocks/metric/IMaterializedViewMetricsEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/IMaterializedViewMetricsEntity.java
@@ -15,7 +15,7 @@
 
 package com.starrocks.metric;
 
-import com.starrocks.scheduler.PartitionBasedMvRefreshProcessor;
+import com.starrocks.scheduler.Constants;
 
 import java.util.List;
 
@@ -60,7 +60,7 @@ public interface IMaterializedViewMetricsEntity {
      * Increase the refresh job status count
      * @param status: refresh job 's final status: SUCCESS, FAILED, EMPTY
      */
-    void increaseRefreshJobStatus(PartitionBasedMvRefreshProcessor.RefreshJobStatus status);
+    void increaseRefreshJobStatus(Constants.TaskRunState status);
 
     /**
      * Increase the refresh meta retry count

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsBlackHoleEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsBlackHoleEntity.java
@@ -15,8 +15,8 @@
 
 package com.starrocks.metric;
 
-import com.google.api.client.util.Lists;
-import com.starrocks.scheduler.PartitionBasedMvRefreshProcessor;
+import com.google.common.collect.Lists;
+import com.starrocks.scheduler.Constants;
 
 import java.util.List;
 
@@ -51,7 +51,7 @@ public class MaterializedViewMetricsBlackHoleEntity implements IMaterializedView
     }
 
     @Override
-    public void increaseRefreshJobStatus(PartitionBasedMvRefreshProcessor.RefreshJobStatus status) {
+    public void increaseRefreshJobStatus(Constants.TaskRunState status) {
 
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
@@ -25,7 +25,7 @@ import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.metric.Metric.MetricUnit;
-import com.starrocks.scheduler.PartitionBasedMvRefreshProcessor;
+import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.TaskBuilder;
 import com.starrocks.scheduler.TaskManager;
 import com.starrocks.scheduler.TaskRunScheduler;
@@ -337,10 +337,10 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
     }
 
     @Override
-    public void increaseRefreshJobStatus(PartitionBasedMvRefreshProcessor.RefreshJobStatus status) {
+    public void increaseRefreshJobStatus(Constants.TaskRunState status) {
         this.counterRefreshJobTotal.increase(1L);
         switch (status) {
-            case EMPTY:
+            case SKIPPED:
                 this.counterRefreshJobEmptyTotal.increase(1L);
                 break;
             case SUCCESS:

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/warehouse/WarehouseMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/warehouse/WarehouseMetrics.java
@@ -17,7 +17,7 @@
 
 package com.starrocks.qe.scheduler.warehouse;
 
-import com.google.api.client.util.Lists;
+import com.google.common.collect.Lists;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.scheduler.slot.BaseSlotTracker;
 import com.starrocks.qe.scheduler.slot.QueryQueueOptions;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/BaseTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/BaseTaskRunProcessor.java
@@ -29,7 +29,7 @@ public abstract class BaseTaskRunProcessor implements TaskRunProcessor {
     }
 
     @Override
-    public void processTaskRun(TaskRunContext context) throws Exception {
+    public Constants.TaskRunState processTaskRun(TaskRunContext context) throws Exception {
         throw new NotImplementedException("Method processTaskRun need to implement");
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/Constants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/Constants.java
@@ -65,11 +65,18 @@ public class Constants {
     //        |
     //         ----------------> MERGED
     public enum TaskRunState {
-        PENDING,    // The task run is created and in the pending queue waiting to be scheduled
-        RUNNING,    // The task run is scheduled into running queue and is running
-        FAILED,     // The task run is failed
-        SUCCESS,    // The task run is finished successfully
-        MERGED,     // The task run is merged
+        // The task run is created and in the pending queue waiting to be scheduled
+        PENDING,
+        // The task run is scheduled into running queue and is running
+        RUNNING,
+        // The task run is failed
+        FAILED,
+        // The task run is finished successfully
+        SUCCESS,
+        // The task run is merged
+        MERGED,
+        // The task run is skipped, which means the task run is not executed due to some conditions(eg: no partitions to
+        // refresh, no data to process, etc.)
         SKIPPED;
 
         /**

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/Constants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/Constants.java
@@ -59,9 +59,9 @@ public class Constants {
 
     //                   ------> FAILED
     //                  |
-    //                  |
     //     PENDING -> RUNNING -> SUCCESS
-    //        |
+    //        |         |
+    //        |          ------> SKIPPED
     //        |
     //         ----------------> MERGED
     public enum TaskRunState {
@@ -69,13 +69,14 @@ public class Constants {
         RUNNING,    // The task run is scheduled into running queue and is running
         FAILED,     // The task run is failed
         SUCCESS,    // The task run is finished successfully
-        MERGED;     // The task run is merged
+        MERGED,     // The task run is merged
+        SKIPPED;
 
         /**
          * Whether the task run state is a success state
          */
         public boolean isSuccessState() {
-            return this.equals(TaskRunState.SUCCESS) || this.equals(TaskRunState.MERGED);
+            return this.equals(TaskRunState.SUCCESS) || this.equals(TaskRunState.MERGED) || this.equals(TaskRunState.SKIPPED);
         }
 
         /**

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/DataCacheSelectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/DataCacheSelectProcessor.java
@@ -31,7 +31,7 @@ public class DataCacheSelectProcessor extends BaseTaskRunProcessor {
     private static final Logger LOG = LogManager.getLogger(DataCacheSelectProcessor.class);
 
     @Override
-    public void processTaskRun(TaskRunContext context) throws Exception {
+    public Constants.TaskRunState processTaskRun(TaskRunContext context) throws Exception {
         StmtExecutor executor = null;
         try {
             ConnectContext ctx = context.getCtx();
@@ -64,6 +64,7 @@ public class DataCacheSelectProcessor extends BaseTaskRunProcessor {
             DataCacheSelectStatement dataCacheSelectStatement = (DataCacheSelectStatement) executor.getParsedStmt();
             boolean isVerbose = dataCacheSelectStatement.isVerbose();
             context.getStatus().setExtraMessage(metrics.debugString(isVerbose));
+            return Constants.TaskRunState.SUCCESS;
         } finally {
             Tracers.close();
             if (executor != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -141,14 +141,6 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     @VisibleForTesting
     private RuntimeProfile runtimeProfile;
     private MVPCTRefreshPartitioner mvRefreshPartitioner;
-
-    // represents the refresh job final job status
-    public enum RefreshJobStatus {
-        SUCCESS,
-        FAILED,
-        EMPTY,
-    }
-
     // for testing
     private TaskRun nextTaskRun = null;
 
@@ -181,7 +173,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     // 4. construct the refresh sql and execute it
     // 5. update the source table version map if refresh task completes successfully
     @Override
-    public void processTaskRun(TaskRunContext context) throws Exception {
+    public Constants.TaskRunState processTaskRun(TaskRunContext context) throws Exception {
         // register tracers
         Tracers.register(context.getCtx());
         QueryDebugOptions queryDebugOptions = context.getCtx().getSessionVariable().getQueryDebugOptions();
@@ -200,16 +192,17 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 // refresh mv
                 Preconditions.checkState(mv != null);
                 mvEntity = MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mv.getMvId());
-                RefreshJobStatus status = doMvRefresh(context, mvEntity);
+                Constants.TaskRunState taskRunState = doMvRefresh(context, mvEntity);
                 // update metrics
-                mvEntity.increaseRefreshJobStatus(status);
+                mvEntity.increaseRefreshJobStatus(taskRunState);
                 connectContext.getState().setOk();
                 // only trigger to post process when mv has been refreshed successfully
-                this.isNeedToTriggerPostProcess = status == RefreshJobStatus.SUCCESS;
+                this.isNeedToTriggerPostProcess = taskRunState == Constants.TaskRunState.SUCCESS;
+                return taskRunState;
             }
         } catch (Exception e) {
             if (mvEntity != null) {
-                mvEntity.increaseRefreshJobStatus(RefreshJobStatus.FAILED);
+                mvEntity.increaseRefreshJobStatus(Constants.TaskRunState.FAILED);
             }
             connectContext.getState().setError(e.getMessage());
             throw e;
@@ -337,7 +330,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         return mvToRefreshedPartitions;
     }
 
-    private RefreshJobStatus doMvRefresh(TaskRunContext context, IMaterializedViewMetricsEntity mvEntity) {
+    private Constants.TaskRunState doMvRefresh(TaskRunContext context, IMaterializedViewMetricsEntity mvEntity) {
         long startRefreshTs = System.currentTimeMillis();
 
         // log mv basic info, it may throw exception if mv is invalid since base table has dropped
@@ -351,7 +344,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         }
 
         // refresh materialized view
-        RefreshJobStatus result = doRefreshMaterializedViewWithRetry(context, mvEntity);
+        Constants.TaskRunState result = doRefreshMaterializedViewWithRetry(context, mvEntity);
 
         // do not generate next task run if the current task run is killed
         if (mvContext.hasNextBatchPartition() && !mvContext.getTaskRun().isKilled()) {
@@ -376,8 +369,9 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     /**
      * Retry the `doRefreshMaterializedView` method to avoid insert fails in occasional cases.
      */
-    private RefreshJobStatus doRefreshMaterializedViewWithRetry(TaskRunContext taskRunContext,
-                                                                IMaterializedViewMetricsEntity mvEntity) throws DmlException {
+    private Constants.TaskRunState doRefreshMaterializedViewWithRetry(
+            TaskRunContext taskRunContext,
+            IMaterializedViewMetricsEntity mvEntity) throws DmlException {
         // Use current connection variables instead of mvContext's session variables to be better debug.
         int maxRefreshMaterializedViewRetryNum = getMaxRefreshMaterializedViewRetryNum(taskRunContext.getCtx());
         logger.info("start to refresh mv with retry times:{}", maxRefreshMaterializedViewRetryNum);
@@ -427,8 +421,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         return maxRefreshMaterializedViewRetryNum;
     }
 
-    private RefreshJobStatus doRefreshMaterializedView(TaskRunContext context,
-                                                       IMaterializedViewMetricsEntity mvEntity) throws Exception {
+    private Constants.TaskRunState doRefreshMaterializedView(TaskRunContext context,
+                                                             IMaterializedViewMetricsEntity mvEntity) throws Exception {
         // 0. Compute the base-table partitions to check for external table
         // The candidate partition info is used to refresh the external table
         Map<TableSnapshotInfo, Set<String>> baseTableCandidatePartitions = Maps.newHashMap();
@@ -464,7 +458,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         try (Timer ignored = Tracers.watchScope("MVRefreshCheckMVToRefreshPartitions")) {
             mvToRefreshedPartitions = checkMvToRefreshedPartitions(context, false);
             if (CollectionUtils.isEmpty(mvToRefreshedPartitions)) {
-                return RefreshJobStatus.EMPTY;
+                return Constants.TaskRunState.SKIPPED;
             }
             // ref table of mv : refreshed partition names
             refTableRefreshPartitions = getRefTableRefreshPartitions(mvToRefreshedPartitions);
@@ -492,7 +486,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             updateMeta(mvToRefreshedPartitions, mvContext.getExecPlan(), refTableRefreshPartitions);
         }
 
-        return RefreshJobStatus.SUCCESS;
+        return Constants.TaskRunState.SUCCESS;
     }
 
     /**
@@ -927,7 +921,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             String errorMsg = String.format("Materialized view: %s/%d is not active due to %s.",
                     mv.getName(), mvId, mv.getInactiveReason());
             logger.warn(errorMsg);
-            mvEntity.increaseRefreshJobStatus(RefreshJobStatus.FAILED);
+            mvEntity.increaseRefreshJobStatus(Constants.TaskRunState.FAILED);
             throw new DmlException(errorMsg);
         }
         // wait util transaction is visible for mv refresh task

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/SqlTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/SqlTaskRunProcessor.java
@@ -31,7 +31,7 @@ public class SqlTaskRunProcessor extends BaseTaskRunProcessor {
     private static final Logger LOG = LogManager.getLogger(SqlTaskRunProcessor.class);
 
     @Override
-    public void processTaskRun(TaskRunContext context) throws Exception {
+    public Constants.TaskRunState processTaskRun(TaskRunContext context) throws Exception {
         StmtExecutor executor = null;
         try {
             ConnectContext ctx = context.getCtx();
@@ -61,6 +61,7 @@ public class SqlTaskRunProcessor extends BaseTaskRunProcessor {
             ctx.setThreadLocalInfo();
             executor.addRunningQueryDetail(sqlStmt);
             executor.execute();
+            return Constants.TaskRunState.SUCCESS;
         } finally {
             Tracers.close();
             if (executor != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -720,6 +720,9 @@ public class TaskManager implements MemoryTrackable {
             case SUCCESS:
                 status.setProgress(100);
                 taskRunManager.getTaskRunHistory().addHistory(status);
+            case SKIPPED:
+                status.setProgress(0);
+                taskRunManager.getTaskRunHistory().addHistory(status);
                 break;
         }
     }
@@ -747,12 +750,6 @@ public class TaskManager implements MemoryTrackable {
                     status.setState(Constants.TaskRunState.RUNNING);
                     taskRunScheduler.addRunningTaskRun(pendingTaskRun);
                 }
-                // for fe restart, should keep logic same as clearUnfinishedTaskRun
-            } else if (toStatus == Constants.TaskRunState.FAILED) {
-                status.setErrorMessage(statusChange.getErrorMessage());
-                status.setErrorCode(statusChange.getErrorCode());
-                status.setState(Constants.TaskRunState.FAILED);
-                taskRunManager.getTaskRunHistory().addHistory(status);
             } else if (toStatus == Constants.TaskRunState.MERGED) {
                 // This only happened when the task run is merged by others and no run ever.
                 LOG.info("Replay update pendingTaskRun which is merged by others, query_id:{}, taskId:{}",
@@ -762,6 +759,11 @@ public class TaskManager implements MemoryTrackable {
                 status.setState(Constants.TaskRunState.MERGED);
                 status.setProgress(100);
                 status.setFinishTime(statusChange.getFinishTime());
+                taskRunManager.getTaskRunHistory().addHistory(status);
+            } else if (toStatus.isFinishState()) {
+                status.setErrorMessage(statusChange.getErrorMessage());
+                status.setErrorCode(statusChange.getErrorCode());
+                status.setState(toStatus);
                 taskRunManager.getTaskRunHistory().addHistory(status);
             } else {
                 LOG.warn("Illegal TaskRun queryId:{} status transform from {} to {}",

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -309,7 +309,7 @@ public class TaskRun implements Comparable<TaskRun> {
         // prepare to execute task run, move it here so that we can catch the exception and set the status
         processor.prepare(taskRunContext);
         // process task run
-        processor.processTaskRun(taskRunContext);
+        Constants.TaskRunState taskRunState = processor.processTaskRun(taskRunContext);
 
         QueryState queryState = runCtx.getState();
         LOG.info("[QueryId:{}] finished to execute task run, task_id:{}, query_state:{}",
@@ -323,7 +323,7 @@ public class TaskRun implements Comparable<TaskRun> {
             status.setErrorCode(errorCode);
             return Constants.TaskRunState.FAILED;
         }
-        return Constants.TaskRunState.SUCCESS;
+        return taskRunState;
     }
 
     public ConnectContext getRunCtx() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -259,7 +259,7 @@ public class TaskRun implements Comparable<TaskRun> {
         return context;
     }
 
-    public boolean executeTaskRun() throws Exception {
+    public Constants.TaskRunState executeTaskRun() throws Exception {
         TaskRunContext taskRunContext = new TaskRunContext();
 
         // Definition will cause a lot of repeats and cost a lot of metadata memory resources, so
@@ -321,16 +321,9 @@ public class TaskRun implements Comparable<TaskRun> {
                 errorCode = queryState.getErrorCode().getCode();
             }
             status.setErrorCode(errorCode);
-            return false;
+            return Constants.TaskRunState.FAILED;
         }
-
-        // Execute post task action, but ignore any exception
-        try {
-            processor.postTaskRun(taskRunContext);
-        } catch (Exception ignored) {
-            LOG.warn("Execute post taskRun failed {} ", status, ignored);
-        }
-        return true;
+        return Constants.TaskRunState.SUCCESS;
     }
 
     public ConnectContext getRunCtx() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunExecutor.java
@@ -57,12 +57,8 @@ public class TaskRunExecutor {
 
         CompletableFuture<Constants.TaskRunState> future = CompletableFuture.supplyAsync(() -> {
             try {
-                boolean isSuccess = taskRun.executeTaskRun();
-                if (isSuccess) {
-                    status.setState(Constants.TaskRunState.SUCCESS);
-                } else {
-                    status.setState(Constants.TaskRunState.FAILED);
-                }
+                Constants.TaskRunState runState = taskRun.executeTaskRun();
+                status.setState(runState);
             } catch (Exception ex) {
                 LOG.warn("failed to execute TaskRun.", ex);
                 status.setState(Constants.TaskRunState.FAILED);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunProcessor.java
@@ -22,7 +22,13 @@ public interface TaskRunProcessor {
      */
     void prepare(TaskRunContext context) throws Exception;
 
-    void processTaskRun(TaskRunContext context) throws Exception;
+    /**
+    * Process a task run with the given context.
+    * @param context: the context containing information about the task run, such as the task definition,
+    * @return: the state of the task run after processing, which can be SUCCESS, FAILED, or SKIPPED.
+    * @throws Exception: if any error occurs during the processing of the task run.
+    */
+    Constants.TaskRunState processTaskRun(TaskRunContext context) throws Exception;
 
     void postTaskRun(TaskRunContext context) throws Exception;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunProcessor.java
@@ -25,10 +25,15 @@ public interface TaskRunProcessor {
     /**
     * Process a task run with the given context.
     * @param context: the context containing information about the task run, such as the task definition,
-    * @return: the state of the task run after processing, which can be SUCCESS, FAILED, or SKIPPED.
+    * @return: the state of the task runs after processing, which can be SUCCESS, FAILED, or SKIPPED.
     * @throws Exception: if any error occurs during the processing of the task run.
     */
     Constants.TaskRunState processTaskRun(TaskRunContext context) throws Exception;
 
+    /**
+     * Post-process after the task run is completed.
+     * @param context: the context containing information about the task run, such as the task definition,
+     * @throws Exception: if any error occurs during the post-processing of the task run.
+     */
     void postTaskRun(TaskRunContext context) throws Exception;
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -426,7 +426,7 @@ public class CreateMaterializedViewTest extends MVTestBase {
         TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
         String mvTaskName = TaskBuilder.getMvTaskName(materializedView.getId());
         List<TaskRunStatus> taskRuns = waitingTaskFinish();
-        Assert.assertEquals(Constants.TaskRunState.SUCCESS, taskRuns.get(0).getState());
+        Assert.assertEquals(Constants.TaskRunState.SKIPPED, taskRuns.get(0).getState());
         Collection<Partition> baseTablePartitions = baseTable.getPartitions();
         Collection<Partition> mvPartitions = materializedView.getPartitions();
         Assert.assertEquals(2, mvPartitions.size());

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/MockTaskRunProcessor.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/MockTaskRunProcessor.java
@@ -38,11 +38,12 @@ public class MockTaskRunProcessor implements TaskRunProcessor {
     }
 
     @Override
-    public void processTaskRun(TaskRunContext context) throws Exception {
+    public Constants.TaskRunState processTaskRun(TaskRunContext context) throws Exception {
         if (sleepTimeMs > 0) {
             Thread.sleep(sleepTimeMs);
         }
         LOG.info("running a task. currentTime:" + LocalDateTime.now());
+        return Constants.TaskRunState.SUCCESS;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -529,7 +529,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
 
         new MockUp<PartitionBasedMvRefreshProcessor>() {
             @Mock
-            public void processTaskRun(TaskRunContext context) throws Exception {
+            public Constants.TaskRunState processTaskRun(TaskRunContext context) throws Exception {
                 throw new RuntimeException("new exception");
             }
         };

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -138,6 +138,7 @@ T_R_DB = "t_r_db"
 T_R_TABLE = "t_r_table"
 
 SECRET_INFOS = {}
+TASK_RUN_SUCCESS_STATES = set(["SUCCESS", "MERGED", "SKIPPED"])
 
 
 class StarrocksSQLApiLib(object):
@@ -1911,7 +1912,8 @@ class StarrocksSQLApiLib(object):
             results = result["result"]
             for _res in results:
                 last_refresh_state = _res[12]
-                if last_refresh_state != "SUCCESS" and last_refresh_state != "MERGED":
+                if last_refresh_state not in TASK_RUN_SUCCESS_STATES:
+                    print("mv %s last refresh state is %s, not in %s" % (mv_name, last_refresh_state, TASK_RUN_SUCCESS_STATES))
                     return False
             return True
 
@@ -1928,7 +1930,7 @@ class StarrocksSQLApiLib(object):
                 tools.assert_true(False, "show mv state error")
             results = result["result"]
             for _res in results:
-                if _res[0] != "SUCCESS" and _res[0] != "MERGED":
+                if _res[0] not in TASK_RUN_SUCCESS_STATES:
                     return False
             return True
 
@@ -1951,7 +1953,7 @@ class StarrocksSQLApiLib(object):
         def get_success_count(results):
             cnt = 0
             for _res in results:
-                if _res[0] == "SUCCESS" or _res[0] == "MERGED":
+                if _res[0] in TASK_RUN_SUCCESS_STATES:
                     cnt += 1
             return cnt
 
@@ -1979,7 +1981,7 @@ class StarrocksSQLApiLib(object):
     def wait_mv_refresh_count(self, db_name, mv_name, expect_count):
         show_sql = """select count(*) from information_schema.materialized_views 
             join information_schema.task_runs using(task_name)
-            where table_schema='{}' and table_name='{}' and (state = 'SUCCESS' or state = 'MERGED')
+            where table_schema='{}' and table_name='{}' and (state = 'SUCCESS' or state = 'MERGED'  or state = 'SKIPPED')
         """.format(
             db_name, mv_name
         )

--- a/test/sql/test_materialized_view/R/test_show_materialized_view
+++ b/test/sql/test_materialized_view/R/test_show_materialized_view
@@ -54,10 +54,10 @@ user_tags_mv1	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union
 DISTRIBUTED BY HASH(`user_id`)
 REFRESH MANUAL
 PROPERTIES (
+"session.insert_timeout" = "3600",
 "replicated_storage" = "true",
 "mv_rewrite_staleness_second" = "3600",
 "replication_num" = "1",
-"session.insert_timeout" = "3600",
 "storage_medium" = "HDD"
 )
 AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
@@ -70,10 +70,10 @@ user_tags_mv1	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union
 DISTRIBUTED BY HASH(`user_id`)
 REFRESH MANUAL
 PROPERTIES (
+"session.insert_timeout" = "3600",
 "replicated_storage" = "true",
 "mv_rewrite_staleness_second" = "3600",
 "replication_num" = "1",
-"session.insert_timeout" = "3600",
 "storage_medium" = "HDD"
 )
 AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
@@ -89,7 +89,7 @@ select
     INACTIVE_REASON
 from information_schema.materialized_views where table_name = 'user_tags_mv1';
 -- result:
-user_tags_mv1	SUCCESS	0	true	
+user_tags_mv1	SKIPPED	0	true	
 -- !result
 set @last_refresh_time = (
     select max(last_refresh_start_time)


### PR DESCRIPTION
## Why I'm doing:
For MV refresh, we cannot distinguish wether base table's data has changed or it's skipped for there is no change for base tables.


Add a new TaskRun State to mark the state when there is no change for base tables: SKIPPED.

## What I'm doing:
This pull request refactors the handling of task run states in the scheduler module by replacing the `RefreshJobStatus` enum with the more comprehensive `Constants.TaskRunState` enum. It also introduces a new `SKIPPED` state to represent cases where tasks are not executed due to specific conditions. Additionally, it standardizes the use of `Lists` across files by switching to `com.google.common.collect.Lists`.

### Refactoring of Task Run States:


* Added a new `SKIPPED` state to the `Constants.TaskRunState` enum to represent tasks that are skipped due to conditions like no partitions to refresh. Updated the `isSuccessState` method to include `SKIPPED` as a success state.
* Updated task run processors (`BaseTaskRunProcessor`, `DataCacheSelectProcessor`, `PartitionBasedMvRefreshProcessor`, `SqlTaskRunProcessor`) to return `Constants.TaskRunState` instead of void in the `processTaskRun` method. [[1]](diffhunk://#diff-462e85856b24e170b8ec3a45184e757043328680fb0a7f448696c6ad662875a9L32-R32) [[2]](diffhunk://#diff-7de40966bf921e10a04b2a93b56b5854b118c8cac075eeeaa03e39f3360181b9L34-R34) [[3]](diffhunk://#diff-679562d94a2bcd6f92b4960e2b727ddf852b6c0e47a92b836c4d0d71a6faa562L184-R176) [[4]](diffhunk://#diff-e4e2172767332728cb757eb96251747ac0686524db32431c138f847c29d027bbL34-R34)
* Updated `IMaterializedViewMetricsEntity` and its implementations to use `Constants.TaskRunState` instead of `RefreshJobStatus` for tracking refresh job statuses. [[1]](diffhunk://#diff-3230c543504454337652f03cfbec5e47c05e4c05361017598927d565ad814cfaL63-R63) [[2]](diffhunk://#diff-40639a2da35e2da4e1ec061f858e7206bad1db8d0228b75ca3d73267908f8288L54-R54) [[3]](diffhunk://#diff-7dc1a2288624ac5b0f54743d8062b4e0dc8ee34df1107a2e18233e5a810af667L340-R343)
* Modified `TaskManager` to handle the new `SKIPPED` state and ensure proper task history updates for all finish states. [[1]](diffhunk://#diff-ed40d0f2bad300ed05a6b9e6fa7f6e8b982d908570d54cb91ff41a98822593feR723-R725) [[2]](diffhunk://#diff-ed40d0f2bad300ed05a6b9e6fa7f6e8b982d908570d54cb91ff41a98822593feL750-L755) [[3]](diffhunk://#diff-ed40d0f2bad300ed05a6b9e6fa7f6e8b982d908570d54cb91ff41a98822593feR763-R767)

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
