### PR TITLE
[BugFix] fix initial tablet meta read when only provide full path

### DIFF
--- a/be/src/storage/lake/filenames.h
+++ b/be/src/storage/lake/filenames.h
@@ -214,4 +214,13 @@ inline std::string_view basename(std::string_view path) {
     return path.substr(path.find_last_of('/') + 1);
 }
 
+// get prefix name
+inline std::string_view prefix_name(std::string_view path) {
+    auto pos = path.find_last_of('/');
+    if (pos == std::string_view::npos) {
+        return path;
+    }
+    return path.substr(0, pos);
+}
+
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -394,21 +394,13 @@ StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(int64_t tablet_id
                                                                const std::shared_ptr<FileSystem>& fs) {
     StatusOr<TabletMetadataPtr> tablet_metadata_or;
     // There are several possible cases for getting tablet metadata:
-    // 1. If the partition is an bundle partition (in cache), and version is kInitialVersion
-    //    then we will read the initial metadata from the initial metadata location.
-    // 2. If the partition is an bundle partition (in cache), and version is not kInitialVersion
+    // 1. If the partition is an bundle partition (in cache),
     //    then we will first try to read the metadata from the bundle metadata location,
     //    if not found, then we will read the metadata from the single tablet metadata.
-    // 3. If the partition is not an bundle partition (not in cache), then we will read the metadata from the single
-    //    tablet metadata location.
+    // 2. If the partition is not an bundle partition (not in cache),
+    //    then we will read the metadata from the single tablet metadata location.
     if (_metacache->lookup_aggregation_partition(tablet_metadata_root_location(tablet_id))) {
-        if (version == kInitialVersion) {
-            // Handle tablet initial metadata
-            tablet_metadata_or =
-                    get_tablet_metadata(tablet_initial_metadata_location(tablet_id), fill_cache, expected_gtid, fs);
-        } else {
-            tablet_metadata_or = get_single_tablet_metadata(tablet_id, version, fill_cache, expected_gtid, fs);
-        }
+        tablet_metadata_or = get_single_tablet_metadata(tablet_id, version, fill_cache, expected_gtid, fs);
         if (tablet_metadata_or.status().is_not_found()) {
             tablet_metadata_or =
                     get_tablet_metadata(tablet_metadata_location(tablet_id, version), fill_cache, expected_gtid, fs);

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -393,6 +393,17 @@ StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(int64_t tablet_id
                                                                int64_t expected_gtid,
                                                                const std::shared_ptr<FileSystem>& fs) {
     StatusOr<TabletMetadataPtr> tablet_metadata_or;
+    // There are several possible cases for getting tablet metadata:
+    // 1. If the partition is an bundle partition (in cache), and version is kInitialVersion
+    //    then we will read the initial metadata from the initial metadata location.
+    // 2. If the partition is an bundle partition (in cache), and version is not kInitialVersion
+    //    then we will first try to read the metadata from the bundle metadata location,
+    //    if not found, then we will read the metadata from the tablet metadata.
+    //    That is because bundle file table may be altered, so bundle partition cache may wasn't correct.
+    // 3. If the partition is not an bundle partition (not in cache), then we will read the metadata from the tablet
+    //    metadata location directly.
+    //    If not found, then we will read the metadata from the tablet initial metadata location,
+    //    That is also because bundle file table may be altered, so bundle partition cache may wasn't correct.
     if (_metacache->lookup_aggregation_partition(tablet_metadata_root_location(tablet_id))) {
         if (version == kInitialVersion) {
             // Handle tablet initial metadata
@@ -408,17 +419,6 @@ StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(int64_t tablet_id
     } else {
         tablet_metadata_or =
                 get_tablet_metadata(tablet_metadata_location(tablet_id, version), fill_cache, expected_gtid, fs);
-        if (!tablet_metadata_or.status().is_not_found()) {
-            return tablet_metadata_or;
-        }
-        if (tablet_metadata_or.status().is_not_found() && version == kInitialVersion) {
-            // Handle tablet initial metadata
-            tablet_metadata_or =
-                    get_tablet_metadata(tablet_initial_metadata_location(tablet_id), fill_cache, expected_gtid, fs);
-        } else if (tablet_metadata_or.status().is_not_found()) {
-            // get single tablet metadata
-            tablet_metadata_or = get_single_tablet_metadata(tablet_id, version, fill_cache, expected_gtid, fs);
-        }
     }
 
     if (!tablet_metadata_or.ok()) {
@@ -449,6 +449,12 @@ StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(const string& pat
         if (metadata_or.status().is_not_found()) {
             metadata_or = get_single_tablet_metadata(tablet_id, version, fill_cache, expected_gtid, fs);
         }
+    }
+
+    if (metadata_or.status().is_not_found() && tablet_id != 0 && version == kInitialVersion) {
+        // If the metadata is not found, we will try to read the initial metadata at least
+        std::string new_path = join_path(prefix_name(path), tablet_initial_metadata_filename());
+        metadata_or = get_tablet_metadata(new_path, fill_cache, expected_gtid, fs);
     }
 
     if (!metadata_or.ok()) {

--- a/be/test/storage/lake/starlet_location_provider_test.cpp
+++ b/be/test/storage/lake/starlet_location_provider_test.cpp
@@ -62,6 +62,7 @@ TEST_F(StarletLocationProviderTest, test_location) {
     location = base_provider->tablet_initial_metadata_location(12345);
     std::string_view filename = basename(location);
     EXPECT_TRUE(is_tablet_initial_metadata(filename));
+    EXPECT_TRUE(location == join_path(prefix_name(location), tablet_initial_metadata_filename()));
 }
 
 TEST_F(StarletLocationProviderTest, test_get_real_location) {

--- a/be/test/storage/lake/starlet_location_provider_test.cpp
+++ b/be/test/storage/lake/starlet_location_provider_test.cpp
@@ -64,6 +64,7 @@ TEST_F(StarletLocationProviderTest, test_location) {
     std::string_view filename = basename(location);
     EXPECT_TRUE(is_tablet_initial_metadata(filename));
     EXPECT_TRUE(location == join_path(prefix_name(location), tablet_initial_metadata_filename()));
+    EXPECT_TRUE("abcdefg" == prefix_name("abcdefg"));
 }
 
 TEST_F(StarletLocationProviderTest, test_get_real_location) {

--- a/be/test/storage/lake/starlet_location_provider_test.cpp
+++ b/be/test/storage/lake/starlet_location_provider_test.cpp
@@ -22,6 +22,7 @@
 #include "fs/fs_starlet.h"
 #include "service/staros_worker.h"
 #include "storage/lake/filenames.h"
+#include "storage/lake/join_path.h"
 #include "testutil/assert.h"
 #include "testutil/id_generator.h"
 #include "util/defer_op.h"

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -686,6 +686,23 @@ TEST_F(LakeTabletManagerTest, put_bundle_tablet_metadata) {
     EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata4));
     auto res = _tablet_manager->get_tablet_metadata(3, 3);
     ASSERT_TRUE(res.ok());
+
+    // get initial tablet meta by path
+    starrocks::TabletMetadata metadata5;
+    {
+        metadata5.set_id(4);
+        metadata5.set_version(1);
+        metadata5.mutable_schema()->CopyFrom(schema_pb1);
+        auto& item1 = (*metadata5.mutable_historical_schemas())[10];
+        item1.CopyFrom(schema_pb1);
+        auto& item2 = (*metadata5.mutable_historical_schemas())[12];
+        item2.CopyFrom(schema_pb3);
+    }
+    // put initial tablet meta
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(std::make_shared<starrocks::TabletMetadata>(metadata5),
+                                                   _tablet_manager->tablet_initial_metadata_location(metadata5.id())));
+    ASSERT_TRUE(_tablet_manager->get_tablet_metadata(4, 1).ok());
+    ASSERT_TRUE(_tablet_manager->get_tablet_metadata(_tablet_manager->tablet_metadata_location(4, 1)).ok());
 }
 
 TEST_F(LakeTabletManagerTest, cache_tablet_metadata) {


### PR DESCRIPTION
## Why I'm doing:
If conf `lake_enable_tablet_creation_optimization` was true, then we will only create one tablet meta named `000000...0000_0000...00001.meta` for one partition.
And current this function `get_tablet_metadata`:
```
StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(const string& path, bool fill_cache,
                                                               int64_t expected_gtid,
                                                               const std::shared_ptr<FileSystem>& fs)
```
Can't handle it. For example, if I want to read the tablet meta with tablet ID 123 and version 1, the input tablet path might be something like `000...7B_000...1.meta`. However, the actual filename stored in the object storage is `000...00_000...1.meta`. Therefore, in the final stage, we need to transform the file path that failed to be read in order to access the correct meta file.

## What I'm doing:
This pull request introduces enhancements to metadata handling in the Lake storage module, including new utility functions, improved logic for retrieving tablet metadata, and additional test cases to validate the changes.

### Metadata Handling Enhancements:

* **New Utility Function for Path Manipulation**:
  Added the `prefix_name` function in `filenames.h` to extract the prefix of a file path, complementing the existing `basename` function. This utility is used in subsequent metadata retrieval logic.

* **Improved Tablet Metadata Retrieval Logic**:
  Refactored the `TabletManager::get_tablet_metadata` method to handle multiple scenarios for retrieving metadata based on partition type, version, and cache status. This includes fallback mechanisms for reading initial metadata when standard metadata is not found. [[1]](diffhunk://#diff-7ef17df66d403c7205ba4ad1aaebf6f057523b94980151564e1bcf0b657bf1b4R396-R406) [[2]](diffhunk://#diff-7ef17df66d403c7205ba4ad1aaebf6f057523b94980151564e1bcf0b657bf1b4L411-L421) [[3]](diffhunk://#diff-7ef17df66d403c7205ba4ad1aaebf6f057523b94980151564e1bcf0b657bf1b4R454-R459)

### Testing Enhancements:

* **Extended Unit Tests for Metadata Retrieval**:
  Updated test cases in `tablet_manager_test.cpp` to validate the retrieval of initial tablet metadata using the new logic and `prefix_name` function. This ensures correctness in handling edge cases.

* **Validation of Path Manipulation**:
  Added assertions in `starlet_location_provider_test.cpp` to confirm the correctness of `prefix_name` and its integration with metadata location generation.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
