### PR TITLE
[Enhancement] use file info instead of file path in bundle data file reader

### DIFF
--- a/be/src/fs/fs.cpp
+++ b/be/src/fs/fs.cpp
@@ -149,13 +149,13 @@ StatusOr<std::unique_ptr<RandomAccessFile>> FileSystem::new_random_access_file_w
         const RandomAccessFileOptions& opts, const FileInfo& file_info) {
     if (file_info.bundle_file_offset.has_value() && file_info.bundle_file_offset.value() >= 0) {
         // If the file is a shared file, we need to create a new random access file with the offset.
-        ASSIGN_OR_RETURN(auto file, new_random_access_file(opts, file_info.path));
+        ASSIGN_OR_RETURN(auto file, new_random_access_file(opts, file_info));
         auto bundle_file = std::make_unique<BundleSeekableInputStream>(
                 file->stream(), file_info.bundle_file_offset.value(), file_info.size.value());
         RETURN_IF_ERROR(bundle_file->init());
         return std::make_unique<RandomAccessFile>(std::move(bundle_file), file->filename(), file->is_cache_hit());
     } else {
-        return new_random_access_file(opts, file_info.path);
+        return new_random_access_file(opts, file_info);
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:
When reading bundled data files, we should pass the file info instead of the file path, as the info may contain file size information. In some filesystem implementations, this avoids additional file size fetch requests.

## What I'm doing:
This pull request modifies the `FileSystem::new_random_access_file_w` method in `be/src/fs/fs.cpp` to improve how `RandomAccessFile` objects are created by passing the entire `FileInfo` object instead of just its `path` attribute.

### Changes to `FileSystem::new_random_access_file_w`:
* Updated calls to `new_random_access_file` to use the full `FileInfo` object instead of only `file_info.path`. This ensures that all relevant file metadata is available during the creation of `RandomAccessFile` instances.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
