### PR TITLE
[BugFix] fix window pre-aggregation for count(*)

### DIFF
--- a/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
+++ b/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
@@ -100,7 +100,8 @@ Status LocalPartitionTopnContext::prepare_pre_agg(RuntimeState* state) {
         TypeDescriptor return_type = TypeDescriptor::from_thrift(fn.ret_type);
         TypeDescriptor serde_type = TypeDescriptor::from_thrift(fn.aggregate_fn.intermediate_type);
 
-        TypeDescriptor arg_type = TypeDescriptor::from_thrift(fn.arg_types[0]);
+        TypeDescriptor arg_type = fn.arg_types.empty() ? TypeDescriptor::from_logical_type(TYPE_UNKNOWN)
+                                                       : TypeDescriptor::from_thrift(fn.arg_types[0]);
 
         // Collect arg_typedescs for aggregate function.
         std::vector<FunctionContext::TypeDesc> arg_typedescs;

--- a/test/sql/test_window_function/R/test_window_pre_agg_with_rank
+++ b/test/sql/test_window_function/R/test_window_pre_agg_with_rank
@@ -94,3 +94,19 @@ WHERE _rowid <= 2 order by c4,c6;
 4	2	2	4	2	2	1	18	2.0
 4	2	2	5	2	22	2	18	2.0
 -- !result
+SELECT 1
+FROM (
+    SELECT
+        COUNT(*) OVER (PARTITION BY c1) as _count,
+        ROW_NUMBER() OVER ( PARTITION BY c1 ORDER BY RAND() ) as rn
+    FROM t1
+) as x
+WHERE rn <= 2;
+-- result:
+1
+1
+1
+1
+1
+1
+-- !result

--- a/test/sql/test_window_function/T/test_window_pre_agg_with_rank
+++ b/test/sql/test_window_function/T/test_window_pre_agg_with_rank
@@ -77,3 +77,13 @@ FROM (
         ) t3
 ) t4
 WHERE _rowid <= 2 order by c4,c6;
+
+-- case 4: count * + row number with same partition and predicate
+SELECT 1
+FROM (
+    SELECT
+        COUNT(*) OVER (PARTITION BY c1) as _count,
+        ROW_NUMBER() OVER ( PARTITION BY c1 ORDER BY RAND() ) as rn
+    FROM t1
+) as x
+WHERE rn <= 2;


### PR DESCRIPTION
## Why I'm doing:

Fixes regression after #52466 
if we disable optimization with flag query will executed correctly
`enable_push_down_pre_agg_with_rank=false`
otherwise will crashed

another workaround: use specific column name instead of `*`

some function have empty arg_types, for example `count(*)`
and code will crash
```
        TypeDescriptor arg_type = TypeDescriptor::from_thrift(fn.arg_types[0]);
```

```
PC: @         0x1330e5b6 std::vector<starrocks::TTypeNode, std::allocator<starrocks::TTypeNode> >::size() const
*** SIGSEGV (@0x10) received by PID 133245 (TID 0x7f7b2a631640) from PID 16; stack trace: ***
    @     0x7f7bf4e3fee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @         0x1cc76d69 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f7bf4de8520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @         0x1330e5b6 std::vector<starrocks::TTypeNode, std::allocator<starrocks::TTypeNode> >::size() const
    @         0x188448e6 starrocks::TypeDescriptor::TypeDescriptor(std::vector<starrocks::TTypeNode, std::allocator<starrocks::TTypeNode> > const&, int*)
    @         0x13382799 starrocks::TypeDescriptor::from_thrift(starrocks::TTypeDesc const&)
    @         0x1837b490 starrocks::pipeline::LocalPartitionTopnContext::prepare_pre_agg(starrocks::RuntimeState*)
    @         0x1837ad8a starrocks::pipeline::LocalPartitionTopnContext::prepare(starrocks::RuntimeState*, starrocks::RuntimeProfile*)
    @         0x183b62fe starrocks::pipeline::LocalPartitionTopnSinkOperator::prepare(starrocks::RuntimeState*)
    @         0x1764e58f starrocks::pipeline::PipelineDriver::prepare(starrocks::RuntimeState*)
```

## What I'm doing:

add validation of parameter and if we have empty arg_types will set it as TYPE_UNKNOWN
it's safe because for `count` function we always override it later as
```cpp
        if (fn.name.function_name == "count") {
            arg_type.type = TYPE_BIGINT;
```

for other functions also safe and will handled by code with return Status::InternalError instead of BE crash

```cpp
        func = get_window_function(fn.name.function_name, arg_type.type, return_type.type, is_input_nullable,
                                   fn.binary_type, state->func_version());

        if (func == nullptr) {
            return Status::InternalError(strings::Substitute("Invalid window function plan: ($0, $1, $2, $3, $4, $5)",
                                                             fn.name.function_name, arg_type.type, return_type.type,
                                                             is_input_nullable, fn.binary_type, state->func_version()));
        }
```

code introduced in 3.4 as optimization, so required branches to fix main, 3.6, 3.5, 3.4

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
