### PR TITLE
[Enhancement] support bundle file deletion for deleteTablets

### DIFF
--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -676,6 +676,110 @@ void vacuum_full(TabletManager* tablet_mgr, const VacuumFullRequest& request, Va
     st.to_protobuf(response->mutable_status());
 }
 
+// The state of the bundle tablet meta, used to determine whether the bundle file can be deleted.
+// ALL_TABLETS_TO_BE_DELETED means all tablets in this bundle tablet meta are going to be deleted,
+// SOME_TABLETS_NOT_TO_BE_DELETED means some tablets in this bundle tablet meta aren't going to be deleted,
+// NO_TABLETS_TO_BE_DELETED means no tablets in this bundle tablet meta are going to be deleted,
+// NOT_BUNDLE_TABLET_META means this tablet meta is not the bundle tablet meta.
+enum class BundleTabletMetaState {
+    ALL_TABLETS_TO_BE_DELETED = 0,
+    SOME_TABLETS_NOT_TO_BE_DELETED = 1,
+    NO_TABLETS_TO_BE_DELETED = 2,
+    NOT_BUNDLE_TABLET_META = 3,
+};
+
+static bool can_bundle_data_file_to_be_deleted(const BundleTabletMetaState& state) {
+    // if there are some tablets in this bundle meta that are not to be deleted,
+    // we can not delete the bundle file.
+    return state == BundleTabletMetaState::ALL_TABLETS_TO_BE_DELETED;
+}
+
+static StatusOr<BundleTabletMetaState> bundle_tablet_meta_checker(const std::string& meta_path,
+                                                                  const std::vector<int64_t>& to_delete_tablet_ids) {
+    RandomAccessFileOptions opts{.skip_fill_local_cache = true};
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(meta_path));
+    ASSIGN_OR_RETURN(auto input_file, fs->new_random_access_file(opts, meta_path));
+    ASSIGN_OR_RETURN(auto serialized_string, input_file->read_all());
+
+    auto file_size = serialized_string.size();
+    auto footer_size = sizeof(uint64_t);
+    auto shared_metadata_size = decode_fixed64_le((uint8_t*)(serialized_string.data() + file_size - footer_size));
+    if (file_size < footer_size + shared_metadata_size) {
+        return Status::Corruption(
+                strings::Substitute("deserialized shared metadata($0) failed, file_size($1) < shared_metadata_size($2)",
+                                    meta_path, file_size, shared_metadata_size + footer_size));
+    }
+
+    auto shared_metadata = std::make_shared<SharedTabletMetadataPB>();
+    std::string_view shared_metadata_str =
+            std::string_view(serialized_string.data() + file_size - footer_size - shared_metadata_size);
+    if (!shared_metadata->ParseFromArray(shared_metadata_str.data(), shared_metadata_size)) {
+        return Status::Corruption(strings::Substitute("deserialized shared metadata failed"));
+    }
+    bool shared_meta_contains_deleted_tablet = false;
+    bool shared_meta_contains_alive_tablet = false;
+    // Check if the shared metadata contains tablets that are not to be deleted.
+    std::unordered_set<int64_t> to_delete_tablet_ids_set(to_delete_tablet_ids.begin(), to_delete_tablet_ids.end());
+    for (const auto& tablet_id : shared_metadata->tablet_meta_pages()) {
+        if (to_delete_tablet_ids_set.find(tablet_id.first) == to_delete_tablet_ids_set.end()) {
+            shared_meta_contains_alive_tablet = true;
+        } else {
+            shared_meta_contains_deleted_tablet = true;
+        }
+    }
+    // Determine the state of the bundle tablet meta based on the presence of deleted and alive tablets.
+    if (shared_meta_contains_deleted_tablet && shared_meta_contains_alive_tablet) {
+        // Some tablets in this bundle meta are not to be deleted,
+        return BundleTabletMetaState::SOME_TABLETS_NOT_TO_BE_DELETED;
+    } else if (shared_meta_contains_deleted_tablet) {
+        // All tablets in this bundle meta are going to be deleted,
+        return BundleTabletMetaState::ALL_TABLETS_TO_BE_DELETED;
+    } else {
+        // No tablets in this bundle meta are going to be deleted,
+        return BundleTabletMetaState::NO_TABLETS_TO_BE_DELETED;
+    }
+}
+
+static Status delete_files_under_txnlog(const std::string& data_dir, const TxnLogPB& log, bool contains_alive_tablets,
+                                        bool is_combined_log, AsyncFileDeleter& deleter) {
+    if (log.has_op_write()) {
+        const auto& op = log.op_write();
+        // Check if the rowset is bundled and if it's safe to delete
+        // We can delete segments if either:
+        // 1. This rowset doesn't use bundle files (bundle_file_offsets_size == 0), or
+        // 2. This is a combined log and all tablets in the combined log are being deleted
+        //
+        // We do not allow delete bundle segment file under not combined log, because the bundle file may be shared by
+        // multiple tablets, and we can't determine whether the bundle file is shared by other alive tablets.
+        // This case can only happen when alter table and set bundle_file = false.
+        if (op.rowset().bundle_file_offsets_size() == 0 || (is_combined_log && !contains_alive_tablets)) {
+            // Iterate through all segments in the rowset and delete them
+            for (const auto& segment : op.rowset().segments()) {
+                RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, segment)));
+            }
+        }
+        // delete delvec files
+        for (const auto& f : op.dels()) {
+            RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, f)));
+        }
+    }
+    if (log.has_op_compaction()) {
+        const auto& op = log.op_compaction();
+        for (const auto& segment : op.output_rowset().segments()) {
+            RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, segment)));
+        }
+    }
+    if (log.has_op_schema_change()) {
+        const auto& op = log.op_schema_change();
+        for (const auto& rowset : op.rowsets()) {
+            for (const auto& segment : rowset.segments()) {
+                RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, segment)));
+            }
+        }
+    }
+    return Status::OK();
+}
+
 // TODO: remote list objects requests
 Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_dir,
                            const std::vector<int64_t>& tablet_ids) {
@@ -684,15 +788,17 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
 
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root_dir));
 
-    std::unordered_map<int64_t, std::set<int64_t>> tablet_versions;
+    std::unordered_set<int64_t> bundle_tablet_versions;
+    std::unordered_map<int64_t, std::map<int64_t, BundleTabletMetaState>> tablet_versions;
     //                 ^^^^^^^ tablet id
-    //                                  ^^^^^^^^^ version number
+    //                                  ^^^^^^^^^ version number -> state of this tablet meta
 
     auto meta_dir = join_path(root_dir, kMetadataDirectoryName);
     auto data_dir = join_path(root_dir, kSegmentDirectoryName);
     auto log_dir = join_path(root_dir, kTxnLogDirectoryName);
 
     std::set<std::string> txn_logs;
+    std::set<std::string> combine_txn_logs;
     RETURN_IF_ERROR(ignore_not_found(fs->iterate_dir(log_dir, [&](std::string_view name) {
         if (is_txn_log(name)) {
             auto [tablet_id, txn_id] = parse_txn_log_filename(name);
@@ -709,6 +815,10 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
             if (!std::binary_search(tablet_ids.begin(), tablet_ids.end(), tablet_id)) {
                 return true;
             }
+        } else if (is_combined_txn_log(name)) {
+            // should be deleted
+            combine_txn_logs.emplace(name);
+            return true;
         } else {
             return true;
         }
@@ -720,6 +830,9 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
     })));
 
     AsyncFileDeleter deleter(config::lake_vacuum_min_batch_delete_size);
+    // Used to avoid deleting bundle files that are shared by multiple tablets.
+    AsyncBundleFileDeleter dummy_bundle_file_deleter(config::lake_vacuum_min_batch_delete_size);
+
     for (const auto& log_name : txn_logs) {
         auto res = tablet_mgr->get_txn_log(join_path(log_dir, log_name), false);
         if (res.status().is_not_found()) {
@@ -727,31 +840,39 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
         } else if (!res.ok()) {
             return res.status();
         } else {
-            auto log = std::move(res).value();
-            if (log->has_op_write()) {
-                const auto& op = log->op_write();
-                for (const auto& segment : op.rowset().segments()) {
-                    RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, segment)));
-                }
-                for (const auto& f : op.dels()) {
-                    RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, f)));
-                }
-            }
-            if (log->has_op_compaction()) {
-                const auto& op = log->op_compaction();
-                for (const auto& segment : op.output_rowset().segments()) {
-                    RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, segment)));
-                }
-            }
-            if (log->has_op_schema_change()) {
-                const auto& op = log->op_schema_change();
-                for (const auto& rowset : op.rowsets()) {
-                    for (const auto& segment : rowset.segments()) {
-                        RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, segment)));
-                    }
-                }
-            }
+            auto log_ptr = std::move(res).value();
+            // delete files under txnlog
+            RETURN_IF_ERROR(delete_files_under_txnlog(data_dir, *log_ptr, false, false, deleter));
+            // delete txnlog
             RETURN_IF_ERROR(deleter.delete_file(join_path(log_dir, log_name)));
+        }
+    }
+
+    for (const auto& log_name : combine_txn_logs) {
+        auto res = tablet_mgr->get_combined_txn_log(join_path(log_dir, log_name), false);
+        if (res.status().is_not_found()) {
+            continue;
+        } else if (!res.ok()) {
+            return res.status();
+        } else {
+            auto combine_log_ptr = std::move(res).value();
+            // check whether every txn_log is contained in tablet_ids.
+            // If not, it means this combine txn log is also shared by other alive tablets.
+            bool contains_alive_tablets = false;
+            for (const auto& log : combine_log_ptr->txn_logs()) {
+                if (!std::binary_search(tablet_ids.begin(), tablet_ids.end(), log.tablet_id())) {
+                    contains_alive_tablets = true;
+                    break;
+                }
+            }
+            // delete files under txnlog
+            for (const auto& log : combine_log_ptr->txn_logs()) {
+                RETURN_IF_ERROR(delete_files_under_txnlog(data_dir, log, contains_alive_tablets, true, deleter));
+            }
+            // delete txnlog
+            if (!contains_alive_tablets) {
+                RETURN_IF_ERROR(deleter.delete_file(join_path(log_dir, log_name)));
+            }
         }
     }
 
@@ -760,21 +881,65 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
             return true;
         }
         auto [tablet_id, version] = parse_tablet_metadata_filename(name);
+        // if the tablet is the bundle tablet, we need to record the version.
+        if (tablet_id == 0) {
+            bundle_tablet_versions.insert(version);
+            return true;
+        }
+        // if the tablet is not in tablet_ids, we need to skip it.
         if (!std::binary_search(tablet_ids.begin(), tablet_ids.end(), tablet_id)) {
             return true;
         }
-        auto [_, inserted] = tablet_versions[tablet_id].insert(version);
-        LOG_IF(FATAL, !inserted) << kDuplicateFilesError << " duplicate file: " << join_path(meta_dir, name);
+        tablet_versions[tablet_id][version] = BundleTabletMetaState::NOT_BUNDLE_TABLET_META;
         return true;
     })));
 
-    for (auto& [tablet_id, versions] : tablet_versions) {
-        DCHECK(!versions.empty());
+    // For tablet meta, there are three cases:
+    // 1. This tablet meta is the bundle tablet meta, and all tablets in this bundle tablet meta are going to be deleted.
+    // 2. This tablet meta is the bundle tablet meta, and some tablets in this bundle tablet aren't going to be deleted.
+    // 3. This tablet meta is not the bundle tablet meta, and it is going to be deleted.
+    //
+    // We will check the bundle tablet meta state for each version in bundle_tablet_versions.
+    // ALL_TABLETS_TO_BE_DELETED means all tablets in this bundle tablet meta are going to be deleted,
+    // SOME_TABLETS_NOT_TO_BE_DELETED means some tablets in this bundle tablet meta aren't going to be deleted,
+    // NO_TABLETS_TO_BE_DELETED means no tablets in this bundle tablet meta are going to be deleted,
+    // NOT_BUNDLE_TABLET_META means this tablet meta is not the bundle tablet meta.
+    //
+    // we will only delete the bundle segment files and bundle tablet meta when the state is ALL_TABLETS_TO_BE_DELETED
+    // and NOT_BUNDLE_TABLET_META.
+    for (auto version : bundle_tablet_versions) {
+        // Get the path of the bundle tablet metadata file for this version
+        // We use the first tablet ID from tablet_ids as a reference to get the location
+        auto path = tablet_mgr->aggregate_tablet_metadata_location(*tablet_ids.begin(), version);
+
+        // Check the state of the bundle tablet metadata for this version
+        // This tells us whether all tablets in this bundle are being deleted or not
+        ASSIGN_OR_RETURN(auto bundle_meta_state, bundle_tablet_meta_checker(path, tablet_ids));
+
+        // If there are any tablets to be deleted in this bundle (not NO_TABLETS_TO_BE_DELETED),
+        // we need to record this state for each tablet in tablet_ids
+        if (bundle_meta_state != BundleTabletMetaState::NO_TABLETS_TO_BE_DELETED) {
+            // Record the bundle meta state for all tablets that are being deleted
+            // This information will be used later to determine if bundle files can be deleted
+            for (auto tablet_id : tablet_ids) {
+                tablet_versions[tablet_id][version] = bundle_meta_state;
+            }
+        }
+    }
+
+    for (auto& [tablet_id, versions_and_states] : tablet_versions) {
+        DCHECK(!versions_and_states.empty());
+        std::set<int64_t> versions_to_delete;
+        for (auto& [version, state] : versions_and_states) {
+            versions_to_delete.insert(version);
+        }
 
         TabletMetadataPtr latest_metadata = nullptr;
 
         // Find metadata files that has garbage data files and delete all those files
-        for (int64_t garbage_version = *versions.rbegin(), min_v = *versions.begin(); garbage_version >= min_v; /**/) {
+        for (int64_t garbage_version = *versions_to_delete.rbegin(), min_v = *versions_to_delete.begin();
+             garbage_version >= min_v;
+             /**/) {
             auto res = tablet_mgr->get_tablet_metadata(tablet_id, garbage_version, false);
             if (res.status().is_not_found()) {
                 break;
@@ -788,7 +953,12 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
                     latest_metadata = metadata;
                 }
                 int64_t dummy_file_size = 0;
-                RETURN_IF_ERROR(collect_garbage_files(*metadata, data_dir, &deleter, nullptr, &dummy_file_size));
+                RETURN_IF_ERROR(
+                        collect_garbage_files(*metadata, data_dir, &deleter,
+                                              can_bundle_data_file_to_be_deleted(versions_and_states[garbage_version])
+                                                      ? nullptr
+                                                      : &dummy_bundle_file_deleter,
+                                              &dummy_file_size));
                 if (metadata->has_prev_garbage_version()) {
                     garbage_version = metadata->prev_garbage_version();
                 } else {
@@ -800,7 +970,11 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
         if (latest_metadata != nullptr) {
             for (const auto& rowset : latest_metadata->rowsets()) {
                 for (const auto& segment : rowset.segments()) {
-                    RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, segment)));
+                    // if the segment file is not shared by other alive tablets, we can delete the segments directly.
+                    if (rowset.bundle_file_offsets_size() == 0 ||
+                        can_bundle_data_file_to_be_deleted(versions_and_states[latest_metadata->version()])) {
+                        RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, segment)));
+                    }
                 }
             }
             if (latest_metadata->has_delvec_meta()) {
@@ -815,9 +989,20 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
             }
         }
 
-        for (auto version : versions) {
-            auto path = join_path(meta_dir, tablet_metadata_filename(tablet_id, version));
-            RETURN_IF_ERROR(deleter.delete_file(std::move(path)));
+        for (auto& [version, state] : versions_and_states) {
+            if (state == BundleTabletMetaState::NOT_BUNDLE_TABLET_META) {
+                // delete the individual tablet metadata file
+                auto path = join_path(meta_dir, tablet_metadata_filename(tablet_id, version));
+                RETURN_IF_ERROR(deleter.delete_file(std::move(path)));
+            } else if (state == BundleTabletMetaState::ALL_TABLETS_TO_BE_DELETED) {
+                // delete the bundle tablet metadata file
+                auto path = join_path(meta_dir, tablet_metadata_filename(0, version));
+                RETURN_IF_ERROR(deleter.delete_file(std::move(path)));
+            } else if (state == BundleTabletMetaState::SOME_TABLETS_NOT_TO_BE_DELETED) {
+                // we can not delete the bundle file, so we just skip it.
+            } else {
+                // do nothing for NO_TABLETS_TO_BE_DELETED
+            }
         }
     }
 

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -899,7 +899,7 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
     for (auto version : bundle_tablet_versions) {
         // Get the path of the bundle tablet metadata file for this version
         // We use the first tablet ID from tablet_ids as a reference to get the location
-        auto path = tablet_mgr->aggregate_tablet_metadata_location(*tablet_ids.begin(), version);
+        auto path = tablet_mgr->bundle_tablet_metadata_location(*tablet_ids.begin(), version);
 
         // Check the state of the bundle tablet metadata for this version
         // This tells us whether all tablets in this bundle are being deleted or not

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -925,6 +925,355 @@ TEST_P(LakeVacuumTest, test_delete_tablets_03) {
 }
 
 // NOLINTNEXTLINE
+TEST_P(LakeVacuumTest, test_delete_tablets_bundle_txnlog_files) {
+    create_data_file("00000000001259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat");
+    ASSERT_OK(_tablet_mgr->put_combined_txn_log(*json_to_pb<CombinedTxnLogPB>(R"DEL(
+        {
+            "txn_logs": [
+               {
+                    "tablet_id": 10,
+                    "txn_id": 1000,
+                    "partition_id": 111,
+                    "op_write": {
+                        "rowset": {
+                            "segments": ["00000000001259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"],
+                            "bundle_file_offsets": [
+                                0
+                            ]
+                        }
+                    }
+                },
+                {
+                    "tablet_id": 11,
+                    "txn_id": 1000,
+                    "partition_id": 111,
+                    "op_write": {
+                        "rowset": {
+                            "segments": ["00000000001259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"],
+                            "bundle_file_offsets": [
+                                1024
+                            ]
+                        }
+                    }
+                },
+                {
+                    "tablet_id": 12,
+                    "txn_id": 1000,
+                    "partition_id": 111,
+                    "op_write": {
+                        "rowset": {
+                            "segments": ["00000000001259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"],
+                            "bundle_file_offsets": [
+                                2048
+                            ]
+                        }
+                    }
+                }
+            ]
+        }
+        )DEL")));
+    {
+        // delete tablet 10
+        DeleteTabletRequest request;
+        DeleteTabletResponse response;
+        request.add_tablet_ids(10);
+        delete_tablets(_tablet_mgr.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+        EXPECT_TRUE(file_exist(combined_txn_log_filename(1000)));
+        EXPECT_TRUE(file_exist("00000000001259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"));
+    }
+    {
+        // delete tablet 10,11
+        DeleteTabletRequest request;
+        DeleteTabletResponse response;
+        request.add_tablet_ids(10);
+        request.add_tablet_ids(11);
+        delete_tablets(_tablet_mgr.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+        EXPECT_TRUE(file_exist(combined_txn_log_filename(1000)));
+        EXPECT_TRUE(file_exist("00000000001259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"));
+    }
+    {
+        // delete tablet 10,11,12
+        DeleteTabletRequest request;
+        DeleteTabletResponse response;
+        request.add_tablet_ids(10);
+        request.add_tablet_ids(11);
+        request.add_tablet_ids(12);
+        delete_tablets(_tablet_mgr.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+        EXPECT_FALSE(file_exist(combined_txn_log_filename(1000)));
+        EXPECT_FALSE(file_exist("00000000001259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"));
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_P(LakeVacuumTest, test_delete_tablets_bundle_metadata_files) {
+    // create bundile metadata files
+    create_data_file("00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat");
+    create_data_file("00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1e.dat");
+    create_data_file("00000000000259e4_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat");
+    create_data_file("00000000000259e4_a542395a-bff5-48a7-a3a7-2ed05691b58d.dat");
+
+    auto t600_v1 = json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 600,
+        "version": 1,
+        "rowsets": []
+        }
+        )DEL");
+
+    auto t601_v1 = json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 601,
+        "version": 1,
+        "rowsets": []
+        }
+        )DEL");
+
+    auto t600_v2 = json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 600,
+        "version": 2,
+        "rowsets": [
+            {
+                "segments": [
+                    "00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"
+                ],
+                "data_size": 4096,
+                "bundle_file_offsets": [
+                    0
+                ]
+            }
+        ]
+        }
+        )DEL");
+
+    auto t601_v2 = json_to_pb<TabletMetadataPB>(R"DEL(
+            {
+            "id": 601,
+            "version": 2,
+            "rowsets": [
+                {
+                    "segments": [
+                        "00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"
+                    ],
+                    "data_size": 4096,
+                    "bundle_file_offsets": [
+                        4096
+                    ]
+                }
+            ]
+            }
+            )DEL");
+
+    auto t600_v3 = json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 600,
+        "version": 3,
+        "rowsets": [
+            {
+                "segments": [
+                    "00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"
+                ],
+                "data_size": 4096,
+                "bundle_file_offsets": [
+                    0
+                ]
+            },
+            {
+                "segments": [
+                    "00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1e.dat"
+                ],
+                "data_size": 4096,
+                "bundle_file_offsets": [
+                    0
+                ]
+            }
+        ]
+        }
+        )DEL");
+
+    auto t601_v3 = json_to_pb<TabletMetadataPB>(R"DEL(
+            {
+            "id": 601,
+            "version": 3,
+            "rowsets": [
+                {
+                    "segments": [
+                        "00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"
+                    ],
+                    "data_size": 4096,
+                    "bundle_file_offsets": [
+                        4096
+                    ]
+                },
+                {
+                    "segments": [
+                        "00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1e.dat"
+                    ],
+                    "data_size": 4096,
+                    "bundle_file_offsets": [
+                        4096
+                    ]
+                }
+            ]
+            }
+            )DEL");
+    // after compaction
+    auto t600_v4 = json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 600,
+        "version": 4,
+        "rowsets": [
+            {
+                "segments": [
+                    "00000000000259e4_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat"
+                ],
+                "data_size": 8192
+            }
+        ],
+        "compaction_inputs": [
+            {
+                "segments": [
+                    "00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"
+                ],
+                "data_size": 4096,
+                "bundle_file_offsets": [
+                    0
+                ]
+            },
+            {
+                "segments": [
+                    "00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1e.dat"
+                ],
+                "data_size": 4096,
+                "bundle_file_offsets": [
+                    0
+                ]
+            }
+        ],
+        "prev_garbage_version": 3
+        }
+        )DEL");
+
+    auto t601_v4 = json_to_pb<TabletMetadataPB>(R"DEL(
+            {
+            "id": 601,
+            "version": 4,
+            "rowsets": [
+                {
+                    "segments": [
+                        "00000000000259e4_a542395a-bff5-48a7-a3a7-2ed05691b58d.dat"
+                    ],
+                    "data_size": 8192
+                }
+            ],
+            "compaction_inputs": [
+                {
+                    "segments": [
+                        "00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"
+                    ],
+                    "data_size": 4096,
+                    "bundle_file_offsets": [
+                        4096
+                    ]
+                },
+                {
+                    "segments": [
+                        "00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1e.dat"
+                    ],
+                    "data_size": 4096,
+                    "bundle_file_offsets": [
+                        4096
+                    ]
+                }
+            ]
+            }
+            )DEL");
+
+    // create SharedTabletMetadata
+    std::map<int64_t, TabletMetadataPB> tablet_metas_v1;
+    tablet_metas_v1[600] = *t600_v1;
+    tablet_metas_v1[601] = *t601_v1;
+    ASSERT_OK(_tablet_mgr->put_aggregate_tablet_metadata(tablet_metas_v1));
+    std::map<int64_t, TabletMetadataPB> tablet_metas_v2;
+    tablet_metas_v2[600] = *t600_v2;
+    tablet_metas_v2[601] = *t601_v2;
+    ASSERT_OK(_tablet_mgr->put_aggregate_tablet_metadata(tablet_metas_v2));
+    std::map<int64_t, TabletMetadataPB> tablet_metas_v3;
+    tablet_metas_v3[600] = *t600_v3;
+    tablet_metas_v3[601] = *t601_v3;
+    ASSERT_OK(_tablet_mgr->put_aggregate_tablet_metadata(tablet_metas_v3));
+    std::map<int64_t, TabletMetadataPB> tablet_metas_v4;
+    tablet_metas_v4[600] = *t600_v4;
+    tablet_metas_v4[601] = *t601_v4;
+    ASSERT_OK(_tablet_mgr->put_aggregate_tablet_metadata(tablet_metas_v4));
+
+    // delete tablet 600
+    {
+        DeleteTabletRequest request;
+        DeleteTabletResponse response;
+        request.add_tablet_ids(600);
+        delete_tablets(_tablet_mgr.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+
+        EXPECT_TRUE(file_exist(tablet_metadata_filename(0, 1)));
+        EXPECT_TRUE(file_exist(tablet_metadata_filename(0, 2)));
+        EXPECT_TRUE(file_exist(tablet_metadata_filename(0, 3)));
+        EXPECT_TRUE(file_exist(tablet_metadata_filename(0, 4)));
+
+        EXPECT_TRUE(file_exist("00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"));
+        EXPECT_TRUE(file_exist("00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1e.dat"));
+        EXPECT_FALSE(file_exist("00000000000259e4_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat"));
+        EXPECT_TRUE(file_exist("00000000000259e4_a542395a-bff5-48a7-a3a7-2ed05691b58d.dat"));
+    }
+    // delete tablet 601
+    {
+        DeleteTabletRequest request;
+        DeleteTabletResponse response;
+        request.add_tablet_ids(601);
+        delete_tablets(_tablet_mgr.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+
+        EXPECT_TRUE(file_exist(tablet_metadata_filename(0, 1)));
+        EXPECT_TRUE(file_exist(tablet_metadata_filename(0, 2)));
+        EXPECT_TRUE(file_exist(tablet_metadata_filename(0, 3)));
+        EXPECT_TRUE(file_exist(tablet_metadata_filename(0, 4)));
+
+        EXPECT_TRUE(file_exist("00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"));
+        EXPECT_TRUE(file_exist("00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1e.dat"));
+        EXPECT_FALSE(file_exist("00000000000259e4_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat"));
+        EXPECT_FALSE(file_exist("00000000000259e4_a542395a-bff5-48a7-a3a7-2ed05691b58d.dat"));
+    }
+    // delete tablet 600,601
+    {
+        DeleteTabletRequest request;
+        DeleteTabletResponse response;
+        request.add_tablet_ids(600);
+        request.add_tablet_ids(601);
+        delete_tablets(_tablet_mgr.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+
+        EXPECT_FALSE(file_exist(tablet_metadata_filename(0, 1)));
+        EXPECT_FALSE(file_exist(tablet_metadata_filename(0, 2)));
+        EXPECT_FALSE(file_exist(tablet_metadata_filename(0, 3)));
+        EXPECT_FALSE(file_exist(tablet_metadata_filename(0, 4)));
+
+        EXPECT_FALSE(file_exist("00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"));
+        EXPECT_FALSE(file_exist("00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1e.dat"));
+        EXPECT_FALSE(file_exist("00000000000259e4_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat"));
+        EXPECT_FALSE(file_exist("00000000000259e4_a542395a-bff5-48a7-a3a7-2ed05691b58d.dat"));
+    }
+}
+
+// NOLINTNEXTLINE
 TEST_P(LakeVacuumTest, test_delete_file_failed) {
     ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
         {

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -1199,19 +1199,19 @@ TEST_P(LakeVacuumTest, test_delete_tablets_bundle_metadata_files) {
     std::map<int64_t, TabletMetadataPB> tablet_metas_v1;
     tablet_metas_v1[600] = *t600_v1;
     tablet_metas_v1[601] = *t601_v1;
-    ASSERT_OK(_tablet_mgr->put_aggregate_tablet_metadata(tablet_metas_v1));
+    ASSERT_OK(_tablet_mgr->put_bundle_tablet_metadata(tablet_metas_v1));
     std::map<int64_t, TabletMetadataPB> tablet_metas_v2;
     tablet_metas_v2[600] = *t600_v2;
     tablet_metas_v2[601] = *t601_v2;
-    ASSERT_OK(_tablet_mgr->put_aggregate_tablet_metadata(tablet_metas_v2));
+    ASSERT_OK(_tablet_mgr->put_bundle_tablet_metadata(tablet_metas_v2));
     std::map<int64_t, TabletMetadataPB> tablet_metas_v3;
     tablet_metas_v3[600] = *t600_v3;
     tablet_metas_v3[601] = *t601_v3;
-    ASSERT_OK(_tablet_mgr->put_aggregate_tablet_metadata(tablet_metas_v3));
+    ASSERT_OK(_tablet_mgr->put_bundle_tablet_metadata(tablet_metas_v3));
     std::map<int64_t, TabletMetadataPB> tablet_metas_v4;
     tablet_metas_v4[600] = *t600_v4;
     tablet_metas_v4[601] = *t601_v4;
-    ASSERT_OK(_tablet_mgr->put_aggregate_tablet_metadata(tablet_metas_v4));
+    ASSERT_OK(_tablet_mgr->put_bundle_tablet_metadata(tablet_metas_v4));
 
     // delete tablet 600
     {

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -1261,7 +1261,7 @@ TEST_P(LakeVacuumTest, test_delete_tablets_bundle_metadata_files) {
         ASSERT_TRUE(response.has_status());
         EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
 
-        EXPECT_FALSE(file_exist(tablet_metadata_filename(0, 1)));
+        EXPECT_TRUE(file_exist(tablet_metadata_filename(0, 1)));
         EXPECT_FALSE(file_exist(tablet_metadata_filename(0, 2)));
         EXPECT_FALSE(file_exist(tablet_metadata_filename(0, 3)));
         EXPECT_FALSE(file_exist(tablet_metadata_filename(0, 4)));

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -1111,7 +1111,8 @@ public class StarMgrMetaSyncerTest {
             }
 
             @Mock
-            public void cleanOneGroup(long groupId, StarOSAgent starOSAgent, List<Long> emptyShardGroup) {
+            public void cleanOneGroup(long groupId, StarOSAgent starOSAgent, List<Long> emptyShardGroup,
+                    boolean isFileBundling) {
                 cleanedGroupIds.add(groupId);
             }
         };
@@ -1205,7 +1206,8 @@ public class StarMgrMetaSyncerTest {
             }
 
             @Mock
-            public void cleanOneGroup(long groupId, StarOSAgent starOSAgent, List<Long> emptyShardGroup) {
+            public void cleanOneGroup(long groupId, StarOSAgent starOSAgent, List<Long> emptyShardGroup,
+                    boolean isFileBundling) {
                 cleanedGroupIds.add(groupId);
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -1111,8 +1111,7 @@ public class StarMgrMetaSyncerTest {
             }
 
             @Mock
-            public void cleanOneGroup(long groupId, StarOSAgent starOSAgent, List<Long> emptyShardGroup,
-                    boolean isFileBundling) {
+            public void cleanOneGroup(long groupId, StarOSAgent starOSAgent, List<Long> emptyShardGroup) {
                 cleanedGroupIds.add(groupId);
             }
         };
@@ -1206,8 +1205,7 @@ public class StarMgrMetaSyncerTest {
             }
 
             @Mock
-            public void cleanOneGroup(long groupId, StarOSAgent starOSAgent, List<Long> emptyShardGroup,
-                    boolean isFileBundling) {
+            public void cleanOneGroup(long groupId, StarOSAgent starOSAgent, List<Long> emptyShardGroup) {
                 cleanedGroupIds.add(groupId);
             }
         };


### PR DESCRIPTION
## Why I'm doing:
In this feature request #58316, we support file bundle to reduce small files and S3 api cost under realtime scenarios. 

In certain scenarios, the FE identifies metadata discrepancies and dispatches a list of tablets to be deleted via StarMgrMetaSyncer. The system then reclaims specific tablet metadata and data files through the delete_tablets interface.

In the previous implementation, this delete_tablets interface lacked support for reclaiming bundle resources including txnlog, meta, and segment files. This PR implements the reclamation of these bundle components.

## What I'm doing:
This pull request introduces significant enhancements to the `delete_tablets_impl` functionality in `lake/vacuum.cpp`, focusing on handling bundle tablet metadata and ensuring safe deletion of shared files. The changes aim to improve the management of bundled files, prevent accidental deletion of shared resources, and optimize garbage collection processes.

### Enhancements to bundle tablet metadata handling:

* **Introduction of `BundleTabletMetaState` enum**: Added a new enum to represent the state of bundle tablet metadata, enabling precise determination of whether bundle files can be safely deleted.
* **`bundle_tablet_meta_checker` utility function**: Implemented a function to analyze the state of bundle tablet metadata and identify whether all, some, or no tablets in a bundle are marked for deletion.

### Improvements to file deletion logic:

* **Refactoring file deletion under transaction logs**: Consolidated and enhanced the logic for deleting files under transaction logs, including handling combined logs and ensuring bundle files are deleted only when safe. [[1]](diffhunk://#diff-891803f977da48b5a81315b3d324316e8bdd578537dc5bdeef32cf34ebb5f750R833-R942) [[2]](diffhunk://#diff-891803f977da48b5a81315b3d324316e8bdd578537dc5bdeef32cf34ebb5f750R973-R979)
* **Avoiding deletion of shared bundle files**: Introduced mechanisms to skip deletion of bundle files shared by multiple tablets unless all associated tablets are marked for deletion. [[1]](diffhunk://#diff-891803f977da48b5a81315b3d324316e8bdd578537dc5bdeef32cf34ebb5f750L791-R961) [[2]](diffhunk://#diff-891803f977da48b5a81315b3d324316e8bdd578537dc5bdeef32cf34ebb5f750R973-R979)

### Updates to metadata processing:

* **Tracking bundle tablet versions**: Updated metadata iteration logic to record bundle tablet versions and their states for safe deletion decisions. [[1]](diffhunk://#diff-891803f977da48b5a81315b3d324316e8bdd578537dc5bdeef32cf34ebb5f750L687-R801) [[2]](diffhunk://#diff-891803f977da48b5a81315b3d324316e8bdd578537dc5bdeef32cf34ebb5f750L818-R1005)
* **Conditional deletion of tablet metadata files**: Enhanced logic to delete individual or bundle tablet metadata files based on their state, ensuring shared resources are preserved when necessary.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
