### PR TITLE
[BugFix] Fix BE crash caused by filesystem is_symlink exception

### DIFF
--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -1462,7 +1462,6 @@ TEST_P(LakePartialUpdateTest, test_partial_update_retry_check_file_exist) {
 TEST_P(LakePartialUpdateTest, test_max_buffer_rows) {
     if (GetParam().partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) {
         GTEST_SKIP() << "this case only for partial update row mode";
-        return;
     }
     auto chunk0 = generate_data(kChunkSize, 0, false, 3);
     auto chunk1 = generate_data(kChunkSize, 0, true, 3);

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -1749,7 +1749,6 @@ TEST_P(LakePrimaryKeyPublishTest, test_cloud_native_index_minor_compact_because_
     if (!GetParam().enable_persistent_index ||
         GetParam().persistent_index_type != PersistentIndexTypePB::CLOUD_NATIVE) {
         GTEST_SKIP() << "this case only for cloud native index";
-        return;
     }
     auto version = 1;
     auto tablet_id = _tablet_metadata->id();
@@ -1791,7 +1790,6 @@ TEST_P(LakePrimaryKeyPublishTest, test_cloud_native_index_minor_compact_because_
     if (!GetParam().enable_persistent_index ||
         GetParam().persistent_index_type != PersistentIndexTypePB::CLOUD_NATIVE) {
         GTEST_SKIP() << "this case only for cloud native index";
-        return;
     }
     auto version = 1;
     auto tablet_id = _tablet_metadata->id();
@@ -1834,7 +1832,6 @@ TEST_P(LakePrimaryKeyPublishTest, test_individual_index_compaction) {
     if (!GetParam().enable_persistent_index ||
         GetParam().persistent_index_type != PersistentIndexTypePB::CLOUD_NATIVE) {
         GTEST_SKIP() << "this case only for cloud native index";
-        return;
     }
     auto version = 1;
     auto tablet_id = _tablet_metadata->id();


### PR DESCRIPTION
## Why I'm doing:

When BE has no permission to access the storage path, BE will crash on creating directory.

```
terminate called after throwing an instance of 'std::filesystem::__cxx11::filesystem_error'
  what():  filesystem error: symlink_status: Permission denied [/home/disk3/storage/data/520]
3.5.0-ee RELEASE (build c3103dd)
query_id:00000000-0000-0000-0000-000000000000, fragment_instance:00000000-0000-0000-0000-000000000000
*** Aborted at 1750231214 (unix time) try "date -d @1750231214" if you are using GNU date ***
terminate called recursively
PC: @     0x7fef56d83387 __GI_raise
*** SIGABRT (@0x3e80000142d) received by PID 5165 (TID 0x7fec3dbb0700) LWP(38539) from PID 5165; stack trace: ***
    @     0x7fef592df20b __pthread_once_slow
terminate called recursively
    @          0xb7cd294 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7fef592e8630 (/usr/lib64/libpthread-2.17.so+0xf62f)
    @     0x7fef56d83387 __GI_raise
    @     0x7fef56d84a78 __GI_abort
    @          0x3a6a003 __gnu_cxx::__verbose_terminate_handler() [clone .cold]
    @          0xf29d096 __cxxabiv1::__terminate(void (*)())
    @          0x3a69e9b std::terminate()
    @          0xf29d233 __cxa_throw
    @          0x3a6d9d3 std::filesystem::symlink_status(std::filesystem::__cxx11::path const&) [clone .cold]
    @          0x6fd7f8c starrocks::PosixFileSystem::create_dir_recursive(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
    @          0x71d9e8c starrocks::DataDir::get_shard(unsigned long*)
    @          0x7224b27 starrocks::TabletManager::_create_tablet_meta_unlocked(starrocks::TCreateTabletReq const&, starrocks::DataDir*, bool, starrocks::Tablet const*, std::shared_ptr<starrocks::TabletMeta>*)
    @          0x7225ce7 starrocks::TabletManager::_create_tablet_meta_and_dir_unlocked(starrocks::TCreateTabletReq const&, bool, starrocks::Tablet const*, std::vector<starrocks::DataDir*, std::allocator<starrocks::DataDir*> > const&)
    @          0x7226af5 starrocks::TabletManager::_internal_create_tablet_unlocked(starrocks::AlterTabletType, starrocks::TCreateTabletReq const&, bool, starrocks::Tablet const*, std::vector<starrocks::DataDir*, std::allocator<starrocks::DataDir*> > const&)
    @          0x72277c8 starrocks::TabletManager::create_tablet(starrocks::TCreateTabletReq const&, std::vector<starrocks::DataDir*, std::allocator<starrocks::DataDir*> >)
    @          0x71c384e starrocks::StorageEngine::create_tablet(starrocks::TCreateTabletReq const&)
    @          0x4800591 starrocks::run_create_tablet_task(std::shared_ptr<starrocks::AgentTaskRequestWithReqBody<starrocks::TCreateTabletReq> > const&, starrocks::ExecEnv*)
    @          0x40dd79f starrocks::ThreadPool::dispatch_thread()
    @          0x40d4d70 starrocks::Thread::supervise_thread(void*)
    @     0x7fef592e0ea5 start_thread
    @     0x7fef56e4bb0d __clone

```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
