### PR TITLE
[Refactor] rename aggregate/shared prefix to bundle

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -339,13 +339,11 @@ struct AggregatePublishContext {
             } else {
                 auto latch = BThreadCountDownLatch(1);
                 auto task = std::make_shared<AutoCleanRunnable>(
-                        [&] {
-                            publish_status = env->lake_tablet_manager()->put_aggregate_tablet_metadata(tablet_metas);
-                        },
+                        [&] { publish_status = env->lake_tablet_manager()->put_bundle_tablet_metadata(tablet_metas); },
                         [&] { latch.count_down(); });
                 Status submit_st = thread_pool->submit(std::move(task));
                 if (!submit_st.ok()) {
-                    LOG(WARNING) << "Fail to submit put_aggregate_tablet_metadata task";
+                    LOG(WARNING) << "Fail to submit put_bundle_tablet_metadata task";
                     publish_status = submit_st;
                 }
                 latch.wait();

--- a/be/src/storage/lake/location_provider.h
+++ b/be/src/storage/lake/location_provider.h
@@ -69,7 +69,7 @@ public:
         return join_path(metadata_root_location(tablet_id), tablet_initial_metadata_filename());
     }
 
-    std::string aggregate_tablet_metadata_location(int64_t tablet_id, int64_t version) const {
+    std::string bundle_tablet_metadata_location(int64_t tablet_id, int64_t version) const {
         return join_path(metadata_root_location(tablet_id), tablet_metadata_filename(0, version));
     }
 

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -470,8 +470,8 @@ Status SchemaChangeHandler::do_process_update_tablet_meta(const TTabletMetaInfo&
 
     // TODO(zhangqiang)
     // aggregate alter txn log
-    if (tablet_meta_info.__isset.aggregate_tablet_metadata) {
-        metadata_update_info->set_aggregate_tablet_metadata(tablet_meta_info.aggregate_tablet_metadata);
+    if (tablet_meta_info.__isset.bundle_tablet_metadata) {
+        metadata_update_info->set_bundle_tablet_metadata(tablet_meta_info.bundle_tablet_metadata);
     }
 
     RETURN_IF_ERROR(tablet.put_txn_log(std::move(txn_log)));

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -82,7 +82,7 @@ public:
 
     Status cache_tablet_metadata(const TabletMetadataPtr& metadata);
 
-    Status put_aggregate_tablet_metadata(std::map<int64_t, TabletMetadataPB>& tablet_metas);
+    Status put_bundle_tablet_metadata(std::map<int64_t, TabletMetadataPB>& tablet_metas);
 
     // When using get_tablet_metadata to determine whether a new version exists in publish version,
     // a valid expected_gtid must be passed in.
@@ -161,7 +161,7 @@ public:
 
     std::string tablet_initial_metadata_location(int64_t tablet_id) const;
 
-    std::string aggregate_tablet_metadata_location(int64_t tablet_id, int64_t version) const;
+    std::string bundle_tablet_metadata_location(int64_t tablet_id, int64_t version) const;
 
     std::string txn_log_location(int64_t tablet_id, int64_t txn_id) const;
 
@@ -182,7 +182,7 @@ public:
 
     UpdateManager* update_mgr();
 
-    CompactionScheduler* compaction_scheduler() { return _compaction_scheduler.get(); }
+    CompactionScheduler* compaction_scheduler() {return _compaction_scheduler.get(); }
 
     void update_metacache_limit(size_t limit);
 

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -182,7 +182,7 @@ public:
 
     UpdateManager* update_mgr();
 
-    CompactionScheduler* compaction_scheduler() {return _compaction_scheduler.get(); }
+    CompactionScheduler* compaction_scheduler() { return _compaction_scheduler.get(); }
 
     void update_metacache_limit(size_t limit);
 

--- a/be/src/storage/lake/tablet_metadata.h
+++ b/be/src/storage/lake/tablet_metadata.h
@@ -23,5 +23,6 @@ namespace starrocks {
 using TabletMetadata = TabletMetadataPB;
 using TabletMetadataPtr = std::shared_ptr<const TabletMetadata>;
 using MutableTabletMetadataPtr = std::shared_ptr<TabletMetadata>;
+using BundleTabletMetadataPtr = std::shared_ptr<BundleTabletMetadataPB>;
 
 } // namespace starrocks

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -85,7 +85,7 @@ Status apply_alter_meta_log(TabletMetadataPB* metadata, const TxnLogPB_OpAlterMe
             metadata->mutable_schema()->CopyFrom(alter_meta.tablet_schema());
         }
 
-        if (alter_meta.has_aggregate_tablet_metadata()) {
+        if (alter_meta.has_bundle_tablet_metadata()) {
             // do nothing
         }
     }

--- a/be/test/storage/lake/alter_tablet_meta_test.cpp
+++ b/be/test/storage/lake/alter_tablet_meta_test.cpp
@@ -609,7 +609,7 @@ TEST_F(AlterTabletMetaTest, test_skip_load_pindex) {
     }
 }
 
-TEST_F(AlterTabletMetaTest, test_aggregate_tablet_metadata) {
+TEST_F(AlterTabletMetaTest, test_bundle_tablet_metadata) {
     lake::SchemaChangeHandler handler(_tablet_mgr.get());
     TUpdateTabletMetaInfoReq update_tablet_meta_req;
     int64_t txn_id = next_id();
@@ -618,7 +618,7 @@ TEST_F(AlterTabletMetaTest, test_aggregate_tablet_metadata) {
     TTabletMetaInfo tablet_meta_info;
     auto tablet_id = _tablet_metadata->id();
     tablet_meta_info.__set_tablet_id(tablet_id);
-    tablet_meta_info.__set_aggregate_tablet_metadata(true);
+    tablet_meta_info.__set_bundle_tablet_metadata(true);
 
     update_tablet_meta_req.tabletMetaInfos.push_back(tablet_meta_info);
     ASSERT_OK(handler.process_update_tablet_meta(update_tablet_meta_req));
@@ -626,8 +626,8 @@ TEST_F(AlterTabletMetaTest, test_aggregate_tablet_metadata) {
     ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_log(tablet_id, txn_id));
     ASSERT_TRUE(txn_log->has_op_alter_metadata());
     for (const auto& alter_meta : txn_log->op_alter_metadata().metadata_update_infos()) {
-        ASSERT_TRUE(alter_meta.has_aggregate_tablet_metadata());
-        ASSERT_TRUE(alter_meta.aggregate_tablet_metadata());
+        ASSERT_TRUE(alter_meta.has_bundle_tablet_metadata());
+        ASSERT_TRUE(alter_meta.bundle_tablet_metadata());
     }
     auto new_tablet_meta = publish_single_version(tablet_id, 2, txn_id);
     ASSERT_OK(new_tablet_meta.status());

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -575,7 +575,7 @@ TEST_F(LakeTabletManagerTest, create_tablet_with_cloud_native_persistent_index) 
     EXPECT_EQ(TPersistentIndexType::CLOUD_NATIVE, metadata->persistent_index_type());
 }
 
-TEST_F(LakeTabletManagerTest, put_aggregate_tablet_metadata) {
+TEST_F(LakeTabletManagerTest, put_bundle_tablet_metadata) {
     std::map<int64_t, TabletMetadataPB> metadatas;
     TabletSchemaPB schema_pb1;
     {
@@ -646,7 +646,7 @@ TEST_F(LakeTabletManagerTest, put_aggregate_tablet_metadata) {
 
     metadatas.emplace(1, metadata1);
     metadatas.emplace(2, metadata2);
-    EXPECT_OK(_tablet_manager->put_aggregate_tablet_metadata(metadatas));
+    EXPECT_OK(_tablet_manager->put_bundle_tablet_metadata(metadatas));
 
     {
         auto res = _tablet_manager->get_tablet_metadata(1, 2);
@@ -657,7 +657,7 @@ TEST_F(LakeTabletManagerTest, put_aggregate_tablet_metadata) {
     }
 
     {
-        std::string fp_name = "tablet_schema_not_found_in_shared_metadata";
+        std::string fp_name = "tablet_schema_not_found_in_bundle_metadata";
         auto fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get(fp_name);
         PFailPointTriggerMode trigger_mode;
         trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);

--- a/be/test/storage/lake/test_util.h
+++ b/be/test/storage/lake/test_util.h
@@ -174,7 +174,7 @@ inline Status TEST_aggregate_publish_version(TabletManager* tablet_mgr, std::vec
         for (const auto& meta : response.tablet_metas()) {
             tablet_metas.emplace(meta.first, meta.second);
         }
-        return tablet_mgr->put_aggregate_tablet_metadata(tablet_metas);
+        return tablet_mgr->put_bundle_tablet_metadata(tablet_metas);
     } else {
         return Status::InternalError(fmt::format("failed to publish version. tablet_sz={} txn_id={} new_version={}",
                                                  tablet_ids.size(), txn_id, new_version));

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -1635,7 +1635,7 @@ TEST(LakeVacuumTest2, test_delete_files_retry4) {
     EXPECT_GT(attempts, 1);
 }
 
-TEST_P(LakeVacuumTest, test_vacuum_shared_metadata) {
+TEST_P(LakeVacuumTest, test_vacuum_bundle_metadata) {
     create_data_file("00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat");
     create_data_file("00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1e.dat");
     create_data_file("00000000000259e4_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat");
@@ -1730,17 +1730,17 @@ TEST_P(LakeVacuumTest, test_vacuum_shared_metadata) {
     t600_v1->mutable_schema()->CopyFrom(schema_pb1);
     tablet_metas_v1[600] = *t600_v1;
     tablet_metas_v1[601] = *t601_v1;
-    ASSERT_OK(_tablet_mgr->put_aggregate_tablet_metadata(tablet_metas_v1));
+    ASSERT_OK(_tablet_mgr->put_bundle_tablet_metadata(tablet_metas_v1));
     std::map<int64_t, TabletMetadataPB> tablet_metas_v2;
     t600_v2->mutable_schema()->CopyFrom(schema_pb1);
     tablet_metas_v2[600] = *t600_v2;
     tablet_metas_v2[601] = *t601_v2;
-    ASSERT_OK(_tablet_mgr->put_aggregate_tablet_metadata(tablet_metas_v2));
+    ASSERT_OK(_tablet_mgr->put_bundle_tablet_metadata(tablet_metas_v2));
     std::map<int64_t, TabletMetadataPB> tablet_metas_v3;
     t600_v3->mutable_schema()->CopyFrom(schema_pb1);
     tablet_metas_v3[600] = *t600_v3;
     tablet_metas_v3[601] = *t601_v3;
-    ASSERT_OK(_tablet_mgr->put_aggregate_tablet_metadata(tablet_metas_v3));
+    ASSERT_OK(_tablet_mgr->put_bundle_tablet_metadata(tablet_metas_v3));
     auto* metacache = _tablet_mgr->metacache();
     metacache->cache_tablet_metadata(_tablet_mgr->tablet_metadata_location(600, 1), t600_v1);
     metacache->cache_tablet_metadata(_tablet_mgr->tablet_metadata_location(601, 1), t601_v1);
@@ -2013,17 +2013,17 @@ TEST_P(LakeVacuumTest, test_vacuum_shared_data_files) {
     t600_v1->mutable_schema()->CopyFrom(schema_pb1);
     tablet_metas_v1[600] = *t600_v1;
     tablet_metas_v1[601] = *t601_v1;
-    ASSERT_OK(_tablet_mgr->put_aggregate_tablet_metadata(tablet_metas_v1));
+    ASSERT_OK(_tablet_mgr->put_bundle_tablet_metadata(tablet_metas_v1));
     std::map<int64_t, TabletMetadataPB> tablet_metas_v2;
     t600_v2->mutable_schema()->CopyFrom(schema_pb1);
     tablet_metas_v2[600] = *t600_v2;
     tablet_metas_v2[601] = *t601_v2;
-    ASSERT_OK(_tablet_mgr->put_aggregate_tablet_metadata(tablet_metas_v2));
+    ASSERT_OK(_tablet_mgr->put_bundle_tablet_metadata(tablet_metas_v2));
     std::map<int64_t, TabletMetadataPB> tablet_metas_v3;
     t600_v3->mutable_schema()->CopyFrom(schema_pb1);
     tablet_metas_v3[600] = *t600_v3;
     tablet_metas_v3[601] = *t601_v3;
-    ASSERT_OK(_tablet_mgr->put_aggregate_tablet_metadata(tablet_metas_v3));
+    ASSERT_OK(_tablet_mgr->put_bundle_tablet_metadata(tablet_metas_v3));
     auto* metacache = _tablet_mgr->metacache();
     metacache->cache_tablet_metadata(_tablet_mgr->tablet_metadata_location(600, 1), t600_v1);
     metacache->cache_tablet_metadata(_tablet_mgr->tablet_metadata_location(601, 1), t601_v1);
@@ -2099,7 +2099,7 @@ TEST_P(LakeVacuumTest, test_vacuum_shared_data_files) {
     t600_v4->mutable_schema()->CopyFrom(schema_pb1);
     tablet_metas_v4[600] = *t600_v4;
     tablet_metas_v4[601] = *t601_v4;
-    ASSERT_OK(_tablet_mgr->put_aggregate_tablet_metadata(tablet_metas_v4));
+    ASSERT_OK(_tablet_mgr->put_bundle_tablet_metadata(tablet_metas_v4));
 
     // shared files will be deleted.
     {

--- a/fe/fe-core/src/main/java/com/starrocks/task/TabletMetadataUpdateAgentTaskFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/TabletMetadataUpdateAgentTaskFactory.java
@@ -278,7 +278,7 @@ public class TabletMetadataUpdateAgentTaskFactory {
             for (Long tabletId : tablets) {
                 TTabletMetaInfo metaInfo = new TTabletMetaInfo();
                 metaInfo.setTablet_id(tabletId);
-                metaInfo.setAggregate_tablet_metadata(enableFileBundling);
+                metaInfo.setBundle_tablet_metadata(enableFileBundling);
                 metaInfos.add(metaInfo);
             }
             return metaInfos;

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -163,10 +163,10 @@ message MetadataUpdateInfoPB {
     optional bool enable_persistent_index = 1;
     optional TabletSchemaPB tablet_schema = 2;
     optional PersistentIndexTypePB persistent_index_type = 3;
-    optional bool aggregate_tablet_metadata = 4;
+    optional bool bundle_tablet_metadata = 4;
 }
 
-message SharedTabletMetadataPB {
+message BundleTabletMetadataPB {
     map<int64, int64> tablet_to_schema = 1; // tablet id -> schema id
     map<int64, TabletSchemaPB> schemas = 2;
     map<int64, PagePointerPB> tablet_meta_pages = 3;

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -455,7 +455,7 @@ struct TTabletMetaInfo {
     10: optional bool create_schema_file;
     11: optional TPersistentIndexType persistent_index_type;
     12: optional TFlatJsonConfig flat_json_config;
-    13: optional bool aggregate_tablet_metadata;
+    13: optional bool bundle_tablet_metadata;
 }
 
 struct TUpdateTabletMetaInfoReq {


### PR DESCRIPTION
## Why I'm doing:
In #58923 , we support file bundling for tablet meta, txnlog and segment files. The configuration to enable this optimization is defined as file_bundling, so variables and functions that previously used aggregate or shared as name prefixes in some places need to be changed to bundle to ensure consistency.

## What I'm doing:
This pull request introduces a significant refactor across multiple files to replace the concept of "aggregate tablet metadata" with "bundle tablet metadata." The changes update method names, variable names, and associated logic throughout the codebase to align with the new terminology, ensuring consistency and improving clarity. Additionally, test cases have been updated to reflect this change.

### Core Changes to Metadata Management:

* [`be/src/storage/lake/tablet_manager.cpp`](diffhunk://#diff-7ef17df66d403c7205ba4ad1aaebf6f057523b94980151564e1bcf0b657bf1b4L285-R293): Replaced the `put_aggregate_tablet_metadata` method with `put_bundle_tablet_metadata`, updated logic to use `BundleTabletMetadataPB` instead of `SharedTabletMetadataPB`, and adjusted serialization/deserialization logic accordingly. [[1]](diffhunk://#diff-7ef17df66d403c7205ba4ad1aaebf6f057523b94980151564e1bcf0b657bf1b4L285-R293) [[2]](diffhunk://#diff-7ef17df66d403c7205ba4ad1aaebf6f057523b94980151564e1bcf0b657bf1b4L307-R307) [[3]](diffhunk://#diff-7ef17df66d403c7205ba4ad1aaebf6f057523b94980151564e1bcf0b657bf1b4L318-R318) [[4]](diffhunk://#diff-7ef17df66d403c7205ba4ad1aaebf6f057523b94980151564e1bcf0b657bf1b4L333-R340) [[5]](diffhunk://#diff-7ef17df66d403c7205ba4ad1aaebf6f057523b94980151564e1bcf0b657bf1b4L480-R480) [[6]](diffhunk://#diff-7ef17df66d403c7205ba4ad1aaebf6f057523b94980151564e1bcf0b657bf1b4L497-R514) [[7]](diffhunk://#diff-7ef17df66d403c7205ba4ad1aaebf6f057523b94980151564e1bcf0b657bf1b4L537-R539) [[8]](diffhunk://#diff-7ef17df66d403c7205ba4ad1aaebf6f057523b94980151564e1bcf0b657bf1b4L549-R550)
* [`be/src/storage/lake/tablet_manager.h`](diffhunk://#diff-b77a64b082da0ac0fd8b28d7f521dbe7e1d235289127491a7aa865f774a6446bL85-R85): Updated method signatures to reflect the new terminology, including `bundle_tablet_metadata_location`. [[1]](diffhunk://#diff-b77a64b082da0ac0fd8b28d7f521dbe7e1d235289127491a7aa865f774a6446bL85-R85) [[2]](diffhunk://#diff-b77a64b082da0ac0fd8b28d7f521dbe7e1d235289127491a7aa865f774a6446bL164-R164)

### Updates to Metadata Location Logic:

* [`be/src/storage/lake/location_provider.h`](diffhunk://#diff-1fd2389fda04a82a1cbc9dec063310fe9266c5bf67e4d4129acb96bd0125ca6aL72-R72): Renamed `aggregate_tablet_metadata_location` to `bundle_tablet_metadata_location` to align with the refactor.

### Adjustments to Schema Change Handling:

* [`be/src/storage/lake/schema_change.cpp`](diffhunk://#diff-891eba0b56724b4dd5fac0e3c0090cfe0150022f235929eee032e7b2f23705d6L473-R474): Replaced references to `aggregate_tablet_metadata` with `bundle_tablet_metadata` in schema change logic.

### Test Updates:

* [`be/test/storage/lake/alter_tablet_meta_test.cpp`](diffhunk://#diff-1b639a6a902213ad0233b71ff6cdc924d4be56a22ae215c06b06a50c561cc1b1L612-R612): Updated test cases to use `bundle_tablet_metadata` instead of `aggregate_tablet_metadata`. [[1]](diffhunk://#diff-1b639a6a902213ad0233b71ff6cdc924d4be56a22ae215c06b06a50c561cc1b1L612-R612) [[2]](diffhunk://#diff-1b639a6a902213ad0233b71ff6cdc924d4be56a22ae215c06b06a50c561cc1b1L621-R630)
* [`be/test/storage/lake/tablet_manager_test.cpp`](diffhunk://#diff-6f0e388b15b892ba0dfe1c361354d61cc3ba3577b328fa11c1c3d49fe345fef6L577-R577): Refactored tests to validate `put_bundle_tablet_metadata` functionality. [[1]](diffhunk://#diff-6f0e388b15b892ba0dfe1c361354d61cc3ba3577b328fa11c1c3d49fe345fef6L577-R577) [[2]](diffhunk://#diff-6f0e388b15b892ba0dfe1c361354d61cc3ba3577b328fa11c1c3d49fe345fef6L646-R646)
* [`be/test/storage/lake/vacuum_test.cpp`](diffhunk://#diff-d94022a29b009225bf18d165ff7a70635bce8158db300aa8432743a522691e37L1638-R1638): Adjusted tests to ensure compatibility with the new `bundle_tablet_metadata` logic. [[1]](diffhunk://#diff-d94022a29b009225bf18d165ff7a70635bce8158db300aa8432743a522691e37L1638-R1638) [[2]](diffhunk://#diff-d94022a29b009225bf18d165ff7a70635bce8158db300aa8432743a522691e37L1726-R1734) [[3]](diffhunk://#diff-d94022a29b009225bf18d165ff7a70635bce8158db300aa8432743a522691e37L2000-R2008) [[4]](diffhunk://#diff-d94022a29b009225bf18d165ff7a70635bce8158db300aa8432743a522691e37L2083-R2083)

### Miscellaneous Updates:

* [`be/src/storage/lake/tablet_metadata.h`](diffhunk://#diff-c7fb33113f7bde7f5e5a1fc1eceb2cb0605f52118ce11a58482c0b5413cc6c96R26): Introduced a new alias `BundleTabletMetadataPtr` for `BundleTabletMetadataPB` to improve code readability.
* [`be/src/service/service_be/lake_service.cpp`](diffhunk://#diff-f7d8833524add42c8ba5cc5ffb982686e7056297f84b684fc52c65c61306cfcaL342-R346): Updated logging and task submission logic to reflect the new terminology.

These changes ensure the codebase aligns with the updated metadata concept, improving clarity and maintainability.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
