### PR TITLE
[Enhancement] add touch_cache and get_numeric_statistics implementation to BundleSeekableInputStream

### DIFF
--- a/be/src/fs/bundle_file.cpp
+++ b/be/src/fs/bundle_file.cpp
@@ -134,6 +134,11 @@ StatusOr<std::string> BundleSeekableInputStream::read_all() {
     return std::move(result);
 }
 
+Status BundleSeekableInputStream::touch_cache(int64_t offset, size_t length) {
+    // Touch the cache for the underlying stream.
+    return _stream->touch_cache(_offset + offset, length);
+}
+
 const std::string& BundleSeekableInputStream::filename() const {
     return _stream->filename();
 }

--- a/be/src/fs/bundle_file.cpp
+++ b/be/src/fs/bundle_file.cpp
@@ -139,6 +139,10 @@ Status BundleSeekableInputStream::touch_cache(int64_t offset, size_t length) {
     return _stream->touch_cache(_offset + offset, length);
 }
 
+StatusOr<std::unique_ptr<io::NumericStatistics>> BundleSeekableInputStream::get_numeric_statistics() {
+    return _stream->get_numeric_statistics();
+}
+
 const std::string& BundleSeekableInputStream::filename() const {
     return _stream->filename();
 }

--- a/be/src/fs/bundle_file.h
+++ b/be/src/fs/bundle_file.h
@@ -102,6 +102,7 @@ public:
     const std::string& filename() const override;
     StatusOr<int64_t> read(void* data, int64_t count) override;
     Status touch_cache(int64_t offset, size_t length) override;
+    StatusOr<std::unique_ptr<io::NumericStatistics>> get_numeric_statistics() override;
 
 private:
     std::shared_ptr<io::SeekableInputStream> _stream;

--- a/be/src/fs/bundle_file.h
+++ b/be/src/fs/bundle_file.h
@@ -101,6 +101,7 @@ public:
     StatusOr<std::string> read_all() override;
     const std::string& filename() const override;
     StatusOr<int64_t> read(void* data, int64_t count) override;
+    Status touch_cache(int64_t offset, size_t length) override;
 
 private:
     std::shared_ptr<io::SeekableInputStream> _stream;

--- a/be/test/fs/bundle_file_test.cpp
+++ b/be/test/fs/bundle_file_test.cpp
@@ -279,7 +279,6 @@ TEST_F(BundleFileTest, test_touch_cache_and_statistics) {
 
     // get numeric statistics
     ASSIGN_OR_ABORT(auto numeric_stats, reader->get_numeric_statistics());
-    ASSERT_TRUE(numeric_stats != nullptr);
 }
 
 } // namespace starrocks

--- a/be/test/fs/bundle_file_test.cpp
+++ b/be/test/fs/bundle_file_test.cpp
@@ -247,4 +247,35 @@ TEST_F(BundleFileTest, test_concurrent_write) {
     }
 }
 
+TEST_F(BundleFileTest, test_touch_cache) {
+    std::string test_data1 = "Hello, SharedFile!";
+    std::string bundle_file_path = _test_dir + "/test_touch_cache_bundle_file.dat";
+
+    auto shared_context = std::make_shared<BundleWritableFileContext>();
+    shared_context->try_create_bundle_file([&]() {
+        WritableFileOptions opts;
+        return fs::new_writable_file(opts, bundle_file_path);
+    });
+    shared_context->try_create_bundle_file([&]() {
+        WritableFileOptions opts;
+        return fs::new_writable_file(opts, bundle_file_path);
+    });
+
+    WritableFileOptions wopts;
+    auto shared_writer = std::make_unique<BundleWritableFile>(shared_context.get(), wopts.encryption_info);
+    shared_context->increase_active_writers();
+    // write some data
+    ASSERT_OK(shared_writer->append(test_data1));
+    ASSERT_OK(shared_writer->sync());
+    ASSERT_OK(shared_writer->close());
+    shared_context->decrease_active_writers();
+
+    // touch cache
+    RandomAccessFileOptions ropts;
+    FileInfo file_info2{.path = bundle_file_path, .size = test_data1.size(), .bundle_file_offset = 0};
+    ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(bundle_file_path));
+    ASSIGN_OR_ABORT(auto reader, fs->new_random_access_file_with_bundling(ropts, bundle_file_path));
+    ASSERT_OK(reader->touch_cache(0, sizeof(test_data1))); // touch the first 30 bytes
+}
+
 } // namespace starrocks

--- a/be/test/fs/bundle_file_test.cpp
+++ b/be/test/fs/bundle_file_test.cpp
@@ -247,7 +247,7 @@ TEST_F(BundleFileTest, test_concurrent_write) {
     }
 }
 
-TEST_F(BundleFileTest, test_touch_cache) {
+TEST_F(BundleFileTest, test_touch_cache_and_statistics) {
     std::string test_data1 = "Hello, SharedFile!";
     std::string bundle_file_path = _test_dir + "/test_touch_cache_bundle_file.dat";
 
@@ -274,8 +274,12 @@ TEST_F(BundleFileTest, test_touch_cache) {
     RandomAccessFileOptions ropts;
     FileInfo file_info2{.path = bundle_file_path, .size = test_data1.size(), .bundle_file_offset = 0};
     ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(bundle_file_path));
-    ASSIGN_OR_ABORT(auto reader, fs->new_random_access_file_with_bundling(ropts, bundle_file_path));
+    ASSIGN_OR_ABORT(auto reader, fs->new_random_access_file_with_bundling(ropts, file_info2));
     ASSERT_OK(reader->touch_cache(0, sizeof(test_data1))); // touch the first 30 bytes
+
+    // get numeric statistics
+    ASSIGN_OR_ABORT(auto numeric_stats, reader->get_numeric_statistics());
+    ASSERT_TRUE(numeric_stats != nullptr);
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
`touch_cache` is used for cache warmup when run `cache select xxx` sql, and `get_numeric_statistics` is called to record cache statistics to metrics.
And `BundleSeekableInputStream` was missing to implement them.

## What I'm doing:
This pull request introduces new functionality to the `BundleSeekableInputStream` class, enabling cache interaction and retrieval of numeric statistics, along with corresponding tests to validate these features. The changes primarily focus on extending the capabilities of the stream handling and ensuring robust testing.

### Enhancements to `BundleSeekableInputStream` functionality:
* **Cache interaction**: Added the `touch_cache` method to allow interacting with the cache for the underlying stream. (`be/src/fs/bundle_file.cpp`, `be/src/fs/bundle_file.h`) [[1]](diffhunk://#diff-b1f32f78edee52acac80df4eb4791f4ee731ed33a1030c625d6460d989e84451R137-R145) [[2]](diffhunk://#diff-94dc39c0caef5e19f06f94b7e7ce7ab8dd820a8af912d279615d2f50477b4b8cR104-R105)
* **Numeric statistics retrieval**: Added the `get_numeric_statistics` method to retrieve statistics from the underlying stream. (`be/src/fs/bundle_file.cpp`, `be/src/fs/bundle_file.h`) [[1]](diffhunk://#diff-b1f32f78edee52acac80df4eb4791f4ee731ed33a1030c625d6460d989e84451R137-R145) [[2]](diffhunk://#diff-94dc39c0caef5e19f06f94b7e7ce7ab8dd820a8af912d279615d2f50477b4b8cR104-R105)

### Testing:
* **New test case**: Added `test_touch_cache_and_statistics` in `BundleFileTest` to validate the functionality of `touch_cache` and `get_numeric_statistics`. This test ensures cache interaction and numeric statistics retrieval work as expected. (`be/test/fs/bundle_file_test.cpp`)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
