### PR TITLE
[BugFix] fix InternalService_RecoverableStub reset_channel for http protocol

### DIFF
--- a/be/src/util/brpc_stub_cache.h
+++ b/be/src/util/brpc_stub_cache.h
@@ -110,7 +110,7 @@ private:
 
         std::shared_ptr<PInternalService_RecoverableStub> get_or_create(const butil::EndPoint& endpoint) {
             if (UNLIKELY(_stubs.size() < config::brpc_max_connections_per_server)) {
-                auto stub = std::make_shared<PInternalService_RecoverableStub>(endpoint);
+                auto stub = std::make_shared<PInternalService_RecoverableStub>(endpoint, "");
                 if (!stub->reset_channel().ok()) {
                     return nullptr;
                 }
@@ -161,8 +161,8 @@ public:
             return *stub_ptr;
         }
         // create
-        auto stub = std::make_shared<PInternalService_RecoverableStub>(endpoint);
-        if (!stub->reset_channel("http").ok()) {
+        auto stub = std::make_shared<PInternalService_RecoverableStub>(endpoint, "http");
+        if (!stub->reset_channel().ok()) {
             return Status::RuntimeError("init brpc http channel error on " + taddr.hostname + ":" +
                                         std::to_string(taddr.port));
         }

--- a/be/src/util/internal_service_recoverable_stub.h
+++ b/be/src/util/internal_service_recoverable_stub.h
@@ -26,10 +26,10 @@ namespace starrocks {
 class PInternalService_RecoverableStub : public PInternalService,
                                          public std::enable_shared_from_this<PInternalService_RecoverableStub> {
 public:
-    PInternalService_RecoverableStub(const butil::EndPoint& endpoint);
+    PInternalService_RecoverableStub(const butil::EndPoint& endpoint, std::string protocol = "");
     ~PInternalService_RecoverableStub();
 
-    Status reset_channel(const std::string& protocol = "", int64_t next_connection_group = 0);
+    Status reset_channel(int64_t next_connection_group = 0);
 
     std::shared_ptr<starrocks::PInternalService_Stub> stub() const {
         std::shared_lock l(_mutex);
@@ -98,6 +98,7 @@ private:
     const butil::EndPoint _endpoint;
     std::atomic<int64_t> _connection_group = 0;
     mutable std::shared_mutex _mutex;
+    std::string _protocol;
 
     GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(PInternalService_RecoverableStub);
 };

--- a/be/test/util/internal_service_recoverable_stub_parallel_test.cpp
+++ b/be/test/util/internal_service_recoverable_stub_parallel_test.cpp
@@ -84,18 +84,18 @@ TEST_F(PInternalService_RecoverableStub_ParallelTest, test_reset_channel_with_co
     EXPECT_EQ(2, stub->connection_group());
 
     // reset channel with the correct next_connection_group
-    EXPECT_TRUE(stub->reset_channel("", 3).ok());
+    EXPECT_TRUE(stub->reset_channel(3).ok());
     EXPECT_EQ(3, stub->connection_group());
 
     // reset with wrong next_connection_group, connection_group() won't increase
-    EXPECT_TRUE(stub->reset_channel("", 5).ok());
+    EXPECT_TRUE(stub->reset_channel(5).ok());
     EXPECT_EQ(3, stub->connection_group());
 
-    EXPECT_TRUE(stub->reset_channel("", 3).ok());
+    EXPECT_TRUE(stub->reset_channel(3).ok());
     EXPECT_EQ(3, stub->connection_group());
 
     // rest channel with correct next_connection_group
-    EXPECT_TRUE(stub->reset_channel("", 4).ok());
+    EXPECT_TRUE(stub->reset_channel(4).ok());
     EXPECT_EQ(4, stub->connection_group());
 }
 
@@ -115,7 +115,7 @@ TEST_F(PInternalService_RecoverableStub_ParallelTest, test_parallel_reset_channe
     for (int i = 0; i < num_threads; ++i) {
         reset_threads.emplace_back([&] {
             ready_future.wait();
-            stub->reset_channel("", next_connection_group);
+            stub->reset_channel(next_connection_group);
         });
     }
 


### PR DESCRIPTION
* channel is not correctly reset for http protocol. options.protocol is lost if is an http stub

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
