### PR TITLE
[Feature] Support marking data files as shared in tablet metadata and skipping to delete shared data files in vacuum, leaving them for full gc to clean up

### DIFF
--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -44,7 +44,7 @@ public:
                     const std::vector<std::vector<ColumnUID>>& unique_column_id_list);
     // handle txn log
     void apply_opwrite(const TxnLogPB_OpWrite& op_write, const std::map<int, FileInfo>& replace_segments,
-                       const std::vector<std::string>& orphan_files);
+                       const std::vector<FileMetaPB>& orphan_files);
     void apply_column_mode_partial_update(const TxnLogPB_OpWrite& op_write);
     void apply_opcompaction(const TxnLogPB_OpCompaction& op_compaction, uint32_t max_compact_input_rowset_id,
                             int64_t output_rowset_schema_id);

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -128,6 +128,9 @@ Status Rowset::add_partial_compaction_segments_info(TxnLogPB_OpCompaction* op_co
             op_compaction->mutable_output_rowset()->add_segment_encryption_metas(
                     metadata().segment_encryption_metas(i));
         }
+        if (metadata().shared_segments_size() > 0) {
+            op_compaction->mutable_output_rowset()->add_shared_segments(metadata().shared_segments(i));
+        }
 
         uncompacted_num_rows += already_compacted_segments[i]->num_rows();
         uncompacted_data_size += file_size;
@@ -139,6 +142,9 @@ Status Rowset::add_partial_compaction_segments_info(TxnLogPB_OpCompaction* op_co
         op_compaction->mutable_output_rowset()->add_segments(file.path);
         op_compaction->mutable_output_rowset()->add_segment_size(file.size.value());
         op_compaction->mutable_output_rowset()->add_segment_encryption_metas(file.encryption_meta);
+        if (metadata().shared_segments_size() > 0) {
+            op_compaction->mutable_output_rowset()->add_shared_segments(false);
+        }
     }
     op_compaction->set_new_segment_count(writer->files().size());
 
@@ -163,6 +169,9 @@ Status Rowset::add_partial_compaction_segments_info(TxnLogPB_OpCompaction* op_co
         if (!clear_encryption_meta) {
             op_compaction->mutable_output_rowset()->add_segment_encryption_metas(
                     metadata().segment_encryption_metas(i));
+        }
+        if (metadata().shared_segments_size() > 0) {
+            op_compaction->mutable_output_rowset()->add_shared_segments(metadata().shared_segments(i));
         }
 
         uncompacted_num_rows += uncompacted_segments[idx]->num_rows();

--- a/be/src/storage/lake/rowset_update_state.h
+++ b/be/src/storage/lake/rowset_update_state.h
@@ -157,7 +157,7 @@ public:
 
     // Handle `segment_id`-th segment file's partial update request.
     Status rewrite_segment(uint32_t segment_id, int64_t txn_id, const RowsetUpdateStateParams& params,
-                           std::map<int, FileInfo>* replace_segments, std::vector<std::string>* orphan_files);
+                           std::map<int, FileInfo>* replace_segments, std::vector<FileMetaPB>* orphan_files);
 
     // Release `segment_id`-th segment file's state.
     void release_segment(uint32_t segment_id);

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -139,6 +139,7 @@ public:
                 FileMetaPB file_meta;
                 file_meta.set_name(sstable.filename());
                 file_meta.set_size(sstable.filesize());
+                file_meta.set_shared(sstable.shared());
                 _metadata->mutable_orphan_files()->Add(std::move(file_meta));
             }
             _metadata->clear_sstable_meta();

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -225,7 +225,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     DeferOp remove_state_entry([&] { _update_state_cache.remove(state_entry); });
     auto& state = state_entry->value();
 
-    std::vector<std::string> orphan_files;
+    std::vector<FileMetaPB> orphan_files;
     std::map<int, FileInfo> replace_segments;
     RssidFileInfoContainer rssid_fileinfo_container;
     rssid_fileinfo_container.add_rssid_to_file(*metadata);

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -262,7 +262,7 @@ TEST_F(MetaFileTest, test_dcg) {
         rowset_metadata.add_segments("aaa.dat");
         TxnLogPB_OpWrite op_write;
         std::map<int, FileInfo> replace_segments;
-        std::vector<std::string> orphan_files;
+        std::vector<FileMetaPB> orphan_files;
         op_write.mutable_rowset()->CopyFrom(rowset_metadata);
         builder.apply_opwrite(op_write, replace_segments, orphan_files);
         Status st = builder.finalize(next_id());
@@ -439,7 +439,7 @@ TEST_F(MetaFileTest, test_unpersistent_del_files_when_compact) {
         rowset_metadata.add_segments("aaa.dat");
         TxnLogPB_OpWrite op_write;
         std::map<int, FileInfo> replace_segments;
-        std::vector<std::string> orphan_files;
+        std::vector<FileMetaPB> orphan_files;
         op_write.mutable_rowset()->CopyFrom(rowset_metadata);
         builder.apply_opwrite(op_write, replace_segments, orphan_files);
         Status st = builder.finalize(next_id());
@@ -459,7 +459,7 @@ TEST_F(MetaFileTest, test_unpersistent_del_files_when_compact) {
         rowset_metadata.add_del_files()->CopyFrom(delfile);
         TxnLogPB_OpWrite op_write;
         std::map<int, FileInfo> replace_segments;
-        std::vector<std::string> orphan_files;
+        std::vector<FileMetaPB> orphan_files;
         op_write.mutable_rowset()->CopyFrom(rowset_metadata);
         builder.apply_opwrite(op_write, replace_segments, orphan_files);
         PersistentIndexSstablePB sstable;
@@ -501,7 +501,7 @@ TEST_F(MetaFileTest, test_unpersistent_del_files_when_compact) {
         rowset_metadata.add_segments("ddd.dat");
         TxnLogPB_OpWrite op_write;
         std::map<int, FileInfo> replace_segments;
-        std::vector<std::string> orphan_files;
+        std::vector<FileMetaPB> orphan_files;
         op_write.mutable_rowset()->CopyFrom(rowset_metadata);
         builder.apply_opwrite(op_write, replace_segments, orphan_files);
         PersistentIndexSstablePB sstable;

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -43,6 +43,8 @@ message DelvecCacheKeyPB {
 message FileMetaPB {
     optional string name = 1;
     optional int64 size = 2;
+    // Whether this file shared by multiple tablets
+    optional bool shared = 3 [default=false];
 }
 
 message DelvecMetadataPB {
@@ -60,6 +62,8 @@ message DeltaColumnGroupVerPB {
     // To do conflict check with compaction task
     repeated int64 versions = 3;
     repeated bytes encryption_metas = 4;
+    // Whether files are shared by multiple tablets
+    repeated bool shared_files = 5;
 }
 
 message DeltaColumnGroupMetadataPB {
@@ -86,6 +90,8 @@ message DelfileWithRowsetId {
     //      And rssid of them will be rowset_id + [0, 0].
     optional uint32 op_offset = 3;
     optional bytes encryption_meta = 4;
+    // Whether this file shared by multiple tablets
+    optional bool shared = 5 [default=false];
 }
 
 message RowsetMetadataPB {
@@ -110,6 +116,8 @@ message RowsetMetadataPB {
     // only be set > 0 if `overlapped` is true
     optional uint32 next_compaction_offset = 13;
     repeated int64 bundle_file_offsets = 14;
+    // Whether segments are shared by multiple tablets
+    repeated bool shared_segments = 15;
 }
 
 // At present, the lake persistent index reuses the logic of the persistent index,

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -200,6 +200,8 @@ message PersistentIndexSstablePB {
     // used for rebuild point of persistent index
     optional uint64 max_rss_rowid = 4;
     optional bytes encryption_meta = 5;
+    // Whether this file shared by multiple tablets
+    optional bool shared = 6 [default=false];
 }
 
 message PersistentIndexSstableMetaPB {


### PR DESCRIPTION
## Why I'm doing:
This is a preliminary work for tablet splitting and merging.
When an old tablet is split to two new tablets, the two new tablets will share all the data files (segment files, delvec files, cloud-native pk index files ...). These shared data files need to be marked as shared in tablet metadata for skipping to delete them in vacuum,  leaving them for full gc to clean up.

## What I'm doing:
Support marking data files as shared in tablet metadata and skipping to delete shared data files in vacuum, leaving them for full gc to clean up.

Fixes https://github.com/StarRocks/starrocks/issues/59134

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
