### PR TITLE
[Feature] Introduce Column Hash Predicate as a Record Predicate for data filtering

### DIFF
--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -270,7 +270,9 @@ set(STORAGE_FILES
     index/vector/tenann_index_reader.cpp
     index/vector/tenann/del_id_filter.cpp
     index/vector/tenann/tenann_index_builder.cpp
-    index/vector/tenann/tenann_index_utils.cpp)
+    index/vector/tenann/tenann_index_utils.cpp
+    record_predicate/record_predicate_helper.cpp
+    record_predicate/column_hash_is_congruent.cpp)
 
 if (NOT BUILD_FORMAT_LIB)
     list(APPEND STORAGE_FILES  lake/starlet_location_provider.cpp)

--- a/be/src/storage/record_predicate/column_hash_is_congruent.cpp
+++ b/be/src/storage/record_predicate/column_hash_is_congruent.cpp
@@ -1,0 +1,72 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/record_predicate/column_hash_is_congruent.h"
+
+#include "column/chunk.h"
+#include "storage/record_predicate/record_predicate_helper.h"
+
+namespace starrocks {
+
+ColumnHashIsCongruent::ColumnHashIsCongruent(const RecordPredicatePB& record_predicate_pb)
+        : RecordPredicate(record_predicate_pb), _modulus(0), _remainder(0) {}
+
+Status ColumnHashIsCongruent::evaluate(Chunk* chunk, uint8_t* selection) const {
+    return evaluate(chunk, selection, 0, chunk->num_rows());
+}
+
+Status ColumnHashIsCongruent::evaluate(Chunk* chunk, uint8_t* selection, uint16_t from, uint16_t to) const {
+    RETURN_IF_ERROR(RecordPredicateHelper::check_valid_schema(*this, *chunk->schema()));
+    size_t size = to - from;
+    std::vector<uint32_t> hashes(size, 0);
+    for (const auto& col_name : _column_names) {
+        chunk->get_column_by_name(col_name)->crc32_hash(&(hashes)[0], from, size);
+    }
+
+    const uint32_t* hashes_data = hashes.data();
+    for (size_t i = from; i < to; ++i) {
+        selection[i] = (hashes_data[i - from] % _modulus == _remainder);
+    }
+    return Status::OK();
+}
+
+Status ColumnHashIsCongruent::init(const RecordPredicatePB& record_predicate_pb) {
+    const auto& column_hash_is_congruent_pb = record_predicate_pb.column_hash_is_congruent();
+    RETURN_IF_ERROR(_check_valid_pb(column_hash_is_congruent_pb));
+    _modulus = column_hash_is_congruent_pb.modulus();
+    _remainder = column_hash_is_congruent_pb.remainder();
+    _column_names.insert(_column_names.end(), column_hash_is_congruent_pb.column_names().begin(),
+                         column_hash_is_congruent_pb.column_names().end());
+    return Status::OK();
+}
+
+Status ColumnHashIsCongruent::_check_valid_pb(const ColumnHashIsCongruentMeta& column_hash_is_congruent_meta) const {
+    if (column_hash_is_congruent_meta.column_names().empty()) {
+        return Status::InternalError("column hash congruent predicate has no hash columns defined");
+    }
+    for (const auto& column_name : column_hash_is_congruent_meta.column_names()) {
+        if (column_name.empty()) {
+            return Status::InternalError("column hash congruent predicate has empty hash column name");
+        }
+    }
+
+    int64_t modulus = column_hash_is_congruent_meta.modulus();
+    int64_t remainder = column_hash_is_congruent_meta.remainder();
+    if (modulus <= 0 || remainder < 0 || remainder >= modulus) {
+        return Status::InternalError("Invalid modulus or remainder in column hash congruent predicate");
+    }
+    return Status::OK();
+}
+
+} // namespace starrocks

--- a/be/src/storage/record_predicate/column_hash_is_congruent.h
+++ b/be/src/storage/record_predicate/column_hash_is_congruent.h
@@ -1,0 +1,48 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "storage/record_predicate/record_predicate.h"
+
+namespace starrocks {
+/*
+ * ColumnHashIsCongruentPB is used to evaluate a chunk of data as following:
+ * 1. Compute the hash value of the specified columns.
+ * 2. Check if the hash value modulo a given modulus equals a specified remainder.
+*/
+class ColumnHashIsCongruent final : public RecordPredicate {
+public:
+    using ColumnHashIsCongruentMeta = RecordPredicatePB::ColumnHashIsCongruentPB;
+
+    ColumnHashIsCongruent(const RecordPredicatePB& record_predicate_pb);
+    ~ColumnHashIsCongruent() override = default;
+
+    Status evaluate(Chunk* chunk, uint8_t* selection) const override;
+
+    Status evaluate(Chunk* chunk, uint8_t* selection, uint16_t from, uint16_t to) const override;
+
+    Status init(const RecordPredicatePB& record_predicate_pb) override;
+
+    const std::vector<std::string>* column_names() const override { return &_column_names; }
+
+private:
+    Status _check_valid_pb(const ColumnHashIsCongruentMeta& column_hash_is_congruent_meta) const;
+
+    int64_t _modulus;
+    int64_t _remainder;
+    std::vector<std::string> _column_names;
+};
+
+} // namespace starrocks

--- a/be/src/storage/record_predicate/record_predicate.h
+++ b/be/src/storage/record_predicate/record_predicate.h
@@ -29,7 +29,8 @@ using RecordPredicateUPtr = std::unique_ptr<RecordPredicate>;
 
 class RecordPredicate {
 public:
-    RecordPredicate(const RecordPredicatePB& record_predicate_pb) : _pred_type(record_predicate_pb.type()), _children() {}
+    RecordPredicate(const RecordPredicatePB& record_predicate_pb)
+            : _pred_type(record_predicate_pb.type()), _children() {}
     virtual ~RecordPredicate() = default;
 
     // @Param chunk: the chunk to be evaluated

--- a/be/src/storage/record_predicate/record_predicate.h
+++ b/be/src/storage/record_predicate/record_predicate.h
@@ -1,0 +1,56 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "gen_cpp/types.pb.h"
+
+namespace starrocks {
+class Chunk;
+class Status;
+/*
+ * RecordPredicate is an abstract base class for predicates on chunk of data. All RecordPredicate
+ * can be only evaluated in storage layer.
+*/
+class RecordPredicate;
+using RecordPredicateSPtr = std::shared_ptr<RecordPredicate>;
+using RecordPredicateUPtr = std::unique_ptr<RecordPredicate>;
+
+class RecordPredicate {
+public:
+    RecordPredicate(const RecordPredicatePB& record_predicate_pb) : _pred_type(record_predicate_pb.type()), _children() {}
+    virtual ~RecordPredicate() = default;
+
+    // @Param chunk: the chunk to be evaluated
+    // @Param selection: the selection vector to be filled, which indicates whether each row in the chunk
+    // is selected (1) or not (0).
+    // @Param from: the starting index of the chunk to evaluate
+    // @Param to: the ending index of the chunk to evaluate
+    // @Return: Status indicating success or failure of the evaluation.
+    // The function without `from` and `to` parameters evaluates the entire chunk.
+    virtual Status evaluate(Chunk* chunk, uint8_t* selection) const = 0;
+    virtual Status evaluate(Chunk* chunk, uint8_t* selection, uint16_t from, uint16_t to) const = 0;
+
+    virtual Status init(const RecordPredicatePB& record_predicate_pb) = 0;
+
+    virtual const std::vector<std::string>* column_names() const = 0;
+
+    RecordPredicatePB::RecordPredicateTypePB type() { return _pred_type; }
+
+protected:
+    RecordPredicatePB::RecordPredicateTypePB _pred_type;
+    std::vector<RecordPredicateUPtr> _children;
+};
+
+} // namespace starrocks

--- a/be/src/storage/record_predicate/record_predicate_helper.cpp
+++ b/be/src/storage/record_predicate/record_predicate_helper.cpp
@@ -1,0 +1,103 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/record_predicate/record_predicate_helper.h"
+
+#include <fmt/format.h>
+
+#include "storage/chunk_helper.h"
+#include "storage/record_predicate/column_hash_is_congruent.h"
+#include "storage/tablet_schema.h"
+
+namespace starrocks {
+
+StatusOr<RecordPredicateUPtr> RecordPredicateHelper::create(const RecordPredicatePB& record_predicate_pb) {
+    RETURN_IF_ERROR(RecordPredicateHelper::_check_valid_pb(record_predicate_pb));
+    RecordPredicateUPtr predicate;
+    switch (record_predicate_pb.type()) {
+    case RecordPredicatePB::COLUMN_HASH_IS_CONGRUENT: {
+        predicate = std::make_unique<ColumnHashIsCongruent>(record_predicate_pb);
+        RETURN_IF_ERROR(predicate->init(record_predicate_pb));
+        break;
+    }
+    default:
+        return Status::InternalError(
+                fmt::format("Unknown record predicate type: {}",
+                            RecordPredicateHelper::from_type_to_string(record_predicate_pb.type())));
+    }
+    return predicate;
+}
+
+Status RecordPredicateHelper::check_valid_schema(const RecordPredicate& predicate, const Schema& chunk_schema) {
+    auto column_names = predicate.column_names();
+    for (const auto& column_name : *column_names) {
+        if (chunk_schema.get_field_index_by_name(column_name) == -1) {
+            return Status::InternalError(fmt::format(
+                    "chunk schema does not contains all columns which record predicate need, {}", column_name));
+        }
+    }
+    return Status::OK();
+}
+
+Status RecordPredicateHelper::get_column_ids(const RecordPredicate& predicate,
+                                             const std::shared_ptr<const TabletSchema>& tablet_schema,
+                                             std::set<ColumnId>* column_ids) {
+    std::vector<ColumnId> schema_cids(tablet_schema->columns().size());
+    std::iota(schema_cids.begin(), schema_cids.end(), 0);
+    Schema schema = ChunkHelper::convert_schema(tablet_schema, schema_cids);
+    return RecordPredicateHelper::get_column_ids(predicate, schema, column_ids);
+}
+
+Status RecordPredicateHelper::get_column_ids(const RecordPredicate& predicate, const Schema& schema,
+                                             std::set<ColumnId>* column_ids) {
+    RETURN_IF_ERROR(RecordPredicateHelper::check_valid_schema(predicate, schema));
+    auto column_names = predicate.column_names();
+    for (const auto& col_name : *column_names) {
+        auto f = schema.get_field_by_name(col_name);
+        if (f != nullptr) {
+            column_ids->insert(f->id());
+        }
+    }
+    return Status::OK();
+}
+
+std::string RecordPredicateHelper::from_type_to_string(RecordPredicatePB::RecordPredicateTypePB pred_type) {
+    switch (pred_type) {
+    case RecordPredicatePB::COLUMN_HASH_IS_CONGRUENT:
+        return "COLUMN_HASH_IS_CONGRUENT";
+    default:
+        break;
+    }
+    return "UNKNOWN";
+}
+
+Status RecordPredicateHelper::_check_valid_pb(const RecordPredicatePB& record_predicate_pb) {
+    switch (record_predicate_pb.type()) {
+    case RecordPredicatePB::COLUMN_HASH_IS_CONGRUENT: {
+        if (!record_predicate_pb.has_column_hash_is_congruent()) {
+            return Status::InternalError(
+                    "record predicate type is COLUMN_HASH_IS_CONGRUENT but no corresponding PredicatePB was defined");
+        }
+        break;
+    }
+    case RecordPredicatePB::UNKNOWN:
+    default:
+        return Status::InternalError(
+                fmt::format("Unknown record predicate type: {}",
+                            RecordPredicateHelper::from_type_to_string(record_predicate_pb.type())));
+    }
+    return Status::OK();
+}
+
+} // namespace starrocks

--- a/be/src/storage/record_predicate/record_predicate_helper.h
+++ b/be/src/storage/record_predicate/record_predicate_helper.h
@@ -1,0 +1,44 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "storage/olap_common.h"
+#include "storage/record_predicate/record_predicate.h"
+
+namespace starrocks {
+class TabletSchema;
+class Schema;
+
+template <typename T>
+class StatusOr;
+
+class RecordPredicateHelper {
+public:
+    static StatusOr<RecordPredicateUPtr> create(const RecordPredicatePB& record_predicate_pb);
+
+    static Status check_valid_schema(const RecordPredicate& predicate, const Schema& chunk_schema);
+    static Status get_column_ids(const RecordPredicate& predicate,
+                                 const std::shared_ptr<const TabletSchema>& tablet_schema,
+                                 std::set<ColumnId>* column_ids);
+    static Status get_column_ids(const RecordPredicate& predicate, const Schema& schema,
+                                 std::set<ColumnId>* column_ids);
+
+    static std::string from_type_to_string(RecordPredicatePB::RecordPredicateTypePB pred_type);
+
+private:
+    static Status _check_valid_pb(const RecordPredicatePB& record_predicate_pb);
+};
+
+} // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -546,6 +546,8 @@ set(EXEC_FILES
         ./storage/lake/persistent_index_sstable_test.cpp
         ./storage/lake/write_combined_txn_log_test.cpp
         ./storage/lake/tablet_retain_info_test.cpp
+        ./storage/record_predicate/column_hash_is_congruent_test.cpp
+        ./storage/record_predicate/record_predicate_helper_test.cpp
         ./cache/datacache_utils_test.cpp
         ./cache/block_cache/block_cache_hit_rate_counter_test.cpp
         ./cache/peer_cache_test.cpp

--- a/be/test/storage/record_predicate/column_hash_is_congruent_test.cpp
+++ b/be/test/storage/record_predicate/column_hash_is_congruent_test.cpp
@@ -1,0 +1,98 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/record_predicate/column_hash_is_congruent.h"
+
+#include <gtest/gtest.h>
+
+#include "storage/chunk_helper.h"
+#include "storage/record_predicate/record_predicate_helper.h"
+#include "storage/tablet_schema.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+class ColumnHashIsCongruentTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        TabletSchemaPB schema_pb;
+        schema_pb.set_keys_type(PRIMARY_KEYS);
+        schema_pb.set_num_short_key_columns(1);
+        schema_pb.set_num_rows_per_row_block(5);
+        schema_pb.set_next_column_unique_id(2);
+
+        ColumnPB& col = *(schema_pb.add_column());
+        col.set_unique_id(1);
+        col.set_name("col1");
+        col.set_type("INT");
+        col.set_is_key(true);
+        col.set_is_nullable(false);
+        col.set_default_value("1");
+
+        ColumnPB& col2 = *(schema_pb.add_column());
+        col2.set_unique_id(2);
+        col2.set_name("col2");
+        col2.set_type("INT");
+        col2.set_is_key(false);
+        col2.set_is_nullable(false);
+        col2.set_default_value("2");
+
+        _table_schema = std::make_shared<const TabletSchema>(schema_pb);
+    }
+
+private:
+    std::shared_ptr<const TabletSchema> _table_schema;
+};
+
+TEST_F(ColumnHashIsCongruentTest, basicColumnHashIsCongruent) {
+    auto chunk = ChunkHelper::new_chunk(*_table_schema->schema(), 2);
+    RecordPredicatePB record_predicate_pb;
+
+    record_predicate_pb.set_type(RecordPredicatePB::COLUMN_HASH_IS_CONGRUENT);
+    ASSERT_ERROR(RecordPredicateHelper::create(record_predicate_pb));
+
+    auto column_hash_is_congruent_pb = record_predicate_pb.mutable_column_hash_is_congruent();
+    ASSERT_ERROR(RecordPredicateHelper::create(record_predicate_pb));
+
+    column_hash_is_congruent_pb->add_column_names("");
+    ASSERT_ERROR(RecordPredicateHelper::create(record_predicate_pb));
+
+    column_hash_is_congruent_pb->clear_column_names();
+    column_hash_is_congruent_pb->add_column_names("not_existed_col_name");
+    column_hash_is_congruent_pb->set_modulus(-1);
+    column_hash_is_congruent_pb->set_remainder(-1);
+    ASSERT_ERROR(RecordPredicateHelper::create(record_predicate_pb));
+    column_hash_is_congruent_pb->set_modulus(2);
+    column_hash_is_congruent_pb->set_remainder(0);
+
+    ASSIGN_OR_ABORT(auto predicate_err, RecordPredicateHelper::create(record_predicate_pb));
+    ASSERT_ERROR(predicate_err->evaluate(chunk.get(), nullptr, 0, 0));
+
+    column_hash_is_congruent_pb->clear_column_names();
+    column_hash_is_congruent_pb->add_column_names("col1");
+    column_hash_is_congruent_pb->set_modulus(2);
+    column_hash_is_congruent_pb->set_remainder(0);
+    chunk->append_default();
+
+    uint32_t hashes = 0;
+    chunk->get_column_by_name("col1")->crc32_hash(&(hashes), 0, 1);
+    bool expected = (hashes % 2 == 0);
+
+    ASSIGN_OR_ABORT(auto predicate, RecordPredicateHelper::create(record_predicate_pb));
+    std::vector<uint8_t> select;
+    select.resize(1);
+    ASSERT_OK(predicate->evaluate(chunk.get(), select.data()));
+    ASSERT_EQ(select[0], expected);
+}
+
+} // namespace starrocks

--- a/be/test/storage/record_predicate/record_predicate_helper_test.cpp
+++ b/be/test/storage/record_predicate/record_predicate_helper_test.cpp
@@ -1,0 +1,79 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/record_predicate/record_predicate_helper.h"
+
+#include <gtest/gtest.h>
+
+#include "storage/chunk_helper.h"
+#include "storage/tablet_schema.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+class RecordPredicateHelperTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        TabletSchemaPB schema_pb;
+        schema_pb.set_keys_type(PRIMARY_KEYS);
+        schema_pb.set_num_short_key_columns(1);
+        schema_pb.set_num_rows_per_row_block(5);
+        schema_pb.set_next_column_unique_id(2);
+
+        ColumnPB& col = *(schema_pb.add_column());
+        col.set_unique_id(1);
+        col.set_name("col1");
+        col.set_type("INT");
+        col.set_is_key(true);
+        col.set_is_nullable(false);
+        col.set_default_value("1");
+
+        ColumnPB& col2 = *(schema_pb.add_column());
+        col2.set_unique_id(2);
+        col2.set_name("col2");
+        col2.set_type("INT");
+        col2.set_is_key(false);
+        col2.set_is_nullable(false);
+        col2.set_default_value("2");
+
+        _table_schema = std::make_shared<const TabletSchema>(schema_pb);
+    }
+
+private:
+    std::shared_ptr<const TabletSchema> _table_schema;
+};
+
+TEST_F(RecordPredicateHelperTest, basicRecordPredicateHelper) {
+    auto chunk = ChunkHelper::new_chunk(*_table_schema->schema(), 2);
+    RecordPredicatePB record_predicate_pb;
+
+    record_predicate_pb.set_type(RecordPredicatePB::COLUMN_HASH_IS_CONGRUENT);
+    auto column_hash_is_congruent_pb = record_predicate_pb.mutable_column_hash_is_congruent();
+    column_hash_is_congruent_pb->add_column_names("col1");
+    column_hash_is_congruent_pb->set_modulus(2);
+    column_hash_is_congruent_pb->set_remainder(0);
+    ASSIGN_OR_ABORT(auto predicate, RecordPredicateHelper::create(record_predicate_pb));
+
+    std::set<ColumnId> column_ids;
+    ASSERT_OK(RecordPredicateHelper::check_valid_schema(*predicate, *_table_schema->schema()));
+
+    column_ids.clear();
+    ASSERT_OK(RecordPredicateHelper::get_column_ids(*predicate, _table_schema, &column_ids));
+    ASSERT_TRUE(column_ids.size() == 1);
+
+    column_ids.clear();
+    ASSERT_OK(RecordPredicateHelper::get_column_ids(*predicate, *_table_schema->schema(), &column_ids));
+    ASSERT_TRUE(column_ids.size() == 1);
+}
+
+} // namespace starrocks

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -118,6 +118,8 @@ message RowsetMetadataPB {
     repeated int64 bundle_file_offsets = 14;
     // Whether segments are shared by multiple tablets
     repeated bool shared_segments = 15;
+    // Record Predicate use for filtering all segments for the current rowset
+    optional RecordPredicatePB record_predicate = 16;
 }
 
 // At present, the lake persistent index reuses the logic of the persistent index,

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -181,6 +181,25 @@ message IsNullPredicatePB {
     optional bool is_not_null = 2;
 }
 
+message RecordPredicatePB {
+    enum RecordPredicateTypePB {
+        UNKNOWN = 0;
+        COLUMN_HASH_IS_CONGRUENT = 1;
+    }
+
+    message ColumnHashIsCongruentPB {
+        optional int64 modulus = 1;
+        optional int64 remainder = 2;
+        repeated string column_names = 3;
+    }
+
+    optional RecordPredicateTypePB type = 1;
+    // set by some type of predicate (RecordPredicateTypePB is AND/OR/NOT...) which will be implemented in the future
+    repeated RecordPredicatePB children = 2;
+    // The following member should be set one of them by predicate type
+    optional ColumnHashIsCongruentPB column_hash_is_congruent = 3;
+}
+
 message IndexValueWithVerPB {
     // will be set after mvcc support
     optional int64 version = 1;


### PR DESCRIPTION
## What I'm doing:
This is a prerequisite for tablet splitting. We introduce `RecordPredicate` and its derived class `ColumnHashIsCongruent` into `RowsetMetadataPB` to provide ability to filter data in all segments of the rowset using this predicate. `RecordPredicate` can be considered as a storage layer only predicate to filter data and `ColumnHashIsCongruent` calculate the available row for a given chunk in the following way:
1. Find columns by hash_column_names in chunk and calculate their combined `crc32` value.
2. `select[i] = (hashes[i] % modulus == remainder)`

Fixes #59134

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
