### PR TITLE
[BugFix] fix `count(1)` optimization on empty table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
@@ -170,8 +170,11 @@ public class RewriteSimpleAggToHDFSScanRule extends TransformationRule {
                 Lists.newArrayList(sumOutputColumnRef, ConstantOperator.createBigint(0)),
                 Expr.getBuiltinFunction(FunctionSet.IFNULL, new Type[] {Type.BIGINT, Type.BIGINT},
                         Function.CompareMode.IS_IDENTICAL));
-        LogicalProjectOperator newProjectOperator = new LogicalProjectOperator(
-                Maps.newHashMap(Collections.singletonMap(aggColumnRef, ifNullCall)));
+        Map<ColumnRefOperator, ScalarOperator> newProjectMap = Maps.newHashMap();
+        newProjectMap.putAll(newAggOperator.getColumnRefMap());
+        newProjectMap.remove(sumOutputColumnRef);
+        newProjectMap.put(aggColumnRef, ifNullCall);
+        LogicalProjectOperator newProjectOperator = new LogicalProjectOperator(newProjectMap);
 
         // project(ifnull) -> agg(sum(__count__)) -> scan
         OptExpression optExpression = OptExpression.create(newProjectOperator);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
@@ -113,10 +113,11 @@ public class RewriteSimpleAggToHDFSScanRule extends TransformationRule {
             return null;
         }
 
-        ColumnRefOperator sumOutputColumnRef = columnRefFactory.create(aggColumnRef.getName(), aggCall.getType(),
-                aggCall.isNullable());
+        ColumnRefOperator sumOutputColumnRef =
+                columnRefFactory.create("sum_" + aggCall.getFnName(), aggCall.getType(), aggCall.isNullable());
         {
-            // generate a placeholder column for scan node
+            // generate a placeholder column for scan node.
+            // ___count___ must be the column name for backend code.
             String metaColumnName = "___" + aggCall.getFnName() + "___";
             Column c = new Column(metaColumnName, Type.NULL);
             c.setIsAllowNull(true);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.optimizer.rule.transformation;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.Expr;
@@ -33,11 +34,13 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalFileScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalHiveScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.pattern.MultiOpPattern;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.RuleType;
 import org.apache.logging.log4j.LogManager;
@@ -78,7 +81,13 @@ public class RewriteSimpleAggToHDFSScanRule extends TransformationRule {
                                                LogicalScanOperator scanOperator,
                                                OptimizerContext context) {
         ColumnRefFactory columnRefFactory = context.getColumnRefFactory();
+
+        // only need to handle count(*)
         Map<ColumnRefOperator, CallOperator> aggs = aggregationOperator.getAggregations();
+        Preconditions.checkArgument(aggs.entrySet().size() == 1);
+        ColumnRefOperator aggColumnRef = aggs.entrySet().iterator().next().getKey();
+        CallOperator aggCall = aggs.entrySet().iterator().next().getValue();
+        Preconditions.checkArgument(aggCall.getFnName().equals(FunctionSet.COUNT) && !aggCall.isDistinct());
 
         Map<ColumnRefOperator, CallOperator> newAggCalls = Maps.newHashMap();
         Map<ColumnRefOperator, Column> newScanColumnRefs = Maps.newHashMap();
@@ -104,35 +113,23 @@ public class RewriteSimpleAggToHDFSScanRule extends TransformationRule {
             return null;
         }
 
-        ColumnRefOperator placeholderColumn = null;
-
-        for (Map.Entry<ColumnRefOperator, CallOperator> kv : aggs.entrySet()) {
-            CallOperator aggCall = kv.getValue();
-            // ___count___
+        ColumnRefOperator sumOutputColumnRef = columnRefFactory.create(aggColumnRef.getName(), aggCall.getType(),
+                aggCall.isNullable());
+        {
+            // generate a placeholder column for scan node
             String metaColumnName = "___" + aggCall.getFnName() + "___";
-            Type columnType = aggCall.getType();
+            Column c = new Column(metaColumnName, Type.NULL);
+            c.setIsAllowNull(true);
+            ColumnRefOperator placeholderColumn =
+                    columnRefFactory.create(metaColumnName, aggCall.getType(), aggCall.isNullable());
+            columnRefFactory.updateColumnToRelationIds(placeholderColumn.getId(), tableRelationId);
+            columnRefFactory.updateColumnRefToColumns(placeholderColumn, c, scanOperator.getTable());
+            newScanColumnRefs.put(placeholderColumn, c);
 
-            if (placeholderColumn == null) {
-                Column c = new Column(metaColumnName, Type.NULL);
-                c.setIsAllowNull(true);
-                placeholderColumn = columnRefFactory.create(metaColumnName, columnType, aggCall.isNullable());
-                columnRefFactory.updateColumnToRelationIds(placeholderColumn.getId(), tableRelationId);
-                columnRefFactory.updateColumnRefToColumns(placeholderColumn, c, scanOperator.getTable());
-                newScanColumnRefs.put(placeholderColumn, c);
-            }
-
-            Function aggFunction = aggCall.getFunction();
-            String newAggFnName = aggCall.getFnName();
-            Type newAggReturnType = aggCall.getType();
-            if (aggCall.getFnName().equals(FunctionSet.COUNT)) {
-                aggFunction = Expr.getBuiltinFunction(FunctionSet.SUM,
-                        new Type[] {Type.BIGINT}, Function.CompareMode.IS_IDENTICAL);
-                newAggFnName = FunctionSet.SUM;
-                newAggReturnType = Type.BIGINT;
-            }
-            CallOperator newAggCall = new CallOperator(newAggFnName, newAggReturnType,
-                    Collections.singletonList(placeholderColumn), aggFunction);
-            newAggCalls.put(kv.getKey(), newAggCall);
+            CallOperator sumCall = new CallOperator(FunctionSet.SUM, Type.BIGINT,
+                    Collections.singletonList(placeholderColumn),
+                    Expr.getBuiltinFunction(FunctionSet.SUM, new Type[] {Type.BIGINT}, Function.CompareMode.IS_IDENTICAL));
+            newAggCalls.put(sumOutputColumnRef, sumCall);
         }
 
         Map<Column, ColumnRefOperator> newScanColumnMeta = Maps.newHashMap();
@@ -163,12 +160,24 @@ public class RewriteSimpleAggToHDFSScanRule extends TransformationRule {
             LOG.warn("Exception caught when set scan operator predicates", e);
             return null;
         }
+
         LogicalAggregationOperator newAggOperator = new LogicalAggregationOperator(aggregationOperator.getType(),
                 aggregationOperator.getGroupingKeys(), newAggCalls);
-
         newAggOperator.setProjection(aggregationOperator.getProjection());
-        OptExpression optExpression = OptExpression.create(newAggOperator);
-        optExpression.getInputs().add(OptExpression.create(newMetaScan));
+
+        // ifnull(sum(__count__)), 0) to avoid null result
+        CallOperator ifNullCall = new CallOperator(FunctionSet.IFNULL, Type.BIGINT,
+                Lists.newArrayList(sumOutputColumnRef, ConstantOperator.createBigint(0)),
+                Expr.getBuiltinFunction(FunctionSet.IFNULL, new Type[] {Type.BIGINT, Type.BIGINT},
+                        Function.CompareMode.IS_IDENTICAL));
+        LogicalProjectOperator newProjectOperator = new LogicalProjectOperator(
+                Maps.newHashMap(Collections.singletonMap(aggColumnRef, ifNullCall)));
+
+        // project(ifnull) -> agg(sum(__count__)) -> scan
+        OptExpression optExpression = OptExpression.create(newProjectOperator);
+        OptExpression aggExpression = OptExpression.create(newAggOperator);
+        optExpression.getInputs().add(aggExpression);
+        aggExpression.getInputs().add(OptExpression.create(newMetaScan));
         return optExpression;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
@@ -95,6 +95,7 @@ public class HiveScanTest extends ConnectorPlanTestBase {
                 String sql = sqlString[i];
                 String plan = getFragmentPlan(sql);
                 assertContains(plan, "___count___");
+                assertContains(plan, "ifnull");
             }
         }
         // negative cases.
@@ -121,6 +122,7 @@ public class HiveScanTest extends ConnectorPlanTestBase {
                 String sql = sqlString[i];
                 // just make sure it's not stuck.
                 String plan = getFragmentPlan(sql);
+                assertNotContains(plan, "___count___");
             }
         }
         connectContext.getSessionVariable().setEnableRewriteSimpleAggToHdfsScan(false);
@@ -141,6 +143,7 @@ public class HiveScanTest extends ConnectorPlanTestBase {
                 String sql = sqlString[i];
                 String plan = getFragmentPlan(sql);
                 assertContains(plan, "___count___");
+                assertContains(plan, "ifnull");
             }
         }
         // negative cases.

--- a/test/sql/test_iceberg/R/test_iceberg_metadata_cache
+++ b/test/sql/test_iceberg/R/test_iceberg_metadata_cache
@@ -9,6 +9,10 @@ create external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uu
 c_date date,c_smallint smallint) partition by(c_date,c_smallint);
 -- result:
 -- !result
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0};
+-- result:
+0
+-- !result
 insert overwrite iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}(c_tinyint,c_string,c_date,c_smallint) values(1+100, concat('overwrite old partition', ' yeah~'),cast('2000-01-01' + interval '1' day as date),10-10),(2+100,'generate new partition','2000-01-02',1),(3+100,'generate new partition','2022-02-02',100/10);
 -- result:
 -- !result

--- a/test/sql/test_iceberg/T/test_iceberg_metadata_cache
+++ b/test/sql/test_iceberg/T/test_iceberg_metadata_cache
@@ -6,6 +6,8 @@ create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
 create external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}(c_tinyint tinyint,c_int int,c_bigint bigint,c_bool boolean,c_float float,c_double double,c_decimal decimal(38,18),c_datetime datetime,c_char char(10),c_varchar varchar(20),c_string string,c_struct struct<col_int int, col_string string, col_date date>,c_map map<boolean, string>,c_array array<int>,
 c_date date,c_smallint smallint) partition by(c_date,c_smallint);
 
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0};
+
 insert overwrite iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}(c_tinyint,c_string,c_date,c_smallint) values(1+100, concat('overwrite old partition', ' yeah~'),cast('2000-01-01' + interval '1' day as date),10-10),(2+100,'generate new partition','2000-01-02',1),(3+100,'generate new partition','2022-02-02',100/10);
 
 insert overwrite iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}(c_bool,c_date,c_int,c_array,c_char,c_smallint,c_struct)


### PR DESCRIPTION
## Why I'm doing:

if t is an empty table

> select count(1) from t

outputs "null"

## What I'm doing:

Fix the rule, add a projection `ifnull(sum(__count__), 0)`

Fixes #60022

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
