### PR TITLE
[BugFix] Fix the success determination logic for the aggregateCompact call

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/AggregateCompactionTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/AggregateCompactionTask.java
@@ -51,11 +51,12 @@ public class AggregateCompactionTask extends CompactionTask {
         }
         try {
             CompactResponse response = responseFuture.get();
-            if (CollectionUtils.isEmpty(response.failedTablets)) {
-                return TaskResult.ALL_SUCCESS;
-            } else {
+            TStatusCode code = TStatusCode.findByValue(response.status.statusCode);
+            if (code != TStatusCode.OK) {
                 // TODO support partial success
                 return TaskResult.NONE_SUCCESS;
+            } else {
+                return TaskResult.ALL_SUCCESS;
             }
         } catch (ExecutionException e) {
             return TaskResult.NONE_SUCCESS;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/AggregateCompactionTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/AggregateCompactionTask.java
@@ -24,6 +24,7 @@ import com.starrocks.proto.CompactResponse;
 import com.starrocks.proto.ComputeNodePB;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
+import com.starrocks.thrift.TStatusCode;
 import com.starrocks.transaction.TabletCommitInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -50,8 +51,7 @@ public class AggregateCompactionTask extends CompactionTask {
         }
         try {
             CompactResponse response = responseFuture.get();
-            TStatusCode code = TStatusCode.findByValue(response.status.statusCode);
-            if (code != TStatusCode.OK) {
+            if (TStatusCode.findByValue(response.status.statusCode) != TStatusCode.OK) {
                 // TODO support partial success
                 return TaskResult.NONE_SUCCESS;
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/AggregateCompactionTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/AggregateCompactionTask.java
@@ -25,7 +25,6 @@ import com.starrocks.proto.ComputeNodePB;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
 import com.starrocks.transaction.TabletCommitInfo;
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/AggregateCompactionTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/AggregateCompactionTaskTest.java
@@ -166,7 +166,8 @@ public class AggregateCompactionTaskTest {
         };
         Assert.assertEquals(CompactionTask.TaskResult.ALL_SUCCESS, task.getResult());
 
-        mockResponse.failedTablets = Lists.newArrayList(1L);
+        mockResponse.status = new StatusPB();
+        mockResponse.status.statusCode = TStatusCode.CANCELLED.getValue();
         new Expectations() {
             {
                 mockFuture.get(); 

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/AggregateCompactionTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/AggregateCompactionTaskTest.java
@@ -21,8 +21,10 @@ import com.starrocks.proto.AggregateCompactRequest;
 import com.starrocks.proto.CompactRequest;
 import com.starrocks.proto.CompactResponse;
 import com.starrocks.proto.ComputeNodePB;
+import com.starrocks.proto.StatusPB;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
+import com.starrocks.thrift.TStatusCode;
 import com.starrocks.transaction.TabletCommitInfo;
 import mockit.Expectations;
 import mockit.Mock;
@@ -150,6 +152,8 @@ public class AggregateCompactionTaskTest {
         aggregateRequest.requests.add(request);
         aggregateRequest.computeNodes.add(nodePB);
         CompactResponse mockResponse = new CompactResponse();
+        mockResponse.status = new StatusPB();
+        mockResponse.status.statusCode = TStatusCode.OK.getValue();
 
         CompactionTask task = new AggregateCompactionTask(10043, lakeService, aggregateRequest);
         Field field = task.getClass().getSuperclass().getDeclaredField("responseFuture");


### PR DESCRIPTION
## Why I'm doing:
Whether the aggregateCompact call is successful should be determined by status, not by failedTablets.

## What I'm doing:
This pull request updates the logic for handling compaction task results in the `AggregateCompactionTask` class and its associated unit tests. The changes focus on improving the handling of response statuses and removing reliance on `failedTablets`.

### Updates to compaction task result handling:

* [`fe/fe-core/src/main/java/com/starrocks/lake/compaction/AggregateCompactionTask.java`](diffhunk://#diff-2a705216c68d0884af48bc90ed7f0db4ad0865ba8443e5f0ea8b35e57093f6cbL54-R59): Replaced the logic that checks `failedTablets` with a new approach based on `statusCode`. The method now uses `TStatusCode` to determine whether the task was successful (`ALL_SUCCESS`) or unsuccessful (`NONE_SUCCESS`).

### Updates to unit tests:

* [`fe/fe-core/src/test/java/com/starrocks/lake/compaction/AggregateCompactionTaskTest.java`](diffhunk://#diff-924ad5e628e441e50379d9e8793695e35a2dbd1663f41338017f95e79093ac30L169-R170): Updated the mock response in the test to set `statusCode` instead of `failedTablets`, ensuring the test aligns with the new logic for determining task results.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
