### PR TITLE
[BugFix] Fix mv refresh bug with iceberg str2date

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -32,7 +32,6 @@ import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.MaxLiteral;
 import com.starrocks.analysis.NullLiteral;
 import com.starrocks.analysis.SlotRef;
-import com.starrocks.analysis.StringLiteral;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.HivePartitionKey;
@@ -70,7 +69,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -499,7 +497,7 @@ public class PartitionUtil {
         boolean isConvertToDate = isConvertToDate(partitionExpr, partitionColumn);
         Map<String, Range<PartitionKey>> mvPartitionRangeMap = new LinkedHashMap<>();
 
-        PrimitiveType partitionColPrimType = partitionColumn.getPrimitiveType();
+        PrimitiveType partitionColPrimType = isConvertToDate ? PrimitiveType.DATE : partitionColumn.getPrimitiveType();
         DateTimeInterval partitionDateTimeInterval = getDateTimeInterval(table, partitionColumn);
 
         // NOTE: For external table, convert partition values to partition ranges just like list partition.
@@ -507,15 +505,14 @@ public class PartitionUtil {
         // This is more robust, and it's better to handle the case where the partition value is not continuous.
         for (Map.Entry<String, PartitionKey> entry : sortedPartitionLinkMap.entrySet()) {
             String partitionKeyName = entry.getKey();
-            PartitionKey lowerBound = entry.getValue();
+            PartitionKey lowerBound = isConvertToDate ? convertToDate(entry.getValue()) : entry.getValue();
             if (lowerBound.getKeys().get(0).isNullable()) {
                 // If partition key is NULL literal, rewrite it to min value.
                 lowerBound = PartitionKey.createInfinityPartitionKeyWithType(
-                        ImmutableList.of(partitionColumn.getPrimitiveType()), false);
+                        ImmutableList.of(partitionColPrimType), false);
             }
             Preconditions.checkState(!mvPartitionRangeMap.containsKey(partitionKeyName));
-            PartitionKey upperBound = nextPartitionKey(lowerBound, partitionDateTimeInterval, partitionColPrimType,
-                    isConvertToDate);
+            PartitionKey upperBound = nextPartitionKey(lowerBound, partitionDateTimeInterval, partitionColPrimType);
             mvPartitionRangeMap.put(partitionKeyName, Range.closedOpen(lowerBound, upperBound));
         }
         return mvPartitionRangeMap;
@@ -523,19 +520,8 @@ public class PartitionUtil {
 
     public static PartitionKey nextPartitionKey(PartitionKey lastPartitionKey,
                                                 DateTimeInterval dateTimeInterval,
-                                                PrimitiveType partitionColPrimType,
-                                                boolean isStringConvertToDate) throws AnalysisException {
-        LiteralExpr literalExpr;
-        if (isStringConvertToDate) {
-            PartitionKey lastDate = convertToDate(lastPartitionKey);
-            String lastDateFormat = lastPartitionKey.getKeys().get(0).getStringValue();
-            DateTimeFormatter formatter = DateUtils.probeFormat(lastDateFormat);
-            DateLiteral nextDate = (DateLiteral) addOffsetForLiteral(lastDate.getKeys().get(0), 1,
-                    dateTimeInterval);
-            literalExpr = new StringLiteral(nextDate.toLocalDateTime().format(formatter));
-        } else {
-            literalExpr = addOffsetForLiteral(lastPartitionKey.getKeys().get(0), 1, dateTimeInterval);
-        }
+                                                PrimitiveType partitionColPrimType) throws AnalysisException {
+        LiteralExpr literalExpr = addOffsetForLiteral(lastPartitionKey.getKeys().get(0), 1, dateTimeInterval);
         PartitionKey partitionKey = new PartitionKey();
         partitionKey.pushColumn(literalExpr, partitionColPrimType);
         return partitionKey;
@@ -576,6 +562,7 @@ public class PartitionUtil {
         String partitionName = null;
 
         Map<String, Range<PartitionKey>> mvPartitionRangeMap = new LinkedHashMap<>();
+        PrimitiveType partitionColPrimType = isConvertToDate ? PrimitiveType.DATE : partitionColumn.getPrimitiveType();
         for (Map.Entry<String, PartitionKey> entry : sortedPartitionLinkMap.entrySet()) {
             // Adapt to the range partitioning method of JDBC Table, the partitionName adopts the name of upperBound
             partitionName = entry.getKey();
@@ -584,14 +571,12 @@ public class PartitionUtil {
                 if (!lastPartitionKey.getKeys().get(0).isMinValue()) {
                     // If partition key is not min value, rewrite it to min value.
                     lastPartitionKey = PartitionKey.createInfinityPartitionKeyWithType(
-                            ImmutableList.of(isConvertToDate ?
-                                    PrimitiveType.DATE : partitionColumn.getPrimitiveType()), false);
+                            ImmutableList.of(partitionColPrimType), false);
                 } else {
                     if (lastPartitionKey.getKeys().get(0).isNullable()) {
                         // If partition key is NULL literal, rewrite it to min value.
                         lastPartitionKey = PartitionKey.createInfinityPartitionKeyWithType(
-                                ImmutableList.of(isConvertToDate ?
-                                        PrimitiveType.DATE : partitionColumn.getPrimitiveType()), false);
+                                ImmutableList.of(partitionColPrimType), false);
                     } else {
                         lastPartitionKey = isConvertToDate ? convertToDate(entry.getValue()) : entry.getValue();
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -1498,9 +1498,10 @@ public class MvUtils {
         return baseTableInfos.stream().map(BaseTableInfo::getReadableString).collect(Collectors.joining(","));
     }
 
-    public static ScalarOperator convertPartitionKeyRangesToListPredicate(List<? extends ScalarOperator> partitionColRefs,
-                                                                          Collection<PRangeCell> pRangeCells,
-                                                                          boolean areAllRangePartitionsSingleton) {
+    public static ScalarOperator convertPartitionKeyRangesToListPredicate(
+            List<? extends ScalarOperator> partitionColRefs,
+            Collection<PRangeCell> pRangeCells,
+            boolean areAllRangePartitionsSingleton) throws AnalysisException {
         final List<Range<PartitionKey>> partitionRanges = pRangeCells
                 .stream()
                 .map(PRangeCell::getRange)
@@ -1509,15 +1510,25 @@ public class MvUtils {
         return convertPartitionKeysToListPredicate(partitionColRefs, partitionRanges, areAllRangePartitionsSingleton);
     }
 
-    public static ScalarOperator convertPartitionKeysToListPredicate(List<? extends ScalarOperator> partitionColRefs,
-                                                                     Collection<PartitionKey> partitionRanges) {
+    private static ConstantOperator convertLiteralToConstantOperator(ScalarOperator partitionColRef,
+                                                                     LiteralExpr literalExpr) throws AnalysisException {
+        if (!partitionColRef.getType().equals(literalExpr.getType())) {
+            literalExpr = LiteralExpr.create(literalExpr.getStringValue(), partitionColRef.getType());
+        }
+        return (ConstantOperator) SqlToScalarOperatorTranslator.translate(literalExpr);
+    }
+
+    public static ScalarOperator convertPartitionKeysToListPredicate(
+            List<? extends ScalarOperator> partitionColRefs,
+            Collection<PartitionKey> partitionRanges) throws AnalysisException {
         final List<ScalarOperator> values = Lists.newArrayList();
         if (partitionColRefs.size() == 1) {
+            ScalarOperator partitionColRef = partitionColRefs.get(0);
             for (PartitionKey key : partitionRanges) {
                 final List<LiteralExpr> literalExprs = key.getKeys();
                 Preconditions.checkArgument(literalExprs.size() == partitionColRefs.size());
                 final LiteralExpr literalExpr = literalExprs.get(0);
-                final ConstantOperator upperBound = (ConstantOperator) SqlToScalarOperatorTranslator.translate(literalExpr);
+                final ConstantOperator upperBound = convertLiteralToConstantOperator(partitionColRef, literalExpr);
                 values.add(upperBound);
             }
             return MvUtils.convertToInPredicate(partitionColRefs.get(0), values);
@@ -1540,9 +1551,10 @@ public class MvUtils {
         }
     }
 
-    private static ScalarOperator convertPartitionKeysToListPredicate(List<? extends ScalarOperator> partitionColRefs,
-                                                                      Collection<Range<PartitionKey>> partitionRanges,
-                                                                      boolean areAllRangePartitionsSingleton) {
+    private static ScalarOperator convertPartitionKeysToListPredicate(
+            List<? extends ScalarOperator> partitionColRefs,
+            Collection<Range<PartitionKey>> partitionRanges,
+            boolean areAllRangePartitionsSingleton) throws AnalysisException {
 
         if (areAllRangePartitionsSingleton) {
             List<PartitionKey> partitionKeys = partitionRanges


### PR DESCRIPTION
## Why I'm doing:
- Fix mv refresh exceptions for iceberg str2date partitions.

## What I'm doing:
* Added a new `convertLiteralToConstantOperator` method in `MvUtils` to ensure type compatibility when converting literals to constant operators, preventing potential type mismatches.
* Updated `convertPartitionKeysToListPredicate` methods in `MvUtils` to use the new `convertLiteralToConstantOperator` method, ensuring consistent type handling.
* Introduced a `compensateImpl` method in `ExternalTableCompensation` to encapsulate the compensation logic, with error handling added to the `compensate` method to log and handle `AnalysisException` gracefully.
* Updated `getIcebergTableCompensation` in `ExternalTableCompensation` to declare and handle `AnalysisException`, ensuring robust error handling during Iceberg table compensation.

Fixes https://github.com/StarRocks/StarRocksTest/pull/9829

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
