### PR TITLE
[BugFix] Fix forgetting to set virtual buckets when BE is upgraded to the new version but FE is still on the old version

### DIFF
--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -290,9 +290,18 @@ Status OlapTablePartitionParam::init(RuntimeState* state) {
                   [](const OlapTableIndexTablets& lhs, const OlapTableIndexTablets& rhs) {
                       return lhs.index_id < rhs.index_id;
                   });
+
+        // If virtual buckets is not set, set its value with tablets.
+        // This may happen during cluster upgrading, when BE is upgraded to the new version but FE is still on the old version.
+        for (auto& index : part->indexes) {
+            if (!index.__isset.virtual_buckets) {
+                index.__set_virtual_buckets(index.tablets);
+            }
+        }
+
         // check index
         for (int j = 0; j < num_indexes; ++j) {
-            auto& index_tablets = part->indexes[j];
+            const auto& index_tablets = part->indexes[j];
             const auto& index_schema = _schema->indexes()[j];
             if (index_tablets.index_id != index_schema->index_id) {
                 std::stringstream ss;
@@ -300,12 +309,6 @@ Status OlapTablePartitionParam::init(RuntimeState* state) {
                    << ", part_index=" << index_tablets.index_id << ", schema_index=" << index_schema->index_id;
                 LOG(WARNING) << ss.str();
                 return Status::InternalError(ss.str());
-            }
-
-            // If virtual buckets is not set, set its value with tablets.
-            // This may happen during cluster upgrading, when BE is upgraded to the new version but FE is still on the old version.
-            if (!index_tablets.__isset.virtual_buckets) {
-                index_tablets.__set_virtual_buckets(index_tablets.tablets);
             }
         }
         _partitions.emplace(part->id, part);
@@ -509,6 +512,15 @@ Status OlapTablePartitionParam::add_partitions(const std::vector<TOlapTableParti
                   [](const OlapTableIndexTablets& lhs, const OlapTableIndexTablets& rhs) {
                       return lhs.index_id < rhs.index_id;
                   });
+
+        // If virtual buckets is not set, set its value with tablets.
+        // This may happen during cluster upgrading, when BE is upgraded to the new version but FE is still on the old version.
+        for (auto& index : part->indexes) {
+            if (!index.__isset.virtual_buckets) {
+                index.__set_virtual_buckets(index.tablets);
+            }
+        }
+
         // check index
         // If an add_partition operation is executed during the ALTER process, the ALTER operation will be canceled first.
         // Therefore, the latest indexes will not include shadow indexes.


### PR DESCRIPTION
## Why I'm doing:
Virtual buckets may not be set during cluster upgrading, when BE is upgraded to the new version but FE is still on the old version.

## What I'm doing:
If virtual buckets is not set, set its value with tablets.

Fixes https://github.com/StarRocks/starrocks/issues/59860, https://github.com/StarRocks/starrocks/issues/59134

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
