### PR TITLE
[UT] Fix unstable ut for Restore cause by @Mocked annotation for SystemInfoService

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
@@ -143,8 +143,7 @@ public class RestoreJobTest {
         }
     }
 
-    @Mocked
-    private SystemInfoService systemInfoService;
+    private SystemInfoService systemInfoService = new SystemInfoService();
 
     @Injectable
     private Repository repo = new Repository(repoId, "repo", false, "bos://my_repo",
@@ -256,7 +255,7 @@ public class RestoreJobTest {
         beIds.add(CatalogMocker.BACKEND1_ID);
         beIds.add(CatalogMocker.BACKEND2_ID);
         beIds.add(CatalogMocker.BACKEND3_ID);
-        new Expectations() {
+        new Expectations(systemInfoService) {
             {
                 systemInfoService.getNodeSelector().seqChooseBackendIds(anyInt, anyBoolean, anyBoolean, null);
                 minTimes = 0;
@@ -440,7 +439,7 @@ public class RestoreJobTest {
         beIds.add(CatalogMocker.BACKEND1_ID);
         beIds.add(CatalogMocker.BACKEND2_ID);
         beIds.add(CatalogMocker.BACKEND3_ID);
-        new Expectations() {
+        new Expectations(systemInfoService) {
             {
                 systemInfoService.getNodeSelector().seqChooseBackendIds(anyInt, anyBoolean, anyBoolean, null);
                 minTimes = 0;
@@ -611,7 +610,7 @@ public class RestoreJobTest {
         beIds.add(CatalogMocker.BACKEND1_ID);
         beIds.add(CatalogMocker.BACKEND2_ID);
         beIds.add(CatalogMocker.BACKEND3_ID);
-        new Expectations() {
+        new Expectations(systemInfoService) {
             {
                 systemInfoService.getNodeSelector().seqChooseBackendIds(anyInt, anyBoolean, anyBoolean, null);
                 minTimes = 0;
@@ -890,7 +889,7 @@ public class RestoreJobTest {
             }
         };
 
-        new Expectations() {
+        new Expectations(systemInfoService) {
             {
                 systemInfoService.checkExceedDiskCapacityLimit((Multimap<Long, Long>) any, anyBoolean);
                 minTimes = 0;

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
@@ -143,8 +143,6 @@ public class RestoreJobTest {
         }
     }
 
-    private SystemInfoService systemInfoService = new SystemInfoService();
-
     @Injectable
     private Repository repo = new Repository(repoId, "repo", false, "bos://my_repo",
             new BlobStorage("broker", Maps.newHashMap()));
@@ -232,6 +230,7 @@ public class RestoreJobTest {
 
     @Test
     public void testRunBackupMultiSubPartitionTable() {
+        SystemInfoService systemInfoService = new SystemInfoService();
         new Expectations() {
             {
 
@@ -419,6 +418,7 @@ public class RestoreJobTest {
 
     @Test
     public void testRunBackupRangeTable() {
+        SystemInfoService systemInfoService = new SystemInfoService();
         new Expectations() {
             {
                 globalStateMgr.getLocalMetastore().getDb(anyLong);
@@ -590,6 +590,7 @@ public class RestoreJobTest {
 
     @Test
     public void testRunBackupListTable() {
+        SystemInfoService systemInfoService = new SystemInfoService();
         new Expectations() {
             {
                 globalStateMgr.getLocalMetastore().getDb(anyLong);
@@ -808,6 +809,7 @@ public class RestoreJobTest {
 
     @Test
     public void testRestoreView() {
+        SystemInfoService systemInfoService = new SystemInfoService();
         new Expectations() {
             {
                 globalStateMgr.getLocalMetastore().getDb(anyLong);


### PR DESCRIPTION
## Why I'm doing:
`Missing 1 invocation to:` will be throw when running the RestoreJobTest for some SystemInfoService stack
The reason is the SystemInfoService object has the `@Mocked` annotation which means all member functions are not mentioned in `Expectations{}` should not be called in the UT. But some background thread will call such functions and get unexpected exception. `@Mocked` annotation will affect the Class itself, so even a new object is new in another thread, it still be affected by the rule.

## What I'm doing:
New a object for SystemInfoService and use partial mocking for jmockit.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
