### PR TITLE
[Feature] introduce RowIdColumn

### DIFF
--- a/be/src/column/CMakeLists.txt
+++ b/be/src/column/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(Column STATIC
         column_visitor_mutable.cpp
         json_column.cpp
         map_column.cpp
+        row_id_column.cpp
         struct_column.cpp
         stream_chunk.cpp
         column_view/column_view_base.cpp

--- a/be/src/column/chunk.cpp
+++ b/be/src/column/chunk.cpp
@@ -413,18 +413,44 @@ std::string Chunk::rebuild_csv_row(size_t index, const std::string& delimiter) c
 
 std::string Chunk::debug_columns() const {
     std::stringstream os;
-    os << "nullable[";
-    for (size_t col = 0; col < _columns.size() - 1; ++col) {
-        os << _columns[col]->is_nullable();
-        os << ", ";
+    if (_columns.empty()) {
+        os << "empty columns[]";
+    } else {
+        os << "nullable[";
+        for (size_t col = 0; col < _columns.size() - 1; ++col) {
+            os << _columns[col]->is_nullable();
+            os << ", ";
+        }
+        os << _columns[_columns.size() - 1]->is_nullable() << "]";
+        os << " const[";
+        for (size_t col = 0; col < _columns.size() - 1; ++col) {
+            os << _columns[col]->is_constant();
+            os << ", ";
+        }
+        os << _columns[_columns.size() - 1]->is_constant() << "]";
+        os << " name[";
+        for (size_t col = 0; col < _columns.size() - 1; ++col) {
+            os << _columns[col]->get_name();
+            os << ", ";
+        }
+        os << _columns[_columns.size() - 1]->get_name() << "]";
+        os << " size[";
+        for (size_t col = 0; col < _columns.size() - 1; ++col) {
+            os << _columns[col]->size();
+            os << ", ";
+        }
+        os << _columns[_columns.size() - 1]->size() << "]";
+        os << " slot_id_to_index[";
+        for (const auto& [slot_id, idx] : _slot_id_to_index) {
+            os << slot_id << ":" << idx << ", ";
+        }
+        os << "]";
+        os << " column_id_to_index[";
+        for (const auto& [column_id, idx] : _cid_to_index) {
+            os << column_id << ":" << idx << ", ";
+        }
+        os << "]";
     }
-    os << _columns[_columns.size() - 1]->is_nullable() << "]";
-    os << " const[";
-    for (size_t col = 0; col < _columns.size() - 1; ++col) {
-        os << _columns[col]->is_constant();
-        os << ", ";
-    }
-    os << _columns[_columns.size() - 1]->is_constant() << "]";
     return os.str();
 }
 

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -108,6 +108,8 @@ public:
 
     virtual bool is_struct() const { return false; }
 
+    virtual bool is_global_row_id() const { return false; }
+
     virtual const uint8_t* raw_data() const = 0;
 
     virtual uint8_t* mutable_raw_data() = 0;

--- a/be/src/column/column_visitor.cpp
+++ b/be/src/column/column_visitor.cpp
@@ -71,5 +71,6 @@ VISIT_IMPL(FixedLengthColumnBase<uint24_t>)
 VISIT_IMPL(FixedLengthColumnBase<int96_t>)
 VISIT_IMPL(FixedLengthColumnBase<decimal12_t>)
 VISIT_IMPL(ObjectColumn<JsonValue>)
+VISIT_IMPL(RowIdColumn)
 
 } // namespace starrocks

--- a/be/src/column/column_visitor.h
+++ b/be/src/column/column_visitor.h
@@ -87,6 +87,7 @@ public:
     }
 
     virtual Status visit(const ColumnView& column) { return Status::NotSupported("ColumnView is not supported"); }
+    virtual Status visit(const RowIdColumn& column);
 };
 
 } // namespace starrocks

--- a/be/src/column/column_visitor_adapter.h
+++ b/be/src/column/column_visitor_adapter.h
@@ -16,6 +16,7 @@
 
 #include "column/column_visitor.h"
 #include "column/column_visitor_mutable.h"
+#include "column/row_id_column.h"
 
 namespace starrocks {
 
@@ -94,6 +95,7 @@ public:
     Status visit(const BinaryColumn& column) override { return _impl->do_visit(column); }
 
     Status visit(const LargeBinaryColumn& column) override { return _impl->do_visit(column); }
+    Status visit(const RowIdColumn& column) override { return _impl->do_visit(column); }
 
 private:
     Impl* _impl;
@@ -169,6 +171,8 @@ public:
     Status visit(BinaryColumn* column) override { return _impl->do_visit(column); }
 
     Status visit(LargeBinaryColumn* column) override { return _impl->do_visit(column); }
+
+    Status visit(RowIdColumn* column) override { return _impl->do_visit(column); }
 
 private:
     Impl* _impl;

--- a/be/src/column/column_visitor_mutable.cpp
+++ b/be/src/column/column_visitor_mutable.cpp
@@ -71,5 +71,6 @@ VISIT_IMPL(FixedLengthColumnBase<TimestampValue>)
 VISIT_IMPL(FixedLengthColumnBase<uint24_t>)
 VISIT_IMPL(FixedLengthColumnBase<int96_t>)
 VISIT_IMPL(FixedLengthColumnBase<decimal12_t>)
+VISIT_IMPL(RowIdColumn)
 
 } // namespace starrocks

--- a/be/src/column/column_visitor_mutable.h
+++ b/be/src/column/column_visitor_mutable.h
@@ -83,5 +83,6 @@ public:
     virtual Status visit(ObjectColumn<JsonValue>* column);
     virtual Status visit(ArrayViewColumn* column) { return Status::NotSupported("ArrayViewColumn is not supported"); }
     virtual Status visit(ColumnView* column) { return Status::NotSupported("ColumnView is not supported"); }
+    virtual Status visit(RowIdColumn* column);
 };
 } // namespace starrocks

--- a/be/src/column/datum.h
+++ b/be/src/column/datum.h
@@ -48,6 +48,7 @@ using DatumKey = std::variant<std::monostate, int8_t, uint8_t, int16_t, uint16_t
                               uint64_t, int96_t, int128_t, int256_t, Slice, decimal12_t, DecimalV2Value, float, double>;
 using DatumMap = std::map<DatumKey, Datum>;
 using DatumStruct = std::vector<Datum>;
+using DatumRowId = std::tuple<uint32_t, uint32_t, uint32_t>;
 
 class Datum {
 public:
@@ -89,6 +90,7 @@ public:
     const BitmapValue* get_bitmap() const { return get<BitmapValue*>(); }
     const PercentileValue* get_percentile() const { return get<PercentileValue*>(); }
     const JsonValue* get_json() const { return get<JsonValue*>(); }
+    const DatumRowId& get_row_id() const { return get<DatumRowId>(); }
 
     void set_int8(int8_t v) { set<decltype(v)>(v); }
     void set_uint8(uint8_t v) { set<decltype(v)>(v); }
@@ -114,6 +116,7 @@ public:
     void set_bitmap(BitmapValue* v) { set<decltype(v)>(v); }
     void set_percentile(PercentileValue* v) { set<decltype(v)>(v); }
     void set_json(JsonValue* v) { set<decltype(v)>(v); }
+    void set_row_id(const DatumRowId& v) { set<decltype(v)>(v); }
 
     template <typename T>
     const T& get() const {
@@ -198,7 +201,7 @@ private:
     using Variant =
             std::variant<std::monostate, int8_t, uint8_t, int16_t, uint16_t, uint24_t, int32_t, uint32_t, int64_t,
                          uint64_t, int96_t, int128_t, int256_t, Slice, decimal12_t, DecimalV2Value, float, double,
-                         DatumArray, DatumMap, HyperLogLog*, BitmapValue*, PercentileValue*, JsonValue*>;
+                         DatumArray, DatumMap, HyperLogLog*, BitmapValue*, PercentileValue*, JsonValue*, DatumRowId>;
     Variant _value;
 };
 

--- a/be/src/column/field.h
+++ b/be/src/column/field.h
@@ -199,6 +199,8 @@ public:
 
     static FieldPtr convert_to_dict_field(const Field& field);
 
+    bool is_row_id_field() const { return _type->type() == TYPE_ROW_ID; }
+
 private:
     constexpr static int kIsKeyShift = 0;
     constexpr static int kNullableShift = 1;

--- a/be/src/column/row_id_column.cpp
+++ b/be/src/column/row_id_column.cpp
@@ -1,0 +1,214 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "column/row_id_column.h"
+
+#include <cstdint>
+
+#include "column/column.h"
+#include "column/datum.h"
+#include "column/vectorized_fwd.h"
+#include "exec/sorting/sort_helper.h"
+
+namespace starrocks {
+
+RowIdColumn::RowIdColumn()
+        : _be_ids(UInt32Column::create()), _seg_ids(UInt32Column::create()), _ord_ids(UInt32Column::create()) {}
+
+RowIdColumn::RowIdColumn(size_t n)
+        : _be_ids(UInt32Column::create(n)), _seg_ids(UInt32Column::create(n)), _ord_ids(UInt32Column::create(n)) {}
+
+RowIdColumn::RowIdColumn(UInt32Column::Ptr be_ids, UInt32Column::Ptr seg_ids, UInt32Column::Ptr ord_ids)
+        : _be_ids(std::move(be_ids)), _seg_ids(std::move(seg_ids)), _ord_ids(std::move(ord_ids)) {}
+
+RowIdColumn::RowIdColumn(const RowIdColumn& rhs)
+        : _be_ids(UInt32Column::static_pointer_cast(rhs._be_ids->clone())),
+          _seg_ids(UInt32Column::static_pointer_cast(rhs._seg_ids->clone())),
+          _ord_ids(UInt32Column::static_pointer_cast(rhs._ord_ids->clone())) {}
+
+RowIdColumn::RowIdColumn(RowIdColumn&& rhs) noexcept
+        : _be_ids(std::move(rhs._be_ids)), _seg_ids(std::move(rhs._seg_ids)), _ord_ids(std::move(rhs._ord_ids)) {}
+
+void RowIdColumn::assign(size_t n, size_t idx) {
+    _be_ids->assign(n, idx);
+    _seg_ids->assign(n, idx);
+    _ord_ids->assign(n, idx);
+}
+
+void RowIdColumn::append_datum(const Datum& datum) {
+    DatumRowId row_id = datum.get<DatumRowId>();
+    _be_ids->append_datum(std::get<0>(row_id));
+    _seg_ids->append_datum(std::get<1>(row_id));
+    _ord_ids->append_datum(std::get<2>(row_id));
+}
+
+void RowIdColumn::append(const Column& src, size_t offset, size_t count) {
+    if (count == 0) {
+        return;
+    }
+    const auto& src_column = down_cast<const RowIdColumn&>(src);
+    _be_ids->append(*src_column._be_ids, offset, count);
+    _seg_ids->append(*src_column._seg_ids, offset, count);
+    _ord_ids->append(*src_column._ord_ids, offset, count);
+}
+
+void RowIdColumn::append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) {
+    if (size == 0) {
+        return;
+    }
+    const auto& src_column = down_cast<const RowIdColumn&>(src);
+    _be_ids->append_selective(*src_column._be_ids, indexes, from, size);
+    _seg_ids->append_selective(*src_column._seg_ids, indexes, from, size);
+    _ord_ids->append_selective(*src_column._ord_ids, indexes, from, size);
+}
+
+void RowIdColumn::append_value_multiple_times(const Column& src, uint32_t idx, uint32_t count) {
+    if (count == 0) {
+        return;
+    }
+    const auto& src_column = down_cast<const RowIdColumn&>(src);
+    _be_ids->append_value_multiple_times(*src_column._be_ids, idx, count);
+    _seg_ids->append_value_multiple_times(*src_column._seg_ids, idx, count);
+    _ord_ids->append_value_multiple_times(*src_column._ord_ids, idx, count);
+}
+
+void RowIdColumn::append_value_multiple_times(const void* value, size_t count) {
+    const auto* datum = reinterpret_cast<const Datum*>(value);
+    const auto& row_id = datum->get<DatumRowId>();
+
+    for (size_t i = 0; i < count; i++) {
+        append_datum(row_id);
+    }
+}
+
+void RowIdColumn::remove_first_n_values(size_t count) {
+    _be_ids->remove_first_n_values(count);
+    _seg_ids->remove_first_n_values(count);
+    _ord_ids->remove_first_n_values(count);
+}
+
+uint32_t RowIdColumn::max_one_element_serialize_size() const {
+    return _be_ids->max_one_element_serialize_size() + _seg_ids->max_one_element_serialize_size() +
+           _ord_ids->max_one_element_serialize_size();
+}
+
+uint32_t RowIdColumn::serialize(size_t idx, uint8_t* pos) const {
+    uint32_t ret = _be_ids->serialize(idx, pos);
+    ret = _seg_ids->serialize(idx, pos + ret);
+    ret = _ord_ids->serialize(idx, pos + ret);
+    return ret;
+}
+
+uint32_t RowIdColumn::serialize_default(uint8_t* pos) const {
+    uint32_t ret = _be_ids->serialize_default(pos);
+    ret += _seg_ids->serialize_default(pos + ret);
+    ret += _ord_ids->serialize_default(pos + ret);
+    return ret;
+}
+void RowIdColumn::serialize_batch(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
+                                  uint32_t max_one_row_size) const {
+    for (size_t i = 0; i < chunk_size; i++) {
+        slice_sizes[i] += serialize(i, dst + i * max_one_row_size + slice_sizes[i]);
+    }
+}
+
+const uint8_t* RowIdColumn::deserialize_and_append(const uint8_t* pos) {
+    pos = _be_ids->deserialize_and_append(pos);
+    pos = _seg_ids->deserialize_and_append(pos);
+    pos = _ord_ids->deserialize_and_append(pos);
+    return pos;
+}
+void RowIdColumn::deserialize_and_append_batch(Buffer<Slice>& srcs, size_t chunk_size) {
+    reserve(chunk_size);
+    for (size_t i = 0; i < chunk_size; i++) {
+        srcs[i].data = (char*)deserialize_and_append((uint8_t*)srcs[i].data);
+    }
+}
+
+MutableColumnPtr RowIdColumn::clone_empty() const {
+    return RowIdColumn::create();
+}
+
+size_t RowIdColumn::filter_range(const Filter& filter, size_t from, size_t to) {
+    size_t result = _be_ids->filter_range(filter, from, to);
+    size_t tmp = _seg_ids->filter_range(filter, from, to);
+    DCHECK_EQ(result, tmp);
+    tmp = _ord_ids->filter_range(filter, from, to);
+    DCHECK_EQ(result, tmp);
+    return result;
+}
+
+int RowIdColumn::compare_at(size_t left, size_t right, const Column& rhs, int null_first) const {
+    const auto& rhs_column = down_cast<const RowIdColumn&>(rhs);
+    const auto& lhs_value = get(left).get<DatumRowId>();
+    const auto& rhs_value = rhs_column.get(right).get<DatumRowId>();
+    return SorterComparator<DatumRowId>::compare(lhs_value, rhs_value);
+}
+
+StatusOr<ColumnPtr> RowIdColumn::replicate(const Buffer<uint32_t>& offsets) {
+    ASSIGN_OR_RETURN(auto be_ids, _be_ids->replicate(offsets));
+    ASSIGN_OR_RETURN(auto seg_ids, _seg_ids->replicate(offsets));
+    ASSIGN_OR_RETURN(auto ord_ids, _ord_ids->replicate(offsets));
+    return RowIdColumn::create(UInt32Column::static_pointer_cast(std::move(be_ids)),
+                               UInt32Column::static_pointer_cast(std::move(seg_ids)),
+                               UInt32Column::static_pointer_cast(std::move(ord_ids)));
+}
+
+Datum RowIdColumn::get(size_t idx) const {
+    uint32_t be_id = _be_ids->get(idx).get<uint32_t>();
+    uint32_t seg_id = _seg_ids->get(idx).get<uint32_t>();
+    uint32_t ord_id = _ord_ids->get(idx).get<uint32_t>();
+    return std::make_tuple(be_id, seg_id, ord_id);
+}
+
+void RowIdColumn::swap_column(Column& rhs) {
+    RowIdColumn& r = down_cast<RowIdColumn&>(rhs);
+    _be_ids->swap_column(*r._be_ids);
+    _seg_ids->swap_column(*r._seg_ids);
+    _ord_ids->swap_column(*r._ord_ids);
+}
+
+void RowIdColumn::reset_column() {
+    _be_ids->reset_column();
+    _seg_ids->reset_column();
+    _ord_ids->reset_column();
+}
+
+std::string RowIdColumn::debug_item(size_t idx) const {
+    std::stringstream ss;
+    DatumRowId row_id = get(idx).get<DatumRowId>();
+    ss << "(" << std::get<0>(row_id) << "," << std::get<1>(row_id) << "," << std::get<2>(row_id) << ")";
+    return ss.str();
+}
+
+std::string RowIdColumn::debug_string() const {
+    std::stringstream ss;
+    for (size_t i = 0; i < size(); i++) {
+        if (i > 0) {
+            ss << ",";
+        }
+        ss << debug_item(i);
+    }
+    return ss.str();
+}
+
+void RowIdColumn::check_or_die() const {
+    DCHECK_EQ(_be_ids->size(), _seg_ids->size());
+    DCHECK_EQ(_be_ids->size(), _ord_ids->size());
+    _be_ids->check_or_die();
+    _seg_ids->check_or_die();
+    _ord_ids->check_or_die();
+}
+
+} // namespace starrocks

--- a/be/src/column/row_id_column.h
+++ b/be/src/column/row_id_column.h
@@ -1,0 +1,230 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <stdexcept>
+
+#include "column/column.h"
+#include "column/datum.h"
+#include "column/fixed_length_column.h"
+#include "column/struct_column.h"
+#include "column/vectorized_fwd.h"
+#include "common/status.h"
+
+namespace starrocks {
+class RowIdColumn final : public CowFactory<ColumnFactory<Column, RowIdColumn>, RowIdColumn> {
+    friend class CowFactory<ColumnFactory<Column, RowIdColumn>, RowIdColumn>;
+
+public:
+    using ValueType = DatumRowId;
+    RowIdColumn();
+    RowIdColumn(size_t n);
+
+    RowIdColumn(UInt32Column::Ptr be_ids, UInt32Column::Ptr seg_ids, UInt32Column::Ptr ord_ids);
+
+    RowIdColumn(const RowIdColumn& rhs);
+
+    RowIdColumn(RowIdColumn&& rhs) noexcept;
+
+    RowIdColumn& operator=(const RowIdColumn& rhs) {
+        RowIdColumn tmp(rhs);
+        this->swap_column(tmp);
+        return *this;
+    }
+
+    RowIdColumn& operator=(RowIdColumn&& rhs) noexcept {
+        RowIdColumn tmp(std::move(rhs));
+        this->swap_column(tmp);
+        return *this;
+    }
+    ~RowIdColumn() override = default;
+    bool is_global_row_id() const override { return true; }
+
+    const uint8_t* raw_data() const override {
+        DCHECK(false) << "RowIdColumn::raw_data() is not supported";
+        throw std::runtime_error("RowIdColumn::raw_data() is not supported");
+    }
+
+    uint8_t* mutable_raw_data() override {
+        DCHECK(false) << "RowIdColumn::mutable_raw_data() is not supported";
+        throw std::runtime_error("RowIdColumn::mutable_raw_data() is not supported");
+    }
+
+    size_t size() const override { return _be_ids->size(); }
+    size_t capacity() const override { return _be_ids->capacity(); }
+    size_t type_size() const override { return _be_ids->type_size() + _seg_ids->type_size() + _ord_ids->type_size(); }
+    size_t byte_size() const override { return _be_ids->byte_size() + _seg_ids->byte_size() + _ord_ids->byte_size(); }
+    size_t byte_size(size_t from, size_t count) const override {
+        return _be_ids->byte_size(from, count) + _seg_ids->byte_size(from, count) + _ord_ids->byte_size(from, count);
+    }
+    size_t byte_size(size_t idx) const override {
+        return _be_ids->byte_size(idx) + _seg_ids->byte_size(idx) + _ord_ids->byte_size(idx);
+    }
+
+    void reserve(size_t n) override {
+        _be_ids->reserve(n);
+        _seg_ids->reserve(n);
+        _ord_ids->reserve(n);
+    }
+    void resize(size_t n) override {
+        _be_ids->resize(n);
+        _seg_ids->resize(n);
+        _ord_ids->resize(n);
+    }
+    void assign(size_t n, size_t idx) override;
+
+    void append_datum(const Datum& datum) override;
+    void append(const Column& src, size_t offset, size_t count) override;
+    void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
+    void append_value_multiple_times(const Column& src, uint32_t idx, uint32_t count) override;
+    bool append_nulls(size_t count) override { return false; }
+
+    size_t append_numbers(const void* buff, size_t length) override { return -1; }
+
+    void append_value_multiple_times(const void* value, size_t count) override;
+    void append_default() override {
+        _be_ids->append_default();
+        _seg_ids->append_default();
+        _ord_ids->append_default();
+    }
+    void append_default(size_t count) override {
+        _be_ids->append_default(count);
+        _seg_ids->append_default(count);
+        _ord_ids->append_default(count);
+    }
+    void fill_default(const Filter& filter) override {
+        DCHECK(false) << "RowIdColumn::fill_default() is not supported";
+    }
+    void update_rows(const Column& src, const uint32_t* indexes) override {
+        DCHECK(false) << "RowIdColumn::update_rows() is not supported";
+    }
+    void remove_first_n_values(size_t count) override;
+    uint32_t max_one_element_serialize_size() const override;
+    uint32_t serialize(size_t idx, uint8_t* pos) const override;
+    uint32_t serialize_default(uint8_t* pos) const override;
+    void serialize_batch(uint8_t* dst, Buffer<uint32_t>& slice_sized, size_t chunk_size,
+                         uint32_t max_one_row_size) const override;
+
+    const uint8_t* deserialize_and_append(const uint8_t* pos) override;
+
+    uint32_t serialize_size(size_t idx) const override {
+        return _be_ids->serialize_size(idx) + _seg_ids->serialize_size(idx) + _ord_ids->serialize_size(idx);
+    }
+    void deserialize_and_append_batch(Buffer<Slice>& srcs, size_t chunk_size) override;
+
+    MutableColumnPtr clone_empty() const override;
+
+    size_t filter_range(const Filter& filter, size_t from, size_t to) override;
+
+    int compare_at(size_t left, size_t right, const Column& right_column, int nan_direction_hint) const override;
+
+    void fnv_hash_at(uint32_t* seed, uint32_t idx) const override {
+        DCHECK(false) << "RowIdColumn::fnv_hash_at() is not supported";
+        throw std::runtime_error("RowIdColumn::fnv_hash_at() is not supported");
+    }
+    void fnv_hash(uint32_t* hash, uint32_t from, uint32_t to) const override {
+        DCHECK(false) << "RowIdColumn::fnv_hash() is not supported";
+        throw std::runtime_error("RowIdColumn::fnv_hash() is not supported");
+    }
+
+    void crc32_hash_at(uint32_t* seed, uint32_t idx) const override {
+        DCHECK(false) << "RowIdColumn::crc32_hash_at() is not supported";
+        throw std::runtime_error("RowIdColumn::crc32_hash_at() is not supported");
+    }
+    void crc32_hash(uint32_t* hash, uint32_t from, uint32_t to) const override {
+        DCHECK(false) << "RowIdColumn::crc32_hash() is not supported";
+        throw std::runtime_error("RowIdColumn::crc32_hash() is not supported");
+    }
+
+    int64_t xor_checksum(uint32_t from, uint32_t to) const override {
+        DCHECK(false) << "RowIdColumn::xor_checksum() is not supported";
+        throw std::runtime_error("RowIdColumn::xor_checksum() is not supported");
+    }
+
+    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false) const override {
+        DCHECK(false) << "RowIdColumn::put_mysql_row_buffer() is not supported";
+        throw std::runtime_error("RowIdColumn::put_mysql_row_buffer() is not supported");
+    }
+
+    StatusOr<ColumnPtr> replicate(const Buffer<uint32_t>& offsets) override;
+
+    std::string get_name() const override { return "row-id"; }
+
+    Datum get(size_t idx) const override;
+
+    bool set_null(size_t idx) override { return false; }
+
+    size_t memory_usage() const override {
+        return _be_ids->memory_usage() + _seg_ids->memory_usage() + _ord_ids->memory_usage();
+    }
+
+    size_t container_memory_usage() const override {
+        return _be_ids->container_memory_usage() + _seg_ids->container_memory_usage() +
+               _ord_ids->container_memory_usage();
+    }
+
+    size_t reference_memory_usage(size_t from, size_t size) const override { return 0; }
+
+    void swap_column(Column& rhs) override;
+
+    void reset_column() override;
+
+    const Columns columns() const { return Columns{_be_ids, _seg_ids, _ord_ids}; }
+    Columns columns() { return Columns{_be_ids, _seg_ids, _ord_ids}; }
+
+    const UInt32Column::Ptr& be_ids_column() const { return _be_ids; }
+    UInt32Column::Ptr& be_ids_column() { return _be_ids; }
+    const UInt32Column::Ptr& seg_ids_column() const { return _seg_ids; }
+    UInt32Column::Ptr& seg_ids_column() { return _seg_ids; }
+    const UInt32Column::Ptr& ord_ids_column() const { return _ord_ids; }
+    UInt32Column::Ptr& ord_ids_column() { return _ord_ids; }
+
+    bool is_nullable() const override { return false; }
+
+    std::string debug_item(size_t idx) const override;
+
+    std::string debug_string() const override;
+
+    Status capacity_limit_reached() const override {
+        RETURN_IF_ERROR(_be_ids->capacity_limit_reached());
+        RETURN_IF_ERROR(_seg_ids->capacity_limit_reached());
+        return _ord_ids->capacity_limit_reached();
+    }
+
+    StatusOr<ColumnPtr> upgrade_if_overflow() override { return nullptr; }
+
+    StatusOr<ColumnPtr> downgrade() override { return nullptr; }
+
+    bool has_large_column() const override { return false; }
+
+    void check_or_die() const override;
+
+    Status unfold_const_children(const starrocks::TypeDescriptor& type) override {
+        return Status::NotSupported("RowIdColumn::unfold_const_children() is not supported");
+    }
+    void mutate_each_subcolumn() override {
+        _be_ids = UInt32Column::static_pointer_cast((std::move(*_be_ids)).mutate());
+        _seg_ids = UInt32Column::static_pointer_cast((std::move(*_seg_ids)).mutate());
+        _ord_ids = UInt32Column::static_pointer_cast((std::move(*_ord_ids)).mutate());
+    }
+
+private:
+    // @TODO(silverbullet233): if this column is generated by local be, we don't need be_ids
+    UInt32Column::Ptr _be_ids;
+    UInt32Column::Ptr _seg_ids;
+    UInt32Column::Ptr _ord_ids;
+};
+} // namespace starrocks

--- a/be/src/column/schema.cpp
+++ b/be/src/column/schema.cpp
@@ -17,6 +17,9 @@
 #include <algorithm>
 #include <utility>
 
+#include "column/field.h"
+#include "types/logical_type.h"
+
 namespace starrocks {
 
 #ifdef BE_TEST
@@ -147,6 +150,7 @@ Schema& Schema::operator=(const Schema& other) {
 void Schema::append(const FieldPtr& field) {
     _fields.emplace_back(field);
     _num_keys += field->is_key();
+
     if (!_share_name_to_index) {
         if (_name_to_index == nullptr) {
             _name_to_index.reset(new std::unordered_map<std::string_view, size_t>());
@@ -284,6 +288,15 @@ size_t Schema::get_field_index_by_name(const std::string& name) const {
         }
     }
     return p->second;
+}
+size_t Schema::get_row_id_field_index() const {
+    size_t num_field = _fields.size();
+    for (size_t i = 0; i < num_field; i++) {
+        if (_fields[i]->type()->type() == TYPE_ROW_ID) {
+            return i;
+        }
+    }
+    return INVALID_ROW_ID_FIELD_IDX;
 }
 
 void Schema::convert_to(Schema* new_schema, const std::vector<LogicalType>& new_types) const {

--- a/be/src/column/schema.h
+++ b/be/src/column/schema.h
@@ -32,6 +32,7 @@ public:
     Schema& operator=(Schema&&) = default;
 
     inline static const std::string FULL_ROW_COLUMN = "__row";
+    inline static const size_t INVALID_ROW_ID_FIELD_IDX = UINT64_MAX;
 
 #ifdef BE_TEST
     explicit Schema(Fields fields);
@@ -91,6 +92,7 @@ public:
     void set_field_by_name(FieldPtr field, const std::string& name);
 
     size_t get_field_index_by_name(const std::string& name) const;
+    size_t get_row_id_field_index() const;
 
     std::vector<ColumnId> field_column_ids(bool use_rowstore = false) const;
 
@@ -131,6 +133,7 @@ private:
     mutable bool _share_name_to_index = false;
 
     uint8_t _keys_type = static_cast<uint8_t>(DUP_KEYS);
+    [[maybe_unused]] size_t _row_id_field_idx = INVALID_ROW_ID_FIELD_IDX;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const Schema& schema) {

--- a/be/src/column/type_traits.h
+++ b/be/src/column/type_traits.h
@@ -21,6 +21,7 @@
 #include "column/json_column.h"
 #include "column/nullable_column.h"
 #include "column/object_column.h"
+#include "column/row_id_column.h"
 #include "column/struct_column.h"
 #include "column/vectorized_fwd.h"
 #include "types/constexpr.h"
@@ -322,6 +323,13 @@ template <>
 struct RunTimeTypeTraits<TYPE_ARRAY> {
     using CppType = DatumArray;
     using ColumnType = ArrayColumn;
+    using ProxyContainerType = void;
+};
+
+template <>
+struct RunTimeTypeTraits<TYPE_ROW_ID> {
+    using CppType = DatumRowId;
+    using ColumnType = RowIdColumn;
     using ProxyContainerType = void;
 };
 

--- a/be/src/column/vectorized_fwd.h
+++ b/be/src/column/vectorized_fwd.h
@@ -52,6 +52,7 @@ class MapColumn;
 class StructColumn;
 class NullableColumn;
 class ConstColumn;
+class RowIdColumn;
 
 template <typename T>
 class FixedLengthColumn;

--- a/be/src/connector/mysql_connector.cpp
+++ b/be/src/connector/mysql_connector.cpp
@@ -195,6 +195,7 @@ Status MySQLDataSource::open(RuntimeState* state) {
             case TYPE_DATETIME_V1:
             case TYPE_NONE:
             case TYPE_MAX_VALUE:
+            case TYPE_ROW_ID:
                 break;
             }
         }

--- a/be/src/exec/es/es_predicate.cpp
+++ b/be/src/exec/es/es_predicate.cpp
@@ -122,7 +122,8 @@ std::string VExtLiteral::_value_to_string(ColumnPtr& column) {
                 [&](auto&& arg) {
                     using T = std::decay_t<decltype(arg)>;
                     if constexpr (is_type_in<T, std::monostate, int96_t, decimal12_t, DecimalV2Value, DatumArray,
-                                             DatumMap, HyperLogLog*, BitmapValue*, PercentileValue*, JsonValue*>()) {
+                                             DatumMap, HyperLogLog*, BitmapValue*, PercentileValue*, JsonValue*,
+                                             DatumRowId>()) {
                         // ignore these types
                     } else if constexpr (std::is_same_v<T, Slice>) {
                         res = std::string(arg.data, arg.size);

--- a/be/src/exec/sorted_streaming_aggregator.cpp
+++ b/be/src/exec/sorted_streaming_aggregator.cpp
@@ -154,6 +154,10 @@ public:
         return Status::NotSupported("Unsupported struct column in column wise comparator");
     }
 
+    Status do_visit(const RowIdColumn& column) {
+        return Status::NotSupported("Unsupported row id column in column wise comparator");
+    }
+
 private:
     const ColumnPtr& _first_column;
     std::vector<uint8_t>& _cmp_vector;
@@ -249,6 +253,9 @@ public:
 
     Status do_visit(StructColumn* column) {
         return Status::NotSupported("Unsupported struct column in column wise comparator");
+    }
+    Status do_visit(RowIdColumn* column) {
+        return Status::NotSupported("Unsupported row id column in column wise comparator");
     }
 
 private:

--- a/be/src/exec/sorting/compare_column.cpp
+++ b/be/src/exec/sorting/compare_column.cpp
@@ -239,6 +239,11 @@ public:
         return Status::OK();
     }
 
+    Status do_visit(const RowIdColumn& column) {
+        DCHECK(false) << "not support row id column sort_and_tie";
+        return Status::NotSupported("Not support RowIdColumn");
+    }
+
     size_t get_equal_count() const { return _equal_count; }
 
 private:
@@ -311,6 +316,10 @@ public:
     Status do_visit(const StructColumn& column) { return Status::NotSupported("Not support"); }
     template <typename T>
     Status do_visit(const ObjectColumn<T>& column) {
+        return Status::NotSupported("not support");
+    }
+    Status do_visit(const RowIdColumn& column) {
+        DCHECK(false) << "not support";
         return Status::NotSupported("not support");
     }
 

--- a/be/src/exec/sorting/sort_column.cpp
+++ b/be/src/exec/sorting/sort_column.cpp
@@ -218,6 +218,11 @@ public:
                                    _build_tie);
     }
 
+    Status do_visit(const RowIdColumn& column) {
+        DCHECK(false) << "not support row id column";
+        return Status::NotSupported("not support row id column sort_and_tie");
+    }
+
 private:
     const std::atomic<bool>& _cancel;
     const SortDesc& _sort_desc;
@@ -405,6 +410,11 @@ public:
                                             _build_tie, _limit, &_pruned_limit));
         _prune_limit();
         return Status::OK();
+    }
+
+    Status do_visit(const RowIdColumn& column) {
+        DCHECK(false) << "not support row id column";
+        return Status::NotSupported("not support row id column");
     }
 
 private:

--- a/be/src/exec/sorting/sort_permute.cpp
+++ b/be/src/exec/sorting/sort_permute.cpp
@@ -30,6 +30,7 @@
 #include "common/status.h"
 #include "exec/sorting/sorting.h"
 #include "gutil/casts.h"
+#include "gutil/integral_types.h"
 #include "gutil/strings/fastmem.h"
 
 namespace starrocks {
@@ -229,6 +230,38 @@ public:
     Status do_visit(JsonColumn* dst) {
         for (auto& p : _perm) {
             dst->append(*_columns[p.chunk_index], p.index_in_chunk, 1);
+        }
+
+        return Status::OK();
+    }
+
+    Status do_visit(RowIdColumn* dst) {
+        using Container = typename FixedLengthColumnBase<uint32_t>::Container;
+        using ColumnType = FixedLengthColumnBase<uint32_t>;
+
+        auto func = [](FixedLengthColumnBase<uint32_t>* dst, Columns& columns, const PermutationView& perm) {
+            ColumnAppendPermutation visitor(columns, perm);
+            return dst->accept_mutable(&visitor);
+        };
+
+        std::vector<ColumnType*> dst_ids;
+        for (const auto& column : dst->columns()) {
+            dst_ids.emplace_back(UInt32Column::static_pointer_cast(column).get());
+        }
+
+        std::vector<Columns> tmp_inputs;
+        tmp_inputs.resize(3);
+        for (size_t i = 0; i < 3; i++) {
+            tmp_inputs[i].clear();
+            for (const auto& column : _columns) {
+                auto id_column = RowIdColumn::static_pointer_cast(column)->columns()[i];
+                tmp_inputs[i].emplace_back(id_column);
+            }
+        }
+
+        DCHECK_EQ(dst_ids.size(), 3);
+        for (size_t i = 0; i < 3; i++) {
+            RETURN_IF_ERROR(func(dst_ids[i], tmp_inputs[i], _perm));
         }
 
         return Status::OK();

--- a/be/src/runtime/types.cpp
+++ b/be/src/runtime/types.cpp
@@ -370,6 +370,8 @@ int TypeDescriptor::get_slot_size() const {
         }
         return struct_size;
     }
+    case TYPE_ROW_ID:
+        return 12;
     case TYPE_UNKNOWN:
     case TYPE_BINARY:
     case TYPE_FUNCTION:

--- a/be/src/runtime/types.h
+++ b/be/src/runtime/types.h
@@ -314,6 +314,8 @@ struct TypeDescriptor {
                type == TYPE_LARGEINT;
     }
 
+    inline bool is_row_id_type() const { return type == TYPE_ROW_ID; }
+
     inline bool is_float_type() const { return type == TYPE_FLOAT || type == TYPE_DOUBLE; }
 
     // Could this type be used at join on conjuncts

--- a/be/src/serde/column_array_serde.cpp
+++ b/be/src/serde/column_array_serde.cpp
@@ -542,6 +542,12 @@ public:
         _size += JsonColumnSerde::max_serialized_size(column);
         return Status::OK();
     }
+    Status do_visit(const RowIdColumn& column) {
+        _size += FixedLengthColumnSerde<uint32_t, false>::max_serialized_size(*column.be_ids_column(), _encode_level);
+        _size += FixedLengthColumnSerde<uint32_t, false>::max_serialized_size(*column.seg_ids_column(), _encode_level);
+        _size += FixedLengthColumnSerde<uint32_t, false>::max_serialized_size(*column.ord_ids_column(), _encode_level);
+        return Status::OK();
+    }
 
     int64_t size() const { return _size; }
 
@@ -604,6 +610,13 @@ public:
 
     Status do_visit(const JsonColumn& column) {
         _cur = JsonColumnSerde::serialize(column, _cur);
+        return Status::OK();
+    }
+
+    Status do_visit(const RowIdColumn& column) {
+        _cur = FixedLengthColumnSerde<uint32_t, false>::serialize(*column.be_ids_column(), _cur, _encode_level);
+        _cur = FixedLengthColumnSerde<uint32_t, false>::serialize(*column.seg_ids_column(), _cur, _encode_level);
+        _cur = FixedLengthColumnSerde<uint32_t, false>::serialize(*column.ord_ids_column(), _cur, _encode_level);
         return Status::OK();
     }
 
@@ -676,6 +689,14 @@ public:
 
     Status do_visit(JsonColumn* column) {
         _cur = JsonColumnSerde::deserialize(_cur, column);
+        return Status::OK();
+    }
+    Status do_visit(RowIdColumn* column) {
+        _cur = FixedLengthColumnSerde<uint32_t, false>::deserialize(_cur, column->be_ids_column().get(), _encode_level);
+        _cur = FixedLengthColumnSerde<uint32_t, false>::deserialize(_cur, column->seg_ids_column().get(),
+                                                                    _encode_level);
+        _cur = FixedLengthColumnSerde<uint32_t, false>::deserialize(_cur, column->ord_ids_column().get(),
+                                                                    _encode_level);
         return Status::OK();
     }
 

--- a/be/src/storage/column_in_predicate.cpp
+++ b/be/src/storage/column_in_predicate.cpp
@@ -704,6 +704,7 @@ ColumnPredicate* new_column_in_predicate_generic(const TypeInfoPtr& type_info, C
     case TYPE_BINARY:
     case TYPE_VARBINARY:
     case TYPE_MAX_VALUE:
+    case TYPE_ROW_ID:
         return nullptr;
         // No default to ensure newly added enumerator will be handled.
     }

--- a/be/src/storage/column_not_in_predicate.cpp
+++ b/be/src/storage/column_not_in_predicate.cpp
@@ -399,6 +399,7 @@ ColumnPredicate* new_column_not_in_predicate(const TypeInfoPtr& type_info, Colum
     case TYPE_BINARY:
     case TYPE_MAX_VALUE:
     case TYPE_VARBINARY:
+    case TYPE_ROW_ID:
         return nullptr;
         // No default to ensure newly added enumerator will be handled.
     }

--- a/be/src/storage/column_predicate_cmp.cpp
+++ b/be/src/storage/column_predicate_cmp.cpp
@@ -185,6 +185,7 @@ static ColumnPredicate* new_column_predicate(const TypeInfoPtr& type_info, Colum
     case TYPE_BINARY:
     case TYPE_VARBINARY:
     case TYPE_MAX_VALUE:
+    case TYPE_ROW_ID:
         return nullptr;
         // No default to ensure newly added enumerator will be handled.
     }

--- a/be/src/storage/convert_helper.cpp
+++ b/be/src/storage/convert_helper.cpp
@@ -1659,6 +1659,7 @@ const FieldConverter* get_field_converter(LogicalType from_type, LogicalType to_
         case TYPE_TIME:
         case TYPE_BINARY:
         case TYPE_MAX_VALUE:
+        case TYPE_ROW_ID:
             return nullptr;
         }
         DCHECK(false) << "unreachable path";

--- a/be/src/storage/olap_type_infra.h
+++ b/be/src/storage/olap_type_infra.h
@@ -157,6 +157,7 @@ auto field_type_dispatch_column(LogicalType ftype, Functor fun, Args&&... args) 
         _TYPE_DISPATCH_CASE(TYPE_MAP)
         _TYPE_DISPATCH_CASE(TYPE_STRUCT)
         _TYPE_DISPATCH_CASE(TYPE_UNSIGNED_SMALLINT)
+        _TYPE_DISPATCH_CASE(TYPE_ROW_ID)
     default:
         CHECK(false) << "unknown type " << ftype;
         __builtin_unreachable();

--- a/be/src/storage/rowset/global_rowid_column_iterator.h
+++ b/be/src/storage/rowset/global_rowid_column_iterator.h
@@ -1,0 +1,146 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "runtime/mem_pool.h"
+#include "runtime/mem_tracker.h"
+#include "storage/rowset/column_iterator.h"
+#include "util/raw_container.h"
+
+namespace starrocks {
+
+class TypeInfo;
+using TypeInfoPtr = std::shared_ptr<TypeInfo>;
+
+// this column iterator is used to generate global row ids for each row in a segment.
+class GlobalRowIdColumnIterator final : public ColumnIterator {
+public:
+    GlobalRowIdColumnIterator(uint32_t be_id, uint32_t seg_id) : _be_id(be_id), _seg_id(seg_id) {}
+
+    Status init(const ColumnIteratorOptions& opts) override { return Status::OK(); }
+
+    Status seek_to_first() override {
+        _current_rowid = 0;
+        return Status::OK();
+    }
+
+    Status seek_to_ordinal(ordinal_t ord_idx) override {
+        _current_rowid = ord_idx;
+        return Status::OK();
+    }
+
+    Status next_batch(size_t* n, Column* dst) override {
+        auto row_id_column = down_cast<RowIdColumn*>(dst);
+        const size_t num = row_id_column->size();
+        auto& be_ids = row_id_column->be_ids_column()->get_data();
+        raw::stl_vector_resize_uninitialized(&be_ids, num + *n);
+        for (size_t i = 0; i < *n; i++) {
+            be_ids[num + i] = _be_id;
+        }
+        auto& seg_ids = row_id_column->seg_ids_column()->get_data();
+        raw::stl_vector_resize_uninitialized(&seg_ids, num + *n);
+        for (size_t i = 0; i < *n; i++) {
+            seg_ids[num + i] = _seg_id;
+        }
+        auto& ord_ids = row_id_column->ord_ids_column()->get_data();
+        raw::stl_vector_resize_uninitialized(&ord_ids, num + *n);
+        for (size_t i = 0; i < *n; i++) {
+            ord_ids[num + i] = _current_rowid + i;
+        }
+        _current_rowid += *n;
+
+        return Status::OK();
+    }
+
+    Status next_batch(const SparseRange<>& range, Column* dst) override {
+        auto row_id_column = down_cast<RowIdColumn*>(dst);
+        SparseRangeIterator<> iter = range.new_iterator();
+        size_t to_read = range.span_size();
+        while (to_read > 0) {
+            _current_rowid = iter.begin();
+            Range<> r = iter.next(to_read);
+            auto& be_ids = row_id_column->be_ids_column()->get_data();
+            auto& seg_ids = row_id_column->seg_ids_column()->get_data();
+            auto& ord_ids = row_id_column->ord_ids_column()->get_data();
+            const size_t num = be_ids.size();
+            raw::stl_vector_resize_uninitialized(&be_ids, num + r.span_size());
+            for (size_t i = 0; i < r.span_size(); i++) {
+                be_ids[num + i] = _be_id;
+            }
+            raw::stl_vector_resize_uninitialized(&seg_ids, num + r.span_size());
+            for (size_t i = 0; i < r.span_size(); i++) {
+                seg_ids[num + i] = _seg_id;
+            }
+            raw::stl_vector_resize_uninitialized(&ord_ids, num + r.span_size());
+            for (size_t i = 0; i < r.span_size(); i++) {
+                ord_ids[num + i] = _current_rowid + i;
+            }
+
+            _current_rowid += r.span_size();
+            to_read -= r.span_size();
+        }
+        return Status::OK();
+    }
+
+    ordinal_t get_current_ordinal() const override { return _current_rowid; }
+
+    ordinal_t num_rows() const override { return 0; }
+
+    Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
+                                      const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
+                                      CompoundNodeType pred_relation) override {
+        return Status::NotSupported("PlaceHolderColumnIterator does not support");
+    }
+
+    bool all_page_dict_encoded() const override { return false; }
+
+    int dict_lookup(const Slice& word) override { return -1; }
+
+    Status next_dict_codes(size_t* n, Column* dst) override {
+        return Status::NotSupported("PlaceHolderColumnIterator does not support");
+    }
+
+    Status decode_dict_codes(const int32_t* codes, size_t size, Column* words) override {
+        return Status::NotSupported("PlaceHolderColumnIterator does not support");
+    }
+
+    Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* dst) override {
+        auto row_id_column = down_cast<RowIdColumn*>(dst);
+        const size_t num = row_id_column->size();
+        auto& be_ids = row_id_column->be_ids_column()->get_data();
+        raw::stl_vector_resize_uninitialized(&be_ids, num + size);
+        for (size_t i = 0; i < size; i++) {
+            be_ids[num + i] = _be_id;
+        }
+        auto& seg_ids = row_id_column->seg_ids_column()->get_data();
+        raw::stl_vector_resize_uninitialized(&seg_ids, num + size);
+        for (size_t i = 0; i < size; i++) {
+            seg_ids[num + i] = _seg_id;
+        }
+        auto& ord_ids = row_id_column->ord_ids_column()->get_data();
+        raw::stl_vector_resize_uninitialized(&ord_ids, num + size);
+        for (size_t i = 0; i < size; i++) {
+            ord_ids[num + i] = rowids[i];
+        }
+        return Status::OK();
+    }
+
+private:
+    uint32_t _be_id;
+    uint32_t _seg_id;
+    uint32_t _current_rowid = 0;
+};
+
+} // namespace starrocks

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -87,6 +87,7 @@ uint32_t TabletColumn::get_field_length_by_type(LogicalType type, uint32_t strin
     case TYPE_DATETIME:
     case TYPE_DECIMAL64:
         return 8;
+    case TYPE_ROW_ID:
     case TYPE_DECIMAL:
         return 12;
     case TYPE_LARGEINT:

--- a/be/src/storage/types.cpp
+++ b/be/src/storage/types.cpp
@@ -51,6 +51,7 @@
 #include "types/date_value.hpp"
 #include "types/large_int_value.h"
 #include "types/map_type_info.h"
+#include "types/row_id_type_info.h"
 #include "types/struct_type_info.h"
 #include "util/hash_util.hpp"
 #include "util/mem_util.hpp"
@@ -341,6 +342,8 @@ TypeInfoPtr get_type_info(LogicalType field_type, [[maybe_unused]] int precision
     } else if (field_type == TYPE_DECIMAL32 || field_type == TYPE_DECIMAL64 || field_type == TYPE_DECIMAL128 ||
                field_type == TYPE_DECIMAL256) {
         return get_decimal_type_info(field_type, precision, scale);
+    } else if (field_type == TYPE_ROW_ID) {
+        return get_row_id_type_info();
     } else {
         return nullptr;
     }

--- a/be/src/types/CMakeLists.txt
+++ b/be/src/types/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(Types STATIC
     logical_type.cpp
     map_type_info.cpp
     struct_type_info.cpp
+    row_id_type_info.cpp
     timestamp_value.cpp
     checker/type_checker.cpp
     type_checker_manager.cpp

--- a/be/src/types/logical_type.cpp
+++ b/be/src/types/logical_type.cpp
@@ -147,7 +147,10 @@ const char* logical_type_to_string(LogicalType type) {
         return "MAX_VALUE";
     case TYPE_VARBINARY:
         return "VARBINARY";
+    case TYPE_ROW_ID:
+        return "ROW_ID";
     }
+
     return "";
 }
 
@@ -162,6 +165,8 @@ LogicalType thrift_to_type(TPrimitiveType::type ttype) {
         return TYPE_UNKNOWN;
     case TPrimitiveType::NULL_TYPE:
         return TYPE_NULL;
+    case TPrimitiveType::ROW_ID:
+        return TYPE_ROW_ID;
 #define M(ttype)                \
     case TPrimitiveType::ttype: \
         return TYPE_##ttype;
@@ -188,7 +193,8 @@ TPrimitiveType::type to_thrift(LogicalType ltype) {
         return TPrimitiveType::INVALID_TYPE;
     case TYPE_NULL:
         return TPrimitiveType::NULL_TYPE;
-
+    case TYPE_ROW_ID:
+        return TPrimitiveType::ROW_ID;
 #define M(thrift_name)       \
     case TYPE_##thrift_name: \
         return TPrimitiveType::thrift_name;
@@ -218,6 +224,8 @@ std::string type_to_string(LogicalType t) {
         return "INVALID";
     case TYPE_NULL:
         return "NULL";
+    case TYPE_ROW_ID:
+        return "ROW_ID";
 #define M(ttype)       \
     case TYPE_##ttype: \
         return #ttype;

--- a/be/src/types/logical_type.h
+++ b/be/src/types/logical_type.h
@@ -73,9 +73,11 @@ enum LogicalType {
 
     TYPE_JSON = 54,
 
+    TYPE_ROW_ID = 55,
+
     // max value of LogicalType, newly-added type should not exceed this value.
     // used to create a fixed-size hash map.
-    TYPE_MAX_VALUE = 55
+    TYPE_MAX_VALUE = 56
 };
 
 // TODO(lism): support varbinary for zone map.
@@ -162,6 +164,7 @@ inline bool is_scalar_field_type(LogicalType type) {
     case TYPE_DECIMAL64:
     case TYPE_DECIMAL128:
     case TYPE_DECIMAL256:
+    case TYPE_ROW_ID:
         return false;
     default:
         return true;

--- a/be/src/types/logical_type_infra.h
+++ b/be/src/types/logical_type_infra.h
@@ -169,6 +169,7 @@ auto type_dispatch_all(LogicalType ltype, Functor fun, Args... args) {
         _TYPE_DISPATCH_CASE(TYPE_HLL)
         _TYPE_DISPATCH_CASE(TYPE_OBJECT)
         _TYPE_DISPATCH_CASE(TYPE_PERCENTILE)
+        _TYPE_DISPATCH_CASE(TYPE_ROW_ID)
     default:
         CHECK(false) << "Unknown type: " << ltype;
         __builtin_unreachable();
@@ -183,6 +184,7 @@ auto type_dispatch_column(LogicalType ltype, Functor fun, Args... args) {
         _TYPE_DISPATCH_CASE(TYPE_HLL)
         _TYPE_DISPATCH_CASE(TYPE_OBJECT)
         _TYPE_DISPATCH_CASE(TYPE_PERCENTILE)
+        _TYPE_DISPATCH_CASE(TYPE_ROW_ID)
     default:
         CHECK(false) << "Unknown type: " << ltype;
         __builtin_unreachable();

--- a/be/src/types/row_id_type_info.cpp
+++ b/be/src/types/row_id_type_info.cpp
@@ -1,0 +1,58 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "types/row_id_type_info.h"
+
+#include "common/logging.h"
+#include "runtime/mem_pool.h"
+
+namespace starrocks {
+
+class RowIdTypeInfo final : public TypeInfo {
+public:
+    RowIdTypeInfo() = default;
+    virtual ~RowIdTypeInfo() = default;
+
+    void shallow_copy(void* dest, const void* src) const override { CHECK(false); }
+
+    void deep_copy(void* dest, const void* src, MemPool* mem_pool) const override { CHECK(false); }
+
+    void direct_copy(void* dest, const void* src) const override { CHECK(false); }
+
+    Status from_string(void* buf, const std::string& scan_key) const override {
+        return Status::NotSupported("Not supported function");
+    }
+
+    std::string to_string(const void* src) const override { return "{}"; }
+
+    void set_to_max(void* buf) const override { DCHECK(false) << "set_to_max of list is not implemented."; }
+
+    void set_to_min(void* buf) const override { DCHECK(false) << "set_to_min of list is not implemented."; }
+
+    size_t size() const override { return 12; }
+
+    LogicalType type() const override { return TYPE_ROW_ID; }
+
+protected:
+    int _datum_cmp_impl(const Datum& left, const Datum& right) const override {
+        CHECK(false) << "not implemented";
+        return -1;
+    }
+};
+
+TypeInfoPtr get_row_id_type_info() {
+    return std::make_shared<RowIdTypeInfo>();
+}
+
+} // namespace starrocks

--- a/be/src/types/row_id_type_info.h
+++ b/be/src/types/row_id_type_info.h
@@ -1,0 +1,23 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+#pragma once
+
+#include "storage/types.h"
+
+namespace starrocks {
+
+TypeInfoPtr get_row_id_type_info();
+
+} // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -18,6 +18,7 @@ set(EXEC_FILES
         ./column/struct_column_test.cpp
         ./column/nullable_column_test.cpp
         ./column/object_column_test.cpp
+        ./column/row_id_column_test.cpp
         ./column/timestamp_value_test.cpp
         ./common/cow_test.cpp
         ./column/schema_test.cpp

--- a/be/test/column/row_id_column_test.cpp
+++ b/be/test/column/row_id_column_test.cpp
@@ -1,0 +1,135 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "column/row_id_column.h"
+
+#include <gtest/gtest.h>
+
+#include "column/array_column.h"
+#include "column/datum.h"
+#include "serde/column_array_serde.h"
+#include "storage/range.h"
+#include "storage/rowset/global_rowid_column_iterator.h"
+#include "testutil/assert.h"
+#include "testutil/parallel_test.h"
+
+namespace starrocks {
+
+PARALLEL_TEST(RowIdColumnTest, test_create) {
+    auto row_id_column = RowIdColumn::create();
+    ASSERT_TRUE(row_id_column->is_global_row_id());
+    ASSERT_EQ(row_id_column->size(), 0);
+
+    auto be_ids = UInt32Column::create();
+    be_ids->append_datum(1);
+    auto seg_ids = UInt32Column::create();
+    seg_ids->append_datum(1);
+    auto ord_ids = UInt32Column::create();
+    ord_ids->append_datum(1);
+
+    row_id_column = RowIdColumn::create(be_ids, seg_ids, ord_ids);
+    ASSERT_EQ(row_id_column->size(), 1);
+    ASSERT_EQ(row_id_column->capacity(), 1);
+    ASSERT_EQ(row_id_column->type_size(), 12);
+    ASSERT_EQ(row_id_column->byte_size(), 12);
+    ASSERT_EQ(row_id_column->byte_size(0, 1), 12);
+    ASSERT_EQ(row_id_column->byte_size(0), 12);
+
+    row_id_column->assign(3, 0);
+    ASSERT_EQ(row_id_column->size(), 3);
+}
+
+PARALLEL_TEST(RowIdColumnTest, test_append_data) {
+    auto row_id_column = RowIdColumn::create();
+    row_id_column->reserve(3);
+    row_id_column->append_datum(DatumRowId(1, 1, 1));
+    row_id_column->append_datum(DatumRowId(2, 2, 2));
+    row_id_column->append_datum(DatumRowId(3, 3, 3));
+    auto src_column = row_id_column->clone();
+
+    ASSERT_EQ(row_id_column->size(), 3);
+    ASSERT_EQ(row_id_column->get(0), DatumRowId(1, 1, 1));
+    ASSERT_EQ(row_id_column->get(1), DatumRowId(2, 2, 2));
+    ASSERT_EQ(row_id_column->get(2), DatumRowId(3, 3, 3));
+    ASSERT_EQ(row_id_column->debug_string(), "(1,1,1),(2,2,2),(3,3,3)");
+
+    row_id_column->remove_first_n_values(1);
+    ASSERT_EQ(row_id_column->size(), 2);
+    ASSERT_EQ(row_id_column->get(0), DatumRowId(2, 2, 2));
+    ASSERT_EQ(row_id_column->get(1), DatumRowId(3, 3, 3));
+
+    row_id_column->append(*row_id_column, 0, 1);
+    ASSERT_EQ(row_id_column->size(), 3);
+    ASSERT_EQ(row_id_column->get(2), DatumRowId(2, 2, 2));
+
+    std::vector<uint32_t> indexes = {1};
+    row_id_column->append_selective(*src_column, indexes.data(), 0, 1);
+    ASSERT_EQ(row_id_column->size(), 4);
+    ASSERT_EQ(row_id_column->get(3), DatumRowId(2, 2, 2));
+
+    row_id_column->resize(1);
+    row_id_column->append_value_multiple_times(*src_column, 0, 2);
+    ASSERT_EQ(row_id_column->size(), 3);
+    ASSERT_EQ(row_id_column->get(1), DatumRowId(1, 1, 1));
+
+    row_id_column->append_default();
+    ASSERT_EQ(row_id_column->size(), 4);
+    ASSERT_EQ(row_id_column->get(3), DatumRowId(0, 0, 0));
+}
+
+PARALLEL_TEST(RowIdColumnTest, test_serialize) {
+    auto row_id_column = RowIdColumn::create();
+    row_id_column->reserve(3);
+    row_id_column->append_datum(DatumRowId(1, 1, 1));
+    row_id_column->append_datum(DatumRowId(2, 2, 2));
+    row_id_column->append_datum(DatumRowId(3, 3, 3));
+
+    ASSERT_EQ(row_id_column->max_one_element_serialize_size(), 12);
+    ASSERT_EQ(serde::ColumnArraySerde::max_serialized_size(*row_id_column), 48);
+    uint8_t buffer[48];
+    const uint8_t* pos = serde::ColumnArraySerde::serialize(*row_id_column, buffer);
+    ASSERT_EQ(pos - buffer, 48);
+
+    auto ret = RowIdColumn::create();
+    pos = serde::ColumnArraySerde::deserialize(buffer, ret.get());
+    ASSERT_EQ(pos - buffer, 48);
+    ASSERT_EQ(ret->size(), 3);
+    ASSERT_EQ(ret->debug_string(), "(1,1,1),(2,2,2),(3,3,3)");
+}
+
+PARALLEL_TEST(RowIdColumnTest, test_column_iterator) {
+    const uint32_t mock_be_id = 1;
+    const uint32_t mock_seg_id = 2;
+    auto iter = std::make_unique<GlobalRowIdColumnIterator>(mock_be_id, mock_seg_id);
+    ASSERT_OK(iter->init({}));
+    ASSERT_OK(iter->seek_to_first());
+    ASSERT_EQ(iter->get_current_ordinal(), 0);
+    ASSERT_OK(iter->seek_to_ordinal(10));
+    ASSERT_EQ(iter->get_current_ordinal(), 10);
+
+    auto result = RowIdColumn::create();
+    size_t n = 5;
+    ASSERT_OK(iter->next_batch(&n, result.get()));
+    ASSERT_EQ(result->size(), 5);
+    ASSERT_EQ(result->debug_string(), "(1,2,10),(1,2,11),(1,2,12),(1,2,13),(1,2,14)");
+    SparseRange<rowid_t> range(15, 16);
+    result->reset_column();
+    ASSERT_OK(iter->next_batch(range, result.get()));
+    ASSERT_EQ(result->debug_string(), "(1,2,15)");
+    std::vector<rowid_t> rowids{1, 2, 3};
+    result->reset_column();
+    ASSERT_OK(iter->fetch_values_by_rowid(rowids.data(), 3, result.get()));
+    ASSERT_EQ(result->debug_string(), "(1,2,1),(1,2,2),(1,2,3)");
+}
+} // namespace starrocks

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -101,8 +101,9 @@ enum TPrimitiveType {
   JSON,
   FUNCTION,
   VARBINARY,
-  DECIMAL256,
-  INT256
+  DECIMAL256
+  INT256,
+  ROW_ID
 }
 
 enum TTypeNodeType {


### PR DESCRIPTION
## Why I'm doing:

This is the first part of #60015. We need a method to uniquely identify each row of data in order to implement delayed reading. 

## What I'm doing:

I introduce a new data type, `ROW_ID`, used to globally identify a row. 
The `ROW_ID` is composed of three parts: 
* `be_id`: identifies a specific BE node
* `seg_id`: identifies a specific segment.
* `ord_id`: identifies the position of the data within the segment

By using these three components, we can locate a specific row of data.

In this PR, I have only implemented some basic functionality for ROW_ID, including RowIdColumn, the in-memory representation of ROW_ID, and GlobalRowIdColumnIterator, which is used to return the corresponding rowid for each row. Subsequent PRs will depend on these components to implement global late materialization.


Fixes #60015

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3