### PR TITLE
[Enhancement] bump up breakpad to 2024.02.16 to fix crash in dump_syms

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -915,7 +915,7 @@ build_breakpad() {
     cd $TP_SOURCE_DIR/$BREAK_PAD_SOURCE
     mkdir -p src/third_party/lss
     cp $TP_PATCH_DIR/linux_syscall_support.h src/third_party/lss
-    LDFLAGS="-L${TP_INSTALL_DIR}/lib -L${TP_INSTALL_DIR}/lib64" \
+    LDFLAGS="-L${TP_LIB_DIR}" \
     CFLAGS= ./configure --prefix=$TP_INSTALL_DIR --enable-shared=no --disable-samples --disable-libevent-regress
     make -j$PARALLEL
     make install

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -915,6 +915,7 @@ build_breakpad() {
     cd $TP_SOURCE_DIR/$BREAK_PAD_SOURCE
     mkdir -p src/third_party/lss
     cp $TP_PATCH_DIR/linux_syscall_support.h src/third_party/lss
+    LDFLAGS="-L${TP_INSTALL_DIR}/lib -L${TP_INSTALL_DIR}/lib64" \
     CFLAGS= ./configure --prefix=$TP_INSTALL_DIR --enable-shared=no --disable-samples --disable-libevent-regress
     make -j$PARALLEL
     make install

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -596,6 +596,10 @@ if [[ -d $TP_SOURCE_DIR/$BREAK_PAD_SOURCE ]] ; then
         patch -p1 < "$TP_PATCH_DIR/breakpad-2022.07.12.patch"
         touch "$PATCHED_MARK"
     fi
+    if [ ! -f "$PATCHED_MARK" ] && [[ $BREAK_PAD_SOURCE == "breakpad-2024.02.16" ]] ; then
+        patch -p1 < "$TP_PATCH_DIR/breakpad-2024.02.16.patch"
+        touch "$PATCHED_MARK"
+    fi
     cd -
     echo "Finished patching $BREAK_PAD_SOURCE"
 fi

--- a/thirdparty/minidump/gen_minidump_symbols.sh
+++ b/thirdparty/minidump/gen_minidump_symbols.sh
@@ -12,10 +12,10 @@ starrocks_home=$(dirname $(dirname $curdir))
 # generate symbol's file in Breakpad's own format.
 $(dirname $curdir)/installed/bin/dump_syms $starrocks_home/output/be/lib/starrocks_be > $starrocks_home/output/be/starrocks_be.sym
 
-((starrocks_be_size_original=`ls -l output/be/lib/starrocks_be | awk '{print $5}'` / (1024*1024)))
+((starrocks_be_size_original=`ls -l $starrocks_home/output/be/lib/starrocks_be | awk '{print $5}'` / (1024*1024)))
 # remove debugging infos
 strip $starrocks_home/output/be/lib/starrocks_be
-((starrocks_be_size_simplify=`ls -l output/be/lib/starrocks_be | awk '{print $5}'` / (1024*1024)))
+((starrocks_be_size_simplify=`ls -l $starrocks_home/output/be/lib/starrocks_be | awk '{print $5}'` / (1024*1024)))
 
 # echo size reduction
 echo "starrocks_be'size ("$starrocks_be_size_original"mb) reduced to ("$starrocks_be_size_simplify"mb)"

--- a/thirdparty/patches/breakpad-2024.02.16.patch
+++ b/thirdparty/patches/breakpad-2024.02.16.patch
@@ -1,0 +1,17 @@
+diff --git a/src/common/linux/dump_symbols.cc b/src/common/linux/dump_symbols.cc
+index b693fc9e..8686ee38 100644
+--- a/src/common/linux/dump_symbols.cc
++++ b/src/common/linux/dump_symbols.cc
+@@ -82,6 +82,12 @@
+ #endif
+ #include "common/using_std_string.h"
+ 
++#ifndef SHF_COMPRESSED
++#define SHF_COMPRESSED       (1 << 11)  /* Section with compressed data. */
++#define ELFCOMPRESS_ZLIB     1          /* ZLIB/DEFLATE algorithm.  */
++#define EM_RISCV             243     /* RISC-V */
++#endif
++
+ // This namespace contains helper functions.
+ namespace {
+ 

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -295,10 +295,10 @@ RYU_SOURCE="ryu-aa31ca9361d21b1a00ee054aac49c87d07e74abc"
 RYU_MD5SUM="cb82b6da904d919470fe3f5a01ca30ff"
 
 # breakpad
-BREAK_PAD_DOWNLOAD="https://github.com/google/breakpad/archive/refs/tags/v2022.07.12.tar.gz"
-BREAK_PAD_NAME="breakpad-2022.07.12.tar.gz"
-BREAK_PAD_SOURCE="breakpad-2022.07.12"
-BREAK_PAD_MD5SUM="d5bcfd3f7b361ef5bda96123c3abdd0a"
+BREAK_PAD_DOWNLOAD="https://github.com/google/breakpad/archive/refs/tags/v2024.02.16.tar.gz"
+BREAK_PAD_NAME="breakpad-2024.02.16.tar.gz"
+BREAK_PAD_SOURCE="breakpad-2024.02.16"
+BREAK_PAD_MD5SUM="ae8c55b23c157771922b5ddca3803055"
 
 # RAGEL
 # ragel-6.9+ is used by hyperscan, so we build it first


### PR DESCRIPTION
we are using and older version of dump_syms that doesn’t understand the .relr.dyn section

Fixes #60004 

update breakpad to version breakpad-2024.02.16

$ bash thirdparty/minidump/gen_minidump_symbols.sh
starrocks_be'size (2153mb) reduced to (556mb)
symbol file is at /home/ubuntu/starrocks/output/be/symbols/starrocks_be/AC7FAB7F8B5BF82100000000000000000

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.5
  - [ ] 3.4
  - [ ] 3.3
