### PR TITLE
[Enhancement] backport bundle data file reader to v3.5 for potential future cluster downgrades (backport #58923)

### DIFF
--- a/be/src/fs/CMakeLists.txt
+++ b/be/src/fs/CMakeLists.txt
@@ -36,6 +36,7 @@ set(EXEC_FILES
     s3/poco_http_client.cpp
     s3/poco_common.cpp
     fs_util.cpp
+    bundle_file.cpp
     )
 
 if (NOT BUILD_FORMAT_LIB)

--- a/be/src/fs/bundle_file.cpp
+++ b/be/src/fs/bundle_file.cpp
@@ -1,0 +1,77 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "fs/bundle_file.h"
+
+#include "fs/fs.h"
+#include "fs/fs_util.h"
+
+namespace starrocks {
+
+Status BundleSeekableInputStream::init() {
+    // Initialize the stream.
+    RETURN_IF_ERROR(_stream->seek(_offset));
+    return Status::OK();
+}
+
+Status BundleSeekableInputStream::seek(int64_t position) {
+    return _stream->seek(_offset + position);
+}
+
+StatusOr<int64_t> BundleSeekableInputStream::position() {
+    ASSIGN_OR_RETURN(auto pos, _stream->position());
+    return pos - _offset;
+}
+
+StatusOr<int64_t> BundleSeekableInputStream::read_at(int64_t offset, void* out, int64_t count) {
+    return _stream->read_at(_offset + offset, out, count);
+}
+
+Status BundleSeekableInputStream::read_at_fully(int64_t offset, void* out, int64_t count) {
+    return _stream->read_at_fully(_offset + offset, out, count);
+}
+
+StatusOr<int64_t> BundleSeekableInputStream::get_size() {
+    return _size;
+}
+
+Status BundleSeekableInputStream::skip(int64_t count) {
+    return _stream->skip(count);
+}
+
+StatusOr<std::string> BundleSeekableInputStream::read_all() {
+    std::string result;
+    result.resize(_size);
+    RETURN_IF_ERROR(_stream->read_at_fully(_offset, result.data(), _size));
+    return std::move(result);
+}
+
+Status BundleSeekableInputStream::touch_cache(int64_t offset, size_t length) {
+    // Touch the cache for the underlying stream.
+    return _stream->touch_cache(_offset + offset, length);
+}
+
+StatusOr<std::unique_ptr<io::NumericStatistics>> BundleSeekableInputStream::get_numeric_statistics() {
+    return _stream->get_numeric_statistics();
+}
+
+const std::string& BundleSeekableInputStream::filename() const {
+    return _stream->filename();
+}
+
+StatusOr<int64_t> BundleSeekableInputStream::read(void* data, int64_t count) {
+    return _stream->read(data, count);
+}
+
+} // namespace starrocks

--- a/be/src/fs/bundle_file.h
+++ b/be/src/fs/bundle_file.h
@@ -1,0 +1,45 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "fs/fs.h"
+
+namespace starrocks {
+
+class BundleSeekableInputStream final : public io::SeekableInputStream {
+public:
+    explicit BundleSeekableInputStream(std::shared_ptr<SeekableInputStream> stream, int64_t offset, int64_t size)
+            : _stream(std::move(stream)), _offset(offset), _size(size) {}
+
+    Status init();
+    Status seek(int64_t position) override;
+    StatusOr<int64_t> position() override;
+    StatusOr<int64_t> read_at(int64_t offset, void* out, int64_t count) override;
+    Status read_at_fully(int64_t offset, void* out, int64_t count) override;
+    StatusOr<int64_t> get_size() override;
+    Status skip(int64_t count) override;
+    StatusOr<std::string> read_all() override;
+    const std::string& filename() const override;
+    StatusOr<int64_t> read(void* data, int64_t count) override;
+    Status touch_cache(int64_t offset, size_t length) override;
+    StatusOr<std::unique_ptr<io::NumericStatistics>> get_numeric_statistics() override;
+
+private:
+    std::shared_ptr<io::SeekableInputStream> _stream;
+    int64_t _offset = 0;
+    int64_t _size = 0;
+};
+
+} // namespace starrocks

--- a/be/src/fs/fs.cpp
+++ b/be/src/fs/fs.cpp
@@ -17,6 +17,7 @@
 #include <fmt/format.h>
 
 #include "fs/azure/fs_azblob.h"
+#include "fs/bundle_file.h"
 #include "fs/encrypt_file.h"
 #include "fs/fs_posix.h"
 #include "fs/fs_s3.h"
@@ -142,6 +143,20 @@ StatusOr<std::shared_ptr<FileSystem>> FileSystem::CreateSharedFromString(std::st
     // Since almost all famous storage are compatible with Hadoop FileSystem, it's always a choice to fallback using
     // Hadoop FileSystem to access storage.
     return get_tls_fs_hdfs();
+}
+
+StatusOr<std::unique_ptr<RandomAccessFile>> FileSystem::new_random_access_file_with_bundling(
+        const RandomAccessFileOptions& opts, const FileInfo& file_info) {
+    if (file_info.bundle_file_offset.has_value() && file_info.bundle_file_offset.value() >= 0) {
+        // If the file is a shared file, we need to create a new random access file with the offset.
+        ASSIGN_OR_RETURN(auto file, new_random_access_file(opts, file_info));
+        auto bundle_file = std::make_unique<BundleSeekableInputStream>(
+                file->stream(), file_info.bundle_file_offset.value(), file_info.size.value());
+        RETURN_IF_ERROR(bundle_file->init());
+        return std::make_unique<RandomAccessFile>(std::move(bundle_file), file->filename(), file->is_cache_hit());
+    } else {
+        return new_random_access_file(opts, file_info);
+    }
 }
 
 const THdfsProperties* FSOptions::hdfs_properties() const {

--- a/be/src/fs/fs.cpp
+++ b/be/src/fs/fs.cpp
@@ -155,7 +155,7 @@ StatusOr<std::unique_ptr<RandomAccessFile>> FileSystem::new_random_access_file_w
         RETURN_IF_ERROR(bundle_file->init());
         return std::make_unique<RandomAccessFile>(std::move(bundle_file), file->filename(), file->is_cache_hit());
     } else {
-        return new_random_access_file(opts, file_info.path);
+        return new_random_access_file(opts, file_info);
     }
 }
 

--- a/be/src/fs/fs.cpp
+++ b/be/src/fs/fs.cpp
@@ -149,13 +149,13 @@ StatusOr<std::unique_ptr<RandomAccessFile>> FileSystem::new_random_access_file_w
         const RandomAccessFileOptions& opts, const FileInfo& file_info) {
     if (file_info.bundle_file_offset.has_value() && file_info.bundle_file_offset.value() >= 0) {
         // If the file is a shared file, we need to create a new random access file with the offset.
-        ASSIGN_OR_RETURN(auto file, new_random_access_file(opts, file_info));
+        ASSIGN_OR_RETURN(auto file, new_random_access_file(opts, file_info.path));
         auto bundle_file = std::make_unique<BundleSeekableInputStream>(
                 file->stream(), file_info.bundle_file_offset.value(), file_info.size.value());
         RETURN_IF_ERROR(bundle_file->init());
         return std::make_unique<RandomAccessFile>(std::move(bundle_file), file->filename(), file->is_cache_hit());
     } else {
-        return new_random_access_file(opts, file_info);
+        return new_random_access_file(opts, file_info.path);
     }
 }
 

--- a/be/src/fs/fs.h
+++ b/be/src/fs/fs.h
@@ -134,6 +134,8 @@ struct FileInfo {
     std::optional<int64_t> size;
     std::string encryption_meta;
     std::shared_ptr<FileSystem> fs;
+    // It is used to store the file offset of the bundle file.
+    std::optional<int64_t> bundle_file_offset;
 };
 
 struct FileWriteStat {
@@ -209,6 +211,10 @@ public:
                                                                                const FileInfo& file_info) {
         return new_random_access_file(opts, file_info.path);
     }
+
+    // Used for sharing segment files only.
+    StatusOr<std::unique_ptr<RandomAccessFile>> new_random_access_file_with_bundling(
+            const RandomAccessFileOptions& opts, const FileInfo& file_info);
 
     // Create an object that writes to a new file with the specified
     // name.  Deletes any existing file with the same name and creates a

--- a/be/src/storage/lake/column_mode_partial_update_handler.cpp
+++ b/be/src/storage/lake/column_mode_partial_update_handler.cpp
@@ -263,6 +263,9 @@ StatusOr<ChunkPtr> ColumnModePartialUpdateHandler::_read_from_source_segment(con
     if (relative_file_info.size.has_value()) {
         fileinfo.size = relative_file_info.size;
     }
+    if (relative_file_info.bundle_file_offset.has_value()) {
+        fileinfo.bundle_file_offset = relative_file_info.bundle_file_offset;
+    }
     uint32_t rowset_id = params.container.rssid_to_rowid().at(rssid);
     // 2. load segment meta.
     ASSIGN_OR_RETURN(auto segment, params.tablet->tablet_mgr()->load_segment(

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -121,6 +121,7 @@ void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write, const std:
         if (replace_seg.first < rowset->segment_encryption_metas_size()) {
             rowset->set_segment_encryption_metas(replace_seg.first, replace_seg.second.encryption_meta);
         }
+        rowset->clear_bundle_file_offsets(); // clear shared file offsets, since we rewrite segments.
     }
 
     rowset->set_id(_tablet_meta->next_rowset_id());

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -417,12 +417,19 @@ Status Rowset::load_segments(std::vector<SegmentPtr>* segments, SegmentReadOptio
     // RowsetMetaData upgrade from old version may not have the field of segment_size
     auto segment_size_size = metadata().segment_size_size();
     auto segment_file_size = metadata().segments_size();
+    auto bundle_file_offsets_size = metadata().bundle_file_offsets_size();
     bool has_segment_size = segment_size_size == segment_file_size;
     LOG_IF(ERROR, segment_size_size > 0 && segment_size_size != segment_file_size)
             << "segment_size size != segment file size, tablet: " << _tablet_id << ", rowset: " << metadata().id()
             << ", segment file size: " << segment_file_size << ", segment_size size: " << segment_size_size;
+    LOG_IF(ERROR, bundle_file_offsets_size > 0 && segment_size_size != bundle_file_offsets_size)
+            << "segment_size size != bundle file offsets size, tablet: " << _tablet_id
+            << ", rowset: " << metadata().id() << ", segment file size: " << segment_file_size
+            << ", bundle file offsets size: " << bundle_file_offsets_size
+            << ", segment_size size: " << segment_size_size;
 
     const auto& files_to_size = metadata().segment_size();
+    const auto& files_to_offset = metadata().bundle_file_offsets();
     int index = 0;
 
     std::vector<std::future<std::pair<StatusOr<SegmentPtr>, std::string>>> segment_futures;
@@ -449,6 +456,9 @@ Status Rowset::load_segments(std::vector<SegmentPtr>* segments, SegmentReadOptio
         auto segment_info = FileInfo{.path = segment_path, .fs = seg_options.fs};
         if (LIKELY(has_segment_size)) {
             segment_info.size = files_to_size.Get(index);
+        }
+        if (bundle_file_offsets_size > 0) {
+            segment_info.bundle_file_offset = files_to_offset.Get(index);
         }
         auto segment_encryption_metas_size = metadata().segment_encryption_metas_size();
         if (segment_encryption_metas_size > 0) {

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -531,6 +531,9 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
         }
         src.encryption_meta = params.op_write.rowset().segment_encryption_metas(segment_id);
     }
+    if (rowset_meta.bundle_file_offsets_size() > 0) {
+        src.bundle_file_offset = rowset_meta.bundle_file_offsets(segment_id);
+    }
 
     int64_t t_rewrite_start = MonotonicMillis();
     if (has_auto_increment_partial_update_state(params) &&

--- a/be/src/storage/meta_reader.cpp
+++ b/be/src/storage/meta_reader.cpp
@@ -189,7 +189,7 @@ Status SegmentMetaCollecter::_init_return_column_iterators() {
     if (_segment->encryption_info()) {
         ropts.encryption_info = *_segment->encryption_info();
     }
-    ASSIGN_OR_RETURN(_read_file, fs->new_random_access_file(ropts, _segment->file_name()));
+    ASSIGN_OR_RETURN(_read_file, fs->new_random_access_file_with_bundling(ropts, _segment->file_info()));
 
     auto max_cid = _params->cids.empty() ? 0 : *std::max_element(_params->cids.begin(), _params->cids.end());
     _column_iterators.resize(max_cid + 1);

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -241,7 +241,7 @@ Status Segment::_open(size_t* footer_length_hint, const FooterPointerPB* partial
         _encryption_info = std::make_unique<FileEncryptionInfo>(opts.encryption_info);
     }
 
-    ASSIGN_OR_RETURN(auto read_file, _fs->new_random_access_file(opts, _segment_file_info));
+    ASSIGN_OR_RETURN(auto read_file, _fs->new_random_access_file_with_bundling(opts, _segment_file_info));
     RETURN_IF_ERROR(Segment::parse_segment_footer(read_file.get(), &footer, footer_length_hint, partial_rowset_footer));
     RETURN_IF_ERROR(_create_column_readers(&footer));
     _num_rows = footer.num_rows();
@@ -363,7 +363,7 @@ Status Segment::_load_index(const LakeIOOptions& lake_io_opts) {
         file_opts.encryption_info = std::move(info);
         _encryption_info = std::make_unique<FileEncryptionInfo>(file_opts.encryption_info);
     }
-    ASSIGN_OR_RETURN(auto read_file, _fs->new_random_access_file(file_opts, _segment_file_info));
+    ASSIGN_OR_RETURN(auto read_file, _fs->new_random_access_file_with_bundling(file_opts, _segment_file_info));
 
     PageReadOptions opts;
     opts.use_page_cache = lake_io_opts.use_page_cache;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -804,7 +804,7 @@ Status SegmentIterator::_init_column_iterator_by_cid(const ColumnId cid, const C
         if (encryption_info) {
             opts.encryption_info = *encryption_info;
         }
-        ASSIGN_OR_RETURN(auto rfile, _opts.fs->new_random_access_file(opts, _segment->file_info()));
+        ASSIGN_OR_RETURN(auto rfile, _opts.fs->new_random_access_file_with_bundling(opts, _segment->file_info()));
         if (config::io_coalesce_lake_read_enable && !_segment->is_default_column(col) &&
             _segment->lake_tablet_manager() != nullptr) {
             ASSIGN_OR_RETURN(auto file_size, rfile->get_size());

--- a/be/src/storage/rowset/segment_rewriter.cpp
+++ b/be/src/storage/rowset/segment_rewriter.cpp
@@ -40,7 +40,7 @@ Status SegmentRewriter::rewrite_partial_update(const FileInfo& src, FileInfo* de
         wopts.encryption_info = ropts.encryption_info;
         dest->encryption_meta = src.encryption_meta;
     }
-    ASSIGN_OR_RETURN(auto rfile, fs->new_random_access_file(ropts, src));
+    ASSIGN_OR_RETURN(auto rfile, fs->new_random_access_file_with_bundling(ropts, src));
     ASSIGN_OR_RETURN(auto wfile, fs->new_writable_file(wopts, dest->path));
 
     SegmentFooterPB footer;

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -109,6 +109,7 @@ message RowsetMetadataPB {
     // set in partial compaction, indicate which segment index next compaction should start from
     // only be set > 0 if `overlapped` is true
     optional uint32 next_compaction_offset = 13;
+    repeated int64 bundle_file_offsets = 14;
 }
 
 // At present, the lake persistent index reuses the logic of the persistent index,


### PR DESCRIPTION
## Why I'm doing:
In PR #58923, we introduced data file bundling to optimize S3 API costs for real-time ingestion scenarios. While we plan to release this optimization in version 4.0, we must consider potential future downgrade requirements. If a 4.0 cluster needs to be downgraded to version 3.5, the 3.5 version must at least maintain the capability to read bundle data files.

## What I'm doing:

Therefore, this PR will backport the relevant logic for reading bundle data files from PR #58923 to version 3.5.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


