### PR TITLE
[BugFix] fix Duplicate key exception when get table statistics

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
@@ -81,10 +81,11 @@ public class CachedStatisticStorage implements StatisticStorage, MemoryTrackable
 
     @Override
     public Map<Long, Optional<Long>> getTableStatistics(Long tableId, Collection<Partition> partitions) {
+        Map<Long, Optional<Long>> statistics = new HashMap<>();
         // get Statistics Table column info, just return default column statistics
         if (StatisticUtils.statisticTableBlackListCheck(tableId)) {
-            return partitions.stream().map(Partition::getId).distinct()
-                    .collect(Collectors.toMap(id -> id, p -> Optional.empty()));
+            partitions.forEach(p -> statistics.put(p.getId(), Optional.empty()));
+            return statistics;
         }
 
         List<TableStatsCacheKey> keys = partitions.stream().map(p -> new TableStatsCacheKey(tableId, p.getId()))
@@ -103,8 +104,8 @@ public class CachedStatisticStorage implements StatisticStorage, MemoryTrackable
         } catch (Exception e) {
             LOG.warn("Faied to execute tableStatsCache.getAll", e);
         }
-        return partitions.stream().map(Partition::getId).distinct()
-                .collect(Collectors.toMap(id -> id, p -> Optional.empty()));
+        partitions.forEach(p -> statistics.put(p.getId(), Optional.empty()));
+        return statistics;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
@@ -83,7 +83,8 @@ public class CachedStatisticStorage implements StatisticStorage, MemoryTrackable
     public Map<Long, Optional<Long>> getTableStatistics(Long tableId, Collection<Partition> partitions) {
         // get Statistics Table column info, just return default column statistics
         if (StatisticUtils.statisticTableBlackListCheck(tableId)) {
-            return partitions.stream().collect(Collectors.toMap(Partition::getId, p -> Optional.empty()));
+            return partitions.stream().map(Partition::getId).distinct()
+                    .collect(Collectors.toMap(id -> id, p -> Optional.empty()));
         }
 
         List<TableStatsCacheKey> keys = partitions.stream().map(p -> new TableStatsCacheKey(tableId, p.getId()))
@@ -102,7 +103,8 @@ public class CachedStatisticStorage implements StatisticStorage, MemoryTrackable
         } catch (Exception e) {
             LOG.warn("Faied to execute tableStatsCache.getAll", e);
         }
-        return partitions.stream().collect(Collectors.toMap(Partition::getId, p -> Optional.empty()));
+        return partitions.stream().map(Partition::getId).distinct()
+                .collect(Collectors.toMap(id -> id, p -> Optional.empty()));
     }
 
     @Override


### PR DESCRIPTION
## Why I'm doing:

```sql
CREATE TABLE `ptbl5` (
  `dt` date NULL COMMENT "",
  `id` int(11) NULL COMMENT "",
  `name` varchar(65533) NULL COMMENT ""
) ENGINE=OLAP
DUPLICATE KEY(`dt`, `id`, `name`)
PARTITION BY RANGE(`dt`)
(PARTITION p20250428 VALUES [("2025-04-28"), ("2025-04-29")),
PARTITION p20250429 VALUES [("2025-04-29"), ("2025-04-30")))
DISTRIBUTED BY HASH(`id`, `name`)
PROPERTIES (
"compression" = "LZ4",
"fast_schema_evolution" = "true",
"replicated_storage" = "true",
"replication_num" = "1"
);

insert into ptbl5 values("2025-04-29",1,'a');

-- ERROR 1064 (HY000): Duplicate key 5031178 (attempted merging values Optional.empty and Optional.empty)
select min(dt),max(dt) from ptbl5;
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
