### PR TITLE
[Tool] add meta tool to print bundle tablet meta

### DIFF
--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -520,9 +520,6 @@ StatusOr<TabletMetadataPtr> TabletManager::get_single_tablet_metadata(int64_t ta
         offset = page_pointer.offset();
         size = page_pointer.size();
     }
-    if (offset + size > file_size) {
-        return Status::Corruption(fmt::format("failed to parse protobuf file {}", path));
-    }
 
     if (file_size < offset + size) {
         return Status::Corruption(

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -462,6 +462,27 @@ StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(const string& pat
     return metadata_or.value();
 }
 
+StatusOr<BundleTabletMetadataPtr> TabletManager::parse_bundle_tablet_metadata(const std::string& path,
+                                                                              const std::string& serialized_string) {
+    auto file_size = serialized_string.size();
+    auto footer_size = sizeof(uint64_t);
+    auto bundle_metadata_size = decode_fixed64_le((uint8_t*)(serialized_string.data() + file_size - footer_size));
+    if (file_size < footer_size + bundle_metadata_size) {
+        return Status::Corruption(
+                strings::Substitute("deserialized shared metadata($0) failed, file_size($1) < bundle_metadata_size($2)",
+                                    path, file_size, bundle_metadata_size + footer_size));
+    }
+
+    auto bundle_metadata = std::make_shared<BundleTabletMetadataPB>();
+    std::string_view bundle_metadata_str =
+            std::string_view(serialized_string.data() + file_size - footer_size - bundle_metadata_size);
+    if (!bundle_metadata->ParseFromArray(bundle_metadata_str.data(), bundle_metadata_size)) {
+        return Status::Corruption(strings::Substitute("deserialized shared metadata failed"));
+    }
+
+    return bundle_metadata;
+}
+
 DEFINE_FAIL_POINT(tablet_schema_not_found_in_bundle_metadata);
 StatusOr<TabletMetadataPtr> TabletManager::get_single_tablet_metadata(int64_t tablet_id, int64_t version,
                                                                       bool fill_cache, int64_t expected_gtid,
@@ -489,20 +510,7 @@ StatusOr<TabletMetadataPtr> TabletManager::get_single_tablet_metadata(int64_t ta
     ASSIGN_OR_RETURN(auto serialized_string, input_file->read_all());
 
     auto file_size = serialized_string.size();
-    auto footer_size = sizeof(uint64_t);
-    auto bundle_metadata_size = decode_fixed64_le((uint8_t*)(serialized_string.data() + file_size - footer_size));
-    if (file_size < footer_size + bundle_metadata_size) {
-        return Status::Corruption(
-                strings::Substitute("deserialized shared metadata($0) failed, file_size($1) < bundle_metadata_size($2)",
-                                    path, file_size, bundle_metadata_size + footer_size));
-    }
-
-    auto bundle_metadata = std::make_shared<BundleTabletMetadataPB>();
-    std::string_view bundle_metadata_str =
-            std::string_view(serialized_string.data() + file_size - footer_size - bundle_metadata_size);
-    if (!bundle_metadata->ParseFromArray(bundle_metadata_str.data(), bundle_metadata_size)) {
-        return Status::Corruption(strings::Substitute("deserialized shared metadata failed"));
-    }
+    ASSIGN_OR_RETURN(auto bundle_metadata, parse_bundle_tablet_metadata(path, serialized_string));
 
     auto meta_it = bundle_metadata->tablet_meta_pages().find(tablet_id);
     size_t offset = 0;

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -99,6 +99,9 @@ public:
                                                            int64_t expected_gtid = 0,
                                                            const std::shared_ptr<FileSystem>& fs = nullptr);
 
+    static StatusOr<BundleTabletMetadataPtr> parse_bundle_tablet_metadata(const std::string& path,
+                                                                          const std::string& serialized_string);
+
     TabletMetadataPtr get_latest_cached_tablet_metadata(int64_t tablet_id);
 
     StatusOr<TabletMetadataIter> list_tablet_metadata(int64_t tablet_id);

--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -1192,11 +1192,6 @@ int meta_tool_main(int argc, char** argv) {
                 return -1;
             }
 
-            if (file_size < offset + size) {
-                std::cerr << "Invalid page pointer for tablet " << page.first << ": offset + size exceeds file size\n";
-                return -1;
-            }
-
             auto metadata = std::make_shared<starrocks::TabletMetadataPB>();
             std::string_view metadata_str = std::string_view(input_data.data() + offset);
             if (!metadata->ParseFromArray(metadata_str.data(), size)) {

--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -57,6 +57,7 @@
 #include "storage/data_dir.h"
 #include "storage/delta_column_group.h"
 #include "storage/key_coder.h"
+#include "storage/lake/tablet_manager.h"
 #include "storage/lake/vacuum.h"
 #include "storage/olap_common.h"
 #include "storage/olap_define.h"
@@ -98,7 +99,7 @@ DEFINE_string(root_path, "", "storage root path");
 DEFINE_string(operation, "",
               "valid operation: get_meta, flag, load_meta, delete_meta, delete_rowset_meta, get_persistent_index_meta, "
               "delete_persistent_index_meta, show_meta, check_table_meta_consistency, print_lake_metadata, "
-              "print_lake_txn_log, print_lake_schema");
+              "print_lake_bundle_metadata, print_lake_txn_log, print_lake_schema");
 DEFINE_int64(tablet_id, 0, "tablet_id for tablet meta");
 DEFINE_string(tablet_uid, "", "tablet_uid for tablet meta");
 DEFINE_int64(table_id, 0, "table id for table meta");
@@ -165,6 +166,8 @@ std::string get_usage(const std::string& progname) {
       {progname} --operation=scan_dcgs --root_path=</path/to/storage/path> --tablet_id=<tabletid>
     print_lake_metadata:
       cat <tablet_meta_file.meta> | {progname} --operation=print_lake_metadata
+    print_lake_bundle_metadata:
+      cat <tablet_meta_file.meta> | {progname} --operation=print_lake_bundle_metadata
     print_lake_txn_log:
       cat <tablet_transaction_log_file.log> | {progname} --operation=print_lake_txn_log
     print_lake_schema:
@@ -1170,6 +1173,77 @@ int meta_tool_main(int argc, char** argv) {
             return -1;
         }
         std::cout << json << '\n';
+    } else if (FLAGS_operation == "print_lake_bundle_metadata") {
+        std::string input_data((std::istreambuf_iterator<char>(std::cin)), std::istreambuf_iterator<char>());
+        auto file_size = input_data.size();
+        auto bundle_metadata_or = starrocks::lake::TabletManager::parse_bundle_tablet_metadata("input", input_data);
+        if (!bundle_metadata_or.ok()) {
+            std::cerr << "Fail to parse bundle metadata: " << bundle_metadata_or.status() << '\n';
+            return -1;
+        }
+        const auto& bundle_metadata = bundle_metadata_or.value();
+        // foreach tablet_meta from bundle_metadata.tablet_meta_pages
+        for (const auto& page : bundle_metadata->tablet_meta_pages()) {
+            const starrocks::PagePointerPB& page_pointer = page.second;
+            auto offset = page_pointer.offset();
+            auto size = page_pointer.size();
+            if (offset + size > file_size) {
+                std::cerr << "Invalid page pointer for tablet " << page.first << ": offset + size exceeds file size\n";
+                return -1;
+            }
+
+            if (file_size < offset + size) {
+                std::cerr << "Invalid page pointer for tablet " << page.first << ": offset + size exceeds file size\n";
+                return -1;
+            }
+
+            auto metadata = std::make_shared<starrocks::TabletMetadataPB>();
+            std::string_view metadata_str = std::string_view(input_data.data() + offset);
+            if (!metadata->ParseFromArray(metadata_str.data(), size)) {
+                std::cerr << "Fail to parse tablet metadata for tablet " << page.first << '\n';
+                return -1;
+            }
+
+            int64_t tablet_id = page.first;
+            std::cout << "Tablet ID: " << tablet_id << '\n';
+            auto schema_id = bundle_metadata->tablet_to_schema().find(tablet_id);
+            if (schema_id == bundle_metadata->tablet_to_schema().end()) {
+                std::cerr << "tablet " << tablet_id
+                          << " metadata can not find schema in shared metadata, maybe the bundle is not complete\n";
+                return -1;
+            }
+            auto schema_it = bundle_metadata->schemas().find(schema_id->second);
+            if (schema_it == bundle_metadata->schemas().end()) {
+                std::cerr << "tablet " << tablet_id << " metadata can not find schema(" << schema_id->second
+                          << ") in shared metadata, maybe the bundle is not complete\n";
+                return -1;
+            } else {
+                metadata->mutable_schema()->CopyFrom(schema_it->second);
+                auto& item = (*metadata->mutable_historical_schemas())[schema_id->second];
+                item.CopyFrom(schema_it->second);
+            }
+
+            for (auto& [_, schema_id] : metadata->rowset_to_schema()) {
+                schema_it = bundle_metadata->schemas().find(schema_id);
+                if (schema_it == bundle_metadata->schemas().end()) {
+                    std::cerr << "rowset metadata can not find schema(" << schema_id
+                              << ") in shared metadata, maybe the bundle is not complete\n";
+                    return -1;
+                } else {
+                    auto& item = (*metadata->mutable_historical_schemas())[schema_id];
+                    item.CopyFrom(schema_it->second);
+                }
+            }
+            json2pb::Pb2JsonOptions options;
+            options.pretty_json = true;
+            std::string json;
+            std::string error;
+            if (!json2pb::ProtoMessageToJson(*metadata, &json, options, &error)) {
+                std::cerr << "Fail to convert protobuf to json: " << error << '\n';
+                return -1;
+            }
+            std::cout << json << '\n';
+        }
     } else if (FLAGS_operation == "print_lake_txn_log") {
         starrocks::TxnLogPB txn_log;
         if (!txn_log.ParseFromIstream(&std::cin)) {


### PR DESCRIPTION
## Why I'm doing:
Add meta tool `print_lake_bundle_metadata` to print bundle tablet meta.

## What I'm doing:
This pull request introduces functionality for parsing and printing bundle tablet metadata, refactors existing code for improved modularity, and updates the meta tool to support the new operation. The most significant changes include adding a new method for parsing bundle tablet metadata, refactoring code in `TabletManager::get_single_tablet_metadata` to use the new method, and extending the meta tool to handle the `print_lake_bundle_metadata` operation.

### Parsing and refactoring bundle tablet metadata:

* **Added `parse_bundle_tablet_metadata` method**: Introduced a static method in `TabletManager` to parse bundle tablet metadata from a serialized string, improving modularity and code reuse. (`be/src/storage/lake/tablet_manager.cpp`, [[1]](diffhunk://#diff-7ef17df66d403c7205ba4ad1aaebf6f057523b94980151564e1bcf0b657bf1b4R465-R485); `be/src/storage/lake/tablet_manager.h`, [[2]](diffhunk://#diff-b77a64b082da0ac0fd8b28d7f521dbe7e1d235289127491a7aa865f774a6446bR102-R104)
* **Refactored `get_single_tablet_metadata`**: Updated the method to use `parse_bundle_tablet_metadata` for parsing bundle metadata, simplifying the implementation and reducing redundancy. (`be/src/storage/lake/tablet_manager.cpp`, [be/src/storage/lake/tablet_manager.cppL492-R513](diffhunk://#diff-7ef17df66d403c7205ba4ad1aaebf6f057523b94980151564e1bcf0b657bf1b4L492-R513))

### Meta tool enhancements:

* **Added `print_lake_bundle_metadata` operation**: Extended the meta tool to include a new operation for printing bundle tablet metadata, allowing users to parse and display metadata in JSON format. (`be/src/tools/meta_tool.cpp`, [[1]](diffhunk://#diff-3f296e98e8e57359f4e1a2c482313ed695c00d30731eb106c4f36c0328aadf95L101-R102) [[2]](diffhunk://#diff-3f296e98e8e57359f4e1a2c482313ed695c00d30731eb106c4f36c0328aadf95R169-R170) [[3]](diffhunk://#diff-3f296e98e8e57359f4e1a2c482313ed695c00d30731eb106c4f36c0328aadf95R1176-R1246)
* **Included `tablet_manager.h`**: Added the necessary header file to support the new functionality in the meta tool. (`be/src/tools/meta_tool.cpp`, [be/src/tools/meta_tool.cppR60](diffhunk://#diff-3f296e98e8e57359f4e1a2c482313ed695c00d30731eb106c4f36c0328aadf95R60))

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
