### PR TITLE
[Enhancement] Add detailed exit code and restart decision logging to BE entrypoint

### DIFF
--- a/docker/dockerfiles/be/be_entrypoint.sh
+++ b/docker/dockerfiles/be/be_entrypoint.sh
@@ -129,6 +129,30 @@ fi
 while true; do
   $STARROCKS_HOME/bin/start_be.sh $addition_args
   ret=$?
+
+  # Enhanced logging for exit status analysis
+  log_stderr "start_be.sh exited with return code: $ret"
+
+  # Decode the exit status to provide more meaningful information
+  if [[ $ret -eq 0 ]]; then
+    log_stderr "Exit reason: Normal termination (exit code 0)"
+  elif [[ $ret -ge 128 && $ret -le 255 ]]; then
+    # Exit codes 128+n indicate termination by signal n
+    signal_num=$((ret - 128))
+    case $signal_num in
+      1)  log_stderr "Exit reason: Terminated by SIGHUP (signal 1) - Hangup" ;;
+      2)  log_stderr "Exit reason: Terminated by SIGINT (signal 2) - Interrupt" ;;
+      3)  log_stderr "Exit reason: Terminated by SIGQUIT (signal 3) - Quit" ;;
+      6)  log_stderr "Exit reason: Terminated by SIGABRT (signal 6) - Abort/Assert failure" ;;
+      9)  log_stderr "Exit reason: Terminated by SIGKILL (signal 9) - Kill" ;;
+      11) log_stderr "Exit reason: Terminated by SIGSEGV (signal 11) - Segmentation fault" ;;
+      15) log_stderr "Exit reason: Terminated by SIGTERM (signal 15) - Termination" ;;
+      *)  log_stderr "Exit reason: Terminated by signal $signal_num (exit code $ret)" ;;
+    esac
+  else
+    log_stderr "Exit reason: Process exited with code $ret (non-signal termination)"
+  fi
+
   if [[ $ret -ne 0 && "x$LOG_CONSOLE" != "x1" ]] ; then
       nol=50
       log_stderr "Last $nol lines of be.INFO ..."
@@ -142,16 +166,42 @@ while true; do
   #  b. coredump is enabled, and the error code is SIGABRT(6) or SIGSEGV(11);
   # otherwise BE process should still exit.
   should_exit=true
+  restart_reason=""
+
+  # Check DEBUG_MODE condition
   if [[ "$DEBUG_MODE" == "true" ]]; then
     should_exit=false
+    restart_reason="DEBUG_MODE is enabled"
+    log_stderr "Restart decision: should_exit=false (reason: $restart_reason)"
+  else
+    log_stderr "Restart decision: DEBUG_MODE is not enabled (DEBUG_MODE=$DEBUG_MODE)"
   fi
 
+  # Check COREDUMP_ENABLED condition for crash signals
   if [[ "$COREDUMP_ENABLED" == "true" && ($ret -eq 134 || $ret -eq 139) ]]; then
     should_exit=false
+    if [[ $ret -eq 134 ]]; then
+      restart_reason="COREDUMP_ENABLED and process crashed with SIGABRT (exit code 134)"
+    elif [[ $ret -eq 139 ]]; then
+      restart_reason="COREDUMP_ENABLED and process crashed with SIGSEGV (exit code 139)"
+    fi
+    log_stderr "Restart decision: should_exit=false (reason: $restart_reason)"
+  else
+    if [[ "$COREDUMP_ENABLED" == "true" ]]; then
+      log_stderr "Restart decision: COREDUMP_ENABLED is true but exit code $ret is not a crash signal (134=SIGABRT, 139=SIGSEGV)"
+    else
+      log_stderr "Restart decision: COREDUMP_ENABLED is not enabled (COREDUMP_ENABLED=$COREDUMP_ENABLED)"
+    fi
   fi
 
+  # Final decision logging
   if [[ "$should_exit" == "true" ]]; then
-    exit  $ret
+    log_stderr "Final decision: should_exit=true - BE process will NOT be restarted"
+    log_stderr "Exiting with return code: $ret"
+    exit $ret
+  else
+    log_stderr "Final decision: should_exit=false - BE process WILL be restarted"
+    log_stderr "Restart reason: $restart_reason"
   fi
 
   # Print a message indicating the failure


### PR DESCRIPTION
## Why I'm doing:
Improve BE container restart transparency with detailed exit status logging

## What I'm doing:
1. Exit Code Analysis
Logs the exact return code from start_be.sh
Decodes exit codes to identify if they're signal-based (128+n format)
Maps common signals to human-readable descriptions:
SIGHUP (1) - Hangup
SIGINT (2) - Interrupt
SIGQUIT (3) - Quit
SIGABRT (6) - Abort/Assert failure
SIGKILL (9) - Kill
SIGSEGV (11) - Segmentation fault
SIGTERM (15) - Termination
2. Restart Decision Logic Transparency
DEBUG_MODE evaluation: Logs whether DEBUG_MODE is enabled and its impact
COREDUMP_ENABLED evaluation: Logs whether coredump is enabled and if the exit code matches crash signals (134=SIGABRT, 139=SIGSEGV)
Final decision: Clearly states whether the process will be restarted and the specific reason
3. Enhanced Decision Flow
Shows step-by-step evaluation of restart conditions
Explains why should_exit is set to true or false
Provides the specific restart reason when applicable
4. Sample output
```
[2025-06-24 10:30:15] start_be.sh exited with return code: 139
[2025-06-24 10:30:15] Exit reason: Terminated by SIGSEGV (signal 11) - Segmentation fault
[2025-06-24 10:30:15] Restart decision: DEBUG_MODE is not enabled (DEBUG_MODE=false)
[2025-06-24 10:30:15] Restart decision: should_exit=false (reason: COREDUMP_ENABLED and process crashed with SIGSEGV (exit code 139))
[2025-06-24 10:30:15] Final decision: should_exit=false - BE process WILL be restarted
[2025-06-24 10:30:15] Restart reason: COREDUMP_ENABLED and process crashed with SIGSEGV (exit code 139)
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3