### PR TITLE
[Enhancement] prefer two-phase plan for distinct aggregation in single node env

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -1282,6 +1282,15 @@ public class ConnectContext {
         return globalStateMgr.getNodeMgr().getClusterInfo().getAliveComputeNodeNumber();
     }
 
+    /**
+     * BackendNode + ComputeNode
+     */
+    public int getAliveExecutionNodesNumber() {
+        return getAliveBackendNumber() +
+                (RunMode.isSharedDataMode() ?
+                        getGlobalStateMgr().getNodeMgr().getClusterInfo().getAliveComputeNodeNumber() : 0);
+    }
+
     public void setPending(boolean pending) {
         isPending = pending;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -385,6 +385,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             "cbo_push_down_aggregate_on_broadcast_join_row_count_limit";
     public static final String CBO_ENABLE_INTERSECT_ADD_DISTINCT = "cbo_enable_intersect_add_distinct";
     public static final String CBO_ENABLE_HISTOGRAM_JOIN_ESTIMATION = "cbo_enable_histogram_join_estimation";
+    public static final String CBO_ENABLE_SINGLE_NODE_PREFER_TWO_STAGE_AGGREGATE =
+            "cbo_enable_single_node_prefer_two_stage_aggregate";
 
     public static final String CBO_PUSH_DOWN_DISTINCT_BELOW_WINDOW = "cbo_push_down_distinct_below_window";
     public static final String CBO_PUSH_DOWN_AGGREGATE = "cbo_push_down_aggregate";
@@ -1690,6 +1692,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = CBO_ENABLE_HISTOGRAM_JOIN_ESTIMATION, flag = VariableMgr.INVISIBLE)
     private boolean cboEnableHistogramJoinEstimation = true;
+
+    @VarAttr(name = CBO_ENABLE_SINGLE_NODE_PREFER_TWO_STAGE_AGGREGATE, flag = VariableMgr.INVISIBLE)
+    private boolean cboEnableSingleNodePreferTwoStageAggregate = true;
 
     @VariableMgr.VarAttr(name = PARSE_TOKENS_LIMIT)
     private int parseTokensLimit = 3500000;
@@ -4062,6 +4067,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setCboEnableHistogramJoinEstimation(boolean cboEnableHistogramJoinEstimation) {
         this.cboEnableHistogramJoinEstimation = cboEnableHistogramJoinEstimation;
+    }
+
+    public boolean isCboEnableSingleNodePreferTwoStageAggregate() {
+        return cboEnableSingleNodePreferTwoStageAggregate;
+    }
+
+    public void setCboEnableSingleNodePreferTwoStageAggregate(boolean value) {
+        this.cboEnableSingleNodePreferTwoStageAggregate = value;
     }
 
     public boolean isCboPushDownDistinctBelowWindow() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
@@ -99,6 +99,13 @@ public abstract class SplitAggregateRule extends TransformationRule {
         return af.getIntermediateType() == null ? af.getReturnType() : af.getIntermediateType();
     }
 
+    /**
+     * If there's only one BE node, splitting into multi-phase has no benefit but only overhead
+     */
+    private static boolean isSingleNodeExecution(ConnectContext context) {
+        return context.getAliveExecutionNodesNumber() == 1;
+    }
+
     protected boolean isSuitableForTwoStageDistinct(OptExpression input, LogicalAggregationOperator operator,
                                                   List<ColumnRefOperator> distinctColumns) {
         if (distinctColumns.isEmpty()) {
@@ -112,6 +119,10 @@ public abstract class SplitAggregateRule extends TransformationRule {
         }
 
         if (aggMode == TWO_STAGE.ordinal()) {
+            return true;
+        }
+
+        if (isSingleNodeExecution(ConnectContext.get())) {
             return true;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
@@ -51,7 +51,7 @@ public abstract class SplitAggregateRule extends TransformationRule {
     }
 
     public Map<ColumnRefOperator, CallOperator> createNormalAgg(AggType aggType,
-                                                                   Map<ColumnRefOperator, CallOperator> aggregationMap) {
+                                                                Map<ColumnRefOperator, CallOperator> aggregationMap) {
         Map<ColumnRefOperator, CallOperator> newAggregationMap = Maps.newHashMap();
         for (Map.Entry<ColumnRefOperator, CallOperator> entry : aggregationMap.entrySet()) {
             ColumnRefOperator column = entry.getKey();
@@ -108,7 +108,7 @@ public abstract class SplitAggregateRule extends TransformationRule {
     }
 
     protected boolean isSuitableForTwoStageDistinct(OptExpression input, LogicalAggregationOperator operator,
-                                                  List<ColumnRefOperator> distinctColumns) {
+                                                    List<ColumnRefOperator> distinctColumns) {
         if (distinctColumns.isEmpty()) {
             return true;
         }
@@ -123,7 +123,10 @@ public abstract class SplitAggregateRule extends TransformationRule {
             return true;
         }
 
-        if (aggMode == AUTO.ordinal() && isSingleNodeExecution(ConnectContext.get()) && !FeConstants.runningUnitTest) {
+        if (aggMode == AUTO.ordinal()
+                && isSingleNodeExecution(ConnectContext.get())
+                && !FeConstants.runningUnitTest
+                && ConnectContext.get().getSessionVariable().isCboEnableSingleNodePreferTwoStageAggregate()) {
             return true;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Type;
+import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.operator.AggType;
@@ -122,7 +123,7 @@ public abstract class SplitAggregateRule extends TransformationRule {
             return true;
         }
 
-        if (isSingleNodeExecution(ConnectContext.get())) {
+        if (isSingleNodeExecution(ConnectContext.get()) && !FeConstants.runningUnitTest) {
             return true;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
@@ -123,7 +123,7 @@ public abstract class SplitAggregateRule extends TransformationRule {
             return true;
         }
 
-        if (isSingleNodeExecution(ConnectContext.get()) && !FeConstants.runningUnitTest) {
+        if (aggMode == AUTO.ordinal() && isSingleNodeExecution(ConnectContext.get()) && !FeConstants.runningUnitTest) {
             return true;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -45,6 +45,7 @@ import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -118,6 +119,11 @@ public class SelectStmtTest {
                 .withTable(createTable1)
                 .withTable(createTableWithPrimaryKey);
         FeConstants.enablePruneEmptyOutputScan = false;
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        FeConstants.runningUnitTest = true;
     }
 
     @Test
@@ -694,7 +700,8 @@ public class SelectStmtTest {
 
         String plan = starRocksAssert.query(sql).explainQuery();
 
-        Assertions.assertTrue(plan.contains("2:AGGREGATE (update finalize)\n" +
+        Assertions.assertTrue(plan.contains("2:AGGREGATE (update serialize)\n" +
+                "  |  STREAMING\n" +
                 "  |  output: count(1: user_id)\n" +
                 "  |  group by: 3: case\n" +
                 "  |  \n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -167,6 +167,7 @@ public class LowCardinalityTest extends PlanTestBase {
         connectContext.getSessionVariable().setEnableLowCardinalityOptimize(true);
         connectContext.getSessionVariable().setCboCteReuse(false);
         connectContext.getSessionVariable().setEnableEliminateAgg(false);
+        FeConstants.runningUnitTest = true;
     }
 
     @AfterAll
@@ -244,7 +245,7 @@ public class LowCardinalityTest extends PlanTestBase {
     public void testDecodeNodeRewrite3() throws Exception {
         String sql = "select L_COMMENT from lineitem group by L_COMMENT";
         String plan = getFragmentPlan(sql);
-        Assertions.assertTrue(plan.contains("  2:Decode\n" +
+        Assertions.assertTrue(plan.contains("  4:Decode\n" +
                 "  |  <dict id 18> : <string id 16>\n"));
     }
 
@@ -279,10 +280,10 @@ public class LowCardinalityTest extends PlanTestBase {
     public void testDecodeNodeRewrite4() throws Exception {
         String sql = "select dept_name from dept group by dept_name,state";
         String plan = getFragmentPlan(sql);
-        Assertions.assertTrue(plan.contains("  3:Decode\n" +
+        Assertions.assertTrue(plan.contains("  5:Decode\n" +
                 "  |  <dict id 4> : <string id 2>\n" +
                 "  |  \n" +
-                "  2:Project\n" +
+                "  4:Project\n" +
                 "  |  <slot 4> : 4: dept_name"));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -244,7 +244,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "    p_type,\n" +
                 "    p_size\n;";
         String plan = getFragmentPlan(sql);
-        Assertions.assertTrue(plan.contains("  13:Decode\n" +
+        Assertions.assertTrue(plan.contains("Decode\n" +
                 "  |  <dict id 27> : <string id 11>"), plan);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -244,7 +244,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "    p_type,\n" +
                 "    p_size\n;";
         String plan = getFragmentPlan(sql);
-        Assertions.assertTrue(plan.contains("  14:Decode\n" +
+        Assertions.assertTrue(plan.contains("  13:Decode\n" +
                 "  |  <dict id 27> : <string id 11>"), plan);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
@@ -981,6 +981,7 @@ public class PlanTestBase extends PlanTestNoneDBBase {
         connectContext.getSessionVariable().setEnableLowCardinalityOptimize(false);
         connectContext.getSessionVariable().setEnableShortCircuit(true);
         connectContext.getSessionVariable().setCboPushDownGroupingSet(false);
+        connectContext.getSessionVariable().setCboEnableSingleNodePreferTwoStageAggregate(false);
     }
 
     @AfterAll


### PR DESCRIPTION
## Why I'm doing:

```sql
SELECT
    get_json_string(data, 'commit.collection') AS event,
    count() AS count,
    count(DISTINCT get_json_string(data, 'did')) AS users
FROM bluesky
WHERE (get_json_string(data, 'kind') = 'commit')
  AND (get_json_string(data, 'commit.operation') = 'create') 
GROUP BY event
ORDER BY count DESC;
```

For this kind of query:
- low-cardinality GROUP_BY
- high-cardinality COUNT_DISTINCT

Different query plans and performance in a single-node env:
1. 1-phase: 9.4s 
2. 2-phase: 2.8s (best)
3. 3-phase: 8.3s (default, without stats on GROUP_BY)
4. 4-phase: 4.3s (with stats on GROUP_BY)

The 2-phase plan is clearly the better option; however, it is not the default. The default plan is the 3-phase plan, as it is more suitable for multi-node clusters due to its ability to handle data skew and provide better scalability. However, in a single-node cluster, the multi-phase plan offers no advantages and only adds unnecessary overhead.

Therefore, we aim to select the 2-phase plan for single-node environments.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
