### PR TITLE
[BugFix] Fix some corner cases when mv meets schema changes

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -610,6 +610,10 @@ public class AlterJobExecutor implements AstVisitor<Void, ConnectContext> {
             ErrorReport.wrapWithRuntimeException(() ->
                     schemaChangeHandler.checkModifiedColumWithMaterializedViews((OlapTable) table, modifiedColumns));
             GlobalStateMgr.getCurrentState().getLocalMetastore().renameColumn(db, table, clause);
+
+            // If modified columns are already done, inactive related mv
+            AlterMVJobExecutor.inactiveRelatedMaterializedViews(db, (OlapTable) table, modifiedColumns);
+
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.WRITE);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1974,10 +1974,17 @@ public class SchemaChangeHandler extends AlterHandler {
                     List<Integer> sortKeyUniqueIds = new ArrayList<>();
                     processModifySortKeyColumn((ReorderColumnsClause) alterClause, olapTable, indexSchemaMap, sortKeyIdxes,
                             sortKeyUniqueIds);
+
+                    // If optimized olap table contains related mvs, set those mv state to inactive.
+                    AlterMVJobExecutor.inactiveRelatedMaterializedView(olapTable,
+                            MaterializedViewExceptions.inactiveReasonForBaseTableReorderColumns(olapTable.getName()), false);
                     return createJobForProcessModifySortKeyColumn(db.getId(), olapTable, indexSchemaMap, sortKeyIdxes,
                             sortKeyUniqueIds);
                 } else {
                     processReorderColumn((ReorderColumnsClause) alterClause, olapTable, indexSchemaMap);
+                    // If optimized olap table contains related mvs, set those mv state to inactive.
+                    AlterMVJobExecutor.inactiveRelatedMaterializedView(olapTable,
+                            MaterializedViewExceptions.inactiveReasonForBaseTableReorderColumns(olapTable.getName()), false);
                 }
             } else if (alterClause instanceof ModifyTablePropertiesClause) {
                 // modify table properties

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -52,6 +52,7 @@ import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.ConnectorPartitionTraits;
 import com.starrocks.connector.ConnectorTableInfo;
 import com.starrocks.connector.PartitionUtil;
+import com.starrocks.metric.MaterializedViewMetricsRegistry;
 import com.starrocks.mv.analyzer.MVPartitionExpr;
 import com.starrocks.persist.AlterMaterializedViewBaseTableInfosLog;
 import com.starrocks.persist.ExpressionSerializedObject;
@@ -1017,8 +1018,12 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     }
 
     private void onDropImpl(Database db, boolean replay) {
-        // 1. Remove from plan cache
         MvId mvId = new MvId(db.getId(), getId());
+
+        // remove materialized view metrics from MetricsRepository
+        MaterializedViewMetricsRegistry.getInstance().remove(mvId);
+
+        // 1. Remove from plan cache
         CachingMvPlanContextBuilder.getInstance().updateMvPlanContextCache(this, false);
 
         // 2. Remove from base tables
@@ -1274,6 +1279,9 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      * @return: true if it is configured to enable mv rewrite, otherwise false.
      */
     public boolean isEnableRewrite() {
+        if (!isActive()) {
+            return false;
+        }
         TableProperty tableProperty = getTableProperty();
         if (tableProperty == null) {
             return true;
@@ -1286,6 +1294,9 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      * @return: true if it is configured to enable transparent rewrite, otherwise false.
      */
     public boolean isEnableTransparentRewrite() {
+        if (!isActive()) {
+            return false;
+        }
         TableProperty tableProperty = getTableProperty();
         if (tableProperty == null) {
             // default is false
@@ -1986,11 +1997,13 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                 // NOTE: use getTable rather getTableChecked to avoid throwing exception when table has changed/recreated.
                 // If the table has changed, MVPCTMetaRepairer will handle it rather than throwing exception here.
                 Optional<Table> refreshedTableOpt = MvUtils.getTable(tableToBaseTableInfoCache.get(table));
+                // when meets a table that has been dropped, no throw exception here so that
                 if (refreshedTableOpt.isEmpty()) {
                     LOG.warn("The table {} is not found in metadata catalog", table.getName());
-                    throw MaterializedViewExceptions.reportBaseTableNotExists(table.getName());
+                    result.put(table, e.getValue());
+                } else {
+                    result.put(refreshedTableOpt.get(), e.getValue());
                 }
-                result.put(refreshedTableOpt.get(), e.getValue());
             } else {
                 result.put(table, e.getValue());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -626,10 +626,10 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      */
     public synchronized void setActive() {
         LOG.info("set {} to active", name);
-        // reset mv rewrite cache when it is active again
-        CachingMvPlanContextBuilder.getInstance().updateMvPlanContextCache(this, true);
         this.active = true;
         this.inactiveReason = null;
+        // reset mv rewrite cache when it is active again
+        CachingMvPlanContextBuilder.getInstance().updateMvPlanContextCache(this, true);
     }
 
     public synchronized void setInactiveAndReason(String reason) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/MaterializedViewExceptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/MaterializedViewExceptions.java
@@ -27,6 +27,8 @@ public class MaterializedViewExceptions {
     // reason for base table optimized, base table's partition is optimized which mv cannot be actived again.
     public static final String INACTIVE_REASON_FOR_BASE_TABLE_OPTIMIZED = "base-table optimized:";
 
+    public static final String INACTIVE_REASON_FOR_BASE_TABLE_REORDER_COLUMNS = "base-table reordered columns:";
+
     /**
      * Create the inactive reason when base table not exists
      */
@@ -55,6 +57,10 @@ public class MaterializedViewExceptions {
 
     public static String inactiveReasonForBaseTableOptimized(String tableName) {
         return INACTIVE_REASON_FOR_BASE_TABLE_OPTIMIZED + tableName;
+    }
+
+    public static String inactiveReasonForBaseTableReorderColumns(String tableName) {
+        return INACTIVE_REASON_FOR_BASE_TABLE_REORDER_COLUMNS + tableName;
     }
 
     public static String inactiveReasonForBaseTableActive(String tableName) {

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsRegistry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsRegistry.java
@@ -49,6 +49,11 @@ public class MaterializedViewMetricsRegistry {
         return INSTANCE;
     }
 
+    public synchronized void remove(MvId mvId) {
+        LOG.info("Removing materialized view metrics for mvId: {}", mvId);
+        idToMVMetrics.remove(mvId);
+    }
+
     public synchronized IMaterializedViewMetricsEntity getMetricsEntity(MvId mvId) {
         if (!Config.enable_materialized_view_metrics_collect) {
             return new MaterializedViewMetricsBlackHoleEntity();

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTMetaRepairer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTMetaRepairer.java
@@ -100,11 +100,7 @@ public class MVPCTMetaRepairer {
         if (baseTable.getTableIdentifier().equals(baseTableInfo.getTableIdentifier())) {
             return true;
         }
-        if (!(baseTable instanceof HiveTable)) {
-            return false;
-        }
-        HiveTable hiveTable = (HiveTable) baseTable;
-        return hiveTable.getHiveTableType() == HiveTable.HiveTableType.EXTERNAL_TABLE;
+        return baseTable instanceof HiveTable;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -409,6 +409,7 @@ public class QueryOptimizer extends Optimizer {
         scheduler.rewriteOnce(tree, rootTaskContext, new MaterializedViewTransparentRewriteRule());
         if (Utils.isOptHasAppliedRule(tree, OP_MV_TRANSPARENT_REWRITE)) {
             tree = new SeparateProjectRule().rewrite(tree, rootTaskContext);
+            deriveLogicalProperty(tree);
         }
         return tree;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
@@ -91,8 +91,14 @@ public class MaterializedViewTransparentRewriteRule extends TransformationRule {
                     mv.getName());
             return Collections.emptyList();
         }
-        OptExpression result = doTransform(connectContext, context, olapScanOperator, input, mv.getMvId());
-        return Collections.singletonList(result);
+        try {
+            OptExpression result = doTransform(connectContext, context, olapScanOperator, input, mv.getMvId());
+            return Collections.singletonList(result);
+        } catch (Exception e) {
+            LOG.warn("Failed to generate transparent rewrite plan for mv: {}, error: {}",
+                    mv.getName(), e.getMessage(), e);
+            return Collections.emptyList();
+        }
     }
 
     private OptExpression doTransform(ConnectContext connectContext,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -1377,11 +1377,38 @@ public class MvUtils {
     }
 
     public static Optional<Table> getTable(BaseTableInfo baseTableInfo) {
-        return GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(new ConnectContext(), baseTableInfo);
+        try {
+            return GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(new ConnectContext(), baseTableInfo);
+        } catch (Exception e) {
+            // For hive catalog, when meets NoSuchObjectException, we should return empty
+            //  msg: NoSuchObjectException: hive_db_8b48cd2f_4bfe_11f0_bc1a_00163e09349d.t1 table not found
+            //        at com.starrocks.connector.hive.HiveMetaClient.callRPC(HiveMetaClient.java:178)
+            //        at com.starrocks.connector.hive.HiveMetaClient.callRPC(HiveMetaClient.java:163)
+            //        at com.starrocks.connector.hive.HiveMetaClient.getTable(HiveMetaClient.java:272)
+            //        at com.starrocks.connector.hive.HiveMetastore.getTable(HiveMetastore.java:116)
+            if (e.getMessage() != null && e.getMessage().contains("NoSuchObjectException")) {
+                return Optional.empty();
+            }
+            throw e;
+        }
     }
 
     public static Optional<Table> getTableWithIdentifier(BaseTableInfo baseTableInfo) {
-        return GlobalStateMgr.getCurrentState().getMetadataMgr().getTableWithIdentifier(new ConnectContext(), baseTableInfo);
+        try {
+            return GlobalStateMgr.getCurrentState().getMetadataMgr().getTableWithIdentifier(new ConnectContext(), baseTableInfo);
+        } catch (Exception e) {
+            // For hive catalog, when meets NoSuchObjectException, we should return empty
+            //  msg: NoSuchObjectException: hive_db_8b48cd2f_4bfe_11f0_bc1a_00163e09349d.t1 table not found
+            //        at com.starrocks.connector.hive.HiveMetaClient.callRPC(HiveMetaClient.java:178)
+            //        at com.starrocks.connector.hive.HiveMetaClient.callRPC(HiveMetaClient.java:163)
+            //        at com.starrocks.connector.hive.HiveMetaClient.getTable(HiveMetaClient.java:272)
+            //        at com.starrocks.connector.hive.HiveMetastore.getTable(HiveMetastore.java:116)
+            LOG.warn("Failed to get table with baseTableInfo: {}, error: {}", baseTableInfo, e.getMessage());
+            if (e.getMessage() != null && e.getMessage().contains("NoSuchObjectException")) {
+                return Optional.empty();
+            }
+            throw e;
+        }
     }
 
     public static Table getTableChecked(BaseTableInfo baseTableInfo) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteMetricsTest.java
@@ -311,9 +311,7 @@ public class MvRewriteMetricsTest extends MVTestBase {
             MaterializedViewMetricsRegistry.collectMaterializedViewMetrics(visitor, true);
             String json = visitor.build();
             System.out.println(json);
-            Assert.assertTrue(json.contains("mv_refresh_jobs"));
-            Assert.assertTrue(json.contains("mv_refresh_total_success_jobs"));
-            Assert.assertTrue(json.contains("mv_refresh_total_retry_meta_count"));
+            Assert.assertEquals("[]", json);
         }
     }
 }


### PR DESCRIPTION
## Why I'm doing:
When I tests MV with schema changes, I meets some unexpected bahaivors as below.

## What I'm doing:
- ColumnRename should inactive affected mvs
- ReorderColumnsClause should inactive affected mvs
- When MV has been dropped, remove its metrics from MaterializedViewMetricsRegistry
- Disable MV rewrite when mv is inactive 
- Try catch exception in [MaterializedViewTransparentRewriteRule.java](https://github.com/StarRocks/starrocks/compare/main...LiShuMing:starrocks:fix_mv_with_schema_change?expand=1#diff-19ea198b6da93acb3b348f6379a091cba6951d3c6c98c4b45c51dae96522e152) when transparent mv is enabled.
- Use deriveLogicalProperty after MaterializedViewTransparentRewriteRule executes
- `MvUtils.getTable` and `MvUtils.getTableWithIdentifier` should handle `NoSuchObjectException` exception when hive table has been dropped
```
            //  msg: NoSuchObjectException: hive_db_8b48cd2f_4bfe_11f0_bc1a_00163e09349d.t1 table not found
            //        at com.starrocks.connector.hive.HiveMetaClient.callRPC(HiveMetaClient.java:178)
            //        at com.starrocks.connector.hive.HiveMetaClient.callRPC(HiveMetaClient.java:163)
            //        at com.starrocks.connector.hive.HiveMetaClient.getTable(HiveMetaClient.java:272)
            //        at com.starrocks.connector.hive.HiveMetastore.getTable(HiveMetastore.java:116)
            //        at com.starrocks.connector.hive.CachingHiveMetastore.loadTable(CachingHiveMetastore.java:311)
            //        at com.google.common.cache.CacheLoader$FunctionToCacheLoader.load(CacheLoader.java:169)
            //        at com.google.common.cache.CacheLoader$1.load(CacheLoader.java:192)
            //        at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3570)
            //        at com.starrocks.connector.hive.HiveMetaClient.callRPC(HiveMetaClient.java:163)
            //        at com.starrocks.connector.hive.HiveMetaClient.getTable(HiveMetaClient.java:272)
            //        at com.starrocks.connector.hive.HiveMetastore.getTable(HiveMetastore.java:116)
            //        at com.starrocks.connector.hive.CachingHiveMetastore.loadTable(CachingHiveMetastore.java:311)
            //        at com.google.common.cache.CacheLoader$FunctionToCacheLoader.load(CacheLoader.java:169)
            //        at com.google.common.cache.CacheLoader$1.load(CacheLoader.java:192)
            //        at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3570)
            //        at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2312)
            //        at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2189)
            //        at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2079)
            //        at com.google.common.cache.LocalCache.get(LocalCache.java:4011)
            //        at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:4034)
            //        at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:5010)
            //        at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:5017)
            //        at com.starrocks.connector.metastore.CachingMetastore.get(CachingMetastore.java:88)
            //        at com.starrocks.connector.hive.CachingHiveMetastore.getTable(CachingHiveMetastore.java:303)
            //        at com.starrocks.connector.hive.CachingHiveMetastore.loadTable(CachingHiveMetastore.java:311)
            //        at com.google.common.cache.CacheLoader$FunctionToCacheLoader.load(CacheLoader.java:169)
            //        at com.google.common.cache.CacheLoader$1.load(CacheLoader.java:192)
            //        at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3570)
            //        at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2312)
            //        at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2189)
            //        at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2079)
            //        at com.google.common.cache.LocalCache.get(LocalCache.java:4011)
            //        at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:4034)
            //        at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:5010)
            //        at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:5017)
            //        at com.starrocks.connector.metastore.CachingMetastore.get(CachingMetastore.java:88)
            //        at com.starrocks.connector.hive.CachingHiveMetastore.getTable(CachingHiveMetastore.java:303)
            //        at com.starrocks.connector.hive.HiveMetastoreOperations.getTable(HiveMetastoreOperations.java:250)
            //        at com.starrocks.connector.hive.HiveMetadata.getTable(HiveMetadata.java:206)
            //        at com.starrocks.connector.CatalogConnectorMetadata.getTable(CatalogConnectorMetadata.java:148)
            //        at com.starrocks.server.MetadataMgr.lambda$getTable$5(MetadataMgr.java:502)
            //        at java.base/java.util.Optional.map(Optional.java:260)
            //        at com.starrocks.server.MetadataMgr.getTable(MetadataMgr.java:502)
            //        at com.starrocks.server.MetadataMgr.getTable(MetadataMgr.java:543)
            //        at com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.getTable(MvUtils.java:1380)
            //        at com.starrocks.qe.ShowExecutor$ShowExecutorVisitor.lambda$visitShowMaterializedViewStatement$0(ShowExecutor.java:371)
            //        at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625)
            //        at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:762)
            //        at com.starrocks.qe.ShowExecutor$ShowExecutorVisitor.visitShowMaterializedViewStatement(ShowExecutor.java:369)
            //        at com.starrocks.qe.ShowExecutor$ShowExecutorVisitor.visitShowMaterializedViewStatement(ShowExecutor.java:319)
            //        at com.starrocks.sql.ast.ShowMaterializedViewsStmt.accept(ShowMaterializedViewsStmt.java:178)
```

Fixes https://github.com/StarRocks/StarRocksTest/pull/9829

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
