### PR TITLE
[Enhancement] add default java opts for iceberg metadata

### DIFF
--- a/conf/be.conf
+++ b/conf/be.conf
@@ -56,3 +56,5 @@ starlet_port = 9070
 # JVM options for be
 # eg:
 # JAVA_OPTS="-Djava.security.krb5.conf=/etc/krb5.conf"
+# used for query iceberg metadata
+JAVA_OPTS="--add-opens=java.base/java.util=ALL-UNNAMED"


### PR DESCRIPTION
## Why I'm doing:
after BE upgrade java sdk to 17,  there are incompatibilities when querying Iceberg metadata.

refer to https://docs.oracle.com/en/java/javase/17/migrate/migrating-jdk-8-later-jdk-releases.html#GUID-12F945EB-71D6-46AF-8C3D-D354FD0B1781
![image](https://github.com/user-attachments/assets/1a053e41-7654-4ebb-99fd-e366acd6408b)


error message
![image](https://github.com/user-attachments/assets/6b6ba22b-133c-4c78-890a-3d9d84863448)


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
