### PR TITLE
[Enhancement] Convert nan/inf to null to avoid client error

### DIFF
--- a/be/src/column/adaptive_nullable_column.cpp
+++ b/be/src/column/adaptive_nullable_column.cpp
@@ -301,9 +301,10 @@ int64_t AdaptiveNullableColumn::xor_checksum(uint32_t from, uint32_t to) const {
     return NullableColumn::xor_checksum(from, to);
 }
 
-void AdaptiveNullableColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol) const {
+void AdaptiveNullableColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol,
+                                                  bool is_inf_nan_convert_to_null) const {
     materialized_nullable();
-    NullableColumn::put_mysql_row_buffer(buf, idx, is_binary_protocol);
+    NullableColumn::put_mysql_row_buffer(buf, idx, is_binary_protocol, is_inf_nan_convert_to_null);
 }
 
 } // namespace starrocks

--- a/be/src/column/adaptive_nullable_column.h
+++ b/be/src/column/adaptive_nullable_column.h
@@ -367,7 +367,8 @@ public:
 
     int64_t xor_checksum(uint32_t from, uint32_t to) const override;
 
-    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false) const override;
+    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false,
+                              bool is_inf_nan_convert_to_null = false) const override;
 
     ColumnPtr& begin_append_not_default_value() {
         switch (_state) {

--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -504,7 +504,8 @@ int64_t ArrayColumn::xor_checksum(uint32_t from, uint32_t to) const {
     return (xor_checksum ^ _elements->xor_checksum(element_from, element_to));
 }
 
-void ArrayColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol) const {
+void ArrayColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol,
+                                       bool is_inf_nan_convert_to_null) const {
     DCHECK_LT(idx, size());
     const size_t offset = _offsets->get_data()[idx];
     const size_t array_size = _offsets->get_data()[idx + 1] - offset;
@@ -512,11 +513,11 @@ void ArrayColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_
     buf->begin_push_array();
     auto* elements = _elements.get();
     if (array_size > 0) {
-        elements->put_mysql_row_buffer(buf, offset);
+        elements->put_mysql_row_buffer(buf, offset, false, is_inf_nan_convert_to_null);
     }
     for (size_t i = 1; i < array_size; i++) {
         buf->separator(',');
-        elements->put_mysql_row_buffer(buf, offset + i);
+        elements->put_mysql_row_buffer(buf, offset + i, false, is_inf_nan_convert_to_null);
     }
     buf->finish_push_array();
 }

--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -155,7 +155,8 @@ public:
 
     int64_t xor_checksum(uint32_t from, uint32_t to) const override;
 
-    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false) const override;
+    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false,
+                              bool is_inf_nan_convert_to_null = false) const override;
 
     std::string get_name() const override { return "array-" + _elements->get_name(); }
 

--- a/be/src/column/array_view_column.cpp
+++ b/be/src/column/array_view_column.cpp
@@ -223,7 +223,8 @@ int64_t ArrayViewColumn::xor_checksum(uint32_t from, uint32_t to) const {
     throw std::runtime_error("ArrayViewColumn::xor_checksum() is not supported");
 }
 
-void ArrayViewColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol) const {
+void ArrayViewColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol,
+                                           bool is_inf_nan_convert_to_null) const {
     DCHECK(false) << "ArrayViewColumn::put_mysql_row_buffer() is not supported";
     throw std::runtime_error("ArrayViewColumn::put_mysql_row_buffer() is not supported");
 }

--- a/be/src/column/array_view_column.h
+++ b/be/src/column/array_view_column.h
@@ -159,7 +159,8 @@ public:
 
     int64_t xor_checksum(uint32_t from, uint32_t to) const override;
 
-    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false) const override;
+    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false,
+                              bool is_inf_nan_convert_to_null = false) const override;
 
     StatusOr<ColumnPtr> replicate(const Buffer<uint32_t>& offsets) override;
 

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -740,7 +740,8 @@ int64_t BinaryColumnBase<T>::xor_checksum(uint32_t from, uint32_t to) const {
 }
 
 template <typename T>
-void BinaryColumnBase<T>::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol) const {
+void BinaryColumnBase<T>::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol,
+                                               bool is_inf_nan_convert_to_null) const {
     T start = _offsets[idx];
     T len = _offsets[idx + 1] - start;
     buf->push_string((const char*)_bytes.data() + start, len);

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -274,7 +274,8 @@ public:
 
     int64_t xor_checksum(uint32_t from, uint32_t to) const override;
 
-    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false) const override;
+    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false,
+                              bool is_inf_nan_convert_to_null = false) const override;
 
     std::string get_name() const override {
         static_assert(std::is_same_v<T, uint32_t> || std::is_same_v<T, uint64_t>);

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -397,7 +397,8 @@ public:
     virtual int64_t xor_checksum(uint32_t from, uint32_t to) const = 0;
 
     // Push one row to MysqlRowBuffer
-    virtual void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false) const = 0;
+    virtual void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false,
+                            bool is_inf_nan_convert_to_null = false) const = 0;
 
     void set_delete_state(DelCondSatisfied delete_state) { _delete_state = delete_state; }
 

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -214,8 +214,9 @@ public:
 
     int64_t xor_checksum(uint32_t from, uint32_t to) const override;
 
-    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false) const override {
-        _data->put_mysql_row_buffer(buf, 0, is_binary_protocol);
+    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false, 
+                              bool is_inf_nan_convert_to_null = false) const override {
+        _data->put_mysql_row_buffer(buf, 0, is_binary_protocol, is_inf_nan_convert_to_null);
     }
 
     std::string get_name() const override { return "const-" + _data->get_name(); }

--- a/be/src/column/decimalv3_column.cpp
+++ b/be/src/column/decimalv3_column.cpp
@@ -59,7 +59,8 @@ int DecimalV3Column<T>::scale() const {
 }
 
 template <typename T>
-void DecimalV3Column<T>::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol) const {
+void DecimalV3Column<T>::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol,
+                                              bool is_inf_nan_convert_to_null) const {
     auto& data = this->get_data();
     auto s = DecimalV3Cast::to_string<T>(data[idx], _precision, _scale);
     buf->push_decimal(s);

--- a/be/src/column/decimalv3_column.h
+++ b/be/src/column/decimalv3_column.h
@@ -48,7 +48,8 @@ public:
 
     MutableColumnPtr clone_empty() const override { return this->create(_precision, _scale); }
 
-    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false) const override;
+    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false,
+                              bool is_inf_nan_convert_to_null = false) const override;
     std::string debug_item(size_t idx) const override;
     void crc32_hash(uint32_t* hash, uint32_t from, uint32_t to) const override;
     int64_t xor_checksum(uint32_t from, uint32_t to) const override;

--- a/be/src/column/fixed_length_column_base.cpp
+++ b/be/src/column/fixed_length_column_base.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <gutil/strings/fastmem.h>
+#include <type_traits>
 
 #include "column/column_helper.h"
 #include "column/fixed_length_column.h"
@@ -333,7 +334,8 @@ int64_t FixedLengthColumnBase<T>::xor_checksum(uint32_t from, uint32_t to) const
 }
 
 template <typename T>
-void FixedLengthColumnBase<T>::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol) const {
+void FixedLengthColumnBase<T>::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol, 
+                                                    bool is_inf_nan_convert_to_null) const {
     if constexpr (IsDecimal<T>) {
         buf->push_decimal(_data[idx].to_string());
     } else if constexpr (IsDate<T>) {
@@ -341,6 +343,12 @@ void FixedLengthColumnBase<T>::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t 
     } else if constexpr (IsTimestamp<T>) {
         buf->push_timestamp(_data[idx], is_binary_protocol);
     } else if constexpr (std::is_arithmetic_v<T>) {
+        if constexpr (std::is_same_v<T, float> || std::is_same_v<T, double>) {
+            if (is_inf_nan_convert_to_null && (std::isnan(_data[idx]) || std::isinf(_data[idx]))) {
+                buf->push_null(is_binary_protocol);
+                return;
+            }
+        }
         buf->push_number(_data[idx], is_binary_protocol);
     } else {
         std::string s = _data[idx].to_string();

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -206,7 +206,8 @@ public:
 
     int64_t xor_checksum(uint32_t from, uint32_t to) const override;
 
-    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false) const override;
+    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false,
+                              bool is_inf_nan_convert_to_null = false) const override;
 
     std::string get_name() const override;
 

--- a/be/src/column/json_column.cpp
+++ b/be/src/column/json_column.cpp
@@ -60,7 +60,8 @@ void JsonColumn::fnv_hash(uint32_t* hash, uint32_t from, uint32_t to) const {
     }
 }
 
-void JsonColumn::put_mysql_row_buffer(starrocks::MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol) const {
+void JsonColumn::put_mysql_row_buffer(starrocks::MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol,
+                                      bool is_inf_nan_convert_to_null) const {
     JsonValue* value = get_object(idx);
     DCHECK(value != nullptr);
     auto json_str = value->to_string();

--- a/be/src/column/json_column.h
+++ b/be/src/column/json_column.h
@@ -50,7 +50,7 @@ public:
 
     void append_datum(const Datum& datum) override;
     void put_mysql_row_buffer(starrocks::MysqlRowBuffer* buf, size_t idx,
-                              bool is_binary_protocol = false) const override;
+                              bool is_binary_protocol = false, bool is_inf_nan_convert_to_null = false) const override;
     std::string get_name() const override;
     bool is_json() const override { return true; }
 

--- a/be/src/column/map_column.cpp
+++ b/be/src/column/map_column.cpp
@@ -567,7 +567,8 @@ int64_t MapColumn::xor_checksum(uint32_t from, uint32_t to) const {
     return (xor_checksum ^ _values->xor_checksum(element_from, element_to));
 }
 
-void MapColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol) const {
+void MapColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol,
+                                     bool is_inf_nan_convert_to_null) const {
     DCHECK_LT(idx, size());
     const size_t offset = _offsets->get_data()[idx];
     const size_t map_size = _offsets->get_data()[idx + 1] - offset;
@@ -576,15 +577,15 @@ void MapColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_bi
     auto* keys = _keys.get();
     auto* values = _values.get();
     if (map_size > 0) {
-        keys->put_mysql_row_buffer(buf, offset);
+        keys->put_mysql_row_buffer(buf, offset, false, is_inf_nan_convert_to_null);
         buf->separator(':');
-        values->put_mysql_row_buffer(buf, offset);
+        values->put_mysql_row_buffer(buf, offset, false, is_inf_nan_convert_to_null);
     }
     for (size_t i = 1; i < map_size; i++) {
         buf->separator(',');
-        keys->put_mysql_row_buffer(buf, offset + i);
+        keys->put_mysql_row_buffer(buf, offset + i, false, is_inf_nan_convert_to_null);
         buf->separator(':');
-        values->put_mysql_row_buffer(buf, offset + i);
+        values->put_mysql_row_buffer(buf, offset + i, false, is_inf_nan_convert_to_null);
     }
     buf->finish_push_bracket();
 }

--- a/be/src/column/map_column.h
+++ b/be/src/column/map_column.h
@@ -144,7 +144,8 @@ public:
 
     int64_t xor_checksum(uint32_t from, uint32_t to) const override;
 
-    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false) const override;
+    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false,
+                              bool is_inf_nan_convert_to_null = false) const override;
 
     std::string get_name() const override { return "map"; }
 

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -493,12 +493,13 @@ int64_t NullableColumn::xor_checksum(uint32_t from, uint32_t to) const {
     return xor_checksum;
 }
 
-void NullableColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol) const {
+void NullableColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol,
+                                          bool is_inf_nan_convert_to_null) const {
     if (_has_null && _null_column->get_data()[idx]) {
         buf->push_null(is_binary_protocol);
     } else {
         buf->update_field_pos();
-        _data_column->put_mysql_row_buffer(buf, idx, is_binary_protocol);
+        _data_column->put_mysql_row_buffer(buf, idx, is_binary_protocol, is_inf_nan_convert_to_null);
     }
 }
 

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -227,7 +227,8 @@ public:
 
     int64_t xor_checksum(uint32_t from, uint32_t to) const override;
 
-    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false) const override;
+    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false,
+                              bool is_inf_nan_convert_to_null = false) const override;
 
     std::string get_name() const override { return "nullable-" + _data_column->get_name(); }
 

--- a/be/src/column/object_column.cpp
+++ b/be/src/column/object_column.cpp
@@ -275,7 +275,8 @@ int64_t ObjectColumn<T>::xor_checksum(uint32_t from, uint32_t to) const {
 }
 
 template <typename T>
-void ObjectColumn<T>::put_mysql_row_buffer(starrocks::MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol) const {
+void ObjectColumn<T>::put_mysql_row_buffer(starrocks::MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol,
+                                           bool is_inf_nan_convert_to_null) const {
     buf->push_null();
 }
 

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -145,7 +145,8 @@ public:
 
     int64_t xor_checksum(uint32_t from, uint32_t to) const override;
 
-    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false) const override;
+    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false,
+                              bool is_inf_nan_convert_to_null = false) const override;
 
     std::string get_name() const override { return std::string{"object"}; }
 

--- a/be/src/column/struct_column.cpp
+++ b/be/src/column/struct_column.cpp
@@ -391,14 +391,15 @@ int64_t StructColumn::xor_checksum(uint32_t from, uint32_t to) const {
     return xor_checksum;
 }
 
-void StructColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol) const {
+void StructColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol,
+                                        bool is_inf_nan_convert_to_null) const {
     DCHECK_LT(idx, size());
     buf->begin_push_bracket();
     for (size_t i = 0; i < _fields.size(); ++i) {
         const auto& field = _fields[i];
         buf->push_string(_field_names[i]);
         buf->separator(':');
-        field->put_mysql_row_buffer(buf, idx);
+        field->put_mysql_row_buffer(buf, idx, false, is_inf_nan_convert_to_null);
         if (i < _fields.size() - 1) {
             // Add struct field separator, last field don't need ','.
             buf->separator(',');

--- a/be/src/column/struct_column.h
+++ b/be/src/column/struct_column.h
@@ -132,7 +132,8 @@ public:
 
     int64_t xor_checksum(uint32_t from, uint32_t to) const override;
 
-    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is) const override;
+    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol,
+                              bool is_inf_nan_convert_to_null = false) const override;
 
     std::string debug_item(size_t idx) const override;
 

--- a/be/src/exec/data_sink.cpp
+++ b/be/src/exec/data_sink.cpp
@@ -293,8 +293,8 @@ Status DataSink::decompose_data_sink_to_pipeline(pipeline::PipelineBuilderContex
         } else {
             op = std::make_shared<ResultSinkOperatorFactory>(
                     context->next_operator_id(), dop, result_sink->get_sink_type(), result_sink->isBinaryFormat(),
-                    result_sink->get_format_type(), result_sink->get_output_exprs(), fragment_ctx,
-                    result_sink->get_row_desc());
+                    result_sink->isInfNanConvertToNull(), result_sink->get_format_type(), 
+                    result_sink->get_output_exprs(), fragment_ctx, result_sink->get_row_desc());
         }
         // Add result sink operator to last pipeline
         prev_operators.emplace_back(op);

--- a/be/src/exec/pipeline/result_sink_operator.cpp
+++ b/be/src/exec/pipeline/result_sink_operator.cpp
@@ -42,7 +42,8 @@ Status ResultSinkOperator::prepare(RuntimeState* state) {
     // Create writer based on sink type
     switch (_sink_type) {
     case TResultSinkType::MYSQL_PROTOCAL:
-        _writer = std::make_shared<MysqlResultWriter>(_sender.get(), _output_expr_ctxs, _is_binary_format, profile);
+        _writer = std::make_shared<MysqlResultWriter>(_sender.get(), _output_expr_ctxs, _is_binary_format,
+                                                      _is_inf_nan_convert_to_null, profile);
         break;
     case TResultSinkType::STATISTIC:
         _writer = std::make_shared<StatisticResultWriter>(_sender.get(), _output_expr_ctxs, profile);

--- a/be/src/exec/pipeline/result_sink_operator.h
+++ b/be/src/exec/pipeline/result_sink_operator.h
@@ -30,13 +30,15 @@ namespace pipeline {
 class ResultSinkOperator final : public Operator {
 public:
     ResultSinkOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
-                       TResultSinkType::type sink_type, bool is_binary_format, TResultSinkFormatType::type format_type,
+                       TResultSinkType::type sink_type, bool is_binary_format, bool is_inf_nan_convert_to_null, 
+                       TResultSinkFormatType::type format_type,
                        std::vector<ExprContext*> output_expr_ctxs, const std::shared_ptr<BufferControlBlock>& sender,
                        std::atomic<int32_t>& num_sinks, std::atomic<int64_t>& num_written_rows,
                        FragmentContext* const fragment_ctx, const RowDescriptor& row_desc)
             : Operator(factory, id, "result_sink", plan_node_id, false, driver_sequence),
               _sink_type(sink_type),
               _is_binary_format(is_binary_format),
+              _is_inf_nan_convert_to_null(is_inf_nan_convert_to_null),
               _format_type(format_type),
               _output_expr_ctxs(std::move(output_expr_ctxs)),
               _sender(sender),
@@ -73,6 +75,7 @@ public:
 private:
     TResultSinkType::type _sink_type;
     bool _is_binary_format;
+    bool _is_inf_nan_convert_to_null;
     TResultSinkFormatType::type _format_type;
     std::vector<ExprContext*> _output_expr_ctxs;
 
@@ -93,13 +96,15 @@ private:
 
 class ResultSinkOperatorFactory final : public OperatorFactory {
 public:
-    ResultSinkOperatorFactory(int32_t id, size_t dop, TResultSinkType::type sink_type, bool is_binary_format,
-                              TResultSinkFormatType::type format_type, std::vector<TExpr> t_output_expr,
-                              FragmentContext* const fragment_ctx, const RowDescriptor& row_desc)
+    ResultSinkOperatorFactory(int32_t id, size_t dop, TResultSinkType::type sink_type, bool is_binary_format, 
+                              bool is_inf_nan_convert_to_null, TResultSinkFormatType::type format_type, 
+                              std::vector<TExpr> t_output_expr, FragmentContext* const fragment_ctx, 
+                              const RowDescriptor& row_desc)
             : OperatorFactory(id, "result_sink", Operator::s_pseudo_plan_node_id_for_final_sink),
               _dop(dop),
               _sink_type(sink_type),
               _is_binary_format(is_binary_format),
+              _is_inf_nan_convert_to_null(is_inf_nan_convert_to_null),
               _format_type(format_type),
               _t_output_expr(std::move(t_output_expr)),
               _fragment_ctx(fragment_ctx),
@@ -116,8 +121,9 @@ public:
         // so it doesn't need memory barrier here.
         _increment_num_sinkers_no_barrier();
         return std::make_shared<ResultSinkOperator>(this, _id, _plan_node_id, driver_sequence, _sink_type,
-                                                    _is_binary_format, _format_type, _output_expr_ctxs, _sender,
-                                                    _num_sinkers, _num_written_rows, _fragment_ctx, _row_desc);
+                                                    _is_binary_format, _is_inf_nan_convert_to_null, _format_type, 
+                                                    _output_expr_ctxs, _sender, _num_sinkers, _num_written_rows, 
+                                                    _fragment_ctx, _row_desc);
     }
 
     Status prepare(RuntimeState* state) override;
@@ -131,6 +137,7 @@ private:
 
     TResultSinkType::type _sink_type;
     bool _is_binary_format;
+    bool _is_inf_nan_convert_to_null;
     TResultSinkFormatType::type _format_type;
     std::vector<TExpr> _t_output_expr;
     std::vector<ExprContext*> _output_expr_ctxs;

--- a/be/src/exec/short_circuit.cpp
+++ b/be/src/exec/short_circuit.cpp
@@ -35,9 +35,10 @@
 namespace starrocks {
 class MysqlResultMemorySink : public DataSink {
 public:
-    MysqlResultMemorySink(const vector<TExpr>& t_exprs, bool is_binary_format,
+    MysqlResultMemorySink(const vector<TExpr>& t_exprs, bool is_binary_format, bool is_inf_nan_convert_to_null,
                           vector<std::unique_ptr<TFetchDataResult>>& results)
-            : _t_exprs(t_exprs), _is_binary_format(is_binary_format), _results(results) {}
+            : _t_exprs(t_exprs), _is_binary_format(is_binary_format),
+            _is_inf_nan_convert_to_null(is_inf_nan_convert_to_null), _results(results) {}
 
     ~MysqlResultMemorySink() override { delete _row_buffer; };
 
@@ -102,6 +103,7 @@ public:
 private:
     const std::vector<TExpr>& _t_exprs;
     const bool _is_binary_format;
+    const bool _is_inf_nan_convert_to_null;
     MysqlRowBuffer* _row_buffer;
     std::vector<std::unique_ptr<TFetchDataResult>>& _results;
     std::vector<ExprContext*> _output_expr_ctxs;
@@ -169,7 +171,9 @@ Status ShortCircuitExecutor::prepare(TExecShortCircuitParams& common_request) {
                                                    0, _source->row_desc(), &_sink));
     } else {
         bool is_binary_format = _common_request->is_binary_row;
-        _sink = std::make_unique<MysqlResultMemorySink>(output_exprs, is_binary_format, _results);
+        bool is_inf_nan_convert_to_null = _common_request->is_inf_nan_convert_to_null;
+        _sink = std::make_unique<MysqlResultMemorySink>(output_exprs, is_binary_format,
+                                                        is_inf_nan_convert_to_null, _results);
     }
 
     // prepare

--- a/be/src/runtime/mysql_result_writer.cpp
+++ b/be/src/runtime/mysql_result_writer.cpp
@@ -49,11 +49,13 @@
 namespace starrocks {
 
 MysqlResultWriter::MysqlResultWriter(BufferControlBlock* sinker, const std::vector<ExprContext*>& output_expr_ctxs,
-                                     bool is_binary_format, RuntimeProfile* parent_profile)
+                                     bool is_binary_format, bool is_inf_nan_convert_to_null, 
+                                     RuntimeProfile* parent_profile)
         : BufferControlResultWriter(sinker, parent_profile),
           _output_expr_ctxs(output_expr_ctxs),
           _row_buffer(nullptr),
-          _is_binary_format(is_binary_format) {}
+          _is_binary_format(is_binary_format), 
+          _is_inf_nan_convert_to_null(is_inf_nan_convert_to_null) {}
 
 MysqlResultWriter::~MysqlResultWriter() {
     delete _row_buffer;
@@ -135,7 +137,7 @@ StatusOr<TFetchDataResultPtr> MysqlResultWriter::_process_chunk(Chunk* chunk) {
                 if (_is_binary_format && !result_column->is_nullable()) {
                     _row_buffer->update_field_pos();
                 }
-                result_column->put_mysql_row_buffer(_row_buffer, i, _is_binary_format);
+                result_column->put_mysql_row_buffer(_row_buffer, i, _is_binary_format, _is_inf_nan_convert_to_null);
             }
             size_t len = _row_buffer->length();
             _row_buffer->move_content(&result_rows[i]);
@@ -183,7 +185,7 @@ StatusOr<TFetchDataResultPtrs> MysqlResultWriter::process_chunk(Chunk* chunk) {
                 if (_is_binary_format && !result_column->is_nullable()) {
                     _row_buffer->update_field_pos();
                 }
-                result_column->put_mysql_row_buffer(_row_buffer, i, _is_binary_format);
+                result_column->put_mysql_row_buffer(_row_buffer, i, _is_binary_format, _is_inf_nan_convert_to_null);
             }
             size_t len = _row_buffer->length();
 

--- a/be/src/runtime/mysql_result_writer.h
+++ b/be/src/runtime/mysql_result_writer.h
@@ -48,7 +48,7 @@ using TFetchDataResultPtrs = std::vector<TFetchDataResultPtr>;
 class MysqlResultWriter final : public BufferControlResultWriter {
 public:
     MysqlResultWriter(BufferControlBlock* sinker, const std::vector<ExprContext*>& output_expr_ctxs,
-                      bool is_binary_format, RuntimeProfile* parent_profile);
+                      bool is_binary_format, bool is_inf_nan_convert_to_null, RuntimeProfile* parent_profile);
 
     ~MysqlResultWriter() override;
 
@@ -65,6 +65,7 @@ private:
     const std::vector<ExprContext*>& _output_expr_ctxs;
     MysqlRowBuffer* _row_buffer;
     bool _is_binary_format;
+    bool _is_inf_nan_convert_to_null;
 
     const size_t _max_row_buffer_size = 1024 * 1024 * 1024;
 };

--- a/be/src/runtime/result_sink.cpp
+++ b/be/src/runtime/result_sink.cpp
@@ -71,6 +71,7 @@ ResultSink::ResultSink(const RowDescriptor& row_desc, const std::vector<TExpr>& 
     }
 
     _is_binary_format = sink.is_binary_row;
+    _is_inf_nan_convert_to_null = sink.is_inf_nan_convert_to_null;
 }
 
 Status ResultSink::prepare_exprs(RuntimeState* state) {
@@ -101,7 +102,8 @@ Status ResultSink::prepare(RuntimeState* state) {
     switch (_sink_type) {
     case TResultSinkType::MYSQL_PROTOCAL:
         _writer.reset(new (std::nothrow)
-                              MysqlResultWriter(_sender.get(), _output_expr_ctxs, _is_binary_format, _profile));
+                              MysqlResultWriter(_sender.get(), _output_expr_ctxs, _is_binary_format,
+                              _is_inf_nan_convert_to_null, _profile));
         break;
     case TResultSinkType::FILE:
         CHECK(_file_opts.get() != nullptr);

--- a/be/src/runtime/result_sink.h
+++ b/be/src/runtime/result_sink.h
@@ -83,11 +83,14 @@ public:
 
     const RowDescriptor& get_row_desc() const { return _row_desc; }
 
+    bool isInfNanConvertToNull() const { return _is_inf_nan_convert_to_null; }
+
 private:
     Status prepare_exprs(RuntimeState* state);
     const RowDescriptor& _row_desc;
     TResultSinkType::type _sink_type;
     bool _is_binary_format;
+    bool _is_inf_nan_convert_to_null;
     // set format_type when sink type is HTTP
     TResultSinkFormatType::type _format_type;
     // set file options when sink type is FILE

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
@@ -89,6 +89,7 @@ import com.starrocks.planner.PlanFragmentId;
 import com.starrocks.planner.PlanNodeId;
 import com.starrocks.planner.ScanNode;
 import com.starrocks.proto.UnlockTabletMetadataRequest;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.rpc.BrpcProxy;
@@ -466,7 +467,8 @@ public class ExportJob implements Writable, GsonPostProcessable {
         fragment.setSink(new ExportSink(exportTempPath, fileNamePrefix + taskIdx + "_", columnSeparator,
                     rowDelimiter, brokerDesc, hdfsProperties));
         try {
-            fragment.createDataSink(TResultSinkType.MYSQL_PROTOCAL);
+            fragment.createDataSink(TResultSinkType.MYSQL_PROTOCAL,
+                    ConnectContext.get().getSessionVariable().isEnableInfNanConvertToNull());
         } catch (Exception e) {
             LOG.info("Fragment finalize failed. e=", e);
             throw new StarRocksException("Fragment finalize failed");

--- a/fe/fe-core/src/main/java/com/starrocks/planner/MultiCastPlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/MultiCastPlanFragment.java
@@ -57,7 +57,7 @@ public class MultiCastPlanFragment extends PlanFragment {
     }
 
     @Override
-    public void createDataSink(TResultSinkType resultSinkType) {
+    public void createDataSink(TResultSinkType resultSinkType, boolean enableInfNanConvertToNull) {
         if (sink != null) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -419,7 +419,7 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     /**
      * Finalize plan tree and create stream sink, if needed.
      */
-    public void createDataSink(TResultSinkType resultSinkType) {
+    public void createDataSink(TResultSinkType resultSinkType, boolean isInfNanConvertToNull) {
         if (sink != null) {
             return;
         }
@@ -438,7 +438,7 @@ public class PlanFragment extends TreeNode<PlanFragment> {
             }
             // add ResultSink
             // we're streaming to an result sink
-            sink = new ResultSink(planRoot.getId(), resultSinkType);
+            sink = new ResultSink(planRoot.getId(), resultSinkType, isInfNanConvertToNull);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ResultSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ResultSink.java
@@ -60,10 +60,12 @@ public class ResultSink extends DataSink {
     private String brokerName;
     private TResultFileSinkOptions fileSinkOptions;
     private boolean isBinaryRow;
+    private boolean isInfNanConvertToNull;
 
-    public ResultSink(PlanNodeId exchNodeId, TResultSinkType sinkType) {
+    public ResultSink(PlanNodeId exchNodeId, TResultSinkType sinkType, boolean enableInfNanConvertToNull) {
         this.exchNodeId = exchNodeId;
         this.sinkType = sinkType;
+        this.isInfNanConvertToNull = enableInfNanConvertToNull;
     }
 
     @Override
@@ -85,6 +87,7 @@ public class ResultSink extends DataSink {
             tResultSink.setFormat(((HttpConnectContext) ConnectContext.get()).getResultSinkFormatType());
         }
         tResultSink.setIs_binary_row(isBinaryRow);
+        tResultSink.setIs_inf_nan_convert_to_null(isInfNanConvertToNull);
         result.setResult_sink(tResultSink);
         return result;
     }
@@ -142,5 +145,9 @@ public class ResultSink extends DataSink {
 
     public void setBinaryRow(boolean isBinaryRow) {
         this.isBinaryRow = isBinaryRow;
+    }
+
+    public void setInfNanConvertToNull(boolean isInfNanConvertToNull) {
+        this.isInfNanConvertToNull = isInfNanConvertToNull;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadPlanner.java
@@ -240,7 +240,8 @@ public class StreamLoadPlanner {
         // whether update.
         fragment.setLoadGlobalDicts(globalDicts);
 
-        fragment.createDataSink(TResultSinkType.MYSQL_PROTOCAL);
+        fragment.createDataSink(TResultSinkType.MYSQL_PROTOCAL,
+                getConnectContext().getSessionVariable().isEnableInfNanConvertToNull());
 
         TExecPlanFragmentParams params = new TExecPlanFragmentParams();
         params.setProtocol_version(InternalServiceVersion.V1);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -414,6 +414,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String CHOOSE_EXECUTE_INSTANCES_MODE = "choose_execute_instances_mode";
 
+    // If enabled, inf and nan values of double and float will be converted to null.
+    public static final String ENABLE_INF_NAN_CONVERT_TO_NULL = "enable_inf_nan_convert_to_null";
+
     // --------  New planner session variables end --------
 
     // Type of compression of transmitted data
@@ -2559,6 +2562,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = INSERT_LOCAL_SHUFFLE_FOR_WINDOW_PRE_AGG)
     private boolean insertLocalShuffleForWindowPreAgg = true;
 
+    @VarAttr(name = ENABLE_INF_NAN_CONVERT_TO_NULL)
+    private boolean enableInfNanConvertToNull = false;
+
     public SessionVariableConstants.ChooseInstancesMode getChooseExecuteInstancesMode() {
         return Enums.getIfPresent(SessionVariableConstants.ChooseInstancesMode.class,
                         StringUtils.upperCase(chooseExecuteInstancesMode))
@@ -2574,6 +2580,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             throw new IllegalArgumentException("Legal values of choose_execute_instances_mode are " + legalValues);
         }
         this.chooseExecuteInstancesMode = StringUtils.upperCase(mode);
+    }
+
+    public boolean isEnableInfNanConvertToNull() {
+        return enableInfNanConvertToNull;
+    }
+
+    public void setEnableInfNanConvertToNull(boolean enableInfNanConvertToNull) {
+        this.enableInfNanConvertToNull = enableInfNanConvertToNull;
     }
 
     public boolean isCboDecimalCastStringStrict() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitExecutor.java
@@ -60,10 +60,12 @@ public class ShortCircuitExecutor {
 
     protected final WorkerProvider workerProvider;
 
+    protected final boolean isInfNanConvertToNull;
+
     protected ShortCircuitExecutor(ConnectContext context, PlanFragment planFragment,
                                    List<TScanRangeLocations> scanRangeLocations, TDescriptorTable tDescriptorTable,
-                                   boolean isBinaryRow,
-                                   boolean enableProfile, String protocol, WorkerProvider workerProvider) {
+                                   boolean isBinaryRow, boolean enableProfile, String protocol, WorkerProvider workerProvider, 
+                                   boolean isInfNanConvertToNull) {
         this.context = context;
         this.planFragment = planFragment;
         this.scanRangeLocations = scanRangeLocations;
@@ -77,6 +79,7 @@ public class ShortCircuitExecutor {
             this.perBeExecutionProfile = Collections.emptyMap();
         }
         this.workerProvider = workerProvider;
+        this.isInfNanConvertToNull = isInfNanConvertToNull;
     }
 
     public static ShortCircuitExecutor create(ConnectContext context, List<PlanFragment> fragments, List<ScanNode> scanNodes,
@@ -91,7 +94,7 @@ public class ShortCircuitExecutor {
         if (!isEmpty && scanNodes.get(0) instanceof OlapScanNode) {
             List<TScanRangeLocations> scanRangeLocations = scanNodes.get(0).getScanRangeLocations(0);
             return new ShortCircuitHybridExecutor(context, fragments.get(0), scanRangeLocations, tDescriptorTable, isBinaryRow,
-                    enableProfile, protocol, workerProvider);
+                    enableProfile, protocol, workerProvider, context.getSessionVariable().isEnableInfNanConvertToNull());
         }
         return null;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitHybridExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitHybridExecutor.java
@@ -76,9 +76,9 @@ public class ShortCircuitHybridExecutor extends ShortCircuitExecutor {
     public ShortCircuitHybridExecutor(ConnectContext context, PlanFragment planFragment,
                                       List<TScanRangeLocations> scanRangeLocations, TDescriptorTable tDescriptorTable,
                                       boolean isBinaryRow, boolean enableProfile, String protocol,
-                                      WorkerProvider workerProvider) {
+                                      WorkerProvider workerProvider, boolean isInfNanConvertToNull) {
         super(context, planFragment, scanRangeLocations, tDescriptorTable, isBinaryRow, enableProfile,
-                protocol, workerProvider);
+                protocol, workerProvider, isInfNanConvertToNull);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/LoadPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/LoadPlanner.java
@@ -388,7 +388,8 @@ public class LoadPlanner {
 
         // 5. finalize
         for (PlanFragment fragment : fragments) {
-            fragment.createDataSink(TResultSinkType.MYSQL_PROTOCAL);
+            fragment.createDataSink(TResultSinkType.MYSQL_PROTOCAL,
+                    getContext().getSessionVariable().isEnableInfNanConvertToNull());
         }
         Collections.reverse(fragments);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -286,7 +286,8 @@ public class PlanFragmentBuilder {
         // Finalize fragments
         for (PlanFragment fragment : execPlan.getFragments()) {
             // TODO(murphy) check it
-            fragment.createDataSink(TResultSinkType.MYSQL_PROTOCAL);
+            fragment.createDataSink(TResultSinkType.MYSQL_PROTOCAL,
+                    connectContext.getSessionVariable().isEnableInfNanConvertToNull());
         }
         Collections.reverse(execPlan.getFragments());
 
@@ -390,6 +391,8 @@ public class PlanFragmentBuilder {
         for (PlanFragment fragment : fragments) {
             fragment.createDataSink(resultSinkType);
             fragment.setCollectExecStatsIds(execPlan.getCollectExecStatsIds());
+            fragment.createDataSink(resultSinkType,
+                    ConnectContext.get().getSessionVariable().isEnableInfNanConvertToNull());
         }
         Collections.reverse(fragments);
         // assign colocate groups to plan fragment

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -164,6 +164,7 @@ struct TResultSink {
     2: optional TResultFileSinkOptions file_options;
     3: optional TResultSinkFormatType format;
     4: optional bool is_binary_row;
+    5: optional bool is_inf_nan_convert_to_null;
 }
 
 struct TMysqlTableSink {

--- a/gensrc/thrift/ShortCircuit.thrift
+++ b/gensrc/thrift/ShortCircuit.thrift
@@ -43,4 +43,5 @@ struct TExecShortCircuitParams {
     8: optional list<TKeyLiteralExpr> key_literal_exprs;
     9: optional list<i64> tablet_ids;
     10: optional list<string> versions;
+    11: optional bool is_inf_nan_convert_to_null;
 }


### PR DESCRIPTION
## Why I'm doing:

fix: https://github.com/StarRocks/starrocks/issues/51233

## What I'm doing:

Added the switch `enable_inf_nan_convert_to_null` to convert `inf` and `nan` to `NULL`, thus avoiding client errors.

Before:
<img width="503" alt="image" src="https://github.com/user-attachments/assets/e6ad6663-684d-404f-9df7-1b0cbaac0b31" />

After:
<img width="480" alt="image" src="https://github.com/user-attachments/assets/8a886afb-21dd-4291-b669-c419ce3dc33a" />




Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3