### PR TITLE
[BugFix] fix default_warehouse initialization in multiple scenarios

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/journal/GlobalStateCheckpointWorker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/GlobalStateCheckpointWorker.java
@@ -36,6 +36,8 @@ public class GlobalStateCheckpointWorker extends CheckpointWorker {
         globalStateMgr.setJournal(journal);
         try {
             globalStateMgr.loadImage();
+            // This is required because the loadImage() may find no image to load, and the initDefaultWarehouse() will
+            // be skipped.
             globalStateMgr.initDefaultWarehouse();
 
             checkEpoch(epoch);

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1271,6 +1271,11 @@ public class GlobalStateMgr {
             replayer = null;
         }
 
+        if (!isDefaultWarehouseCreated) {
+            // A brand-new cluster was up for the first time, the leader node initializes its default warehouse here.
+            initDefaultWarehouse();
+        }
+
         // set this after replay thread stopped. to avoid replay thread modify them.
         isReady.set(false);
 
@@ -1311,10 +1316,6 @@ public class GlobalStateMgr {
             // start other daemon threads that should run on all FEs
             startAllNodeTypeDaemonThreads();
             insertOverwriteJobMgr.cancelRunningJobs();
-
-            if (!isDefaultWarehouseCreated) {
-                initDefaultWarehouse();
-            }
 
             MetricRepo.init();
 
@@ -1524,18 +1525,18 @@ public class GlobalStateMgr {
             return;
         }
 
-        // transfer from INIT/UNKNOWN to OBSERVER/FOLLOWER
+        if (!isDefaultWarehouseCreated) {
+            // A brand-new cluster was up for the first time, the follower/observer node initializes its default warehouse here.
+            initDefaultWarehouse();
+        }
 
+        // transfer from INIT/UNKNOWN to OBSERVER/FOLLOWER
         if (replayer == null) {
             createReplayer();
             replayer.start();
         }
 
         startAllNodeTypeDaemonThreads();
-
-        if (!isDefaultWarehouseCreated) {
-            initDefaultWarehouse();
-        }
 
         MetricRepo.init();
 


### PR DESCRIPTION
## Why I'm doing:

Need to considering the following cases for the default_warehouse initialization.
1. new setup cluster for the first time, -> leader node initialization in `transferToLeader()` after all journals replayed
2. new setup cluster for the first time, -> non-leader node initialization in `transferToNonLeader()` after all journals replayed
3. fe node restart, no image exists, but edit log exists to replay, -> default_warehouse initialization just after `loadImage()` before `replayJournals()`
4. fe node restart, has images and editlog to replay, -> initializing the default_warehouse during the `warehouseManger.load()` as part of `loadImage()`

## What I'm doing:

Fixes #51576

1. If the FE started with meta image, the default warehouse will be initialized along with the `WarehouseManager::load()`, although `WarehouseManager::save()` is empty. So after `loadImage()`, the default warehouse will be ready for any actions in `postImageLoad()` or `replayJournal()` for both leader and non-leader nodes.
2. In case there is no meta image available at all, usually it is the cluster first setup or cluster running not for long and the first image is not trigger. The default warehouse will be initialized again inside the role transfer `transferToLeader()/transferToNonLeader()` before `replayJournal()` so that the default_warehouse will be still ready for journal replays in case any EditLog that may need default_warehouse to perform some checks.

Because the `initDefaultWarehouse()` may be called multiple times, one is from the WarehouseManager::load() if there is any meta image available, one is from the role transfer before `replayJournal()`, so the interface must be implemented idempotent. 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
