### PR TITLE
[Enhancement] improve crc64 for hashset performance

### DIFF
--- a/be/src/bench/hash_functions_bench.cpp
+++ b/be/src/bench/hash_functions_bench.cpp
@@ -22,6 +22,8 @@
 
 #include "bench/bench_util.h"
 #include "exprs/hash_functions.h"
+#include "util/hash.h"
+#include "util/phmap/phmap.h"
 
 namespace starrocks {
 
@@ -83,6 +85,121 @@ static void BM_HashFunctions_Eval(benchmark::State& state) {
 }
 
 BENCHMARK(BM_HashFunctions_Eval)->Apply(BM_HashFunctions_Eval_Arg);
+
+const static size_t kCRC32HashSeed = 0x811C9DC5;
+// Custom hash functor using crc_hash_64
+struct CrcHash64String {
+    size_t operator()(const std::string& s) const {
+        return starrocks::crc_hash_64(s.data(), static_cast<int32_t>(s.size()), kCRC32HashSeed);
+    }
+};
+
+struct CrcHash64StringUnmixed {
+    size_t operator()(const std::string& s) const {
+        return starrocks::crc_hash_64_unmixed(s.data(), static_cast<int32_t>(s.size()), kCRC32HashSeed);
+    }
+};
+
+// Generate a dataset to simulate HashSet fingerprint collisions, which can degrade HashSet performance
+static std::vector<std::string> gen_32bytes_string(size_t num_elems) {
+    std::vector<std::string> data;
+    data.reserve(num_elems);
+    for (size_t i = 0; i < num_elems; ++i) {
+        char buf[33];
+        snprintf(buf, sizeof(buf), "%032zu", i);
+        // construct lowest 7bit conflicts
+        size_t hash = starrocks::crc_hash_64_unmixed(buf, sizeof(buf), kCRC32HashSeed);
+        while ((hash & 0xF) != 0) {
+            buf[32]++;
+            hash = starrocks::crc_hash_64_unmixed(buf, sizeof(buf), kCRC32HashSeed);
+        }
+        data.emplace_back(buf);
+    }
+    std::random_device rd;
+    std::mt19937 g(rd());
+    std::shuffle(data.begin(), data.end(), g);
+
+    return data;
+}
+
+template <class HashFunction>
+static void BM_PhmapFlatHashSet_CrcHash64_Insert_Impl(benchmark::State& state) {
+    size_t num_elems = state.range(0);
+    auto data = gen_32bytes_string(num_elems);
+    for (auto _ : state) {
+        phmap::flat_hash_set<std::string, HashFunction> set;
+        for (const auto& s : data) {
+            set.insert(s);
+        }
+        benchmark::DoNotOptimize(set);
+    }
+}
+
+static void BM_PhmapFlatHashSet_CrcHash64_Insert(benchmark::State& state) {
+    BM_PhmapFlatHashSet_CrcHash64_Insert_Impl<CrcHash64String>(state);
+}
+
+static void BM_PhmapFlatHashSet_CrcHash64_Insert_Unmixed(benchmark::State& state) {
+    BM_PhmapFlatHashSet_CrcHash64_Insert_Impl<CrcHash64StringUnmixed>(state);
+}
+
+template <class HashFunction>
+static void BM_PhmapFlatHashSet_CrcHash64_Lookup_Impl(benchmark::State& state) {
+    size_t num_elems = state.range(0);
+    auto data = gen_32bytes_string(num_elems);
+    // Half success, half failure
+    auto lookup_data = gen_32bytes_string(num_elems * 2);
+
+    phmap::flat_hash_set<std::string, HashFunction> set;
+    for (const auto& s : data) {
+        set.insert(s);
+    }
+
+    for (auto _ : state) {
+        size_t found = 0;
+        for (const auto& s : lookup_data) {
+            found += set.count(s);
+        }
+        benchmark::DoNotOptimize(found);
+    }
+}
+
+static void BM_PhmapFlatHashSet_CrcHash64_Lookup(benchmark::State& state) {
+    BM_PhmapFlatHashSet_CrcHash64_Lookup_Impl<CrcHash64String>(state);
+}
+
+static void BM_PhmapFlatHashSet_CrcHash64_Lookup_Unmixed(benchmark::State& state) {
+    BM_PhmapFlatHashSet_CrcHash64_Lookup_Impl<CrcHash64StringUnmixed>(state);
+}
+
+// 2025-06-19T15:48:27+08:00
+// Running ./hash_functions_bench
+// Run on (32 X 2500 MHz CPU s)
+// CPU Caches:
+//   L1 Data 32 KiB (x16)
+//   L1 Instruction 32 KiB (x16)
+//   L2 Unified 1024 KiB (x16)
+//   L3 Unified 36608 KiB (x1)
+// Load Average: 0.12, 0.09, 0.25
+// -----------------------------------------------------------------------------------------------
+// Benchmark                                                     Time             CPU   Iterations
+// -----------------------------------------------------------------------------------------------
+// BM_PhmapFlatHashSet_CrcHash64_Insert/10000              1098692 ns      1098642 ns          642
+// BM_PhmapFlatHashSet_CrcHash64_Insert/100000            13848007 ns     13846984 ns           48
+// BM_PhmapFlatHashSet_CrcHash64_Insert/1000000          552114016 ns    552078649 ns            1
+// BM_PhmapFlatHashSet_CrcHash64_Insert_Unmixed/10000      1290259 ns      1290163 ns          541
+// BM_PhmapFlatHashSet_CrcHash64_Insert_Unmixed/100000    18784369 ns     18783587 ns           38
+// BM_PhmapFlatHashSet_CrcHash64_Insert_Unmixed/1000000  626093501 ns    626056004 ns            1
+// BM_PhmapFlatHashSet_CrcHash64_Lookup/10000               605826 ns       605798 ns         1161
+// BM_PhmapFlatHashSet_CrcHash64_Lookup/100000            11105350 ns     11104843 ns           63
+// BM_PhmapFlatHashSet_CrcHash64_Lookup/1000000          254053820 ns    254043024 ns            3
+// BM_PhmapFlatHashSet_CrcHash64_Lookup_Unmixed/10000       709504 ns       709473 ns          987
+// BM_PhmapFlatHashSet_CrcHash64_Lookup_Unmixed/100000    10992399 ns     10991650 ns           63
+// BM_PhmapFlatHashSet_CrcHash64_Lookup_Unmixed/1000000  254696960 ns    254686158 ns            3
+BENCHMARK(BM_PhmapFlatHashSet_CrcHash64_Insert)->Arg(10 * 1000)->Arg(100 * 1000)->Arg(1000 * 1000);
+BENCHMARK(BM_PhmapFlatHashSet_CrcHash64_Insert_Unmixed)->Arg(10 * 1000)->Arg(100 * 1000)->Arg(1000 * 1000);
+BENCHMARK(BM_PhmapFlatHashSet_CrcHash64_Lookup)->Arg(10 * 1000)->Arg(100 * 1000)->Arg(1000 * 1000);
+BENCHMARK(BM_PhmapFlatHashSet_CrcHash64_Lookup_Unmixed)->Arg(10 * 1000)->Arg(100 * 1000)->Arg(1000 * 1000);
 
 } // namespace starrocks
 

--- a/be/test/exec/join_hash_map_test.cpp
+++ b/be/test/exec/join_hash_map_test.cpp
@@ -995,7 +995,7 @@ TEST_F(JoinHashMapTest, JoinKeyHash) {
     }
 
     auto v3 = JoinKeyHash<Slice>()(Slice{"abcd", 4}, num_buckets, log_num_buckets);
-    ASSERT_EQ(v3, 2777932099l % num_buckets);
+    ASSERT_EQ(v3, 11538);
 }
 
 // NOLINTNEXTLINE

--- a/test/sql/test_array_fn/R/test_array_intersect
+++ b/test/sql/test_array_fn/R/test_array_intersect
@@ -113,7 +113,7 @@ SELECT id, array_intersect(array_decimal128, [1234567890.1234567890, 3344556677.
 -- !result
 SELECT id, array_intersect(array_varchar, ['apple', 'banana', 'cherry']) AS intersect_varchar FROM test_array_intersect order by id;
 -- result:
-1	["banana","apple","cherry"]
+1	["cherry","apple","banana"]
 2	[]
 3	[]
 -- !result
@@ -125,7 +125,7 @@ SELECT id, array_intersect(array_date, ['2025-01-01', '2025-01-08']) AS intersec
 -- !result
 SELECT id, array_intersect(array_datetime, ['2025-01-01 12:00:00', '2025-01-08 19:00:00']) AS intersect_datetime FROM test_array_intersect order by id;
 -- result:
-1	["2025-01-08 19:00:00","2025-01-01 12:00:00"]
+1	["2025-01-01 12:00:00","2025-01-08 19:00:00"]
 2	[]
 3	[]
 -- !result


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Add a mix for crc64 to improve the hash function quality.

The current crc64 function is utilized for `phmap::flat_hash_set`, which uses the lowest 7 bits as a fingerprint to enhance lookup performance. However, crc64 is not an ideal hash function for this purpose due to several reasons:
1. **Mismatch with SwissTable Assumptions**: SwissTable uses the upper 57 bits for group indexing and the lower 7 bits as a fingerprint. CRC-32 only provides 32 bits, and its lower bits exhibit poor correlation (the higher bits are more active in polynomial feedback). Truncating directly results in the "poor 7 bits" being used as fingerprints, which increases collision rates within the same probe group.
2. **Predictable Linear Properties**: CRC is a linear codec, meaning it follows the property crc(a ⊕ b) = crc(a) ⊕ crc(b). For structured keys like log IDs or sequential numbers, this predictability can lead to patterned collisions, resulting in longer probe chains and more frequent rehashing.


Experiment:
1. In the Insert scenario, `Mixed` performs significantly faster than `Unmixed` due to the grouped hashing mechanism. This approach requires iterating through all 16 slots in a group to ensure no equivalent element exists within the group, if the fingerprint cannot effectively filter the unequal element.
2. In the Lookup scenario, the performance difference is negligible, as comparing 32-byte strings is not computationally expensive.

```
// -----------------------------------------------------------------------------------------------
// Benchmark                                                     Time             CPU   Iterations
// -----------------------------------------------------------------------------------------------
// BM_PhmapFlatHashSet_CrcHash64_Insert/10000              1098692 ns      1098642 ns          642
// BM_PhmapFlatHashSet_CrcHash64_Insert/100000            13848007 ns     13846984 ns           48
// BM_PhmapFlatHashSet_CrcHash64_Insert/1000000          552114016 ns    552078649 ns            1
// BM_PhmapFlatHashSet_CrcHash64_Insert_Unmixed/10000      1290259 ns      1290163 ns          541
// BM_PhmapFlatHashSet_CrcHash64_Insert_Unmixed/100000    18784369 ns     18783587 ns           38
// BM_PhmapFlatHashSet_CrcHash64_Insert_Unmixed/1000000  626093501 ns    626056004 ns            1
// BM_PhmapFlatHashSet_CrcHash64_Lookup/10000               605826 ns       605798 ns         1161
// BM_PhmapFlatHashSet_CrcHash64_Lookup/100000            11105350 ns     11104843 ns           63
// BM_PhmapFlatHashSet_CrcHash64_Lookup/1000000          254053820 ns    254043024 ns            3
// BM_PhmapFlatHashSet_CrcHash64_Lookup_Unmixed/10000       709504 ns       709473 ns          987
// BM_PhmapFlatHashSet_CrcHash64_Lookup_Unmixed/100000    10992399 ns     10991650 ns           63
// BM_PhmapFlatHashSet_CrcHash64_Lookup_Unmixed/1000000  254696960 ns    254686158 ns            3
```

**TODO: Consider if other hash functions might be more suitable for flat_hash_set.**

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
