### PR TITLE
[BugFix] Fix prune unused predicate column bug

### DIFF
--- a/be/src/exec/olap_common.cpp
+++ b/be/src/exec/olap_common.cpp
@@ -703,6 +703,19 @@ bool ColumnValueRange<T>::is_empty_value_range() const {
 }
 
 template <class T>
+bool ColumnValueRange<T>::is_full_value_range() const {
+    if (is_fixed_value_range()) {
+        return false;
+    }
+
+    bool full_low = (_low_value == _type_min && _low_op == FILTER_LARGER_OR_EQUAL) ||
+                    (_low_value < _type_min && _low_op == FILTER_LARGER);
+    bool full_high = (_high_value == _type_max && _high_op == FILTER_LESS_OR_EQUAL) ||
+                     (_high_value > _type_max && _high_op == FILTER_LESS);
+    return full_high && full_low;
+}
+
+template <class T>
 bool ColumnValueRange<T>::is_fixed_value_convertible() const {
     if (is_fixed_value_range()) {
         return false;

--- a/be/src/exec/olap_common.cpp
+++ b/be/src/exec/olap_common.cpp
@@ -704,7 +704,7 @@ bool ColumnValueRange<T>::is_empty_value_range() const {
 
 template <class T>
 bool ColumnValueRange<T>::is_full_value_range() const {
-    if (is_fixed_value_range()) {
+    if (_is_init_state || is_fixed_value_range()) {
         return false;
     }
 

--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -94,6 +94,8 @@ public:
 
     bool is_empty_value_range() const;
 
+    bool is_full_value_range() const;
+
     bool is_init_state() const { return _is_init_state; }
 
     bool is_fixed_value_convertible() const;

--- a/be/test/storage/conjunctive_predicates_test.cpp
+++ b/be/test/storage/conjunctive_predicates_test.cpp
@@ -382,7 +382,15 @@ TEST_P(ConjunctiveTestFixture, test_parse_conjuncts) {
 
     // col >= false will be elimated
     if (ltype == TYPE_BOOLEAN && op == TExprOpcode::GE) {
-        ASSERT_TRUE(pred_tree.empty());
+        ASSERT_EQ(1, pred_tree.size());
+
+        const auto& root = pred_tree.root();
+        ASSERT_TRUE(root.compound_children().empty());
+        ASSERT_EQ(1, root.col_children_map().size());
+
+        const auto* predicate = root.col_children_map().find(0)->second[0].col_pred();
+        ASSERT_TRUE(predicate != nullptr);
+        ASSERT_EQ(PredicateType::kNotNull, predicate->type());
         return;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -196,13 +196,17 @@ import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.LikePredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.MatchExprOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 import com.starrocks.sql.optimizer.operator.stream.PhysicalStreamAggOperator;
 import com.starrocks.sql.optimizer.operator.stream.PhysicalStreamJoinOperator;
 import com.starrocks.sql.optimizer.operator.stream.PhysicalStreamScanOperator;
-import com.starrocks.sql.optimizer.rule.tree.AddDecodeNodeForDictStringRule.DecodeVisitor;
 import com.starrocks.sql.optimizer.rule.tree.prunesubfield.SubfieldAccessPathNormalizer;
 import com.starrocks.sql.optimizer.rule.tree.prunesubfield.SubfieldExpressionCollector;
 import com.starrocks.sql.optimizer.statistics.Statistics;
@@ -235,6 +239,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static com.starrocks.analysis.BinaryType.EQ_FOR_NULL;
 import static com.starrocks.catalog.Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF;
 import static com.starrocks.sql.common.ErrorType.INTERNAL_ERROR;
 import static com.starrocks.sql.common.UnsupportedException.unsupportedException;
@@ -603,10 +608,10 @@ public class PlanFragmentBuilder {
             // ------------------------------------------------------------------------------------
             Set<Integer> pushdownPredUsedColumnIds = new HashSet<>();
             Set<Integer> nonPushdownPredUsedColumnIds = new HashSet<>();
+            IsSimpleStrictPredicateVisitor checkVistor = new IsSimpleStrictPredicateVisitor(sessionVariable);
             for (ScalarOperator predicate : predicates) {
                 ColumnRefSet usedColumns = predicate.getUsedColumns();
-                boolean isPushdown =
-                        DecodeVisitor.isSimpleStrictPredicate(predicate, sessionVariable.isEnablePushdownOrPredicate())
+                boolean isPushdown = predicate.accept(checkVistor, null)
                                 && Arrays.stream(usedColumns.getColumnIds()).noneMatch(nonPushdownColumnIds::contains);
                 if (isPushdown) {
                     for (int cid : usedColumns.getColumnIds()) {
@@ -627,6 +632,89 @@ public class PlanFragmentBuilder {
                     .filter(cid -> !nonPushdownPredUsedColumnIds.contains(cid) && !outputColumnIds.contains(cid))
                     .collect(Collectors.toSet());
             scanNode.setUnUsedOutputStringColumns(unUsedOutputColumnIds);
+        }
+
+        // The predicate no function all, this implementation is consistent with BE olap scan node
+        private static class IsSimpleStrictPredicateVisitor extends ScalarOperatorVisitor<Boolean, Void> {
+
+            private final boolean enablePushDownOrPredicate;
+
+            private final boolean enablePushDownExprPredicate;
+
+            public IsSimpleStrictPredicateVisitor(SessionVariable variable) {
+                this.enablePushDownOrPredicate = variable.isEnablePushdownOrPredicate();
+                this.enablePushDownExprPredicate = variable.isEnableColumnExprPredicate();
+            }
+
+            @Override
+            public Boolean visit(ScalarOperator scalarOperator, Void context) {
+                return false;
+            }
+
+            @Override
+            public Boolean visitCompoundPredicate(CompoundPredicateOperator predicate, Void context) {
+                if (!enablePushDownOrPredicate) {
+                    return false;
+                }
+
+                if (!predicate.isAnd() && !predicate.isOr() && !enablePushDownExprPredicate) {
+                    return false;
+                }
+
+                return predicate.getChildren().stream().allMatch(child -> child.accept(this, context));
+            }
+
+            @Override
+            public Boolean visitBinaryPredicate(BinaryPredicateOperator predicate, Void context) {
+                if (predicate.getBinaryType() == EQ_FOR_NULL) {
+                    return false;
+                }
+                if (predicate.getUsedColumns().cardinality() > 1) {
+                    return false;
+                }
+                if (!predicate.getChild(1).isConstant()) {
+                    return false;
+                }
+
+                if (!checkTypeCanPushDown(predicate)) {
+                    return false;
+                }
+
+                return predicate.getChild(0).isColumnRef();
+            }
+
+            @Override
+            public Boolean visitInPredicate(InPredicateOperator predicate, Void context) {
+                if (!checkTypeCanPushDown(predicate)) {
+                    return false;
+                }
+
+                return predicate.getChild(0).isColumnRef() && predicate.allValuesMatch(ScalarOperator::isConstantRef);
+            }
+
+            @Override
+            public Boolean visitIsNullPredicate(IsNullPredicateOperator predicate, Void context) {
+                if (!checkTypeCanPushDown(predicate)) {
+                    return false;
+                }
+
+                return predicate.getChild(0).isColumnRef();
+            }
+
+            @Override
+            public Boolean visitMatchExprOperator(MatchExprOperator predicate, Void context) {
+                // match expression is always satisfy the following format:
+                // SlotRef MATCH StringLiteral which is always SimpleStrictPredicate
+                return true;
+            }
+
+            // These type predicates couldn't be pushed down to storage engine,
+            // which are consistent with BE implementations.
+            private boolean checkTypeCanPushDown(ScalarOperator scalarOperator) {
+                Type leftType = scalarOperator.getChild(0).getType();
+                return !leftType.isFloatingPointType() && !leftType.isComplexType() && !leftType.isJsonType() &&
+                        !leftType.isTime();
+            }
         }
 
         @Override

--- a/test/sql/test_scan/test_pushdown_or_predicate/R/test_pushdown_and_rewrite_predicate
+++ b/test/sql/test_scan/test_pushdown_or_predicate/R/test_pushdown_and_rewrite_predicate
@@ -1,0 +1,45 @@
+-- name: test_pushdown_and_rewrite_predicate
+CREATE TABLE `t1` (
+  `c_1_0` decimal(14, 11) NULL COMMENT "",
+  `c_1_1` decimal(34, 32) NULL COMMENT "",
+  `c_1_13` boolean NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`c_1_0`)
+DISTRIBUTED BY HASH(`c_1_1`)
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1
+values (1, 1, 1), (2, 2, 0), (3,3,null);
+-- result:
+-- !result
+SELECT t1.c_1_0 FROM t1 WHERE (ANY_MATCH([false])) BETWEEN ((NOT (CAST(t1.c_1_1 AS BOOLEAN)))) AND (t1.c_1_13) order by c_1_0;
+-- result:
+1.00000000000
+2.00000000000
+-- !result
+SELECT t1.c_1_0 FROM t1 WHERE c_1_13 >= any_match([FALSE]) order by c_1_0;
+-- result:
+1.00000000000
+2.00000000000
+-- !result
+SELECT t1.c_1_0 FROM t1 WHERE c_1_13 <= any_match([TRUE]) order by c_1_0;
+-- result:
+1.00000000000
+2.00000000000
+-- !result
+SELECT t1.c_1_0 FROM t1 WHERE c_1_13 > -2 order by c_1_0;
+-- result:
+1.00000000000
+2.00000000000
+-- !result
+SELECT t1.c_1_0 FROM t1 WHERE c_1_13 < 2 order by c_1_0;
+-- result:
+1.00000000000
+2.00000000000
+-- !result

--- a/test/sql/test_scan/test_pushdown_or_predicate/T/test_pushdown_and_rewrite_predicate
+++ b/test/sql/test_scan/test_pushdown_or_predicate/T/test_pushdown_and_rewrite_predicate
@@ -1,0 +1,29 @@
+-- name: test_pushdown_and_rewrite_predicate
+
+CREATE TABLE `t1` (
+  `c_1_0` decimal(14, 11) NULL COMMENT "",
+  `c_1_1` decimal(34, 32) NULL COMMENT "",
+  `c_1_13` boolean NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`c_1_0`)
+DISTRIBUTED BY HASH(`c_1_1`)
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+
+
+insert into t1
+values (1, 1, 1), (2, 2, 0), (3,3,null);
+
+SELECT t1.c_1_0 FROM t1 WHERE (ANY_MATCH([false])) BETWEEN ((NOT (CAST(t1.c_1_1 AS BOOLEAN)))) AND (t1.c_1_13) order by c_1_0;
+
+SELECT t1.c_1_0 FROM t1 WHERE c_1_13 >= any_match([FALSE]) order by c_1_0;
+
+SELECT t1.c_1_0 FROM t1 WHERE c_1_13 <= any_match([TRUE]) order by c_1_0;
+
+SELECT t1.c_1_0 FROM t1 WHERE c_1_13 > -2 order by c_1_0;
+
+SELECT t1.c_1_0 FROM t1 WHERE c_1_13 < 2 order by c_1_0;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Bug 1:
when enable `enableColumnExprPredicate` session variable, `NOT` predicate canbe push down to storage as a `ColumnExprPredicate`, but FE doesn't update the check,  it's take `PruneUnusedPredicateColumn` to generate an error unused column ids, make the be crash

Bug 2:
sql:  `select * from t1 where p > 1`, the predicate `p > 1`, the `p` is boolean type,  will generate value range predicate by `p`'s type, and the range predicate will optimize `p > 1` to `true`.
when `p` is nullable, the optimize will ignore `NULL` value, we need add `IS NOT NULL` predicate

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
