### PR TITLE
[BugFix] fix range partition prune when table has empty partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PartitionColumnMinMaxRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PartitionColumnMinMaxRewriteRule.java
@@ -47,6 +47,8 @@ import com.starrocks.sql.optimizer.rule.RuleType;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.NotImplementedException;
 
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -222,7 +224,7 @@ public class PartitionColumnMinMaxRewriteRule extends TransformationRule {
         PartitionInfo partitionInfo = table.getPartitionInfo();
         Set<Long> nullPartitions = partitionInfo.getNullValuePartitions();
 
-        List<Long> pruned = Lists.newArrayList();
+        Set<Long> prunedSet = new LinkedHashSet<>();
         if (hasMinMax.first) {
             List<Long> sorted = partitionInfo.getSortedPartitions(true);
             sorted.retainAll(nonEmptyPartitionIds);
@@ -230,7 +232,7 @@ public class PartitionColumnMinMaxRewriteRule extends TransformationRule {
                 return null;
             }
             for (long partitionId : sorted) {
-                pruned.add(partitionId);
+                prunedSet.add(partitionId);
                 // at least reserve one non-null partition, null-partition might be useless
                 if (!nullPartitions.contains(partitionId)) {
                     break;
@@ -245,7 +247,7 @@ public class PartitionColumnMinMaxRewriteRule extends TransformationRule {
                 return null;
             }
             for (long partitionId : sorted) {
-                pruned.add(partitionId);
+                prunedSet.add(partitionId);
                 // at least reserve one non-null partition, null-partition might be useless
                 if (!nullPartitions.contains(partitionId)) {
                     break;
@@ -253,6 +255,7 @@ public class PartitionColumnMinMaxRewriteRule extends TransformationRule {
             }
         }
 
+        List<Long> pruned = new ArrayList<>(prunedSet);
         LogicalOlapScanOperator scan = new LogicalOlapScanOperator.Builder()
                 .withOperator(scanOperator)
                 .setSelectedPartitionId(pruned)


### PR DESCRIPTION
## Why I'm doing:

the root cause of this [issue](https://github.com/StarRocks/starrocks/pull/60040) is that we did not deduplicate the prune partition ids. It will be triggered when the following conditions are met.
1. olap table with range partition
2. table has empty partition
3. query has both min and max aggregation function.

## What I'm doing:
When there is min/max in the query, we deduplicate the pruned partitions.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
