### PR TITLE
[Enhancement] Add database name to PartitionBasedMvRefreshProcessor logs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -803,7 +803,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
             Optional<Table> optTable = MvUtils.getTable(baseTableInfo);
             if (optTable.isEmpty()) {
-                logger.warn("table {} do not exist when refreshing materialized view", baseTableInfo.getTableInfoStr());
+                logger.warn("table {}.{} do not exist when refreshing materialized view", baseTableInfo.getDbName(),
+                        baseTableInfo.getTableInfoStr());
                 mv.setInactiveAndReason(
                         MaterializedViewExceptions.inactiveReasonForBaseTableNotExists(baseTableInfo.getTableName()));
                 throw new DmlException("Materialized view base table: %s not exist.", baseTableInfo.getTableInfoStr());
@@ -838,7 +839,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             // check new table
             Optional<Table> optNewTable = MvUtils.getTable(baseTableInfo);
             if (optNewTable.isEmpty()) {
-                logger.warn("table {} does not exist after refreshing materialized view", baseTableInfo.getTableInfoStr());
+                logger.warn("table {}.{} does not exist after refreshing materialized view", baseTableInfo.getDbName(),
+                        baseTableInfo.getTableInfoStr());
                 mv.setInactiveAndReason(
                         MaterializedViewExceptions.inactiveReasonForBaseTableNotExists(baseTableInfo.getTableName()));
                 throw new DmlException("Materialized view base table: %s not exist.", baseTableInfo.getTableInfoStr());
@@ -1246,7 +1248,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             for (BaseTableInfo baseTableInfo : baseTableInfos) {
                 Optional<Table> tableOpt = MvUtils.getTableWithIdentifier(baseTableInfo);
                 if (tableOpt.isEmpty()) {
-                    logger.warn("table {} doesn't exist", baseTableInfo.getTableInfoStr());
+                    logger.warn("table {}.{} doesn't exist", baseTableInfo.getDbName(), baseTableInfo.getTableInfoStr());
                     throw new DmlException("Materialized view base table: %s not exist.",
                             baseTableInfo.getTableInfoStr());
                 }
@@ -1336,8 +1338,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                     // It's ok to add empty set for a table, means no partition corresponding to this mv partition
                     needRefreshTablePartitionNames.addAll(mvToBaseNameRef.get(snapshotTable));
                 } else {
-                    logger.info("ref-base-table {} is not found in `mvRefBaseTableIntersectedPartitions` " +
-                            "because of empty update", snapshotTable.getName());
+                    logger.info("ref-base-table {}.{} is not found in `mvRefBaseTableIntersectedPartitions` " +
+                            "because of empty update", snapshotInfo.getBaseTableInfo().getDbName(), snapshotTable.getName());
                 }
             }
             if (needRefreshTablePartitionNames != null) {
@@ -1384,8 +1386,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 Partition partition = olapTable.getPartition(partitionName);
                 // it's ok to skip because only existed partitions are updated in the version map.
                 if (partition == null) {
-                    logger.warn("partition {} not found in base table {}, refreshedPartitionNames:{}",
-                            partitionName, baseTable.getName(), refreshedPartitionNames);
+                    logger.warn("partition {} not found in base table {}.{}, refreshedPartitionNames:{}",
+                            partitionName, baseTableInfo.getDbName(), baseTable.getName(), refreshedPartitionNames);
                     continue;
                 }
                 MaterializedView.BasePartitionInfo basePartitionInfo = new MaterializedView.BasePartitionInfo(
@@ -1395,7 +1397,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 partitionInfos.put(partition.getName(), basePartitionInfo);
             }
             if (logger.isDebugEnabled()) {
-                logger.debug("Collect olap base table {}'s refreshed partition infos: {}", baseTable.getName(), partitionInfos);
+                logger.debug("Collect olap base table {}.{}'s refreshed partition infos: {}", baseTableInfo.getDbName(),
+                        baseTable.getName(), partitionInfos);
             }
             return partitionInfos;
         } else if (MVPCTRefreshPartitioner.isPartitionRefreshSupported(baseTable)) {
@@ -1403,7 +1406,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         } else {
             // FIXME: base table does not support partition-level refresh and does not update the meta
             //  in materialized view.
-            logger.warn("refresh mv with non-supported-partition-level refresh base table {}", baseTable.getName());
+            logger.warn("refresh mv with non-supported-partition-level refresh base table {}.{}", baseTableInfo.getDbName(),
+                    baseTable.getName());
             return Maps.newHashMap();
         }
     }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:
This PR addresses Issue #59948 ↗ by including the database name in log messages generated by ‎`PartitionBasedMvRefreshProcessor`. Previously, log entries only displayed the table name, which made it difficult to distinguish between tables with the same name in different databases (schemas), especially in multi-tenant scenarios. With this enhancement, logs now include both the database and table name, making it easier to identify the exact source of each log entry and improving troubleshooting and traceability.
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3