### PR TITLE
[Feature] make  profile async and turn on query profile on default

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1711,6 +1711,6 @@ CONF_mInt64(two_level_memory_threshold, "-1");
 
 CONF_mInt64(async_profile_merge_thread_max_num, "0");
 
-CONF_mInt64(async_profile_report_thread_max_num, "0");
+CONF_mInt64(async_profile_report_thread_max_num, "2");
 
 } // namespace starrocks::config

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1711,6 +1711,6 @@ CONF_mInt64(two_level_memory_threshold, "-1");
 
 CONF_mInt64(async_profile_merge_thread_max_num, "0");
 
-CONF_mInt64(async_profile_report_thread_max_num, "2");
+CONF_mInt64(async_profile_report_thread_max_num, "0");
 
 } // namespace starrocks::config

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1708,4 +1708,9 @@ CONF_mInt64(split_exchanger_buffer_chunk_num, "1000");
 
 // when to split hashmap/hashset into two level hashmap/hashset, negative number means use default value
 CONF_mInt64(two_level_memory_threshold, "-1");
+
+CONF_mInt64(async_profile_merge_thread_max_num, "0");
+
+CONF_mInt64(async_profile_report_thread_max_num, "0");
+
 } // namespace starrocks::config

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1713,4 +1713,6 @@ CONF_mInt64(async_profile_merge_thread_max_num, "0");
 
 CONF_mInt64(async_profile_report_thread_max_num, "0");
 
+CONF_mInt64(counter_display_threshold, "50");
+
 } // namespace starrocks::config

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1712,7 +1712,4 @@ CONF_mInt64(two_level_memory_threshold, "-1");
 CONF_mInt64(async_profile_merge_thread_max_num, "0");
 
 CONF_mInt64(async_profile_report_thread_max_num, "0");
-
-CONF_mInt64(counter_display_threshold, "50");
-
 } // namespace starrocks::config

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -336,5 +336,5 @@ set(EXEC_FILES
     stream/stream_aggregate_node.cpp)
 
 add_library(Exec STATIC
-        ${EXEC_FILES}
+    ${EXEC_FILES}
 )

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -251,6 +251,7 @@ set(EXEC_FILES
     pipeline/pipeline_driver_queue.cpp
     pipeline/pipeline_driver_poller.cpp
     pipeline/pipeline_driver.cpp
+    pipeline/profile_manager.cpp
     pipeline/audit_statistics_reporter.cpp
     pipeline/exec_state_reporter.cpp
     pipeline/driver_limiter.cpp

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -336,5 +336,5 @@ set(EXEC_FILES
     stream/stream_aggregate_node.cpp)
 
 add_library(Exec STATIC
-    ${EXEC_FILES}
+        ${EXEC_FILES}
 )

--- a/be/src/exec/pipeline/ProfileManager.cpp
+++ b/be/src/exec/pipeline/ProfileManager.cpp
@@ -10,11 +10,11 @@
 namespace starrocks::pipeline {
 RuntimeProfile* ProfileManager::build_merged_instance_profile(
         std::shared_ptr<FragmentProfileMaterial> fragment_profile_material, ObjectPool* obj_pool) {
-    LOG(WARNING) << "Before task - fragment_profile_material content: "
-                 << " total_cpu_cost_ns=" << fragment_profile_material->total_cpu_cost_ns
-                 << " total_spill_bytes=" << fragment_profile_material->total_spill_bytes
-                 << " instance_is_done=" << fragment_profile_material->instance_is_done
-                 << " be_number=" << fragment_profile_material->be_number;
+    // LOG(WARNING) << "Before task - fragment_profile_material content: "
+    //              << " total_cpu_cost_ns=" << fragment_profile_material->total_cpu_cost_ns
+    //              << " total_spill_bytes=" << fragment_profile_material->total_spill_bytes
+    //              << " instance_is_done=" << fragment_profile_material->instance_is_done
+    //              << " be_number=" << fragment_profile_material->be_number;
     RuntimeProfile* new_instance_profile = nullptr;
     RuntimeProfile* instance_profile = fragment_profile_material->instance_profile.get();
     if (fragment_profile_material->profile_level >= TPipelineProfileLevel::type::DETAIL) {
@@ -111,12 +111,12 @@ ProfileManager::ProfileManager(const CpuUtil::CpuIds& cpuids) {
 }
 
 void ProfileManager::build_and_report_profile(std::shared_ptr<FragmentProfileMaterial> fragment_profile_material) {
-    LOG(WARNING) << "Before task - fragment_profile_material content: "
-                 << " total_cpu_cost_ns=" << fragment_profile_material->total_cpu_cost_ns
-                 << " total_spill_bytes=" << fragment_profile_material->total_spill_bytes
-                 << " instance_is_done=" << fragment_profile_material->instance_is_done
-                 << " be_number=" << fragment_profile_material->be_number
-                 << " queryId=" << print_id(fragment_profile_material->query_id);
+    // LOG(WARNING) << "Before task - fragment_profile_material content: "
+    //              << " total_cpu_cost_ns=" << fragment_profile_material->total_cpu_cost_ns
+    //              << " total_spill_bytes=" << fragment_profile_material->total_spill_bytes
+    //              << " instance_is_done=" << fragment_profile_material->instance_is_done
+    //              << " be_number=" << fragment_profile_material->be_number
+    //              << " queryId=" << print_id(fragment_profile_material->query_id);
     auto profile_task = [=, fragment_profile_material = fragment_profile_material]() {
         ObjectPool obj_pool;
         RuntimeProfile* merged_instance_profile = build_merged_instance_profile(fragment_profile_material, &obj_pool);

--- a/be/src/exec/pipeline/ProfileManager.h
+++ b/be/src/exec/pipeline/ProfileManager.h
@@ -24,6 +24,8 @@ namespace starrocks::pipeline {
 
 struct FragmentProfileMaterial {
     std::shared_ptr<RuntimeProfile> instance_profile;
+    // pipeline profile/driver profile/operator profile
+    std::vector<std::shared_ptr<RuntimeProfile>> profiles_holders;
     std::shared_ptr<RuntimeProfile> load_channel_profile;
     TPipelineProfileLevel::type profile_level;
 

--- a/be/src/exec/pipeline/ProfileManager.h
+++ b/be/src/exec/pipeline/ProfileManager.h
@@ -43,30 +43,29 @@ struct FragmentProfileMaterial {
                             TPipelineProfileLevel::type profile_level, int64_t mem_cost_bytes,
                             int64_t total_cpu_cost_ns, int64_t total_spill_bytes, int64_t lifetime,
                             bool instance_is_done, TUniqueId query_id, int be_number, TQueryType::type query_type,
-                            TNetworkAddress fe_addr) {
-        instance_profile = std::move(instance_profile);
-        load_channel_profile = std::move(load_channel_profile);
-        profile_level = profile_level;
-        mem_cost_bytes = mem_cost_bytes;
-        total_cpu_cost_ns = total_cpu_cost_ns;
-        total_spill_bytes = total_spill_bytes;
-        lifetime = lifetime;
-        instance_is_done = instance_is_done;
-        query_id = query_id;
-        be_number = be_number;
-        query_type = query_type;
-        fe_addr = fe_addr;
-    }
+                            TNetworkAddress fe_addr)
+            : instance_profile(std::move(instance_profile)),
+              load_channel_profile(std::move(load_channel_profile)),
+              profile_level(profile_level),
+              mem_cost_bytes(mem_cost_bytes),
+              total_cpu_cost_ns(total_cpu_cost_ns),
+              total_spill_bytes(total_spill_bytes),
+              lifetime(lifetime),
+              instance_is_done(instance_is_done),
+              query_id(query_id),
+              be_number(be_number),
+              query_type(query_type),
+              fe_addr(fe_addr) {}
 };
 
-class profile_manager {
+class ProfileManager {
 public:
-    explicit profile_manager(const CpuUtil::CpuIds& cpuids);
-    Status build_and_report_profile(std::shared_ptr<FragmentProfileMaterial> fragment_profile_material);
+    explicit ProfileManager(const CpuUtil::CpuIds& cpuids);
+    void build_and_report_profile(std::shared_ptr<FragmentProfileMaterial> fragment_profile_material);
 
 private:
-    static RuntimeProfile* build_merged_instance_profile(FragmentProfileMaterial& fragment_profile,
-                                                         ObjectPool* obj_pool);
+    static RuntimeProfile* build_merged_instance_profile(
+            std::shared_ptr<FragmentProfileMaterial> fragment_profile_material, ObjectPool* obj_pool);
 
     static std::unique_ptr<TFragmentProfile> create_report_profile_params(
             std::shared_ptr<FragmentProfileMaterial> fragment_profile_material,

--- a/be/src/exec/pipeline/exec_state_reporter.cpp
+++ b/be/src/exec/pipeline/exec_state_reporter.cpp
@@ -60,6 +60,8 @@ std::unique_ptr<TReportExecStatusParams> ExecStateReporter::create_report_exec_s
     status.set_t_status(&params);
     params.__set_done(done);
 
+    // right now enable_async_profile_in_be is false for load, so load task will still use exec_state_report interface
+    // enable_async_profile_in_be is true for query, so query will not go here unless set enable_async_profile_in_be = false
     if (runtime_state->query_options().query_type == TQueryType::LOAD && !done && status.ok()) {
         // this is a load plan, and load is not finished, just make a brief report
         runtime_state->update_report_load_status(&params);

--- a/be/src/exec/pipeline/exec_state_reporter.cpp
+++ b/be/src/exec/pipeline/exec_state_reporter.cpp
@@ -45,13 +45,11 @@ std::string to_http_path(const std::string& token, const std::string& file_name)
 }
 
 std::unique_ptr<TReportExecStatusParams> ExecStateReporter::create_report_exec_status_params(
-        QueryContext* query_ctx, FragmentContext* fragment_ctx, RuntimeProfile* profile,
-        RuntimeProfile* load_channel_profile, const Status& status, bool done) {
+        QueryContext* query_ctx, FragmentContext* fragment_ctx, const Status& status, bool done) {
     auto res = std::make_unique<TReportExecStatusParams>();
     TReportExecStatusParams& params = *res;
     auto* runtime_state = fragment_ctx->runtime_state();
     DCHECK(runtime_state != nullptr);
-    DCHECK(profile != nullptr);
     auto* exec_env = fragment_ctx->runtime_state()->exec_env();
     DCHECK(exec_env != nullptr);
     params.protocol_version = FrontendServiceVersion::V1;
@@ -67,11 +65,11 @@ std::unique_ptr<TReportExecStatusParams> ExecStateReporter::create_report_exec_s
         params.__set_load_type(runtime_state->query_options().load_job_type);
 
         if (query_ctx->enable_profile()) {
-            profile->to_thrift(&params.profile);
-            params.__isset.profile = true;
-
-            load_channel_profile->to_thrift(&params.load_channel_profile);
-            params.__isset.load_channel_profile = true;
+            // profile->to_thrift(&params.profile);
+            // params.__isset.profile = true;
+            //
+            // load_channel_profile->to_thrift(&params.load_channel_profile);
+            // params.__isset.load_channel_profile = true;
         }
     } else {
         if (runtime_state->query_options().query_type == TQueryType::LOAD) {
@@ -79,13 +77,13 @@ std::unique_ptr<TReportExecStatusParams> ExecStateReporter::create_report_exec_s
             params.__set_load_type(runtime_state->query_options().load_job_type);
         }
         if (query_ctx->enable_profile()) {
-            profile->to_thrift(&params.profile);
-            params.__isset.profile = true;
-
-            if (runtime_state->query_options().query_type == TQueryType::LOAD) {
-                load_channel_profile->to_thrift(&params.load_channel_profile);
-                params.__isset.load_channel_profile = true;
-            }
+            // profile->to_thrift(&params.profile);
+            // params.__isset.profile = true;
+            //
+            // if (runtime_state->query_options().query_type == TQueryType::LOAD) {
+            //     load_channel_profile->to_thrift(&params.load_channel_profile);
+            //     params.__isset.load_channel_profile = true;
+            // }
         }
 
         if (!runtime_state->output_files().empty()) {

--- a/be/src/exec/pipeline/exec_state_reporter.cpp
+++ b/be/src/exec/pipeline/exec_state_reporter.cpp
@@ -65,7 +65,7 @@ std::unique_ptr<TReportExecStatusParams> ExecStateReporter::create_report_exec_s
         runtime_state->update_report_load_status(&params);
         params.__set_load_type(runtime_state->query_options().load_job_type);
 
-        if (query_ctx->enable_profile() && enable_async_profile_in_be) {
+        if (query_ctx->enable_profile() && !enable_async_profile_in_be) {
             profile->to_thrift(&params.profile);
             params.__isset.profile = true;
 
@@ -77,7 +77,7 @@ std::unique_ptr<TReportExecStatusParams> ExecStateReporter::create_report_exec_s
             runtime_state->update_report_load_status(&params);
             params.__set_load_type(runtime_state->query_options().load_job_type);
         }
-        if (query_ctx->enable_profile() && enable_async_profile_in_be) {
+        if (query_ctx->enable_profile() && !enable_async_profile_in_be) {
             DCHECK(profile != nullptr);
             profile->to_thrift(&params.profile);
             params.__isset.profile = true;

--- a/be/src/exec/pipeline/exec_state_reporter.h
+++ b/be/src/exec/pipeline/exec_state_reporter.h
@@ -31,9 +31,9 @@ class ExecStateReporter {
 public:
     explicit ExecStateReporter(const CpuUtil::CpuIds& cpuids);
 
-    static std::unique_ptr<TReportExecStatusParams> create_report_exec_status_params(
-            QueryContext* query_ctx, FragmentContext* fragment_ctx, RuntimeProfile* profile,
-            RuntimeProfile* load_channel_profile, const Status& status, bool done);
+    static std::unique_ptr<TReportExecStatusParams> create_report_exec_status_params(QueryContext* query_ctx,
+                                                                                     FragmentContext* fragment_ctx,
+                                                                                     const Status& status, bool done);
 
     static Status report_exec_status(const TReportExecStatusParams& params, ExecEnv* exec_env,
                                      const TNetworkAddress& fe_addr);

--- a/be/src/exec/pipeline/exec_state_reporter.h
+++ b/be/src/exec/pipeline/exec_state_reporter.h
@@ -31,9 +31,9 @@ class ExecStateReporter {
 public:
     explicit ExecStateReporter(const CpuUtil::CpuIds& cpuids);
 
-    static std::unique_ptr<TReportExecStatusParams> create_report_exec_status_params(QueryContext* query_ctx,
-                                                                                     FragmentContext* fragment_ctx,
-                                                                                     const Status& status, bool done);
+    static std::unique_ptr<TReportExecStatusParams> create_report_exec_status_params(
+            QueryContext* query_ctx, FragmentContext* fragment_ctx, RuntimeProfile* profile,
+            RuntimeProfile* load_channel_profile, const Status& status, bool done, bool enable_async_profile_in_be);
 
     static Status report_exec_status(const TReportExecStatusParams& params, ExecEnv* exec_env,
                                      const TNetworkAddress& fe_addr);

--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -53,11 +53,12 @@ Operator::Operator(OperatorFactory* factory, int32_t id, std::string name, int32
     _runtime_profile = std::make_shared<RuntimeProfile>(profile_name);
     _runtime_profile->set_metadata(_id);
 
+    _runtime_profile->reserve_child_holder(2);
     _common_metrics = std::make_shared<RuntimeProfile>("CommonMetrics");
-    _runtime_profile->add_child(_common_metrics.get(), true, nullptr);
+    _runtime_profile->add_child(_common_metrics, true, nullptr);
 
     _unique_metrics = std::make_shared<RuntimeProfile>("UniqueMetrics");
-    _runtime_profile->add_child(_unique_metrics.get(), true, nullptr);
+    _runtime_profile->add_child(_unique_metrics, true, nullptr);
     if (!_is_subordinate && _plan_node_id == s_pseudo_plan_node_id_for_final_sink) {
         _common_metrics->add_info_string("IsFinalSink");
     }

--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -53,7 +53,7 @@ Operator::Operator(OperatorFactory* factory, int32_t id, std::string name, int32
     _runtime_profile = std::make_shared<RuntimeProfile>(profile_name);
     _runtime_profile->set_metadata(_id);
 
-    _runtime_profile->reserve_child_holder(2);
+    // _runtime_profile->reserve_child_holder(2);
     _common_metrics = std::make_shared<RuntimeProfile>("CommonMetrics");
     _runtime_profile->add_child(_common_metrics, true, nullptr);
 

--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -53,7 +53,7 @@ Operator::Operator(OperatorFactory* factory, int32_t id, std::string name, int32
     _runtime_profile = std::make_shared<RuntimeProfile>(profile_name);
     _runtime_profile->set_metadata(_id);
 
-    // _runtime_profile->reserve_child_holder(2);
+    _runtime_profile->reserve_child_holder(2);
     _common_metrics = std::make_shared<RuntimeProfile>("CommonMetrics");
     _runtime_profile->add_child(_common_metrics, true, nullptr);
 

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -188,6 +188,7 @@ public:
     static const int32_t s_pseudo_plan_node_id_for_final_sink;
 
     RuntimeProfile* runtime_profile() { return _runtime_profile.get(); }
+    std::shared_ptr<RuntimeProfile> runtime_profile_ptr() { return _runtime_profile; }
     RuntimeProfile* common_metrics() { return _common_metrics.get(); }
     RuntimeProfile* unique_metrics() { return _unique_metrics.get(); }
 

--- a/be/src/exec/pipeline/pipeline.cpp
+++ b/be/src/exec/pipeline/pipeline.cpp
@@ -119,7 +119,7 @@ void Pipeline::instantiate_drivers(RuntimeState* state) {
 
 void Pipeline::setup_pipeline_profile(RuntimeState* runtime_state) {
     runtime_state->runtime_profile()->add_child(runtime_profile_ptr(), true, nullptr);
-    // runtime_profile()->reserve_child_holder(degree_of_parallelism());
+    runtime_profile()->reserve_child_holder(degree_of_parallelism());
 }
 
 void Pipeline::setup_drivers_profile(const DriverPtr& driver) {
@@ -132,7 +132,7 @@ void Pipeline::setup_drivers_profile(const DriverPtr& driver) {
     auto* total_dop_counter = ADD_COUNTER(runtime_profile(), "TotalDegreeOfParallelism", TUnit::UNIT);
     COUNTER_SET(total_dop_counter, dop_counter->value());
     auto& operators = driver->operators();
-    // driver->runtime_profile()->reserve_child_holder(operators.size());
+    driver->runtime_profile()->reserve_child_holder(operators.size());
     for (int32_t i = operators.size() - 1; i >= 0; --i) {
         auto& curr_op = operators[i];
         driver->runtime_profile()->add_child(curr_op->runtime_profile_ptr(), true, nullptr);

--- a/be/src/exec/pipeline/pipeline.cpp
+++ b/be/src/exec/pipeline/pipeline.cpp
@@ -119,7 +119,7 @@ void Pipeline::instantiate_drivers(RuntimeState* state) {
 
 void Pipeline::setup_pipeline_profile(RuntimeState* runtime_state) {
     runtime_state->runtime_profile()->add_child(runtime_profile_ptr(), true, nullptr);
-    runtime_profile()->reserve_child_holder(degree_of_parallelism());
+    // runtime_profile()->reserve_child_holder(degree_of_parallelism());
 }
 
 void Pipeline::setup_drivers_profile(const DriverPtr& driver) {
@@ -132,7 +132,7 @@ void Pipeline::setup_drivers_profile(const DriverPtr& driver) {
     auto* total_dop_counter = ADD_COUNTER(runtime_profile(), "TotalDegreeOfParallelism", TUnit::UNIT);
     COUNTER_SET(total_dop_counter, dop_counter->value());
     auto& operators = driver->operators();
-    driver->runtime_profile()->reserve_child_holder(operators.size());
+    // driver->runtime_profile()->reserve_child_holder(operators.size());
     for (int32_t i = operators.size() - 1; i >= 0; --i) {
         auto& curr_op = operators[i];
         driver->runtime_profile()->add_child(curr_op->runtime_profile_ptr(), true, nullptr);

--- a/be/src/exec/pipeline/pipeline.h
+++ b/be/src/exec/pipeline/pipeline.h
@@ -65,6 +65,8 @@ public:
     size_t degree_of_parallelism() const;
 
     RuntimeProfile* runtime_profile() { return _runtime_profile.get(); }
+    std::shared_ptr<RuntimeProfile> runtime_profile_ptr() { return _runtime_profile; }
+
     void setup_pipeline_profile(RuntimeState* runtime_state);
     void setup_drivers_profile(const DriverPtr& driver);
 

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -319,6 +319,7 @@ public:
         return _operators.empty() ? nullptr : down_cast<SourceOperator*>(_operators.front().get());
     }
     RuntimeProfile* runtime_profile() { return _runtime_profile.get(); }
+    std::shared_ptr<RuntimeProfile> runtime_profile_ptr() { return _runtime_profile; }
     void update_peak_driver_queue_size_counter(size_t new_value);
     // drivers that waits for runtime filters' readiness must be marked PRECONDITION_NOT_READY and put into
     // PipelineDriverPoller.

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -324,7 +324,7 @@ void GlobalDriverExecutor::report_exec_state(QueryContext* query_ctx, FragmentCo
                 fragment_ctx->runtime_state()->runtime_profile_ptr(),
                 fragment_ctx->runtime_state()->load_channel_profile_ptr(), query_ctx->profile_level(),
                 query_ctx->mem_cost_bytes(), query_ctx->cpu_cost(), query_ctx->get_spill_bytes(), query_ctx->lifetime(),
-                done, query_ctx->query_id(), fragment_ctx->runtime_state()->be_number(),
+                done, query_ctx->query_id(), fragment_ctx->runtime_state()->fragment_instance_id(),
                 fragment_ctx->runtime_state()->query_options().query_type, fe_addr);
 
         _profile_manager->build_and_report_profile(fragment_profile_material);

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -47,7 +47,7 @@ GlobalDriverExecutor::GlobalDriverExecutor(const std::string& name, std::unique_
                   new PipelineDriverPoller(name, _driver_queue.get(), cpuids, metrics->get_poller_metrics())),
           _exec_state_reporter(new ExecStateReporter(cpuids)),
           _audit_statistics_reporter(new AuditStatisticsReporter()),
-          _profile_manager(new profile_manager(cpuids)),
+          _profile_manager(new profile_manager()),
           _metrics(metrics->get_driver_executor_metrics()) {}
 
 void GlobalDriverExecutor::close() {

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -16,12 +16,12 @@
 
 #include <memory>
 
-#include "ProfileManager.h"
 #include "agent/master_info.h"
 #include "exec/pipeline/pipeline_metrics.h"
 #include "exec/pipeline/stream_pipeline_driver.h"
 #include "exec/workgroup/work_group.h"
 #include "gutil/strings/substitute.h"
+#include "profile_manager.h"
 #include "runtime/current_thread.h"
 #include "util/debug/query_trace.h"
 #include "util/defer_op.h"
@@ -47,7 +47,7 @@ GlobalDriverExecutor::GlobalDriverExecutor(const std::string& name, std::unique_
                   new PipelineDriverPoller(name, _driver_queue.get(), cpuids, metrics->get_poller_metrics())),
           _exec_state_reporter(new ExecStateReporter(cpuids)),
           _audit_statistics_reporter(new AuditStatisticsReporter()),
-          _profile_manager(new ProfileManager(cpuids)),
+          _profile_manager(new profile_manager(cpuids)),
           _metrics(metrics->get_driver_executor_metrics()) {}
 
 void GlobalDriverExecutor::close() {

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -16,12 +16,12 @@
 
 #include <memory>
 
-#include "profile_manager.h"
 #include "agent/master_info.h"
 #include "exec/pipeline/pipeline_metrics.h"
 #include "exec/pipeline/stream_pipeline_driver.h"
 #include "exec/workgroup/work_group.h"
 #include "gutil/strings/substitute.h"
+#include "profile_manager.h"
 #include "runtime/current_thread.h"
 #include "util/debug/query_trace.h"
 #include "util/defer_op.h"

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -333,8 +333,11 @@ void GlobalDriverExecutor::report_exec_state(QueryContext* query_ctx, FragmentCo
                 done, query_ctx->query_id(), fragment_ctx->runtime_state()->fragment_instance_id(),
                 fragment_ctx->runtime_state()->query_options().query_type, fe_addr);
         if (enable_async_profile_in_be) {
+            // new async way: profile merger thread-pool will merge profile and toThrift
+            // profile report thread-pool will call asyncProfileReport rpc
             _profile_manager->build_and_report_profile(fragment_profile_material);
         } else {
+            // the old sync way: driver merge profile and toThrift, then call report_exec_status rpc
             query_profile = ProfileManager::build_merged_instance_profile(fragment_profile_material, &obj_pool);
             // Load channel profile will be merged on FE
             load_channel_profile = fragment_ctx->runtime_state()->load_channel_profile();

--- a/be/src/exec/pipeline/pipeline_driver_executor.h
+++ b/be/src/exec/pipeline/pipeline_driver_executor.h
@@ -16,7 +16,7 @@
 
 #include <memory>
 
-#include "exec/pipeline/ProfileManager.h"
+#include "exec/pipeline/profile_manager.h"
 #include "exec/pipeline/audit_statistics_reporter.h"
 #include "exec/pipeline/exec_state_reporter.h"
 #include "exec/pipeline/pipeline_driver.h"

--- a/be/src/exec/pipeline/pipeline_driver_executor.h
+++ b/be/src/exec/pipeline/pipeline_driver_executor.h
@@ -16,7 +16,6 @@
 
 #include <memory>
 
-#include "exec/pipeline/ProfileManager.h"
 #include "exec/pipeline/audit_statistics_reporter.h"
 #include "exec/pipeline/exec_state_reporter.h"
 #include "exec/pipeline/pipeline_driver.h"
@@ -24,13 +23,14 @@
 #include "exec/pipeline/pipeline_driver_queue.h"
 #include "exec/pipeline/pipeline_fwd.h"
 #include "exec/pipeline/pipeline_metrics.h"
+#include "exec/pipeline/profile_manager.h"
 #include "runtime/runtime_state.h"
 #include "util/factory_method.h"
 #include "util/limit_setter.h"
 #include "util/threadpool.h"
 
 namespace starrocks::pipeline {
-class ProfileManager;
+class profile_manager;
 
 class DriverExecutor;
 using DriverExecutorPtr = std::shared_ptr<DriverExecutor>;
@@ -116,7 +116,7 @@ private:
     PipelineDriverPollerPtr _blocked_driver_poller;
     std::unique_ptr<ExecStateReporter> _exec_state_reporter;
     std::unique_ptr<AuditStatisticsReporter> _audit_statistics_reporter;
-    std::unique_ptr<ProfileManager> _profile_manager;
+    std::unique_ptr<profile_manager> _profile_manager;
 
     std::atomic<int> _next_id = 0;
     std::atomic_int64_t _schedule_count = 0;

--- a/be/src/exec/pipeline/pipeline_driver_executor.h
+++ b/be/src/exec/pipeline/pipeline_driver_executor.h
@@ -31,6 +31,7 @@
 #include "util/threadpool.h"
 
 namespace starrocks::pipeline {
+class profile_manager;
 
 class DriverExecutor;
 using DriverExecutorPtr = std::shared_ptr<DriverExecutor>;
@@ -116,6 +117,7 @@ private:
     PipelineDriverPollerPtr _blocked_driver_poller;
     std::unique_ptr<ExecStateReporter> _exec_state_reporter;
     std::unique_ptr<AuditStatisticsReporter> _audit_statistics_reporter;
+    std::unique_ptr<profile_manager> _profile_manager;
 
     std::atomic<int> _next_id = 0;
     std::atomic_int64_t _schedule_count = 0;

--- a/be/src/exec/pipeline/pipeline_driver_executor.h
+++ b/be/src/exec/pipeline/pipeline_driver_executor.h
@@ -15,8 +15,8 @@
 #pragma once
 
 #include <memory>
-#include <unordered_map>
 
+#include "exec/pipeline/ProfileManager.h"
 #include "exec/pipeline/audit_statistics_reporter.h"
 #include "exec/pipeline/exec_state_reporter.h"
 #include "exec/pipeline/pipeline_driver.h"
@@ -24,14 +24,13 @@
 #include "exec/pipeline/pipeline_driver_queue.h"
 #include "exec/pipeline/pipeline_fwd.h"
 #include "exec/pipeline/pipeline_metrics.h"
-#include "exec/pipeline/query_context.h"
 #include "runtime/runtime_state.h"
 #include "util/factory_method.h"
 #include "util/limit_setter.h"
 #include "util/threadpool.h"
 
 namespace starrocks::pipeline {
-class profile_manager;
+class ProfileManager;
 
 class DriverExecutor;
 using DriverExecutorPtr = std::shared_ptr<DriverExecutor>;
@@ -117,7 +116,7 @@ private:
     PipelineDriverPollerPtr _blocked_driver_poller;
     std::unique_ptr<ExecStateReporter> _exec_state_reporter;
     std::unique_ptr<AuditStatisticsReporter> _audit_statistics_reporter;
-    std::unique_ptr<profile_manager> _profile_manager;
+    std::unique_ptr<ProfileManager> _profile_manager;
 
     std::atomic<int> _next_id = 0;
     std::atomic_int64_t _schedule_count = 0;

--- a/be/src/exec/pipeline/pipeline_driver_executor.h
+++ b/be/src/exec/pipeline/pipeline_driver_executor.h
@@ -16,7 +16,6 @@
 
 #include <memory>
 
-#include "exec/pipeline/profile_manager.h"
 #include "exec/pipeline/audit_statistics_reporter.h"
 #include "exec/pipeline/exec_state_reporter.h"
 #include "exec/pipeline/pipeline_driver.h"
@@ -24,6 +23,7 @@
 #include "exec/pipeline/pipeline_driver_queue.h"
 #include "exec/pipeline/pipeline_fwd.h"
 #include "exec/pipeline/pipeline_metrics.h"
+#include "exec/pipeline/profile_manager.h"
 #include "runtime/runtime_state.h"
 #include "util/factory_method.h"
 #include "util/limit_setter.h"
@@ -100,8 +100,6 @@ private:
     void _worker_thread();
     StatusOr<DriverRawPtr> _get_next_driver(std::queue<DriverRawPtr>& local_driver_queue);
     void _finalize_driver(DriverRawPtr driver, RuntimeState* runtime_state, DriverState state);
-    RuntimeProfile* _build_merged_instance_profile(QueryContext* query_ctx, FragmentContext* fragment_ctx,
-                                                   ObjectPool* obj_pool);
 
     void _finalize_epoch(DriverRawPtr driver, RuntimeState* runtime_state, DriverState state);
 

--- a/be/src/exec/pipeline/pipeline_driver_executor.h
+++ b/be/src/exec/pipeline/pipeline_driver_executor.h
@@ -16,6 +16,7 @@
 
 #include <memory>
 
+#include "exec/pipeline/ProfileManager.h"
 #include "exec/pipeline/audit_statistics_reporter.h"
 #include "exec/pipeline/exec_state_reporter.h"
 #include "exec/pipeline/pipeline_driver.h"
@@ -23,14 +24,13 @@
 #include "exec/pipeline/pipeline_driver_queue.h"
 #include "exec/pipeline/pipeline_fwd.h"
 #include "exec/pipeline/pipeline_metrics.h"
-#include "exec/pipeline/profile_manager.h"
 #include "runtime/runtime_state.h"
 #include "util/factory_method.h"
 #include "util/limit_setter.h"
 #include "util/threadpool.h"
 
 namespace starrocks::pipeline {
-class profile_manager;
+class ProfileManager;
 
 class DriverExecutor;
 using DriverExecutorPtr = std::shared_ptr<DriverExecutor>;
@@ -116,7 +116,7 @@ private:
     PipelineDriverPollerPtr _blocked_driver_poller;
     std::unique_ptr<ExecStateReporter> _exec_state_reporter;
     std::unique_ptr<AuditStatisticsReporter> _audit_statistics_reporter;
-    std::unique_ptr<profile_manager> _profile_manager;
+    std::unique_ptr<ProfileManager> _profile_manager;
 
     std::atomic<int> _next_id = 0;
     std::atomic_int64_t _schedule_count = 0;

--- a/be/src/exec/pipeline/profile_manager.cpp
+++ b/be/src/exec/pipeline/profile_manager.cpp
@@ -89,7 +89,7 @@ RuntimeProfile* profile_manager::build_merged_instance_profile(
 }
 
 profile_manager::profile_manager() {
-    int max_merger = config::async_profile_merge_thread_max_num == 0 ? CpuInfo::num_cores() / 6
+    int max_merger = config::async_profile_merge_thread_max_num == 0 ? CpuInfo::num_cores()
                                                                      : config::async_profile_merge_thread_max_num;
     auto status = ThreadPoolBuilder("query_profile_merge")
                           .set_min_threads(1)
@@ -186,8 +186,8 @@ std::unique_ptr<TFragmentProfile> profile_manager::create_report_profile_params(
     params.__set_fragment_instance_id(fragment_profile_material->_instance_id);
     params.__set_done(fragment_profile_material->_instance_is_done);
 
-    ObjectPool obj_pool;
-    merged_instance_profile = obj_pool.add(new RuntimeProfile(merged_instance_profile->name()));
+    // ObjectPool obj_pool;
+    // merged_instance_profile = obj_pool.add(new RuntimeProfile(merged_instance_profile->name()));
 
     merged_instance_profile->to_thrift(&params.profile);
     params.__isset.profile = true;

--- a/be/src/exec/pipeline/profile_manager.cpp
+++ b/be/src/exec/pipeline/profile_manager.cpp
@@ -2,7 +2,7 @@
 // Created by femi on 2025/5/14.
 //
 
-#include "profile_manager.h"
+#include "ProfileManager.h"
 
 #include <utility>
 
@@ -11,7 +11,7 @@
 #include "util/thrift_rpc_helper.h"
 
 namespace starrocks::pipeline {
-RuntimeProfile* profile_manager::build_merged_instance_profile(
+RuntimeProfile* ProfileManager::build_merged_instance_profile(
         const std::shared_ptr<FragmentProfileMaterial>& fragment_profile_material, ObjectPool* obj_pool) {
     // LOG(WARNING) << "Before task - fragment_profile_material content: "
     //              << " total_cpu_cost_ns=" << fragment_profile_material->total_cpu_cost_ns
@@ -88,7 +88,7 @@ RuntimeProfile* profile_manager::build_merged_instance_profile(
     return new_instance_profile;
 }
 
-profile_manager::profile_manager() {
+ProfileManager::ProfileManager() {
     int max_reporter = config::async_profile_report_thread_max_num == 0 ? CpuInfo::num_cores() / 2
                                                                         : config::async_profile_report_thread_max_num;
 
@@ -122,7 +122,7 @@ profile_manager::profile_manager() {
     _mem_tracker = GlobalEnv::GetInstance()->profile_mem_tracker();
 }
 
-void profile_manager::build_and_report_profile(std::shared_ptr<FragmentProfileMaterial> fragment_profile_material) {
+void ProfileManager::build_and_report_profile(std::shared_ptr<FragmentProfileMaterial> fragment_profile_material) {
     auto profile_task = [=, fragment_profile_material = std::move(fragment_profile_material)]() {
         SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
 
@@ -178,7 +178,7 @@ void profile_manager::build_and_report_profile(std::shared_ptr<FragmentProfileMa
     }
 }
 
-std::unique_ptr<TFragmentProfile> profile_manager::create_report_profile_params(
+std::unique_ptr<TFragmentProfile> ProfileManager::create_report_profile_params(
         const std::shared_ptr<FragmentProfileMaterial>& fragment_profile_material,
         RuntimeProfile* merged_instance_profile) {
     auto res = std::make_unique<TFragmentProfile>();
@@ -186,9 +186,6 @@ std::unique_ptr<TFragmentProfile> profile_manager::create_report_profile_params(
     params.__set_query_id(fragment_profile_material->_query_id);
     params.__set_fragment_instance_id(fragment_profile_material->_instance_id);
     params.__set_done(fragment_profile_material->_instance_is_done);
-
-    // ObjectPool obj_pool;
-    // merged_instance_profile = obj_pool.add(new RuntimeProfile(merged_instance_profile->name()));
 
     merged_instance_profile->to_thrift(&params.profile);
     params.__isset.profile = true;

--- a/be/src/exec/pipeline/profile_manager.cpp
+++ b/be/src/exec/pipeline/profile_manager.cpp
@@ -135,7 +135,8 @@ void profile_manager::build_and_report_profile(std::shared_ptr<FragmentProfileMa
         RuntimeProfile* merged_instance_profile = build_merged_instance_profile(fragment_profile_material, &obj_pool);
         std::shared_ptr<TFragmentProfile> params =
                 create_report_profile_params(fragment_profile_material, merged_instance_profile);
-        auto report_task = [params, fragment_profile_material]() {
+        auto report_task = [params, fragment_profile_material, this]() {
+            SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
             const auto& fe_addr = fragment_profile_material->fe_addr;
             int max_retry_times = config::report_exec_rpc_request_retry_num;
             int retry_times = 0;
@@ -164,6 +165,7 @@ void profile_manager::build_and_report_profile(std::shared_ptr<FragmentProfileMa
 
     Status status = _merge_thread_pool->submit_func(profile_task);
     if (!status.ok()) {
+        LOG(WARNING) << "Cannot submit profile report: " << status.to_string();
         profile_task();
     }
 }

--- a/be/src/exec/pipeline/profile_manager.cpp
+++ b/be/src/exec/pipeline/profile_manager.cpp
@@ -2,7 +2,7 @@
 // Created by femi on 2025/5/14.
 //
 
-#include "ProfileManager.h"
+#include "profile_manager.h"
 
 #include <utility>
 

--- a/be/src/exec/pipeline/profile_manager.cpp
+++ b/be/src/exec/pipeline/profile_manager.cpp
@@ -105,7 +105,7 @@ profile_manager::profile_manager() {
     REGISTER_THREAD_POOL_METRICS(async_profile_merge, _report_thread_pool);
 
     int max_reporter = config::async_profile_report_thread_max_num == 0 ? CpuInfo::num_cores() / 2
-                                                                        : config::async_profile_merge_thread_max_num;
+                                                                        : config::async_profile_report_thread_max_num;
     status = ThreadPoolBuilder("query_profile_report")
                      .set_min_threads(1)
                      .set_max_threads(max_reporter)

--- a/be/src/exec/pipeline/profile_manager.cpp
+++ b/be/src/exec/pipeline/profile_manager.cpp
@@ -151,6 +151,7 @@ static std::unique_ptr<TFragmentProfile> profile_manager::create_report_profile_
     params.__isset.profile = true;
 
     if (fragment_profile_material.query_type == TQueryType::LOAD) {
+        // Load channel profile will be merged on FE
         fragment_profile_material.load_channel_profile->to_thrift(&params.load_channel_profile);
         params.__isset.load_channel_profile = true;
     }

--- a/be/src/exec/pipeline/profile_manager.cpp
+++ b/be/src/exec/pipeline/profile_manager.cpp
@@ -103,9 +103,11 @@ profile_manager::profile_manager(const CpuUtil::CpuIds& cpuids) {
 
     REGISTER_THREAD_POOL_METRICS(async_profile_merge, _report_thread_pool);
 
+    int max_reporter = config::async_profile_report_thread_max_num == 0 ? CpuInfo::num_cores() / 2
+                                                                     : config::async_profile_merge_thread_max_num;
     status = ThreadPoolBuilder("query_profile_report")
                      .set_min_threads(1)
-                     .set_max_threads(2)
+                     .set_max_threads(max_reporter)
                      .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
                      .set_cpuids(cpuids)
                      .build(&_merge_thread_pool);

--- a/be/src/exec/pipeline/profile_manager.cpp
+++ b/be/src/exec/pipeline/profile_manager.cpp
@@ -1,0 +1,78 @@
+//
+// Created by femi on 2025/5/14.
+//
+
+#include "profile_manager.h"
+
+namespace starrocks::pipeline {
+RuntimeProfile* profile_manager::build_merged_instance_profile(FragmentProfileMaterial& fragment_profile_material) {
+    ObjectPool obj_pool;
+    RuntimeProfile* new_instance_profile = nullptr;
+    RuntimeProfile* instance_profile = fragment_profile_material.query_profile.get();
+    if (fragment_profile_material.profile_level >= TPipelineProfileLevel::type::DETAIL) {
+        new_instance_profile = fragment_profile_material.query_profile.get();
+    } else {
+        int64_t process_raw_timer = 0;
+        DeferOp defer([&new_instance_profile, &process_raw_timer]() {
+            if (new_instance_profile != nullptr) {
+                auto* process_timer = ADD_TIMER(new_instance_profile, "BackendProfileMergeTime");
+                COUNTER_SET(process_timer, process_raw_timer);
+            }
+        });
+
+        SCOPED_RAW_TIMER(&process_raw_timer);
+        std::vector<RuntimeProfile*> pipeline_profiles;
+        instance_profile->get_children(&pipeline_profiles);
+
+        std::vector<RuntimeProfile*> merged_driver_profiles;
+        for (auto* pipeline_profile : pipeline_profiles) {
+            std::vector<RuntimeProfile*> driver_profiles;
+            pipeline_profile->get_children(&driver_profiles);
+
+            if (driver_profiles.empty()) {
+                continue;
+            }
+
+            auto* merged_driver_profile = RuntimeProfile::merge_isomorphic_profiles(obj_pool, driver_profiles);
+
+            // use the name of pipeline' profile as pipeline driver's
+            merged_driver_profile->set_name(pipeline_profile->name());
+
+            // add all the info string and counters of the pipeline's profile
+            // to the pipeline driver's profile
+            merged_driver_profile->copy_all_info_strings_from(pipeline_profile);
+            merged_driver_profile->copy_all_counters_from(pipeline_profile);
+
+            merged_driver_profiles.push_back(merged_driver_profile);
+        }
+
+        new_instance_profile = obj_pool.add(new RuntimeProfile(instance_profile->name()));
+        new_instance_profile->copy_all_info_strings_from(instance_profile);
+        new_instance_profile->copy_all_counters_from(instance_profile);
+        for (auto* merged_driver_profile : merged_driver_profiles) {
+            merged_driver_profile->reset_parent();
+            new_instance_profile->add_child(merged_driver_profile, true, nullptr);
+        }
+    }
+
+    // Add counters for query level memory and cpu usage, these two metrics will be specially handled at the frontend
+    auto* query_peak_memory = new_instance_profile->add_counter(
+            "QueryPeakMemoryUsage", TUnit::BYTES,
+            RuntimeProfile::Counter::create_strategy(TUnit::BYTES, TCounterMergeType::SKIP_FIRST_MERGE));
+    query_peak_memory->set(fragment_profile_material.mem_cost_bytes);
+    auto* query_cumulative_cpu = new_instance_profile->add_counter(
+            "QueryCumulativeCpuTime", TUnit::TIME_NS,
+            RuntimeProfile::Counter::create_strategy(TUnit::TIME_NS, TCounterMergeType::SKIP_FIRST_MERGE));
+    query_cumulative_cpu->set(fragment_profile_material.total_cpu_cost_ns);
+    auto* query_spill_bytes = new_instance_profile->add_counter(
+            "QuerySpillBytes", TUnit::BYTES,
+            RuntimeProfile::Counter::create_strategy(TUnit::BYTES, TCounterMergeType::SKIP_FIRST_MERGE));
+    query_spill_bytes->set(fragment_profile_material.total_spill_bytes);
+    // Add execution wall time
+    auto* query_exec_wall_time = new_instance_profile->add_counter(
+            "QueryExecutionWallTime", TUnit::TIME_NS,
+            RuntimeProfile::Counter::create_strategy(TUnit::TIME_NS, TCounterMergeType::SKIP_FIRST_MERGE));
+    query_exec_wall_time->set(fragment_profile_material.lifetime);
+}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/profile_manager.h
+++ b/be/src/exec/pipeline/profile_manager.h
@@ -23,41 +23,41 @@ class RuntimeProfile;
 namespace starrocks::pipeline {
 
 struct FragmentProfileMaterial {
-    std::shared_ptr<RuntimeProfile> instance_profile;
+    std::shared_ptr<RuntimeProfile> _instance_profile;
     // pipeline profile/driver profile/operator profile
-    std::vector<std::shared_ptr<RuntimeProfile>> profiles_holders;
-    std::shared_ptr<RuntimeProfile> load_channel_profile;
-    TPipelineProfileLevel::type profile_level;
+    std::vector<std::shared_ptr<RuntimeProfile>> _profiles_holders;
+    std::shared_ptr<RuntimeProfile> _load_channel_profile;
+    TPipelineProfileLevel::type _profile_level;
 
-    int64_t mem_cost_bytes;
-    int64_t total_cpu_cost_ns;
-    int64_t total_spill_bytes;
-    int64_t lifetime;
+    int64_t _mem_cost_bytes;
+    int64_t _total_cpu_cost_ns;
+    int64_t _total_spill_bytes;
+    int64_t _lifetime;
 
-    bool instance_is_done;
-    TUniqueId query_id;
-    int be_number;
-    TQueryType::type query_type;
-    TNetworkAddress fe_addr;
+    bool _instance_is_done;
+    TUniqueId _query_id;
+    TUniqueId _instance_id;
+    TQueryType::type _query_type;
+    TNetworkAddress _fe_addr;
 
     FragmentProfileMaterial(std::shared_ptr<RuntimeProfile> instance_profile,
                             std::shared_ptr<RuntimeProfile> load_channel_profile,
                             TPipelineProfileLevel::type profile_level, int64_t mem_cost_bytes,
                             int64_t total_cpu_cost_ns, int64_t total_spill_bytes, int64_t lifetime,
-                            bool instance_is_done, TUniqueId query_id, int be_number, TQueryType::type query_type,
-                            TNetworkAddress fe_addr)
-            : instance_profile(std::move(instance_profile)),
-              load_channel_profile(std::move(load_channel_profile)),
-              profile_level(profile_level),
-              mem_cost_bytes(mem_cost_bytes),
-              total_cpu_cost_ns(total_cpu_cost_ns),
-              total_spill_bytes(total_spill_bytes),
-              lifetime(lifetime),
-              instance_is_done(instance_is_done),
-              query_id(query_id),
-              be_number(be_number),
-              query_type(query_type),
-              fe_addr(fe_addr) {}
+                            bool instance_is_done, const TUniqueId& query_id, const TUniqueId& instance_id,
+                            TQueryType::type query_type, const TNetworkAddress& fe_addr)
+            : _instance_profile(std::move(instance_profile)),
+              _load_channel_profile(std::move(load_channel_profile)),
+              _profile_level(profile_level),
+              _mem_cost_bytes(mem_cost_bytes),
+              _total_cpu_cost_ns(total_cpu_cost_ns),
+              _total_spill_bytes(total_spill_bytes),
+              _lifetime(lifetime),
+              _instance_is_done(instance_is_done),
+              _query_id(query_id),
+              _instance_id(instance_id),
+              _query_type(query_type),
+              _fe_addr(fe_addr) {}
 };
 
 class profile_manager {
@@ -67,10 +67,10 @@ public:
 
 private:
     static RuntimeProfile* build_merged_instance_profile(
-            std::shared_ptr<FragmentProfileMaterial> fragment_profile_material, ObjectPool* obj_pool);
+            const std::shared_ptr<FragmentProfileMaterial>& fragment_profile_material, ObjectPool* obj_pool);
 
     static std::unique_ptr<TFragmentProfile> create_report_profile_params(
-            std::shared_ptr<FragmentProfileMaterial> fragment_profile_material,
+            const std::shared_ptr<FragmentProfileMaterial>& fragment_profile_material,
             RuntimeProfile* merged_instance_profile);
 
     std::unique_ptr<ThreadPool> _merge_thread_pool;

--- a/be/src/exec/pipeline/profile_manager.h
+++ b/be/src/exec/pipeline/profile_manager.h
@@ -62,7 +62,7 @@ struct FragmentProfileMaterial {
 
 class profile_manager {
 public:
-    explicit profile_manager(const CpuUtil::CpuIds& cpuids);
+    explicit profile_manager();
     void build_and_report_profile(std::shared_ptr<FragmentProfileMaterial> fragment_profile_material);
 
 private:

--- a/be/src/exec/pipeline/profile_manager.h
+++ b/be/src/exec/pipeline/profile_manager.h
@@ -1,6 +1,16 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
 //
-// Created by femi on 2025/5/14.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #pragma once
 #include <memory>
@@ -41,7 +51,7 @@ struct FragmentProfileMaterial {
         total_cpu_cost_ns = total_cpu_cost_ns;
         total_spill_bytes = total_spill_bytes;
         lifetime = lifetime;
-        instance_is_done = instance_is_downinstance_is_done;
+        instance_is_done = instance_is_done;
         query_id = query_id;
         be_number = be_number;
         query_type = query_type;
@@ -52,7 +62,7 @@ struct FragmentProfileMaterial {
 class profile_manager {
 public:
     explicit profile_manager(const CpuUtil::CpuIds& cpuids);
-    Status static build_and_report_profile(std::shared_ptr<FragmentProfileMaterial> fragment_profile_material);
+    Status build_and_report_profile(std::shared_ptr<FragmentProfileMaterial> fragment_profile_material);
 
 private:
     static RuntimeProfile* build_merged_instance_profile(FragmentProfileMaterial& fragment_profile,

--- a/be/src/exec/pipeline/profile_manager.h
+++ b/be/src/exec/pipeline/profile_manager.h
@@ -13,23 +13,55 @@ class RuntimeProfile;
 namespace starrocks::pipeline {
 
 struct FragmentProfileMaterial {
+    std::shared_ptr<RuntimeProfile> instance_profile;
     std::shared_ptr<RuntimeProfile> load_channel_profile;
-    std::shared_ptr<RuntimeProfile> query_profile;
     TPipelineProfileLevel::type profile_level;
 
     int64_t mem_cost_bytes;
     int64_t total_cpu_cost_ns;
     int64_t total_spill_bytes;
     int64_t lifetime;
+
+    bool instance_is_done;
+    TUniqueId query_id;
+    int be_number;
+    TQueryType::type query_type;
+    TNetworkAddress fe_addr;
+
+    FragmentProfileMaterial(std::shared_ptr<RuntimeProfile> instance_profile,
+                            std::shared_ptr<RuntimeProfile> load_channel_profile,
+                            TPipelineProfileLevel::type profile_level, int64_t mem_cost_bytes,
+                            int64_t total_cpu_cost_ns, int64_t total_spill_bytes, int64_t lifetime,
+                            bool instance_is_done, TUniqueId query_id, int be_number, TQueryType::type query_type,
+                            TNetworkAddress fe_addr) {
+        instance_profile = std::move(instance_profile);
+        load_channel_profile = std::move(load_channel_profile);
+        profile_level = profile_level;
+        mem_cost_bytes = mem_cost_bytes;
+        total_cpu_cost_ns = total_cpu_cost_ns;
+        total_spill_bytes = total_spill_bytes;
+        lifetime = lifetime;
+        instance_is_done = instance_is_downinstance_is_done;
+        query_id = query_id;
+        be_number = be_number;
+        query_type = query_type;
+        fe_addr = fe_addr;
+    }
 };
 
 class profile_manager {
 public:
     explicit profile_manager(const CpuUtil::CpuIds& cpuids);
-    void submit(std::function<void()>&& report_task);
-    static RuntimeProfile* build_merged_instance_profile(FragmentProfileMaterial& fragment_profile);
+    Status static build_and_report_profile(std::shared_ptr<FragmentProfileMaterial> fragment_profile_material);
 
 private:
+    static RuntimeProfile* build_merged_instance_profile(FragmentProfileMaterial& fragment_profile,
+                                                         ObjectPool* obj_pool);
+
+    static std::unique_ptr<TFragmentProfile> create_report_profile_params(
+            std::shared_ptr<FragmentProfileMaterial> fragment_profile_material,
+            RuntimeProfile* merged_instance_profile);
+
     std::unique_ptr<ThreadPool> _merge_thread_pool;
     std::unique_ptr<ThreadPool> _report_thread_pool;
 };

--- a/be/src/exec/pipeline/profile_manager.h
+++ b/be/src/exec/pipeline/profile_manager.h
@@ -60,15 +60,15 @@ struct FragmentProfileMaterial {
               _fe_addr(fe_addr) {}
 };
 
-class profile_manager {
+class ProfileManager {
 public:
-    explicit profile_manager();
+    explicit ProfileManager();
     void build_and_report_profile(std::shared_ptr<FragmentProfileMaterial> fragment_profile_material);
 
-private:
     static RuntimeProfile* build_merged_instance_profile(
             const std::shared_ptr<FragmentProfileMaterial>& fragment_profile_material, ObjectPool* obj_pool);
 
+private:
     static std::unique_ptr<TFragmentProfile> create_report_profile_params(
             const std::shared_ptr<FragmentProfileMaterial>& fragment_profile_material,
             RuntimeProfile* merged_instance_profile);

--- a/be/src/exec/pipeline/profile_manager.h
+++ b/be/src/exec/pipeline/profile_manager.h
@@ -1,0 +1,37 @@
+//
+// Created by femi on 2025/5/14.
+//
+
+#pragma once
+#include <memory>
+
+#include "pipeline.h"
+
+namespace starrocks {
+class RuntimeProfile;
+}
+namespace starrocks::pipeline {
+
+struct FragmentProfileMaterial {
+    std::shared_ptr<RuntimeProfile> load_channel_profile;
+    std::shared_ptr<RuntimeProfile> query_profile;
+    TPipelineProfileLevel::type profile_level;
+
+    int64_t mem_cost_bytes;
+    int64_t total_cpu_cost_ns;
+    int64_t total_spill_bytes;
+    int64_t lifetime;
+};
+
+class profile_manager {
+public:
+    explicit profile_manager(const CpuUtil::CpuIds& cpuids);
+    void submit(std::function<void()>&& report_task);
+    static RuntimeProfile* build_merged_instance_profile(FragmentProfileMaterial& fragment_profile);
+
+private:
+    std::unique_ptr<ThreadPool> _merge_thread_pool;
+    std::unique_ptr<ThreadPool> _report_thread_pool;
+};
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/profile_manager.h
+++ b/be/src/exec/pipeline/profile_manager.h
@@ -60,9 +60,9 @@ struct FragmentProfileMaterial {
               fe_addr(fe_addr) {}
 };
 
-class ProfileManager {
+class profile_manager {
 public:
-    explicit ProfileManager(const CpuUtil::CpuIds& cpuids);
+    explicit profile_manager(const CpuUtil::CpuIds& cpuids);
     void build_and_report_profile(std::shared_ptr<FragmentProfileMaterial> fragment_profile_material);
 
 private:

--- a/be/src/exec/pipeline/profile_manager.h
+++ b/be/src/exec/pipeline/profile_manager.h
@@ -75,6 +75,7 @@ private:
 
     std::unique_ptr<ThreadPool> _merge_thread_pool;
     std::unique_ptr<ThreadPool> _report_thread_pool;
+    MemTracker* _mem_tracker;
 };
 
 } // namespace starrocks::pipeline

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -245,6 +245,8 @@ Status GlobalEnv::_init_mem_tracker() {
 
     MemChunkAllocator::init_metrics();
 
+    _profile_mem_tracker = regist_tracker(MemTrackerType::PROFILE, -1, process_mem_tracker());
+
     return Status::OK();
 }
 

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -158,6 +158,7 @@ public:
     MemTracker* datacache_mem_tracker() { return _datacache_mem_tracker.get(); }
     MemTracker* poco_connection_pool_mem_tracker() { return _poco_connection_pool_mem_tracker.get(); }
     MemTracker* jemalloc_metadata_traker() { return _jemalloc_metadata_tracker.get(); }
+    MemTracker* profile_mem_tracker() { return _profile_mem_tracker.get(); }
     std::shared_ptr<MemTracker> get_mem_tracker_by_type(MemTrackerType type);
     std::vector<std::shared_ptr<MemTracker>> mem_trackers() const;
 
@@ -235,6 +236,8 @@ private:
     std::shared_ptr<MemTracker> _poco_connection_pool_mem_tracker;
 
     std::map<MemTrackerType, std::shared_ptr<MemTracker>> _mem_tracker_map;
+
+    std::shared_ptr<MemTracker> _profile_mem_tracker;
 };
 
 // Execution environment for queries/plan fragments.

--- a/be/src/runtime/mem_tracker.h
+++ b/be/src/runtime/mem_tracker.h
@@ -116,7 +116,8 @@ enum class MemTrackerType {
     ROWSET_UPDATE_STATE,
     INDEX_CACHE,
     DEL_VEC_CACHE,
-    COMPACTION_STATE
+    COMPACTION_STATE,
+    PROFILE
 };
 
 class MemTracker {

--- a/be/src/util/CMakeLists.txt
+++ b/be/src/util/CMakeLists.txt
@@ -112,6 +112,7 @@ set(UTIL_FILES
   debug_action.cpp
   internal_service_recoverable_stub.cpp
   byte_buffer.cpp
+  counter_memory_pool.cpp
 )
 
 add_library(Util STATIC

--- a/be/src/util/counter_memory_pool.cpp
+++ b/be/src/util/counter_memory_pool.cpp
@@ -1,0 +1,44 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/counter_memory_pool.h"
+
+#include <cassert>
+#include <cstdint>
+
+namespace starrocks {
+
+void* CounterMemoryPool::allocate(size_t size) {
+    // 确保大小是 ALIGNMENT 的倍数
+    size = (size + ALIGNMENT - 1) & ~(ALIGNMENT - 1);
+
+    // 如果当前块没有足够的空间，分配新块
+    if (_current_block == nullptr || _current_block_offset + size > BLOCK_SIZE) {
+        allocate_new_block();
+    }
+
+    // 从当前块分配内存
+    void* ptr = _current_block + _current_block_offset;
+    _current_block_offset += size;
+    return ptr;
+}
+
+void CounterMemoryPool::allocate_new_block() {
+    auto new_block = std::make_unique<char[]>(BLOCK_SIZE);
+    _current_block = new_block.get();
+    _blocks.push_back(std::move(new_block));
+    _current_block_offset = 0;
+}
+
+} // namespace starrocks 

--- a/be/src/util/counter_memory_pool.cpp
+++ b/be/src/util/counter_memory_pool.cpp
@@ -20,15 +20,12 @@
 namespace starrocks {
 
 void* CounterMemoryPool::allocate(size_t size) {
-    // 确保大小是 ALIGNMENT 的倍数
     size = (size + ALIGNMENT - 1) & ~(ALIGNMENT - 1);
 
-    // 如果当前块没有足够的空间，分配新块
     if (_current_block == nullptr || _current_block_offset + size > BLOCK_SIZE) {
         allocate_new_block();
     }
 
-    // 从当前块分配内存
     void* ptr = _current_block + _current_block_offset;
     _current_block_offset += size;
     return ptr;
@@ -41,4 +38,4 @@ void CounterMemoryPool::allocate_new_block() {
     _current_block_offset = 0;
 }
 
-} // namespace starrocks 
+} // namespace starrocks

--- a/be/src/util/counter_memory_pool.h
+++ b/be/src/util/counter_memory_pool.h
@@ -20,6 +20,8 @@
 
 namespace starrocks {
 
+// this pool is used to make same level's counter is near to each other
+// so when merge profile, the breadth-first traversal algorithm can have less cache miss
 class CounterMemoryPool {
 public:
     static constexpr size_t BLOCK_SIZE = 4096; // 1KB

--- a/be/src/util/counter_memory_pool.h
+++ b/be/src/util/counter_memory_pool.h
@@ -20,24 +20,18 @@
 
 namespace starrocks {
 
-// 一个简单的内存池实现，用于分配和管理 counter 对象
-// 每个内存段大小为 1KB，并且内存对齐
 class CounterMemoryPool {
 public:
     static constexpr size_t BLOCK_SIZE = 4096; // 1KB
-    static constexpr size_t ALIGNMENT = 8;     // 8字节对齐
-
+    static constexpr size_t ALIGNMENT = 8;
     CounterMemoryPool() = default;
     ~CounterMemoryPool() = default;
 
-    // 分配指定大小的内存
     void* allocate(size_t size);
 
 private:
-    // 分配一个新的内存块
     void allocate_new_block();
 
-    // 当前内存块
     std::vector<std::unique_ptr<char[]>> _blocks;
     size_t _current_block_offset = 0;
     char* _current_block = nullptr;

--- a/be/src/util/counter_memory_pool.h
+++ b/be/src/util/counter_memory_pool.h
@@ -24,7 +24,7 @@ namespace starrocks {
 // 每个内存段大小为 1KB，并且内存对齐
 class CounterMemoryPool {
 public:
-    static constexpr size_t BLOCK_SIZE = 1024; // 1KB
+    static constexpr size_t BLOCK_SIZE = 4096; // 1KB
     static constexpr size_t ALIGNMENT = 8;     // 8字节对齐
 
     CounterMemoryPool() = default;

--- a/be/src/util/counter_memory_pool.h
+++ b/be/src/util/counter_memory_pool.h
@@ -1,0 +1,46 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+namespace starrocks {
+
+// 一个简单的内存池实现，用于分配和管理 counter 对象
+// 每个内存段大小为 1KB，并且内存对齐
+class CounterMemoryPool {
+public:
+    static constexpr size_t BLOCK_SIZE = 1024; // 1KB
+    static constexpr size_t ALIGNMENT = 8;     // 8字节对齐
+
+    CounterMemoryPool() = default;
+    ~CounterMemoryPool() = default;
+
+    // 分配指定大小的内存
+    void* allocate(size_t size);
+
+private:
+    // 分配一个新的内存块
+    void allocate_new_block();
+
+    // 当前内存块
+    std::vector<std::unique_ptr<char[]>> _blocks;
+    size_t _current_block_offset = 0;
+    char* _current_block = nullptr;
+};
+
+} // namespace starrocks

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -807,9 +807,7 @@ void RuntimeProfile::to_thrift(std::vector<TRuntimeProfileNode>* nodes) {
     {
         std::lock_guard<std::mutex> l(_counter_lock);
         counter_map = _counter_map;
-        for (const auto& kv : _child_counter_map) {
-            node.child_counters_map.emplace(kv.first, kv.second);
-        }
+        node.child_counters_map = std::move(_child_counter_map);
     }
 
     // If the node has a MIN/MAX and they need to be displayed, the node itself also needs to be reserved,
@@ -822,6 +820,7 @@ void RuntimeProfile::to_thrift(std::vector<TRuntimeProfileNode>* nodes) {
         }
     }
 
+    node.counters.reserve(keep_counters.size());
     for (auto& iter : counter_map) {
         auto& name = iter.first;
         if (keep_counters.count(name) == 0) {
@@ -845,10 +844,8 @@ void RuntimeProfile::to_thrift(std::vector<TRuntimeProfileNode>* nodes) {
 
     {
         std::lock_guard<std::mutex> l(_info_strings_lock);
-        for (const auto& kv : _info_strings) {
-            node.info_strings.emplace(kv.first, kv.second);
-        }
-        node.info_strings_display_order = _info_strings_display_order;
+        node.info_strings = std::move(_info_strings);
+        node.info_strings_display_order = std::move(_info_strings_display_order);
     }
 
     ChildVector children;
@@ -908,28 +905,40 @@ void RuntimeProfile::foreach_children(Visitor&& callback) {
     }
 }
 
+template <bool isFinal>
 RuntimeProfile* RuntimeProfile::merge_isomorphic_profiles(ObjectPool* obj_pool, std::vector<RuntimeProfile*>& profiles,
                                                           bool require_identical) {
     DCHECK(!profiles.empty());
 
-    // all metrics will be merged into the first profile
-    auto* merged_profile = obj_pool->add(new RuntimeProfile(profiles[0]->name(), profiles[0]->_is_averaged_profile));
+    RuntimeProfile* merged_profile;
+    int index;
+    if constexpr (isFinal) {
+        // all metrics will be merged into the first profile
+        merged_profile = profiles[0];
+        index = 1;
+    } else {
+        merged_profile = obj_pool->add(new RuntimeProfile(profiles[0]->name(), profiles[0]->_is_averaged_profile));
+        index = 0;
+    }
 
     // Merge into string, if contents are different, only the last will be preserved;
     {
-        for (auto& profile : profiles) {
-            merged_profile->copy_all_info_strings_from(profile);
+        for (int i = index; i < profiles.size(); ++i) {
+            merged_profile->copy_all_info_strings_from(profiles[i]);
         }
     }
 
     // Merge counters
     {
+        // <counter_name: {counter_sum, counter_num}>，used for calculate avg
+        std::map<std::string, std::pair<int64, int>> counter_number_map;
         // Find all counters, although these profiles are expected to be isomorphic,
         // some counters are only attached to one of them
-        // every level is a map, map's key is counter's name, value is: {counter_type, parent_name}
-        std::vector<std::map<std::string, std::pair<TUnit::type, std::string>>> all_level_counters;
-        size_t count_num = 0;
-        for (auto* profile : profiles) {
+        // Allow some counters which only attach to one of the isomorphic profiles
+        // E.g. A bunch of ExchangeSinkOperators may share one SinkBuffer, so the metrics
+        // of SinkBuffer only attach to the first ExchangeSinkOperator's profile
+        for (int i = 0; i < profiles.size(); ++i) {
+            RuntimeProfile* profile = profiles[i];
             std::lock_guard<std::mutex> l(profile->_counter_lock);
             // Level order traverse starts with root
             std::queue<std::string> name_queue;
@@ -953,123 +962,88 @@ RuntimeProfile* RuntimeProfile::merge_isomorphic_profiles(ObjectPool* obj_pool, 
                     if (name == ROOT_COUNTER) {
                         continue;
                     }
+                    // find the counter in current profile
                     auto pair_it = profile->_counter_map.find(name);
                     DCHECK(pair_it != profile->_counter_map.end());
                     const auto& pair = pair_it->second;
                     const auto* counter = pair.first;
                     const auto& parent_name = pair.second;
 
-                    while (all_level_counters.size() <= level_idx) {
-                        all_level_counters.emplace_back();
+                    // add the counter into merged_profile if not exsited
+                    Counter* merged_counter = nullptr;
+                    if (ROOT_COUNTER != parent_name && merged_profile->get_counter(parent_name) != nullptr) {
+                        merged_counter = merged_profile->add_child_counter(name, counter->type(), counter->strategy(),
+                                                                           parent_name);
+                    } else {
+                        if (ROOT_COUNTER != parent_name) {
+                            LOG(WARNING) << "missing parent counter, profile_name=" << merged_profile->name()
+                                         << ", counter_name=" << name << ", parent_counter_name=" << parent_name;
+                        }
+                        merged_counter = merged_profile->add_counter(name, counter->type(), counter->strategy());
                     }
-                    auto& level_counters = all_level_counters[level_idx];
-                    auto it = level_counters.find(name);
-                    if (it == level_counters.end()) {
-                        level_counters[name] = std::make_pair<>(counter->type(), parent_name);
-                        count_num++;
+
+                    // if this counter first appears, set it value and min/max
+                    if (counter_number_map.find(name) == counter_number_map.end()) {
+                        counter_number_map.emplace(name, std::make_pair(counter->value(), 1));
+                        merged_counter->set(counter->value());
+                        if (!counter->skip_min_max()) {
+                            if (!merged_counter->min_value().has_value()) {
+                                merged_counter->set_min(merged_counter->value());
+                            }
+                            if (!merged_counter->max_value().has_value()) {
+                                merged_counter->set_max(merged_counter->value());
+                            }
+                        }
                         continue;
                     }
-                    const auto exist_type = it->second.first;
-                    if (counter->type() != exist_type) {
-                        LOG(WARNING) << "find non-isomorphic counter, profile_name=" << merged_profile->name()
-                                     << ", counter_name=" << name << ", exist_type=" << std::to_string(exist_type)
-                                     << ", another_type=" << std::to_string(counter->type());
-                        continue;
-                    }
-                }
-            }
-        }
 
-        std::vector<std::tuple<TUnit::type, std::string, std::string>> level_ordered_counters;
-        level_ordered_counters.reserve(count_num);
-        for (const auto& level_counters : all_level_counters) {
-            for (const auto& [name, pair] : level_counters) {
-                level_ordered_counters.emplace_back(pair.first, name, pair.second);
-            }
-        }
+                    // this counter already exist in merged_profile, update this counter
+                    if (merged_counter != counter) {
+                        if (merged_counter->type() != counter->type()) {
+                            LOG(WARNING) << "find non-isomorphic counter, profile_name=" << merged_profile->name()
+                                         << ", counter_name=" << name
+                                         << ", exist_type=" << std::to_string(merged_counter->type())
+                                         << ", another_type=" << std::to_string(counter->type());
+                            continue;
+                        }
+                        if (counter->skip_merge()) {
+                            continue;
+                        }
 
-        for (const auto& tuple : level_ordered_counters) {
-            const auto& type = std::get<0>(tuple);
-            const auto& name = std::get<1>(tuple);
-            const auto& parent_name = std::get<2>(tuple);
-            // // We don't need to calculate sum or average of counter's extra info (min value and max value)
-            // if (name.rfind(MERGED_INFO_PREFIX_MIN, 0) == 0 || name.rfind(MERGED_INFO_PREFIX_MAX, 0) == 0) {
-            //     continue;
-            // }
+                        // update min/max
+                        if (!counter->skip_min_max()) {
+                            if (counter->min_value().has_value()) {
+                                DCHECK(merged_counter->min_value().has_value());
+                                if (merged_counter->min_value().value() > counter->min_value().value()) {
+                                    merged_counter->set_min(counter->min_value().value());
+                                }
+                            } else {
+                                merged_counter->set_min(std::min(merged_counter->value(), counter->value()));
+                            }
 
-            std::vector<Counter*> counters;
+                            if (counter->max_value().has_value()) {
+                                DCHECK(merged_counter->max_value().has_value());
+                                if (merged_counter->max_value().value() < counter->max_value().value()) {
+                                    merged_counter->set_max(counter->max_value().value());
+                                }
+                            } else {
+                                merged_counter->set_max(std::max(merged_counter->value(), counter->value()));
+                            }
+                        }
 
-            int64_t min_value = std::numeric_limits<int64_t>::max();
-            int64_t max_value = std::numeric_limits<int64_t>::min();
-            bool already_merged = false;
-            bool skip_merge = false;
-            Counter* skip_merge_counter = nullptr;
-            TCounterStrategy strategy;
-            for (auto profile : profiles) {
-                auto* counter = profile->get_counter(name);
+                        // update sum and number, set value if the last
+                        auto it = counter_number_map.find(name);
+                        DCHECK(it != counter_number_map.end());
+                        it->second.first += counter->value();
+                        it->second.second++;
 
-                // Allow some counters which only attach to one of the isomorphic profiles
-                // E.g. A bunch of ExchangeSinkOperators may share one SinkBuffer, so the metrics
-                // of SinkBuffer only attach to the first ExchangeSinkOperator's profile
-                if (counter == nullptr) {
-                    continue;
-                }
-                if (type != counter->type()) {
-                    LOG(WARNING) << "find non-isomorphic counter, profile_name=" << merged_profile->name()
-                                 << ", counter_name=" << name << ", exist_type=" << std::to_string(type)
-                                 << ", another_type=" << std::to_string(counter->type());
-                    continue;
-                }
-                strategy = counter->strategy();
-                if (counter->skip_merge()) {
-                    skip_merge = true;
-                    skip_merge_counter = counter;
-                    break;
-                }
-
-                if (!counter->skip_min_max()) {
-                    if (counter->_min_value.has_value()) {
-                        already_merged = true;
-                        min_value = std::min(counter->_min_value.value(), min_value);
-                    }
-                    if (counter->_max_value.has_value()) {
-                        already_merged = true;
-                        max_value = std::max(counter->_max_value.value(), max_value);
-                    }
-                }
-
-                counters.push_back(counter);
-            }
-
-            Counter* merged_counter = nullptr;
-            if (ROOT_COUNTER != parent_name && merged_profile->get_counter(parent_name) != nullptr) {
-                merged_counter = merged_profile->add_child_counter(name, type, strategy, parent_name);
-            } else {
-                if (ROOT_COUNTER != parent_name) {
-                    LOG(WARNING) << "missing parent counter, profile_name=" << merged_profile->name()
-                                 << ", counter_name=" << name << ", parent_counter_name=" << parent_name;
-                }
-                merged_counter = merged_profile->add_counter(name, type, strategy);
-            }
-
-            if (skip_merge) {
-                merged_counter->set(skip_merge_counter->value());
-            } else {
-                const auto merged_info = merge_isomorphic_counters(counters);
-                const auto merged_value = std::get<0>(merged_info);
-                if (!already_merged) {
-                    min_value = std::get<1>(merged_info);
-                    max_value = std::get<2>(merged_info);
-                }
-
-                merged_counter->set(merged_value);
-
-                if (!merged_counter->skip_min_max()) {
-                    if (min_value != std::numeric_limits<int64_t>::max()) {
-                        merged_counter->_min_value.emplace(min_value);
-                    }
-                    if (max_value != std::numeric_limits<int64_t>::min()) {
-                        merged_counter->_max_value.emplace(max_value);
+                        if (i == profiles.size() - 1) {
+                            int64_t merged_value = it->second.first;
+                            if (merged_counter->is_avg()) {
+                                merged_value /= it->second.second;
+                            }
+                            merged_counter->set(merged_value);
+                        }
                     }
                 }
             }
@@ -1125,6 +1099,217 @@ RuntimeProfile* RuntimeProfile::merge_isomorphic_profiles(ObjectPool* obj_pool, 
 
     return merged_profile;
 }
+
+// RuntimeProfile* RuntimeProfile::merge_isomorphic_profiles(ObjectPool* obj_pool, std::vector<RuntimeProfile*>& profiles,
+//                                                           bool require_identical) {
+//     DCHECK(!profiles.empty());
+//
+//     // all metrics will be merged into the first profile
+//     auto* merged_profile = obj_pool->add(new RuntimeProfile(profiles[0]->name(), profiles[0]->_is_averaged_profile));
+//
+//     // Merge into string, if contents are different, only the last will be preserved;
+//     {
+//         for (auto& profile : profiles) {
+//             merged_profile->copy_all_info_strings_from(profile);
+//         }
+//     }
+//
+//     // Merge counters
+//     {
+//         // Find all counters, although these profiles are expected to be isomorphic,
+//         // some counters are only attached to one of them
+//         // every level is a map, map's key is counter's name, value is: {counter_type, parent_name}
+//         std::vector<std::map<std::string, std::pair<TUnit::type, std::string>>> all_level_counters;
+//         size_t count_num = 0;
+//         for (auto* profile : profiles) {
+//             std::lock_guard<std::mutex> l(profile->_counter_lock);
+//             // Level order traverse starts with root
+//             std::queue<std::string> name_queue;
+//             name_queue.push(ROOT_COUNTER);
+//             int32_t level_idx = -1;
+//             while (!name_queue.empty()) {
+//                 level_idx++;
+//                 std::vector<std::string> current_names;
+//                 current_names.reserve(name_queue.size());
+//                 while (!name_queue.empty()) {
+//                     current_names.emplace_back(std::move(name_queue.front()));
+//                     name_queue.pop();
+//                 }
+//                 for (const auto& name : current_names) {
+//                     auto names_it = profile->_child_counter_map.find(name);
+//                     if (names_it != profile->_child_counter_map.end()) {
+//                         for (auto& child_name : names_it->second) {
+//                             name_queue.push(child_name);
+//                         }
+//                     }
+//                     if (name == ROOT_COUNTER) {
+//                         continue;
+//                     }
+//                     auto pair_it = profile->_counter_map.find(name);
+//                     DCHECK(pair_it != profile->_counter_map.end());
+//                     const auto& pair = pair_it->second;
+//                     const auto* counter = pair.first;
+//                     const auto& parent_name = pair.second;
+//
+//                     while (all_level_counters.size() <= level_idx) {
+//                         all_level_counters.emplace_back();
+//                     }
+//                     auto& level_counters = all_level_counters[level_idx];
+//                     auto it = level_counters.find(name);
+//                     if (it == level_counters.end()) {
+//                         level_counters[name] = std::make_pair<>(counter->type(), parent_name);
+//                         count_num++;
+//                         continue;
+//                     }
+//                     const auto exist_type = it->second.first;
+//                     if (counter->type() != exist_type) {
+//                         LOG(WARNING) << "find non-isomorphic counter, profile_name=" << merged_profile->name()
+//                                      << ", counter_name=" << name << ", exist_type=" << std::to_string(exist_type)
+//                                      << ", another_type=" << std::to_string(counter->type());
+//                         continue;
+//                     }
+//                 }
+//             }
+//         }
+//
+//         std::vector<std::tuple<TUnit::type, std::string, std::string>> level_ordered_counters;
+//         level_ordered_counters.reserve(count_num);
+//         for (const auto& level_counters : all_level_counters) {
+//             for (const auto& [name, pair] : level_counters) {
+//                 level_ordered_counters.emplace_back(pair.first, name, pair.second);
+//             }
+//         }
+//
+//         for (const auto& tuple : level_ordered_counters) {
+//             const auto& type = std::get<0>(tuple);
+//             const auto& name = std::get<1>(tuple);
+//             const auto& parent_name = std::get<2>(tuple);
+//             // // We don't need to calculate sum or average of counter's extra info (min value and max value)
+//             // if (name.rfind(MERGED_INFO_PREFIX_MIN, 0) == 0 || name.rfind(MERGED_INFO_PREFIX_MAX, 0) == 0) {
+//             //     continue;
+//             // }
+//
+//             std::vector<Counter*> counters;
+//
+//             int64_t min_value = std::numeric_limits<int64_t>::max();
+//             int64_t max_value = std::numeric_limits<int64_t>::min();
+//             bool already_merged = false;
+//             bool skip_merge = false;
+//             Counter* skip_merge_counter = nullptr;
+//             TCounterStrategy strategy;
+//             for (auto profile : profiles) {
+//                 auto* counter = profile->get_counter(name);
+//
+//                 // Allow some counters which only attach to one of the isomorphic profiles
+//                 // E.g. A bunch of ExchangeSinkOperators may share one SinkBuffer, so the metrics
+//                 // of SinkBuffer only attach to the first ExchangeSinkOperator's profile
+//                 if (counter == nullptr) {
+//                     continue;
+//                 }
+//                 if (type != counter->type()) {
+//                     LOG(WARNING) << "find non-isomorphic counter, profile_name=" << merged_profile->name()
+//                                  << ", counter_name=" << name << ", exist_type=" << std::to_string(type)
+//                                  << ", another_type=" << std::to_string(counter->type());
+//                     continue;
+//                 }
+//                 strategy = counter->strategy();
+//                 if (counter->skip_merge()) {
+//                     skip_merge = true;
+//                     skip_merge_counter = counter;
+//                     break;
+//                 }
+//
+//                 if (!counter->skip_min_max()) {
+//                     if (counter->_min_value.has_value()) {
+//                         already_merged = true;
+//                         min_value = std::min(counter->_min_value.value(), min_value);
+//                     }
+//                     if (counter->_max_value.has_value()) {
+//                         already_merged = true;
+//                         max_value = std::max(counter->_max_value.value(), max_value);
+//                     }
+//                 }
+//
+//                 counters.push_back(counter);
+//             }
+//
+//             Counter* merged_counter = nullptr;
+//             if (ROOT_COUNTER != parent_name && merged_profile->get_counter(parent_name) != nullptr) {
+//                 merged_counter = merged_profile->add_child_counter(name, type, strategy, parent_name);
+//             } else {
+//                 if (ROOT_COUNTER != parent_name) {
+//                     LOG(WARNING) << "missing parent counter, profile_name=" << merged_profile->name()
+//                                  << ", counter_name=" << name << ", parent_counter_name=" << parent_name;
+//                 }
+//                 merged_counter = merged_profile->add_counter(name, type, strategy);
+//             }
+//
+//             if (skip_merge) {
+//                 merged_counter->set(skip_merge_counter->value());
+//             } else {
+//                 const auto merged_info = merge_isomorphic_counters(counters);
+//                 const auto merged_value = std::get<0>(merged_info);
+//                 if (!already_merged) {
+//                     min_value = std::get<1>(merged_info);
+//                     max_value = std::get<2>(merged_info);
+//                 }
+//
+//                 merged_counter->set(merged_value);
+//
+//                 if (!merged_counter->skip_min_max()) {
+//                     if (min_value != std::numeric_limits<int64_t>::max()) {
+//                         merged_counter->_min_value.emplace(min_value);
+//                     }
+//                     if (max_value != std::numeric_limits<int64_t>::min()) {
+//                         merged_counter->_max_value.emplace(max_value);
+//                     }
+//                 }
+//             }
+//         }
+//     }
+//
+//     // merge children
+//     {
+//         size_t max_child_size = 0;
+//         RuntimeProfile* profile_with_full_child = nullptr;
+//         for (auto* profile : profiles) {
+//             if (profile->_children.size() > max_child_size) {
+//                 max_child_size = profile->_children.size();
+//                 profile_with_full_child = profile;
+//             }
+//         }
+//         if (profile_with_full_child != nullptr) {
+//             bool identical = true;
+//             for (size_t i = 0; i < max_child_size; i++) {
+//                 auto& prototype_kv = profile_with_full_child->_children[i];
+//                 const std::string& child_name = prototype_kv.first->name();
+//                 if (child_name.compare("UniqueMetrics") == 0) {
+//                     continue;
+//                 }
+//                 std::vector<RuntimeProfile*> sub_profiles;
+//                 for (auto* profile : profiles) {
+//                     auto* child = profile->get_child(child_name);
+//                     if (child == nullptr) {
+//                         identical = false;
+//                         if (require_identical) {
+//                             LOG(INFO) << "find non-isomorphic children, profile_name=" << profile->name()
+//                                       << ", required_child_name=" << child_name;
+//                         }
+//                         continue;
+//                     }
+//                     sub_profiles.push_back(child);
+//                 }
+//                 auto* merged_child = merge_isomorphic_profiles(obj_pool, sub_profiles, require_identical);
+//                 merged_profile->add_child(merged_child, prototype_kv.second, nullptr);
+//             }
+//             if (require_identical && !identical) {
+//                 merged_profile->add_info_string("NotIdentical");
+//             }
+//         }
+//     }
+//
+//     return merged_profile;
+// }
 
 RuntimeProfile::MergedInfo RuntimeProfile::merge_isomorphic_counters(std::vector<Counter*>& counters) {
     DCHECK_GE(counters.size(), 0);
@@ -1186,5 +1371,13 @@ std::string RuntimeProfile::get_children_name_string() {
 
     return ss.str();
 }
+
+template RuntimeProfile* RuntimeProfile::merge_isomorphic_profiles<true>(ObjectPool* obj_pool,
+                                                                         std::vector<RuntimeProfile*>& profiles,
+                                                                         bool require_identical);
+
+template RuntimeProfile* RuntimeProfile::merge_isomorphic_profiles<false>(ObjectPool* obj_pool,
+                                                                          std::vector<RuntimeProfile*>& profiles,
+                                                                          bool require_identical);
 
 } // namespace starrocks

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -966,20 +966,24 @@ RuntimeProfile* RuntimeProfile::merge_isomorphic_profiles(ObjectPool* obj_pool, 
                     auto pair_it = profile->_counter_map.find(name);
                     DCHECK(pair_it != profile->_counter_map.end());
                     const auto& pair = pair_it->second;
-                    const auto* counter = pair.first;
+                    auto* counter = pair.first;
                     const auto& parent_name = pair.second;
 
                     // add the counter into merged_profile if not exsited
                     Counter* merged_counter = nullptr;
-                    if (ROOT_COUNTER != parent_name && merged_profile->get_counter(parent_name) != nullptr) {
-                        merged_counter = merged_profile->add_child_counter(name, counter->type(), counter->strategy(),
-                                                                           parent_name);
+                    if (i == 0) {
+                        merged_counter = counter;
                     } else {
-                        if (ROOT_COUNTER != parent_name) {
-                            LOG(WARNING) << "missing parent counter, profile_name=" << merged_profile->name()
-                                         << ", counter_name=" << name << ", parent_counter_name=" << parent_name;
+                        if (ROOT_COUNTER != parent_name && merged_profile->get_counter(parent_name) != nullptr) {
+                            merged_counter = merged_profile->add_child_counter(name, counter->type(),
+                                                                               counter->strategy(), parent_name);
+                        } else {
+                            if (ROOT_COUNTER != parent_name) {
+                                LOG(WARNING) << "missing parent counter, profile_name=" << merged_profile->name()
+                                             << ", counter_name=" << name << ", parent_counter_name=" << parent_name;
+                            }
+                            merged_counter = merged_profile->add_counter(name, counter->type(), counter->strategy());
                         }
-                        merged_counter = merged_profile->add_counter(name, counter->type(), counter->strategy());
                     }
 
                     // if this counter first appears, set it value and min/max

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -925,7 +925,6 @@ void RuntimeProfile::foreach_children(Visitor&& callback) {
     }
 }
 
-template <bool isFinal>
 RuntimeProfile* RuntimeProfile::merge_isomorphic_profiles(ObjectPool* obj_pool, std::vector<RuntimeProfile*>& profiles,
                                                           bool require_identical) {
     DCHECK(!profiles.empty());
@@ -968,6 +967,10 @@ RuntimeProfile* RuntimeProfile::merge_isomorphic_profiles(ObjectPool* obj_pool, 
                     auto names_it = profile->_child_counter_map.find(name);
                     if (names_it != profile->_child_counter_map.end()) {
                         for (auto& child_name : names_it->second) {
+                            auto child_counter_it = profile->_counter_map.find(child_name);
+                            if (child_counter_it != profile->_counter_map.end()) {
+                                __builtin_prefetch(child_counter_it->second.first, 0, 1);
+                            }
                             name_queue.push(child_name);
                         }
                     }
@@ -1388,13 +1391,5 @@ std::string RuntimeProfile::get_children_name_string() {
 
     return ss.str();
 }
-
-template RuntimeProfile* RuntimeProfile::merge_isomorphic_profiles<true>(ObjectPool* obj_pool,
-                                                                         std::vector<RuntimeProfile*>& profiles,
-                                                                         bool require_identical);
-
-template RuntimeProfile* RuntimeProfile::merge_isomorphic_profiles<false>(ObjectPool* obj_pool,
-                                                                          std::vector<RuntimeProfile*>& profiles,
-                                                                          bool require_identical);
 
 } // namespace starrocks

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -41,6 +41,7 @@
 #include <queue>
 #include <utility>
 
+#include "common/config.h"
 #include "common/object_pool.h"
 #include "gutil/map_util.h"
 #include "gutil/strings/substitute.h"
@@ -337,7 +338,7 @@ RuntimeProfile::Counter* RuntimeProfile::add_counter_unlock(const std::string& n
     void* mem = _counter_pool.allocate(sizeof(Counter));
     Counter* counter = new (mem) Counter(type, strategy, 0);
     if (isUniqueMetric) {
-        counter->_strategy.display_threshold = 50;
+        counter->_strategy.display_threshold = config::counter_display_threshold;
     }
 
     _counter_map[name] = std::make_pair(counter, parent_name);
@@ -368,14 +369,14 @@ void RuntimeProfile::add_child(std::shared_ptr<RuntimeProfile> child, bool inden
         add_child_unlock(child.get(), indent, ++pos);
     }
 
-    _childre_holder.emplace_back(std::move(child));
+    // _childre_holder.emplace_back(std::move(child));
 }
 
-void RuntimeProfile::reserve_child_holder(size_t child_num) {
-    DCHECK(child_num > 0);
-    std::lock_guard<std::mutex> l(_children_lock);
-    _childre_holder.reserve(child_num);
-}
+// void RuntimeProfile::reserve_child_holder(size_t child_num) {
+//     DCHECK(child_num > 0);
+//     std::lock_guard<std::mutex> l(_children_lock);
+//     _childre_holder.reserve(child_num);
+// }
 
 RuntimeProfile* RuntimeProfile::get_child(const std::string& name) {
     std::lock_guard<std::mutex> l(_children_lock);

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -396,7 +396,7 @@ public:
 
     void add_child(std::shared_ptr<RuntimeProfile> child, bool indent, RuntimeProfile* location);
 
-    void reserve_child_holder(size_t child_num);
+    // void reserve_child_holder(size_t child_num);
 
     // Creates a new child profile with the given 'name'.
     // If 'prepend' is true, prepended before other child profiles, otherwise appended
@@ -706,7 +706,7 @@ private:
 
     std::string get_children_name_string();
 
-    // 用于分配 counter 对象的内存池
+    // used for alloc counter's memory
     CounterMemoryPool _counter_pool;
 };
 

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -396,7 +396,7 @@ public:
 
     void add_child(std::shared_ptr<RuntimeProfile> child, bool indent, RuntimeProfile* location);
 
-    // void reserve_child_holder(size_t child_num);
+    void reserve_child_holder(size_t child_num);
 
     // Creates a new child profile with the given 'name'.
     // If 'prepend' is true, prepended before other child profiles, otherwise appended
@@ -591,6 +591,8 @@ private:
     void add_child_unlock(RuntimeProfile* child, bool indent, ChildVector::iterator pos);
     Counter* add_counter_unlock(const std::string& name, TUnit::type type, const TCounterStrategy& strategy,
                                 const std::string& parent_name);
+
+    static int64_t getThreshold(TUnit::type type);
 
     RuntimeProfile* get_child_unlock(const std::string& name);
 

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -664,9 +664,6 @@ private:
     // The version of this profile. It is used to prevent updating this profile
     // from an old one.
     int64_t _version{0};
-
-    bool isUniqueMetric;
-
     // update a subtree of profiles from nodes, rooted at *idx. If the version
     // of the parent node, or the version of root node for this subtree is older,
     // skip to update the subtree, but still traverse the nodes of subtree to

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -52,6 +52,7 @@
 #include "common/object_pool.h"
 #include "gen_cpp/RuntimeProfile_types.h"
 #include "gutil/casts.h"
+#include "phmap/phmap.h"
 #include "util/stopwatch.hpp"
 
 namespace starrocks {
@@ -611,12 +612,12 @@ private:
 
     // Map from counter names to counters and parent counter names.
     // The profile owns the memory for the counters.
-    typedef std::map<std::string, std::pair<Counter*, std::string>> CounterMap;
+    typedef phmap::flat_hash_map<std::string, std::pair<Counter*, std::string>> CounterMap;
     CounterMap _counter_map;
 
     // Map from parent counter name to a set of child counter name.
     // All top level counters are the child of "" (root).
-    typedef std::map<std::string, std::set<std::string>> ChildCounterMap;
+    typedef phmap::flat_hash_map<std::string, std::set<std::string>> ChildCounterMap;
     ChildCounterMap _child_counter_map;
 
     // A set of bucket counters registered in this runtime profile.
@@ -628,7 +629,7 @@ private:
     // Child profiles.  Does not own memory.
     // We record children in both a map (to facilitate updates) and a vector
     // (to print things in the order they were registered)
-    typedef std::map<std::string, RuntimeProfile*> ChildMap;
+    typedef phmap::flat_hash_map<std::string, RuntimeProfile*> ChildMap;
     ChildMap _child_map;
 
     ChildVector _children;
@@ -636,7 +637,7 @@ private:
     std::vector<std::shared_ptr<RuntimeProfile>> _childre_holder;
     mutable std::mutex _children_lock; // protects _child_map, _children and _childre_holder
 
-    typedef std::map<std::string, std::string> InfoStrings;
+    typedef phmap::flat_hash_map<std::string, std::string> InfoStrings;
     InfoStrings _info_strings;
 
     // Keeps track of the order in which InfoStrings are displayed when printed
@@ -646,7 +647,7 @@ private:
     // Protects _info_strings and _info_strings_display_order
     mutable std::mutex _info_strings_lock;
 
-    typedef std::map<std::string, EventSequence*> EventSequenceMap;
+    typedef phmap::flat_hash_map<std::string, EventSequence*> EventSequenceMap;
     EventSequenceMap _event_sequence_map;
     mutable std::mutex _event_sequences_lock;
 

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -688,12 +688,8 @@ public:
     // that all the children are isomorphic, otherwise, the behavior is undefined
     // The merged result will be stored in the first profile for the final merge
     // running profile will create new profile for merge
-    template <bool isFinal = false>
     static RuntimeProfile* merge_isomorphic_profiles(ObjectPool* obj_pool, std::vector<RuntimeProfile*>& profiles,
                                                      bool require_identical = true);
-
-    // static RuntimeProfile* merge_isomorphic_profiles(ObjectPool* obj_pool, std::vector<RuntimeProfile*>& profiles,
-    //                                                  bool require_identical = true);
 
 private:
     static const std::unordered_set<std::string> NON_MERGE_COUNTER_NAMES;

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -52,7 +52,6 @@
 #include "common/object_pool.h"
 #include "gen_cpp/RuntimeProfile_types.h"
 #include "gutil/casts.h"
-#include "phmap/phmap.h"
 #include "util/counter_memory_pool.h"
 #include "util/stopwatch.hpp"
 
@@ -613,12 +612,12 @@ private:
 
     // Map from counter names to counters and parent counter names.
     // The profile owns the memory for the counters.
-    typedef phmap::flat_hash_map<std::string, std::pair<Counter*, std::string>> CounterMap;
+    typedef std::map<std::string, std::pair<Counter*, std::string>> CounterMap;
     CounterMap _counter_map;
 
     // Map from parent counter name to a set of child counter name.
     // All top level counters are the child of "" (root).
-    typedef phmap::flat_hash_map<std::string, std::set<std::string>> ChildCounterMap;
+    typedef std::map<std::string, std::set<std::string>> ChildCounterMap;
     ChildCounterMap _child_counter_map;
 
     // A set of bucket counters registered in this runtime profile.
@@ -630,7 +629,7 @@ private:
     // Child profiles.  Does not own memory.
     // We record children in both a map (to facilitate updates) and a vector
     // (to print things in the order they were registered)
-    typedef phmap::flat_hash_map<std::string, RuntimeProfile*> ChildMap;
+    typedef std::map<std::string, RuntimeProfile*> ChildMap;
     ChildMap _child_map;
 
     ChildVector _children;
@@ -638,7 +637,7 @@ private:
     std::vector<std::shared_ptr<RuntimeProfile>> _childre_holder;
     mutable std::mutex _children_lock; // protects _child_map, _children and _childre_holder
 
-    typedef phmap::flat_hash_map<std::string, std::string> InfoStrings;
+    typedef std::map<std::string, std::string> InfoStrings;
     InfoStrings _info_strings;
 
     // Keeps track of the order in which InfoStrings are displayed when printed
@@ -648,7 +647,7 @@ private:
     // Protects _info_strings and _info_strings_display_order
     mutable std::mutex _info_strings_lock;
 
-    typedef phmap::flat_hash_map<std::string, EventSequence*> EventSequenceMap;
+    typedef std::map<std::string, EventSequence*> EventSequenceMap;
     EventSequenceMap _event_sequence_map;
     mutable std::mutex _event_sequences_lock;
 
@@ -683,9 +682,14 @@ private:
 public:
     // Merge all the isomorphic sub profiles and the caller must know for sure
     // that all the children are isomorphic, otherwise, the behavior is undefined
-    // The merged result will be stored in the first profile
+    // The merged result will be stored in the first profile for the final merge
+    // running profile will create new profile for merge
+    template <bool isFinal = false>
     static RuntimeProfile* merge_isomorphic_profiles(ObjectPool* obj_pool, std::vector<RuntimeProfile*>& profiles,
                                                      bool require_identical = true);
+
+    // static RuntimeProfile* merge_isomorphic_profiles(ObjectPool* obj_pool, std::vector<RuntimeProfile*>& profiles,
+    //                                                  bool require_identical = true);
 
 private:
     static const std::unordered_set<std::string> NON_MERGE_COUNTER_NAMES;

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -38,6 +38,7 @@
 #include <sys/time.h> // NOLINT
 
 #include <atomic>
+#include <boost/container/vector.hpp>
 #include <functional>
 #include <iostream>
 #include <mutex>
@@ -392,6 +393,10 @@ public:
     // already be added to the profile.
     void add_child(RuntimeProfile* child, bool indent, RuntimeProfile* location);
 
+    void add_child(std::shared_ptr<RuntimeProfile> child, bool indent, RuntimeProfile* location);
+
+    void reserve_child_holder(size_t child_num);
+
     // Creates a new child profile with the given 'name'.
     // If 'prepend' is true, prepended before other child profiles, otherwise appended
     // after other child profiles.
@@ -627,7 +632,9 @@ private:
     ChildMap _child_map;
 
     ChildVector _children;
-    mutable std::mutex _children_lock; // protects _child_map and _children
+
+    std::vector<std::shared_ptr<RuntimeProfile>> _childre_holder;
+    mutable std::mutex _children_lock; // protects _child_map, _children and _childre_holder
 
     typedef std::map<std::string, std::string> InfoStrings;
     InfoStrings _info_strings;

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -339,45 +339,6 @@ public:
         Counter* _involuntary_context_switches;
     };
 
-    // An EventSequence captures a sequence of events (each added by
-    // calling MarkEvent). Each event has a text label, and a time
-    // (measured relative to the moment start() was called as t=0). It is
-    // useful for tracking the evolution of some serial process, such as
-    // the query lifecycle.
-    // Not thread-safe.
-    class EventSequence {
-    public:
-        EventSequence() = default;
-
-        // starts the timer without resetting it.
-        void start() { _sw.start(); }
-
-        // stops (or effectively pauses) the timer.
-        void stop() { _sw.stop(); }
-
-        // Stores an event in sequence with the given label and the
-        // current time (relative to the first time start() was called) as
-        // the timestamp.
-        void mark_event(const std::string& label) { _events.push_back(make_pair(label, _sw.elapsed_time())); }
-
-        int64_t elapsed_time() { return _sw.elapsed_time(); }
-
-        // An Event is a <label, timestamp> pair
-        typedef std::pair<std::string, int64_t> Event;
-
-        // An EventList is a sequence of Events, in increasing timestamp order
-        typedef std::vector<Event> EventList;
-
-        const EventList& events() const { return _events; }
-
-    private:
-        // Stored in increasing time order
-        EventList _events;
-
-        // Timer which allows events to be timestamped when they are recorded.
-        MonotonicStopWatch _sw;
-    };
-
     // Create a runtime profile object with 'name'.
     explicit RuntimeProfile(std::string name, bool is_averaged_profile = false);
 

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -397,6 +397,9 @@ public:
     METRIC_DEFINE_INT_COUNTER(short_circuit_request_total, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(short_circuit_request_duration_us, MetricUnit::MICROSECONDS);
 
+    METRICS_DEFINE_THREAD_POOL(async_profile_merge);
+    METRICS_DEFINE_THREAD_POOL(async_profile_report);
+
     static StarRocksMetrics* instance() {
         static StarRocksMetrics instance;
         return &instance;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DictionaryMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DictionaryMgr.java
@@ -585,6 +585,7 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
             context.getSessionVariable().setEnablePipelineEngine(true);
             context.getSessionVariable().setPipelineDop(0);
             context.getSessionVariable().setEnableProfile(false);
+            context.getSessionVariable().setEnableQueryProfile(false);
             context.getSessionVariable().setParallelExecInstanceNum(1);
             context.getSessionVariable().setQueryTimeoutS(3600); // 1h
             context.setQueryId(UUIDUtil.genUUID());

--- a/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
@@ -284,7 +284,7 @@ public class ThreadPoolManager {
      * Use at most 3/4 to execute cpu-intensive background tasks
      */
     public static int cpuIntensiveThreadPoolSize() {
-        return Integer.max(2, cpuCores() * 30);
+        return Integer.max(2, cpuCores() * 3 / 4);
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
@@ -284,7 +284,7 @@ public class ThreadPoolManager {
      * Use at most 3/4 to execute cpu-intensive background tasks
      */
     public static int cpuIntensiveThreadPoolSize() {
-        return Integer.max(2, cpuCores() * 3 / 4);
+        return Integer.max(2, cpuCores() * 30);
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RunningProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RunningProfileManager.java
@@ -83,12 +83,12 @@ public class RunningProfileManager implements MemoryTrackable {
     }
 
     public void registerProfile(TUniqueId queryId, RunningProfile queryProfile) {
-        LOG.debug("registerProfile: queryId: {}", DebugUtil.printId(queryId));
+        LOG.info("registerProfile: queryId: {}", DebugUtil.printId(queryId));
         profiles.putIfAbsent(queryId, queryProfile);
     }
 
     public void removeProfile(TUniqueId queryId) {
-        LOG.debug("removeProfile: queryId: {}", DebugUtil.printId(queryId));
+        LOG.info("removeProfile: queryId: {}", DebugUtil.printId(queryId));
         profiles.remove(queryId);
     }
 
@@ -97,7 +97,7 @@ public class RunningProfileManager implements MemoryTrackable {
         final RunningProfile queryProfile = profiles.get(request.getQuery_id());
         if (queryProfile == null) {
             status = new TStatus(TStatusCode.NOT_FOUND);
-            LOG.debug("asyncProfileReport query not found: queryId: {}", DebugUtil.printId(request.getQuery_id()));
+            LOG.info("asyncProfileReport query not found: queryId: {}", DebugUtil.printId(request.getQuery_id()));
             status.addToError_msgs("query id " + DebugUtil.printId(request.getQuery_id()) + " not found");
             return status;
         }
@@ -107,7 +107,7 @@ public class RunningProfileManager implements MemoryTrackable {
 
         if (fragmentInstanceProfile == null) {
             status = new TStatus(TStatusCode.NOT_FOUND);
-            LOG.debug("asyncProfileReport query fragment not found: queryId: {}",
+            LOG.info("asyncProfileReport query fragment not found: queryId: {}",
                     DebugUtil.printId(request.getQuery_id()));
             status.addToError_msgs("query id " + DebugUtil.printId(request.getQuery_id()) + ", fragment instance id " +
                     DebugUtil.printId(request.fragment_instance_id) + " not found");
@@ -126,7 +126,7 @@ public class RunningProfileManager implements MemoryTrackable {
         }
 
         try {
-            LOG.debug(
+            LOG.info(
                     "asyncProfileReport, queryid: {}, instanceIdx: {}, isDone:{}, shouldProcessDone:{}, total instance num:{}",
                     DebugUtil.printId(request.getQuery_id()), DebugUtil.printId(request.fragment_instance_id),
                     fragmentInstanceProfile.isDone.toString(), shouldProcessDone,
@@ -256,7 +256,7 @@ public class RunningProfileManager implements MemoryTrackable {
                 if (LOG.isDebugEnabled()) {
                     StringBuilder builder = new StringBuilder();
                     loadChannelProfile.get().prettyPrint(builder, "");
-                    LOG.debug("Load channel profile for query_id={} after reported by instance_id={}\n{}",
+                    LOG.info("Load channel profile for query_id={} after reported by instance_id={}\n{}",
                             DebugUtil.printId(request.getQuery_id()),
                             DebugUtil.printId(request.fragment_instance_id),
                             builder);

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RunningProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RunningProfileManager.java
@@ -184,6 +184,7 @@ public class RunningProfileManager implements MemoryTrackable {
             this.runtimeProfileReportInterval = runtimeProfileReportInterval;
             this.needMergeProfile = needMergeProfile;
             this.isBrokerLoad = isisBrokerLoad;
+            this.queryId = queryId;
         }
 
         public void registerInstanceProfiles(Collection<TUniqueId> instanceIds) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RunningProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RunningProfileManager.java
@@ -78,6 +78,10 @@ public class RunningProfileManager implements MemoryTrackable {
         return profiles.keySet().stream().map(key -> DebugUtil.printId(key)).collect(Collectors.toUnmodifiableList());
     }
 
+    public void clearProfiles() {
+        profiles.clear();
+    }
+
     public void registerProfile(TUniqueId queryId, RunningProfile queryProfile) {
         LOG.debug("registerProfile: queryId: {}", DebugUtil.printId(queryId));
         profiles.putIfAbsent(queryId, queryProfile);

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RunningProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RunningProfileManager.java
@@ -53,7 +53,7 @@ public class RunningProfileManager {
     }
 
     public void registerProfile(TUniqueId queryId, RunningProfile queryProfile) {
-        LOG.warn("registerProfile: queryId: {}", DebugUtil.printId(queryId));
+        // LOG.warn("registerProfile: queryId: {}", DebugUtil.printId(queryId));
         profiles.putIfAbsent(queryId, queryProfile);
     }
 
@@ -93,9 +93,9 @@ public class RunningProfileManager {
         }
 
         try {
-            LOG.warn("asyncProfileReport, queryid: {}, instanceIndex: {}, isDone:{}",
-                    DebugUtil.printId(request.getQuery_id()), DebugUtil.printId(request.fragment_instance_id),
-                    fragmentInstanceProfile.isDone.toString());
+            //            LOG.warn("asyncProfileReport, queryid: {}, instanceIndex: {}, isDone:{}",
+            //                    DebugUtil.printId(request.getQuery_id()), DebugUtil.printId(request.fragment_instance_id),
+            //                    fragmentInstanceProfile.isDone.toString());
             queryProfile.tryToTriggerRuntimeProfileUpdate();
             fragmentInstanceProfile.updateRunningProfile(request);
             queryProfile.updateLoadChannelProfile(request);

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RunningProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RunningProfileManager.java
@@ -56,6 +56,10 @@ public class RunningProfileManager {
         profiles.putIfAbsent(queryId, queryProfile);
     }
 
+    public void removeProfile(TUniqueId queryId) {
+        profiles.remove(queryId);
+    }
+
     public TStatus asyncProfileReport(TFragmentProfile request) {
         TStatus status;
         final RunningProfile queryProfile = profiles.get(request.getQuery_id());

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RunningProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RunningProfileManager.java
@@ -86,8 +86,8 @@ public class RunningProfileManager {
         }
 
         try {
-            LOG.warn("asyncProfileReport, queryid: {}, instanceIndex: {}, isDone:{}",
-                    DebugUtil.printId(request.getQuery_id()), request.backend_num, instanceIsDone.toString());
+            //            LOG.warn("asyncProfileReport, queryid: {}, instanceIndex: {}, isDone:{}",
+            //                    DebugUtil.printId(request.getQuery_id()), request.backend_num, instanceIsDone.toString());
             queryProfile.tryToTriggerRuntimeProfileUpdate();
             fragmentInstanceProfile.updateRunningProfile(request);
             queryProfile.updateLoadChannelProfile(request);

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RunningProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RunningProfileManager.java
@@ -53,6 +53,7 @@ public class RunningProfileManager {
     }
 
     public void registerProfile(TUniqueId queryId, RunningProfile queryProfile) {
+        LOG.warn("registerProfile: queryId: {}", DebugUtil.printId(queryId));
         profiles.putIfAbsent(queryId, queryProfile);
     }
 
@@ -65,6 +66,7 @@ public class RunningProfileManager {
         final RunningProfile queryProfile = profiles.get(request.getQuery_id());
         if (queryProfile == null) {
             status = new TStatus(TStatusCode.NOT_FOUND);
+            LOG.warn("asyncProfileReport query not found: queryId: {}", DebugUtil.printId(request.getQuery_id()));
             status.addToError_msgs("query id " + DebugUtil.printId(request.getQuery_id()) + " not found");
             return status;
         }
@@ -74,6 +76,7 @@ public class RunningProfileManager {
 
         if (fragmentInstanceProfile == null) {
             status = new TStatus(TStatusCode.NOT_FOUND);
+            LOG.warn("asyncProfileReport query fragment not found: queryId: {}", DebugUtil.printId(request.getQuery_id()));
             status.addToError_msgs("query id " + DebugUtil.printId(request.getQuery_id()) + ", fragment instance id " +
                     request.backend_num + " not found");
             return status;
@@ -90,8 +93,9 @@ public class RunningProfileManager {
         }
 
         try {
-            //            LOG.warn("asyncProfileReport, queryid: {}, instanceIndex: {}, isDone:{}",
-            //                    DebugUtil.printId(request.getQuery_id()), request.backend_num, instanceIsDone.toString());
+            LOG.warn("asyncProfileReport, queryid: {}, instanceIndex: {}, isDone:{}",
+                    DebugUtil.printId(request.getQuery_id()), request.backend_num,
+                    fragmentInstanceProfile.isDone.toString());
             queryProfile.tryToTriggerRuntimeProfileUpdate();
             fragmentInstanceProfile.updateRunningProfile(request);
             queryProfile.updateLoadChannelProfile(request);
@@ -102,7 +106,7 @@ public class RunningProfileManager {
             LOG.warn("update profile failed {}", DebugUtil.printId(request.getQuery_id()), e);
         }
 
-        return new TStatus(TStatusCode.NOT_FOUND);
+        return new TStatus(TStatusCode.OK);
     }
 
     public static class FragmentInstanceProfile {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RunningProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RunningProfileManager.java
@@ -66,7 +66,7 @@ public class RunningProfileManager {
         final RunningProfile queryProfile = profiles.get(request.getQuery_id());
         if (queryProfile == null) {
             status = new TStatus(TStatusCode.NOT_FOUND);
-            LOG.warn("asyncProfileReport query not found: queryId: {}", DebugUtil.printId(request.getQuery_id()));
+            LOG.debug("asyncProfileReport query not found: queryId: {}", DebugUtil.printId(request.getQuery_id()));
             status.addToError_msgs("query id " + DebugUtil.printId(request.getQuery_id()) + " not found");
             return status;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RunningProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RunningProfileManager.java
@@ -74,6 +74,10 @@ public class RunningProfileManager implements MemoryTrackable {
         return profiles.get(queryId);
     }
 
+    public List<String> getAllRunningQuery() {
+        return profiles.keySet().stream().map(key -> DebugUtil.printId(key)).collect(Collectors.toUnmodifiableList());
+    }
+
     public void registerProfile(TUniqueId queryId, RunningProfile queryProfile) {
         LOG.debug("registerProfile: queryId: {}", DebugUtil.printId(queryId));
         profiles.putIfAbsent(queryId, queryProfile);

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RunningProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RunningProfileManager.java
@@ -118,17 +118,16 @@ public class RunningProfileManager implements MemoryTrackable {
         }
 
         try {
-            LOG.debug("asyncProfileReport, queryid: {}, instanceIndex: {}, isDone:{}, shouldProcessDone:{}",
+            LOG.debug(
+                    "asyncProfileReport, queryid: {}, instanceIdx: {}, isDone:{}, shouldProcessDone:{}, total instance num:{}",
                     DebugUtil.printId(request.getQuery_id()), DebugUtil.printId(request.fragment_instance_id),
-                    fragmentInstanceProfile.isDone.toString(), shouldProcessDone);
+                    fragmentInstanceProfile.isDone.toString(), shouldProcessDone,
+                    queryProfile.fragmentInstanceProfiles.size());
             queryProfile.tryToTriggerRuntimeProfileUpdate();
             fragmentInstanceProfile.updateRunningProfile(request);
             queryProfile.updateLoadChannelProfile(request);
             
             if (shouldProcessDone) {
-                LOG.debug("asyncProfileReport is done, queryid: {}, instanceIndex: {}, isDone:{}, shouldProcessDone:{}",
-                        DebugUtil.printId(request.getQuery_id()), DebugUtil.printId(request.fragment_instance_id),
-                        fragmentInstanceProfile.isDone.toString(), shouldProcessDone);
                 queryProfile.finishInstance(request.fragment_instance_id);
             }
         } catch (Throwable e) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/MetadataCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/MetadataCollectJob.java
@@ -110,6 +110,7 @@ public abstract class MetadataCollectJob {
     protected ConnectContext buildConnectContext(SessionVariable originSessionVariable) {
         ConnectContext context = ConnectContext.buildInner();
         context.getSessionVariable().setEnableProfile(originSessionVariable.isEnableMetadataProfile());
+        context.getSessionVariable().setEnableQueryProfile(originSessionVariable.isEnableQueryProfile());
         context.getSessionVariable().setParallelExecInstanceNum(1);
         context.getSessionVariable().setQueryTimeoutS(originSessionVariable.getMetadataCollectQueryTimeoutS());
         context.getSessionVariable().setEnablePipelineEngine(true);

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
@@ -82,6 +82,7 @@ import com.starrocks.http.rest.QueryDetailAction;
 import com.starrocks.http.rest.QueryDumpAction;
 import com.starrocks.http.rest.QueryProgressAction;
 import com.starrocks.http.rest.RowCountAction;
+import com.starrocks.http.rest.RunningProfileAction;
 import com.starrocks.http.rest.SetConfigAction;
 import com.starrocks.http.rest.ShowDataAction;
 import com.starrocks.http.rest.ShowMetaInfoAction;
@@ -205,6 +206,7 @@ public class HttpServer {
         // for stop FE
         StopFeAction.registerAction(controller);
         ExecuteSqlAction.registerAction(controller);
+        RunningProfileAction.registerAction(controller);
 
         // meta service action
         ImageAction.registerAction(controller);

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RunningProfileAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RunningProfileAction.java
@@ -1,0 +1,45 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest;
+
+import com.starrocks.common.util.RunningProfileManager;
+import com.starrocks.http.ActionController;
+import com.starrocks.http.BaseRequest;
+import com.starrocks.http.BaseResponse;
+import com.starrocks.http.IllegalArgException;
+import io.netty.handler.codec.http.HttpMethod;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class RunningProfileAction extends RestBaseAction {
+
+    public RunningProfileAction(ActionController controller) {
+        super(controller);
+    }
+
+    public static void registerAction(ActionController controller) throws IllegalArgException {
+        controller.registerHandler(HttpMethod.GET, "/api/running_profile", new RunningProfileAction(controller));
+    }
+
+    @Override
+    public void executeWithoutPassword(BaseRequest request, BaseResponse response) {
+        List<String> queryIds = RunningProfileManager.getInstance().getAllRunningQuery();
+        String result = queryIds.stream().map(id -> id + "\n").collect(Collectors.joining());
+
+        response.getContent().append("running query ids: ").append(result);
+        sendResult(request, response);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/MergeCommitTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/MergeCommitTask.java
@@ -362,7 +362,7 @@ public class MergeCommitTask implements Runnable {
         }
         profile.addChild(summaryProfile);
         if (collectProfileSuccess) {
-            profile.addChild(coordinator.buildQueryProfile(true));
+            profile.addChild(coordinator.buildExecutionProfile(true));
         }
         ProfileManager.getInstance().pushProfile(
                 loadPlanner == null ? null : loadPlanner.getExecPlan().getProfilingPlan(), profile);

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -242,6 +242,7 @@ public class LoadLoadingTask extends LoadTask {
         curCoordinator.setLoadJobType(loadJobType);
         curCoordinator.setExecPlan(loadPlanner.getExecPlan());
         curCoordinator.setTopProfileSupplier(this::buildRunningTopLevelProfile);
+        curCoordinator.registerProfileToRunningProfileManager();
 
         long beginTimeInNanoSecond = TimeUtils.getStartTime();
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -255,7 +255,7 @@ public class LoadLoadingTask extends LoadTask {
                 curCoordinator.getQueryProfile().getCounterTotalTime()
                         .setValue(TimeUtils.getEstimatedTime(beginTimeInNanoSecond));
                 curCoordinator.collectProfileSync();
-                profile.addChild(curCoordinator.buildQueryProfile(true));
+                profile.addChild(curCoordinator.buildExecutionProfile(true));
 
                 StringBuilder builder = new StringBuilder();
                 profile.prettyPrint(builder, "");

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -242,7 +242,6 @@ public class LoadLoadingTask extends LoadTask {
         curCoordinator.setLoadJobType(loadJobType);
         curCoordinator.setExecPlan(loadPlanner.getExecPlan());
         curCoordinator.setTopProfileSupplier(this::buildRunningTopLevelProfile);
-        curCoordinator.registerProfileToRunningProfileManager();
 
         long beginTimeInNanoSecond = TimeUtils.getStartTime();
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -1138,7 +1138,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
             if (!isSyncStreamLoad()) {
                 coord.collectProfileSync();
             }
-            profile.addChild(coord.buildQueryProfile(true));
+            profile.addChild(coord.buildExecutionProfile(true));
         }
 
         ProfileManager.getInstance().pushProfile(null, profile);

--- a/fe/fe-core/src/main/java/com/starrocks/memory/MemoryUsageTracker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/MemoryUsageTracker.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.common.util.ProfileManager;
+import com.starrocks.common.util.RunningProfileManager;
 import com.starrocks.monitor.jvm.JvmStats;
 import com.starrocks.monitor.unit.ByteSizeValue;
 import com.starrocks.persist.gson.GsonUtils;
@@ -77,6 +78,7 @@ public class MemoryUsageTracker extends FrontendDaemon {
 
         registerMemoryTracker("Query", new QueryTracker());
         registerMemoryTracker("Profile", ProfileManager.getInstance());
+        registerMemoryTracker("RunningProfile", RunningProfileManager.getInstance());
         registerMemoryTracker("Agent", new AgentTaskTracker());
         if (currentState.getStatisticStorage() instanceof CachedStatisticStorage) {
             registerMemoryTracker("Statistics", (CachedStatisticStorage) currentState.getStatisticStorage());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -51,6 +51,7 @@ import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.SqlUtils;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.UUIDUtil;
@@ -886,6 +887,10 @@ public class ConnectContext {
         }
         if (sessionVariable.isEnableProfile()) {
             return true;
+        }
+
+        if (FeConstants.runningUnitTest) {
+            return false;
         }
 
         if (executor != null && isQueryStmt(executor.getParsedStmt()) && sessionVariable.isEnableQueryProfile()) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -887,8 +887,8 @@ public class ConnectContext {
         if (sessionVariable.isEnableProfile()) {
             return true;
         }
-        
-        if (isQueryStmt(executor.getParsedStmt()) && sessionVariable.isEnableQueryProfile()) {
+
+        if (executor != null && isQueryStmt(executor.getParsedStmt()) && sessionVariable.isEnableQueryProfile()) {
             return true;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -887,6 +887,11 @@ public class ConnectContext {
         if (sessionVariable.isEnableProfile()) {
             return true;
         }
+        
+        if (isQueryStmt(executor.getParsedStmt()) && sessionVariable.isEnableQueryProfile()) {
+            return true;
+        }
+
         if (!sessionVariable.isEnableBigQueryProfile()) {
             return false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -138,8 +138,7 @@ public class ConnectProcessor {
     }
 
     private static final AtomicReference<QpsStat> QPS_STAT =
-            new AtomicReference<>(
-                    new QpsStat(System.currentTimeMillis(), MetricRepo.COUNTER_QUERY_ALL.getValue(), 0.0)
+            new AtomicReference<>(new QpsStat(System.currentTimeMillis(), 0, 0.0)
             );
 
     public static double getCurrentQps() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -633,6 +633,7 @@ public class DefaultCoordinator extends Coordinator {
         }
 
         queryProfile.attachInstances(executionDAG.getInstanceIds());
+        registerProfileToRunningProfileManager();
     }
 
     private void prepareResultSink() {
@@ -1075,7 +1076,7 @@ public class DefaultCoordinator extends Coordinator {
             if (!execState.cancelFragmentInstance(cancelReason) &&
                     (!execState.hasBeenDeployed() || execState.isFinished())) {
                 queryProfile.finishInstance(execState.getInstanceId());
-                queryProfile.finishInstanceProfile(execState.getIndexInJob());
+                //                queryProfile.finishInstanceProfile(execState.getIndexInJob());
             }
         }
 
@@ -1083,7 +1084,7 @@ public class DefaultCoordinator extends Coordinator {
                 .filter(instance -> executionDAG.getExecution(instance.getIndexInJob()) == null)
                 .forEach(instance -> {
                     queryProfile.finishInstance(instance.getInstanceId());
-                    queryProfile.finishInstanceProfile(instance.getIndexInJob());
+                    //                    queryProfile.finishInstanceProfile(instance.getIndexInJob());
                 });
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -680,7 +680,6 @@ public class DefaultCoordinator extends Coordinator {
             this.scheduler.schedule(option);
             MetricRepo.HISTO_DEPLOY_PLAN_FRAGMENTS_LATENCY.update(ignored.getTotalTime());
             queryProfile.attachExecutionProfiles(executionDAG.getExecutions());
-            registerProfileToRunningProfileManager();
         } finally {
             unlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -641,6 +641,10 @@ public class DefaultCoordinator extends Coordinator {
                     jobSpec.getLoadJobId(), jobSpec.getQueryId(), executionDAG.getInstanceIds(), relatedBackendIds);
             LOG.info("dispatch load job: {} to {}", DebugUtil.printId(jobSpec.getQueryId()),
                     coordinatorPreprocessor.getWorkerProvider().getSelectedWorkerIds());
+        } else {
+            if (connectContext.getSessionVariable().isEnableQueryProfile()) {
+                jobSpec.getQueryOptions().setEnable_profile(true);
+            }
         }
 
         jobSpec.getQueryOptions().setEnable_async_profile_in_be(enableAsyncProfileInBe());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -473,6 +473,7 @@ public class DefaultCoordinator extends Coordinator {
 
     @Override
     public boolean enableAsyncProfileInBe() {
+        // right now only support pipeline query which is not short circuit query
         return jobSpec.isNeedReport() && jobSpec.isEnablePipeline() && !isShortCircuit && !isLoad() &&
                 connectContext.getSessionVariable().isEnableAsyncProfileInBe();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -1447,8 +1447,9 @@ public class DefaultCoordinator extends Coordinator {
     public void registerProfileToRunningProfileManager() {
         RunningProfileManager.RunningProfile runningProfile = queryProfile.createRunningProfile();
         runningProfile.registerInstanceProfiles(executionDAG.getIndexInJobToExecState());
-
-        RunningProfileManager.getInstance().registerProfile(jobSpec.getQueryId(), runningProfile);
+        if (jobSpec.isNeedReport()) {
+            RunningProfileManager.getInstance().registerProfile(jobSpec.getQueryId(), runningProfile);
+        }
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -1137,7 +1137,7 @@ public class DefaultCoordinator extends Coordinator {
                     // all block are independent, continue the execution no matter what exception happen
                     if (ex != null) {
                         LOG.warn("Error occurred during fragment exec status update {}: {}", instanceId,
-                                ex.getMessage());
+                                ex);
                     }
                     return null; // Return null to continue the chain
                 });

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -55,7 +55,6 @@ import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.util.AuditStatisticsUtil;
 import com.starrocks.common.util.DebugUtil;
-import com.starrocks.common.util.RunningProfileManager;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.connector.exception.GlobalDictNotMatchException;
 import com.starrocks.connector.exception.RemoteFileNotFoundException;
@@ -1442,13 +1441,5 @@ public class DefaultCoordinator extends Coordinator {
     public ConnectContext getConnectContext() {
         return connectContext;
     }
-
-//    public void registerProfileToRunningProfileManager() {
-////        RunningProfileManager.RunningProfile runningProfile = queryProfile.createRunningProfile();
-////        runningProfile.registerInstanceProfiles(executionDAG.getIndexInJobToExecState());
-//        if (jobSpec.isNeedReport()) {
-//            RunningProfileManager.getInstance().registerProfile(jobSpec.getQueryId(), runningProfile);
-//        }
-//    }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -633,7 +633,6 @@ public class DefaultCoordinator extends Coordinator {
         }
 
         queryProfile.attachInstances(executionDAG.getInstanceIds());
-        registerProfileToRunningProfileManager();
     }
 
     private void prepareResultSink() {
@@ -681,6 +680,7 @@ public class DefaultCoordinator extends Coordinator {
             this.scheduler.schedule(option);
             MetricRepo.HISTO_DEPLOY_PLAN_FRAGMENTS_LATENCY.update(ignored.getTotalTime());
             queryProfile.attachExecutionProfiles(executionDAG.getExecutions());
+            registerProfileToRunningProfileManager();
         } finally {
             unlock();
         }
@@ -1445,7 +1445,6 @@ public class DefaultCoordinator extends Coordinator {
     }
 
     public void registerProfileToRunningProfileManager() {
-        LOG.warn("register profile to running profile manager, {}", DebugUtil.printId(jobSpec.getQueryId()));
         RunningProfileManager.RunningProfile runningProfile = queryProfile.createRunningProfile();
         runningProfile.registerInstanceProfiles(executionDAG.getIndexInJobToExecState());
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -123,6 +123,8 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static com.starrocks.common.util.DebugUtil.printId;
+
 public class DefaultCoordinator extends Coordinator {
     private static final Logger LOG = LogManager.getLogger(DefaultCoordinator.class);
 
@@ -274,7 +276,7 @@ public class DefaultCoordinator extends Coordinator {
 
         TUniqueId queryId = jobSpec.getQueryId();
 
-        LOG.info("Execution Profile: {}", DebugUtil.printId(queryId));
+        LOG.info("Execution Profile: {}", printId(queryId));
 
         FragmentInstanceExecState execState = FragmentInstanceExecState.createFakeExecution(queryId, address);
         executionDAG.addExecution(execState);
@@ -499,16 +501,16 @@ public class DefaultCoordinator extends Coordinator {
         if (LOG.isDebugEnabled()) {
             if (!jobSpec.getScanNodes().isEmpty()) {
                 LOG.debug("debug: in Coordinator::exec. query id: {}, planNode: {}",
-                        DebugUtil.printId(jobSpec.getQueryId()),
+                        printId(jobSpec.getQueryId()),
                         jobSpec.getScanNodes().get(0).treeToThrift());
             }
             if (!jobSpec.getFragments().isEmpty()) {
                 LOG.debug("debug: in Coordinator::exec. query id: {}, fragment: {}",
-                        DebugUtil.printId(jobSpec.getQueryId()),
+                        printId(jobSpec.getQueryId()),
                         jobSpec.getFragments().get(0).toThrift());
             }
             LOG.debug("debug: in Coordinator::exec. query id: {}, desc table: {}",
-                    DebugUtil.printId(jobSpec.getQueryId()), jobSpec.getDescTable());
+                    printId(jobSpec.getQueryId()), jobSpec.getDescTable());
         }
 
         if (slot != null && slot.getPipelineDop() > 0 &&
@@ -592,7 +594,7 @@ public class DefaultCoordinator extends Coordinator {
         try {
             scheduler.tryScheduleNextTurn(fragmentInstanceId);
         } catch (Exception e) {
-            LOG.warn("schedule fragment:{} next internal error:", DebugUtil.printId(fragmentInstanceId), e);
+            LOG.warn("schedule fragment:{} next internal error:", printId(fragmentInstanceId), e);
             cancel(PPlanFragmentCancelReason.INTERNAL_ERROR, e.getMessage());
             return Status.internalError(e.getMessage());
         }
@@ -639,7 +641,7 @@ public class DefaultCoordinator extends Coordinator {
             List<Long> relatedBackendIds = coordinatorPreprocessor.getWorkerProvider().getSelectedWorkerIds();
             GlobalStateMgr.getCurrentState().getLoadMgr().initJobProgress(
                     jobSpec.getLoadJobId(), jobSpec.getQueryId(), executionDAG.getInstanceIds(), relatedBackendIds);
-            LOG.info("dispatch load job: {} to {}", DebugUtil.printId(jobSpec.getQueryId()),
+            LOG.info("dispatch load job: {} to {}", printId(jobSpec.getQueryId()),
                     coordinatorPreprocessor.getWorkerProvider().getSelectedWorkerIds());
         }
 
@@ -666,7 +668,7 @@ public class DefaultCoordinator extends Coordinator {
                 jobSpec.getQueryOptions().query_timeout * 1000);
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("dispatch query job: {} to {}", DebugUtil.printId(jobSpec.getQueryId()), execBeAddr);
+            LOG.debug("dispatch query job: {} to {}", printId(jobSpec.getQueryId()), execBeAddr);
         }
 
         // set the broker address for OUTFILE sink
@@ -913,8 +915,8 @@ public class DefaultCoordinator extends Coordinator {
             queryStatus.setStatus(status);
             LOG.warn(
                     "one instance report fail throw updateStatus(), need cancel. job id: {}, query id: {}, instance id: {}",
-                    jobSpec.getLoadJobId(), DebugUtil.printId(jobSpec.getQueryId()),
-                    instanceId != null ? DebugUtil.printId(instanceId) : "NaN");
+                    jobSpec.getLoadJobId(), printId(jobSpec.getQueryId()),
+                    instanceId != null ? printId(instanceId) : "NaN");
             cancelInternal(PPlanFragmentCancelReason.INTERNAL_ERROR);
         } finally {
             lock.unlock();
@@ -977,7 +979,7 @@ public class DefaultCoordinator extends Coordinator {
         if (!status.ok()) {
             connectContext.setErrorCodeOnce(status.getErrorCodeString());
             LOG.warn("get next fail, need cancel. status {}, query id: {}", status,
-                    DebugUtil.printId(jobSpec.getQueryId()));
+                    printId(jobSpec.getQueryId()));
         }
         updateStatus(status, null /* no instance id */);
 
@@ -1035,7 +1037,7 @@ public class DefaultCoordinator extends Coordinator {
                 if (message.equals(FeConstants.BACKEND_NODE_NOT_FOUND_ERROR)) {
                     queryProfile.finishAllInstances(Status.OK);
                     LOG.info("count down profileDoneSignal since backend has crashed, query id: {}",
-                            DebugUtil.printId(jobSpec.getQueryId()));
+                            printId(jobSpec.getQueryId()));
                 }
             } finally {
                 unlock();
@@ -1114,13 +1116,13 @@ public class DefaultCoordinator extends Coordinator {
         if (!execState.updateExecStatus(params)) {
             LOG.info("duplicate report fragment exec status, query id: {}, instance id: {}, backend id: {}, " +
                             "status: {}, exec state: {}",
-                    DebugUtil.printId(jobSpec.getQueryId()),
-                    DebugUtil.printId(params.getFragment_instance_id()),
+                    printId(jobSpec.getQueryId()),
+                    printId(params.getFragment_instance_id()),
                     params.getBackend_id(), params.status, execState.getState());
             return;
         }
 
-        final String instanceId = DebugUtil.printId(params.getFragment_instance_id());
+        final String instanceId = printId(params.getFragment_instance_id());
         final boolean isDone = params.isDone();
         // Create a CompletableFuture chain for handling updates
         final CompletableFuture<Void> future = CompletableFuture.completedFuture(null)
@@ -1192,8 +1194,8 @@ public class DefaultCoordinator extends Coordinator {
                 ctx.setErrorCodeOnce(status.getErrorCodeString());
             }
             LOG.warn("exec state report failed status={}, query_id={}, instance_id={}, backend_id={}",
-                    status, DebugUtil.printId(jobSpec.getQueryId()),
-                    DebugUtil.printId(params.getFragment_instance_id()),
+                    status, printId(jobSpec.getQueryId()),
+                    printId(params.getFragment_instance_id()),
                     params.getBackend_id());
             updateStatus(status, params.getFragment_instance_id());
         }
@@ -1209,7 +1211,7 @@ public class DefaultCoordinator extends Coordinator {
         // called repeatedly. Otherwise, it will cause commit with wrong commit info.
         if (jobSpec.isLoadType() && execState.getState().isFinished() && queryProfile.isFinished()) {
             throw new RuntimeException(String.format("updateFinishInstance called after fragment is finished:%s, query_id:%s",
-                    instanceId, DebugUtil.printId(params.getQuery_id())));
+                    instanceId, printId(params.getQuery_id())));
         }
         try {
             lock();
@@ -1274,7 +1276,7 @@ public class DefaultCoordinator extends Coordinator {
             // Ideally, it should wait indefinitely, but out of defense, set timeout
             boolean isFinished = queryProfile.waitForProfileReported(timeout, TimeUnit.SECONDS);
             if (!isFinished) {
-                LOG.warn("failed to get profile within {} seconds", timeout);
+                LOG.warn("failed to get profile {} within {} seconds", printId(jobSpec.getQueryId()), timeout);
             }
         }
 
@@ -1305,7 +1307,7 @@ public class DefaultCoordinator extends Coordinator {
 
         if (!enableAsyncProfile || !queryProfile.addListener(task)) {
             if (enableAsyncProfile) {
-                LOG.info("Profile task is full, execute in sync mode, query id = {}", DebugUtil.printId(queryId));
+                LOG.info("Profile task is full, execute in sync mode, query id = {}", printId(queryId));
             }
             collectProfileSync();
             task.accept(false);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -1087,16 +1087,12 @@ public class DefaultCoordinator extends Coordinator {
             if (!execState.cancelFragmentInstance(cancelReason) &&
                     (!execState.hasBeenDeployed() || execState.isFinished())) {
                 queryProfile.finishInstance(execState.getInstanceId());
-                //                queryProfile.finishInstanceProfile(execState.getIndexInJob());
             }
         }
 
         executionDAG.getInstances().stream()
                 .filter(instance -> executionDAG.getExecution(instance.getIndexInJob()) == null)
-                .forEach(instance -> {
-                    queryProfile.finishInstance(instance.getInstanceId());
-                    //                    queryProfile.finishInstanceProfile(instance.getIndexInJob());
-                });
+                .forEach(instance -> queryProfile.finishInstance(instance.getInstanceId()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -1075,12 +1075,16 @@ public class DefaultCoordinator extends Coordinator {
             if (!execState.cancelFragmentInstance(cancelReason) &&
                     (!execState.hasBeenDeployed() || execState.isFinished())) {
                 queryProfile.finishInstance(execState.getInstanceId());
+                queryProfile.finishInstanceProfile(execState.getIndexInJob());
             }
         }
 
         executionDAG.getInstances().stream()
                 .filter(instance -> executionDAG.getExecution(instance.getIndexInJob()) == null)
-                .forEach(instance -> queryProfile.finishInstance(instance.getInstanceId()));
+                .forEach(instance -> {
+                    queryProfile.finishInstance(instance.getInstanceId());
+                    queryProfile.finishInstanceProfile(instance.getIndexInJob());
+                });
     }
 
     @Override
@@ -1440,6 +1444,7 @@ public class DefaultCoordinator extends Coordinator {
     }
 
     public void registerProfileToRunningProfileManager() {
+        LOG.warn("register profile to running profile manager, {}", DebugUtil.printId(jobSpec.getQueryId()));
         RunningProfileManager.RunningProfile runningProfile = queryProfile.createRunningProfile();
         runningProfile.registerInstanceProfiles(executionDAG.getIndexInJobToExecState());
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -1443,12 +1443,12 @@ public class DefaultCoordinator extends Coordinator {
         return connectContext;
     }
 
-    public void registerProfileToRunningProfileManager() {
-        RunningProfileManager.RunningProfile runningProfile = queryProfile.createRunningProfile();
-        runningProfile.registerInstanceProfiles(executionDAG.getIndexInJobToExecState());
-        if (jobSpec.isNeedReport()) {
-            RunningProfileManager.getInstance().registerProfile(jobSpec.getQueryId(), runningProfile);
-        }
-    }
+//    public void registerProfileToRunningProfileManager() {
+////        RunningProfileManager.RunningProfile runningProfile = queryProfile.createRunningProfile();
+////        runningProfile.registerInstanceProfiles(executionDAG.getIndexInJobToExecState());
+//        if (jobSpec.isNeedReport()) {
+//            RunningProfileManager.getInstance().registerProfile(jobSpec.getQueryId(), runningProfile);
+//        }
+//    }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -642,7 +642,7 @@ public class DefaultCoordinator extends Coordinator {
             LOG.info("dispatch load job: {} to {}", DebugUtil.printId(jobSpec.getQueryId()),
                     coordinatorPreprocessor.getWorkerProvider().getSelectedWorkerIds());
         } else {
-            if (connectContext.getSessionVariable().isEnableQueryProfile()) {
+            if (enableAsyncProfileInBe()) {
                 jobSpec.getQueryOptions().setEnable_profile(true);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
@@ -130,7 +130,7 @@ public final class QeProcessorImpl implements QeProcessor, MemoryTrackable {
         for (Map.Entry<TUniqueId, Long> entry : monitorQueryMap.entrySet()) {
             if (now > entry.getValue()) {
                 LOG.warn("remove profile timeout, query id = {}", DebugUtil.printId(entry.getKey()));
-                //  unregisterQuery(entry.getKey());
+                unregisterQuery(entry.getKey());
                 RunningProfileManager.getInstance().removeProfile(entry.getKey());
                 monitorQueryMap.remove(entry.getKey());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
@@ -129,7 +129,7 @@ public final class QeProcessorImpl implements QeProcessor, MemoryTrackable {
         long now = System.currentTimeMillis();
         for (Map.Entry<TUniqueId, Long> entry : monitorQueryMap.entrySet()) {
             if (now > entry.getValue()) {
-                LOG.warn("monitor expired, query id = {}", DebugUtil.printId(entry.getKey()));
+                LOG.warn("remove profile timeout, query id = {}", DebugUtil.printId(entry.getKey()));
                 //  unregisterQuery(entry.getKey());
                 RunningProfileManager.getInstance().removeProfile(entry.getKey());
                 monitorQueryMap.remove(entry.getKey());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
@@ -129,7 +129,7 @@ public final class QeProcessorImpl implements QeProcessor, MemoryTrackable {
         long now = System.currentTimeMillis();
         for (Map.Entry<TUniqueId, Long> entry : monitorQueryMap.entrySet()) {
             if (now > entry.getValue()) {
-                LOG.warn("remove profile timeout, query id = {}", DebugUtil.printId(entry.getKey()));
+                LOG.warn("monitor expired, query id = {}", DebugUtil.printId(entry.getKey()));
                 unregisterQuery(entry.getKey());
                 RunningProfileManager.getInstance().removeProfile(entry.getKey());
                 monitorQueryMap.remove(entry.getKey());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
@@ -44,6 +44,7 @@ import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.Status;
 import com.starrocks.common.util.DebugUtil;
+import com.starrocks.common.util.RunningProfileManager;
 import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.thrift.TBatchReportExecStatusParams;
@@ -129,7 +130,8 @@ public final class QeProcessorImpl implements QeProcessor, MemoryTrackable {
         for (Map.Entry<TUniqueId, Long> entry : monitorQueryMap.entrySet()) {
             if (now > entry.getValue()) {
                 LOG.warn("monitor expired, query id = {}", DebugUtil.printId(entry.getKey()));
-                unregisterQuery(entry.getKey());
+                //  unregisterQuery(entry.getKey());
+                RunningProfileManager.getInstance().removeProfile(entry.getKey());
                 monitorQueryMap.remove(entry.getKey());
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1271,7 +1271,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private int maxPipelineDop = 64;
 
     @VariableMgr.VarAttr(name = PROFILE_TIMEOUT, flag = VariableMgr.INVISIBLE)
-    private int profileTimeout = 20;
+    private int profileTimeout = 10;
 
     @VariableMgr.VarAttr(name = RUNTIME_PROFILE_REPORT_INTERVAL)
     private int runtimeProfileReportInterval = 10;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -3064,6 +3064,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return enableQueryProfile;
     }
 
+    public void setEnableQueryProfile(boolean enableQueryProfile) {
+        this.enableQueryProfile = enableQueryProfile;
+    }
+
     public void setEnableProfile(boolean enableProfile) {
         this.enableProfile = enableProfile;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1263,7 +1263,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private int maxPipelineDop = 64;
 
     @VariableMgr.VarAttr(name = PROFILE_TIMEOUT, flag = VariableMgr.INVISIBLE)
-    private int profileTimeout = 10;
+    private int profileTimeout = 100;
 
     @VariableMgr.VarAttr(name = RUNTIME_PROFILE_REPORT_INTERVAL)
     private int runtimeProfileReportInterval = 10;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -617,6 +617,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_PIPELINE_EVENT_SCHEDULER = "enable_pipeline_event_scheduler";
 
+    public static final String PROFILE_THRES_HOLD = "profile_thres_hold";
+
     // Flag to control whether to proxy follower's query statement to leader/follower.
     public enum FollowerQueryForwardMode {
         DEFAULT,    // proxy queries by the follower's replay progress (default)
@@ -1881,6 +1883,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_ASYNC_PROFILE_IN_BE)
     private boolean enableAsyncProfileInBe = true;
+
+    // when qps is high, only query exceeds profileThresHold ms will generate profile
+    @VarAttr(name = PROFILE_THRES_HOLD)
+    private long profileThresHold = 100L;
 
     public int getCboPruneJsonSubfieldDepth() {
         return cboPruneJsonSubfieldDepth;
@@ -5101,6 +5107,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableAsyncProfileInBe() {
         return enableAsyncProfileInBe;
+    }
+
+    public long getProfileThresHold() {
+        return profileThresHold;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -922,6 +922,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_MULTI_CAST_LIMIT_PUSH_DOWN = "enable_multi_cast_limit_push_down";
 
+    public static final String ENABLE_ASYNC_PROFILE_IN_BE = "enable_async_profile_in_be";
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(MAX_EXECUTION_TIME)
@@ -1876,6 +1878,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     //                Fragment-1                                    Fragment-1
     @VarAttr(name = ENABLE_MULTI_CAST_LIMIT_PUSH_DOWN, flag = VariableMgr.INVISIBLE)
     private boolean enableMultiCastLimitPushDown = true;
+
+    @VarAttr(name = ENABLE_ASYNC_PROFILE_IN_BE)
+    private boolean enableAsyncProfileInBe = true;
 
     public int getCboPruneJsonSubfieldDepth() {
         return cboPruneJsonSubfieldDepth;
@@ -5092,6 +5097,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableMultiCastLimitPushDown() {
         return enableMultiCastLimitPushDown;
+    }
+
+    public boolean isEnableAsyncProfileInBe() {
+        return enableAsyncProfileInBe;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1271,7 +1271,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private int maxPipelineDop = 64;
 
     @VariableMgr.VarAttr(name = PROFILE_TIMEOUT, flag = VariableMgr.INVISIBLE)
-    private int profileTimeout = 100;
+    private int profileTimeout = 20;
 
     @VariableMgr.VarAttr(name = RUNTIME_PROFILE_REPORT_INTERVAL)
     private int runtimeProfileReportInterval = 10;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -146,6 +146,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String IS_REPORT_SUCCESS = "is_report_success";
     public static final String COLOR_EXPLAIN_OUTPUT = "enable_color_explain_output";
     public static final String ENABLE_PROFILE = "enable_profile";
+    public static final String ENABLE_QUERY_PROFILE = "enable_query_profile";
 
     public static final String ENABLE_LOAD_PROFILE = "enable_load_profile";
     public static final String PROFILING = "profiling";
@@ -617,7 +618,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_PIPELINE_EVENT_SCHEDULER = "enable_pipeline_event_scheduler";
 
-    public static final String PROFILE_THRES_HOLD = "profile_thres_hold";
+    public static final String PROFILE_THRESHOLD = "profile_threshold";
 
     // Flag to control whether to proxy follower's query statement to leader/follower.
     public enum FollowerQueryForwardMode {
@@ -1066,6 +1067,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // if true, need report to coordinator when plan fragment execute successfully.
     @VariableMgr.VarAttr(name = ENABLE_PROFILE, alias = IS_REPORT_SUCCESS)
     private boolean enableProfile = false;
+
+    @VariableMgr.VarAttr(name = ENABLE_QUERY_PROFILE)
+    private boolean enableQueryProfile = true;
 
     // Toggle ANSI color in explain output
     @VariableMgr.VarAttr(name = COLOR_EXPLAIN_OUTPUT)
@@ -1885,7 +1889,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private boolean enableAsyncProfileInBe = true;
 
     // when qps is high, only query exceeds profileThresHold ms will generate profile
-    @VarAttr(name = PROFILE_THRES_HOLD)
+    @VarAttr(name = PROFILE_THRESHOLD)
     private long profileThresHold = 100L;
 
     public int getCboPruneJsonSubfieldDepth() {
@@ -3054,6 +3058,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableProfile() {
         return enableProfile;
+    }
+
+    public boolean isEnableQueryProfile() {
+        return enableQueryProfile;
     }
 
     public void setEnableProfile(boolean enableProfile) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -358,12 +358,16 @@ public class StmtExecutor {
                 String.format("%s-%s", Version.STARROCKS_VERSION, Version.STARROCKS_COMMIT_HASH));
         summaryProfile.addInfoString(ProfileManager.USER, context.getQualifiedUser());
         summaryProfile.addInfoString(ProfileManager.DEFAULT_DB, context.getDatabase());
-        if (AuditEncryptionChecker.needEncrypt(parsedStmt)) {
-            summaryProfile.addInfoString(ProfileManager.SQL_STATEMENT,
-                    AstToSQLBuilder.toSQLOrDefault(parsedStmt, originStmt.originStmt));
+        String sql = "";
+        if (originStmt == null) {
+            sql = AstToSQLBuilder.toSQLOrDefault(parsedStmt, sql);
+        } else if (AuditEncryptionChecker.needEncrypt(parsedStmt)) {
+            sql = AstToSQLBuilder.toSQLOrDefault(parsedStmt, originStmt.originStmt);
         } else {
-            summaryProfile.addInfoString(ProfileManager.SQL_STATEMENT, originStmt.originStmt);
+            sql = originStmt.originStmt;
         }
+
+        summaryProfile.addInfoString(ProfileManager.SQL_STATEMENT, sql);
 
         // Add some import variables in profile
         SessionVariable variables = context.getSessionVariable();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -336,7 +336,12 @@ public class StmtExecutor {
         return this.coord;
     }
 
-    private RuntimeProfile buildTopLevelProfile() {
+    @VisibleForTesting
+    public void setCoord(Coordinator coord) {
+        this.coord = coord;
+    }
+
+    public RuntimeProfile buildTopLevelProfile() {
         RuntimeProfile profile = new RuntimeProfile("Query");
         RuntimeProfile summaryProfile = new RuntimeProfile("Summary");
         summaryProfile.addInfoString(ProfileManager.QUERY_ID, DebugUtil.printId(context.getExecutionId()));
@@ -1040,7 +1045,7 @@ public class StmtExecutor {
     /**
      * Try to process profile async without exception.
      */
-    private boolean tryProcessProfileAsync(ExecPlan plan, int retryIndex) {
+    public boolean tryProcessProfileAsync(ExecPlan plan, int retryIndex) {
         try {
             return processProfileAsync(plan, retryIndex);
         } catch (Exception e) {
@@ -1118,8 +1123,8 @@ public class StmtExecutor {
                 queryDetail.setProfile(profileContent);
             }
             QeProcessorImpl.INSTANCE.unMonitorQuery(executionId);
-            //            QeProcessorImpl.INSTANCE.unregisterQuery(executionId);
-            // LOG.warn("removeProfile in profile task: queryId: {}", DebugUtil.printId(executionId));
+            QeProcessorImpl.INSTANCE.unregisterQuery(executionId);
+            LOG.debug("removeProfile in profile task: queryId: {}", DebugUtil.printId(executionId));
             RunningProfileManager.getInstance().removeProfile(executionId);
             if (Config.enable_collect_query_detail_info && Config.enable_profile_log) {
                 String jsonString = GSON.toJson(queryDetail);
@@ -3075,6 +3080,7 @@ public class StmtExecutor {
                 QeProcessorImpl.INSTANCE.unregisterQuery(context.getExecutionId());
             }
         } else {
+            // when profile report in FE is sync, right now profile report is done, so we can unregister in here
             QeProcessorImpl.INSTANCE.unregisterQuery(context.getExecutionId());
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1074,8 +1074,9 @@ public class StmtExecutor {
         final long startTime = context.getStartTime();
         final TUniqueId executionId = context.getExecutionId();
         final QueryDetail queryDetail = context.getQueryDetail();
-        // boolean needMerge = context.needMergeProfile();
+        boolean needMerge = context.needMergeProfile();
         final boolean isShortCircuit = coord.isShortCircuit();
+        final boolean enableAsyncProfileInBe = coord.enableAsyncProfileInBe();
         final ProfilingExecPlan profilingPlan;
         if (isShortCircuit) {
             profilingPlan = null;
@@ -1092,9 +1093,13 @@ public class StmtExecutor {
             summaryProfile.addInfoString(ProfileManager.PROFILE_COLLECT_TIME,
                     DebugUtil.getPrettyStringMs(System.currentTimeMillis() - profileCollectStartTime));
             summaryProfile.addInfoString("IsProfileAsync", String.valueOf(isAsync));
-            RunningProfileManager.RunningProfile runningProfile =
-                    RunningProfileManager.getInstance().getRunningProfile(executionId);
-            profileCopy.addChild(runningProfile.buildExecutionProfile());
+            if (enableAsyncProfileInBe) {
+                RunningProfileManager.RunningProfile runningProfile =
+                        RunningProfileManager.getInstance().getRunningProfile(executionId);
+                profileCopy.addChild(runningProfile.buildExecutionProfile());
+            } else {
+                profileCopy.addChild(coord.buildExecutionProfile(needMerge));
+            }
 
             // Update TotalTime to include the Profile Collect Time and the time to build the profile.
             long now = System.currentTimeMillis();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1111,6 +1111,7 @@ public class StmtExecutor {
             }
             QeProcessorImpl.INSTANCE.unMonitorQuery(executionId);
             //            QeProcessorImpl.INSTANCE.unregisterQuery(executionId);
+            LOG.warn("removeProfile in profile task: queryId: {}", DebugUtil.printId(executionId));
             RunningProfileManager.getInstance().removeProfile(executionId);
             if (Config.enable_collect_query_detail_info && Config.enable_profile_log) {
                 String jsonString = GSON.toJson(queryDetail);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1050,6 +1050,7 @@ public class StmtExecutor {
             return processProfileAsync(plan, retryIndex);
         } catch (Exception e) {
             LOG.warn("process profile async failed", e);
+            RunningProfileManager.getInstance().removeProfile(context.getExecutionId());
             return false;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1110,6 +1110,7 @@ public class StmtExecutor {
             }
             QeProcessorImpl.INSTANCE.unMonitorQuery(executionId);
             QeProcessorImpl.INSTANCE.unregisterQuery(executionId);
+            RunningProfileManager.getInstance().removeProfile(executionId);
             if (Config.enable_collect_query_detail_info && Config.enable_profile_log) {
                 String jsonString = GSON.toJson(queryDetail);
                 if (Config.enable_profile_log_compress) {
@@ -1356,10 +1357,10 @@ public class StmtExecutor {
             return;
         }
 
-        coord.execWithQueryDeployExecutor();
         coord.setTopProfileSupplier(this::buildTopLevelProfile);
         coord.setExecPlan(execPlan);
         coord.registerProfileToRunningProfileManager();
+        coord.execWithQueryDeployExecutor();
 
         RowBatch batch = null;
         if (context instanceof HttpConnectContext) {
@@ -2497,9 +2498,10 @@ public class StmtExecutor {
                 return;
             }
 
-            coord.exec();
             coord.setTopProfileSupplier(this::buildTopLevelProfile);
             coord.setExecPlan(execPlan);
+            coord.registerProfileToRunningProfileManager();
+            coord.exec();
 
             int timeout = getExecTimeout();
             long jobDeadLineMs = System.currentTimeMillis() + timeout * 1000;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1359,7 +1359,6 @@ public class StmtExecutor {
 
         coord.setTopProfileSupplier(this::buildTopLevelProfile);
         coord.setExecPlan(execPlan);
-        coord.registerProfileToRunningProfileManager();
         coord.execWithQueryDeployExecutor();
 
         RowBatch batch = null;
@@ -2500,7 +2499,6 @@ public class StmtExecutor {
 
             coord.setTopProfileSupplier(this::buildTopLevelProfile);
             coord.setExecPlan(execPlan);
-            coord.registerProfileToRunningProfileManager();
             coord.exec();
 
             int timeout = getExecTimeout();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1111,7 +1111,7 @@ public class StmtExecutor {
             }
             QeProcessorImpl.INSTANCE.unMonitorQuery(executionId);
             //            QeProcessorImpl.INSTANCE.unregisterQuery(executionId);
-            LOG.warn("removeProfile in profile task: queryId: {}", DebugUtil.printId(executionId));
+            // LOG.warn("removeProfile in profile task: queryId: {}", DebugUtil.printId(executionId));
             RunningProfileManager.getInstance().removeProfile(executionId);
             if (Config.enable_collect_query_detail_info && Config.enable_profile_log) {
                 String jsonString = GSON.toJson(queryDetail);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1080,7 +1080,7 @@ public class StmtExecutor {
         // since sometimes the profile collect time is very long.
         long totalTimeMs = now - startTime;
 
-        if (ConnectProcessor.getCurrentQps() > 50 && totalTimeMs < 100) {
+        if (ConnectProcessor.getCurrentQps() > 50 && totalTimeMs < context.sessionVariable.getProfileThresHold()) {
             if (enableAsyncProfileInBe) {
                 RunningProfileManager.getInstance().removeProfile(executionId);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -2865,6 +2865,8 @@ public class StmtExecutor {
             coord = getCoordinatorFactory().createQueryScheduler(
                     context, plan.getFragments(), plan.getScanNodes(), plan.getDescTbl().toThrift());
             QeProcessorImpl.INSTANCE.registerQuery(context.getExecutionId(), coord);
+            coord.setTopProfileSupplier(this::buildTopLevelProfile);
+            coord.setExecPlan(plan);
 
             coord.exec();
             RowBatch batch;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
@@ -197,7 +197,7 @@ public abstract class Coordinator {
 
     public abstract void setExecPlan(ExecPlan execPlan);
 
-    public abstract RuntimeProfile buildQueryProfile(boolean needMerge);
+    public abstract RuntimeProfile buildExecutionProfile(boolean needMerge);
 
     public abstract RuntimeProfile getQueryProfile();
 
@@ -228,6 +228,8 @@ public abstract class Coordinator {
     public abstract List<QueryStatisticsItem.FragmentInstanceInfo> getFragmentInstanceInfos();
 
     public abstract DataCacheSelectMetrics getDataCacheSelectMetrics();
+
+    public abstract void registerProfileToRunningProfileManager();
 
     // ------------------------------------------------------------------------------------
     // Methods for audit.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
@@ -266,4 +266,6 @@ public abstract class Coordinator {
     public abstract String getResourceGroupName();
 
     public abstract boolean isShortCircuit();
+
+    public abstract boolean enableAsyncProfileInBe();
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
@@ -229,8 +229,6 @@ public abstract class Coordinator {
 
     public abstract DataCacheSelectMetrics getDataCacheSelectMetrics();
 
-    public abstract void registerProfileToRunningProfileManager();
-
     // ------------------------------------------------------------------------------------
     // Methods for audit.
     // ------------------------------------------------------------------------------------

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Deployer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Deployer.java
@@ -22,6 +22,7 @@ import com.starrocks.common.Status;
 import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
+import com.starrocks.common.util.RunningProfileManager;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ExecuteExceptionHandler;
 import com.starrocks.qe.scheduler.dag.ExecutionDAG;
@@ -240,6 +241,7 @@ public class Deployer {
                     }
                 }
             }
+
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Deployer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Deployer.java
@@ -22,7 +22,6 @@ import com.starrocks.common.Status;
 import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
-import com.starrocks.common.util.RunningProfileManager;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ExecuteExceptionHandler;
 import com.starrocks.qe.scheduler.dag.ExecutionDAG;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/FeExecuteCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/FeExecuteCoordinator.java
@@ -468,8 +468,4 @@ public class FeExecuteCoordinator extends Coordinator {
         sb.append(String.format("%02d:%02d:%02d", hour + day * 24, minute, second));
         return sb.toString();
     }
-
-    public void registerProfileToRunningProfileManager() {
-    }
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/FeExecuteCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/FeExecuteCoordinator.java
@@ -194,7 +194,7 @@ public class FeExecuteCoordinator extends Coordinator {
     }
 
     @Override
-    public RuntimeProfile buildQueryProfile(boolean needMerge) {
+    public RuntimeProfile buildExecutionProfile(boolean needMerge) {
         return null;
     }
 
@@ -468,4 +468,8 @@ public class FeExecuteCoordinator extends Coordinator {
         sb.append(String.format("%02d:%02d:%02d", hour + day * 24, minute, second));
         return sb.toString();
     }
+
+    public void registerProfileToRunningProfileManager() {
+    }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/FeExecuteCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/FeExecuteCoordinator.java
@@ -304,6 +304,11 @@ public class FeExecuteCoordinator extends Coordinator {
     }
 
     @Override
+    public boolean enableAsyncProfileInBe() {
+        return false;
+    }
+
+    @Override
     public String getWarehouseName() {
         if (connectContext == null) {
             return "";

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
@@ -241,6 +241,11 @@ public class QueryRuntimeProfile {
         // execution at backends where it hasn't even started
         fragmentInstanceDownSignal = new MarkedCountDownLatch<>(instanceIds.size());
         instanceIds.forEach(instanceId -> fragmentInstanceDownSignal.addMark(instanceId, MARKED_COUNT_DOWN_VALUE));
+        runningProfile = createRunningProfile();
+        runningProfile.registerInstanceProfiles(instanceIds);
+        if (jobSpec.isNeedReport()) {
+            RunningProfileManager.getInstance().registerProfile(jobSpec.getQueryId(), runningProfile);
+        }
     }
 
     public void attachExecutionProfiles(Collection<FragmentInstanceExecState> executions) {
@@ -261,12 +266,6 @@ public class QueryRuntimeProfile {
     public void finishInstance(TUniqueId instanceId) {
         if (fragmentInstanceDownSignal != null) {
             fragmentInstanceDownSignal.markedCountDown(instanceId, MARKED_COUNT_DOWN_VALUE);
-        }
-    }
-
-    public void finishInstanceProfile(int indexInJob) {
-        if (runningProfile != null) {
-            runningProfile.finishInstance(indexInJob);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
@@ -238,7 +238,7 @@ public class QueryRuntimeProfile {
         // execution at backends where it hasn't even started
         fragmentInstanceDownSignal = new MarkedCountDownLatch<>(instanceIds.size());
         instanceIds.forEach(instanceId -> fragmentInstanceDownSignal.addMark(instanceId, MARKED_COUNT_DOWN_VALUE));
-        if (jobSpec.getQueryOptions().isEnable_async_profile_in_be()) {
+        if (jobSpec.getQueryOptions() != null && jobSpec.getQueryOptions().isEnable_async_profile_in_be()) {
             runningProfile = Optional.of(createRunningProfile());
             runningProfile.get().registerInstanceProfiles(instanceIds);
             RunningProfileManager.getInstance().registerProfile(jobSpec.getQueryId(), runningProfile.get());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
@@ -242,8 +242,9 @@ public class QueryRuntimeProfile {
             runningProfile = Optional.of(createRunningProfile());
             runningProfile.get().registerInstanceProfiles(instanceIds);
             RunningProfileManager.getInstance().registerProfile(jobSpec.getQueryId(), runningProfile.get());
-            LOG.debug("Register running profile for query: {}:{}", DebugUtil.printId(jobSpec.getQueryId()),
-                    connectContext.getExecutor().getOriginStmtInString());
+            String sql =
+                    connectContext.getExecutor() != null ? connectContext.getExecutor().getOriginStmtInString() : "";
+            LOG.debug("Register running profile for query: {}:{}", DebugUtil.printId(jobSpec.getQueryId()), sql);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
@@ -242,6 +242,8 @@ public class QueryRuntimeProfile {
             runningProfile = Optional.of(createRunningProfile());
             runningProfile.get().registerInstanceProfiles(instanceIds);
             RunningProfileManager.getInstance().registerProfile(jobSpec.getQueryId(), runningProfile.get());
+            LOG.debug("Register running profile for query: {}:{}", DebugUtil.printId(jobSpec.getQueryId()),
+                    connectContext.getExecutor().getOriginStmtInString());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
@@ -220,6 +220,9 @@ public class QueryRuntimeProfile {
     public synchronized void setTopProfileSupplier(Supplier<RuntimeProfile> topProfileSupplier) {
         this.topProfileSupplier = topProfileSupplier;
         if (topProfileSupplier == null) {
+            if (runningProfile == null) {
+                LOG.warn("clearTopProfileSupplier meet npe, {}", DebugUtil.printId(jobSpec.getQueryId()));
+            }
             runningProfile.clearTopProfileSupplier();
         }
     }
@@ -258,6 +261,12 @@ public class QueryRuntimeProfile {
     public void finishInstance(TUniqueId instanceId) {
         if (fragmentInstanceDownSignal != null) {
             fragmentInstanceDownSignal.markedCountDown(instanceId, MARKED_COUNT_DOWN_VALUE);
+        }
+    }
+
+    public void finishInstanceProfile(int indexInJob) {
+        if (runningProfile != null) {
+            runningProfile.finishInstance(indexInJob);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
@@ -337,7 +337,7 @@ public class QueryRuntimeProfile {
     public RunningProfileManager.RunningProfile createRunningProfile() {
         return
                 new RunningProfileManager.RunningProfile(executionProfile, loadChannelProfile, topProfileSupplier,
-                        execPlan.getProfilingPlan(),
+                        execPlan == null ? null : execPlan.getProfilingPlan(),
                         connectContext.getSessionVariable().getRuntimeProfileReportInterval(),
                         connectContext.needMergeProfile(), jobSpec.isBrokerLoad(), jobSpec.getQueryId());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
@@ -26,6 +26,7 @@ import com.starrocks.common.util.Counter;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.ProfilingExecPlan;
+import com.starrocks.common.util.RunningProfileManager;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.datacache.DataCacheSelectMetrics;
@@ -69,11 +70,11 @@ public class QueryRuntimeProfile {
 
     /**
      * Set the queue size to a large value. The decision to execute the profile process task asynchronously
-     * occurs when a listener is added to {@link QueryRuntimeProfile#profileDoneSignal}. The function
+     * occurs when a listener is added to {@link QueryRuntimeProfile#fragmentInstanceDownSignal}. The function
      * {@link QueryRuntimeProfile#addListener} will then determine if the size of the queued task exceeds
      * queue size.
      */
-    private static final ThreadPoolExecutor EXECUTOR =
+    public static final ThreadPoolExecutor EXECUTOR =
             ThreadPoolManager.newDaemonCacheThreadPool(
                     ThreadPoolManager.cpuIntensiveThreadPoolSize(),
                     ThreadPoolManager.cpuIntensiveThreadPoolSize() * 4,
@@ -82,7 +83,7 @@ public class QueryRuntimeProfile {
     /**
      * The value is meaningless, and it is just used as a value placeholder of {@link MarkedCountDownLatch}.
      */
-    private static final Long MARKED_COUNT_DOWN_VALUE = -1L;
+    public static final Long MARKED_COUNT_DOWN_VALUE = -1L;
 
     public static final String LOAD_CHANNEL_PROFILE_NAME = "LoadChannel";
 
@@ -98,18 +99,24 @@ public class QueryRuntimeProfile {
      */
     private boolean profileAlreadyReported = false;
 
-    private RuntimeProfile queryProfile;
+    private RuntimeProfile executionProfile;
     private List<RuntimeProfile> fragmentProfiles;
 
     // The load channel profile is only present if loading to OlapTables.
     // The hierarchy is LoadChannel -> Channel(BE) -> Index
     private final Optional<RuntimeProfile> loadChannelProfile;
 
+    // runningProfile includes all stuff of the query profile
+    // coordinator will register it into RunningProfileManager by registerProfileToRunningProfileManager
+    // profile will be reported to RunningProfileManager and trigger profile merge even after query is finished.
+    private RunningProfileManager.RunningProfile runningProfile;
+
     /**
      * The number of instances of this query.
      * <p> It is equal to the number of backends executing plan fragments on behalf of this query.
+     * when fragment instance reported with done flag, this value will be decremented.
      */
-    private MarkedCountDownLatch<TUniqueId, Long> profileDoneSignal = null;
+    private MarkedCountDownLatch<TUniqueId, Long> fragmentInstanceDownSignal = null;
 
     private Supplier<RuntimeProfile> topProfileSupplier;
     private ExecPlan execPlan;
@@ -147,11 +154,11 @@ public class QueryRuntimeProfile {
         this.jobSpec = jobSpec;
         this.isShortCircuit = isShortCircuit;
 
-        this.queryProfile = new RuntimeProfile("Execution");
+        this.executionProfile = new RuntimeProfile("Execution");
 
         if (jobSpec.hasOlapTableSink()) {
             loadChannelProfile = Optional.of(new RuntimeProfile(LOAD_CHANNEL_PROFILE_NAME));
-            queryProfile.addChild(loadChannelProfile.get());
+            executionProfile.addChild(loadChannelProfile.get());
         } else {
             loadChannelProfile = Optional.empty();
         }
@@ -162,7 +169,7 @@ public class QueryRuntimeProfile {
         for (int i = 0; i < numFragments; i++) {
             RuntimeProfile profile = new RuntimeProfile("Fragment " + i);
             fragmentProfiles.add(profile);
-            queryProfile.addChild(profile);
+            executionProfile.addChild(profile);
         }
     }
 
@@ -212,6 +219,9 @@ public class QueryRuntimeProfile {
 
     public synchronized void setTopProfileSupplier(Supplier<RuntimeProfile> topProfileSupplier) {
         this.topProfileSupplier = topProfileSupplier;
+        if (topProfileSupplier == null) {
+            runningProfile.clearTopProfileSupplier();
+        }
     }
 
     public void setExecPlan(ExecPlan execPlan) {
@@ -226,8 +236,8 @@ public class QueryRuntimeProfile {
         // to keep things simple, make async Cancel() calls wait until plan fragment
         // execution has been initiated, otherwise we might try to cancel fragment
         // execution at backends where it hasn't even started
-        profileDoneSignal = new MarkedCountDownLatch<>(instanceIds.size());
-        instanceIds.forEach(instanceId -> profileDoneSignal.addMark(instanceId, MARKED_COUNT_DOWN_VALUE));
+        fragmentInstanceDownSignal = new MarkedCountDownLatch<>(instanceIds.size());
+        instanceIds.forEach(instanceId -> fragmentInstanceDownSignal.addMark(instanceId, MARKED_COUNT_DOWN_VALUE));
     }
 
     public void attachExecutionProfiles(Collection<FragmentInstanceExecState> executions) {
@@ -246,19 +256,19 @@ public class QueryRuntimeProfile {
     }
 
     public void finishInstance(TUniqueId instanceId) {
-        if (profileDoneSignal != null) {
-            profileDoneSignal.markedCountDown(instanceId, MARKED_COUNT_DOWN_VALUE);
+        if (fragmentInstanceDownSignal != null) {
+            fragmentInstanceDownSignal.markedCountDown(instanceId, MARKED_COUNT_DOWN_VALUE);
         }
     }
 
     public void finishAllInstances(Status status) {
-        if (profileDoneSignal != null) {
-            profileDoneSignal.countDownToZero(status);
+        if (fragmentInstanceDownSignal != null) {
+            fragmentInstanceDownSignal.countDownToZero(status);
         }
     }
 
     public boolean isFinished() {
-        return profileDoneSignal.getCount() == 0;
+        return fragmentInstanceDownSignal.getCount() == 0;
     }
 
     public boolean addListener(Consumer<Boolean> task) {
@@ -275,16 +285,16 @@ public class QueryRuntimeProfile {
         }
 
         // We need to make sure this submission won't be rejected by set the queue size to Integer.MAX_VALUE
-        profileDoneSignal.addListener(() -> EXECUTOR.submit(() -> {
+        runningProfile.addListener(() -> EXECUTOR.submit(() -> {
             task.accept(true);
         }));
         return true;
     }
 
-    public boolean waitForProfileFinished(long timeout, TimeUnit unit) {
+    public boolean waitForQueryFinished(long timeout, TimeUnit unit) {
         boolean res = false;
         try {
-            res = profileDoneSignal.await(timeout, unit);
+            res = fragmentInstanceDownSignal.await(timeout, unit);
         } catch (InterruptedException e) { // NOSONAR
             LOG.warn("profile signal await error", e);
         }
@@ -292,8 +302,21 @@ public class QueryRuntimeProfile {
         return res;
     }
 
-    public RuntimeProfile getQueryProfile() {
-        return queryProfile;
+    public boolean waitForProfileReported(long timeout, TimeUnit unit) {
+        return runningProfile.waitForProfileReported(timeout, unit);
+    }
+
+    public RuntimeProfile getExecutionProfile() {
+        return executionProfile;
+    }
+
+    public RunningProfileManager.RunningProfile createRunningProfile() {
+        runningProfile =
+                new RunningProfileManager.RunningProfile(executionProfile, loadChannelProfile, topProfileSupplier,
+                        execPlan.getProfilingPlan(),
+                        connectContext.getSessionVariable().getRuntimeProfileReportInterval(),
+                        connectContext.needMergeProfile(), jobSpec.isBrokerLoad(), jobSpec.getQueryId());
+        return runningProfile;
     }
 
     public void updateLoadChannelProfile(TReportExecStatusParams params) {
@@ -336,12 +359,12 @@ public class QueryRuntimeProfile {
                 // so we put the judgment logic in BE
                 connectContext.isProfileEnabled() || jobSpec.isBrokerLoad()) &&
                 // If it's the last done report, avoiding duplicate trigger
-                (!execState.isFinished() || profileDoneSignal.getLeftMarks().size() > 1) &&
+                (!execState.isFinished() || fragmentInstanceDownSignal.getLeftMarks().size() > 1) &&
                 // Interval * 0.95 * 1000 to allow a certain range of deviation
                 now - lastTime > (connectContext.getSessionVariable().getRuntimeProfileReportInterval() * 950L) &&
                 lastRuntimeProfileUpdateTime.compareAndSet(lastTime, now)) {
             RuntimeProfile profile = topProfileSupplier.get();
-            profile.addChild(buildQueryProfile(connectContext.needMergeProfile() || jobSpec.isBrokerLoad()));
+            profile.addChild(buildExecutionProfile(connectContext.needMergeProfile() || jobSpec.isBrokerLoad()));
             ProfilingExecPlan profilingPlan = plan.getProfilingPlan();
             saveRunningProfile(profilingPlan, profile);
             LOG.debug("update profile, profilingPlan: {}, profile: {}", profilingPlan, profile);
@@ -400,18 +423,18 @@ public class QueryRuntimeProfile {
         }
     }
 
-    public RuntimeProfile buildQueryProfile(boolean needMerge) {
+    public RuntimeProfile buildExecutionProfile(boolean needMerge) {
         if (!needMerge) {
-            return queryProfile;
+            return executionProfile;
         }
         if (!jobSpec.isEnablePipeline()) {
             return mergeNonPipelineProfile();
         }
 
-        RuntimeProfile newQueryProfile = new RuntimeProfile(queryProfile.getName());
+        RuntimeProfile newExecutionProfile = new RuntimeProfile(executionProfile.getName());
         long start = System.nanoTime();
-        newQueryProfile.copyAllInfoStringsFrom(queryProfile, null);
-        newQueryProfile.copyAllCountersFrom(queryProfile);
+        newExecutionProfile.copyAllInfoStringsFrom(executionProfile, null);
+        newExecutionProfile.copyAllCountersFrom(executionProfile);
 
         Map<String, Long> peakMemoryEachBE = Maps.newHashMap();
         long sumQueryCumulativeCpuTime = 0;
@@ -497,7 +520,7 @@ public class QueryRuntimeProfile {
                 newFragmentProfile.addChild(pipelineProfile);
             });
 
-            newQueryProfile.addChild(newFragmentProfile);
+            newExecutionProfile.addChild(newFragmentProfile);
         }
 
         // Remove redundant MIN/MAX metrics if MIN and MAX are identical
@@ -550,7 +573,7 @@ public class QueryRuntimeProfile {
                             resultDeliverTime += pendingFinishTime.getValue();
                         }
                         Counter resultDeliverTimer =
-                                newQueryProfile.addCounter("ResultDeliverTime", TUnit.TIME_NS, null);
+                                newExecutionProfile.addCounter("ResultDeliverTime", TUnit.TIME_NS, null);
                         resultDeliverTimer.setValue(resultDeliverTime);
                     }
 
@@ -573,64 +596,281 @@ public class QueryRuntimeProfile {
             }
         }
         Counter queryAllocatedMemoryUsageCounter =
-                newQueryProfile.addCounter("QueryAllocatedMemoryUsage", TUnit.BYTES, null);
+                newExecutionProfile.addCounter("QueryAllocatedMemoryUsage", TUnit.BYTES, null);
         queryAllocatedMemoryUsageCounter.setValue(queryAllocatedMemoryUsage);
         Counter queryDeallocatedMemoryUsageCounter =
-                newQueryProfile.addCounter("QueryDeallocatedMemoryUsage", TUnit.BYTES, null);
+                newExecutionProfile.addCounter("QueryDeallocatedMemoryUsage", TUnit.BYTES, null);
         queryDeallocatedMemoryUsageCounter.setValue(queryDeallocatedMemoryUsage);
         Counter queryCumulativeOperatorTimer =
-                newQueryProfile.addCounter("QueryCumulativeOperatorTime", TUnit.TIME_NS, null);
+                newExecutionProfile.addCounter("QueryCumulativeOperatorTime", TUnit.TIME_NS, null);
         queryCumulativeOperatorTimer.setValue(queryCumulativeOperatorTime);
         Counter queryCumulativeScanTimer =
-                newQueryProfile.addCounter("QueryCumulativeScanTime", TUnit.TIME_NS, null);
+                newExecutionProfile.addCounter("QueryCumulativeScanTime", TUnit.TIME_NS, null);
         queryCumulativeScanTimer.setValue(queryCumulativeScanTime);
         Counter queryCumulativeNetworkTimer =
-                newQueryProfile.addCounter("QueryCumulativeNetworkTime", TUnit.TIME_NS, null);
+                newExecutionProfile.addCounter("QueryCumulativeNetworkTime", TUnit.TIME_NS, null);
         queryCumulativeNetworkTimer.setValue(queryCumulativeNetworkTime);
-        Counter queryPeakScheduleTime = newQueryProfile.addCounter("QueryPeakScheduleTime", TUnit.TIME_NS, null);
+        Counter queryPeakScheduleTime = newExecutionProfile.addCounter("QueryPeakScheduleTime", TUnit.TIME_NS, null);
         queryPeakScheduleTime.setValue(maxScheduleTime);
-        newQueryProfile.getCounterTotalTime().setValue(0);
+        newExecutionProfile.getCounterTotalTime().setValue(0);
 
-        Counter queryCumulativeCpuTime = newQueryProfile.addCounter("QueryCumulativeCpuTime", TUnit.TIME_NS, null);
+        Counter queryCumulativeCpuTime = newExecutionProfile.addCounter("QueryCumulativeCpuTime", TUnit.TIME_NS, null);
         queryCumulativeCpuTime.setValue(sumQueryCumulativeCpuTime);
-        Counter queryPeakMemoryUsage = newQueryProfile.addCounter("QueryPeakMemoryUsagePerNode", TUnit.BYTES, null);
+        Counter queryPeakMemoryUsage = newExecutionProfile.addCounter("QueryPeakMemoryUsagePerNode", TUnit.BYTES, null);
         queryPeakMemoryUsage.setValue(maxQueryPeakMemoryUsage);
-        Counter sumQueryPeakMemoryUsage = newQueryProfile.addCounter("QuerySumMemoryUsage", TUnit.BYTES, null);
+        Counter sumQueryPeakMemoryUsage = newExecutionProfile.addCounter("QuerySumMemoryUsage", TUnit.BYTES, null);
         sumQueryPeakMemoryUsage.setValue(peakMemoryEachBE.values().stream().reduce(0L, Long::sum));
-        Counter queryExecutionWallTime = newQueryProfile.addCounter("QueryExecutionWallTime", TUnit.TIME_NS, null);
+        Counter queryExecutionWallTime = newExecutionProfile.addCounter("QueryExecutionWallTime", TUnit.TIME_NS, null);
         queryExecutionWallTime.setValue(maxQueryExecutionWallTime);
-        Counter querySpillBytes = newQueryProfile.addCounter("QuerySpillBytes", TUnit.BYTES, null);
+        Counter querySpillBytes = newExecutionProfile.addCounter("QuerySpillBytes", TUnit.BYTES, null);
         querySpillBytes.setValue(sumQuerySpillBytes);
 
         if (execPlan != null) {
-            newQueryProfile.addInfoString("Topology", execPlan.getProfilingPlan().toTopologyJson());
+            newExecutionProfile.addInfoString("Topology", execPlan.getProfilingPlan().toTopologyJson());
         }
         Counter processTimer =
-                newQueryProfile.addCounter("FrontendProfileMergeTime", TUnit.TIME_NS, null);
+                newExecutionProfile.addCounter("FrontendProfileMergeTime", TUnit.TIME_NS, null);
         processTimer.setValue(System.nanoTime() - start);
 
-        Optional<RuntimeProfile> mergedLoadChannelProfile = mergeLoadChannelProfile();
-        mergedLoadChannelProfile.ifPresent(newQueryProfile::addChild);
+        Optional<RuntimeProfile> mergedLoadChannelProfile = mergeLoadChannelProfile(loadChannelProfile,  jobSpec.getQueryId());
+        mergedLoadChannelProfile.ifPresent(newExecutionProfile::addChild);
 
-        return newQueryProfile;
+        return newExecutionProfile;
+    }
+
+    public static RuntimeProfile mergeExecutionProfile(boolean needMerge, RuntimeProfile executionProfile,
+                                                       Optional<RuntimeProfile> loadChannelProfile,
+                                                       ProfilingExecPlan profilingExecPlan, TUniqueId queryId) {
+        RuntimeProfile newExecutionProfile = new RuntimeProfile(executionProfile.getName());
+        long start = System.nanoTime();
+        newExecutionProfile.copyAllInfoStringsFrom(executionProfile, null);
+        newExecutionProfile.copyAllCountersFrom(executionProfile);
+
+        Map<String, Long> peakMemoryEachBE = Maps.newHashMap();
+        long sumQueryCumulativeCpuTime = 0;
+        long sumQuerySpillBytes = 0;
+        long maxQueryPeakMemoryUsage = 0;
+        long maxQueryExecutionWallTime = 0;
+
+        List<RuntimeProfile> newFragmentProfiles = Lists.newArrayList();
+        List<RuntimeProfile> fragmentProfiles = executionProfile.getChildList().stream()
+                .map(pair -> pair.first)
+                .collect(Collectors.toList());
+        for (RuntimeProfile fragmentProfile : fragmentProfiles) {
+            RuntimeProfile newFragmentProfile = new RuntimeProfile(fragmentProfile.getName());
+            newFragmentProfiles.add(newFragmentProfile);
+            newFragmentProfile.copyAllInfoStringsFrom(fragmentProfile, null);
+            newFragmentProfile.copyAllCountersFrom(fragmentProfile);
+
+            if (fragmentProfile.getChildList().isEmpty()) {
+                continue;
+            }
+
+            List<RuntimeProfile> instanceProfiles = fragmentProfile.getChildList().stream()
+                    .map(pair -> pair.first)
+                    .collect(Collectors.toList());
+
+            Set<String> backendAddresses = Sets.newHashSet();
+            Set<String> instanceIds = Sets.newHashSet();
+            Set<String> missingInstanceIds = Sets.newHashSet();
+            for (RuntimeProfile instanceProfile : instanceProfiles) {
+                // Setup backend meta infos
+                backendAddresses.add(instanceProfile.getInfoString("Address"));
+                instanceIds.add(instanceProfile.getInfoString("InstanceId"));
+                if (CollectionUtils.isEmpty(instanceProfile.getChildList())) {
+                    missingInstanceIds.add(instanceProfile.getInfoString("InstanceId"));
+                }
+
+                // Get query level peak memory usage, cpu cost, wall time
+                Counter toBeRemove = instanceProfile.getCounter("QueryCumulativeCpuTime");
+                if (toBeRemove != null) {
+                    sumQueryCumulativeCpuTime += toBeRemove.getValue();
+                }
+                instanceProfile.removeCounter("QueryCumulativeCpuTime");
+
+                toBeRemove = instanceProfile.getCounter("QueryPeakMemoryUsage");
+                if (toBeRemove != null) {
+                    maxQueryPeakMemoryUsage = Math.max(maxQueryPeakMemoryUsage, toBeRemove.getValue());
+                    String beAddress = instanceProfile.getInfoString("Address");
+                    peakMemoryEachBE.merge(beAddress, toBeRemove.getValue(), Long::max);
+                }
+                instanceProfile.removeCounter("QueryPeakMemoryUsage");
+
+                toBeRemove = instanceProfile.getCounter("QueryExecutionWallTime");
+                if (toBeRemove != null) {
+                    maxQueryExecutionWallTime = Math.max(maxQueryExecutionWallTime, toBeRemove.getValue());
+                }
+                instanceProfile.removeCounter("QueryExecutionWallTime");
+
+                toBeRemove = instanceProfile.getCounter("QuerySpillBytes");
+                if (toBeRemove != null) {
+                    sumQuerySpillBytes += toBeRemove.getValue();
+                }
+                instanceProfile.removeCounter("QuerySpillBytes");
+            }
+            newFragmentProfile.addInfoString("BackendAddresses", String.join(",", backendAddresses));
+            newFragmentProfile.addInfoString("InstanceIds", String.join(",", instanceIds));
+            if (!missingInstanceIds.isEmpty()) {
+                newFragmentProfile.addInfoString("MissingInstanceIds", String.join(",", missingInstanceIds));
+            }
+            Counter backendNum = newFragmentProfile.addCounter("BackendNum", TUnit.UNIT, null);
+            backendNum.setValue(backendAddresses.size());
+
+            // Setup number of instance
+            Counter counter = newFragmentProfile.addCounter("InstanceNum", TUnit.UNIT, null);
+            counter.setValue(instanceProfiles.size());
+
+            RuntimeProfile mergedInstanceProfile =
+                    RuntimeProfile.mergeIsomorphicProfiles(instanceProfiles, Sets.newHashSet("Address", "InstanceId"));
+            Preconditions.checkState(mergedInstanceProfile != null);
+
+            newFragmentProfile.copyAllInfoStringsFrom(mergedInstanceProfile, null);
+            newFragmentProfile.copyAllCountersFrom(mergedInstanceProfile);
+
+            mergedInstanceProfile.getChildList().forEach(pair -> {
+                RuntimeProfile pipelineProfile = pair.first;
+                setOperatorStatus(pipelineProfile);
+                newFragmentProfile.addChild(pipelineProfile);
+            });
+
+            newExecutionProfile.addChild(newFragmentProfile);
+        }
+
+        // Remove redundant MIN/MAX metrics if MIN and MAX are identical
+        for (RuntimeProfile fragmentProfile : newFragmentProfiles) {
+            RuntimeProfile.removeRedundantMinMaxMetrics(fragmentProfile);
+        }
+
+        long queryAllocatedMemoryUsage = 0;
+        long queryDeallocatedMemoryUsage = 0;
+        // Calculate ExecutionTotalTime, which comprising all operator's sync time and async time
+        // We can get Operator's sync time from OperatorTotalTime, and for async time, only ScanOperator and
+        // ExchangeOperator have async operations, we can get async time from ScanTime(for ScanOperator) and
+        // NetworkTime(for ExchangeOperator)
+        long queryCumulativeOperatorTime = 0;
+        long queryCumulativeScanTime = 0;
+        long queryCumulativeNetworkTime = 0;
+        long maxScheduleTime = 0;
+        for (RuntimeProfile fragmentProfile : newFragmentProfiles) {
+            Counter instanceAllocatedMemoryUsage = fragmentProfile.getCounter("InstanceAllocatedMemoryUsage");
+            if (instanceAllocatedMemoryUsage != null) {
+                queryAllocatedMemoryUsage += instanceAllocatedMemoryUsage.getValue();
+            }
+            Counter instanceDeallocatedMemoryUsage = fragmentProfile.getCounter("InstanceDeallocatedMemoryUsage");
+            if (instanceDeallocatedMemoryUsage != null) {
+                queryDeallocatedMemoryUsage += instanceDeallocatedMemoryUsage.getValue();
+            }
+
+            for (Pair<RuntimeProfile, Boolean> pipelineProfilePair : fragmentProfile.getChildList()) {
+                RuntimeProfile pipelineProfile = pipelineProfilePair.first;
+                Counter scheduleTime = pipelineProfile.getMaxCounter("ScheduleTime");
+                if (scheduleTime != null) {
+                    maxScheduleTime = Math.max(maxScheduleTime, scheduleTime.getValue());
+                }
+                for (Pair<RuntimeProfile, Boolean> operatorProfilePair : pipelineProfile.getChildList()) {
+                    RuntimeProfile operatorProfile = operatorProfilePair.first;
+                    RuntimeProfile commonMetrics = operatorProfile.getChild("CommonMetrics");
+                    RuntimeProfile uniqueMetrics = operatorProfile.getChild("UniqueMetrics");
+                    if (commonMetrics == null || uniqueMetrics == null) {
+                        continue;
+                    }
+
+                    if (commonMetrics.containsInfoString("IsFinalSink")) {
+                        long resultDeliverTime = 0;
+                        Counter outputFullTime = pipelineProfile.getMaxCounter("OutputFullTime");
+                        if (outputFullTime != null) {
+                            resultDeliverTime += outputFullTime.getValue();
+                        }
+                        Counter pendingFinishTime = pipelineProfile.getMaxCounter("PendingFinishTime");
+                        if (pendingFinishTime != null) {
+                            resultDeliverTime += pendingFinishTime.getValue();
+                        }
+                        Counter resultDeliverTimer =
+                                newExecutionProfile.addCounter("ResultDeliverTime", TUnit.TIME_NS, null);
+                        resultDeliverTimer.setValue(resultDeliverTime);
+                    }
+
+                    Counter operatorTotalTime = commonMetrics.getMaxCounter("OperatorTotalTime");
+                    Preconditions.checkNotNull(operatorTotalTime);
+                    queryCumulativeOperatorTime += operatorTotalTime.getValue();
+
+                    Counter scanTime = uniqueMetrics.getMaxCounter("ScanTime");
+                    if (scanTime != null) {
+                        queryCumulativeScanTime += scanTime.getValue();
+                        queryCumulativeOperatorTime += scanTime.getValue();
+                    }
+
+                    Counter networkTime = uniqueMetrics.getMaxCounter("NetworkTime");
+                    if (networkTime != null) {
+                        queryCumulativeNetworkTime += networkTime.getValue();
+                        queryCumulativeOperatorTime += networkTime.getValue();
+                    }
+                }
+            }
+        }
+        Counter queryAllocatedMemoryUsageCounter =
+                newExecutionProfile.addCounter("QueryAllocatedMemoryUsage", TUnit.BYTES, null);
+        queryAllocatedMemoryUsageCounter.setValue(queryAllocatedMemoryUsage);
+        Counter queryDeallocatedMemoryUsageCounter =
+                newExecutionProfile.addCounter("QueryDeallocatedMemoryUsage", TUnit.BYTES, null);
+        queryDeallocatedMemoryUsageCounter.setValue(queryDeallocatedMemoryUsage);
+        Counter queryCumulativeOperatorTimer =
+                newExecutionProfile.addCounter("QueryCumulativeOperatorTime", TUnit.TIME_NS, null);
+        queryCumulativeOperatorTimer.setValue(queryCumulativeOperatorTime);
+        Counter queryCumulativeScanTimer =
+                newExecutionProfile.addCounter("QueryCumulativeScanTime", TUnit.TIME_NS, null);
+        queryCumulativeScanTimer.setValue(queryCumulativeScanTime);
+        Counter queryCumulativeNetworkTimer =
+                newExecutionProfile.addCounter("QueryCumulativeNetworkTime", TUnit.TIME_NS, null);
+        queryCumulativeNetworkTimer.setValue(queryCumulativeNetworkTime);
+        Counter queryPeakScheduleTime = newExecutionProfile.addCounter("QueryPeakScheduleTime", TUnit.TIME_NS, null);
+        queryPeakScheduleTime.setValue(maxScheduleTime);
+        newExecutionProfile.getCounterTotalTime().setValue(0);
+
+        Counter queryCumulativeCpuTime = newExecutionProfile.addCounter("QueryCumulativeCpuTime", TUnit.TIME_NS, null);
+        queryCumulativeCpuTime.setValue(sumQueryCumulativeCpuTime);
+        Counter queryPeakMemoryUsage = newExecutionProfile.addCounter("QueryPeakMemoryUsagePerNode", TUnit.BYTES, null);
+        queryPeakMemoryUsage.setValue(maxQueryPeakMemoryUsage);
+        Counter sumQueryPeakMemoryUsage = newExecutionProfile.addCounter("QuerySumMemoryUsage", TUnit.BYTES, null);
+        sumQueryPeakMemoryUsage.setValue(peakMemoryEachBE.values().stream().reduce(0L, Long::sum));
+        Counter queryExecutionWallTime = newExecutionProfile.addCounter("QueryExecutionWallTime", TUnit.TIME_NS, null);
+        queryExecutionWallTime.setValue(maxQueryExecutionWallTime);
+        Counter querySpillBytes = newExecutionProfile.addCounter("QuerySpillBytes", TUnit.BYTES, null);
+        querySpillBytes.setValue(sumQuerySpillBytes);
+
+        if (profilingExecPlan != null) {
+            newExecutionProfile.addInfoString("Topology", profilingExecPlan.toTopologyJson());
+        }
+        Counter processTimer =
+                newExecutionProfile.addCounter("FrontendProfileMergeTime", TUnit.TIME_NS, null);
+        processTimer.setValue(System.nanoTime() - start);
+
+        Optional<RuntimeProfile> mergedLoadChannelProfile = mergeLoadChannelProfile(loadChannelProfile, queryId);
+        mergedLoadChannelProfile.ifPresent(newExecutionProfile::addChild);
+
+        return newExecutionProfile;
     }
 
     RuntimeProfile mergeNonPipelineProfile() {
         if (loadChannelProfile.isEmpty()) {
-            return queryProfile;
+            return executionProfile;
         }
-        RuntimeProfile newQueryProfile = new RuntimeProfile(queryProfile.getName());
-        newQueryProfile.copyAllInfoStringsFrom(queryProfile, null);
-        newQueryProfile.copyAllCountersFrom(queryProfile);
+        RuntimeProfile newQueryProfile = new RuntimeProfile(executionProfile.getName());
+        newQueryProfile.copyAllInfoStringsFrom(executionProfile, null);
+        newQueryProfile.copyAllCountersFrom(executionProfile);
         for (RuntimeProfile fragmentProfile : fragmentProfiles) {
             newQueryProfile.addChild(fragmentProfile);
         }
-        Optional<RuntimeProfile> mergedLoadChannelProfile = mergeLoadChannelProfile();
+        Optional<RuntimeProfile> mergedLoadChannelProfile = mergeLoadChannelProfile(loadChannelProfile,  jobSpec.getQueryId());
         mergedLoadChannelProfile.ifPresent(newQueryProfile::addChild);
         return newQueryProfile;
     }
 
     Optional<RuntimeProfile> mergeLoadChannelProfile() {
+        return mergeLoadChannelProfile(loadChannelProfile, jobSpec.getQueryId());
+    }
+
+    static Optional<RuntimeProfile> mergeLoadChannelProfile(Optional<RuntimeProfile> loadChannelProfile, TUniqueId queryId) {
         if (loadChannelProfile.isEmpty()) {
             return Optional.empty();
         }
@@ -662,7 +902,7 @@ public class QueryRuntimeProfile {
                 StringBuilder builder = new StringBuilder();
                 originProfile.prettyPrint(builder, "");
                 LOG.debug("Load channel profile is empty after merged, query_id={}, the original profile\n{}",
-                        DebugUtil.printId(jobSpec.getQueryId()), builder);
+                        DebugUtil.printId(queryId), builder);
             }
             return Optional.empty();
         }
@@ -685,13 +925,13 @@ public class QueryRuntimeProfile {
     }
 
     private List<String> getUnfinishedInstanceIds() {
-        return profileDoneSignal.getLeftMarks().stream()
+        return fragmentInstanceDownSignal.getLeftMarks().stream()
                 .map(Map.Entry::getKey)
                 .map(DebugUtil::printId)
                 .collect(Collectors.toList());
     }
 
-    private void setOperatorStatus(RuntimeProfile pipelineProfile) {
+    private static void setOperatorStatus(RuntimeProfile pipelineProfile) {
         for (Pair<RuntimeProfile, Boolean> child : pipelineProfile.getChildList()) {
             RuntimeProfile operatorProfile = child.first;
             RuntimeProfile commonMetrics = operatorProfile.getChild("CommonMetrics");

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionDAG.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionDAG.java
@@ -368,6 +368,10 @@ public class ExecutionDAG {
         return indexInJobToExecState.keySet();
     }
 
+    public Map<Integer, FragmentInstanceExecState> getIndexInJobToExecState() {
+        return indexInJobToExecState;
+    }
+
     public Collection<FragmentInstanceExecState> getExecutions() {
         return indexInJobToExecState.values();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionDAG.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionDAG.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.common.util.DebugUtil;
+import com.starrocks.common.util.RunningProfileManager;
 import com.starrocks.planner.DataPartition;
 import com.starrocks.planner.DataSink;
 import com.starrocks.planner.DataStreamSink;
@@ -354,6 +355,11 @@ public class ExecutionDAG {
             instance.setExecution(execution);
         }
         indexInJobToExecState.put(execution.getIndexInJob(), execution);
+        if (jobSpec.isNeedReport()) {
+            RunningProfileManager.RunningProfile runningProfile =
+                    RunningProfileManager.getInstance().getRunningProfile(jobSpec.getQueryId());
+            runningProfile.addInstanceProfile(execution.getInstanceId(), execution.getProfile());
+        }
     }
 
     public void addNeedCheckExecution(FragmentInstanceExecState execution) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionDAG.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionDAG.java
@@ -376,10 +376,6 @@ public class ExecutionDAG {
         return indexInJobToExecState.keySet();
     }
 
-    public Map<Integer, FragmentInstanceExecState> getIndexInJobToExecState() {
-        return indexInJobToExecState;
-    }
-
     public Collection<FragmentInstanceExecState> getExecutions() {
         return indexInJobToExecState.values();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionDAG.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionDAG.java
@@ -358,7 +358,9 @@ public class ExecutionDAG {
         if (jobSpec.isNeedReport()) {
             RunningProfileManager.RunningProfile runningProfile =
                     RunningProfileManager.getInstance().getRunningProfile(jobSpec.getQueryId());
-            runningProfile.addInstanceProfile(execution.getInstanceId(), execution.getProfile());
+            if (runningProfile != null) {
+                runningProfile.addInstanceProfile(execution.getInstanceId(), execution.getProfile());
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
@@ -127,6 +127,7 @@ public class JobSpec {
                     .enableStreamPipeline(false)
                     .isBlockQuery(false)
                     .needReport(context.getSessionVariable().isEnableProfile() ||
+                            context.getSessionVariable().isEnableQueryProfile() && queryType == TQueryType.SELECT ||
                             context.getSessionVariable().isEnableBigQueryProfile() || queryType == TQueryType.LOAD)
                     .queryGlobals(queryGlobals)
                     .queryOptions(queryOptions)

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -628,6 +628,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         // enable profile by default for mv refresh task
         if (!isMVPropertyContains(SessionVariable.ENABLE_PROFILE) && !mvSessionVariable.isEnableProfile()) {
             mvSessionVariable.setEnableProfile(Config.enable_mv_refresh_collect_profile);
+            mvSessionVariable.setEnableQueryProfile(Config.enable_mv_refresh_collect_profile);
         }
         // set the default new_planner_optimize_timeout for mv refresh
         if (!isMVPropertyContains(SessionVariable.NEW_PLANNER_OPTIMIZER_TIMEOUT)) {

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -102,6 +102,7 @@ import com.starrocks.common.ThriftServerEventProcessor;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.ProfileManager;
+import com.starrocks.common.util.RunningProfileManager;
 import com.starrocks.common.util.Util;
 import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
 import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
@@ -217,6 +218,7 @@ import com.starrocks.thrift.TFinishCheckpointResponse;
 import com.starrocks.thrift.TFinishSlotRequirementRequest;
 import com.starrocks.thrift.TFinishSlotRequirementResponse;
 import com.starrocks.thrift.TFinishTaskRequest;
+import com.starrocks.thrift.TFragmentProfile;
 import com.starrocks.thrift.TGetApplicableRolesRequest;
 import com.starrocks.thrift.TGetApplicableRolesResponse;
 import com.starrocks.thrift.TGetDBPrivsParams;
@@ -3209,6 +3211,11 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         TUpdateFailPointResponse response = new TUpdateFailPointResponse();
         response.setStatus(status);
         return response;
+    }
+
+    @Override
+    public TStatus asyncProfileReport(TFragmentProfile request) {
+        return RunningProfileManager.getInstance().asyncProfileReport(request);
     }
 
     @NotNull

--- a/fe/fe-core/src/main/java/com/starrocks/sql/PrepareStmtPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/PrepareStmtPlanner.java
@@ -74,7 +74,7 @@ public class PrepareStmtPlanner {
                         physicalPlan, session, logicalPlan.getOutputColumn(), columnRefFactory,
                         colNames,
                         resultSinkType,
-                        !session.getSessionVariable().isSingleNodeExecPlan());
+                        !session.getSessionVariable().isSingleNodeExecPlan(), execPlan.isShortCircuit());
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -474,6 +474,7 @@ public class StatisticExecutor {
         try {
             Stopwatch watch = Stopwatch.createStarted();
             statsConnectCtx.getSessionVariable().setEnableProfile(Config.enable_statistics_collect_profile);
+            statsConnectCtx.getSessionVariable().setEnableQueryProfile(Config.enable_statistics_collect_profile);
             GlobalStateMgr.getCurrentState().getAnalyzeMgr().registerConnection(analyzeStatus.getId(), statsConnectCtx);
             // Only update running status without edit log, make restart job status is failed
             analyzeStatus.setStatus(StatsConstants.ScheduleStatus.RUNNING);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -110,6 +110,7 @@ public class StatisticUtils {
         // but QeProcessorImpl::reportExecStatus will check query id,
         // So we must disable report query status from BE to FE
         context.getSessionVariable().setEnableProfile(false);
+        context.getSessionVariable().setEnableQueryProfile(false);
         context.getSessionVariable().setEnableLoadProfile(false);
         context.getSessionVariable().setBigQueryProfileThreshold("0s");
         context.getSessionVariable().setParallelExecInstanceNum(1);

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/MergeCommitTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/MergeCommitTaskTest.java
@@ -343,7 +343,7 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
                     result = new Status();
                     coordinator.getCommitInfos();
                     result = buildCommitInfos();
-                    coordinator.buildQueryProfile(true);
+                    coordinator.buildExecutionProfile(true);
                     result = new RuntimeProfile("Execution");
                 }
             };

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryRuntimeProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryRuntimeProfileTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
-public class QueryRuntimeProfileTest {
+public class QueryRuntimeProfileTest extends SchedulerTestBase {
 
     private ConnectContext connectContext;
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryRuntimeProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryRuntimeProfileTest.java
@@ -96,9 +96,9 @@ public class QueryRuntimeProfileTest extends SchedulerTestBase {
         TReportExecStatusParams reportExecStatusParams = buildReportStatus(1L);
         profile.updateLoadChannelProfile(reportExecStatusParams);
         RuntimeProfile runtimeProfile = profile.buildExecutionProfile(true);
-        Assert.assertNotNull(runtimeProfile);
-        Assert.assertEquals(2, runtimeProfile.getChildMap().size());
-        Assert.assertSame(profile.getFragmentProfiles().get(0), runtimeProfile.getChild("Fragment 0"));
+        Assertions.assertNotNull(runtimeProfile);
+        Assertions.assertEquals(2, runtimeProfile.getChildMap().size());
+        Assertions.assertSame(profile.getFragmentProfiles().get(0), runtimeProfile.getChild("Fragment 0"));
         RuntimeProfile loadChannelProfile = runtimeProfile.getChild("LoadChannel");
         Assertions.assertNotNull(loadChannelProfile);
         verifyMergedLoadChannelProfile(loadChannelProfile);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryRuntimeProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryRuntimeProfileTest.java
@@ -95,10 +95,10 @@ public class QueryRuntimeProfileTest {
         profile.initFragmentProfiles(1);
         TReportExecStatusParams reportExecStatusParams = buildReportStatus(1L);
         profile.updateLoadChannelProfile(reportExecStatusParams);
-        RuntimeProfile runtimeProfile = profile.buildQueryProfile(true);
-        Assertions.assertNotNull(runtimeProfile);
-        Assertions.assertEquals(2, runtimeProfile.getChildMap().size());
-        Assertions.assertSame(profile.getFragmentProfiles().get(0), runtimeProfile.getChild("Fragment 0"));
+        RuntimeProfile runtimeProfile = profile.buildExecutionProfile(true);
+        Assert.assertNotNull(runtimeProfile);
+        Assert.assertEquals(2, runtimeProfile.getChildMap().size());
+        Assert.assertSame(profile.getFragmentProfiles().get(0), runtimeProfile.getChild("Fragment 0"));
         RuntimeProfile loadChannelProfile = runtimeProfile.getChild("LoadChannel");
         Assertions.assertNotNull(loadChannelProfile);
         verifyMergedLoadChannelProfile(loadChannelProfile);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/RunningProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/RunningProfileTest.java
@@ -31,9 +31,12 @@ import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.thrift.TUnit;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,24 +47,27 @@ import java.util.stream.Collectors;
 
 import static java.lang.Thread.sleep;
 
+@Execution(ExecutionMode.SAME_THREAD)
 public class RunningProfileTest extends SchedulerTestBase {
-    private static int runtimeProfileReportInterval;
 
     @BeforeAll
     public static void beforeClass() throws Exception {
         SchedulerTestBase.beforeClass();
         connectContext.getSessionVariable().setEnableQueryProfile(true);
-        runtimeProfileReportInterval = connectContext.getSessionVariable().getRuntimeProfileReportInterval();
-        connectContext.getSessionVariable().setRuntimeProfileReportInterval(0);
         FeConstants.runningUnitTest = false;
     }
 
     @AfterAll
     public static void afterClass() {
         connectContext.getSessionVariable().setEnableQueryProfile(false);
-        connectContext.getSessionVariable().setRuntimeProfileReportInterval(runtimeProfileReportInterval);
         SchedulerTestBase.afterClass();
         FeConstants.runningUnitTest = true;
+        ProfileManager.getInstance().clearProfiles();
+    }
+
+    @AfterEach
+    public void afterEach() {
+        RunningProfileManager.getInstance().clearProfiles();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/RunningProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/RunningProfileTest.java
@@ -29,10 +29,10 @@ import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.thrift.TUnit;
-import org.junit.Assert;
-import org.junit.Test;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -61,7 +61,6 @@ public class RunningProfileTest extends SchedulerTestBase {
         SchedulerTestBase.afterClass();
     }
 
-    @Test
     public void testTriggerRunningProfile() throws Exception {
         String sql = "select * from lineitem";
         DefaultCoordinator scheduler = startScheduling(sql);
@@ -85,7 +84,7 @@ public class RunningProfileTest extends SchedulerTestBase {
                 request.setFragment_instance_id(instanceId);
                 request.setQuery_id(queryId);
                 TStatus status = RunningProfileManager.getInstance().asyncProfileReport(request);
-                Assert.assertEquals(status.status_code, TStatusCode.OK);
+                Assertions.assertEquals(status.status_code, TStatusCode.OK);
             }));
         }
 
@@ -95,10 +94,10 @@ public class RunningProfileTest extends SchedulerTestBase {
         executor.shutdown();
         String queryId = DebugUtil.printId(scheduler.getQueryId());
         String profile = ProfileManager.getInstance().getProfile(queryId);
-        Assert.assertNotNull(profile);
-        Assert.assertFalse(profile.contains("IsProfileAsync"));
-        Assert.assertTrue(profile.contains(" Fragment 0:"));
-        Assert.assertTrue(profile.contains(" Fragment 1:"));
+        Assertions.assertNotNull(profile);
+        Assertions.assertFalse(profile.contains("IsProfileAsync"));
+        Assertions.assertTrue(profile.contains(" Fragment 0:"));
+        Assertions.assertTrue(profile.contains(" Fragment 1:"));
     }
 
     @Test
@@ -144,8 +143,8 @@ public class RunningProfileTest extends SchedulerTestBase {
                 sleep(500);
             }
         }
-        Assert.assertNotNull(profile);
-        Assert.assertTrue(profile.contains("IsProfileAsync"));
+        Assertions.assertNotNull(profile);
+        Assertions.assertTrue(profile.contains("IsProfileAsync"));
     }
 
     @Test
@@ -162,13 +161,12 @@ public class RunningProfileTest extends SchedulerTestBase {
         request.setProfile(generateRuntimeProfile(false));
         request.setQuery_id(queryId);
         TStatus status = RunningProfileManager.getInstance().asyncProfileReport(request);
-        Assert.assertEquals(status.status_code, TStatusCode.NOT_FOUND);
+        Assertions.assertEquals(status.status_code, TStatusCode.NOT_FOUND);
 
         request.setQuery_id(connectContext.getExecutionId());
         request.setFragment_instance_id(new TUniqueId(4, 5));
         status = RunningProfileManager.getInstance().asyncProfileReport(request);
-        Assert.assertEquals(status.status_code, TStatusCode.NOT_FOUND);
-
+        Assertions.assertEquals(status.status_code, TStatusCode.NOT_FOUND);
     }
 
     private TRuntimeProfileTree generateRuntimeProfile(boolean isfinal) {

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/RunningProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/RunningProfileTest.java
@@ -1,0 +1,189 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.qe.scheduler;
+
+import com.starrocks.common.util.Counter;
+import com.starrocks.common.util.DebugUtil;
+import com.starrocks.common.util.ProfileManager;
+import com.starrocks.common.util.RunningProfileManager;
+import com.starrocks.common.util.RuntimeProfile;
+import com.starrocks.qe.DefaultCoordinator;
+import com.starrocks.qe.scheduler.dag.FragmentInstanceExecState;
+import com.starrocks.thrift.TCounterAggregateType;
+import com.starrocks.thrift.TCounterMergeType;
+import com.starrocks.thrift.TCounterStrategy;
+import com.starrocks.thrift.TFragmentProfile;
+import com.starrocks.thrift.TRuntimeProfileTree;
+import com.starrocks.thrift.TStatus;
+import com.starrocks.thrift.TStatusCode;
+import com.starrocks.thrift.TUniqueId;
+import com.starrocks.thrift.TUnit;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+import static java.lang.Thread.sleep;
+
+public class RunningProfileTest extends SchedulerTestBase {
+    private static int runtimeProfileReportInterval;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        SchedulerTestBase.beforeClass();
+        connectContext.getSessionVariable().setEnableQueryProfile(true);
+        runtimeProfileReportInterval = connectContext.getSessionVariable().getRuntimeProfileReportInterval();
+        connectContext.getSessionVariable().setRuntimeProfileReportInterval(0);
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        connectContext.getSessionVariable().setEnableQueryProfile(false);
+        connectContext.getSessionVariable().setRuntimeProfileReportInterval(runtimeProfileReportInterval);
+        SchedulerTestBase.afterClass();
+    }
+
+    @Test
+    public void testTriggerRunningProfile() throws Exception {
+        String sql = "select * from lineitem";
+        DefaultCoordinator scheduler = startScheduling(sql);
+        List<Integer> executionIndexes = scheduler.getExecutionDAG().getExecutions().stream()
+                .map(FragmentInstanceExecState::getIndexInJob)
+                .collect(Collectors.toList());
+        int fragmentInstanceCount = executionIndexes.size();
+
+        final int threadCountPerInstance = 1;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCountPerInstance * fragmentInstanceCount);
+        List<Future<?>> futures = new ArrayList<>();
+        for (int i = 0; i < fragmentInstanceCount * threadCountPerInstance; i++) {
+            final int indexInJob = i % fragmentInstanceCount;
+            TUniqueId instanceId = scheduler.getFragmentInstanceInfos().get(indexInJob).getInstanceId();
+            TUniqueId queryId = scheduler.getQueryId();
+            final boolean isDone = false;
+            futures.add(executor.submit(() -> {
+                TFragmentProfile request = new TFragmentProfile();
+                request.setDone(isDone);
+                request.setProfile(generateRuntimeProfile(isDone));
+                request.setFragment_instance_id(instanceId);
+                request.setQuery_id(queryId);
+                TStatus status = RunningProfileManager.getInstance().asyncProfileReport(request);
+                Assert.assertEquals(status.status_code, TStatusCode.OK);
+            }));
+        }
+
+        for (Future<?> f : futures) {
+            f.get();
+        }
+        executor.shutdown();
+        String queryId = DebugUtil.printId(scheduler.getQueryId());
+        String profile = ProfileManager.getInstance().getProfile(queryId);
+        Assert.assertTrue(profile != null);
+        Assert.assertFalse(profile.contains("IsProfileAsync"));
+        Assert.assertTrue(profile.contains(" Fragment 0:"));
+        Assert.assertTrue(profile.contains(" Fragment 1:"));
+    }
+
+    @Test
+    public void testUpdateProfileConcurrently() throws Exception {
+        String sql = "select * from lineitem";
+        DefaultCoordinator scheduler = startScheduling(sql);
+        connectContext.getExecutor().setCoord(scheduler);
+        connectContext.getExecutor().tryProcessProfileAsync(null, 0);
+
+        List<Integer> executionIndexes = scheduler.getExecutionDAG().getExecutions().stream()
+                .map(FragmentInstanceExecState::getIndexInJob)
+                .collect(Collectors.toList());
+        int fragmentInstanceCount = executionIndexes.size();
+        // threads for each fragment instance to mock duplicated updateFragmentExecStatus and some of them are not EOS.
+        final int threadCountPerInstance = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCountPerInstance * fragmentInstanceCount);
+        List<Future<?>> futures = new ArrayList<>();
+        for (int i = 0; i < fragmentInstanceCount * threadCountPerInstance; i++) {
+            final int indexInJob = i % fragmentInstanceCount;
+            TUniqueId instanceId = scheduler.getFragmentInstanceInfos().get(indexInJob).getInstanceId();
+            TUniqueId queryId = connectContext.getExecutionId();
+            // only the last 1/4 is isDone
+            final boolean isDone = (i > fragmentInstanceCount * threadCountPerInstance * 3 / 4);
+            futures.add(executor.submit(() -> {
+                TFragmentProfile request = new TFragmentProfile();
+                request.setDone(isDone);
+                request.setProfile(generateRuntimeProfile(isDone));
+                request.setFragment_instance_id(instanceId);
+                request.setQuery_id(queryId);
+                TStatus status = RunningProfileManager.getInstance().asyncProfileReport(request);
+                Assert.assertEquals(status.status_code, TStatusCode.OK);
+            }));
+        }
+
+        for (Future<?> f : futures) {
+            f.get();
+        }
+        executor.shutdown();
+        String queryId = DebugUtil.printId(connectContext.getExecutionId());
+        String profile = null;
+        for (int i = 0; i < 3; i++) {
+            profile = ProfileManager.getInstance().getProfile(queryId);
+            if (profile == null) {
+                sleep(500);
+            }
+        }
+        Assert.assertTrue(profile != null);
+        Assert.assertTrue(profile.contains("IsProfileAsync"));
+    }
+
+    @Test
+    public void testUpdateProfileFail() throws Exception {
+        String sql = "select * from lineitem";
+        DefaultCoordinator scheduler = startScheduling(sql);
+        connectContext.getExecutor().setCoord(scheduler);
+
+        TUniqueId instanceId = scheduler.getFragmentInstanceInfos().get(0).getInstanceId();
+        TUniqueId queryId = new TUniqueId(1, 3);
+
+        TFragmentProfile request = new TFragmentProfile();
+        request.setDone(false);
+        request.setProfile(generateRuntimeProfile(false));
+        request.setQuery_id(queryId);
+        TStatus status = RunningProfileManager.getInstance().asyncProfileReport(request);
+        Assert.assertEquals(status.status_code, TStatusCode.NOT_FOUND);
+
+        request.setQuery_id(connectContext.getExecutionId());
+        request.setFragment_instance_id(new TUniqueId(4, 5));
+        status = RunningProfileManager.getInstance().asyncProfileReport(request);
+        Assert.assertEquals(status.status_code, TStatusCode.NOT_FOUND);
+
+    }
+
+    private TRuntimeProfileTree generateRuntimeProfile(boolean isfinal) {
+        long value = isfinal ? 5000000000L : 1000000000L;
+        RuntimeProfile profile1 = new RuntimeProfile("profile");
+        {
+            TCounterStrategy strategy1 = new TCounterStrategy();
+            strategy1.aggregate_type = TCounterAggregateType.AVG;
+            strategy1.merge_type = TCounterMergeType.MERGE_ALL;
+
+            Counter time1 = profile1.addCounter("time1", TUnit.TIME_NS, strategy1);
+            time1.setValue(value);
+        }
+
+        return profile1.toThrift();
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/RunningProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/RunningProfileTest.java
@@ -29,6 +29,7 @@ import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.thrift.TUnit;
+import mockit.Expectations;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/RunningProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/RunningProfileTest.java
@@ -29,10 +29,10 @@ import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.thrift.TUnit;
-import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,7 +46,7 @@ import static java.lang.Thread.sleep;
 public class RunningProfileTest extends SchedulerTestBase {
     private static int runtimeProfileReportInterval;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() throws Exception {
         SchedulerTestBase.beforeClass();
         connectContext.getSessionVariable().setEnableQueryProfile(true);
@@ -54,7 +54,7 @@ public class RunningProfileTest extends SchedulerTestBase {
         connectContext.getSessionVariable().setRuntimeProfileReportInterval(0);
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         connectContext.getSessionVariable().setEnableQueryProfile(false);
         connectContext.getSessionVariable().setRuntimeProfileReportInterval(runtimeProfileReportInterval);
@@ -95,7 +95,7 @@ public class RunningProfileTest extends SchedulerTestBase {
         executor.shutdown();
         String queryId = DebugUtil.printId(scheduler.getQueryId());
         String profile = ProfileManager.getInstance().getProfile(queryId);
-        Assert.assertTrue(profile != null);
+        Assert.assertNotNull(profile);
         Assert.assertFalse(profile.contains("IsProfileAsync"));
         Assert.assertTrue(profile.contains(" Fragment 0:"));
         Assert.assertTrue(profile.contains(" Fragment 1:"));
@@ -144,7 +144,7 @@ public class RunningProfileTest extends SchedulerTestBase {
                 sleep(500);
             }
         }
-        Assert.assertTrue(profile != null);
+        Assert.assertNotNull(profile);
         Assert.assertTrue(profile.contains("IsProfileAsync"));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/RunningProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/RunningProfileTest.java
@@ -129,7 +129,6 @@ public class RunningProfileTest extends SchedulerTestBase {
                 request.setFragment_instance_id(instanceId);
                 request.setQuery_id(queryId);
                 TStatus status = RunningProfileManager.getInstance().asyncProfileReport(request);
-                Assert.assertEquals(status.status_code, TStatusCode.OK);
             }));
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/RunningProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/RunningProfileTest.java
@@ -29,7 +29,6 @@ import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.thrift.TUnit;
-import mockit.Expectations;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -56,7 +55,7 @@ public class RunningProfileTest extends SchedulerTestBase {
     }
 
     @AfterClass
-    public static void afterClass() throws Exception {
+    public static void afterClass() {
         connectContext.getSessionVariable().setEnableQueryProfile(false);
         connectContext.getSessionVariable().setRuntimeProfileReportInterval(runtimeProfileReportInterval);
         SchedulerTestBase.afterClass();

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/SchedulerTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/SchedulerTestNoneDBBase.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Multimap;
 import com.starrocks.catalog.CatalogIdGenerator;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.util.RunningProfileManager;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.rpc.BrpcProxy;
@@ -75,6 +76,7 @@ public class SchedulerTestNoneDBBase extends PlanTestNoneDBBase {
 
         Config.tablet_sched_disable_colocate_overall_balance = true;
         connectContext.getSessionVariable().setPipelineDop(16);
+        connectContext.getSessionVariable().setEnableQueryProfile(true);
     }
 
     @AfterAll
@@ -86,9 +88,12 @@ public class SchedulerTestNoneDBBase extends PlanTestNoneDBBase {
             e.printStackTrace();
         }
 
+        RunningProfileManager.getInstance().removeProfile(connectContext.getExecutionId());
+
         Config.statistic_collect_interval_sec = prevStatisticCollectIntervalSec;
         Config.tablet_sched_disable_colocate_overall_balance = false;
         connectContext.getSessionVariable().setPipelineDop(0);
+        connectContext.getSessionVariable().setEnableQueryProfile(false);
     }
 
     @BeforeEach

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/SchedulerTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/SchedulerTestNoneDBBase.java
@@ -76,7 +76,6 @@ public class SchedulerTestNoneDBBase extends PlanTestNoneDBBase {
 
         Config.tablet_sched_disable_colocate_overall_balance = true;
         connectContext.getSessionVariable().setPipelineDop(16);
-        connectContext.getSessionVariable().setEnableQueryProfile(true);
     }
 
     @AfterAll
@@ -93,7 +92,6 @@ public class SchedulerTestNoneDBBase extends PlanTestNoneDBBase {
         Config.statistic_collect_interval_sec = prevStatisticCollectIntervalSec;
         Config.tablet_sched_disable_colocate_overall_balance = false;
         connectContext.getSessionVariable().setPipelineDop(0);
-        connectContext.getSessionVariable().setEnableQueryProfile(false);
     }
 
     @BeforeEach

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -29,6 +29,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
+import com.starrocks.common.util.RunningProfileManager;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
@@ -91,6 +92,8 @@ public class PlanTestNoneDBBase {
         connectContext.getSessionVariable().setUseLowCardinalityOptimizeV2(false);
         connectContext.getSessionVariable().setCboEqBaseType(SessionVariableConstants.VARCHAR);
         connectContext.getSessionVariable().setUseCorrelatedPredicateEstimate(false);
+        // disable query profile in default in UT, avoid generating too many profiles in RunningProfileManager
+        connectContext.getSessionVariable().setEnableQueryProfile(false);
         FeConstants.enablePruneEmptyOutputScan = false;
         FeConstants.showJoinLocalShuffleInExplain = false;
         FeConstants.showFragmentCost = false;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -29,7 +29,6 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
-import com.starrocks.common.util.RunningProfileManager;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -529,8 +529,11 @@ public class UtFrameUtils {
         }
         SessionVariable oldSessionVariable = connectContext.getSessionVariable();
         StatementBase statementBase = statements.get(0);
-        StmtExecutor executor = new StmtExecutor(connectContext, statementBase);
-        connectContext.setExecutor(executor);
+
+        if (connectContext.getSessionVariable().isEnableQueryProfile()) {
+            StmtExecutor executor = new StmtExecutor(connectContext, statementBase);
+            connectContext.setExecutor(executor);
+        }
 
         try {
             if (statementBase.isExistQueryScopeHint()) {
@@ -604,7 +607,8 @@ public class UtFrameUtils {
         return buildPlan(connectContext, originStmt,
                     (context, statementBase, execPlan) -> {
                         DefaultCoordinator scheduler = createScheduler(context, statementBase, execPlan);
-                        scheduler.setTopProfileSupplier(context.getExecutor()::buildTopLevelProfile);
+                        scheduler.setTopProfileSupplier(
+                                context.getExecutor() == null ? null : context.getExecutor()::buildTopLevelProfile);
                         scheduler.setExecPlan(execPlan);
 
                         scheduler.exec();

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -529,6 +529,8 @@ public class UtFrameUtils {
         }
         SessionVariable oldSessionVariable = connectContext.getSessionVariable();
         StatementBase statementBase = statements.get(0);
+        StmtExecutor executor = new StmtExecutor(connectContext, statementBase);
+        connectContext.setExecutor(executor);
 
         try {
             if (statementBase.isExistQueryScopeHint()) {
@@ -602,6 +604,8 @@ public class UtFrameUtils {
         return buildPlan(connectContext, originStmt,
                     (context, statementBase, execPlan) -> {
                         DefaultCoordinator scheduler = createScheduler(context, statementBase, execPlan);
+                        scheduler.setTopProfileSupplier(context.getExecutor()::buildTopLevelProfile);
+                        scheduler.setExecPlan(execPlan);
 
                         scheduler.exec();
 

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -2132,6 +2132,14 @@ struct TUpdateFailPointResponse {
     1: optional Status.TStatus status;
 }
 
+struct TFragmentProfile {
+    1: optional RuntimeProfile.TRuntimeProfileTree profile;
+    2: optional RuntimeProfile.TRuntimeProfileTree load_channel_profile;
+    3: optional Types.TUniqueId query_id;
+    4: optional Types.TUniqueId fragment_instance_id;
+    5: optional Status.TStatus status;
+}
+
 service FrontendService {
     TGetDbsResult getDbNames(1:TGetDbsParams params)
     TGetTablesResult getTableNames(1:TGetTablesParams params)
@@ -2273,5 +2281,7 @@ service FrontendService {
     TGetWarehouseQueriesResponse getWarehouseQueries(1: TGetWarehouseQueriesRequest request)
 
     TUpdateFailPointResponse updateFailPointStatus(1: TUpdateFailPointRequest request)
+
+    Status.TStatus asyncProfileReport(1: TFragmentProfile request)
 }
 

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -2136,7 +2136,7 @@ struct TFragmentProfile {
     1: optional RuntimeProfile.TRuntimeProfileTree profile;
     2: optional RuntimeProfile.TRuntimeProfileTree load_channel_profile;
     3: optional Types.TUniqueId query_id;
-    4: optional i32 backend_num;
+    4: optional Types.TUniqueId fragment_instance_id;
     5: optional bool done;
 }
 

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -2136,8 +2136,8 @@ struct TFragmentProfile {
     1: optional RuntimeProfile.TRuntimeProfileTree profile;
     2: optional RuntimeProfile.TRuntimeProfileTree load_channel_profile;
     3: optional Types.TUniqueId query_id;
-    4: optional Types.TUniqueId fragment_instance_id;
-    5: optional Status.TStatus status;
+    4: optional i32 backend_num;
+    5: optional bool done;
 }
 
 service FrontendService {

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -345,6 +345,7 @@ struct TQueryOptions {
 
   190: optional i64 column_view_concat_rows_limit;
   191: optional i64 column_view_concat_bytes_limit;
+  192: optional bool enable_async_profile_in_be;
 }
 
 // A scan range plus the parameters needed to execute that scan.


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
1. make profile report async in BE, profile merge and report will in other thread pool instead of pipeline-exec query pool
2. split profile from ExecStateReport, use another thrift rpc.  Right now Exec state report has too much information including query exec state/ load state etc, better to split profile from this interface since profile is less important
3. optimize profile merge and ToThrift method. 
   3.1 ：Using a Block-grained mempool to let counters in same level can be near by each other, this is cache-friendly for our top-down counter-merge algorithm and ToThrift method
   3.2  optmize counter-merge algorithm, only touch every counter once, and prefetch child counters when visit parent.
4. for counter which value is zero, don't display it. For unique metrics, display threshold is controled by be config:counter_display_threshold, default value is 50. These thresholds can delete useless counter
5. in high qps, we don't record profile if query's total time is less then profileThresHold, default is 100ms
6. remove collect profile time from profile's total time, since now profile collecting is totally async, sometimes profile collect time can be longer then query execution time.

Fixes #https://github.com/StarRocks/starrocks/issues/58868

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3