### PR TITLE
[BugFix] Fix incorect usage of jline.internal.Log as LOG

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
@@ -24,7 +24,6 @@ import com.starrocks.connector.hive.HiveWriteUtils;
 import com.starrocks.connector.hive.Partition;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
-import jline.internal.Log;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -229,7 +228,7 @@ public class RemoteFileOperations {
         try {
             fileSystem = FileSystem.get(writePath.toUri(), conf);
         } catch (Exception e) {
-            Log.error("Failed to get fileSystem", e);
+            LOG.error("Failed to get fileSystem", e);
             throw new StarRocksConnectorException("Failed to move data files to target location. " +
                     "Failed to get file system on path %s. msg: %s", writePath, e.getMessage());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/partition/PartitionSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/partition/PartitionSelector.java
@@ -76,7 +76,6 @@ import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.thrift.TResultBatch;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import jline.internal.Log;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.logging.log4j.LogManager;
@@ -605,7 +604,7 @@ public class PartitionSelector {
                 return result;
             }
         } catch (Exception e) {
-            Log.warn("Failed to prune partitions by FE's constant evaluation, transform to partitions_meta instead",
+            LOG.warn("Failed to prune partitions by FE's constant evaluation, transform to partitions_meta instead",
                     e);
         }
 


### PR DESCRIPTION
## Why I'm doing:

When trying to migrate maven to gradle to better support incremental build, found some compile error:
```

Execution failed for task ':fe-core:compileJava'.
> Compilation failed; see the compiler output below.
  /home/decster/projects/starrocks-fe/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java:232: error: cannot find symbol
              Log.error("Failed to get fileSystem", e);
              ^
    symbol:   variable Log
    location: class RemoteFileOperations
  /home/decster/projects/starrocks-fe/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/partition/PartitionSelector.java:608: error: cannot find symbol
              Log.warn("Failed to prune partitions by FE's constant evaluation, transform to partitions_meta instead",
              ^
    symbol:   variable Log
    location: class PartitionSelector
```

## What I'm doing:

Fix incorect usage of jline.internal.Log as LOG

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
