### PR TITLE
[Enhancement] faster from_unixtime

### DIFF
--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -235,17 +235,6 @@ echo "===== Patching thirdparty archives..."
 ###################################################################################
 PATCHED_MARK="patched_mark"
 
-#patch cctz
-if [[ -d $TP_SOURCE_DIR/$CCTZ_SOURCE ]] ; then
-    cd $TP_SOURCE_DIR/$CCTZ_SOURCE
-    if [ ! -f "$PATCHED_MARK" ] && [[ $CCTZ_SOURCE == "cctz-2.3" ]] ; then
-        patch -p1 < "$TP_PATCH_DIR/cctz_civil_cache.patch"
-        touch "$PATCHED_MARK"
-    fi
-    cd -
-    echo "Finished patching $CCTZ_SOURCE"
-fi
-
 # glog patch
 cd $TP_SOURCE_DIR/$GLOG_SOURCE
 if [ ! -f $PATCHED_MARK ] && [ $GLOG_SOURCE == "glog-0.3.3" ]; then

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -235,6 +235,17 @@ echo "===== Patching thirdparty archives..."
 ###################################################################################
 PATCHED_MARK="patched_mark"
 
+#patch cctz
+if [[ -d $TP_SOURCE_DIR/$CCTZ_SOURCE ]] ; then
+    cd $TP_SOURCE_DIR/$CCTZ_SOURCE
+    if [ ! -f "$PATCHED_MARK" ] && [[ $CCTZ_SOURCE == "cctz-2.3" ]] ; then
+        patch -p1 < "$TP_PATCH_DIR/cctz_civil_cache.patch"
+        touch "$PATCHED_MARK"
+    fi
+    cd -
+    echo "Finished patching $CCTZ_SOURCE"
+fi
+
 # glog patch
 cd $TP_SOURCE_DIR/$GLOG_SOURCE
 if [ ! -f $PATCHED_MARK ] && [ $GLOG_SOURCE == "glog-0.3.3" ]; then
@@ -609,4 +620,15 @@ if [[ -d $TP_SOURCE_DIR/$AZURE_SOURCE ]] ; then
     fi
     cd -
     echo "Finished patching $AZURE_SOURCE"
+fi
+
+#patch cctz
+if [[ -d $TP_SOURCE_DIR/$CCTZ_SOURCE ]] ; then
+    cd $TP_SOURCE_DIR/$CCTZ_SOURCE
+    if [ ! -f "$PATCHED_MARK" ] && [[ $CCTZ_SOURCE == "cctz-2.3" ]] ; then
+        patch -p1 < "$TP_PATCH_DIR/cctz_civil_cache.patch"
+        touch "$PATCHED_MARK"
+    fi
+    cd -
+    echo "Finished patching $CCTZ_SOURCE"
 fi

--- a/thirdparty/patches/cctz_civil_cache.patch
+++ b/thirdparty/patches/cctz_civil_cache.patch
@@ -1,0 +1,130 @@
+diff --git a/src/cctz_benchmark.cc b/src/cctz_benchmark.cc
+index 179ae50..87a7722 100644
+--- a/src/cctz_benchmark.cc
++++ b/src/cctz_benchmark.cc
+@@ -797,6 +797,20 @@ void BM_Time_ToCivil_CCTZ(benchmark::State& state) {
+ }
+ BENCHMARK(BM_Time_ToCivil_CCTZ);
+ 
++void BM_Time_ToCivil_Cached(benchmark::State &state) {
++  const cctz::time_zone tz = TestTimeZone();
++  std::chrono::system_clock::time_point tp =
++      std::chrono::system_clock::from_time_t(1750656243);
++  std::chrono::system_clock::time_point tp2 =
++      std::chrono::system_clock::from_time_t(1750656245);
++  while (state.KeepRunning()) {
++    std::swap(tp, tp2);
++    tp += std::chrono::seconds(1);
++    benchmark::DoNotOptimize(cctz::convert(tp, tz));
++  }
++}
++BENCHMARK(BM_Time_ToCivil_Cached);
++
+ void BM_Time_ToCivil_Libc(benchmark::State& state) {
+   // No timezone support, so just use localtime.
+   time_t t = 1384569027;
+diff --git a/src/time_zone_info.cc b/src/time_zone_info.cc
+index eb1cd8a..6258c27 100644
+--- a/src/time_zone_info.cc
++++ b/src/time_zone_info.cc
+@@ -41,12 +41,14 @@
+ #include <cstring>
+ #include <functional>
+ #include <iostream>
++#include <mutex>
+ #include <memory>
+ #include <sstream>
+ #include <string>
+ 
+ #include "cctz/civil_time.h"
+ #include "time_zone_fixed.h"
++#include "time_zone_if.h"
+ #include "time_zone_posix.h"
+ 
+ namespace cctz {
+@@ -79,6 +81,21 @@ const std::int_least32_t kSecsPerYear[2] = {
+   366 * kSecsPerDay,
+ };
+ 
++static constexpr int kCivilCacheDays = 200 * 365;
++static civil_day gCivilCache[kCivilCacheDays];
++static std::once_flag gCivilCacheInit;
++
++static void InitCivilDaysCache() {
++  std::call_once(gCivilCacheInit, [&]() {
++    civil_day epoch;
++    for (int i = 0; i < kCivilCacheDays; i++) {
++      gCivilCache[i] = epoch;
++      epoch++;
++    }
++  });
++}
++
++
+ // Single-byte, unsigned numeric values are encoded directly.
+ inline std::uint_fast8_t Decode8(const char* cp) {
+   return static_cast<std::uint_fast8_t>(*cp) & 0xff;
+@@ -751,14 +768,56 @@ time_zone::absolute_lookup TimeZoneInfo::LocalTime(
+           tt.utc_offset, tt.is_dst, &abbreviations_[tt.abbr_index]};
+ }
+ 
++static inline int64_t floor_div(int64_t n, int64_t d) {
++  int64_t q = n / d;
++  int64_t r = n % d;
++  return (r < 0) ? q - 1 : q;
++}
++
+ // BreakTime() translation for a particular transition.
+-time_zone::absolute_lookup TimeZoneInfo::LocalTime(
+-    std::int_fast64_t unix_time, const Transition& tr) const {
+-  const TransitionType& tt = transition_types_[tr.type_index];
+-  // Note: (unix_time - tr.unix_time) will never overflow as we
+-  // have ensured that there is always a "nearby" transition.
+-  return {tr.civil_sec + (unix_time - tr.unix_time),  // TODO: Optimize.
+-          tt.utc_offset, tt.is_dst, &abbreviations_[tt.abbr_index]};
++time_zone::absolute_lookup TimeZoneInfo::LocalTime(std::int_fast64_t unix_time,
++                                                   const Transition &tr) const {
++  const TransitionType &tt = transition_types_[tr.type_index];
++  // Baseline
++  // return {tr.civil_sec + (unix_time-tr.unix_time), tt.utc_offset, tt.is_dst,
++  // &abbreviations_[tt.abbr_index]};
++
++  // Optimization: Utilizing a cache for n_days() operation to mitigate its 30+ns performance impact.
++  // Benchmark                                 Time             CPU      Time Old      Time New       CPU Old       CPU New
++  // ----------------------------------------------------------------------------------------------------------------------
++  // BM_Time_ToCivil_CCTZ                   -0.2508         -0.2508            55            41            55            41
++  // BM_Time_ToCivil_Cached                 -0.5182         -0.5182            71            34            71            34
++  // BM_Time_ToCivil_Libc                   +0.0020         +0.0020           217           217           217           217
++  // BM_Time_ToCivilUTC_CCTZ                -0.6477         -0.6477            73            26            73            26
++  // BM_Time_ToCivilUTC_Libc                +0.0145         +0.0144            43            44            43            44
++  // OVERALL_GEOMEAN                        -0.3358         -0.3358             0             0             0             0
++  std::int_fast64_t local_unix = unix_time + tt.utc_offset;
++  if (local_unix < unix_time) {
++    // Handle overflow case
++    return {tr.civil_sec + (unix_time - tr.unix_time), tt.utc_offset, tt.is_dst,
++            &abbreviations_[tt.abbr_index]};
++  }
++
++  constexpr int64_t SECS_PER_DAY = 86400;
++  std::int_fast64_t days = floor_div(local_unix, SECS_PER_DAY);
++  std::int_fast64_t sod = local_unix - days * SECS_PER_DAY;
++  if (sod < 0) {
++    sod += SECS_PER_DAY;
++  }
++
++  if (0 <= days && days < kCivilCacheDays) {
++    InitCivilDaysCache();
++    civil_day local_civil_day = gCivilCache[days];
++    civil_second local_civil(local_civil_day.year(), local_civil_day.month(), local_civil_day.day(), 
++      sod / (3600), sod % 3600 / 60, sod % 60);
++    return {local_civil, tt.utc_offset, tt.is_dst,
++            &abbreviations_[tt.abbr_index]};
++  } else {
++    // Note: (unix_time - tr.unix_time) will never overflow as we
++    // have ensured that there is always a "nearby" transition.
++    return {tr.civil_sec + (unix_time - tr.unix_time), tt.utc_offset, tt.is_dst,
++            &abbreviations_[tt.abbr_index]};
++  }
+ }
+ 
+ // MakeTime() translation with a conversion-preserving +N * 400-year shift.


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

The `from_unixtime` SQL function utilizes the `cctz::convert` function to transform a Unix timestamp into timezone-specific local time. However, this conversion process takes approximately 40 nanoseconds, potentially leading to a performance bottleneck.

How is the `cctz::convert` performed? 
1. It first looks up the transition for the specified timezone and timestamp, utilizing a cache to speed up this process.
2. `tr.civil_sec + (unix_time - tr.unix_time)`: It then calculates the new time by adding the difference between the current and transition timestamps to the transition's civil time. This step involves a complex calculation with the addition operator to adjust the civil day accordingly. 
3. Pseudo code:
  ```
  y = 1970; m = 1;
while d > 365:
  while d > days_in_century(y):
    d -= days_in_century(y); y += 100;
  while d > days_in_4years(y):
    d -= days_in_4years(y); y += 4;
  while d > days_in_year(y):
    d -= days_in_year(y);  y += 1;
while d > days_in_month(y,m):
  d -= days_in_month(y,m);
  if (++m > 12) { y++; m = 1; }
return y, m, d;
   ```


How can we enhance this process?  
1. Look up the transitions to adjust the UTCOffset, which can be efficiently cached.  
2. Look up the `unix_days to civil_days` cache to obtain the `YMD`. This cache stores a 200-year mapping starting from 1970-01-01, utilizing minimal memory.  
3. Pseudo code:
  ```
  int64_t local_unix = unixtime + UTCOffset;
  int64_t days = local_unix / 86400;
  int64_t seconds_of_day = local_unix % 86400;
  civil_day cd = cache[local_unix];
  civil_second cs = civil_second(cd)j+ seconds_of_day;
  ```


The correctness ? 
- Passed all tests in cctz codebase

The performance benefit ? 
- Reduced CPU time by 25% ~ 64%

```
+  // Benchmark                                 Time             CPU      Time Old      Time New       CPU Old       CPU New
+  // ----------------------------------------------------------------------------------------------------------------------
+  // BM_Time_ToCivil_CCTZ                   -0.2508         -0.2508            55            41            55            41
+  // BM_Time_ToCivil_Cached                 -0.5182         -0.5182            71            34            71            34
+  // BM_Time_ToCivil_Libc                   +0.0020         +0.0020           217           217           217           217
+  // BM_Time_ToCivilUTC_CCTZ                -0.6477         -0.6477            73            26            73            26
+  // BM_Time_ToCivilUTC_Libc                +0.0145         +0.0144            43            44            43            44
+  // OVERALL_GEOMEAN                        -0.3358         -0.3358             0             0             0             0
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
