### PR TITLE
[BugFix] Create temporary partitions bugfix + fix comparisons on Type.Date and Type.Datetime

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DateLiteral.java
@@ -444,10 +444,10 @@ public class DateLiteral extends LiteralExpr {
 
     @Override
     public boolean isNullable() {
-        if (type == Type.DATETIME) {
+        if (type.isDatetime()) {
             return this.compareLiteral(DateLiteral.MIN_DATETIME) < 0
                     || DateLiteral.MAX_DATETIME.compareLiteral(this) < 0;
-        } else if (type == Type.DATE) {
+        } else if (type.isDate()) {
             return this.compareLiteral(DateLiteral.MIN_DATE) < 0 || DateLiteral.MAX_DATE.compareLiteral(this) < 0;
         }
         return true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PartitionDescAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PartitionDescAnalyzer.java
@@ -266,7 +266,7 @@ public class PartitionDescAnalyzer {
                         partitionGranularity);
         }
         if (!(standardBeginTime.equals(partitionBeginDateTime) && standardEndTime.equals(partitionEndDateTime))) {
-            DateTimeFormatter outputDateFormat = partitionColumnType == Type.DATE
+            DateTimeFormatter outputDateFormat = partitionColumnType.isDate()
                     ? DateUtils.DATE_FORMATTER_UNIX : DateUtils.DATE_TIME_FORMATTER_UNIX;
 
             String msg = "Batch build partition range [" +

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/MultiRangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/MultiRangePartitionDesc.java
@@ -45,7 +45,6 @@ import java.util.Map;
 import java.util.TimeZone;
 
 public class MultiRangePartitionDesc extends PartitionDesc {
-    private static final Logger LOG = LogManager.getLogger(MultiRangePartitionDesc.class);
 
     private final String defaultPrefix = "p";
     private final String defaultTempPartitionPrefix = "tp";
@@ -105,7 +104,6 @@ public class MultiRangePartitionDesc extends PartitionDesc {
     private List<SingleRangePartitionDesc> buildDateTypePartition(PartitionConvertContext context)
             throws AnalysisException {
         // int type does not support datekey int type
-        LOG.debug("buildDateTypePartition: partition column type: {}", context.getFirstPartitionColumnType());
 
         LocalDateTime beginTime;
         LocalDateTime endTime;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/MultiRangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/MultiRangePartitionDesc.java
@@ -30,6 +30,8 @@ import com.starrocks.common.util.TimeUtils;
 import com.starrocks.sql.analyzer.PartitionDescAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.parser.NodePosition;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -43,6 +45,7 @@ import java.util.Map;
 import java.util.TimeZone;
 
 public class MultiRangePartitionDesc extends PartitionDesc {
+    private static final Logger LOG = LogManager.getLogger(MultiRangePartitionDesc.class);
 
     private final String defaultPrefix = "p";
     private final String defaultTempPartitionPrefix = "tp";
@@ -102,6 +105,7 @@ public class MultiRangePartitionDesc extends PartitionDesc {
     private List<SingleRangePartitionDesc> buildDateTypePartition(PartitionConvertContext context)
             throws AnalysisException {
         // int type does not support datekey int type
+        LOG.debug("buildDateTypePartition: partition column type: {}", context.getFirstPartitionColumnType());
 
         LocalDateTime beginTime;
         LocalDateTime endTime;
@@ -180,7 +184,7 @@ public class MultiRangePartitionDesc extends PartitionDesc {
         }
 
         DateTimeFormatter outputDateFormat = DateUtils.DATE_FORMATTER;
-        if (context.getFirstPartitionColumnType() == Type.DATETIME) {
+        if (context.getFirstPartitionColumnType().isDatetime()) {
             outputDateFormat = DateUtils.DATE_TIME_FORMATTER;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/MultiRangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/MultiRangePartitionDesc.java
@@ -30,8 +30,6 @@ import com.starrocks.common.util.TimeUtils;
 import com.starrocks.sql.analyzer.PartitionDescAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.parser.NodePosition;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/PartitionValue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/PartitionValue.java
@@ -70,7 +70,7 @@ public class PartitionValue implements ParseNode {
         if (isMax()) {
             return LiteralExpr.createInfinity(type, true);
         } else {
-            if (type == Type.DATETIME) {
+            if (type.isDatetime()) {
                 try {
                     return LiteralExpr.create(value, type);
                 } catch (AnalysisException ex) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ListPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ListPartitionPruner.java
@@ -500,7 +500,7 @@ public class ListPartitionPruner implements PartitionPruner {
     private static LiteralExpr castLiteralExpr(LiteralExpr literalExpr, Type type) {
         LiteralExpr result = null;
         String value = literalExpr.getStringValue();
-        if (literalExpr.getType() == Type.DATE && type.isNumericType()) {
+        if (literalExpr.getType().isDate() && type.isNumericType()) {
             value = String.valueOf(literalExpr.getLongValue() / 1000000);
         }
         try {


### PR DESCRIPTION
## Why I'm doing:
When adding temporary partitions using an ALTER TABLE statement with START and END values that include hour/minute/second, StarRocks would incorrectly truncate the partition key values and only preserve the date part after parsing, even if the partition column is of type DATETIME. This leads to errors when adding hourly temporary partitions, including failed validation due to "The lower values must smaller than upper values."

* Logging at each step showed that:
    * The table and partition column’s type remained DATETIME throughout the parser, visitor, and analyzer.
    * However, inside MultiRangePartitionDesc.buildDateTypePartition(), even though the type was reported as DATETIME, the code used the DATE formatter unless the object passed an identity (==) comparison to Type.DATETIME.

### Note on what I learned during unit test writing

I found by forcibly creating a non-singleton ScalarType in tests—that there must exist at least one code path in the system where a ScalarType (such as DATETIME) is instantiated without going through the canonical singleton factory method (Type.DATETIME, Type.fromPrimitiveType, etc.). This probably happens during some sort of image deserialization, by json/protobuf libraries maybe. 
The added unit test demonstrates  this risk. While this PR addresses the specific instance I found, similar issues could exist in other type comparison sites throughout the codebase, hard to say. 

## What I'm doing:
* Replaced == with .isDatetime() when comparing partition column types to Type.DATETIME in date partition construction logic.
    * For this, the relevant one is in com.starrocks.sql.ast.MultiRangePartitionDesc#buildDateTypePartition. I also went and did the same thing where there was obviously the same bug for Date and Datetime types. 
* Another possible solution would have been to override Type.equals() but I'm not confident that I'd do it correctly for all cases and it would have a bigger blast radius. 
* Temporary partitions now correctly parse and preserve full datetime values, supporting hourly partitioning aligned with the schema.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
