### PR TITLE
[BugFix] Filesystem cache failure in concurrent scenarios.

### DIFF
--- a/be/src/service/staros_worker.h
+++ b/be/src/service/staros_worker.h
@@ -134,6 +134,7 @@ private:
 
 private:
     mutable std::shared_mutex _mtx;
+    std::shared_mutex _cache_mtx;
     std::unordered_map<ShardId, ShardInfoDetails> _shards;
     std::unique_ptr<Cache> _fs_cache;
     add_shard_listener _add_shard_listener;

--- a/be/test/service/staros_worker_test.cpp
+++ b/be/test/service/staros_worker_test.cpp
@@ -19,6 +19,7 @@
 #include <fslib/fslib_all_initializer.h>
 #include <gtest/gtest.h>
 
+#include <condition_variable>
 #include <functional>
 
 #include "common/config.h"
@@ -125,6 +126,94 @@ TEST(StarOSWorkerTest, test_build_scheme_from_shard_info) {
     auto scheme_or = StarOSWorker::build_scheme_from_shard_info(shard_info);
     EXPECT_TRUE(scheme_or.ok());
     EXPECT_EQ("gs://", scheme_or.value());
+}
+
+TEST(StarOSWorkerTest, test_fs_cache_concurrent) {
+    staros::starlet::fslib::register_builtin_filesystems();
+    staros::starlet::ShardInfo shard_info;
+    shard_info.id = 1;
+    auto fs_info = shard_info.path_info.mutable_fs_info();
+    fs_info->set_fs_type(staros::FileStoreType::S3);
+    auto s3_fs_info = fs_info->mutable_s3_fs_info();
+    s3_fs_info->set_bucket("test_bucket");
+    s3_fs_info->set_endpoint("test_endpoint");
+    s3_fs_info->set_region("us-east-1");
+    auto credential = s3_fs_info->mutable_credential();
+    auto simple_credential = credential->mutable_simple_credential();
+    simple_credential->set_access_key("test_ak");
+    simple_credential->set_access_key_secret("test_sk");
+    shard_info.path_info.set_full_path(absl::StrFormat("s3://%s/%d/", s3_fs_info->bucket(), time(NULL)));
+
+    shard_info.cache_info.set_enable_cache(true);
+    shard_info.cache_info.set_async_write_back(false);
+
+    auto schema_or = StarOSWorker::build_scheme_from_shard_info(shard_info);
+    EXPECT_TRUE(schema_or.ok());
+    auto schema = schema_or.value();
+
+    auto conf_or = shard_info.fslib_conf_from_this(false, "");
+    EXPECT_TRUE(conf_or.ok());
+    auto conf = conf_or.value();
+
+    auto cache_key = StarOSWorker::get_cache_key(schema, conf);
+
+    auto worker = std::make_shared<StarOSWorker>();
+    g_worker = worker;
+
+    EXPECT_TRUE(worker->add_shard(shard_info).ok());
+
+    std::shared_ptr<std::string> key1, key2;
+    std::mutex mtx;
+    std::condition_variable cv;
+    bool ready = false;
+    int ready_count = 0;
+
+    EXPECT_FALSE(worker->lookup_fs_cache(cache_key));
+
+    auto thread_func = [&](std::shared_ptr<std::string>& key) {
+        {
+            std::unique_lock<std::mutex> lock(mtx);
+            ready_count++;
+            cv.notify_all();
+            cv.wait(lock, [&] { return ready; });
+        }
+
+        auto result = worker->build_filesystem_from_shard_info(shard_info, conf);
+        EXPECT_TRUE(result.ok());
+        key = result->first;
+    };
+
+    std::thread t1(thread_func, std::ref(key1));
+    std::thread t2(thread_func, std::ref(key2));
+
+    {
+        std::unique_lock<std::mutex> lock(mtx);
+        cv.wait(lock, [&] { return ready_count == 2; });
+        ready = true;
+    }
+    cv.notify_all();
+
+    t1.join();
+    t2.join();
+
+    EXPECT_EQ(key1.get(), key2.get());
+
+    EXPECT_EQ(*key1, *key2);
+
+    EXPECT_TRUE(worker->lookup_fs_cache(cache_key));
+
+    EXPECT_TRUE(worker->get_shard_filesystem(shard_info.id, conf).ok());
+
+    EXPECT_TRUE(worker->lookup_fs_cache(cache_key));
+
+    EXPECT_TRUE(worker->remove_shard(shard_info.id).ok());
+
+    EXPECT_TRUE(worker->lookup_fs_cache(cache_key));
+
+    key1.reset();
+    key2.reset();
+
+    EXPECT_FALSE(worker->lookup_fs_cache(cache_key));
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
Before shard 11724 inserts the cache, shard 10063 enters the build_filesystem_from_shard_info function, leading to a result where the same string cache_key has two std::shared_ptr<std::string> objects.
```
I20250615 23:55:12.801891 139846642751232 staros_worker.cpp:354] StarOSWorker::insert_fs_cache: key = 4f745a4a455fa97c78a0660ba33dae18b476a308a6dc4a1d4d97ba48728644f4
I20250615 23:55:12.801900 139846642751232 staros_worker.cpp:364] StarOSWorker::insert_fs_cache: key = 4f745a4a455fa97c78a0660ba33dae18b476a308a6dc4a1d4d97ba48728644f4 , capacity = 4
I20250615 23:55:12.801905 139846642751232 staros_worker.cpp:212] StarOSWorker::get_shard_filesystem: get shard 11724 fs from cache failed.

I20250615 23:55:12.710220 139846634358528 staros_worker.cpp:193] StarOSWorker::get_shard_filesystem: build_filesystem_from_shard_info shard id = 10063.
I20250615 23:55:12.743501 139846634358528 staros_worker.cpp:354] StarOSWorker::insert_fs_cache: key = 4f745a4a455fa97c78a0660ba33dae18b476a308a6dc4a1d4d97ba48728644f4
I20250615 23:55:12.743510 139846634358528 staros_worker.cpp:364] StarOSWorker::insert_fs_cache: key = 4f745a4a455fa97c78a0660ba33dae18b476a308a6dc4a1d4d97ba48728644f4 , capacity = 4
I20250615 23:55:12.743515 139846634358528 staros_worker.cpp:208] StarOSWorker::get_shard_filesystem: get shard 10063 fs from cache after create.
I20250615 23:55:12.743518 139846634358528 staros_worker.cpp:371] StarOSWorker::erase_fs_cache: key = 4f745a4a455fa97c78a0660ba33dae18b476a308a6dc4a1d4d97ba48728644f4 , capacity = 4
```
## What I'm doing:

Fixes #58539

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
