### PR TITLE
[BugFix] Fix child class loader of jni readers

### DIFF
--- a/java-extensions/common-runtime/pom.xml
+++ b/java-extensions/common-runtime/pom.xml
@@ -19,7 +19,6 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>bundle</artifactId>
-            <version>${aws-v2-sdk.version}</version>
         </dependency>
     </dependencies>
 

--- a/java-extensions/hadoop-lib/pom.xml
+++ b/java-extensions/hadoop-lib/pom.xml
@@ -18,6 +18,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-aws</artifactId>
         </dependency>

--- a/java-extensions/hadoop-lib/pom.xml
+++ b/java-extensions/hadoop-lib/pom.xml
@@ -18,11 +18,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-aws</artifactId>
         </dependency>

--- a/java-extensions/hive-reader/pom.xml
+++ b/java-extensions/hive-reader/pom.xml
@@ -33,11 +33,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-aws</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
         </dependency>

--- a/java-extensions/hive-reader/src/main/java/com/starrocks/hive/reader/HiveScannerFactory.java
+++ b/java-extensions/hive-reader/src/main/java/com/starrocks/hive/reader/HiveScannerFactory.java
@@ -17,24 +17,11 @@ package com.starrocks.hive.reader;
 import com.starrocks.jni.connector.ScannerFactory;
 import com.starrocks.jni.connector.ScannerHelper;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-
 public class HiveScannerFactory implements ScannerFactory {
     static ClassLoader classLoader;
 
     static {
-        String basePath = System.getenv("STARROCKS_HOME");
-        List<File> preloadFiles = new ArrayList<>();
-        preloadFiles.add(new File(basePath + "/lib/jni-packages/starrocks-hadoop-ext.jar"));
-        File dir = new File(basePath + "/lib/hive-reader-lib");
-        preloadFiles.addAll(Arrays.asList(Objects.requireNonNull(dir.listFiles())));
-        dir = new File(basePath + "/lib/common-runtime-lib");
-        preloadFiles.addAll(Arrays.asList(Objects.requireNonNull(dir.listFiles())));
-        classLoader = ScannerHelper.createChildFirstClassLoader(preloadFiles, "hive scanner");
+        classLoader = ScannerHelper.createModuleClassLoader("hive-reader-lib");
     }
 
     @Override

--- a/java-extensions/hudi-reader/pom.xml
+++ b/java-extensions/hudi-reader/pom.xml
@@ -36,11 +36,6 @@
 
         <dependency>
             <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-aws</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-core</artifactId>
         </dependency>
 

--- a/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiSliceScannerFactory.java
+++ b/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiSliceScannerFactory.java
@@ -17,24 +17,11 @@ package com.starrocks.hudi.reader;
 import com.starrocks.jni.connector.ScannerFactory;
 import com.starrocks.jni.connector.ScannerHelper;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-
 public class HudiSliceScannerFactory implements ScannerFactory {
     static ClassLoader classLoader;
 
     static {
-        String basePath = System.getenv("STARROCKS_HOME");
-        List<File> preloadFiles = new ArrayList<>();
-        preloadFiles.add(new File(basePath + "/lib/jni-packages/starrocks-hadoop-ext.jar"));
-        File dir = new File(basePath + "/lib/hudi-reader-lib");
-        preloadFiles.addAll(Arrays.asList(Objects.requireNonNull(dir.listFiles())));
-        dir = new File(basePath + "/lib/common-runtime-lib");
-        preloadFiles.addAll(Arrays.asList(Objects.requireNonNull(dir.listFiles())));
-        classLoader = ScannerHelper.createChildFirstClassLoader(preloadFiles, "hudi scanner");
+        classLoader = ScannerHelper.createModuleClassLoader("hudi-reader-lib");
     }
 
     /**

--- a/java-extensions/iceberg-metadata-reader/pom.xml
+++ b/java-extensions/iceberg-metadata-reader/pom.xml
@@ -29,11 +29,6 @@
 
         <dependency>
             <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-aws</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
         </dependency>
 

--- a/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/IcebergMetadataScannerFactory.java
+++ b/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/IcebergMetadataScannerFactory.java
@@ -17,22 +17,11 @@ package com.starrocks.connector.iceberg;
 import com.starrocks.jni.connector.ScannerFactory;
 import com.starrocks.jni.connector.ScannerHelper;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-
 public class IcebergMetadataScannerFactory implements ScannerFactory {
     static ClassLoader classLoader;
 
     static {
-        String basePath = System.getenv("STARROCKS_HOME");
-        File dir = new File(basePath + "/lib/iceberg-reader-lib");
-        List<File> preloadFiles = new ArrayList<>(Arrays.asList(Objects.requireNonNull(dir.listFiles())));
-        dir = new File(basePath + "/lib/common-runtime-lib");
-        preloadFiles.addAll(Arrays.asList(Objects.requireNonNull(dir.listFiles())));
-        classLoader = ScannerHelper.createChildFirstClassLoader(preloadFiles, "iceberg metadata scanner");
+        classLoader = ScannerHelper.createModuleClassLoader("iceberg-reader-lib");
     }
 
     @Override

--- a/java-extensions/java-utils/src/main/java/com/starrocks/utils/loader/ChildFirstClassLoader.java
+++ b/java-extensions/java-utils/src/main/java/com/starrocks/utils/loader/ChildFirstClassLoader.java
@@ -39,8 +39,7 @@ public class ChildFirstClassLoader extends URLClassLoader {
         super(urls, null);
         this.parentLoader = new ParentClassLoader(parent);
         // load native method class from parent
-        this.parentFirstClass = new ArrayList<>(
-                Arrays.asList("com.starrocks.utils.NativeMethodHelper", "org.slf4j.ILoggerFactory", "org.slf4j.Logger"));
+        this.parentFirstClass = new ArrayList<>(Arrays.asList("com.starrocks.utils.NativeMethodHelper"));
     }
 
     @Override

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ScannerHelper.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ScannerHelper.java
@@ -49,7 +49,7 @@ public class ScannerHelper {
         preloadFiles.addAll(Arrays.asList(Objects.requireNonNull(dir.listFiles())));
         dir = new File(basePath + "/lib/common-runtime-lib");
         preloadFiles.addAll(Arrays.asList(Objects.requireNonNull(dir.listFiles())));
-        dir = new File(basePath + "/lib/hadoop-lib");
+        dir = new File(basePath + "/lib/hadoop/common");
         preloadFiles.addAll(Arrays.asList(Objects.requireNonNull(dir.listFiles())));
         ClassLoader classLoader = ScannerHelper.createChildFirstClassLoader(preloadFiles, moduleName);
         return classLoader;

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ScannerHelper.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ScannerHelper.java
@@ -20,7 +20,9 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 
 public class ScannerHelper {
@@ -36,6 +38,20 @@ public class ScannerHelper {
             }
         }).toArray(URL[]::new);
         ClassLoader classLoader = new ChildFirstClassLoader(jars, ClassLoader.getSystemClassLoader());
+        return classLoader;
+    }
+
+    public static ClassLoader createModuleClassLoader(String moduleName) {
+        String basePath = System.getenv("STARROCKS_HOME");
+        List<File> preloadFiles = new ArrayList<>();
+        preloadFiles.add(new File(basePath + "/lib/jni-packages/starrocks-hadoop-ext.jar"));
+        File dir = new File(basePath + "/lib/" + moduleName);
+        preloadFiles.addAll(Arrays.asList(Objects.requireNonNull(dir.listFiles())));
+        dir = new File(basePath + "/lib/common-runtime-lib");
+        preloadFiles.addAll(Arrays.asList(Objects.requireNonNull(dir.listFiles())));
+        dir = new File(basePath + "/lib/hadoop-lib");
+        preloadFiles.addAll(Arrays.asList(Objects.requireNonNull(dir.listFiles())));
+        ClassLoader classLoader = ScannerHelper.createChildFirstClassLoader(preloadFiles, moduleName);
         return classLoader;
     }
 

--- a/java-extensions/kudu-reader/pom.xml
+++ b/java-extensions/kudu-reader/pom.xml
@@ -34,11 +34,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-aws</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
         </dependency>

--- a/java-extensions/kudu-reader/src/main/java/com/starrocks/kudu/reader/KuduSplitScannerFactory.java
+++ b/java-extensions/kudu-reader/src/main/java/com/starrocks/kudu/reader/KuduSplitScannerFactory.java
@@ -17,23 +17,11 @@ package com.starrocks.kudu.reader;
 import com.starrocks.jni.connector.ScannerFactory;
 import com.starrocks.jni.connector.ScannerHelper;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-
 public class KuduSplitScannerFactory implements ScannerFactory {
     static ClassLoader classLoader;
 
     static {
-        String basePath = System.getenv("STARROCKS_HOME");
-        List<File> preloadFiles = new ArrayList<>();
-        File dir = new File(basePath + "/lib/kudu-reader-lib");
-        preloadFiles.addAll(Arrays.asList(Objects.requireNonNull(dir.listFiles())));
-        dir = new File(basePath + "/lib/common-runtime-lib");
-        preloadFiles.addAll(Arrays.asList(Objects.requireNonNull(dir.listFiles())));
-        classLoader = ScannerHelper.createChildFirstClassLoader(preloadFiles, "kudu scanner");
+        classLoader = ScannerHelper.createModuleClassLoader("kudu-reader-lib");
     }
 
     /**

--- a/java-extensions/paimon-reader/pom.xml
+++ b/java-extensions/paimon-reader/pom.xml
@@ -33,11 +33,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-aws</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>io.trino.hive</groupId>
             <artifactId>hive-apache</artifactId>
         </dependency>

--- a/java-extensions/pom.xml
+++ b/java-extensions/pom.xml
@@ -460,6 +460,12 @@
                 <artifactId>kryo-shaded</artifactId>
                 <version>${kryo.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bundle</artifactId>
+                <version>${aws-v2-sdk.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Why I'm doing:

A customer hit problem when accessing iceberg metadata table

```
In [3]: print(s)
(1064, "Failed to open the off-heap table scanner. java exception details: java.io.IOException: Failed to open the IcebergFilesTableScanner
	at com.starrocks.connector.iceberg.AbstractIcebergMetadataScanner.open(AbstractIcebergMetadataScanner.java:69)
Caused by: java.lang.ClassCastException: class org.apache.hadoop.fs.azure.NativeAzureFileSystem$Secure cannot be cast to class org.apache.hadoop.fs.FileSystem (org.apache.hadoop.fs.azure.NativeAzureFileSystem$Secure is in unnamed module of loader 'app'; org.apache.hadoop.fs.FileSystem is in unnamed module of loader com.starrocks.utils.loader.ChildFirstClassLoader @750ec7f5)
	at org.apache.hadoop.fs.FileSystem.createFileSystemInternal(FileSystem.java:3738)
	at org.apache.hadoop.fs.FileSystem.lambda$createFileSystem$0(FileSystem.java:3760)
	at com.starrocks.connector.hadoop.HadoopExt.doAs(HadoopExt.java:61)
	at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:3760)
	at org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:3859)
	at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:3807)
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:601)
	at org.apache.hadoop.fs.Path.getFileSystem(Path.java:366)
	at org.apache.iceberg.hadoop.Util.getFs(Util.java:55)
	at org.apache.iceberg.hadoop.HadoopInputFile.fromLocation(HadoopInputFile.java:62)
	at org.apache.iceberg.hadoop.HadoopFileIO.newInputFile(HadoopFileIO.java:92)
	at org.apache.iceberg.io.ResolvingFileIO.newInputFile(ResolvingFileIO.java:94)
	at org.apache.iceberg.io.FileIO.newInputFile(FileIO.java:70)
	at org.apache.iceberg.ManifestFiles.newInputFile(ManifestFiles.java:420)
	at org.apache.iceberg.ManifestFiles.read(ManifestFiles.java:131)
	at com.starrocks.connector.iceberg.IcebergFilesTableScanner.initReader(IcebergFilesTableScanner.java:97)
	at com.starrocks.connector.iceberg.AbstractIcebergMetadataScanner.open(AbstractIcebergMetadataScanner.java:64)
: BE:10001")
```

Root Cause: The issue arises because hadoop-azure.jar and hadoop-filesystem.jar are loaded by different class loaders, causing AzureFileSystem to be incompatible with FileSystem during casting.

Quick Solution: Copy all Azure-related JAR files into the common-runtime-lib directory.
This ensures both hadoop-azure.jar and the Hadoop filesystem JAR are loaded by the same class loader, resolving the class cast conflict.

## What I'm doing:

Here I refactor child class loader,  we make sure classes are loaded by the same class loader
- starrocks-hadoop-ext.jar
- module related jar
- common-runtime-lib (right now it's just aws bundle)
- hadoop/common (hadoop jars and azure and gcs related jars)

Fixes #60171

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
