### PR TITLE
[Enhancement] Spill PartitionWise aggregation

### DIFF
--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -53,7 +53,8 @@ public:
         HASH_JOIN_SPILL_HASH_SLOT_ID = -1,
         SORT_ORDINAL_COLUMN_SLOT_ID = -2,
         HASH_JOIN_BUILD_INDEX_SLOT_ID = -3,
-        HASH_JOIN_PROBE_INDEX_SLOT_ID = -4
+        HASH_JOIN_PROBE_INDEX_SLOT_ID = -4,
+        HASH_AGG_SPILL_HASH_SLOT_ID = -5
     };
 
     using ChunkPtr = std::shared_ptr<Chunk>;

--- a/be/src/exec/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/aggregate/aggregate_blocking_node.cpp
@@ -27,6 +27,7 @@
 #include "exec/pipeline/aggregate/sorted_aggregate_streaming_source_operator.h"
 #include "exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.h"
 #include "exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.h"
+#include "exec/pipeline/aggregate/spillable_partitionwise_aggregate_operator.h"
 #include "exec/pipeline/bucket_process_operator.h"
 #include "exec/pipeline/chunk_accumulate_operator.h"
 #include "exec/pipeline/exchange/local_exchange_source_operator.h"
@@ -182,28 +183,43 @@ pipeline::OpFactories AggregateBlockingNode::_decompose_to_pipeline(pipeline::Op
     auto workgroup = context->fragment_context()->workgroup();
     auto degree_of_parallelism = context->source_operator(ops_with_sink)->degree_of_parallelism();
     auto spill_channel_factory = std::make_shared<SpillProcessChannelFactory>(degree_of_parallelism);
-    if (std::is_same_v<SinkFactory, SpillableAggregateBlockingSinkOperatorFactory>) {
+    if (std::is_same_v<SinkFactory, SpillableAggregateBlockingSinkOperatorFactory> ||
+        std::is_same_v<SinkFactory, SpillablePartitionWiseAggregateSinkOperatorFactory>) {
         context->interpolate_spill_process(id(), spill_channel_factory, degree_of_parallelism);
     }
 
     auto should_cache = context->should_interpolate_cache_operator(id(), ops_with_sink[0]);
     auto* upstream_source_op = context->source_operator(ops_with_sink);
-    auto operators_generator = [this, should_cache, upstream_source_op, context,
-                                spill_channel_factory](bool post_cache) {
+    auto operators_generator = [
+        this, &should_cache, upstream_source_op, context,
+        spill_channel_factory
+    ]<typename SinkFactoryT = SinkFactory, typename SourceFactoryT = SourceFactory>(bool post_cache) {
         // create aggregator factory
         // shared by sink operator and source operator
         auto aggregator_factory = std::make_shared<AggFactory>(_tnode);
         AggrMode aggr_mode = should_cache ? (post_cache ? AM_BLOCKING_POST_CACHE : AM_BLOCKING_PRE_CACHE) : AM_DEFAULT;
         aggregator_factory->set_aggr_mode(aggr_mode);
-        auto sink_operator = std::make_shared<SinkFactory>(context->next_operator_id(), id(), aggregator_factory,
-                                                           _build_runtime_filters, spill_channel_factory);
-        auto source_operator = std::make_shared<SourceFactory>(context->next_operator_id(), id(), aggregator_factory);
+        auto sink_operator = std::make_shared<SinkFactoryT>(context->next_operator_id(), id(), aggregator_factory,
+                                                            _build_runtime_filters, spill_channel_factory);
+        auto source_operator = std::make_shared<SourceFactoryT>(context->next_operator_id(), id(), aggregator_factory);
 
         context->inherit_upstream_source_properties(source_operator.get(), upstream_source_op);
         return std::tuple<OpFactoryPtr, SourceOperatorFactoryPtr>(sink_operator, source_operator);
     };
 
     auto [agg_sink_op, agg_source_op] = operators_generator(false);
+    if constexpr (std::is_same_v<SourceFactory, SpillablePartitionWiseAggregateSourceOperatorFactory>) {
+        auto old_value = should_cache;
+        should_cache = true;
+        DeferOp restore([old_value, &should_cache]() { should_cache = old_value; });
+        auto [agg_blocking_sink_op, agg_blocking_source_op] =
+                operators_generator.template
+                operator()<AggregateBlockingSinkOperatorFactory, AggregateBlockingSourceOperatorFactory>(true);
+        ConjugateOperatorFactoryPtr conjugate_op =
+                std::make_shared<query_cache::ConjugateOperatorFactory>(agg_blocking_sink_op, agg_blocking_source_op);
+        std::dynamic_pointer_cast<SpillablePartitionWiseAggregateSourceOperatorFactory>(agg_source_op)
+                ->set_pw_agg_factory(std::move(conjugate_op));
+    }
     // Create a shared RefCountedRuntimeFilterCollector
     // Initialize OperatorFactory's fields involving runtime filters.
     auto&& rc_rf_probe_collector = std::make_shared<RcRfProbeCollector>(2, std::move(this->runtime_filter_collector()));
@@ -297,9 +313,17 @@ pipeline::OpFactories AggregateBlockingNode::decompose_to_pipeline(pipeline::Pip
             enable_agg_spill = false;
         }
         if (enable_agg_spill && has_group_by_keys) {
-            ops_with_source = _decompose_to_pipeline<AggregatorFactory, SpillableAggregateBlockingSourceOperatorFactory,
-                                                     SpillableAggregateBlockingSinkOperatorFactory>(ops_with_sink,
-                                                                                                    context, false);
+            if (runtime_state()->enable_spill_partitionwise_agg()) {
+                ops_with_source =
+                        _decompose_to_pipeline<AggregatorFactory, SpillablePartitionWiseAggregateSourceOperatorFactory,
+                                               SpillablePartitionWiseAggregateSinkOperatorFactory>(ops_with_sink,
+                                                                                                   context, false);
+            } else {
+                ops_with_source =
+                        _decompose_to_pipeline<AggregatorFactory, SpillableAggregateBlockingSourceOperatorFactory,
+                                               SpillableAggregateBlockingSinkOperatorFactory>(ops_with_sink, context,
+                                                                                              false);
+            }
         } else {
             ops_with_source = _decompose_to_pipeline<AggregatorFactory, AggregateBlockingSourceOperatorFactory,
                                                      AggregateBlockingSinkOperatorFactory>(

--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -1206,6 +1206,19 @@ void Aggregator::_destroy_state(AggDataPtr __restrict state) {
     }
 }
 
+const std::vector<SlotId>& Aggregator::output_group_by_slot_ids() const {
+    if (!_opt_partition_by_slot_ids.has_value()) {
+        std::vector<SlotId> slot_ids;
+        const auto num_group_by_columns = _group_by_expr_ctxs.size();
+        slot_ids.resize(num_group_by_columns);
+        auto slots_begin = _output_tuple_desc->slots().begin();
+        std::transform(slots_begin, slots_begin + num_group_by_columns, slot_ids.begin(),
+                       [](auto slot) { return slot->id(); });
+        _opt_partition_by_slot_ids = std::move(slot_ids);
+    }
+    return _opt_partition_by_slot_ids.value();
+}
+
 ChunkPtr Aggregator::_build_output_chunk(const Columns& group_by_columns, const Columns& agg_result_columns,
                                          bool use_intermediate_as_output) {
     ChunkPtr result_chunk = std::make_shared<Chunk>();

--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -1206,19 +1206,6 @@ void Aggregator::_destroy_state(AggDataPtr __restrict state) {
     }
 }
 
-const std::vector<SlotId>& Aggregator::output_group_by_slot_ids() const {
-    if (!_opt_partition_by_slot_ids.has_value()) {
-        std::vector<SlotId> slot_ids;
-        const auto num_group_by_columns = _group_by_expr_ctxs.size();
-        slot_ids.resize(num_group_by_columns);
-        auto slots_begin = _output_tuple_desc->slots().begin();
-        std::transform(slots_begin, slots_begin + num_group_by_columns, slot_ids.begin(),
-                       [](auto slot) { return slot->id(); });
-        _opt_partition_by_slot_ids = std::move(slot_ids);
-    }
-    return _opt_partition_by_slot_ids.value();
-}
-
 ChunkPtr Aggregator::_build_output_chunk(const Columns& group_by_columns, const Columns& agg_result_columns,
                                          bool use_intermediate_as_output) {
     ChunkPtr result_chunk = std::make_shared<Chunk>();

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -425,8 +425,6 @@ public:
     auto defer_notify_source() { return _pip_observable.defer_notify_source(); }
     auto defer_notify_sink() { return _pip_observable.defer_notify_sink(); }
 
-    const std::vector<SlotId>& output_group_by_slot_ids() const;
-
 protected:
     AggregatorParamsPtr _params;
 
@@ -505,7 +503,6 @@ protected:
     std::vector<ExprContext*> _group_by_expr_ctxs;
     Columns _group_by_columns;
     std::vector<ColumnType> _group_by_types;
-    mutable std::optional<std::vector<SlotId>> _opt_partition_by_slot_ids{};
 
     // Tuple into which Update()/Merge()/Serialize() results are stored.
     TupleId _intermediate_tuple_id;

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -425,6 +425,8 @@ public:
     auto defer_notify_source() { return _pip_observable.defer_notify_source(); }
     auto defer_notify_sink() { return _pip_observable.defer_notify_sink(); }
 
+    const std::vector<SlotId>& output_group_by_slot_ids() const;
+
 protected:
     AggregatorParamsPtr _params;
 
@@ -503,6 +505,7 @@ protected:
     std::vector<ExprContext*> _group_by_expr_ctxs;
     Columns _group_by_columns;
     std::vector<ColumnType> _group_by_types;
+    mutable std::optional<std::vector<SlotId>> _opt_partition_by_slot_ids{};
 
     // Tuple into which Update()/Merge()/Serialize() results are stored.
     TupleId _intermediate_tuple_id;

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.h
@@ -50,6 +50,8 @@ public:
     StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
     Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
     Status reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) override;
+    AggregatorPtr& aggregator() { return _aggregator; }
+    void set_agg_group_by_with_limit(bool v) { _agg_group_by_with_limit = v; }
 
 protected:
     AggregateBlockingSinkOperatorFactory* factory() {
@@ -103,6 +105,7 @@ public:
     Status prepare(RuntimeState* state) override;
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override;
+    AggregatorFactoryPtr& aggregator_factory() { return _aggregator_factory; }
 
     void set_runtime_filter_collector(RuntimeFilterHub* hub, int32_t plan_node_id,
                                       std::unique_ptr<RuntimeFilterCollector>&& collector);

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
@@ -42,6 +42,8 @@ public:
 
     StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
 
+    AggregatorPtr aggregator() { return _aggregator; }
+
 protected:
     // It is used to perform aggregation algorithms shared by
     // AggregateBlockingSinkOperator. It is

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.h
@@ -47,6 +47,7 @@ public:
     StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
     Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
     Status reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) override;
+    AggregatorPtr& aggregator() { return _aggregator; }
 
 protected:
     // It is used to perform aggregation algorithms shared by
@@ -85,6 +86,8 @@ public:
                 _aggregator_factory->get_or_create(driver_sequence), this, _id, _plan_node_id, driver_sequence,
                 _aggregator_factory->get_shared_limit_countdown());
     }
+
+    AggregatorFactoryPtr& aggregator_factory() { return _aggregator_factory; }
 
 private:
     AggregatorFactoryPtr _aggregator_factory = nullptr;

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
@@ -42,6 +42,8 @@ public:
 
     StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
 
+    AggregatorPtr& aggregator() { return _aggregator; }
+
 protected:
     // It is used to perform aggregation algorithms shared by
     // AggregateDistinctBlockingSinkOperator. It is

--- a/be/src/exec/pipeline/aggregate/aggregate_operators.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_operators.cpp
@@ -27,3 +27,5 @@
 #include "spillable_aggregate_blocking_sink_operator.cpp"
 #include "spillable_aggregate_blocking_source_operator.cpp"
 #include "spillable_aggregate_distinct_blocking_operator.cpp"
+#include "spillable_partitionwise_aggregate_operator.cpp"
+#include "spillable_partitionwise_distinct_operator.cpp"

--- a/be/src/exec/pipeline/aggregate/spillable_partitionwise_aggregate_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_partitionwise_aggregate_operator.cpp
@@ -332,7 +332,7 @@ Status SpillablePartitionWiseAggregateSinkOperatorFactory::prepare(RuntimeState*
     RETURN_IF_ERROR(OperatorFactory::prepare(state));
 
     // init spill options
-    _spill_options = std::make_shared<spill::SpilledOptions>(config::spill_init_partition);
+    _spill_options = std::make_shared<spill::SpilledOptions>(state->spill_partitionwise_agg_partition_num());
 
     _spill_options->spill_mem_table_bytes_size = state->spill_mem_table_size();
     if (state->enable_agg_spill_preaggregation()) {

--- a/be/src/exec/pipeline/aggregate/spillable_partitionwise_aggregate_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_partitionwise_aggregate_operator.cpp
@@ -1,0 +1,548 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+
+#include "exec/pipeline/aggregate/spillable_partitionwise_aggregate_operator.h"
+
+namespace starrocks::pipeline {
+
+DEFINE_FAIL_POINT(spill_always_streaming);
+DEFINE_FAIL_POINT(spill_always_selection_streaming);
+
+bool SpillablePartitionWiseAggregateSinkOperator::need_input() const {
+    return !is_finished() && !_agg_op->aggregator()->is_full() && !_agg_op->aggregator()->spill_channel()->has_task();
+}
+
+bool SpillablePartitionWiseAggregateSinkOperator::is_finished() const {
+    if (!spilled()) {
+        return _is_finished || _agg_op->is_finished();
+    }
+    return _is_finished || _agg_op->aggregator()->is_finished();
+}
+
+Status SpillablePartitionWiseAggregateSinkOperator::set_finishing(RuntimeState* state) {
+    if (_is_finished) {
+        return Status::OK();
+    }
+    ONCE_DETECT(_set_finishing_once);
+    auto defer_set_finishing = DeferOp([this]() {
+        _agg_op->aggregator()->spill_channel()->set_finishing_if_not_reuseable();
+        _is_finished = true;
+    });
+
+    // cancel spill task
+    if (state->is_cancelled()) {
+        _agg_op->aggregator()->spiller()->cancel();
+    }
+
+    if (!_agg_op->aggregator()->spiller()->spilled() && _streaming_chunks.empty()) {
+        RETURN_IF_ERROR(_agg_op->set_finishing(state));
+        return Status::OK();
+    }
+    if (!_agg_op->aggregator()->spill_channel()->has_task()) {
+        if (_agg_op->aggregator()->hash_map_variant().size() > 0 || !_streaming_chunks.empty()) {
+            _agg_op->aggregator()->hash_map_variant().visit([&](auto& hash_map_with_key) {
+                _agg_op->aggregator()->it_hash() = _agg_op->aggregator()->_state_allocator.begin();
+            });
+            _agg_op->aggregator()->spill_channel()->add_spill_task(_build_spill_task(state));
+        }
+    }
+
+    auto flush_function = [this](RuntimeState* state) {
+        auto& spiller = _agg_op->aggregator()->spiller();
+        return spiller->flush(state, TRACKER_WITH_SPILLER_READER_GUARD(state, spiller));
+    };
+
+    _agg_op->aggregator()->ref();
+    auto set_call_back_function = [this](RuntimeState* state) {
+        return _agg_op->aggregator()->spiller()->set_flush_all_call_back(
+                [this, state]() {
+                    auto defer = DeferOp([&]() { _agg_op->aggregator()->unref(state); });
+                    RETURN_IF_ERROR(_agg_op->set_finishing(state));
+                    return Status::OK();
+                },
+                state, TRACKER_WITH_SPILLER_READER_GUARD(state, _agg_op->aggregator()->spiller()));
+    };
+
+    SpillProcessTasksBuilder task_builder(state);
+    task_builder.then(flush_function).finally(set_call_back_function);
+
+    RETURN_IF_ERROR(_agg_op->aggregator()->spill_channel()->execute(task_builder));
+
+    return Status::OK();
+}
+
+void SpillablePartitionWiseAggregateSinkOperator::close(RuntimeState* state) {
+    _agg_op->close(state);
+    Operator::close(state);
+}
+
+Status SpillablePartitionWiseAggregateSinkOperator::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(Operator::prepare(state));
+    RETURN_IF_ERROR(_agg_op->prepare(state));
+    DCHECK(!_agg_op->aggregator()->is_none_group_by_exprs());
+    _agg_op->aggregator()->spiller()->set_metrics(
+            spill::SpillProcessMetrics(_unique_metrics.get(), state->mutable_total_spill_bytes()));
+
+    if (state->spill_mode() == TSpillMode::FORCE) {
+        _spill_strategy = spill::SpillStrategy::SPILL_ALL;
+    }
+
+    if (state->enable_spill_partitionwise_agg_skew_elimination()) {
+        auto* agg_op_factory = dynamic_cast<AggregateBlockingSinkOperatorFactory*>(_agg_op->get_factory());
+        _agg_op->aggregator()->spiller()->options().opt_aggregator_params =
+                convert_to_aggregator_params(agg_op_factory->aggregator_factory()->t_node());
+    }
+    _peak_revocable_mem_bytes = _unique_metrics->AddHighWaterMarkCounter(
+            "PeakRevocableMemoryBytes", TUnit::BYTES, RuntimeProfile::Counter::create_strategy(TUnit::BYTES));
+    _hash_table_spill_times = ADD_COUNTER(_unique_metrics.get(), "HashTableSpillTimes", TUnit::UNIT);
+    _agg_op->set_agg_group_by_with_limit(false);
+    _agg_op->aggregator()->params()->enable_pipeline_share_limit = false;
+
+    return Status::OK();
+}
+
+Status SpillablePartitionWiseAggregateSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
+    if (chunk == nullptr || chunk->is_empty()) {
+        return Status::OK();
+    }
+
+    if (_spill_strategy == spill::SpillStrategy::NO_SPILL) {
+        RETURN_IF_ERROR(_agg_op->push_chunk(state, chunk));
+        set_revocable_mem_bytes(_agg_op->aggregator()->hash_map_memory_usage());
+        return Status::OK();
+    }
+
+    if (state->enable_agg_spill_preaggregation()) {
+        return _try_to_spill_by_auto(state, chunk);
+    } else {
+        return _try_to_spill_by_force(state, chunk);
+    }
+    return Status::OK();
+}
+
+Status SpillablePartitionWiseAggregateSinkOperator::reset_state(RuntimeState* state,
+                                                                const std::vector<ChunkPtr>& refill_chunks) {
+    _is_finished = false;
+    ONCE_RESET(_set_finishing_once);
+    RETURN_IF_ERROR(_agg_op->aggregator()->spiller()->reset_state(state));
+    RETURN_IF_ERROR(_agg_op->reset_state(state, refill_chunks));
+    return Status::OK();
+}
+
+Status SpillablePartitionWiseAggregateSinkOperator::_try_to_spill_by_force(RuntimeState* state, const ChunkPtr& chunk) {
+    RETURN_IF_ERROR(_agg_op->push_chunk(state, chunk));
+    set_revocable_mem_bytes(_agg_op->aggregator()->hash_map_memory_usage());
+    return _spill_all_data(state, true);
+}
+
+void SpillablePartitionWiseAggregateSinkOperator::_add_streaming_chunk(ChunkPtr chunk) {
+    _streaming_rows += chunk->num_rows();
+    _streaming_bytes += chunk->memory_usage();
+    _streaming_chunks.push(std::move(chunk));
+}
+
+Status SpillablePartitionWiseAggregateSinkOperator::_try_to_spill_by_auto(RuntimeState* state, const ChunkPtr& chunk) {
+    RETURN_IF_ERROR(_agg_op->aggregator()->evaluate_groupby_exprs(chunk.get()));
+    const auto chunk_size = chunk->num_rows();
+
+    const size_t ht_mem_usage = _agg_op->aggregator()->hash_map_memory_usage();
+    bool ht_need_expansion = _agg_op->aggregator()->hash_map_variant().need_expand(chunk_size);
+    const size_t max_mem_usage = state->spill_mem_table_size();
+
+    auto spiller = _agg_op->aggregator()->spiller();
+
+    // goal: control buffered data memory usage, aggregate data as much as possible before spill
+    // this strategy is similar to the LIMITED_MEM mode in agg streaming
+
+    bool always_streaming = false;
+    bool always_selection_streaming = false;
+
+    FAIL_POINT_TRIGGER_EXECUTE(spill_always_streaming, {
+        if (_agg_op->aggregator()->hash_map_variant().size() != 0) {
+            always_streaming = true;
+        }
+    });
+    FAIL_POINT_TRIGGER_EXECUTE(spill_always_selection_streaming, {
+        if (_agg_op->aggregator()->hash_map_variant().size() != 0) {
+            always_selection_streaming = true;
+        }
+    });
+
+    // if hash table don't need expand or it's still very small after expansion, just put all data into it
+    bool build_hash_table =
+            !ht_need_expansion || (ht_need_expansion && _streaming_bytes + ht_mem_usage * 2 <= max_mem_usage);
+    build_hash_table = build_hash_table && !always_selection_streaming;
+    if (_streaming_bytes + ht_mem_usage > max_mem_usage || always_streaming) {
+        // if current memory usage exceeds limit,
+        // use force streaming mode and spill all data
+        SCOPED_TIMER(_agg_op->aggregator()->streaming_timer());
+        ChunkPtr res = std::make_shared<Chunk>();
+        RETURN_IF_ERROR(_agg_op->aggregator()->output_chunk_by_streaming(chunk.get(), &res, true));
+        _add_streaming_chunk(res);
+        return _spill_all_data(state, true);
+    } else if (build_hash_table) {
+        SCOPED_TIMER(_agg_op->aggregator()->agg_compute_timer());
+        TRY_CATCH_ALLOC_SCOPE_START()
+        _agg_op->aggregator()->build_hash_map(chunk_size);
+        _agg_op->aggregator()->try_convert_to_two_level_map();
+        RETURN_IF_ERROR(_agg_op->aggregator()->compute_batch_agg_states(chunk.get(), chunk_size));
+        TRY_CATCH_ALLOC_SCOPE_END()
+
+        _agg_op->aggregator()->update_num_input_rows(chunk_size);
+        RETURN_IF_ERROR(_agg_op->aggregator()->check_has_error());
+        _continuous_low_reduction_chunk_num = 0;
+    } else {
+        TRY_CATCH_ALLOC_SCOPE_START()
+        // selective preaggregation
+        {
+            SCOPED_TIMER(_agg_op->aggregator()->agg_compute_timer());
+            _agg_op->aggregator()->build_hash_map_with_selection(chunk_size);
+        }
+
+        size_t hit_count = SIMD::count_zero(_agg_op->aggregator()->streaming_selection());
+        // very poor aggregation
+        if (hit_count == 0) {
+            // put all data into buffer
+            ChunkPtr tmp = std::make_shared<Chunk>();
+            RETURN_IF_ERROR(_agg_op->aggregator()->output_chunk_by_streaming(chunk.get(), &tmp, true));
+            _add_streaming_chunk(std::move(tmp));
+        } else if (hit_count == _agg_op->aggregator()->streaming_selection().size()) {
+            // very high reduction
+            SCOPED_TIMER(_agg_op->aggregator()->agg_compute_timer());
+            RETURN_IF_ERROR(_agg_op->aggregator()->compute_batch_agg_states(chunk.get(), chunk_size));
+        } else {
+            // middle case
+            {
+                SCOPED_TIMER(_agg_op->aggregator()->agg_compute_timer());
+                RETURN_IF_ERROR(
+                        _agg_op->aggregator()->compute_batch_agg_states_with_selection(chunk.get(), chunk_size));
+            }
+            {
+                SCOPED_TIMER(_agg_op->aggregator()->streaming_timer());
+                ChunkPtr res = std::make_shared<Chunk>();
+                RETURN_IF_ERROR(
+                        _agg_op->aggregator()->output_chunk_by_streaming_with_selection(chunk.get(), &res, true));
+                _add_streaming_chunk(std::move(res));
+            }
+        }
+        if (hit_count * 1.0 / chunk_size <= HT_LOW_REDUCTION_THRESHOLD) {
+            _continuous_low_reduction_chunk_num++;
+        }
+
+        _agg_op->aggregator()->update_num_input_rows(hit_count);
+        TRY_CATCH_ALLOC_SCOPE_END()
+        RETURN_IF_ERROR(_agg_op->aggregator()->check_has_error());
+    }
+
+    // finally, check memory usage of streaming_chunks and hash table, decide whether to spill
+    size_t revocable_mem_bytes = _streaming_bytes + _agg_op->aggregator()->hash_map_memory_usage();
+    set_revocable_mem_bytes(revocable_mem_bytes);
+    if (revocable_mem_bytes > max_mem_usage) {
+        // If the aggregation degree of HT_LOW_REDUCTION_CHUNK_LIMIT consecutive chunks is less than HT_LOW_REDUCTION_THRESHOLD,
+        // it is meaningless to keep the hash table in memory, just spill it.
+        bool should_spill_hash_table = _continuous_low_reduction_chunk_num >= HT_LOW_REDUCTION_CHUNK_LIMIT ||
+                                       _agg_op->aggregator()->hash_map_memory_usage() > max_mem_usage;
+        if (should_spill_hash_table) {
+            _continuous_low_reduction_chunk_num = 0;
+        }
+        // spill all data
+        return _spill_all_data(state, should_spill_hash_table);
+    }
+
+    return Status::OK();
+}
+
+ChunkPtr& SpillablePartitionWiseAggregateSinkOperator::_append_hash_column(ChunkPtr& chunk) {
+    auto slot_ids = _agg_op->aggregator()->output_group_by_slot_ids();
+    size_t num_rows = chunk->num_rows();
+    auto hash_column = spill::SpillHashColumn::create(num_rows);
+    auto& hash_values = hash_column->get_data();
+    // TODO: use different hash method
+    for (auto& slot_id : slot_ids) {
+        auto column = chunk->get_column_by_slot_id(slot_id);
+        column->fnv_hash(hash_values.data(), 0, num_rows);
+    }
+    chunk->append_column(std::move(hash_column), Chunk::HASH_AGG_SPILL_HASH_SLOT_ID);
+    return chunk;
+}
+
+Status SpillablePartitionWiseAggregateSinkOperator::_spill_all_data(RuntimeState* state, bool should_spill_hash_table) {
+    RETURN_IF(_agg_op->aggregator()->hash_map_variant().size() == 0, Status::OK());
+    if (should_spill_hash_table) {
+        _agg_op->aggregator()->hash_map_variant().visit([&](auto& hash_map_with_key) {
+            _agg_op->aggregator()->it_hash() = _agg_op->aggregator()->_state_allocator.begin();
+        });
+    }
+    CHECK(!_agg_op->aggregator()->spill_channel()->has_task());
+    RETURN_IF_ERROR(
+            _agg_op->aggregator()->spill_aggregate_data(state, _build_spill_task(state, should_spill_hash_table)));
+    return Status::OK();
+}
+
+std::function<StatusOr<ChunkPtr>()> SpillablePartitionWiseAggregateSinkOperator::_build_spill_task(
+        RuntimeState* state, bool should_spill_hash_table) {
+    auto chunk_provider = [this, state, should_spill_hash_table]() -> StatusOr<ChunkPtr> {
+        if (!_streaming_chunks.empty()) {
+            auto chunk = _streaming_chunks.front();
+            _streaming_chunks.pop();
+            return chunk;
+        }
+        if (should_spill_hash_table) {
+            if (!_agg_op->aggregator()->is_ht_eos()) {
+                auto chunk = std::make_shared<Chunk>();
+                RETURN_IF_ERROR(_agg_op->aggregator()->convert_hash_map_to_chunk(state->chunk_size(), &chunk, true));
+                return chunk;
+            }
+            COUNTER_UPDATE(_agg_op->aggregator()->input_row_count(), _agg_op->aggregator()->num_input_rows());
+            COUNTER_UPDATE(_agg_op->aggregator()->rows_returned_counter(),
+                           _agg_op->aggregator()->hash_map_variant().size());
+            COUNTER_UPDATE(_hash_table_spill_times, 1);
+            RETURN_IF_ERROR(_agg_op->aggregator()->reset_state(state, {}, nullptr));
+        }
+        _streaming_rows = 0;
+        _streaming_bytes = 0;
+        return Status::EndOfFile("no more data in current aggregator");
+    };
+    return [this, chunk_provider]() -> StatusOr<ChunkPtr> {
+        auto maybe_chunk = chunk_provider();
+        if (maybe_chunk.ok()) {
+            auto chunk = std::move(maybe_chunk.value());
+            if (!chunk) {
+                return chunk;
+            }
+            return this->_append_hash_column(chunk);
+        }
+        return maybe_chunk;
+    };
+}
+
+Status SpillablePartitionWiseAggregateSinkOperatorFactory::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(OperatorFactory::prepare(state));
+
+    // init spill options
+    _spill_options = std::make_shared<spill::SpilledOptions>(config::spill_init_partition);
+
+    _spill_options->spill_mem_table_bytes_size = state->spill_mem_table_size();
+    if (state->enable_agg_spill_preaggregation()) {
+        _spill_options->mem_table_pool_size = std::max(1, state->spill_mem_table_num() - 1);
+    } else {
+        _spill_options->mem_table_pool_size = state->spill_mem_table_num();
+    }
+    _spill_options->spill_type = spill::SpillFormaterType::SPILL_BY_COLUMN;
+    _spill_options->block_manager = state->query_ctx()->spill_manager()->block_manager();
+    _spill_options->name = "agg-blocking-spill";
+    _spill_options->splittable = false;
+    _spill_options->enable_block_compaction = state->spill_enable_compaction();
+    _spill_options->plan_node_id = _plan_node_id;
+    _spill_options->encode_level = state->spill_encode_level();
+    _spill_options->wg = state->fragment_ctx()->workgroup();
+    _spill_options->enable_buffer_read = state->enable_spill_buffer_read();
+    _spill_options->max_read_buffer_bytes = state->max_spill_read_buffer_bytes_per_driver();
+
+    return Status::OK();
+}
+
+OperatorPtr SpillablePartitionWiseAggregateSinkOperatorFactory::create(int32_t degree_of_parallelism,
+                                                                       int32_t driver_sequence) {
+    auto agg_op = std::static_pointer_cast<AggregateBlockingSinkOperator>(
+            _agg_op_factory->create(degree_of_parallelism, driver_sequence));
+    // create spiller
+    auto spiller = _spill_factory->create(*_spill_options);
+    // create spill process channel
+
+    auto spill_channel = _spill_channel_factory->get_or_create(driver_sequence);
+
+    spill_channel->set_spiller(spiller);
+    agg_op->aggregator()->set_spiller(spiller);
+    agg_op->aggregator()->set_spill_channel(std::move(spill_channel));
+    return make_shared<SpillablePartitionWiseAggregateSinkOperator>(this, _id, _plan_node_id, driver_sequence,
+                                                                    std::move(agg_op));
+}
+
+Status SpillablePartitionWiseAggregateSourceOperator::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(SourceOperator::prepare(state));
+    RETURN_IF_ERROR(_non_pw_agg->prepare(state));
+    RETURN_IF_ERROR(_pw_agg->prepare(state));
+    return Status::OK();
+}
+
+void SpillablePartitionWiseAggregateSourceOperator::close(RuntimeState* state) {
+    _pw_agg->close(state);
+    _non_pw_agg->close(state);
+    return SourceOperator::close(state);
+}
+
+bool SpillablePartitionWiseAggregateSourceOperator::has_output() const {
+    auto& spiller = _non_pw_agg->aggregator()->spiller();
+    bool has_spilled = spiller->spilled();
+
+    if (!has_spilled) {
+        return _non_pw_agg->has_output();
+    }
+
+    // is_sink_complete returning true indicates that sink operator has finished all spilling tasks
+    // and source operator can process spill partitions one by one safely.
+    if (!_non_pw_agg->aggregator()->is_sink_complete()) {
+        return false;
+    }
+
+    // at first time, we must call pull_chunk to acquire all partitions
+    if (_partitions.empty()) {
+        return true;
+    }
+    // if we processed all partitions, then no data to output
+    if (_curr_partition_idx >= _partitions.size()) {
+        return false;
+    }
+
+    // if current partition reader is not created, or no async store task trigger, or has output data.
+    // we must invoke pull_chunk to try to obtain chunk from current partition reader and push it to pw_agg
+    if (!_curr_partition_reader || !_curr_partition_reader->has_restore_task() ||
+        _curr_partition_reader->has_output_data()) {
+        return true;
+    }
+
+    // pw_agg receives all data of the current partition, then it should output result.
+    if (_curr_partition_eos && !_pw_agg->is_finished()) {
+        return true;
+    }
+
+    return false;
+}
+
+bool SpillablePartitionWiseAggregateSourceOperator::is_finished() const {
+    if (_is_finished) {
+        return true;
+    }
+    auto& spiller = _non_pw_agg->aggregator()->spiller();
+    if (!spiller->spilled()) {
+        return _non_pw_agg->is_finished();
+    } else {
+        return !_partitions.empty() && _curr_partition_idx >= _partitions.size();
+    }
+}
+
+Status SpillablePartitionWiseAggregateSourceOperator::set_finishing(RuntimeState* state) {
+    if (state->is_cancelled()) {
+        _non_pw_agg->aggregator()->spiller()->cancel();
+    }
+    RETURN_IF_ERROR(_non_pw_agg->set_finishing(state));
+    RETURN_IF_ERROR(_pw_agg->set_finishing(state));
+    return Status::OK();
+}
+
+Status SpillablePartitionWiseAggregateSourceOperator::set_finished(RuntimeState* state) {
+    _is_finished = true;
+    RETURN_IF_ERROR(_non_pw_agg->set_finished(state));
+    RETURN_IF_ERROR(_pw_agg->set_finished(state));
+    return Status::OK();
+}
+
+StatusOr<ChunkPtr> SpillablePartitionWiseAggregateSourceOperator::pull_chunk(RuntimeState* state) {
+    RETURN_IF_ERROR(_non_pw_agg->aggregator()->spiller()->task_status());
+    if (!_non_pw_agg->aggregator()->spiller()->spilled()) {
+        return _non_pw_agg->pull_chunk(state);
+    }
+    ASSIGN_OR_RETURN(auto res, _pull_spilled_chunk(state));
+    return res;
+}
+
+Status SpillablePartitionWiseAggregateSourceOperator::reset_state(RuntimeState* state,
+                                                                  const std::vector<ChunkPtr>& refill_chunks) {
+    _is_finished = false;
+    _partitions.clear();
+    _curr_partition_reader.reset();
+    _curr_partition_idx = 0;
+    _curr_partition_eos = false;
+    RETURN_IF_ERROR(_non_pw_agg->reset_state(state, refill_chunks));
+    RETURN_IF_ERROR(_pw_agg->reset_state(state, refill_chunks));
+    return Status::OK();
+}
+
+StatusOr<ChunkPtr> SpillablePartitionWiseAggregateSourceOperator::_pull_spilled_chunk(RuntimeState* state) {
+    auto& spiller = _non_pw_agg->aggregator()->spiller();
+    // retrieve all partitions
+    if (_partitions.empty()) {
+        spiller->get_all_partitions(&_partitions);
+        DCHECK(!_partitions.empty());
+    }
+
+    // processed all partitions
+    if (_curr_partition_idx >= _partitions.size()) {
+        return nullptr;
+    }
+
+    // initialize current partition reader at first
+    if (!_curr_partition_reader) {
+        _curr_partition_eos = false;
+        _curr_partition_reader = std::move(spiller->get_partition_spill_readers({_partitions[_curr_partition_idx]})[0]);
+    }
+
+    // if current partition has un-processed data, we try read the data out and push it to pw_agg
+    if (!_curr_partition_eos) {
+        if (!_curr_partition_reader->has_restore_task()) {
+            RETURN_IF_ERROR(_curr_partition_reader->trigger_restore(
+                    state, RESOURCE_TLS_MEMTRACER_GUARD(state, std::weak_ptr(_curr_partition_reader))));
+        }
+        if (_curr_partition_reader->has_output_data()) {
+            auto maybe_chunk = _curr_partition_reader->restore(
+                    state, RESOURCE_TLS_MEMTRACER_GUARD(state, std::weak_ptr(_curr_partition_reader)));
+            if (maybe_chunk.ok() && maybe_chunk.value() && !maybe_chunk.value()->is_empty()) {
+                DCHECK(_pw_agg->need_input() && !_pw_agg->is_finished());
+                RETURN_IF_ERROR(_pw_agg->push_chunk(state, std::move(maybe_chunk.value())));
+            } else if (maybe_chunk.status().is_end_of_file()) {
+                _curr_partition_eos = true;
+                RETURN_IF_ERROR(_pw_agg->set_finishing(state));
+            } else if (!maybe_chunk.ok()) {
+                return maybe_chunk.status();
+            }
+        }
+        return nullptr;
+    } else if (!_pw_agg->is_finished()) {
+        // all data of the current partition is push to _pw_agg, so we can pull chunk from it
+        DCHECK(!_pw_agg->need_input() && _pw_agg->has_output());
+        return _pw_agg->pull_chunk(state);
+    } else {
+        // the _pw_agg has processed all the data of the current partition, so we switch to next partition
+        DCHECK(_curr_partition_eos && _pw_agg->is_finished());
+        DCHECK(!_curr_partition_reader->has_restore_task());
+        DCHECK(_curr_partition_reader->restore_finished());
+        //switch to next partition
+        ++_curr_partition_idx;
+        _curr_partition_eos = false;
+        _curr_partition_reader.reset();
+        RETURN_IF_ERROR(_pw_agg->reset_state(state, {}));
+    }
+    return nullptr;
+}
+
+Status SpillablePartitionWiseAggregateSourceOperatorFactory::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(SourceOperatorFactory::prepare(state));
+    RETURN_IF_ERROR(_non_pw_agg_factory->prepare(state));
+    RETURN_IF_ERROR(_pw_agg_factory->prepare(state));
+    return Status::OK();
+}
+
+OperatorPtr SpillablePartitionWiseAggregateSourceOperatorFactory::create(int32_t degree_of_parallelism,
+                                                                         int32_t driver_sequence) {
+    return std::make_shared<SpillablePartitionWiseAggregateSourceOperator>(
+            this, _id, _plan_node_id, driver_sequence,
+            std::static_pointer_cast<AggregateBlockingSourceOperator>(
+                    _non_pw_agg_factory->create(degree_of_parallelism, driver_sequence)),
+            std::static_pointer_cast<query_cache::ConjugateOperator>(
+                    _pw_agg_factory->create(degree_of_parallelism, driver_sequence)));
+}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate/spillable_partitionwise_aggregate_operator.h
+++ b/be/src/exec/pipeline/aggregate/spillable_partitionwise_aggregate_operator.h
@@ -192,7 +192,7 @@ public:
             SpillProcessChannelFactoryPtr spill_channel_factory)
             : OperatorFactory(id, "spillable_partitionwise_agg_sink", plan_node_id),
               _agg_op_factory(std::make_shared<AggregateBlockingSinkOperatorFactory>(
-                      id, plan_node_id, std::move(aggregator_factory), build_runtime_filters, nullptr)),
+                      id, plan_node_id, std::move(aggregator_factory), build_runtime_filters, spill_channel_factory)),
               _spill_channel_factory(std::move(spill_channel_factory)) {}
 
     ~SpillablePartitionWiseAggregateSinkOperatorFactory() override = default;

--- a/be/src/exec/pipeline/aggregate/spillable_partitionwise_aggregate_operator.h
+++ b/be/src/exec/pipeline/aggregate/spillable_partitionwise_aggregate_operator.h
@@ -1,0 +1,214 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+
+#pragma once
+#include <memory>
+
+#include "exec/aggregator.h"
+#include "exec/pipeline/aggregate/aggregate_blocking_source_operator.h"
+#include "exec/pipeline/source_operator.h"
+#include "exec/query_cache/conjugate_operator.h"
+#include "exec/spill/spill_components.h"
+#include "storage/chunk_helper.h"
+
+namespace starrocks::pipeline {
+class SpillablePartitionWiseAggregateSourceOperator;
+class SpillablePartitionWiseAggregateSourceOperatorFactory;
+
+using SPWAggregateSourceOperatorRawPtr = SpillablePartitionWiseAggregateSourceOperator*;
+using SPWAggregateSourceOperatorPtr = std::shared_ptr<SPWAggregateSourceOperatorRawPtr>;
+using SPWAggregateSourceOperatorFactoryRawPtr = SpillablePartitionWiseAggregateSourceOperatorFactory*;
+using SPWAggregateSourceOperatorFactoryPtr = std::shared_ptr<SPWAggregateSourceOperatorFactoryRawPtr>;
+using AggregateBlockingSourceOperatorPtr = std::shared_ptr<AggregateBlockingSourceOperator>;
+using ConjugateOperatorPtr = starrocks::query_cache::ConjugateOperatorPtr;
+using AggregateBlockingSourceOperatorFactoryPtr = std::shared_ptr<AggregateBlockingSourceOperatorFactory>;
+using ConjugateOperatorFactoryPtr = starrocks::query_cache::ConjugateOperatorFactoryPtr;
+
+using AggregateBlockingSinkOperatorPtr = std::shared_ptr<AggregateBlockingSinkOperator>;
+using AggregateBlockingSinkOperatorFactoryPtr = std::shared_ptr<AggregateBlockingSinkOperatorFactory>;
+class SpillablePartitionWiseAggregateSinkOperator;
+class SpillablePartitionWiseAggregateSinkOperatorFactory;
+using SPWAggregateSinkOperatorRawPtr = SpillablePartitionWiseAggregateSinkOperator*;
+using SPWAggregateSinkOperatorPtr = std::shared_ptr<SpillablePartitionWiseAggregateSinkOperator>;
+using SPWAggregateSinkOperatorFactoryRawPtr = SpillablePartitionWiseAggregateSinkOperatorFactory*;
+using SPWAggregateSinkOperatorFactoryPtr = std::shared_ptr<SpillablePartitionWiseAggregateSinkOperatorFactory>;
+
+class SpillablePartitionWiseAggregateSourceOperator final : public SourceOperator {
+public:
+    SpillablePartitionWiseAggregateSourceOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id,
+                                                  int32_t driver_sequence,
+                                                  const AggregateBlockingSourceOperatorPtr non_pw_agg,
+                                                  ConjugateOperatorPtr pw_agg)
+            : SourceOperator(factory, id, "spillable_partitionwise_agg_source", plan_node_id, false, driver_sequence),
+              _non_pw_agg(std::move(non_pw_agg)),
+              _pw_agg(std::move(pw_agg)) {}
+
+    ~SpillablePartitionWiseAggregateSourceOperator() override = default;
+
+    bool has_output() const override;
+    bool is_finished() const override;
+
+    Status set_finishing(RuntimeState* state) override;
+    Status set_finished(RuntimeState* state) override;
+
+    Status prepare(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
+
+    StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
+    Status reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) override;
+
+private:
+    AggregateBlockingSourceOperatorPtr _non_pw_agg;
+    ConjugateOperatorPtr _pw_agg;
+    StatusOr<ChunkPtr> _pull_spilled_chunk(RuntimeState* state);
+
+    std::vector<const SpillPartitionInfo*> _partitions;
+    size_t _curr_partition_idx{0};
+    std::shared_ptr<spill::SpillerReader> _curr_partition_reader;
+    bool _curr_partition_eos{false};
+    bool _is_finished{false};
+};
+
+class SpillablePartitionWiseAggregateSourceOperatorFactory final : public SourceOperatorFactory {
+public:
+    SpillablePartitionWiseAggregateSourceOperatorFactory(int32_t id, int32_t plan_node_id,
+                                                         AggregatorFactoryPtr aggregator_factory)
+            : SourceOperatorFactory(id, "spillable_partitionwise_agg_source", plan_node_id),
+              _non_pw_agg_factory(std::make_shared<AggregateBlockingSourceOperatorFactory>(
+                      id, plan_node_id, std::move(aggregator_factory))) {}
+
+    ~SpillablePartitionWiseAggregateSourceOperatorFactory() override = default;
+
+    Status prepare(RuntimeState* state) override;
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override;
+
+    bool support_event_scheduler() const override { return false; }
+
+    void set_pw_agg_factory(ConjugateOperatorFactoryPtr&& pw_agg_factory) {
+        _pw_agg_factory = std::move(pw_agg_factory);
+    }
+
+private:
+    AggregateBlockingSourceOperatorFactoryPtr _non_pw_agg_factory;
+    ConjugateOperatorFactoryPtr _pw_agg_factory;
+};
+
+class SpillablePartitionWiseAggregateSinkOperator : public Operator {
+public:
+    SpillablePartitionWiseAggregateSinkOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id,
+                                                int32_t driver_sequence, AggregateBlockingSinkOperatorPtr&& agg_op)
+            : Operator(factory, id, "spillable_partitionwise_agg_sink", plan_node_id, false, driver_sequence),
+              _agg_op(std::move(agg_op)) {}
+
+    ~SpillablePartitionWiseAggregateSinkOperator() override = default;
+
+    bool need_input() const override;
+    bool is_finished() const override;
+    Status set_finishing(RuntimeState* state) override;
+
+    StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override { return Status::InternalError("Not support"); }
+
+    bool has_output() const override { throw Status::InternalError("Not support"); }
+
+    void close(RuntimeState* state) override;
+
+    Status prepare(RuntimeState* state) override;
+    Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
+
+    bool spillable() const override { return true; }
+
+    void set_execute_mode(int performance_level) override {
+        _spill_strategy = spill::SpillStrategy::SPILL_ALL;
+        TRACE_SPILL_LOG << "AggregateBlockingSink, mark spill " << (void*)this;
+    }
+
+    size_t estimated_memory_reserved(const ChunkPtr& chunk) override {
+        if (chunk && !chunk->is_empty()) {
+            if (_agg_op->aggregator()->hash_map_variant().need_expand(chunk->num_rows())) {
+                return chunk->memory_usage() + _agg_op->aggregator()->hash_map_memory_usage();
+            }
+            return chunk->memory_usage();
+        }
+        return 0;
+    }
+
+    Status reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) override;
+
+    // only the prepare/open phase calls are valid.
+    SpillProcessChannelPtr spill_channel() { return _agg_op->aggregator()->spill_channel(); }
+
+private:
+    bool spilled() const { return _agg_op->aggregator()->spiller()->spilled(); }
+
+private:
+    Status _try_to_spill_by_force(RuntimeState* state, const ChunkPtr& chunk);
+
+    Status _try_to_spill_by_auto(RuntimeState* state, const ChunkPtr& chunk);
+
+    Status _spill_all_data(RuntimeState* state, bool should_spill_hash_table);
+
+    void _add_streaming_chunk(ChunkPtr chunk);
+
+    ChunkPtr& _append_hash_column(ChunkPtr& chunk);
+
+    AggregateBlockingSinkOperatorPtr _agg_op;
+    std::function<StatusOr<ChunkPtr>()> _build_spill_task(RuntimeState* state, bool should_spill_hash_table = true);
+
+    DECLARE_ONCE_DETECTOR(_set_finishing_once);
+    spill::SpillStrategy _spill_strategy = spill::SpillStrategy::NO_SPILL;
+
+    std::queue<ChunkPtr> _streaming_chunks;
+    size_t _streaming_rows = 0;
+    size_t _streaming_bytes = 0;
+
+    int32_t _continuous_low_reduction_chunk_num = 0;
+
+    bool _is_finished = false;
+
+    RuntimeProfile::Counter* _hash_table_spill_times = nullptr;
+
+    static constexpr double HT_LOW_REDUCTION_THRESHOLD = 0.5;
+    static constexpr int32_t HT_LOW_REDUCTION_CHUNK_LIMIT = 5;
+};
+
+class SpillablePartitionWiseAggregateSinkOperatorFactory : public OperatorFactory {
+public:
+    SpillablePartitionWiseAggregateSinkOperatorFactory(
+            int32_t id, int32_t plan_node_id, AggregatorFactoryPtr aggregator_factory,
+            const std::vector<RuntimeFilterBuildDescriptor*>& build_runtime_filters,
+            SpillProcessChannelFactoryPtr spill_channel_factory)
+            : OperatorFactory(id, "spillable_partitionwise_agg_sink", plan_node_id),
+              _agg_op_factory(std::make_shared<AggregateBlockingSinkOperatorFactory>(
+                      id, plan_node_id, std::move(aggregator_factory), build_runtime_filters, nullptr)),
+              _spill_channel_factory(std::move(spill_channel_factory)) {}
+
+    ~SpillablePartitionWiseAggregateSinkOperatorFactory() override = default;
+
+    Status prepare(RuntimeState* state) override;
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override;
+
+    bool support_event_scheduler() const override { return false; }
+
+private:
+    ObjectPool _pool;
+    std::shared_ptr<spill::SpilledOptions> _spill_options;
+    std::shared_ptr<spill::SpillerFactory> _spill_factory = std::make_shared<spill::SpillerFactory>();
+    AggregateBlockingSinkOperatorFactoryPtr _agg_op_factory;
+    SpillProcessChannelFactoryPtr _spill_channel_factory;
+};
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate/spillable_partitionwise_distinct_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_partitionwise_distinct_operator.cpp
@@ -1,0 +1,393 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+
+#include "exec/pipeline/aggregate/spillable_partitionwise_distinct_operator.h"
+
+#include "util/failpoint/fail_point.h"
+
+namespace starrocks::pipeline {
+
+DEFINE_FAIL_POINT(spill_always_streaming);
+DEFINE_FAIL_POINT(spill_always_selection_streaming);
+
+bool SpillablePartitionWiseDistinctSinkOperator::need_input() const {
+    return !is_finished() && !_distinct_op->aggregator()->is_full() &&
+           !_distinct_op->aggregator()->spill_channel()->has_task();
+}
+
+bool SpillablePartitionWiseDistinctSinkOperator::is_finished() const {
+    if (!spilled()) {
+        return _is_finished || _distinct_op->is_finished();
+    }
+    return _is_finished || _distinct_op->aggregator()->is_finished();
+}
+
+Status SpillablePartitionWiseDistinctSinkOperator::set_finishing(RuntimeState* state) {
+    if (_is_finished) {
+        return Status::OK();
+    }
+    ONCE_DETECT(_set_finishing_once);
+    auto defer_set_finishing = DeferOp([this]() {
+        _distinct_op->aggregator()->spill_channel()->set_finishing_if_not_reuseable();
+        _is_finished = true;
+    });
+
+    // cancel spill task
+    if (state->is_cancelled()) {
+        _distinct_op->aggregator()->spiller()->cancel();
+    }
+
+    if (!_distinct_op->aggregator()->spiller()->spilled()) {
+        RETURN_IF_ERROR(_distinct_op->set_finishing(state));
+        return Status::OK();
+    }
+
+    auto flush_function = [this](RuntimeState* state) {
+        auto& spiller = _distinct_op->aggregator()->spiller();
+        return spiller->flush(state, TRACKER_WITH_SPILLER_READER_GUARD(state, spiller));
+    };
+
+    _distinct_op->aggregator()->ref();
+    auto set_call_back_function = [this](RuntimeState* state) {
+        return _distinct_op->aggregator()->spiller()->set_flush_all_call_back(
+                [this, state]() {
+                    auto defer = DeferOp([&]() { _distinct_op->aggregator()->unref(state); });
+                    RETURN_IF_ERROR(_distinct_op->set_finishing(state));
+                    return Status::OK();
+                },
+                state, TRACKER_WITH_SPILLER_READER_GUARD(state, _distinct_op->aggregator()->spiller()));
+    };
+
+    SpillProcessTasksBuilder task_builder(state);
+    task_builder.then(flush_function).finally(set_call_back_function);
+
+    RETURN_IF_ERROR(_distinct_op->aggregator()->spill_channel()->execute(task_builder));
+
+    return Status::OK();
+}
+
+void SpillablePartitionWiseDistinctSinkOperator::close(RuntimeState* state) {
+    _distinct_op->close(state);
+    Operator::close(state);
+}
+
+Status SpillablePartitionWiseDistinctSinkOperator::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(Operator::prepare(state));
+    RETURN_IF_ERROR(_distinct_op->prepare(state));
+    DCHECK(!_distinct_op->aggregator()->is_none_group_by_exprs());
+    _distinct_op->aggregator()->spiller()->set_metrics(
+            spill::SpillProcessMetrics(_unique_metrics.get(), state->mutable_total_spill_bytes()));
+
+    if (state->spill_mode() == TSpillMode::FORCE) {
+        _spill_strategy = spill::SpillStrategy::SPILL_ALL;
+    }
+    if (state->enable_spill_partitionwise_agg_skew_elimination()) {
+        auto* distinct_op_factory =
+                dynamic_cast<AggregateDistinctBlockingSinkOperatorFactory*>(_distinct_op->get_factory());
+        _distinct_op->aggregator()->spiller()->options().opt_aggregator_params =
+                convert_to_aggregator_params(distinct_op_factory->aggregator_factory()->t_node());
+    }
+    _peak_revocable_mem_bytes = _unique_metrics->AddHighWaterMarkCounter(
+            "PeakRevocableMemoryBytes", TUnit::BYTES, RuntimeProfile::Counter::create_strategy(TUnit::BYTES));
+    _hash_table_spill_times = ADD_COUNTER(_unique_metrics.get(), "HashTableSpillTimes", TUnit::UNIT);
+
+    return Status::OK();
+}
+
+Status SpillablePartitionWiseDistinctSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
+    if (chunk == nullptr || chunk->is_empty()) {
+        return Status::OK();
+    }
+    RETURN_IF_ERROR(_distinct_op->push_chunk(state, chunk));
+    // direct return if is_finished. (hash set reach limit)
+    if (_distinct_op->is_finished()) return Status::OK();
+    set_revocable_mem_bytes(_distinct_op->aggregator()->hash_set_memory_usage());
+    if (_spill_strategy == spill::SpillStrategy::SPILL_ALL) {
+        return _spill_all_data(state);
+    }
+    return Status::OK();
+}
+
+Status SpillablePartitionWiseDistinctSinkOperator::_spill_all_data(RuntimeState* state) {
+    auto& aggregator = _distinct_op->aggregator();
+    RETURN_IF(aggregator->hash_set_variant().size() == 0, Status::OK());
+    aggregator->hash_set_variant().visit(
+            [&](auto& hash_set_with_key) { aggregator->it_hash() = hash_set_with_key->hash_set.begin(); });
+    CHECK(!aggregator->spill_channel()->has_task());
+    RETURN_IF_ERROR(aggregator->spill_aggregate_data(state, _build_spill_task(state)));
+    return Status::OK();
+}
+
+Status SpillablePartitionWiseDistinctSinkOperator::reset_state(RuntimeState* state,
+                                                               const std::vector<ChunkPtr>& refill_chunks) {
+    _is_finished = false;
+    ONCE_RESET(_set_finishing_once);
+    RETURN_IF_ERROR(_distinct_op->aggregator()->spiller()->reset_state(state));
+    RETURN_IF_ERROR(_distinct_op->reset_state(state, refill_chunks));
+    return Status::OK();
+}
+
+ChunkPtr& SpillablePartitionWiseDistinctSinkOperator::_append_hash_column(ChunkPtr& chunk) {
+    auto slot_ids = _distinct_op->aggregator()->output_group_by_slot_ids();
+    size_t num_rows = chunk->num_rows();
+    auto hash_column = spill::SpillHashColumn::create(num_rows);
+    auto& hash_values = hash_column->get_data();
+    // TODO: use different hash method
+    for (auto& slot_id : slot_ids) {
+        auto column = chunk->get_column_by_slot_id(slot_id);
+        column->fnv_hash(hash_values.data(), 0, num_rows);
+    }
+    chunk->append_column(std::move(hash_column), Chunk::HASH_AGG_SPILL_HASH_SLOT_ID);
+    return chunk;
+}
+
+std::function<StatusOr<ChunkPtr>()> SpillablePartitionWiseDistinctSinkOperator::_build_spill_task(RuntimeState* state) {
+    auto chunk_provider = [this, state]() -> StatusOr<ChunkPtr> {
+        auto& aggregator = _distinct_op->aggregator();
+        if (!aggregator->is_ht_eos()) {
+            auto chunk = std::make_shared<Chunk>();
+            aggregator->convert_hash_set_to_chunk(state->chunk_size(), &chunk);
+            return chunk;
+        }
+        RETURN_IF_ERROR(aggregator->reset_state(state, {}, nullptr));
+        return Status::EndOfFile("no more data in current aggregator");
+    };
+    return [this, chunk_provider]() -> StatusOr<ChunkPtr> {
+        auto maybe_chunk = chunk_provider();
+        if (maybe_chunk.ok()) {
+            auto chunk = std::move(maybe_chunk.value());
+            if (!chunk) {
+                return chunk;
+            }
+            return this->_append_hash_column(chunk);
+        }
+        return maybe_chunk;
+    };
+}
+
+Status SpillablePartitionWiseDistinctSinkOperatorFactory::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(OperatorFactory::prepare(state));
+
+    // init spill options
+    _spill_options = std::make_shared<spill::SpilledOptions>(config::spill_init_partition);
+
+    _spill_options->spill_mem_table_bytes_size = state->spill_mem_table_size();
+    _spill_options->mem_table_pool_size = state->spill_mem_table_num();
+    _spill_options->spill_type = spill::SpillFormaterType::SPILL_BY_COLUMN;
+    _spill_options->block_manager = state->query_ctx()->spill_manager()->block_manager();
+    _spill_options->name = "distinct-blocking-spill";
+    _spill_options->splittable = false;
+    _spill_options->enable_block_compaction = state->spill_enable_compaction();
+    _spill_options->plan_node_id = _plan_node_id;
+    _spill_options->encode_level = state->spill_encode_level();
+    _spill_options->wg = state->fragment_ctx()->workgroup();
+    _spill_options->enable_buffer_read = state->enable_spill_buffer_read();
+    _spill_options->max_read_buffer_bytes = state->max_spill_read_buffer_bytes_per_driver();
+
+    return Status::OK();
+}
+
+OperatorPtr SpillablePartitionWiseDistinctSinkOperatorFactory::create(int32_t degree_of_parallelism,
+                                                                      int32_t driver_sequence) {
+    auto distinct_op = std::static_pointer_cast<AggregateDistinctBlockingSinkOperator>(
+            _distinct_op_factory->create(degree_of_parallelism, driver_sequence));
+    // create spiller
+    auto spiller = _spill_factory->create(*_spill_options);
+    // create spill process channel
+
+    auto spill_channel = _spill_channel_factory->get_or_create(driver_sequence);
+
+    spill_channel->set_spiller(spiller);
+    distinct_op->aggregator()->set_spiller(spiller);
+    distinct_op->aggregator()->set_spill_channel(std::move(spill_channel));
+    return make_shared<SpillablePartitionWiseDistinctSinkOperator>(this, _id, _plan_node_id, driver_sequence,
+                                                                   std::move(distinct_op));
+}
+
+Status SpillablePartitionWiseDistinctSourceOperator::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(SourceOperator::prepare(state));
+    RETURN_IF_ERROR(_non_pw_distinct->prepare(state));
+    RETURN_IF_ERROR(_pw_distinct->prepare(state));
+    return Status::OK();
+}
+
+void SpillablePartitionWiseDistinctSourceOperator::close(RuntimeState* state) {
+    _pw_distinct->close(state);
+    _non_pw_distinct->close(state);
+    return SourceOperator::close(state);
+}
+
+bool SpillablePartitionWiseDistinctSourceOperator::has_output() const {
+    auto& spiller = _non_pw_distinct->aggregator()->spiller();
+    bool has_spilled = spiller->spilled();
+
+    if (!has_spilled) {
+        return _non_pw_distinct->has_output();
+    }
+
+    // is_sink_complete returning true indicates that sink operator has finished all spilling tasks
+    // and source operator can process spill partitions one by one safely.
+    if (!_non_pw_distinct->aggregator()->is_sink_complete()) {
+        return false;
+    }
+
+    // at first time, we must call pull_chunk to acquire all partitions
+    if (_partitions.empty()) {
+        return true;
+    }
+    // if we processed all partitions, then no data to output
+    if (_curr_partition_idx >= _partitions.size()) {
+        return false;
+    }
+
+    // if current partition reader is not created, or no async store task trigger, or has output data.
+    // we must invoke pull_chunk to try to obtain chunk from current partition reader and push it to pw_agg
+    if (!_curr_partition_reader || !_curr_partition_reader->has_restore_task() ||
+        _curr_partition_reader->has_output_data()) {
+        return true;
+    }
+
+    // pw_agg receives all data of the current partition, then it should output result.
+    if (_curr_partition_eos && !_pw_distinct->is_finished()) {
+        return true;
+    }
+
+    return false;
+}
+
+bool SpillablePartitionWiseDistinctSourceOperator::is_finished() const {
+    if (_is_finished) {
+        return true;
+    }
+    auto& spiller = _non_pw_distinct->aggregator()->spiller();
+    if (!spiller->spilled()) {
+        return _non_pw_distinct->is_finished();
+    } else {
+        return !_partitions.empty() && _curr_partition_idx >= _partitions.size();
+    }
+}
+
+Status SpillablePartitionWiseDistinctSourceOperator::set_finishing(RuntimeState* state) {
+    if (state->is_cancelled()) {
+        _non_pw_distinct->aggregator()->spiller()->cancel();
+    }
+    RETURN_IF_ERROR(_non_pw_distinct->set_finishing(state));
+    RETURN_IF_ERROR(_pw_distinct->set_finishing(state));
+    return Status::OK();
+}
+
+Status SpillablePartitionWiseDistinctSourceOperator::set_finished(RuntimeState* state) {
+    _is_finished = true;
+    RETURN_IF_ERROR(_non_pw_distinct->set_finished(state));
+    RETURN_IF_ERROR(_pw_distinct->set_finished(state));
+    return Status::OK();
+}
+
+StatusOr<ChunkPtr> SpillablePartitionWiseDistinctSourceOperator::pull_chunk(RuntimeState* state) {
+    RETURN_IF_ERROR(_non_pw_distinct->aggregator()->spiller()->task_status());
+    if (!_non_pw_distinct->aggregator()->spiller()->spilled()) {
+        return _non_pw_distinct->pull_chunk(state);
+    }
+    ASSIGN_OR_RETURN(auto res, _pull_spilled_chunk(state));
+    return res;
+}
+
+Status SpillablePartitionWiseDistinctSourceOperator::reset_state(RuntimeState* state,
+                                                                 const std::vector<ChunkPtr>& refill_chunks) {
+    _is_finished = false;
+    _partitions.clear();
+    _curr_partition_reader.reset();
+    _curr_partition_idx = 0;
+    _curr_partition_eos = false;
+    RETURN_IF_ERROR(_non_pw_distinct->reset_state(state, refill_chunks));
+    RETURN_IF_ERROR(_pw_distinct->reset_state(state, refill_chunks));
+    return Status::OK();
+}
+
+StatusOr<ChunkPtr> SpillablePartitionWiseDistinctSourceOperator::_pull_spilled_chunk(RuntimeState* state) {
+    auto& spiller = _non_pw_distinct->aggregator()->spiller();
+    // retrieve all partitions
+    if (_partitions.empty()) {
+        spiller->get_all_partitions(&_partitions);
+        DCHECK(!_partitions.empty());
+    }
+
+    // processed all partitions
+    if (_curr_partition_idx >= _partitions.size()) {
+        return nullptr;
+    }
+
+    // initialize current partition reader at first
+    if (!_curr_partition_reader) {
+        _curr_partition_eos = false;
+        _curr_partition_reader = std::move(spiller->get_partition_spill_readers({_partitions[_curr_partition_idx]})[0]);
+    }
+
+    // if current partition has un-processed data, we try read the data out and push it to pw_agg
+    if (!_curr_partition_eos) {
+        if (!_curr_partition_reader->has_restore_task()) {
+            RETURN_IF_ERROR(_curr_partition_reader->trigger_restore(
+                    state, RESOURCE_TLS_MEMTRACER_GUARD(state, std::weak_ptr(_curr_partition_reader))));
+        }
+        if (_curr_partition_reader->has_output_data()) {
+            auto maybe_chunk = _curr_partition_reader->restore(
+                    state, RESOURCE_TLS_MEMTRACER_GUARD(state, std::weak_ptr(_curr_partition_reader)));
+            if (maybe_chunk.ok() && maybe_chunk.value() && !maybe_chunk.value()->is_empty()) {
+                DCHECK(_pw_distinct->need_input() && !_pw_distinct->is_finished());
+                RETURN_IF_ERROR(_pw_distinct->push_chunk(state, std::move(maybe_chunk.value())));
+            } else if (maybe_chunk.status().is_end_of_file()) {
+                _curr_partition_eos = true;
+                RETURN_IF_ERROR(_pw_distinct->set_finishing(state));
+            } else if (!maybe_chunk.ok()) {
+                return maybe_chunk.status();
+            }
+        }
+        return nullptr;
+    } else if (!_pw_distinct->is_finished()) {
+        // all data of the current partition is push to _pw_distinct, so we can pull chunk from it
+        DCHECK(!_pw_distinct->need_input() && _pw_distinct->has_output());
+        return _pw_distinct->pull_chunk(state);
+    } else {
+        // the _pw_distinct has processed all the data of the current partition, so we switch to next partition
+        DCHECK(_curr_partition_eos && _pw_distinct->is_finished());
+        DCHECK(!_curr_partition_reader->has_restore_task());
+        DCHECK(_curr_partition_reader->restore_finished());
+        //switch to next partition
+        ++_curr_partition_idx;
+        _curr_partition_eos = false;
+        _curr_partition_reader.reset();
+        RETURN_IF_ERROR(_pw_distinct->reset_state(state, {}));
+    }
+    return nullptr;
+}
+
+Status SpillablePartitionWiseDistinctSourceOperatorFactory::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(SourceOperatorFactory::prepare(state));
+    RETURN_IF_ERROR(_non_pw_distinct_factory->prepare(state));
+    RETURN_IF_ERROR(_pw_distinct_factory->prepare(state));
+    return Status::OK();
+}
+
+OperatorPtr SpillablePartitionWiseDistinctSourceOperatorFactory::create(int32_t degree_of_parallelism,
+                                                                        int32_t driver_sequence) {
+    return std::make_shared<SpillablePartitionWiseDistinctSourceOperator>(
+            this, _id, _plan_node_id, driver_sequence,
+            std::static_pointer_cast<AggregateDistinctBlockingSourceOperator>(
+                    _non_pw_distinct_factory->create(degree_of_parallelism, driver_sequence)),
+            std::static_pointer_cast<query_cache::ConjugateOperator>(
+                    _pw_distinct_factory->create(degree_of_parallelism, driver_sequence)));
+}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate/spillable_partitionwise_distinct_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_partitionwise_distinct_operator.cpp
@@ -181,8 +181,7 @@ Status SpillablePartitionWiseDistinctSinkOperatorFactory::prepare(RuntimeState* 
     RETURN_IF_ERROR(OperatorFactory::prepare(state));
 
     // init spill options
-    _spill_options = std::make_shared<spill::SpilledOptions>(config::spill_init_partition);
-
+    _spill_options = std::make_shared<spill::SpilledOptions>(state->spill_partitionwise_agg_partition_num());
     _spill_options->spill_mem_table_bytes_size = state->spill_mem_table_size();
     _spill_options->mem_table_pool_size = state->spill_mem_table_num();
     _spill_options->spill_type = spill::SpillFormaterType::SPILL_BY_COLUMN;

--- a/be/src/exec/pipeline/aggregate/spillable_partitionwise_distinct_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_partitionwise_distinct_operator.cpp
@@ -19,9 +19,6 @@
 
 namespace starrocks::pipeline {
 
-DEFINE_FAIL_POINT(spill_always_streaming);
-DEFINE_FAIL_POINT(spill_always_selection_streaming);
-
 bool SpillablePartitionWiseDistinctSinkOperator::need_input() const {
     return !is_finished() && !_distinct_op->aggregator()->is_full() &&
            !_distinct_op->aggregator()->spill_channel()->has_task();
@@ -140,12 +137,13 @@ Status SpillablePartitionWiseDistinctSinkOperator::reset_state(RuntimeState* sta
 }
 
 ChunkPtr& SpillablePartitionWiseDistinctSinkOperator::_append_hash_column(ChunkPtr& chunk) {
-    auto slot_ids = _distinct_op->aggregator()->output_group_by_slot_ids();
+    const auto& group_by_exprs = _distinct_op->aggregator()->group_by_expr_ctxs();
     size_t num_rows = chunk->num_rows();
-    auto hash_column = spill::SpillHashColumn::create(num_rows);
+    auto hash_column = spill::SpillHashColumn::create(num_rows, HashUtil::FNV_SEED);
     auto& hash_values = hash_column->get_data();
     // TODO: use different hash method
-    for (auto& slot_id : slot_ids) {
+    for (auto* expr : group_by_exprs) {
+        auto slot_id = down_cast<const ColumnRef*>(expr->root())->slot_id();
         auto column = chunk->get_column_by_slot_id(slot_id);
         column->fnv_hash(hash_values.data(), 0, num_rows);
     }

--- a/be/src/exec/pipeline/aggregate/spillable_partitionwise_distinct_operator.h
+++ b/be/src/exec/pipeline/aggregate/spillable_partitionwise_distinct_operator.h
@@ -182,7 +182,7 @@ public:
                                                       SpillProcessChannelFactoryPtr spill_channel_factory)
             : OperatorFactory(id, "spillable_partitionwise_distinct_sink", plan_node_id),
               _distinct_op_factory(std::make_shared<AggregateDistinctBlockingSinkOperatorFactory>(
-                      id, plan_node_id, std::move(aggregator_factory), nullptr)),
+                      id, plan_node_id, std::move(aggregator_factory), spill_channel_factory)),
               _spill_channel_factory(std::move(spill_channel_factory)) {}
 
     ~SpillablePartitionWiseDistinctSinkOperatorFactory() override = default;

--- a/be/src/exec/pipeline/aggregate/spillable_partitionwise_distinct_operator.h
+++ b/be/src/exec/pipeline/aggregate/spillable_partitionwise_distinct_operator.h
@@ -1,0 +1,204 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+
+#pragma once
+#include <memory>
+
+#include "exec/aggregator.h"
+#include "exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.h"
+#include "exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h"
+#include "exec/pipeline/source_operator.h"
+#include "exec/query_cache/conjugate_operator.h"
+#include "exec/spill/spill_components.h"
+#include "storage/chunk_helper.h"
+
+namespace starrocks::pipeline {
+class SpillablePartitionWiseDistinctSourceOperator;
+class SpillablePartitionWiseDistinctSourceOperatorFactory;
+
+using SPWDistinctSourceOperatorRawPtr = SpillablePartitionWiseDistinctSourceOperator*;
+using SPWDistinctSourceOperatorPtr = std::shared_ptr<SPWDistinctSourceOperatorRawPtr>;
+using SPWDistinctSourceOperatorFactoryRawPtr = SpillablePartitionWiseDistinctSourceOperatorFactory*;
+using SPWDistinctSourceOperatorFactoryPtr = std::shared_ptr<SPWDistinctSourceOperatorFactoryRawPtr>;
+using DistinctSourceOperatorPtr = std::shared_ptr<AggregateDistinctBlockingSourceOperator>;
+using ConjugateOperatorPtr = starrocks::query_cache::ConjugateOperatorPtr;
+using DistinctSourceOperatorFactoryPtr = std::shared_ptr<AggregateDistinctBlockingSourceOperatorFactory>;
+using ConjugateOperatorFactoryPtr = starrocks::query_cache::ConjugateOperatorFactoryPtr;
+
+using DistinctSinkOperatorPtr = std::shared_ptr<AggregateDistinctBlockingSinkOperator>;
+using DistinctSinkOperatorFactoryPtr = std::shared_ptr<AggregateDistinctBlockingSinkOperatorFactory>;
+class SpillablePartitionWiseDistinctSinkOperator;
+class SpillablePartitionWiseDistinctSinkOperatorFactory;
+using SPWDistinctSinkOperatorRawPtr = SpillablePartitionWiseDistinctSinkOperator*;
+using SPWDistinctSinkOperatorPtr = std::shared_ptr<SpillablePartitionWiseDistinctSinkOperator>;
+using SPWDistinctSinkOperatorFactoryRawPtr = SpillablePartitionWiseDistinctSinkOperatorFactory*;
+using SPWDistinctSinkOperatorFactoryPtr = std::shared_ptr<SpillablePartitionWiseDistinctSinkOperatorFactory>;
+
+class SpillablePartitionWiseDistinctSourceOperator final : public SourceOperator {
+public:
+    SpillablePartitionWiseDistinctSourceOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id,
+                                                 int32_t driver_sequence, const DistinctSourceOperatorPtr non_pw_agg,
+                                                 ConjugateOperatorPtr pw_agg)
+            : SourceOperator(factory, id, "spillable_partitionwise_distinct_source", plan_node_id, false,
+                             driver_sequence),
+              _non_pw_distinct(std::move(non_pw_agg)),
+              _pw_distinct(std::move(pw_agg)) {}
+
+    ~SpillablePartitionWiseDistinctSourceOperator() override = default;
+
+    bool has_output() const override;
+    bool is_finished() const override;
+
+    Status set_finishing(RuntimeState* state) override;
+    Status set_finished(RuntimeState* state) override;
+
+    Status prepare(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
+
+    StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
+    Status reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) override;
+
+private:
+    DistinctSourceOperatorPtr _non_pw_distinct;
+    ConjugateOperatorPtr _pw_distinct;
+    StatusOr<ChunkPtr> _pull_spilled_chunk(RuntimeState* state);
+
+    std::vector<const SpillPartitionInfo*> _partitions;
+    size_t _curr_partition_idx{0};
+    std::shared_ptr<spill::SpillerReader> _curr_partition_reader;
+    bool _curr_partition_eos{false};
+    bool _is_finished{false};
+};
+
+class SpillablePartitionWiseDistinctSourceOperatorFactory final : public SourceOperatorFactory {
+public:
+    SpillablePartitionWiseDistinctSourceOperatorFactory(int32_t id, int32_t plan_node_id,
+                                                        AggregatorFactoryPtr aggregator_factory)
+            : SourceOperatorFactory(id, "spillable_partitionwise_distinct_source", plan_node_id),
+              _non_pw_distinct_factory(std::make_shared<AggregateDistinctBlockingSourceOperatorFactory>(
+                      id, plan_node_id, std::move(aggregator_factory))) {}
+
+    ~SpillablePartitionWiseDistinctSourceOperatorFactory() override = default;
+
+    Status prepare(RuntimeState* state) override;
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override;
+
+    bool support_event_scheduler() const override { return false; }
+
+    void set_pw_distinct_factory(ConjugateOperatorFactoryPtr&& pw_agg_factory) {
+        _pw_distinct_factory = std::move(pw_agg_factory);
+    }
+
+private:
+    DistinctSourceOperatorFactoryPtr _non_pw_distinct_factory;
+    ConjugateOperatorFactoryPtr _pw_distinct_factory;
+};
+
+class SpillablePartitionWiseDistinctSinkOperator : public Operator {
+public:
+    SpillablePartitionWiseDistinctSinkOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id,
+                                               int32_t driver_sequence, DistinctSinkOperatorPtr&& agg_op)
+            : Operator(factory, id, "spillable_partitionwise_distinct_sink", plan_node_id, false, driver_sequence),
+              _distinct_op(std::move(agg_op)) {}
+
+    ~SpillablePartitionWiseDistinctSinkOperator() override = default;
+
+    bool need_input() const override;
+    bool is_finished() const override;
+    Status set_finishing(RuntimeState* state) override;
+
+    StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override { return Status::InternalError("Not support"); }
+
+    bool has_output() const override { throw Status::InternalError("Not support"); }
+
+    void close(RuntimeState* state) override;
+
+    Status prepare(RuntimeState* state) override;
+    Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
+
+    bool spillable() const override { return true; }
+
+    void set_execute_mode(int performance_level) override {
+        _spill_strategy = spill::SpillStrategy::SPILL_ALL;
+        TRACE_SPILL_LOG << "AggregateDistinctBlockingSink, mark spill " << (void*)this;
+    }
+
+    size_t estimated_memory_reserved(const ChunkPtr& chunk) override {
+        if (chunk && !chunk->is_empty()) {
+            if (_distinct_op->aggregator()->hash_set_variant().need_expand(chunk->num_rows())) {
+                return chunk->memory_usage() + _distinct_op->aggregator()->hash_set_memory_usage();
+            }
+            return chunk->memory_usage();
+        }
+        return 0;
+    }
+
+    Status reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) override;
+
+    // only the prepare/open phase calls are valid.
+    SpillProcessChannelPtr spill_channel() { return _distinct_op->aggregator()->spill_channel(); }
+
+private:
+    bool spilled() const { return _distinct_op->aggregator()->spiller()->spilled(); }
+
+private:
+    Status _spill_all_data(RuntimeState* state);
+
+    ChunkPtr& _append_hash_column(ChunkPtr& chunk);
+
+    DistinctSinkOperatorPtr _distinct_op;
+    std::function<StatusOr<ChunkPtr>()> _build_spill_task(RuntimeState* state);
+
+    DECLARE_ONCE_DETECTOR(_set_finishing_once);
+    spill::SpillStrategy _spill_strategy = spill::SpillStrategy::NO_SPILL;
+
+    int32_t _continuous_low_reduction_chunk_num = 0;
+
+    bool _is_finished = false;
+
+    RuntimeProfile::Counter* _hash_table_spill_times = nullptr;
+
+    static constexpr double HT_LOW_REDUCTION_THRESHOLD = 0.5;
+    static constexpr int32_t HT_LOW_REDUCTION_CHUNK_LIMIT = 5;
+};
+
+class SpillablePartitionWiseDistinctSinkOperatorFactory : public OperatorFactory {
+public:
+    SpillablePartitionWiseDistinctSinkOperatorFactory(int32_t id, int32_t plan_node_id,
+                                                      AggregatorFactoryPtr aggregator_factory,
+                                                      SpillProcessChannelFactoryPtr spill_channel_factory)
+            : OperatorFactory(id, "spillable_partitionwise_distinct_sink", plan_node_id),
+              _distinct_op_factory(std::make_shared<AggregateDistinctBlockingSinkOperatorFactory>(
+                      id, plan_node_id, std::move(aggregator_factory), nullptr)),
+              _spill_channel_factory(std::move(spill_channel_factory)) {}
+
+    ~SpillablePartitionWiseDistinctSinkOperatorFactory() override = default;
+
+    Status prepare(RuntimeState* state) override;
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override;
+
+    bool support_event_scheduler() const override { return false; }
+
+private:
+    ObjectPool _pool;
+    std::shared_ptr<spill::SpilledOptions> _spill_options;
+    std::shared_ptr<spill::SpillerFactory> _spill_factory = std::make_shared<spill::SpillerFactory>();
+    DistinctSinkOperatorFactoryPtr _distinct_op_factory;
+    SpillProcessChannelFactoryPtr _spill_channel_factory;
+};
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/spill/mem_table.h
+++ b/be/src/exec/spill/mem_table.h
@@ -116,6 +116,8 @@ public:
 
     StatusOr<std::shared_ptr<SpillInputStream>> as_input_stream(bool shared) override;
 
+    std::vector<ChunkPtr>& get_chunks() { return _chunks; }
+
 private:
     size_t _processed_index = 0;
     std::vector<ChunkPtr> _chunks;

--- a/be/src/exec/spill/options.h
+++ b/be/src/exec/spill/options.h
@@ -23,6 +23,11 @@
 #include "exec/spill/block_manager.h"
 #include "exec/workgroup/work_group_fwd.h"
 
+namespace starrocks {
+class AggregatorParams;
+using AggregatorParamsPtr = std::shared_ptr<AggregatorParams>;
+}; // namespace starrocks
+
 namespace starrocks::spill {
 struct SpilledChunkBuildSchema {
     void set_schema(const ChunkPtr& chunk) {
@@ -52,7 +57,6 @@ private:
 
 // using ChunkBuilder = std::function<ChunkUniquePtr()>;
 enum class SpillFormaterType { NONE, SPILL_BY_COLUMN };
-
 // spill options
 struct SpilledOptions {
     SpilledOptions() : SpilledOptions(-1) {}
@@ -109,6 +113,8 @@ struct SpilledOptions {
     size_t max_read_buffer_bytes = UINT64_MAX;
 
     int64_t spill_hash_join_probe_op_max_bytes = 1LL << 31;
+
+    mutable std::optional<AggregatorParamsPtr> opt_aggregator_params{};
 };
 
 // spill strategy

--- a/be/src/exec/spill/spill_components.cpp
+++ b/be/src/exec/spill/spill_components.cpp
@@ -24,6 +24,7 @@
 #include "block_manager.h"
 #include "column/vectorized_fwd.h"
 #include "common/config.h"
+#include "exec/aggregator.h"
 #include "exec/spill/common.h"
 #include "exec/spill/data_stream.h"
 #include "exec/spill/executor.h"
@@ -33,6 +34,7 @@
 #include "exec/workgroup/scan_task_queue.h"
 #include "exec/workgroup/work_group.h"
 #include "exec/workgroup/work_group_fwd.h"
+#include "runtime/runtime_state.h"
 #include "util/bit_util.h"
 #include "util/runtime_profile.h"
 
@@ -576,6 +578,166 @@ Status PartitionedSpillerWriter::_split_input_partitions(workgroup::YieldContext
     for (auto partition : splitting_partitions) {
         _remove_partition(partition);
     }
+    return Status::OK();
+}
+
+Status PartitionedSpillerWriter::_pick_and_compact_skew_partitions(std::vector<SpilledPartition*>& partitions) {
+    if (!_spiller->options().opt_aggregator_params.has_value()) {
+        return Status::OK();
+    }
+
+    if (partitions.empty()) {
+        return Status::OK();
+    }
+
+    for (auto& partition : partitions) {
+        SCOPED_TIMER(_spiller->metrics().skew_mem_table_merge_timer);
+        auto mem_table = std::dynamic_pointer_cast<UnorderedMemTable>(partition->spill_writer->mem_table());
+        auto chunks = mem_table->get_chunks();
+        auto input_num_rows = mem_table->num_rows();
+        auto input_mem_size = mem_table->mem_usage();
+        auto is_done = mem_table->is_done();
+        mem_table->reset();
+        RETURN_IF_ERROR(
+                _compact_skew_chunks(input_num_rows, chunks, _spiller->options().opt_aggregator_params.value()));
+        for (const auto& chunk : chunks) {
+            RETURN_IF_ERROR(mem_table->append(chunk));
+        }
+        auto output_num_rows = mem_table->num_rows();
+        auto output_mem_size = mem_table->mem_usage();
+        partition->num_rows += output_num_rows;
+        partition->num_rows -= input_num_rows;
+        partition->mem_size += output_mem_size;
+        partition->mem_size -= input_mem_size;
+        if (is_done) {
+            RETURN_IF_ERROR(mem_table->done());
+        }
+        _spiller->mutable_spilled_append_rows() += output_num_rows;
+        _spiller->mutable_spilled_append_rows() -= input_num_rows;
+        if (output_num_rows != input_num_rows) {
+            COUNTER_UPDATE(_spiller->metrics().skew_mem_table_count, 1);
+            COUNTER_UPDATE(_spiller->metrics().skew_mem_table_input_bytes, input_mem_size);
+            COUNTER_UPDATE(_spiller->metrics().skew_mem_table_output_bytes, output_mem_size);
+            COUNTER_UPDATE(_spiller->metrics().skew_mem_table_input_rows, input_num_rows);
+            COUNTER_UPDATE(_spiller->metrics().skew_mem_table_output_rows, output_num_rows);
+            COUNTER_SET(_spiller->metrics().skew_mem_table_skew_ratio,
+                        (input_mem_size - output_mem_size) * 100.0 / input_mem_size);
+        }
+    }
+    return Status::OK();
+}
+
+Status PartitionedSpillerWriter::_compact_skew_chunks(size_t num_rows, std::vector<ChunkPtr>& chunks,
+                                                      AggregatorParamsPtr& aggregator_params) {
+    if (num_rows < 2) {
+        return Status::OK();
+    }
+    std::random_device rd;     //Will be used to obtain a seed for the random number engine
+    std::mt19937_64 gen(rd()); //Standard mersenne_twister_engine seeded with rd()
+    std::uniform_int_distribution<size_t> distrib(0, num_rows - 1);
+    std::vector<size_t> samples(30);
+    for (auto i = 0; i < samples.size(); ++i) {
+        samples[i] = distrib(gen);
+    }
+    std::sort(samples.begin(), samples.end());
+    size_t curr_chunk_idx = 0;
+    size_t curr_num_rows = chunks[curr_chunk_idx]->num_rows();
+    phmap::flat_hash_map<uint32_t, size_t, StdHashWithSeed<uint32_t, PhmapSeed2>> hash_value_counts;
+
+    for (auto idx : samples) {
+        while (idx >= curr_num_rows) {
+            ++curr_chunk_idx;
+            if (chunks[curr_chunk_idx] == nullptr || chunks[curr_chunk_idx]->is_empty()) {
+                continue;
+            }
+            curr_num_rows += chunks[curr_chunk_idx]->num_rows();
+        }
+        const auto& curr_chunk = chunks[curr_chunk_idx];
+        const auto row_idx = idx - (curr_num_rows - curr_chunk->num_rows());
+        auto* hash_column = down_cast<UInt32Column*>(curr_chunk->columns().back().get());
+        auto hash_value = hash_column->get_data()[row_idx];
+        ++hash_value_counts[hash_value];
+    }
+    for (auto& curr_chunk : chunks) {
+        if (curr_chunk == nullptr || curr_chunk->is_empty()) {
+            continue;
+        }
+        auto* hash_column = down_cast<UInt32Column*>(curr_chunk->columns().back().get());
+        auto& hash_values = hash_column->get_data();
+        for (auto& hash_value : hash_values) {
+            auto it = hash_value_counts.find(hash_value);
+            if (it != hash_value_counts.end()) {
+                ++it->second;
+            }
+        }
+    }
+
+    auto mode_elem_it = std::max_element(hash_value_counts.begin(), hash_value_counts.end(),
+                                         [](const auto& lhs, const auto& rhs) { return lhs.second < rhs.second; });
+
+    if (mode_elem_it->second < num_rows * 0.25) {
+        return Status::OK();
+    }
+    auto merger = std::make_shared<Aggregator>(aggregator_params);
+    merger->set_aggr_mode(AM_STREAMING_POST_CACHE);
+    RuntimeProfile* profile = _runtime_state->runtime_profile()->create_child("spillable_pw_skew_elimination", true);
+    RETURN_IF_ERROR(merger->prepare(_runtime_state, _runtime_state->obj_pool(), profile));
+    RETURN_IF_ERROR(merger->open(_runtime_state));
+    DeferOp defer([&merger, this]() { merger->close(_runtime_state); });
+    auto target_hash_value = mode_elem_it->first;
+    std::vector<ChunkPtr> new_chunks;
+    for (auto& chunk : chunks) {
+        if (chunk == nullptr || chunk->is_empty()) {
+            continue;
+        }
+        auto* hash_column = down_cast<UInt32Column*>(chunk->columns().back().get());
+        auto& hash_values = hash_column->get_data();
+        std::vector<uint32_t> indices;
+        Filter filter;
+        indices.reserve(chunk->num_rows());
+        filter.reserve(chunk->num_rows());
+        for (uint32_t i = 0; i < hash_values.size(); ++i) {
+            if (hash_values[i] == target_hash_value) {
+                indices.push_back(i);
+                filter.push_back(0);
+            } else {
+                filter.push_back(1);
+            }
+        }
+        auto chunk_merging = chunk->clone_empty_with_slot(indices.size());
+        chunk_merging->append_selective(*chunk, indices.data(), 0, indices.size());
+        chunk->filter(filter);
+        if (!chunk_merging->is_empty()) {
+            RETURN_IF_ERROR(merger->evaluate_groupby_exprs(chunk_merging.get()));
+            if (merger->only_group_by_exprs()) {
+                merger->build_hash_set(chunk_merging->num_rows());
+            } else {
+                merger->build_hash_map(chunk_merging->num_rows(), false);
+                RETURN_IF_ERROR(merger->compute_batch_agg_states(chunk_merging.get(), chunk_merging->num_rows()));
+            }
+        }
+        if (!chunk->is_empty()) {
+            new_chunks.emplace_back(std::move(chunk));
+        }
+    }
+    auto chunk_merged = std::make_shared<Chunk>();
+    if (merger->only_group_by_exprs()) {
+        merger->hash_set_variant().visit(
+                [&](auto& hash_set_with_key) { merger->it_hash() = hash_set_with_key->hash_set.begin(); });
+        auto hash_set_sz = merger->hash_set_variant().size();
+        merger->convert_hash_set_to_chunk(hash_set_sz, &chunk_merged);
+    } else {
+        merger->hash_map_variant().visit(
+                [&](auto& hash_map_with_key) { merger->it_hash() = merger->_state_allocator.begin(); });
+        auto hash_map_sz = merger->hash_map_variant().size();
+        RETURN_IF_ERROR(merger->convert_hash_map_to_chunk(hash_map_sz, &chunk_merged, true));
+    }
+    if (chunk_merged != nullptr && !chunk_merged->is_empty()) {
+        auto hash_column = UInt32Column::create(chunk_merged->num_rows(), target_hash_value);
+        chunk_merged->append_column(hash_column, Chunk::HASH_AGG_SPILL_HASH_SLOT_ID);
+        new_chunks.emplace_back(std::move(chunk_merged));
+    }
+    chunks = std::move(new_chunks);
     return Status::OK();
 }
 

--- a/be/src/exec/spill/spill_components.h
+++ b/be/src/exec/spill/spill_components.h
@@ -352,6 +352,9 @@ private:
     Status _split_input_partitions(workgroup::YieldContext& ctx, SerdeContext& context,
                                    const std::vector<SpilledPartition*>& splitting_partitions);
 
+    Status _pick_and_compact_skew_partitions(std::vector<SpilledPartition*>& partitions);
+    Status _compact_skew_chunks(size_t num_rows, std::vector<ChunkPtr>& chunks, AggregatorParamsPtr& aggregator_params);
+
     // split partition by hash
     // hash-based partitioning can have significant degradation in the case of heavily skewed data.
     // TODO:

--- a/be/src/exec/spill/spiller.cpp
+++ b/be/src/exec/spill/spiller.cpp
@@ -109,6 +109,16 @@ SpillProcessMetrics::SpillProcessMetrics(RuntimeProfile* profile, std::atomic_in
     mem_table_finalize_timer = ADD_CHILD_TIMER(profile, "MemTableFinalizeTime", parent);
     flush_task_yield_times = ADD_CHILD_COUNTER(profile, "FlushIOTaskYieldCount", TUnit::UNIT, parent);
     restore_task_yield_times = ADD_CHILD_COUNTER(profile, "RestoreIOTaskYieldCount", TUnit::UNIT, parent);
+
+    skew_mem_table_count = ADD_CHILD_COUNTER(profile, "SkewMemTableCount", TUnit::UNIT, parent);
+    skew_mem_table_skew_ratio = profile->AddLowWaterMarkCounter(
+            "SkewMemTableSkewRatio", TUnit::DOUBLE_VALUE,
+            RuntimeProfile::Counter::create_strategy(TCounterAggregateType::AVG), parent);
+    skew_mem_table_merge_timer = ADD_CHILD_TIMER(profile, "SkewMemTableMergeTime", parent);
+    skew_mem_table_input_bytes = ADD_CHILD_COUNTER(profile, "SkewMemTableInputBytes", TUnit::BYTES, parent);
+    skew_mem_table_output_bytes = ADD_CHILD_COUNTER(profile, "SkewMemTableOutputBytes", TUnit::BYTES, parent);
+    skew_mem_table_input_rows = ADD_CHILD_COUNTER(profile, "SkewMemTableInputRows", TUnit::UNIT, parent);
+    skew_mem_table_output_rows = ADD_CHILD_COUNTER(profile, "SkewMemTableOutputRows", TUnit::UNIT, parent);
 }
 
 Status Spiller::prepare(RuntimeState* state) {

--- a/be/src/exec/spill/spiller.h
+++ b/be/src/exec/spill/spiller.h
@@ -131,6 +131,13 @@ public:
     RuntimeProfile::Counter* mem_table_finalize_timer = nullptr;
     RuntimeProfile::Counter* flush_task_yield_times = nullptr;
     RuntimeProfile::Counter* restore_task_yield_times = nullptr;
+    RuntimeProfile::Counter* skew_mem_table_count = nullptr;
+    RuntimeProfile::LowWaterMarkCounter* skew_mem_table_skew_ratio = nullptr;
+    RuntimeProfile::Counter* skew_mem_table_merge_timer = nullptr;
+    RuntimeProfile::Counter* skew_mem_table_input_rows = nullptr;
+    RuntimeProfile::Counter* skew_mem_table_output_rows = nullptr;
+    RuntimeProfile::Counter* skew_mem_table_input_bytes = nullptr;
+    RuntimeProfile::Counter* skew_mem_table_output_bytes = nullptr;
 };
 
 // major spill interfaces
@@ -196,6 +203,8 @@ public:
     bool has_output_data() { return _reader->has_output_data(); }
 
     size_t spilled_append_rows() const { return _spilled_append_rows; }
+
+    size_t& mutable_spilled_append_rows() { return _spilled_append_rows; }
 
     size_t restore_read_rows() const { return _restore_read_rows; }
 

--- a/be/src/exec/spill/spiller.hpp
+++ b/be/src/exec/spill/spiller.hpp
@@ -47,7 +47,18 @@ Status Spiller::spill(RuntimeState* state, const ChunkPtr& chunk, MemGuard&& gua
                     << ",spiller:" << this;
 
     if (_chunk_builder.chunk_schema()->empty()) {
-        _chunk_builder.chunk_schema()->set_schema(chunk);
+        if (!_opts.splittable && _opts.init_partition_nums > 0) {
+            // For splittable spiller, we need to set the schema before spilling.
+            // This is because the partitioned spiller needs to know the schema of the chunk.
+            std::shared_ptr<Chunk> new_chunk = chunk->clone_empty(0);
+            new_chunk->remove_column_by_slot_id(Chunk::HASH_AGG_SPILL_HASH_SLOT_ID);
+            _chunk_builder.chunk_schema()->set_schema(new_chunk);
+        } else {
+            // For non-splittable spiller, we can set the schema after spilling.
+            // This is because the raw spiller does not need to know the schema of the chunk.
+            _chunk_builder.chunk_schema()->set_schema(chunk);
+        }
+
         RETURN_IF_ERROR(_serde->prepare());
         _init_max_block_nums();
     }

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -336,13 +336,22 @@ public:
     }
 
     bool enable_agg_spill() const { return spillable_operator_mask() & (1LL << TSpillableOperatorType::AGG); }
-    bool enable_agg_distinct_spill() const {
+    bool enable_spill_partitionwise_agg() const { return enable_agg_spill() && spill_partitionwise_agg(); }
+    bool enable_spill_partitionwise_agg_skew_elimination() const {
+        return enable_agg_spill() && spill_partitionwise_agg_skew_elimination();
+    }
+    bool enable_agg_distint_spill() const {
         return spillable_operator_mask() & (1LL << TSpillableOperatorType::AGG_DISTINCT);
     }
     bool enable_sort_spill() const { return spillable_operator_mask() & (1LL << TSpillableOperatorType::SORT); }
     bool enable_nl_join_spill() const { return spillable_operator_mask() & (1LL << TSpillableOperatorType::NL_JOIN); }
     bool enable_multi_cast_local_exchange_spill() const {
         return spillable_operator_mask() & (1LL << TSpillableOperatorType::MULTI_CAST_LOCAL_EXCHANGE);
+    }
+
+    bool spill_partitionwise_agg() const { return _spill_options->spill_partitionwise_agg; }
+    bool spill_partitionwise_agg_skew_elimination() const {
+        return _spill_options->spill_partitionwise_agg_skew_elimination;
     }
 
     int32_t spill_mem_table_size() const {

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -337,6 +337,13 @@ public:
 
     bool enable_agg_spill() const { return spillable_operator_mask() & (1LL << TSpillableOperatorType::AGG); }
     bool enable_spill_partitionwise_agg() const { return enable_agg_spill() && spill_partitionwise_agg(); }
+    int spill_partitionwise_agg_partition_num() const {
+        if (_spill_options->spill_partitionwise_agg_partition_num <= 0) {
+            return config::spill_init_partition;
+        } else {
+            return std::max(std::min(_spill_options->spill_partitionwise_agg_partition_num, 256), 4);
+        }
+    }
     bool enable_spill_partitionwise_agg_skew_elimination() const {
         return enable_agg_spill() && spill_partitionwise_agg_skew_elimination();
     }

--- a/be/src/runtime/types.cpp
+++ b/be/src/runtime/types.cpp
@@ -276,8 +276,7 @@ bool TypeDescriptor::support_orderby() const {
     if (type == TYPE_ARRAY) {
         return children[0].support_orderby();
     }
-    return type != TYPE_JSON && type != TYPE_OBJECT && type != TYPE_PERCENTILE && type != TYPE_HLL &&
-           type != TYPE_MAP && type != TYPE_STRUCT;
+    return type != TYPE_JSON && type != TYPE_OBJECT && type != TYPE_PERCENTILE && type != TYPE_HLL && type != TYPE_MAP;
 }
 
 bool TypeDescriptor::support_groupby() const {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -209,6 +209,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_AGG_SPILL_PREAGGREGATION = "enable_agg_spill_preaggregation";
 
     public static final String SPILL_PARTITIONWISE_AGG = "spill_partitionwise_agg";
+    public static final String SPILL_PARTITIONWISE_AGG_PARTITION_NUM = "spill_partitionwise_agg_partition_num";
     public static final String SPILL_PARTITIONWISE_AGG_SKEW_ELIMINATION = "spill_partitionwise_agg_skew_elimination";
     public static final String ENABLE_SPILL_BUFFER_READ = "enable_spill_buffer_read";
     public static final String MAX_SPILL_READ_BUFFER_BYTES_PER_DRIVER = "max_spill_read_buffer_bytes_per_driver";
@@ -1354,6 +1355,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = SPILL_PARTITIONWISE_AGG)
     public boolean spillPartitionWiseAgg = false;
+
+    @VarAttr(name = SPILL_PARTITIONWISE_AGG_PARTITION_NUM, flag = VariableMgr.INVISIBLE)
+    public int spillPartitionWiseAggPartitionNum = 32;
 
     @VarAttr(name = SPILL_PARTITIONWISE_AGG_SKEW_ELIMINATION, flag = VariableMgr.INVISIBLE)
     public boolean spillPartitionWiseAggSkewElimination = true;
@@ -3376,6 +3380,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return this.spillPartitionWiseAgg;
     }
 
+    public void setSpillPartitionWiseAggPartitionNum(int value) {
+        this.spillPartitionWiseAggPartitionNum = value;
+    }
+
+    public int getSpillPartitionWiseAggPartitionNum() {
+        return this.spillPartitionWiseAggPartitionNum;
+    }
+
     public void setSpillPartitionWiseAggSkewElimination(boolean value) {
         this.spillPartitionWiseAggSkewElimination = value;
     }
@@ -5111,6 +5123,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             spillOptions.setSpillable_operator_mask(spillableOperatorMask);
             spillOptions.setEnable_agg_spill_preaggregation(enableAggSpillPreaggregation);
             spillOptions.setSpill_partitionwise_agg(spillPartitionWiseAgg);
+            spillOptions.setSpill_partitionwise_agg_partition_num(spillPartitionWiseAggPartitionNum);
             spillOptions.setSpill_partitionwise_agg_skew_elimination(spillPartitionWiseAggSkewElimination);
             spillOptions.setSpill_enable_direct_io(spillEnableDirectIO);
             spillOptions.setSpill_rand_ratio(spillRandRatio);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -207,6 +207,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // spill mode: auto, force
     public static final String SPILL_MODE = "spill_mode";
     public static final String ENABLE_AGG_SPILL_PREAGGREGATION = "enable_agg_spill_preaggregation";
+
+    public static final String SPILL_PARTITIONWISE_AGG = "spill_partitionwise_agg";
+    public static final String SPILL_PARTITIONWISE_AGG_SKEW_ELIMINATION = "spill_partitionwise_agg_skew_elimination";
     public static final String ENABLE_SPILL_BUFFER_READ = "enable_spill_buffer_read";
     public static final String MAX_SPILL_READ_BUFFER_BYTES_PER_DRIVER = "max_spill_read_buffer_bytes_per_driver";
     public static final String SPILL_HASH_JOIN_PROBE_OP_MAX_BYTES = "spill_hash_join_probe_op_max_bytes";
@@ -1348,6 +1351,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_AGG_SPILL_PREAGGREGATION, flag = VariableMgr.INVISIBLE)
     public boolean enableAggSpillPreaggregation = true;
+
+    @VarAttr(name = SPILL_PARTITIONWISE_AGG)
+    public boolean spillPartitionWiseAgg = false;
+
+    @VarAttr(name = SPILL_PARTITIONWISE_AGG_SKEW_ELIMINATION, flag = VariableMgr.INVISIBLE)
+    public boolean spillPartitionWiseAggSkewElimination = true;
 
     @VarAttr(name = ENABLE_SPILL_BUFFER_READ, flag = VariableMgr.INVISIBLE)
     public boolean enableSpillBufferRead = true;
@@ -3359,6 +3368,22 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return this.spillEncodeLevel;
     }
 
+    public void setSpillPartitionWiseAgg(boolean value) {
+        this.spillPartitionWiseAgg = value;
+    }
+
+    public boolean getSpillPartitionWiseAgg() {
+        return this.spillPartitionWiseAgg;
+    }
+
+    public void setSpillPartitionWiseAggSkewElimination(boolean value) {
+        this.spillPartitionWiseAggSkewElimination = value;
+    }
+
+    public boolean getSpillPartitionWiseAggSkewElimination() {
+        return this.spillPartitionWiseAggSkewElimination;
+    }
+
     public boolean getForwardToLeader() {
         return forwardToLeader;
     }
@@ -5085,6 +5110,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             spillOptions.setSpill_encode_level(spillEncodeLevel);
             spillOptions.setSpillable_operator_mask(spillableOperatorMask);
             spillOptions.setEnable_agg_spill_preaggregation(enableAggSpillPreaggregation);
+            spillOptions.setSpill_partitionwise_agg(spillPartitionWiseAgg);
+            spillOptions.setSpill_partitionwise_agg_skew_elimination(spillPartitionWiseAggSkewElimination);
             spillOptions.setSpill_enable_direct_io(spillEnableDirectIO);
             spillOptions.setSpill_rand_ratio(spillRandRatio);
             spillOptions.setSpill_enable_compaction(spillEnableCompaction);

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -173,7 +173,8 @@ struct TSpillOptions {
   25: optional i64 spill_hash_join_probe_op_max_bytes;
 
   26: optional bool spill_partitionwise_agg;
-  27: optional bool spill_partitionwise_agg_skew_elimination;
+  27: optional i32 spill_partitionwise_agg_partition_num;
+  28: optional bool spill_partitionwise_agg_skew_elimination;
 }
 
 // Query options with their respective defaults

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -171,6 +171,9 @@ struct TSpillOptions {
   23: optional bool enable_spill_buffer_read;
   24: optional i64 max_spill_read_buffer_bytes_per_driver;
   25: optional i64 spill_hash_join_probe_op_max_bytes;
+
+  26: optional bool spill_partitionwise_agg;
+  27: optional bool spill_partitionwise_agg_skew_elimination;
 }
 
 // Query options with their respective defaults

--- a/test/sql/test_spill_partition_wise_agg/R/test_spill_partition_wise_agg
+++ b/test/sql/test_spill_partition_wise_agg/R/test_spill_partition_wise_agg
@@ -1,0 +1,386 @@
+-- name: test_spill_partition_wise_agg
+drop table if exists res_table;
+-- result:
+-- !result
+drop table if exists lineorder2;
+-- result:
+-- !result
+CREATE TABLE `lineorder2` (
+  `lo_orderkey` int(11) NOT NULL COMMENT "",
+  `lo_linenumber` int(11) NOT NULL COMMENT "",
+  `lo_custkey` int(11) NOT NULL COMMENT "",
+  `lo_partkey` int(11) NOT NULL COMMENT "",
+  `lo_suppkey` int(11) NOT NULL COMMENT "",
+  `lo_orderdate` int(11) NOT NULL COMMENT "",
+  `lo_orderpriority` varchar(16) NOT NULL COMMENT "",
+  `lo_shippriority` int(11) NOT NULL COMMENT "",
+  `lo_quantity` int(11) NOT NULL COMMENT "",
+  `lo_extendedprice` int(11) NOT NULL COMMENT "",
+  `lo_ordtotalprice` int(11) NOT NULL COMMENT "",
+  `lo_discount` int(11) NOT NULL COMMENT "",
+  `lo_revenue` int(11) NOT NULL COMMENT "",
+  `lo_supplycost` int(11) NOT NULL COMMENT "",
+  `lo_tax` int(11) NOT NULL COMMENT "",
+  `lo_commitdate` int(11) NOT NULL COMMENT "",
+  `lo_shipmode` varchar(11) NOT NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`lo_orderkey`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`lo_orderdate`)
+(PARTITION p1 VALUES [("-2147483648"), ("19930101")),
+PARTITION p2 VALUES [("19930101"), ("19940101")),
+PARTITION p3 VALUES [("19940101"), ("19950101")),
+PARTITION p4 VALUES [("19950101"), ("19960101")),
+PARTITION p5 VALUES [("19960101"), ("19970101")),
+PARTITION p6 VALUES [("19970101"), ("19980101")),
+PARTITION p7 VALUES [("19980101"), ("19990101")))
+DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48 
+PROPERTIES (
+"colocate_with" = "groupa1",
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into lineorder2 select * from lineorder;
+-- result:
+E: (5502, "Getting analyzing error. Detail message: Unknown table 'test_db_10e946dda2304f5fb79627f4f6ee3a1d.lineorder'.")
+-- !result
+insert into lineorder2 
+select 384 as lo_orderkey, 
+1 as lo_linenumber, 
+2260169 as lo_custkey, 
+892207 as lo_partkey, 
+107841 as lo_suppkey, 
+19920303 as lo_orderdate, 
+"5-LOW" as lo_orderpriority, 
+0 as lo_shippriority, 
+38 as lo_quantity, 
+4556808 as lo_extendedprice, 
+17026608 as lo_ordtotalprice, 
+7 as lo_discount, 
+4237831 as lo_revenue, 
+71949 as lo_supplycost, 
+1 as lo_tax, 
+19920418 as lo_commitdate, 
+"TRUCK" as lo_shipmode 
+from table(generate_series(1,6000000));
+-- result:
+-- !result
+create table res_table (res bigint) properties('replication_num'='1');
+-- result:
+-- !result
+truncate table res_table;
+-- result:
+-- !result
+insert into res_table with cte as(
+select lo_custkey,lo_orderkey,  sum(lo_quantity) as sum_qty  from lineorder2  group by lo_custkey,lo_orderkey
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true) */ sum(murmur_hash3_32(lo_custkey,lo_orderkey,sum_qty)) fp from cte;
+-- result:
+-- !result
+insert into res_table with cte as(
+select lo_custkey,lo_orderkey,  sum(lo_quantity) as sum_qty  from lineorder2  group by lo_custkey,lo_orderkey
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=false,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true) */ sum(murmur_hash3_32(lo_custkey,lo_orderkey,sum_qty)) fp from cte;
+-- result:
+-- !result
+insert into res_table with cte as(
+select lo_custkey,lo_orderkey,  sum(lo_quantity) as sum_qty  from lineorder2  group by lo_custkey,lo_orderkey
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=false, spill_partitionwise_agg_skew_elimination=false) */ sum(murmur_hash3_32(lo_custkey,lo_orderkey,sum_qty)) fp from cte;
+-- result:
+-- !result
+insert into res_table with cte as(
+select lo_custkey,lo_orderkey,  sum(lo_quantity) as sum_qty  from lineorder2  group by lo_custkey,lo_orderkey
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=false, spill_partitionwise_agg_skew_elimination=true) */ sum(murmur_hash3_32(lo_custkey,lo_orderkey,sum_qty)) fp from cte;
+-- result:
+-- !result
+insert into res_table with cte as(
+select lo_custkey,lo_orderkey,  sum(lo_quantity) as sum_qty  from lineorder2  group by lo_custkey,lo_orderkey
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true, spill_mem_table_size=4096) */ sum(murmur_hash3_32(lo_custkey,lo_orderkey,sum_qty)) fp from cte;
+-- result:
+-- !result
+select assert_true(count(1) = 5 and count(distinct res) = 1) from res_table;
+-- result:
+1
+-- !result
+truncate table res_table;
+-- result:
+-- !result
+insert into res_table with cte as (
+select 
+[named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+),
+cte1 as(
+select group_by, sum(lo_quantity) as sum_qty from cte
+group by group_by
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true) */ sum(murmur_hash3_32(group_by[1].key1,group_by[1].key2, group_by[2].key1,group_by[2].key2, sum_qty)) from cte1;
+-- result:
+-- !result
+insert into res_table with cte as (
+select 
+[named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+),
+cte1 as(
+select group_by, sum(lo_quantity) as sum_qty from cte
+group by group_by
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=false,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true) */ sum(murmur_hash3_32(group_by[1].key1,group_by[1].key2, group_by[2].key1,group_by[2].key2, sum_qty)) from cte1;
+-- result:
+-- !result
+insert into res_table with cte as (
+select 
+[named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+),
+cte1 as(
+select group_by, sum(lo_quantity) as sum_qty from cte
+group by group_by
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=false, spill_partitionwise_agg_skew_elimination=false) */ sum(murmur_hash3_32(group_by[1].key1,group_by[1].key2, group_by[2].key1,group_by[2].key2, sum_qty)) from cte1;
+-- result:
+-- !result
+insert into res_table with cte as (
+select 
+[named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+),
+cte1 as(
+select group_by, sum(lo_quantity) as sum_qty from cte
+group by group_by
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=false, spill_partitionwise_agg_skew_elimination=true) */ sum(murmur_hash3_32(group_by[1].key1,group_by[1].key2, group_by[2].key1,group_by[2].key2, sum_qty)) from cte1;
+-- result:
+-- !result
+insert into res_table with cte as (
+select 
+[named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+),
+cte1 as(
+select group_by, sum(lo_quantity) as sum_qty from cte
+group by group_by
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true, spill_mem_table_size=4096) */ sum(murmur_hash3_32(group_by[1].key1,group_by[1].key2, group_by[2].key1,group_by[2].key2, sum_qty)) from cte1;
+-- result:
+-- !result
+select assert_true(count(1) = 5 and count(distinct res) = 1) from res_table;
+-- result:
+1
+-- !result
+truncate table res_table;
+-- result:
+-- !result
+insert into res_table with cte as(
+select distinct lo_custkey,lo_orderkey,lo_quantity 
+from lineorder2
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true) */ sum(murmur_hash3_32(lo_custkey,lo_orderkey,lo_quantity)) from cte;
+-- result:
+-- !result
+insert into res_table with cte as(
+select distinct lo_custkey,lo_orderkey,lo_quantity 
+from lineorder2
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=false,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true) */ sum(murmur_hash3_32(lo_custkey,lo_orderkey,lo_quantity)) from cte;
+-- result:
+-- !result
+insert into res_table with cte as(
+select distinct lo_custkey,lo_orderkey,lo_quantity 
+from lineorder2
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=false, spill_partitionwise_agg_skew_elimination=false) */ sum(murmur_hash3_32(lo_custkey,lo_orderkey,lo_quantity)) from cte;
+-- result:
+-- !result
+insert into res_table with cte as(
+select distinct lo_custkey,lo_orderkey,lo_quantity 
+from lineorder2
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=false, spill_partitionwise_agg_skew_elimination=true) */ sum(murmur_hash3_32(lo_custkey,lo_orderkey,lo_quantity)) from cte;
+-- result:
+-- !result
+insert into res_table with cte as(
+select distinct lo_custkey,lo_orderkey,lo_quantity 
+from lineorder2
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true, spill_mem_table_size=4096) */ sum(murmur_hash3_32(lo_custkey,lo_orderkey,lo_quantity)) from cte;
+-- result:
+-- !result
+select assert_true(count(1) = 5 and count(distinct res) = 1) from res_table;
+-- result:
+1
+-- !result
+truncate table res_table;
+-- result:
+-- !result
+insert into res_table with cte as (
+select 
+distinct [named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true) */
+sum(murmur_hash3_32(group_by[1].key1,group_by[1].key2, group_by[2].key1,group_by[2].key2, lo_quantity)) from cte;
+-- result:
+-- !result
+insert into res_table with cte as (
+select 
+distinct [named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=false,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true) */
+sum(murmur_hash3_32(group_by[1].key1,group_by[1].key2, group_by[2].key1,group_by[2].key2, lo_quantity)) from cte;
+-- result:
+-- !result
+insert into res_table with cte as (
+select 
+distinct [named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=false, spill_partitionwise_agg_skew_elimination=false) */
+sum(murmur_hash3_32(group_by[1].key1,group_by[1].key2, group_by[2].key1,group_by[2].key2, lo_quantity)) from cte;
+-- result:
+-- !result
+insert into res_table with cte as (
+select 
+distinct [named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=false, spill_partitionwise_agg_skew_elimination=true) */
+sum(murmur_hash3_32(group_by[1].key1,group_by[1].key2, group_by[2].key1,group_by[2].key2, lo_quantity)) from cte;
+-- result:
+-- !result
+insert into res_table with cte as (
+select 
+distinct [named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true, spill_mem_table_size=4096) */
+sum(murmur_hash3_32(group_by[1].key1,group_by[1].key2, group_by[2].key1,group_by[2].key2, lo_quantity)) from cte;
+-- result:
+-- !result
+select assert_true(count(1) = 5 and count(distinct res) = 1) from res_table;
+-- result:
+1
+-- !result
+truncate table res_table;
+-- result:
+-- !result
+insert into res_table with cte as(
+select lo_partkey, lo_suppkey,  sum(lo_quantity) as sum_qty, count(distinct lo_shipmode) as cnt_shipmode  from lineorder2  group by lo_partkey,lo_suppkey
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true) */ sum(murmur_hash3_32(lo_partkey,lo_suppkey,sum_qty, cnt_shipmode)) fp from cte;
+-- result:
+-- !result
+insert into res_table with cte as(
+select lo_partkey, lo_suppkey,  sum(lo_quantity) as sum_qty, count(distinct lo_shipmode) as cnt_shipmode  from lineorder2  group by lo_partkey,lo_suppkey
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=false,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true) */ sum(murmur_hash3_32(lo_partkey,lo_suppkey,sum_qty, cnt_shipmode)) fp from cte;
+-- result:
+-- !result
+insert into res_table with cte as(
+select lo_partkey, lo_suppkey,  sum(lo_quantity) as sum_qty, count(distinct lo_shipmode) as cnt_shipmode  from lineorder2  group by lo_partkey,lo_suppkey
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=false, spill_partitionwise_agg_skew_elimination=false) */ sum(murmur_hash3_32(lo_partkey,lo_suppkey,sum_qty, cnt_shipmode)) fp from cte;
+-- result:
+-- !result
+insert into res_table with cte as(
+select lo_partkey, lo_suppkey,  sum(lo_quantity) as sum_qty, count(distinct lo_shipmode) as cnt_shipmode  from lineorder2  group by lo_partkey,lo_suppkey
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=false, spill_partitionwise_agg_skew_elimination=true) */ sum(murmur_hash3_32(lo_partkey,lo_suppkey,sum_qty, cnt_shipmode)) fp from cte;
+-- result:
+-- !result
+insert into res_table with cte as(
+select lo_partkey, lo_suppkey,  sum(lo_quantity) as sum_qty, count(distinct lo_shipmode) as cnt_shipmode  from lineorder2  group by lo_partkey,lo_suppkey
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true, spill_mem_table_size=4096) */ sum(murmur_hash3_32(lo_partkey,lo_suppkey,sum_qty, cnt_shipmode)) fp from cte;
+-- result:
+-- !result
+select assert_true(count(1) = 5 and count(distinct res) = 1) from res_table;
+-- result:
+1
+-- !result
+truncate table res_table;
+-- result:
+-- !result
+insert into res_table with cte as (
+select 
+[named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+),
+cte1 as(
+select count(distinct group_by) as cnt_group_by, sum(lo_quantity) as sum_qty from cte
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true) */ murmur_hash3_32(cnt_group_by, sum_qty) from cte1;
+-- result:
+-- !result
+insert into res_table with cte as (
+select 
+[named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+),
+cte1 as(
+select count(distinct group_by) as cnt_group_by, sum(lo_quantity) as sum_qty from cte
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=false,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true) */ murmur_hash3_32(cnt_group_by, sum_qty) from cte1;
+-- result:
+-- !result
+insert into res_table with cte as (
+select 
+[named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+),
+cte1 as(
+select count(distinct group_by) as cnt_group_by, sum(lo_quantity) as sum_qty from cte
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=false, spill_partitionwise_agg_skew_elimination=false) */ murmur_hash3_32(cnt_group_by, sum_qty) from cte1;
+-- result:
+-- !result
+insert into res_table with cte as (
+select 
+[named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+),
+cte1 as(
+select count(distinct group_by) as cnt_group_by, sum(lo_quantity) as sum_qty from cte
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=false, spill_partitionwise_agg_skew_elimination=true) */ murmur_hash3_32(cnt_group_by, sum_qty) from cte1;
+-- result:
+-- !result
+insert into res_table with cte as (
+select 
+[named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+),
+cte1 as(
+select count(distinct group_by) as cnt_group_by, sum(lo_quantity) as sum_qty from cte
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true, spill_mem_table_size=4096) */ murmur_hash3_32(cnt_group_by, sum_qty) from cte1;
+-- result:
+-- !result
+select assert_true(count(1) = 5 and count(distinct res) = 1) from res_table;
+-- result:
+1
+-- !result

--- a/test/sql/test_spill_partition_wise_agg/R/test_spill_partition_wise_agg
+++ b/test/sql/test_spill_partition_wise_agg/R/test_spill_partition_wise_agg
@@ -1,4 +1,8 @@
 -- name: test_spill_partition_wise_agg
+function: prepare_data("ssb", "${db[0]}")
+-- result:
+None
+-- !result
 drop table if exists res_table;
 -- result:
 -- !result
@@ -36,7 +40,6 @@ PARTITION p6 VALUES [("19970101"), ("19980101")),
 PARTITION p7 VALUES [("19980101"), ("19990101")))
 DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48 
 PROPERTIES (
-"colocate_with" = "groupa1",
 "compression" = "LZ4",
 "fast_schema_evolution" = "true",
 "replicated_storage" = "true",
@@ -46,7 +49,6 @@ PROPERTIES (
 -- !result
 insert into lineorder2 select * from lineorder;
 -- result:
-E: (5502, "Getting analyzing error. Detail message: Unknown table 'test_db_10e946dda2304f5fb79627f4f6ee3a1d.lineorder'.")
 -- !result
 insert into lineorder2 
 select 384 as lo_orderkey, 

--- a/test/sql/test_spill_partition_wise_agg/T/test_spill_partition_wise_agg
+++ b/test/sql/test_spill_partition_wise_agg/T/test_spill_partition_wise_agg
@@ -1,4 +1,5 @@
 -- name: test_spill_partition_wise_agg
+function: prepare_data("ssb", "${db[0]}")
 drop table if exists res_table;
 drop table if exists lineorder2;
 CREATE TABLE `lineorder2` (
@@ -32,7 +33,6 @@ PARTITION p6 VALUES [("19970101"), ("19980101")),
 PARTITION p7 VALUES [("19980101"), ("19990101")))
 DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48 
 PROPERTIES (
-"colocate_with" = "groupa1",
 "compression" = "LZ4",
 "fast_schema_evolution" = "true",
 "replicated_storage" = "true",

--- a/test/sql/test_spill_partition_wise_agg/T/test_spill_partition_wise_agg
+++ b/test/sql/test_spill_partition_wise_agg/T/test_spill_partition_wise_agg
@@ -1,0 +1,283 @@
+-- name: test_spill_partition_wise_agg
+drop table if exists res_table;
+drop table if exists lineorder2;
+CREATE TABLE `lineorder2` (
+  `lo_orderkey` int(11) NOT NULL COMMENT "",
+  `lo_linenumber` int(11) NOT NULL COMMENT "",
+  `lo_custkey` int(11) NOT NULL COMMENT "",
+  `lo_partkey` int(11) NOT NULL COMMENT "",
+  `lo_suppkey` int(11) NOT NULL COMMENT "",
+  `lo_orderdate` int(11) NOT NULL COMMENT "",
+  `lo_orderpriority` varchar(16) NOT NULL COMMENT "",
+  `lo_shippriority` int(11) NOT NULL COMMENT "",
+  `lo_quantity` int(11) NOT NULL COMMENT "",
+  `lo_extendedprice` int(11) NOT NULL COMMENT "",
+  `lo_ordtotalprice` int(11) NOT NULL COMMENT "",
+  `lo_discount` int(11) NOT NULL COMMENT "",
+  `lo_revenue` int(11) NOT NULL COMMENT "",
+  `lo_supplycost` int(11) NOT NULL COMMENT "",
+  `lo_tax` int(11) NOT NULL COMMENT "",
+  `lo_commitdate` int(11) NOT NULL COMMENT "",
+  `lo_shipmode` varchar(11) NOT NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`lo_orderkey`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`lo_orderdate`)
+(PARTITION p1 VALUES [("-2147483648"), ("19930101")),
+PARTITION p2 VALUES [("19930101"), ("19940101")),
+PARTITION p3 VALUES [("19940101"), ("19950101")),
+PARTITION p4 VALUES [("19950101"), ("19960101")),
+PARTITION p5 VALUES [("19960101"), ("19970101")),
+PARTITION p6 VALUES [("19970101"), ("19980101")),
+PARTITION p7 VALUES [("19980101"), ("19990101")))
+DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48 
+PROPERTIES (
+"colocate_with" = "groupa1",
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+insert into lineorder2 select * from lineorder;
+insert into lineorder2 
+select 384 as lo_orderkey, 
+1 as lo_linenumber, 
+2260169 as lo_custkey, 
+892207 as lo_partkey, 
+107841 as lo_suppkey, 
+19920303 as lo_orderdate, 
+"5-LOW" as lo_orderpriority, 
+0 as lo_shippriority, 
+38 as lo_quantity, 
+4556808 as lo_extendedprice, 
+17026608 as lo_ordtotalprice, 
+7 as lo_discount, 
+4237831 as lo_revenue, 
+71949 as lo_supplycost, 
+1 as lo_tax, 
+19920418 as lo_commitdate, 
+"TRUCK" as lo_shipmode 
+from table(generate_series(1,6000000));
+create table res_table (res bigint) properties('replication_num'='1');
+truncate table res_table;
+insert into res_table with cte as(
+select lo_custkey,lo_orderkey,  sum(lo_quantity) as sum_qty  from lineorder2  group by lo_custkey,lo_orderkey
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true) */ sum(murmur_hash3_32(lo_custkey,lo_orderkey,sum_qty)) fp from cte;
+insert into res_table with cte as(
+select lo_custkey,lo_orderkey,  sum(lo_quantity) as sum_qty  from lineorder2  group by lo_custkey,lo_orderkey
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=false,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true) */ sum(murmur_hash3_32(lo_custkey,lo_orderkey,sum_qty)) fp from cte;
+insert into res_table with cte as(
+select lo_custkey,lo_orderkey,  sum(lo_quantity) as sum_qty  from lineorder2  group by lo_custkey,lo_orderkey
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=false, spill_partitionwise_agg_skew_elimination=false) */ sum(murmur_hash3_32(lo_custkey,lo_orderkey,sum_qty)) fp from cte;
+insert into res_table with cte as(
+select lo_custkey,lo_orderkey,  sum(lo_quantity) as sum_qty  from lineorder2  group by lo_custkey,lo_orderkey
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=false, spill_partitionwise_agg_skew_elimination=true) */ sum(murmur_hash3_32(lo_custkey,lo_orderkey,sum_qty)) fp from cte;
+insert into res_table with cte as(
+select lo_custkey,lo_orderkey,  sum(lo_quantity) as sum_qty  from lineorder2  group by lo_custkey,lo_orderkey
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true, spill_mem_table_size=4096) */ sum(murmur_hash3_32(lo_custkey,lo_orderkey,sum_qty)) fp from cte;
+select assert_true(count(1) = 5 and count(distinct res) = 1) from res_table;
+truncate table res_table;
+insert into res_table with cte as (
+select 
+[named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+),
+cte1 as(
+select group_by, sum(lo_quantity) as sum_qty from cte
+group by group_by
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true) */ sum(murmur_hash3_32(group_by[1].key1,group_by[1].key2, group_by[2].key1,group_by[2].key2, sum_qty)) from cte1;
+insert into res_table with cte as (
+select 
+[named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+),
+cte1 as(
+select group_by, sum(lo_quantity) as sum_qty from cte
+group by group_by
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=false,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true) */ sum(murmur_hash3_32(group_by[1].key1,group_by[1].key2, group_by[2].key1,group_by[2].key2, sum_qty)) from cte1;
+insert into res_table with cte as (
+select 
+[named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+),
+cte1 as(
+select group_by, sum(lo_quantity) as sum_qty from cte
+group by group_by
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=false, spill_partitionwise_agg_skew_elimination=false) */ sum(murmur_hash3_32(group_by[1].key1,group_by[1].key2, group_by[2].key1,group_by[2].key2, sum_qty)) from cte1;
+insert into res_table with cte as (
+select 
+[named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+),
+cte1 as(
+select group_by, sum(lo_quantity) as sum_qty from cte
+group by group_by
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=false, spill_partitionwise_agg_skew_elimination=true) */ sum(murmur_hash3_32(group_by[1].key1,group_by[1].key2, group_by[2].key1,group_by[2].key2, sum_qty)) from cte1;
+insert into res_table with cte as (
+select 
+[named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+),
+cte1 as(
+select group_by, sum(lo_quantity) as sum_qty from cte
+group by group_by
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true, spill_mem_table_size=4096) */ sum(murmur_hash3_32(group_by[1].key1,group_by[1].key2, group_by[2].key1,group_by[2].key2, sum_qty)) from cte1;
+select assert_true(count(1) = 5 and count(distinct res) = 1) from res_table;
+truncate table res_table;
+insert into res_table with cte as(
+select distinct lo_custkey,lo_orderkey,lo_quantity 
+from lineorder2
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true) */ sum(murmur_hash3_32(lo_custkey,lo_orderkey,lo_quantity)) from cte;
+insert into res_table with cte as(
+select distinct lo_custkey,lo_orderkey,lo_quantity 
+from lineorder2
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=false,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true) */ sum(murmur_hash3_32(lo_custkey,lo_orderkey,lo_quantity)) from cte;
+insert into res_table with cte as(
+select distinct lo_custkey,lo_orderkey,lo_quantity 
+from lineorder2
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=false, spill_partitionwise_agg_skew_elimination=false) */ sum(murmur_hash3_32(lo_custkey,lo_orderkey,lo_quantity)) from cte;
+insert into res_table with cte as(
+select distinct lo_custkey,lo_orderkey,lo_quantity 
+from lineorder2
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=false, spill_partitionwise_agg_skew_elimination=true) */ sum(murmur_hash3_32(lo_custkey,lo_orderkey,lo_quantity)) from cte;
+insert into res_table with cte as(
+select distinct lo_custkey,lo_orderkey,lo_quantity 
+from lineorder2
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true, spill_mem_table_size=4096) */ sum(murmur_hash3_32(lo_custkey,lo_orderkey,lo_quantity)) from cte;
+select assert_true(count(1) = 5 and count(distinct res) = 1) from res_table;
+truncate table res_table;
+insert into res_table with cte as (
+select 
+distinct [named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true) */
+sum(murmur_hash3_32(group_by[1].key1,group_by[1].key2, group_by[2].key1,group_by[2].key2, lo_quantity)) from cte;
+insert into res_table with cte as (
+select 
+distinct [named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=false,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true) */
+sum(murmur_hash3_32(group_by[1].key1,group_by[1].key2, group_by[2].key1,group_by[2].key2, lo_quantity)) from cte;
+insert into res_table with cte as (
+select 
+distinct [named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=false, spill_partitionwise_agg_skew_elimination=false) */
+sum(murmur_hash3_32(group_by[1].key1,group_by[1].key2, group_by[2].key1,group_by[2].key2, lo_quantity)) from cte;
+insert into res_table with cte as (
+select 
+distinct [named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=false, spill_partitionwise_agg_skew_elimination=true) */
+sum(murmur_hash3_32(group_by[1].key1,group_by[1].key2, group_by[2].key1,group_by[2].key2, lo_quantity)) from cte;
+insert into res_table with cte as (
+select 
+distinct [named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true, spill_mem_table_size=4096) */
+sum(murmur_hash3_32(group_by[1].key1,group_by[1].key2, group_by[2].key1,group_by[2].key2, lo_quantity)) from cte;
+select assert_true(count(1) = 5 and count(distinct res) = 1) from res_table;
+truncate table res_table;
+insert into res_table with cte as(
+select lo_partkey, lo_suppkey,  sum(lo_quantity) as sum_qty, count(distinct lo_shipmode) as cnt_shipmode  from lineorder2  group by lo_partkey,lo_suppkey
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true) */ sum(murmur_hash3_32(lo_partkey,lo_suppkey,sum_qty, cnt_shipmode)) fp from cte;
+insert into res_table with cte as(
+select lo_partkey, lo_suppkey,  sum(lo_quantity) as sum_qty, count(distinct lo_shipmode) as cnt_shipmode  from lineorder2  group by lo_partkey,lo_suppkey
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=false,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true) */ sum(murmur_hash3_32(lo_partkey,lo_suppkey,sum_qty, cnt_shipmode)) fp from cte;
+insert into res_table with cte as(
+select lo_partkey, lo_suppkey,  sum(lo_quantity) as sum_qty, count(distinct lo_shipmode) as cnt_shipmode  from lineorder2  group by lo_partkey,lo_suppkey
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=false, spill_partitionwise_agg_skew_elimination=false) */ sum(murmur_hash3_32(lo_partkey,lo_suppkey,sum_qty, cnt_shipmode)) fp from cte;
+insert into res_table with cte as(
+select lo_partkey, lo_suppkey,  sum(lo_quantity) as sum_qty, count(distinct lo_shipmode) as cnt_shipmode  from lineorder2  group by lo_partkey,lo_suppkey
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=false, spill_partitionwise_agg_skew_elimination=true) */ sum(murmur_hash3_32(lo_partkey,lo_suppkey,sum_qty, cnt_shipmode)) fp from cte;
+insert into res_table with cte as(
+select lo_partkey, lo_suppkey,  sum(lo_quantity) as sum_qty, count(distinct lo_shipmode) as cnt_shipmode  from lineorder2  group by lo_partkey,lo_suppkey
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true, spill_mem_table_size=4096) */ sum(murmur_hash3_32(lo_partkey,lo_suppkey,sum_qty, cnt_shipmode)) fp from cte;
+select assert_true(count(1) = 5 and count(distinct res) = 1) from res_table;
+truncate table res_table;
+insert into res_table with cte as (
+select 
+[named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+),
+cte1 as(
+select count(distinct group_by) as cnt_group_by, sum(lo_quantity) as sum_qty from cte
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true) */ murmur_hash3_32(cnt_group_by, sum_qty) from cte1;
+insert into res_table with cte as (
+select 
+[named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+),
+cte1 as(
+select count(distinct group_by) as cnt_group_by, sum(lo_quantity) as sum_qty from cte
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=false,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true) */ murmur_hash3_32(cnt_group_by, sum_qty) from cte1;
+insert into res_table with cte as (
+select 
+[named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+),
+cte1 as(
+select count(distinct group_by) as cnt_group_by, sum(lo_quantity) as sum_qty from cte
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=false, spill_partitionwise_agg_skew_elimination=false) */ murmur_hash3_32(cnt_group_by, sum_qty) from cte1;
+insert into res_table with cte as (
+select 
+[named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+),
+cte1 as(
+select count(distinct group_by) as cnt_group_by, sum(lo_quantity) as sum_qty from cte
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=false, spill_partitionwise_agg_skew_elimination=true) */ murmur_hash3_32(cnt_group_by, sum_qty) from cte1;
+insert into res_table with cte as (
+select 
+[named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
+lo_quantity
+from lineorder2
+),
+cte1 as(
+select count(distinct group_by) as cnt_group_by, sum(lo_quantity) as sum_qty from cte
+)
+select /*+SET_VAR(new_planner_agg_stage=3,spill_mode='force',enable_spill=true,spill_partitionwise_agg=true, enable_agg_spill_preaggregation=true, spill_partitionwise_agg_skew_elimination=true, spill_mem_table_size=4096) */ murmur_hash3_32(cnt_group_by, sum_qty) from cte1;
+select assert_true(count(1) = 5 and count(distinct res) = 1) from res_table;


### PR DESCRIPTION
## Why I'm doing:

**Motivation**

Introduce spillable partitionwise aggregate/distinct operator to replace  its spillable sorted-based counterpart.

In Sort-based streamin agg implementation, SpillerWriter append input data to OrderedMemTable, when OrderedMemTable's size reach pre-configured limit, the data is sorted by group-by columns, then materialize chunk and convert it into serialized form and flush to disk. The Sort-based streaming agg would create an SpillerReader which uses sort merger to create a totally ordered run from these sorted blocks, then the agg would read from SpillerReader sequentially and merge the same adjascent group by columns. For complex types, both write-time
Sorting and read-time merging is time-consuming.
![sort_spill](https://github.com/user-attachments/assets/17792855-26db-4ab3-8431-6ef0caea387a)

In Partition-wise agg, input data is shuffled into dozens of SpillPartition by group-by columns, then each SpillPartition flush a block into durable device. and Partitionwise agg would process each SpillPartition one by one, it read the data from the current SpillPartition and push the data into it, then the final aggregating results can be pulled from it, after all the data of the current SpillPartition is processed, Partitionwise agg reset its state then process the next SpillPartition. In this implementation, write-time shuffle cost is introduced but write-time sorting and read-time merging in sorted-based streaming agg are eliminated.

![hash_spill](https://github.com/user-attachments/assets/7d6c5b6e-a6d4-471d-a743-09c2b09e49ff)

**Test**
Test Environment
1. Cluster: 1 FE x 3 BE(ecs.c6.4xlarge, 16c32g)
2. Dataset: SSB_100g

Test query
```sql
-- Q1  (group by int,int)
select lo_custkey,lo_orderkey, sum(lo_quantity) as sum_qty from lineorder group by lo_custkey,lo_orderkey order by sum_qty desc limit 10;

-- Q2  (group by array[struct])
with cte as (
select 
[named_struct("key1", lo_orderkey, "key2", lo_custkey), named_struct("key1",lo_partkey, "key2", lo_suppkey)] as group_by,
lo_quantity
from lineorder
)
select group_by, sum(lo_quantity) as sum_qty from cte
group by group_by
order by sum_qty desc
limit 10;
```

Test Result

![image](https://github.com/user-attachments/assets/e6e659fb-93f8-4c01-803d-239c9d51e51c)
From the test result, partitionwise agg outperforms sort-based streaming agg. when the agregation's group by columns are simple type(Q1), partitionwise agg speedup 1.26X(dop=1) and 1.35X(dop=0); for complex group by columns(Q2), partitionwise agg is 2.X times as fast as sort-based, the root cause is that method compare_at of complex times is poor performance. Let's inspect Q2(pipeline_dop=0)'s profiles as follows.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
