### PR TITLE
[Enhancement] Abort transaction with failed tablets when retrying broker load job

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -633,4 +633,11 @@ public class BrokerLoadJob extends BulkLoadJob {
         }
         return String.valueOf(value);
     }
+
+    @Override
+    protected void updateTabletFailInfos(TaskAttachment attachment) {
+        if (attachment instanceof BrokerLoadingTaskAttachment) {
+            failInfos.addAll(((BrokerLoadingTaskAttachment) attachment).getFailInfoList());
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadingTaskAttachment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadingTaskAttachment.java
@@ -62,6 +62,11 @@ public class BrokerLoadingTaskAttachment extends TaskAttachment {
         this.writeDurationMs = writeDurationMs;
     }
 
+    // For failed loading task
+    public BrokerLoadingTaskAttachment(long taskId, List<TabletFailInfo> failInfoList) {
+        this(taskId, null, null, null, failInfoList, null, -1L);
+    }
+
     public String getCounter(String key) {
         return counters.get(key);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
@@ -238,6 +238,13 @@ public abstract class BulkLoadJob extends LoadJob {
         return failInfos;
     }
 
+    @Override
+    protected void reset() {
+        super.reset();
+        commitInfos.clear();
+        failInfos.clear();
+    }
+
     /**
      * Not retryable cases
      * 1. already retry too many times
@@ -253,7 +260,7 @@ public abstract class BulkLoadJob extends LoadJob {
 
     @Override
     public void onTaskFailed(long taskId, FailMsg failMsg) {
-        boolean needRetry = false;
+        List<TabletFailInfo> lastFailInfos = null;
         writeLock();
         try {
             // check if job has been completed
@@ -265,27 +272,29 @@ public abstract class BulkLoadJob extends LoadJob {
                 return;
             }
 
-            needRetry = isRetryable(failMsg);
+            boolean needRetry = isRetryable(failMsg);
             if (!needRetry) {
+                // For not retryable failure, cancel job and return
                 unprotectedExecuteCancel(failMsg, true);
                 logFinalOperation();
+                return;
+            } else {
+                lastFailInfos = Lists.newArrayList(failInfos);
             }
         } finally {
             writeUnlock();
         }
 
         // For retryable failure, should abort the transaction and retry as soon as possible
-        if (needRetry) {
-            try {
-                LOG.debug("Loading task with retryable failure try to abort transaction, " +
-                                "job_id: {}, task_id: {}, txn_id: {}, task fail message: {}",
-                        id, taskId, transactionId, failMsg.getMsg());
-                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(
-                        dbId, transactionId, failMsg.getMsg());
-            } catch (StarRocksException e) {
-                LOG.warn("Loading task failed to abort transaction, job_id: {}, task_id: {}, txn_id: {}, " +
-                        "task fail message: {}, abort exception:", id, taskId, transactionId, failMsg.getMsg(), e);
-            }
+        try {
+            LOG.debug("Loading task with retryable failure try to abort transaction, " +
+                            "job_id: {}, task_id: {}, txn_id: {}, task fail message: {}",
+                    id, taskId, transactionId, failMsg.getMsg());
+            GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(
+                    dbId, transactionId, failMsg.getMsg(), lastFailInfos);
+        } catch (StarRocksException e) {
+            LOG.warn("Loading task failed to abort transaction, job_id: {}, task_id: {}, txn_id: {}, " +
+                    "task fail message: {}, abort exception:", id, taskId, transactionId, failMsg.getMsg(), e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -1220,7 +1220,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     }
 
     @Override
-    public void onTaskFailed(long taskId, FailMsg failMsg) {
+    public void onTaskFailed(long taskId, FailMsg failMsg, TaskAttachment attachment) {
     }
 
     // This analyze will be invoked after the replay is finished.

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -295,6 +295,8 @@ public class LoadLoadingTask extends LoadTask {
                         curCoordinator.getRejectedRecordPaths(),
                         System.currentTimeMillis() - writeBeginTime);
             } else {
+                attachment = new BrokerLoadingTaskAttachment(signature,
+                        TabletFailInfo.fromThrift(curCoordinator.getFailInfos()));
                 throw new LoadException(status.getErrorMsg());
             }
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadTask.java
@@ -84,7 +84,8 @@ public abstract class LoadTask extends PriorityLeaderTask {
         } finally {
             if (!isFinished) {
                 // callback on pending task failed
-                callback.onTaskFailed(signature, failMsg);
+                callback.onTaskFailed(signature, failMsg, attachment);
+                attachment = null;
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadTaskCallback.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadTaskCallback.java
@@ -24,5 +24,5 @@ public interface LoadTaskCallback {
 
     void onTaskFinished(TaskAttachment attachment);
 
-    void onTaskFailed(long taskId, FailMsg failMsg);
+    void onTaskFailed(long taskId, FailMsg failMsg, TaskAttachment attachment);
 }

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
@@ -464,7 +464,7 @@ public class BrokerLoadJobTest {
 
         BrokerLoadJob brokerLoadJob = new BrokerLoadJob();
         failMsg = new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, "load_run_fail");
-        brokerLoadJob.onTaskFailed(taskId, failMsg);
+        brokerLoadJob.onTaskFailed(taskId, failMsg, null);
 
         Map<Long, LoadTask> idToTasks = Deencapsulation.getField(brokerLoadJob, "idToTasks");
         Assert.assertEquals(0, idToTasks.size());
@@ -482,7 +482,7 @@ public class BrokerLoadJobTest {
 
         BrokerLoadJob brokerLoadJob = new BrokerLoadJob();
         failMsg = new FailMsg(FailMsg.CancelType.USER_CANCEL, "Failed to allocate resource to query: pending timeout");
-        brokerLoadJob.onTaskFailed(taskId, failMsg);
+        brokerLoadJob.onTaskFailed(taskId, failMsg, null);
 
         Map<Long, LoadTask> idToTasks = Deencapsulation.getField(brokerLoadJob, "idToTasks");
         Assert.assertEquals(0, idToTasks.size());
@@ -500,9 +500,8 @@ public class BrokerLoadJobTest {
         };
 
         BrokerLoadJob brokerLoadJob = new BrokerLoadJob();
-        brokerLoadJob.failInfos = failInfos;
         failMsg = new FailMsg(FailMsg.CancelType.UNKNOWN, "[E1008]Reached timeout=7200000ms @127.0.0.1:8060");
-        brokerLoadJob.onTaskFailed(taskId, failMsg);
+        brokerLoadJob.onTaskFailed(taskId, failMsg, new BrokerLoadingTaskAttachment(brokerLoadJob.getId(), failInfos));
 
         new Expectations() {
             {
@@ -515,7 +514,7 @@ public class BrokerLoadJobTest {
         try {
             BrokerLoadJob brokerLoadJob1 = new BrokerLoadJob();
             failMsg = new FailMsg(FailMsg.CancelType.UNKNOWN, "[E1008]Reached timeout=7200000ms @127.0.0.1:8060");
-            brokerLoadJob1.onTaskFailed(taskId, failMsg);
+            brokerLoadJob1.onTaskFailed(taskId, failMsg, null);
         } catch (Exception e) {
             Assert.fail("should not throw exception");
         }

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
@@ -395,11 +395,13 @@ public class BrokerLoadJobTest {
         long createTimestamp = context.getStartTime() - 1;
         brokerLoadJob2.createTimestamp = createTimestamp;
         brokerLoadJob2.timeoutSecond = 0;
+        brokerLoadJob2.failInfos = Lists.newArrayList(new TabletFailInfo(1L, 2L));
         brokerLoadJob2.afterAborted(txnState, txnOperated, txnStatusChangeReason);
         idToTasks = Deencapsulation.getField(brokerLoadJob2, "idToTasks");
         Assert.assertEquals(1, idToTasks.size());
         Assert.assertTrue(brokerLoadJob2.createTimestamp > createTimestamp);
         Assert.assertEquals(brokerLoadJob2.createTimestamp, context.getStartTime());
+        Assert.assertTrue(brokerLoadJob2.failInfos.isEmpty());
 
         // test when txnOperated is false
         BrokerLoadJob brokerLoadJob3 = new BrokerLoadJob();
@@ -489,20 +491,22 @@ public class BrokerLoadJobTest {
     @Test
     public void testTaskAbortTransactionOnTimeoutFailure(@Mocked GlobalTransactionMgr globalTransactionMgr,
             @Injectable long taskId, @Injectable FailMsg failMsg) throws StarRocksException {
+        List<TabletFailInfo> failInfos = Lists.newArrayList(new TabletFailInfo(1L, 2L));
         new Expectations() {
             {
-                globalTransactionMgr.abortTransaction(anyLong, anyLong, anyString);
+                globalTransactionMgr.abortTransaction(anyLong, anyLong, anyString, failInfos);
                 times = 1;
             }
         };
 
         BrokerLoadJob brokerLoadJob = new BrokerLoadJob();
+        brokerLoadJob.failInfos = failInfos;
         failMsg = new FailMsg(FailMsg.CancelType.UNKNOWN, "[E1008]Reached timeout=7200000ms @127.0.0.1:8060");
         brokerLoadJob.onTaskFailed(taskId, failMsg);
 
         new Expectations() {
             {
-                globalTransactionMgr.abortTransaction(anyLong, anyLong, anyString);
+                globalTransactionMgr.abortTransaction(anyLong, anyLong, anyString, Lists.newArrayList());
                 times = 1;
                 result = new StarRocksException("Artificial exception");
             }


### PR DESCRIPTION
## Why I'm doing:

In broker load job plan, replicas or backends that failed in the previous write attempt will be avoided as primary replicas to improve load reliability. 
The last write failure information are updated when the previous transaction is aborted, using the failed tablets.

## What I'm doing:

Update the last write failure information when retrying broker load job.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
