### PR TITLE
[Enhancement] optimize count(1) for iceberg table

### DIFF
--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -166,7 +166,6 @@ private:
 
     std::vector<std::string> _hive_column_names;
     bool _case_sensitive = false;
-    bool _can_use_any_column = false;
     bool _can_use_min_max_count_opt = false;
     const HiveTableDescriptor* _hive_table = nullptr;
 

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -124,19 +124,13 @@ Status HdfsScanner::_build_scanner_context() {
     // build columns of materialized and partition.
     for (size_t i = 0; i < _scanner_params.materialize_slots.size(); i++) {
         auto* slot = _scanner_params.materialize_slots[i];
-
-        // if `can_use_any_column`, we can set this column to non-existed column without reading it.
-        if (_scanner_params.can_use_any_column) {
-            ctx.update_with_none_existed_slot(slot);
-        } else {
-            HdfsScannerContext::ColumnInfo column;
-            column.slot_desc = slot;
-            column.idx_in_chunk = _scanner_params.materialize_index_in_chunk[i];
-            column.decode_needed =
-                    slot->is_output_column() || _scanner_params.slots_of_multi_field_conjunct.find(slot->id()) !=
-                                                        _scanner_params.slots_of_multi_field_conjunct.end();
-            ctx.materialized_columns.emplace_back(std::move(column));
-        }
+        HdfsScannerContext::ColumnInfo column;
+        column.slot_desc = slot;
+        column.idx_in_chunk = _scanner_params.materialize_index_in_chunk[i];
+        column.decode_needed =
+                slot->is_output_column() || _scanner_params.slots_of_multi_field_conjunct.find(slot->id()) !=
+                                                    _scanner_params.slots_of_multi_field_conjunct.end();
+        ctx.materialized_columns.emplace_back(std::move(column));
     }
 
     for (size_t i = 0; i < _scanner_params.partition_slots.size(); i++) {
@@ -163,7 +157,6 @@ Status HdfsScanner::_build_scanner_context() {
     ctx.hive_column_names = _scanner_params.hive_column_names;
     ctx.case_sensitive = _scanner_params.case_sensitive;
     ctx.orc_use_column_names = _scanner_params.orc_use_column_names;
-    ctx.can_use_any_column = _scanner_params.can_use_any_column;
     ctx.can_use_min_max_count_opt = _scanner_params.can_use_min_max_count_opt;
     ctx.use_file_metacache = _scanner_params.use_file_metacache;
     ctx.use_file_pagecache = _scanner_params.use_file_pagecache;
@@ -196,12 +189,34 @@ Status HdfsScanner::_build_scanner_context() {
     ctx.rf_scan_range_pruner = opts.obj_pool->add(
             new RuntimeScanRangePruner(predicate_parser, ctx.conjuncts_manager->unarrived_runtime_filters()));
 
+    RETURN_IF_ERROR(ctx.update_return_count_columns());
+    if (ctx.scan_range->__isset.file_record_count) {
+        ctx.has_file_record_count = true;
+    }
     return Status::OK();
 }
 
 Status HdfsScanner::get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
     SCOPED_RAW_TIMER(&_total_running_time);
     RETURN_IF_CANCELLED(_runtime_state);
+
+    // short circuit for ___count___ optimization.
+    if (_scanner_ctx.return_count_column && _scanner_ctx.has_file_record_count) {
+        if (_scanner_ctx.emit_count_column) {
+            return Status::EndOfFile("");
+        }
+        int64_t file_record_count = 0;
+        if (_scanner_ctx.scan_range->offset == 0) {
+            file_record_count = _scanner_ctx.scan_range->file_record_count;
+        }
+        _scanner_ctx.append_or_update_count_column_to_chunk(chunk, file_record_count);
+        _scanner_ctx.append_or_update_partition_column_to_chunk(chunk, 1);
+        _scanner_ctx.append_or_update_extended_column_to_chunk(chunk, 1);
+        _scanner_ctx.emit_count_column = true;
+        _app_stats.rows_read += 1;
+        return Status::OK();
+    }
+
     RETURN_IF_ERROR(_runtime_state->check_mem_limit("get chunk from scanner"));
     Status status = do_get_next(runtime_state, chunk);
     if (status.ok()) {
@@ -223,9 +238,13 @@ Status HdfsScanner::open(RuntimeState* runtime_state) {
     if (_opened) {
         return Status::OK();
     }
-    RETURN_IF_ERROR(_build_scanner_context());
-    RETURN_IF_ERROR(do_open(runtime_state));
     _opened = true;
+    RETURN_IF_ERROR(_build_scanner_context());
+    // short circuit for ___count___ optimization.
+    if (_scanner_ctx.return_count_column && _scanner_ctx.has_file_record_count) {
+        return Status::OK();
+    }
+    RETURN_IF_ERROR(do_open(runtime_state));
     VLOG_FILE << "open file success: " << _scanner_params.path << ", scan range = ["
               << _scanner_params.scan_range->offset << ","
               << (_scanner_params.scan_range->length + _scanner_params.scan_range->offset)
@@ -235,6 +254,10 @@ Status HdfsScanner::open(RuntimeState* runtime_state) {
 
 void HdfsScanner::close() noexcept {
     if (!_runtime_state) {
+        return;
+    }
+    // short circuit for ___count___ optimization.
+    if (_scanner_ctx.return_count_column && _scanner_ctx.has_file_record_count) {
         return;
     }
     VLOG_FILE << "close file success: " << _scanner_params.path << ", scan range = ["
@@ -514,26 +537,29 @@ void HdfsScannerContext::update_with_none_existed_slot(SlotDescriptor* slot) {
     }
 }
 
-Status HdfsScannerContext::update_materialized_columns(const std::unordered_set<std::string>& names) {
-    std::vector<ColumnInfo> updated_columns;
-
+Status HdfsScannerContext::update_return_count_columns() {
     // special handling for ___count__ optimization.
-    {
-        for (auto& column : materialized_columns) {
-            if (column.name() == "___count___") {
-                return_count_column = true;
-                break;
-            }
-        }
-
-        if (return_count_column && materialized_columns.size() != 1) {
-            return Status::InternalError("Plan inconsistency. ___count___ column should be unique.");
+    for (auto& column : materialized_columns) {
+        if (column.name() == "___count___") {
+            return_count_column = true;
+            break;
         }
     }
+    if (!return_count_column) {
+        return Status::OK();
+    }
+    if (materialized_columns.size() != 1) {
+        return Status::InternalError("Plan inconsistency. ___count___ column should be unique.");
+    }
+    update_with_none_existed_slot(materialized_columns[0].slot_desc);
+    materialized_columns.clear();
+    return Status::OK();
+}
 
+Status HdfsScannerContext::update_materialized_columns(const std::unordered_set<std::string>& names) {
+    std::vector<ColumnInfo> updated_columns;
     for (auto& column : materialized_columns) {
         auto col_name = column.formatted_name(case_sensitive);
-        // if `can_use_any_column`, we can set this column to non-existed column without reading it.
         if (names.find(col_name) == names.end()) {
             update_with_none_existed_slot(column.slot_desc);
         } else {
@@ -549,20 +575,10 @@ Status HdfsScannerContext::append_or_update_not_existed_columns_to_chunk(ChunkPt
     if (not_existed_slots.empty()) return Status::OK();
     ChunkPtr& ck = (*chunk);
 
-    // special handling for ___count___ optimization
-    {
-        for (auto* slot_desc : not_existed_slots) {
-            if (slot_desc->col_name() == "___count___") {
-                return_count_column = true;
-                break;
-            }
-        }
-        if (return_count_column && not_existed_slots.size() != 1) {
-            return Status::InternalError("Plan inconsistency. ___count___ column should be unique.");
-        }
-    }
-
     if (return_count_column) {
+        // it's different from ``append_or_update_count_column_to_chunk`
+        // which outputs the exact count value
+        // but this function outputs count value of 1
         auto* slot_desc = not_existed_slots[0];
         TypeDescriptor desc;
         desc.type = TYPE_BIGINT;
@@ -570,14 +586,16 @@ Status HdfsScannerContext::append_or_update_not_existed_columns_to_chunk(ChunkPt
         col->append_datum(int64_t(1));
         col->assign(row_count, 0);
         ck->append_or_update_column(std::move(col), slot_desc->id());
-    } else {
-        for (auto* slot_desc : not_existed_slots) {
-            auto col = ColumnHelper::create_column(slot_desc->type(), slot_desc->is_nullable());
-            if (row_count > 0) {
-                col->append_default(row_count);
-            }
-            ck->append_or_update_column(std::move(col), slot_desc->id());
+        ck->set_num_rows(row_count);
+        return Status::OK();
+    }
+
+    for (auto* slot_desc : not_existed_slots) {
+        auto col = ColumnHelper::create_column(slot_desc->type(), slot_desc->is_nullable());
+        if (row_count > 0) {
+            col->append_default(row_count);
         }
+        ck->append_or_update_column(std::move(col), slot_desc->id());
     }
     ck->set_num_rows(row_count);
     return Status::OK();

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -344,6 +344,7 @@ struct HdfsScannerContext {
 
     bool can_use_min_max_count_opt = false;
 
+    bool is_first_split = false;
     bool return_count_column = false;
     bool emit_count_column = false;
     bool can_use_file_record_count = false;

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -272,7 +272,6 @@ struct HdfsScannerParams {
     bool use_file_pagecache = false;
 
     std::atomic<int32_t>* lazy_column_coalesce_counter;
-    bool can_use_any_column = false;
     bool can_use_min_max_count_opt = false;
     bool orc_use_column_names = false;
     bool parquet_page_index_enable = false;
@@ -343,11 +342,10 @@ struct HdfsScannerContext {
 
     bool orc_use_column_names = false;
 
-    bool can_use_any_column = false;
-
     bool can_use_min_max_count_opt = false;
-
     bool return_count_column = false;
+    bool has_file_record_count = false;
+    bool emit_count_column = false;
 
     bool use_file_metacache = false;
     bool use_file_pagecache = false;
@@ -371,6 +369,8 @@ struct HdfsScannerContext {
     // update none_existed_slot
     // update conjunct
     void update_with_none_existed_slot(SlotDescriptor* slot);
+
+    Status update_return_count_columns();
 
     // update materialized column against data file.
     // and to update not_existed slots and conjuncts.

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -343,9 +343,10 @@ struct HdfsScannerContext {
     bool orc_use_column_names = false;
 
     bool can_use_min_max_count_opt = false;
+
     bool return_count_column = false;
-    bool has_file_record_count = false;
     bool emit_count_column = false;
+    bool can_use_file_record_count = false;
 
     bool use_file_metacache = false;
     bool use_file_pagecache = false;

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -346,8 +346,12 @@ struct HdfsScannerContext {
 
     bool is_first_split = false;
     bool return_count_column = false;
-    bool emit_count_column = false;
     bool can_use_file_record_count = false;
+
+    // used by short circuit cases:
+    // get_next just returns chunk for once.
+    // and it returns EOF the next time.
+    bool no_more_chunks = false;
 
     bool use_file_metacache = false;
     bool use_file_pagecache = false;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
@@ -204,6 +204,12 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
         hdfsScanRange.setOffset(file.content() == FileContent.DATA ? task.start() : 0);
         hdfsScanRange.setLength(file.content() == FileContent.DATA ? task.length() : file.fileSizeInBytes());
 
+        boolean isFirstSplit = (hdfsScanRange.getOffset() == 0);
+        // But sometimes first task offset is 4. For example, the first four bytes are magic bytes in parquet file.
+        if (file.splitOffsets() != null && !file.splitOffsets().isEmpty()) {
+            isFirstSplit |= (file.splitOffsets().get(0) == hdfsScanRange.getOffset());
+        }
+
         if (!partitionSlotIdsCache.containsKey(file.specId())) {
             hdfsScanRange.setPartition_id(-1);
         } else {
@@ -245,7 +251,8 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
         }
 
         hdfsScanRange.setExtended_columns(extendedColumns);
-        hdfsScanRange.setFile_record_count(file.recordCount());
+        hdfsScanRange.setRecord_count(file.recordCount());
+        hdfsScanRange.setIs_first_split(isFirstSplit);
         return hdfsScanRange;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
@@ -191,6 +191,7 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
         }
         return res;
     }
+
     protected THdfsScanRange buildScanRange(FileScanTask task, ContentFile<?> file, Long partitionId) throws AnalysisException {
         DescriptorTable.ReferencedPartitionInfo referencedPartitionInfo = referencedPartitions.get(partitionId);
         THdfsScanRange hdfsScanRange = new THdfsScanRange();
@@ -244,6 +245,7 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
         }
 
         hdfsScanRange.setExtended_columns(extendedColumns);
+        hdfsScanRange.setFile_record_count(file.recordCount());
         return hdfsScanRange;
     }
 
@@ -322,7 +324,7 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
     }
 
     private PartitionKey getPartitionKey(StructLike partition, PartitionSpec spec, List<Integer> indexes,
-                                           BiMap<Integer, PartitionField> indexToField) throws AnalysisException {
+                                         BiMap<Integer, PartitionField> indexToField) throws AnalysisException {
         List<String> partitionValues = new ArrayList<>();
         List<Column> cols = new ArrayList<>();
         indexes.forEach((index) -> {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -427,8 +427,11 @@ struct THdfsScanRange {
 
     32: optional string candidate_node
 
+    // how many records are in this file?
+    // could be used for optimization like count(1)
     33: optional i64 record_count
 
+    // is this scan range the first split of this file?
     34: optional bool is_first_split
 }
 

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -1191,6 +1191,7 @@ struct THdfsScanNode {
 
     13: optional CloudConfiguration.TCloudConfiguration cloud_configuration;
 
+    // deprecated. not used any more.
     14: optional bool can_use_any_column;
 
     15: optional bool can_use_min_max_count_opt;

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -426,6 +426,8 @@ struct THdfsScanRange {
     31:optional TDeletionVectorDescriptor deletion_vector_descriptor
 
     32: optional string candidate_node
+
+    33: optional i64 file_record_count
 }
 
 struct TBinlogScanRange {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -427,7 +427,9 @@ struct THdfsScanRange {
 
     32: optional string candidate_node
 
-    33: optional i64 file_record_count
+    33: optional i64 record_count
+
+    34: optional bool is_first_split
 }
 
 struct TBinlogScanRange {


### PR DESCRIPTION
## Why I'm doing:

Since we have `file_record_count` of each file from iceberg metadata, we can use that info instead of reading data from file.

## What I'm doing:

This PR does:
1. pass `file_record_count` from iceberg metadata down to scan range
2. if we spot the `count(1)` sql pattern and we have `file_record_count` field, then we can use that.
3. but only when scan range offset is 0, otherwise we will double-count for a file being splitted into multiple scan ranges.
4. remove `canUseAnyColumn` since we don't need it any more. 

Fixes #46525 

--------

Take following query for example on tpcds1T
> select count(1) from iceberg.zz_iceberg_tpcds_sf1000_iceberg_parquet_lz4.store_sales;

Before this pr, we can see from the profile that we read like 800MB data

![image](https://github.com/user-attachments/assets/a38bab76-a4d5-4a75-bbac-17055870b9f7)

And after this pr, we don't read any data

![image](https://github.com/user-attachments/assets/8cbcb209-62c2-4fee-b68b-d35f88652947)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
