### PR TITLE
[BugFix] allow DECOMMISSION replica while loading to prevent publish failure

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
@@ -269,7 +269,8 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
     }
 
     // return map of (BE id -> path hash) of normal replicas
-    public Multimap<Replica, Long> getNormalReplicaBackendPathMap(SystemInfoService infoService) {
+    public Multimap<Replica, Long> getNormalReplicaBackendPathMap(SystemInfoService infoService,
+            boolean allowDecommission) {
         Multimap<Replica, Long> map = LinkedHashMultimap.create();
         try (CloseableLock ignored = CloseableLock.lock(this.rwLock.readLock())) {
             for (Replica replica : replicas) {
@@ -282,7 +283,8 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
                 }
                 ReplicaState state = replica.getState();
                 if (infoService.checkBackendAlive(replica.getBackendId())
-                        && (state == ReplicaState.NORMAL || state == ReplicaState.ALTER)) {
+                        && (state == ReplicaState.NORMAL || state == ReplicaState.ALTER
+                                || (allowDecommission && state == ReplicaState.DECOMMISSION))) {
                     map.put(replica, replica.getPathHash());
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -810,8 +810,9 @@ public class OlapTableSink extends DataSink {
                         // we should ensure the replica backend is alive
                         // otherwise, there will be a 'unknown node id, id=xxx' error for stream load
                         LocalTablet localTablet = (LocalTablet) tablet;
+                        // Load task shounld allow decommission replica, otherwise publish version will fail
                         Multimap<Replica, Long> bePathsMap =
-                                localTablet.getNormalReplicaBackendPathMap(infoService);
+                                localTablet.getNormalReplicaBackendPathMap(infoService, true);
                         if (bePathsMap.keySet().size() < quorum) {
                             throw new StarRocksException(InternalErrorCode.REPLICA_FEW_ERR,
                                     String.format("Tablet lost replicas. Check if any backend is down or not. " +

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -2152,7 +2152,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                     LocalTablet localTablet = (LocalTablet) tablet;
                     Multimap<Replica, Long> bePathsMap =
                             localTablet.getNormalReplicaBackendPathMap(
-                                    GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
+                                    GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(), false);
                     if (bePathsMap.keySet().size() < quorum) {
                         throw new StarRocksException(String.format("Tablet lost replicas. Check if any backend is down or not. " +
                                         "tablet_id: %s, replicas: %s. Check quorum number failed(buildTablets): " +
@@ -2445,7 +2445,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                         LocalTablet localTablet = (LocalTablet) tablet;
                         Multimap<Replica, Long> bePathsMap =
                                 localTablet.getNormalReplicaBackendPathMap(
-                                        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
+                                        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(), false);
                         if (bePathsMap.keySet().size() < quorum) {
                             String errorMsg = String.format("Tablet lost replicas. Check if any backend is down or not. " +
                                             "tablet_id: %s, replicas: %s. Check quorum number failed" +

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/LocalTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/LocalTabletTest.java
@@ -309,10 +309,39 @@ public class LocalTabletTest {
             }
         };
 
-        Multimap<Replica, Long> map = tablet.getNormalReplicaBackendPathMap(infoService);
+        Multimap<Replica, Long> map = tablet.getNormalReplicaBackendPathMap(infoService, false);
         Assert.assertTrue(map.size() == 2);
         for (Map.Entry<Replica, Long> entry : map.entries()) {
             Assert.assertTrue(entry.getKey().getBackendId() != 20002);
         }
+    }
+
+    @Test
+    public void testGetNormalReplicaBackendPathMapFilterDecommission() {
+        List<Replica> replicas = Lists.newArrayList(new Replica(10001, 20001, ReplicaState.NORMAL, 10, -1),
+                new Replica(10002, 20002, ReplicaState.NORMAL, 10, -1),
+                new Replica(10003, 20003, ReplicaState.DECOMMISSION, 10, -1));
+        LocalTablet tablet = new LocalTablet(10004, replicas);
+        new MockUp<SimpleScheduler>() {
+            @Mock
+            public boolean isInBlocklist(long id) {
+                return false;
+            }
+        };
+
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public boolean checkBackendAlive(long id) {
+                return true;
+            }
+        };
+
+        Multimap<Replica, Long> map = tablet.getNormalReplicaBackendPathMap(infoService, false);
+        Assert.assertTrue(map.size() == 2);
+        for (Map.Entry<Replica, Long> entry : map.entries()) {
+            Assert.assertTrue(entry.getKey().getBackendId() != 20003);
+        }
+        Multimap<Replica, Long> map2 = tablet.getNormalReplicaBackendPathMap(infoService, true);
+        Assert.assertTrue(map2.size() == 3);
     }
 }


### PR DESCRIPTION
## Why I'm doing:
In the current implementation, the publish version operation does not ignore replicas in the DECOMMISSION state. However, during data ingestion, replicas in DECOMMISSION state are skipped, which can cause publish version failures and impact cluster stability.

To address this, we will improve the current implementation by ​​not skipping DECOMMISSION-state replicas during data ingestion​​.

## What I'm doing:
This pull request introduces changes to enhance the handling of replica states in various methods, particularly adding support for filtering replicas based on their decommission state. The primary change is the addition of a `allowDecommission` parameter to the `getNormalReplicaBackendPathMap` method in `LocalTablet`, which enables more granular control over replica filtering. Corresponding updates have been made to multiple parts of the codebase to integrate this functionality, along with new test cases to validate the changes.

### Enhancements to replica filtering:

* **Updated `getNormalReplicaBackendPathMap` method:** Added a `allowDecommission` parameter to allow filtering replicas based on their decommission state. This enables inclusion of decommissioned replicas when specified. (`fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java`, [[1]](diffhunk://#diff-5f8817a41d9742097251b6339090de9eefc9d568e7607b3b9f954f162913fba3L272-R273) [[2]](diffhunk://#diff-5f8817a41d9742097251b6339090de9eefc9d568e7607b3b9f954f162913fba3L285-R287)

### Integration of `allowDecommission` in related methods:

* **Updated `createLocation` method in `OlapTableSink`:** Modified the call to `getNormalReplicaBackendPathMap` to pass `true` for the `allowDecommission` parameter, ensuring decommissioned replicas are considered during load tasks. (`fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java`, [fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.javaR813-R815](diffhunk://#diff-b0dd1943e6dee863d455359fe7ba963508c81f06b0bb2ccd70aef7de2ae6fd2eR813-R815))
* **Updated `buildTablets` and `buildCreatePartitionResponse` methods in `FrontendServiceImpl`:** Modified calls to `getNormalReplicaBackendPathMap` to explicitly pass `false` for the `allowDecommission` parameter, maintaining the original behavior for these methods. (`fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java`, [[1]](diffhunk://#diff-921ba54538823c20a429c7eee2020ea9795b7b2d014e0aef418e52d8aba1d234L2155-R2155) [[2]](diffhunk://#diff-921ba54538823c20a429c7eee2020ea9795b7b2d014e0aef418e52d8aba1d234L2448-R2448)

### Addition of new test cases:

* **Added test cases in `LocalTabletTest`:** Introduced a new test method, `testGetNormalReplicaBackendPathMapFilterDecommission`, to validate the behavior of the `allowDecommission` parameter in `getNormalReplicaBackendPathMap`. This ensures both inclusion and exclusion of decommissioned replicas are correctly handled. (`fe/fe-core/src/test/java/com/starrocks/catalog/LocalTabletTest.java`, [fe/fe-core/src/test/java/com/starrocks/catalog/LocalTabletTest.javaL312-R346](diffhunk://#diff-63bb503d88e93183063bf5ad1661a6e4126193fae09f68f51fe90e907b42514aL312-R346))

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
