### PR TITLE
[BugFix] Fix mv union rewrite handling null partition bugs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -303,6 +303,15 @@ public class Utils {
             return null;
         }
 
+        // for and predicate, filter redundant true
+        if (type == CompoundPredicateOperator.CompoundType.AND) {
+            link = link.stream()
+                    .filter(so -> !ConstantOperator.TRUE.equals(so))
+                    .collect(Collectors.toCollection(Lists::newLinkedList));
+            if (link.isEmpty()) {
+                return ConstantOperator.TRUE;
+            }
+        }
         if (link.size() == 1) {
             return link.get(0);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedTimeSeriesRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedTimeSeriesRewriter.java
@@ -55,10 +55,10 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
-import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.property.ReplaceShuttle;
+import com.starrocks.sql.optimizer.rewrite.scalar.NegateFilterShuttle;
 import com.starrocks.sql.optimizer.rule.Rule;
 import com.starrocks.sql.optimizer.rule.tree.pdagg.AggregatePushDownContext;
 import com.starrocks.sql.optimizer.transformer.ExpressionMapping;
@@ -653,8 +653,9 @@ public class AggregatedTimeSeriesRewriter extends MaterializedViewRewriter {
 
         // non-rewritten predicates
         List<ScalarOperator> leftQueryPartitionPredicates = Lists.newArrayList(queryNonPartitionPredicates);
-        List<ScalarOperator> notQueryPartitionPredicates = rewrittenPartitionPredicates.stream()
-                .map(CompoundPredicateOperator::not)
+        final NegateFilterShuttle negateFilterShuttle = NegateFilterShuttle.getInstance();
+        final List<ScalarOperator> notQueryPartitionPredicates = rewrittenPartitionPredicates.stream()
+                .map(pred -> negateFilterShuttle.negateFilter(pred))
                 .collect(Collectors.toList());
         leftQueryPartitionPredicates.add(Utils.compoundOr(notQueryPartitionPredicates));
         leftQueryPartitionPredicates.addAll(queryPartitionPredicates);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedTimeSeriesRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedTimeSeriesRewriter.java
@@ -652,7 +652,7 @@ public class AggregatedTimeSeriesRewriter extends MaterializedViewRewriter {
         rewrittenPartitionPredicates.addAll(queryNonPartitionPredicates);
 
         // non-rewritten predicates
-        List<ScalarOperator> leftQueryPartitionPredicates = Lists.newArrayList(queryNonPartitionPredicates);
+        final List<ScalarOperator> leftQueryPartitionPredicates = Lists.newArrayList(queryNonPartitionPredicates);
         final NegateFilterShuttle negateFilterShuttle = NegateFilterShuttle.getInstance();
         final List<ScalarOperator> notQueryPartitionPredicates = rewrittenPartitionPredicates.stream()
                 .map(pred -> negateFilterShuttle.negateFilter(pred))

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithPartitionTest.java
@@ -98,9 +98,10 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                         "     partitions=4/5\n" +
                         "     rollup: partial_mv_6\n" +
                         "     tabletRatio=8/8")
-                .contains("TABLE: test_base_part\n" +
+                .contains("     TABLE: test_base_part\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     partitions=1/5");
+                        "     PREDICATES: 10: c3 < 3000, (10: c3 >= 2000) OR (10: c3 IS NULL)\n" +
+                        "     partitions=2/5");
 
         // test query delta
         sql("select c1, c3, c2 from test_base_part where c3 < 1000")
@@ -134,11 +135,10 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                         "     PREAGGREGATION: ON\n" +
                         "     partitions=1/1\n" +
                         "     rollup: partial_mv_6")
-                .contains("TABLE: test_base_part\n" +
+                .contains("     TABLE: test_base_part\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     partitions=1/5\n" +
-                        "     rollup: test_base_part\n" +
-                        "     tabletRatio=2/2");
+                        "     PREDICATES: (10: c3 >= 2000) OR (10: c3 IS NULL)\n" +
+                        "     partitions=2/5");
 
         // test query predicate
         // TODO: add more post actions after MV Rewrite:
@@ -182,14 +182,14 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                         "     partitions=5/5")
                 .contains("TABLE: test_base_part\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 9: c2 >= 2000\n" +
+                        "     PREDICATES: (9: c2 >= 2000) OR (9: c2 IS NULL)\n" +
                         "     partitions=5/5");
 
         sql("select c1, c3, c2 from test_base_part where c2 < 3000 and c3 < 3000")
                 .contains("partial_mv_6")
                 .contains("     TABLE: test_base_part\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 9: c2 < 3000, 9: c2 >= 2000\n" +
+                        "     PREDICATES: 9: c2 < 3000, (9: c2 >= 2000) OR (9: c2 IS NULL)\n" +
                         "     partitions=5/5");
         // test query delta
         sql("select c1, c3, c2 from test_base_part where c2 < 1000 and c3 < 1000")
@@ -282,22 +282,21 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                         " on t1.c1 = t2.c1 and t1.c3=t2.c3 \n" +
                         " where t1.c3 < 3000")
                 .contains("UNION")
-                .contains("7:OlapScanNode\n" +
-                        "     TABLE: partial_mv_6\n" +
+                .contains("TABLE: partial_mv_6\n" +
                         "     PREAGGREGATION: ON\n" +
                         "     partitions=4/5");
         sql(
                 " select t1.c1, t1.c3, t2.c2 from test_base_part t1 \n" +
                         " inner join test_base_part2 t2 \n" +
                         " on t1.c1=t2.c1 and t1.c3=t2.c3 ")
-                .contains("TABLE: test_base_part\n" +
+                .contains("     TABLE: test_base_part\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 15: c1 IS NOT NULL, 16: c3 IS NOT NULL\n" +
-                        "     partitions=1/5")
-                .contains("TABLE: test_base_part\n" +
+                        "     PREDICATES: (16: c3 >= 2000) OR (16: c3 IS NULL), 15: c1 IS NOT NULL, 16: c3 IS NOT NULL\n" +
+                        "     partitions=2/5")
+                .contains("     TABLE: test_base_part2\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 15: c1 IS NOT NULL, 16: c3 IS NOT NULL\n" +
-                        "     partitions=1/5");
+                        "     PREDICATES: 19: c1 IS NOT NULL, 21: c3 IS NOT NULL\n" +
+                        "     partitions=5/5");
 
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
         connectContext.getSessionVariable().setMaterializedViewUnionRewriteMode(0);
@@ -370,23 +369,21 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                 " on t1.c1 = t2.c1 and t1.c3=t2.c3 \n" +
                 " where t1.c3 < 3000")
                 .contains("UNION")
-                .contains("7:OlapScanNode\n" +
-                        "     TABLE: partial_mv_6\n" +
+                .contains("TABLE: partial_mv_6\n" +
                         "     PREAGGREGATION: ON\n" +
                         "     partitions=1/1");
 
         sql(" select t1.c1, t1.c3, t2.c2 from test_base_part t1 \n" +
                 " inner join test_base_part2 t2 \n" +
                 " on t1.c1=t2.c1 and t1.c3=t2.c3 ")
-                .contains("TABLE: test_base_part\n" +
+                .contains("     TABLE: test_base_part\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 15: c1 IS NOT NULL, 16: c3 IS NOT NULL\n" +
-                        "     partitions=1/5\n" +
-                        "     rollup: test_base_part")
-                .contains("TABLE: test_base_part2\n" +
+                        "     PREDICATES: (16: c3 >= 2000) OR (16: c3 IS NULL), 15: c1 IS NOT NULL, 16: c3 IS NOT NULL\n" +
+                        "     partitions=2/5")
+                .contains("     TABLE: test_base_part2\n" +
                         "     PREAGGREGATION: ON\n" +
                         "     PREDICATES: 19: c1 IS NOT NULL, 21: c3 IS NOT NULL\n" +
-                        "     partitions=1/5");
+                        "     partitions=5/5");
 
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
         connectContext.getSessionVariable().setMaterializedViewUnionRewriteMode(0);
@@ -495,9 +492,9 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
 
         // test non match
         sql("select c1, c3, c2 from test_base_part")
-                .contains("TABLE: test_base_part\n" +
+                .contains("     TABLE: test_base_part\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 9: c2 <= 10\n" +
+                        "     PREDICATES: (9: c2 <= 10) OR (9: c2 IS NULL)\n" +
                         "     partitions=5/5");
 
         starRocksAssert.dropMaterializedView("partial_mv_8");
@@ -554,10 +551,10 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
 
             String query = "select c1, c3, sum(c4) from test_base_part where c3 < 2000 group by c1, c3;";
             String plan = getFragmentPlan(query);
-            PlanTestBase.assertContains(plan, "partial_mv_11", "TABLE: test_base_part\n" +
+            PlanTestBase.assertContains(plan, "     TABLE: test_base_part\n" +
                     "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/5");
-            PlanTestBase.assertNotContains(plan, "10: c3 IS NULL");
+                    "     PREDICATES: 10: c3 < 2000, (10: c3 >= 1000) OR (10: c3 IS NULL)\n" +
+                    "     partitions=2/5");
             starRocksAssert.dropMaterializedView("partial_mv_11");
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
@@ -162,9 +162,9 @@ public class MvRewriteHiveTest extends MVTestBase {
         String plan1 = getFragmentPlan(query1);
         PlanTestBase.assertContains(plan1, "0:UNION");
         PlanTestBase.assertContains(plan1, "hive_union_mv_1");
-        PlanTestBase.assertContains(plan1, "1:HdfsScanNode\n" +
-                "     TABLE: supplier\n" +
-                "     NON-PARTITION PREDICATES: 12: s_suppkey < 10, 12: s_suppkey >= 5");
+        PlanTestBase.assertContains(plan1, "     TABLE: supplier\n" +
+                "     NON-PARTITION PREDICATES: 12: s_suppkey < 10, (12: s_suppkey >= 5) OR (12: s_suppkey IS NULL)\n" +
+                "     MIN/MAX PREDICATES: 12: s_suppkey < 10");
         dropMv("test", "hive_union_mv_1");
     }
 
@@ -185,7 +185,9 @@ public class MvRewriteHiveTest extends MVTestBase {
 
         String query1 = "select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where s_suppkey < 10";
         String plan = getFragmentPlan(query1);
-        PlanTestBase.assertContains(plan, "TABLE: supplier", "NON-PARTITION PREDICATES: 18: s_suppkey < 10, 18: s_suppkey >= 5");
+        PlanTestBase.assertContains(plan, "     TABLE: supplier\n" +
+                "     NON-PARTITION PREDICATES: 12: s_suppkey < 10, (12: s_suppkey >= 5) OR (12: s_suppkey IS NULL)\n" +
+                "     MIN/MAX PREDICATES: 12: s_suppkey < 10");
         connectContext.getSessionVariable().setUseNthExecPlan(0);
         dropMv("test", "hive_union_mv_1");
         dropMv("test", "hive_join_mv_1");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteUnionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteUnionTest.java
@@ -254,17 +254,16 @@ public class MvRewriteUnionTest extends MVTestBase {
 
         PlanTestBase.assertContains(plan8, "join_agg_union_mv_2");
         PlanTestBase.assertContainsIgnoreColRefs(plan8, "5:HASH JOIN\n" +
-                "  |  join op: RIGHT OUTER JOIN (PARTITIONED)\n" +
-                "  |  colocate: false, reason: \n" +
-                "  |  equal join conjunct: 24: t1d = 20: v1");
-        PlanTestBase.assertContainsIgnoreColRefs(plan8, "1:OlapScanNode\n" +
+                        "  |  join op: RIGHT OUTER JOIN (PARTITIONED)\n" +
+                        "  |  colocate: false, reason: \n" +
+                        "  |  equal join conjunct: 24: t1d = 20: v1",
                 "     TABLE: test_all_type2\n" +
-                "     PREAGGREGATION: ON\n" +
-                "     PREDICATES: 24: t1d >= 100, 24: t1d < 120");
-        PlanTestBase.assertContainsIgnoreColRefs(plan8, "1:OlapScanNode\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: 24: t1d < 120",
                 "     TABLE: t02\n" +
-                "     PREAGGREGATION: ON\n" +
-                "     PREDICATES: 20: v1 >= 100, 20: v1 < 120");
+                        "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: (20: v1 >= 100) OR (20: v1 IS NULL), 20: v1 < 120\n" +
+                        "     partitions=1/1");
         dropMv("test", "join_agg_union_mv_2");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTimeSeriesRewriteWithHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTimeSeriesRewriteWithHiveTest.java
@@ -47,11 +47,15 @@ public class MvTimeSeriesRewriteWithHiveTest extends MVTestBase {
                     "     PREDICATES: 26: dt >= '1998-01-02'\n" +
                     "     partitions=1/2");
             PlanTestBase.assertContains(plan, "     TABLE: lineitem_par\n" +
-                    "     PARTITION PREDICATES: (NOT (date_trunc('month', 35: l_shipdate) >= '1998-01-02')) OR " +
-                    "(NOT (date_trunc('month', 35: l_shipdate) >= '1998-01-02')), 35: l_shipdate >= '1998-01-02', " +
+                    "     PARTITION PREDICATES: ((date_trunc('month', 35: l_shipdate) < '1998-01-02') " +
+                    "OR (date_trunc('month', 35: l_shipdate) IS NULL)) " +
+                    "OR ((date_trunc('month', 35: l_shipdate) < '1998-01-02') " +
+                    "OR (date_trunc('month', 35: l_shipdate) IS NULL)), 35: l_shipdate >= '1998-01-02', " +
                     "35: l_shipdate >= '1998-01-02'\n" +
-                    "     NO EVAL-PARTITION PREDICATES: (NOT (date_trunc('month', 35: l_shipdate) >= '1998-01-02')) OR " +
-                    "(NOT (date_trunc('month', 35: l_shipdate) >= '1998-01-02'))\n" +
+                    "     NO EVAL-PARTITION PREDICATES: ((date_trunc('month', 35: l_shipdate) < '1998-01-02') " +
+                    "OR (date_trunc('month', 35: l_shipdate) IS NULL)) " +
+                    "OR ((date_trunc('month', 35: l_shipdate) < '1998-01-02') " +
+                    "OR (date_trunc('month', 35: l_shipdate) IS NULL))\n" +
                     "     partitions=4/6");
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTimeSeriesRewriteWithOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTimeSeriesRewriteWithOlapTest.java
@@ -134,7 +134,8 @@ public class MvTimeSeriesRewriteWithOlapTest extends MVTestBase {
                 "     partitions=62/63");
         PlanTestBase.assertContains(plan, "     TABLE: t0\n" +
                 "     PREAGGREGATION: ON\n" +
-                "     PREDICATES: date_trunc('day', 22: k1) < '2024-01-01 01:00:00', 22: k1 >= '2024-01-01 01:00:00'\n" +
+                "     PREDICATES: (date_trunc('day', 22: k1) < '2024-01-01 01:00:00') " +
+                "OR (date_trunc('day', 22: k1) IS NULL), 22: k1 >= '2024-01-01 01:00:00'\n" +
                 "     partitions=1/5");
         starRocksAssert.dropMaterializedView("test_mv1");
     }
@@ -160,7 +161,9 @@ public class MvTimeSeriesRewriteWithOlapTest extends MVTestBase {
                     "     partitions=62/63");
             PlanTestBase.assertContains(plan, "     TABLE: t0\n" +
                     "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: date_trunc('day', 24: k1) < '2024-01-01 01:00:00', 24: k1 >= '2024-01-01 01:00:00'\n" +
+                    "     PREDICATES: (date_trunc('day', 24: k1) < '2024-01-01 01:00:00') " +
+                    "OR (date_trunc('day', 24: k1) IS " +
+                    "NULL), 24: k1 >= '2024-01-01 01:00:00'\n" +
                     "     partitions=1/5");
         }
         {
@@ -173,7 +176,8 @@ public class MvTimeSeriesRewriteWithOlapTest extends MVTestBase {
                     "     PREDICATES: 14: dt <= '2023-12-31 01:00:00'");
             PlanTestBase.assertContains(plan, "     TABLE: t0\n" +
                     "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: date_trunc('day', 24: k1) > '2023-12-31 01:00:00', 24: k1 <= '2024-01-01 01:00:00'\n" +
+                    "     PREDICATES: (date_trunc('day', 24: k1) > '2023-12-31 01:00:00') " +
+                    "OR (date_trunc('day', 24: k1) IS NULL), 24: k1 <= '2024-01-01 01:00:00'\n" +
                     "     partitions=2/5");
         }
         {
@@ -187,9 +191,10 @@ public class MvTimeSeriesRewriteWithOlapTest extends MVTestBase {
                     "     partitions=31/63");
             PlanTestBase.assertContains(plan, "     TABLE: t0\n" +
                     "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: (date_trunc('day', 24: k1) > '2024-01-31 01:00:00') OR " +
-                    "(date_trunc('day', 24: k1) < '2024-01-01 01:00:00'), 24: k1 <= '2024-02-01 01:00:00', " +
-                    "24: k1 >= '2024-01-01 01:00:00'\n" +
+                    "     PREDICATES: ((date_trunc('day', 24: k1) > '2024-01-31 01:00:00') " +
+                    "OR (date_trunc('day', 24: k1) IS NULL)) " +
+                    "OR (date_trunc('day', 24: k1) < '2024-01-01 01:00:00'), " +
+                    "24: k1 <= '2024-02-01 01:00:00', 24: k1 >= '2024-01-01 01:00:00'\n" +
                     "     partitions=2/5");
         }
         starRocksAssert.dropMaterializedView("test_mv1");
@@ -220,11 +225,13 @@ public class MvTimeSeriesRewriteWithOlapTest extends MVTestBase {
                 "     partitions=3/4");
         PlanTestBase.assertContains(plan, "     TABLE: test_mv1\n" +
                 "     PREAGGREGATION: ON\n" +
-                "     PREDICATES: date_trunc('month', 45: dt) < '2024-01-01 01:00:00', 45: dt >= '2024-01-01 01:00:00'\n" +
+                "     PREDICATES: (date_trunc('month', 45: dt) < '2024-01-01 01:00:00') " +
+                "OR (date_trunc('month', 45: dt) IS NULL), 45: dt >= '2024-01-01 01:00:00'\n" +
                 "     partitions=31/63");
         PlanTestBase.assertContains(plan, "     TABLE: t0\n" +
                 "     PREAGGREGATION: ON\n" +
-                "     PREDICATES: date_trunc('day', 25: k1) < '2024-01-01 01:00:00', 25: k1 >= '2024-01-01 01:00:00'\n" +
+                "     PREDICATES: (date_trunc('day', 25: k1) < '2024-01-01 01:00:00') " +
+                "OR (date_trunc('day', 25: k1) IS NULL), 25: k1 >= '2024-01-01 01:00:00'\n" +
                 "     partitions=1/5");
         starRocksAssert.dropMaterializedView("test_mv1");
         starRocksAssert.dropMaterializedView("test_mv2");
@@ -260,9 +267,6 @@ public class MvTimeSeriesRewriteWithOlapTest extends MVTestBase {
         PlanTestBase.assertContains(plan, "     TABLE: test_mv3\n" +
                 "     PREAGGREGATION: ON\n" +
                 "     PREDICATES: 19: dt >= '2020-03-23 12:12:00'");
-        PlanTestBase.assertContains(plan, "     TABLE: test_mv2\n" +
-                "     PREAGGREGATION: ON\n" +
-                "     PREDICATES: 43: dt >= '2020-03-23 12:12:00', date_trunc('month', 43: dt) < '2020-03-22 12:12:00'\n");
         PlanTestBase.assertContains(plan, "     TABLE: t2\n" +
                 "     PREAGGREGATION: ON");
         starRocksAssert.dropMaterializedView("test_mv1");
@@ -290,7 +294,8 @@ public class MvTimeSeriesRewriteWithOlapTest extends MVTestBase {
                 "     partitions=62/63");
         PlanTestBase.assertContains(plan, "     TABLE: t0\n" +
                 "     PREAGGREGATION: ON\n" +
-                "     PREDICATES: date_trunc('day', 14: k1) < '2024-01-01 01:00:00', 14: k1 >= '2024-01-01 01:00:00'\n" +
+                "     PREDICATES: (date_trunc('day', 14: k1) < '2024-01-01 01:00:00') " +
+                "OR (date_trunc('day', 14: k1) IS NULL), 14: k1 >= '2024-01-01 01:00:00'\n" +
                 "     partitions=1/5");
         PlanTestBase.assertContains(plan, "  16:AGGREGATE (update serialize)\n" +
                 "  |  output: array_unique_agg(18: count)\n" +

--- a/test/sql/test_materialized_view_rewrite/R/test_mv_rewrite_with_time_series_multi_mvs
+++ b/test/sql/test_materialized_view_rewrite/R/test_mv_rewrite_with_time_series_multi_mvs
@@ -53,15 +53,15 @@ from t0 group by date_trunc('month', ts);
 refresh materialized view test_mv3 with sync mode;
 [UC]analyze table test_mv1 WITH SYNC MODE;
 -- result:
-test_db_d07f7af7f3f145c28057ec2aa87a3b8e.test_mv1	analyze	status	OK
+test_db_0f44f338f5ae4e80ae9ef9679844d213.test_mv1	analyze	status	OK
 -- !result
 [UC]analyze table test_mv2 WITH SYNC MODE;
 -- result:
-test_db_d07f7af7f3f145c28057ec2aa87a3b8e.test_mv2	analyze	status	OK
+test_db_0f44f338f5ae4e80ae9ef9679844d213.test_mv2	analyze	status	OK
 -- !result
 [UC]analyze table test_mv3 WITH SYNC MODE;
 -- result:
-test_db_d07f7af7f3f145c28057ec2aa87a3b8e.test_mv3	analyze	status	OK
+test_db_0f44f338f5ae4e80ae9ef9679844d213.test_mv3	analyze	status	OK
 -- !result
 set enable_materialized_view_rewrite=true;
 -- result:
@@ -74,11 +74,11 @@ set materialized_view_rewrite_mode="force";
 -- !result
 function: print_hit_materialized_views("select sum(v1), sum(v2) from t0 where ts > '2020-02-23 12:12:00' order by 1;")
 -- result:
-test_mv2,test_mv3
+test_mv3
 -- !result
 function: print_hit_materialized_views("select sum(v1), sum(v2) from t0 where ts >= '2020-03-23 12:12:00' order by 1;")
 -- result:
-test_mv2,test_mv3
+test_mv3
 -- !result
 function: print_hit_materialized_views("select sum(v1), sum(v2) from t0 where ts < '2020-04-23 12:12:00'  order by 1;")
 -- result:
@@ -184,15 +184,15 @@ from test_mv2 group by date_trunc('month', dt);
 refresh materialized view test_mv3 with sync mode;
 [UC]analyze table test_mv1 WITH SYNC MODE;
 -- result:
-test_db_d07f7af7f3f145c28057ec2aa87a3b8e.test_mv1	analyze	status	OK
+test_db_0f44f338f5ae4e80ae9ef9679844d213.test_mv1	analyze	status	OK
 -- !result
 [UC]analyze table test_mv2 WITH SYNC MODE;
 -- result:
-test_db_d07f7af7f3f145c28057ec2aa87a3b8e.test_mv2	analyze	status	OK
+test_db_0f44f338f5ae4e80ae9ef9679844d213.test_mv2	analyze	status	OK
 -- !result
 [UC]analyze table test_mv3 WITH SYNC MODE;
 -- result:
-test_db_d07f7af7f3f145c28057ec2aa87a3b8e.test_mv3	analyze	status	OK
+test_db_0f44f338f5ae4e80ae9ef9679844d213.test_mv3	analyze	status	OK
 -- !result
 function: print_hit_materialized_views("select sum(v1), sum(v2) from t0 where ts > '2020-02-23 12:12:00' order by 1;")
 -- result:
@@ -224,7 +224,7 @@ test_mv2
 -- !result
 select sum(v1), sum(v2) from t0 where ts > '2020-02-23 12:12:00' order by 1;
 -- result:
-11	16
+12	17
 -- !result
 select sum(v1), sum(v2) from t0 where ts >= '2020-03-23 12:12:00' order by 1;
 -- result:


### PR DESCRIPTION
## Why I'm doing:

When I test with mv union rewrite, I found two bugs:
- MV union rewrite may lose `null` partitions after rewrite which may cause result inconsistent with no rewrite, use  `NegateFilterShuttle` is safer than `CompoundOperator.not`;
- MV union rewrite may cause bad plan (losing columns) with losing necessary columns.

## What I'm doing:

This pull request introduces optimizations and enhancements to materialized view rewriting and predicate handling in the query optimizer. Key changes include improved predicate negation using a new utility, better handling of enforced non-existent columns, and updates to test cases to reflect the new behavior.

### Optimizations to Predicate Handling:
* Updated `createCompound` in `Utils.java` to filter redundant `TRUE` values in `AND` predicates, ensuring cleaner and more efficient predicate construction.
* Replaced direct negation logic with the `NegateFilterShuttle` utility for more consistent and reusable predicate negation in `AggregatedTimeSeriesRewriter.java` and `MaterializedViewRewriter.java`. [[1]](diffhunk://#diff-58483d5aceb932787d60c442258da89f2f2cf7a812e2d626d4760eafc9700000L655-R658) [[2]](diffhunk://#diff-928c7b191892f7924196f34f738f512fb867cce2c78828d6f59fde45d69321cbL1996-R2007)

### Enhancements to Materialized View Rewriting:
* Enhanced the `doQueryBasedRewrite` method in `MaterializedViewRewriter.java` to account for required output columns and improve the pruning of enforced non-existent columns. This ensures more accurate and efficient rewrite logic.
* Modified the `pruneEnforcedColumns` method to accept a set of enforced non-existent columns, improving its flexibility and correctness.

Fixes https://github.com/StarRocks/StarRocksTest/pull/9829

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
