### PR TITLE
[BugFix]Fix backend stream callback loss.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -645,9 +645,6 @@ public class TransactionState implements Writable, GsonPreProcessable {
             // GlobalTransactionMgr between beforeStateTransform and afterStateTransform
             TxnStateChangeCallback callback = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
                     .getCallbackFactory().getCallback(callbackId);
-            if (callback == null && this.sourceType == LoadJobSourceType.BACKEND_STREAMING) {
-                callback = GlobalStateMgr.getCurrentState().getStreamLoadMgr().getTaskByLabel(this.label);
-            }
             // before status changed
             if (callback != null) {
                 switch (transactionStatus) {
@@ -682,9 +679,6 @@ public class TransactionState implements Writable, GsonPreProcessable {
 
             TxnStateChangeCallback callback = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
                     .getCallbackFactory().getCallback(callbackId);
-            if (callback == null && this.sourceType == LoadJobSourceType.BACKEND_STREAMING) {
-                callback = GlobalStateMgr.getCurrentState().getStreamLoadMgr().getTaskByLabel(this.label);
-            }
 
             // after status changed
             if (callback != null) {


### PR DESCRIPTION
## Why I'm doing:
A flink-connector task imports multiple tables, restarts leader FE, current checkpoint A fails, and there are 2 states of transactions in CPA: prepare/prepared.

After flink task restart, playback starts from CPA, rollback is performed for transactions in prepare state, and commit is performed for transactions in prepared state. but the commit operation will fail because the callback is not persisted, and the callback is lost after FE restart(beginLoadTaskFromFrontend don't edit log).

There are two solutions:
1 Replace the label, but the topic offset of the prepared transaction is already from x--->y, replacing the label is consumed from y, and the data between x and y will be lost.
2 Playback from A-1, so that if it is a DUPLICATE KEY table, will lead to duplicate data import.

## What I'm doing:

BACKEND_STREAMING does not need to rely on callbacks:
1 beginLoadTaskFromBackend does not do the logCreateStreamLoadJob action and the BACKEND StreamLoadTask is not persisted.
2 StreamLoadMgr does not load BACKEND StreamLoadTask when leader FE is restarted

Fixes #60244

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
