### PR TITLE
[Feature] record dummy warehouse info after table's loading

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
@@ -69,12 +69,14 @@ public class LakeTableHelper {
         table.removeTableBinds(replay);
         if (replay) {
             table.removeTabletsFromInvertedIndex();
+            GlobalStateMgr.getCurrentState().getWarehouseMgr().removeTableWarehouseInfo(table.getId());
             return true;
         }
         LakeTableCleaner cleaner = new LakeTableCleaner(table);
         boolean succ = cleaner.cleanTable();
         if (succ) {
             table.removeTabletsFromInvertedIndex();
+            GlobalStateMgr.getCurrentState().getWarehouseMgr().removeTableWarehouseInfo(table.getId());
         }
         return succ;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
@@ -65,6 +65,7 @@ public class WarehouseManager implements Writable {
 
     public static final String DEFAULT_WAREHOUSE_NAME = "default_warehouse";
     public static final long DEFAULT_WAREHOUSE_ID = 0L;
+    public static final long INVALID_WAREHOUSE_ID = -1L;
 
     // default compute resource
     public static final ComputeResource DEFAULT_RESOURCE = WarehouseComputeResource.DEFAULT;
@@ -343,6 +344,14 @@ public class WarehouseManager implements Writable {
 
     public void alterCnGroup(AlterCnGroupStmt stmt) throws DdlException {
         throw new DdlException("CnGroup is not implemented");
+    }
+
+    public void recordWarehouseInfoForTable(long tableId, long warehouseId) {
+
+    }
+
+    public void removeTableWarehouseInfo(long tableId) {
+
     }
 
     public Set<String> getAllWarehouseNames() {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
@@ -24,6 +24,7 @@ import com.starrocks.lake.compaction.CompactionTxnCommitAttachment;
 import com.starrocks.lake.compaction.PartitionIdentifier;
 import com.starrocks.lake.compaction.Quantiles;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -120,6 +121,11 @@ public class LakeTableTxnLogApplier implements TransactionLogApplier {
                 dictCollectedVersions = partitionCommitInfo.getDictCollectedVersions();
             }
             maxPartitionVersionTime = Math.max(maxPartitionVersionTime, versionTime);
+        }
+
+        if (txnState.getSourceType() != TransactionState.LoadJobSourceType.LAKE_COMPACTION) {
+            WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+            warehouseManager.recordWarehouseInfoForTable(tableId, txnState.getWarehouseId());
         }
 
         if (!GlobalStateMgr.isCheckpointThread() && dictCollectedVersions.size() == validDictCacheColumns.size()) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

add dummy api in starrocks to manage warehouse info for table's load transaction.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
