### PR TITLE
[Enhancement] from_unixtime: return datetime type

### DIFF
--- a/be/src/exprs/time_functions.h
+++ b/be/src/exprs/time_functions.h
@@ -704,6 +704,9 @@ public:
     DEFINE_VECTORIZED_FN(from_unix_to_datetime_64);
     DEFINE_VECTORIZED_FN(from_unix_to_datetime_32);
     DEFINE_VECTORIZED_FN(from_unix_to_datetime_ms_64);
+    DEFINE_VECTORIZED_FN(from_unix_to_datetime_64_v2);
+    DEFINE_VECTORIZED_FN(from_unix_to_datetime_32_v2);
+    DEFINE_VECTORIZED_FN(from_unix_to_datetime_ms_64_v2);
 
     // from_unix_datetime with format's auxiliary method
     static Status from_unix_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope);
@@ -822,9 +825,10 @@ public:
     DEFINE_VECTORIZED_FN(iceberg_hours_since_epoch_datetime);
 
 private:
-    DEFINE_VECTORIZED_FN_TEMPLATE(_t_from_unix_to_datetime);
-
-    DEFINE_VECTORIZED_FN_TEMPLATE(_t_from_unix_to_datetime_ms);
+    template <LogicalType Type, LogicalType ReturnType>
+    static StatusOr<ColumnPtr> _t_from_unix_to_datetime(FunctionContext* context, const Columns& columns);
+    template <LogicalType Type, LogicalType ReturnType>
+    static StatusOr<ColumnPtr> _t_from_unix_to_datetime_ms(FunctionContext* context, const Columns& columns);
 
     DEFINE_VECTORIZED_FN_TEMPLATE(_t_to_unix_from_datetime);
 

--- a/docs/en/sql-reference/sql-functions/date-time-functions/from_unixtime.md
+++ b/docs/en/sql-reference/sql-functions/date-time-functions/from_unixtime.md
@@ -24,7 +24,8 @@ Other formats are invalid and NULL will be returned.
 ## Syntax
 
 ```Haskell
-VARCHAR from_unixtime(BIGINT unix_timestamp[, VARCHAR string_format])
+DATETIME from_unixtime(BIGINT unix_timestamp)
+VARCHAR from_unixtime(BIGINT unix_timestamp, VARCHAR string_format)
 ```
 
 ## Parameters
@@ -35,7 +36,7 @@ VARCHAR from_unixtime(BIGINT unix_timestamp[, VARCHAR string_format])
 
 ## Return value
 
-Returns a DATETIME or DATE value of the VARCHAR type. If `string_format` specifies the DATE format, a DATE value of the VARCHAR type is returned.
+Retruns a DATETIME value if the format is not specified; Returns a VARCHAR type is the format is specified.
 
 If the timestamp exceeds the value range or if `string_format` is invalid, NULL will be returned.
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -88,6 +88,8 @@ public class FunctionSet {
     public static final String FROM_DAYS = "from_days";
     public static final String FROM_UNIXTIME = "from_unixtime";
     public static final String FROM_UNIXTIME_MS = "from_unixtime_ms";
+    public static final String FROM_UNIXTIME_V2 = "from_unixtime_v2";
+    public static final String FROM_UNIXTIME_MS_V2 = "from_unixtime_ms_v2";
     public static final String HOUR = "hour";
     public static final String MINUTE = "minute";
     public static final String MONTH = "month";

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -917,6 +917,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_MULTI_CAST_LIMIT_PUSH_DOWN = "enable_multi_cast_limit_push_down";
 
+    public static final String FROM_UNIXTIME_BEHAVIOR_VERSION = "from_unixtime_behavior_version";
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(MAX_EXECUTION_TIME)
@@ -1846,6 +1848,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_DEFER_PROJECT_AFTER_TOPN)
     private boolean enableDeferProjectAfterTopN = true;
+
+    @VarAttr(name = FROM_UNIXTIME_BEHAVIOR_VERSION, flag = VariableMgr.INVISIBLE)
+    private int fromUnixTimeBehaviorVersion = 2;
 
     // When this variable is enabled, the limits of consumers a CTE are pushed down to the producer of the CTE.
     // The limits can then be applied before the exchange.
@@ -5037,6 +5042,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableMultiCastLimitPushDown() {
         return enableMultiCastLimitPushDown;
+    }
+
+    public int getFromUnixTimeBehaviorVersion() {
+        return fromUnixTimeBehaviorVersion;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -734,6 +734,25 @@ public class ScalarOperatorFunctions {
     }
 
     @ConstantFunction.List(list = {
+            @ConstantFunction(name = "from_unixtime_v2", argTypes = {INT}, returnType = DATETIME, isMonotonic = true),
+            @ConstantFunction(name = "from_unixtime_v2", argTypes = {BIGINT}, returnType = DATETIME, isMonotonic = true)
+    })
+    public static ConstantOperator fromUnixTimeV2(ConstantOperator unixTime) throws AnalysisException {
+        long value = 0;
+        if (unixTime.getType().isInt()) {
+            value = unixTime.getInt();
+        } else {
+            value = unixTime.getBigint();
+        }
+        if (value < 0 || value > TimeUtils.MAX_UNIX_TIMESTAMP) {
+            throw new AnalysisException(
+                    "unixtime should larger than zero and less than " + TimeUtils.MAX_UNIX_TIMESTAMP);
+        }
+        return ConstantOperator.createDatetime(
+                LocalDateTime.ofInstant(Instant.ofEpochSecond(value), TimeUtils.getTimeZone().toZoneId()));
+    }
+
+    @ConstantFunction.List(list = {
             @ConstantFunction(name = "from_unixtime_ms", argTypes = {BIGINT}, returnType = VARCHAR, isMonotonic = true),
     })
     public static ConstantOperator fromUnixTimeMs(ConstantOperator unixTime) throws AnalysisException {
@@ -747,6 +766,22 @@ public class ScalarOperatorFunctions {
         ConstantOperator dl = ConstantOperator.createDatetime(
                 LocalDateTime.ofInstant(Instant.ofEpochSecond(second), TimeUtils.getTimeZone().toZoneId()));
         return ConstantOperator.createVarchar(dl.toString());
+    }
+
+    @ConstantFunction.List(list = {
+            @ConstantFunction(name = "from_unixtime_ms_v2", argTypes = {
+                    BIGINT}, returnType = DATETIME, isMonotonic = true),
+    })
+    public static ConstantOperator fromUnixTimeMsV2(ConstantOperator unixTime) throws AnalysisException {
+        long millisecond = unixTime.getBigint();
+
+        if (millisecond < 0 || millisecond > TimeUtils.MAX_UNIX_TIMESTAMP * 1000) {
+            throw new AnalysisException(
+                    "unixtime should larger than zero and less than " + TimeUtils.MAX_UNIX_TIMESTAMP);
+        }
+        long second = millisecond / 1000;
+        return ConstantOperator.createDatetime(
+                LocalDateTime.ofInstant(Instant.ofEpochSecond(second), TimeUtils.getTimeZone().toZoneId()));
     }
 
     @ConstantFunction.List(list = {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SyntaxSugars.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SyntaxSugars.java
@@ -37,6 +37,11 @@ public class SyntaxSugars {
                 .put(FunctionSet.STRUCT, SyntaxSugars::struct)
                 .put(FunctionSet.BOOLOR_AGG, SyntaxSugars::boolOrAgg)
                 .put(FunctionSet.APPROX_COUNT_DISTINCT_HLL_SKETCH, SyntaxSugars::hllSketchCount)
+
+                // replace the V1 to V2
+                .put(FunctionSet.FROM_UNIXTIME, SyntaxSugars::fromUnixTime)
+                .put(FunctionSet.FROM_UNIXTIME_MS, SyntaxSugars::fromUnixTimeMs)
+
                 .build();
     }
 
@@ -82,5 +87,13 @@ public class SyntaxSugars {
 
     private static FunctionCallExpr boolOrAgg(FunctionCallExpr call) {
         return new FunctionCallExpr(FunctionSet.BOOL_OR, call.getChildren());
+    }
+
+    private static FunctionCallExpr fromUnixTime(FunctionCallExpr call) {
+        return new FunctionCallExpr(FunctionSet.FROM_UNIXTIME_V2, call.getChildren());
+    }
+
+    private static FunctionCallExpr fromUnixTimeMs(FunctionCallExpr call) {
+        return new FunctionCallExpr(FunctionSet.FROM_UNIXTIME_MS_V2, call.getChildren());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SyntaxSugars.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SyntaxSugars.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.qe.ConnectContext;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -90,10 +91,20 @@ public class SyntaxSugars {
     }
 
     private static FunctionCallExpr fromUnixTime(FunctionCallExpr call) {
-        return new FunctionCallExpr(FunctionSet.FROM_UNIXTIME_V2, call.getChildren());
+        ConnectContext session = ConnectContext.get();
+        if (session != null && session.getSessionVariable().getFromUnixTimeBehaviorVersion() == 2) {
+            return new FunctionCallExpr(FunctionSet.FROM_UNIXTIME_V2, call.getChildren());
+        } else {
+            return call;
+        }
     }
 
     private static FunctionCallExpr fromUnixTimeMs(FunctionCallExpr call) {
-        return new FunctionCallExpr(FunctionSet.FROM_UNIXTIME_MS_V2, call.getChildren());
+        ConnectContext session = ConnectContext.get();
+        if (session != null && session.getSessionVariable().getFromUnixTimeBehaviorVersion() == 2) {
+            return new FunctionCallExpr(FunctionSet.FROM_UNIXTIME_V2, call.getChildren());
+        } else {
+            return call;
+        }
     }
 }

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -565,10 +565,13 @@ vectorized_functions = [
     [50286, 'unix_timestamp', True, False, 'BIGINT', ['DATE'], 'TimeFunctions::to_unix_from_date_64'],
     [50287, 'unix_timestamp', True, False, 'BIGINT', ['VARCHAR', 'VARCHAR'],
      'TimeFunctions::to_unix_from_datetime_with_format_64'],
+     
+    # [deprecated] V1 returns VARCHAR type
     [50288, 'from_unixtime', True, False, 'VARCHAR', ['BIGINT'], 'TimeFunctions::from_unix_to_datetime_64'],
     [50289, 'from_unixtime', True, False, 'VARCHAR', ['BIGINT', 'VARCHAR'],
-     'TimeFunctions::from_unix_to_datetime_with_format_64',
-     'TimeFunctions::from_unix_prepare', 'TimeFunctions::from_unix_close'],
+        'TimeFunctions::from_unix_to_datetime_with_format_64',
+        'TimeFunctions::from_unix_prepare', 'TimeFunctions::from_unix_close'],
+    # [deprecated] V1 returns VARCHAR type
     [50290, 'from_unixtime_ms', True, False, 'VARCHAR', ['BIGINT'], 'TimeFunctions::from_unix_to_datetime_ms_64'],
     [50291, 'from_unixtime', True, False, 'VARCHAR', ['BIGINT', 'VARCHAR', 'VARCHAR'],
      'TimeFunctions::from_unix_to_datetime_with_format_timezone',
@@ -578,10 +581,16 @@ vectorized_functions = [
     [50302, 'unix_timestamp', True, False, 'INT', ['DATE'], 'TimeFunctions::to_unix_from_date_32'],
     [50303, 'unix_timestamp', True, False, 'INT', ['VARCHAR', 'VARCHAR'],
      'TimeFunctions::to_unix_from_datetime_with_format_32'],
+    # [deprecated] V1 returns VARCHAR type
     [50304, 'from_unixtime', True, False, 'VARCHAR', ['INT'], 'TimeFunctions::from_unix_to_datetime_32'],
     [50305, 'from_unixtime', True, False, 'VARCHAR', ['INT', 'VARCHAR'],
      'TimeFunctions::from_unix_to_datetime_with_format_32',
      'TimeFunctions::from_unix_prepare', 'TimeFunctions::from_unix_close'],
+
+    # V2 from_unixtime returns DATETIME type if the format parameter is omitted
+    [50306, 'from_unixtime_v2', True, False, 'DATETIME', ['BIGINT'], 'TimeFunctions::from_unix_to_datetime_64_v2'],
+    [50307, 'from_unixtime_v2', True, False, 'DATETIME', ['INT'], 'TimeFunctions::from_unix_to_datetime_32_v2'],
+    [50308, 'from_unixtime_ms_v2', True, False, 'DATETIME', ['BIGINT'], 'TimeFunctions::from_unix_to_datetime_ms_64_v2'],
 
     [50310, 'dayname', True, False, 'VARCHAR', ['DATETIME'], 'TimeFunctions::day_name'],
     [50311, 'monthname', True, False, 'VARCHAR', ['DATETIME'], 'TimeFunctions::month_name'],


### PR DESCRIPTION
## Why I'm doing:

The `from_unixtime` function converts a Unix timestamp into a datetime based on the specified format.

The current implementation always returns a VARCHAR type regardless of the input parameter. This behavior is inconsistent with the MySQL protocol and introduces unnecessary overhead during string formatting.

## What I'm doing:

The signature of the `from_unixtime` function is updated to return a `DATETIME` directly when the format parameter is omitted.

To ensure compatibility during version upgrades, we have introduced a new function signature, `from_unixtime_v2`. This approach allows the replacement to occur only within the AST, enabling both versions of the implementation to coexist seamlessly.

Performance benefit: reduce function latency by ~30%.

Behavior change:
- `from_unixtime` returns `DATETIME` type when the format parameter is omitted
- previously it returns `VARCHAR` 


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
