### PR TITLE
[BugFix] Fix assertion failure for insert stmt planning of shuffle for primary key table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -917,7 +917,7 @@ public class InsertPlanner {
             return new PhysicalPropertySet();
         }
 
-        List<Column> columns = table.getFullSchema();
+        List<Column> columns = outputFullSchema;
         Preconditions.checkState(columns.size() == outputColumns.size(),
                 "outputColumn's size must equal with table's column size");
 

--- a/test/sql/test_insert_empty/R/test_insert_partial_update
+++ b/test/sql/test_insert_empty/R/test_insert_partial_update
@@ -68,3 +68,24 @@ insert into test4 (pk, v0) values(1, 'v0_1'), (3, 'v3_1');
 -- result:
 [REGEX].*partial update on table with sort key must provide all sort key columns.*
 -- !result
+-- name: test_non_replicated_storage_multi_replica_pk
+CREATE TABLE `t_non_replicated_storage_multi_replica_pk` (
+  `k` STRING NOT NULL COMMENT "",
+  `v1` int,
+  `v2` int
+) ENGINE=OLAP 
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "2",
+"replicated_storage" = "false"
+);
+-- result:
+-- !result
+insert into t_non_replicated_storage_multi_replica_pk (k,v2) select "abc", 10;
+-- result:
+-- !result
+select * from t_non_replicated_storage_multi_replica_pk;
+-- result:
+abc	10	10
+-- !result

--- a/test/sql/test_insert_empty/R/test_insert_partial_update
+++ b/test/sql/test_insert_empty/R/test_insert_partial_update
@@ -71,7 +71,7 @@ insert into test4 (pk, v0) values(1, 'v0_1'), (3, 'v3_1');
 -- name: test_non_replicated_storage_multi_replica_pk
 CREATE TABLE `t_non_replicated_storage_multi_replica_pk` (
   `k` STRING NOT NULL COMMENT "",
-  `v1` int,
+  `v1` int DEFAULT "10",
   `v2` int
 ) ENGINE=OLAP 
 PRIMARY KEY(`k`)

--- a/test/sql/test_insert_empty/T/test_insert_partial_update
+++ b/test/sql/test_insert_empty/T/test_insert_partial_update
@@ -35,3 +35,18 @@ primary KEY (pk) DISTRIBUTED BY HASH(pk) BUCKETS 1 order by (v1) PROPERTIES("rep
 
 insert into test4 values(1, 'v0', 1), (2, 'v2', 2);
 insert into test4 (pk, v0) values(1, 'v0_1'), (3, 'v3_1');
+
+-- name: test_non_replicated_storage_multi_replica_pk
+CREATE TABLE `t_non_replicated_storage_multi_replica_pk` (
+  `k` STRING NOT NULL COMMENT "",
+  `v1` int DEFAULT "10",
+  `v2` int
+) ENGINE=OLAP 
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "2",
+"replicated_storage" = "false"
+);
+
+insert into t_non_replicated_storage_multi_replica_pk (k,v2) select "abc", 10;

--- a/test/sql/test_insert_empty/T/test_insert_partial_update
+++ b/test/sql/test_insert_empty/T/test_insert_partial_update
@@ -50,3 +50,4 @@ PROPERTIES (
 );
 
 insert into t_non_replicated_storage_multi_replica_pk (k,v2) select "abc", 10;
+select * from t_non_replicated_storage_multi_replica_pk;


### PR DESCRIPTION
## Why I'm doing:
If we create a table satisify the following condition: 1. primary key table, 2. replication_num > 1
3. without replicate storage. In this case, if we execute a partial update insert stmt, we will get
assertion failure because we need to build the shuffle property in this case but if insert stmt is
in partial update mode, the list of ColumnRefOperator has not the same size of full schema.

## What I'm doing:
We just use outputFullSchema which generated by partial update checking instead of Table::getFullSchema()

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
