### PR TITLE
[BugFix] Fix mv is not inactive after column rename

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -217,9 +217,6 @@ public class AlterJobMgr {
             try {
                 mvQueryStatement = recreateMVQuery(materializedView, context, createMvSql);
             } catch (Exception e) {
-                LOG.warn("Can not active materialized view [%s]" +
-                        " because analyze materialized view define sql: \n\n%s" +
-                        "\n\nCause an error: %s", materializedView.getName(), createMvSql, e);
                 throw new SemanticException("Can not active materialized view [%s]" +
                         " because analyze materialized view define sql: \n\n%s" +
                         "\n\nCause an error: %s", materializedView.getName(), createMvSql, e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -522,6 +522,8 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
 
         try {
             if (AlterMaterializedViewStatusClause.ACTIVE.equalsIgnoreCase(status)) {
+                // check if the materialized view can be activated without rebuilding relationships.
+                materializedView.fixRelationship();
                 if (materializedView.isActive()) {
                     return null;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -522,7 +522,6 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
 
         try {
             if (AlterMaterializedViewStatusClause.ACTIVE.equalsIgnoreCase(status)) {
-                materializedView.fixRelationship();
                 if (materializedView.isActive()) {
                     return null;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/EsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/EsTable.java
@@ -490,6 +490,7 @@ public class EsTable extends Table implements GsonPostProcessable {
 
     @Override
     public void onDrop(Database db, boolean force, boolean replay) {
+        super.onDrop(db, force, replay);
         GlobalStateMgr.getCurrentState().getEsRepository().deRegisterTable(this.id);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FileTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FileTable.java
@@ -210,6 +210,7 @@ public class FileTable extends Table {
 
     @Override
     public void onDrop(Database db, boolean force, boolean replay) {
+        super.onDrop(db, force, replay);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -378,6 +378,7 @@ public class HiveTable extends Table {
 
     @Override
     public void onDrop(Database db, boolean force, boolean replay) {
+        super.onDrop(db, force, replay);
         if (Config.enable_hms_events_incremental_sync && isResourceMappingCatalog(getCatalogName())) {
             GlobalStateMgr.getCurrentState().getMetastoreEventsProcessor().unRegisterTableFromResource(
                     String.join(".", getCatalogName(), hiveDbName, hiveTableName));

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
@@ -315,6 +315,7 @@ public class HudiTable extends Table {
 
     @Override
     public void onDrop(Database db, boolean force, boolean replay) {
+        super.onDrop(db, force, replay);
         if (isResourceMappingCatalog(getCatalogName())) {
             GlobalStateMgr.getCurrentState().getMetadataMgr().dropTable(getCatalogName(), db.getFullName(), name);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1107,7 +1107,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      * NOTE: caller need to hold the db lock
      */
     public void fixRelationship() {
-        onReloadImpl(false);
+        onReload(false);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1937,43 +1937,41 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      * NOTE: This method should be only called once in FE restart phase.
      */
     private void analyzePartitionExprs() {
-        try {
-            // initialize table to base table info cache
-            for (BaseTableInfo tableInfo : this.baseTableInfos) {
-                this.tableToBaseTableInfoCache.put(MvUtils.getTableChecked(tableInfo), tableInfo);
-            }
-            // analyze partition exprs for ref base tables
-            analyzeRefBaseTablePartitionExprs();
-            // analyze partition exprs
-            Map<Table, List<Expr>> refBaseTablePartitionExprs = getRefBaseTablePartitionExprs(false);
-            ConnectContext connectContext = ConnectContext.buildInner();
-            if (refBaseTablePartitionExprs != null) {
-                for (BaseTableInfo baseTableInfo : baseTableInfos) {
-                    Optional<Table> refBaseTableOpt = MvUtils.getTable(baseTableInfo);
-                    if (refBaseTableOpt.isEmpty()) {
-                        continue;
-                    }
-                    Table refBaseTable = refBaseTableOpt.get();
-                    if (!refBaseTablePartitionExprs.containsKey(refBaseTable)) {
-                        continue;
-                    }
-                    List<Expr> partitionExprs = refBaseTablePartitionExprs.get(refBaseTable);
-                    TableName tableName = new TableName(baseTableInfo.getCatalogName(),
-                            baseTableInfo.getDbName(), baseTableInfo.getTableName());
-                    for (Expr partitionExpr : partitionExprs) {
-                        analyzePartitionExpr(connectContext, refBaseTable, tableName, partitionExpr);
-                    }
+        // Don't use try-catch here, so can inactive mv if analyze failed, see #onReload()
+
+        // initialize table to base table info cache
+        for (BaseTableInfo tableInfo : this.baseTableInfos) {
+            this.tableToBaseTableInfoCache.put(MvUtils.getTableChecked(tableInfo), tableInfo);
+        }
+        // analyze partition exprs for ref base tables
+        analyzeRefBaseTablePartitionExprs();
+        // analyze partition exprs
+        Map<Table, List<Expr>> refBaseTablePartitionExprs = getRefBaseTablePartitionExprs(false);
+        ConnectContext connectContext = ConnectContext.buildInner();
+        if (refBaseTablePartitionExprs != null) {
+            for (BaseTableInfo baseTableInfo : baseTableInfos) {
+                Optional<Table> refBaseTableOpt = MvUtils.getTable(baseTableInfo);
+                if (refBaseTableOpt.isEmpty()) {
+                    continue;
+                }
+                Table refBaseTable = refBaseTableOpt.get();
+                if (!refBaseTablePartitionExprs.containsKey(refBaseTable)) {
+                    continue;
+                }
+                List<Expr> partitionExprs = refBaseTablePartitionExprs.get(refBaseTable);
+                TableName tableName = new TableName(baseTableInfo.getCatalogName(),
+                        baseTableInfo.getDbName(), baseTableInfo.getTableName());
+                for (Expr partitionExpr : partitionExprs) {
+                    analyzePartitionExpr(connectContext, refBaseTable, tableName, partitionExpr);
                 }
             }
-            // analyze partition slots for ref base tables
-            analyzeRefBaseTablePartitionSlots();
-            // analyze partition columns for ref base tables
-            analyzeRefBaseTablePartitionColumns();
-            // analyze partition retention condition
-            analyzeMVRetentionCondition(connectContext);
-        } catch (Exception e) {
-            LOG.warn("Analyze partition exprs failed", e);
         }
+        // analyze partition slots for ref base tables
+        analyzeRefBaseTablePartitionSlots();
+        // analyze partition columns for ref base tables
+        analyzeRefBaseTablePartitionColumns();
+        // analyze partition retention condition
+        analyzeMVRetentionCondition(connectContext);
     }
 
     public synchronized void analyzeMVRetentionCondition(ConnectContext connectContext) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -47,7 +47,6 @@ import com.google.gson.annotations.SerializedName;
 import com.staros.proto.FileCacheInfo;
 import com.staros.proto.FilePathInfo;
 import com.starrocks.alter.AlterJobV2Builder;
-import com.starrocks.alter.AlterMVJobExecutor;
 import com.starrocks.alter.OlapTableAlterJobV2Builder;
 import com.starrocks.alter.OlapTableRollupJobBuilder;
 import com.starrocks.alter.OptimizeJobV2Builder;
@@ -78,7 +77,6 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.InvalidOlapTableStateException;
-import com.starrocks.common.MaterializedViewExceptions;
 import com.starrocks.common.Pair;
 import com.starrocks.common.io.DeepCopy;
 import com.starrocks.common.util.DateUtils;
@@ -3336,12 +3334,12 @@ public class OlapTable extends Table {
     // If you are modifying this function, please check if you need to modify LakeTable.onDrop also.
     @Override
     public void onDrop(Database db, boolean force, boolean replay) {
+        super.onDrop(db, force, replay);
+
         // drop all temp partitions of this table, so that there is no temp partitions
         // in recycle bin,
         // which make things easier.
         dropAllTempPartitions();
-        AlterMVJobExecutor.inactiveRelatedMaterializedView(this,
-                MaterializedViewExceptions.inactiveReasonForBaseTableNotExists(getName()), replay);
         if (!replay && hasAutoIncrementColumn()) {
             sendDropAutoIncrementMapTask();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -41,10 +41,12 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.alter.AlterMVJobExecutor;
 import com.starrocks.analysis.DescriptorTable.ReferencedPartitionInfo;
 import com.starrocks.catalog.constraint.ForeignKeyConstraint;
 import com.starrocks.catalog.constraint.UniqueConstraint;
 import com.starrocks.catalog.system.SystemTable;
+import com.starrocks.common.MaterializedViewExceptions;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.server.GlobalStateMgr;
@@ -706,7 +708,9 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
      * @param replay is this is a log replay operation
      */
     public void onDrop(Database db, boolean force, boolean replay) {
-        // Do nothing by default.
+        // inactive relative materialized views if the base table/view/external table is dropped.
+        AlterMVJobExecutor.inactiveRelatedMaterializedView(this,
+                MaterializedViewExceptions.inactiveReasonForBaseTableNotExists(getName()), replay);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
@@ -103,7 +103,12 @@ public class MVActiveChecker extends FrontendDaemon {
                 if (table.isMaterializedView()) {
                     MaterializedView mv = (MaterializedView) table;
                     if (!mv.isActive()) {
-                        tryToActivate(mv, true);
+                        try {
+                            tryToActivate(mv, true);
+                        } catch (Exception e) {
+                            LOG.warn("[MVActiveChecker] failed to activate MV {} in database {}",
+                                    mv.getName(), db.getFullName(), e);
+                        }
                     }
                 }
             }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
@@ -455,7 +455,7 @@ public class AlterMaterializedViewTest extends MVTestBase  {
         Assert.assertEquals("base-table dropped: base_tbl_active", mv.getInactiveReason());
         checker.runForTest(true);
         Assert.assertFalse(mv.isActive());
-        Assert.assertEquals("base-table dropped: base_tbl_active", mv.getInactiveReason());
+        Assert.assertTrue(mv.getInactiveReason().contains("base-table dropped: base_tbl_active"));
 
         // create the table again, and activate it
         connectContext.setThreadLocalInfo();

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
@@ -244,7 +244,7 @@ public class AlterMaterializedViewTest extends MVTestBase  {
                         "         left join mv_dim_data1 d on a.item_id = d.item_id\n" +
                         "group by date_trunc(\"day\", a.datekey), a.item_id;");
 
-        starRocksAssert.refreshMV("refresh materialized view mv_test1");
+        starRocksAssert.refreshMV("refresh materialized view mv_test1 with sync mode;");
         MaterializedView mv = (MaterializedView) starRocksAssert.getTable(connectContext.getDatabase(), "mv_test1");
         Assert.assertTrue(starRocksAssert.waitRefreshFinished(mv.getId()));
 

--- a/test/sql/test_mv/R/basic
+++ b/test/sql/test_mv/R/basic
@@ -33,5 +33,5 @@ DROP TABLE ss;
 -- !result
 SELECT is_active, inactive_reason FROM information_schema.materialized_views WHERE table_name='mv1' and table_schema='db_${uuid0}';
 -- result:
-false	base-table dropped: ss
+[REGEX]false	.*base-table dropped: ss.*
 -- !result


### PR DESCRIPTION
## Why I'm doing:

` MVActiveChecker.tryToActivate(mv)` can active mv even if it meets exceptions:
```
2025-06-23 16:09:39.928+08:00 WARN (starrocks-taskrun-pool-0|2813) [MaterializedView.analyzePartitionExprs():1975] Analyze partition exprs failed
java.lang.NullPointerException: Cannot invoke "com.starrocks.analysis.TableName.getTbl()" because the return value of "com.starrocks.analysis.SlotRef.getTblNameWithoutAnalyzed()" is null
        at com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.lambda$getMvPartitionExpr$14(MvUtils.java:1501) ~[starrocks-fe.jar:?]
        at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:178) ~[?:?]
        at java.util.Iterator.forEachRemaining(Iterator.java:133) ~[?:?]
        at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1845) ~[?:?]
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921) ~[?:?]
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
        at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682) ~[?:?]
        at com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.getMvPartitionExpr(MvUtils.java:1503) ~[starrocks-fe.jar:?]
        at com.starrocks.catalog.MaterializedView.analyzeRefBaseTablePartitionExprs(MaterializedView.java:2033) ~[starrocks-fe.jar:?]
        at com.starrocks.catalog.MaterializedView.analyzePartitionExprs(MaterializedView.java:1946) ~[starrocks-fe.jar:?]
        at com.starrocks.catalog.MaterializedView.onReloadImpl(MaterializedView.java:1214) ~[starrocks-fe.jar:?]
        at com.starrocks.catalog.MaterializedView.onReload(MaterializedView.java:1093) ~[starrocks-fe.jar:?]
        at com.starrocks.catalog.MaterializedView.onReload(MaterializedView.java:1078) ~[starrocks-fe.jar:?]
        at com.starrocks.alter.AlterJobMgr.alterMaterializedViewStatus(AlterJobMgr.java:232) ~[starrocks-fe.jar:?]
        at com.starrocks.alter.AlterMVJobExecutor.visitAlterMaterializedViewStatusClause(AlterMVJobExecutor.java:532) ~[starrocks-fe.jar:?]
        at com.starrocks.alter.AlterMVJobExecutor.visitAlterMaterializedViewStatusClause(AlterMVJobExecutor.java:91) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.AlterMaterializedViewStatusClause.accept(AlterMaterializedViewStatusClause.java:45) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:105) ~[starrocks-fe.jar:?]
        at com.starrocks.alter.AlterJobExecutor.visitAlterMaterializedViewStatement(AlterJobExecutor.java:264) ~[starrocks-fe.jar:?]
        at com.starrocks.alter.AlterJobExecutor.visitAlterMaterializedViewStatement(AlterJobExecutor.java:116) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.AlterMaterializedViewStmt.accept(AlterMaterializedViewStmt.java:49) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:105) ~[starrocks-fe.jar:?]
        at com.starrocks.alter.AlterJobExecutor.process(AlterJobExecutor.java:129) ~[starrocks-fe.jar:?]
        at com.starrocks.server.LocalMetastore.alterMaterializedView(LocalMetastore.java:3303) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DDLStmtExecutor$StmtExecutorVisitor.lambda$visitAlterMaterializedViewStatement$14(DDLStmtExecutor.java:394) ~[starrocks-fe.jar:?]
        at com.starrocks.common.ErrorReport.wrapWithRuntimeException(ErrorReport.java:129) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DDLStmtExecutor$StmtExecutorVisitor.visitAlterMaterializedViewStatement(DDLStmtExecutor.java:393) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DDLStmtExecutor$StmtExecutorVisitor.visitAlterMaterializedViewStatement(DDLStmtExecutor.java:208) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.AlterMaterializedViewStmt.accept(AlterMaterializedViewStmt.java:49) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:105) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DDLStmtExecutor.execute(DDLStmtExecutor.java:193) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.handleDdlStmt(StmtExecutor.java:2096) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:782) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectContext.executeSql(ConnectContext.java:1320) ~[starrocks-fe.jar:?]
        at com.starrocks.scheduler.MVActiveChecker.tryToActivate(MVActiveChecker.java:155) ~[starrocks-fe.jar:?]
        at com.starrocks.scheduler.MVActiveChecker.tryToActivate(MVActiveChecker.java:114) ~[starrocks-fe.jar:?]
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.prepare(PartitionBasedMvRefreshProcessor.java:941) ~[starrocks-fe.jar:?]
        at com.starrocks.scheduler.TaskRun.executeTaskRun(TaskRun.java:311) ~[starrocks-fe.jar:?]
        at com.starrocks.scheduler.TaskRunExecutor.lambda$executeTaskRun$0(TaskRunExecutor.java:60) ~[starrocks-fe.jar:?]
        at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
2025-06-23 16:09:39.929+08:00 INFO (starrocks-taskrun-pool-0|2813) [MaterializedView.onReloadImpl():1220] finish reloading mv mv1 in 1ms, total base table count: 1
2025-06-23 16:09:39.929+08:00 INFO (starrocks-taskrun-pool-0|2813) [MaterializedView.setActive():633] set mv1 to active

```

This is not expected since mv refresh will meet other unexpected exceptions since its necessary meta datas are lost:
```
mysql> show materialized views\G;
*************************** 1. row ***************************
                                  id: 13164
                       database_name: test_rename_column5d71abb9_5009_11f0_9288_00163e09349d
                                name: mv1
                        refresh_type: ASYNC
                           is_active: true
                     inactive_reason:
                      partition_type: RANGE
                             task_id: 13166
                           task_name: mv-13164
             last_refresh_start_time: 2025-06-23 16:09:41
          last_refresh_finished_time: 2025-06-23 16:09:42
               last_refresh_duration: 1.011
                  last_refresh_state: FAILED
          last_refresh_force_refresh: false
        last_refresh_start_partition: NULL
          last_refresh_end_partition: NULL
last_refresh_base_refresh_partitions: {}
  last_refresh_mv_refresh_partitions: []
             last_refresh_error_code: -1
          last_refresh_error_message: Refresh mv mv1 failed after 1 times, try lock failed: 0, error-msg : java.lang.IllegalArgumentException
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:129)
        at com.starrocks.sql.common.RangePartitionDiffer.computePartitionDiff(RangePartitionDiffer.java:333)
        at com.starrocks.sql.common.RangePartitionDiffer.computePartitionDiff(RangePartitionDiffer.java:326)
        at com.starrocks.scheduler.mv.MVPCTRefreshRangePartitioner.syncAddOrDropPartitions(MVPCTRefreshRangePartitioner.java:101)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.syncPartitions(PartitionBasedMvRefreshProcessor.java:1004)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedView(PartitionBasedMvRefreshProcessor.java:455)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedViewWithRetry(PartitionBasedMvRefreshProcessor.java:411)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doMvRefresh(PartitionBasedMvRefreshProcessor.java:363)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.processTaskRun(PartitionBasedMvRefreshProcessor.java:197)
        at com.starrocks.scheduler.TaskRun.executeTaskRun(TaskRun.java:313)
        at com.starrocks.scheduler.TaskRunExecutor.lambda$executeTaskRun$0(TaskRunExecutor.java:60)
        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
                                rows: 27
                                text: CREATE MATERIALIZED VIEW `mv1` (`k1`, `k2`, `k3`)

```
## What I'm doing:
- Remove try-catch in `analyzePartitionExprs` since `onReload` will inactive the mv if it meets exceptions
```
    public void onReload(boolean postLoadImage) {
        try {
            boolean desiredActive = active;
            active = false;
            boolean reloadActive = onReloadImpl(postLoadImage);
            if (desiredActive && reloadActive) {
                setActive();
            }
        } catch (Throwable e) {
            LOG.error("reload mv failed: {}", this, e);
            setInactiveAndReason("reload failed: " + e.getMessage());
        }
    }


```
- Inactive related MVs no matter which table it is.

Fixes [#issue](https://github.com/StarRocks/StarRocksTest/issues/9854) https://github.com/StarRocks/StarRocksTest/pull/9858

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
