### PR TITLE
[BugFix] Fix the bug in the PageHandle move assignment operator

### DIFF
--- a/be/src/storage/rowset/page_handle.h
+++ b/be/src/storage/rowset/page_handle.h
@@ -67,8 +67,8 @@ public:
 
     PageHandleTmpl& operator=(PageHandleTmpl&& other) noexcept {
         std::swap(_is_data_owner, other._is_data_owner);
-        _data = other._data;
-        _cache_data = std::move(other._cache_data);
+        std::swap(_data, other._data);
+        std::swap(_cache_data, other._cache_data);
         return *this;
     }
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -177,7 +177,7 @@ set(EXEC_FILES
         ./exprs/vectorized_literal_test.cpp
         ./exprs/min_max_predicate_test.cpp
         ./exprs/in_const_predicate_test.cpp
-	./exprs/table_function/test_list_rowsets.cpp
+        ./exprs/table_function/test_list_rowsets.cpp
         ./formats/csv/array_converter_test.cpp
         ./formats/csv/boolean_converter_test.cpp
         ./formats/csv/csv_file_writer_test.cpp
@@ -335,6 +335,7 @@ set(EXEC_FILES
         ./storage/rowset/index_page_test.cpp
         ./storage/rowset/metadata_cache_test.cpp
         ./storage/rowset/page_io_test.cpp
+        ./storage/rowset/page_handle_test.cpp
         ./storage/index/vector_index_test.cpp
         ./storage/index/vector_search_test.cpp
         ./storage/snapshot_meta_test.cpp

--- a/be/test/storage/rowset/page_handle_test.cpp
+++ b/be/test/storage/rowset/page_handle_test.cpp
@@ -1,0 +1,81 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/rowset/page_handle.h"
+
+#include "cache/lrucache_engine.h"
+#include "cache/object_cache/page_cache.h"
+
+#include <gtest/gtest.h>
+
+#include "testutil/assert.h"
+
+namespace starrocks {
+class PageHandleTest : public testing::Test {
+public:
+    void SetUp() override;
+    void TearDown() override {}
+
+protected:
+    std::shared_ptr<LRUCacheEngine> _cache_engine;
+    std::shared_ptr<StoragePageCache> _page_cache;
+};
+
+void PageHandleTest::SetUp() {
+    CacheOptions options {.mem_space_size = 10 * 1024 * 1024};
+    _cache_engine = std::make_shared<LRUCacheEngine>();
+    ASSERT_OK(_cache_engine->init(options));
+    _page_cache = std::make_shared<StoragePageCache>(_cache_engine.get());
+}
+
+TEST_F(PageHandleTest, test_operator_not_owner) {
+    ObjectCacheWriteOptions opts;
+
+    std::vector<uint8_t>* p1 = new std::vector<uint8_t>(2);
+    (*p1)[0] = 0;
+    (*p1)[1] = 1;
+    PageCacheHandle cache_handle_1;
+    ASSERT_OK(_page_cache->insert("key1", p1, opts, &cache_handle_1));
+    PageHandle handle1(std::move(cache_handle_1));
+
+    std::vector<uint8_t>* p2 = new std::vector<uint8_t>(2);
+    (*p2)[0] = 1;
+    (*p2)[1] = 0;
+    PageCacheHandle cache_handle_2;
+    ASSERT_OK(_page_cache->insert("key2", p2, opts, &cache_handle_2));
+    PageHandle handle2(std::move(cache_handle_2));
+
+    handle1 = std::move(handle2);
+    const auto* data = handle1.data();
+    ASSERT_EQ((*data)[0], 1);
+    ASSERT_EQ((*data)[1], 0);
+}
+
+TEST_F(PageHandleTest, test_operator_owner) {
+    std::vector<uint8_t>* p1 = new std::vector<uint8_t>(2);
+    (*p1)[0] = 0;
+    (*p1)[1] = 1;
+    PageHandle handle1(p1);
+
+    std::vector<uint8_t>* p2 = new std::vector<uint8_t>(2);
+    (*p2)[0] = 1;
+    (*p2)[1] = 0;
+    PageHandle handle2(p2);
+
+    handle1 = std::move(handle2);
+    const auto* data = handle1.data();
+    ASSERT_EQ((*data)[0], 1);
+    ASSERT_EQ((*data)[1], 0);
+}
+}

--- a/be/test/storage/rowset/page_handle_test.cpp
+++ b/be/test/storage/rowset/page_handle_test.cpp
@@ -14,11 +14,10 @@
 
 #include "storage/rowset/page_handle.h"
 
-#include "cache/lrucache_engine.h"
-#include "cache/object_cache/page_cache.h"
-
 #include <gtest/gtest.h>
 
+#include "cache/lrucache_engine.h"
+#include "cache/object_cache/page_cache.h"
 #include "testutil/assert.h"
 
 namespace starrocks {
@@ -33,7 +32,7 @@ protected:
 };
 
 void PageHandleTest::SetUp() {
-    CacheOptions options {.mem_space_size = 10 * 1024 * 1024};
+    CacheOptions options{.mem_space_size = 10 * 1024 * 1024};
     _cache_engine = std::make_shared<LRUCacheEngine>();
     ASSERT_OK(_cache_engine->init(options));
     _page_cache = std::make_shared<StoragePageCache>(_cache_engine.get());
@@ -78,4 +77,4 @@ TEST_F(PageHandleTest, test_operator_owner) {
     ASSERT_EQ((*data)[0], 1);
     ASSERT_EQ((*data)[1], 0);
 }
-}
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

Previous implementation would cause `PageHandle` to be `use-after-free` when using the move assignment operator.

```
==825539==ERROR: AddressSanitizer: heap-use-after-free on address 0x6030007412e8 at pc 0x00001b07a03a bp 0x7ffde470d640 sp 0x7ffde470d630                                                                          
READ of size 8 at 0x6030007412e8 thread T0                                                                                                                                                                         
    #0 0x1b07a039 in std::vector<unsigned char, std::allocator<unsigned char> >::~vector() (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1b07a039)                                                       
    #1 0x1e6069b0 in starrocks::PageHandleTmpl<std::vector<unsigned char, std::allocator<unsigned char> > >::~PageHandleTmpl() (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e6069b0)                   
    #2 0x1fe1ceae in starrocks::PageHandleTest_test_operator_owner_Test::TestBody() (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1fe1ceae)                                                              
    #3 0x37837a83 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test
+0x37837a83)                                                                                                                                                                                                       
    #4 0x3782906d in testing::Test::Run() (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x3782906d)                                                                                                        
    #5 0x378291d4 in testing::TestInfo::Run() (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x378291d4)                                                                                                    
    #6 0x378292c4 in testing::TestSuite::Run() (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x378292c4)                                                                                                   
    #7 0x37829885 in testing::internal::UnitTestImpl::RunAllTests() (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x37829885)                                                                              
    #8 0x37829ac0 in testing::UnitTest::Run() (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x37829ac0)                                                                                                    
    #9 0x1ad581c5 in RUN_ALL_TESTS() (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1ad581c5)                                                                                                             
    #10 0x1ad41ae9 in starrocks::init_test_env(int, char**) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1ad41ae9)                                                                                      
    #11 0x1ad4254e in main (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1ad4254e)                                                                                                                       
    #12 0x7f64ee190d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)                                                                                                                                                  
    #13 0x7f64ee190e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f)                                                                                                                              
    #14 0x1ac6a024 in _start (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1ac6a024)
```


## What I'm doing:

Fix the bug in the `PageHandle` move assignment pperator

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
