### PR TITLE
[BugFix] Fix partition creation failure during multi-table write with in a single transaction

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -456,7 +456,7 @@ public class InsertOverwriteJobRunner {
                         // wait a little bit even if txnState is finished
                         Thread.sleep(200);
                     } while (txnState.isRunning() && --waitTimes > 0);
-                    tmpPartitionNames = txnState.getCreatedPartitionNames();
+                    tmpPartitionNames = txnState.getCreatedPartitionNames(tableId);
                     job.setTmpPartitionIds(tmpPartitionNames.stream()
                             .map(name -> targetTable.getPartition(name, true).getId())
                             .collect(Collectors.toList()));
@@ -547,7 +547,7 @@ public class InsertOverwriteJobRunner {
                         if (txnState == null) {
                             throw new DmlException("transaction state is null dbId:%s, txnId:%s", dbId, insertStmt.getTxnId());
                         }
-                        tmpPartitionNames = txnState.getCreatedPartitionNames();
+                        tmpPartitionNames = txnState.getCreatedPartitionNames(tableId);
                         job.setTmpPartitionIds(tmpPartitionNames.stream()
                                 .map(name -> targetTable.getPartition(name, true).getId())
                                 .collect(Collectors.toList()));

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -2283,7 +2283,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             return result;
         }
 
-        if (txnState.getPartitionNameToTPartition().size() > Config.max_partitions_in_one_batch) {
+        if (txnState.getPartitionNameToTPartition(tableId).size() > Config.max_partitions_in_one_batch) {
             errorStatus.setError_msgs(Lists.newArrayList(
                     String.format("Table %s automatic create partition failed. error: partitions in one batch exceed limit %d," +
                                     "You can modify this restriction on by setting" + " max_partitions_in_one_batch larger.",
@@ -2398,7 +2398,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         }
         for (String partitionName : partitionColNames) {
             // get partition info from snapshot
-            TOlapTablePartition tPartition = txnState.getPartitionNameToTPartition().get(partitionName);
+            TOlapTablePartition tPartition = txnState.getPartitionNameToTPartition(olapTable.getId()).get(partitionName);
             if (tPartition != null) {
                 partitions.add(tPartition);
                 for (TOlapTableIndexTablets index : tPartition.getIndexes()) {
@@ -2538,7 +2538,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             tPartition.addToIndexes(tIndex);
         }
         partitions.add(tPartition);
-        txnState.getPartitionNameToTPartition().put(partition.getName(), tPartition);
+        txnState.getPartitionNameToTPartition(olapTable.getId()).put(partition.getName(), tPartition);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -82,7 +82,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 
@@ -325,10 +324,10 @@ public class TransactionState implements Writable, GsonPreProcessable {
     // For a transaction, we need to ensure that different clients obtain consistent partition information,
     // to avoid inconsistencies caused by replica migration and other operations during the transaction process.
     // Therefore, a snapshot of this information is maintained here.
-    private ConcurrentMap<String, TOlapTablePartition> partitionNameToTPartition = Maps.newConcurrentMap();
+    private Map<Long, ConcurrentMap<String, TOlapTablePartition>> tableToPartitionNameToTPartition = Maps.newConcurrentMap();
     private ConcurrentMap<Long, TTabletLocation> tabletIdToTTabletLocation = Maps.newConcurrentMap();
 
-    private List<String> createdPartitionNames = Lists.newArrayList();
+    private Map<Long, List<String>> tableToCreatedPartitionNames = Maps.newHashMap();
     private AtomicBoolean isCreatePartitionFailed = new AtomicBoolean(false);
 
     private final ReentrantReadWriteLock txnLock = new ReentrantReadWriteLock(true);
@@ -1129,18 +1128,23 @@ public class TransactionState implements Writable, GsonPreProcessable {
         return useCombinedTxnLog;
     }
 
-    public ConcurrentMap<String, TOlapTablePartition> getPartitionNameToTPartition() {
-        return partitionNameToTPartition;
+    public ConcurrentMap<String, TOlapTablePartition> getPartitionNameToTPartition(long tableId) {
+        writeLock();
+        try {
+            return tableToPartitionNameToTPartition.computeIfAbsent(tableId, k -> Maps.newConcurrentMap());
+        } finally {
+            writeUnlock();
+        }
     }
 
     public ConcurrentMap<Long, TTabletLocation> getTabletIdToTTabletLocation() {
         return tabletIdToTTabletLocation;
     }
 
-    public List<String> getCreatedPartitionNames() {
+    public List<String> getCreatedPartitionNames(long tableId) {
         writeLock();
         try {
-            return createdPartitionNames;
+            return tableToCreatedPartitionNames.computeIfAbsent(tableId, k -> new ArrayList<>());
         } finally {
             writeUnlock();
         }
@@ -1149,12 +1153,16 @@ public class TransactionState implements Writable, GsonPreProcessable {
     public void clearAutomaticPartitionSnapshot() {
         writeLock();
         try {
-            createdPartitionNames = partitionNameToTPartition.keySet().stream().collect(Collectors.toList());
+            tableToPartitionNameToTPartition.forEach((tableId, partitionNameToTPartition) -> {
+                List<String> createdPartitionNames = tableToCreatedPartitionNames.computeIfAbsent(
+                        tableId, k -> new ArrayList<>());
+                createdPartitionNames.addAll(partitionNameToTPartition.keySet());
+            });
+            tabletIdToTTabletLocation.clear();
+            tableToPartitionNameToTPartition.clear();
         } finally {
             writeUnlock();
         }
-        partitionNameToTPartition.clear();
-        tabletIdToTTabletLocation.clear();
     }
 
     public void setIsCreatePartitionFailed(boolean v) {

--- a/test/sql/test_automatic_partition/R/test_multi_insert
+++ b/test/sql/test_automatic_partition/R/test_multi_insert
@@ -1,0 +1,27 @@
+-- name: test_multi_insert @slow
+create table t1(k int) partition by k distributed by hash(k);
+-- result:
+-- !result
+create table t2(k int) partition by k distributed by random;
+-- result:
+-- !result
+begin;
+-- result:
+-- !result
+insert into t1 select * from table(generate_series(0,128));
+-- result:
+-- !result
+insert into t2 select * from table(generate_series(0,128));
+-- result:
+-- !result
+commit;
+-- result:
+-- !result
+select count(*) from t1;
+-- result:
+129
+-- !result
+select count(*) from t2;
+-- result:
+129
+-- !result

--- a/test/sql/test_automatic_partition/T/test_multi_insert
+++ b/test/sql/test_automatic_partition/T/test_multi_insert
@@ -1,0 +1,9 @@
+-- name: test_multi_insert @slow
+create table t1(k int) partition by k distributed by hash(k);
+create table t2(k int) partition by k distributed by random;
+begin;
+insert into t1 select * from table(generate_series(0,128));
+insert into t2 select * from table(generate_series(0,128));
+commit;
+select count(*) from t1;
+select count(*) from t2;


### PR DESCRIPTION
## Why I'm doing:

in automatic partitions creation, a list of partitionInfo is cached in txnState, but the scenario where multiple tables are ingested within a single transaction is not considered. As a result, the retrieved partitionInfo is incorrect, leading to ingestion failure.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
