### PR TITLE
[BugFix] extend the DEFER LOCK optimization to SUBMIT TASK

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -53,6 +53,7 @@ import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.SubmitTaskStmt;
 import com.starrocks.sql.ast.UpdateStmt;
 import com.starrocks.sql.ast.ValuesRelation;
 import com.starrocks.sql.common.ErrorType;
@@ -218,8 +219,13 @@ public class StatementPlanner {
             }
         };
         try (Timer ignored = Tracers.watchScope("Analyzer")) {
-            if (statement instanceof InsertStmt) {
-                InsertStmt insertStmt = (InsertStmt) statement;
+            InsertStmt insertStmt = null;
+            if (statement instanceof SubmitTaskStmt) {
+                insertStmt = ((SubmitTaskStmt) statement).getInsertStmt();
+            } else if (statement instanceof InsertStmt) {
+                insertStmt = (InsertStmt) statement;
+            }
+            if (insertStmt != null) {
                 Map<Long, Database> dbs = Maps.newHashMap();
                 Map<Long, Set<Long>> tables = Maps.newHashMap();
                 PlannerMetaLocker.collectTablesNeedLock(insertStmt.getQueryStatement(), session, dbs, tables);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
@@ -353,6 +353,16 @@ public class Analyzer {
 
         @Override
         public Void visitSubmitTaskStatement(SubmitTaskStmt statement, ConnectContext context) {
+            analyzeSubmitTask(statement, context);
+            return null;
+        }
+
+        public static void analyzeSubmitTask(SubmitTaskStmt statement, ConnectContext context) {
+            StatementBase workhouse = analyzeSubmitTaskWorkhorse(statement, context);
+            analyzeSubmitTaskOnly(workhouse, statement, context);
+        }
+
+        public static StatementBase analyzeSubmitTaskWorkhorse(SubmitTaskStmt statement, ConnectContext context) {
             StatementBase taskStmt = null;
             if (statement.getCreateTableAsSelectStmt() != null) {
                 CreateTableAsSelectStmt createTableAsSelectStmt = statement.getCreateTableAsSelectStmt();
@@ -369,7 +379,12 @@ public class Analyzer {
             } else {
                 throw new SemanticException("Submit task statement is not supported");
             }
-            boolean hasTemporaryTable = AnalyzerUtils.hasTemporaryTables(taskStmt);
+            return taskStmt;
+        }
+
+        public static void analyzeSubmitTaskOnly(StatementBase taskStatement, SubmitTaskStmt statement,
+                                                 ConnectContext context) {
+            boolean hasTemporaryTable = AnalyzerUtils.hasTemporaryTables(taskStatement);
             if (hasTemporaryTable) {
                 throw new SemanticException("Cannot submit task based on temporary table");
             }
@@ -378,7 +393,6 @@ public class Analyzer {
             String sqlText = origStmt.originStmt.substring(statement.getSqlBeginIndex());
             statement.setSqlText(sqlText);
             TaskAnalyzer.analyzeSubmitTaskStmt(statement, context);
-            return null;
         }
 
         @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerTest.java
@@ -1,0 +1,56 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql;
+
+import com.starrocks.common.FeConstants;
+import com.starrocks.sql.analyzer.PlannerMetaLocker;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StatementPlannerTest extends PlanTestBase {
+
+    @Test
+    public void testDeferLock() throws Exception {
+        {
+            FeConstants.runningUnitTest = true;
+            String sql = "insert into t0 select * from t0";
+            StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            PlannerMetaLocker locker = new PlannerMetaLocker(connectContext, stmt);
+            assertTrue(StatementPlanner.analyzeStatement(stmt, connectContext, locker));
+        }
+
+        {
+            FeConstants.runningUnitTest = false;
+            String sql = "insert into t0 select * from t0";
+            StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            PlannerMetaLocker locker = new PlannerMetaLocker(connectContext, stmt);
+            assertFalse(StatementPlanner.analyzeStatement(stmt, connectContext, locker));
+        }
+
+        {
+            FeConstants.runningUnitTest = true;
+            String sql = "submit task as insert into t0 select * from t0";
+            StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            PlannerMetaLocker locker = new PlannerMetaLocker(connectContext, stmt);
+            assertTrue(StatementPlanner.analyzeStatement(stmt, connectContext, locker));
+        }
+    }
+
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

#48933 introduced an optimization for the INSERT-SELECT statement, significantly reducing the lock scope of the analyzer. This enhancement is particularly beneficial for external table data ingestion, where catalog access can be time-consuming.

Unfortunately, this optimization cannot currently be applied to SUBMIT TASK. Therefore, we aim to extend this optimization to SUBMIT TASK.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
