### PR TITLE
[BugFix] fix modify column wrongly handled for older version table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -788,6 +788,7 @@ public class SchemaChangeHandler extends AlterHandler {
 
         // retain old column name
         modColumn.setName(oriColumn.getName());
+        modColumn.setColumnId(oriColumn.getColumnId());
         modColumn.setUniqueId(oriColumn.getUniqueId());
 
         if (!oriColumn.isGeneratedColumn() && modColumn.isGeneratedColumn()) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -903,6 +903,10 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         return columnId;
     }
 
+    public void setColumnId(ColumnId cId) {
+        this.columnId = ColumnId.create(cId.getId());
+    }
+
     public void setUniqueId(int colUniqueId) {
         this.uniqueId = colUniqueId;
     }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
need to pass columnId to CN when doing DDL

```
set up 3.1.13 cluster
create table t (id int, AAA varchar(10), dt date) 
DUPLICATE KEY(`id`)
partition by range(`dt`)
(PARTITION p20250507 VALUES [("2025-05-07"), ("2025-05-08")),
PARTITION p20250508 VALUES [("2025-05-08"), ("2025-05-09")),
PARTITION p20250509 VALUES [("2025-05-09"), ("2025-05-10")))
DISTRIBUTED BY HASH(`id`) buckets 1
properties (
'replication_num'='1'
);

insert into t values ('1','abc','2025-05-09 12:00:00');

select * from t;
AAA will be abc

upgrade to 3.3.14
alter table t modify column aaa varchar(100);

select * from t;
AAA will be NULL
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
