### PR TITLE
[BugFix] Fix some bugs in scenarios where file_bundling and alter operations intersect

### DIFF
--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -430,15 +430,15 @@ StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(int64_t tablet_id
                                                                const std::shared_ptr<FileSystem>& fs) {
     StatusOr<TabletMetadataPtr> tablet_metadata_or;
     auto cache_key = _location_provider->real_location(tablet_metadata_root_location(tablet_id));
-    ASSIGN_OR_RETURN(auto cache_key, _location_provider->real_location(tablet_metadata_root_location(tablet_id)));
-    if (_metacache->lookup_aggregation_partition(cache_key)) {
+    if (cache_key.ok() && _metacache->lookup_aggregation_partition(*cache_key)) {
         if (version == kInitialVersion) {
             // Handle tablet initial metadata
             tablet_metadata_or =
                     get_tablet_metadata(tablet_metadata_location(tablet_id, version), fill_cache, expected_gtid, fs);
         }
     } else {
-        tablet_metadata_or = get_tablet_metadata((tablet_id, version), fill_cache, expected_gtid, fs);
+        tablet_metadata_or =
+                get_tablet_metadata(tablet_metadata_location(tablet_id, version), fill_cache, expected_gtid, fs);
     }
 
     if (!tablet_metadata_or.ok()) {

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -438,8 +438,7 @@ StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(int64_t tablet_id
                     get_tablet_metadata(tablet_metadata_location(tablet_id, version), fill_cache, expected_gtid, fs);
         }
     } else {
-        tablet_metadata_or =
-                get_tablet_metadata((tablet_id, version), fill_cache, expected_gtid, fs);
+        tablet_metadata_or = get_tablet_metadata((tablet_id, version), fill_cache, expected_gtid, fs);
     }
 
     if (!tablet_metadata_or.ok()) {

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -634,7 +634,7 @@ TEST_F(LakeTabletManagerTest, put_bundle_tablet_metadata) {
     starrocks::TabletMetadataPB metadata2;
     {
         metadata2.set_id(2);
-        metadata2.set_version(3);
+        metadata2.set_version(2);
         metadata2.mutable_schema()->CopyFrom(schema_pb2);
         auto& item1 = (*metadata2.mutable_historical_schemas())[10];
         item1.CopyFrom(schema_pb1);
@@ -646,35 +646,11 @@ TEST_F(LakeTabletManagerTest, put_bundle_tablet_metadata) {
 
     metadatas.emplace(1, metadata1);
     metadatas.emplace(2, metadata2);
-
-    {
-        auto fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get("get_real_location_failed");
-        PFailPointTriggerMode trigger_mode;
-        trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);
-        fp->setMode(trigger_mode);
-        ASSERT_FALSE(_tablet_manager->put_bundle_tablet_metadata(metadatas).ok());
-        trigger_mode.set_mode(FailPointTriggerModeType::DISABLE);
-        fp->setMode(trigger_mode);
-
-        fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get("tablet_meta_not_found");
-        trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);
-        fp->setMode(trigger_mode);
-        ASSERT_FALSE(_tablet_manager->put_bundle_tablet_metadata(metadatas).ok());
-        trigger_mode.set_mode(FailPointTriggerModeType::DISABLE);
-        fp->setMode(trigger_mode);
-    }
-
-    ASSERT_FALSE(_tablet_manager->put_bundle_tablet_metadata(metadatas).ok());
-
-    metadata2.set_version(2);
-    metadatas.clear();
-    metadatas.emplace(1, metadata1);
-    metadatas.emplace(2, metadata2);
     ASSERT_OK(_tablet_manager->put_bundle_tablet_metadata(metadatas));
 
     {
         auto res = _tablet_manager->get_tablet_metadata(1, 2);
-        ASSERT_TRUE(res.ok());
+        EXPECT_TRUE(res.ok()) << res.status().to_string();
         TabletMetadataPtr metadata = std::move(res).value();
         ASSERT_EQ(metadata->schema().id(), 10);
         ASSERT_EQ(metadata->historical_schemas_size(), 2);

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -634,7 +634,7 @@ TEST_F(LakeTabletManagerTest, put_bundle_tablet_metadata) {
     starrocks::TabletMetadataPB metadata2;
     {
         metadata2.set_id(2);
-        metadata2.set_version(2);
+        metadata2.set_version(3);
         metadata2.mutable_schema()->CopyFrom(schema_pb2);
         auto& item1 = (*metadata2.mutable_historical_schemas())[10];
         item1.CopyFrom(schema_pb1);
@@ -646,7 +646,31 @@ TEST_F(LakeTabletManagerTest, put_bundle_tablet_metadata) {
 
     metadatas.emplace(1, metadata1);
     metadatas.emplace(2, metadata2);
-    EXPECT_OK(_tablet_manager->put_bundle_tablet_metadata(metadatas));
+
+    {
+        auto fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get("get_real_location_failed");
+        PFailPointTriggerMode trigger_mode;
+        trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);
+        fp->setMode(trigger_mode);
+        ASSERT_FALSE(_tablet_manager->put_bundle_tablet_metadata(metadatas).ok());
+        trigger_mode.set_mode(FailPointTriggerModeType::DISABLE);
+        fp->setMode(trigger_mode);
+
+        fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get("tablet_meta_not_found");
+        trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);
+        fp->setMode(trigger_mode);
+        ASSERT_FALSE(_tablet_manager->put_bundle_tablet_metadata(metadatas).ok());
+        trigger_mode.set_mode(FailPointTriggerModeType::DISABLE);
+        fp->setMode(trigger_mode);
+    }
+
+    ASSERT_FALSE(_tablet_manager->put_bundle_tablet_metadata(metadatas).ok());
+
+    metadata2.set_version(2);
+    metadatas.clear();
+    metadatas.emplace(1, metadata1);
+    metadatas.emplace(2, metadata2);
+    ASSERT_OK(_tablet_manager->put_bundle_tablet_metadata(metadatas));
 
     {
         auto res = _tablet_manager->get_tablet_metadata(1, 2);

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -1771,7 +1771,7 @@ TEST_P(LakeVacuumTest, test_vacuum_bundle_metadata) {
         vacuum(_tablet_mgr.get(), request, &response);
         ASSERT_TRUE(response.has_status());
         EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
-        EXPECT_EQ(0, response.vacuumed_files());
+        EXPECT_EQ(2, response.vacuumed_files());
         // The size of deleted metadata files is not counted in vacuumed_file_size.
         EXPECT_EQ(0, response.vacuumed_file_size());
 
@@ -1802,7 +1802,7 @@ TEST_P(LakeVacuumTest, test_vacuum_bundle_metadata) {
         vacuum(_tablet_mgr.get(), request, &response);
         ASSERT_TRUE(response.has_status());
         EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
-        EXPECT_EQ(2, response.vacuumed_files());
+        EXPECT_EQ(4, response.vacuumed_files());
         EXPECT_EQ(0, response.vacuumed_file_size());
 
         EXPECT_FALSE(file_exist(tablet_metadata_filename(0, 1)));
@@ -2054,7 +2054,7 @@ TEST_P(LakeVacuumTest, test_vacuum_shared_data_files) {
         vacuum(_tablet_mgr.get(), request, &response);
         ASSERT_TRUE(response.has_status());
         EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
-        EXPECT_EQ(0, response.vacuumed_files());
+        EXPECT_EQ(2, response.vacuumed_files());
         // The size of deleted metadata files is not counted in vacuumed_file_size.
         EXPECT_EQ(0, response.vacuumed_file_size());
 
@@ -2083,7 +2083,7 @@ TEST_P(LakeVacuumTest, test_vacuum_shared_data_files) {
         vacuum(_tablet_mgr.get(), request, &response);
         ASSERT_TRUE(response.has_status());
         EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
-        EXPECT_EQ(2, response.vacuumed_files());
+        EXPECT_EQ(4, response.vacuumed_files());
         EXPECT_EQ(0, response.vacuumed_file_size());
 
         EXPECT_FALSE(file_exist(tablet_metadata_filename(0, 1)));
@@ -2123,7 +2123,7 @@ TEST_P(LakeVacuumTest, test_vacuum_shared_data_files) {
         vacuum(_tablet_mgr.get(), request, &response);
         ASSERT_TRUE(response.has_status());
         EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
-        EXPECT_EQ(5, response.vacuumed_files());
+        EXPECT_EQ(7, response.vacuumed_files());
         EXPECT_EQ(16384, response.vacuumed_file_size());
 
         EXPECT_FALSE(file_exist(tablet_metadata_filename(0, 1)));

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
@@ -41,6 +41,7 @@ import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.lake.LakeTableHelper;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.Utils;
+import com.starrocks.proto.AggregatePublishVersionRequest;
 import com.starrocks.proto.TxnInfoPB;
 import com.starrocks.proto.TxnTypePB;
 import com.starrocks.qe.OriginStatement;
@@ -678,6 +679,7 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
         try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
             OlapTable table = getTableOrThrow(db, tableId);
             boolean useAggregatePublish = table.isFileBundling();
+            AggregatePublishVersionRequest request = new AggregatePublishVersionRequest();
             for (long partitionId : physicalPartitionIdToRollupIndex.keySet()) {
                 PhysicalPartition physicalPartition = table.getPhysicalPartition(partitionId);
                 Preconditions.checkState(physicalPartition != null, partitionId);
@@ -695,9 +697,14 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
                 rollUpTxnInfo.commitTime = finishedTimeMs / 1000;
                 rollUpTxnInfo.txnType = TxnTypePB.TXN_NORMAL;
                 rollUpTxnInfo.gtid = watershedGtid;
-                // publish rollup tablets
-                Utils.publishVersion(physicalPartitionIdToRollupIndex.get(partitionId).getTablets(), rollUpTxnInfo,
-                        1, commitVersion, computeResource, useAggregatePublish);
+                if (!useAggregatePublish) {
+                    // publish rollup tablets
+                    Utils.publishVersion(physicalPartitionIdToRollupIndex.get(partitionId).getTablets(), rollUpTxnInfo,
+                            1, commitVersion, computeResource, false);
+                } else {
+                    Utils.createSubRequestForAggregatePublish(physicalPartitionIdToRollupIndex.get(partitionId).getTablets(), 
+                            Lists.newArrayList(rollUpTxnInfo), 1, commitVersion, null, computeResource, request);
+                }
 
                 TxnInfoPB originTxnInfo = new TxnInfoPB();
                 originTxnInfo.txnId = -1L;
@@ -705,10 +712,17 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
                 originTxnInfo.commitTime = finishedTimeMs / 1000;
                 originTxnInfo.txnType = TxnTypePB.TXN_EMPTY;
                 originTxnInfo.gtid = watershedGtid;
-                // publish origin tablets
-                Utils.publishVersion(allOtherPartitionTablets, originTxnInfo, commitVersion - 1,
-                        commitVersion, computeResource, useAggregatePublish);
-
+                if (!useAggregatePublish) {
+                    // publish origin tablets
+                    Utils.publishVersion(allOtherPartitionTablets, originTxnInfo, commitVersion - 1,
+                            commitVersion, computeResource, false);
+                } else {
+                    Utils.createSubRequestForAggregatePublish(allOtherPartitionTablets, Lists.newArrayList(originTxnInfo), 
+                            commitVersion - 1, commitVersion, null, computeResource, request);
+                }
+            }
+            if (useAggregatePublish) {
+                Utils.sendAggregatePublishVersionRequest(request, 1, computeResource, null, null);
             }
             return true;
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
@@ -159,7 +159,10 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
             OlapTable table = getTableOrThrow(db, tableId);
             Preconditions.checkState(table.getState() == OlapTable.OlapTableState.ROLLUP);
 
-            enableTabletCreationOptimization |= table.isFileBundling();
+            // disable tablet creation optimaization to avoid overwriting files with the same name.
+            if (table.isFileBundling()) {
+                enableTabletCreationOptimization = false;
+            }
             if (enableTabletCreationOptimization) {
                 numTablets = physicalPartitionIdToRollupIndex.size();
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -367,7 +367,10 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
             OlapTable table = getTableOrThrow(db, tableId);
             Preconditions.checkState(table.getState() == OlapTable.OlapTableState.SCHEMA_CHANGE);
 
-            enableTabletCreationOptimization |= table.isFileBundling();
+            // disable tablet creation optimaization to avoid overwriting files with the same name.
+            if (table.isFileBundling()) {
+                enableTabletCreationOptimization = false;
+            }
             if (enableTabletCreationOptimization) {
                 numTablets = physicalPartitionIndexMap.size();
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
@@ -221,12 +221,11 @@ public class Utils {
         return true;
     }
 
-    public static void aggregatePublishVersion(@NotNull List<Tablet> tablets, List<TxnInfoPB> txnInfos,
-                                               long baseVersion, long newVersion,
-                                               Map<Long, Double> compactionScores,
-                                               Map<ComputeNode, List<Long>> nodeToTablets,
-                                               ComputeResource computeResource,
-                                               Map<Long, Long> tabletRowNum) 
+    public static void createSubRequestForAggregatePublish(@NotNull List<Tablet> tablets, List<TxnInfoPB> txnInfos,
+                                                           long baseVersion, long newVersion,
+                                                           Map<ComputeNode, List<Long>> nodeToTablets,
+                                                           ComputeResource computeResource,
+                                                           AggregatePublishVersionRequest request)
             throws NoAliveBackendException, RpcException {
         if (nodeToTablets == null) {
             nodeToTablets = new HashMap<>();
@@ -256,13 +255,6 @@ public class Utils {
             throw new NoAliveBackendException("No alive node for handle publish version request in background warehouse");
         }
 
-        // choose one aggregator
-        LakeAggregator lakeAggregator = new LakeAggregator();
-        ComputeNode aggregatorNode = lakeAggregator.chooseAggregatorNode(computeResource);
-        if (aggregatorNode == null) {
-            throw new NoAliveBackendException("No alive compute node for handle aggregate publish version");
-        }
-        AggregatePublishVersionRequest request = new AggregatePublishVersionRequest();
         List<ComputeNodePB> computeNodes = new ArrayList<>();
         List<PublishVersionRequest> publishReqs = new ArrayList<>();
         for (Map.Entry<ComputeNode, List<Long>> entry : nodeToTablets.entrySet()) {
@@ -285,15 +277,45 @@ public class Utils {
             computeNodes.add(computeNodePB);
             publishReqs.add(singleReq);
         }
+        if (request.getComputeNodes() != null) {
+            List<ComputeNodePB> originalComputeNodes = new ArrayList<>(request.getComputeNodes());
+            computeNodes.addAll(originalComputeNodes);
+        }
+        if (request.getPublishReqs() != null) {
+            List<PublishVersionRequest> originalPublishReqs = new ArrayList<>(request.getPublishReqs());
+            publishReqs.addAll(originalPublishReqs);
+        }
+
         request.setComputeNodes(computeNodes);
-        request.setPublishReqs(publishReqs);
+        request.setPublishReqs(publishReqs);                
+    }
+
+    public static void sendAggregatePublishVersionRequest(AggregatePublishVersionRequest request,
+                                                          long baseVersion, ComputeResource computeResource,
+                                                          Map<Long, Double> compactionScores,
+                                                          Map<Long, Long> tabletRowNum) 
+            throws NoAliveBackendException, RpcException {
+        WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+        if (computeResource == null || !warehouseManager.isResourceAvailable(computeResource)) {
+            LOG.warn("publish version operation should be successful even if the warehouse is not exist, " +
+                    "and switch the warehouse id from {} to {}[{}]", computeResource,
+                    warehouseManager.getBackgroundWarehouse().getId(),
+                    warehouseManager.getBackgroundWarehouse().getName());
+            computeResource = warehouseManager.getBackgroundComputeResource();
+        }
+
+        // choose one aggregator
+        LakeAggregator lakeAggregator = new LakeAggregator();
+        ComputeNode aggregatorNode = lakeAggregator.chooseAggregatorNode(computeResource);
+        if (aggregatorNode == null) {
+            throw new NoAliveBackendException("No alive compute node for handle aggregate publish version");
+        }
 
         LakeService lakeService = BrpcProxy.getLakeService(aggregatorNode.getHost(), aggregatorNode.getBrpcPort());
         Future<PublishVersionResponse> future = lakeService.aggregatePublishVersion(request);
 
         try {
             PublishVersionResponse response = future.get();
-            
             if (response != null) {
                 TStatusCode code = TStatusCode.findByValue(response.status.statusCode);
                 if (code != TStatusCode.OK) {
@@ -313,6 +335,24 @@ public class Utils {
             }
         } catch (Exception e) {
             throw new RpcException(aggregatorNode.getHost(), e.getMessage());
+        }
+    }
+
+    public static void aggregatePublishVersion(@NotNull List<Tablet> tablets, List<TxnInfoPB> txnInfos,
+                                               long baseVersion, long newVersion,
+                                               Map<Long, Double> compactionScores,
+                                               Map<ComputeNode, List<Long>> nodeToTablets,
+                                               ComputeResource computeResource,
+                                               Map<Long, Long> tabletRowNum)
+            throws NoAliveBackendException, RpcException {
+        AggregatePublishVersionRequest request = new AggregatePublishVersionRequest();
+        try {
+            createSubRequestForAggregatePublish(tablets, txnInfos, baseVersion, newVersion,
+                                                nodeToTablets, computeResource, request);
+            sendAggregatePublishVersionRequest(request, baseVersion, computeResource, compactionScores,
+                                               tabletRowNum);
+        } catch (Exception e) {
+            throw e;
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

After enabling file_bundling, there are several bugs in alter tasks:

1. When file_bundling is enabled, an initial metadata file (000000_0000001.meta) is created during table creation. When executing an alter to create a new tablet, the same metadata file is also created, causing overwriting of duplicate-named metadata files.
2. When creating a Lake rollup with file_bundling enabled, tablets should be aggregated first, followed by a single aggregatePublish execution, rather than splitting into two operations.
3. In CN, the meta paths of tablets with file_bundling enabled are cached to reduce invalid get API calls. However, the cached paths are virtual paths provided by StarOS bound to the tablet ID, which prevents other tablets under the same partition from hitting the cache.

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/9831,  https://github.com/StarRocks/StarRocksTest/issues/9840,  https://github.com/StarRocks/StarRocksTest/issues/9842

1. Disable create bundle_metadata when doing alter job and create tablet metadata for each tablet. 
2. Aggregate publish version request first and run aggregatePublish once when adding lake rollup.
3. Using the real partition path as the cache key.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
