### PR TITLE
[BugFix] Clean the stale datacache data to free disk spaces immediately.

### DIFF
--- a/be/src/cache/block_cache/datacache_utils.h
+++ b/be/src/cache/block_cache/datacache_utils.h
@@ -32,7 +32,10 @@ public:
     static Status parse_conf_datacache_disk_paths(const std::string& config_path, std::vector<std::string>* paths,
                                                   bool ignore_broken_disk);
 
-    static void clean_residual_datacache(const std::string& disk_path);
+    static void clean_residual_datacache(const std::string& disk_path, bool ignore_persistent_cache);
+
+    static void clean_stale_datacache(const std::string& stale_data_path_conf,
+                                      std::vector<std::string> cur_cache_paths);
 
     static Status change_disk_path(const std::string& old_disk_path, const std::string& new_disk_path);
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1305,6 +1305,10 @@ CONF_Bool(datacache_unified_instance_enable, "true");
 // * lru: the typical `Least Recently Used` eviction policy.
 // * slru: segment lru eviction policies, which can better reduce cache pollution problem.
 CONF_String(datacache_eviction_policy, "slru");
+// Only used to clean the old and stale datacache files.
+// Users usually do not need to configure it.
+CONF_String(datacache_stale_data_path, "");
+CONF_Alias(datacache_stale_data_path, datacache_disk_path);
 
 // The following configurations will be deprecated, and we use the `datacache` prefix instead.
 // But it is temporarily necessary to keep them for a period of time to be compatible with

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1305,17 +1305,16 @@ CONF_Bool(datacache_unified_instance_enable, "true");
 // * lru: the typical `Least Recently Used` eviction policy.
 // * slru: segment lru eviction policies, which can better reduce cache pollution problem.
 CONF_String(datacache_eviction_policy, "slru");
-// Only used to clean the old and stale datacache files.
-// Users usually do not need to configure it.
-CONF_String(datacache_stale_data_path, "");
-CONF_Alias(datacache_stale_data_path, datacache_disk_path);
 
 // The following configurations will be deprecated, and we use the `datacache` prefix instead.
 // But it is temporarily necessary to keep them for a period of time to be compatible with
 // the old configuration files.
 CONF_Bool(block_cache_enable, "false");
 CONF_Int64(block_cache_disk_size, "0");
-CONF_String(block_cache_disk_path, "${STARROCKS_HOME}/block_cache/");
+// The `block_cache_disk_path` and `datacache_disk_path` has been deprecated,
+// users should not configure it.
+CONF_String(block_cache_disk_path, "");
+CONF_Alias(block_cache_disk_path, datacache_disk_path);
 CONF_String(block_cache_meta_path, "${STARROCKS_HOME}/block_cache/");
 CONF_Int64(block_cache_block_size, "262144");   // 256K
 CONF_Int64(block_cache_mem_size, "2147483648"); // 2GB

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -465,6 +465,18 @@ Status CacheEnv::_init_datacache() {
             total_quota_bytes += disk_size;
         }
 
+        std::string stale_data_path = config::datacache_stale_data_path.empty() ? config::block_cache_disk_path
+                                                                                : config::datacache_stale_data_path;
+        // Automatically clean the old stale datacache to free disk space.
+        if (!stale_data_path.empty()) {
+            std::vector<std::string> cur_cache_paths;
+            cur_cache_paths.reserve(cache_options.disk_spaces.size());
+            for (auto& space : cache_options.disk_spaces) {
+                cur_cache_paths.push_back(space.path);
+            }
+            DataCacheUtils::clean_stale_datacache(stale_data_path, cur_cache_paths);
+        }
+
         if (cache_options.disk_spaces.empty() || total_quota_bytes != 0) {
             config::datacache_auto_adjust_enable = false;
         }

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -465,16 +465,16 @@ Status CacheEnv::_init_datacache() {
             total_quota_bytes += disk_size;
         }
 
-        std::string stale_data_path = config::datacache_stale_data_path.empty() ? config::block_cache_disk_path
-                                                                                : config::datacache_stale_data_path;
         // Automatically clean the old stale datacache to free disk space.
-        if (!stale_data_path.empty()) {
+        if (!config::block_cache_disk_path.empty()) {
+            LOG(WARNING) << "The `datacache_disk_path` and `block_cache_disk_path` have been deprecated and will be "
+                         << "ignored, currently the cache data is located in `${storage_root_path}/datacache`.";
             std::vector<std::string> cur_cache_paths;
             cur_cache_paths.reserve(cache_options.disk_spaces.size());
             for (auto& space : cache_options.disk_spaces) {
                 cur_cache_paths.push_back(space.path);
             }
-            DataCacheUtils::clean_stale_datacache(stale_data_path, cur_cache_paths);
+            DataCacheUtils::clean_stale_datacache(config::block_cache_disk_path, cur_cache_paths);
         }
 
         if (cache_options.disk_spaces.empty() || total_quota_bytes != 0) {

--- a/be/test/cache/block_cache/block_cache_test.cpp
+++ b/be/test/cache/block_cache/block_cache_test.cpp
@@ -329,7 +329,7 @@ TEST_F(BlockCacheTest, clear_residual_blockfiles) {
     }
 
     cache->shutdown();
-    DataCacheUtils::clean_residual_datacache(cache_dir);
+    DataCacheUtils::clean_residual_datacache(cache_dir, true);
 
     {
         std::vector<std::string> files;

--- a/be/test/cache/block_cache/datacache_utils_test.cpp
+++ b/be/test/cache/block_cache/datacache_utils_test.cpp
@@ -180,7 +180,7 @@ TEST_F(DataCacheUtilsTest, clean_stale_cache_data) {
     }
 
     std::string stale_data_path_conf = fmt::format("{};{};{}", old_dir, old_dir2, new_dir);
-    std::vector<std::string> cur_cache_paths = { std::filesystem::absolute(std::filesystem::path(new_dir)) };
+    std::vector<std::string> cur_cache_paths = {std::filesystem::absolute(std::filesystem::path(new_dir))};
     DataCacheUtils::clean_stale_datacache(stale_data_path_conf, cur_cache_paths);
 
     {

--- a/be/test/cache/block_cache/datacache_utils_test.cpp
+++ b/be/test/cache/block_cache/datacache_utils_test.cpp
@@ -20,6 +20,7 @@
 
 #include "fs/fs_util.h"
 #include "gen_cpp/DataCache_types.h"
+#include "testutil/assert.h"
 
 namespace starrocks {
 class DataCacheUtilsTest : public ::testing::Test {};
@@ -143,6 +144,65 @@ TEST_F(DataCacheUtilsTest, get_device_id_func) {
     ASSERT_GT(DataCacheUtils::disk_device_id("./not_exist"), 0);
     ASSERT_GT(DataCacheUtils::disk_device_id("./not_exist1/not_exist2"), 0);
     ASSERT_EQ(DataCacheUtils::disk_device_id("./not_exist"), DataCacheUtils::disk_device_id("./not_exist1/not_exist2"));
+}
+
+TEST_F(DataCacheUtilsTest, clean_stale_cache_data) {
+    const std::string old_dir = "./old_disk_cache_path";
+    const std::string old_dir2 = "./old_disk_cache_path2";
+    const std::string new_dir = "./new_disk_cache_path";
+    ASSERT_OK(fs::create_directories(old_dir));
+    ASSERT_OK(fs::create_directories(old_dir2));
+    ASSERT_OK(fs::create_directories(new_dir));
+
+    size_t file_count = 10;
+    {
+        for (size_t i = 0; i < file_count; ++i) {
+            std::string filename1 = fmt::format("{}/blockfile_{}", old_dir, i);
+            std::string filename2 = fmt::format("{}/blockfile_{}", old_dir2, i);
+            std::string filename3 = fmt::format("{}/blockfile_{}", new_dir, i);
+            ASSERT_OK(fs::new_writable_file(filename1));
+            ASSERT_OK(fs::new_writable_file(filename2));
+            ASSERT_OK(fs::new_writable_file(filename3));
+        }
+        ASSERT_OK(fs::create_directories(fmt::format("{}/meta", old_dir2)));
+
+        std::vector<std::string> files;
+        auto st = fs::get_children(old_dir, &files);
+        ASSERT_EQ(files.size(), file_count);
+
+        files.clear();
+        st = fs::get_children(old_dir2, &files);
+        ASSERT_EQ(files.size(), file_count + 1);
+
+        files.clear();
+        st = fs::get_children(new_dir, &files);
+        ASSERT_EQ(files.size(), file_count);
+    }
+
+    std::string stale_data_path_conf = fmt::format("{};{};{}", old_dir, old_dir2, new_dir);
+    std::vector<std::string> cur_cache_paths = { std::filesystem::absolute(std::filesystem::path(new_dir)) };
+    DataCacheUtils::clean_stale_datacache(stale_data_path_conf, cur_cache_paths);
+
+    {
+        // clean successfully
+        std::vector<std::string> files;
+        auto st = fs::get_children(old_dir, &files);
+        ASSERT_EQ(files.size(), 0);
+
+        // skip cleaning because it is persistent cache path
+        files.clear();
+        st = fs::get_children(old_dir2, &files);
+        ASSERT_EQ(files.size(), file_count + 1);
+
+        // skip cleaning because it is in use
+        files.clear();
+        st = fs::get_children(new_dir, &files);
+        ASSERT_EQ(files.size(), file_count);
+    }
+
+    fs::remove_all(old_dir);
+    fs::remove_all(old_dir2);
+    fs::remove_all(new_dir);
 }
 
 TEST_F(DataCacheUtilsTest, change_cache_path_suc) {


### PR DESCRIPTION
## Why I'm doing:
Now we have deprecated the `datacache_disk_path` configuration and use the `${storage_root_path}/datacache` as the datacache path.
However, if users configured their own datacache paths before, after upgrading to current version, the old datacache data still remains until users manually clean it.

## What I'm doing:
Automatically check and clean the stale datacache data to free the disk spaces immediately.

For safety, we only clean cache directories that meet the following conditions:
* Only clean the data files that prefix with `blockfile_` in the directory, does not remove the cache directory.
* If there is a `meta` directory in the cache directory, means it is a persistent cache directory and be generated by StarRocks 3.4 or later, we will ignore the cache directory.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

