### PR TITLE
[Enhancement] Add a force refresh strategy and add meta functions for better debug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -152,6 +152,12 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      */
     public enum PartitionRefreshStrategy {
         /**
+         * FORCE: Force strategy.
+         * always refresh all partitions regardless of their last refresh time.
+         */
+        FORCE,
+
+        /**
          * STRICT: Traditional strategy.
          * Selects a fixed number of candidate partitions based on partition_refresh_number.
          */

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -1672,10 +1672,6 @@ public class PropertyAnalyzer {
                 materializedView.getTableProperty().getProperties()
                         .put(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_STRATEGY, strategy);
                 materializedView.getTableProperty().setPartitionRefreshStrategy(strategy);
-                if (isNonPartitioned) {
-                    throw new AnalysisException(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_STRATEGY
-                            + " does not support non-partitioned materialized view.");
-                }
             }
             // exclude trigger tables
             if (properties.containsKey(PropertyAnalyzer.PROPERTIES_EXCLUDED_TRIGGER_TABLES)) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -295,11 +295,26 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             logger.warn("failed to lock database: {} in checkMvToRefreshedPartitions", db.getFullName());
             throw new LockTimeoutException("Failed to lock database: " + db.getFullName());
         }
+        PartitionRefreshStrategy partitionRefreshStrategy = PartitionRefreshStrategy.valueOf(
+                mv.getTableProperty().getPartitionRefreshStrategy().trim().toUpperCase());
+
+        boolean isForce = partitionRefreshStrategy == PartitionRefreshStrategy.FORCE || tentative;
         try {
-            Set<String> mvPotentialPartitionNames = Sets.newHashSet();
-            mvToRefreshedPartitions = getPartitionsToRefreshForMaterializedView(
-                    context.getProperties(), mvPotentialPartitionNames, tentative);
-            if (mvToRefreshedPartitions.isEmpty()) {
+            final Set<String> mvPotentialPartitionNames = Sets.newHashSet();
+            final MVRefreshParams mvRefreshParams = new MVRefreshParams(mv.getPartitionInfo(), context.getProperties(), isForce);
+            final PartitionInfo partitionInfo = mv.getPartitionInfo();
+            mvToRefreshedPartitions = getPartitionsToRefreshForMaterializedView(partitionInfo,
+                    mvRefreshParams, mvPotentialPartitionNames);
+            // update mv extra message
+            if (!tentative) {
+                updateTaskRunStatus(status -> {
+                    MVTaskRunExtraMessage extraMessage = status.getMvTaskRunExtraMessage();
+                    extraMessage.setForceRefresh(mvRefreshParams.isForce());
+                    extraMessage.setPartitionStart(mvRefreshParams.getRangeStart());
+                    extraMessage.setPartitionEnd(mvRefreshParams.getRangeEnd());
+                });
+            }
+            if (CollectionUtils.isEmpty(mvToRefreshedPartitions)) {
                 logger.info("no partitions to refresh for materialized view");
                 return mvToRefreshedPartitions;
             }
@@ -311,8 +326,6 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 filterPartitionByRefreshNumber(mvToRefreshedPartitions, mvPotentialPartitionNames, mv,
                         tentative);
             } else {
-                PartitionRefreshStrategy partitionRefreshStrategy = PartitionRefreshStrategy.valueOf(
-                        mv.getTableProperty().getPartitionRefreshStrategy().trim().toUpperCase());
                 switch (partitionRefreshStrategy) {
                     case ADAPTIVE:
                         filterPartitionByAdaptiveRefreshNumber(mvToRefreshedPartitions, mvPotentialPartitionNames, mv,
@@ -983,32 +996,6 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         boolean result = mvRefreshPartitioner.syncAddOrDropPartitions();
         logger.info("finish sync partitions, cost(ms): {}", stopwatch.elapsed(TimeUnit.MILLISECONDS));
         return result;
-    }
-
-    /**
-     * If it's tentative, don't really consider the staleness of MV, but all potential partitions
-     */
-    @VisibleForTesting
-    public Set<String> getPartitionsToRefreshForMaterializedView(Map<String, String> properties,
-                                                                 Set<String> mvPotentialPartitionNames,
-                                                                 boolean tentative)
-            throws AnalysisException {
-        PartitionInfo partitionInfo = mv.getPartitionInfo();
-        MVRefreshParams mvRefreshParams = new MVRefreshParams(partitionInfo, properties, tentative);
-        Set<String> needRefreshMvPartitionNames = getPartitionsToRefreshForMaterializedView(partitionInfo,
-                mvRefreshParams, mvPotentialPartitionNames);
-
-        // update mv extra message
-        if (!tentative) {
-            updateTaskRunStatus(status -> {
-                MVTaskRunExtraMessage extraMessage = status.getMvTaskRunExtraMessage();
-                extraMessage.setForceRefresh(mvRefreshParams.isForce());
-                extraMessage.setPartitionStart(mvRefreshParams.getRangeStart());
-                extraMessage.setPartitionEnd(mvRefreshParams.getRangeEnd());
-            });
-        }
-
-        return needRefreshMvPartitionNames;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -286,7 +286,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
      * If it's tentative, only return the result rather than modify any state
      * IF it's not, it would modify the context state, like `NEXT_PARTITION_START`
      */
-    private Set<String> checkMvToRefreshedPartitions(TaskRunContext context, boolean tentative)
+    @VisibleForTesting
+    public Set<String> checkMvToRefreshedPartitions(TaskRunContext context, boolean tentative)
             throws AnalysisException, LockTimeoutException {
         Set<String> mvToRefreshedPartitions = null;
         Locker locker = new Locker();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.optimizer.function;
 
+import com.google.common.collect.Maps;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
@@ -23,6 +24,7 @@ import com.starrocks.analysis.TableName;
 import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.authorization.ObjectType;
 import com.starrocks.authorization.PrivilegeType;
+import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.InternalCatalog;
@@ -36,6 +38,7 @@ import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.connector.ConnectorPartitionTraits;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.hive.Partition;
@@ -55,6 +58,7 @@ import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.dump.QueryDumper;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.rewrite.ConstantFunction;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.thrift.TResultBatch;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -74,6 +78,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.starrocks.catalog.PrimitiveType.BOOLEAN;
 import static com.starrocks.catalog.PrimitiveType.VARCHAR;
@@ -149,6 +154,124 @@ public class MetaFunctions {
             MaterializedView mv = (MaterializedView) table;
             String meta = mv.inspectMeta();
             return ConstantOperator.createVarchar(meta);
+        } finally {
+            locker.unLockDatabase(dbTable.getLeft().getId(), LockType.READ);
+        }
+    }
+
+    static class MVRefreshInfoMeta {
+        // base table to refresh info
+        @SerializedName(value = "tableToUpdatePartitions")
+        private final Map<String, Set<String>> tableToUpdatePartitions;
+        // olap table info
+        @SerializedName("baseTableVisibleVersionMap")
+        private final Map<String, Map<String, MaterializedView.BasePartitionInfo>> baseOlapTableVisibleVersionMap;
+        // external table info
+        @SerializedName("baseTableInfoVisibleVersionMap")
+        private final Map<String, Map<String, MaterializedView.BasePartitionInfo>> baseExternalTableInfoVisibleVersionMap;
+
+        public MVRefreshInfoMeta(
+                Map<String, Set<String>> tableToUpdatePartitions,
+                Map<String, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap,
+                Map<String, Map<String, MaterializedView.BasePartitionInfo>> baseTableInfoVisibleVersionMap) {
+            this.tableToUpdatePartitions = tableToUpdatePartitions;
+            this.baseOlapTableVisibleVersionMap = baseTableVisibleVersionMap;
+            this.baseExternalTableInfoVisibleVersionMap = baseTableInfoVisibleVersionMap;
+        }
+        public String inspect() {
+            return GsonUtils.GSON.toJson(this);
+        }
+    }
+    @ConstantFunction(name = "inspect_mv_refresh_info", argTypes = {VARCHAR}, returnType = VARCHAR, isMetaFunction = true)
+    public static ConstantOperator inspectMVRefreshInfo(ConstantOperator mvName) {
+        TableName tableName = TableName.fromString(mvName.getVarchar());
+        Pair<Database, Table> dbTable = inspectTable(tableName);
+        Table table = dbTable.getRight();
+        if (!table.isMaterializedView()) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_INVALID_PARAMETER,
+                    tableName + " is not materialized view");
+        }
+        Locker locker = new Locker();
+        MaterializedView mv = (MaterializedView) table;
+        try {
+            locker.lockDatabase(dbTable.getLeft().getId(), LockType.READ);
+            Map<String, Set<String>> tableToUpdatePartitions = Maps.newHashMap();
+            Map<Long, String> tableIdToTableNameMap = Maps.newHashMap();
+            for (BaseTableInfo baseTableInfo : mv.getBaseTableInfos()) {
+                Table baseTable = MvUtils.getTableChecked(baseTableInfo);
+                Set<String> toUpdatePartitions = null;
+                if (baseTable instanceof OlapTable) {
+                    toUpdatePartitions = mv.getUpdatedPartitionNamesOfOlapTable((OlapTable) baseTable, false);
+                } else {
+                    toUpdatePartitions = mv.getUpdatedPartitionNamesOfExternalTable(baseTable, false);
+                }
+                if (CollectionUtils.isNotEmpty(toUpdatePartitions)) {
+                    tableToUpdatePartitions.put(baseTable.getName(), toUpdatePartitions);
+                }
+                tableIdToTableNameMap.put(baseTable.getId(), baseTable.getName());
+            }
+            Map<Long, Map<String, MaterializedView.BasePartitionInfo>> olapVisibleVersionMap =
+                    mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
+            Map<String, Map<String, MaterializedView.BasePartitionInfo>> baseOlapTableVisibleVersionMap =
+                    olapVisibleVersionMap.entrySet().stream()
+                            .map(entry -> Pair.of(tableIdToTableNameMap.get(entry.getKey()), entry.getValue()))
+                            .collect(Collectors.toMap(x -> x.getLeft(), x -> x.getRight()));
+
+            Map<BaseTableInfo, Map<String, MaterializedView.BasePartitionInfo>> externalVisibleVersionMap =
+                    mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableInfoVisibleVersionMap();
+            Map<String, Map<String, MaterializedView.BasePartitionInfo>> baseExternalTableVisibleVersionMap =
+                    externalVisibleVersionMap.entrySet().stream()
+                            .map(entry -> Pair.of(entry.getKey().getReadableString(), entry.getValue()))
+                            .collect(Collectors.toMap(x -> x.getLeft(), x -> x.getRight()));
+            MVRefreshInfoMeta meta = new MVRefreshInfoMeta(tableToUpdatePartitions,
+                    baseOlapTableVisibleVersionMap,
+                    baseExternalTableVisibleVersionMap);
+            String json = meta.inspect();
+            return ConstantOperator.createVarchar(json);
+        } finally {
+            locker.unLockDatabase(dbTable.getLeft().getId(), LockType.READ);
+        }
+    }
+
+    @ConstantFunction(name = "inspect_table_partition_info", argTypes = {VARCHAR}, returnType = VARCHAR, isMetaFunction = true)
+    public static ConstantOperator inspectTablePartitionInfo(ConstantOperator mvName) {
+        TableName tableName = TableName.fromString(mvName.getVarchar());
+        Pair<Database, Table> dbTable = inspectTable(tableName);
+        Table table = dbTable.getRight();
+        if (table == null) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_INVALID_PARAMETER,
+                    tableName + " is not a table");
+        }
+        Locker locker = new Locker();
+        try {
+            locker.lockDatabase(dbTable.getLeft().getId(), LockType.READ);
+
+            JsonObject obj = new JsonObject();
+            if (table instanceof OlapTable) {
+                OlapTable olapTable = (OlapTable) table;
+                olapTable.getPartitions()
+                        .stream()
+                        .forEach(partition -> {
+                            MaterializedView.BasePartitionInfo basePartitionInfo =
+                                    new MaterializedView.BasePartitionInfo(partition.getId(),
+                                            partition.getDefaultPhysicalPartition().getVisibleVersion(),
+                                            partition.getDefaultPhysicalPartition().getVisibleVersionTime());
+                            obj.add(partition.getName(), GsonUtils.GSON.toJsonTree(basePartitionInfo));
+                        });
+            } else {
+                Map<String, PartitionInfo> partitionNameWithPartitionInfo =
+                        ConnectorPartitionTraits.build(table).getPartitionNameWithPartitionInfo();
+                partitionNameWithPartitionInfo.entrySet()
+                        .stream()
+                        .map(entry -> Pair.of(entry.getKey(),
+                                MaterializedView.BasePartitionInfo.fromExternalTable(entry.getValue())))
+                        .forEach(pair -> {
+                            obj.add(pair.getLeft(),
+                                    pair.getRight() == null ? JsonNull.INSTANCE : GsonUtils.GSON.toJsonTree(pair.getRight()));
+                        });
+            }
+            String json = obj.toString();
+            return ConstantOperator.createVarchar(json);
         } finally {
             locker.unLockDatabase(dbTable.getLeft().getId(), LockType.READ);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
@@ -164,10 +164,10 @@ public class MetaFunctions {
         @SerializedName(value = "tableToUpdatePartitions")
         private final Map<String, Set<String>> tableToUpdatePartitions;
         // olap table info
-        @SerializedName("baseTableVisibleVersionMap")
+        @SerializedName("baseOlapTableVisibleVersionMap")
         private final Map<String, Map<String, MaterializedView.BasePartitionInfo>> baseOlapTableVisibleVersionMap;
         // external table info
-        @SerializedName("baseTableInfoVisibleVersionMap")
+        @SerializedName("baseExternalTableInfoVisibleVersionMap")
         private final Map<String, Map<String, MaterializedView.BasePartitionInfo>> baseExternalTableInfoVisibleVersionMap;
 
         public MVRefreshInfoMeta(
@@ -184,6 +184,9 @@ public class MetaFunctions {
     }
     @ConstantFunction(name = "inspect_mv_refresh_info", argTypes = {VARCHAR}, returnType = VARCHAR, isMetaFunction = true)
     public static ConstantOperator inspectMVRefreshInfo(ConstantOperator mvName) {
+        if (mvName == null) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_INVALID_PARAMETER, mvName);
+        }
         TableName tableName = TableName.fromString(mvName.getVarchar());
         Pair<Database, Table> dbTable = inspectTable(tableName);
         Table table = dbTable.getRight();
@@ -234,8 +237,11 @@ public class MetaFunctions {
     }
 
     @ConstantFunction(name = "inspect_table_partition_info", argTypes = {VARCHAR}, returnType = VARCHAR, isMetaFunction = true)
-    public static ConstantOperator inspectTablePartitionInfo(ConstantOperator mvName) {
-        TableName tableName = TableName.fromString(mvName.getVarchar());
+    public static ConstantOperator inspectTablePartitionInfo(ConstantOperator input) {
+        if (input == null) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_INVALID_PARAMETER, input);
+        }
+        TableName tableName = TableName.fromString(input.getVarchar());
         Pair<Database, Table> dbTable = inspectTable(tableName);
         Table table = dbTable.getRight();
         if (table == null) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/MetaFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/MetaFunctionsTest.java
@@ -262,7 +262,8 @@ public class MetaFunctionsTest extends MVTestBase {
     @Test
     public void inspectTablePartitionInfoHandlesEmptyPartitions() throws Exception {
         starRocksAssert.withTable("create table empty_partition_table(k1 int, v1 int) properties('replication_num'='1')");
-        ConstantOperator result = MetaFunctions.inspectTablePartitionInfo(ConstantOperator.createVarchar("test.empty_partition_table"));
+        ConstantOperator result = MetaFunctions.inspectTablePartitionInfo(
+                ConstantOperator.createVarchar("test.empty_partition_table"));
         Assert.assertNotNull(result);
         Assert.assertTrue(result.getVarchar().contains("empty_partition_table"));
         starRocksAssert.dropTable("empty_partition_table");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/MetaFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/MetaFunctionsTest.java
@@ -17,53 +17,38 @@ package com.starrocks.sql.optimizer.rewrite;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Type;
-import com.starrocks.common.Config;
 import com.starrocks.common.ErrorReportException;
-import com.starrocks.common.FeConstants;
 import com.starrocks.leader.ReportHandler;
 import com.starrocks.memory.MemoryUsageTracker;
 import com.starrocks.persist.gson.GsonUtils;
-import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.sql.optimizer.function.MetaFunctions;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
 import com.starrocks.thrift.TResultBatch;
-import com.starrocks.utframe.StarRocksAssert;
-import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
+import org.junit.runners.MethodSorters;
 
 import java.nio.ByteBuffer;
 import java.util.List;
 
-public class MetaFunctionsTest {
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class MetaFunctionsTest extends MVTestBase {
 
     static {
         MemoryUsageTracker.registerMemoryTracker("Report", new ReportHandler());
     }
 
-    private static ConnectContext connectContext;
-    private static StarRocksAssert starRocksAssert;
-
     @BeforeClass
     public static void beforeClass() throws Exception {
-        FeConstants.runningUnitTest = true;
-        Config.alter_scheduler_interval_millisecond = 100;
-        Config.dynamic_partition_enable = true;
-        Config.dynamic_partition_check_interval_seconds = 1;
-        Config.enable_strict_storage_medium_check = false;
-        UtFrameUtils.createMinStarRocksCluster();
-        UtFrameUtils.addMockBackend(10002);
-        UtFrameUtils.addMockBackend(10003);
-        // create connect context
-        connectContext = UtFrameUtils.createDefaultCtx();
-        starRocksAssert = new StarRocksAssert(connectContext);
-
+        MVTestBase.beforeClass();
         starRocksAssert.withDatabase("test").useDatabase("test")
                 .withTable("CREATE TABLE test.tbl1\n" +
                         "(\n" +
@@ -146,6 +131,7 @@ public class MetaFunctionsTest {
     public void testInspectTableAccessDeniedException() {
         connectContext.setCurrentUserIdentity(testUser);
         connectContext.setCurrentRoleIds(testUser);
+        connectContext.setThreadLocalInfo();
         MetaFunctions.inspectTable(new TableName("test", "tbl1"));
     }
 
@@ -153,6 +139,7 @@ public class MetaFunctionsTest {
     public void testInspectExternalTableAccessDeniedException() {
         connectContext.setCurrentUserIdentity(testUser);
         connectContext.setCurrentRoleIds(testUser);
+        connectContext.setThreadLocalInfo();
         MetaFunctions.inspectTable(new TableName("test", "mysql_external_table"));
     }
 
@@ -221,6 +208,73 @@ public class MetaFunctionsTest {
             };
             Assert.assertNull(lookupString("t1", "v1", "c1"));
         }
+    }
 
+    @Test
+    public void inspectMVRefreshInfoReturnsValidJsonForMaterializedView() throws Exception {
+        starRocksAssert.withRefreshedMaterializedView("create materialized view mv1 distributed by random " +
+                "as select k1, sum(v1) from test.tbl1 group by k1");
+        ConstantOperator result = MetaFunctions.inspectMVRefreshInfo(ConstantOperator.createVarchar("test.mv1"));
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.getVarchar().contains("tableToUpdatePartitions"));
+        starRocksAssert.dropMaterializedView("mv1");
+    }
+
+    @Test(expected = SemanticException.class)
+    public void inspectMVRefreshInfoThrowsExceptionForNonMaterializedView() throws Exception {
+        starRocksAssert.withTable("create table tbl2(k1 int, v1 int) properties('replication_num'='1')");
+        MetaFunctions.inspectMVRefreshInfo(ConstantOperator.createVarchar("test.tbl2"));
+        starRocksAssert.dropTable("tbl2");
+    }
+
+    @Test
+    public void inspectTablePartitionInfoReturnsValidJsonForOlapTable() throws Exception {
+        starRocksAssert.withTable("create table tbl3(k1 int, v1 int) partition by range(k1) " +
+                "(partition p1 values less than('10'), partition p2 values less than('20')) " +
+                "properties('replication_num'='1')");
+        ConstantOperator result = MetaFunctions.inspectTablePartitionInfo(ConstantOperator.createVarchar("test.tbl3"));
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.getVarchar().contains("p1"));
+        Assert.assertTrue(result.getVarchar().contains("p2"));
+        starRocksAssert.dropTable("tbl3");
+    }
+
+    @Test(expected = SemanticException.class)
+    public void inspectTablePartitionInfoThrowsExceptionForInvalidTable() {
+        MetaFunctions.inspectTablePartitionInfo(ConstantOperator.createVarchar("test.invalid_table"));
+    }
+
+    @Test
+    public void inspectMVRefreshInfoHandlesEmptyBaseTables() throws Exception {
+        starRocksAssert.withMaterializedView("create materialized view mv_empty distributed by random " +
+                "   as select k1 from test.tbl1 group by k1");
+        ConstantOperator result = MetaFunctions.inspectMVRefreshInfo(ConstantOperator.createVarchar("test.mv_empty"));
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.getVarchar().contains("{}")); // Ensure empty base tables are handled
+        starRocksAssert.dropMaterializedView("mv_empty");
+    }
+
+    @Test(expected = SemanticException.class)
+    public void inspectMVRefreshInfoThrowsExceptionForNullInput() {
+        MetaFunctions.inspectMVRefreshInfo(null);
+    }
+
+    @Test
+    public void inspectTablePartitionInfoHandlesEmptyPartitions() throws Exception {
+        starRocksAssert.withTable("create table empty_partition_table(k1 int, v1 int) properties('replication_num'='1')");
+        ConstantOperator result = MetaFunctions.inspectTablePartitionInfo(ConstantOperator.createVarchar("test.empty_partition_table"));
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.getVarchar().contains("empty_partition_table"));
+        starRocksAssert.dropTable("empty_partition_table");
+    }
+
+    @Test(expected = SemanticException.class)
+    public void inspectTablePartitionInfoThrowsExceptionForNullInput() {
+        MetaFunctions.inspectTablePartitionInfo(null);
+    }
+
+    @Test(expected = SemanticException.class)
+    public void inspectTablePartitionInfoThrowsExceptionForNonExistentTable() {
+        MetaFunctions.inspectTablePartitionInfo(ConstantOperator.createVarchar("test.non_existent_table"));
     }
 }

--- a/test/sql/test_materialized_view/R/test_mv_meta_functions
+++ b/test/sql/test_materialized_view/R/test_mv_meta_functions
@@ -26,19 +26,44 @@ insert into user_tags values('2023-04-13', 3, 'e', 6);
 create materialized view user_tags_mv1  distributed by hash(user_id) as select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;
 -- result:
 -- !result
+[UC]select inspect_mv_refresh_info('user_tags_mv1');
+-- result:
+{"tableToUpdatePartitions":{"user_tags":["p1"]},"baseTableVisibleVersionMap":{"user_tags":{}},"baseTableInfoVisibleVersionMap":{}}
+-- !result
+[UC]select inspect_table_partition_info('user_tags');
+-- result:
+{"p1":{"id":12210,"version":8,"lastRefreshTime":1750235292626,"lastFileModifiedTime":-1,"fileNumber":-1}}
+-- !result
 refresh materialized view user_tags_mv1 with sync mode;
-select inspect_mv_plan('user_tags_mv1');
+[UC]select inspect_mv_plan('user_tags_mv1');
 -- result:
-[REGEX]plan 0.*
+plan 0: 
+LogicalAggregation {type=GLOBAL ,aggregations={5: bitmap_agg=bitmap_agg(4: tag_id)} ,groupKeys=[2: user_id] ,projection=null ,predicate=null}
+->  LogicalOlapScanOperator {table=12211, selectedPartitionId=null, selectedIndexId=12212, outputColumns=[2: user_id, 4: tag_id], predicate=null, prunedPartitionPredicates=[], limit=-1}
 
 -- !result
-select inspect_mv_plan('user_tags_mv1', true);
+[UC]select inspect_mv_plan('user_tags_mv1', true);
 -- result:
-[REGEX]plan 0.*
+plan 0: 
+LogicalAggregation {type=GLOBAL ,aggregations={5: bitmap_agg=bitmap_agg(4: tag_id)} ,groupKeys=[2: user_id] ,projection=null ,predicate=null}
+->  LogicalOlapScanOperator {table=12211, selectedPartitionId=null, selectedIndexId=12212, outputColumns=[2: user_id, 4: tag_id], predicate=null, prunedPartitionPredicates=[], limit=-1}
 
 -- !result
-select inspect_mv_plan('user_tags_mv1', false);
+[UC]select inspect_mv_plan('user_tags_mv1', false);
 -- result:
-[REGEX]plan 0:.* 
+plan 0: 
+LogicalAggregation {type=GLOBAL ,aggregations={5: bitmap_agg=bitmap_agg(4: tag_id)} ,groupKeys=[2: user_id] ,projection=null ,predicate=null}
+->  LogicalOlapScanOperator {table=12211, selectedPartitionId=null, selectedIndexId=12212, outputColumns=[2: user_id, 4: tag_id], predicate=null, prunedPartitionPredicates=[], limit=-1}
 
+-- !result
+insert into user_tags values('2023-04-13', 3, 'e', 6);
+-- result:
+-- !result
+[UC]select inspect_mv_refresh_info('user_tags_mv1');
+-- result:
+{"tableToUpdatePartitions":{"user_tags":["p1"]},"baseTableVisibleVersionMap":{"user_tags":{"p1":{"id":12210,"version":8,"lastRefreshTime":1750235292626,"lastFileModifiedTime":-1,"fileNumber":-1}}},"baseTableInfoVisibleVersionMap":{}}
+-- !result
+[UC]select inspect_table_partition_info('user_tags');
+-- result:
+{"p1":{"id":12210,"version":9,"lastRefreshTime":1750235294261,"lastFileModifiedTime":-1,"fileNumber":-1}}
 -- !result

--- a/test/sql/test_materialized_view/R/test_mv_refresh_strategy_with_force
+++ b/test/sql/test_materialized_view/R/test_mv_refresh_strategy_with_force
@@ -39,7 +39,7 @@ select * from user_tags_mv1 order by user_id;
 -- !result
 [UC]task_name=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='user_tags_mv1';
 -- result:
-mv-12451
+mv-15039
 -- !result
 SELECT count(1) FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}';
 -- result:
@@ -70,72 +70,39 @@ properties('partition_refresh_strategy' = 'force')
 refresh deferred manual
 as select user_id, time, count(tag_id) from user_tags group by user_id, time;
 -- result:
-E: (6013, 'Getting analyzing error. Detail message: Invalid parameter partition_refresh_strategy does not support non-partitioned materialized view..')
 -- !result
 refresh materialized view user_tags_mv2 with sync mode;
 select * from user_tags_mv2 order by user_id;
 -- result:
-E: (5502, "Getting analyzing error. Detail message: Unknown table 'db_482d138907ca4db99ca127e30156b0eb.user_tags_mv2'.")
+1	2023-04-13	2
+2	2023-04-14	1
+3	2023-04-14	1
 -- !result
 [UC]task_name=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='user_tags_mv2';
 -- result:
+mv-15098
 -- !result
 SELECT count(1) FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}';
 -- result:
-20
+1
 -- !result
 SELECT `STATE` FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}' order by CREATE_TIME desc;
 -- result:
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
 SUCCESS
 -- !result
 refresh materialized view user_tags_mv2 with sync mode;
 select * from user_tags_mv2 order by user_id;
 -- result:
-E: (5502, "Getting analyzing error. Detail message: Unknown table 'db_482d138907ca4db99ca127e30156b0eb.user_tags_mv2'.")
+1	2023-04-13	2
+2	2023-04-14	1
+3	2023-04-14	1
 -- !result
 SELECT count(1) FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}';
 -- result:
-20
+2
 -- !result
 SELECT `STATE` FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}' order by CREATE_TIME desc;
 -- result:
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
-SUCCESS
 SUCCESS
 SUCCESS
 -- !result

--- a/test/sql/test_materialized_view/R/test_mv_refresh_strategy_with_force
+++ b/test/sql/test_materialized_view/R/test_mv_refresh_strategy_with_force
@@ -39,7 +39,7 @@ select * from user_tags_mv1 order by user_id;
 -- !result
 [UC]task_name=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='user_tags_mv1';
 -- result:
-mv-11499
+mv-12451
 -- !result
 SELECT count(1) FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}';
 -- result:
@@ -65,19 +65,76 @@ SELECT `STATE` FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}
 SUCCESS
 SUCCESS
 -- !result
-refresh materialized view user_tags_mv1 with sync mode;
-select * from user_tags_mv1 order by user_id;
+create materialized view user_tags_mv2  distributed by hash(user_id) 
+properties('partition_refresh_strategy' = 'force')
+refresh deferred manual
+as select user_id, time, count(tag_id) from user_tags group by user_id, time;
 -- result:
-1	2023-04-13	2
-2	2023-04-14	1
-3	2023-04-14	1
+E: (6013, 'Getting analyzing error. Detail message: Invalid parameter partition_refresh_strategy does not support non-partitioned materialized view..')
+-- !result
+refresh materialized view user_tags_mv2 with sync mode;
+select * from user_tags_mv2 order by user_id;
+-- result:
+E: (5502, "Getting analyzing error. Detail message: Unknown table 'db_482d138907ca4db99ca127e30156b0eb.user_tags_mv2'.")
+-- !result
+[UC]task_name=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='user_tags_mv2';
+-- result:
 -- !result
 SELECT count(1) FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}';
 -- result:
-3
+20
 -- !result
 SELECT `STATE` FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}' order by CREATE_TIME desc;
 -- result:
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+-- !result
+refresh materialized view user_tags_mv2 with sync mode;
+select * from user_tags_mv2 order by user_id;
+-- result:
+E: (5502, "Getting analyzing error. Detail message: Unknown table 'db_482d138907ca4db99ca127e30156b0eb.user_tags_mv2'.")
+-- !result
+SELECT count(1) FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}';
+-- result:
+20
+-- !result
+SELECT `STATE` FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}' order by CREATE_TIME desc;
+-- result:
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
 SUCCESS
 SUCCESS
 SUCCESS

--- a/test/sql/test_materialized_view/R/test_mv_refresh_strategy_with_force
+++ b/test/sql/test_materialized_view/R/test_mv_refresh_strategy_with_force
@@ -1,0 +1,87 @@
+-- name: test_mv_refresh_strategy_with_force
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table user_tags (time date, user_id int, user_name varchar(20), tag_id int) 
+partition by date_trunc('day', time)  
+distributed by hash(time) buckets 3 
+properties('replication_num' = '1');
+-- result:
+-- !result
+insert into user_tags values('2023-04-13', 1, 'a', 1);
+-- result:
+-- !result
+insert into user_tags values('2023-04-13', 1, 'b', 2);
+-- result:
+-- !result
+insert into user_tags values('2023-04-14', 2, 'e', 5);
+-- result:
+-- !result
+insert into user_tags values('2023-04-14', 3, 'e', 6);
+-- result:
+-- !result
+create materialized view user_tags_mv1  distributed by hash(user_id) 
+partition by date_trunc('day', time)
+properties('partition_refresh_strategy' = 'force')
+refresh deferred manual
+as select user_id, time, count(tag_id) from user_tags group by user_id, time;
+-- result:
+-- !result
+refresh materialized view user_tags_mv1 with sync mode;
+select * from user_tags_mv1 order by user_id;
+-- result:
+1	2023-04-13	2
+2	2023-04-14	1
+3	2023-04-14	1
+-- !result
+[UC]task_name=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='user_tags_mv1';
+-- result:
+mv-11499
+-- !result
+SELECT count(1) FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}';
+-- result:
+1
+-- !result
+SELECT `STATE` FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}' order by CREATE_TIME desc;
+-- result:
+SUCCESS
+-- !result
+refresh materialized view user_tags_mv1 with sync mode;
+select * from user_tags_mv1 order by user_id;
+-- result:
+1	2023-04-13	2
+2	2023-04-14	1
+3	2023-04-14	1
+-- !result
+SELECT count(1) FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}';
+-- result:
+2
+-- !result
+SELECT `STATE` FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}' order by CREATE_TIME desc;
+-- result:
+SUCCESS
+SUCCESS
+-- !result
+refresh materialized view user_tags_mv1 with sync mode;
+select * from user_tags_mv1 order by user_id;
+-- result:
+1	2023-04-13	2
+2	2023-04-14	1
+3	2023-04-14	1
+-- !result
+SELECT count(1) FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}';
+-- result:
+3
+-- !result
+SELECT `STATE` FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}' order by CREATE_TIME desc;
+-- result:
+SUCCESS
+SUCCESS
+SUCCESS
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/T/test_mv_meta_functions
+++ b/test/sql/test_materialized_view/T/test_mv_meta_functions
@@ -9,10 +9,16 @@ insert into user_tags values('2023-04-13', 2, 'e', 5);
 insert into user_tags values('2023-04-13', 3, 'e', 6);
 
 create materialized view user_tags_mv1  distributed by hash(user_id) as select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;
+[UC]select inspect_mv_refresh_info('user_tags_mv1');
+[UC]select inspect_table_partition_info('user_tags');
+
 refresh materialized view user_tags_mv1 with sync mode;
 
-select inspect_mv_plan('user_tags_mv1');
+[UC]select inspect_mv_plan('user_tags_mv1');
+[UC]select inspect_mv_plan('user_tags_mv1', true);
+[UC]select inspect_mv_plan('user_tags_mv1', false);
 
-select inspect_mv_plan('user_tags_mv1', true);
+insert into user_tags values('2023-04-13', 3, 'e', 6);
 
-select inspect_mv_plan('user_tags_mv1', false);
+[UC]select inspect_mv_refresh_info('user_tags_mv1');
+[UC]select inspect_table_partition_info('user_tags');

--- a/test/sql/test_materialized_view/T/test_mv_refresh_strategy_with_force
+++ b/test/sql/test_materialized_view/T/test_mv_refresh_strategy_with_force
@@ -1,0 +1,39 @@
+-- name: test_mv_refresh_strategy_with_force
+create database db_${uuid0};
+use db_${uuid0};
+
+
+create table user_tags (time date, user_id int, user_name varchar(20), tag_id int) 
+partition by date_trunc('day', time)  
+distributed by hash(time) buckets 3 
+properties('replication_num' = '1');
+
+insert into user_tags values('2023-04-13', 1, 'a', 1);
+insert into user_tags values('2023-04-13', 1, 'b', 2);
+insert into user_tags values('2023-04-14', 2, 'e', 5);
+insert into user_tags values('2023-04-14', 3, 'e', 6);
+
+create materialized view user_tags_mv1  distributed by hash(user_id) 
+partition by date_trunc('day', time)
+properties('partition_refresh_strategy' = 'force')
+refresh deferred manual
+as select user_id, time, count(tag_id) from user_tags group by user_id, time;
+
+refresh materialized view user_tags_mv1 with sync mode;
+select * from user_tags_mv1 order by user_id;
+[UC]task_name=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='user_tags_mv1';
+
+SELECT count(1) FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}';
+SELECT `STATE` FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}' order by CREATE_TIME desc;
+
+refresh materialized view user_tags_mv1 with sync mode;
+select * from user_tags_mv1 order by user_id;
+SELECT count(1) FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}';
+SELECT `STATE` FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}' order by CREATE_TIME desc;
+
+refresh materialized view user_tags_mv1 with sync mode;
+select * from user_tags_mv1 order by user_id;
+SELECT count(1) FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}';
+SELECT `STATE` FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}' order by CREATE_TIME desc;
+
+drop database db_${uuid0} force;

--- a/test/sql/test_materialized_view/T/test_mv_refresh_strategy_with_force
+++ b/test/sql/test_materialized_view/T/test_mv_refresh_strategy_with_force
@@ -31,8 +31,19 @@ select * from user_tags_mv1 order by user_id;
 SELECT count(1) FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}';
 SELECT `STATE` FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}' order by CREATE_TIME desc;
 
-refresh materialized view user_tags_mv1 with sync mode;
-select * from user_tags_mv1 order by user_id;
+create materialized view user_tags_mv2  distributed by hash(user_id) 
+properties('partition_refresh_strategy' = 'force')
+refresh deferred manual
+as select user_id, time, count(tag_id) from user_tags group by user_id, time;
+refresh materialized view user_tags_mv2 with sync mode;
+select * from user_tags_mv2 order by user_id;
+[UC]task_name=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='user_tags_mv2';
+
+SELECT count(1) FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}';
+SELECT `STATE` FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}' order by CREATE_TIME desc;
+
+refresh materialized view user_tags_mv2 with sync mode;
+select * from user_tags_mv2 order by user_id;
 SELECT count(1) FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}';
 SELECT `STATE` FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}' order by CREATE_TIME desc;
 


### PR DESCRIPTION
## Why I'm doing:

I found that mv has not been refreshed as expect even the base table has changed which is weird to debug and cannot  track base tables's change, And in some cases, we want to always refresh the mv totally periodically.

## What I'm doing:
This pull request introduces enhancements to the materialized view (MV) refresh mechanism, including a new partition refresh strategy, refactoring of related logic, and additional utility functions for inspecting MV metadata. It also includes new test cases to validate the changes. Below are the key updates:

1. Enhancements to Materialized View Refresh Logic to support force mv refresh case
  - Introduced a new `FORCE` partition refresh strategy in the `PartitionRefreshStrategy` enum. This strategy refreshes all partitions regardless of their last refresh time. (`MaterializedView.java`, [fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.javaR154-R159](diffhunk://#diff-30af13c1a1cdd2dcedc3200a0a9a3497645f60a2a173ec4b2ca17217af93afb0R154-R159))


2. New Utility Functions for Metadata Inspection to be better track with base table and mv's version mapping:
  - Added the `inspect_mv_refresh_info` function to retrieve detailed MV refresh metadata, including partition updates and version maps for base tables. (`MetaFunctions.java`, [fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.javaR162-R285](diffhunk://#diff-686b532e43d91bc659acdcd39eef21ea3803c9b85c375ea86703e7e6605fafd8R162-R285))
  - Added the `inspect_table_partition_info` function to inspect partition information for a given table. (`MetaFunctions.java`, [fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.javaR162-R285](diffhunk://#diff-686b532e43d91bc659acdcd39eef21ea3803c9b85c375ea86703e7e6605fafd8R162-R285))


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
