### PR TITLE
[BugFix] LakeRollup should use physical partition ID instead of partition ID.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableRollupBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableRollupBuilder.java
@@ -74,7 +74,7 @@ public class LakeTableRollupBuilder extends AlterJobV2Builder {
                 long physicalPartitionId = physicalPartition.getId();
                 // create shard group
                 long shardGroupId = GlobalStateMgr.getCurrentState().getStarOSAgent().
-                        createShardGroup(dbId, olapTable.getId(), partitionId, rollupIndexId);
+                        createShardGroup(dbId, olapTable.getId(), physicalPartitionId, rollupIndexId);
                 // index state is SHADOW
                 MaterializedIndex mvIndex = new MaterializedIndex(rollupIndexId,
                         MaterializedIndex.IndexState.SHADOW, shardGroupId);
@@ -98,8 +98,8 @@ public class LakeTableRollupBuilder extends AlterJobV2Builder {
                         .collect(Collectors.toList());
                 List<Long> shadowTabletIds = GlobalStateMgr.getCurrentState().getStarOSAgent().createShards(
                         originTablets.size(),
-                        olapTable.getPartitionFilePathInfo(partitionId),
-                        olapTable.getPartitionFileCacheInfo(partitionId),
+                        olapTable.getPartitionFilePathInfo(physicalPartitionId),
+                        olapTable.getPartitionFileCacheInfo(physicalPartitionId),
                         shardGroupId, originTableIds, shardProperties, computeResource);
                 Preconditions.checkState(originTablets.size() == shadowTabletIds.size());
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableRollupBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableRollupBuilder.java
@@ -74,7 +74,7 @@ public class LakeTableRollupBuilder extends AlterJobV2Builder {
                 long physicalPartitionId = physicalPartition.getId();
                 // create shard group
                 long shardGroupId = GlobalStateMgr.getCurrentState().getStarOSAgent().
-                        createShardGroup(dbId, olapTable.getId(), physicalPartitionId, rollupIndexId);
+                        createShardGroup(dbId, olapTable.getId(), partitionId, rollupIndexId);
                 // index state is SHADOW
                 MaterializedIndex mvIndex = new MaterializedIndex(rollupIndexId,
                         MaterializedIndex.IndexState.SHADOW, shardGroupId);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableRollupBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableRollupBuilder.java
@@ -69,12 +69,11 @@ public class LakeTableRollupBuilder extends AlterJobV2Builder {
         for (Partition partition : olapTable.getPartitions()) {
             long partitionId = partition.getId();
             TStorageMedium medium = olapTable.getPartitionInfo().getDataProperty(partitionId).getStorageMedium();
-
+            // create shard group
+            long shardGroupId = GlobalStateMgr.getCurrentState().getStarOSAgent().
+                        createShardGroup(dbId, olapTable.getId(), partitionId, rollupIndexId);
             for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
                 long physicalPartitionId = physicalPartition.getId();
-                // create shard group
-                long shardGroupId = GlobalStateMgr.getCurrentState().getStarOSAgent().
-                        createShardGroup(dbId, olapTable.getId(), partitionId, rollupIndexId);
                 // index state is SHADOW
                 MaterializedIndex mvIndex = new MaterializedIndex(rollupIndexId,
                         MaterializedIndex.IndexState.SHADOW, shardGroupId);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -451,9 +451,6 @@ public class StarOSAgent {
         return workerId;
     }
 
-    // ATTN
-    // the partitionId is physical partitionId right now, but the partitionId is logical partitonId in 
-    // old version.
     public long createShardGroup(long dbId, long tableId, long partitionId, long indexId) throws DdlException {
         prepare();
         List<ShardGroupInfo> shardGroupInfos = null;
@@ -485,9 +482,6 @@ public class StarOSAgent {
         }
     }
 
-    // ATTN
-    // (https://github.com/StarRocks/starrocks/pull/60073)
-    // The partitionId of ShardGroupInfo may be different in different version
     public List<ShardGroupInfo> listShardGroup() {
         prepare();
         try {
@@ -498,6 +492,10 @@ public class StarOSAgent {
         }
     }
 
+    // ATTN
+    // (https://github.com/StarRocks/starrocks/pull/60073)
+    // The partitionId in pathInfo of LakeRollup may be different in different version.
+    // The partitionId should be physical partitionId but LakeRollup use logical partitonId before this pr.
     public List<Long> createShards(int numShards, FilePathInfo pathInfo, FileCacheInfo cacheInfo, long groupId,
                                    @Nullable List<Long> matchShardIds, @NotNull Map<String, String> properties,
                                    ComputeResource computeResource)

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -451,6 +451,9 @@ public class StarOSAgent {
         return workerId;
     }
 
+    // ATTN
+    // the partitionId is physical partitionId right now, but the partitionId is logical partitonId in 
+    // old version.
     public long createShardGroup(long dbId, long tableId, long partitionId, long indexId) throws DdlException {
         prepare();
         List<ShardGroupInfo> shardGroupInfos = null;
@@ -482,6 +485,9 @@ public class StarOSAgent {
         }
     }
 
+    // ATTN
+    // (https://github.com/StarRocks/starrocks/pull/60073)
+    // The partitionId of ShardGroupInfo may be different in different version
     public List<ShardGroupInfo> listShardGroup() {
         prepare();
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1729,12 +1729,13 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                               ComputeResource computeResource) throws DdlException {
         PartitionInfo partitionInfo = table.getPartitionInfo();
         Map<Long, MaterializedIndex> indexMap = new HashMap<>();
+        long physicalPartitionId = GlobalStateMgr.getCurrentState().getNextId();
         for (long indexId : table.getIndexIdToMeta().keySet()) {
             long shardGroupId = PhysicalPartition.INVALID_SHARD_GROUP_ID;
             if (table.isCloudNativeTableOrMaterializedView()) {
                 // create shard group
                 shardGroupId = GlobalStateMgr.getCurrentState().getStarOSAgent().
-                        createShardGroup(db.getId(), table.getId(), partitionId, indexId);
+                        createShardGroup(db.getId(), table.getId(), physicalPartitionId, indexId);
             }
             MaterializedIndex rollup = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL, shardGroupId);
             indexMap.put(indexId, rollup);
@@ -1745,7 +1746,6 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                 partitionName,
                 distributionInfo);
 
-        long physicalPartitionId = GlobalStateMgr.getCurrentState().getNextId();
         PhysicalPartition physicalPartition = new PhysicalPartition(
                 physicalPartitionId,
                 logicalPartition.generatePhysicalPartitionName(physicalPartitionId),

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1729,7 +1729,6 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                               ComputeResource computeResource) throws DdlException {
         PartitionInfo partitionInfo = table.getPartitionInfo();
         Map<Long, MaterializedIndex> indexMap = new HashMap<>();
-        long physicalPartitionId = GlobalStateMgr.getCurrentState().getNextId();
         for (long indexId : table.getIndexIdToMeta().keySet()) {
             long shardGroupId = PhysicalPartition.INVALID_SHARD_GROUP_ID;
             if (table.isCloudNativeTableOrMaterializedView()) {
@@ -1746,6 +1745,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                 partitionName,
                 distributionInfo);
 
+        long physicalPartitionId = GlobalStateMgr.getCurrentState().getNextId();
         PhysicalPartition physicalPartition = new PhysicalPartition(
                 physicalPartitionId,
                 logicalPartition.generatePhysicalPartitionName(physicalPartitionId),

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1735,7 +1735,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             if (table.isCloudNativeTableOrMaterializedView()) {
                 // create shard group
                 shardGroupId = GlobalStateMgr.getCurrentState().getStarOSAgent().
-                        createShardGroup(db.getId(), table.getId(), physicalPartitionId, indexId);
+                        createShardGroup(db.getId(), table.getId(), partitionId, indexId);
             }
             MaterializedIndex rollup = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL, shardGroupId);
             indexMap.put(indexId, rollup);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeRollupJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeRollupJobTest.java
@@ -233,7 +233,7 @@ public class LakeRollupJobTest {
                     Assert.assertTrue(false);
                 }
                 long targetPartitionId = Long.parseLong(labels.get("partitionId"));
-                Assert.assertEquals(targetPartitionId, physicalPartition.getId());
+                Assert.assertEquals(targetPartitionId, partitionId);
             }
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeRollupJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeRollupJobTest.java
@@ -14,7 +14,10 @@
 
 package com.starrocks.alter;
 
+import com.staros.proto.ShardGroupInfo;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.proc.RollupProcDir;
@@ -38,6 +41,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class LakeRollupJobTest {
@@ -213,6 +217,25 @@ public class LakeRollupJobTest {
             Thread.sleep(100);
         }
         Assert.assertEquals(AlterJobV2.JobState.FINISHED, lakeRollupJob4.getJobState());
+
+        for (Partition partition : table.getPartitions()) {
+            long partitionId = partition.getId();
+            for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
+                List<ShardGroupInfo> shardGroupInfos = null;
+                shardGroupInfos = GlobalStateMgr.getCurrentState().getStarOSAgent().listShardGroup();
+                Assert.assertTrue(shardGroupInfos != null && !shardGroupInfos.isEmpty());
+                Optional<ShardGroupInfo> targetGroup = shardGroupInfos.stream()
+                        .filter(group -> group.getGroupId() == physicalPartition.getShardGroupId())
+                        .findFirst();
+                Assert.assertTrue(targetGroup.isPresent());
+                Map<String, String> labels = targetGroup.get().getLabelsMap();
+                if (!labels.containsKey("partitionId")) {
+                    Assert.assertTrue(false);
+                }
+                long targetPartitionId = Long.parseLong(labels.get("partitionId"));
+                Assert.assertEquals(targetPartitionId, physicalPartition.getId());
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
In shared-data mode, the allocation of `shardGroup` and `shard` should correspond to the physical partition ID, rather than the partition ID.

## What I'm doing:

Fixes https://github.com/StarRocks/starrocks/issues/60184

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
